### PR TITLE
feat(gui-app): pass Ctrl chords through to focused terminals on Windows/Linux

### DIFF
--- a/clients/desktop/src/electron-main/menu/__tests__/menu-builder.test.ts
+++ b/clients/desktop/src/electron-main/menu/__tests__/menu-builder.test.ts
@@ -7,6 +7,7 @@ interface CapturedMenuItem {
   readonly role?: string;
   readonly type?: string;
   readonly accelerator?: string;
+  readonly registerAccelerator?: boolean;
   readonly enabled?: boolean;
   readonly submenu?: readonly CapturedMenuItem[];
   readonly click?: (menuItem: unknown, browserWindow: unknown) => void;
@@ -388,6 +389,60 @@ describe("buildApplicationMenu", () => {
         false,
       );
     }
+  });
+
+  it("keeps terminal-conflicting accelerator labels visible but unregisters them off macOS", () => {
+    for (const platform of ["win32", "linux"] as const) {
+      const items = template(
+        buildApplicationMenu(buildState(platform), {
+          command: () => undefined,
+          focusWindow: () => undefined,
+          openExternal: () => undefined,
+        }),
+      );
+      const fileMenu = menuByLabel(items, "File").submenu ?? [];
+      const editMenu = menuByLabel(items, "Edit").submenu ?? [];
+      const windowMenu = menuByLabel(items, "Window").submenu ?? [];
+
+      const closeTab = menuByLabel(fileMenu, "Close Tab");
+      const settings = menuByLabel(fileMenu, "Settings...");
+      const find = menuByLabel(editMenu, "Find");
+      const findNext = menuByLabel(editMenu, "Find Next");
+      const findPrevious = menuByLabel(editMenu, "Find Previous");
+      const minimize = menuByLabel(windowMenu, "Minimize");
+
+      expect(closeTab.accelerator).toBe("CmdOrCtrl+W");
+      expect(settings.accelerator).toBe("CmdOrCtrl+,");
+      expect(find.accelerator).toBe("CommandOrControl+F");
+      expect(findNext.accelerator).toBe("CommandOrControl+G");
+      expect(minimize.accelerator).toBe("CmdOrCtrl+M");
+      expect(closeTab.registerAccelerator).toBe(false);
+      expect(settings.registerAccelerator).toBe(false);
+      expect(find.registerAccelerator).toBe(false);
+      expect(findNext.registerAccelerator).toBe(false);
+      expect(minimize.registerAccelerator).toBe(false);
+      expect(findPrevious.registerAccelerator).toBeUndefined();
+    }
+  });
+
+  it("keeps terminal-conflicting accelerators registered on macOS", () => {
+    const items = template(
+      buildApplicationMenu(buildState("darwin"), {
+        command: () => undefined,
+        focusWindow: () => undefined,
+        openExternal: () => undefined,
+      }),
+    );
+    const appMenu = menuByLabel(items, "Traycer").submenu ?? [];
+    const fileMenu = menuByLabel(items, "File").submenu ?? [];
+    const editMenu = menuByLabel(items, "Edit").submenu ?? [];
+    const windowMenu = menuByLabel(items, "Window").submenu ?? [];
+
+    expect(menuByLabel(appMenu, "Settings...").registerAccelerator).toBe(true);
+    expect(menuByLabel(fileMenu, "Close Tab").registerAccelerator).toBe(true);
+    expect(menuByLabel(editMenu, "Find").registerAccelerator).toBe(true);
+    expect(menuByLabel(editMenu, "Find Next").registerAccelerator).toBe(true);
+    expect(menuByLabel(windowMenu, "Minimize").registerAccelerator).toBe(true);
   });
 
   it("disables File Close Tab when no target window tab is closable", () => {

--- a/clients/desktop/src/electron-main/menu/__tests__/menu-builder.test.ts
+++ b/clients/desktop/src/electron-main/menu/__tests__/menu-builder.test.ts
@@ -82,6 +82,17 @@ function menuByLabel(
   return item;
 }
 
+function menuByRole(
+  items: readonly CapturedMenuItem[],
+  role: string,
+): CapturedMenuItem {
+  const item = items.find((entry) => entry.role === role);
+  if (item === undefined) {
+    throw new Error(`missing menu role ${role}`);
+  }
+  return item;
+}
+
 describe("buildApplicationMenu", () => {
   it("assigns stable ids to every renderer-visible Windows submenu", () => {
     const items = template(
@@ -482,6 +493,7 @@ describe("buildApplicationMenu", () => {
       );
       const fileMenu = menuByLabel(items, "File").submenu ?? [];
       const editMenu = menuByLabel(items, "Edit").submenu ?? [];
+      const viewMenu = menuByLabel(items, "View").submenu ?? [];
       const windowMenu = menuByLabel(items, "Window").submenu ?? [];
 
       const closeTab = menuByLabel(fileMenu, "Close Tab");
@@ -502,6 +514,12 @@ describe("buildApplicationMenu", () => {
       expect(findNext.registerAccelerator).toBe(false);
       expect(minimize.registerAccelerator).toBe(false);
       expect(findPrevious.registerAccelerator).toBeUndefined();
+      expect(menuByRole(fileMenu, "quit").registerAccelerator).toBe(false);
+      expect(menuByRole(editMenu, "selectAll").registerAccelerator).toBe(
+        false,
+      );
+      expect(menuByRole(viewMenu, "reload").registerAccelerator).toBe(false);
+      expect(menuByRole(windowMenu, "close").registerAccelerator).toBe(false);
     });
   });
 
@@ -516,6 +534,7 @@ describe("buildApplicationMenu", () => {
     const appMenu = menuByLabel(items, "Traycer").submenu ?? [];
     const fileMenu = menuByLabel(items, "File").submenu ?? [];
     const editMenu = menuByLabel(items, "Edit").submenu ?? [];
+    const viewMenu = menuByLabel(items, "View").submenu ?? [];
     const windowMenu = menuByLabel(items, "Window").submenu ?? [];
 
     expect(menuByLabel(appMenu, "Settings...").registerAccelerator).toBe(true);
@@ -523,6 +542,8 @@ describe("buildApplicationMenu", () => {
     expect(menuByLabel(editMenu, "Find").registerAccelerator).toBe(true);
     expect(menuByLabel(editMenu, "Find Next").registerAccelerator).toBe(true);
     expect(menuByLabel(windowMenu, "Minimize").registerAccelerator).toBe(true);
+    expect(menuByRole(editMenu, "selectAll").registerAccelerator).toBe(true);
+    expect(menuByRole(viewMenu, "reload").registerAccelerator).toBe(true);
   });
 
   it("disables File Close Tab when no target window tab is closable", () => {

--- a/clients/desktop/src/electron-main/menu/__tests__/menu-builder.test.ts
+++ b/clients/desktop/src/electron-main/menu/__tests__/menu-builder.test.ts
@@ -472,7 +472,7 @@ describe("buildApplicationMenu", () => {
   });
 
   it("keeps terminal-conflicting accelerator labels visible but unregisters them off macOS", () => {
-    for (const platform of ["win32", "linux"] as const) {
+    (["win32", "linux"] as const).forEach((platform) => {
       const items = template(
         buildApplicationMenu(buildState(platform), {
           command: () => undefined,
@@ -502,7 +502,7 @@ describe("buildApplicationMenu", () => {
       expect(findNext.registerAccelerator).toBe(false);
       expect(minimize.registerAccelerator).toBe(false);
       expect(findPrevious.registerAccelerator).toBeUndefined();
-    }
+    });
   });
 
   it("keeps terminal-conflicting accelerators registered on macOS", () => {

--- a/clients/desktop/src/electron-main/menu/__tests__/menu-builder.test.ts
+++ b/clients/desktop/src/electron-main/menu/__tests__/menu-builder.test.ts
@@ -471,6 +471,60 @@ describe("buildApplicationMenu", () => {
     }
   });
 
+  it("keeps terminal-conflicting accelerator labels visible but unregisters them off macOS", () => {
+    for (const platform of ["win32", "linux"] as const) {
+      const items = template(
+        buildApplicationMenu(buildState(platform), {
+          command: () => undefined,
+          focusWindow: () => undefined,
+          openExternal: () => undefined,
+        }),
+      );
+      const fileMenu = menuByLabel(items, "File").submenu ?? [];
+      const editMenu = menuByLabel(items, "Edit").submenu ?? [];
+      const windowMenu = menuByLabel(items, "Window").submenu ?? [];
+
+      const closeTab = menuByLabel(fileMenu, "Close Tab");
+      const settings = menuByLabel(fileMenu, "Settings...");
+      const find = menuByLabel(editMenu, "Find");
+      const findNext = menuByLabel(editMenu, "Find Next");
+      const findPrevious = menuByLabel(editMenu, "Find Previous");
+      const minimize = menuByLabel(windowMenu, "Minimize");
+
+      expect(closeTab.accelerator).toBe("CmdOrCtrl+W");
+      expect(settings.accelerator).toBe("CmdOrCtrl+,");
+      expect(find.accelerator).toBe("CommandOrControl+F");
+      expect(findNext.accelerator).toBe("CommandOrControl+G");
+      expect(minimize.accelerator).toBe("CmdOrCtrl+M");
+      expect(closeTab.registerAccelerator).toBe(false);
+      expect(settings.registerAccelerator).toBe(false);
+      expect(find.registerAccelerator).toBe(false);
+      expect(findNext.registerAccelerator).toBe(false);
+      expect(minimize.registerAccelerator).toBe(false);
+      expect(findPrevious.registerAccelerator).toBeUndefined();
+    }
+  });
+
+  it("keeps terminal-conflicting accelerators registered on macOS", () => {
+    const items = template(
+      buildApplicationMenu(buildState("darwin"), {
+        command: () => undefined,
+        focusWindow: () => undefined,
+        openExternal: () => undefined,
+      }),
+    );
+    const appMenu = menuByLabel(items, "Traycer").submenu ?? [];
+    const fileMenu = menuByLabel(items, "File").submenu ?? [];
+    const editMenu = menuByLabel(items, "Edit").submenu ?? [];
+    const windowMenu = menuByLabel(items, "Window").submenu ?? [];
+
+    expect(menuByLabel(appMenu, "Settings...").registerAccelerator).toBe(true);
+    expect(menuByLabel(fileMenu, "Close Tab").registerAccelerator).toBe(true);
+    expect(menuByLabel(editMenu, "Find").registerAccelerator).toBe(true);
+    expect(menuByLabel(editMenu, "Find Next").registerAccelerator).toBe(true);
+    expect(menuByLabel(windowMenu, "Minimize").registerAccelerator).toBe(true);
+  });
+
   it("disables File Close Tab when no target window tab is closable", () => {
     const state = { ...buildState("darwin"), canCloseTab: false };
     const items = template(

--- a/clients/desktop/src/electron-main/menu/__tests__/menu-builder.test.ts
+++ b/clients/desktop/src/electron-main/menu/__tests__/menu-builder.test.ts
@@ -515,9 +515,7 @@ describe("buildApplicationMenu", () => {
       expect(minimize.registerAccelerator).toBe(false);
       expect(findPrevious.registerAccelerator).toBeUndefined();
       expect(menuByRole(fileMenu, "quit").registerAccelerator).toBe(false);
-      expect(menuByRole(editMenu, "selectAll").registerAccelerator).toBe(
-        false,
-      );
+      expect(menuByRole(editMenu, "selectAll").registerAccelerator).toBe(false);
       expect(menuByRole(viewMenu, "reload").registerAccelerator).toBe(false);
       expect(menuByRole(windowMenu, "close").registerAccelerator).toBe(false);
     });

--- a/clients/desktop/src/electron-main/menu/menu-builder.ts
+++ b/clients/desktop/src/electron-main/menu/menu-builder.ts
@@ -24,7 +24,7 @@ export function buildApplicationMenu(
     [
       ...buildAppMenu(state, actions),
       buildFileMenu(state, actions),
-      buildEditMenu(actions),
+      buildEditMenu(state, actions),
       buildViewMenu(state, actions),
       buildWindowMenu(state, actions),
       buildHelpMenu(state, actions),
@@ -49,7 +49,7 @@ function buildAppMenu(
             actions.command("app.aboutDetails", browserWindow ?? null),
         },
         { type: "separator" },
-        settingsItem(actions),
+        settingsItem(state.platform, actions),
         authItem(state, actions),
         { type: "separator" },
         restartHostItem(actions),
@@ -75,7 +75,7 @@ function buildFileMenu(
     state.platform === "darwin"
       ? []
       : [
-          settingsItem(actions),
+          settingsItem(state.platform, actions),
           authItem(state, actions),
           { type: "separator" } satisfies MenuItemConstructorOptions,
         ];
@@ -98,6 +98,9 @@ function buildFileMenu(
       {
         label: "Close Tab",
         accelerator: "CmdOrCtrl+W",
+        registerAccelerator: registerTerminalConflictingAccelerator(
+          state.platform,
+        ),
         enabled: state.canCloseTab,
         click: (_item, browserWindow) =>
           actions.command("epic.closeTab", browserWindow ?? null),
@@ -110,7 +113,10 @@ function buildFileMenu(
   };
 }
 
-function buildEditMenu(actions: MenuBuildActions): MenuItemConstructorOptions {
+function buildEditMenu(
+  state: MenuState,
+  actions: MenuBuildActions,
+): MenuItemConstructorOptions {
   return {
     label: "Edit",
     submenu: [
@@ -125,12 +131,18 @@ function buildEditMenu(actions: MenuBuildActions): MenuItemConstructorOptions {
       {
         label: "Find",
         accelerator: "CommandOrControl+F",
+        registerAccelerator: registerTerminalConflictingAccelerator(
+          state.platform,
+        ),
         click: (_menuItem, browserWindow) =>
           actions.command("view.findInPage", browserWindow ?? null),
       },
       {
         label: "Find Next",
         accelerator: "CommandOrControl+G",
+        registerAccelerator: registerTerminalConflictingAccelerator(
+          state.platform,
+        ),
         click: (_menuItem, browserWindow) =>
           actions.command("view.findNext", browserWindow ?? null),
       },
@@ -200,6 +212,9 @@ function buildWindowMenu(
       {
         label: "Minimize",
         accelerator: "CmdOrCtrl+M",
+        registerAccelerator: registerTerminalConflictingAccelerator(
+          state.platform,
+        ),
         enabled: state.windows.length > 0,
         click: (_item, browserWindow) =>
           actions.command("window.minimizeWindow", browserWindow ?? null),
@@ -276,13 +291,23 @@ function buildHelpMenu(
   };
 }
 
-function settingsItem(actions: MenuBuildActions): MenuItemConstructorOptions {
+function settingsItem(
+  platform: NodeJS.Platform,
+  actions: MenuBuildActions,
+): MenuItemConstructorOptions {
   return {
     label: "Settings...",
     accelerator: "CmdOrCtrl+,",
+    registerAccelerator: registerTerminalConflictingAccelerator(platform),
     click: (_item, browserWindow) =>
       actions.command("app.openSettings", browserWindow ?? null),
   };
+}
+
+function registerTerminalConflictingAccelerator(
+  platform: NodeJS.Platform,
+): boolean {
+  return platform === "darwin";
 }
 
 function authItem(

--- a/clients/desktop/src/electron-main/menu/menu-builder.ts
+++ b/clients/desktop/src/electron-main/menu/menu-builder.ts
@@ -113,7 +113,7 @@ function buildFileMenu(
       ...nonMacAccountItems,
       ...(state.platform === "darwin"
         ? []
-        : [{ role: "quit" } satisfies MenuItemConstructorOptions]),
+        : [terminalConflictingRole("quit", state.platform)]),
     ],
   };
 }
@@ -132,7 +132,7 @@ function buildEditMenu(
       { role: "cut" },
       { role: "copy" },
       { role: "paste" },
-      { role: "selectAll" },
+      terminalConflictingRole("selectAll", state.platform),
       { type: "separator" },
       {
         label: "Find",
@@ -194,7 +194,7 @@ function buildViewMenu(
           { role: "togglefullscreen" } satisfies MenuItemConstructorOptions,
         ];
   const submenu: MenuItemConstructorOptions[] = [
-    { role: "reload" },
+    terminalConflictingRole("reload", state.platform),
     { role: "forceReload" },
     { type: "separator" },
     {
@@ -267,7 +267,7 @@ function buildWindowMenu(
             click: (_item, browserWindow) =>
               actions.command("window.closeWindow", browserWindow ?? null),
           }
-        : { role: "close" },
+        : terminalConflictingRole("close", state.platform),
     ],
   };
 }
@@ -337,6 +337,22 @@ function registerTerminalConflictingAccelerator(
   platform: NodeJS.Platform,
 ): boolean {
   return platform === "darwin";
+}
+
+/**
+ * Electron's role defaults register these Ctrl accelerators before the
+ * renderer can apply its focused-terminal policy. Keep the native menu action,
+ * but release its accelerator on Windows/Linux so the renderer or xterm owns
+ * the key event. macOS keeps its native menu key equivalents.
+ */
+function terminalConflictingRole(
+  role: "close" | "quit" | "reload" | "selectAll",
+  platform: NodeJS.Platform,
+): MenuItemConstructorOptions {
+  return {
+    role,
+    registerAccelerator: registerTerminalConflictingAccelerator(platform),
+  };
 }
 
 function authItem(

--- a/clients/desktop/src/electron-main/menu/menu-builder.ts
+++ b/clients/desktop/src/electron-main/menu/menu-builder.ts
@@ -52,7 +52,7 @@ function buildAppMenu(
             actions.command("app.aboutDetails", browserWindow ?? null),
         },
         { type: "separator" },
-        settingsItem(actions),
+        settingsItem(state.platform, actions),
         authItem(state, actions),
         { type: "separator" },
         ...hostUpdateItems(state, actions),
@@ -79,7 +79,7 @@ function buildFileMenu(
     state.platform === "darwin"
       ? []
       : [
-          settingsItem(actions),
+          settingsItem(state.platform, actions),
           authItem(state, actions),
           { type: "separator" } satisfies MenuItemConstructorOptions,
         ];
@@ -103,6 +103,9 @@ function buildFileMenu(
       {
         label: "Close Tab",
         accelerator: "CmdOrCtrl+W",
+        registerAccelerator: registerTerminalConflictingAccelerator(
+          state.platform,
+        ),
         enabled: state.canCloseTab,
         click: (_item, browserWindow) =>
           actions.command("epic.closeTab", browserWindow ?? null),
@@ -134,12 +137,18 @@ function buildEditMenu(
       {
         label: "Find",
         accelerator: "CommandOrControl+F",
+        registerAccelerator: registerTerminalConflictingAccelerator(
+          state.platform,
+        ),
         click: (_menuItem, browserWindow) =>
           actions.command("view.findInPage", browserWindow ?? null),
       },
       {
         label: "Find Next",
         accelerator: "CommandOrControl+G",
+        registerAccelerator: registerTerminalConflictingAccelerator(
+          state.platform,
+        ),
         click: (_menuItem, browserWindow) =>
           actions.command("view.findNext", browserWindow ?? null),
       },
@@ -231,6 +240,9 @@ function buildWindowMenu(
       {
         label: "Minimize",
         accelerator: "CmdOrCtrl+M",
+        registerAccelerator: registerTerminalConflictingAccelerator(
+          state.platform,
+        ),
         enabled: state.windows.length > 0,
         click: (_item, browserWindow) =>
           actions.command("window.minimizeWindow", browserWindow ?? null),
@@ -308,13 +320,23 @@ function buildHelpMenu(
   };
 }
 
-function settingsItem(actions: MenuBuildActions): MenuItemConstructorOptions {
+function settingsItem(
+  platform: NodeJS.Platform,
+  actions: MenuBuildActions,
+): MenuItemConstructorOptions {
   return {
     label: "Settings...",
     accelerator: "CmdOrCtrl+,",
+    registerAccelerator: registerTerminalConflictingAccelerator(platform),
     click: (_item, browserWindow) =>
       actions.command("app.openSettings", browserWindow ?? null),
   };
+}
+
+function registerTerminalConflictingAccelerator(
+  platform: NodeJS.Platform,
+): boolean {
+  return platform === "darwin";
 }
 
 function authItem(

--- a/clients/gui-app/src/components/epic-canvas/renderers/terminal-tile-xterm.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/terminal-tile-xterm.tsx
@@ -527,6 +527,7 @@ function createXtermEntry(
   const containerEl = document.createElement("div");
   containerEl.className = "h-full w-full overflow-hidden";
   containerEl.dataset.testid = "terminal-xterm-host";
+  containerEl.setAttribute("data-terminal-host", "");
 
   const term = new Terminal(initialOptions);
   const fitAddon = new FitAddon();

--- a/clients/gui-app/src/components/epic-canvas/renderers/terminal-tile-xterm.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/terminal-tile-xterm.tsx
@@ -707,6 +707,7 @@ function createXtermEntry(
   const containerEl = document.createElement("div");
   containerEl.className = "h-full w-full overflow-hidden";
   containerEl.dataset.testid = "terminal-xterm-host";
+  containerEl.setAttribute("data-terminal-host", "");
 
   const term = new Terminal(initialOptions);
   // Measure cells with the Unicode 11 width tables, not xterm's Unicode 6

--- a/clients/gui-app/src/lib/keybindings/actions.ts
+++ b/clients/gui-app/src/lib/keybindings/actions.ts
@@ -61,6 +61,8 @@ export type ActionCategory = "epics" | "tabs" | "groups" | "app";
 
 export type ActionKind = "chord" | "digit";
 
+export type TerminalPolicy = "app" | "shell";
+
 /**
  * An action's default chord. A bare string (or `null` for "unbound") is the
  * same on every platform. A `{ mac, other }` pair declares per-platform
@@ -79,6 +81,9 @@ export interface ActionMeta {
   readonly category: ActionCategory;
   readonly kind: ActionKind;
   readonly defaultChord: ActionDefaultChord;
+  readonly secondaryChord: ActionDefaultChord | undefined;
+  readonly terminalPolicy: TerminalPolicy;
+  readonly secondaryTerminalPolicy: TerminalPolicy | undefined;
 }
 
 /** The platform-effective default chord for an action (`null` when unbound). */
@@ -87,6 +92,17 @@ export function resolveActionDefaultChord(
 ): ChordString | null {
   const def = meta.defaultChord;
   if (def === null || typeof def === "string") return def;
+  return isMac() ? def.mac : def.other;
+}
+
+/** The platform-effective secondary chord for an action, if one exists. */
+export function resolveActionSecondaryChord(
+  meta: ActionMeta,
+): ChordString | null {
+  const def = meta.secondaryChord;
+  if (def === undefined || def === null || typeof def === "string") {
+    return def ?? null;
+  }
   return isMac() ? def.mac : def.other;
 }
 
@@ -99,6 +115,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "epics",
     kind: "digit",
     defaultChord: "alt",
+    secondaryChord: undefined,
+    terminalPolicy: "app",
+    secondaryTerminalPolicy: undefined,
   },
   "tab.switch.byDigit": {
     id: "tab.switch.byDigit",
@@ -108,6 +127,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "tabs",
     kind: "digit",
     defaultChord: "mod",
+    secondaryChord: undefined,
+    terminalPolicy: "app",
+    secondaryTerminalPolicy: undefined,
   },
   "epic.new": {
     id: "epic.new",
@@ -116,6 +138,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "epics",
     kind: "chord",
     defaultChord: "mod+n",
+    secondaryChord: undefined,
+    terminalPolicy: "shell",
+    secondaryTerminalPolicy: undefined,
   },
   "epic.duplicate-tab": {
     id: "epic.duplicate-tab",
@@ -124,6 +149,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "epics",
     kind: "chord",
     defaultChord: "mod+shift+k",
+    secondaryChord: undefined,
+    terminalPolicy: "app",
+    secondaryTerminalPolicy: undefined,
   },
   "epic.next": {
     id: "epic.next",
@@ -132,6 +160,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "epics",
     kind: "chord",
     defaultChord: "mod+shift+]",
+    secondaryChord: undefined,
+    terminalPolicy: "app",
+    secondaryTerminalPolicy: undefined,
   },
   "epic.prev": {
     id: "epic.prev",
@@ -140,6 +171,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "epics",
     kind: "chord",
     defaultChord: "mod+shift+[",
+    secondaryChord: undefined,
+    terminalPolicy: "app",
+    secondaryTerminalPolicy: undefined,
   },
   "epic.close": {
     id: "epic.close",
@@ -149,6 +183,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "epics",
     kind: "chord",
     defaultChord: "mod+shift+w",
+    secondaryChord: undefined,
+    terminalPolicy: "app",
+    secondaryTerminalPolicy: undefined,
   },
   "tab.new": {
     id: "tab.new",
@@ -158,6 +195,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "tabs",
     kind: "chord",
     defaultChord: "mod+t",
+    secondaryChord: undefined,
+    terminalPolicy: "shell",
+    secondaryTerminalPolicy: undefined,
   },
   "tab.close": {
     id: "tab.close",
@@ -167,6 +207,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "tabs",
     kind: "chord",
     defaultChord: "mod+w",
+    secondaryChord: undefined,
+    terminalPolicy: "shell",
+    secondaryTerminalPolicy: undefined,
   },
   "tab.close-others": {
     id: "tab.close-others",
@@ -176,6 +219,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     kind: "chord",
     // ⌘⌥W - matches Safari's "Close Other Tabs".
     defaultChord: "mod+alt+w",
+    secondaryChord: undefined,
+    terminalPolicy: "shell",
+    secondaryTerminalPolicy: undefined,
   },
   "tab.close-right": {
     id: "tab.close-right",
@@ -186,6 +232,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     kind: "chord",
     // ⌘⇧⌥] - the `]` echoes "Next tab" (⌘⇧]); ⌥ marks the destructive variant.
     defaultChord: "mod+shift+alt+]",
+    secondaryChord: undefined,
+    terminalPolicy: "app",
+    secondaryTerminalPolicy: undefined,
   },
   "tab.close-all": {
     id: "tab.close-all",
@@ -196,6 +245,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     kind: "chord",
     // ⌘⇧⌥W - the "close" W family; all three modifiers signal the widest scope.
     defaultChord: "mod+shift+alt+w",
+    secondaryChord: undefined,
+    terminalPolicy: "app",
+    secondaryTerminalPolicy: undefined,
   },
   "tab.next": {
     id: "tab.next",
@@ -204,6 +256,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "tabs",
     kind: "chord",
     defaultChord: "mod+]",
+    secondaryChord: undefined,
+    terminalPolicy: "shell",
+    secondaryTerminalPolicy: undefined,
   },
   "tab.prev": {
     id: "tab.prev",
@@ -212,6 +267,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "tabs",
     kind: "chord",
     defaultChord: "mod+[",
+    secondaryChord: undefined,
+    terminalPolicy: "shell",
+    secondaryTerminalPolicy: undefined,
   },
   "group.split.horizontal": {
     id: "group.split.horizontal",
@@ -221,6 +279,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "groups",
     kind: "chord",
     defaultChord: "mod+d",
+    secondaryChord: undefined,
+    terminalPolicy: "shell",
+    secondaryTerminalPolicy: undefined,
   },
   "group.split.vertical": {
     id: "group.split.vertical",
@@ -230,6 +291,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "groups",
     kind: "chord",
     defaultChord: "mod+shift+d",
+    secondaryChord: undefined,
+    terminalPolicy: "app",
+    secondaryTerminalPolicy: undefined,
   },
   "group.split-right": {
     id: "group.split-right",
@@ -239,6 +303,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "groups",
     kind: "chord",
     defaultChord: "mod+\\",
+    secondaryChord: undefined,
+    terminalPolicy: "shell",
+    secondaryTerminalPolicy: undefined,
   },
   "group.focus.up": {
     id: "group.focus.up",
@@ -247,6 +314,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "groups",
     kind: "chord",
     defaultChord: "mod+alt+arrowup",
+    secondaryChord: undefined,
+    terminalPolicy: "app",
+    secondaryTerminalPolicy: undefined,
   },
   "group.focus.down": {
     id: "group.focus.down",
@@ -255,6 +325,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "groups",
     kind: "chord",
     defaultChord: "mod+alt+arrowdown",
+    secondaryChord: undefined,
+    terminalPolicy: "app",
+    secondaryTerminalPolicy: undefined,
   },
   "group.focus.left": {
     id: "group.focus.left",
@@ -263,6 +336,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "groups",
     kind: "chord",
     defaultChord: "mod+alt+arrowleft",
+    secondaryChord: undefined,
+    terminalPolicy: "app",
+    secondaryTerminalPolicy: undefined,
   },
   "group.focus.right": {
     id: "group.focus.right",
@@ -271,6 +347,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "groups",
     kind: "chord",
     defaultChord: "mod+alt+arrowright",
+    secondaryChord: undefined,
+    terminalPolicy: "app",
+    secondaryTerminalPolicy: undefined,
   },
   "group.focus-editor": {
     id: "group.focus-editor",
@@ -280,6 +359,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "groups",
     kind: "chord",
     defaultChord: "mod+l",
+    secondaryChord: undefined,
+    terminalPolicy: "shell",
+    secondaryTerminalPolicy: undefined,
   },
   "tile.find.replace": {
     id: "tile.find.replace",
@@ -289,6 +371,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "app",
     kind: "chord",
     defaultChord: "mod+alt+f",
+    secondaryChord: undefined,
+    terminalPolicy: "app",
+    secondaryTerminalPolicy: undefined,
   },
   "app.sidebar.toggle": {
     id: "app.sidebar.toggle",
@@ -297,6 +382,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "app",
     kind: "chord",
     defaultChord: "mod+b",
+    secondaryChord: undefined,
+    terminalPolicy: "shell",
+    secondaryTerminalPolicy: undefined,
   },
   "app.history.open": {
     id: "app.history.open",
@@ -305,6 +393,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "app",
     kind: "chord",
     defaultChord: "mod+y",
+    secondaryChord: undefined,
+    terminalPolicy: "shell",
+    secondaryTerminalPolicy: undefined,
   },
   "app.settings.open": {
     id: "app.settings.open",
@@ -313,6 +404,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "app",
     kind: "chord",
     defaultChord: "mod+,",
+    secondaryChord: undefined,
+    terminalPolicy: "shell",
+    secondaryTerminalPolicy: undefined,
   },
   "app.settings.section.byDigit": {
     id: "app.settings.section.byDigit",
@@ -322,6 +416,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "app",
     kind: "digit",
     defaultChord: "alt",
+    secondaryChord: undefined,
+    terminalPolicy: "app",
+    secondaryTerminalPolicy: undefined,
   },
   "app.palette.open": {
     id: "app.palette.open",
@@ -331,6 +428,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "app",
     kind: "chord",
     defaultChord: "mod+k",
+    secondaryChord: { mac: "ctrl+shift+p", other: "mod+shift+p" },
+    terminalPolicy: "shell",
+    secondaryTerminalPolicy: "app",
   },
   "app.zoom.in": {
     id: "app.zoom.in",
@@ -339,6 +439,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "app",
     kind: "chord",
     defaultChord: "mod+=",
+    secondaryChord: undefined,
+    terminalPolicy: "shell",
+    secondaryTerminalPolicy: undefined,
   },
   "app.zoom.out": {
     id: "app.zoom.out",
@@ -347,6 +450,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "app",
     kind: "chord",
     defaultChord: "mod+-",
+    secondaryChord: undefined,
+    terminalPolicy: "shell",
+    secondaryTerminalPolicy: undefined,
   },
   "app.zoom.reset": {
     id: "app.zoom.reset",
@@ -355,6 +461,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "app",
     kind: "chord",
     defaultChord: "mod+0",
+    secondaryChord: undefined,
+    terminalPolicy: "shell",
+    secondaryTerminalPolicy: undefined,
   },
   "composer.dictation.toggle": {
     id: "composer.dictation.toggle",
@@ -367,6 +476,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     // macOS), avoiding the Command-based conflicts: ⌘Space (Spotlight),
     // ⌘⇧Space (window summon), ⌘⇧V (split group vertically).
     defaultChord: "ctrl+shift+m",
+    secondaryChord: undefined,
+    terminalPolicy: "app",
+    secondaryTerminalPolicy: undefined,
   },
   "composer.model-picker.toggle": {
     id: "composer.model-picker.toggle",
@@ -379,6 +491,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     // via the Control-aware encoder), while Alt+Shift+M avoids the Windows/Linux
     // Ctrl+Alt=AltGr conflict and doesn't collide with dictation's ⌃⇧M.
     defaultChord: { mac: "ctrl+alt+m", other: "alt+shift+m" },
+    secondaryChord: undefined,
+    terminalPolicy: "app",
+    secondaryTerminalPolicy: undefined,
   },
   "model.provider.byDigit": {
     id: "model.provider.byDigit",
@@ -388,6 +503,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "app",
     kind: "digit",
     defaultChord: "mod",
+    secondaryChord: undefined,
+    terminalPolicy: "app",
+    secondaryTerminalPolicy: undefined,
   },
   "model.reasoning.byDigit": {
     id: "model.reasoning.byDigit",
@@ -397,6 +515,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "app",
     kind: "digit",
     defaultChord: "alt",
+    secondaryChord: undefined,
+    terminalPolicy: "app",
+    secondaryTerminalPolicy: undefined,
   },
   "model.profile.byDigit": {
     id: "model.profile.byDigit",
@@ -406,6 +527,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "app",
     kind: "digit",
     defaultChord: "mod+shift",
+    secondaryChord: undefined,
+    terminalPolicy: "app",
+    secondaryTerminalPolicy: undefined,
   },
   // In-app back/forward (`nav.back` / `nav.forward`) intentionally has NO
   // keyboard chord: `mod`/`alt`+Arrow both collide with native text-editing

--- a/clients/gui-app/src/lib/keybindings/actions.ts
+++ b/clients/gui-app/src/lib/keybindings/actions.ts
@@ -82,6 +82,13 @@ export interface ActionMeta {
   readonly kind: ActionKind;
   readonly defaultChord: ActionDefaultChord;
   readonly secondaryChord: ActionDefaultChord | undefined;
+  /**
+   * When a terminal is focused on Windows/Linux, only mark default Ctrl chords
+   * as "shell" if @xterm/xterm's evaluateKeyboardEvent Ctrl branch actually
+   * emits PTY bytes: Ctrl+A-Z, Ctrl+space, Ctrl+3-8, Ctrl+/, Ctrl+[, Ctrl+\, or
+   * Ctrl+]. Non-encodable Ctrl chords must stay app-owned or the key becomes a
+   * terminal no-op.
+   */
   readonly terminalPolicy: TerminalPolicy;
   readonly secondaryTerminalPolicy: TerminalPolicy | undefined;
 }
@@ -405,7 +412,7 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     kind: "chord",
     defaultChord: "mod+,",
     secondaryChord: undefined,
-    terminalPolicy: "shell",
+    terminalPolicy: "app",
     secondaryTerminalPolicy: undefined,
   },
   "app.settings.section.byDigit": {
@@ -440,7 +447,7 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     kind: "chord",
     defaultChord: "mod+=",
     secondaryChord: undefined,
-    terminalPolicy: "shell",
+    terminalPolicy: "app",
     secondaryTerminalPolicy: undefined,
   },
   "app.zoom.out": {
@@ -451,7 +458,7 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     kind: "chord",
     defaultChord: "mod+-",
     secondaryChord: undefined,
-    terminalPolicy: "shell",
+    terminalPolicy: "app",
     secondaryTerminalPolicy: undefined,
   },
   "app.zoom.reset": {
@@ -462,7 +469,7 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     kind: "chord",
     defaultChord: "mod+0",
     secondaryChord: undefined,
-    terminalPolicy: "shell",
+    terminalPolicy: "app",
     secondaryTerminalPolicy: undefined,
   },
   "composer.dictation.toggle": {

--- a/clients/gui-app/src/lib/keybindings/actions.ts
+++ b/clients/gui-app/src/lib/keybindings/actions.ts
@@ -75,6 +75,8 @@ export type ActionCategory = "epics" | "tabs" | "groups" | "app";
 
 export type ActionKind = "chord" | "digit";
 
+export type TerminalPolicy = "app" | "shell";
+
 /**
  * An action's default chord. A bare string (or `null` for "unbound") is the
  * same on every platform. A `{ mac, other }` pair declares per-platform
@@ -93,6 +95,9 @@ export interface ActionMeta {
   readonly category: ActionCategory;
   readonly kind: ActionKind;
   readonly defaultChord: ActionDefaultChord;
+  readonly secondaryChord: ActionDefaultChord | undefined;
+  readonly terminalPolicy: TerminalPolicy;
+  readonly secondaryTerminalPolicy: TerminalPolicy | undefined;
 }
 
 /** The platform-effective default chord for an action (`null` when unbound). */
@@ -101,6 +106,17 @@ export function resolveActionDefaultChord(
 ): ChordString | null {
   const def = meta.defaultChord;
   if (def === null || typeof def === "string") return def;
+  return isMac() ? def.mac : def.other;
+}
+
+/** The platform-effective secondary chord for an action, if one exists. */
+export function resolveActionSecondaryChord(
+  meta: ActionMeta,
+): ChordString | null {
+  const def = meta.secondaryChord;
+  if (def === undefined || def === null || typeof def === "string") {
+    return def ?? null;
+  }
   return isMac() ? def.mac : def.other;
 }
 
@@ -113,6 +129,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "epics",
     kind: "digit",
     defaultChord: "alt",
+    secondaryChord: undefined,
+    terminalPolicy: "app",
+    secondaryTerminalPolicy: undefined,
   },
   "tab.switch.byDigit": {
     id: "tab.switch.byDigit",
@@ -122,6 +141,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "tabs",
     kind: "digit",
     defaultChord: "mod",
+    secondaryChord: undefined,
+    terminalPolicy: "app",
+    secondaryTerminalPolicy: undefined,
   },
   "epic.new": {
     id: "epic.new",
@@ -130,6 +152,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "epics",
     kind: "chord",
     defaultChord: "mod+n",
+    secondaryChord: undefined,
+    terminalPolicy: "shell",
+    secondaryTerminalPolicy: undefined,
   },
   "epic.duplicate-tab": {
     id: "epic.duplicate-tab",
@@ -138,6 +163,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "epics",
     kind: "chord",
     defaultChord: "mod+shift+k",
+    secondaryChord: undefined,
+    terminalPolicy: "app",
+    secondaryTerminalPolicy: undefined,
   },
   "epic.next": {
     id: "epic.next",
@@ -146,6 +174,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "epics",
     kind: "chord",
     defaultChord: "mod+shift+]",
+    secondaryChord: undefined,
+    terminalPolicy: "app",
+    secondaryTerminalPolicy: undefined,
   },
   "epic.prev": {
     id: "epic.prev",
@@ -154,6 +185,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "epics",
     kind: "chord",
     defaultChord: "mod+shift+[",
+    secondaryChord: undefined,
+    terminalPolicy: "app",
+    secondaryTerminalPolicy: undefined,
   },
   "epic.close": {
     id: "epic.close",
@@ -163,6 +197,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "epics",
     kind: "chord",
     defaultChord: "mod+shift+w",
+    secondaryChord: undefined,
+    terminalPolicy: "app",
+    secondaryTerminalPolicy: undefined,
   },
   "tab.new": {
     id: "tab.new",
@@ -172,6 +209,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "tabs",
     kind: "chord",
     defaultChord: "mod+t",
+    secondaryChord: undefined,
+    terminalPolicy: "shell",
+    secondaryTerminalPolicy: undefined,
   },
   "tab.close": {
     id: "tab.close",
@@ -181,6 +221,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "tabs",
     kind: "chord",
     defaultChord: "mod+w",
+    secondaryChord: undefined,
+    terminalPolicy: "shell",
+    secondaryTerminalPolicy: undefined,
   },
   "tab.close-others": {
     id: "tab.close-others",
@@ -190,6 +233,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     kind: "chord",
     // ⌘⌥W - matches Safari's "Close Other Tabs".
     defaultChord: "mod+alt+w",
+    secondaryChord: undefined,
+    terminalPolicy: "shell",
+    secondaryTerminalPolicy: undefined,
   },
   "tab.close-right": {
     id: "tab.close-right",
@@ -200,6 +246,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     kind: "chord",
     // ⌘⇧⌥] - the `]` echoes "Next tab" (⌘⇧]); ⌥ marks the destructive variant.
     defaultChord: "mod+shift+alt+]",
+    secondaryChord: undefined,
+    terminalPolicy: "app",
+    secondaryTerminalPolicy: undefined,
   },
   "tab.close-all": {
     id: "tab.close-all",
@@ -210,6 +259,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     kind: "chord",
     // ⌘⇧⌥W - the "close" W family; all three modifiers signal the widest scope.
     defaultChord: "mod+shift+alt+w",
+    secondaryChord: undefined,
+    terminalPolicy: "app",
+    secondaryTerminalPolicy: undefined,
   },
   "tab.next": {
     id: "tab.next",
@@ -219,6 +271,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "tabs",
     kind: "chord",
     defaultChord: "mod+]",
+    secondaryChord: undefined,
+    terminalPolicy: "shell",
+    secondaryTerminalPolicy: undefined,
   },
   "tab.prev": {
     id: "tab.prev",
@@ -228,6 +283,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "tabs",
     kind: "chord",
     defaultChord: "mod+[",
+    secondaryChord: undefined,
+    terminalPolicy: "shell",
+    secondaryTerminalPolicy: undefined,
   },
   "tab.split.add": {
     id: "tab.split.add",
@@ -278,6 +336,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "groups",
     kind: "chord",
     defaultChord: "mod+d",
+    secondaryChord: undefined,
+    terminalPolicy: "shell",
+    secondaryTerminalPolicy: undefined,
   },
   "group.split.vertical": {
     id: "group.split.vertical",
@@ -287,6 +348,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "groups",
     kind: "chord",
     defaultChord: "mod+shift+d",
+    secondaryChord: undefined,
+    terminalPolicy: "app",
+    secondaryTerminalPolicy: undefined,
   },
   "group.split-right": {
     id: "group.split-right",
@@ -296,6 +360,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "groups",
     kind: "chord",
     defaultChord: "mod+\\",
+    secondaryChord: undefined,
+    terminalPolicy: "shell",
+    secondaryTerminalPolicy: undefined,
   },
   "group.focus.up": {
     id: "group.focus.up",
@@ -304,6 +371,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "groups",
     kind: "chord",
     defaultChord: "mod+alt+arrowup",
+    secondaryChord: undefined,
+    terminalPolicy: "app",
+    secondaryTerminalPolicy: undefined,
   },
   "group.focus.down": {
     id: "group.focus.down",
@@ -312,6 +382,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "groups",
     kind: "chord",
     defaultChord: "mod+alt+arrowdown",
+    secondaryChord: undefined,
+    terminalPolicy: "app",
+    secondaryTerminalPolicy: undefined,
   },
   "group.focus.left": {
     id: "group.focus.left",
@@ -320,6 +393,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "groups",
     kind: "chord",
     defaultChord: "mod+alt+arrowleft",
+    secondaryChord: undefined,
+    terminalPolicy: "app",
+    secondaryTerminalPolicy: undefined,
   },
   "group.focus.right": {
     id: "group.focus.right",
@@ -328,6 +404,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "groups",
     kind: "chord",
     defaultChord: "mod+alt+arrowright",
+    secondaryChord: undefined,
+    terminalPolicy: "app",
+    secondaryTerminalPolicy: undefined,
   },
   "group.focus-editor": {
     id: "group.focus-editor",
@@ -337,6 +416,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "groups",
     kind: "chord",
     defaultChord: "mod+l",
+    secondaryChord: undefined,
+    terminalPolicy: "shell",
+    secondaryTerminalPolicy: undefined,
   },
   "tile.find.replace": {
     id: "tile.find.replace",
@@ -346,6 +428,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "app",
     kind: "chord",
     defaultChord: "mod+alt+f",
+    secondaryChord: undefined,
+    terminalPolicy: "app",
+    secondaryTerminalPolicy: undefined,
   },
   "app.sidebar.toggle": {
     id: "app.sidebar.toggle",
@@ -354,6 +439,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "app",
     kind: "chord",
     defaultChord: "mod+b",
+    secondaryChord: undefined,
+    terminalPolicy: "shell",
+    secondaryTerminalPolicy: undefined,
   },
   "nav.back": {
     id: "nav.back",
@@ -409,6 +497,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "app",
     kind: "chord",
     defaultChord: "mod+y",
+    secondaryChord: undefined,
+    terminalPolicy: "shell",
+    secondaryTerminalPolicy: undefined,
   },
   "app.settings.open": {
     id: "app.settings.open",
@@ -417,6 +508,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "app",
     kind: "chord",
     defaultChord: "mod+,",
+    secondaryChord: undefined,
+    terminalPolicy: "shell",
+    secondaryTerminalPolicy: undefined,
   },
   "app.settings.section.byDigit": {
     id: "app.settings.section.byDigit",
@@ -426,6 +520,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "app",
     kind: "digit",
     defaultChord: "alt",
+    secondaryChord: undefined,
+    terminalPolicy: "app",
+    secondaryTerminalPolicy: undefined,
   },
   "app.palette.open": {
     id: "app.palette.open",
@@ -435,6 +532,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "app",
     kind: "chord",
     defaultChord: "mod+k",
+    secondaryChord: { mac: "ctrl+shift+p", other: "mod+shift+p" },
+    terminalPolicy: "shell",
+    secondaryTerminalPolicy: "app",
   },
   "app.terminal.toggle": {
     id: "app.terminal.toggle",
@@ -472,6 +572,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "app",
     kind: "chord",
     defaultChord: "mod+=",
+    secondaryChord: undefined,
+    terminalPolicy: "shell",
+    secondaryTerminalPolicy: undefined,
   },
   "app.zoom.out": {
     id: "app.zoom.out",
@@ -480,6 +583,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "app",
     kind: "chord",
     defaultChord: "mod+-",
+    secondaryChord: undefined,
+    terminalPolicy: "shell",
+    secondaryTerminalPolicy: undefined,
   },
   "app.zoom.reset": {
     id: "app.zoom.reset",
@@ -488,6 +594,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "app",
     kind: "chord",
     defaultChord: "mod+0",
+    secondaryChord: undefined,
+    terminalPolicy: "shell",
+    secondaryTerminalPolicy: undefined,
   },
   "composer.dictation.toggle": {
     id: "composer.dictation.toggle",
@@ -501,6 +610,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     // (split group vertically). The desktop global summon shortcut is checked
     // live by conflict detection rather than hand-avoided here.
     defaultChord: "ctrl+shift+m",
+    secondaryChord: undefined,
+    terminalPolicy: "app",
+    secondaryTerminalPolicy: undefined,
   },
   "composer.stash": {
     id: "composer.stash",
@@ -522,6 +634,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     // via the Control-aware encoder), while Alt+Shift+M avoids the Windows/Linux
     // Ctrl+Alt=AltGr conflict and doesn't collide with dictation's ⌃⇧M.
     defaultChord: { mac: "ctrl+alt+m", other: "alt+shift+m" },
+    secondaryChord: undefined,
+    terminalPolicy: "app",
+    secondaryTerminalPolicy: undefined,
   },
   "model.provider.byDigit": {
     id: "model.provider.byDigit",
@@ -531,6 +646,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "app",
     kind: "digit",
     defaultChord: "mod",
+    secondaryChord: undefined,
+    terminalPolicy: "app",
+    secondaryTerminalPolicy: undefined,
   },
   "model.reasoning.byDigit": {
     id: "model.reasoning.byDigit",
@@ -540,6 +658,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "app",
     kind: "digit",
     defaultChord: "alt",
+    secondaryChord: undefined,
+    terminalPolicy: "app",
+    secondaryTerminalPolicy: undefined,
   },
   "model.profile.byDigit": {
     id: "model.profile.byDigit",
@@ -549,6 +670,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "app",
     kind: "digit",
     defaultChord: "mod+shift",
+    secondaryChord: undefined,
+    terminalPolicy: "app",
+    secondaryTerminalPolicy: undefined,
   },
 };
 export function getDefaultBindings(): Readonly<

--- a/clients/gui-app/src/lib/keybindings/actions.ts
+++ b/clients/gui-app/src/lib/keybindings/actions.ts
@@ -98,10 +98,10 @@ export interface ActionMeta {
   readonly secondaryChord: ActionDefaultChord | undefined;
   /**
    * When a terminal is focused on Windows/Linux, only mark default Ctrl chords
-   * as "shell" if @xterm/xterm's evaluateKeyboardEvent Ctrl branch actually
-   * emits PTY bytes: Ctrl+A-Z, Ctrl+space, Ctrl+3-8, Ctrl+/, Ctrl+[, Ctrl+\, or
-   * Ctrl+]. Non-encodable Ctrl chords must stay app-owned or the key becomes a
-   * terminal no-op.
+   * as "shell" if @xterm/xterm's evaluateKeyboardEvent actually emits PTY
+   * bytes. Plain Ctrl covers A-Z, space, 3-8, /, [, \, and ]; Ctrl+Alt letters
+   * and space use xterm's Escape-prefixed Alt path. Other Ctrl chords must stay
+   * app-owned or the key becomes a terminal no-op.
    */
   readonly terminalPolicy: TerminalPolicy;
   readonly secondaryTerminalPolicy: TerminalPolicy | undefined;
@@ -302,6 +302,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "tabs",
     kind: "chord",
     defaultChord: { mac: "mod+alt+n", other: "ctrl+alt+n" },
+    secondaryChord: undefined,
+    terminalPolicy: "shell",
+    secondaryTerminalPolicy: undefined,
   },
   "tab.split.swap": {
     id: "tab.split.swap",
@@ -310,6 +313,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "tabs",
     kind: "chord",
     defaultChord: null,
+    secondaryChord: undefined,
+    terminalPolicy: "app",
+    secondaryTerminalPolicy: undefined,
   },
   "tab.split.separate": {
     id: "tab.split.separate",
@@ -318,6 +324,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "tabs",
     kind: "chord",
     defaultChord: null,
+    secondaryChord: undefined,
+    terminalPolicy: "app",
+    secondaryTerminalPolicy: undefined,
   },
   "tab.split.close-left": {
     id: "tab.split.close-left",
@@ -326,6 +335,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "tabs",
     kind: "chord",
     defaultChord: null,
+    secondaryChord: undefined,
+    terminalPolicy: "app",
+    secondaryTerminalPolicy: undefined,
   },
   "tab.split.close-right": {
     id: "tab.split.close-right",
@@ -334,6 +346,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "tabs",
     kind: "chord",
     defaultChord: null,
+    secondaryChord: undefined,
+    terminalPolicy: "app",
+    secondaryTerminalPolicy: undefined,
   },
   "group.split.horizontal": {
     id: "group.split.horizontal",
@@ -458,6 +473,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     kind: "chord",
     // `<` / `>` mnemonic without stealing arrow or Option-word navigation.
     defaultChord: "mod+shift+,",
+    secondaryChord: undefined,
+    terminalPolicy: "app",
+    secondaryTerminalPolicy: undefined,
   },
   "nav.forward": {
     id: "nav.forward",
@@ -466,6 +484,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "app",
     kind: "chord",
     defaultChord: "mod+shift+.",
+    secondaryChord: undefined,
+    terminalPolicy: "app",
+    secondaryTerminalPolicy: undefined,
   },
   "app.resources.open": {
     id: "app.resources.open",
@@ -477,6 +498,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     // cross-platform consistency. Clearing the binding lets Shift+Esc pass
     // through to a focused terminal.
     defaultChord: "shift+escape",
+    secondaryChord: undefined,
+    terminalPolicy: "app",
+    secondaryTerminalPolicy: undefined,
   },
   "app.rate-limits.open": {
     id: "app.rate-limits.open",
@@ -485,6 +509,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "app",
     kind: "chord",
     defaultChord: "mod+shift+u",
+    secondaryChord: undefined,
+    terminalPolicy: "app",
+    secondaryTerminalPolicy: undefined,
   },
   "app.notifications.open": {
     id: "app.notifications.open",
@@ -496,6 +523,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     // ⌘⇧N - N for notifications, in the same ⌘⇧ family as the other global
     // panel openers (⌘⇧U usage limits). ⌘N is taken by "New task".
     defaultChord: "mod+shift+n",
+    secondaryChord: undefined,
+    terminalPolicy: "app",
+    secondaryTerminalPolicy: undefined,
   },
   "app.history.open": {
     id: "app.history.open",
@@ -551,6 +581,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "app",
     kind: "chord",
     defaultChord: "mod+j",
+    secondaryChord: undefined,
+    terminalPolicy: "shell",
+    secondaryTerminalPolicy: undefined,
   },
   "app.terminal.new": {
     id: "app.terminal.new",
@@ -560,6 +593,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "app",
     kind: "chord",
     defaultChord: "mod+shift+j",
+    secondaryChord: undefined,
+    terminalPolicy: "app",
+    secondaryTerminalPolicy: undefined,
   },
   "app.terminal.maximize": {
     id: "app.terminal.maximize",
@@ -571,6 +607,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     // ⌘⌥J extends the ⌘J terminal family; ⌥ marks the layout variant, the
     // same convention as ⌘⌥W (close others) and ⌘⌥F (find and replace).
     defaultChord: "mod+alt+j",
+    secondaryChord: undefined,
+    terminalPolicy: "shell",
+    secondaryTerminalPolicy: undefined,
   },
   "app.zoom.in": {
     id: "app.zoom.in",
@@ -629,6 +668,9 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     category: "app",
     kind: "chord",
     defaultChord: "mod+s",
+    secondaryChord: undefined,
+    terminalPolicy: "shell",
+    secondaryTerminalPolicy: undefined,
   },
   "composer.model-picker.toggle": {
     id: "composer.model-picker.toggle",

--- a/clients/gui-app/src/lib/keybindings/actions.ts
+++ b/clients/gui-app/src/lib/keybindings/actions.ts
@@ -96,6 +96,13 @@ export interface ActionMeta {
   readonly kind: ActionKind;
   readonly defaultChord: ActionDefaultChord;
   readonly secondaryChord: ActionDefaultChord | undefined;
+  /**
+   * When a terminal is focused on Windows/Linux, only mark default Ctrl chords
+   * as "shell" if @xterm/xterm's evaluateKeyboardEvent Ctrl branch actually
+   * emits PTY bytes: Ctrl+A-Z, Ctrl+space, Ctrl+3-8, Ctrl+/, Ctrl+[, Ctrl+\, or
+   * Ctrl+]. Non-encodable Ctrl chords must stay app-owned or the key becomes a
+   * terminal no-op.
+   */
   readonly terminalPolicy: TerminalPolicy;
   readonly secondaryTerminalPolicy: TerminalPolicy | undefined;
 }
@@ -509,7 +516,7 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     kind: "chord",
     defaultChord: "mod+,",
     secondaryChord: undefined,
-    terminalPolicy: "shell",
+    terminalPolicy: "app",
     secondaryTerminalPolicy: undefined,
   },
   "app.settings.section.byDigit": {
@@ -573,7 +580,7 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     kind: "chord",
     defaultChord: "mod+=",
     secondaryChord: undefined,
-    terminalPolicy: "shell",
+    terminalPolicy: "app",
     secondaryTerminalPolicy: undefined,
   },
   "app.zoom.out": {
@@ -584,7 +591,7 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     kind: "chord",
     defaultChord: "mod+-",
     secondaryChord: undefined,
-    terminalPolicy: "shell",
+    terminalPolicy: "app",
     secondaryTerminalPolicy: undefined,
   },
   "app.zoom.reset": {
@@ -595,7 +602,7 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     kind: "chord",
     defaultChord: "mod+0",
     secondaryChord: undefined,
-    terminalPolicy: "shell",
+    terminalPolicy: "app",
     secondaryTerminalPolicy: undefined,
   },
   "composer.dictation.toggle": {

--- a/clients/gui-app/src/lib/keybindings/dispatch.ts
+++ b/clients/gui-app/src/lib/keybindings/dispatch.ts
@@ -19,7 +19,10 @@ import type { EpicViewTab } from "@/stores/epics/canvas/types";
 import {
   ACTION_IDS,
   ACTION_META,
+  resolveActionDefaultChord,
+  resolveActionSecondaryChord,
   type ActionId,
+  type TerminalPolicy,
 } from "@/lib/keybindings/actions";
 import {
   digitFromCode,
@@ -121,13 +124,40 @@ export function registerDynamicActionHandler(
 // Chord lookup
 // ---------------------------------------------------------------------------
 
-export function findActionForChord(chord: ChordString): ActionId | null {
+export interface ActionChordMatch {
+  readonly actionId: ActionId;
+  readonly terminalPolicy: TerminalPolicy;
+}
+
+export function findActionMatchForChord(
+  chord: ChordString,
+): ActionChordMatch | null {
   const bindings = useKeybindingStore.getState().bindings;
   for (const id of ACTION_IDS) {
-    if (ACTION_META[id].kind !== "chord") continue;
-    if (bindings[id] === chord) return id;
+    const meta = ACTION_META[id];
+    if (meta.kind !== "chord") continue;
+    const binding = bindings[id];
+    if (binding === null) continue;
+    if (binding === chord) {
+      const terminalPolicy =
+        binding === resolveActionDefaultChord(meta)
+          ? meta.terminalPolicy
+          : "app";
+      return { actionId: id, terminalPolicy };
+    }
+    const secondaryChord = resolveActionSecondaryChord(meta);
+    if (secondaryChord === chord) {
+      return {
+        actionId: id,
+        terminalPolicy: meta.secondaryTerminalPolicy ?? meta.terminalPolicy,
+      };
+    }
   }
   return null;
+}
+
+export function findActionForChord(chord: ChordString): ActionId | null {
+  return findActionMatchForChord(chord)?.actionId ?? null;
 }
 
 // ---------------------------------------------------------------------------

--- a/clients/gui-app/src/lib/keybindings/dispatch.ts
+++ b/clients/gui-app/src/lib/keybindings/dispatch.ts
@@ -153,6 +153,11 @@ export function findActionMatchForChord(
           : "app";
       return { actionId: id, terminalPolicy };
     }
+  }
+
+  for (const id of ACTION_IDS) {
+    const meta = ACTION_META[id];
+    if (meta.kind !== "chord" || bindings[id] === null) continue;
     const secondaryChord = resolveActionSecondaryChord(meta);
     if (secondaryChord === chord) {
       return {

--- a/clients/gui-app/src/lib/keybindings/dispatch.ts
+++ b/clients/gui-app/src/lib/keybindings/dispatch.ts
@@ -22,7 +22,10 @@ import type { EpicViewTab } from "@/stores/epics/canvas/types";
 import {
   ACTION_IDS,
   ACTION_META,
+  resolveActionDefaultChord,
+  resolveActionSecondaryChord,
   type ActionId,
+  type TerminalPolicy,
 } from "@/lib/keybindings/actions";
 import {
   digitFromCode,
@@ -129,13 +132,40 @@ export function registerDynamicActionHandler(
 // Chord lookup
 // ---------------------------------------------------------------------------
 
-export function findActionForChord(chord: ChordString): ActionId | null {
+export interface ActionChordMatch {
+  readonly actionId: ActionId;
+  readonly terminalPolicy: TerminalPolicy;
+}
+
+export function findActionMatchForChord(
+  chord: ChordString,
+): ActionChordMatch | null {
   const bindings = useKeybindingStore.getState().bindings;
   for (const id of ACTION_IDS) {
-    if (ACTION_META[id].kind !== "chord") continue;
-    if (bindings[id] === chord) return id;
+    const meta = ACTION_META[id];
+    if (meta.kind !== "chord") continue;
+    const binding = bindings[id];
+    if (binding === null) continue;
+    if (binding === chord) {
+      const terminalPolicy =
+        binding === resolveActionDefaultChord(meta)
+          ? meta.terminalPolicy
+          : "app";
+      return { actionId: id, terminalPolicy };
+    }
+    const secondaryChord = resolveActionSecondaryChord(meta);
+    if (secondaryChord === chord) {
+      return {
+        actionId: id,
+        terminalPolicy: meta.secondaryTerminalPolicy ?? meta.terminalPolicy,
+      };
+    }
   }
   return null;
+}
+
+export function findActionForChord(chord: ChordString): ActionId | null {
+  return findActionMatchForChord(chord)?.actionId ?? null;
 }
 
 // ---------------------------------------------------------------------------

--- a/clients/gui-app/src/providers/__tests__/keybinding-provider-visual.test.tsx
+++ b/clients/gui-app/src/providers/__tests__/keybinding-provider-visual.test.tsx
@@ -250,6 +250,23 @@ function keyDown(init: KeyboardEventInit): KeyboardEvent {
   return dispatchKeyboard("keydown", init);
 }
 
+function terminalKeyDown(init: KeyboardEventInit): KeyboardEvent {
+  const terminalHost = document.createElement("div");
+  terminalHost.setAttribute("data-terminal-host", "");
+  const textarea = document.createElement("textarea");
+  terminalHost.append(textarea);
+  document.body.append(terminalHost);
+  const event = new KeyboardEvent("keydown", {
+    bubbles: true,
+    cancelable: true,
+    ...init,
+  });
+  act(() => {
+    textarea.dispatchEvent(event);
+  });
+  return event;
+}
+
 function keyUp(init: KeyboardEventInit): KeyboardEvent {
   return dispatchKeyboard("keyup", init);
 }
@@ -559,6 +576,79 @@ describe("<KeybindingProvider /> visual leader hints", () => {
 
     expect(event.defaultPrevented).toBe(true);
     expectModHintVisible(false);
+  });
+
+  it("passes non-mac shell-policy Ctrl chords through when a terminal is focused", () => {
+    platformMock.mac = false;
+    renderProbe("/epics/e1");
+
+    const event = terminalKeyDown({
+      code: "KeyK",
+      key: "k",
+      ctrlKey: true,
+    });
+
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it("reserves non-mac app-policy Ctrl digit chords when a terminal is focused", () => {
+    platformMock.mac = false;
+    renderProbe("/epics/e1");
+
+    const event = terminalKeyDown({
+      code: "Digit2",
+      key: "2",
+      ctrlKey: true,
+    });
+
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("reserves the palette secondary chord when a terminal is focused", () => {
+    platformMock.mac = false;
+    renderProbe("/epics/e1");
+
+    const event = terminalKeyDown({
+      code: "KeyP",
+      key: "p",
+      ctrlKey: true,
+      shiftKey: true,
+    });
+
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("reserves explicit user-rebound Ctrl chords when a terminal is focused", () => {
+    platformMock.mac = false;
+    useKeybindingStore.setState({
+      bindings: {
+        ...getDefaultBindings(),
+        "group.split.horizontal": "mod+shift+x",
+      },
+    });
+    renderProbe("/epics/e1");
+
+    const event = terminalKeyDown({
+      code: "KeyX",
+      key: "x",
+      ctrlKey: true,
+      shiftKey: true,
+    });
+
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("reserves macOS Command chords when a terminal is focused", () => {
+    platformMock.mac = true;
+    renderProbe("/epics/e1");
+
+    const event = terminalKeyDown({
+      code: "KeyK",
+      key: "k",
+      metaKey: true,
+    });
+
+    expect(event.defaultPrevented).toBe(true);
   });
 
   it("clears pending timers and visible hints on window blur", () => {

--- a/clients/gui-app/src/providers/__tests__/keybinding-provider-visual.test.tsx
+++ b/clients/gui-app/src/providers/__tests__/keybinding-provider-visual.test.tsx
@@ -604,6 +604,25 @@ describe("<KeybindingProvider /> visual leader hints", () => {
     expect(event.defaultPrevented).toBe(true);
   });
 
+  it("reserves non-encodable non-mac Ctrl punctuation chords when a terminal is focused", () => {
+    platformMock.mac = false;
+    renderProbe("/epics/e1");
+
+    const settings = terminalKeyDown({
+      code: "Comma",
+      key: ",",
+      ctrlKey: true,
+    });
+    const zoomOut = terminalKeyDown({
+      code: "Minus",
+      key: "-",
+      ctrlKey: true,
+    });
+
+    expect(settings.defaultPrevented).toBe(true);
+    expect(zoomOut.defaultPrevented).toBe(true);
+  });
+
   it("reserves the palette secondary chord when a terminal is focused", () => {
     platformMock.mac = false;
     renderProbe("/epics/e1");

--- a/clients/gui-app/src/providers/__tests__/keybinding-provider-visual.test.tsx
+++ b/clients/gui-app/src/providers/__tests__/keybinding-provider-visual.test.tsx
@@ -814,6 +814,25 @@ describe("<KeybindingProvider /> visual leader hints", () => {
     expect(event.defaultPrevented).toBe(true);
   });
 
+  it("reserves non-encodable non-mac Ctrl punctuation chords when a terminal is focused", () => {
+    platformMock.mac = false;
+    renderProbe("/epics/e1");
+
+    const settings = terminalKeyDown({
+      code: "Comma",
+      key: ",",
+      ctrlKey: true,
+    });
+    const zoomOut = terminalKeyDown({
+      code: "Minus",
+      key: "-",
+      ctrlKey: true,
+    });
+
+    expect(settings.defaultPrevented).toBe(true);
+    expect(zoomOut.defaultPrevented).toBe(true);
+  });
+
   it("reserves the palette secondary chord when a terminal is focused", () => {
     platformMock.mac = false;
     renderProbe("/epics/e1");

--- a/clients/gui-app/src/providers/__tests__/keybinding-provider-visual.test.tsx
+++ b/clients/gui-app/src/providers/__tests__/keybinding-provider-visual.test.tsx
@@ -277,6 +277,23 @@ function keyDown(init: KeyboardEventInit): KeyboardEvent {
   return dispatchKeyboard("keydown", init);
 }
 
+function terminalKeyDown(init: KeyboardEventInit): KeyboardEvent {
+  const terminalHost = document.createElement("div");
+  terminalHost.setAttribute("data-terminal-host", "");
+  const textarea = document.createElement("textarea");
+  terminalHost.append(textarea);
+  document.body.append(terminalHost);
+  const event = new KeyboardEvent("keydown", {
+    bubbles: true,
+    cancelable: true,
+    ...init,
+  });
+  act(() => {
+    textarea.dispatchEvent(event);
+  });
+  return event;
+}
+
 function keyUp(init: KeyboardEventInit): KeyboardEvent {
   return dispatchKeyboard("keyup", init);
 }
@@ -769,6 +786,79 @@ describe("<KeybindingProvider /> visual leader hints", () => {
 
     expect(event.defaultPrevented).toBe(true);
     expectModHintVisible(false);
+  });
+
+  it("passes non-mac shell-policy Ctrl chords through when a terminal is focused", () => {
+    platformMock.mac = false;
+    renderProbe("/epics/e1");
+
+    const event = terminalKeyDown({
+      code: "KeyK",
+      key: "k",
+      ctrlKey: true,
+    });
+
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it("reserves non-mac app-policy Ctrl digit chords when a terminal is focused", () => {
+    platformMock.mac = false;
+    renderProbe("/epics/e1");
+
+    const event = terminalKeyDown({
+      code: "Digit2",
+      key: "2",
+      ctrlKey: true,
+    });
+
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("reserves the palette secondary chord when a terminal is focused", () => {
+    platformMock.mac = false;
+    renderProbe("/epics/e1");
+
+    const event = terminalKeyDown({
+      code: "KeyP",
+      key: "p",
+      ctrlKey: true,
+      shiftKey: true,
+    });
+
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("reserves explicit user-rebound Ctrl chords when a terminal is focused", () => {
+    platformMock.mac = false;
+    useKeybindingStore.setState({
+      bindings: {
+        ...getDefaultBindings(),
+        "group.split.horizontal": "mod+shift+x",
+      },
+    });
+    renderProbe("/epics/e1");
+
+    const event = terminalKeyDown({
+      code: "KeyX",
+      key: "x",
+      ctrlKey: true,
+      shiftKey: true,
+    });
+
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("reserves macOS Command chords when a terminal is focused", () => {
+    platformMock.mac = true;
+    renderProbe("/epics/e1");
+
+    const event = terminalKeyDown({
+      code: "KeyK",
+      key: "k",
+      metaKey: true,
+    });
+
+    expect(event.defaultPrevented).toBe(true);
   });
 
   it("clears pending timers and visible hints on window blur", () => {

--- a/clients/gui-app/src/providers/__tests__/keybinding-provider-visual.test.tsx
+++ b/clients/gui-app/src/providers/__tests__/keybinding-provider-visual.test.tsx
@@ -792,13 +792,46 @@ describe("<KeybindingProvider /> visual leader hints", () => {
     platformMock.mac = false;
     renderProbe("/epics/e1");
 
-    const event = terminalKeyDown({
+    const palette = terminalKeyDown({
       code: "KeyK",
       key: "k",
       ctrlKey: true,
     });
+    const closeOthers = terminalKeyDown({
+      code: "KeyW",
+      key: "w",
+      ctrlKey: true,
+      altKey: true,
+    });
+    const split = terminalKeyDown({
+      code: "KeyN",
+      key: "n",
+      ctrlKey: true,
+      altKey: true,
+    });
+    const toggleTerminal = terminalKeyDown({
+      code: "KeyJ",
+      key: "j",
+      ctrlKey: true,
+    });
+    const maximizeTerminal = terminalKeyDown({
+      code: "KeyJ",
+      key: "j",
+      ctrlKey: true,
+      altKey: true,
+    });
+    const stash = terminalKeyDown({
+      code: "KeyS",
+      key: "s",
+      ctrlKey: true,
+    });
 
-    expect(event.defaultPrevented).toBe(false);
+    expect(palette.defaultPrevented).toBe(false);
+    expect(closeOthers.defaultPrevented).toBe(false);
+    expect(split.defaultPrevented).toBe(false);
+    expect(toggleTerminal.defaultPrevented).toBe(false);
+    expect(maximizeTerminal.defaultPrevented).toBe(false);
+    expect(stash.defaultPrevented).toBe(false);
   });
 
   it("reserves non-mac app-policy Ctrl digit chords when a terminal is focused", () => {
@@ -849,22 +882,28 @@ describe("<KeybindingProvider /> visual leader hints", () => {
 
   it("reserves explicit user-rebound Ctrl chords when a terminal is focused", () => {
     platformMock.mac = false;
+    const calls: Array<string> = [];
+    const unregister = registerDynamicActionHandler("app.zoom.in", () =>
+      calls.push("zoom-in"),
+    );
     useKeybindingStore.setState({
       bindings: {
         ...getDefaultBindings(),
-        "group.split.horizontal": "mod+shift+x",
+        "app.zoom.in": "mod+shift+p",
       },
     });
     renderProbe("/epics/e1");
 
     const event = terminalKeyDown({
-      code: "KeyX",
-      key: "x",
+      code: "KeyP",
+      key: "p",
       ctrlKey: true,
       shiftKey: true,
     });
+    unregister();
 
     expect(event.defaultPrevented).toBe(true);
+    expect(calls).toEqual(["zoom-in"]);
   });
 
   it("reserves macOS Command chords when a terminal is focused", () => {

--- a/clients/gui-app/src/providers/keybinding-provider.tsx
+++ b/clients/gui-app/src/providers/keybinding-provider.tsx
@@ -6,8 +6,8 @@ import {
 } from "@/lib/keybindings/chord";
 import {
   dispatchAction,
+  findActionMatchForChord,
   type DigitActionMatch,
-  findActionForChord,
   isExternallyHandled,
   isRepeatSensitiveAction,
   matchDigitAction,
@@ -17,6 +17,8 @@ import {
 import { subscribeLeaderScopes } from "@/lib/keybindings/leader-scope";
 import { getHistoryController } from "@/lib/history-navigation";
 import type { ActionId } from "@/lib/keybindings/actions";
+import { ACTION_META, type TerminalPolicy } from "@/lib/keybindings/actions";
+import { isMac } from "@/lib/keybindings/platform";
 import {
   routerAdapterFor,
   type KeybindingRouterSource,
@@ -305,6 +307,14 @@ export function KeybindingProvider(props: KeybindingProviderProps) {
       // is the primary key + at least one modifier is held.
       const digitMatch = matchDigitAction(event);
       if (digitMatch !== null) {
+        if (
+          shouldPassCtrlChordToFocusedTerminal(
+            event,
+            ACTION_META[digitMatch.actionId].terminalPolicy,
+          )
+        ) {
+          return;
+        }
         event.preventDefault();
         event.stopPropagation();
         handleDigitMatch(digitMatch, digitSequenceRef, digitSequenceTimerRef);
@@ -315,11 +325,19 @@ export function KeybindingProvider(props: KeybindingProviderProps) {
 
       const actionId = resolveReservedAction(event);
       if (actionId === null) return;
+      if (
+        shouldPassCtrlChordToFocusedTerminal(
+          event,
+          actionId.terminalPolicy,
+        )
+      ) {
+        return;
+      }
 
       // Toggles (e.g. the model picker) must act once per physical press. Still
       // reserve the chord on OS key-repeat so the browser default can't run,
       // but skip re-dispatch so a held chord doesn't flip the toggle rapidly.
-      if (event.repeat && isRepeatSensitiveAction(actionId)) {
+      if (event.repeat && isRepeatSensitiveAction(actionId.actionId)) {
         event.preventDefault();
         event.stopPropagation();
         return;
@@ -331,7 +349,7 @@ export function KeybindingProvider(props: KeybindingProviderProps) {
       // (Cmd+Alt+Left/Right = history back/forward on Chrome+Safari).
       event.preventDefault();
       event.stopPropagation();
-      dispatchAction(actionId, adapter);
+      dispatchAction(actionId.actionId, adapter);
     };
 
     // Mouse back/forward (buttons 3/4). Desktop-only: gated on the current
@@ -436,12 +454,37 @@ export function KeybindingProvider(props: KeybindingProviderProps) {
  * OUTSIDE this dispatcher (e.g. dictation, owned by a capture-phase hook) -
  * reserving those would swallow the key when the owner is inactive.
  */
-function resolveReservedAction(event: KeyboardEvent): ActionId | null {
+interface ReservedAction {
+  readonly actionId: ActionId;
+  readonly terminalPolicy: TerminalPolicy;
+}
+
+function resolveReservedAction(event: KeyboardEvent): ReservedAction | null {
   const chord = resolveMatchingChord(event);
   if (chord === null) return null;
-  const actionId = findActionForChord(chord);
-  if (actionId === null) return null;
-  return isExternallyHandled(actionId) ? null : actionId;
+  const match = findActionMatchForChord(chord);
+  if (match === null) return null;
+  if (isExternallyHandled(match.actionId)) return null;
+  return match;
+}
+
+function shouldPassCtrlChordToFocusedTerminal(
+  event: KeyboardEvent,
+  terminalPolicy: TerminalPolicy,
+): boolean {
+  return (
+    !isMac() &&
+    event.ctrlKey &&
+    terminalPolicy === "shell" &&
+    isTerminalEventTarget(event.target)
+  );
+}
+
+function isTerminalEventTarget(target: EventTarget | null): boolean {
+  return (
+    target instanceof HTMLElement &&
+    target.closest("[data-terminal-host]") !== null
+  );
 }
 
 function clearDigitSequenceTimer(timerRef: RefBox<number | null>): void {

--- a/clients/gui-app/src/providers/keybinding-provider.tsx
+++ b/clients/gui-app/src/providers/keybinding-provider.tsx
@@ -341,10 +341,7 @@ export function KeybindingProvider(props: KeybindingProviderProps) {
       const actionId = resolveReservedAction(event);
       if (actionId === null) return;
       if (
-        shouldPassCtrlChordToFocusedTerminal(
-          event,
-          actionId.terminalPolicy,
-        )
+        shouldPassCtrlChordToFocusedTerminal(event, actionId.terminalPolicy)
       ) {
         return;
       }

--- a/clients/gui-app/src/providers/keybinding-provider.tsx
+++ b/clients/gui-app/src/providers/keybinding-provider.tsx
@@ -326,20 +326,15 @@ export function KeybindingProvider(props: KeybindingProviderProps) {
       // digit-by-number flow. `matchDigitAction` only succeeds when a digit
       // is the primary key + at least one modifier is held.
       const digitMatch = matchDigitAction(event);
-      if (digitMatch !== null) {
-        if (
-          shouldPassCtrlChordToFocusedTerminal(
-            event,
-            ACTION_META[digitMatch.actionId].terminalPolicy,
-          )
-        ) {
-          return;
-        }
-        event.preventDefault();
-        event.stopPropagation();
-        handleDigitMatch(digitMatch, digitSequenceRef, digitSequenceTimerRef);
+      if (
+        handleDigitKeyDown(
+          event,
+          digitMatch,
+          digitSequenceRef,
+          digitSequenceTimerRef,
+        )
+      )
         return;
-      }
 
       resetDigitSequence(digitSequenceRef, digitSequenceTimerRef);
 
@@ -613,6 +608,27 @@ function handleDigitMatch(
   }
 
   scheduleDigitSequenceCommit(sequenceRef, timerRef);
+  return true;
+}
+
+function handleDigitKeyDown(
+  event: KeyboardEvent,
+  match: DigitActionMatch | null,
+  sequenceRef: RefBox<DigitSequenceSession | null>,
+  timerRef: RefBox<number | null>,
+): boolean {
+  if (match === null) return false;
+  if (
+    shouldPassCtrlChordToFocusedTerminal(
+      event,
+      ACTION_META[match.actionId].terminalPolicy,
+    )
+  )
+    return true;
+
+  event.preventDefault();
+  event.stopPropagation();
+  handleDigitMatch(match, sequenceRef, timerRef);
   return true;
 }
 

--- a/clients/gui-app/src/providers/keybinding-provider.tsx
+++ b/clients/gui-app/src/providers/keybinding-provider.tsx
@@ -6,8 +6,8 @@ import {
 } from "@/lib/keybindings/chord";
 import {
   dispatchAction,
+  findActionMatchForChord,
   type DigitActionMatch,
-  findActionForChord,
   isExternallyHandled,
   isRepeatSensitiveAction,
   matchDigitAction,
@@ -17,6 +17,8 @@ import {
 import { subscribeLeaderScopes } from "@/lib/keybindings/leader-scope";
 import { historyNavChromeAvailable } from "@/lib/history-navigation";
 import type { ActionId } from "@/lib/keybindings/actions";
+import { ACTION_META, type TerminalPolicy } from "@/lib/keybindings/actions";
+import { isMac } from "@/lib/keybindings/platform";
 import {
   routerAdapterFor,
   type KeybindingRouterSource,
@@ -325,6 +327,14 @@ export function KeybindingProvider(props: KeybindingProviderProps) {
       // is the primary key + at least one modifier is held.
       const digitMatch = matchDigitAction(event);
       if (digitMatch !== null) {
+        if (
+          shouldPassCtrlChordToFocusedTerminal(
+            event,
+            ACTION_META[digitMatch.actionId].terminalPolicy,
+          )
+        ) {
+          return;
+        }
         event.preventDefault();
         event.stopPropagation();
         handleDigitMatch(digitMatch, digitSequenceRef, digitSequenceTimerRef);
@@ -335,11 +345,19 @@ export function KeybindingProvider(props: KeybindingProviderProps) {
 
       const actionId = resolveReservedAction(event);
       if (actionId === null) return;
+      if (
+        shouldPassCtrlChordToFocusedTerminal(
+          event,
+          actionId.terminalPolicy,
+        )
+      ) {
+        return;
+      }
 
       // Toggles (e.g. the model picker) must act once per physical press. Still
       // reserve the chord on OS key-repeat so the browser default can't run,
       // but skip re-dispatch so a held chord doesn't flip the toggle rapidly.
-      if (event.repeat && isRepeatSensitiveAction(actionId)) {
+      if (event.repeat && isRepeatSensitiveAction(actionId.actionId)) {
         event.preventDefault();
         event.stopPropagation();
         return;
@@ -351,7 +369,7 @@ export function KeybindingProvider(props: KeybindingProviderProps) {
       // (Cmd+Alt+Left/Right = history back/forward on Chrome+Safari).
       event.preventDefault();
       event.stopPropagation();
-      dispatchAction(actionId, adapter);
+      dispatchAction(actionId.actionId, adapter);
     };
 
     // Mouse back/forward (buttons 3/4). Desktop-only, on the shared chrome
@@ -458,23 +476,48 @@ export function KeybindingProvider(props: KeybindingProviderProps) {
  * OUTSIDE this dispatcher (e.g. dictation, owned by a capture-phase hook) -
  * reserving those would swallow the key when the owner is inactive.
  */
-function resolveReservedAction(event: KeyboardEvent): ActionId | null {
+interface ReservedAction {
+  readonly actionId: ActionId;
+  readonly terminalPolicy: TerminalPolicy;
+}
+
+function resolveReservedAction(event: KeyboardEvent): ReservedAction | null {
   const chord = resolveMatchingChord(event);
   if (chord === null) return null;
-  const actionId = findActionForChord(chord);
-  if (actionId === null) return null;
+  const match = findActionMatchForChord(chord);
+  if (match === null) return null;
   // Cmd+Left/Right is browser history on macOS, but it is also the native
   // beginning/end-of-line command in text fields. Keep the familiar global
   // navigation binding without breaking editing. The same safeguard applies
   // if a non-Mac user explicitly remaps history to Ctrl+Left/Right.
   if (
-    (actionId === "nav.back" || actionId === "nav.forward") &&
+    (match.actionId === "nav.back" || match.actionId === "nav.forward") &&
     (chord === "mod+arrowleft" || chord === "mod+arrowright") &&
     (isEditableEventTarget(event.target) || isDiffsEditorEvent(event))
   ) {
     return null;
   }
-  return isExternallyHandled(actionId) ? null : actionId;
+  if (isExternallyHandled(match.actionId)) return null;
+  return match;
+}
+
+function shouldPassCtrlChordToFocusedTerminal(
+  event: KeyboardEvent,
+  terminalPolicy: TerminalPolicy,
+): boolean {
+  return (
+    !isMac() &&
+    event.ctrlKey &&
+    terminalPolicy === "shell" &&
+    isTerminalEventTarget(event.target)
+  );
+}
+
+function isTerminalEventTarget(target: EventTarget | null): boolean {
+  return (
+    target instanceof HTMLElement &&
+    target.closest("[data-terminal-host]") !== null
+  );
 }
 
 function isDiffsHistoryShortcut(event: KeyboardEvent): boolean {


### PR DESCRIPTION
## Summary
- Adds focus-based terminal keybinding policy for Windows/Linux: when focus is inside an xterm host, default shell-owned Ctrl chords fall through to xterm instead of being reserved by the app.
- Stamps xterm host containers with `data-terminal-host` and gates renderer reservation after action resolution, preserving macOS Command behavior and app-owned terminal skip-list chords.
- Adds static `terminalPolicy` metadata for every keybinding action plus a terminal-safe command palette secondary default (`Ctrl+Shift+P` on Windows/Linux via `mod+shift+p`, Control+Shift+P on macOS via `ctrl+shift+p`).
- Keeps explicit user-rebound chords app-owned in terminals, so existing chord-capture overrides remain the opt-in escape hatch until the Settings toggle follow-up exists.
- Disables Electron menu accelerator registration on Windows/Linux for terminal-conflicting menu items while keeping labels visible: Close Tab, Find, Find Next, Minimize, Settings, and the native Select All, Reload, Close, and Linux Quit roles. Settings remains unregistered off macOS so the focus-aware renderer can handle `Ctrl+,`.

## Encoder correction
Terminal policies now follow the installed `@xterm/xterm` `evaluateKeyboardEvent` encoder rather than keyboard intuition. Plain Ctrl emits PTY bytes for A-Z, space, 3-8, `/`, `[`, `\\`, and `]`; on Windows/Linux, Ctrl+Alt letters and space use xterm's Escape-prefixed Alt path. Non-encodable chords such as `mod+,`, `mod+-`, `mod+=`, `mod+0`, and ordinary Ctrl+Shift letters remain app-owned.

## Default terminal policy
App-owned skip-list in focused terminals:
- Ctrl+digit tab switching / model picker digit actions
- Alt+digit task/settings/model actions
- `mod+alt+arrow*` group focus
- `mod+shift+*` tab-management and global panel actions
- voice input
- command palette secondary chord
- `mod+alt+f` find and replace
- non-encodable `mod+,`, `mod+-`, `mod+=`, and `mod+0`

Shell-owned pass-through defaults in focused terminals:
- Current defaults: `mod+k`, `mod+w`, `mod+d`, `mod+t`, `mod+n`, `mod+b`, `mod+y`, `mod+l`, `mod+j`, `mod+s`, `mod+[`, `mod+]`, `mod+\\`, `mod+alt+w`, `ctrl+alt+n`, and `mod+alt+j`
- The permitted encoder set is letters plus space, 3-8, `/`, `[`, `\\`, and `]` only.

## Confirm or override
- Alt+digit stays app-owned by default.
- Accept the kitty-protocol gap for Ctrl+Shift/Ctrl+digit capable TUIs; the future per-action Settings toggle is the remedy.
- `mod+alt+f` stays app-owned by default.

## Scope notes
- The Settings-screen "In terminal" per-action toggle is intentionally not included here. This PR only wires the static metadata and runtime policy gate.
- This is the Windows/Linux companion to #266. #266 has already merged into `main`, so this PR targets `main` rather than the now-deleted `fix/macos-ctrl-chord-passthrough` branch.

## Verification
- `bun run --cwd clients/gui-app compile`
- `bun run --cwd clients/gui-app test` (578 passed, 1 skipped files; 4,800 passed, 1 skipped tests)
- `bun run --cwd clients/gui-app lint`
- `bun run --cwd clients/desktop compile`

?? Generated with [Claude Code](https://claude.com/claude-code)