### PR TITLE
feat(gui-app): add persistent multi-project picker

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/sidebar/new-conversation-modal.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/new-conversation-modal.tsx
@@ -86,6 +86,7 @@ import {
   workspaceComposerCanStart,
 } from "@/lib/composer/workspace-composer-availability";
 import { effectiveWorktreeIntent } from "@/lib/worktree/effective-worktree-intent";
+import { resolvePrimaryPath } from "@/lib/worktree/resolve-primary-path";
 import { deriveWorkspaceMode } from "@/lib/worktree/workspace-mode";
 import { cn } from "@/lib/utils";
 import { ActiveHostWorkspaceControls } from "@/components/home/host-workspace-selector/host-workspace-selector";
@@ -1043,13 +1044,29 @@ function useLatestConversationSettingsSeed(): {
 }
 
 function useGlobalWorkspaceSnapshot(): LandingDraftWorkspaceSnapshot {
-  return useWorkspaceFoldersStore(
-    useShallow((state) => ({
-      folders: state.folders,
-      folderInfoByPath: state.folderInfoByPath,
-      primaryPath: state.primaryPath,
-    })),
+  // A brand-new conversation (no latest-conversation seed) starts with ONLY
+  // the pinned default project selected - the rest of the saved list stays
+  // available as unselected picker rows, mirroring the landing draft seed.
+  const folders = useWorkspaceFoldersStore((state) => state.folders);
+  const folderInfoByPath = useWorkspaceFoldersStore(
+    (state) => state.folderInfoByPath,
   );
+  const pinnedPath = useWorkspaceFoldersStore((state) => state.pinnedPath);
+  return useMemo(() => {
+    const pinned = resolvePrimaryPath(folders, pinnedPath);
+    const pinnedInfo =
+      pinned !== null && Object.hasOwn(folderInfoByPath, pinned)
+        ? folderInfoByPath[pinned]
+        : null;
+    if (pinnedInfo === null) {
+      return { folders: [], folderInfoByPath: {}, primaryPath: null };
+    }
+    return {
+      folders: [pinnedInfo.path],
+      folderInfoByPath: { [pinnedInfo.path]: pinnedInfo },
+      primaryPath: pinnedInfo.path,
+    };
+  }, [folders, folderInfoByPath, pinnedPath]);
 }
 
 function toTuiPlacement(

--- a/clients/gui-app/src/components/epic-canvas/sidebar/new-conversation-modal.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/new-conversation-modal.tsx
@@ -1043,6 +1043,7 @@ function useLatestConversationSettingsSeed(): {
   }, [defaults, fallbackComposerMode, projection]);
 }
 
+/** Builds the pinned-only workspace seed for a brand-new conversation. */
 function useGlobalWorkspaceSnapshot(): LandingDraftWorkspaceSnapshot {
   // A brand-new conversation (no latest-conversation seed) starts with ONLY
   // the pinned default project selected - the rest of the saved list stays

--- a/clients/gui-app/src/components/home/__tests__/home-hero.test.tsx
+++ b/clients/gui-app/src/components/home/__tests__/home-hero.test.tsx
@@ -3,12 +3,14 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { cleanup, render, screen } from "@testing-library/react";
 import { HomeHero } from "@/components/home/home-hero";
 import { useAuthStore } from "@/stores/auth/auth-store";
+import { useLandingDraftStore } from "@/stores/home/landing-draft-store";
 import { useWorkspaceFoldersStore } from "@/stores/workspace/workspace-folders-store";
 
 describe("<HomeHero />", () => {
   beforeEach(() => {
     window.localStorage.clear();
     useWorkspaceFoldersStore.setState({ folders: [] });
+    useLandingDraftStore.setState({ pendingWorkspace: null });
     useAuthStore.setState({
       status: "signed-out",
       profile: null,
@@ -19,6 +21,7 @@ describe("<HomeHero />", () => {
   afterEach(() => {
     cleanup();
     useWorkspaceFoldersStore.setState({ folders: [] });
+    useLandingDraftStore.setState({ pendingWorkspace: null });
     useAuthStore.setState({
       status: "signed-out",
       profile: null,
@@ -37,7 +40,7 @@ describe("<HomeHero />", () => {
       contextMetadata: { userId: "test-user", username: "Ada Lovelace" },
     });
 
-    render(<HomeHero workspaceFolders={null} />);
+    render(<HomeHero workspaceFolders={null} workspacePrimaryPath={null} />);
 
     expect(screen.getByRole("heading").textContent).toMatch(/, Ada$/);
   });
@@ -56,7 +59,7 @@ describe("<HomeHero />", () => {
       },
     });
 
-    render(<HomeHero workspaceFolders={null} />);
+    render(<HomeHero workspaceFolders={null} workspacePrimaryPath={null} />);
 
     expect(screen.getByRole("heading").textContent).not.toContain(",");
   });
@@ -75,13 +78,13 @@ describe("<HomeHero />", () => {
       },
     });
 
-    render(<HomeHero workspaceFolders={null} />);
+    render(<HomeHero workspaceFolders={null} workspacePrimaryPath={null} />);
 
     expect(screen.getByRole("heading").textContent).not.toContain(",");
   });
 
   it("keeps the generic greeting when no profile is available", () => {
-    render(<HomeHero workspaceFolders={null} />);
+    render(<HomeHero workspaceFolders={null} workspacePrimaryPath={null} />);
 
     expect(screen.getByRole("heading").textContent).not.toContain(",");
   });
@@ -89,7 +92,12 @@ describe("<HomeHero />", () => {
   it("uses draft workspace folders over global folders", () => {
     useWorkspaceFoldersStore.setState({ folders: ["/tmp/global-app"] });
 
-    render(<HomeHero workspaceFolders={["/tmp/draft-app"]} />);
+    render(
+      <HomeHero
+        workspaceFolders={["/tmp/draft-app"]}
+        workspacePrimaryPath={null}
+      />,
+    );
 
     expect(screen.getByText("draft-app")).toBeTruthy();
     expect(screen.queryByText("global-app")).toBeNull();
@@ -98,8 +106,39 @@ describe("<HomeHero />", () => {
   it("does not fall back to global folders for an explicit empty draft workspace", () => {
     useWorkspaceFoldersStore.setState({ folders: ["/tmp/global-app"] });
 
-    render(<HomeHero workspaceFolders={[]} />);
+    render(<HomeHero workspaceFolders={[]} workspacePrimaryPath={null} />);
 
     expect(screen.queryByText("global-app")).toBeNull();
+  });
+
+  it("names the draft's MAIN project, not whichever folder is first", () => {
+    render(
+      <HomeHero
+        workspaceFolders={["/tmp/extra-app", "/tmp/main-app"]}
+        workspacePrimaryPath="/tmp/main-app"
+      />,
+    );
+
+    expect(screen.getByText("main-app")).toBeTruthy();
+    expect(screen.queryByText("extra-app")).toBeNull();
+  });
+
+  it("names the pending blank-landing main over the pinned default", () => {
+    useWorkspaceFoldersStore.setState({
+      folders: ["/tmp/pinned-app"],
+      pinnedPath: "/tmp/pinned-app",
+    });
+    useLandingDraftStore.setState({
+      pendingWorkspace: {
+        folders: ["/tmp/switched-app"],
+        folderInfoByPath: {},
+        primaryPath: "/tmp/switched-app",
+      },
+    });
+
+    render(<HomeHero workspaceFolders={null} workspacePrimaryPath={null} />);
+
+    expect(screen.getByText("switched-app")).toBeTruthy();
+    expect(screen.queryByText("pinned-app")).toBeNull();
   });
 });

--- a/clients/gui-app/src/components/home/__tests__/home-page.test.tsx
+++ b/clients/gui-app/src/components/home/__tests__/home-page.test.tsx
@@ -279,7 +279,11 @@ describe("<HomePage />", () => {
       },
       contextMetadata: { userId: "test-user", username: "alice" },
     });
-    useLandingDraftStore.setState({ drafts: [], activeDraftId: null });
+    useLandingDraftStore.setState({
+      drafts: [],
+      activeDraftId: null,
+      pendingWorkspace: null,
+    });
     draftRuntimeRegistry.resetForTesting();
     useEpicCanvasStore.setState({
       tabsById: {},
@@ -295,7 +299,11 @@ describe("<HomePage />", () => {
 
   afterEach(() => {
     cleanup();
-    useLandingDraftStore.setState({ drafts: [], activeDraftId: null });
+    useLandingDraftStore.setState({
+      drafts: [],
+      activeDraftId: null,
+      pendingWorkspace: null,
+    });
     useEpicCanvasStore.setState({
       tabsById: {},
       openTabOrder: [],
@@ -528,6 +536,27 @@ describe("<HomePage />", () => {
           name: "host",
           repoIdentifier: { owner: "traycerai", repo: "host" },
         },
+      },
+    });
+    // Blank-landing launches use the PENDING per-chat snapshot (the untouched
+    // landing is pinned-only) - this is the state a user selecting BOTH saved
+    // rows in the picker produces.
+    useLandingDraftStore.setState({
+      pendingWorkspace: {
+        folders: ["/tmp/gui-app", "/tmp/host"],
+        folderInfoByPath: {
+          "/tmp/gui-app": {
+            path: "/tmp/gui-app",
+            name: "gui-app",
+            repoIdentifier: { owner: "traycerai", repo: "gui-app" },
+          },
+          "/tmp/host": {
+            path: "/tmp/host",
+            name: "host",
+            repoIdentifier: { owner: "traycerai", repo: "host" },
+          },
+        },
+        primaryPath: null,
       },
     });
     homeMocks.request.mockResolvedValue({ roomInfo: null });

--- a/clients/gui-app/src/components/home/__tests__/use-landing-composer-actions.test.tsx
+++ b/clients/gui-app/src/components/home/__tests__/use-landing-composer-actions.test.tsx
@@ -142,7 +142,11 @@ describe("useLandingComposerActions", () => {
       primaryPath: null,
     });
     useWorktreeIntentStagingStore.getState().resetForTests();
-    useLandingDraftStore.setState({ drafts: [], activeDraftId: null });
+    useLandingDraftStore.setState({
+      drafts: [],
+      activeDraftId: null,
+      pendingWorkspace: null,
+    });
     useTabsStore.setState({
       items: [],
       activeItemId: null,
@@ -174,7 +178,11 @@ describe("useLandingComposerActions", () => {
       primaryPath: null,
     });
     useWorktreeIntentStagingStore.getState().resetForTests();
-    useLandingDraftStore.setState({ drafts: [], activeDraftId: null });
+    useLandingDraftStore.setState({
+      drafts: [],
+      activeDraftId: null,
+      pendingWorkspace: null,
+    });
     useTabsStore.setState({
       items: [],
       activeItemId: null,
@@ -735,6 +743,22 @@ describe("useLandingComposerActions", () => {
         },
       },
     });
+    // Blank-landing launches use the PENDING per-chat snapshot (never the
+    // whole saved list) - this is the state a user selecting both rows in
+    // the picker produces.
+    useLandingDraftStore.setState({
+      pendingWorkspace: {
+        folders: [UNKNOWN_WORKSPACE_PATH, WORKSPACE_PATH],
+        folderInfoByPath: {
+          [WORKSPACE_PATH]: {
+            path: WORKSPACE_PATH,
+            name: "traycer",
+            repoIdentifier: { owner: "traycerai", repo: "traycer" },
+          },
+        },
+        primaryPath: null,
+      },
+    });
     const queryClient = new QueryClient({
       defaultOptions: { queries: { retry: false } },
     });
@@ -797,6 +821,26 @@ describe("useLandingComposerActions", () => {
       },
       // The user explicitly switched primary to the SECOND folder.
       primaryPath: SECOND_PATH,
+    });
+    // The same switch, as the blank landing's PENDING snapshot records it -
+    // the representation the launch boundary now reads.
+    useLandingDraftStore.setState({
+      pendingWorkspace: {
+        folders: [WORKSPACE_PATH, SECOND_PATH],
+        folderInfoByPath: {
+          [WORKSPACE_PATH]: {
+            path: WORKSPACE_PATH,
+            name: "traycer",
+            repoIdentifier: { owner: "traycerai", repo: "traycer" },
+          },
+          [SECOND_PATH]: {
+            path: SECOND_PATH,
+            name: "second",
+            repoIdentifier: null,
+          },
+        },
+        primaryPath: SECOND_PATH,
+      },
     });
     // The staged intent still carries a STALE primary bit on the first
     // folder (staged before the switch) - launch must restamp it by path.
@@ -982,6 +1026,26 @@ describe("useLandingComposerActions", () => {
       },
       // The user clicked the pin on the NON-GIT folder.
       primaryPath: NON_GIT_PATH,
+    });
+    // The same selection/primary, as the blank landing's PENDING snapshot
+    // records it - the representation the launch boundary now reads.
+    useLandingDraftStore.setState({
+      pendingWorkspace: {
+        folders: [WORKSPACE_PATH, NON_GIT_PATH],
+        folderInfoByPath: {
+          [WORKSPACE_PATH]: {
+            path: WORKSPACE_PATH,
+            name: "traycer",
+            repoIdentifier: { owner: "traycerai", repo: "traycer" },
+          },
+          [NON_GIT_PATH]: {
+            path: NON_GIT_PATH,
+            name: "non-git",
+            repoIdentifier: null,
+          },
+        },
+        primaryPath: NON_GIT_PATH,
+      },
     });
     // What `setPrimaryFolder`'s restamp actually leaves behind: the git
     // folder's worktree entry, demoted, and no entry at all for the non-git
@@ -1822,8 +1886,15 @@ describe("useLandingComposerActions", () => {
       await Promise.resolve();
     });
     expect(landingMocks.request).not.toHaveBeenCalled();
+    // The mint moved the pick to the draft's own slot (it rides with the
+    // draft for the retry); nothing is orphaned under the null landing key.
     expect(
       useWorktreeIntentStagingStore.getState().intentByKey["landing:"],
+    ).toBeUndefined();
+    expect(
+      useWorktreeIntentStagingStore.getState().intentByKey[
+        `landing:${draftId}`
+      ],
     ).toEqual(stagedIntent);
     queryClient.clear();
   });
@@ -1860,8 +1931,17 @@ describe("useLandingComposerActions", () => {
     await act(async () => {
       await Promise.resolve();
     });
+    // The mint moved the pick to the draft's own slot (it rides with the
+    // retained draft for the retry); nothing stays under the null key.
+    const rejectedDraftId = useLandingDraftStore.getState().activeDraftId;
+    if (rejectedDraftId === null) throw new Error("expected generated draft");
     expect(
       useWorktreeIntentStagingStore.getState().intentByKey["landing:"],
+    ).toBeUndefined();
+    expect(
+      useWorktreeIntentStagingStore.getState().intentByKey[
+        `landing:${rejectedDraftId}`
+      ],
     ).toEqual(stagedIntent);
     queryClient.clear();
   });

--- a/clients/gui-app/src/components/home/composer/__tests__/landing-composer-rate-limit-banner.test.tsx
+++ b/clients/gui-app/src/components/home/composer/__tests__/landing-composer-rate-limit-banner.test.tsx
@@ -129,6 +129,11 @@ vi.mock("@/stores/home/landing-draft-store", () => {
   return {
     useLandingDraftStore: (selector: (value: typeof state) => unknown) =>
       selector(state),
+    usePendingOrPinnedLandingWorkspace: () => ({
+      folders: [],
+      folderInfoByPath: {},
+      primaryPath: null,
+    }),
   };
 });
 

--- a/clients/gui-app/src/components/home/composer/__tests__/landing-composer-submit-gate.test.tsx
+++ b/clients/gui-app/src/components/home/composer/__tests__/landing-composer-submit-gate.test.tsx
@@ -82,6 +82,11 @@ vi.mock("@/stores/home/landing-draft-store", () => {
   );
   return {
     useLandingDraftStore,
+    usePendingOrPinnedLandingWorkspace: () => ({
+      folders: [],
+      folderInfoByPath: {},
+      primaryPath: null,
+    }),
   };
 });
 

--- a/clients/gui-app/src/components/home/composer/landing-composer.tsx
+++ b/clients/gui-app/src/components/home/composer/landing-composer.tsx
@@ -58,7 +58,10 @@ import { useCreateTuiAgent } from "@/hooks/agent/use-create-tui-agent";
 import { useComposerToolbarStore } from "@/components/home/hooks/use-composer-toolbar-store";
 import { fallbackSeedSource } from "@/lib/composer/composer-seed-source";
 import { useComposerRunSettingsStore } from "@/stores/composer/composer-run-settings-store";
-import { useLandingDraftStore } from "@/stores/home/landing-draft-store";
+import {
+  useLandingDraftStore,
+  usePendingOrPinnedLandingWorkspace,
+} from "@/stores/home/landing-draft-store";
 import {
   draftRuntimeRegistry,
   EMPTY_DRAFT_RUNTIME_CONTENT,
@@ -216,12 +219,19 @@ export function LandingComposer(props: LandingComposerProps) {
     terminalAgentCreate.isPending;
 
   const hasSubmittableContent = contentIsSubmittable(runtimeState.content);
-  const draftWorkspace = useLandingDraftStore((state) => {
+  // Blank landing: the availability gate must check the folders this submit
+  // will actually run with - the shared pending-or-pinned snapshot, never the
+  // whole saved list (an unavailable UNSELECTED saved project must not block
+  // a valid pinned-only landing).
+  const pendingOrPinnedWorkspace = usePendingOrPinnedLandingWorkspace();
+  const boundDraftWorkspace = useLandingDraftStore((state) => {
     if (draftId === null) return null;
     return (
       state.drafts.find((draft) => draft.id === draftId)?.workspace ?? null
     );
   });
+  const draftWorkspace =
+    draftId === null ? pendingOrPinnedWorkspace : boundDraftWorkspace;
   const defaultHostClient = useHostClient();
   // Rate-limit switch prompt for the landing composer's own toolbar
   // selection, scoped to the app-wide default host (landing has no tab of

--- a/clients/gui-app/src/components/home/composer/landing-composer.tsx
+++ b/clients/gui-app/src/components/home/composer/landing-composer.tsx
@@ -96,6 +96,7 @@ interface LandingComposerProps {
   readonly workspaceControls: (disabled: boolean) => ReactNode;
 }
 
+/** Renders and coordinates the composer used by landing-page drafts. */
 export function LandingComposer(props: LandingComposerProps) {
   const editorRef = useRef<ComposerPromptEditorHandle | null>(null);
   const createdUnboundDraftIdRef = useRef<string | null>(null);

--- a/clients/gui-app/src/components/home/home-hero.tsx
+++ b/clients/gui-app/src/components/home/home-hero.tsx
@@ -45,6 +45,7 @@ interface HomeHeroProps {
   readonly workspacePrimaryPath: string | null;
 }
 
+/** Renders the landing greeting for the active or pending main project. */
 export function HomeHero({
   workspaceFolders,
   workspacePrimaryPath,

--- a/clients/gui-app/src/components/home/home-hero.tsx
+++ b/clients/gui-app/src/components/home/home-hero.tsx
@@ -1,7 +1,8 @@
 import { useState } from "react";
 import { basenameOfPath } from "@/lib/path";
+import { resolvePrimaryPath } from "@/lib/worktree/resolve-primary-path";
 import { useAuthStore } from "@/stores/auth/auth-store";
-import { useWorkspaceFoldersStore } from "@/stores/workspace/workspace-folders-store";
+import { usePendingOrPinnedLandingWorkspace } from "@/stores/home/landing-draft-store";
 
 const PROMPT_POOL: ReadonlyArray<string> = [
   "What should we work on?",
@@ -39,16 +40,32 @@ function readFirstName(userName: string): string | null {
 
 interface HomeHeroProps {
   readonly workspaceFolders: ReadonlyArray<string> | null;
+  // The draft's raw stored primary. The folder list alone cannot name the
+  // MAIN project (a main switch may leave an additional folder at index 0).
+  readonly workspacePrimaryPath: string | null;
 }
 
-export function HomeHero({ workspaceFolders }: HomeHeroProps) {
-  const globalFolders = useWorkspaceFoldersStore((state) => state.folders);
-  const folders = workspaceFolders === null ? globalFolders : workspaceFolders;
+export function HomeHero({
+  workspaceFolders,
+  workspacePrimaryPath,
+}: HomeHeroProps) {
+  // Blank landing (no draft yet): the shared pending-or-pinned resolver -
+  // the same snapshot the picker shows and a minted draft will start from.
+  const pendingOrPinned = usePendingOrPinnedLandingWorkspace();
   const profile = useAuthStore((state) => state.profile);
   const [greeting] = useState(() => timeGreeting(new Date().getHours()));
   const [prompt] = useState(() => pickPrompt());
 
-  const projectName = folders.length > 0 ? basenameOfPath(folders[0]) : null;
+  // Greet with the chat's MAIN project: the draft's resolved primary, else
+  // the blank landing's pending/pinned main - never array position zero.
+  const projectPath =
+    workspaceFolders !== null
+      ? resolvePrimaryPath(workspaceFolders, workspacePrimaryPath)
+      : resolvePrimaryPath(
+          pendingOrPinned.folders,
+          pendingOrPinned.primaryPath,
+        );
+  const projectName = projectPath !== null ? basenameOfPath(projectPath) : null;
   const firstName = profile === null ? null : readFirstName(profile.userName);
 
   return (

--- a/clients/gui-app/src/components/home/hooks/use-landing-composer-actions.ts
+++ b/clients/gui-app/src/components/home/hooks/use-landing-composer-actions.ts
@@ -23,7 +23,6 @@ import { hostQueryKeys } from "@/lib/query-keys";
 import { useEpicCreate } from "@/hooks/epic/use-epic-create-mutation";
 import { useCreateTuiAgent } from "@/hooks/agent/use-create-tui-agent";
 import { useAuthStore } from "@/stores/auth/auth-store";
-import { useWorkspaceFoldersStore } from "@/stores/workspace/workspace-folders-store";
 import {
   readStagedWorktreeIntent,
   stagedWorktreeIntentIsSuspended,
@@ -33,6 +32,7 @@ import {
 import { useWorktreeIntentMemoryStore } from "@/stores/worktree/worktree-intent-memory-store";
 import type { WorkspaceFolderInfo } from "@/stores/workspace/workspace-folders-store";
 import {
+  readPendingOrPinnedLandingWorkspace,
   useLandingDraftStore,
   type LandingDraftWorkspaceSnapshot,
 } from "@/stores/home/landing-draft-store";
@@ -906,19 +906,17 @@ function readLandingWorkspaceContext(
       draftId: exactDraftId,
     };
   }
-  const globalState = useWorkspaceFoldersStore.getState();
-  const globalWorkspace = {
-    folders: globalState.folders,
-    folderInfoByPath: globalState.folderInfoByPath,
-    primaryPath: globalState.primaryPath,
-  };
+  // No draft yet (blank landing): launch with the same pending-or-pinned
+  // snapshot the picker shows - never the whole saved list, which would pull
+  // every saved project (and the legacy global primary) into the run.
+  const pendingWorkspace = readPendingOrPinnedLandingWorkspace();
   return {
     ...canonicalLaunchWorkspace(
-      globalWorkspace,
+      pendingWorkspace,
       stagedWorktreeIntent,
-      readCachedDefaultWorktreeIntent(queryClient, hostId, globalWorkspace),
+      readCachedDefaultWorktreeIntent(queryClient, hostId, pendingWorkspace),
     ),
-    workspaceFolderInfoByPath: globalState.folderInfoByPath,
+    workspaceFolderInfoByPath: pendingWorkspace.folderInfoByPath,
     worktreeIntentSuspended,
     draftId: null,
   };

--- a/clients/gui-app/src/components/home/hooks/use-landing-composer-actions.ts
+++ b/clients/gui-app/src/components/home/hooks/use-landing-composer-actions.ts
@@ -871,6 +871,7 @@ interface LandingWorkspaceContext {
   readonly draftId: string | null;
 }
 
+/** Resolves the workspace and staged intent used for a landing launch. */
 function readLandingWorkspaceContext(
   draftId: string | null,
   queryClient: QueryClient,

--- a/clients/gui-app/src/components/home/host-workspace-selector/__tests__/folder-controls.test.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/__tests__/folder-controls.test.tsx
@@ -72,6 +72,7 @@ vi.mock("@/components/ui/dropdown-menu", () => {
 import { FolderBranchControl } from "../folder-branch-control";
 import { FolderLocationControl } from "../folder-location-control";
 import { FolderRow } from "../folder-row";
+import { useWorkspaceFoldersStore } from "@/stores/workspace/workspace-folders-store";
 import { WorkspaceFolderRows } from "../workspace-folder-rows";
 import { WorkspaceFolderSummaryControl } from "../workspace-folder-summary-control";
 import { WorkspaceSummaryTrigger } from "../workspace-summary-trigger";
@@ -81,24 +82,6 @@ import { tooltipTextNear } from "@/components/ui/__tests__/tooltip-probe";
 const NOOP = (): void => undefined;
 const NOOP_ADD = (): Promise<boolean> => Promise.resolve(false);
 const EMPTY_COUNTS: ReadonlyMap<string, number> = new Map();
-
-function tabForward(): void {
-  const focusable = Array.from(
-    document.querySelectorAll<HTMLElement>(
-      'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
-    ),
-  );
-  const currentIndex = focusable.findIndex(
-    (element) => element === document.activeElement,
-  );
-  const next = focusable[currentIndex + 1] ?? focusable[0];
-  fireEvent.keyDown(document.activeElement ?? document.body, {
-    key: "Tab",
-    code: "Tab",
-  });
-  next.focus();
-  fireEvent.keyUp(next, { key: "Tab", code: "Tab" });
-}
 
 const GIT_SUMMARY: WorktreeWorkspaceSummary = {
   workspacePath: "/repo",
@@ -141,9 +124,12 @@ function item(over: Partial<WorkspaceRunItem>): WorkspaceRunItem {
     defaultNewBranchName: "traycer/swift-otter",
     repoIdentifier: { owner: "acme", repo: "app" },
     isPrimary: true,
-    canChangePrimary: true,
-    makePrimaryDisabled: false,
-    makePrimaryDisabledReason: null,
+    selected: true,
+    onToggleSelected: NOOP,
+    selectionDisabledReason: null,
+    onUseAsMain: null,
+    isPinned: false,
+    onTogglePin: NOOP,
     hostClient: null,
     modeDisabled: false,
     modeDisabledReason: null,
@@ -153,13 +139,16 @@ function item(over: Partial<WorkspaceRunItem>): WorkspaceRunItem {
     onSelectMode: NOOP,
     onEmit: NOOP,
     onLocate: null,
-    onMakePrimary: NOOP,
     onRemove: null,
     ...over,
   };
 }
 
 afterEach(cleanup);
+// The rows read the global multi-select preference; keep tests order-independent.
+afterEach(() => {
+  useWorkspaceFoldersStore.setState({ allowMultipleFolders: false });
+});
 
 describe("FolderLocationControl", () => {
   function renderControl(over: Partial<WorkspaceRunItem>): void {
@@ -309,14 +298,16 @@ describe("FolderLocationControl", () => {
 });
 
 describe("FolderRow", () => {
-  function renderRow(
+  function renderRowWithMulti(
     over: Partial<WorkspaceRunItem>,
     onEdit: (p: string) => void,
+    multiSelectEnabled: boolean,
   ): void {
     render(
       <TooltipProvider>
         <FolderRow
           item={item(over)}
+          multiSelectEnabled={multiSelectEnabled}
           onEditEnvironment={onEdit}
           uncommittedByPath={EMPTY_COUNTS}
           boundaryEl={null}
@@ -324,6 +315,12 @@ describe("FolderRow", () => {
         />
       </TooltipProvider>,
     );
+  }
+  function renderRow(
+    over: Partial<WorkspaceRunItem>,
+    onEdit: (p: string) => void,
+  ): void {
+    renderRowWithMulti(over, onEdit, true);
   }
 
   it("opens the scripts editor from the ⚙ button in every mode", () => {
@@ -374,20 +371,32 @@ describe("FolderRow", () => {
     expect(writeText).toHaveBeenCalledWith("/wt/feat-login");
   });
 
-  it("hides the copy-path action for a new worktree that has no path yet", () => {
+  it("falls back to the source folder path for a new worktree that has no run path yet", () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
     renderRow({ mode: "worktree", currentIntent: null }, NOOP);
-    expect(screen.queryByLabelText("Copy folder path")).toBeNull();
+    fireEvent.click(screen.getByLabelText("Copy folder path"));
+    expect(writeText).toHaveBeenCalledWith("/repo");
   });
 
-  it("keeps the copy-path icon's default state free of stacked opacity attenuation and >=3:1 against the popover in every theme preset", () => {
+  it("keeps the revealed copy-path icon free of stacked opacity attenuation and >=3:1 against the popover in every theme preset", () => {
     renderRow(
       { mode: "local", displayPath: "/repo", currentIntent: null },
       NOOP,
     );
     const copyButton = screen.getByLabelText("Copy folder path");
-    // The bug was `text-muted-foreground/70` (a fractional text color) MULTIPLIED
-    // by an outer `opacity-[var(--fc-opacity,0.7)]` - ~49% effective opacity.
-    // Both must be gone from the default (non-hover) state.
+    // Hover-revealed: hidden at rest via the WRAPPER's opacity-0 (user
+    // decision - one copy icon per row reads as noise), shown on row
+    // hover/focus. The revealed state must still be free of the old bug:
+    // `text-muted-foreground/70` (a fractional text color) MULTIPLIED by an
+    // outer `opacity-[var(--fc-opacity,0.7)]` - ~49% effective opacity.
+    const wrapper = copyButton.closest("span");
+    expect(wrapper?.className).toContain("opacity-0");
+    expect(wrapper?.className).toContain("group-hover:opacity-100");
+    expect(wrapper?.className).toContain("group-focus-within:opacity-100");
     expect(copyButton.className).not.toMatch(/text-muted-foreground\/\d/);
     expect(copyButton.className).not.toMatch(/opacity-\[var\(--fc-opacity/);
     expect(copyButton.className).toContain("text-muted-foreground");
@@ -406,11 +415,11 @@ describe("FolderRow", () => {
     }
   });
 
-  it("keeps pin, identity, controls, and actions on one aligned row", () => {
+  it("keeps main marker, identity, controls, and actions on one aligned row", () => {
     renderRow({ displayName: "a-folder-name-that-needs-room" }, NOOP);
 
     const row = screen.getByTestId("folder-row");
-    const pin = screen.getByTestId("folder-primary-pin");
+    const pin = screen.getByTestId("folder-main-marker");
     const identity = screen.getByTestId("folder-chip");
     const actions = screen.getByTestId("folder-row-actions");
     const location = screen.getByTestId("folder-location-trigger");
@@ -436,19 +445,22 @@ describe("FolderRow", () => {
     expect(tooltipTextNear(identity.children[1])).toBe("/repo");
   });
 
-  it("reserves two stable trailing action slots", () => {
-    renderRow({ isPrimary: true, canChangePrimary: true }, NOOP);
+  it("reserves three stable trailing action slots (pin, scripts, remove)", () => {
+    renderRow({ isPrimary: true }, NOOP);
 
     const actions = screen.getByTestId("folder-row-actions");
-    expect(actions.children).toHaveLength(2);
+    expect(actions.children).toHaveLength(3);
     expect(actions.className).toContain("justify-self-end");
     expect(
-      actions.children[0].querySelector(
+      actions.children[0].querySelector('[data-testid="folder-pin-default"]'),
+    ).not.toBeNull();
+    expect(
+      actions.children[1].querySelector(
         '[data-testid="folder-scripts-trigger"]',
       ),
     ).not.toBeNull();
     expect(
-      actions.children[1].querySelector('[data-testid="folder-remove"]'),
+      actions.children[2].querySelector('[data-testid="folder-remove"]'),
     ).not.toBeNull();
   });
 
@@ -589,13 +601,26 @@ describe("FolderRow", () => {
     expect(screen.queryByTestId("folder-branch-trigger")).toBeNull();
   });
 
-  it("shows the delete button even for a single folder, wired to onRemove", () => {
+  it("shows the delete button even for a single folder, removing only after confirmation", () => {
     const onRemove = vi.fn();
     renderRow({ onRemove }, NOOP);
     const remove = screen.getByTestId("folder-remove");
     expect(remove).toBeTruthy();
+    // The trash opens a confirmation first - it never removes directly.
     fireEvent.click(remove);
+    expect(onRemove).not.toHaveBeenCalled();
+    const dialog = screen.getByTestId("confirm-destructive-dialog");
+    expect(dialog.textContent).toContain("Remove repo from saved projects?");
+    fireEvent.click(screen.getByTestId("confirm-action"));
     expect(onRemove).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancelling the remove confirmation keeps the project", () => {
+    const onRemove = vi.fn();
+    renderRow({ onRemove }, NOOP);
+    fireEvent.click(screen.getByTestId("folder-remove"));
+    fireEvent.click(screen.getByTestId("confirm-cancel"));
+    expect(onRemove).not.toHaveBeenCalled();
   });
 
   it("offers both Locate and Remove on an Unavailable row", () => {
@@ -608,6 +633,7 @@ describe("FolderRow", () => {
     expect(onLocate).toHaveBeenCalledTimes(1);
 
     fireEvent.click(screen.getByTestId("folder-remove"));
+    fireEvent.click(screen.getByTestId("confirm-action"));
     expect(onRemove).toHaveBeenCalledTimes(1);
   });
 
@@ -616,6 +642,7 @@ describe("FolderRow", () => {
       <TooltipProvider>
         <FolderRow
           item={item({ unresolved: true, onLocate: NOOP, onRemove: NOOP })}
+          multiSelectEnabled
           onEditEnvironment={NOOP}
           uncommittedByPath={EMPTY_COUNTS}
           boundaryEl={null}
@@ -628,126 +655,211 @@ describe("FolderRow", () => {
     expect(screen.queryByTestId("folder-remove")).toBeNull();
   });
 
-  it("shows a filled Primary pin with an explanatory tooltip", async () => {
-    renderRow({ isPrimary: true }, NOOP);
-    const pin = screen.getByTestId("folder-primary-pin");
-    expect(pin.tagName).toBe("BUTTON");
-    expect(pin.getAttribute("aria-disabled")).toBe("true");
-    expect(pin.getAttribute("aria-label")).toBe("Primary folder information");
-    expect(pin.querySelector("svg")?.getAttribute("fill")).toBe("currentColor");
-    tabForward();
-    expect(document.activeElement).toBe(pin);
+  it("marks the main row with the filled marker, a tinted row, and no checkbox", async () => {
+    renderRow({ isPrimary: true, selected: true }, NOOP);
+    const marker = screen.getByTestId("folder-main-marker");
+    expect(marker).toBeTruthy();
+    // The row tint replaced the old "Main" text badge (user decision).
+    expect(screen.getByTestId("folder-row").className).toContain(
+      "bg-primary/5",
+    );
+    expect(screen.queryByTestId("folder-main-badge")).toBeNull();
+    // The main slot is structural: there is no checkbox to uncheck.
+    expect(screen.queryByTestId("folder-select-checkbox")).toBeNull();
+    fireEvent.focus(marker);
     expect((await screen.findByRole("tooltip")).textContent).toContain(
       "New agent commands and terminals start here",
     );
   });
 
-  it("shows an outline locked pin with a disabled cursor and explanation", async () => {
-    renderRow({ isPrimary: false, canChangePrimary: false }, NOOP);
-    const pin = screen.getByTestId("folder-secondary-pin");
-    expect(pin.querySelector("svg")?.getAttribute("fill")).toBe("none");
-    expect(pin.getAttribute("aria-disabled")).toBe("true");
-    expect(pin.className).toContain("cursor-not-allowed");
-    fireEvent.focus(pin);
-    expect((await screen.findByRole("tooltip")).textContent).toContain(
-      "cannot be changed after the agent starts",
+  it("shows a plain checked checkbox (no main styling) on an additional row", () => {
+    renderRow({ isPrimary: false, selected: true }, NOOP);
+    const checkbox = screen.getByTestId("folder-select-checkbox");
+    expect(checkbox.getAttribute("data-state")).toBe("checked");
+    expect(screen.queryByTestId("folder-main-marker")).toBeNull();
+    expect(screen.getByTestId("folder-row").className).not.toContain(
+      "bg-primary/5",
     );
   });
 
-  it("explains the post-start lock on the filled Primary pin", async () => {
-    renderRow({ isPrimary: true, canChangePrimary: false }, NOOP);
-    const pin = screen.getByTestId("folder-primary-pin");
-    expect(pin.getAttribute("aria-disabled")).toBe("true");
-    expect(pin.className).toContain("cursor-not-allowed");
-    tabForward();
-    expect(document.activeElement).toBe(pin);
-    expect((await screen.findByRole("tooltip")).textContent).toContain(
-      "cannot be changed after the agent starts",
-    );
+  it("toggles additional membership through the checkbox, wired to onToggleSelected", () => {
+    const onToggleSelected = vi.fn();
+    renderRow({ isPrimary: false, selected: false, onToggleSelected }, NOOP);
+    const checkbox = screen.getByTestId("folder-select-checkbox");
+    expect(checkbox.getAttribute("data-state")).toBe("unchecked");
+    fireEvent.click(checkbox);
+    expect(onToggleSelected).toHaveBeenCalledWith(true);
   });
 
-  it("hides the Make primary action on the primary row itself", () => {
-    renderRow({ isPrimary: true, canChangePrimary: true }, NOOP);
-    expect(screen.queryByTestId("folder-make-primary")).toBeNull();
-    expect(screen.getByTestId("folder-primary-pin")).toBeTruthy();
+  it("switches the main project by clicking another row's name", () => {
+    const onUseAsMain = vi.fn();
+    renderRow({ isPrimary: false, selected: false, onUseAsMain }, NOOP);
+    const name = screen.getByTestId("folder-use-as-main");
+    expect(name.textContent).toBe("repo");
+    fireEvent.click(name);
+    expect(onUseAsMain).toHaveBeenCalledTimes(1);
   });
 
-  it("offers a keyboard-operable Make primary action on a non-primary row, wired to onMakePrimary", () => {
-    const onMakePrimary = vi.fn();
+  it("keeps the name inert (path tooltip only) when the main cannot move here", () => {
+    renderRow({ isPrimary: false, selected: true, onUseAsMain: null }, NOOP);
+    expect(screen.queryByTestId("folder-use-as-main")).toBeNull();
+  });
+
+  it("disables the checkbox with the given selection reason", () => {
+    const onToggleSelected = vi.fn();
     renderRow(
-      { isPrimary: false, canChangePrimary: true, onMakePrimary },
+      {
+        isPrimary: false,
+        selected: false,
+        onToggleSelected,
+        selectionDisabledReason: "Not available on the selected host.",
+      },
       NOOP,
     );
-    const button = screen.getByRole("button", { name: "Set as primary" });
-    expect(button).toBeTruthy();
-    expect(button.hasAttribute("disabled")).toBe(false);
-    fireEvent.click(button);
-    expect(onMakePrimary).toHaveBeenCalledTimes(1);
+    const checkbox = screen.getByTestId("folder-select-checkbox");
+    expect(checkbox.hasAttribute("disabled")).toBe(true);
+    fireEvent.click(checkbox);
+    expect(onToggleSelected).not.toHaveBeenCalled();
   });
 
-  it("replaces Make primary with a passive outline pin when the surface can't change primary", () => {
-    renderRow({ isPrimary: false, canChangePrimary: false }, NOOP);
-    expect(screen.queryByTestId("folder-make-primary")).toBeNull();
-    expect(screen.getByTestId("folder-secondary-pin")).toBeTruthy();
+  it("pins the default project for new tasks from the row actions", () => {
+    const onTogglePin = vi.fn();
+    renderRow({ isPinned: false, onTogglePin }, NOOP);
+    const pin = screen.getByTestId("folder-pin-default");
+    expect(pin.getAttribute("aria-pressed")).toBe("false");
+    expect(pin.querySelector("svg")?.getAttribute("fill")).toBe("none");
+    fireEvent.click(pin);
+    expect(onTogglePin).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps the disabled pin keyboard-reachable while metadata is pending", async () => {
+  it("fills the pin on the pinned default project with an explanatory tooltip", async () => {
+    renderRow({ isPinned: true }, NOOP);
+    const pin = screen.getByTestId("folder-pin-default");
+    expect(pin.getAttribute("aria-pressed")).toBe("true");
+    expect(pin.querySelector("svg")?.getAttribute("fill")).toBe("currentColor");
+    fireEvent.focus(pin);
+    expect((await screen.findByRole("tooltip")).textContent).toContain(
+      "New tasks start with this project selected",
+    );
+  });
+
+  it("hides the pin slot for a row outside the saved list", () => {
+    renderRow({ onTogglePin: null }, NOOP);
+    expect(screen.queryByTestId("folder-pin-default")).toBeNull();
+  });
+
+  it("shows display-only facts (no location/branch controls) on an unselected row", () => {
+    let edited = "";
+    renderRow(
+      { selected: false, isPrimary: false, branchLabel: "development" },
+      (p) => {
+        edited = p;
+      },
+    );
+    const facts = screen.getByTestId("folder-row-unselected-facts");
+    expect(facts.textContent).toContain("development");
+    // The branch fact renders in the Branch track; the Location track stays
+    // an (empty) separate cell so the column headers hold for every row.
+    expect(screen.getByTestId("folder-row-unselected-location")).toBeTruthy();
+    expect(screen.queryByTestId("folder-location-trigger")).toBeNull();
+    expect(screen.queryByTestId("folder-branch-trigger")).toBeNull();
+    // The saved-list actions stay available - including scripts, which are a
+    // property of the saved project, not of the chat's selection.
+    fireEvent.click(screen.getByTestId("folder-scripts-trigger"));
+    expect(edited).toBe("/repo");
+    expect(screen.getByTestId("folder-pin-default")).toBeTruthy();
+    expect(screen.getByTestId("folder-remove")).toBeTruthy();
+  });
+
+  it("hides the checkbox on an unselected row when multi-select is off, keeping the switch affordance", () => {
+    const onUseAsMain = vi.fn();
+    renderRowWithMulti(
+      { selected: false, isPrimary: false, onUseAsMain },
+      NOOP,
+      false,
+    );
+    expect(screen.queryByTestId("folder-select-checkbox")).toBeNull();
+    // An empty spacer keeps the grid's first column aligned.
+    expect(screen.getByTestId("folder-select-spacer")).toBeTruthy();
+    // The row can still become the main project by clicking its name.
+    fireEvent.click(screen.getByTestId("folder-use-as-main"));
+    expect(onUseAsMain).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the checkbox on a still-selected extra when multi-select is off", () => {
+    const onToggleSelected = vi.fn();
+    renderRowWithMulti(
+      { selected: true, isPrimary: false, onToggleSelected },
+      NOOP,
+      false,
+    );
+    const checkbox = screen.getByTestId("folder-select-checkbox");
+    expect(checkbox.getAttribute("data-state")).toBe("checked");
+    fireEvent.click(checkbox);
+    expect(onToggleSelected).toHaveBeenCalledWith(false);
+  });
+
+  it("keeps remove live while metadata is pending", () => {
+    const onRemove = vi.fn();
+    renderRow(
+      { metadataPending: true, isPrimary: false, summary: null, onRemove },
+      NOOP,
+    );
+    expect(screen.getByTestId("folder-row-loading")).toBeTruthy();
+    fireEvent.click(screen.getByTestId("folder-remove"));
+    fireEvent.click(screen.getByTestId("confirm-action"));
+    expect(onRemove).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables checking an unresolved row with an explanation, keeping Locate and Remove live", () => {
+    const onToggleSelected = vi.fn();
+    const onLocate = vi.fn();
     const onRemove = vi.fn();
     renderRow(
       {
-        metadataPending: true,
+        unresolved: true,
+        selected: false,
         isPrimary: false,
-        canChangePrimary: true,
-        makePrimaryDisabled: true,
-        makePrimaryDisabledReason: "Loading folder metadata",
-        summary: null,
+        onToggleSelected,
+        selectionDisabledReason: "Not available on the selected host.",
+        onLocate,
         onRemove,
       },
       NOOP,
     );
-    expect(screen.getByTestId("folder-row-loading")).toBeTruthy();
-    // aria-disabled keeps the explanation in normal keyboard traversal while
-    // guarding activation during the fetch.
-    const pin = screen.getByTestId("folder-make-primary");
-    expect(pin.hasAttribute("disabled")).toBe(false);
-    expect(pin.getAttribute("aria-disabled")).toBe("true");
-    tabForward();
-    expect(document.activeElement).toBe(pin);
-    const tooltip = await screen.findByRole("tooltip");
-    expect(pin.getAttribute("aria-describedby")).toBe(tooltip.id);
-    expect(tooltip.textContent).toContain("Loading folder metadata");
-    // Remove stays live - a pending row is still removable.
+    const checkbox = screen.getByTestId("folder-select-checkbox");
+    expect(checkbox.hasAttribute("disabled")).toBe(true);
+    fireEvent.click(checkbox);
+    expect(onToggleSelected).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByTestId("folder-row-locate"));
+    expect(onLocate).toHaveBeenCalledTimes(1);
     fireEvent.click(screen.getByTestId("folder-remove"));
+    fireEvent.click(screen.getByTestId("confirm-action"));
     expect(onRemove).toHaveBeenCalledTimes(1);
   });
 
-  it("tabs to the disabled Make primary explanation for an unresolved row", async () => {
-    const onMakePrimary = vi.fn();
+  it("switches the main by clicking the row's empty background, but not its controls", () => {
+    const onUseAsMain = vi.fn();
+    const onToggleSelected = vi.fn();
     renderRow(
-      {
-        unresolved: true,
-        isPrimary: false,
-        canChangePrimary: true,
-        makePrimaryDisabled: true,
-        makePrimaryDisabledReason: "Resolve this folder to make it primary",
-        onLocate: NOOP,
-        onMakePrimary,
-        onRemove: NOOP,
-      },
+      { isPrimary: false, selected: false, onUseAsMain, onToggleSelected },
       NOOP,
     );
-    const button = screen.getByTestId("folder-make-primary");
-    expect(button.hasAttribute("disabled")).toBe(false);
-    expect(button.getAttribute("aria-disabled")).toBe("true");
-    tabForward();
-    expect(document.activeElement).toBe(button);
-    const tooltip = await screen.findByRole("tooltip");
-    expect(button.getAttribute("aria-describedby")).toBe(tooltip.id);
-    expect(tooltip.textContent).toContain(
-      "Resolve this folder to make it primary",
-    );
-    fireEvent.click(button);
-    expect(onMakePrimary).not.toHaveBeenCalled();
+    // A click on one of the row's own controls must NOT switch the main...
+    fireEvent.click(screen.getByTestId("folder-select-checkbox"));
+    expect(onUseAsMain).not.toHaveBeenCalled();
+    // ...while a click on the row's background does.
+    fireEvent.click(screen.getByTestId("folder-row"));
+    expect(onUseAsMain).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the row background inert when the main cannot move here", () => {
+    renderRow({ isPrimary: false, selected: true, onUseAsMain: null }, NOOP);
+    const row = screen.getByTestId("folder-row");
+    expect(row.className).not.toContain("cursor-pointer");
+    fireEvent.click(row);
+    // No handler to call - nothing to assert beyond not crashing; the
+    // affordance classes are the observable contract.
   });
 });
 
@@ -775,6 +887,129 @@ describe("WorkspaceFolderRows", () => {
     expect(screen.getByTestId("device-slot")).toBeTruthy();
     expect(screen.getByTestId("folder-row")).toBeTruthy();
     expect(screen.getByTestId("folder-add")).toBeTruthy();
+    // The column header names the grid's tracks above the rows.
+    const header = screen.getByTestId("workspace-folder-header");
+    expect(header.textContent).toContain("Project");
+    expect(header.textContent).toContain("Location");
+    expect(header.textContent).toContain("Branch");
+  });
+
+  it("renders the multi-select toggle on the Add-folder line, reflecting the global preference", () => {
+    render(
+      <TooltipProvider>
+        <WorkspaceFolderRows
+          items={[
+            item({}),
+            item({
+              key: "/repo2",
+              displayName: "repo2",
+              isPrimary: false,
+              selected: false,
+            }),
+          ]}
+          trailingSlot={null}
+          onAddFolder={NOOP_ADD}
+          addFolderPending={false}
+          addFolderDisabled={false}
+          addFolderDisabledReason={null}
+          onUpdate={null}
+          updateEnabled={false}
+          updatePending={false}
+          onEditEnvironment={NOOP}
+          nestedInPopover={false}
+          readOnly={false}
+          bindingResolved
+        />
+      </TooltipProvider>,
+    );
+    const toggle = screen.getByTestId("workspace-multi-folder-toggle");
+    expect(toggle.textContent).toContain("Allow multiple folders in chat");
+    const checkbox = screen.getByTestId(
+      "workspace-multi-folder-toggle-checkbox",
+    );
+    // Off by default: single-project chats until the user opts in.
+    expect(checkbox.getAttribute("data-state")).toBe("unchecked");
+    // ...which also hides the unselected row's additional checkbox.
+    expect(screen.queryByTestId("folder-select-checkbox")).toBeNull();
+    fireEvent.click(checkbox);
+    expect(useWorkspaceFoldersStore.getState().allowMultipleFolders).toBe(true);
+    expect(screen.getByTestId("folder-select-checkbox")).toBeTruthy();
+  });
+
+  it("unticking the toggle deselects every additional folder but never the main", () => {
+    useWorkspaceFoldersStore.setState({ allowMultipleFolders: true });
+    const onToggleMain = vi.fn();
+    const onToggleExtra = vi.fn();
+    const onToggleUnselected = vi.fn();
+    render(
+      <TooltipProvider>
+        <WorkspaceFolderRows
+          items={[
+            item({ onToggleSelected: onToggleMain }),
+            item({
+              key: "/repo2",
+              displayName: "repo2",
+              isPrimary: false,
+              selected: true,
+              onToggleSelected: onToggleExtra,
+            }),
+            item({
+              key: "/repo3",
+              displayName: "repo3",
+              isPrimary: false,
+              selected: false,
+              onToggleSelected: onToggleUnselected,
+            }),
+          ]}
+          trailingSlot={null}
+          onAddFolder={NOOP_ADD}
+          addFolderPending={false}
+          addFolderDisabled={false}
+          addFolderDisabledReason={null}
+          onUpdate={null}
+          updateEnabled={false}
+          updatePending={false}
+          onEditEnvironment={NOOP}
+          nestedInPopover={false}
+          readOnly={false}
+          bindingResolved
+        />
+      </TooltipProvider>,
+    );
+    fireEvent.click(
+      screen.getByTestId("workspace-multi-folder-toggle-checkbox"),
+    );
+    expect(useWorkspaceFoldersStore.getState().allowMultipleFolders).toBe(
+      false,
+    );
+    // Only the still-selected EXTRA leaves the chat; the main row and the
+    // already-unselected saved row are untouched.
+    expect(onToggleExtra).toHaveBeenCalledWith(false);
+    expect(onToggleMain).not.toHaveBeenCalled();
+    expect(onToggleUnselected).not.toHaveBeenCalled();
+  });
+
+  it("hides the multi-select toggle on read-only surfaces", () => {
+    render(
+      <TooltipProvider>
+        <WorkspaceFolderRows
+          items={[item({})]}
+          trailingSlot={null}
+          onAddFolder={NOOP_ADD}
+          addFolderPending={false}
+          addFolderDisabled={false}
+          addFolderDisabledReason={null}
+          onUpdate={null}
+          updateEnabled={false}
+          updatePending={false}
+          onEditEnvironment={NOOP}
+          nestedInPopover={false}
+          readOnly
+          bindingResolved
+        />
+      </TooltipProvider>,
+    );
+    expect(screen.queryByTestId("workspace-multi-folder-toggle")).toBeNull();
   });
 
   it("lets the container own all text-track widths so long values cannot overflow a modal", () => {
@@ -822,8 +1057,10 @@ describe("WorkspaceFolderRows", () => {
     );
 
     const grid = screen.getByTestId("workspace-folder-grid");
+    // Project gets a wider text track (long repo names must stay readable),
+    // balanced against the Branch track's from-source annotations.
     expect(grid.className).toContain(
-      "grid-cols-[1.5rem_minmax(0,1fr)_minmax(0,1fr)_minmax(0,1.5fr)_auto]",
+      "grid-cols-[1.5rem_minmax(0,1.1fr)_minmax(0,1fr)_minmax(0,1.25fr)_auto]",
     );
     expect(grid.className).not.toContain("max-content");
 
@@ -1017,11 +1254,15 @@ describe("WorkspaceFolderRows", () => {
 });
 
 describe("WorkspaceSummaryTrigger", () => {
-  it("summarizes the primary folder and extra count", () => {
+  it("summarizes the first two selected projects and folds the rest into +N", () => {
     render(
       <TooltipProvider>
         <WorkspaceSummaryTrigger
-          items={[item({}), item({ key: "/repo2", displayName: "repo2" })]}
+          items={[
+            item({}),
+            item({ key: "/repo2", displayName: "repo2", isPrimary: false }),
+            item({ key: "/repo3", displayName: "repo3", isPrimary: false }),
+          ]}
           readOnly={false}
           bindingResolved
         />
@@ -1030,7 +1271,34 @@ describe("WorkspaceSummaryTrigger", () => {
     const trigger = screen.getByTestId("workspace-summary-trigger");
     expect(trigger.textContent).toContain("repo");
     expect(trigger.textContent).toContain("feat/x");
+    expect(screen.getByTestId("workspace-summary-secondary").textContent).toBe(
+      "repo2",
+    );
     expect(trigger.textContent).toContain("+1");
+  });
+
+  it("keeps unselected saved projects out of the collapsed summary", () => {
+    render(
+      <TooltipProvider>
+        <WorkspaceSummaryTrigger
+          items={[
+            item({}),
+            item({
+              key: "/repo2",
+              displayName: "repo2",
+              isPrimary: false,
+              selected: false,
+            }),
+          ]}
+          readOnly={false}
+          bindingResolved
+        />
+      </TooltipProvider>,
+    );
+    const trigger = screen.getByTestId("workspace-summary-trigger");
+    expect(trigger.textContent).toContain("repo");
+    expect(screen.queryByTestId("workspace-summary-secondary")).toBeNull();
+    expect(trigger.textContent).not.toContain("+1");
   });
 
   it("shows the new target and its source in the collapsed workspace trigger", () => {

--- a/clients/gui-app/src/components/home/host-workspace-selector/__tests__/home-summary-empty.test.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/__tests__/home-summary-empty.test.tsx
@@ -383,7 +383,11 @@ describe("landing workspace summary empty state", () => {
     useInitialChatHandoffStore.getState().resetForTests();
     useComposerRunSettingsStore.getState().resetForTests();
     draftRuntimeRegistry.resetForTesting();
-    useLandingDraftStore.setState({ drafts: [], activeDraftId: null });
+    useLandingDraftStore.setState({
+      drafts: [],
+      activeDraftId: null,
+      pendingWorkspace: null,
+    });
     useEpicCanvasStore.setState({
       tabsById: {},
       openTabOrder: [],
@@ -394,6 +398,7 @@ describe("landing workspace summary empty state", () => {
       folders: [],
       folderInfoByPath: {},
       primaryPath: null,
+      pinnedPath: null,
     });
     useWorktreeIntentMemoryStore.getState().resetForTests();
     useWorktreeIntentStagingStore.getState().resetForTests();
@@ -407,7 +412,11 @@ describe("landing workspace summary empty state", () => {
     useInitialChatHandoffStore.getState().resetForTests();
     useComposerRunSettingsStore.getState().resetForTests();
     draftRuntimeRegistry.resetForTesting();
-    useLandingDraftStore.setState({ drafts: [], activeDraftId: null });
+    useLandingDraftStore.setState({
+      drafts: [],
+      activeDraftId: null,
+      pendingWorkspace: null,
+    });
     useEpicCanvasStore.setState({
       tabsById: {},
       openTabOrder: [],
@@ -418,6 +427,7 @@ describe("landing workspace summary empty state", () => {
       folders: [],
       folderInfoByPath: {},
       primaryPath: null,
+      pinnedPath: null,
     });
     useWorktreeIntentMemoryStore.getState().resetForTests();
     useWorktreeIntentStagingStore.getState().resetForTests();
@@ -444,6 +454,19 @@ describe("landing workspace summary empty state", () => {
   });
 
   it("queries disk metadata for unresolved folders and renders them usable when git exists", () => {
+    // The folder must be part of the chat's selection (the global list in the
+    // no-draft fallback) for the interactive location/branch controls to show.
+    useWorkspaceFoldersStore.setState({
+      folders: ["/workspace/app"],
+      folderInfoByPath: {
+        "/workspace/app": {
+          path: "/workspace/app",
+          name: "app",
+          repoIdentifier: { owner: "acme", repo: "app" },
+        },
+      },
+      primaryPath: "/workspace/app",
+    });
     mocks.resolvedWorkspace.current = {
       folders: [
         {
@@ -476,6 +499,17 @@ describe("landing workspace summary empty state", () => {
   });
 
   it("renders unresolved folders with non-git disk metadata as local-only folders", async () => {
+    useWorkspaceFoldersStore.setState({
+      folders: ["/workspace/app"],
+      folderInfoByPath: {
+        "/workspace/app": {
+          path: "/workspace/app",
+          name: "app",
+          repoIdentifier: { owner: "acme", repo: "app" },
+        },
+      },
+      primaryPath: "/workspace/app",
+    });
     mocks.resolvedWorkspace.current = {
       folders: [
         {
@@ -820,6 +854,14 @@ describe("landing workspace summary empty state", () => {
         },
         primaryPath: folderAPath,
       });
+      // The blank landing edits a per-chat PENDING snapshot now: adding B to
+      // the saved list alone no longer selects it into the chat - staged
+      // intent seeding only covers selected rows, so select B explicitly.
+      useLandingDraftStore
+        .getState()
+        .addPendingResolvedFolders([
+          { path: folderBPath, name: "lib", repoIdentifier: folderBRepo },
+        ]);
     });
 
     await waitFor(() => {

--- a/clients/gui-app/src/components/home/host-workspace-selector/__tests__/in-epic-surface-primary-readonly.test.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/__tests__/in-epic-surface-primary-readonly.test.tsx
@@ -184,7 +184,7 @@ afterEach(() => {
 describe.each(["chat", "terminal-agent"] as const)(
   "InEpicSurface (%s owner)",
   (kind) => {
-    it("renders the primary pin read-only and offers NO Set-as-primary action on any bound row", async () => {
+    it("locks the bound main as a marker row; secondaries keep additional checkboxes", async () => {
       renderBoundSurface(kind);
 
       // Open the folder-rows popover from the collapsed summary.
@@ -192,16 +192,34 @@ describe.each(["chat", "terminal-agent"] as const)(
       const rows = await screen.findAllByTestId("folder-row");
       expect(rows).toHaveLength(2);
 
-      // The filled pin marks the bound primary (read-only display)...
-      expect(screen.getByTestId("folder-primary-pin")).toBeTruthy();
-      // ...and the collapsed chip agreed with it (isPrimary, not items[0]).
+      // The bound PRIMARY (beta, `isPrimary` — not array position) renders
+      // the locked main marker + badge, with no checkbox to uncheck...
+      const alphaRow = rows.find(
+        (row) => row.getAttribute("data-path") === "/repo/alpha",
+      );
+      const betaRow = rows.find(
+        (row) => row.getAttribute("data-path") === "/repo/beta",
+      );
+      expect(
+        betaRow?.querySelector('[data-testid="folder-main-marker"]'),
+      ).not.toBeNull();
+      expect(betaRow?.className).toContain("bg-primary/5");
+      expect(
+        betaRow?.querySelector('[data-testid="folder-select-checkbox"]'),
+      ).toBeNull();
+      // ...the secondary keeps its checked additional-folder checkbox...
+      const alphaCheckbox = alphaRow?.querySelector(
+        '[data-testid="folder-select-checkbox"]',
+      );
+      expect(alphaCheckbox?.getAttribute("data-state")).toBe("checked");
+      // ...and the collapsed chip agreed with the marker (isPrimary, not
+      // items[0]).
       expect(
         screen.getByTestId("workspace-summary-trigger").textContent,
       ).toContain("beta");
 
-      // No atomic set-primary RPC exists for a live binding - the action
-      // must be absent on EVERY row of a bound surface.
-      expect(screen.queryByTestId("folder-make-primary")).toBeNull();
+      // A live chat's main is fixed: no switch affordance on any row.
+      expect(screen.queryByTestId("folder-use-as-main")).toBeNull();
       // The other row actions are still there (the rows are editable).
       expect(screen.getAllByTestId("folder-remove").length).toBeGreaterThan(0);
     });

--- a/clients/gui-app/src/components/home/host-workspace-selector/__tests__/in-epic-surface-primary-readonly.test.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/__tests__/in-epic-surface-primary-readonly.test.tsx
@@ -1,6 +1,12 @@
 import "../../../../../__tests__/test-browser-apis";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
 import type {
   WorktreeBinding,
   WorktreeBindingEntry,
@@ -188,40 +194,45 @@ describe.each(["chat", "terminal-agent"] as const)(
       renderBoundSurface(kind);
 
       // Open the folder-rows popover from the collapsed summary.
-      fireEvent.click(screen.getByTestId("workspace-summary-trigger"));
-      const rows = await screen.findAllByTestId("folder-row");
-      expect(rows).toHaveLength(2);
+      const summary = screen.getByRole("button", {
+        name: /beta.*alpha/i,
+      });
+      fireEvent.click(summary);
+      const alphaRow = await screen.findByRole("group", {
+        name: "alpha project",
+      });
+      const betaRow = screen.getByRole("group", {
+        name: "beta project",
+      });
 
       // The bound PRIMARY (beta, `isPrimary` — not array position) renders
-      // the locked main marker + badge, with no checkbox to uncheck...
-      const alphaRow = rows.find(
-        (row) => row.getAttribute("data-path") === "/repo/alpha",
-      );
-      const betaRow = rows.find(
-        (row) => row.getAttribute("data-path") === "/repo/beta",
-      );
+      // the locked main marker, with no checkbox to uncheck...
       expect(
-        betaRow?.querySelector('[data-testid="folder-main-marker"]'),
-      ).not.toBeNull();
-      expect(betaRow?.className).toContain("bg-primary/5");
-      expect(
-        betaRow?.querySelector('[data-testid="folder-select-checkbox"]'),
-      ).toBeNull();
+        within(betaRow).getByRole("img", { name: "Main project" }),
+      ).toBeTruthy();
+      expect(within(betaRow).queryByRole("checkbox")).toBeNull();
       // ...the secondary keeps its checked additional-folder checkbox...
-      const alphaCheckbox = alphaRow?.querySelector(
-        '[data-testid="folder-select-checkbox"]',
-      );
-      expect(alphaCheckbox?.getAttribute("data-state")).toBe("checked");
-      // ...and the collapsed chip agreed with the marker (isPrimary, not
-      // items[0]).
       expect(
-        screen.getByTestId("workspace-summary-trigger").textContent,
-      ).toContain("beta");
+        within(alphaRow).getByRole("checkbox", {
+          name: "Also use alpha in this chat",
+          checked: true,
+        }),
+      ).toBeTruthy();
+      // ...and the collapsed summary agreed with the marker (isPrimary, not
+      // items[0]) by naming beta first, as asserted by the role query above.
 
       // A live chat's main is fixed: no switch affordance on any row.
-      expect(screen.queryByTestId("folder-use-as-main")).toBeNull();
+      expect(
+        screen.queryByRole("button", {
+          name: /as the main project for this chat/i,
+        }),
+      ).toBeNull();
       // The other row actions are still there (the rows are editable).
-      expect(screen.getAllByTestId("folder-remove").length).toBeGreaterThan(0);
+      expect(
+        within(alphaRow).getByRole("button", {
+          name: "Remove alpha from saved projects",
+        }),
+      ).toBeTruthy();
     });
   },
 );

--- a/clients/gui-app/src/components/home/host-workspace-selector/__tests__/use-home-workspace-source-cap-eviction.test.ts
+++ b/clients/gui-app/src/components/home/host-workspace-selector/__tests__/use-home-workspace-source-cap-eviction.test.ts
@@ -59,8 +59,16 @@ beforeEach(() => {
     folders: [],
     folderInfoByPath: {},
     primaryPath: null,
+    pinnedPath: null,
+    // These scenarios exercise MULTI-folder adds; with the default
+    // single-project mode an add would switch the main instead.
+    allowMultipleFolders: true,
   });
-  useLandingDraftStore.setState({ drafts: [], activeDraftId: null });
+  useLandingDraftStore.setState({
+    drafts: [],
+    activeDraftId: null,
+    pendingWorkspace: null,
+  });
   useWorktreeIntentStagingStore.getState().resetForTests();
 });
 
@@ -69,8 +77,14 @@ afterEach(() => {
     folders: [],
     folderInfoByPath: {},
     primaryPath: null,
+    pinnedPath: null,
+    allowMultipleFolders: false,
   });
-  useLandingDraftStore.setState({ drafts: [], activeDraftId: null });
+  useLandingDraftStore.setState({
+    drafts: [],
+    activeDraftId: null,
+    pendingWorkspace: null,
+  });
   useWorktreeIntentStagingStore.getState().resetForTests();
 });
 
@@ -133,6 +147,11 @@ describe("useHomeWorkspaceSource addResolvedFolders - cap eviction unstages the 
     );
     useWorkspaceFoldersStore.getState().addResolvedFolders(initialFolders);
     const draftId = useLandingDraftStore.getState().createDraft(null);
+    // A new draft seeds with only the pinned default now - build the full
+    // divergent 50-folder draft membership explicitly.
+    useLandingDraftStore
+      .getState()
+      .addDraftResolvedFolders(draftId, initialFolders);
 
     // Keep both representations at the supported 50-folder cap while making
     // their membership and primary choices diverge. On the next add, global

--- a/clients/gui-app/src/components/home/host-workspace-selector/__tests__/use-home-workspace-source-primary.test.ts
+++ b/clients/gui-app/src/components/home/host-workspace-selector/__tests__/use-home-workspace-source-primary.test.ts
@@ -24,8 +24,13 @@ function resetStores(): void {
     folders: [],
     folderInfoByPath: {},
     primaryPath: null,
+    allowMultipleFolders: false,
   });
-  useLandingDraftStore.setState({ drafts: [], activeDraftId: null });
+  useLandingDraftStore.setState({
+    drafts: [],
+    activeDraftId: null,
+    pendingWorkspace: null,
+  });
   useWorktreeIntentStagingStore.getState().resetForTests();
 }
 
@@ -41,6 +46,9 @@ afterEach(resetStores);
  */
 describe("useHomeWorkspaceSource primaryWorkspacePath - the pinned folder wins", () => {
   it("resolves the pinned folder, not the first one (no active draft)", () => {
+    // Adding TWO folders needs multi-select on; in the default single-project
+    // mode the add would keep only the first as the pending landing's main.
+    useWorkspaceFoldersStore.setState({ allowMultipleFolders: true });
     const stagingKey: WorktreeStagingKey = {
       surface: "landing",
       draftId: null,
@@ -62,6 +70,9 @@ describe("useHomeWorkspaceSource primaryWorkspacePath - the pinned folder wins",
   });
 
   it("resolves the pinned folder for the active landing draft", () => {
+    // A draft-backed add of TWO folders needs multi-select on; in the default
+    // single-project mode the add would switch the main instead.
+    useWorkspaceFoldersStore.setState({ allowMultipleFolders: true });
     const draftId = useLandingDraftStore.getState().createDraft(null);
     const stagingKey: WorktreeStagingKey = { surface: "landing", draftId };
     const { result } = renderHook(() =>

--- a/clients/gui-app/src/components/home/host-workspace-selector/__tests__/use-home-workspace-source-primary.test.ts
+++ b/clients/gui-app/src/components/home/host-workspace-selector/__tests__/use-home-workspace-source-primary.test.ts
@@ -24,6 +24,7 @@ function resetStores(): void {
     folders: [],
     folderInfoByPath: {},
     primaryPath: null,
+    pinnedPath: null,
     allowMultipleFolders: false,
   });
   useLandingDraftStore.setState({

--- a/clients/gui-app/src/components/home/host-workspace-selector/__tests__/use-home-workspace-source-selection.test.ts
+++ b/clients/gui-app/src/components/home/host-workspace-selector/__tests__/use-home-workspace-source-selection.test.ts
@@ -1,0 +1,377 @@
+import "../../../../../__tests__/test-browser-apis";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useHomeWorkspaceSource } from "../use-home-workspace-source";
+import { useWorkspaceFoldersStore } from "@/stores/workspace/workspace-folders-store";
+import { useLandingDraftStore } from "@/stores/home/landing-draft-store";
+import { useWorktreeIntentStagingStore } from "@/stores/worktree/worktree-intent-staging-store";
+import type { WorkspaceFolderInfo } from "@/stores/workspace/workspace-folders-store";
+import type { WorktreeStagingKey } from "@/stores/worktree/worktree-intent-staging-store";
+
+function folder(name: string): WorkspaceFolderInfo {
+  return { path: `/tmp/${name}`, name, repoIdentifier: null };
+}
+
+const ALPHA = folder("alpha");
+const BETA = folder("beta");
+const GAMMA = folder("gamma");
+
+function resetStores(): void {
+  window.localStorage.clear();
+  useWorkspaceFoldersStore.setState({
+    folders: [],
+    folderInfoByPath: {},
+    primaryPath: null,
+    pinnedPath: null,
+    allowMultipleFolders: false,
+  });
+  useLandingDraftStore.setState({
+    drafts: [],
+    activeDraftId: null,
+    pendingWorkspace: null,
+  });
+  useWorktreeIntentStagingStore.getState().resetForTests();
+}
+
+beforeEach(resetStores);
+afterEach(resetStores);
+
+function seedSavedProjects(): void {
+  useWorkspaceFoldersStore.setState({
+    folders: [ALPHA.path, BETA.path, GAMMA.path],
+    folderInfoByPath: {
+      [ALPHA.path]: ALPHA,
+      [BETA.path]: BETA,
+      [GAMMA.path]: GAMMA,
+    },
+    primaryPath: ALPHA.path,
+    pinnedPath: ALPHA.path,
+  });
+}
+
+function draftWorkspaceOf(draftId: string) {
+  return useLandingDraftStore
+    .getState()
+    .drafts.find((draft) => draft.id === draftId)?.workspace;
+}
+
+describe("useHomeWorkspaceSource - saved-list selection", () => {
+  it("selectFolder adds a SAVED project to the draft only; the saved list is untouched", () => {
+    seedSavedProjects();
+    const draftId = useLandingDraftStore.getState().createDraft(null);
+    const stagingKey: WorktreeStagingKey = { surface: "landing", draftId };
+    const { result } = renderHook(() =>
+      useHomeWorkspaceSource(stagingKey, null),
+    );
+
+    // A new draft seeds with the pinned default only.
+    expect(result.current.folders).toEqual([ALPHA.path]);
+    expect(result.current.canToggleSelection).toBe(true);
+
+    act(() => {
+      result.current.selectFolder(BETA.path);
+    });
+
+    expect(draftWorkspaceOf(draftId)?.folders).toEqual([ALPHA.path, BETA.path]);
+    expect(useWorkspaceFoldersStore.getState().folders).toEqual([
+      ALPHA.path,
+      BETA.path,
+      GAMMA.path,
+    ]);
+  });
+
+  it("deselectFolder removes from the draft only and keeps the project saved", () => {
+    seedSavedProjects();
+    const draftId = useLandingDraftStore.getState().createDraft(null);
+    const stagingKey: WorktreeStagingKey = { surface: "landing", draftId };
+    const { result } = renderHook(() =>
+      useHomeWorkspaceSource(stagingKey, null),
+    );
+    act(() => {
+      result.current.selectFolder(BETA.path);
+    });
+
+    act(() => {
+      result.current.deselectFolder(ALPHA.path);
+    });
+
+    expect(draftWorkspaceOf(draftId)?.folders).toEqual([BETA.path]);
+    // The saved list AND the pin are untouched by a per-chat deselect.
+    expect(useWorkspaceFoldersStore.getState().folders).toEqual([
+      ALPHA.path,
+      BETA.path,
+      GAMMA.path,
+    ]);
+    expect(useWorkspaceFoldersStore.getState().pinnedPath).toBe(ALPHA.path);
+  });
+
+  it("deselecting the primary reports the reassignment for the live region", () => {
+    seedSavedProjects();
+    const draftId = useLandingDraftStore.getState().createDraft(null);
+    const stagingKey: WorktreeStagingKey = { surface: "landing", draftId };
+    const { result } = renderHook(() =>
+      useHomeWorkspaceSource(stagingKey, null),
+    );
+    act(() => {
+      result.current.selectFolder(BETA.path);
+    });
+
+    let transition: {
+      primaryChanged: boolean;
+      newPrimaryName: string | null;
+    } = { primaryChanged: false, newPrimaryName: null };
+    act(() => {
+      transition = result.current.deselectFolder(ALPHA.path);
+    });
+
+    expect(transition.primaryChanged).toBe(true);
+    expect(transition.newPrimaryName).toBe(BETA.name);
+  });
+
+  it("removeFolder deletes from the saved list AND the draft selection", () => {
+    seedSavedProjects();
+    const draftId = useLandingDraftStore.getState().createDraft(null);
+    const stagingKey: WorktreeStagingKey = { surface: "landing", draftId };
+    const { result } = renderHook(() =>
+      useHomeWorkspaceSource(stagingKey, null),
+    );
+
+    act(() => {
+      result.current.removeFolder(ALPHA.path);
+    });
+
+    expect(useWorkspaceFoldersStore.getState().folders).toEqual([
+      BETA.path,
+      GAMMA.path,
+    ]);
+    expect(draftWorkspaceOf(draftId)?.folders).toEqual([]);
+  });
+
+  it("setPinnedFolder writes the global default without touching the draft selection", () => {
+    seedSavedProjects();
+    const draftId = useLandingDraftStore.getState().createDraft(null);
+    const stagingKey: WorktreeStagingKey = { surface: "landing", draftId };
+    const { result } = renderHook(() =>
+      useHomeWorkspaceSource(stagingKey, null),
+    );
+
+    act(() => {
+      result.current.setPinnedFolder(GAMMA.path);
+    });
+
+    expect(useWorkspaceFoldersStore.getState().pinnedPath).toBe(GAMMA.path);
+    expect(draftWorkspaceOf(draftId)?.folders).toEqual([ALPHA.path]);
+  });
+
+  it("switchMainFolder swaps the main in one action, keeping additional folders", () => {
+    seedSavedProjects();
+    const draftId = useLandingDraftStore.getState().createDraft(null);
+    const stagingKey: WorktreeStagingKey = { surface: "landing", draftId };
+    const { result } = renderHook(() =>
+      useHomeWorkspaceSource(stagingKey, null),
+    );
+    // Main: alpha (pinned seed) + beta checked as additional.
+    act(() => {
+      result.current.selectFolder(BETA.path);
+    });
+
+    act(() => {
+      result.current.switchMainFolder(GAMMA.path);
+    });
+
+    const workspace = draftWorkspaceOf(draftId);
+    // Old main (alpha) left the chat; the additional folder (beta) stayed;
+    // gamma is the new main.
+    expect(workspace?.folders).toEqual([BETA.path, GAMMA.path]);
+    expect(workspace?.primaryPath).toBe(GAMMA.path);
+    // The saved list and pin are untouched by a per-chat switch.
+    expect(useWorkspaceFoldersStore.getState().folders).toEqual([
+      ALPHA.path,
+      BETA.path,
+      GAMMA.path,
+    ]);
+    expect(useWorkspaceFoldersStore.getState().pinnedPath).toBe(ALPHA.path);
+  });
+
+  it("switchMainFolder promotes an additional folder without duplicating it", () => {
+    seedSavedProjects();
+    const draftId = useLandingDraftStore.getState().createDraft(null);
+    const stagingKey: WorktreeStagingKey = { surface: "landing", draftId };
+    const { result } = renderHook(() =>
+      useHomeWorkspaceSource(stagingKey, null),
+    );
+    act(() => {
+      result.current.selectFolder(BETA.path);
+    });
+
+    act(() => {
+      result.current.switchMainFolder(BETA.path);
+    });
+
+    const workspace = draftWorkspaceOf(draftId);
+    expect(workspace?.folders).toEqual([BETA.path]);
+    expect(workspace?.primaryPath).toBe(BETA.path);
+  });
+
+  it("switchMainFolder on the blank landing writes the pending snapshot a new draft consumes", () => {
+    seedSavedProjects();
+    const stagingKey: WorktreeStagingKey = {
+      surface: "landing",
+      draftId: null,
+    };
+    const { result } = renderHook(() =>
+      useHomeWorkspaceSource(stagingKey, null),
+    );
+
+    // Untouched blank landing shows what a fresh draft would start from.
+    expect(result.current.folders).toEqual([ALPHA.path]);
+    expect(result.current.canToggleSelection).toBe(true);
+
+    act(() => {
+      result.current.switchMainFolder(GAMMA.path);
+    });
+
+    expect(result.current.folders).toEqual([GAMMA.path]);
+    expect(result.current.primaryWorkspacePath).toBe(GAMMA.path);
+    // The saved list and pin are untouched by the pre-typing switch...
+    expect(useWorkspaceFoldersStore.getState().folders).toEqual([
+      ALPHA.path,
+      BETA.path,
+      GAMMA.path,
+    ]);
+    expect(useWorkspaceFoldersStore.getState().pinnedPath).toBe(ALPHA.path);
+
+    // A pre-typing Branch pick stages under the null landing key.
+    act(() => {
+      result.current.stageEntry({
+        kind: "worktree",
+        scripts: null,
+        workspacePath: GAMMA.path,
+        repoIdentifier: null,
+        isPrimary: true,
+        branch: {
+          type: "new",
+          name: "traycer/pre-typing-pick",
+          source: "main",
+          carryUncommittedChanges: false,
+        },
+      });
+    });
+
+    // ...and the first substantive edit mints a draft that KEEPS the switch
+    // (the original bug discarded it and re-seeded from the pin).
+    let draftId = "";
+    act(() => {
+      draftId = useLandingDraftStore.getState().createDraftWithId("d1", null);
+    });
+    expect(draftWorkspaceOf(draftId)?.folders).toEqual([GAMMA.path]);
+    expect(draftWorkspaceOf(draftId)?.primaryPath).toBe(GAMMA.path);
+    expect(useLandingDraftStore.getState().pendingWorkspace).toBeNull();
+    // The staged pick follows the pending workspace to the minted draft's
+    // own staging slot instead of being orphaned under the null key.
+    const staged = useWorktreeIntentStagingStore.getState().intentByKey;
+    expect(staged["landing:"]).toBeUndefined();
+    expect(staged["landing:d1"]?.entries).toHaveLength(1);
+    expect(staged["landing:d1"]?.entries[0]).toMatchObject({
+      workspacePath: GAMMA.path,
+      branch: { name: "traycer/pre-typing-pick" },
+    });
+  });
+
+  it("adding on the blank landing in single-project mode survives the draft mint", () => {
+    seedSavedProjects();
+    const stagingKey: WorktreeStagingKey = {
+      surface: "landing",
+      draftId: null,
+    };
+    const { result } = renderHook(() =>
+      useHomeWorkspaceSource(stagingKey, null),
+    );
+    const delta = folder("delta");
+
+    // Default: allowMultipleFolders is off - the add becomes the new main.
+    act(() => {
+      result.current.addResolvedFolders([delta]);
+    });
+
+    expect(result.current.folders).toEqual([delta.path]);
+    expect(result.current.primaryWorkspacePath).toBe(delta.path);
+    // The add SAVED the project globally.
+    expect(useWorkspaceFoldersStore.getState().folders).toContain(delta.path);
+
+    let draftId = "";
+    act(() => {
+      draftId = useLandingDraftStore.getState().createDraftWithId("d1", null);
+    });
+    expect(draftWorkspaceOf(draftId)?.folders).toEqual([delta.path]);
+    expect(draftWorkspaceOf(draftId)?.primaryPath).toBe(delta.path);
+  });
+
+  it("addResolvedFolders in single-project mode saves the folder and switches the main to it", () => {
+    seedSavedProjects();
+    const draftId = useLandingDraftStore.getState().createDraft(null);
+    const stagingKey: WorktreeStagingKey = { surface: "landing", draftId };
+    const { result } = renderHook(() =>
+      useHomeWorkspaceSource(stagingKey, null),
+    );
+    const delta = folder("delta");
+
+    // Default: allowMultipleFolders is off.
+    act(() => {
+      result.current.addResolvedFolders([delta]);
+    });
+
+    const workspace = draftWorkspaceOf(draftId);
+    // The chat holds exactly the added folder (old main alpha left)...
+    expect(workspace?.folders).toEqual([delta.path]);
+    expect(workspace?.primaryPath).toBe(delta.path);
+    // ...and the folder was still saved to the global list.
+    expect(useWorkspaceFoldersStore.getState().folders).toContain(delta.path);
+    expect(useWorkspaceFoldersStore.getState().folders).toContain(ALPHA.path);
+  });
+
+  it("addResolvedFolders with multi-select on keeps the existing selection and appends", () => {
+    seedSavedProjects();
+    useWorkspaceFoldersStore.setState({ allowMultipleFolders: true });
+    const draftId = useLandingDraftStore.getState().createDraft(null);
+    const stagingKey: WorktreeStagingKey = { surface: "landing", draftId };
+    const { result } = renderHook(() =>
+      useHomeWorkspaceSource(stagingKey, null),
+    );
+    const delta = folder("delta");
+
+    act(() => {
+      result.current.addResolvedFolders([delta]);
+    });
+
+    const workspace = draftWorkspaceOf(draftId);
+    expect(workspace?.folders).toEqual([ALPHA.path, delta.path]);
+    expect(workspace?.primaryPath).toBe(ALPHA.path);
+  });
+
+  it("disables selection toggles in the global-fallback representation", () => {
+    seedSavedProjects();
+    // A modal key with no patch and no seed is the remaining true fallback
+    // (the blank landing now edits the pending snapshot instead).
+    const stagingKey: WorktreeStagingKey = {
+      surface: "new-conversation",
+      epicId: "epic-1",
+      parentId: null,
+    };
+    const { result } = renderHook(() =>
+      useHomeWorkspaceSource(stagingKey, null),
+    );
+
+    expect(result.current.canToggleSelection).toBe(false);
+
+    act(() => {
+      result.current.deselectFolder(BETA.path);
+    });
+    // A fallback deselect must never destroy a saved project.
+    expect(useWorkspaceFoldersStore.getState().folders).toEqual([
+      ALPHA.path,
+      BETA.path,
+      GAMMA.path,
+    ]);
+  });
+});

--- a/clients/gui-app/src/components/home/host-workspace-selector/__tests__/workspace-folder-hover-list.test.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/__tests__/workspace-folder-hover-list.test.tsx
@@ -34,9 +34,12 @@ function folder(over: {
     defaultNewBranchName: "traycer/swift-otter",
     repoIdentifier: null,
     isPrimary: true,
-    canChangePrimary: true,
-    makePrimaryDisabled: false,
-    makePrimaryDisabledReason: null,
+    selected: true,
+    onToggleSelected: null,
+    selectionDisabledReason: null,
+    onUseAsMain: null,
+    isPinned: false,
+    onTogglePin: null,
     hostClient: null,
     modeDisabled: false,
     modeDisabledReason: null,
@@ -46,7 +49,6 @@ function folder(over: {
     onSelectMode: NOOP,
     onEmit: NOOP,
     onLocate: null,
-    onMakePrimary: NOOP,
     onRemove: null,
   };
 }

--- a/clients/gui-app/src/components/home/host-workspace-selector/folder-row.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/folder-row.tsx
@@ -1,21 +1,46 @@
-import { FileSliders, Folder, Pin, Trash2, TriangleAlert } from "lucide-react";
+import { useState, type MouseEvent } from "react";
+import {
+  CircleDot,
+  FileSliders,
+  Folder,
+  Pin,
+  Trash2,
+  TriangleAlert,
+} from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { ConfirmDestructiveDialog } from "@/components/ui/confirm-destructive-dialog";
 import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 import { cn } from "@/lib/utils";
 import { CopyPathButton } from "./copy-path-button";
 import { FolderLocationControl } from "./folder-location-control";
 import { FolderBranchControl } from "./folder-branch-control";
-import { workspaceRunPath, type WorkspaceRunItem } from "./workspace-run-item";
+import {
+  workspaceRunBranchSourceLabel,
+  workspaceRunPath,
+  type WorkspaceRunItem,
+} from "./workspace-run-item";
+import { WorkspaceBranchLabel } from "./workspace-branch-label";
 
 /**
  * One compact single-line folder row using the parent grid's shared columns:
- * primary pin / folder / location / branch / actions. A filled pin marks the
- * primary folder; every other row keeps the same outline-pin slot. Actions are
- * always visible in a muted tone, brightening on hover/focus.
+ * main-marker-or-checkbox / folder / location / branch / actions. The chat's
+ * MAIN project shows a filled marker + a primary-tinted row and cannot be
+ * unchecked - clicking another row (its name, or its empty background)
+ * switches the main there instead. Checkboxes
+ * mark ADDITIONAL projects only. The pin action (default project for new
+ * chats) lives with the other row actions. Actions are always visible in a
+ * muted tone, brightening on hover/focus.
  */
 export function FolderRow(props: {
   readonly item: WorkspaceRunItem;
+  /**
+   * The global "Allow multiple folders in chat" preference. When off,
+   * unselected rows drop their ADDITIONAL checkbox (a still-selected extra
+   * keeps it so it can always be removed).
+   */
+  readonly multiSelectEnabled: boolean;
   readonly onEditEnvironment: (workspacePath: string) => void;
   /** Host-wide uncommitted counts keyed by worktree path. */
   readonly uncommittedByPath: ReadonlyMap<string, number>;
@@ -24,15 +49,47 @@ export function FolderRow(props: {
   readonly readOnly: boolean;
 }) {
   const { item } = props;
-  const runPath = workspaceRunPath(item);
+  // The chat/terminal's actual run path when it exists; the folder's own path
+  // otherwise (a NEW worktree has no path on disk yet) - so every row offers
+  // a copy action.
+  const runPath = workspaceRunPath(item) ?? item.displayPath;
+  const isMain = item.selected && item.isPrimary;
+  const switchable = !props.readOnly && item.onUseAsMain !== null;
+  const handleRowBackgroundClick = (
+    event: MouseEvent<HTMLDivElement>,
+  ): void => {
+    const onUseAsMain = item.onUseAsMain;
+    if (props.readOnly || onUseAsMain === null) return;
+    if (!(event.target instanceof Element)) return;
+    // Only the row's own EMPTY background is the switch surface: clicks on
+    // portaled popover content (React events bubble through portals) and on
+    // the row's interactive controls must not switch the main.
+    if (!event.currentTarget.contains(event.target)) return;
+    if (event.target.closest("button, a, input, label") !== null) return;
+    onUseAsMain();
+  };
 
   return (
+    // The background click is a redundant POINTER shortcut for the fully
+    // accessible use-as-main name button inside the row - the wrapper itself
+    // is a layout div with no semantics (hence presentation, not button:
+    // a focusable row would double up the tab stops of its own controls).
     <div
-      className="group col-span-full grid min-w-0 grid-cols-subgrid items-center"
+      role="presentation"
+      className={cn(
+        "group col-span-full grid min-w-0 grid-cols-subgrid items-center rounded-md transition-colors",
+        isMain && "bg-primary/5",
+        switchable && "cursor-pointer hover:bg-accent/40 active:bg-accent/60",
+      )}
+      onClick={handleRowBackgroundClick}
       data-testid="folder-row"
       data-path={item.displayPath}
     >
-      <PrimaryPinControl item={item} readOnly={props.readOnly} />
+      <FolderSelectControl
+        item={item}
+        multiSelectEnabled={props.multiSelectEnabled}
+        readOnly={props.readOnly}
+      />
       <span
         className="inline-flex w-full max-w-full min-w-0 items-center gap-1.5 px-1 py-1 text-ui-sm"
         data-testid="folder-chip"
@@ -41,20 +98,7 @@ export function FolderRow(props: {
           className="size-3.5 shrink-0 text-muted-foreground/70"
           aria-hidden
         />
-        {/* Scoped to the NAME, not the whole chip. The chip also holds the
-              missing-folder warning and the copy-path button, each with its own
-              tooltip - a chip-wide trigger meant hovering either one could
-              surface the path tooltip alongside theirs. */}
-        <TooltipWrapper
-          label={item.displayPath}
-          side="top"
-          sideOffset={undefined}
-          align={undefined}
-        >
-          <span className="min-w-0 truncate font-medium text-foreground/90">
-            {item.displayName}
-          </span>
-        </TooltipWrapper>
+        <FolderNameControl item={item} readOnly={props.readOnly} />
         {item.missing ? (
           <TooltipWrapper
             label="This bound folder is missing on disk."
@@ -69,9 +113,12 @@ export function FolderRow(props: {
             />
           </TooltipWrapper>
         ) : null}
-        {runPath === null ? null : (
+        {/* Hover-revealed (with a keyboard-focus fallback): every row has a
+            copy action now, and a constantly-visible icon per row is noise.
+            Pushed to the column's right edge, clear of the name text. */}
+        <span className="ml-auto inline-flex shrink-0 opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100">
           <CopyPathButton path={runPath} testId="folder-copy-path" />
-        )}
+        </span>
       </span>
       <FolderRowBody
         item={item}
@@ -153,6 +200,34 @@ function FolderRowBody(props: {
     );
   }
 
+  // A saved project not used by the current chat: keep its facts visible
+  // (current branch), but not the interactive location/branch controls -
+  // those configure the chat's run and only mean something once selected.
+  // The branch fact sits in the Branch track (an empty Location cell keeps
+  // the grid flow), so the column headers stay truthful for every row.
+  if (!item.selected) {
+    return (
+      <>
+        <div aria-hidden data-testid="folder-row-unselected-location" />
+        <div
+          className="flex min-w-0 items-center px-1.5 py-1 text-ui-sm text-muted-foreground"
+          data-testid="folder-row-unselected-facts"
+        >
+          <WorkspaceBranchLabel
+            target={item.branchLabel}
+            source={workspaceRunBranchSourceLabel(item.currentIntent)}
+            className={undefined}
+          />
+        </div>
+        <FolderRowActions
+          item={item}
+          readOnly={props.readOnly}
+          onEditEnvironment={props.onEditEnvironment}
+        />
+      </>
+    );
+  }
+
   return (
     <>
       <FolderLocationControl
@@ -175,7 +250,7 @@ function FolderRowBody(props: {
   );
 }
 
-/** Two stable trailing slots keep scripts and remove aligned across rows. */
+/** Three stable trailing slots keep pin, scripts, and remove aligned. */
 function FolderRowActions(props: {
   readonly item: WorkspaceRunItem;
   readonly readOnly: boolean;
@@ -183,12 +258,18 @@ function FolderRowActions(props: {
 }) {
   if (props.readOnly) return null;
   const { item } = props;
+  // Scripts are a property of the SAVED project (not the chat's selection),
+  // so the ⚙ shows on unselected rows too - gated only on the metadata the
+  // dialog needs being available.
   const showEnvironment = !item.unresolved && !item.metadataPending;
   return (
     <span
-      className="col-start-5 grid shrink-0 grid-cols-2 items-center justify-self-end gap-0.5"
+      className="col-start-5 grid shrink-0 grid-cols-3 items-center justify-self-end gap-0.5"
       data-testid="folder-row-actions"
     >
+      <span className="inline-flex size-6 items-center justify-center">
+        {item.onTogglePin === null ? null : <PinDefaultButton item={item} />}
+      </span>
       <span className="inline-flex size-6 items-center justify-center">
         {showEnvironment ? (
           <EnvironmentButton item={item} onEdit={props.onEditEnvironment} />
@@ -201,49 +282,161 @@ function FolderRowActions(props: {
   );
 }
 
-/** Stable first-column primary state: filled when primary, outline otherwise. */
-function PrimaryPinControl(props: {
+/**
+ * The name area. On rows that can become the chat's main project it is a
+ * button - clicking it SWITCHES the main there in one action (the previous
+ * main leaves the chat; additional checked folders stay). The main row
+ * itself, unresolved rows, and bound owners keep the plain name with the
+ * path tooltip.
+ */
+function FolderNameControl(props: {
   readonly item: WorkspaceRunItem;
   readonly readOnly: boolean;
 }) {
   const { item } = props;
-  const primaryLocked = !item.canChangePrimary;
-  if (item.isPrimary) {
+  const switchable = !props.readOnly && item.onUseAsMain !== null;
+  if (!switchable) {
+    // Scoped to the NAME, not the whole chip. The chip also holds the
+    // missing-folder warning and the copy-path button, each with its own
+    // tooltip - a chip-wide trigger meant hovering either one could
+    // surface the path tooltip alongside theirs.
+    return (
+      <TooltipWrapper
+        label={item.displayPath}
+        side="top"
+        sideOffset={undefined}
+        align={undefined}
+      >
+        <span className="min-w-0 truncate font-medium text-foreground/90">
+          {item.displayName}
+        </span>
+      </TooltipWrapper>
+    );
+  }
+  return (
+    <TooltipWrapper
+      label={`Use as main project · ${item.displayPath}`}
+      side="top"
+      sideOffset={undefined}
+      align={undefined}
+    >
+      <button
+        type="button"
+        data-testid="folder-use-as-main"
+        aria-label={`Use ${item.displayName} as the main project for this chat`}
+        onClick={item.onUseAsMain}
+        className="min-w-0 truncate rounded-sm text-left font-medium text-foreground/90 outline-none transition-colors hover:text-primary hover:underline focus-visible:ring-2 focus-visible:ring-ring/60"
+      >
+        {item.displayName}
+      </button>
+    </TooltipWrapper>
+  );
+}
+
+/**
+ * Stable first-column state. The chat's MAIN project shows a filled,
+ * non-uncheckable marker (switch mains by clicking another row's name);
+ * every other row shows the ADDITIONAL-folder checkbox. `onToggleSelected
+ * === null` (read-only / transient fallback) keeps the column's width with
+ * the state shown but inert.
+ */
+function FolderSelectControl(props: {
+  readonly item: WorkspaceRunItem;
+  readonly multiSelectEnabled: boolean;
+  readonly readOnly: boolean;
+}) {
+  const { item } = props;
+  if (item.selected && item.isPrimary) {
     return (
       <TooltipWrapper
         label={
-          primaryLocked
-            ? "Primary folder. New agent commands and terminals start here. Primary cannot be changed after the agent starts."
-            : "Primary folder. New agent commands and terminals start here."
+          item.onUseAsMain === null && item.onToggleSelected === null
+            ? "Main project. New agent commands and terminals start here."
+            : "Main project. New agent commands and terminals start here. Click another project's row to switch."
         }
         side="top"
         sideOffset={undefined}
         align={undefined}
       >
-        <button
-          type="button"
-          aria-disabled
-          aria-label="Primary folder information"
-          className={cn(
-            "inline-flex size-6 shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
-            primaryLocked ? "cursor-not-allowed" : "cursor-help",
-          )}
-          data-testid="folder-primary-pin"
+        <span
+          className="inline-flex size-6 shrink-0 cursor-help items-center justify-center text-primary"
+          data-testid="folder-main-marker"
         >
-          <Pin className="size-3.5" aria-hidden fill="currentColor" />
-        </button>
+          <CircleDot className="size-4" aria-label="Main project" />
+        </span>
       </TooltipWrapper>
     );
   }
-  if (item.canChangePrimary && !props.readOnly) {
-    return <MakePrimaryButton item={item} />;
+  // Multi-select is a global opt-in: with it off, an unselected saved row
+  // shows no checkbox at all (an empty spacer keeps the grid columns
+  // aligned). A row still IN the chat keeps its checkbox regardless, so an
+  // extra folder can always be removed.
+  if (!props.multiSelectEnabled && !item.selected) {
+    return (
+      <span
+        className="inline-flex size-6 shrink-0"
+        aria-hidden
+        data-testid="folder-select-spacer"
+      />
+    );
   }
+  const inert = props.readOnly || item.onToggleSelected === null;
+  const disabledReason = item.selectionDisabledReason;
+  const label = additionalCheckboxLabel(item, inert, disabledReason);
+  const checkbox = (
+    <span className="inline-flex size-6 shrink-0 items-center justify-center">
+      <Checkbox
+        checked={item.selected}
+        disabled={inert || disabledReason !== null}
+        aria-label={`Also use ${item.displayName} in this chat`}
+        data-testid="folder-select-checkbox"
+        // The primitive's `border-input` outline all but vanishes on the dark
+        // popover when unchecked - brighten it so the box reads as a control.
+        className="border-muted-foreground/50 hover:border-muted-foreground/80"
+        onCheckedChange={(checked) => {
+          item.onToggleSelected?.(checked === true);
+        }}
+      />
+    </span>
+  );
+  if (label === null) return checkbox;
+  return (
+    <TooltipWrapper
+      label={label}
+      side="top"
+      sideOffset={undefined}
+      align={undefined}
+    >
+      {checkbox}
+    </TooltipWrapper>
+  );
+}
+
+function additionalCheckboxLabel(
+  item: WorkspaceRunItem,
+  inert: boolean,
+  disabledReason: string | null,
+): string | null {
+  if (disabledReason !== null) return disabledReason;
+  if (inert) return null;
+  return item.selected
+    ? "Additional folder in this chat. Uncheck to keep it saved but leave it out."
+    : "Also use this saved project in this chat, alongside the main project.";
+}
+
+/**
+ * The saved-list pin: marks this project as the DEFAULT for brand-new tasks.
+ * New chats inside an existing task inherit that task's workspace instead.
+ * Filled when pinned; changing a chat's selection never moves it.
+ */
+function PinDefaultButton(props: { readonly item: WorkspaceRunItem }) {
+  const { item } = props;
   return (
     <TooltipWrapper
       label={
-        item.canChangePrimary
-          ? "Primary cannot be changed from this view."
-          : "Primary cannot be changed after the agent starts."
+        item.isPinned
+          ? "Default project. New tasks start with this project selected."
+          : "Set as the default project for new tasks."
       }
       side="top"
       sideOffset={undefined}
@@ -251,12 +444,26 @@ function PrimaryPinControl(props: {
     >
       <button
         type="button"
-        className="inline-flex size-6 shrink-0 cursor-not-allowed items-center justify-center rounded-md text-muted-foreground/45 outline-none focus-visible:ring-2 focus-visible:ring-ring/45"
-        aria-disabled
-        aria-label="Not primary folder. Primary is locked"
-        data-testid="folder-secondary-pin"
+        aria-label={
+          item.isPinned
+            ? `${item.displayName} is the default project for new tasks`
+            : `Set ${item.displayName} as the default project for new tasks`
+        }
+        aria-pressed={item.isPinned}
+        data-testid="folder-pin-default"
+        onClick={item.onTogglePin ?? undefined}
+        className={cn(
+          "inline-flex size-6 shrink-0 items-center justify-center rounded-md outline-none transition-[opacity,color,background-color] focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-ring/60",
+          item.isPinned
+            ? "bg-primary/10 text-primary"
+            : "text-muted-foreground opacity-[var(--fc-opacity,0.7)] hover:bg-accent/50 hover:text-foreground hover:opacity-100",
+        )}
       >
-        <Pin className="size-3.5" aria-hidden />
+        <Pin
+          className="size-3.5"
+          aria-hidden
+          fill={item.isPinned ? "currentColor" : "none"}
+        />
       </button>
     </TooltipWrapper>
   );
@@ -291,58 +498,26 @@ function EnvironmentButton(props: {
   );
 }
 
-/**
- * The outline-pin action that switches primary to this row's folder.
- * Rendered in the first column for a non-primary row on a surface with
- * `canChangePrimary` (the primary row shows the filled status pin instead).
- * Always visible in the muted row-action tone (never hover-revealed or
- * `display: none`), so it stays discoverable and keyboard/screen-reader
- * reachable.
- */
-function MakePrimaryButton(props: { readonly item: WorkspaceRunItem }) {
-  const { item } = props;
-  // ONE tooltip, not one per concern: when the pin is disabled the reason is
-  // strictly more informative than restating the action, and rendering both
-  // put two tooltips on a single trigger.
-  const label =
-    item.makePrimaryDisabled && item.makePrimaryDisabledReason !== null
-      ? item.makePrimaryDisabledReason
-      : "Set as primary";
-  return (
-    <TooltipWrapper
-      label={label}
-      side="top"
-      sideOffset={undefined}
-      align={undefined}
-    >
-      <button
-        type="button"
-        aria-label="Set as primary"
-        aria-disabled={item.makePrimaryDisabled}
-        data-testid="folder-make-primary"
-        onClick={item.makePrimaryDisabled ? undefined : item.onMakePrimary}
-        className="inline-flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground opacity-[var(--fc-opacity,0.7)] outline-none transition-[opacity,color,background-color] hover:bg-accent/50 hover:text-foreground hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-ring/60 aria-disabled:cursor-not-allowed aria-disabled:text-muted-foreground/60 aria-disabled:hover:bg-transparent aria-disabled:hover:text-muted-foreground/60 aria-disabled:hover:opacity-[var(--fc-opacity,0.7)]"
-      >
-        <Pin className="size-3.5" />
-      </button>
-    </TooltipWrapper>
-  );
-}
-
 function RemoveFolderButton(props: { readonly item: WorkspaceRunItem }) {
   const { item } = props;
+  // Deleting a saved project is confirmed first: the trash sits beside
+  // frequently-clicked row controls, and the removal also drops the project
+  // from the current chat's selection (other chats keep their binding).
+  const [confirmOpen, setConfirmOpen] = useState(false);
   // Always rendered AND always visible (even for a single folder). The
   // last-folder / active-owner guard is the per-item `removeDisabled` (with a
   // tooltip), not a hidden button — so the delete option is always discoverable.
   const button = (
     <button
       type="button"
-      aria-label={`Remove ${item.displayName}`}
+      aria-label={`Remove ${item.displayName} from saved projects`}
       data-testid="folder-remove"
       disabled={
         item.onRemove === null || item.removePending || item.removeDisabled
       }
-      onClick={item.onRemove ?? undefined}
+      onClick={() => {
+        setConfirmOpen(true);
+      }}
       className="inline-flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground opacity-[var(--fc-opacity,0.7)] outline-none transition-[opacity,color,background-color] hover:bg-destructive/10 hover:text-destructive hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-ring/60 disabled:cursor-not-allowed disabled:text-muted-foreground/60 disabled:hover:bg-transparent disabled:hover:text-muted-foreground/60 disabled:hover:opacity-[var(--fc-opacity,0.7)]"
     >
       {item.removePending ? (
@@ -356,17 +531,40 @@ function RemoveFolderButton(props: { readonly item: WorkspaceRunItem }) {
       )}
     </button>
   );
+  const confirmDialog = (
+    <ConfirmDestructiveDialog
+      open={confirmOpen}
+      onOpenChange={setConfirmOpen}
+      title={`Remove ${item.displayName} from saved projects?`}
+      description="The project leaves your saved projects and the current chat. Other chats keep it. Nothing on disk is deleted."
+      cascadeSummary={null}
+      actionLabel="Remove"
+      isPending={false}
+      onConfirm={() => {
+        setConfirmOpen(false);
+        item.onRemove?.();
+      }}
+    />
+  );
   if (item.removeDisabled && item.removeDisabledReason !== null) {
     return (
-      <TooltipWrapper
-        label={item.removeDisabledReason}
-        side="top"
-        sideOffset={undefined}
-        align={undefined}
-      >
-        <span className="inline-flex shrink-0">{button}</span>
-      </TooltipWrapper>
+      <>
+        <TooltipWrapper
+          label={item.removeDisabledReason}
+          side="top"
+          sideOffset={undefined}
+          align={undefined}
+        >
+          <span className="inline-flex shrink-0">{button}</span>
+        </TooltipWrapper>
+        {confirmDialog}
+      </>
     );
   }
-  return button;
+  return (
+    <>
+      {button}
+      {confirmDialog}
+    </>
+  );
 }

--- a/clients/gui-app/src/components/home/host-workspace-selector/folder-row.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/folder-row.tsx
@@ -71,9 +71,9 @@ export function FolderRow(props: {
 
   return (
     // The background click is a redundant POINTER shortcut for the fully
-    // accessible use-as-main name button inside the row - the wrapper itself
-    // is a layout div with no semantics (hence presentation, not button:
-    // a focusable row would double up the tab stops of its own controls).
+    // accessible use-as-main name button inside the row. The outer wrapper
+    // remains presentational; the non-interactive contents group below gives
+    // the row an accessible name without adding another tab stop.
     <div
       role="presentation"
       className={cn(
@@ -85,48 +85,54 @@ export function FolderRow(props: {
       data-testid="folder-row"
       data-path={item.displayPath}
     >
-      <FolderSelectControl
-        item={item}
-        multiSelectEnabled={props.multiSelectEnabled}
-        readOnly={props.readOnly}
-      />
-      <span
-        className="inline-flex w-full max-w-full min-w-0 items-center gap-1.5 px-1 py-1 text-ui-sm"
-        data-testid="folder-chip"
+      <div
+        role="group"
+        aria-label={`${item.displayName} project`}
+        className="contents"
       >
-        <Folder
-          className="size-3.5 shrink-0 text-muted-foreground/70"
-          aria-hidden
+        <FolderSelectControl
+          item={item}
+          multiSelectEnabled={props.multiSelectEnabled}
+          readOnly={props.readOnly}
         />
-        <FolderNameControl item={item} readOnly={props.readOnly} />
-        {item.missing ? (
-          <TooltipWrapper
-            label="This bound folder is missing on disk."
-            side="top"
-            sideOffset={undefined}
-            align={undefined}
-          >
-            <TriangleAlert
-              className="size-3.5 shrink-0 text-destructive opacity-100"
-              aria-hidden
-              data-testid="folder-row-missing"
-            />
-          </TooltipWrapper>
-        ) : null}
-        {/* Hover-revealed (with a keyboard-focus fallback): every row has a
-            copy action now, and a constantly-visible icon per row is noise.
-            Pushed to the column's right edge, clear of the name text. */}
-        <span className="ml-auto inline-flex shrink-0 opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100">
-          <CopyPathButton path={runPath} testId="folder-copy-path" />
+        <span
+          className="inline-flex w-full max-w-full min-w-0 items-center gap-1.5 px-1 py-1 text-ui-sm"
+          data-testid="folder-chip"
+        >
+          <Folder
+            className="size-3.5 shrink-0 text-muted-foreground/70"
+            aria-hidden
+          />
+          <FolderNameControl item={item} readOnly={props.readOnly} />
+          {item.missing ? (
+            <TooltipWrapper
+              label="This bound folder is missing on disk."
+              side="top"
+              sideOffset={undefined}
+              align={undefined}
+            >
+              <TriangleAlert
+                className="size-3.5 shrink-0 text-destructive opacity-100"
+                aria-hidden
+                data-testid="folder-row-missing"
+              />
+            </TooltipWrapper>
+          ) : null}
+          {/* Hover-revealed (with a keyboard-focus fallback): every row has a
+              copy action now, and a constantly-visible icon per row is noise.
+              Pushed to the column's right edge, clear of the name text. */}
+          <span className="ml-auto inline-flex shrink-0 opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100">
+            <CopyPathButton path={runPath} testId="folder-copy-path" />
+          </span>
         </span>
-      </span>
-      <FolderRowBody
-        item={item}
-        readOnly={props.readOnly}
-        boundaryEl={props.boundaryEl}
-        uncommittedByPath={props.uncommittedByPath}
-        onEditEnvironment={props.onEditEnvironment}
-      />
+        <FolderRowBody
+          item={item}
+          readOnly={props.readOnly}
+          boundaryEl={props.boundaryEl}
+          uncommittedByPath={props.uncommittedByPath}
+          onEditEnvironment={props.onEditEnvironment}
+        />
+      </div>
     </div>
   );
 }
@@ -362,7 +368,7 @@ function FolderSelectControl(props: {
           className="inline-flex size-6 shrink-0 cursor-help items-center justify-center text-primary"
           data-testid="folder-main-marker"
         >
-          <CircleDot className="size-4" aria-label="Main project" />
+          <CircleDot className="size-4" role="img" aria-label="Main project" />
         </span>
       </TooltipWrapper>
     );
@@ -412,6 +418,7 @@ function FolderSelectControl(props: {
   );
 }
 
+/** Explains an editable or disabled additional-project checkbox. */
 function additionalCheckboxLabel(
   item: WorkspaceRunItem,
   inert: boolean,

--- a/clients/gui-app/src/components/home/host-workspace-selector/folder-row.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/folder-row.tsx
@@ -505,6 +505,7 @@ function EnvironmentButton(props: {
   );
 }
 
+/** Removes a saved project after explicit destructive confirmation. */
 function RemoveFolderButton(props: { readonly item: WorkspaceRunItem }) {
   const { item } = props;
   // Deleting a saved project is confirmed first: the trash sits beside

--- a/clients/gui-app/src/components/home/host-workspace-selector/host-workspace-selector.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/host-workspace-selector.tsx
@@ -2670,6 +2670,7 @@ function savedUnboundRunItemFields(input: {
   };
 }
 
+/** Explains why a saved project cannot be added to the current binding. */
 function unboundSelectionDisabledReason(input: {
   readonly entry: ResolvedFolder;
   readonly activeRunLocksBinding: boolean;

--- a/clients/gui-app/src/components/home/host-workspace-selector/host-workspace-selector.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/host-workspace-selector.tsx
@@ -310,6 +310,7 @@ type ActiveHostWorkspaceControlsProps = {
   readonly disabled: boolean;
 };
 
+/** Resolves the active host and renders its workspace-selection controls. */
 export function ActiveHostWorkspaceControls(
   props: ActiveHostWorkspaceControlsProps,
 ) {
@@ -481,6 +482,7 @@ function fixedUnavailableHostEntry(
   };
 }
 
+/** Renders editable pre-creation workspace rows from the active source. */
 function HomeWorkspaceRows(props: {
   readonly workspaceSource: HomeWorkspaceSource;
   readonly resolvedFolders: ReadonlyArray<ResolvedFolder>;
@@ -1114,6 +1116,7 @@ function homeSelectionFields(input: {
   };
 }
 
+/** Builds a picker row contract for a folder resolved on the active host. */
 function workspaceRunItemForResolvedFolder(input: {
   readonly entry: ResolvedFolder;
   readonly activeHostClient: HostClient<HostRpcRegistry> | null;
@@ -1248,6 +1251,7 @@ type HomeSelectionFields = Pick<
   | "onTogglePin"
 >;
 
+/** Builds a fallback row when a saved folder is unresolved on this host. */
 function workspaceRunItemForUnresolvedFolder(input: {
   readonly activeHostClient: HostClient<HostRpcRegistry> | null;
   readonly announcePrimaryChange: (folderName: string) => void;
@@ -1430,6 +1434,7 @@ function unresolvedWorkspaceRunItem(input: {
   };
 }
 
+/** Builds a loading row while the host resolves a saved folder's metadata. */
 function pendingWorkspaceRunItem(input: {
   readonly path: string;
   readonly name: string;
@@ -1533,8 +1538,10 @@ interface InEpicSurfaceProps {
   readonly directoryEntries: ReadonlyArray<HostDirectoryEntry>;
 }
 
-// Coordinates host-bound folder metadata, staged worktree edits, add/remove
-// mutations, and terminal resume state in one owner-scoped surface.
+/**
+ * Coordinates host-bound folder metadata, staged worktree edits, add/remove
+ * mutations, and terminal resume state in one owner-scoped surface.
+ */
 // eslint-disable-next-line complexity
 function InEpicSurface(props: InEpicSurfaceProps) {
   const { surface } = props;
@@ -2041,6 +2048,7 @@ function InEpicSurface(props: InEpicSurfaceProps) {
     ],
   );
 
+  /** Picks, saves, and sequentially adds folders to the current owner. */
   const addFoldersToOwnerBinding = async (): Promise<boolean> => {
     const result = await folderActions.pickAndPrepareFolders();
     if (result === null) return false;

--- a/clients/gui-app/src/components/home/host-workspace-selector/host-workspace-selector.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/host-workspace-selector.tsx
@@ -45,8 +45,12 @@ import { useEpicCreateChat } from "@/hooks/epic/use-epic-chat-mutations";
 import { useEpicNestedFocusNavigation } from "@/hooks/epic/use-epic-nested-focus-navigation";
 import { useResolvedWorkspaceFolders } from "@/hooks/workspace/use-resolved-workspace-folders-query";
 import type { ResolvedFolder } from "@/lib/workspace/resolved-folder";
-import { useWorkspaceFolderActionsForClient } from "@/hooks/workspace/use-workspace-folder-actions";
+import {
+  preparedWorkspaceFolderToWorkspaceFolderInfo,
+  useWorkspaceFolderActionsForClient,
+} from "@/hooks/workspace/use-workspace-folder-actions";
 import type { LandingDraftWorkspaceSnapshot } from "@/stores/home/landing-draft-store";
+import { useWorkspaceFoldersStore } from "@/stores/workspace/workspace-folders-store";
 import { resolvePrimaryPath } from "@/lib/worktree/resolve-primary-path";
 import { usePickAndAddWorkspaceFolders } from "./use-pick-and-add-folders";
 import {
@@ -349,19 +353,48 @@ export function ActiveHostWorkspaceControls(
               primaryChanged: false,
               newPrimaryName: null,
             }),
+            selectFolder: () => undefined,
+            deselectFolder: () => ({
+              primaryChanged: false,
+              newPrimaryName: null,
+            }),
+            switchMainFolder: () => undefined,
             setPrimaryFolder: () => undefined,
+            setPinnedFolder: () => undefined,
             stageEntry: () => undefined,
           }
         : homeWorkspaceSource,
     [disabled, homeWorkspaceSource],
   );
+  // The picker renders the persistent SAVED list plus any surface-only
+  // folders (e.g. fork seeds outside the saved list), so resolution runs
+  // over that union - saved-list order first. The global-fallback
+  // representation passes `null` through (the resolver reads the global
+  // store, which IS the saved list there).
+  const displaySource = useMemo(() => {
+    const base = workspaceSource.source;
+    if (base === null) return null;
+    const savedSet = new Set(workspaceSource.savedFolders);
+    const folders = [
+      ...workspaceSource.savedFolders,
+      ...base.folders.filter((path) => !savedSet.has(path)),
+    ];
+    return {
+      folders,
+      folderInfoByPath: {
+        ...workspaceSource.savedFolderInfoByPath,
+        ...base.folderInfoByPath,
+      },
+    };
+  }, [
+    workspaceSource.savedFolderInfoByPath,
+    workspaceSource.savedFolders,
+    workspaceSource.source,
+  ]);
   // Resolve repo-identifier → path against the scope-correct host: the
   // default host in active scope, the source agent's FIXED host in the
   // terminal-agent fork dialog (else paths resolve on the wrong machine).
-  const resolved = useResolvedWorkspaceFolders(
-    workspaceSource.source,
-    activeHostClient,
-  );
+  const resolved = useResolvedWorkspaceFolders(displaySource, activeHostClient);
   const handleSelectHost = (hostId: string): void => {
     if (disabled) return;
     if (props.hostScope.kind === "fixed") return;
@@ -481,17 +514,36 @@ function HomeWorkspaceRows(props: {
   const folderIntentByPath = useWorktreeIntentMemoryStore(
     (state) => state.folderIntentByPath,
   );
+  // Which display rows the current chat actually uses. `resolvedFolders` is
+  // the saved-list ∪ surface union; the surface's own folder list is the
+  // selection.
+  const selectedPaths = useMemo(
+    () => new Set(workspaceSource.folders),
+    [workspaceSource.folders],
+  );
   // The single resolved primary every row / the collapsed chip / the launch
-  // boundary agrees on - re-derived from the CURRENT resolved folder set so a
-  // stale/removed `primaryPath` always falls back to the first remaining
-  // folder without a separate write.
+  // boundary agrees on - re-derived from the CURRENT resolved SELECTION (the
+  // pinned default when selected, else the first selected folder) so a
+  // stale/removed `primaryPath` always falls back without a separate write.
   const resolvedPrimaryPath = useMemo(
     () =>
       resolvePrimaryPath(
-        resolvedFolders.map((entry) => entry.path),
+        resolvedFolders
+          .map((entry) => entry.path)
+          .filter((path) => selectedPaths.has(path)),
         workspaceSource.primaryPath,
       ),
-    [resolvedFolders, workspaceSource.primaryPath],
+    [resolvedFolders, selectedPaths, workspaceSource.primaryPath],
+  );
+  // The saved-list pin (default project for NEW tasks), membership-validated
+  // the same way. Independent of the chat's own primary.
+  const resolvedPinnedPath = useMemo(
+    () =>
+      resolvePrimaryPath(
+        workspaceSource.savedFolders,
+        workspaceSource.pinnedPath,
+      ),
+    [workspaceSource.savedFolders, workspaceSource.pinnedPath],
   );
   // Polite live-region announcement for a primary change - either an
   // explicit "Make primary" click or the deterministic reassignment when
@@ -545,9 +597,13 @@ function HomeWorkspaceRows(props: {
     stagingKey,
     unresolvedMetadataPaths,
   ]);
+  // Seeding / default-branch derivation / branch validation apply to the
+  // SELECTED folders only: an unselected saved project never stages a
+  // worktree intent (nothing about it rides the launch).
   const gitSummaries = useMemo<ReadonlyArray<WorktreeWorkspaceSummaryV13>>(
     () =>
       resolvedFolders.flatMap((entry) => {
+        if (!selectedPaths.has(entry.path)) return [];
         const summary = summaryForResolvedFolder(entry, summariesByPath);
         return summary !== null &&
           summary.resolvedAt !== null &&
@@ -555,7 +611,7 @@ function HomeWorkspaceRows(props: {
           ? [summary]
           : [];
       }),
-    [resolvedFolders, summariesByPath],
+    [resolvedFolders, selectedPaths, summariesByPath],
   );
   const worktreeBranchPrefix = useSettingsStore((s) => s.worktreeBranchPrefix);
   const defaultBranchByPath = useMemo(
@@ -743,7 +799,9 @@ function HomeWorkspaceRows(props: {
           onLocate: () => {
             void pickAndAddFolders();
           },
+          resolvedPinnedPath,
           resolvedPrimaryPath,
+          selectedPaths,
           setFolderIntent,
           summariesByPath,
           workspaceSource,
@@ -755,7 +813,9 @@ function HomeWorkspaceRows(props: {
       pickAndAddFolders,
       activeHostClient,
       resolvedFolders,
+      resolvedPinnedPath,
       resolvedPrimaryPath,
+      selectedPaths,
       workspaceSource,
       setFolderIntent,
       summariesByPath,
@@ -996,6 +1056,64 @@ type UnresolvedWorkspaceFolder = Extract<
   { readonly kind: "unresolved" }
 >;
 
+/**
+ * The selection / main-switch / pin fields shared by every home-surface row
+ * shape (resolved, unresolved, metadata-pending). Selection toggles and the
+ * main switch route through the workspace source's surface-only mutations
+ * (the saved list is never touched); the pin always writes the global
+ * default-for-new-chats.
+ */
+function homeSelectionFields(input: {
+  readonly path: string;
+  readonly name: string;
+  readonly unresolvedOnHost: boolean;
+  readonly selectedPaths: ReadonlySet<string>;
+  readonly resolvedPinnedPath: string | null;
+  readonly resolvedPrimaryPath: string | null;
+  readonly workspaceSource: HomeWorkspaceSource;
+  readonly announcePrimaryChange: (folderName: string) => void;
+}): HomeSelectionFields {
+  const { workspaceSource } = input;
+  const selected = input.selectedPaths.has(input.path);
+  const isMain = selected && input.path === input.resolvedPrimaryPath;
+  const saved = workspaceSource.savedFolders.includes(input.path);
+  return {
+    selected,
+    onToggleSelected:
+      workspaceSource.canToggleSelection && !isMain
+        ? (nextSelected) => {
+            if (nextSelected) {
+              workspaceSource.selectFolder(input.path);
+              return;
+            }
+            const transition = workspaceSource.deselectFolder(input.path);
+            if (
+              transition.primaryChanged &&
+              transition.newPrimaryName !== null
+            ) {
+              input.announcePrimaryChange(transition.newPrimaryName);
+            }
+          }
+        : null,
+    selectionDisabledReason: input.unresolvedOnHost
+      ? "Not available on the selected host."
+      : null,
+    // The main row switches by picking ANOTHER row, and an unresolved folder
+    // can't run here, so neither offers the switch.
+    onUseAsMain:
+      isMain || input.unresolvedOnHost
+        ? null
+        : () => {
+            workspaceSource.switchMainFolder(input.path);
+            input.announcePrimaryChange(input.name);
+          },
+    isPinned: input.path === input.resolvedPinnedPath,
+    onTogglePin: saved
+      ? () => workspaceSource.setPinnedFolder(input.path)
+      : null,
+  };
+}
+
 function workspaceRunItemForResolvedFolder(input: {
   readonly entry: ResolvedFolder;
   readonly activeHostClient: HostClient<HostRpcRegistry> | null;
@@ -1003,7 +1121,9 @@ function workspaceRunItemForResolvedFolder(input: {
   readonly defaultBranchByPath: Readonly<Record<string, string>>;
   readonly isFetchingSummaries: boolean;
   readonly onLocate: () => void;
+  readonly resolvedPinnedPath: string | null;
   readonly resolvedPrimaryPath: string | null;
+  readonly selectedPaths: ReadonlySet<string>;
   readonly setFolderIntent: (
     intent: WorktreeFolderIntent,
     timestamp: number,
@@ -1012,6 +1132,16 @@ function workspaceRunItemForResolvedFolder(input: {
   readonly workspaceSource: HomeWorkspaceSource;
 }): WorkspaceRunItem {
   const summary = summaryForResolvedFolder(input.entry, input.summariesByPath);
+  const selectionFields = homeSelectionFields({
+    path: input.entry.path,
+    name: input.entry.name,
+    unresolvedOnHost: input.entry.kind === "unresolved" && summary === null,
+    selectedPaths: input.selectedPaths,
+    resolvedPinnedPath: input.resolvedPinnedPath,
+    resolvedPrimaryPath: input.resolvedPrimaryPath,
+    workspaceSource: input.workspaceSource,
+    announcePrimaryChange: input.announcePrimaryChange,
+  });
   if (input.entry.kind === "unresolved") {
     const unresolvedItem = workspaceRunItemForUnresolvedFolder({
       activeHostClient: input.activeHostClient,
@@ -1020,6 +1150,7 @@ function workspaceRunItemForResolvedFolder(input: {
       isFetchingSummaries: input.isFetchingSummaries,
       onLocate: input.onLocate,
       resolvedPrimaryPath: input.resolvedPrimaryPath,
+      selectionFields,
       summary,
       workspaceSource: input.workspaceSource,
     });
@@ -1074,9 +1205,7 @@ function workspaceRunItemForResolvedFolder(input: {
     repoIdentifier:
       summary?.repoIdentifier ?? repoIdentifierForResolvedFolder(input.entry),
     isPrimary,
-    canChangePrimary: true,
-    makePrimaryDisabled: false,
-    makePrimaryDisabledReason: null,
+    ...selectionFields,
     hostClient: input.activeHostClient,
     modeDisabled: !metadataResolved,
     modeDisabledReason: metadataResolved
@@ -1100,10 +1229,6 @@ function workspaceRunItemForResolvedFolder(input: {
       });
     },
     onLocate: null,
-    onMakePrimary: () => {
-      input.workspaceSource.setPrimaryFolder(input.entry.path);
-      input.announcePrimaryChange(input.entry.name);
-    },
     onRemove: () => {
       const transition = input.workspaceSource.removeFolder(input.entry.path);
       if (transition.primaryChanged && transition.newPrimaryName !== null) {
@@ -1113,6 +1238,16 @@ function workspaceRunItemForResolvedFolder(input: {
   };
 }
 
+type HomeSelectionFields = Pick<
+  WorkspaceRunItem,
+  | "selected"
+  | "onToggleSelected"
+  | "selectionDisabledReason"
+  | "onUseAsMain"
+  | "isPinned"
+  | "onTogglePin"
+>;
+
 function workspaceRunItemForUnresolvedFolder(input: {
   readonly activeHostClient: HostClient<HostRpcRegistry> | null;
   readonly announcePrimaryChange: (folderName: string) => void;
@@ -1120,6 +1255,7 @@ function workspaceRunItemForUnresolvedFolder(input: {
   readonly isFetchingSummaries: boolean;
   readonly onLocate: () => void;
   readonly resolvedPrimaryPath: string | null;
+  readonly selectionFields: HomeSelectionFields;
   readonly summary: WorktreeWorkspaceSummaryV13 | null;
   readonly workspaceSource: HomeWorkspaceSource;
 }): WorkspaceRunItem | null {
@@ -1138,6 +1274,7 @@ function workspaceRunItemForUnresolvedFolder(input: {
       repoIdentifier: input.entry.repoIdentifier,
       hostClient: input.activeHostClient,
       isPrimary,
+      selectionFields: input.selectionFields,
       onRemove,
     });
   }
@@ -1146,11 +1283,8 @@ function workspaceRunItemForUnresolvedFolder(input: {
     name: input.entry.name,
     repoIdentifier: input.entry.repoIdentifier,
     isPrimary,
+    selectionFields: input.selectionFields,
     onLocate: input.onLocate,
-    onMakePrimary: () => {
-      input.workspaceSource.setPrimaryFolder(input.entry.path);
-      input.announcePrimaryChange(input.entry.name);
-    },
     onRemove,
   });
 }
@@ -1261,8 +1395,8 @@ function unresolvedWorkspaceRunItem(input: {
   readonly name: string;
   readonly repoIdentifier: WorktreeWorkspaceSummaryV13["repoIdentifier"];
   readonly isPrimary: boolean;
+  readonly selectionFields: HomeSelectionFields;
   readonly onLocate: () => void;
-  readonly onMakePrimary: () => void;
   readonly onRemove: () => void;
 }): WorkspaceRunItem {
   return {
@@ -1282,9 +1416,7 @@ function unresolvedWorkspaceRunItem(input: {
     defaultNewBranchName: "",
     repoIdentifier: input.repoIdentifier,
     isPrimary: input.isPrimary,
-    canChangePrimary: true,
-    makePrimaryDisabled: true,
-    makePrimaryDisabledReason: "Resolve this folder to make it primary",
+    ...input.selectionFields,
     hostClient: null,
     modeDisabled: true,
     modeDisabledReason: "Folder not on this host",
@@ -1294,7 +1426,6 @@ function unresolvedWorkspaceRunItem(input: {
     onSelectMode: () => undefined,
     onEmit: () => undefined,
     onLocate: input.onLocate,
-    onMakePrimary: input.onMakePrimary,
     onRemove: input.onRemove,
   };
 }
@@ -1305,6 +1436,7 @@ function pendingWorkspaceRunItem(input: {
   readonly repoIdentifier: WorktreeWorkspaceSummaryV13["repoIdentifier"];
   readonly hostClient: HostClient<HostRpcRegistry> | null;
   readonly isPrimary: boolean;
+  readonly selectionFields: HomeSelectionFields;
   readonly onRemove: () => void;
 }): WorkspaceRunItem {
   return {
@@ -1322,9 +1454,7 @@ function pendingWorkspaceRunItem(input: {
     defaultNewBranchName: "",
     repoIdentifier: input.repoIdentifier,
     isPrimary: input.isPrimary,
-    canChangePrimary: true,
-    makePrimaryDisabled: true,
-    makePrimaryDisabledReason: "Loading folder metadata",
+    ...input.selectionFields,
     hostClient: input.hostClient,
     modeDisabled: true,
     modeDisabledReason: "Loading folder metadata",
@@ -1334,7 +1464,6 @@ function pendingWorkspaceRunItem(input: {
     onSelectMode: () => undefined,
     onEmit: () => undefined,
     onLocate: null,
-    onMakePrimary: () => undefined,
     onRemove: input.onRemove,
   };
 }
@@ -1429,6 +1558,15 @@ function InEpicSurface(props: InEpicSurfaceProps) {
   const removeBindingEntryMutation = useWorkspaceBindingRemoveEntryForClient(
     props.hostClient,
   );
+  // Owner-binding removals are SERIALIZED through this queue, mirroring the
+  // Add Folder path's sequential loop: the binding is a single
+  // read-modify-write row host-side, so concurrent removeEntry calls (e.g.
+  // the multi-folder toggle collapsing several extras at once) could clobber
+  // one another and lose a removal. `queuedRemoveBindingPathsRef` also keeps
+  // one path from being enqueued twice before its mutation starts (the
+  // pendingRemovePaths guard only covers in-flight mutations).
+  const removeBindingQueueRef = useRef<Promise<void> | null>(null);
+  const queuedRemoveBindingPathsRef = useRef<Set<string> | null>(null);
   const addFolderMutation = useWorkspaceBindingAddFolderForClient(
     props.hostClient,
   );
@@ -1456,9 +1594,57 @@ function InEpicSurface(props: InEpicSurfaceProps) {
       Array.from(new Set(bindingEntries.map((entry) => entry.workspacePath))),
     [bindingEntries],
   );
+  // The persistent saved-project list also renders here as unselected rows:
+  // checking one adds it to THIS owner's binding, so switching projects
+  // mid-epic is a checkbox action rather than re-picking folders. Saved
+  // paths resolve against the OWNER's fixed host - a project that doesn't
+  // exist on this host stays listed but can't be checked.
+  const savedFolders = useWorkspaceFoldersStore((s) => s.folders);
+  const savedFolderInfoByPath = useWorkspaceFoldersStore(
+    (s) => s.folderInfoByPath,
+  );
+  const savedPinnedPath = useWorkspaceFoldersStore((s) => s.pinnedPath);
+  const setSavedPinnedFolder = useWorkspaceFoldersStore(
+    (s) => s.setPinnedFolder,
+  );
+  const removeSavedFolder = useWorkspaceFoldersStore((s) => s.removeFolder);
+  const savedSource = useMemo(
+    () => ({ folders: savedFolders, folderInfoByPath: savedFolderInfoByPath }),
+    [savedFolders, savedFolderInfoByPath],
+  );
+  const savedResolved = useResolvedWorkspaceFolders(
+    savedSource,
+    props.hostClient,
+  );
+  const boundPathSet = useMemo(
+    () => new Set(bindingWorkspacePaths),
+    [bindingWorkspacePaths],
+  );
+  const unboundSavedFolders = useMemo(
+    () =>
+      savedResolved.folders.filter((entry) => !boundPathSet.has(entry.path)),
+    [savedResolved.folders, boundPathSet],
+  );
+  const resolvedPinnedPath = useMemo(
+    () => resolvePrimaryPath(savedFolders, savedPinnedPath),
+    [savedFolders, savedPinnedPath],
+  );
+  const savedPathSet = useMemo(() => new Set(savedFolders), [savedFolders]);
+  // Fetch disk metadata for the unbound-but-resolvable saved rows too, so
+  // their current branch shows; unresolved rows have no path on this host to
+  // list.
+  const metadataQueryPaths = useMemo(
+    () => [
+      ...bindingWorkspacePaths,
+      ...unboundSavedFolders.flatMap((entry) =>
+        entry.kind === "unresolved" ? [] : [entry.path],
+      ),
+    ],
+    [bindingWorkspacePaths, unboundSavedFolders],
+  );
   const metadataQuery = useWorktreeListByWorkspacePathsForClient(
     props.hostClient,
-    { workspacePaths: bindingWorkspacePaths, enabled: true },
+    { workspacePaths: metadataQueryPaths, enabled: true },
   );
   const summariesByPath = useMemo(
     () =>
@@ -1819,9 +2005,55 @@ function InEpicSurface(props: InEpicSurfaceProps) {
   const activeRunLocksBinding =
     surface.kind === "chat" && surface.isOwnerActive;
 
+  // Checking a saved project's row: add that known path to THIS owner's
+  // binding (no folder dialog). Mirrors `addFoldersToOwnerBinding`'s
+  // per-folder post-processing: default-seed once metadata resolves, and
+  // never resume the PTY on its own.
+  const addSavedFolderToBinding = useCallback(
+    (workspacePath: string): void => {
+      addFolderMutation.mutate(
+        {
+          epicId: surface.epicId,
+          ownerId: surface.ownerId,
+          ownerKind,
+          workspacePath,
+        },
+        {
+          onSuccess: () => {
+            pendingDefaultPathsRef.current?.add(workspacePath);
+            if (surface.kind === "terminal-agent") {
+              markBindingDirtyWithoutResume([workspacePath]);
+            } else {
+              handleBindingCommitted([workspacePath]);
+            }
+          },
+        },
+      );
+    },
+    [
+      addFolderMutation,
+      handleBindingCommitted,
+      markBindingDirtyWithoutResume,
+      ownerKind,
+      surface.epicId,
+      surface.kind,
+      surface.ownerId,
+    ],
+  );
+
   const addFoldersToOwnerBinding = async (): Promise<boolean> => {
     const result = await folderActions.pickAndPrepareFolders();
     if (result === null) return false;
+    // Every explicit add SAVES the project for future chats too (same rule as
+    // the pre-create surfaces) - a folder added to a live chat must show up
+    // in the persistent saved list, be pinnable, and survive this chat.
+    // Saved-list cap evictions never unbind rows here: bound rows come from
+    // the owner binding, not the saved list.
+    useWorkspaceFoldersStore
+      .getState()
+      .addResolvedFolders(
+        result.folders.map(preparedWorkspaceFolderToWorkspaceFolderInfo),
+      );
     const addedWorkspacePaths: string[] = [];
     // Add each picked folder independently and sequentially: the binding is a
     // single read-modify-write row, so parallel writes would clobber one
@@ -1844,6 +2076,18 @@ function InEpicSurface(props: InEpicSurfaceProps) {
       }
     }
     if (addedWorkspacePaths.length === 0) return false;
+    // A live binding cannot atomically switch its main project, so an add
+    // with the multi-folder opt-in OFF still lands ALONGSIDE the existing
+    // folders. Flip the opt-in on when that produces a multi-folder chat, so
+    // the picker state (row checkboxes, footer toggle) matches reality
+    // instead of silently violating the single-folder promise.
+    const foldersState = useWorkspaceFoldersStore.getState();
+    if (
+      !foldersState.allowMultipleFolders &&
+      workspaces.length + addedWorkspacePaths.length > 1
+    ) {
+      foldersState.setAllowMultipleFolders(true);
+    }
     // The folders are in the binding now, but adding never resumes the PTY —
     // the explicit "Update" does. Mark dirty so "Update" is enabled (a non-git
     // add stages nothing). Chat has no PTY to resume (no-op callback).
@@ -1984,6 +2228,57 @@ function InEpicSurface(props: InEpicSurfaceProps) {
           diskWorktrees: otherWorktrees,
         });
         const emit = emitForFolder(ws);
+        // `forgetSaved`: the trash flow also deletes the SAVED project - but
+        // only after the host confirms the unbind, so a failed unbind can
+        // never leave this chat bound to a project that has already vanished
+        // from saved projects.
+        const removeFromBinding = (forgetSaved: boolean): void => {
+          const queuedPaths = (queuedRemoveBindingPathsRef.current ??=
+            new Set());
+          if (removePending || queuedPaths.has(ws.workspacePath)) {
+            return;
+          }
+          queuedPaths.add(ws.workspacePath);
+          removeBindingQueueRef.current = (
+            removeBindingQueueRef.current ?? Promise.resolve()
+          ).then(() =>
+            removeBindingEntryMutation
+              .mutateAsync({
+                epicId: surface.epicId,
+                ownerId: surface.ownerId,
+                ownerKind,
+                workspacePath: ws.workspacePath,
+              })
+              .then(() => {
+                // Terminal-agent: remove from the binding but don't resume —
+                // only "Update" does. Chat: no PTY to resume (no-op
+                // callback).
+                //
+                // A folder removed before its metadata resolved has nothing
+                // to seed - its summary never arrives, so left in place the
+                // path would pin the pending-defaults guard and block
+                // Update's resume forever.
+                pendingDefaultPathsRef.current?.delete(ws.workspacePath);
+                // And if metadata DID resolve first, the seeding effect may
+                // already have staged a default worktree intent for this
+                // path - unstage it, or the next Update would call
+                // worktree.create for a folder no longer in the binding.
+                unstageWorktreeEntry(stagedKey, ws.workspacePath);
+                if (forgetSaved) removeSavedFolder(ws.workspacePath);
+                if (surface.kind === "terminal-agent") {
+                  markBindingDirtyWithoutResume([ws.workspacePath]);
+                  return;
+                }
+                handleBindingCommitted([ws.workspacePath]);
+              })
+              // The mutation hook's onError already surfaces the toast; a
+              // failed removal must not break the queue for later ones.
+              .catch(() => undefined)
+              .finally(() => {
+                queuedPaths.delete(ws.workspacePath);
+              }),
+          );
+        };
         return {
           key: ws.workspacePath,
           displayName: workspaceFolderName(ws.workspacePath),
@@ -1993,22 +2288,41 @@ function InEpicSurface(props: InEpicSurfaceProps) {
           missing: visibleMissingWorktreePaths.includes(ws.workspacePath),
           isGitRepo: rowIsGitRepo,
           mode: currentMode,
-          branchLabel:
-            currentMode === "local"
-              ? (currentBranch ?? modeLabel)
-              : branchLabel,
+          branchLabel: boundRowBranchLabel(
+            currentMode,
+            currentBranch,
+            modeLabel,
+            branchLabel,
+          ),
           summary: ws,
           currentIntent,
           defaultNewBranchName,
           repoIdentifier: ws.repoIdentifier,
           isPrimary,
-          // Bound owner rows (chat / terminal-agent) have no atomic
-          // set-primary RPC yet - the badge renders read-only here; switching
-          // stays scoped to not-yet-created pickers (landing, fork dialogs,
-          // the new-conversation modal, the terminal-agent launcher).
-          canChangePrimary: false,
-          makePrimaryDisabled: false,
-          makePrimaryDisabledReason: null,
+          // A bound row IS in the chat: unchecking a SECONDARY removes it
+          // from this owner's binding (the saved list keeps the project).
+          // The bound PRIMARY renders the locked main marker instead of a
+          // checkbox, and no bound row offers the main switch: a live
+          // chat's primary is fixed host-side (no set-primary RPC).
+          selected: true,
+          onToggleSelected: isPrimary
+            ? null
+            : (nextSelected) => {
+                if (nextSelected) return;
+                removeFromBinding(false);
+              },
+          selectionDisabledReason: boundSelectionDisabledReason({
+            activeRunLocksBinding,
+            activeRunNotice,
+            removePending,
+          }),
+          onUseAsMain: null,
+          ...savedPinFields(
+            ws.workspacePath,
+            savedPathSet,
+            resolvedPinnedPath,
+            setSavedPinnedFolder,
+          ),
           hostClient: props.hostClient,
           modeDisabled: activeRunLocksBinding || rowMetadataPending,
           modeDisabledReason: modeDisabledReasonFor(
@@ -2023,7 +2337,6 @@ function InEpicSurface(props: InEpicSurfaceProps) {
           ),
           removePending,
           onEmit: emit,
-          onMakePrimary: () => undefined,
           onSelectMode: (nextMode) => {
             if (ws.resolvedAt === null) return;
             if (!locationSelectionChanges(nextMode, currentIntent, currentMode))
@@ -2050,36 +2363,10 @@ function InEpicSurface(props: InEpicSurfaceProps) {
           },
           onLocate: null,
           onRemove: () => {
-            if (removePending) return;
-            removeBindingEntryMutation.mutate(
-              {
-                epicId: surface.epicId,
-                ownerId: surface.ownerId,
-                ownerKind,
-                workspacePath: ws.workspacePath,
-              },
-              {
-                // Terminal-agent: remove from the binding but don't resume —
-                // only "Update" does. Chat: no PTY to resume (no-op callback).
-                onSuccess: () => {
-                  // A folder removed before its metadata resolved has nothing
-                  // to seed - its summary never arrives, so left in place the
-                  // path would pin the pending-defaults guard and block
-                  // Update's resume forever.
-                  pendingDefaultPathsRef.current?.delete(ws.workspacePath);
-                  // And if metadata DID resolve first, the seeding effect may
-                  // already have staged a default worktree intent for this
-                  // path - unstage it, or the next Update would call
-                  // worktree.create for a folder no longer in the binding.
-                  unstageWorktreeEntry(stagedKey, ws.workspacePath);
-                  if (surface.kind === "terminal-agent") {
-                    markBindingDirtyWithoutResume([ws.workspacePath]);
-                    return;
-                  }
-                  handleBindingCommitted([ws.workspacePath]);
-                },
-              },
-            );
+            // The trash deletes the project from the SAVED list too;
+            // unchecking (above) only detaches it from this chat. Saved-list
+            // deletion is sequenced inside the unbind's onSuccess.
+            removeFromBinding(true);
           },
         };
       }),
@@ -2092,6 +2379,10 @@ function InEpicSurface(props: InEpicSurfaceProps) {
       markBindingDirtyWithoutResume,
       pendingBranchByPath,
       pendingRemovePaths,
+      removeSavedFolder,
+      resolvedPinnedPath,
+      savedPathSet,
+      setSavedPinnedFolder,
       stagedKey,
       unstageWorktreeEntry,
       props.hostClient,
@@ -2106,6 +2397,54 @@ function InEpicSurface(props: InEpicSurfaceProps) {
       visibleMissingWorktreePaths,
       workspaces,
     ],
+  );
+
+  // The unbound saved projects, appended after the bound rows: unchecked,
+  // display-only facts, checkable when the path resolves on this host.
+  // Handlers attach here (not in the pure display-field helper) so the
+  // ref-capturing binding-add callback is only stored on the item, never
+  // passed through a render-time function call.
+  const savedUnboundItems = useMemo<ReadonlyArray<WorkspaceRunItem>>(
+    () =>
+      unboundSavedFolders.map((entry) => ({
+        ...savedUnboundRunItemFields({
+          entry,
+          hostClient: props.hostClient,
+          metadataFetching: metadataQuery.isFetching,
+          resolvedPinnedPath,
+          summariesByPath,
+        }),
+        onToggleSelected: (nextSelected: boolean) => {
+          if (!nextSelected) return;
+          addSavedFolderToBinding(entry.path);
+        },
+        selectionDisabledReason: unboundSelectionDisabledReason({
+          entry,
+          activeRunLocksBinding,
+          activeRunNotice,
+        }),
+        // A live chat's primary is fixed host-side - saved rows can join as
+        // additional folders but never become the main here.
+        onUseAsMain: null,
+        onTogglePin: () => setSavedPinnedFolder(entry.path),
+        onRemove: () => removeSavedFolder(entry.path),
+      })),
+    [
+      activeRunLocksBinding,
+      activeRunNotice,
+      addSavedFolderToBinding,
+      metadataQuery.isFetching,
+      props.hostClient,
+      removeSavedFolder,
+      resolvedPinnedPath,
+      setSavedPinnedFolder,
+      summariesByPath,
+      unboundSavedFolders,
+    ],
+  );
+  const pickerItems = useMemo<ReadonlyArray<WorkspaceRunItem>>(
+    () => [...workspaceRunItems, ...savedUnboundItems],
+    [workspaceRunItems, savedUnboundItems],
   );
 
   // Setup/teardown editor, hosted here so it outlives the popover. In-epic
@@ -2168,7 +2507,7 @@ function InEpicSurface(props: InEpicSurfaceProps) {
         </div>
         <div className="min-w-0 flex-[1_1_auto] max-w-[min(100%,34rem)] overflow-hidden">
           <WorkspaceFolderSummaryControl
-            items={workspaceRunItems}
+            items={pickerItems}
             readOnly={readOnly}
             bindingResolved={surface.bindingResolved}
             addFolderPending={
@@ -2224,6 +2563,121 @@ function InEpicSurface(props: InEpicSurfaceProps) {
       />
     </>
   );
+}
+
+/**
+ * The saved-list pin fields for a bound row: the pin action only exists for
+ * folders that are actually in the saved list (a bound-but-unsaved folder
+ * can't be a default for new tasks).
+ */
+function savedPinFields(
+  workspacePath: string,
+  savedPathSet: ReadonlySet<string>,
+  resolvedPinnedPath: string | null,
+  setSavedPinnedFolder: (folderPath: string) => void,
+): Pick<WorkspaceRunItem, "isPinned" | "onTogglePin"> {
+  return {
+    isPinned: workspacePath === resolvedPinnedPath,
+    onTogglePin: savedPathSet.has(workspacePath)
+      ? () => setSavedPinnedFolder(workspacePath)
+      : null,
+  };
+}
+
+/** A local bound row reads as its checkout's branch (else the mode label);
+ * worktree rows keep the derived branch label. */
+function boundRowBranchLabel(
+  currentMode: WorkspaceRunMode,
+  currentBranch: string | null,
+  modeLabel: string,
+  branchLabel: string,
+): string {
+  if (currentMode !== "local") return branchLabel;
+  return currentBranch ?? modeLabel;
+}
+
+/**
+ * Why a bound row's checkbox is inert: an active run locks the binding, and
+ * an in-flight removal must not double-fire. (The bound main renders a
+ * locked marker, not a checkbox, so "at least one folder" is structural.)
+ */
+function boundSelectionDisabledReason(input: {
+  readonly activeRunLocksBinding: boolean;
+  readonly activeRunNotice: string;
+  readonly removePending: boolean;
+}): string | null {
+  if (input.activeRunLocksBinding) return input.activeRunNotice;
+  if (input.removePending) return "Removing this folder…";
+  return null;
+}
+
+/**
+ * Display fields for a saved project not bound to this owner: an unchecked,
+ * display-only row (name + current branch). The caller attaches the handlers
+ * (check → add to binding, trash → delete saved, pin). Rows that don't
+ * resolve on this host stay visible but can't be checked.
+ */
+function savedUnboundRunItemFields(input: {
+  readonly entry: ResolvedFolder;
+  readonly hostClient: HostClient<HostRpcRegistry> | null;
+  readonly metadataFetching: boolean;
+  readonly resolvedPinnedPath: string | null;
+  readonly summariesByPath: ReadonlyMap<string, WorktreeWorkspaceSummaryV13>;
+}): Omit<
+  WorkspaceRunItem,
+  | "onToggleSelected"
+  | "selectionDisabledReason"
+  | "onUseAsMain"
+  | "onTogglePin"
+  | "onRemove"
+> {
+  const { entry } = input;
+  const unresolvedOnHost = entry.kind === "unresolved";
+  const summary = unresolvedOnHost
+    ? null
+    : (input.summariesByPath.get(entry.path) ?? null);
+  const metadataResolved = summary !== null && summary.resolvedAt !== null;
+  return {
+    key: entry.path,
+    displayName: entry.name,
+    displayPath: entry.path,
+    unresolved: unresolvedOnHost,
+    metadataPending:
+      !unresolvedOnHost && !metadataResolved && input.metadataFetching,
+    missing: false,
+    isGitRepo: metadataResolved && summary.isGitRepo,
+    mode: "local",
+    branchLabel: unresolvedOnHost
+      ? "Unavailable"
+      : (branchForSummary(summary) ?? "Local"),
+    summary,
+    currentIntent: null,
+    defaultNewBranchName: "",
+    repoIdentifier:
+      summary?.repoIdentifier ?? repoIdentifierForResolvedFolder(entry),
+    isPrimary: false,
+    selected: false,
+    isPinned: entry.path === input.resolvedPinnedPath,
+    hostClient: input.hostClient,
+    modeDisabled: true,
+    modeDisabledReason: null,
+    removeDisabled: false,
+    removeDisabledReason: null,
+    removePending: false,
+    onSelectMode: () => undefined,
+    onEmit: () => undefined,
+    onLocate: null,
+  };
+}
+
+function unboundSelectionDisabledReason(input: {
+  readonly entry: ResolvedFolder;
+  readonly activeRunLocksBinding: boolean;
+  readonly activeRunNotice: string;
+}): string | null {
+  if (input.entry.kind === "unresolved") return "Not available on this host.";
+  if (input.activeRunLocksBinding) return input.activeRunNotice;
+  return null;
 }
 
 // No staged pick yet (`capturedEntry === null`): a git folder reflects the

--- a/clients/gui-app/src/components/home/host-workspace-selector/use-home-workspace-source.ts
+++ b/clients/gui-app/src/components/home/host-workspace-selector/use-home-workspace-source.ts
@@ -79,10 +79,12 @@ export interface HomeWorkspaceSource {
   readonly stageEntry: (entry: WorktreeFolderIntent) => void;
 }
 
+/** Returns the draft ID represented by a landing staging key. */
 function landingDraftIdFor(stagingKey: WorktreeStagingKey): string | null {
   return stagingKey.surface === "landing" ? stagingKey.draftId : null;
 }
 
+/** Returns the epic ID represented by a new-conversation staging key. */
 function newConversationEpicIdFor(
   stagingKey: WorktreeStagingKey,
 ): string | null {

--- a/clients/gui-app/src/components/home/host-workspace-selector/use-home-workspace-source.ts
+++ b/clients/gui-app/src/components/home/host-workspace-selector/use-home-workspace-source.ts
@@ -12,6 +12,7 @@ import {
   removeLandingDraftWorkspaceFolder,
   setLandingDraftWorkspacePrimary,
   useLandingDraftStore,
+  usePendingOrPinnedLandingWorkspace,
   type LandingDraftWorkspaceSnapshot,
 } from "@/stores/home/landing-draft-store";
 import { useNewConversationModalStore } from "@/stores/epics/new-conversation-modal-store";
@@ -47,12 +48,45 @@ export interface HomeWorkspaceSource {
   readonly primaryPath: string | null;
   /** Membership-validated primary folder for launch consumers. */
   readonly primaryWorkspacePath: string | null;
+  /** The persistent saved-project list (global store), selection-independent. */
+  readonly savedFolders: ReadonlyArray<string>;
+  readonly savedFolderInfoByPath: Readonly<Record<string, WorkspaceFolderInfo>>;
+  /** The pinned default project for NEW tasks (never a per-chat state). */
+  readonly pinnedPath: string | null;
+  // Whether per-chat selection toggles are meaningful here. `false` only for
+  // the implicit global-fallback representation (no draft / modal / seed /
+  // pending landing), where "selection" IS the saved list and a deselect
+  // would destroy a saved project.
+  readonly canToggleSelection: boolean;
   readonly addResolvedFolders: (
     folders: ReadonlyArray<WorkspaceFolderInfo>,
   ) => void;
   readonly removeFolder: (folderPath: string) => PrimaryRemovalTransition;
+  /** Selects a SAVED project for the current chat (surface-only add). */
+  readonly selectFolder: (folderPath: string) => void;
+  /** Deselects a project from the current chat; the saved list is untouched. */
+  readonly deselectFolder: (folderPath: string) => PrimaryRemovalTransition;
+  /**
+   * Switches the chat's MAIN project to `folderPath` in one action: selects
+   * it, makes it primary, and drops the previous main from the chat (unless
+   * it was the same folder). Additional (checked) folders are untouched. In
+   * the global-fallback representation this only moves primary - selection
+   * IS the saved list there.
+   */
+  readonly switchMainFolder: (folderPath: string) => void;
   readonly setPrimaryFolder: (folderPath: string) => void;
+  readonly setPinnedFolder: (folderPath: string) => void;
   readonly stageEntry: (entry: WorktreeFolderIntent) => void;
+}
+
+function landingDraftIdFor(stagingKey: WorktreeStagingKey): string | null {
+  return stagingKey.surface === "landing" ? stagingKey.draftId : null;
+}
+
+function newConversationEpicIdFor(
+  stagingKey: WorktreeStagingKey,
+): string | null {
+  return stagingKey.surface === "new-conversation" ? stagingKey.epicId : null;
 }
 
 /**
@@ -67,9 +101,8 @@ export function useHomeWorkspaceSource(
   stagingKey: WorktreeStagingKey,
   workspaceSeed: LandingDraftWorkspaceSnapshot | null,
 ): HomeWorkspaceSource {
-  const draftId = stagingKey.surface === "landing" ? stagingKey.draftId : null;
-  const modalEpicId =
-    stagingKey.surface === "new-conversation" ? stagingKey.epicId : null;
+  const draftId = landingDraftIdFor(stagingKey);
+  const modalEpicId = newConversationEpicIdFor(stagingKey);
   const draftWorkspace = useLandingDraftStore(
     useShallow((state) => {
       if (draftId === null) return null;
@@ -106,8 +139,14 @@ export function useHomeWorkspaceSource(
   const setGlobalPrimaryFolder = useWorkspaceFoldersStore(
     (state) => state.setPrimaryFolder,
   );
+  const setGlobalPinnedFolder = useWorkspaceFoldersStore(
+    (state) => state.setPinnedFolder,
+  );
   const globalPrimaryPath = useWorkspaceFoldersStore(
     (state) => state.primaryPath,
+  );
+  const globalPinnedPath = useWorkspaceFoldersStore(
+    (state) => state.pinnedPath,
   );
   const globalFolders = useWorkspaceFoldersStore((state) => state.folders);
   const globalFolderInfoByPath = useWorkspaceFoldersStore(
@@ -117,13 +156,20 @@ export function useHomeWorkspaceSource(
     addDraftResolvedFolders,
     removeDraftFolder,
     setDraftWorkspacePrimary,
+    addPendingResolvedFolders,
+    removePendingFolder,
+    setPendingWorkspacePrimary,
   } = useLandingDraftStore(
     useShallow((state) => ({
       addDraftResolvedFolders: state.addDraftResolvedFolders,
       removeDraftFolder: state.removeDraftFolder,
       setDraftWorkspacePrimary: state.setDraftWorkspacePrimary,
+      addPendingResolvedFolders: state.addPendingResolvedFolders,
+      removePendingFolder: state.removePendingFolder,
+      setPendingWorkspacePrimary: state.setPendingWorkspacePrimary,
     })),
   );
+  const pendingOrPinnedWorkspace = usePendingOrPinnedLandingWorkspace();
   const { addModalResolvedFolders, removeModalFolder, setModalPrimaryFolder } =
     useNewConversationModalStore(
       useShallow((state) => ({
@@ -146,7 +192,18 @@ export function useHomeWorkspaceSource(
     seededWorkspaceState.seed === workspaceSeed
       ? seededWorkspaceState.workspace
       : workspaceSeed;
-  const source = modalWorkspace ?? draftWorkspace ?? seededWorkspace;
+  // The BLANK landing (no draft minted yet, no seed, no modal) edits a real
+  // per-chat PENDING snapshot in the landing-draft store - never the global
+  // fallback. `createDraftWithId` consumes that snapshot as the new draft's
+  // workspace, so a pre-typing add/main-switch survives the first substantive
+  // editor change instead of being silently discarded.
+  const usingPendingLanding =
+    stagingKey.surface === "landing" &&
+    stagingKey.draftId === null &&
+    seededWorkspace === null;
+  const pendingSource = usingPendingLanding ? pendingOrPinnedWorkspace : null;
+  const source =
+    modalWorkspace ?? draftWorkspace ?? seededWorkspace ?? pendingSource;
   const activeDraftId = draftWorkspace === null ? null : draftId;
   const modalSeedWorkspace = useMemo(
     () => workspaceSeed ?? emptyLandingDraftWorkspaceSnapshot(),
@@ -178,180 +235,295 @@ export function useHomeWorkspaceSource(
       .getState()
       .setSnapshot(stagingKey, seededWorkspace);
   }, [usingSeededWorkspace, seededWorkspace, stagingKey]);
-  return useMemo(
-    () => ({
+  const usingGlobalFallback = source === null;
+  return useMemo(() => {
+    const applySetPrimary = (folderPath: string): void => {
+      // Suppress only the duplicate EVENT on a same-primary re-selection;
+      // the state writes below must still run so a staged worktree intent's
+      // stale isPrimary bit is restamped before launch consumers read it.
+      if (folderPath !== primaryPath) {
+        Analytics.getInstance().track(AnalyticsEvent.WorkspacePrimaryChanged, {
+          source: "direct_ui",
+        });
+      }
+      if (modalEpicId !== null) {
+        setModalPrimaryFolder(modalEpicId, modalSeedWorkspace, folderPath);
+      } else {
+        if (!usingSeededWorkspace) {
+          setGlobalPrimaryFolder(folderPath);
+        }
+        if (activeDraftId !== null) {
+          setDraftWorkspacePrimary(activeDraftId, folderPath);
+        }
+        if (usingPendingLanding) {
+          setPendingWorkspacePrimary(folderPath);
+        }
+        if (usingSeededWorkspace) {
+          setSeededWorkspaceState((current) => ({
+            seed: current.seed,
+            workspace:
+              current.workspace === null
+                ? null
+                : setLandingDraftWorkspacePrimary(
+                    current.workspace,
+                    folderPath,
+                  ),
+          }));
+        }
+      }
+      // Restamp staged intent entries in place (never remove/unstage) so a
+      // switch never leaves a stale `isPrimary` bit for another consumer
+      // to read before the next launch-boundary canonicalization.
+      const restamped = restampWorktreeIntentPrimary(
+        capturedIntent,
+        folderPath,
+      );
+      if (restamped !== capturedIntent) {
+        setStagedIntent(stagingKey, restamped);
+      }
+    };
+    const applySurfaceOnlyAdd = (
+      infos: ReadonlyArray<WorkspaceFolderInfo>,
+    ): void => {
+      if (modalEpicId !== null) {
+        const evicted = addModalResolvedFolders(
+          modalEpicId,
+          modalSeedWorkspace,
+          infos,
+        );
+        for (const path of evicted) unstageStoreEntry(stagingKey, path);
+        return;
+      }
+      if (activeDraftId !== null) {
+        const evicted = addDraftResolvedFolders(activeDraftId, infos);
+        for (const path of evicted) unstageStoreEntry(stagingKey, path);
+      }
+      if (usingPendingLanding) {
+        const evicted = addPendingResolvedFolders(infos);
+        for (const path of evicted) unstageStoreEntry(stagingKey, path);
+      }
+      if (usingSeededWorkspace) {
+        const beforeWorkspace =
+          seededWorkspaceState.workspace ??
+          emptyLandingDraftWorkspaceSnapshot();
+        const afterWorkspace = mergeLandingDraftWorkspaceFolders(
+          beforeWorkspace,
+          infos,
+        );
+        const afterSet = new Set(afterWorkspace.folders);
+        const evicted = beforeWorkspace.folders.filter(
+          (path) => !afterSet.has(path),
+        );
+        setSeededWorkspaceState((current) => ({
+          seed: current.seed,
+          workspace: mergeLandingDraftWorkspaceFolders(
+            current.workspace ?? emptyLandingDraftWorkspaceSnapshot(),
+            infos,
+          ),
+        }));
+        for (const path of evicted) unstageStoreEntry(stagingKey, path);
+      }
+    };
+    const applySurfaceOnlyRemove = (folderPath: string): void => {
+      if (modalEpicId !== null) {
+        removeModalFolder(modalEpicId, modalSeedWorkspace, folderPath);
+        return;
+      }
+      if (activeDraftId !== null) {
+        removeDraftFolder(activeDraftId, folderPath);
+      }
+      if (usingPendingLanding) {
+        removePendingFolder(folderPath);
+      }
+      if (usingSeededWorkspace) {
+        setSeededWorkspaceState((current) => ({
+          seed: current.seed,
+          workspace:
+            current.workspace === null
+              ? null
+              : removeLandingDraftWorkspaceFolder(
+                  current.workspace,
+                  folderPath,
+                ),
+        }));
+      }
+    };
+    const removalTransitionFor = (
+      folderPath: string,
+    ): PrimaryRemovalTransition => {
+      const beforeFolders = source?.folders ?? globalFolders;
+      const beforePrimary = resolvePrimaryPath(beforeFolders, primaryPath);
+      const afterFolders = beforeFolders.filter((path) => path !== folderPath);
+      const afterPrimary = resolvePrimaryPath(afterFolders, primaryPath);
+      const primaryChanged =
+        beforePrimary === folderPath &&
+        afterPrimary !== null &&
+        afterPrimary !== beforePrimary;
+      return {
+        primaryChanged,
+        newPrimaryName: primaryRemovalNewName(
+          primaryChanged,
+          afterPrimary,
+          sourceFolderInfoByPath,
+        ),
+      };
+    };
+    return {
       source,
       capturedIntent,
       folders,
       primaryPath,
       primaryWorkspacePath,
-      addResolvedFolders: (folders) => {
-        // The 50-folder cap can evict a SECONDARY folder as a side effect of
-        // an add; an evicted folder disappears from rows/persistence but its
-        // staged intent entry (if any) would otherwise survive and still
-        // reach launch. Cleanup must follow the ACTIVE representation's
-        // eviction set: the global cache and an active draft can legitimately
+      savedFolders: globalFolders,
+      savedFolderInfoByPath: globalFolderInfoByPath,
+      pinnedPath: globalPinnedPath,
+      canToggleSelection: !usingGlobalFallback,
+      addResolvedFolders: (added) => {
+        // Every explicit add SAVES the folder for future chats (the global
+        // list) and selects it for the current representation. The 50-folder
+        // cap can evict a SECONDARY folder as a side effect of an add; an
+        // evicted folder disappears from rows/persistence but its staged
+        // intent entry (if any) would otherwise survive and still reach
+        // launch. Cleanup must follow the ACTIVE representation's eviction
+        // set: the global cache and an active draft can legitimately
         // diverge, so a cache-only eviction must not erase surviving draft
         // branch/scripts state.
-        if (modalEpicId !== null) {
-          const evicted = addModalResolvedFolders(
-            modalEpicId,
-            modalSeedWorkspace,
-            folders,
-          );
-          for (const path of evicted) unstageStoreEntry(stagingKey, path);
+        const globalEvicted = addGlobalResolvedFolders(added);
+        if (usingGlobalFallback) {
+          for (const path of globalEvicted) {
+            unstageStoreEntry(stagingKey, path);
+          }
           return;
         }
-        if (!usingSeededWorkspace) {
-          const evicted = addGlobalResolvedFolders(folders);
-          if (activeDraftId === null) {
-            for (const path of evicted) unstageStoreEntry(stagingKey, path);
-          }
+        // Single-project mode ("Allow multiple folders in chat" off): an
+        // explicit add means "work on this project now" - only the first
+        // picked folder joins the chat, as its new MAIN (the previous main
+        // leaves; the rest are saved for later). Read at call time: the
+        // toggle can flip while this seam's memo is still current.
+        const allowMultiple =
+          useWorkspaceFoldersStore.getState().allowMultipleFolders;
+        if (allowMultiple) {
+          applySurfaceOnlyAdd(added);
+          return;
         }
-        if (activeDraftId !== null) {
-          const evicted = addDraftResolvedFolders(activeDraftId, folders);
-          for (const path of evicted) unstageStoreEntry(stagingKey, path);
-        }
-        if (usingSeededWorkspace) {
-          const beforeWorkspace =
-            seededWorkspaceState.workspace ??
-            emptyLandingDraftWorkspaceSnapshot();
-          const afterWorkspace = mergeLandingDraftWorkspaceFolders(
-            beforeWorkspace,
-            folders,
-          );
-          const afterSet = new Set(afterWorkspace.folders);
-          const evicted = beforeWorkspace.folders.filter(
-            (path) => !afterSet.has(path),
-          );
-          setSeededWorkspaceState((current) => ({
-            seed: current.seed,
-            workspace: mergeLandingDraftWorkspaceFolders(
-              current.workspace ?? emptyLandingDraftWorkspaceSnapshot(),
-              folders,
-            ),
-          }));
-          for (const path of evicted) unstageStoreEntry(stagingKey, path);
-        }
+        const first = added.length > 0 ? added[0] : null;
+        if (first === null) return;
+        const currentMain = resolvePrimaryPath(folders, primaryPath);
+        applySurfaceOnlyAdd([first]);
+        if (currentMain === null || currentMain === first.path) return;
+        applySetPrimary(first.path);
+        unstageStoreEntry(stagingKey, currentMain);
+        applySurfaceOnlyRemove(currentMain);
       },
       removeFolder: (folderPath) => {
-        const beforeFolders = source?.folders ?? globalFolders;
-        const beforePrimary = resolvePrimaryPath(beforeFolders, primaryPath);
+        // The trash action deletes the project from the SAVED list and drops
+        // it from the current chat's selection.
         unstageStoreEntry(stagingKey, folderPath);
-        if (modalEpicId !== null) {
-          removeModalFolder(modalEpicId, modalSeedWorkspace, folderPath);
-        } else {
-          if (!usingSeededWorkspace) {
-            removeGlobalFolder(folderPath);
-          }
-          if (activeDraftId !== null) {
-            removeDraftFolder(activeDraftId, folderPath);
-          }
-          if (usingSeededWorkspace) {
-            setSeededWorkspaceState((current) => ({
-              seed: current.seed,
-              workspace:
-                current.workspace === null
-                  ? null
-                  : removeLandingDraftWorkspaceFolder(
-                      current.workspace,
-                      folderPath,
-                    ),
-            }));
-          }
-        }
-        const afterFolders = beforeFolders.filter(
-          (path) => path !== folderPath,
-        );
-        const afterPrimary = resolvePrimaryPath(afterFolders, primaryPath);
-        const primaryChanged =
-          beforePrimary === folderPath &&
-          afterPrimary !== null &&
-          afterPrimary !== beforePrimary;
-        return {
-          primaryChanged,
-          newPrimaryName: primaryRemovalNewName(
-            primaryChanged,
-            afterPrimary,
-            sourceFolderInfoByPath,
-          ),
-        };
+        const transition = removalTransitionFor(folderPath);
+        removeGlobalFolder(folderPath);
+        applySurfaceOnlyRemove(folderPath);
+        return transition;
       },
-      setPrimaryFolder: (folderPath) => {
-        // Suppress only the duplicate EVENT on a same-primary re-selection;
-        // the state writes below must still run so a staged worktree intent's
-        // stale isPrimary bit is restamped before launch consumers read it.
-        if (folderPath !== primaryPath) {
-          Analytics.getInstance().track(
-            AnalyticsEvent.WorkspacePrimaryChanged,
-            { source: "direct_ui" },
-          );
+      selectFolder: (folderPath) => {
+        if (usingGlobalFallback) return;
+        const info = Object.hasOwn(globalFolderInfoByPath, folderPath)
+          ? globalFolderInfoByPath[folderPath]
+          : null;
+        if (info === null) return;
+        applySurfaceOnlyAdd([info]);
+      },
+      deselectFolder: (folderPath) => {
+        const transition = removalTransitionFor(folderPath);
+        if (usingGlobalFallback) return transition;
+        unstageStoreEntry(stagingKey, folderPath);
+        applySurfaceOnlyRemove(folderPath);
+        return transition;
+      },
+      setPrimaryFolder: applySetPrimary,
+      switchMainFolder: (folderPath) => {
+        const currentMain = resolvePrimaryPath(folders, primaryPath);
+        if (folderPath === currentMain) return;
+        // In the global-fallback representation every saved folder is
+        // "selected", so a switch is purely a primary move.
+        if (usingGlobalFallback) {
+          applySetPrimary(folderPath);
+          return;
         }
-        if (modalEpicId !== null) {
-          setModalPrimaryFolder(modalEpicId, modalSeedWorkspace, folderPath);
-        } else {
-          if (!usingSeededWorkspace) {
-            setGlobalPrimaryFolder(folderPath);
-          }
-          if (activeDraftId !== null) {
-            setDraftWorkspacePrimary(activeDraftId, folderPath);
-          }
-          if (usingSeededWorkspace) {
-            setSeededWorkspaceState((current) => ({
-              seed: current.seed,
-              workspace:
-                current.workspace === null
-                  ? null
-                  : setLandingDraftWorkspacePrimary(
-                      current.workspace,
-                      folderPath,
-                    ),
-            }));
-          }
-        }
-        // Restamp staged intent entries in place (never remove/unstage) so a
-        // switch never leaves a stale `isPrimary` bit for another consumer
-        // to read before the next launch-boundary canonicalization.
-        const restamped = restampWorktreeIntentPrimary(
-          capturedIntent,
+        const info = folderInfoFor(
           folderPath,
+          globalFolderInfoByPath,
+          sourceFolderInfoByPath,
         );
-        if (restamped !== capturedIntent) {
-          setStagedIntent(stagingKey, restamped);
+        if (info === null) return;
+        // Select the new main first, then move primary, then drop the old
+        // main - this order never leaves the chat without a primary folder.
+        applySurfaceOnlyAdd([info]);
+        applySetPrimary(folderPath);
+        if (currentMain !== null) {
+          unstageStoreEntry(stagingKey, currentMain);
+          applySurfaceOnlyRemove(currentMain);
         }
+      },
+      setPinnedFolder: (folderPath) => {
+        // The pin is a property of the SAVED list (default for new tasks),
+        // never of the active chat's selection - it always writes globally.
+        setGlobalPinnedFolder(folderPath);
       },
       stageEntry: (entry) => {
         stageStoreEntry(stagingKey, entry);
       },
-    }),
-    [
-      activeDraftId,
-      addDraftResolvedFolders,
-      addGlobalResolvedFolders,
-      addModalResolvedFolders,
-      capturedIntent,
-      folders,
-      globalFolders,
-      modalEpicId,
-      modalSeedWorkspace,
-      primaryPath,
-      primaryWorkspacePath,
-      removeDraftFolder,
-      removeGlobalFolder,
-      removeModalFolder,
-      seededWorkspaceState,
-      setDraftWorkspacePrimary,
-      setGlobalPrimaryFolder,
-      setModalPrimaryFolder,
-      setStagedIntent,
-      sourceFolderInfoByPath,
-      usingSeededWorkspace,
-      source,
-      stageStoreEntry,
-      stagingKey,
-      unstageStoreEntry,
-    ],
-  );
+    };
+  }, [
+    activeDraftId,
+    addDraftResolvedFolders,
+    addGlobalResolvedFolders,
+    addModalResolvedFolders,
+    capturedIntent,
+    addPendingResolvedFolders,
+    folders,
+    globalFolderInfoByPath,
+    globalFolders,
+    globalPinnedPath,
+    modalEpicId,
+    modalSeedWorkspace,
+    primaryPath,
+    primaryWorkspacePath,
+    removeDraftFolder,
+    removeGlobalFolder,
+    removeModalFolder,
+    removePendingFolder,
+    seededWorkspaceState,
+    setDraftWorkspacePrimary,
+    setGlobalPinnedFolder,
+    setGlobalPrimaryFolder,
+    setModalPrimaryFolder,
+    setPendingWorkspacePrimary,
+    setStagedIntent,
+    sourceFolderInfoByPath,
+    usingGlobalFallback,
+    usingPendingLanding,
+    usingSeededWorkspace,
+    source,
+    stageStoreEntry,
+    stagingKey,
+    unstageStoreEntry,
+  ]);
+}
+
+/** Saved-list metadata first (the switch target is usually a saved project),
+ * then the active representation's own metadata (fork-seeded extras). */
+function folderInfoFor(
+  folderPath: string,
+  globalFolderInfoByPath: Readonly<Record<string, WorkspaceFolderInfo>>,
+  sourceFolderInfoByPath: Readonly<Record<string, WorkspaceFolderInfo>>,
+): WorkspaceFolderInfo | null {
+  if (Object.hasOwn(globalFolderInfoByPath, folderPath)) {
+    return globalFolderInfoByPath[folderPath];
+  }
+  if (Object.hasOwn(sourceFolderInfoByPath, folderPath)) {
+    return sourceFolderInfoByPath[folderPath];
+  }
+  return null;
 }
 
 // The narrated reassignment name for `removeFolder`'s

--- a/clients/gui-app/src/components/home/host-workspace-selector/workspace-folder-rows.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/workspace-folder-rows.tsx
@@ -1,10 +1,12 @@
-import { useMemo, useState, type ReactNode } from "react";
+import { useId, useMemo, useState, type ReactNode } from "react";
 import { FolderPlus, RotateCw } from "lucide-react";
 import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
+import { Checkbox } from "@/components/ui/checkbox";
 import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 import { useHostQuery } from "@/hooks/host/use-host-query";
 import type { HostRpcRegistry } from "@/lib/host";
 import { cn } from "@/lib/utils";
+import { useWorkspaceFoldersStore } from "@/stores/workspace/workspace-folders-store";
 import { FolderRow } from "./folder-row";
 import type { WorkspaceRunItem } from "./workspace-run-item";
 
@@ -43,6 +45,13 @@ export function WorkspaceFolderRows(props: {
   readonly nestedInPopover: boolean;
 }) {
   const { items } = props;
+  // The global multi-select preference gates the per-row ADDITIONAL
+  // checkboxes; the bottom-line toggle below flips it. This is the one piece
+  // of state this component reads/writes itself - it is a global UI
+  // preference, not binding/staging/mutation logic (still item handlers).
+  const allowMultipleFolders = useWorkspaceFoldersStore(
+    (state) => state.allowMultipleFolders,
+  );
   // Captured so the branch-form's nested source dropdown uses this container as
   // its collision boundary (in-epic, where the rows live inside a popover).
   const [boundaryEl, setBoundaryEl] = useState<HTMLDivElement | null>(null);
@@ -106,6 +115,14 @@ export function WorkspaceFolderRows(props: {
         pending={props.updatePending}
       />
     );
+  const multiToggle =
+    props.readOnly ||
+    !items.some((item) => item.onToggleSelected !== null) ? null : (
+      <AllowMultipleFoldersToggle
+        items={items}
+        checked={allowMultipleFolders}
+      />
+    );
 
   if (items.length === 0) {
     return (
@@ -143,13 +160,24 @@ export function WorkspaceFolderRows(props: {
     >
       <div className="flex min-w-0 flex-1 flex-col items-stretch gap-1.5">
         <div
-          className="grid w-full min-w-0 grid-cols-[1.5rem_minmax(0,1fr)_minmax(0,1fr)_minmax(0,1.5fr)_auto] items-center gap-x-1.5 gap-y-1.5"
+          className="grid w-full min-w-0 grid-cols-[1.5rem_minmax(0,1.1fr)_minmax(0,1fr)_minmax(0,1.25fr)_auto] items-center gap-x-1.5 gap-y-1.5"
           data-testid="workspace-folder-grid"
         >
+          <div
+            className="col-span-full grid min-w-0 grid-cols-subgrid items-center text-ui-xs font-medium tracking-wider text-muted-foreground/70 uppercase"
+            data-testid="workspace-folder-header"
+          >
+            <span aria-hidden />
+            <span className="px-1">Project</span>
+            <span className="px-1.5">Location</span>
+            <span className="px-1.5">Branch</span>
+            <span aria-hidden />
+          </div>
           {items.map((item) => (
             <FolderRow
               key={item.key}
               item={item}
+              multiSelectEnabled={allowMultipleFolders}
               onEditEnvironment={props.onEditEnvironment}
               uncommittedByPath={uncommittedByPath}
               boundaryEl={nestedBoundaryEl}
@@ -157,17 +185,79 @@ export function WorkspaceFolderRows(props: {
             />
           ))}
         </div>
-        {updateButton === null ? (
+        {multiToggle === null && updateButton === null ? (
           addFolder
         ) : (
           <div className="flex w-full items-center justify-between gap-3">
             {addFolder}
-            {updateButton}
+            <div className="flex shrink-0 items-center gap-3">
+              {multiToggle}
+              {updateButton}
+            </div>
           </div>
         )}
       </div>
       {trailing}
     </div>
+  );
+}
+
+/**
+ * The bottom-line "Allow multiple folders in chat" checkbox - the global
+ * opt-in for ADDITIONAL folders (per-row checkboxes). Rendered only when the
+ * surface has per-chat selection (some row carries a toggle handler), so
+ * read-only and legacy surfaces are unchanged. Unticking collapses THIS
+ * surface to its main project: every additional folder is deselected through
+ * its own item handler (it stays in the saved list). Rows whose selection is
+ * currently locked (`selectionDisabledReason`) are left as they are - the
+ * preference still turns off, it just doesn't mutate a locked surface.
+ */
+function AllowMultipleFoldersToggle(props: {
+  readonly items: ReadonlyArray<WorkspaceRunItem>;
+  readonly checked: boolean;
+}) {
+  const checkboxId = useId();
+  const setAllowMultipleFolders = useWorkspaceFoldersStore(
+    (state) => state.setAllowMultipleFolders,
+  );
+  return (
+    <span
+      className="inline-flex shrink-0 items-center gap-2 px-1.5"
+      data-testid="workspace-multi-folder-toggle"
+    >
+      <Checkbox
+        id={checkboxId}
+        checked={props.checked}
+        data-testid="workspace-multi-folder-toggle-checkbox"
+        // Match the row checkboxes: the default `border-input` outline is
+        // near-invisible on the dark popover when unchecked.
+        className="border-muted-foreground/50 hover:border-muted-foreground/80"
+        onCheckedChange={(checked) => {
+          const next = checked === true;
+          setAllowMultipleFolders(next);
+          if (next) return;
+          for (const item of props.items) {
+            // Honor the same per-row guard the checkboxes render under
+            // (e.g. an active run locks a live binding): the preference
+            // still flips off for future chats, but a locked surface keeps
+            // its additional folders instead of mutating mid-run.
+            if (
+              item.selected &&
+              !item.isPrimary &&
+              item.selectionDisabledReason === null
+            ) {
+              item.onToggleSelected?.(false);
+            }
+          }
+        }}
+      />
+      <label
+        htmlFor={checkboxId}
+        className="cursor-pointer text-ui-sm text-muted-foreground select-none"
+      >
+        Allow multiple folders in chat
+      </label>
+    </span>
   );
 }
 

--- a/clients/gui-app/src/components/home/host-workspace-selector/workspace-folder-summary-control.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/workspace-folder-summary-control.tsx
@@ -124,7 +124,11 @@ export function WorkspaceFolderSummaryControl(props: {
   // clicked, so the preview must be forced closed while the picker is open.
   const popoverTrigger = (
     <HoverPreviewCard
-      content={<WorkspaceFolderHoverList items={props.items} />}
+      content={
+        <WorkspaceFolderHoverList
+          items={props.items.filter((item) => item.selected)}
+        />
+      }
       side={props.popoverSide}
       sideOffset={4}
       align="start"

--- a/clients/gui-app/src/components/home/host-workspace-selector/workspace-run-item.ts
+++ b/clients/gui-app/src/components/home/host-workspace-selector/workspace-run-item.ts
@@ -34,7 +34,7 @@ export interface WorkspaceRunItem {
   readonly defaultNewBranchName: string;
   readonly repoIdentifier: WorktreeFolderIntent["repoIdentifier"];
   // The chat's MAIN project (its primary folder). Shown as the filled main
-  // marker + "Main" badge; it cannot be unchecked, only switched via another
+  // marker + a tinted row; it cannot be unchecked, only switched via another
   // row's `onUseAsMain`.
   readonly isPrimary: boolean;
   // Whether this saved project is used by the current chat (main or

--- a/clients/gui-app/src/components/home/host-workspace-selector/workspace-run-item.ts
+++ b/clients/gui-app/src/components/home/host-workspace-selector/workspace-run-item.ts
@@ -33,17 +33,29 @@ export interface WorkspaceRunItem {
   readonly currentIntent: WorktreeFolderIntent | null;
   readonly defaultNewBranchName: string;
   readonly repoIdentifier: WorktreeFolderIntent["repoIdentifier"];
+  // The chat's MAIN project (its primary folder). Shown as the filled main
+  // marker + "Main" badge; it cannot be unchecked, only switched via another
+  // row's `onUseAsMain`.
   readonly isPrimary: boolean;
-  // Surface capability (same value for every row in a given surface): true
-  // for every not-yet-created-owner picker (landing, fork dialogs, the
-  // new-conversation modal, the terminal-agent launcher); false for bound
-  // owner rows (chat / terminal-agent), where the primary pin is
-  // read-only - there is no atomic set-primary RPC for a live binding.
-  readonly canChangePrimary: boolean;
-  // True for a row that can't act on "Make primary" yet (unresolved /
-  // still loading its disk metadata), independent of `canChangePrimary`.
-  readonly makePrimaryDisabled: boolean;
-  readonly makePrimaryDisabledReason: string | null;
+  // Whether this saved project is used by the current chat (main or
+  // additional). Unselected rows stay in the picker (persistent saved list)
+  // but render display-only facts.
+  readonly selected: boolean;
+  // Additional-folder checkbox (never rendered on the main row). `null`
+  // hides it (read-only surfaces / the transient global-fallback
+  // representation, where selection IS the saved list).
+  readonly onToggleSelected: ((nextSelected: boolean) => void) | null;
+  readonly selectionDisabledReason: string | null;
+  // Switches the chat's main project to this row (click on the name area).
+  // `null` = not switchable here: the main row itself, unresolved rows, and
+  // bound owners (a live chat's primary is fixed host-side).
+  readonly onUseAsMain: (() => void) | null;
+  // The saved-list pin: this project is the DEFAULT for brand-new tasks
+  // (in-task chats inherit the task's workspace). Per-chat selection never
+  // moves it.
+  readonly isPinned: boolean;
+  /** `null` hides the pin action (row not in the saved list / read-only). */
+  readonly onTogglePin: (() => void) | null;
   readonly hostClient: HostClient<HostRpcRegistry> | null;
   readonly modeDisabled: boolean;
   readonly modeDisabledReason: string | null;
@@ -53,7 +65,6 @@ export interface WorkspaceRunItem {
   readonly onSelectMode: (mode: WorkspaceRunMode) => void;
   readonly onEmit: (intent: WorktreeFolderIntent) => void;
   readonly onLocate: (() => void) | null;
-  readonly onMakePrimary: () => void;
   readonly onRemove: (() => void) | null;
 }
 

--- a/clients/gui-app/src/components/home/host-workspace-selector/workspace-summary-trigger.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/workspace-summary-trigger.tsx
@@ -180,6 +180,7 @@ export function WorkspaceSummaryTrigger(
   return trigger;
 }
 
+/** Describes why the collapsed workspace summary has no selected project. */
 function SummaryEmptyState(props: {
   readonly bindingResolved: boolean;
   readonly hasSavedProjects: boolean;

--- a/clients/gui-app/src/components/home/host-workspace-selector/workspace-summary-trigger.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/workspace-summary-trigger.tsx
@@ -35,16 +35,25 @@ export function WorkspaceSummaryTrigger(
   },
 ) {
   const { items, readOnly, bindingResolved, className, ref, ...rest } = props;
+  // The chip previews the CURRENT CHAT's folders, so unselected saved-list
+  // rows stay out of it (they still render in the expanded picker).
+  const selectedItems = items.filter((item) => item.selected);
   // Resolve by the marked `isPrimary` row, not array order: the host
   // normalizes binding flags without reordering entries, so the collapsed
   // chip must agree with the primary pin/row rather than always reading
   // position 0.
   const primary =
-    items.length === 0
+    selectedItems.length === 0
       ? null
-      : (items.find((item) => item.isPrimary) ?? items[0]);
-  const extraCount = Math.max(0, items.length - 1);
-  const anyMissing = items.some((item) => item.missing);
+      : (selectedItems.find((item) => item.isPrimary) ?? selectedItems[0]);
+  // The first TWO selected projects show by name (primary first); the rest
+  // fold into "+N".
+  const secondary =
+    primary === null
+      ? null
+      : (selectedItems.find((item) => item !== primary) ?? null);
+  const extraCount = Math.max(0, selectedItems.length - 2);
+  const anyMissing = selectedItems.some((item) => item.missing);
   const [readOnlyPopoverOpen, setReadOnlyPopoverOpen] = useState(false);
   const [readOnlyHoverOpen, setReadOnlyHoverOpen] = useState(false);
 
@@ -64,7 +73,10 @@ export function WorkspaceSummaryTrigger(
       {...rest}
     >
       {primary === null ? (
-        <SummaryEmptyState bindingResolved={bindingResolved} />
+        <SummaryEmptyState
+          bindingResolved={bindingResolved}
+          hasSavedProjects={items.length > 0}
+        />
       ) : (
         <>
           {anyMissing ? (
@@ -88,6 +100,14 @@ export function WorkspaceSummaryTrigger(
               className={undefined}
             />
           </span>
+          {secondary === null ? null : (
+            <span
+              className="min-w-0 max-w-[min(24vw,9rem)] shrink-[2] truncate text-current/80"
+              data-testid="workspace-summary-secondary"
+            >
+              {secondary.displayName}
+            </span>
+          )}
           {extraCount > 0 ? (
             <span className="shrink-0 rounded-md bg-muted/80 px-1.5 py-0.5 text-overline font-medium text-current">
               +{extraCount}
@@ -117,7 +137,7 @@ export function WorkspaceSummaryTrigger(
         }}
       >
         <HoverPreviewCard
-          content={<WorkspaceFolderHoverList items={items} />}
+          content={<WorkspaceFolderHoverList items={selectedItems} />}
           side="bottom"
           sideOffset={4}
           align="start"
@@ -160,9 +180,16 @@ export function WorkspaceSummaryTrigger(
   return trigger;
 }
 
-function SummaryEmptyState(props: { readonly bindingResolved: boolean }) {
+function SummaryEmptyState(props: {
+  readonly bindingResolved: boolean;
+  readonly hasSavedProjects: boolean;
+}) {
   if (props.bindingResolved) {
-    return <span className="text-current/70">No workspace linked</span>;
+    return (
+      <span className="text-current/70">
+        {props.hasSavedProjects ? "No folders selected" : "No workspace linked"}
+      </span>
+    );
   }
   return (
     <>

--- a/clients/gui-app/src/components/home/landing-draft-surface.tsx
+++ b/clients/gui-app/src/components/home/landing-draft-surface.tsx
@@ -19,7 +19,8 @@ import { LandingTerminalPaneAnchor } from "@/components/home/terminal-panel/land
  */
 export function LandingDraftSurface() {
   const draftId = useDraftSurfaceId();
-  const { workspaceFolders, settings } = useLandingDraftShell(draftId);
+  const { workspaceFolders, workspacePrimaryPath, settings } =
+    useLandingDraftShell(draftId);
   const activity = useTabSurfaceActivity();
 
   // Pre-mint the mount identity for the null-draft landing so the first
@@ -65,7 +66,10 @@ export function LandingDraftSurface() {
         </div>
 
         <section className="mx-auto flex w-full max-w-3xl items-end justify-center px-6 pb-10 pt-3">
-          <HomeHero workspaceFolders={workspaceFolders} />
+          <HomeHero
+            workspaceFolders={workspaceFolders}
+            workspacePrimaryPath={workspacePrimaryPath}
+          />
         </section>
 
         <div className="mx-auto flex min-h-0 w-full max-w-3xl flex-col px-6">

--- a/clients/gui-app/src/hooks/composer/__tests__/use-workspace-mention-roots.test.tsx
+++ b/clients/gui-app/src/hooks/composer/__tests__/use-workspace-mention-roots.test.tsx
@@ -17,17 +17,30 @@ import { useLandingDraftStore } from "@/stores/home/landing-draft-store";
 import { useWorktreeIntentStagingStore } from "@/stores/worktree/worktree-intent-staging-store";
 
 function setGlobalFolders(folders: ReadonlyArray<string>): void {
-  useWorkspaceFoldersStore.setState({ folders });
+  // Real store writes always pair a folder with its metadata; draft seeding
+  // (pinned default) reads it, so the fixture must too.
+  useWorkspaceFoldersStore.setState({
+    folders,
+    folderInfoByPath: Object.fromEntries(
+      folders.map((path) => [
+        path,
+        { path, name: path.split("/").pop() ?? path, repoIdentifier: null },
+      ]),
+    ),
+  });
 }
 
 function resetStores(): void {
   useWorkspaceFoldersStore.setState({
     folders: [],
     folderInfoByPath: {},
+    primaryPath: null,
+    pinnedPath: null,
   });
   useLandingDraftStore.setState({
     drafts: [],
     activeDraftId: null,
+    pendingWorkspace: null,
   });
   useWorktreeIntentStagingStore.setState({ intentByKey: {} });
 }
@@ -163,6 +176,17 @@ describe("useLandingComposerMentionRoots", () => {
     const { result } = renderHook(() => useLandingComposerMentionRoots(null));
 
     expect(result.current).toEqual(["/worktrees/repo-feature"]);
+  });
+
+  it("scopes base-landing roots to the pending selection, not every saved project", () => {
+    setGlobalFolders(["/repo", "/other-saved"]);
+    useWorkspaceFoldersStore.setState({ pinnedPath: "/repo" });
+
+    const { result } = renderHook(() => useLandingComposerMentionRoots(null));
+
+    // Untouched blank landing = pinned-only; the unselected saved project
+    // must not surface as a mention root.
+    expect(result.current).toEqual(["/repo"]);
   });
 
   it("uses an imported draft worktree path for draft-scoped landing composers", () => {

--- a/clients/gui-app/src/hooks/composer/use-workspace-mention-roots.ts
+++ b/clients/gui-app/src/hooks/composer/use-workspace-mention-roots.ts
@@ -36,6 +36,7 @@ export function useWorkspaceMentionRoots(
   }, [fallbackToGlobalWhenEmpty, preferredRoots, workspaceFolders]);
 }
 
+/** Resolves mention roots from the active draft or blank-landing selection. */
 export function useLandingComposerMentionRoots(
   draftId: string | null,
 ): ReadonlyArray<string> {

--- a/clients/gui-app/src/hooks/composer/use-workspace-mention-roots.ts
+++ b/clients/gui-app/src/hooks/composer/use-workspace-mention-roots.ts
@@ -6,7 +6,10 @@ import type {
   WorktreeIntent,
 } from "@traycer/protocol/host/worktree-schemas";
 import { useWorkspaceFoldersStore } from "@/stores/workspace/workspace-folders-store";
-import { useLandingDraftStore } from "@/stores/home/landing-draft-store";
+import {
+  useLandingDraftStore,
+  usePendingOrPinnedLandingWorkspace,
+} from "@/stores/home/landing-draft-store";
 import {
   useWorktreeIntentStagingStore,
   worktreeStagingKeyString,
@@ -43,7 +46,9 @@ export function useLandingComposerMentionRoots(
       null
     );
   });
-  const globalFolders = useWorkspaceFoldersStore((state) => state.folders);
+  // Blank landing: mention roots must match the chat's actual selection (the
+  // shared pending-or-pinned snapshot), not every saved project.
+  const pendingOrPinnedWorkspace = usePendingOrPinnedLandingWorkspace();
   const stagingKeyId = worktreeStagingKeyString({
     surface: "landing",
     draftId,
@@ -52,9 +57,9 @@ export function useLandingComposerMentionRoots(
     (state) => state.intentByKey[stagingKeyId] ?? null,
   );
   const preferredRoots = useMemo(() => {
-    const folders = draftFolders ?? globalFolders;
+    const folders = draftFolders ?? pendingOrPinnedWorkspace.folders;
     return mentionRootsFromWorktreeIntent(folders, stagedIntent);
-  }, [draftFolders, globalFolders, stagedIntent]);
+  }, [draftFolders, pendingOrPinnedWorkspace, stagedIntent]);
 
   // `preferredRoots` already resolves the global folders (intent-aware) in the
   // base-landing case, so the global fallback inside `useWorkspaceMentionRoots`

--- a/clients/gui-app/src/stores/home/__tests__/landing-draft-store.test.ts
+++ b/clients/gui-app/src/stores/home/__tests__/landing-draft-store.test.ts
@@ -508,6 +508,30 @@ describe("useLandingDraftStore", () => {
     ).toBe("terminal");
   });
 
+  it("seeds a new draft with only the pinned default project selected", () => {
+    useWorkspaceFoldersStore.setState({
+      folders: [WORKSPACE_A.path, WORKSPACE_B.path, WORKSPACE_C.path],
+      folderInfoByPath: {
+        [WORKSPACE_A.path]: WORKSPACE_A,
+        [WORKSPACE_B.path]: WORKSPACE_B,
+        [WORKSPACE_C.path]: WORKSPACE_C,
+      },
+      primaryPath: WORKSPACE_A.path,
+      pinnedPath: WORKSPACE_B.path,
+    });
+
+    const id = useLandingDraftStore.getState().createDraft(null);
+
+    const workspace = useLandingDraftStore
+      .getState()
+      .drafts.find((draft) => draft.id === id)?.workspace;
+    expect(workspace?.folders).toEqual([WORKSPACE_B.path]);
+    expect(workspace?.primaryPath).toBe(WORKSPACE_B.path);
+    expect(Object.keys(workspace?.folderInfoByPath ?? {})).toEqual([
+      WORKSPACE_B.path,
+    ]);
+  });
+
   it("keeps workspace snapshots independent per draft", () => {
     useWorkspaceFoldersStore.setState({
       folders: [WORKSPACE_A.path],

--- a/clients/gui-app/src/stores/home/__tests__/landing-draft-store.test.ts
+++ b/clients/gui-app/src/stores/home/__tests__/landing-draft-store.test.ts
@@ -112,11 +112,13 @@ function resetStore(): void {
   useLandingDraftStore.setState({
     drafts: [],
     activeDraftId: null,
+    pendingWorkspace: null,
   });
   useWorkspaceFoldersStore.setState({
     folders: [],
     folderInfoByPath: {},
     primaryPath: null,
+    pinnedPath: null,
   });
   useSettingsStore.setState({
     composerMode: "chat",

--- a/clients/gui-app/src/stores/home/landing-draft-mint-bridge.ts
+++ b/clients/gui-app/src/stores/home/landing-draft-mint-bridge.ts
@@ -1,0 +1,23 @@
+// Dependency-free leaf (mirrors `landing-draft-content` / the
+// draftRuntimeRegistry wiring): the landing-draft store and the
+// worktree-intent staging store live on cycle-sensitive import islands, so
+// draft mint hands the blank landing's staged picks over through this bridge
+// instead of importing the staging store directly (a static import re-enters
+// the store graph mid-eval and leaves `landing-image-gc` with a partially
+// initialized module).
+
+type LandingDraftMintObserver = (draftId: string) => void;
+
+let observer: LandingDraftMintObserver | null = null;
+
+/** Registered once by the worktree-intent staging store after construction. */
+export function setLandingDraftMintObserver(
+  next: LandingDraftMintObserver,
+): void {
+  observer = next;
+}
+
+/** Called by `createDraftWithId` for every freshly minted landing draft. */
+export function notifyLandingDraftMinted(draftId: string): void {
+  observer?.(draftId);
+}

--- a/clients/gui-app/src/stores/home/landing-draft-store.ts
+++ b/clients/gui-app/src/stores/home/landing-draft-store.ts
@@ -840,6 +840,7 @@ export function pinnedLandingDraftWorkspaceSnapshot(globalState: {
   });
 }
 
+/** Reads the pinned-only workspace snapshot from the current global store. */
 function readCurrentLandingDraftWorkspaceSnapshot(): LandingDraftWorkspaceSnapshot {
   return pinnedLandingDraftWorkspaceSnapshot(
     useWorkspaceFoldersStore.getState(),

--- a/clients/gui-app/src/stores/home/landing-draft-store.ts
+++ b/clients/gui-app/src/stores/home/landing-draft-store.ts
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { create } from "zustand";
 import { useShallow } from "zustand/react/shallow";
 import {
@@ -25,6 +26,7 @@ import type {
 } from "@/lib/windows/types";
 import type { DesktopPerWindowProjectionBridge } from "@/lib/windows/per-window-projection-debounce";
 import { basePersistOptions, persistKey, STORE_KEYS } from "@/lib/persist";
+import { notifyLandingDraftMinted } from "@/stores/home/landing-draft-mint-bridge";
 import {
   resolvePrimaryPath,
   trimFoldersPreservingPrimary,
@@ -75,6 +77,13 @@ export interface LandingDraftWorkspaceSnapshot {
 interface LandingDraftStoreState {
   readonly drafts: ReadonlyArray<LandingDraftTab>;
   readonly activeDraftId: string | null;
+  // Workspace edits made on the BLANK landing (no draft minted yet). The
+  // picker routes its add/remove/main-switch there so a pre-typing choice is
+  // a real per-chat snapshot, and `createDraftWithId` consumes it as the new
+  // draft's workspace instead of re-deriving pinned-only state (which would
+  // silently discard those edits). In-memory only (not persisted/projected):
+  // a reload before typing simply re-seeds from the pinned default.
+  readonly pendingWorkspace: LandingDraftWorkspaceSnapshot | null;
   /** Always creates a fresh draft, sets it as active, returns its id. */
   createDraft: (settings: ChatRunSettings | null) => string;
   /** Coordinator-only stable-id source creation. */
@@ -107,6 +116,15 @@ interface LandingDraftStoreState {
   ) => ReadonlyArray<string>;
   removeDraftFolder: (id: string, folderPath: string) => void;
   setDraftWorkspacePrimary: (id: string, folderPath: string) => void;
+  // Pending-landing counterparts of the per-draft workspace mutations. Each
+  // lazily seeds `pendingWorkspace` from the pinned default before applying,
+  // so the first picker edit on a blank landing starts from the same snapshot
+  // a fresh draft would.
+  addPendingResolvedFolders: (
+    folders: ReadonlyArray<WorkspaceFolderInfo>,
+  ) => ReadonlyArray<string>;
+  removePendingFolder: (folderPath: string) => void;
+  setPendingWorkspacePrimary: (folderPath: string) => void;
 }
 
 export const LANDING_DRAFT_PERSIST_KEY = persistKey(STORE_KEYS.landingDraft);
@@ -327,6 +345,7 @@ export const useLandingDraftStore = create<LandingDraftStoreState>()(
     (set, get) => ({
       drafts: [],
       activeDraftId: null,
+      pendingWorkspace: null,
 
       createDraft: (settings) => {
         return get().createDraftWithId(uuidv4(), settings);
@@ -334,6 +353,12 @@ export const useLandingDraftStore = create<LandingDraftStoreState>()(
 
       createDraftWithId: (id, settings) => {
         if (get().drafts.some((draft) => draft.id === id)) return id;
+        // The blank landing's staged Location/Branch/Scripts picks live under
+        // `landing:null`; the staging store (via the mint bridge) moves them
+        // to the minted draft's own slot alongside the pending workspace, or
+        // the surface rekeys, finds nothing staged, and reseeds defaults over
+        // the user's picks.
+        notifyLandingDraftMinted(id);
         const next: LandingDraftTab = {
           id,
           content: EMPTY_LANDING_DRAFT_CONTENT,
@@ -342,11 +367,16 @@ export const useLandingDraftStore = create<LandingDraftStoreState>()(
           settings: copyChatRunSettings(settings),
           // Seed from the global last-used mode; the draft owns it from here.
           composerMode: useSettingsStore.getState().composerMode,
-          workspace: readCurrentLandingDraftWorkspaceSnapshot(),
+          // Blank-landing picker edits (pending snapshot) become THIS draft's
+          // workspace; without them, seed the pinned default.
+          workspace:
+            get().pendingWorkspace ??
+            readCurrentLandingDraftWorkspaceSnapshot(),
         };
         set((state) => ({
           drafts: [...uniqueLandingDrafts(state.drafts), next],
           activeDraftId: next.id,
+          pendingWorkspace: null,
         }));
         return next.id;
       },
@@ -464,6 +494,34 @@ export const useLandingDraftStore = create<LandingDraftStoreState>()(
           ),
         );
       },
+
+      addPendingResolvedFolders: (folders) => {
+        const before =
+          get().pendingWorkspace ?? readCurrentLandingDraftWorkspaceSnapshot();
+        const next = mergeLandingDraftWorkspaceFolders(before, folders);
+        set({ pendingWorkspace: next });
+        const afterSet = new Set(next.folders);
+        return before.folders.filter((path) => !afterSet.has(path));
+      },
+
+      removePendingFolder: (folderPath) => {
+        const before =
+          get().pendingWorkspace ?? readCurrentLandingDraftWorkspaceSnapshot();
+        set({
+          pendingWorkspace: removeLandingDraftWorkspaceFolder(
+            before,
+            folderPath,
+          ),
+        });
+      },
+
+      setPendingWorkspacePrimary: (folderPath) => {
+        const before =
+          get().pendingWorkspace ?? readCurrentLandingDraftWorkspaceSnapshot();
+        set({
+          pendingWorkspace: setLandingDraftWorkspacePrimary(before, folderPath),
+        });
+      },
     }),
     {
       ...basePersistOptions(LANDING_DRAFT_PERSIST_KEY),
@@ -543,6 +601,7 @@ draftRuntimeRegistry.configure({
 export function useActiveLandingDraftShell(): {
   readonly draftId: string | null;
   readonly workspaceFolders: ReadonlyArray<string> | null;
+  readonly workspacePrimaryPath: string | null;
   readonly settings: ChatRunSettings | null;
 } {
   const activeDraftId = useLandingDraftStore((state) => state.activeDraftId);
@@ -553,6 +612,10 @@ export function useActiveLandingDraftShell(): {
 export function useLandingDraftShell(draftId: string | null): {
   readonly draftId: string | null;
   readonly workspaceFolders: ReadonlyArray<string> | null;
+  // Raw stored primary for the draft's workspace - the folder list alone
+  // cannot name the main project (a main switch may leave an additional
+  // folder at index 0). Resolve via `resolvePrimaryPath(folders, primary)`.
+  readonly workspacePrimaryPath: string | null;
   readonly settings: ChatRunSettings | null;
 } {
   return useLandingDraftStore(
@@ -561,6 +624,7 @@ export function useLandingDraftShell(draftId: string | null): {
       return {
         draftId: draft?.id ?? null,
         workspaceFolders: draft?.workspace.folders ?? null,
+        workspacePrimaryPath: draft?.workspace.primaryPath ?? null,
         settings: draft?.settings ?? null,
       };
     }),
@@ -745,15 +809,75 @@ function normalizeChatRunSettings(
   };
 }
 
-function readCurrentLandingDraftWorkspaceSnapshot(): LandingDraftWorkspaceSnapshot {
-  const globalState = useWorkspaceFoldersStore.getState();
+/**
+ * The workspace a brand-new task starts from: ONLY the pinned default project
+ * selected — the saved list stays in the global store and renders as
+ * unselected picker rows. `resolvePrimaryPath` covers a stale/absent pin
+ * (first saved folder) and the empty saved list (`null`). Pure so the
+ * blank-landing picker can derive the same snapshot from its own store
+ * subscriptions.
+ */
+export function pinnedLandingDraftWorkspaceSnapshot(globalState: {
+  readonly folders: ReadonlyArray<string>;
+  readonly pinnedPath: string | null;
+  readonly folderInfoByPath: Readonly<Record<string, WorkspaceFolderInfo>>;
+}): LandingDraftWorkspaceSnapshot {
+  const pinned = resolvePrimaryPath(
+    globalState.folders,
+    globalState.pinnedPath,
+  );
+  const pinnedInfo =
+    pinned !== null && Object.hasOwn(globalState.folderInfoByPath, pinned)
+      ? globalState.folderInfoByPath[pinned]
+      : null;
+  if (pinnedInfo === null) return emptyLandingDraftWorkspaceSnapshot();
   return normalizeLandingDraftWorkspace({
-    folders: [...globalState.folders],
-    folderInfoByPath: copyWorkspaceFolderInfoByPath(
-      globalState.folderInfoByPath,
-    ),
-    primaryPath: globalState.primaryPath,
+    folders: [pinnedInfo.path],
+    folderInfoByPath: copyWorkspaceFolderInfoByPath({
+      [pinnedInfo.path]: pinnedInfo,
+    }),
+    primaryPath: pinnedInfo.path,
   });
+}
+
+function readCurrentLandingDraftWorkspaceSnapshot(): LandingDraftWorkspaceSnapshot {
+  return pinnedLandingDraftWorkspaceSnapshot(
+    useWorkspaceFoldersStore.getState(),
+  );
+}
+
+/**
+ * The single blank-landing workspace resolver: pending picker edits when they
+ * exist, else the pinned-only snapshot a fresh draft would start from. EVERY
+ * null-draft consumer (picker, hero, availability gate, mention roots, launch
+ * boundary) must read through this, or it will disagree with the selection
+ * the picker shows and the minted draft will actually use.
+ */
+export function readPendingOrPinnedLandingWorkspace(): LandingDraftWorkspaceSnapshot {
+  return (
+    useLandingDraftStore.getState().pendingWorkspace ??
+    readCurrentLandingDraftWorkspaceSnapshot()
+  );
+}
+
+/** Reactive {@link readPendingOrPinnedLandingWorkspace} for render consumers. */
+export function usePendingOrPinnedLandingWorkspace(): LandingDraftWorkspaceSnapshot {
+  const pending = useLandingDraftStore((state) => state.pendingWorkspace);
+  const folders = useWorkspaceFoldersStore((state) => state.folders);
+  const pinnedPath = useWorkspaceFoldersStore((state) => state.pinnedPath);
+  const folderInfoByPath = useWorkspaceFoldersStore(
+    (state) => state.folderInfoByPath,
+  );
+  return useMemo(
+    () =>
+      pending ??
+      pinnedLandingDraftWorkspaceSnapshot({
+        folders,
+        pinnedPath,
+        folderInfoByPath,
+      }),
+    [pending, folders, pinnedPath, folderInfoByPath],
+  );
 }
 
 export function emptyLandingDraftWorkspaceSnapshot(): LandingDraftWorkspaceSnapshot {

--- a/clients/gui-app/src/stores/workspace/__tests__/workspace-folders-store.test.ts
+++ b/clients/gui-app/src/stores/workspace/__tests__/workspace-folders-store.test.ts
@@ -17,6 +17,8 @@ beforeEach(() => {
     folders: [],
     folderInfoByPath: {},
     primaryPath: null,
+    pinnedPath: null,
+    allowMultipleFolders: false,
   });
 });
 
@@ -99,6 +101,141 @@ describe("useWorkspaceFoldersStore", () => {
     expect(state.folders).toContain("/f50");
     // "/f1" was the oldest SECONDARY - it is the one evicted, not "/f0".
     expect(state.folders).not.toContain("/f1");
+  });
+
+  it("stamps the first added folder as the pinned default when none is set yet", () => {
+    useWorkspaceFoldersStore
+      .getState()
+      .addResolvedFolders([folderInfo("/a"), folderInfo("/b")]);
+    expect(useWorkspaceFoldersStore.getState().pinnedPath).toBe("/a");
+  });
+
+  it("setPinnedFolder moves the pin; a non-member path is a no-op; later adds never move it", () => {
+    useWorkspaceFoldersStore
+      .getState()
+      .addResolvedFolders([folderInfo("/a"), folderInfo("/b")]);
+
+    useWorkspaceFoldersStore.getState().setPinnedFolder("/b");
+    expect(useWorkspaceFoldersStore.getState().pinnedPath).toBe("/b");
+
+    useWorkspaceFoldersStore.getState().setPinnedFolder("/not-a-folder");
+    expect(useWorkspaceFoldersStore.getState().pinnedPath).toBe("/b");
+
+    useWorkspaceFoldersStore.getState().addResolvedFolders([folderInfo("/c")]);
+    expect(useWorkspaceFoldersStore.getState().pinnedPath).toBe("/b");
+  });
+
+  it("keeps the pin independent of setPrimaryFolder (per-chat primary is not the default)", () => {
+    useWorkspaceFoldersStore
+      .getState()
+      .addResolvedFolders([folderInfo("/a"), folderInfo("/b")]);
+    useWorkspaceFoldersStore.getState().setPrimaryFolder("/b");
+    expect(useWorkspaceFoldersStore.getState().pinnedPath).toBe("/a");
+  });
+
+  it("removing the pinned folder falls the pin back to the first remaining folder", () => {
+    useWorkspaceFoldersStore
+      .getState()
+      .addResolvedFolders([
+        folderInfo("/a"),
+        folderInfo("/b"),
+        folderInfo("/c"),
+      ]);
+    useWorkspaceFoldersStore.getState().setPinnedFolder("/b");
+
+    useWorkspaceFoldersStore.getState().removeFolder("/b");
+
+    expect(useWorkspaceFoldersStore.getState().pinnedPath).toBe("/a");
+  });
+
+  it("multi-select preference is off by default and flips via setAllowMultipleFolders", () => {
+    expect(useWorkspaceFoldersStore.getState().allowMultipleFolders).toBe(
+      false,
+    );
+    useWorkspaceFoldersStore.getState().setAllowMultipleFolders(true);
+    expect(useWorkspaceFoldersStore.getState().allowMultipleFolders).toBe(true);
+    useWorkspaceFoldersStore.getState().setAllowMultipleFolders(false);
+    expect(useWorkspaceFoldersStore.getState().allowMultipleFolders).toBe(
+      false,
+    );
+  });
+
+  it("rehydrates allowMultipleFolders: only an explicit true survives; pre-toggle payloads default off", async () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        version: 1,
+        state: {
+          folders: ["/a"],
+          folderInfoByPath: { "/a": folderInfo("/a") },
+          primaryPath: "/a",
+          allowMultipleFolders: true,
+        },
+      }),
+    );
+    await useWorkspaceFoldersStore.persist.rehydrate();
+    expect(useWorkspaceFoldersStore.getState().allowMultipleFolders).toBe(true);
+
+    // A payload persisted before the toggle existed (no field at all).
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        version: 1,
+        state: {
+          folders: ["/a"],
+          folderInfoByPath: { "/a": folderInfo("/a") },
+          primaryPath: "/a",
+        },
+      }),
+    );
+    await useWorkspaceFoldersStore.persist.rehydrate();
+    expect(useWorkspaceFoldersStore.getState().allowMultipleFolders).toBe(
+      false,
+    );
+  });
+
+  it("rehydrates a payload persisted before pinnedPath by seeding the pin from the stored primary", async () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        version: 1,
+        state: {
+          folders: ["/a", "/b"],
+          folderInfoByPath: {
+            "/a": folderInfo("/a"),
+            "/b": folderInfo("/b"),
+          },
+          primaryPath: "/b",
+        },
+      }),
+    );
+
+    await useWorkspaceFoldersStore.persist.rehydrate();
+
+    expect(useWorkspaceFoldersStore.getState().pinnedPath).toBe("/b");
+  });
+
+  it("rehydrates a valid persisted pinnedPath verbatim, independent of primary", async () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        version: 1,
+        state: {
+          folders: ["/a", "/b"],
+          folderInfoByPath: {
+            "/a": folderInfo("/a"),
+            "/b": folderInfo("/b"),
+          },
+          primaryPath: "/a",
+          pinnedPath: "/b",
+        },
+      }),
+    );
+
+    await useWorkspaceFoldersStore.persist.rehydrate();
+
+    expect(useWorkspaceFoldersStore.getState().primaryPath).toBe("/a");
+    expect(useWorkspaceFoldersStore.getState().pinnedPath).toBe("/b");
   });
 
   it("rehydrates a v1 payload (no primaryPath field) by resolving folders[0] as primary", async () => {

--- a/clients/gui-app/src/stores/workspace/workspace-folders-store.ts
+++ b/clients/gui-app/src/stores/workspace/workspace-folders-store.ts
@@ -17,6 +17,14 @@ interface WorkspaceFoldersStore {
   folders: ReadonlyArray<string>;
   folderInfoByPath: Readonly<Record<string, WorkspaceFolderInfo>>;
   primaryPath: string | null;
+  // The pinned DEFAULT project for brand-new tasks. Independent of any chat's
+  // current selection (a draft's own `primaryPath`): changing what a chat
+  // uses never moves this pin, and moving the pin never touches open drafts.
+  pinnedPath: string | null;
+  // Whether chats may hold ADDITIONAL folders beyond the main project (the
+  // picker's per-row checkboxes). Off by default: single-project chats with
+  // multi-select as an explicit opt-in. One global preference, like the list.
+  allowMultipleFolders: boolean;
   // Returns the paths EVICTED by the 50-folder cap (empty when nothing was
   // evicted) so callers can unstage any in-flight worktree intent for them -
   // otherwise an evicted folder can disappear from rows/persistence while
@@ -26,6 +34,8 @@ interface WorkspaceFoldersStore {
   ) => ReadonlyArray<string>;
   removeFolder: (folderPath: string) => void;
   setPrimaryFolder: (folderPath: string) => void;
+  setPinnedFolder: (folderPath: string) => void;
+  setAllowMultipleFolders: (allow: boolean) => void;
 }
 
 const INITIAL_FOLDERS: ReadonlyArray<string> = [];
@@ -40,6 +50,8 @@ export const useWorkspaceFoldersStore = create<WorkspaceFoldersStore>()(
       folders: INITIAL_FOLDERS,
       folderInfoByPath: INITIAL_FOLDER_INFO_BY_PATH,
       primaryPath: null,
+      pinnedPath: null,
+      allowMultipleFolders: false,
       addResolvedFolders: (folders) => {
         const before = get().folders;
         set((state) => mergeWorkspaceFolderInfo(state, folders));
@@ -61,6 +73,7 @@ export const useWorkspaceFoldersStore = create<WorkspaceFoldersStore>()(
             // removed folder WAS the primary; `resolvePrimaryPath` also
             // covers the "no folders left" case (`null`).
             primaryPath: resolvePrimaryPath(nextFolders, state.primaryPath),
+            pinnedPath: resolvePrimaryPath(nextFolders, state.pinnedPath),
           };
         });
       },
@@ -70,6 +83,20 @@ export const useWorkspaceFoldersStore = create<WorkspaceFoldersStore>()(
           if (state.primaryPath === folderPath) return state;
           return { primaryPath: folderPath };
         });
+      },
+      setPinnedFolder: (folderPath) => {
+        set((state) => {
+          if (!state.folders.includes(folderPath)) return state;
+          if (state.pinnedPath === folderPath) return state;
+          return { pinnedPath: folderPath };
+        });
+      },
+      setAllowMultipleFolders: (allow) => {
+        set((state) =>
+          state.allowMultipleFolders === allow
+            ? state
+            : { allowMultipleFolders: allow },
+        );
       },
     }),
     {
@@ -122,6 +149,17 @@ export const useWorkspaceFoldersStore = create<WorkspaceFoldersStore>()(
             folders,
             parsePersistedPrimaryPath(persisted.primaryPath),
           ),
+          // Migration: a payload persisted before `pinnedPath` existed seeds
+          // the pin from the stored primary (the previous "default folder for
+          // a new chat" in effect), else the first folder.
+          pinnedPath: resolvePrimaryPath(
+            folders,
+            parsePersistedPrimaryPath(persisted.pinnedPath) ??
+              parsePersistedPrimaryPath(persisted.primaryPath),
+          ),
+          // Anything but an explicit `true` (including pre-toggle payloads)
+          // resolves to the off default.
+          allowMultipleFolders: persisted.allowMultipleFolders === true,
         };
       },
     },
@@ -196,7 +234,7 @@ function mergeWorkspaceFolderInfo(
   | WorkspaceFoldersStore
   | Pick<
       WorkspaceFoldersStore,
-      "folders" | "folderInfoByPath" | "primaryPath"
+      "folders" | "folderInfoByPath" | "primaryPath" | "pinnedPath"
     > {
   const trimmed = folders.flatMap((folder) => {
     const path = folder.path.trim();
@@ -244,6 +282,9 @@ function mergeWorkspaceFolderInfo(
     // or one whose stored primary no longer names a folder); an existing
     // valid primary is never disturbed by an add.
     primaryPath: resolvePrimaryPath(nextFolders, state.primaryPath),
+    // Same rule for the new-chat default pin: the first add stamps it, a
+    // later add never moves it while the pinned folder is still saved.
+    pinnedPath: resolvePrimaryPath(nextFolders, state.pinnedPath),
   };
 }
 

--- a/clients/gui-app/src/stores/workspace/workspace-folders-store.ts
+++ b/clients/gui-app/src/stores/workspace/workspace-folders-store.ts
@@ -227,6 +227,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
+/** Merges resolved folders while preserving a valid primary and pinned path. */
 function mergeWorkspaceFolderInfo(
   state: WorkspaceFoldersStore,
   folders: ReadonlyArray<WorkspaceFolderInfo>,

--- a/clients/gui-app/src/stores/worktree/worktree-intent-staging-store.ts
+++ b/clients/gui-app/src/stores/worktree/worktree-intent-staging-store.ts
@@ -12,6 +12,7 @@ import {
   setWorktreeIntentEntryScripts,
 } from "@/components/home/host-workspace-selector/worktree-intent-merge";
 import { basePersistOptions, worktreeIntentStagingKey } from "@/lib/persist";
+import { setLandingDraftMintObserver } from "@/stores/home/landing-draft-mint-bridge";
 import {
   worktreeFolderIntentReferencesRemoved,
   type RemovedWorktreeRefs,
@@ -201,6 +202,19 @@ interface WorktreeIntentStagingStore {
     key: WorktreeStagingKey,
     workspacePaths: readonly string[],
   ) => void;
+  /**
+   * Move one slot's staged intent + suspended paths to another slot. Used at
+   * draft mint: the blank landing stages under `landing:null`, and those
+   * picks must follow the pending workspace into the minted draft's own slot
+   * (otherwise the surface rekeys, finds nothing staged, and reseeds
+   * defaults). If the target already holds staged intent (a restored draft
+   * id), the target wins and the source is still cleared so it cannot leak
+   * into a later mint.
+   */
+  readonly adoptSlot: (
+    from: WorktreeStagingKey,
+    to: WorktreeStagingKey,
+  ) => void;
   readonly clear: (key: WorktreeStagingKey) => void;
   /**
    * Drops staged entries that reference just-removed worktrees across EVERY
@@ -357,6 +371,39 @@ export const useWorktreeIntentStagingStore =
             }
             return { suspendedWorkspacePathsByKey };
           }),
+        adoptSlot: (from, to) =>
+          set((state) => {
+            const fromId = worktreeStagingKeyString(from);
+            const toId = worktreeStagingKeyString(to);
+            if (fromId === toId) return state;
+            const sourceIntent = state.intentByKey[fromId];
+            const sourceSuspended = state.suspendedWorkspacePathsByKey[fromId];
+            if (sourceIntent === undefined && sourceSuspended === undefined) {
+              return state;
+            }
+            const intentByKey = { ...state.intentByKey };
+            const suspendedWorkspacePathsByKey = {
+              ...state.suspendedWorkspacePathsByKey,
+            };
+            delete intentByKey[fromId];
+            delete suspendedWorkspacePathsByKey[fromId];
+            if (state.intentByKey[toId] === undefined) {
+              if (sourceIntent !== undefined) {
+                intentByKey[toId] = sourceIntent;
+              }
+              if (sourceSuspended !== undefined) {
+                suspendedWorkspacePathsByKey[toId] = sourceSuspended;
+              }
+            }
+            return {
+              intentByKey,
+              suspendedWorkspacePathsByKey,
+              revisionByKey: incrementStagingRevision(
+                incrementStagingRevision(state.revisionByKey, fromId),
+                toId,
+              ),
+            };
+          }),
         clear: (key) =>
           set((state) => {
             const id = worktreeStagingKeyString(key);
@@ -439,6 +486,20 @@ export const useWorktreeIntentStagingStore =
       },
     ),
   );
+
+// Wired after store construction through the dependency-free mint bridge
+// (mirrors `draftRuntimeRegistry.configure`): a direct import between the
+// landing-draft store and this one re-enters the cycle-sensitive store
+// graph mid-eval. At draft mint the blank landing's staged picks move from
+// `landing:null` to the minted draft's own slot.
+setLandingDraftMintObserver((draftId) => {
+  useWorktreeIntentStagingStore
+    .getState()
+    .adoptSlot(
+      { surface: "landing", draftId: null },
+      { surface: "landing", draftId },
+    );
+});
 
 /** Non-hook read of the staged intent for a surface (for getState callers). */
 export function readStagedWorktreeIntent(


### PR DESCRIPTION
## Summary

- keep saved projects separate from each chat's selected workspace folders
- let users switch the main project, opt into additional folders, and pin the default for new tasks
- seed blank and new drafts from the pinned project while preserving picker choices through draft minting
- keep composer context, mention roots, and launch data scoped to the chat's selected folders

This removes the destructive add/remove cycle when moving between codebases: saved projects remain available for future chats while each chat owns its current selection.

## UI preview

<img width="746" height="394" alt="Persistent multi-project picker showing saved projects, the pinned default, and multi-folder selections" src="https://github.com/user-attachments/assets/e0f24bdb-c352-4850-bf41-7264bbacd01b" />

## Related issue

Closes #786

## Validation

- Manually verified the updated picker UI and project-selection workflow in the desktop app
- `pre-commit run --all-files` passed all available hooks, including the full Nx workspace check; the ShellCheck hook could not run because `shellcheck` is not installed locally
- Added and updated tests for saved-project persistence, per-chat selection, draft minting, picker controls, and mention roots

## Checklist

- [x] `bun run build`, `bun run lint`, and `bun run test` pass
- [x] Code is formatted (`bun run format`)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Tests added/updated where it makes sense
- [x] Commits are signed off (`git commit -s`) per DCO