### PR TITLE
feat(gui-app): isolate new-chat worktrees with Project Profiles

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/sidebar/new-conversation-modal.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/new-conversation-modal.tsx
@@ -126,16 +126,14 @@ import {
   ACTIVE_TILE_PLACEMENT,
   type ConversationTilePlacement,
 } from "@/lib/canvas/conversation-tile-placement";
-import type { LandingDraftWorkspaceSnapshot } from "@/stores/home/landing-draft-store";
 import { useSettingsStore } from "@/stores/settings/settings-store";
 import {
   selectEpicRunSettingsEntry,
   selectGlobalLastRunSettings,
   useComposerRunSettingsStore,
 } from "@/stores/composer/composer-run-settings-store";
-import { selectEffectiveWorkspaceFoldersBucket } from "@/lib/workspace/effective-workspace-folders";
-import { useProjectProfilesStore } from "@/stores/workspace/project-profiles-store";
-import { useWorkspaceFoldersStore } from "@/stores/workspace/workspace-folders-store";
+import { resolveNewConversationWorkspaceSeed } from "@/lib/workspace/new-conversation-workspace-seed";
+import type { ResolvedWorkspaceFolder } from "@traycer/protocol/host/epic/snapshot-meta";
 import {
   anyHostHasStagedWorktreeIntent,
   newConversationModalStagingKey,
@@ -1122,6 +1120,14 @@ export function NewConversationModalBody(props: {
 }
 
 /**
+ * Shared empty fallback for the epic's stored folder read - the selector must
+ * not mint a fresh array per call when the epic has no snapshot meta yet
+ * (RENDER_PERF_INVARIANTS).
+ */
+const EMPTY_RESOLVED_WORKSPACE_FOLDERS: readonly ResolvedWorkspaceFolder[] =
+  Object.freeze([]);
+
+/**
  * Workspace seed that drives the modal's workspace controls + submit intent.
  * For a child (per-row `+`, `parentId !== null`) it inherits the PARENT's
  * binding so the child lands in the parent's worktree. The parent may be a chat
@@ -1195,7 +1201,18 @@ function useNewConversationModalSeed(
   latestWorkspaceSeed: LatestConversationWorkspaceSeed | null,
 ): NewConversationModalSeed {
   const latestSettingsSeed = useLatestConversationSettingsSeed();
-  const globalWorkspace = useGlobalWorkspaceSnapshot(hostId);
+  // The epic's own stored workspace folders (resolved to on-disk checkouts by
+  // the serving host at subscribe time) - the in-epic fallback when no
+  // conversation on this epic carries a binding. Deliberately NOT the
+  // active-project overlay: a conversation created inside an existing epic
+  // must not be re-homed into whatever project the header switcher has
+  // selected. Reference-stable across snapshots that leave the array
+  // unchanged, so the `??` empty fallback is the only allocation risk -
+  // pinned to a module constant.
+  const epicWorkspaceFolders = useEpicStore(
+    (state) =>
+      state.snapshotMeta?.workspaceFolders ?? EMPTY_RESOLVED_WORKSPACE_FOLDERS,
+  );
   // Carry forward the last settings used on this epic ON THIS HOST (the
   // chat-tile composer writes `setEpicRunSettings` on send), then the same
   // host's cross-epic last-run, then the projected latest-conversation
@@ -1215,9 +1232,19 @@ function useNewConversationModalSeed(
         runSettingsSeed.globalLastRunSettings ??
         latestSettingsSeed.settings,
       composerMode: latestSettingsSeed.composerMode,
-      workspace: latestWorkspaceSeed?.workspace ?? globalWorkspace,
+      workspace: resolveNewConversationWorkspaceSeed({
+        latestWorkspace: latestWorkspaceSeed?.workspace ?? null,
+        epicWorkspaceFolders,
+        hostId,
+      }),
     }),
-    [globalWorkspace, latestSettingsSeed, latestWorkspaceSeed, runSettingsSeed],
+    [
+      epicWorkspaceFolders,
+      hostId,
+      latestSettingsSeed,
+      latestWorkspaceSeed,
+      runSettingsSeed,
+    ],
   );
 }
 
@@ -1274,23 +1301,6 @@ function useLatestConversationSettingsSeed(): {
       composerMode: "terminal",
     };
   }, [defaults, fallbackComposerMode, projection]);
-}
-
-function useGlobalWorkspaceSnapshot(
-  hostId: string | null,
-): LandingDraftWorkspaceSnapshot {
-  const foldersByHost = useWorkspaceFoldersStore((state) => state.byHost);
-  const profilesByHost = useProjectProfilesStore((state) => state.byHost);
-  const bucket = selectEffectiveWorkspaceFoldersBucket(
-    { byHost: foldersByHost },
-    { byHost: profilesByHost },
-    hostId,
-  );
-  return {
-    folders: bucket.folders,
-    folderInfoByPath: bucket.folderInfoByPath,
-    primaryPath: bucket.primaryPath,
-  };
 }
 
 /**

--- a/clients/gui-app/src/components/epic-canvas/sidebar/new-conversation-modal.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/new-conversation-modal.tsx
@@ -133,10 +133,9 @@ import {
   selectGlobalLastRunSettings,
   useComposerRunSettingsStore,
 } from "@/stores/composer/composer-run-settings-store";
-import {
-  selectWorkspaceFoldersBucket,
-  useWorkspaceFoldersStore,
-} from "@/stores/workspace/workspace-folders-store";
+import { selectEffectiveWorkspaceFoldersBucket } from "@/lib/workspace/effective-workspace-folders";
+import { useProjectProfilesStore } from "@/stores/workspace/project-profiles-store";
+import { useWorkspaceFoldersStore } from "@/stores/workspace/workspace-folders-store";
 import {
   anyHostHasStagedWorktreeIntent,
   newConversationModalStagingKey,
@@ -1280,16 +1279,18 @@ function useLatestConversationSettingsSeed(): {
 function useGlobalWorkspaceSnapshot(
   hostId: string | null,
 ): LandingDraftWorkspaceSnapshot {
-  return useWorkspaceFoldersStore(
-    useShallow((state) => {
-      const bucket = selectWorkspaceFoldersBucket(state, hostId);
-      return {
-        folders: bucket.folders,
-        folderInfoByPath: bucket.folderInfoByPath,
-        primaryPath: bucket.primaryPath,
-      };
-    }),
+  const foldersByHost = useWorkspaceFoldersStore((state) => state.byHost);
+  const profilesByHost = useProjectProfilesStore((state) => state.byHost);
+  const bucket = selectEffectiveWorkspaceFoldersBucket(
+    { byHost: foldersByHost },
+    { byHost: profilesByHost },
+    hostId,
   );
+  return {
+    folders: bucket.folders,
+    folderInfoByPath: bucket.folderInfoByPath,
+    primaryPath: bucket.primaryPath,
+  };
 }
 
 /**

--- a/clients/gui-app/src/components/epics/__tests__/epics-list-panel.test.tsx
+++ b/clients/gui-app/src/components/epics/__tests__/epics-list-panel.test.tsx
@@ -157,6 +157,8 @@ const testState = vi.hoisted(() => ({
     ownershipScopes: [] as HistoryFacets["ownershipScopes"],
   },
   isFetching: false,
+  projectFilterActive: false,
+  preProjectFilterCount: 0,
   bridge: null as DesktopWindowsBridge | null,
   worktreeCandidates: [] as WorktreeCleanupCandidateStub[],
   worktreesByEpicId: new Map<string, readonly WorktreeHostEntryV12[]>(),
@@ -188,6 +190,8 @@ vi.mock("@/hooks/home/use-history-query", () => ({
     isFetching: testState.isFetching,
     error: null,
     hostId: "host-test",
+    projectFilterActive: testState.projectFilterActive,
+    preProjectFilterCount: testState.preProjectFilterCount,
     refetch: testState.refetch,
     fetchNextPage: testState.fetchNextPage,
     hasNextPage: false,
@@ -385,6 +389,8 @@ describe("<EpicsListPanel />", () => {
       ownershipScopes: [],
     };
     testState.isFetching = false;
+    testState.projectFilterActive = false;
+    testState.preProjectFilterCount = 0;
     testState.bridge = null;
     testState.worktreeCandidates = [];
     testState.worktreesByEpicId = new Map();
@@ -1510,5 +1516,44 @@ describe("<EpicsListPanel />", () => {
 
     expect(event.defaultPrevented).toBe(false);
     expect(document.activeElement).toBe(input);
+  });
+
+  it("points at All projects when the active project hides every chat", async () => {
+    testState.items = [];
+    testState.projectFilterActive = true;
+    testState.preProjectFilterCount = 3;
+
+    renderPanel("page", "/");
+
+    const empty = await screen.findByTestId("epics-list-project-empty");
+    expect(empty.textContent).toContain("Older chats are under All projects.");
+    expect(screen.queryByTestId("epics-list-empty")).toBeNull();
+  });
+
+  it("keeps the plain empty state when no chats exist outside the project either", async () => {
+    testState.items = [];
+    testState.projectFilterActive = true;
+    testState.preProjectFilterCount = 0;
+
+    renderPanel("page", "/");
+
+    expect(await screen.findByTestId("epics-list-empty")).not.toBeNull();
+    expect(screen.queryByTestId("epics-list-project-empty")).toBeNull();
+  });
+
+  it("points at All projects when search matches exist only outside the project", async () => {
+    testState.items = [];
+    testState.projectFilterActive = true;
+    testState.preProjectFilterCount = 2;
+    useHistorySearchStore.setState({
+      search: { ...DEFAULT_HISTORY_SEARCH, query: "missing" },
+    });
+
+    renderPanel("page", "/");
+
+    expect(
+      await screen.findByTestId("epics-list-project-empty"),
+    ).not.toBeNull();
+    expect(screen.queryByTestId("epics-list-filtered-empty")).toBeNull();
   });
 });

--- a/clients/gui-app/src/components/epics/epics-list-panel.tsx
+++ b/clients/gui-app/src/components/epics/epics-list-panel.tsx
@@ -100,7 +100,16 @@ import {
 } from "@/hooks/home/use-history-query";
 import { historyListEmptyState } from "@/lib/workspace/history-item-matches-project";
 import { claimEpicOnActiveProfile } from "@/lib/workspace/claim-epic-on-active-profile";
-import { workspaceHintFromHistoryItem } from "@/lib/workspace/header-tab-matches-project";
+import {
+  historyItemProjectBadge,
+  workspaceHintFromHistoryItem,
+} from "@/lib/workspace/header-tab-matches-project";
+import {
+  selectActiveProjectProfile,
+  selectProjectProfilesBucket,
+  useProjectProfilesStore,
+} from "@/stores/workspace/project-profiles-store";
+import { PROJECT_PROFILE_COLOR_DOT } from "@/components/layout/header/project-profile-colors";
 import { useNotificationIndicators } from "@/hooks/notifications/use-notification-indicators-query";
 import {
   useAmbientHistorySearchState,
@@ -1364,6 +1373,7 @@ const EpicsListRow = memo(function EpicsListRow(props: EpicsListRowProps) {
     hostId,
     projectFilterActive,
   } = props;
+  const projectBadge = useHistoryRowProjectBadge(hostId, item);
   const isPhase = item.taskType === "phase";
   const rowSweep = useHistoryRowSweep({
     item,
@@ -1583,6 +1593,7 @@ const EpicsListRow = memo(function EpicsListRow(props: EpicsListRowProps) {
           "updated ..." label squeezes the title to nothing at phone width. */}
       <div className={historyRowContentClassName(rowSweep.isVisible)}>
         <span className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden max-md:basis-full">
+          <HistoryRowProjectLabel badge={projectBadge} />
           <HistoryRowLeadingIcon item={item} />
           {isRenaming ? (
             <input
@@ -1711,6 +1722,47 @@ function HistoryPinControl(props: {
       </TooltipTrigger>
       <TooltipContent>{label}</TooltipContent>
     </Tooltip>
+  );
+}
+
+function useHistoryRowProjectBadge(
+  hostId: string | null,
+  item: Pick<HistoryItem, "epicId" | "worktreePaths" | "linkedWorkspaces">,
+) {
+  return useProjectProfilesStore(
+    useShallow((state) =>
+      historyItemProjectBadge(
+        selectActiveProjectProfile(state, hostId),
+        selectProjectProfilesBucket(state, hostId).profiles,
+        item,
+      ),
+    ),
+  );
+}
+
+function HistoryRowProjectLabel(props: {
+  readonly badge: {
+    readonly color: keyof typeof PROJECT_PROFILE_COLOR_DOT;
+    readonly name: string;
+  } | null;
+}): ReactNode {
+  if (props.badge === null) return null;
+  return (
+    <span
+      data-testid="epics-list-row-project"
+      className="flex shrink-0 items-center gap-1.5 text-muted-foreground"
+    >
+      <span
+        aria-hidden
+        className={cn(
+          "size-2 rounded-full",
+          PROJECT_PROFILE_COLOR_DOT[props.badge.color],
+        )}
+      />
+      <span className="max-w-[8rem] truncate text-ui-xs font-medium">
+        {props.badge.name}
+      </span>
+    </span>
   );
 }
 

--- a/clients/gui-app/src/components/epics/epics-list-panel.tsx
+++ b/clients/gui-app/src/components/epics/epics-list-panel.tsx
@@ -100,6 +100,7 @@ import {
 } from "@/hooks/home/use-history-query";
 import { historyListEmptyState } from "@/lib/workspace/history-item-matches-project";
 import { claimEpicOnActiveProfile } from "@/lib/workspace/claim-epic-on-active-profile";
+import { workspaceHintFromHistoryItem } from "@/lib/workspace/header-tab-matches-project";
 import { useNotificationIndicators } from "@/hooks/notifications/use-notification-indicators-query";
 import {
   useAmbientHistorySearchState,
@@ -1437,11 +1438,19 @@ const EpicsListRow = memo(function EpicsListRow(props: EpicsListRowProps) {
     [],
   );
   const openEpic = useCallback(() => {
+    if (!isPhase) {
+      useEpicCanvasStore
+        .getState()
+        .stampEpicWorkspaceHint(
+          item.epicId,
+          workspaceHintFromHistoryItem(item),
+        );
+    }
     openHistoryItem(item);
     if (projectFilterActive) {
       claimEpicOnActiveProfile(hostId, item.epicId);
     }
-  }, [hostId, item, openHistoryItem, projectFilterActive]);
+  }, [hostId, isPhase, item, openHistoryItem, projectFilterActive]);
   const toggleEpicSelection = () => {
     if (!canDeleteItem) return;
     onToggleSelection(item.epicId);

--- a/clients/gui-app/src/components/epics/epics-list-panel.tsx
+++ b/clients/gui-app/src/components/epics/epics-list-panel.tsx
@@ -98,6 +98,7 @@ import {
   type HistoryFacets,
   type HistoryFetchResult,
 } from "@/hooks/home/use-history-query";
+import { historyListEmptyState } from "@/lib/workspace/history-item-matches-project";
 import { useNotificationIndicators } from "@/hooks/notifications/use-notification-indicators-query";
 import {
   useAmbientHistorySearchState,
@@ -278,6 +279,8 @@ function EpicsListPanelBody(props: EpicsListPanelBodyProps): ReactNode {
     isFetching,
     error,
     hostId,
+    projectFilterActive,
+    preProjectFilterCount,
     refetch,
     fetchNextPage,
     hasNextPage,
@@ -616,6 +619,8 @@ function EpicsListPanelBody(props: EpicsListPanelBodyProps): ReactNode {
             isFetching={isFetching}
             hasActiveFilters={hasActiveFilters}
             chatHostFilterUnsupported={chatHostFilterUnsupported}
+            projectFilterActive={projectFilterActive}
+            preProjectFilterCount={preProjectFilterCount}
             items={items}
             onRetry={handleRetry}
             selectionMode={selectionMode}
@@ -1055,6 +1060,8 @@ function HistoryListBody(props: HistoryListBodyProps): ReactNode {
         isFetching={props.isFetching}
         hasActiveFilters={props.hasActiveFilters}
         chatHostFilterUnsupported={props.chatHostFilterUnsupported}
+        projectFilterActive={props.projectFilterActive}
+        preProjectFilterCount={props.preProjectFilterCount}
         items={props.items}
         onRetry={props.onRetry}
         selectionMode={props.selectionMode}
@@ -1087,6 +1094,8 @@ interface EpicsListBodyProps {
   readonly isFetching: boolean;
   readonly hasActiveFilters: boolean;
   readonly chatHostFilterUnsupported: boolean;
+  readonly projectFilterActive: boolean;
+  readonly preProjectFilterCount: number;
   readonly items: ReadonlyArray<HistoryItem>;
   readonly onRetry: () => void;
   readonly selectionMode: boolean;
@@ -1121,6 +1130,8 @@ function EpicsListBody(props: EpicsListBodyProps): ReactNode {
     isFetching,
     hasActiveFilters,
     chatHostFilterUnsupported,
+    projectFilterActive,
+    preProjectFilterCount,
     items,
     onRetry,
     selectionMode,
@@ -1155,11 +1166,37 @@ function EpicsListBody(props: EpicsListBodyProps): ReactNode {
   if (chatHostFilterUnsupported) {
     return <EpicsListChatHostFilterUnsupported />;
   }
+  const emptyState = historyListEmptyState({
+    visibleCount: items.length,
+    preProjectFilterCount,
+    hasActiveFilters,
+    projectFilterActive,
+  });
   if (items.length === 0 && !hasActiveFilters) {
+    if (emptyState === "hidden-by-active-project") {
+      return <EpicsListProjectHiddenEmpty />;
+    }
     return <EpicsListEmpty />;
   }
   if (items.length === 0 && hasActiveFilters && isFetching) {
     return <EpicsListFilteringLoading />;
+  }
+  if (items.length === 0) {
+    // Active filters, no in-flight refetch: the list is genuinely empty for
+    // this filter set.
+    if (emptyState === "hidden-by-active-project") {
+      return <EpicsListProjectHiddenEmpty />;
+    }
+    return (
+      <div
+        className="flex flex-col items-center justify-center gap-2 py-16 text-center text-ui-sm text-muted-foreground"
+        data-testid="epics-list-filtered-empty"
+      >
+        <p className="font-medium text-foreground">
+          No tasks match these filters.
+        </p>
+      </div>
+    );
   }
   return (
     <>
@@ -1200,6 +1237,23 @@ function EpicsListBody(props: EpicsListBodyProps): ReactNode {
         onLoadMore={onLoadMore}
       />
     </>
+  );
+}
+
+/**
+ * A project profile hid every visible row while chats still exist outside
+ * the project. Say where they went - "No tasks yet" here reads as data loss.
+ */
+function EpicsListProjectHiddenEmpty() {
+  return (
+    <div
+      className="flex flex-col items-center justify-center gap-2 py-16 text-center text-ui-sm text-muted-foreground"
+      data-testid="epics-list-project-empty"
+    >
+      <p className="font-medium text-foreground">
+        Older chats are under All projects.
+      </p>
+    </div>
   );
 }
 

--- a/clients/gui-app/src/components/epics/epics-list-panel.tsx
+++ b/clients/gui-app/src/components/epics/epics-list-panel.tsx
@@ -99,6 +99,7 @@ import {
   type HistoryFetchResult,
 } from "@/hooks/home/use-history-query";
 import { historyListEmptyState } from "@/lib/workspace/history-item-matches-project";
+import { claimEpicOnActiveProfile } from "@/lib/workspace/claim-epic-on-active-profile";
 import { useNotificationIndicators } from "@/hooks/notifications/use-notification-indicators-query";
 import {
   useAmbientHistorySearchState,
@@ -621,6 +622,7 @@ function EpicsListPanelBody(props: EpicsListPanelBodyProps): ReactNode {
             chatHostFilterUnsupported={chatHostFilterUnsupported}
             projectFilterActive={projectFilterActive}
             preProjectFilterCount={preProjectFilterCount}
+            hostId={hostId}
             items={items}
             onRetry={handleRetry}
             selectionMode={selectionMode}
@@ -1062,6 +1064,7 @@ function HistoryListBody(props: HistoryListBodyProps): ReactNode {
         chatHostFilterUnsupported={props.chatHostFilterUnsupported}
         projectFilterActive={props.projectFilterActive}
         preProjectFilterCount={props.preProjectFilterCount}
+        hostId={props.hostId}
         items={props.items}
         onRetry={props.onRetry}
         selectionMode={props.selectionMode}
@@ -1096,6 +1099,7 @@ interface EpicsListBodyProps {
   readonly chatHostFilterUnsupported: boolean;
   readonly projectFilterActive: boolean;
   readonly preProjectFilterCount: number;
+  readonly hostId: string | null;
   readonly items: ReadonlyArray<HistoryItem>;
   readonly onRetry: () => void;
   readonly selectionMode: boolean;
@@ -1132,6 +1136,7 @@ function EpicsListBody(props: EpicsListBodyProps): ReactNode {
     chatHostFilterUnsupported,
     projectFilterActive,
     preProjectFilterCount,
+    hostId,
     items,
     onRetry,
     selectionMode,
@@ -1225,6 +1230,8 @@ function EpicsListBody(props: EpicsListBodyProps): ReactNode {
               worktrees={worktreesByEpicId.get(item.epicId) ?? EMPTY_WORKTREES}
               isOpen={openEpicIds.has(item.epicId)}
               onRowKeyDown={onRowKeyDown}
+              hostId={hostId}
+              projectFilterActive={projectFilterActive}
             />
           ))}
         </ul>
@@ -1275,6 +1282,8 @@ interface EpicsListRowProps {
   readonly openInNewWindowAvailable: boolean;
   readonly worktrees: readonly WorktreeHostEntryV12[];
   readonly isOpen: boolean;
+  readonly hostId: string | null;
+  readonly projectFilterActive: boolean;
   /** Arrow-key traversal, bound to whichever control covers the whole card. */
   readonly onRowKeyDown: (event: React.KeyboardEvent<HTMLElement>) => void;
 }
@@ -1351,6 +1360,8 @@ const EpicsListRow = memo(function EpicsListRow(props: EpicsListRowProps) {
     worktrees,
     isOpen,
     onRowKeyDown,
+    hostId,
+    projectFilterActive,
   } = props;
   const isPhase = item.taskType === "phase";
   const rowSweep = useHistoryRowSweep({
@@ -1427,7 +1438,10 @@ const EpicsListRow = memo(function EpicsListRow(props: EpicsListRowProps) {
   );
   const openEpic = useCallback(() => {
     openHistoryItem(item);
-  }, [item, openHistoryItem]);
+    if (projectFilterActive) {
+      claimEpicOnActiveProfile(hostId, item.epicId);
+    }
+  }, [hostId, item, openHistoryItem, projectFilterActive]);
   const toggleEpicSelection = () => {
     if (!canDeleteItem) return;
     onToggleSelection(item.epicId);

--- a/clients/gui-app/src/components/home/hooks/use-landing-composer-actions.ts
+++ b/clients/gui-app/src/components/home/hooks/use-landing-composer-actions.ts
@@ -29,10 +29,7 @@ import { UNKNOWN_HOST_PLACEHOLDER } from "@/lib/host/constants";
 import { useEpicCreateForClient } from "@/hooks/epic/use-epic-create-mutation";
 import { useCreateTuiAgentForClient } from "@/hooks/agent/use-create-tui-agent";
 import { useAuthStore } from "@/stores/auth/auth-store";
-import {
-  selectWorkspaceFoldersBucket,
-  useWorkspaceFoldersStore,
-} from "@/stores/workspace/workspace-folders-store";
+import { readEffectiveWorkspaceSnapshot } from "@/lib/workspace/effective-workspace-folders";
 import {
   readStagedWorktreeIntent,
   stagedWorktreeIntentIsSuspended,
@@ -1046,12 +1043,10 @@ function readLandingWorkspaceContext(
       hostId,
     };
   }
-  // The launch host's own folder bucket - the same `hostId` the cached
-  // default-intent read below is keyed by.
-  const globalBucket = selectWorkspaceFoldersBucket(
-    useWorkspaceFoldersStore.getState(),
-    hostId,
-  );
+  // The launch host's own effective folder set (profile-narrowed when a
+  // Project Profile is active) - the same `hostId` the cached default-intent
+  // read below is keyed by.
+  const globalBucket = readEffectiveWorkspaceSnapshot(hostId);
   const globalWorkspace = {
     folders: globalBucket.folders,
     folderInfoByPath: globalBucket.folderInfoByPath,

--- a/clients/gui-app/src/components/home/hooks/use-landing-composer-actions.ts
+++ b/clients/gui-app/src/components/home/hooks/use-landing-composer-actions.ts
@@ -30,6 +30,7 @@ import { useEpicCreateForClient } from "@/hooks/epic/use-epic-create-mutation";
 import { useCreateTuiAgentForClient } from "@/hooks/agent/use-create-tui-agent";
 import { useAuthStore } from "@/stores/auth/auth-store";
 import { readEffectiveWorkspaceSnapshot } from "@/lib/workspace/effective-workspace-folders";
+import { claimEpicOnActiveProfile } from "@/lib/workspace/claim-epic-on-active-profile";
 import {
   readStagedWorktreeIntent,
   stagedWorktreeIntentIsSuspended,
@@ -466,6 +467,7 @@ export function useLandingComposerActions(
       // Mark before the one-shot create request so the existence reconciler
       // cannot prune the result while `epic.listTasks` still lags it.
       markEpicCreatedThisSession(epicId);
+      claimEpicOnActiveProfile(activeHostId, epicId);
 
       void createLandingEpic({
         epicId,
@@ -729,6 +731,7 @@ export function useLandingComposerActions(
       // synchronous marker is what keeps the existence reconciler from
       // force-closing the tab before `epic.listTasks` reflects the new epic.
       markEpicCreatedThisSession(epicId);
+      claimEpicOnActiveProfile(workspaceContext.hostId, epicId);
       const replaced =
         workspaceContext.draftId === null
           ? null

--- a/clients/gui-app/src/components/home/host-workspace-selector/__tests__/create-project-from-picked-folders.test.ts
+++ b/clients/gui-app/src/components/home/host-workspace-selector/__tests__/create-project-from-picked-folders.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { createProjectFromPickedFolders } from "../use-pick-and-add-folders";
+import { useProjectProfilesStore } from "@/stores/workspace/project-profiles-store";
+import { useLandingDraftStore } from "@/stores/home/landing-draft-store";
+import { useWorkspaceFoldersStore } from "@/stores/workspace/workspace-folders-store";
+
+const HOST = "host-a";
+
+describe("createProjectFromPickedFolders", () => {
+  beforeEach(() => {
+    useProjectProfilesStore.setState({ byHost: {} });
+    useLandingDraftStore.setState({ drafts: [], activeDraftId: null });
+    useWorkspaceFoldersStore.setState({ byHost: {} });
+  });
+  afterEach(() => {
+    useProjectProfilesStore.setState({ byHost: {} });
+    useLandingDraftStore.setState({ drafts: [], activeDraftId: null });
+    useWorkspaceFoldersStore.setState({ byHost: {} });
+  });
+
+  it("creates and activates a project named after the folder", () => {
+    useWorkspaceFoldersStore.getState().addResolvedFolders(HOST, [
+      {
+        path: "/Users/g/Titanos",
+        name: "Titanos",
+        repoIdentifier: null,
+        hostId: HOST,
+      },
+    ]);
+    expect(
+      createProjectFromPickedFolders({
+        hostId: HOST,
+        folders: [
+          {
+            path: "/Users/g/Titanos",
+            name: "Titanos",
+            repoIdentifier: null,
+            hostId: HOST,
+          },
+        ],
+      }),
+    ).toBe(true);
+    const bucket = useProjectProfilesStore.getState().byHost[HOST];
+    expect(bucket.profiles[0].name).toBe("Titanos");
+    expect(bucket.profiles[0].folderPaths).toEqual(["/Users/g/Titanos"]);
+    expect(bucket.activeProfileId).toBe(bucket.profiles[0].id);
+  });
+});

--- a/clients/gui-app/src/components/home/host-workspace-selector/__tests__/home-summary-empty.test.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/__tests__/home-summary-empty.test.tsx
@@ -621,7 +621,7 @@ describe("landing workspace summary empty state", () => {
     expect(hostTrigger.className).toContain("hover:bg-foreground/5");
     expect(screen.queryByTestId("workspace-summary-trigger")).toBeNull();
     expect(screen.getByTestId("folder-add").textContent).toContain(
-      "Add folder",
+      "Add project",
     );
 
     fireEvent.click(screen.getByTestId("folder-add"));

--- a/clients/gui-app/src/components/home/host-workspace-selector/__tests__/use-home-workspace-source-profile.test.ts
+++ b/clients/gui-app/src/components/home/host-workspace-selector/__tests__/use-home-workspace-source-profile.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useHomeWorkspaceSource } from "../use-home-workspace-source";
+import {
+  selectWorkspaceFoldersBucket,
+  useWorkspaceFoldersStore,
+  type WorkspaceFolderInfo,
+} from "@/stores/workspace/workspace-folders-store";
+import {
+  selectActiveProjectProfile,
+  useProjectProfilesStore,
+} from "@/stores/workspace/project-profiles-store";
+import { useLandingDraftStore } from "@/stores/home/landing-draft-store";
+import { useWorktreeIntentStagingStore } from "@/stores/worktree/worktree-intent-staging-store";
+import type { WorktreeStagingKey } from "@/stores/worktree/worktree-intent-staging-store";
+
+const HOST = "host-a";
+
+const TITANOS: WorkspaceFolderInfo = {
+  path: "/tmp/titanos",
+  name: "titanos",
+  repoIdentifier: null,
+  hostId: HOST,
+};
+const CRM: WorkspaceFolderInfo = {
+  path: "/tmp/crm",
+  name: "crm",
+  repoIdentifier: null,
+  hostId: HOST,
+};
+
+const STAGING_KEY: WorktreeStagingKey = {
+  surface: "landing",
+  hostId: HOST,
+  draftId: null,
+};
+
+function resetStores(): void {
+  useWorkspaceFoldersStore.setState({ byHost: {} });
+  useProjectProfilesStore.setState({ byHost: {} });
+  useLandingDraftStore.setState({ drafts: [], activeDraftId: null });
+  useWorktreeIntentStagingStore.getState().resetForTests();
+}
+
+describe("useHomeWorkspaceSource picker edits with an active profile", () => {
+  beforeEach(resetStores);
+  afterEach(resetStores);
+
+  it("add/remove/primary stay on the active project and leave the catalog intact", () => {
+    useWorkspaceFoldersStore
+      .getState()
+      .addResolvedFolders(HOST, [TITANOS, CRM]);
+    const profileId = useProjectProfilesStore.getState().createProfile(HOST, {
+      name: "Titanos",
+      color: "orange",
+      folderPaths: [TITANOS.path],
+      primaryPath: TITANOS.path,
+    });
+    useProjectProfilesStore.getState().setActiveProfile(HOST, profileId);
+
+    const { result } = renderHook(() =>
+      useHomeWorkspaceSource(STAGING_KEY, null, HOST),
+    );
+    expect(result.current.folders).toEqual([TITANOS.path]);
+
+    act(() => {
+      result.current.addResolvedFolders([CRM]);
+    });
+    expect(result.current.folders).toEqual([TITANOS.path, CRM.path]);
+    expect(
+      selectActiveProjectProfile(useProjectProfilesStore.getState(), HOST)
+        ?.folderPaths,
+    ).toEqual([TITANOS.path, CRM.path]);
+
+    act(() => {
+      result.current.setPrimaryFolder(CRM.path);
+    });
+    expect(result.current.primaryWorkspacePath).toBe(CRM.path);
+    expect(
+      selectActiveProjectProfile(useProjectProfilesStore.getState(), HOST)
+        ?.primaryPath,
+    ).toBe(CRM.path);
+    expect(
+      selectWorkspaceFoldersBucket(useWorkspaceFoldersStore.getState(), HOST)
+        .primaryPath,
+    ).toBe(TITANOS.path);
+
+    act(() => {
+      result.current.removeFolder(CRM.path);
+    });
+    expect(result.current.folders).toEqual([TITANOS.path]);
+    expect(
+      selectWorkspaceFoldersBucket(useWorkspaceFoldersStore.getState(), HOST)
+        .folders,
+    ).toEqual([TITANOS.path, CRM.path]);
+  });
+});

--- a/clients/gui-app/src/components/home/host-workspace-selector/host-workspace-selector.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/host-workspace-selector.tsx
@@ -65,7 +65,12 @@ import { locateReplaceBoundFolder } from "./locate-replace-bound-folder";
 import {
   useLocateAndReplaceWorkspaceFolder,
   usePickAndAddWorkspaceFolders,
+  usePickAndCreateProject,
 } from "./use-pick-and-add-folders";
+import {
+  selectActiveProjectProfile,
+  useProjectProfilesStore,
+} from "@/stores/workspace/project-profiles-store";
 import {
   readStagedWorktreeIntent,
   stagedWorktreeIntentIsSuspended,
@@ -668,6 +673,13 @@ function HomeWorkspaceRows(props: {
     activeHostClient,
     workspaceSource,
   );
+  const pickAndCreateProject = usePickAndCreateProject(
+    activeHostClient,
+    workspaceSource,
+  );
+  const activeProject = useProjectProfilesStore((state) =>
+    selectActiveProjectProfile(state, props.activeHostId),
+  );
   // Locate on an absent row must REPLACE the dead path — add-only left it
   // blocking readiness until the user manually removed it.
   const locateAndReplaceFolder = useLocateAndReplaceWorkspaceFolder(
@@ -1099,6 +1111,13 @@ function HomeWorkspaceRows(props: {
     if (props.disabled) return false;
     return pickAndAddFolders();
   }, [pickAndAddFolders, props.disabled]);
+  const addProject = useCallback(async (): Promise<boolean> => {
+    if (props.disabled) return false;
+    return pickAndCreateProject();
+  }, [pickAndCreateProject, props.disabled]);
+  const emptyUnscoped = items.length === 0 && activeProject === null;
+  const addFolderLabel = emptyUnscoped ? "Add project" : "Add folder";
+  const addFolderAction = emptyUnscoped ? addProject : addFolders;
   const scriptsTarget = useMemo<WorktreeScriptsTarget | null>(() => {
     if (scriptsTargetPath === null) return null;
     const summary = summariesByPath.get(scriptsTargetPath);
@@ -1141,7 +1160,8 @@ function HomeWorkspaceRows(props: {
           items={items}
           hostSlot={props.hostSlot}
           addFolderPending={addFolderPending}
-          onAddFolder={addFolders}
+          onAddFolder={addFolderAction}
+          addFolderLabel={addFolderLabel}
           onEditEnvironment={handleEditEnvironment}
           refresh={summariesRefresh}
           disabled={props.disabled}
@@ -1156,7 +1176,8 @@ function HomeWorkspaceRows(props: {
           addFolderPending={addFolderPending}
           addFolderDisabled={props.disabled}
           addFolderDisabledReason={null}
-          onAddFolder={addFolders}
+          addFolderLabel={addFolderLabel}
+          onAddFolder={addFolderAction}
           // Landing has no live PTY to resume: edits apply inline, no Update.
           onUpdate={null}
           updateEnabled={false}
@@ -1190,6 +1211,7 @@ function HomeWorkspaceSummaryControl(props: {
   readonly items: ReadonlyArray<WorkspaceRunItem>;
   readonly hostSlot: ReactNode;
   readonly addFolderPending: boolean;
+  readonly addFolderLabel: string;
   readonly onAddFolder: AddFolderHandler;
   readonly onEditEnvironment: (workspacePath: string) => void;
   readonly refresh: WorktreeWorkspacesRefresh;
@@ -1216,6 +1238,7 @@ function HomeWorkspaceSummaryControl(props: {
           addFolderPending={props.addFolderPending}
           addFolderDisabled={props.disabled}
           addFolderDisabledReason={null}
+          addFolderLabel={props.addFolderLabel}
           onAddFolder={props.onAddFolder}
           onUpdate={null}
           updateEnabled={false}
@@ -2793,6 +2816,7 @@ function InEpicSurface(props: InEpicSurfaceProps) {
             addFolderDisabledReason={
               activeRunLocksBinding ? activeRunNotice : null
             }
+            addFolderLabel="Add folder"
             onAddFolder={addFoldersToOwnerBinding}
             onUpdate={
               surface.kind === "terminal-agent"

--- a/clients/gui-app/src/components/home/host-workspace-selector/use-home-workspace-source.ts
+++ b/clients/gui-app/src/components/home/host-workspace-selector/use-home-workspace-source.ts
@@ -4,11 +4,12 @@ import type {
   WorktreeFolderIntent,
   WorktreeIntent,
 } from "@traycer/protocol/host/worktree-schemas";
+import { selectEffectiveWorkspaceFoldersBucket } from "@/lib/workspace/effective-workspace-folders";
+import { useProjectProfilesStore } from "@/stores/workspace/project-profiles-store";
 import {
-  selectWorkspaceFoldersBucket,
   useWorkspaceFoldersStore,
+  type WorkspaceFolderInfo,
 } from "@/stores/workspace/workspace-folders-store";
-import type { WorkspaceFolderInfo } from "@/stores/workspace/workspace-folders-store";
 import {
   emptyLandingDraftWorkspaceSnapshot,
   mergeLandingDraftWorkspaceFolders,
@@ -112,15 +113,16 @@ export function useHomeWorkspaceSource(
   const setGlobalPrimaryFolder = useWorkspaceFoldersStore(
     (state) => state.setPrimaryFolder,
   );
-  const globalPrimaryPath = useWorkspaceFoldersStore(
-    (state) => selectWorkspaceFoldersBucket(state, hostId).primaryPath,
+  const foldersByHost = useWorkspaceFoldersStore((state) => state.byHost);
+  const profilesByHost = useProjectProfilesStore((state) => state.byHost);
+  const effectiveBucket = selectEffectiveWorkspaceFoldersBucket(
+    { byHost: foldersByHost },
+    { byHost: profilesByHost },
+    hostId,
   );
-  const globalFolders = useWorkspaceFoldersStore(
-    (state) => selectWorkspaceFoldersBucket(state, hostId).folders,
-  );
-  const globalFolderInfoByPath = useWorkspaceFoldersStore(
-    (state) => selectWorkspaceFoldersBucket(state, hostId).folderInfoByPath,
-  );
+  const globalPrimaryPath = effectiveBucket.primaryPath;
+  const globalFolders = effectiveBucket.folders;
+  const globalFolderInfoByPath = effectiveBucket.folderInfoByPath;
   const {
     addDraftResolvedFolders,
     removeDraftFolder,

--- a/clients/gui-app/src/components/home/host-workspace-selector/use-home-workspace-source.ts
+++ b/clients/gui-app/src/components/home/host-workspace-selector/use-home-workspace-source.ts
@@ -5,6 +5,10 @@ import type {
   WorktreeIntent,
 } from "@traycer/protocol/host/worktree-schemas";
 import { selectEffectiveWorkspaceFoldersBucket } from "@/lib/workspace/effective-workspace-folders";
+import {
+  activeProfileOwnsPickerEdits,
+  syncActiveProfileFolders,
+} from "@/lib/workspace/sync-active-profile-folders";
 import { useProjectProfilesStore } from "@/stores/workspace/project-profiles-store";
 import {
   useWorkspaceFoldersStore,
@@ -214,6 +218,12 @@ export function useHomeWorkspaceSource(
         }
         if (!usingSeededWorkspace) {
           const evicted = addGlobalResolvedFolders(hostId, folders);
+          syncActiveProfileFolders({
+            hostId,
+            addPaths: folders.map((folder) => folder.path),
+            removePath: null,
+            primaryPath: null,
+          });
           if (activeDraftId === null) {
             for (const path of evicted) unstageStoreEntry(stagingKey, path);
           }
@@ -252,7 +262,16 @@ export function useHomeWorkspaceSource(
           removeModalFolder(modalEpicId, modalSeedWorkspace, folderPath);
         } else {
           if (!usingSeededWorkspace) {
-            removeGlobalFolder(hostId, folderPath);
+            if (activeProfileOwnsPickerEdits(hostId)) {
+              syncActiveProfileFolders({
+                hostId,
+                addPaths: [],
+                removePath: folderPath,
+                primaryPath: null,
+              });
+            } else {
+              removeGlobalFolder(hostId, folderPath);
+            }
           }
           if (activeDraftId !== null) {
             removeDraftFolder(activeDraftId, folderPath);
@@ -301,7 +320,16 @@ export function useHomeWorkspaceSource(
           setModalPrimaryFolder(modalEpicId, modalSeedWorkspace, folderPath);
         } else {
           if (!usingSeededWorkspace) {
-            setGlobalPrimaryFolder(hostId, folderPath);
+            if (activeProfileOwnsPickerEdits(hostId)) {
+              syncActiveProfileFolders({
+                hostId,
+                addPaths: [],
+                removePath: null,
+                primaryPath: folderPath,
+              });
+            } else {
+              setGlobalPrimaryFolder(hostId, folderPath);
+            }
           }
           if (activeDraftId !== null) {
             setDraftWorkspacePrimary(activeDraftId, folderPath);

--- a/clients/gui-app/src/components/home/host-workspace-selector/use-pick-and-add-folders.ts
+++ b/clients/gui-app/src/components/home/host-workspace-selector/use-pick-and-add-folders.ts
@@ -47,7 +47,7 @@ export function usePickAndCreateProject(
 ): () => Promise<boolean> {
   const folderActions = useWorkspaceFolderActionsForClient(client);
   return useCallback(async (): Promise<boolean> => {
-    const result = await folderActions.pickAndPrepareFolders();
+    const result = await folderActions.pickAndPrepareFolders(true);
     if (result === null) return false;
     const folders = result.folders.map((folder) =>
       preparedWorkspaceFolderToWorkspaceFolderInfo(folder, result.hostId),

--- a/clients/gui-app/src/components/home/host-workspace-selector/use-pick-and-add-folders.ts
+++ b/clients/gui-app/src/components/home/host-workspace-selector/use-pick-and-add-folders.ts
@@ -6,6 +6,9 @@ import {
 } from "@/hooks/workspace/use-workspace-folder-actions";
 import type { HostRpcRegistry } from "@/lib/host";
 import type { WorkspaceFolderInfo } from "@/stores/workspace/workspace-folders-store";
+import { useLandingDraftStore } from "@/stores/home/landing-draft-store";
+import { useProjectProfilesStore } from "@/stores/workspace/project-profiles-store";
+import { workspaceFolderName } from "@/lib/worktree/workspace-folder-name";
 import type { HomeWorkspaceSource } from "./use-home-workspace-source";
 
 /**
@@ -33,6 +36,52 @@ export function usePickAndAddWorkspaceFolders(
     workspaceSource.addResolvedFolders(folders);
     return folders.length > 0;
   }, [folderActions, workspaceSource]);
+}
+
+/**
+ * Empty-home CTA: pick a folder and make it THIS project's main in one step.
+ */
+export function usePickAndCreateProject(
+  client: HostClient<HostRpcRegistry> | null,
+  workspaceSource: HomeWorkspaceSource,
+): () => Promise<boolean> {
+  const folderActions = useWorkspaceFolderActionsForClient(client);
+  return useCallback(async (): Promise<boolean> => {
+    const result = await folderActions.pickAndPrepareFolders();
+    if (result === null) return false;
+    const folders = result.folders.map((folder) =>
+      preparedWorkspaceFolderToWorkspaceFolderInfo(folder, result.hostId),
+    );
+    if (folders.length === 0) return false;
+    workspaceSource.addResolvedFolders(folders);
+    return createProjectFromPickedFolders({
+      hostId: result.hostId,
+      folders,
+    });
+  }, [folderActions, workspaceSource]);
+}
+
+export function createProjectFromPickedFolders(args: {
+  readonly hostId: string;
+  readonly folders: ReadonlyArray<WorkspaceFolderInfo>;
+}): boolean {
+  if (args.folders.length === 0) return false;
+  const first = args.folders[0];
+  const name =
+    first.name.trim().length > 0
+      ? first.name.trim()
+      : workspaceFolderName(first.path);
+  const store = useProjectProfilesStore.getState();
+  const id = store.createProfile(args.hostId, {
+    name,
+    color: "orange",
+    folderPaths: args.folders.map((folder) => folder.path),
+    primaryPath: first.path,
+  });
+  if (id === null) return false;
+  store.setActiveProfile(args.hostId, id);
+  useLandingDraftStore.getState().replaceActiveDraftWorkspaceFromStores();
+  return true;
 }
 
 /**

--- a/clients/gui-app/src/components/home/host-workspace-selector/workspace-folder-rows.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/workspace-folder-rows.tsx
@@ -26,6 +26,8 @@ export function WorkspaceFolderRows(props: {
   readonly addFolderPending: boolean;
   readonly addFolderDisabled: boolean;
   readonly addFolderDisabledReason: string | null;
+  /** Empty-home landing passes "Add project"; everywhere else omit. */
+  readonly addFolderLabel?: string;
   // Terminal-agent "Update": applies the staged folder edits and resumes the
   // PTY. `null` on chat / landing surfaces (no live session to resume), where
   // the button is hidden. When set, it renders to the right of "Add folder".
@@ -98,6 +100,9 @@ export function WorkspaceFolderRows(props: {
       pending={props.addFolderPending}
       disabled={props.addFolderDisabled}
       disabledReason={props.addFolderDisabledReason}
+      label={
+        props.addFolderLabel === undefined ? "Add folder" : props.addFolderLabel
+      }
     />
   );
   // Terminal-agent "Update" action: pinned to the far right of the folder block
@@ -187,6 +192,7 @@ export function AddFolderButton(props: {
   readonly pending: boolean;
   readonly disabled: boolean;
   readonly disabledReason: string | null;
+  readonly label: string;
 }) {
   const button = (
     <Button
@@ -209,7 +215,7 @@ export function AddFolderButton(props: {
       ) : (
         <FolderPlus data-icon="inline-start" />
       )}
-      <span className="truncate">Add folder</span>
+<span className="truncate">{props.label}</span>
     </Button>
   );
   if (props.disabled && props.disabledReason !== null) {

--- a/clients/gui-app/src/components/home/host-workspace-selector/workspace-folder-summary-control.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/workspace-folder-summary-control.tsx
@@ -141,6 +141,7 @@ export function WorkspaceFolderSummaryControl(props: {
   readonly addFolderPending: boolean;
   readonly addFolderDisabled: boolean;
   readonly addFolderDisabledReason: string | null;
+  readonly addFolderLabel?: string;
   readonly onAddFolder: AddFolderHandler;
   readonly onUpdate: (() => void) | null;
   readonly updateEnabled: boolean;
@@ -276,6 +277,11 @@ export function WorkspaceFolderSummaryControl(props: {
         pending={props.addFolderPending}
         disabled={props.addFolderDisabled}
         disabledReason={props.addFolderDisabledReason}
+        label={
+          props.addFolderLabel === undefined
+            ? "Add folder"
+            : props.addFolderLabel
+        }
       />
     );
   }
@@ -397,6 +403,11 @@ export function WorkspaceFolderSummaryControl(props: {
             addFolderPending={props.addFolderPending}
             addFolderDisabled={props.addFolderDisabled}
             addFolderDisabledReason={props.addFolderDisabledReason}
+            addFolderLabel={
+              props.addFolderLabel === undefined
+                ? "Add folder"
+                : props.addFolderLabel
+            }
             onAddFolder={props.onAddFolder}
             onUpdate={props.onUpdate === null ? null : handleUpdate}
             updateEnabled={props.updateEnabled}

--- a/clients/gui-app/src/components/layout/header/__tests__/project-profile-create-dialog.test.tsx
+++ b/clients/gui-app/src/components/layout/header/__tests__/project-profile-create-dialog.test.tsx
@@ -144,4 +144,13 @@ describe("<ProjectProfileCreateDialog />", () => {
     expect(active?.folderPaths).toEqual([PICKED_PATH]);
     expect(active?.primaryPath).toBe(PICKED_PATH);
   });
+
+  it("hides All current folders and Empty until Advanced is opened", () => {
+    render(<Harness />);
+    expect(screen.queryByTestId("project-profile-seed-all")).toBeNull();
+    expect(screen.queryByTestId("project-profile-seed-empty")).toBeNull();
+    fireEvent.click(screen.getByTestId("project-profile-advanced"));
+    expect(screen.getByTestId("project-profile-seed-all")).not.toBeNull();
+    expect(screen.getByTestId("project-profile-seed-empty")).not.toBeNull();
+  });
 });

--- a/clients/gui-app/src/components/layout/header/__tests__/project-profile-create-dialog.test.tsx
+++ b/clients/gui-app/src/components/layout/header/__tests__/project-profile-create-dialog.test.tsx
@@ -1,0 +1,147 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { useState } from "react";
+import { ProjectProfileCreateDialog } from "@/components/layout/header/project-profile-create-dialog";
+import type { PrepareFoldersWithHostResult } from "@/hooks/workspace/use-workspace-folder-actions";
+import {
+  selectWorkspaceFoldersBucket,
+  useWorkspaceFoldersStore,
+} from "@/stores/workspace/workspace-folders-store";
+import {
+  selectActiveProjectProfile,
+  useProjectProfilesStore,
+} from "@/stores/workspace/project-profiles-store";
+
+const HOST = "host-a";
+const PICKED_PATH = "/picked/crm";
+
+const testState = vi.hoisted(() => ({
+  pickResult: null as PrepareFoldersWithHostResult | null,
+}));
+
+vi.mock("@/hooks/workspace/use-workspace-folder-actions", async (importActual) => ({
+  ...(await importActual()),
+  useWorkspaceFolderActions: () => ({
+    isPreparing: false,
+    pickAndPrepareFolders: () => Promise.resolve(testState.pickResult),
+  }),
+}));
+
+function catalogFolders(): ReadonlyArray<string> {
+  return selectWorkspaceFoldersBucket(
+    useWorkspaceFoldersStore.getState(),
+    HOST,
+  ).folders;
+}
+
+function Harness() {
+  const [open, setOpen] = useState(true);
+  return (
+    <>
+      <button type="button" data-testid="reopen" onClick={() => setOpen(true)}>
+        Reopen
+      </button>
+      <ProjectProfileCreateDialog
+        hostId={HOST}
+        open={open}
+        onOpenChange={setOpen}
+      />
+    </>
+  );
+}
+
+function pickFolder() {
+  fireEvent.click(screen.getByTestId("project-profile-choose-folder"));
+}
+
+function typeName(name: string) {
+  fireEvent.change(screen.getByTestId("project-profile-name"), {
+    target: { value: name },
+  });
+}
+
+describe("<ProjectProfileCreateDialog />", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    testState.pickResult = {
+      folders: [
+        {
+          workspacePath: PICKED_PATH,
+          workspaceName: "crm",
+          repoIdentifier: null,
+          repoUrl: null,
+        },
+      ],
+      repoIdentifiers: [],
+      hostId: HOST,
+    };
+    useWorkspaceFoldersStore.setState({ byHost: {} });
+    useProjectProfilesStore.setState({ byHost: {} });
+  });
+
+  afterEach(() => {
+    cleanup();
+    useWorkspaceFoldersStore.setState({ byHost: {} });
+    useProjectProfilesStore.setState({ byHost: {} });
+  });
+
+  it("keeps the picked folder out of the catalog while the dialog is open", async () => {
+    render(<Harness />);
+
+    pickFolder();
+
+    expect(
+      await screen.findByTestId(`project-profile-folder-${PICKED_PATH}`),
+    ).not.toBeNull();
+    expect(catalogFolders()).toEqual([]);
+  });
+
+  it("discards the pick on Cancel and leaves the catalog untouched", async () => {
+    render(<Harness />);
+
+    pickFolder();
+    await screen.findByTestId(`project-profile-folder-${PICKED_PATH}`);
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("project-profile-create-dialog")).toBeNull();
+    });
+    expect(catalogFolders()).toEqual([]);
+
+    fireEvent.click(screen.getByTestId("reopen"));
+    expect(
+      await screen.findByTestId("project-profile-create-dialog"),
+    ).not.toBeNull();
+    expect(
+      screen.queryByTestId(`project-profile-folder-${PICKED_PATH}`),
+    ).toBeNull();
+    expect(catalogFolders()).toEqual([]);
+  });
+
+  it("adds the picked folder to the catalog on Create and seeds the profile from it", async () => {
+    render(<Harness />);
+
+    typeName("CRM");
+    pickFolder();
+    await screen.findByTestId(`project-profile-folder-${PICKED_PATH}`);
+    fireEvent.click(screen.getByTestId("project-profile-create-confirm"));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("project-profile-create-dialog")).toBeNull();
+    });
+    expect(catalogFolders()).toEqual([PICKED_PATH]);
+    const active = selectActiveProjectProfile(
+      useProjectProfilesStore.getState(),
+      HOST,
+    );
+    expect(active?.name).toBe("CRM");
+    expect(active?.folderPaths).toEqual([PICKED_PATH]);
+    expect(active?.primaryPath).toBe(PICKED_PATH);
+  });
+});

--- a/clients/gui-app/src/components/layout/header/__tests__/project-profile-switcher.test.tsx
+++ b/clients/gui-app/src/components/layout/header/__tests__/project-profile-switcher.test.tsx
@@ -33,9 +33,9 @@ describe("<ProjectProfileSwitcher />", () => {
 
   it("labels the trigger All projects when no profile is active", () => {
     mount();
-    expect(
-      screen.getByRole("button", { name: "Project: All projects" }),
-    ).toBeTruthy();
+    const trigger = screen.getByRole("button", { name: "Project: All projects" });
+    expect(trigger).toBeTruthy();
+    expect(trigger.textContent).toContain("All projects");
   });
 
   it("labels the trigger with the active profile name", () => {
@@ -47,9 +47,9 @@ describe("<ProjectProfileSwitcher />", () => {
     });
     useProjectProfilesStore.getState().setActiveProfile(HOST, id);
     mount();
-    expect(
-      screen.getByRole("button", { name: "Project: Titanos" }),
-    ).toBeTruthy();
+    const trigger = screen.getByRole("button", { name: "Project: Titanos" });
+    expect(trigger).toBeTruthy();
+    expect(trigger.textContent).toContain("Titanos");
   });
 
   it("asks before deleting the active project", () => {

--- a/clients/gui-app/src/components/layout/header/__tests__/project-profile-switcher.test.tsx
+++ b/clients/gui-app/src/components/layout/header/__tests__/project-profile-switcher.test.tsx
@@ -1,8 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { ProjectProfileSwitcher } from "@/components/layout/header/project-profile-switcher";
-import { useProjectProfilesStore } from "@/stores/workspace/project-profiles-store";
+import {
+  selectActiveProjectProfile,
+  useProjectProfilesStore,
+} from "@/stores/workspace/project-profiles-store";
 
 const HOST = "host-a";
 
@@ -47,5 +50,24 @@ describe("<ProjectProfileSwitcher />", () => {
     expect(
       screen.getByRole("button", { name: "Project: Titanos" }),
     ).toBeTruthy();
+  });
+
+  it("asks before deleting the active project", () => {
+    const id = useProjectProfilesStore.getState().createProfile(HOST, {
+      name: "Titanos",
+      color: "orange",
+      folderPaths: ["/titanos"],
+      primaryPath: "/titanos",
+    });
+    useProjectProfilesStore.getState().setActiveProfile(HOST, id);
+    mount();
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Project: Titanos" }));
+    fireEvent.click(screen.getByTestId("project-profile-delete"));
+    expect(screen.getByTestId("confirm-destructive-dialog")).not.toBeNull();
+    expect(selectActiveProjectProfile(useProjectProfilesStore.getState(), HOST)?.name).toBe(
+      "Titanos",
+    );
+    fireEvent.click(screen.getByTestId("confirm-action"));
+    expect(selectActiveProjectProfile(useProjectProfilesStore.getState(), HOST)).toBeNull();
   });
 });

--- a/clients/gui-app/src/components/layout/header/__tests__/project-profile-switcher.test.tsx
+++ b/clients/gui-app/src/components/layout/header/__tests__/project-profile-switcher.test.tsx
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { ProjectProfileSwitcher } from "@/components/layout/header/project-profile-switcher";
+import { useProjectProfilesStore } from "@/stores/workspace/project-profiles-store";
+
+const HOST = "host-a";
+
+vi.mock("@/hooks/host/use-reactive-active-host-id", () => ({
+  useReactiveActiveHostId: () => HOST,
+}));
+
+function mount() {
+  render(
+    <TooltipProvider>
+      <ProjectProfileSwitcher />
+    </TooltipProvider>,
+  );
+}
+
+describe("<ProjectProfileSwitcher />", () => {
+  beforeEach(() => {
+    useProjectProfilesStore.setState({ byHost: {} });
+  });
+
+  afterEach(() => {
+    cleanup();
+    useProjectProfilesStore.setState({ byHost: {} });
+  });
+
+  it("labels the trigger All projects when no profile is active", () => {
+    mount();
+    expect(screen.getByTestId("project-profile-switcher").textContent).toContain(
+      "All projects",
+    );
+  });
+
+  it("labels the trigger with the active profile name", () => {
+    const id = useProjectProfilesStore.getState().createProfile(HOST, {
+      name: "Titanos",
+      color: "orange",
+      folderPaths: ["/titanos"],
+      primaryPath: "/titanos",
+    });
+    useProjectProfilesStore.getState().setActiveProfile(HOST, id);
+    mount();
+    expect(screen.getByTestId("project-profile-switcher").textContent).toContain(
+      "Titanos",
+    );
+  });
+});

--- a/clients/gui-app/src/components/layout/header/__tests__/project-profile-switcher.test.tsx
+++ b/clients/gui-app/src/components/layout/header/__tests__/project-profile-switcher.test.tsx
@@ -30,9 +30,9 @@ describe("<ProjectProfileSwitcher />", () => {
 
   it("labels the trigger All projects when no profile is active", () => {
     mount();
-    expect(screen.getByTestId("project-profile-switcher").textContent).toContain(
-      "All projects",
-    );
+    expect(
+      screen.getByRole("button", { name: "Project: All projects" }),
+    ).toBeTruthy();
   });
 
   it("labels the trigger with the active profile name", () => {
@@ -44,8 +44,8 @@ describe("<ProjectProfileSwitcher />", () => {
     });
     useProjectProfilesStore.getState().setActiveProfile(HOST, id);
     mount();
-    expect(screen.getByTestId("project-profile-switcher").textContent).toContain(
-      "Titanos",
-    );
+    expect(
+      screen.getByRole("button", { name: "Project: Titanos" }),
+    ).toBeTruthy();
   });
 });

--- a/clients/gui-app/src/components/layout/header/__tests__/project-profile-switcher.test.tsx
+++ b/clients/gui-app/src/components/layout/header/__tests__/project-profile-switcher.test.tsx
@@ -9,8 +9,8 @@ import {
 
 const HOST = "host-a";
 
-vi.mock("@/hooks/host/use-reactive-active-host-id", () => ({
-  useReactiveActiveHostId: () => HOST,
+vi.mock("@/hooks/host/use-addressable-host-id", () => ({
+  useAddressableHostId: () => HOST,
 }));
 
 function mount() {

--- a/clients/gui-app/src/components/layout/header/app-header.tsx
+++ b/clients/gui-app/src/components/layout/header/app-header.tsx
@@ -66,7 +66,7 @@ export function AppHeader(props: AppHeaderProps): ReactNode {
 /**
  * Desktop navigation chrome. Frameless desktop shells use this row as the
  * native title bar: tabs and controls stay interactive, while the empty spacer
- * before the right-side controls remains available for window dragging.
+ * after the tab strip remains available for window dragging.
  */
 function DesktopAppHeader(props: AppHeaderProps): ReactNode {
   const { variant } = props;
@@ -111,28 +111,10 @@ function DesktopAppHeader(props: AppHeaderProps): ReactNode {
         enabled={!navDisabled}
         framelessDesktop={framelessDesktop}
       />
-      {/* Left drag handle: breathing room beside the traffic lights +
-          back/forward arrows so the window can be grabbed from the left end
-          too. Desktop-only (the browser app has neither traffic lights nor
-          arrows, so a left gap there would be stray).
-
-          IMPORTANT: this must be a DIRECT child of <header> (a top-level
-          title-bar element), mirroring the right-side spacer below. An
-          otherwise-identical drag spacer nested inside the flex tab-strip
-          section was NOT honored as a draggable region (only the right
-          spacer, a direct header child, dragged). Electron registers
-          `-webkit-app-region: drag` reliably only on top-level title-bar
-          elements. */}
-      {showTabStrip && framelessDesktop ? (
-        <div
-          aria-hidden
-          className="relative z-10 hidden h-full shrink-0 basis-[clamp(1rem,3vw,3rem)] md:block"
-          style={spacerDragStyle}
-        />
-      ) : null}
       <div
         className={cn(
           "relative z-10 flex min-w-0 flex-1 items-center",
+          showTabStrip && "pl-1",
           draggable && "[-webkit-app-region:drag]",
         )}
       >

--- a/clients/gui-app/src/components/layout/header/app-header.tsx
+++ b/clients/gui-app/src/components/layout/header/app-header.tsx
@@ -107,6 +107,10 @@ function DesktopAppHeader(props: AppHeaderProps): ReactNode {
     >
       <WindowsMenuBar />
       {showTabStrip ? <HistoryNavButtons /> : null}
+      <HeaderProjectProfileSlot
+        enabled={!navDisabled}
+        framelessDesktop={framelessDesktop}
+      />
       {/* Left drag handle: breathing room beside the traffic lights +
           back/forward arrows so the window can be grabbed from the left end
           too. Desktop-only (the browser app has neither traffic lights nor
@@ -122,7 +126,7 @@ function DesktopAppHeader(props: AppHeaderProps): ReactNode {
       {showTabStrip && framelessDesktop ? (
         <div
           aria-hidden
-          className="relative z-10 hidden h-full shrink-0 basis-[clamp(2rem,6vw,6rem)] md:block"
+          className="relative z-10 hidden h-full shrink-0 basis-[clamp(1rem,3vw,3rem)] md:block"
           style={spacerDragStyle}
         />
       ) : null}
@@ -153,7 +157,6 @@ function DesktopAppHeader(props: AppHeaderProps): ReactNode {
         {!navDisabled && showGlobalResourceMonitor ? (
           <ResourceMonitorPopover className={undefined} />
         ) : null}
-        <HeaderProjectProfileSlot enabled={!navDisabled} />
         {!navDisabled ? <HistoryButton /> : null}
         {showBell ? <HeaderNotificationsBell /> : null}
         <HeaderIdentity showAppSettings={!navDisabled} />
@@ -162,9 +165,19 @@ function DesktopAppHeader(props: AppHeaderProps): ReactNode {
   );
 }
 
-function HeaderProjectProfileSlot(props: { readonly enabled: boolean }) {
+function HeaderProjectProfileSlot(props: {
+  readonly enabled: boolean;
+  readonly framelessDesktop: boolean;
+}) {
   if (!props.enabled) return null;
-  return <ProjectProfileSwitcher />;
+  return (
+    <div
+      className="relative z-10 shrink-0"
+      style={props.framelessDesktop ? NO_DRAG_STYLE : undefined}
+    >
+      <ProjectProfileSwitcher />
+    </div>
+  );
 }
 
 // Hiding the bell when signed-out keeps the notifications-store +

--- a/clients/gui-app/src/components/layout/header/app-header.tsx
+++ b/clients/gui-app/src/components/layout/header/app-header.tsx
@@ -5,6 +5,7 @@ import { TabStrip } from "@/components/layout/tabs/tab-strip";
 import { AppUpdateHeaderButton } from "@/components/layout/header/app-update-button";
 import { HistoryButton } from "@/components/layout/header/history-button";
 import { HistoryNavButtons } from "@/components/layout/header/history-nav-buttons";
+import { ProjectProfileSwitcher } from "@/components/layout/header/project-profile-switcher";
 import { WindowsMenuBar } from "@/components/layout/header/windows-menu-bar";
 import { RateLimitIconButton } from "@/components/layout/header/rate-limit-icon";
 import { ResourceMonitorPopover } from "@/components/resources/resource-monitor-popover";
@@ -152,12 +153,18 @@ function DesktopAppHeader(props: AppHeaderProps): ReactNode {
         {!navDisabled && showGlobalResourceMonitor ? (
           <ResourceMonitorPopover className={undefined} />
         ) : null}
+        <HeaderProjectProfileSlot enabled={!navDisabled} />
         {!navDisabled ? <HistoryButton /> : null}
         {showBell ? <HeaderNotificationsBell /> : null}
         <HeaderIdentity showAppSettings={!navDisabled} />
       </div>
     </header>
   );
+}
+
+function HeaderProjectProfileSlot(props: { readonly enabled: boolean }) {
+  if (!props.enabled) return null;
+  return <ProjectProfileSwitcher />;
 }
 
 // Hiding the bell when signed-out keeps the notifications-store +

--- a/clients/gui-app/src/components/layout/header/project-profile-colors.ts
+++ b/clients/gui-app/src/components/layout/header/project-profile-colors.ts
@@ -1,0 +1,12 @@
+import type { ProjectProfileColor } from "@/stores/workspace/project-profiles-store";
+
+export const PROJECT_PROFILE_COLOR_DOT: Readonly<
+  Record<ProjectProfileColor, string>
+> = {
+  orange: "bg-orange-500",
+  blue: "bg-blue-500",
+  green: "bg-green-500",
+  purple: "bg-purple-500",
+  rose: "bg-rose-500",
+  amber: "bg-amber-500",
+};

--- a/clients/gui-app/src/components/layout/header/project-profile-create-dialog.tsx
+++ b/clients/gui-app/src/components/layout/header/project-profile-create-dialog.tsx
@@ -130,7 +130,7 @@ export function ProjectProfileCreateDialog(props: {
   };
 
   const chooseFolder = async () => {
-    const result = await pickAndPrepareFolders();
+    const result = await pickAndPrepareFolders(true);
     if (result === null || result.folders.length === 0) return;
     const first = result.folders[0];
     if (hostId !== null && result.hostId !== hostId) return;

--- a/clients/gui-app/src/components/layout/header/project-profile-create-dialog.tsx
+++ b/clients/gui-app/src/components/layout/header/project-profile-create-dialog.tsx
@@ -12,6 +12,8 @@ import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
 import { folderSeedForNewProfile } from "@/lib/workspace/project-profile-seed";
 import type { ProjectProfileSeed } from "@/lib/workspace/project-profile-seed";
+import { resolvePrimaryPath } from "@/lib/worktree/resolve-primary-path";
+import { workspaceFolderName } from "@/lib/worktree/workspace-folder-name";
 import {
   PROJECT_PROFILE_COLORS,
   useProjectProfilesStore,
@@ -24,16 +26,11 @@ import {
 import { useLandingDraftStore } from "@/stores/home/landing-draft-store";
 import { PROJECT_PROFILE_COLOR_DOT } from "./project-profile-colors";
 
-const SEED_OPTIONS: ReadonlyArray<{
-  readonly id: ProjectProfileSeed;
+const EXTRA_SEEDS: ReadonlyArray<{
+  readonly id: Exclude<ProjectProfileSeed, "folder">;
   readonly label: string;
   readonly hint: string;
 }> = [
-  {
-    id: "primary",
-    label: "Primary folder",
-    hint: "New chats only open this project's main folder",
-  },
   {
     id: "all",
     label: "All current folders",
@@ -42,7 +39,7 @@ const SEED_OPTIONS: ReadonlyArray<{
   {
     id: "empty",
     label: "Empty",
-    hint: "Add folders after creating the project",
+    hint: "Add this project's folder after creating it",
   },
 ];
 
@@ -54,23 +51,29 @@ export function ProjectProfileCreateDialog(props: {
   const { hostId, open, onOpenChange } = props;
   const [name, setName] = useState("");
   const [color, setColor] = useState<ProjectProfileColor>("orange");
-  const [seed, setSeed] = useState<ProjectProfileSeed>("primary");
+  const [seed, setSeed] = useState<ProjectProfileSeed>("folder");
+  const [pickedFolder, setPickedFolder] = useState<string | null>(null);
+  const catalog = useWorkspaceFoldersStore((state) =>
+    selectWorkspaceFoldersBucket(state, hostId),
+  );
+  const catalogPrimary = resolvePrimaryPath(
+    catalog.folders,
+    catalog.primaryPath,
+  );
+  const selectedFolder = pickedFolder ?? catalogPrimary;
 
   const reset = () => {
     setName("");
     setColor("orange");
-    setSeed("primary");
+    setSeed("folder");
+    setPickedFolder(null);
   };
 
   const submit = () => {
     if (hostId === null) return;
     const trimmed = name.trim();
     if (trimmed.length === 0) return;
-    const catalog = selectWorkspaceFoldersBucket(
-      useWorkspaceFoldersStore.getState(),
-      hostId,
-    );
-    const folders = folderSeedForNewProfile(catalog, seed);
+    const folders = folderSeedForNewProfile(catalog, seed, selectedFolder);
     const id = useProjectProfilesStore.getState().createProfile(hostId, {
       name: trimmed,
       color,
@@ -93,18 +96,21 @@ export function ProjectProfileCreateDialog(props: {
       }}
     >
       <DialogContent
-        className="sm:max-w-md"
+        className="max-w-[min(92vw,28rem)]"
         data-testid="project-profile-create-dialog"
       >
         <DialogHeader>
           <DialogTitle>New project</DialogTitle>
           <DialogDescription>
-            Isolate this chat's folders so a new worktree is not created for
-            every repo you have ever added.
+            Each project has its own main folder. New chats only open that
+            folder — not every repo you have ever added.
           </DialogDescription>
         </DialogHeader>
         <div className="flex flex-col gap-3">
-          <label className="flex flex-col gap-1.5" htmlFor="project-profile-name">
+          <label
+            className="flex flex-col gap-1.5"
+            htmlFor="project-profile-name"
+          >
             <span className="text-ui-sm font-medium">Name</span>
             <Input
               id="project-profile-name"
@@ -137,9 +143,51 @@ export function ProjectProfileCreateDialog(props: {
             </div>
           </fieldset>
           <fieldset className="flex flex-col gap-1.5">
-            <legend className="text-ui-sm font-medium">Start with</legend>
+            <legend className="text-ui-sm font-medium">
+              This project's folder
+            </legend>
+            {catalog.folders.length === 0 ? (
+              <p className="text-ui-xs text-muted-foreground">
+                Add a folder in the workspace picker first, then pick it here.
+              </p>
+            ) : (
+              <div className="flex max-h-48 flex-col gap-1 overflow-y-auto">
+                {catalog.folders.map((folderPath) => (
+                  <button
+                    key={folderPath}
+                    type="button"
+                    data-testid={`project-profile-folder-${folderPath}`}
+                    aria-pressed={
+                      seed === "folder" && selectedFolder === folderPath
+                    }
+                    onClick={() => {
+                      setSeed("folder");
+                      setPickedFolder(folderPath);
+                    }}
+                    className={cn(
+                      "flex flex-col items-start rounded-md px-2.5 py-1.5 text-left",
+                      seed === "folder" && selectedFolder === folderPath
+                        ? "bg-foreground/8"
+                        : "hover:bg-foreground/5",
+                    )}
+                  >
+                    <span className="text-ui-sm font-medium">
+                      {workspaceFolderName(folderPath)}
+                    </span>
+                    <span className="text-ui-xs text-muted-foreground">
+                      {folderPath}
+                    </span>
+                  </button>
+                ))}
+              </div>
+            )}
+          </fieldset>
+          <fieldset className="flex flex-col gap-1.5">
+            <legend className="text-ui-sm font-medium text-muted-foreground">
+              Or
+            </legend>
             <div className="flex flex-col gap-1">
-              {SEED_OPTIONS.map((option) => (
+              {EXTRA_SEEDS.map((option) => (
                 <button
                   key={option.id}
                   type="button"

--- a/clients/gui-app/src/components/layout/header/project-profile-create-dialog.tsx
+++ b/clients/gui-app/src/components/layout/header/project-profile-create-dialog.tsx
@@ -11,9 +11,11 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
-import { folderSeedForNewProfile } from "@/lib/workspace/project-profile-seed";
-import type { ProjectProfileSeed } from "@/lib/workspace/project-profile-seed";
-import { resolvePrimaryPath } from "@/lib/worktree/resolve-primary-path";
+import {
+  canConfirmNewProject,
+  folderSeedForNewProfile,
+  type ProjectProfileSeed,
+} from "@/lib/workspace/project-profile-seed";
 import { workspaceFolderName } from "@/lib/worktree/workspace-folder-name";
 import {
   PROJECT_PROFILE_COLORS,
@@ -61,11 +63,7 @@ export function ProjectProfileCreateDialog(props: {
   const catalog = useWorkspaceFoldersStore((state) =>
     selectWorkspaceFoldersBucket(state, hostId),
   );
-  const catalogPrimary = resolvePrimaryPath(
-    catalog.folders,
-    catalog.primaryPath,
-  );
-  const selectedFolder = pickedFolder ?? catalogPrimary;
+  const selectedFolder = pickedFolder;
   const { pickAndPrepareFolders, isPreparing } = useWorkspaceFolderActions();
 
   const reset = () => {
@@ -78,7 +76,15 @@ export function ProjectProfileCreateDialog(props: {
   const submit = () => {
     if (hostId === null) return;
     const trimmed = name.trim();
-    if (trimmed.length === 0) return;
+    if (
+      !canConfirmNewProject({
+        name: trimmed,
+        seed,
+        pickedFolder,
+      })
+    ) {
+      return;
+    }
     const folders = folderSeedForNewProfile(catalog, seed, selectedFolder);
     const id = useProjectProfilesStore.getState().createProfile(hostId, {
       name: trimmed,
@@ -255,7 +261,14 @@ export function ProjectProfileCreateDialog(props: {
           <Button
             type="button"
             data-testid="project-profile-create-confirm"
-            disabled={hostId === null || name.trim().length === 0}
+            disabled={
+              hostId === null ||
+              !canConfirmNewProject({
+                name,
+                seed,
+                pickedFolder,
+              })
+            }
             onClick={submit}
           >
             Create project

--- a/clients/gui-app/src/components/layout/header/project-profile-create-dialog.tsx
+++ b/clients/gui-app/src/components/layout/header/project-profile-create-dialog.tsx
@@ -25,6 +25,7 @@ import {
 import {
   selectWorkspaceFoldersBucket,
   useWorkspaceFoldersStore,
+  type WorkspaceFolderInfo,
 } from "@/stores/workspace/workspace-folders-store";
 import { useLandingDraftStore } from "@/stores/home/landing-draft-store";
 import {
@@ -60,6 +61,12 @@ export function ProjectProfileCreateDialog(props: {
   const [color, setColor] = useState<ProjectProfileColor>("orange");
   const [seed, setSeed] = useState<ProjectProfileSeed>("folder");
   const [pickedFolder, setPickedFolder] = useState<string | null>(null);
+  // A folder picked via the native/remote picker that is NOT in the host
+  // catalog yet. Dialog-local only: it reaches the catalog on Create (the
+  // profile seed reads the catalog), never on pick - Cancel must leave the
+  // host library untouched.
+  const [pendingFolder, setPendingFolder] =
+    useState<WorkspaceFolderInfo | null>(null);
   const catalog = useWorkspaceFoldersStore((state) =>
     selectWorkspaceFoldersBucket(state, hostId),
   );
@@ -71,6 +78,7 @@ export function ProjectProfileCreateDialog(props: {
     setColor("orange");
     setSeed("folder");
     setPickedFolder(null);
+    setPendingFolder(null);
   };
 
   const submit = () => {
@@ -85,7 +93,27 @@ export function ProjectProfileCreateDialog(props: {
     ) {
       return;
     }
-    const folders = folderSeedForNewProfile(catalog, seed, selectedFolder);
+    // The picked folder joins the catalog only now, on confirm, so
+    // `folderSeedForNewProfile` can resolve it below. An "Empty" project
+    // deliberately skips the write - the user asked for no folders.
+    if (
+      pendingFolder !== null &&
+      seed !== "empty" &&
+      !catalog.folders.includes(pendingFolder.path)
+    ) {
+      useWorkspaceFoldersStore
+        .getState()
+        .addResolvedFolders(hostId, [pendingFolder]);
+    }
+    const confirmedCatalog = selectWorkspaceFoldersBucket(
+      useWorkspaceFoldersStore.getState(),
+      hostId,
+    );
+    const folders = folderSeedForNewProfile(
+      confirmedCatalog,
+      seed,
+      selectedFolder,
+    );
     const id = useProjectProfilesStore.getState().createProfile(hostId, {
       name: trimmed,
       color,
@@ -103,25 +131,31 @@ export function ProjectProfileCreateDialog(props: {
     const result = await pickAndPrepareFolders();
     if (result === null || result.folders.length === 0) return;
     const first = result.folders[0];
-    useWorkspaceFoldersStore.getState().addResolvedFolders(
-      result.hostId,
-      result.folders.map((folder) =>
-        preparedWorkspaceFolderToWorkspaceFolderInfo(folder, result.hostId),
-      ),
-    );
     if (hostId !== null && result.hostId !== hostId) return;
     setSeed("folder");
     setPickedFolder(first.workspacePath);
+    setPendingFolder(
+      preparedWorkspaceFolderToWorkspaceFolderInfo(first, result.hostId),
+    );
+  };
+
+  const pendingPath =
+    pendingFolder !== null && !catalog.folders.includes(pendingFolder.path)
+      ? pendingFolder.path
+      : null;
+  const folderRows =
+    pendingPath === null
+      ? catalog.folders
+      : [pendingPath, ...catalog.folders];
+
+  // Every close path (Cancel, overlay, Escape) discards the dialog-local pick.
+  const handleOpenChange = (next: boolean) => {
+    if (!next) reset();
+    onOpenChange(next);
   };
 
   return (
-    <Dialog
-      open={open}
-      onOpenChange={(next) => {
-        if (!next) reset();
-        onOpenChange(next);
-      }}
-    >
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent
         className="max-w-[min(92vw,28rem)]"
         data-testid="project-profile-create-dialog"
@@ -173,13 +207,13 @@ export function ProjectProfileCreateDialog(props: {
             <legend className="text-ui-sm font-medium">
               This project's folder
             </legend>
-            {catalog.folders.length === 0 ? (
+            {folderRows.length === 0 ? (
               <p className="text-ui-xs text-muted-foreground">
                 Choose the folder this project should open.
               </p>
             ) : (
               <div className="flex max-h-48 flex-col gap-1 overflow-y-auto">
-                {catalog.folders.map((folderPath) => (
+                {folderRows.map((folderPath) => (
                   <button
                     key={folderPath}
                     type="button"
@@ -254,7 +288,7 @@ export function ProjectProfileCreateDialog(props: {
           <Button
             type="button"
             variant="outline"
-            onClick={() => onOpenChange(false)}
+            onClick={() => handleOpenChange(false)}
           >
             Cancel
           </Button>

--- a/clients/gui-app/src/components/layout/header/project-profile-create-dialog.tsx
+++ b/clients/gui-app/src/components/layout/header/project-profile-create-dialog.tsx
@@ -1,0 +1,185 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+import { folderSeedForNewProfile } from "@/lib/workspace/project-profile-seed";
+import type { ProjectProfileSeed } from "@/lib/workspace/project-profile-seed";
+import {
+  PROJECT_PROFILE_COLORS,
+  useProjectProfilesStore,
+  type ProjectProfileColor,
+} from "@/stores/workspace/project-profiles-store";
+import {
+  selectWorkspaceFoldersBucket,
+  useWorkspaceFoldersStore,
+} from "@/stores/workspace/workspace-folders-store";
+import { useLandingDraftStore } from "@/stores/home/landing-draft-store";
+import { PROJECT_PROFILE_COLOR_DOT } from "./project-profile-colors";
+
+const SEED_OPTIONS: ReadonlyArray<{
+  readonly id: ProjectProfileSeed;
+  readonly label: string;
+  readonly hint: string;
+}> = [
+  {
+    id: "primary",
+    label: "Primary folder",
+    hint: "New chats only open this project's main folder",
+  },
+  {
+    id: "all",
+    label: "All current folders",
+    hint: "Keep today's multi-repo set on this project",
+  },
+  {
+    id: "empty",
+    label: "Empty",
+    hint: "Add folders after creating the project",
+  },
+];
+
+export function ProjectProfileCreateDialog(props: {
+  readonly hostId: string | null;
+  readonly open: boolean;
+  readonly onOpenChange: (open: boolean) => void;
+}) {
+  const { hostId, open, onOpenChange } = props;
+  const [name, setName] = useState("");
+  const [color, setColor] = useState<ProjectProfileColor>("orange");
+  const [seed, setSeed] = useState<ProjectProfileSeed>("primary");
+
+  const reset = () => {
+    setName("");
+    setColor("orange");
+    setSeed("primary");
+  };
+
+  const submit = () => {
+    if (hostId === null) return;
+    const trimmed = name.trim();
+    if (trimmed.length === 0) return;
+    const catalog = selectWorkspaceFoldersBucket(
+      useWorkspaceFoldersStore.getState(),
+      hostId,
+    );
+    const folders = folderSeedForNewProfile(catalog, seed);
+    const id = useProjectProfilesStore.getState().createProfile(hostId, {
+      name: trimmed,
+      color,
+      folderPaths: folders.folderPaths,
+      primaryPath: folders.primaryPath,
+    });
+    if (id === null) return;
+    useProjectProfilesStore.getState().setActiveProfile(hostId, id);
+    useLandingDraftStore.getState().replaceActiveDraftWorkspaceFromStores();
+    reset();
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) reset();
+        onOpenChange(next);
+      }}
+    >
+      <DialogContent
+        className="sm:max-w-md"
+        data-testid="project-profile-create-dialog"
+      >
+        <DialogHeader>
+          <DialogTitle>New project</DialogTitle>
+          <DialogDescription>
+            Isolate this chat's folders so a new worktree is not created for
+            every repo you have ever added.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex flex-col gap-3">
+          <label className="flex flex-col gap-1.5" htmlFor="project-profile-name">
+            <span className="text-ui-sm font-medium">Name</span>
+            <Input
+              id="project-profile-name"
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              placeholder="Titanos"
+              data-testid="project-profile-name"
+            />
+          </label>
+          <fieldset className="flex flex-col gap-1.5">
+            <legend className="text-ui-sm font-medium">Color</legend>
+            <div className="flex flex-wrap gap-1.5">
+              {PROJECT_PROFILE_COLORS.map((option) => (
+                <button
+                  key={option}
+                  type="button"
+                  aria-label={option}
+                  aria-pressed={option === color}
+                  data-testid={`project-profile-color-${option}`}
+                  onClick={() => setColor(option)}
+                  className={cn(
+                    "size-7 rounded-full ring-offset-background focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:outline-none",
+                    PROJECT_PROFILE_COLOR_DOT[option],
+                    option === color
+                      ? "ring-2 ring-foreground"
+                      : "opacity-70 hover:opacity-100",
+                  )}
+                />
+              ))}
+            </div>
+          </fieldset>
+          <fieldset className="flex flex-col gap-1.5">
+            <legend className="text-ui-sm font-medium">Start with</legend>
+            <div className="flex flex-col gap-1">
+              {SEED_OPTIONS.map((option) => (
+                <button
+                  key={option.id}
+                  type="button"
+                  data-testid={`project-profile-seed-${option.id}`}
+                  aria-pressed={seed === option.id}
+                  onClick={() => setSeed(option.id)}
+                  className={cn(
+                    "flex flex-col items-start rounded-md px-2.5 py-1.5 text-left",
+                    seed === option.id
+                      ? "bg-foreground/8"
+                      : "hover:bg-foreground/5",
+                  )}
+                >
+                  <span className="text-ui-sm font-medium">{option.label}</span>
+                  <span className="text-ui-xs text-muted-foreground">
+                    {option.hint}
+                  </span>
+                </button>
+              ))}
+            </div>
+          </fieldset>
+        </div>
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            data-testid="project-profile-create-confirm"
+            disabled={hostId === null || name.trim().length === 0}
+            onClick={submit}
+          >
+            Create project
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/clients/gui-app/src/components/layout/header/project-profile-create-dialog.tsx
+++ b/clients/gui-app/src/components/layout/header/project-profile-create-dialog.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { FolderPlus } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -24,6 +25,10 @@ import {
   useWorkspaceFoldersStore,
 } from "@/stores/workspace/workspace-folders-store";
 import { useLandingDraftStore } from "@/stores/home/landing-draft-store";
+import {
+  preparedWorkspaceFolderToWorkspaceFolderInfo,
+  useWorkspaceFolderActions,
+} from "@/hooks/workspace/use-workspace-folder-actions";
 import { PROJECT_PROFILE_COLOR_DOT } from "./project-profile-colors";
 
 const EXTRA_SEEDS: ReadonlyArray<{
@@ -61,6 +66,7 @@ export function ProjectProfileCreateDialog(props: {
     catalog.primaryPath,
   );
   const selectedFolder = pickedFolder ?? catalogPrimary;
+  const { pickAndPrepareFolders, isPreparing } = useWorkspaceFolderActions();
 
   const reset = () => {
     setName("");
@@ -85,6 +91,21 @@ export function ProjectProfileCreateDialog(props: {
     useLandingDraftStore.getState().replaceActiveDraftWorkspaceFromStores();
     reset();
     onOpenChange(false);
+  };
+
+  const chooseFolder = async () => {
+    const result = await pickAndPrepareFolders();
+    if (result === null || result.folders.length === 0) return;
+    const first = result.folders[0];
+    useWorkspaceFoldersStore.getState().addResolvedFolders(
+      result.hostId,
+      result.folders.map((folder) =>
+        preparedWorkspaceFolderToWorkspaceFolderInfo(folder, result.hostId),
+      ),
+    );
+    if (hostId !== null && result.hostId !== hostId) return;
+    setSeed("folder");
+    setPickedFolder(first.workspacePath);
   };
 
   return (
@@ -148,7 +169,7 @@ export function ProjectProfileCreateDialog(props: {
             </legend>
             {catalog.folders.length === 0 ? (
               <p className="text-ui-xs text-muted-foreground">
-                Add a folder in the workspace picker first, then pick it here.
+                Choose the folder this project should open.
               </p>
             ) : (
               <div className="flex max-h-48 flex-col gap-1 overflow-y-auto">
@@ -181,6 +202,19 @@ export function ProjectProfileCreateDialog(props: {
                 ))}
               </div>
             )}
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              data-testid="project-profile-choose-folder"
+              disabled={hostId === null || isPreparing}
+              onClick={() => {
+                void chooseFolder();
+              }}
+            >
+              <FolderPlus className="size-3.5" />
+              {isPreparing ? "Opening…" : "Choose folder"}
+            </Button>
           </fieldset>
           <fieldset className="flex flex-col gap-1.5">
             <legend className="text-ui-sm font-medium text-muted-foreground">

--- a/clients/gui-app/src/components/layout/header/project-profile-create-dialog.tsx
+++ b/clients/gui-app/src/components/layout/header/project-profile-create-dialog.tsx
@@ -61,6 +61,7 @@ export function ProjectProfileCreateDialog(props: {
   const [color, setColor] = useState<ProjectProfileColor>("orange");
   const [seed, setSeed] = useState<ProjectProfileSeed>("folder");
   const [pickedFolder, setPickedFolder] = useState<string | null>(null);
+  const [advancedOpen, setAdvancedOpen] = useState(false);
   // A folder picked via the native/remote picker that is NOT in the host
   // catalog yet. Dialog-local only: it reaches the catalog on Create (the
   // profile seed reads the catalog), never on pick - Cancel must leave the
@@ -79,6 +80,7 @@ export function ProjectProfileCreateDialog(props: {
     setSeed("folder");
     setPickedFolder(null);
     setPendingFolder(null);
+    setAdvancedOpen(false);
   };
 
   const submit = () => {
@@ -256,33 +258,47 @@ export function ProjectProfileCreateDialog(props: {
               {isPreparing ? "Opening…" : "Choose folder"}
             </Button>
           </fieldset>
-          <fieldset className="flex flex-col gap-1.5">
-            <legend className="text-ui-sm font-medium text-muted-foreground">
-              Or
-            </legend>
-            <div className="flex flex-col gap-1">
-              {EXTRA_SEEDS.map((option) => (
-                <button
-                  key={option.id}
-                  type="button"
-                  data-testid={`project-profile-seed-${option.id}`}
-                  aria-pressed={seed === option.id}
-                  onClick={() => setSeed(option.id)}
-                  className={cn(
-                    "flex flex-col items-start rounded-md px-2.5 py-1.5 text-left",
-                    seed === option.id
-                      ? "bg-foreground/8"
-                      : "hover:bg-foreground/5",
-                  )}
-                >
-                  <span className="text-ui-sm font-medium">{option.label}</span>
-                  <span className="text-ui-xs text-muted-foreground">
-                    {option.hint}
-                  </span>
-                </button>
-              ))}
-            </div>
-          </fieldset>
+          <details className="flex flex-col gap-1.5" open={advancedOpen}>
+            <summary
+              className="cursor-pointer text-ui-sm font-medium text-muted-foreground"
+              data-testid="project-profile-advanced"
+              onClick={(event) => {
+                event.preventDefault();
+                setAdvancedOpen((open) => !open);
+              }}
+            >
+              Advanced
+            </summary>
+            {advancedOpen ? (
+              <fieldset className="flex flex-col gap-1.5">
+                <legend className="sr-only">More ways to start</legend>
+                <div className="flex flex-col gap-1">
+                  {EXTRA_SEEDS.map((option) => (
+                    <button
+                      key={option.id}
+                      type="button"
+                      data-testid={`project-profile-seed-${option.id}`}
+                      aria-pressed={seed === option.id}
+                      onClick={() => setSeed(option.id)}
+                      className={cn(
+                        "flex flex-col items-start rounded-md px-2.5 py-1.5 text-left",
+                        seed === option.id
+                          ? "bg-foreground/8"
+                          : "hover:bg-foreground/5",
+                      )}
+                    >
+                      <span className="text-ui-sm font-medium">
+                        {option.label}
+                      </span>
+                      <span className="text-ui-xs text-muted-foreground">
+                        {option.hint}
+                      </span>
+                    </button>
+                  ))}
+                </div>
+              </fieldset>
+            ) : null}
+          </details>
         </div>
         <DialogFooter>
           <Button

--- a/clients/gui-app/src/components/layout/header/project-profile-switcher.tsx
+++ b/clients/gui-app/src/components/layout/header/project-profile-switcher.tsx
@@ -1,0 +1,153 @@
+import { Check, ChevronDown, FolderKanban, Plus, Trash2 } from "lucide-react";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
+import { cn } from "@/lib/utils";
+import { useReactiveActiveHostId } from "@/hooks/host/use-reactive-active-host-id";
+import {
+  selectActiveProjectProfile,
+  selectProjectProfilesBucket,
+  useProjectProfilesStore,
+} from "@/stores/workspace/project-profiles-store";
+import { useLandingDraftStore } from "@/stores/home/landing-draft-store";
+import { ProjectProfileCreateDialog } from "./project-profile-create-dialog";
+import { PROJECT_PROFILE_COLOR_DOT } from "./project-profile-colors";
+
+/**
+ * Header switcher for Project Profiles (#1113 v1).
+ *
+ * Zero profiles keeps today's global folder list. Activating a profile
+ * re-snapshots the landing draft so the next send only worktrees that
+ * project's folders.
+ */
+export function ProjectProfileSwitcher() {
+  const hostId = useReactiveActiveHostId();
+  const bucket = useProjectProfilesStore((state) =>
+    selectProjectProfilesBucket(state, hostId),
+  );
+  const active = useProjectProfilesStore((state) =>
+    selectActiveProjectProfile(state, hostId),
+  );
+  const [createOpen, setCreateOpen] = useState(false);
+  const disabled = hostId === null;
+  const label = active === null ? "All projects" : active.name;
+
+  return (
+    <>
+      <DropdownMenu>
+        <TooltipWrapper
+          label="Project"
+          side="top"
+          sideOffset={6}
+          align={undefined}
+        >
+          <DropdownMenuTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              disabled={disabled}
+              aria-label={`Project: ${label}`}
+              data-testid="project-profile-switcher"
+              className="max-w-[11rem] text-muted-foreground hover:text-foreground"
+            >
+              <FolderKanban className="size-3.5 shrink-0" />
+              {active !== null ? (
+                <span
+                  aria-hidden
+                  className={cn(
+                    "size-2 shrink-0 rounded-full",
+                    PROJECT_PROFILE_COLOR_DOT[active.color],
+                  )}
+                />
+              ) : null}
+              <span className="min-w-0 truncate">{label}</span>
+              <ChevronDown className="size-3 shrink-0 opacity-70" />
+            </Button>
+          </DropdownMenuTrigger>
+        </TooltipWrapper>
+        <DropdownMenuContent align="end" className="min-w-48">
+          <DropdownMenuItem
+            data-testid="project-profile-all"
+            onSelect={() => activateProfile(hostId, null)}
+          >
+            <Check
+              className={cn(
+                "size-3.5",
+                active === null ? "opacity-100" : "opacity-0",
+              )}
+            />
+            All projects
+          </DropdownMenuItem>
+          {bucket.profiles.map((profile) => (
+            <DropdownMenuItem
+              key={profile.id}
+              data-testid={`project-profile-${profile.id}`}
+              onSelect={() => activateProfile(hostId, profile.id)}
+            >
+              <Check
+                className={cn(
+                  "size-3.5",
+                  profile.id === active?.id ? "opacity-100" : "opacity-0",
+                )}
+              />
+              <span
+                aria-hidden
+                className={cn(
+                  "size-2 shrink-0 rounded-full",
+                  PROJECT_PROFILE_COLOR_DOT[profile.color],
+                )}
+              />
+              <span className="min-w-0 truncate">{profile.name}</span>
+            </DropdownMenuItem>
+          ))}
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            data-testid="project-profile-create"
+            onSelect={() => setCreateOpen(true)}
+          >
+            <Plus className="size-3.5" />
+            New project
+          </DropdownMenuItem>
+          {active !== null ? (
+            <DropdownMenuItem
+              variant="destructive"
+              data-testid="project-profile-delete"
+              onSelect={() => deleteActiveProfile(hostId, active.id)}
+            >
+              <Trash2 className="size-3.5" />
+              Delete {active.name}
+            </DropdownMenuItem>
+          ) : null}
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <ProjectProfileCreateDialog
+        hostId={hostId}
+        open={createOpen}
+        onOpenChange={setCreateOpen}
+      />
+    </>
+  );
+}
+
+function activateProfile(
+  hostId: string | null,
+  profileId: string | null,
+): void {
+  if (hostId === null) return;
+  useProjectProfilesStore.getState().setActiveProfile(hostId, profileId);
+  useLandingDraftStore.getState().replaceActiveDraftWorkspaceFromStores();
+}
+
+function deleteActiveProfile(hostId: string | null, profileId: string): void {
+  if (hostId === null) return;
+  useProjectProfilesStore.getState().deleteProfile(hostId, profileId);
+  useLandingDraftStore.getState().replaceActiveDraftWorkspaceFromStores();
+}

--- a/clients/gui-app/src/components/layout/header/project-profile-switcher.tsx
+++ b/clients/gui-app/src/components/layout/header/project-profile-switcher.tsx
@@ -1,6 +1,7 @@
 import { Check, ChevronDown, FolderKanban, Plus, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
+import { ConfirmDestructiveDialog } from "@/components/ui/confirm-destructive-dialog";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -36,6 +37,7 @@ export function ProjectProfileSwitcher() {
     selectActiveProjectProfile(state, hostId),
   );
   const [createOpen, setCreateOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
   const disabled = hostId === null;
   const label = active === null ? "All projects" : active.name;
 
@@ -123,7 +125,7 @@ export function ProjectProfileSwitcher() {
             <DropdownMenuItem
               variant="destructive"
               data-testid="project-profile-delete"
-              onSelect={() => deleteActiveProfile(hostId, active.id)}
+              onSelect={() => setDeleteOpen(true)}
             >
               <Trash2 className="size-3.5" />
               <span className="min-w-0 truncate">Delete {active.name}</span>
@@ -136,6 +138,21 @@ export function ProjectProfileSwitcher() {
           hostId={hostId}
           open={createOpen}
           onOpenChange={setCreateOpen}
+        />
+      ) : null}
+      {active !== null ? (
+        <ConfirmDestructiveDialog
+          open={deleteOpen}
+          onOpenChange={setDeleteOpen}
+          title={`Delete ${active.name}?`}
+          description="This only removes the project shortcut. Chats and folders stay. If another project exists, Traycer switches to it instead of All projects."
+          cascadeSummary={null}
+          actionLabel="Delete project"
+          isPending={false}
+          onConfirm={() => {
+            deleteActiveProfile(hostId, active.id);
+            setDeleteOpen(false);
+          }}
         />
       ) : null}
     </>

--- a/clients/gui-app/src/components/layout/header/project-profile-switcher.tsx
+++ b/clients/gui-app/src/components/layout/header/project-profile-switcher.tsx
@@ -11,7 +11,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 import { cn } from "@/lib/utils";
-import { useReactiveActiveHostId } from "@/hooks/host/use-reactive-active-host-id";
+import { useAddressableHostId } from "@/hooks/host/use-addressable-host-id";
 import {
   selectActiveProjectProfile,
   selectProjectProfilesBucket,
@@ -29,7 +29,7 @@ import { PROJECT_PROFILE_COLOR_DOT } from "./project-profile-colors";
  * project's folders.
  */
 export function ProjectProfileSwitcher() {
-  const hostId = useReactiveActiveHostId();
+  const hostId = useAddressableHostId();
   const bucket = useProjectProfilesStore((state) =>
     selectProjectProfilesBucket(state, hostId),
   );

--- a/clients/gui-app/src/components/layout/header/project-profile-switcher.tsx
+++ b/clients/gui-app/src/components/layout/header/project-profile-switcher.tsx
@@ -56,7 +56,7 @@ export function ProjectProfileSwitcher() {
               disabled={disabled}
               aria-label={`Project: ${label}`}
               data-testid="project-profile-switcher"
-              className="max-w-[11rem] text-muted-foreground hover:text-foreground"
+              className="max-w-[min(40vw,11rem)] text-muted-foreground hover:text-foreground"
             >
               <FolderKanban className="size-3.5 shrink-0" />
               {active !== null ? (
@@ -73,7 +73,10 @@ export function ProjectProfileSwitcher() {
             </Button>
           </DropdownMenuTrigger>
         </TooltipWrapper>
-        <DropdownMenuContent align="end" className="min-w-48">
+        <DropdownMenuContent
+          align="end"
+          className="min-w-[min(12rem,92vw)] max-w-[min(92vw,20rem)]"
+        >
           <DropdownMenuItem
             data-testid="project-profile-all"
             onSelect={() => activateProfile(hostId, null)}
@@ -123,7 +126,7 @@ export function ProjectProfileSwitcher() {
               onSelect={() => deleteActiveProfile(hostId, active.id)}
             >
               <Trash2 className="size-3.5" />
-              Delete {active.name}
+              <span className="min-w-0 truncate">Delete {active.name}</span>
             </DropdownMenuItem>
           ) : null}
         </DropdownMenuContent>

--- a/clients/gui-app/src/components/layout/header/project-profile-switcher.tsx
+++ b/clients/gui-app/src/components/layout/header/project-profile-switcher.tsx
@@ -131,11 +131,13 @@ export function ProjectProfileSwitcher() {
           ) : null}
         </DropdownMenuContent>
       </DropdownMenu>
-      <ProjectProfileCreateDialog
-        hostId={hostId}
-        open={createOpen}
-        onOpenChange={setCreateOpen}
-      />
+      {createOpen ? (
+        <ProjectProfileCreateDialog
+          hostId={hostId}
+          open={createOpen}
+          onOpenChange={setCreateOpen}
+        />
+      ) : null}
     </>
   );
 }

--- a/clients/gui-app/src/components/layout/header/project-profile-switcher.tsx
+++ b/clients/gui-app/src/components/layout/header/project-profile-switcher.tsx
@@ -50,30 +50,35 @@ export function ProjectProfileSwitcher() {
           sideOffset={6}
           align={undefined}
         >
-          <DropdownMenuTrigger asChild>
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              disabled={disabled}
-              aria-label={`Project: ${label}`}
-              data-testid="project-profile-switcher"
-              className="max-w-[min(40vw,11rem)] text-muted-foreground hover:text-foreground"
-            >
-              <FolderKanban className="size-3.5 shrink-0" />
-              {active !== null ? (
-                <span
-                  aria-hidden
-                  className={cn(
-                    "size-2 shrink-0 rounded-full",
-                    PROJECT_PROFILE_COLOR_DOT[active.color],
-                  )}
-                />
-              ) : null}
-              <span className="min-w-0 truncate">{label}</span>
-              <ChevronDown className="size-3 shrink-0 opacity-70" />
-            </Button>
-          </DropdownMenuTrigger>
+          {/* Span keeps TooltipTrigger from composing onto DropdownMenuTrigger.
+              Nested asChild slots drop the button children and leave a blank
+              hole in the frameless title bar. Same pattern as HistoryNavButtons. */}
+          <span className="inline-flex">
+            <DropdownMenuTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                disabled={disabled}
+                aria-label={`Project: ${label}`}
+                data-testid="project-profile-switcher"
+                className="max-w-[min(40vw,12rem)] border border-border/70 bg-foreground/8 text-canvas-foreground hover:bg-foreground/12 hover:text-foreground"
+              >
+                <FolderKanban className="size-3.5 shrink-0" />
+                {active !== null ? (
+                  <span
+                    aria-hidden
+                    className={cn(
+                      "size-2 shrink-0 rounded-full",
+                      PROJECT_PROFILE_COLOR_DOT[active.color],
+                    )}
+                  />
+                ) : null}
+                <span className="min-w-0 truncate">{label}</span>
+                <ChevronDown className="size-3 shrink-0 opacity-70" />
+              </Button>
+            </DropdownMenuTrigger>
+          </span>
         </TooltipWrapper>
         <DropdownMenuContent
           align="end"

--- a/clients/gui-app/src/components/layout/tabs/tab-strip-context-menu.tsx
+++ b/clients/gui-app/src/components/layout/tabs/tab-strip-context-menu.tsx
@@ -1,7 +1,10 @@
 import {
   ArrowLeftRight,
+  Check,
   CopyPlus,
   ExternalLink,
+  FolderKanban,
+  FolderPlus,
   Maximize2,
   PanelLeftClose,
   PanelRightClose,
@@ -16,6 +19,9 @@ import {
   ContextMenuContent,
   ContextMenuItem,
   ContextMenuSeparator,
+  ContextMenuSub,
+  ContextMenuSubContent,
+  ContextMenuSubTrigger,
 } from "@/components/ui/context-menu";
 import {
   DropdownMenuContent,
@@ -29,6 +35,89 @@ import {
   type TabSplitCommandAvailability,
   type TabSplitCommandId,
 } from "@/stores/tabs/tab-split-commands";
+import { useAddressableHostId } from "@/hooks/host/use-addressable-host-id";
+import { workspaceHintForOpenEpic } from "@/hooks/workspace/use-project-scoped-header-strip";
+import {
+  assignEpicToProjectProfile,
+  createProjectFromWorkspaceHint,
+  folderAlreadyOwnsAProject,
+} from "@/lib/workspace/assign-epic-to-project";
+import { claimedProfileIdForEpic } from "@/lib/workspace/history-item-matches-project";
+import { resolveOwningProjectProfile } from "@/lib/workspace/header-tab-matches-project";
+import { workspaceFolderName } from "@/lib/worktree/workspace-folder-name";
+import { PROJECT_PROFILE_COLOR_DOT } from "@/components/layout/header/project-profile-colors";
+import {
+  selectProjectProfilesBucket,
+  useProjectProfilesStore,
+} from "@/stores/workspace/project-profiles-store";
+
+function TabProjectMenuItems(props: { readonly tab: HeaderTab }): React.ReactNode {
+  const { tab } = props;
+  const hostId = useAddressableHostId();
+  const bucket = useProjectProfilesStore((state) =>
+    selectProjectProfilesBucket(state, hostId),
+  );
+  if (tab.kind !== "epic") return null;
+  const hint = workspaceHintForOpenEpic(tab.epicId);
+  const claimedId = claimedProfileIdForEpic(bucket.profiles, tab.epicId);
+  const owner =
+    claimedId === null
+      ? resolveOwningProjectProfile(bucket.profiles, tab.epicId, hint)
+      : (bucket.profiles.find((profile) => profile.id === claimedId) ?? null);
+  const folderPath = hint?.primaryPath ?? hint?.linkedWorkspaces[0]?.workspacePath ?? null;
+  const canCreateFromFolder =
+    folderPath !== null &&
+    !folderAlreadyOwnsAProject(bucket.profiles, folderPath);
+  const folderLabel =
+    folderPath === null ? null : workspaceFolderName(folderPath);
+  if (bucket.profiles.length === 0 && !canCreateFromFolder) return null;
+  return (
+    <>
+      <ContextMenuSub>
+        <ContextMenuSubTrigger data-testid={`tab-move-project-${tab.id}`}>
+          <FolderKanban />
+          Move to project
+        </ContextMenuSubTrigger>
+        <ContextMenuSubContent>
+          {bucket.profiles.map((profile) => {
+            const current = owner?.id === profile.id;
+            return (
+              <ContextMenuItem
+                key={profile.id}
+                data-testid={`tab-move-project-${tab.id}-${profile.id}`}
+                onSelect={() => {
+                  assignEpicToProjectProfile(hostId, tab.epicId, profile.id);
+                }}
+              >
+                <span
+                  aria-hidden
+                  className={`size-2 shrink-0 rounded-full ${PROJECT_PROFILE_COLOR_DOT[profile.color]}`}
+                />
+                <span className="min-w-0 flex-1 truncate">{profile.name}</span>
+                {current ? <Check className="ml-auto size-3.5" /> : null}
+              </ContextMenuItem>
+            );
+          })}
+          {canCreateFromFolder && folderLabel !== null ? (
+            <>
+              {bucket.profiles.length > 0 ? <ContextMenuSeparator /> : null}
+              <ContextMenuItem
+                data-testid={`tab-new-project-${tab.id}`}
+                onSelect={() => {
+                  createProjectFromWorkspaceHint(hostId, tab.epicId, hint);
+                }}
+              >
+                <FolderPlus />
+                New project from {folderLabel}
+              </ContextMenuItem>
+            </>
+          ) : null}
+        </ContextMenuSubContent>
+      </ContextMenuSub>
+      <ContextMenuSeparator />
+    </>
+  );
+}
 
 interface TabContextMenuContentProps {
   readonly tab: HeaderTab;
@@ -100,7 +189,7 @@ export function TabContextMenuContent(
               />
             ) : null}
           </ContextMenuItem>
-          <ContextMenuSeparator />
+          <TabProjectMenuItems tab={tab} />
         </>
       ) : null}
       {showDuplicate ? (

--- a/clients/gui-app/src/components/layout/tabs/tab-strip-item.tsx
+++ b/clients/gui-app/src/components/layout/tabs/tab-strip-item.tsx
@@ -75,6 +75,8 @@ import {
   useEpicActivityStatus,
   type EpicActivityStatus,
 } from "@/hooks/epic/use-epic-activity-status";
+import { useHeaderTabProjectBadge } from "@/hooks/workspace/use-project-scoped-header-strip";
+import { PROJECT_PROFILE_COLOR_DOT } from "@/components/layout/header/project-profile-colors";
 import { reportableErrorToast } from "@/lib/reportable-error-toast";
 
 const NO_DRAG_CLASS = "[-webkit-app-region:no-drag]";
@@ -199,6 +201,7 @@ export const TabItem = memo(function TabItem(props: TabItemProps) {
   const activityStatus = useEpicActivityStatus(
     tab.kind === "epic" ? tab.epicId : null,
   );
+  const projectBadge = useHeaderTabProjectBadge(tab);
   const permissionRole = useRegisteredEpicPermissionRole(
     tab.kind === "epic" ? tab.epicId : null,
   );
@@ -399,6 +402,17 @@ export const TabItem = memo(function TabItem(props: TabItemProps) {
           )}
           <StripPairPreview tabKind={tab.kind} tabId={tab.id} />
           <span className="relative z-20 flex min-w-0 flex-1 items-center justify-center gap-1.5 outline-none">
+            {projectBadge !== null ? (
+              <span
+                aria-label={projectBadge.name}
+                title={projectBadge.name}
+                data-testid={`tab-project-color-${tab.id}`}
+                className={cn(
+                  "size-2 shrink-0 rounded-full",
+                  PROJECT_PROFILE_COLOR_DOT[projectBadge.color],
+                )}
+              />
+            ) : null}
             <TabLeadingIcon
               icon={tab.icon}
               titleGenerationPending={titleGenerationPending}

--- a/clients/gui-app/src/components/layout/tabs/tab-strip.tsx
+++ b/clients/gui-app/src/components/layout/tabs/tab-strip.tsx
@@ -22,6 +22,7 @@ import {
   useHeaderStripItemIds,
   useHeaderTabs,
 } from "@/stores/tabs/use-header-tabs";
+import { useProjectScopedHeaderStripItemIds } from "@/hooks/workspace/use-project-scoped-header-strip";
 import { useTabsStore } from "@/stores/tabs/store";
 import { tabDuplicate, tabResolveIntent } from "@/stores/tabs/registry";
 import type { HeaderTab } from "@/stores/tabs/types";
@@ -62,6 +63,11 @@ export function TabStrip() {
 
 function TabStripBody() {
   const headerItemIds = useHeaderStripItemIds();
+  const visibleHeaderItemIds = useProjectScopedHeaderStripItemIds();
+  const visibleHeaderItemIdSet = useMemo(
+    () => new Set(visibleHeaderItemIds),
+    [visibleHeaderItemIds],
+  );
   const layoutItems = useTabsStore((state) => state.items);
   const allTabs = useHeaderTabs();
   const navigate = useNavigate();
@@ -79,6 +85,12 @@ function TabStripBody() {
   const dropIndicatorIndex = useHeaderStripDropIndex();
 
   const isLandingPage = activePathname === "/";
+  useEffect(() => {
+    if (isLandingPage) return;
+    if (activeItemId === null) return;
+    if (visibleHeaderItemIdSet.has(activeItemId)) return;
+    void navigate({ to: "/" });
+  }, [activeItemId, isLandingPage, navigate, visibleHeaderItemIdSet]);
   const indicatorEpicIds = useMemo(
     () => allTabs.flatMap((tab) => (tab.kind === "epic" ? [tab.epicId] : [])),
     [allTabs],
@@ -250,7 +262,7 @@ function TabStripBody() {
     return null;
   }
 
-  const canCloseOtherTabs = headerItemIds.length > 1;
+  const canCloseOtherTabs = visibleHeaderItemIds.length > 1;
 
   return (
     <NotificationIndicatorsProvider indicators={notificationIndicators}>
@@ -268,20 +280,29 @@ function TabStripBody() {
               onWheel={handleWheel}
               className="no-scrollbar flex min-w-0 max-w-full flex-[0_1_auto] touch-pan-x items-end overflow-x-auto overscroll-x-contain"
             >
-              {headerItemIds.map((itemId, index) => (
+              {headerItemIds.map((itemId, index) => {
+                if (!visibleHeaderItemIdSet.has(itemId)) return null;
+                const visibleIndex = visibleHeaderItemIds.indexOf(itemId);
+                const nextVisibleId = visibleHeaderItemIds[visibleIndex + 1];
+                return (
                 <HeaderStripItemRenderer
                   key={itemId}
                   itemId={itemId}
                   stripIndex={index}
                   memberOffset={memberOffsetBefore(layoutItems, index)}
                   isActive={itemId === activeItemId}
-                  isNextActive={headerItemIds[index + 1] === activeItemId}
-                  nextIsSplit={layoutItems[index + 1]?.kind === "split"}
-                  isLastItem={index === headerItemIds.length - 1}
+                  isNextActive={nextVisibleId === activeItemId}
+                  nextIsSplit={
+                    nextVisibleId === undefined
+                      ? false
+                      : layoutItems.find((item) => item.id === nextVisibleId)
+                          ?.kind === "split"
+                  }
+                  isLastItem={visibleIndex === visibleHeaderItemIds.length - 1}
                   showDropIndicatorBefore={dropIndicatorIndex === index}
                   showDropIndicatorAfter={
                     dropIndicatorIndex === index + 1 &&
-                    index === headerItemIds.length - 1
+                    visibleIndex === visibleHeaderItemIds.length - 1
                   }
                   onClose={closeTabFlow.requestCloseTab}
                   onCloseOtherTabs={closeTabFlow.closeOtherTabs}
@@ -294,7 +315,8 @@ function TabStripBody() {
                   pendingSetPinnedEpicIds={pendingSetPinnedEpicIds}
                   onSetTaskPinned={handleSetTaskPinned}
                 />
-              ))}
+                );
+              })}
             </div>
           </LayoutGroup>
           <TabStripNewButton onNewTab={handleNewTab} />

--- a/clients/gui-app/src/components/layout/tabs/tab-strip.tsx
+++ b/clients/gui-app/src/components/layout/tabs/tab-strip.tsx
@@ -26,6 +26,9 @@ import {
   usePersistOpenEpicWorkspaceStamps,
   useProjectScopedHeaderStripItemIds,
 } from "@/hooks/workspace/use-project-scoped-header-strip";
+import { hiddenActiveTabFallback } from "@/lib/workspace/hidden-active-tab-fallback";
+import { createDraftAndReplaceRoute } from "@/lib/draft-entry-route";
+import { flattenStripItemRefs, type StripItem } from "@/stores/tabs/layout";
 import { useTabsStore } from "@/stores/tabs/store";
 import { tabDuplicate, tabResolveIntent } from "@/stores/tabs/registry";
 import type { HeaderTab } from "@/stores/tabs/types";
@@ -48,7 +51,6 @@ import {
   type TabSplitCommandId,
 } from "@/stores/tabs/tab-split-commands";
 import { activatePreparedPairTabIntent } from "@/lib/tab-navigation";
-import type { StripItem } from "@/stores/tabs/layout";
 import {
   useEpicSetPinned,
   usePendingSetPinnedEpicIds,
@@ -90,11 +92,31 @@ function TabStripBody() {
 
   const isLandingPage = activePathname === "/";
   useEffect(() => {
-    if (isLandingPage) return;
-    if (activeItemId === null) return;
-    if (visibleHeaderItemIdSet.has(activeItemId)) return;
-    void navigate({ to: "/" });
-  }, [activeItemId, isLandingPage, navigate, visibleHeaderItemIdSet]);
+    const fallback = hiddenActiveTabFallback({
+      isLandingPage,
+      activeItemId,
+      visibleItemIds: visibleHeaderItemIds,
+    });
+    if (fallback.kind === "keep") return;
+    if (fallback.kind === "new-draft") {
+      createDraftAndReplaceRoute(navigate);
+      return;
+    }
+    const item = layoutItems.find((entry) => entry.id === fallback.itemId);
+    const ref = item === undefined ? undefined : flattenStripItemRefs(item)[0];
+    const tab = ref === undefined ? null : getHeaderTab(ref);
+    if (tab === null) {
+      createDraftAndReplaceRoute(navigate);
+      return;
+    }
+    navigateToTabIntent(navigate, tabResolveIntent(tab), { replace: true });
+  }, [
+    activeItemId,
+    isLandingPage,
+    layoutItems,
+    navigate,
+    visibleHeaderItemIds,
+  ]);
   const indicatorEpicIds = useMemo(
     () => allTabs.flatMap((tab) => (tab.kind === "epic" ? [tab.epicId] : [])),
     [allTabs],

--- a/clients/gui-app/src/components/layout/tabs/tab-strip.tsx
+++ b/clients/gui-app/src/components/layout/tabs/tab-strip.tsx
@@ -22,7 +22,10 @@ import {
   useHeaderStripItemIds,
   useHeaderTabs,
 } from "@/stores/tabs/use-header-tabs";
-import { useProjectScopedHeaderStripItemIds } from "@/hooks/workspace/use-project-scoped-header-strip";
+import {
+  usePersistOpenEpicWorkspaceStamps,
+  useProjectScopedHeaderStripItemIds,
+} from "@/hooks/workspace/use-project-scoped-header-strip";
 import { useTabsStore } from "@/stores/tabs/store";
 import { tabDuplicate, tabResolveIntent } from "@/stores/tabs/registry";
 import type { HeaderTab } from "@/stores/tabs/types";
@@ -62,6 +65,7 @@ export function TabStrip() {
 }
 
 function TabStripBody() {
+  usePersistOpenEpicWorkspaceStamps();
   const headerItemIds = useHeaderStripItemIds();
   const visibleHeaderItemIds = useProjectScopedHeaderStripItemIds();
   const visibleHeaderItemIdSet = useMemo(

--- a/clients/gui-app/src/hooks/home/use-history-query.ts
+++ b/clients/gui-app/src/hooks/home/use-history-query.ts
@@ -67,6 +67,10 @@ export interface UseHistoryQueryResult {
   isFetching: boolean;
   error: Error | null;
   hostId: string | null;
+  /** True while a project profile filters the visible list. */
+  projectFilterActive: boolean;
+  /** Loaded rows BEFORE the project filter (search filters still applied). */
+  preProjectFilterCount: number;
   refetch: () => Promise<unknown>;
   fetchNextPage: () => void;
   hasNextPage: boolean;
@@ -281,6 +285,8 @@ export function useHistoryQuery(
       (isPullRequestNumberQuery ? activityIndex.error : null) ??
       taskContexts.error,
     hostId,
+    projectFilterActive: activeProfile !== null,
+    preProjectFilterCount: allItems.length,
     refetch,
     fetchNextPage,
     // Pagination follows the plain cloud query; id-fetched local matches are

--- a/clients/gui-app/src/hooks/home/use-history-query.ts
+++ b/clients/gui-app/src/hooks/home/use-history-query.ts
@@ -33,6 +33,11 @@ import type { ListTasksResponse } from "@traycer/protocol/host/epic/unary-schema
 import type { WorktreeHostEntryV12 } from "@traycer/protocol/host/worktree-schemas";
 import type { HistorySearchState } from "@/lib/history-search";
 import { patchHistorySearch } from "@/lib/history-search";
+import { filterHistoryItemsForProject } from "@/lib/workspace/history-item-matches-project";
+import {
+  selectActiveProjectProfile,
+  useProjectProfilesStore,
+} from "@/stores/workspace/project-profiles-store";
 import Fuse, { type IFuseOptions } from "fuse.js";
 import { useCallback, useMemo, useState } from "react";
 
@@ -171,6 +176,13 @@ export function useHistoryQuery(
     () => withHistoryItemWorktreeMetadata(allBaseItems, worktreesByEpicId),
     [allBaseItems, worktreesByEpicId],
   );
+  const activeProfile = useProjectProfilesStore((state) =>
+    selectActiveProjectProfile(state, hostId),
+  );
+  const projectItems = useMemo(
+    () => filterHistoryItemsForProject(allItems, activeProfile),
+    [activeProfile, allItems],
+  );
 
   const data = useMemo<HistoryFetchResult | undefined>(() => {
     if (tasksQuery.data === undefined) {
@@ -183,9 +195,9 @@ export function useHistoryQuery(
     // When id-fetched extras joined the settled list they arrive appended out
     // of order, so that path re-sorts the union client-side instead.
     const items = shouldProjectLocally
-      ? projectHistoryItems(allItems, params.search)
+      ? projectHistoryItems(projectItems, params.search)
       : settledHistoryItems(
-          allItems,
+          projectItems,
           contextExtrasCount,
           params.search.sort,
           debouncedQuery,
@@ -247,6 +259,7 @@ export function useHistoryQuery(
     debouncedQuery,
     isQueryDebouncing,
     params.search,
+    projectItems,
     shouldProjectLocally,
     tasksQuery.data,
     tasksQuery.isPlaceholderData,

--- a/clients/gui-app/src/hooks/home/use-history-query.ts
+++ b/clients/gui-app/src/hooks/home/use-history-query.ts
@@ -36,6 +36,7 @@ import { patchHistorySearch } from "@/lib/history-search";
 import { filterHistoryItemsForProject } from "@/lib/workspace/history-item-matches-project";
 import {
   selectActiveProjectProfile,
+  selectProjectProfilesBucket,
   useProjectProfilesStore,
 } from "@/stores/workspace/project-profiles-store";
 import Fuse, { type IFuseOptions } from "fuse.js";
@@ -183,9 +184,12 @@ export function useHistoryQuery(
   const activeProfile = useProjectProfilesStore((state) =>
     selectActiveProjectProfile(state, hostId),
   );
+  const projectProfiles = useProjectProfilesStore(
+    (state) => selectProjectProfilesBucket(state, hostId).profiles,
+  );
   const projectItems = useMemo(
-    () => filterHistoryItemsForProject(allItems, activeProfile),
-    [activeProfile, allItems],
+    () => filterHistoryItemsForProject(allItems, activeProfile, projectProfiles),
+    [activeProfile, allItems, projectProfiles],
   );
 
   const data = useMemo<HistoryFetchResult | undefined>(() => {

--- a/clients/gui-app/src/hooks/workspace/__tests__/use-header-tab-project-badge.test.tsx
+++ b/clients/gui-app/src/hooks/workspace/__tests__/use-header-tab-project-badge.test.tsx
@@ -7,8 +7,8 @@ import { useProjectProfilesStore } from "@/stores/workspace/project-profiles-sto
 
 const HOST = "host-a";
 
-vi.mock("@/hooks/host/use-reactive-active-host-id", () => ({
-  useReactiveActiveHostId: () => HOST,
+vi.mock("@/hooks/host/use-addressable-host-id", () => ({
+  useAddressableHostId: () => HOST,
 }));
 
 const TITANOS_TAB = {

--- a/clients/gui-app/src/hooks/workspace/__tests__/use-header-tab-project-badge.test.tsx
+++ b/clients/gui-app/src/hooks/workspace/__tests__/use-header-tab-project-badge.test.tsx
@@ -1,0 +1,62 @@
+import { renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useHeaderTabProjectBadge } from "@/hooks/workspace/use-project-scoped-header-strip";
+import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import type { HeaderTab } from "@/stores/tabs/types";
+import { useProjectProfilesStore } from "@/stores/workspace/project-profiles-store";
+
+const HOST = "host-a";
+
+vi.mock("@/hooks/host/use-reactive-active-host-id", () => ({
+  useReactiveActiveHostId: () => HOST,
+}));
+
+const TITANOS_TAB = {
+  kind: "epic",
+  id: "tab-titanos",
+  epicId: "epic-titanos",
+  name: "Titanos",
+} as HeaderTab;
+
+describe("useHeaderTabProjectBadge", () => {
+  beforeEach(() => {
+    useProjectProfilesStore.setState({ byHost: {} });
+    useEpicCanvasStore.setState({ tabsById: {} });
+  });
+
+  afterEach(() => {
+    useProjectProfilesStore.setState({ byHost: {} });
+    useEpicCanvasStore.setState({ tabsById: {} });
+  });
+
+  it("does not loop when All projects paints a color dot", () => {
+    useProjectProfilesStore.getState().createProfile(HOST, {
+      name: "Titanos",
+      color: "orange",
+      folderPaths: ["/titanos"],
+      primaryPath: "/titanos",
+    });
+    useEpicCanvasStore.setState({
+      tabsById: {
+        "tab-titanos": {
+          tabId: "tab-titanos",
+          epicId: "epic-titanos",
+          name: "Titanos",
+          projectWorkspace: {
+            primaryPath: "/titanos",
+            linkedWorkspaces: [
+              { hostId: HOST, workspacePath: "/titanos" },
+            ],
+            worktreePaths: [],
+          },
+        },
+      },
+    });
+
+    const hook = renderHook(() => useHeaderTabProjectBadge(TITANOS_TAB));
+    const first = hook.result.current;
+    expect(first).toEqual({ color: "orange", name: "Titanos" });
+    hook.rerender();
+    expect(hook.result.current).toBe(first);
+  });
+});

--- a/clients/gui-app/src/hooks/workspace/use-project-scoped-header-strip.ts
+++ b/clients/gui-app/src/hooks/workspace/use-project-scoped-header-strip.ts
@@ -16,6 +16,7 @@ import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 import { selectHeaderStripItemIds } from "@/stores/tabs/selectors";
 import { useTabsStore } from "@/stores/tabs/store";
 import { activeHostIdOrNull } from "@/lib/host/runtime";
+import { claimEpicOnMatchingProfile } from "@/lib/workspace/assign-epic-to-project";
 import type { HeaderTab } from "@/stores/tabs/types";
 import {
   selectActiveProjectProfile,
@@ -29,6 +30,9 @@ export function useProjectScopedHeaderStripItemIds(): ReadonlyArray<string> {
   const profile = useProjectProfilesStore((state) =>
     selectActiveProjectProfile(state, hostId),
   );
+  const profiles = useProjectProfilesStore(
+    useShallow((state) => selectProjectProfilesBucket(state, hostId).profiles),
+  );
   const itemIds = useTabsStore(useShallow(selectHeaderStripItemIds));
   const items = useTabsStore(useShallow((state) => state.items));
   const epicTabsById = useEpicCanvasStore(
@@ -40,15 +44,17 @@ export function useProjectScopedHeaderStripItemIds(): ReadonlyArray<string> {
         itemIds,
         items,
         profile,
+        profiles,
         epicIdForTabId: (tabId) => epicTabsById[tabId]?.epicId ?? null,
         workspaceHintForEpic: (epicId) =>
           workspaceHintForEpic(epicId, epicTabsById),
       }),
-    [epicTabsById, itemIds, items, profile],
+    [epicTabsById, itemIds, items, profile, profiles],
   );
 }
 
 export function usePersistOpenEpicWorkspaceStamps(): void {
+  const hostId = useAddressableHostId();
   const stampEpicWorkspaceHint = useEpicCanvasStore(
     (state) => state.stampEpicWorkspaceHint,
   );
@@ -65,18 +71,18 @@ export function usePersistOpenEpicWorkspaceStamps(): void {
       const live = liveWorkspaceHintForEpic(tab.epicId);
       if (live === null) continue;
       if (
-        (tab.projectWorkspace?.primaryPath ?? null) ===
+        (tab.projectWorkspace?.primaryPath ?? null) !==
         (live.primaryPath ?? null)
       ) {
-        continue;
+        stampEpicWorkspaceHint(tab.epicId, {
+          primaryPath: live.primaryPath ?? null,
+          linkedWorkspaces: live.linkedWorkspaces,
+          worktreePaths: live.worktreePaths,
+        });
       }
-      stampEpicWorkspaceHint(tab.epicId, {
-        primaryPath: live.primaryPath ?? null,
-        linkedWorkspaces: live.linkedWorkspaces,
-        worktreePaths: live.worktreePaths,
-      });
+      claimEpicOnMatchingProfile(hostId, tab.epicId, live);
     }
-  }, [openTabs, stampEpicWorkspaceHint]);
+  }, [hostId, openTabs, stampEpicWorkspaceHint]);
 }
 
 export function workspaceHintForOpenEpic(
@@ -92,17 +98,17 @@ export function scopeHeaderTabsToActiveProject(
   tabs: ReadonlyArray<HeaderTab>,
   hostId: string | null,
 ): ReadonlyArray<HeaderTab> {
-  const profile = selectActiveProjectProfile(
-    useProjectProfilesStore.getState(),
-    hostId,
-  );
+  const state = useProjectProfilesStore.getState();
+  const profile = selectActiveProjectProfile(state, hostId);
   if (profile === null) return tabs;
+  const profiles = selectProjectProfilesBucket(state, hostId).profiles;
   const tabsById = useEpicCanvasStore.getState().tabsById;
   return tabs.filter((tab) =>
     headerTabRecordMatchesProject(
       tab,
       profile,
       tab.kind === "epic" ? workspaceHintForEpic(tab.epicId, tabsById) : null,
+      profiles,
     ),
   );
 }

--- a/clients/gui-app/src/hooks/workspace/use-project-scoped-header-strip.ts
+++ b/clients/gui-app/src/hooks/workspace/use-project-scoped-header-strip.ts
@@ -1,0 +1,83 @@
+import { useMemo } from "react";
+import { useShallow } from "zustand/react/shallow";
+import { useAddressableHostId } from "@/hooks/host/use-addressable-host-id";
+import { getOpenEpicRegistry } from "@/lib/registries/epic-session-registry";
+import {
+  filterHeaderStripItemIdsForProject,
+  type EpicWorkspaceHint,
+} from "@/lib/workspace/header-tab-matches-project";
+import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import { selectHeaderStripItemIds } from "@/stores/tabs/selectors";
+import { useTabsStore } from "@/stores/tabs/store";
+import { activeHostIdOrNull } from "@/lib/host/runtime";
+import { headerTabRecordMatchesProject } from "@/lib/workspace/header-tab-matches-project";
+import type { HeaderTab } from "@/stores/tabs/types";
+import {
+  selectActiveProjectProfile,
+  useProjectProfilesStore,
+} from "@/stores/workspace/project-profiles-store";
+
+export function useProjectScopedHeaderStripItemIds(): ReadonlyArray<string> {
+  const hostId = useAddressableHostId();
+  const profile = useProjectProfilesStore((state) =>
+    selectActiveProjectProfile(state, hostId),
+  );
+  const itemIds = useTabsStore(useShallow(selectHeaderStripItemIds));
+  const items = useTabsStore(useShallow((state) => state.items));
+  const epicTabsById = useEpicCanvasStore(
+    useShallow((state) => state.tabsById),
+  );
+  return useMemo(
+    () =>
+      filterHeaderStripItemIdsForProject({
+        itemIds,
+        items,
+        profile,
+        epicIdForTabId: (tabId) => epicTabsById[tabId]?.epicId ?? null,
+        workspaceHintForEpic,
+      }),
+    [epicTabsById, itemIds, items, profile],
+  );
+}
+
+export function workspaceHintForOpenEpic(
+  epicId: string,
+): EpicWorkspaceHint | null {
+  return workspaceHintForEpic(epicId);
+}
+
+export function scopeHeaderTabsToActiveProject(
+  tabs: ReadonlyArray<HeaderTab>,
+  hostId: string | null,
+): ReadonlyArray<HeaderTab> {
+  const profile = selectActiveProjectProfile(
+    useProjectProfilesStore.getState(),
+    hostId,
+  );
+  if (profile === null) return tabs;
+  return tabs.filter((tab) =>
+    headerTabRecordMatchesProject(
+      tab,
+      profile,
+      tab.kind === "epic" ? workspaceHintForEpic(tab.epicId) : null,
+    ),
+  );
+}
+
+export function readActiveHostIdForProjectScope(): string | null {
+  return activeHostIdOrNull();
+}
+
+function workspaceHintForEpic(epicId: string): EpicWorkspaceHint | null {
+  const handle = getOpenEpicRegistry().peek(epicId);
+  if (handle === null) return null;
+  const folders = handle.store.getState().snapshotMeta?.workspaceFolders;
+  if (folders === undefined || folders.length === 0) return null;
+  return {
+    worktreePaths: [],
+    linkedWorkspaces: folders.map((folder) => ({
+      hostId: folder.hostId,
+      workspacePath: folder.workspacePath,
+    })),
+  };
+}

--- a/clients/gui-app/src/hooks/workspace/use-project-scoped-header-strip.ts
+++ b/clients/gui-app/src/hooks/workspace/use-project-scoped-header-strip.ts
@@ -118,13 +118,19 @@ export function useHeaderTabProjectBadge(
   const tabsById = useEpicCanvasStore(useShallow((state) => state.tabsById));
   const hint =
     tab.kind === "epic" ? workspaceHintForEpic(tab.epicId, tabsById) : null;
-  return useProjectProfilesStore((state) => {
-    if (tab.kind !== "epic") return null;
-    const bucket = selectProjectProfilesBucket(state, hostId);
-    const active = selectActiveProjectProfile(state, hostId);
-    const owner = resolveOwningProjectProfile(bucket.profiles, tab.epicId, hint);
-    return headerTabProjectBadge(active, owner);
-  });
+  return useProjectProfilesStore(
+    useShallow((state) => {
+      if (tab.kind !== "epic") return null;
+      const bucket = selectProjectProfilesBucket(state, hostId);
+      const active = selectActiveProjectProfile(state, hostId);
+      const owner = resolveOwningProjectProfile(
+        bucket.profiles,
+        tab.epicId,
+        hint,
+      );
+      return headerTabProjectBadge(active, owner);
+    }),
+  );
 }
 
 function workspaceHintForEpic(

--- a/clients/gui-app/src/hooks/workspace/use-project-scoped-header-strip.ts
+++ b/clients/gui-app/src/hooks/workspace/use-project-scoped-header-strip.ts
@@ -1,20 +1,27 @@
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { useShallow } from "zustand/react/shallow";
 import { useAddressableHostId } from "@/hooks/host/use-addressable-host-id";
 import { getOpenEpicRegistry } from "@/lib/registries/epic-session-registry";
 import {
   filterHeaderStripItemIdsForProject,
+  headerTabProjectBadge,
+  headerTabRecordMatchesProject,
+  resolveEpicWorkspaceHint,
+  resolveOwningProjectProfile,
+  stampedWorkspaceHintForEpic,
+  workspaceHintFromSnapshotFolders,
   type EpicWorkspaceHint,
 } from "@/lib/workspace/header-tab-matches-project";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 import { selectHeaderStripItemIds } from "@/stores/tabs/selectors";
 import { useTabsStore } from "@/stores/tabs/store";
 import { activeHostIdOrNull } from "@/lib/host/runtime";
-import { headerTabRecordMatchesProject } from "@/lib/workspace/header-tab-matches-project";
 import type { HeaderTab } from "@/stores/tabs/types";
 import {
   selectActiveProjectProfile,
+  selectProjectProfilesBucket,
   useProjectProfilesStore,
+  type ProjectProfile,
 } from "@/stores/workspace/project-profiles-store";
 
 export function useProjectScopedHeaderStripItemIds(): ReadonlyArray<string> {
@@ -34,16 +41,51 @@ export function useProjectScopedHeaderStripItemIds(): ReadonlyArray<string> {
         items,
         profile,
         epicIdForTabId: (tabId) => epicTabsById[tabId]?.epicId ?? null,
-        workspaceHintForEpic,
+        workspaceHintForEpic: (epicId) =>
+          workspaceHintForEpic(epicId, epicTabsById),
       }),
     [epicTabsById, itemIds, items, profile],
   );
 }
 
+export function usePersistOpenEpicWorkspaceStamps(): void {
+  const stampEpicWorkspaceHint = useEpicCanvasStore(
+    (state) => state.stampEpicWorkspaceHint,
+  );
+  const openTabs = useEpicCanvasStore(
+    useShallow((state) =>
+      state.openTabOrder.flatMap((tabId) => {
+        const tab = state.tabsById[tabId];
+        return tab === undefined ? [] : [tab];
+      }),
+    ),
+  );
+  useEffect(() => {
+    for (const tab of openTabs) {
+      const live = liveWorkspaceHintForEpic(tab.epicId);
+      if (live === null) continue;
+      if (
+        (tab.projectWorkspace?.primaryPath ?? null) ===
+        (live.primaryPath ?? null)
+      ) {
+        continue;
+      }
+      stampEpicWorkspaceHint(tab.epicId, {
+        primaryPath: live.primaryPath ?? null,
+        linkedWorkspaces: live.linkedWorkspaces,
+        worktreePaths: live.worktreePaths,
+      });
+    }
+  }, [openTabs, stampEpicWorkspaceHint]);
+}
+
 export function workspaceHintForOpenEpic(
   epicId: string,
 ): EpicWorkspaceHint | null {
-  return workspaceHintForEpic(epicId);
+  return workspaceHintForEpic(
+    epicId,
+    useEpicCanvasStore.getState().tabsById,
+  );
 }
 
 export function scopeHeaderTabsToActiveProject(
@@ -55,11 +97,12 @@ export function scopeHeaderTabsToActiveProject(
     hostId,
   );
   if (profile === null) return tabs;
+  const tabsById = useEpicCanvasStore.getState().tabsById;
   return tabs.filter((tab) =>
     headerTabRecordMatchesProject(
       tab,
       profile,
-      tab.kind === "epic" ? workspaceHintForEpic(tab.epicId) : null,
+      tab.kind === "epic" ? workspaceHintForEpic(tab.epicId, tabsById) : null,
     ),
   );
 }
@@ -68,16 +111,36 @@ export function readActiveHostIdForProjectScope(): string | null {
   return activeHostIdOrNull();
 }
 
-function workspaceHintForEpic(epicId: string): EpicWorkspaceHint | null {
+export function useHeaderTabProjectBadge(
+  tab: HeaderTab,
+): { readonly color: ProjectProfile["color"]; readonly name: string } | null {
+  const hostId = useAddressableHostId();
+  const tabsById = useEpicCanvasStore(useShallow((state) => state.tabsById));
+  const hint =
+    tab.kind === "epic" ? workspaceHintForEpic(tab.epicId, tabsById) : null;
+  return useProjectProfilesStore((state) => {
+    if (tab.kind !== "epic") return null;
+    const bucket = selectProjectProfilesBucket(state, hostId);
+    const active = selectActiveProjectProfile(state, hostId);
+    const owner = resolveOwningProjectProfile(bucket.profiles, tab.epicId, hint);
+    return headerTabProjectBadge(active, owner);
+  });
+}
+
+function workspaceHintForEpic(
+  epicId: string,
+  tabsById: Parameters<typeof stampedWorkspaceHintForEpic>[0],
+): EpicWorkspaceHint | null {
+  return resolveEpicWorkspaceHint({
+    live: liveWorkspaceHintForEpic(epicId),
+    stamped: stampedWorkspaceHintForEpic(tabsById, epicId),
+  });
+}
+
+function liveWorkspaceHintForEpic(epicId: string): EpicWorkspaceHint | null {
   const handle = getOpenEpicRegistry().peek(epicId);
   if (handle === null) return null;
   const folders = handle.store.getState().snapshotMeta?.workspaceFolders;
-  if (folders === undefined || folders.length === 0) return null;
-  return {
-    worktreePaths: [],
-    linkedWorkspaces: folders.map((folder) => ({
-      hostId: folder.hostId,
-      workspacePath: folder.workspacePath,
-    })),
-  };
+  if (folders === undefined) return null;
+  return workspaceHintFromSnapshotFolders(folders);
 }

--- a/clients/gui-app/src/hooks/workspace/use-resolved-workspace-folders-query.ts
+++ b/clients/gui-app/src/hooks/workspace/use-resolved-workspace-folders-query.ts
@@ -9,8 +9,9 @@ import type { HostClient } from "@traycer-clients/shared/host-client/host-client
 import type { HostRpcRegistry } from "@/lib/host";
 import { useHostQuery } from "@/hooks/host/use-host-query";
 import type { ResolvedFolder } from "@/lib/workspace/resolved-folder";
+import { selectEffectiveWorkspaceFoldersBucket } from "@/lib/workspace/effective-workspace-folders";
+import { useProjectProfilesStore } from "@/stores/workspace/project-profiles-store";
 import {
-  selectWorkspaceFoldersBucket,
   useWorkspaceFoldersStore,
   type WorkspaceFolderInfo,
 } from "@/stores/workspace/workspace-folders-store";
@@ -84,12 +85,15 @@ export function useResolvedWorkspaceFolders(
   // and the resolution host must agree.
   hostId: string | null,
 ): ResolvedWorkspaceFoldersQueryResult {
-  const globalFolders = useWorkspaceFoldersStore(
-    (s) => selectWorkspaceFoldersBucket(s, hostId).folders,
+  const foldersByHost = useWorkspaceFoldersStore((s) => s.byHost);
+  const profilesByHost = useProjectProfilesStore((s) => s.byHost);
+  const effectiveBucket = selectEffectiveWorkspaceFoldersBucket(
+    { byHost: foldersByHost },
+    { byHost: profilesByHost },
+    hostId,
   );
-  const globalFolderInfoByPath = useWorkspaceFoldersStore(
-    (s) => selectWorkspaceFoldersBucket(s, hostId).folderInfoByPath,
-  );
+  const globalFolders = effectiveBucket.folders;
+  const globalFolderInfoByPath = effectiveBucket.folderInfoByPath;
   const folders = source === null ? globalFolders : source.folders;
   const folderInfoByPath =
     source === null ? globalFolderInfoByPath : source.folderInfoByPath;

--- a/clients/gui-app/src/lib/commands/__tests__/epics.source.test.tsx
+++ b/clients/gui-app/src/lib/commands/__tests__/epics.source.test.tsx
@@ -61,6 +61,8 @@ function historyResult(
     isFetching: false,
     error: null,
     hostId: "host-1",
+    projectFilterActive: false,
+    preProjectFilterCount: items.length,
     refetch: () => Promise.resolve(),
     fetchNextPage: () => undefined,
     hasNextPage: false,

--- a/clients/gui-app/src/lib/persist/__tests__/keys.test.ts
+++ b/clients/gui-app/src/lib/persist/__tests__/keys.test.ts
@@ -116,6 +116,10 @@ describe("persist key builders — output-preserving against current source", ()
     expect(persistKey("folder-picker-preferences")).toBe(
       "traycer-gui-app:folder-picker-preferences",
     );
+    // Source: src/stores/workspace/project-profiles-store.ts
+    expect(persistKey("project-profiles")).toBe(
+      "traycer-gui-app:project-profiles",
+    );
     // Source: src/stores/notifications/notifications-popover-store.ts
     expect(persistKey("notifications-filter")).toBe(
       "traycer-gui-app:notifications-filter",

--- a/clients/gui-app/src/lib/persist/__tests__/store-persist-names.test.ts
+++ b/clients/gui-app/src/lib/persist/__tests__/store-persist-names.test.ts
@@ -24,6 +24,7 @@ import { useTabsStore } from "@/stores/tabs/store";
 import { useAppLocalNotificationsStore } from "@/stores/notifications/app-local-notifications-store";
 import { useWorkspaceFoldersStore } from "@/stores/workspace/workspace-folders-store";
 import { useRemoteFolderPickerStore } from "@/stores/workspace/remote-folder-picker-store";
+import { useProjectProfilesStore } from "@/stores/workspace/project-profiles-store";
 import { useSetupTerminalsStore } from "@/stores/worktree/setup-terminals";
 import { useWorktreeIntentMemoryStore } from "@/stores/worktree/worktree-intent-memory-store";
 import { useWorktreeIntentStagingStore } from "@/stores/worktree/worktree-intent-staging-store";
@@ -132,6 +133,11 @@ const STORE_PERSIST_NAME_CASES: ReadonlyArray<
     "useRemoteFolderPickerStore",
     useRemoteFolderPickerStore,
     "traycer-gui-app:folder-picker-preferences",
+  ],
+  [
+    "useProjectProfilesStore",
+    useProjectProfilesStore,
+    "traycer-gui-app:project-profiles",
   ],
   [
     "useSetupTerminalsStore",

--- a/clients/gui-app/src/lib/persist/keys.ts
+++ b/clients/gui-app/src/lib/persist/keys.ts
@@ -312,6 +312,11 @@ export const PERSIST_STORES = [
     kind: "static",
   },
   {
+    camelName: "projectProfiles",
+    leaf: "project-profiles",
+    kind: "static",
+  },
+  {
     camelName: "providersWorkspaceSelection",
     leaf: "providers-workspace-selection",
     kind: "static",

--- a/clients/gui-app/src/lib/workspace/__tests__/assign-epic-to-project.test.ts
+++ b/clients/gui-app/src/lib/workspace/__tests__/assign-epic-to-project.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  assignEpicToProjectProfile,
+  claimEpicOnMatchingProfile,
+  createProjectFromWorkspaceHint,
+} from "../assign-epic-to-project";
+import { useProjectProfilesStore } from "@/stores/workspace/project-profiles-store";
+
+const HOST = "host-a";
+
+describe("assignEpicToProjectProfile", () => {
+  beforeEach(() => {
+    useProjectProfilesStore.setState({ byHost: {} });
+  });
+  afterEach(() => {
+    useProjectProfilesStore.setState({ byHost: {} });
+  });
+
+  it("moves an epic from All projects onto Titanos", () => {
+    const titanos = useProjectProfilesStore.getState().createProfile(HOST, {
+      name: "Titanos",
+      color: "orange",
+      folderPaths: ["/titanos"],
+      primaryPath: "/titanos",
+    });
+    assignEpicToProjectProfile(HOST, "epic-login", titanos);
+    expect(
+      useProjectProfilesStore.getState().byHost[HOST].profiles[0].epicIds,
+    ).toEqual(["epic-login"]);
+  });
+
+  it("moves an epic off CRM onto Titanos", () => {
+    const titanos = useProjectProfilesStore.getState().createProfile(HOST, {
+      name: "Titanos",
+      color: "orange",
+      folderPaths: ["/titanos"],
+      primaryPath: "/titanos",
+    });
+    const crm = useProjectProfilesStore.getState().createProfile(HOST, {
+      name: "CRM",
+      color: "blue",
+      folderPaths: ["/crm"],
+      primaryPath: "/crm",
+    });
+    assignEpicToProjectProfile(HOST, "epic-1", crm);
+    assignEpicToProjectProfile(HOST, "epic-1", titanos);
+    const profiles = useProjectProfilesStore.getState().byHost[HOST].profiles;
+    expect(profiles.find((p) => p.id === titanos)?.epicIds).toEqual(["epic-1"]);
+    expect(profiles.find((p) => p.id === crm)?.epicIds).toEqual([]);
+  });
+});
+
+describe("claimEpicOnMatchingProfile", () => {
+  beforeEach(() => {
+    useProjectProfilesStore.setState({ byHost: {} });
+  });
+  afterEach(() => {
+    useProjectProfilesStore.setState({ byHost: {} });
+  });
+
+  it("claims a Titanos-only chat while All projects is active", () => {
+    useProjectProfilesStore.getState().createProfile(HOST, {
+      name: "Titanos",
+      color: "orange",
+      folderPaths: ["/titanos"],
+      primaryPath: "/titanos",
+    });
+    useProjectProfilesStore.getState().createProfile(HOST, {
+      name: "CRM",
+      color: "blue",
+      folderPaths: ["/crm"],
+      primaryPath: "/crm",
+    });
+    claimEpicOnMatchingProfile(HOST, "epic-titanos", {
+      primaryPath: "/titanos",
+      linkedWorkspaces: [{ hostId: HOST, workspacePath: "/titanos" }],
+      worktreePaths: [],
+    });
+    expect(
+      useProjectProfilesStore.getState().byHost[HOST].profiles[0].epicIds,
+    ).toEqual(["epic-titanos"]);
+  });
+
+  it("does not claim a fan-out chat that touched two projects", () => {
+    useProjectProfilesStore.getState().createProfile(HOST, {
+      name: "Titanos",
+      color: "orange",
+      folderPaths: ["/titanos"],
+      primaryPath: "/titanos",
+    });
+    useProjectProfilesStore.getState().createProfile(HOST, {
+      name: "CRM",
+      color: "blue",
+      folderPaths: ["/crm"],
+      primaryPath: "/crm",
+    });
+    claimEpicOnMatchingProfile(HOST, "epic-fanout", {
+      primaryPath: "/titanos",
+      linkedWorkspaces: [
+        { hostId: HOST, workspacePath: "/titanos" },
+        { hostId: HOST, workspacePath: "/crm" },
+      ],
+      worktreePaths: [],
+    });
+    expect(
+      useProjectProfilesStore.getState().byHost[HOST].profiles[0].epicIds,
+    ).toEqual([]);
+  });
+
+  it("does not steal an epic the user already moved", () => {
+    const titanos = useProjectProfilesStore.getState().createProfile(HOST, {
+      name: "Titanos",
+      color: "orange",
+      folderPaths: ["/titanos"],
+      primaryPath: "/titanos",
+    });
+    useProjectProfilesStore.getState().createProfile(HOST, {
+      name: "CRM",
+      color: "blue",
+      folderPaths: ["/crm"],
+      primaryPath: "/crm",
+    });
+    assignEpicToProjectProfile(HOST, "epic-1", titanos);
+    claimEpicOnMatchingProfile(HOST, "epic-1", {
+      primaryPath: "/crm",
+      linkedWorkspaces: [{ hostId: HOST, workspacePath: "/crm" }],
+      worktreePaths: [],
+    });
+    const profiles = useProjectProfilesStore.getState().byHost[HOST].profiles;
+    expect(profiles[0].epicIds).toEqual(["epic-1"]);
+    expect(profiles[1].epicIds).toEqual([]);
+  });
+});
+
+describe("createProjectFromWorkspaceHint", () => {
+  beforeEach(() => {
+    useProjectProfilesStore.setState({ byHost: {} });
+  });
+  afterEach(() => {
+    useProjectProfilesStore.setState({ byHost: {} });
+  });
+
+  it("creates a project from the chat folder and claims the epic", () => {
+    const id = createProjectFromWorkspaceHint(HOST, "epic-new", {
+      primaryPath: "/Users/g/work/NovoApp",
+      linkedWorkspaces: [
+        { hostId: HOST, workspacePath: "/Users/g/work/NovoApp" },
+      ],
+      worktreePaths: [],
+    });
+    expect(id).not.toBeNull();
+    const profile = useProjectProfilesStore.getState().byHost[HOST].profiles[0];
+    expect(profile.name).toBe("NovoApp");
+    expect(profile.folderPaths).toEqual(["/Users/g/work/NovoApp"]);
+    expect(profile.epicIds).toEqual(["epic-new"]);
+    expect(
+      useProjectProfilesStore.getState().byHost[HOST].activeProfileId,
+    ).toBeNull();
+  });
+
+  it("does not duplicate a project that already owns the folder", () => {
+    useProjectProfilesStore.getState().createProfile(HOST, {
+      name: "Titanos",
+      color: "orange",
+      folderPaths: ["/titanos"],
+      primaryPath: "/titanos",
+    });
+    expect(
+      createProjectFromWorkspaceHint(HOST, "epic-1", {
+        primaryPath: "/titanos",
+        linkedWorkspaces: [{ hostId: HOST, workspacePath: "/titanos" }],
+        worktreePaths: [],
+      }),
+    ).toBeNull();
+    expect(useProjectProfilesStore.getState().byHost[HOST].profiles).toHaveLength(
+      1,
+    );
+  });
+});

--- a/clients/gui-app/src/lib/workspace/__tests__/claim-epic-on-active-profile.test.ts
+++ b/clients/gui-app/src/lib/workspace/__tests__/claim-epic-on-active-profile.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { claimEpicOnActiveProfile } from "../claim-epic-on-active-profile";
+import { useProjectProfilesStore } from "@/stores/workspace/project-profiles-store";
+
+const HOST = "host-a";
+
+describe("claimEpicOnActiveProfile", () => {
+  beforeEach(() => {
+    useProjectProfilesStore.setState({ byHost: {} });
+  });
+  afterEach(() => {
+    useProjectProfilesStore.setState({ byHost: {} });
+  });
+
+  it("is a no-op when no project is active", () => {
+    claimEpicOnActiveProfile(HOST, "epic-1");
+    expect(useProjectProfilesStore.getState().byHost[HOST]).toBeUndefined();
+  });
+
+  it("records the epic on the active project so local-mode chats stay visible", () => {
+    const id = useProjectProfilesStore.getState().createProfile(HOST, {
+      name: "Titanos",
+      color: "orange",
+      folderPaths: ["/titanos"],
+      primaryPath: "/titanos",
+    });
+    useProjectProfilesStore.getState().setActiveProfile(HOST, id);
+    claimEpicOnActiveProfile(HOST, "epic-local");
+    expect(
+      useProjectProfilesStore.getState().byHost[HOST].profiles[0].epicIds,
+    ).toEqual(["epic-local"]);
+  });
+});

--- a/clients/gui-app/src/lib/workspace/__tests__/effective-workspace-folders.test.ts
+++ b/clients/gui-app/src/lib/workspace/__tests__/effective-workspace-folders.test.ts
@@ -35,6 +35,7 @@ function profile(
     name: "Titanos",
     color: "orange",
     primaryPath: overrides.folderPaths[0] ?? null,
+    epicIds: [],
     ...overrides,
   };
 }

--- a/clients/gui-app/src/lib/workspace/__tests__/effective-workspace-folders.test.ts
+++ b/clients/gui-app/src/lib/workspace/__tests__/effective-workspace-folders.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import { selectEffectiveWorkspaceFoldersBucket } from "../effective-workspace-folders";
+import type { WorkspaceFoldersHostBucket } from "@/stores/workspace/workspace-folders-store";
+import type { ProjectProfile } from "@/stores/workspace/project-profiles-store";
+
+const HOST = "host-a";
+
+function folderInfo(path: string) {
+  return {
+    path,
+    name: path.slice(1),
+    repoIdentifier: null,
+    hostId: HOST,
+  };
+}
+
+function catalog(
+  folders: ReadonlyArray<string>,
+  primaryPath: string | null,
+): WorkspaceFoldersHostBucket {
+  return {
+    folders,
+    folderInfoByPath: Object.fromEntries(
+      folders.map((path) => [path, folderInfo(path)]),
+    ),
+    primaryPath,
+  };
+}
+
+function profile(
+  overrides: Partial<ProjectProfile> & Pick<ProjectProfile, "folderPaths">,
+): ProjectProfile {
+  return {
+    id: "p1",
+    name: "Titanos",
+    color: "orange",
+    primaryPath: overrides.folderPaths[0] ?? null,
+    ...overrides,
+  };
+}
+
+describe("selectEffectiveWorkspaceFoldersBucket", () => {
+  it("returns the full catalog when no profile is active", () => {
+    const foldersState = {
+      byHost: { [HOST]: catalog(["/titanos", "/crm", "/bkza"], "/titanos") },
+    };
+    const profilesState = {
+      byHost: { [HOST]: { profiles: [], activeProfileId: null } },
+    };
+    expect(
+      selectEffectiveWorkspaceFoldersBucket(foldersState, profilesState, HOST)
+        .folders,
+    ).toEqual(["/titanos", "/crm", "/bkza"]);
+  });
+
+  it("narrows the catalog to the active profile's folders and primary", () => {
+    const foldersState = {
+      byHost: { [HOST]: catalog(["/titanos", "/crm", "/bkza"], "/crm") },
+    };
+    const profilesState = {
+      byHost: {
+        [HOST]: {
+          profiles: [
+            profile({ folderPaths: ["/titanos"], primaryPath: "/titanos" }),
+          ],
+          activeProfileId: "p1",
+        },
+      },
+    };
+    const effective = selectEffectiveWorkspaceFoldersBucket(
+      foldersState,
+      profilesState,
+      HOST,
+    );
+    expect(effective.folders).toEqual(["/titanos"]);
+    expect(effective.primaryPath).toBe("/titanos");
+    expect(Object.keys(effective.folderInfoByPath)).toEqual(["/titanos"]);
+  });
+
+  it("drops profile paths that left the catalog instead of inventing folders", () => {
+    const foldersState = {
+      byHost: { [HOST]: catalog(["/titanos"], "/titanos") },
+    };
+    const profilesState = {
+      byHost: {
+        [HOST]: {
+          profiles: [
+            profile({
+              folderPaths: ["/titanos", "/gone"],
+              primaryPath: "/gone",
+            }),
+          ],
+          activeProfileId: "p1",
+        },
+      },
+    };
+    const effective = selectEffectiveWorkspaceFoldersBucket(
+      foldersState,
+      profilesState,
+      HOST,
+    );
+    expect(effective.folders).toEqual(["/titanos"]);
+    expect(effective.primaryPath).toBe("/titanos");
+  });
+});

--- a/clients/gui-app/src/lib/workspace/__tests__/header-tab-matches-project.test.ts
+++ b/clients/gui-app/src/lib/workspace/__tests__/header-tab-matches-project.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import {
+  filterHeaderStripItemIdsForProject,
+  headerTabMatchesProject,
+} from "../header-tab-matches-project";
+import type { ProjectProfile } from "@/stores/workspace/project-profiles-store";
+import type { StripItem } from "@/stores/tabs/layout";
+
+const TITANOS: ProjectProfile = {
+  id: "p-titanos",
+  name: "Titanos",
+  color: "orange",
+  folderPaths: ["/Users/g/work/Titanos"],
+  primaryPath: "/Users/g/work/Titanos",
+  epicIds: ["claimed-titanos"],
+};
+
+describe("headerTabMatchesProject", () => {
+  it("keeps every tab when All projects is active", () => {
+    expect(
+      headerTabMatchesProject({ kind: "epic", epicId: "crm" }, null, null),
+    ).toBe(true);
+  });
+
+  it("keeps settings, history, and draft tabs on a project", () => {
+    expect(headerTabMatchesProject({ kind: "settings" }, TITANOS, null)).toBe(
+      true,
+    );
+    expect(headerTabMatchesProject({ kind: "history" }, TITANOS, null)).toBe(
+      true,
+    );
+    expect(headerTabMatchesProject({ kind: "draft" }, TITANOS, null)).toBe(true);
+  });
+
+  it("keeps a claimed epic on that project", () => {
+    expect(
+      headerTabMatchesProject(
+        { kind: "epic", epicId: "claimed-titanos" },
+        TITANOS,
+        null,
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps an unclaimed epic whose workspace is the project folder", () => {
+    expect(
+      headerTabMatchesProject({ kind: "epic", epicId: "old-titanos" }, TITANOS, {
+        worktreePaths: [],
+        linkedWorkspaces: [
+          { hostId: "host-a", workspacePath: "/Users/g/work/Titanos" },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it("hides an unclaimed epic from another folder", () => {
+    expect(
+      headerTabMatchesProject({ kind: "epic", epicId: "crm" }, TITANOS, {
+        worktreePaths: [],
+        linkedWorkspaces: [
+          { hostId: "host-a", workspacePath: "/Users/g/work/CRM" },
+        ],
+      }),
+    ).toBe(false);
+  });
+
+  it("hides an unclaimed epic with no workspace hint", () => {
+    expect(
+      headerTabMatchesProject({ kind: "epic", epicId: "unknown" }, TITANOS, null),
+    ).toBe(false);
+  });
+});
+
+describe("filterHeaderStripItemIdsForProject", () => {
+  const items: ReadonlyArray<StripItem> = [
+    { kind: "tab", id: "tab:epic:titanos", ref: { kind: "epic", id: "tab-t" } },
+    { kind: "tab", id: "tab:epic:crm", ref: { kind: "epic", id: "tab-c" } },
+    { kind: "tab", id: "tab:draft:home", ref: { kind: "draft", id: "draft-1" } },
+  ];
+
+  it("hides a foreign epic tab and keeps the landing draft", () => {
+    expect(
+      filterHeaderStripItemIdsForProject({
+        itemIds: items.map((item) => item.id),
+        items,
+        profile: TITANOS,
+        epicIdForTabId: (tabId) => {
+          if (tabId === "tab-t") return "claimed-titanos";
+          if (tabId === "tab-c") return "crm";
+          return null;
+        },
+        workspaceHintForEpic: () => null,
+      }),
+    ).toEqual(["tab:epic:titanos", "tab:draft:home"]);
+  });
+
+  it("hides a split that mixes this project with another", () => {
+    const splitItems: ReadonlyArray<StripItem> = [
+      {
+        kind: "split",
+        id: "split:mix",
+        left: { kind: "tab", ref: { kind: "epic", id: "tab-t" } },
+        right: { kind: "tab", ref: { kind: "epic", id: "tab-c" } },
+        focusedSide: "left",
+        routeBackingSide: "left",
+        leftRatio: 0.5,
+      },
+    ];
+    expect(
+      filterHeaderStripItemIdsForProject({
+        itemIds: ["split:mix"],
+        items: splitItems,
+        profile: TITANOS,
+        epicIdForTabId: (tabId) => {
+          if (tabId === "tab-t") return "claimed-titanos";
+          if (tabId === "tab-c") return "crm";
+          return null;
+        },
+        workspaceHintForEpic: () => null,
+      }),
+    ).toEqual([]);
+  });
+});

--- a/clients/gui-app/src/lib/workspace/__tests__/header-tab-matches-project.test.ts
+++ b/clients/gui-app/src/lib/workspace/__tests__/header-tab-matches-project.test.ts
@@ -2,6 +2,10 @@ import { describe, expect, it } from "vitest";
 import {
   filterHeaderStripItemIdsForProject,
   headerTabMatchesProject,
+  headerTabProjectBadge,
+  resolveEpicWorkspaceHint,
+  resolveOwningProjectProfile,
+  stampedWorkspaceHintForEpic,
 } from "../header-tab-matches-project";
 import type { ProjectProfile } from "@/stores/workspace/project-profiles-store";
 import type { StripItem } from "@/stores/tabs/layout";
@@ -13,6 +17,15 @@ const TITANOS: ProjectProfile = {
   folderPaths: ["/Users/g/work/Titanos"],
   primaryPath: "/Users/g/work/Titanos",
   epicIds: ["claimed-titanos"],
+};
+
+const CRM: ProjectProfile = {
+  id: "p-crm",
+  name: "CRM",
+  color: "blue",
+  folderPaths: ["/Users/g/work/CRM"],
+  primaryPath: "/Users/g/work/CRM",
+  epicIds: ["claimed-crm"],
 };
 
 describe("headerTabMatchesProject", () => {
@@ -69,6 +82,79 @@ describe("headerTabMatchesProject", () => {
       headerTabMatchesProject({ kind: "epic", epicId: "unknown" }, TITANOS, null),
     ).toBe(false);
   });
+
+  it("hides a fan-out epic whose primary folder is not this project", () => {
+    expect(
+      headerTabMatchesProject({ kind: "epic", epicId: "issue-1180" }, TITANOS, {
+        worktreePaths: [],
+        linkedWorkspaces: [
+          { hostId: "host-a", workspacePath: "/Users/g/work/Traycer" },
+          { hostId: "host-a", workspacePath: "/Users/g/work/Titanos" },
+        ],
+      }),
+    ).toBe(false);
+  });
+
+  it("hides a claimed epic whose primary folder belongs to another project", () => {
+    expect(
+      headerTabMatchesProject(
+        { kind: "epic", epicId: "claimed-titanos" },
+        TITANOS,
+        {
+          worktreePaths: [],
+          linkedWorkspaces: [
+            { hostId: "host-a", workspacePath: "/Users/g/work/CRM" },
+          ],
+        },
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("resolveOwningProjectProfile", () => {
+  const profiles = [TITANOS, CRM];
+
+  it("returns the profile whose folder is the epic primary workspace", () => {
+    expect(
+      resolveOwningProjectProfile(profiles, "any-epic", {
+        worktreePaths: [],
+        linkedWorkspaces: [
+          { hostId: "host-a", workspacePath: "/Users/g/work/CRM" },
+          { hostId: "host-a", workspacePath: "/Users/g/work/Titanos" },
+        ],
+      }),
+    ).toEqual(CRM);
+  });
+
+  it("returns the claimed profile when the epic has no workspace", () => {
+    expect(resolveOwningProjectProfile(profiles, "claimed-titanos", null)).toEqual(
+      TITANOS,
+    );
+  });
+
+  it("returns null when no profile owns the epic", () => {
+    expect(
+      resolveOwningProjectProfile(profiles, "orphan", {
+        worktreePaths: [],
+        linkedWorkspaces: [
+          { hostId: "host-a", workspacePath: "/Users/g/work/Traycer" },
+        ],
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("headerTabProjectBadge", () => {
+  it("hides the color while a project is active", () => {
+    expect(headerTabProjectBadge(TITANOS, CRM)).toBeNull();
+  });
+
+  it("shows the owning color only on All projects", () => {
+    expect(headerTabProjectBadge(null, CRM)).toEqual({
+      color: "blue",
+      name: "CRM",
+    });
+  });
 });
 
 describe("filterHeaderStripItemIdsForProject", () => {
@@ -119,5 +205,126 @@ describe("filterHeaderStripItemIdsForProject", () => {
         workspaceHintForEpic: () => null,
       }),
     ).toEqual([]);
+  });
+
+  it("keeps a path-owned tab when only the persisted stamp is present", () => {
+    expect(
+      filterHeaderStripItemIdsForProject({
+        itemIds: items.map((item) => item.id),
+        items,
+        profile: TITANOS,
+        epicIdForTabId: (tabId) => {
+          if (tabId === "tab-t") return "old-titanos";
+          if (tabId === "tab-c") return "crm";
+          return null;
+        },
+        workspaceHintForEpic: (epicId) =>
+          resolveEpicWorkspaceHint({
+            live: null,
+            stamped: stampedWorkspaceHintForEpic(
+              {
+                "tab-t": {
+                  epicId: "old-titanos",
+                  projectWorkspace: {
+                    worktreePaths: [],
+                    linkedWorkspaces: [
+                      {
+                        hostId: "host-a",
+                        workspacePath: "/Users/g/work/Titanos",
+                      },
+                    ],
+                    primaryPath: "/Users/g/work/Titanos",
+                  },
+                },
+                "tab-c": {
+                  epicId: "crm",
+                  projectWorkspace: {
+                    worktreePaths: [],
+                    linkedWorkspaces: [
+                      {
+                        hostId: "host-a",
+                        workspacePath: "/Users/g/work/CRM",
+                      },
+                    ],
+                    primaryPath: "/Users/g/work/CRM",
+                  },
+                },
+              },
+              epicId,
+            ),
+          }),
+      }),
+    ).toEqual(["tab:epic:titanos", "tab:draft:home"]);
+  });
+});
+
+describe("resolveEpicWorkspaceHint", () => {
+  const stamped = {
+    worktreePaths: [],
+    linkedWorkspaces: [
+      { hostId: "host-a", workspacePath: "/Users/g/work/Titanos" },
+    ],
+    primaryPath: "/Users/g/work/Titanos",
+  };
+  const live = {
+    worktreePaths: [],
+    linkedWorkspaces: [
+      { hostId: "host-a", workspacePath: "/Users/g/work/CRM" },
+    ],
+    primaryPath: "/Users/g/work/CRM",
+  };
+
+  it("uses the live session folders when they exist", () => {
+    expect(resolveEpicWorkspaceHint({ live, stamped })).toEqual(live);
+  });
+
+  it("uses the stamped folders when the session is cold", () => {
+    expect(resolveEpicWorkspaceHint({ live: null, stamped })).toEqual(stamped);
+  });
+
+  it("ignores an empty live peek instead of wiping the stamp", () => {
+    expect(
+      resolveEpicWorkspaceHint({
+        live: { worktreePaths: [], linkedWorkspaces: [] },
+        stamped,
+      }),
+    ).toEqual(stamped);
+  });
+});
+
+describe("stampedWorkspaceHintForEpic", () => {
+  it("reads the stamp from any tab of that epic", () => {
+    expect(
+      stampedWorkspaceHintForEpic(
+        {
+          "tab-a": {
+            epicId: "old-titanos",
+            projectWorkspace: {
+              worktreePaths: [],
+              linkedWorkspaces: [
+                { hostId: "host-a", workspacePath: "/Users/g/work/Titanos" },
+              ],
+              primaryPath: "/Users/g/work/Titanos",
+            },
+          },
+        },
+        "old-titanos",
+      ),
+    ).toEqual({
+      worktreePaths: [],
+      linkedWorkspaces: [
+        { hostId: "host-a", workspacePath: "/Users/g/work/Titanos" },
+      ],
+      primaryPath: "/Users/g/work/Titanos",
+    });
+  });
+
+  it("returns null when no tab of that epic has a stamp", () => {
+    expect(
+      stampedWorkspaceHintForEpic(
+        { "tab-a": { epicId: "old-titanos" } },
+        "old-titanos",
+      ),
+    ).toBeNull();
   });
 });

--- a/clients/gui-app/src/lib/workspace/__tests__/header-tab-matches-project.test.ts
+++ b/clients/gui-app/src/lib/workspace/__tests__/header-tab-matches-project.test.ts
@@ -109,7 +109,7 @@ describe("headerTabMatchesProject", () => {
     ).toBe(false);
   });
 
-  it("hides a claimed epic whose primary folder belongs to another project", () => {
+  it("keeps a claimed epic even when the folder belongs to another project", () => {
     expect(
       headerTabMatchesProject(
         { kind: "epic", epicId: "claimed-titanos" },
@@ -120,6 +120,22 @@ describe("headerTabMatchesProject", () => {
             { hostId: "host-a", workspacePath: "/Users/g/work/CRM" },
           ],
         },
+      ),
+    ).toBe(true);
+  });
+
+  it("hides an epic claimed on another project even when the folder matches", () => {
+    expect(
+      headerTabMatchesProject(
+        { kind: "epic", epicId: "claimed-titanos" },
+        CRM,
+        {
+          worktreePaths: [],
+          linkedWorkspaces: [
+            { hostId: "host-a", workspacePath: "/Users/g/work/CRM" },
+          ],
+        },
+        [TITANOS, CRM],
       ),
     ).toBe(false);
   });

--- a/clients/gui-app/src/lib/workspace/__tests__/header-tab-matches-project.test.ts
+++ b/clients/gui-app/src/lib/workspace/__tests__/header-tab-matches-project.test.ts
@@ -95,6 +95,19 @@ describe("headerTabMatchesProject", () => {
     ).toBe(false);
   });
 
+  it("hides a fan-out epic even when Titanos is first in the folder list", () => {
+    expect(
+      headerTabMatchesProject({ kind: "epic", epicId: "issue-1180" }, TITANOS, {
+        worktreePaths: [],
+        linkedWorkspaces: [
+          { hostId: "host-a", workspacePath: "/Users/g/work/Titanos" },
+          { hostId: "host-a", workspacePath: "/Users/g/work/Traycer" },
+        ],
+        primaryPath: "/Users/g/work/Titanos",
+      }),
+    ).toBe(false);
+  });
+
   it("hides a claimed epic whose primary folder belongs to another project", () => {
     expect(
       headerTabMatchesProject(
@@ -114,7 +127,18 @@ describe("headerTabMatchesProject", () => {
 describe("resolveOwningProjectProfile", () => {
   const profiles = [TITANOS, CRM];
 
-  it("returns the profile whose folder is the epic primary workspace", () => {
+  it("returns the profile only when every workspace folder is inside it", () => {
+    expect(
+      resolveOwningProjectProfile(profiles, "any-epic", {
+        worktreePaths: [],
+        linkedWorkspaces: [
+          { hostId: "host-a", workspacePath: "/Users/g/work/CRM" },
+        ],
+      }),
+    ).toEqual(CRM);
+  });
+
+  it("returns null when the epic also has folders outside that profile", () => {
     expect(
       resolveOwningProjectProfile(profiles, "any-epic", {
         worktreePaths: [],
@@ -123,7 +147,7 @@ describe("resolveOwningProjectProfile", () => {
           { hostId: "host-a", workspacePath: "/Users/g/work/Titanos" },
         ],
       }),
-    ).toEqual(CRM);
+    ).toBeNull();
   });
 
   it("returns the claimed profile when the epic has no workspace", () => {

--- a/clients/gui-app/src/lib/workspace/__tests__/header-tab-matches-project.test.ts
+++ b/clients/gui-app/src/lib/workspace/__tests__/header-tab-matches-project.test.ts
@@ -3,6 +3,7 @@ import {
   filterHeaderStripItemIdsForProject,
   headerTabMatchesProject,
   headerTabProjectBadge,
+  historyItemProjectBadge,
   resolveEpicWorkspaceHint,
   resolveOwningProjectProfile,
   stampedWorkspaceHintForEpic,
@@ -178,6 +179,40 @@ describe("headerTabProjectBadge", () => {
       color: "blue",
       name: "CRM",
     });
+  });
+});
+
+describe("historyItemProjectBadge", () => {
+  const profiles = [TITANOS, CRM];
+  const titanosOnly = {
+    epicId: "old-titanos",
+    worktreePaths: [] as const,
+    linkedWorkspaces: [
+      { hostId: "host-a", workspacePath: "/Users/g/work/Titanos" },
+    ],
+  };
+  const fanOut = {
+    epicId: "issue-1180",
+    worktreePaths: [] as const,
+    linkedWorkspaces: [
+      { hostId: "host-a", workspacePath: "/Users/g/work/Titanos" },
+      { hostId: "host-a", workspacePath: "/Users/g/work/CRM" },
+    ],
+  };
+
+  it("puts Titanos color and name on an owned History row in All projects", () => {
+    expect(historyItemProjectBadge(null, profiles, titanosOnly)).toEqual({
+      color: "orange",
+      name: "Titanos",
+    });
+  });
+
+  it("hides the History badge while a project is active", () => {
+    expect(historyItemProjectBadge(TITANOS, profiles, titanosOnly)).toBeNull();
+  });
+
+  it("hides the History badge on a fan-out row with no single owner", () => {
+    expect(historyItemProjectBadge(null, profiles, fanOut)).toBeNull();
   });
 });
 

--- a/clients/gui-app/src/lib/workspace/__tests__/hidden-active-tab-fallback.test.ts
+++ b/clients/gui-app/src/lib/workspace/__tests__/hidden-active-tab-fallback.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { hiddenActiveTabFallback } from "../hidden-active-tab-fallback";
+
+describe("hiddenActiveTabFallback", () => {
+  it("keeps the active tab when it is still visible", () => {
+    expect(
+      hiddenActiveTabFallback({
+        isLandingPage: false,
+        activeItemId: "tab:epic:titanos",
+        visibleItemIds: ["tab:epic:titanos", "tab:draft:home"],
+      }),
+    ).toEqual({ kind: "keep" });
+  });
+
+  it("activates the first visible tab when All projects is on / with tabs", () => {
+    expect(
+      hiddenActiveTabFallback({
+        isLandingPage: true,
+        activeItemId: null,
+        visibleItemIds: ["tab:epic:issue-1180", "tab:epic:titanos"],
+      }),
+    ).toEqual({ kind: "activate", itemId: "tab:epic:issue-1180" });
+  });
+
+  it("activates a visible sibling when the active tab is hidden", () => {
+    expect(
+      hiddenActiveTabFallback({
+        isLandingPage: false,
+        activeItemId: "tab:epic:crm",
+        visibleItemIds: ["tab:epic:titanos"],
+      }),
+    ).toEqual({ kind: "activate", itemId: "tab:epic:titanos" });
+  });
+
+  it("opens one Start Page when a hidden tab has no visible sibling", () => {
+    expect(
+      hiddenActiveTabFallback({
+        isLandingPage: false,
+        activeItemId: "tab:epic:crm",
+        visibleItemIds: [],
+      }),
+    ).toEqual({ kind: "new-draft" });
+  });
+
+  it("leaves the empty first-run landing alone so /draft/new can mint once", () => {
+    expect(
+      hiddenActiveTabFallback({
+        isLandingPage: true,
+        activeItemId: null,
+        visibleItemIds: [],
+      }),
+    ).toEqual({ kind: "keep" });
+  });
+});

--- a/clients/gui-app/src/lib/workspace/__tests__/history-item-matches-project.test.ts
+++ b/clients/gui-app/src/lib/workspace/__tests__/history-item-matches-project.test.ts
@@ -44,7 +44,7 @@ describe("historyItemMatchesProject", () => {
     );
   });
 
-  it("matches a fan-out chat via the documented Traycer worktree path", () => {
+  it("does not match a fan-out chat that also has another project's worktree", () => {
     expect(
       historyItemMatchesProject(
         item("fanout", [
@@ -53,7 +53,42 @@ describe("historyItemMatchesProject", () => {
         ], []),
         PROFILE,
       ),
+    ).toBe(false);
+  });
+
+  it("matches a Titanos-only chat via the documented Traycer worktree path", () => {
+    expect(
+      historyItemMatchesProject(
+        item(
+          "titanos-only",
+          ["/Users/g/.traycer/worktrees/gavasques__titanos/traycer-titanos-x"],
+          [],
+        ),
+        PROFILE,
+      ),
     ).toBe(true);
+  });
+
+  it("does not match a fan-out chat that also linked another folder", () => {
+    expect(
+      historyItemMatchesProject(
+        item(
+          "fanout-linked",
+          [],
+          ["/Users/g/work/Titanos", "/Users/g/work/CRM"],
+        ),
+        PROFILE,
+      ),
+    ).toBe(false);
+  });
+
+  it("does not match a claimed chat that also has another project's folder", () => {
+    expect(
+      historyItemMatchesProject(
+        item("claimed", [], ["/Users/g/work/CRM"]),
+        PROFILE,
+      ),
+    ).toBe(false);
   });
 
   it("matches a local-mode chat by its originating workspace path", () => {

--- a/clients/gui-app/src/lib/workspace/__tests__/history-item-matches-project.test.ts
+++ b/clients/gui-app/src/lib/workspace/__tests__/history-item-matches-project.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import {
+  filterHistoryItemsForProject,
+  historyItemMatchesProject,
+} from "../history-item-matches-project";
+import type { ProjectProfile } from "@/stores/workspace/project-profiles-store";
+
+const PROFILE: ProjectProfile = {
+  id: "p1",
+  name: "Titanos",
+  color: "orange",
+  folderPaths: ["/Users/g/Titanos"],
+  primaryPath: "/Users/g/Titanos",
+  epicIds: ["claimed"],
+};
+
+function item(
+  epicId: string,
+  worktreePaths: ReadonlyArray<string>,
+): { readonly epicId: string; readonly worktreePaths: ReadonlyArray<string> } {
+  return { epicId, worktreePaths };
+}
+
+describe("historyItemMatchesProject", () => {
+  it("matches an explicitly claimed epic", () => {
+    expect(historyItemMatchesProject(item("claimed", []), PROFILE)).toBe(true);
+  });
+
+  it("matches a fan-out chat that still has a worktree under the project", () => {
+    expect(
+      historyItemMatchesProject(
+        item("fanout", [
+          "/Users/g/.traycer/worktrees/gavasques__titanos/traycer-titanos-x",
+          "/Users/g/.traycer/worktrees/gavasques__crm/traycer-crm-y",
+        ]),
+        PROFILE,
+      ),
+    ).toBe(true);
+  });
+
+  it("does not match a chat that never touched the project folder", () => {
+    expect(
+      historyItemMatchesProject(
+        item("other", [
+          "/Users/g/.traycer/worktrees/gavasques__crm/traycer-crm-y",
+        ]),
+        PROFILE,
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("filterHistoryItemsForProject", () => {
+  it("keeps the full list when no profile is active", () => {
+    const items = [item("a", [])];
+    expect(filterHistoryItemsForProject(items, null)).toBe(items);
+  });
+});

--- a/clients/gui-app/src/lib/workspace/__tests__/history-item-matches-project.test.ts
+++ b/clients/gui-app/src/lib/workspace/__tests__/history-item-matches-project.test.ts
@@ -126,6 +126,30 @@ describe("historyItemMatchesProject", () => {
     ).toBe(true);
   });
 
+  it("matches equivalent Windows paths that differ only in casing", () => {
+    const windowsProfile: ProjectProfile = {
+      ...PROFILE,
+      folderPaths: ["C:\\Users\\g\\work\\Titanos"],
+      primaryPath: "C:\\Users\\g\\work\\Titanos",
+      epicIds: [],
+    };
+    expect(
+      historyItemMatchesProject(
+        item("win-case", [], ["c:\\users\\g\\work\\titanos"]),
+        windowsProfile,
+      ),
+    ).toBe(true);
+  });
+
+  it("does not treat POSIX paths as case-insensitive", () => {
+    expect(
+      historyItemMatchesProject(
+        item("posix-case", [], ["/Users/g/work/titanos"]),
+        PROFILE,
+      ),
+    ).toBe(false);
+  });
+
   it("does not match a chat that never touched the project folder", () => {
     expect(
       historyItemMatchesProject(

--- a/clients/gui-app/src/lib/workspace/__tests__/history-item-matches-project.test.ts
+++ b/clients/gui-app/src/lib/workspace/__tests__/history-item-matches-project.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   filterHistoryItemsForProject,
   historyItemMatchesProject,
+  historyListEmptyState,
 } from "../history-item-matches-project";
 import type { ProjectProfile } from "@/stores/workspace/project-profiles-store";
 
@@ -166,5 +167,81 @@ describe("filterHistoryItemsForProject", () => {
   it("keeps the full list when no profile is active", () => {
     const items = [item("a", [], [])];
     expect(filterHistoryItemsForProject(items, null)).toBe(items);
+  });
+});
+
+describe("historyListEmptyState", () => {
+  it("returns null while rows are visible", () => {
+    expect(
+      historyListEmptyState({
+        visibleCount: 2,
+        preProjectFilterCount: 5,
+        hasActiveFilters: false,
+        projectFilterActive: true,
+      }),
+    ).toBeNull();
+  });
+
+  it("points at All projects when the active project hides every chat", () => {
+    expect(
+      historyListEmptyState({
+        visibleCount: 0,
+        preProjectFilterCount: 5,
+        hasActiveFilters: false,
+        projectFilterActive: true,
+      }),
+    ).toBe("hidden-by-active-project");
+  });
+
+  it("points at All projects when search matches exist only outside the project", () => {
+    expect(
+      historyListEmptyState({
+        visibleCount: 0,
+        preProjectFilterCount: 3,
+        hasActiveFilters: true,
+        projectFilterActive: true,
+      }),
+    ).toBe("hidden-by-active-project");
+  });
+
+  it("keeps the plain empty copy when the project truly has no chats anywhere", () => {
+    expect(
+      historyListEmptyState({
+        visibleCount: 0,
+        preProjectFilterCount: 0,
+        hasActiveFilters: false,
+        projectFilterActive: true,
+      }),
+    ).toBe("no-tasks");
+  });
+
+  it("keeps the plain empty copy when no project is active", () => {
+    expect(
+      historyListEmptyState({
+        visibleCount: 0,
+        preProjectFilterCount: 0,
+        hasActiveFilters: false,
+        projectFilterActive: false,
+      }),
+    ).toBe("no-tasks");
+  });
+
+  it("keeps the filter empty copy when nothing matches the search", () => {
+    expect(
+      historyListEmptyState({
+        visibleCount: 0,
+        preProjectFilterCount: 0,
+        hasActiveFilters: true,
+        projectFilterActive: true,
+      }),
+    ).toBe("no-filter-matches");
+    expect(
+      historyListEmptyState({
+        visibleCount: 0,
+        preProjectFilterCount: 0,
+        hasActiveFilters: true,
+        projectFilterActive: false,
+      }),
+    ).toBe("no-filter-matches");
   });
 });

--- a/clients/gui-app/src/lib/workspace/__tests__/history-item-matches-project.test.ts
+++ b/clients/gui-app/src/lib/workspace/__tests__/history-item-matches-project.test.ts
@@ -82,13 +82,13 @@ describe("historyItemMatchesProject", () => {
     ).toBe(false);
   });
 
-  it("does not match a claimed chat that also has another project's folder", () => {
+  it("matches a claimed chat even when the folder belongs to another project", () => {
     expect(
       historyItemMatchesProject(
         item("claimed", [], ["/Users/g/work/CRM"]),
         PROFILE,
       ),
-    ).toBe(false);
+    ).toBe(true);
   });
 
   it("matches a local-mode chat by its originating workspace path", () => {

--- a/clients/gui-app/src/lib/workspace/__tests__/history-item-matches-project.test.ts
+++ b/clients/gui-app/src/lib/workspace/__tests__/history-item-matches-project.test.ts
@@ -9,37 +9,121 @@ const PROFILE: ProjectProfile = {
   id: "p1",
   name: "Titanos",
   color: "orange",
-  folderPaths: ["/Users/g/Titanos"],
-  primaryPath: "/Users/g/Titanos",
+  folderPaths: ["/Users/g/work/Titanos"],
+  primaryPath: "/Users/g/work/Titanos",
   epicIds: ["claimed"],
 };
 
 function item(
   epicId: string,
   worktreePaths: ReadonlyArray<string>,
-): { readonly epicId: string; readonly worktreePaths: ReadonlyArray<string> } {
-  return { epicId, worktreePaths };
+  linkedWorkspaces: ReadonlyArray<string>,
+): {
+  readonly epicId: string;
+  readonly worktreePaths: ReadonlyArray<string>;
+  readonly linkedWorkspaces: ReadonlyArray<{
+    readonly hostId: string;
+    readonly workspacePath: string;
+  }>;
+} {
+  return {
+    epicId,
+    worktreePaths,
+    linkedWorkspaces: linkedWorkspaces.map((workspacePath) => ({
+      hostId: "host-a",
+      workspacePath,
+    })),
+  };
 }
 
 describe("historyItemMatchesProject", () => {
   it("matches an explicitly claimed epic", () => {
-    expect(historyItemMatchesProject(item("claimed", []), PROFILE)).toBe(true);
+    expect(historyItemMatchesProject(item("claimed", [], []), PROFILE)).toBe(
+      true,
+    );
   });
 
-  it("matches a fan-out chat that still has a worktree under the project", () => {
+  it("matches a fan-out chat via the documented Traycer worktree path", () => {
     expect(
       historyItemMatchesProject(
         item("fanout", [
           "/Users/g/.traycer/worktrees/gavasques__titanos/traycer-titanos-x",
           "/Users/g/.traycer/worktrees/gavasques__crm/traycer-crm-y",
-        ]),
+        ], []),
         PROFILE,
       ),
     ).toBe(true);
   });
 
-  it("does not match an unclaimed local-mode chat with no worktrees", () => {
-    expect(historyItemMatchesProject(item("local", []), PROFILE)).toBe(false);
+  it("matches a local-mode chat by its originating workspace path", () => {
+    expect(
+      historyItemMatchesProject(
+        item("local", [], ["/Users/g/work/Titanos"]),
+        PROFILE,
+      ),
+    ).toBe(true);
+  });
+
+  it("does not match an unclaimed chat with no worktrees and no workspace", () => {
+    expect(historyItemMatchesProject(item("empty", [], []), PROFILE)).toBe(
+      false,
+    );
+  });
+
+  it("does not match another folder that only shares the basename", () => {
+    expect(
+      historyItemMatchesProject(
+        item(
+          "clone",
+          [
+            "/Users/g/.traycer/worktrees/gavasques__titanos/traycer-titanos-x",
+          ],
+          ["/Users/g/personal/Titanos"],
+        ),
+        PROFILE,
+      ),
+    ).toBe(false);
+  });
+
+  it("does not match a path that merely contains the folder name", () => {
+    expect(
+      historyItemMatchesProject(
+        item("substring", ["/Users/g/not-titanos/src"], ["/Users/g/not-titanos"]),
+        PROFILE,
+      ),
+    ).toBe(false);
+  });
+
+  it("matches a Windows worktree path against a Windows project folder", () => {
+    const windowsProfile: ProjectProfile = {
+      ...PROFILE,
+      folderPaths: ["C:\\Users\\g\\work\\Titanos"],
+      primaryPath: "C:\\Users\\g\\work\\Titanos",
+      epicIds: [],
+    };
+    expect(
+      historyItemMatchesProject(
+        item("win", [
+          "C:\\Users\\g\\.traycer\\worktrees\\gavasques__titanos\\traycer-titanos-x",
+        ], []),
+        windowsProfile,
+      ),
+    ).toBe(true);
+  });
+
+  it("matches a Windows originating workspace regardless of slash style", () => {
+    const windowsProfile: ProjectProfile = {
+      ...PROFILE,
+      folderPaths: ["C:/Users/g/work/Titanos"],
+      primaryPath: "C:/Users/g/work/Titanos",
+      epicIds: [],
+    };
+    expect(
+      historyItemMatchesProject(
+        item("win-local", [], ["C:\\Users\\g\\work\\Titanos"]),
+        windowsProfile,
+      ),
+    ).toBe(true);
   });
 
   it("does not match a chat that never touched the project folder", () => {
@@ -47,7 +131,7 @@ describe("historyItemMatchesProject", () => {
       historyItemMatchesProject(
         item("other", [
           "/Users/g/.traycer/worktrees/gavasques__crm/traycer-crm-y",
-        ]),
+        ], []),
         PROFILE,
       ),
     ).toBe(false);
@@ -56,7 +140,7 @@ describe("historyItemMatchesProject", () => {
 
 describe("filterHistoryItemsForProject", () => {
   it("keeps the full list when no profile is active", () => {
-    const items = [item("a", [])];
+    const items = [item("a", [], [])];
     expect(filterHistoryItemsForProject(items, null)).toBe(items);
   });
 });

--- a/clients/gui-app/src/lib/workspace/__tests__/history-item-matches-project.test.ts
+++ b/clients/gui-app/src/lib/workspace/__tests__/history-item-matches-project.test.ts
@@ -38,6 +38,10 @@ describe("historyItemMatchesProject", () => {
     ).toBe(true);
   });
 
+  it("does not match an unclaimed local-mode chat with no worktrees", () => {
+    expect(historyItemMatchesProject(item("local", []), PROFILE)).toBe(false);
+  });
+
   it("does not match a chat that never touched the project folder", () => {
     expect(
       historyItemMatchesProject(

--- a/clients/gui-app/src/lib/workspace/__tests__/history-item-matches-project.test.ts
+++ b/clients/gui-app/src/lib/workspace/__tests__/history-item-matches-project.test.ts
@@ -177,6 +177,21 @@ describe("historyItemMatchesProject", () => {
     ).toBe(true);
   });
 
+  it("matches equivalent UNC paths that differ only in casing", () => {
+    const uncProfile: ProjectProfile = {
+      ...PROFILE,
+      folderPaths: ["\\\\Fileserver\\Repos\\Titanos"],
+      primaryPath: "\\\\Fileserver\\Repos\\Titanos",
+      epicIds: [],
+    };
+    expect(
+      historyItemMatchesProject(
+        item("unc-case", [], ["\\\\FILESERVER\\repos\\titanos"]),
+        uncProfile,
+      ),
+    ).toBe(true);
+  });
+
   it("does not treat POSIX paths as case-insensitive", () => {
     expect(
       historyItemMatchesProject(

--- a/clients/gui-app/src/lib/workspace/__tests__/new-conversation-workspace-seed.test.ts
+++ b/clients/gui-app/src/lib/workspace/__tests__/new-conversation-workspace-seed.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+import type { ResolvedWorkspaceFolder } from "@traycer/protocol/host/epic/snapshot-meta";
+import { resolveNewConversationWorkspaceSeed } from "../new-conversation-workspace-seed";
+import type { LandingDraftWorkspaceSnapshot } from "@/stores/home/landing-draft-store";
+import type { WorkspaceFolderInfo } from "@/stores/workspace/workspace-folders-store";
+
+const HOST_A = "host-a";
+const HOST_B = "host-b";
+
+function epicFolder(
+  workspacePath: string,
+  hostId: string,
+): ResolvedWorkspaceFolder {
+  return {
+    workspacePath,
+    hostId,
+    repoIdentifier: null,
+    lastSyncedAt: null,
+  };
+}
+
+const LATEST_WORKSPACE: LandingDraftWorkspaceSnapshot = {
+  folders: ["/work/.traycer/worktrees/crm/feature-x"],
+  folderInfoByPath: {
+    "/work/.traycer/worktrees/crm/feature-x": {
+      path: "/work/.traycer/worktrees/crm/feature-x",
+      name: "feature-x",
+      repoIdentifier: { owner: "g", repo: "crm" },
+      hostId: HOST_A,
+    } satisfies WorkspaceFolderInfo,
+  },
+  primaryPath: "/work/.traycer/worktrees/crm/feature-x",
+};
+
+describe("resolveNewConversationWorkspaceSeed", () => {
+  it("prefers the latest conversation's workspace verbatim when present", () => {
+    const result = resolveNewConversationWorkspaceSeed({
+      latestWorkspace: LATEST_WORKSPACE,
+      epicWorkspaceFolders: [epicFolder("/work/crm", HOST_A)],
+      hostId: HOST_A,
+    });
+    expect(result).toBe(LATEST_WORKSPACE);
+  });
+
+  it("seeds the epic's own stored folders on the create host when no conversation seed exists", () => {
+    const result = resolveNewConversationWorkspaceSeed({
+      latestWorkspace: null,
+      epicWorkspaceFolders: [
+        epicFolder("/work/crm", HOST_A),
+        {
+          workspacePath: "/work/crm-api",
+          hostId: HOST_A,
+          repoIdentifier: { owner: "g", repo: "crm-api" },
+          lastSyncedAt: null,
+        },
+      ],
+      hostId: HOST_A,
+    });
+    expect(result.folders).toEqual(["/work/crm", "/work/crm-api"]);
+    expect(result.primaryPath).toBe("/work/crm");
+    expect(result.folderInfoByPath["/work/crm"]).toEqual({
+      path: "/work/crm",
+      name: "crm",
+      repoIdentifier: null,
+      hostId: HOST_A,
+    });
+    // The stored repo link survives into the folder info so picker chips and
+    // the synthesized local intent keep it.
+    expect(result.folderInfoByPath["/work/crm-api"].repoIdentifier).toEqual({
+      owner: "g",
+      repo: "crm-api",
+    });
+  });
+
+  it("ignores the epic's folders that live on another host", () => {
+    const result = resolveNewConversationWorkspaceSeed({
+      latestWorkspace: null,
+      epicWorkspaceFolders: [
+        epicFolder("/work/crm", HOST_A),
+        epicFolder("/other/crm", HOST_B),
+      ],
+      hostId: HOST_B,
+    });
+    expect(result.folders).toEqual(["/other/crm"]);
+    expect(result.primaryPath).toBe("/other/crm");
+  });
+
+  it("falls back to empty folders when the epic has no stored folders - never the overlay", () => {
+    const result = resolveNewConversationWorkspaceSeed({
+      latestWorkspace: null,
+      epicWorkspaceFolders: [],
+      hostId: HOST_A,
+    });
+    expect(result).toEqual({
+      folders: [],
+      folderInfoByPath: {},
+      primaryPath: null,
+    });
+  });
+
+  it("falls back to empty folders when none of the epic's folders live on the create host", () => {
+    const result = resolveNewConversationWorkspaceSeed({
+      latestWorkspace: null,
+      epicWorkspaceFolders: [epicFolder("/work/crm", HOST_A)],
+      hostId: HOST_B,
+    });
+    expect(result.folders).toEqual([]);
+    expect(result.primaryPath).toBeNull();
+  });
+
+  it("matches no folders before a create host is known", () => {
+    const result = resolveNewConversationWorkspaceSeed({
+      latestWorkspace: null,
+      epicWorkspaceFolders: [epicFolder("/work/crm", HOST_A)],
+      hostId: null,
+    });
+    expect(result.folders).toEqual([]);
+  });
+
+  it("still prefers an explicitly empty latest seed over the epic's folders", () => {
+    // A resolved-but-empty latest seed (e.g. the source conversation's binding
+    // resolved folderless) is an answer, not an absence: do not re-fill it
+    // from the epic's stored set.
+    const emptyLatest: LandingDraftWorkspaceSnapshot = {
+      folders: [],
+      folderInfoByPath: {},
+      primaryPath: null,
+    };
+    const result = resolveNewConversationWorkspaceSeed({
+      latestWorkspace: emptyLatest,
+      epicWorkspaceFolders: [epicFolder("/work/crm", HOST_A)],
+      hostId: HOST_A,
+    });
+    expect(result).toBe(emptyLatest);
+  });
+});

--- a/clients/gui-app/src/lib/workspace/__tests__/next-active-profile-after-delete.test.ts
+++ b/clients/gui-app/src/lib/workspace/__tests__/next-active-profile-after-delete.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { nextActiveProfileIdAfterDelete } from "../next-active-profile-after-delete";
+import type { ProjectProfile } from "@/stores/workspace/project-profiles-store";
+
+function profile(id: string, name: string): ProjectProfile {
+  return {
+    id,
+    name,
+    color: "orange",
+    folderPaths: [`/${name.toLowerCase()}`],
+    primaryPath: `/${name.toLowerCase()}`,
+    epicIds: [],
+  };
+}
+
+describe("nextActiveProfileIdAfterDelete", () => {
+  it("keeps the current profile when a sibling is deleted", () => {
+    expect(
+      nextActiveProfileIdAfterDelete({
+        profiles: [profile("titanos", "Titanos"), profile("crm", "CRM")],
+        activeProfileId: "titanos",
+        deletedProfileId: "crm",
+      }),
+    ).toBe("titanos");
+  });
+
+  it("activates the next sibling when the active profile is deleted", () => {
+    expect(
+      nextActiveProfileIdAfterDelete({
+        profiles: [
+          profile("titanos", "Titanos"),
+          profile("crm", "CRM"),
+          profile("bkza", "BKZA"),
+        ],
+        activeProfileId: "titanos",
+        deletedProfileId: "titanos",
+      }),
+    ).toBe("crm");
+  });
+
+  it("activates the previous sibling when the last profile is deleted", () => {
+    expect(
+      nextActiveProfileIdAfterDelete({
+        profiles: [profile("titanos", "Titanos"), profile("crm", "CRM")],
+        activeProfileId: "crm",
+        deletedProfileId: "crm",
+      }),
+    ).toBe("titanos");
+  });
+
+  it("returns All projects when the last remaining profile is deleted", () => {
+    expect(
+      nextActiveProfileIdAfterDelete({
+        profiles: [profile("titanos", "Titanos")],
+        activeProfileId: "titanos",
+        deletedProfileId: "titanos",
+      }),
+    ).toBeNull();
+  });
+});

--- a/clients/gui-app/src/lib/workspace/__tests__/project-profile-seed.test.ts
+++ b/clients/gui-app/src/lib/workspace/__tests__/project-profile-seed.test.ts
@@ -9,22 +9,36 @@ const CATALOG: WorkspaceFoldersHostBucket = {
 };
 
 describe("folderSeedForNewProfile", () => {
-  it("defaults isolation to the primary folder only", () => {
-    expect(folderSeedForNewProfile(CATALOG, "primary")).toEqual({
+  it("uses the folder the user picked as that project's main", () => {
+    expect(folderSeedForNewProfile(CATALOG, "folder", "/crm")).toEqual({
+      folderPaths: ["/crm"],
+      primaryPath: "/crm",
+    });
+  });
+
+  it("falls back to the catalog primary when no folder is picked", () => {
+    expect(folderSeedForNewProfile(CATALOG, "folder", null)).toEqual({
+      folderPaths: ["/titanos"],
+      primaryPath: "/titanos",
+    });
+  });
+
+  it("ignores a path that is not in the catalog", () => {
+    expect(folderSeedForNewProfile(CATALOG, "folder", "/missing")).toEqual({
       folderPaths: ["/titanos"],
       primaryPath: "/titanos",
     });
   });
 
   it("can copy the full current workspace for a true multi-repo project", () => {
-    expect(folderSeedForNewProfile(CATALOG, "all")).toEqual({
+    expect(folderSeedForNewProfile(CATALOG, "all", null)).toEqual({
       folderPaths: ["/titanos", "/crm", "/bkza"],
       primaryPath: "/titanos",
     });
   });
 
   it("can start empty", () => {
-    expect(folderSeedForNewProfile(CATALOG, "empty")).toEqual({
+    expect(folderSeedForNewProfile(CATALOG, "empty", null)).toEqual({
       folderPaths: [],
       primaryPath: null,
     });

--- a/clients/gui-app/src/lib/workspace/__tests__/project-profile-seed.test.ts
+++ b/clients/gui-app/src/lib/workspace/__tests__/project-profile-seed.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { folderSeedForNewProfile } from "../project-profile-seed";
+import {
+  canConfirmNewProject,
+  folderSeedForNewProfile,
+} from "../project-profile-seed";
 import type { WorkspaceFoldersHostBucket } from "@/stores/workspace/workspace-folders-store";
 
 const CATALOG: WorkspaceFoldersHostBucket = {
@@ -16,17 +19,17 @@ describe("folderSeedForNewProfile", () => {
     });
   });
 
-  it("falls back to the catalog primary when no folder is picked", () => {
+  it("does not silently bind the host-wide primary when no folder is picked", () => {
     expect(folderSeedForNewProfile(CATALOG, "folder", null)).toEqual({
-      folderPaths: ["/titanos"],
-      primaryPath: "/titanos",
+      folderPaths: [],
+      primaryPath: null,
     });
   });
 
   it("ignores a path that is not in the catalog", () => {
     expect(folderSeedForNewProfile(CATALOG, "folder", "/missing")).toEqual({
-      folderPaths: ["/titanos"],
-      primaryPath: "/titanos",
+      folderPaths: [],
+      primaryPath: null,
     });
   });
 
@@ -42,5 +45,41 @@ describe("folderSeedForNewProfile", () => {
       folderPaths: [],
       primaryPath: null,
     });
+  });
+});
+
+describe("canConfirmNewProject", () => {
+  it("blocks Create until a folder is picked when the seed is folder", () => {
+    expect(
+      canConfirmNewProject({
+        name: "Titanos",
+        seed: "folder",
+        pickedFolder: null,
+      }),
+    ).toBe(false);
+    expect(
+      canConfirmNewProject({
+        name: "Titanos",
+        seed: "folder",
+        pickedFolder: "/titanos",
+      }),
+    ).toBe(true);
+  });
+
+  it("allows All / Empty with only a name", () => {
+    expect(
+      canConfirmNewProject({
+        name: "Multi",
+        seed: "all",
+        pickedFolder: null,
+      }),
+    ).toBe(true);
+    expect(
+      canConfirmNewProject({
+        name: "Blank",
+        seed: "empty",
+        pickedFolder: null,
+      }),
+    ).toBe(true);
   });
 });

--- a/clients/gui-app/src/lib/workspace/__tests__/project-profile-seed.test.ts
+++ b/clients/gui-app/src/lib/workspace/__tests__/project-profile-seed.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { folderSeedForNewProfile } from "../project-profile-seed";
+import type { WorkspaceFoldersHostBucket } from "@/stores/workspace/workspace-folders-store";
+
+const CATALOG: WorkspaceFoldersHostBucket = {
+  folders: ["/titanos", "/crm", "/bkza"],
+  folderInfoByPath: {},
+  primaryPath: "/titanos",
+};
+
+describe("folderSeedForNewProfile", () => {
+  it("defaults isolation to the primary folder only", () => {
+    expect(folderSeedForNewProfile(CATALOG, "primary")).toEqual({
+      folderPaths: ["/titanos"],
+      primaryPath: "/titanos",
+    });
+  });
+
+  it("can copy the full current workspace for a true multi-repo project", () => {
+    expect(folderSeedForNewProfile(CATALOG, "all")).toEqual({
+      folderPaths: ["/titanos", "/crm", "/bkza"],
+      primaryPath: "/titanos",
+    });
+  });
+
+  it("can start empty", () => {
+    expect(folderSeedForNewProfile(CATALOG, "empty")).toEqual({
+      folderPaths: [],
+      primaryPath: null,
+    });
+  });
+});

--- a/clients/gui-app/src/lib/workspace/assign-epic-to-project.ts
+++ b/clients/gui-app/src/lib/workspace/assign-epic-to-project.ts
@@ -1,0 +1,108 @@
+import { workspaceFolderName } from "@/lib/worktree/workspace-folder-name";
+import type { EpicWorkspaceHint } from "@/lib/workspace/header-tab-matches-project";
+import { claimedProfileIdForEpic } from "@/lib/workspace/history-item-matches-project";
+import { resolveOwningProjectProfile } from "@/lib/workspace/header-tab-matches-project";
+import {
+  PROJECT_PROFILE_COLORS,
+  selectProjectProfilesBucket,
+  useProjectProfilesStore,
+  type ProjectProfile,
+  type ProjectProfileColor,
+} from "@/stores/workspace/project-profiles-store";
+
+function hintPrimaryFolder(hint: EpicWorkspaceHint | null): string | null {
+  if (hint === null) return null;
+  if (typeof hint.primaryPath === "string" && hint.primaryPath.length > 0) {
+    return hint.primaryPath;
+  }
+  const linked = hint.linkedWorkspaces[0]?.workspacePath;
+  if (linked !== undefined && linked.length > 0) return linked;
+  const worktree = hint.worktreePaths[0];
+  if (worktree !== undefined && worktree.length > 0) return worktree;
+  return null;
+}
+
+function nextUnusedColor(
+  profiles: ReadonlyArray<ProjectProfile>,
+): ProjectProfileColor {
+  const used = new Set(profiles.map((profile) => profile.color));
+  return (
+    PROJECT_PROFILE_COLORS.find((color) => !used.has(color)) ?? "orange"
+  );
+}
+
+export function folderAlreadyOwnsAProject(
+  profiles: ReadonlyArray<ProjectProfile>,
+  folderPath: string,
+): boolean {
+  return profiles.some(
+    (profile) =>
+      profile.primaryPath === folderPath ||
+      profile.folderPaths.includes(folderPath),
+  );
+}
+
+/**
+ * Bind an unclaimed epic to the one project whose folders contain every
+ * workspace path. No-op in All projects when the chat touched more than one
+ * project (fan-out) — the user must Move it. Never steals an explicit claim.
+ */
+export function claimEpicOnMatchingProfile(
+  hostId: string | null,
+  epicId: string,
+  hint: EpicWorkspaceHint | null,
+): void {
+  if (hostId === null || epicId.length === 0) return;
+  const store = useProjectProfilesStore.getState();
+  const bucket = selectProjectProfilesBucket(store, hostId);
+  if (claimedProfileIdForEpic(bucket.profiles, epicId) !== null) return;
+  const owner = resolveOwningProjectProfile(bucket.profiles, epicId, hint);
+  if (owner === null) return;
+  store.addProfileEpics(hostId, owner.id, [epicId]);
+}
+
+/** Exclusive move. `profileId` null removes the epic from every project. */
+export function assignEpicToProjectProfile(
+  hostId: string | null,
+  epicId: string,
+  profileId: string | null,
+): void {
+  if (hostId === null || epicId.length === 0) return;
+  const store = useProjectProfilesStore.getState();
+  const bucket = selectProjectProfilesBucket(store, hostId);
+  for (const profile of bucket.profiles) {
+    if (profileId !== null && profile.id === profileId) {
+      store.addProfileEpics(hostId, profile.id, [epicId]);
+    } else {
+      store.removeProfileEpic(hostId, profile.id, epicId);
+    }
+  }
+}
+
+/**
+ * Create a project from this chat's folder and claim the epic. Does not switch
+ * the header — All projects stays so the color dot can appear.
+ */
+export function createProjectFromWorkspaceHint(
+  hostId: string | null,
+  epicId: string,
+  hint: EpicWorkspaceHint | null,
+): string | null {
+  if (hostId === null || epicId.length === 0) return null;
+  const folderPath = hintPrimaryFolder(hint);
+  if (folderPath === null) return null;
+  const store = useProjectProfilesStore.getState();
+  const bucket = selectProjectProfilesBucket(store, hostId);
+  if (folderAlreadyOwnsAProject(bucket.profiles, folderPath)) return null;
+  const name = workspaceFolderName(folderPath);
+  if (name.length === 0) return null;
+  const id = store.createProfile(hostId, {
+    name,
+    color: nextUnusedColor(bucket.profiles),
+    folderPaths: [folderPath],
+    primaryPath: folderPath,
+  });
+  if (id === null) return null;
+  assignEpicToProjectProfile(hostId, epicId, id);
+  return id;
+}

--- a/clients/gui-app/src/lib/workspace/claim-epic-on-active-profile.ts
+++ b/clients/gui-app/src/lib/workspace/claim-epic-on-active-profile.ts
@@ -1,0 +1,19 @@
+import {
+  selectActiveProjectProfile,
+  useProjectProfilesStore,
+} from "@/stores/workspace/project-profiles-store";
+
+/**
+ * Bind a newly minted epic to the active Project Profile so History keeps
+ * it even when the chat ran local (no worktree under ~/.traycer/worktrees).
+ */
+export function claimEpicOnActiveProfile(
+  hostId: string | null,
+  epicId: string,
+): void {
+  if (hostId === null || epicId.length === 0) return;
+  const store = useProjectProfilesStore.getState();
+  const active = selectActiveProjectProfile(store, hostId);
+  if (active === null) return;
+  store.addProfileEpics(hostId, active.id, [epicId]);
+}

--- a/clients/gui-app/src/lib/workspace/effective-workspace-folders.ts
+++ b/clients/gui-app/src/lib/workspace/effective-workspace-folders.ts
@@ -1,0 +1,69 @@
+import type { WorkspaceFoldersHostBucket } from "@/stores/workspace/workspace-folders-store";
+import {
+  selectWorkspaceFoldersBucket,
+  useWorkspaceFoldersStore,
+} from "@/stores/workspace/workspace-folders-store";
+import {
+  selectActiveProjectProfile,
+  useProjectProfilesStore,
+  type ProjectProfilesHostBucket,
+} from "@/stores/workspace/project-profiles-store";
+import { resolvePrimaryPath } from "@/lib/worktree/resolve-primary-path";
+
+interface FoldersState {
+  readonly byHost: Readonly<Record<string, WorkspaceFoldersHostBucket>>;
+}
+
+interface ProfilesState {
+  readonly byHost: Readonly<Record<string, ProjectProfilesHostBucket>>;
+}
+
+/**
+ * The folders a new chat / landing draft should launch with.
+ *
+ * Zero profiles, or All projects (`activeProfileId === null`), keep today's
+ * host bucket. An active profile narrows that bucket to the profile's own
+ * folder list so a Titanos chat cannot inherit BKZA/CRM worktrees.
+ */
+export function selectEffectiveWorkspaceFoldersBucket(
+  foldersState: FoldersState,
+  profilesState: ProfilesState,
+  hostId: string | null,
+): WorkspaceFoldersHostBucket {
+  const catalog = selectWorkspaceFoldersBucket(foldersState, hostId);
+  const profile = selectActiveProjectProfile(profilesState, hostId);
+  if (profile === null) return catalog;
+
+  const catalogSet = new Set(catalog.folders);
+  const folders = profile.folderPaths.filter((path) => catalogSet.has(path));
+  if (folders.length === 0) {
+    return {
+      folders: [],
+      folderInfoByPath: {},
+      primaryPath: null,
+    };
+  }
+  const folderSet = new Set(folders);
+  const folderInfoByPath = Object.fromEntries(
+    Object.entries(catalog.folderInfoByPath).filter(([path]) =>
+      folderSet.has(path),
+    ),
+  );
+  return {
+    folders,
+    folderInfoByPath,
+    primaryPath: resolvePrimaryPath(folders, profile.primaryPath),
+  };
+}
+
+/** Imperative launch-time read. Callers that need React updates subscribe
+ *  to both stores and pass them into {@link selectEffectiveWorkspaceFoldersBucket}. */
+export function readEffectiveWorkspaceSnapshot(
+  hostId: string | null,
+): WorkspaceFoldersHostBucket {
+  return selectEffectiveWorkspaceFoldersBucket(
+    useWorkspaceFoldersStore.getState(),
+    useProjectProfilesStore.getState(),
+    hostId,
+  );
+}

--- a/clients/gui-app/src/lib/workspace/header-tab-matches-project.ts
+++ b/clients/gui-app/src/lib/workspace/header-tab-matches-project.ts
@@ -163,6 +163,21 @@ export function headerTabProjectBadge(
   return { color: owner.color, name: owner.name };
 }
 
+export function historyItemProjectBadge(
+  activeProfile: ProjectProfile | null,
+  profiles: ReadonlyArray<ProjectProfile>,
+  item: Pick<HistoryItem, "epicId" | "worktreePaths" | "linkedWorkspaces">,
+): { readonly color: ProjectProfile["color"]; readonly name: string } | null {
+  return headerTabProjectBadge(
+    activeProfile,
+    resolveOwningProjectProfile(
+      profiles,
+      item.epicId,
+      workspaceHintFromHistoryItem(item),
+    ),
+  );
+}
+
 export function filterHeaderStripItemIdsForProject(input: {
   readonly itemIds: ReadonlyArray<string>;
   readonly items: ReadonlyArray<StripItem>;

--- a/clients/gui-app/src/lib/workspace/header-tab-matches-project.ts
+++ b/clients/gui-app/src/lib/workspace/header-tab-matches-project.ts
@@ -1,0 +1,141 @@
+import type { HistoryItem } from "@/components/home/data/home-page.data";
+import type { SplitSide, StripItem } from "@/stores/tabs/layout";
+import type { ProjectProfile } from "@/stores/workspace/project-profiles-store";
+import { historyItemMatchesProject } from "@/lib/workspace/history-item-matches-project";
+
+export type ProjectScopedHeaderTab =
+  | { readonly kind: "epic"; readonly epicId: string }
+  | { readonly kind: "draft" }
+  | { readonly kind: "history" }
+  | { readonly kind: "settings" };
+
+export type EpicWorkspaceHint = Pick<
+  HistoryItem,
+  "worktreePaths" | "linkedWorkspaces"
+>;
+
+export function headerTabMatchesProject(
+  tab: ProjectScopedHeaderTab,
+  profile: ProjectProfile | null,
+  hint: EpicWorkspaceHint | null,
+): boolean {
+  if (profile === null) return true;
+  if (tab.kind !== "epic") return true;
+  return historyItemMatchesProject(
+    {
+      epicId: tab.epicId,
+      worktreePaths: hint?.worktreePaths ?? [],
+      linkedWorkspaces: hint?.linkedWorkspaces ?? [],
+    },
+    profile,
+  );
+}
+
+export function filterHeaderStripItemIdsForProject(input: {
+  readonly itemIds: ReadonlyArray<string>;
+  readonly items: ReadonlyArray<StripItem>;
+  readonly profile: ProjectProfile | null;
+  readonly epicIdForTabId: (tabId: string) => string | null;
+  readonly workspaceHintForEpic: (epicId: string) => EpicWorkspaceHint | null;
+}): ReadonlyArray<string> {
+  const profile = input.profile;
+  if (profile === null) return input.itemIds;
+  const byId = new Map(input.items.map((item) => [item.id, item]));
+  return input.itemIds.filter((itemId) => {
+    const item = byId.get(itemId);
+    if (item === undefined) return true;
+    return stripItemMatchesProject(
+      item,
+      profile,
+      input.epicIdForTabId,
+      input.workspaceHintForEpic,
+    );
+  });
+}
+
+function stripItemMatchesProject(
+  item: StripItem,
+  profile: ProjectProfile,
+  epicIdForTabId: (tabId: string) => string | null,
+  workspaceHintForEpic: (epicId: string) => EpicWorkspaceHint | null,
+): boolean {
+  if (item.kind === "tab") {
+    return tabRefMatchesProject(
+      item.ref.kind,
+      item.ref.id,
+      profile,
+      epicIdForTabId,
+      workspaceHintForEpic,
+    );
+  }
+  return (
+    sideMatchesProject(
+      item.left,
+      profile,
+      epicIdForTabId,
+      workspaceHintForEpic,
+    ) &&
+    sideMatchesProject(
+      item.right,
+      profile,
+      epicIdForTabId,
+      workspaceHintForEpic,
+    )
+  );
+}
+
+function sideMatchesProject(
+  side: SplitSide,
+  profile: ProjectProfile,
+  epicIdForTabId: (tabId: string) => string | null,
+  workspaceHintForEpic: (epicId: string) => EpicWorkspaceHint | null,
+): boolean {
+  if (side.kind !== "tab") return true;
+  return tabRefMatchesProject(
+    side.ref.kind,
+    side.ref.id,
+    profile,
+    epicIdForTabId,
+    workspaceHintForEpic,
+  );
+}
+
+function tabRefMatchesProject(
+  kind: string,
+  tabId: string,
+  profile: ProjectProfile,
+  epicIdForTabId: (tabId: string) => string | null,
+  workspaceHintForEpic: (epicId: string) => EpicWorkspaceHint | null,
+): boolean {
+  if (kind !== "epic") {
+    return headerTabMatchesProject({ kind: scopedKind(kind) }, profile, null);
+  }
+  const epicId = epicIdForTabId(tabId);
+  if (epicId === null) return false;
+  return headerTabMatchesProject(
+    { kind: "epic", epicId },
+    profile,
+    workspaceHintForEpic(epicId),
+  );
+}
+
+function scopedKind(
+  kind: string,
+): Exclude<ProjectScopedHeaderTab["kind"], "epic"> {
+  if (kind === "history") return "history";
+  if (kind === "settings") return "settings";
+  return "draft";
+}
+
+export function headerTabRecordMatchesProject(
+  tab: { readonly kind: string; readonly epicId?: string },
+  profile: ProjectProfile | null,
+  hint: EpicWorkspaceHint | null,
+): boolean {
+  if (tab.kind === "epic") {
+    const epicId = tab.epicId;
+    if (epicId === undefined) return false;
+    return headerTabMatchesProject({ kind: "epic", epicId }, profile, hint);
+  }
+  return headerTabMatchesProject({ kind: scopedKind(tab.kind) }, profile, hint);
+}

--- a/clients/gui-app/src/lib/workspace/header-tab-matches-project.ts
+++ b/clients/gui-app/src/lib/workspace/header-tab-matches-project.ts
@@ -90,23 +90,47 @@ export function workspaceHintFromSnapshotFolders(
   };
 }
 
+function hintWorkspacePaths(
+  hint: EpicWorkspaceHint | null,
+): ReadonlyArray<string> {
+  if (hint === null) return [];
+  const paths: string[] = [];
+  const push = (value: string | null | undefined): void => {
+    if (value === undefined || value === null || value.length === 0) return;
+    if (paths.includes(value)) return;
+    paths.push(value);
+  };
+  push(hint.primaryPath);
+  for (const workspace of hint.linkedWorkspaces) {
+    push(workspace.workspacePath);
+  }
+  for (const worktree of hint.worktreePaths) {
+    push(worktree);
+  }
+  return paths;
+}
+
+function pathOwnedByProfile(path: string, profile: ProjectProfile): boolean {
+  return historyItemMatchesProject(
+    {
+      epicId: "",
+      linkedWorkspaces: path.includes(TRAYCER_WORKTREES_MARKER)
+        ? []
+        : [{ hostId: "", workspacePath: path }],
+      worktreePaths: path.includes(TRAYCER_WORKTREES_MARKER) ? [path] : [],
+    },
+    { ...profile, epicIds: [] },
+  );
+}
+
 function epicOwnedByProfile(
   epicId: string,
   hint: EpicWorkspaceHint | null,
   profile: ProjectProfile,
 ): boolean {
-  const primary = hintPrimaryPath(hint);
-  if (primary === null) return profile.epicIds.includes(epicId);
-  return historyItemMatchesProject(
-    {
-      epicId: "",
-      linkedWorkspaces: primary.includes(TRAYCER_WORKTREES_MARKER)
-        ? []
-        : [{ hostId: "", workspacePath: primary }],
-      worktreePaths: primary.includes(TRAYCER_WORKTREES_MARKER) ? [primary] : [],
-    },
-    { ...profile, epicIds: [] },
-  );
+  const paths = hintWorkspacePaths(hint);
+  if (paths.length === 0) return profile.epicIds.includes(epicId);
+  return paths.every((path) => pathOwnedByProfile(path, profile));
 }
 
 export function headerTabMatchesProject(

--- a/clients/gui-app/src/lib/workspace/header-tab-matches-project.ts
+++ b/clients/gui-app/src/lib/workspace/header-tab-matches-project.ts
@@ -12,7 +12,102 @@ export type ProjectScopedHeaderTab =
 export type EpicWorkspaceHint = Pick<
   HistoryItem,
   "worktreePaths" | "linkedWorkspaces"
->;
+> & {
+  readonly primaryPath?: string | null;
+};
+
+const TRAYCER_WORKTREES_MARKER = "/.traycer/worktrees/";
+
+function hintPrimaryPath(hint: EpicWorkspaceHint | null): string | null {
+  if (hint === null) return null;
+  if (typeof hint.primaryPath === "string" && hint.primaryPath.length > 0) {
+    return hint.primaryPath;
+  }
+  const linked = hint.linkedWorkspaces[0]?.workspacePath;
+  if (linked !== undefined && linked.length > 0) return linked;
+  const worktree = hint.worktreePaths[0];
+  if (worktree !== undefined && worktree.length > 0) return worktree;
+  return null;
+}
+
+export function resolveEpicWorkspaceHint(input: {
+  readonly live: EpicWorkspaceHint | null;
+  readonly stamped: EpicWorkspaceHint | null;
+}): EpicWorkspaceHint | null {
+  if (hintPrimaryPath(input.live) !== null) return input.live;
+  if (hintPrimaryPath(input.stamped) !== null) return input.stamped;
+  return null;
+}
+
+export function stampedWorkspaceHintForEpic(
+  tabsById: Readonly<
+    Record<
+      string,
+      | {
+          readonly epicId: string;
+          readonly projectWorkspace?: EpicWorkspaceHint | null;
+        }
+      | undefined
+    >
+  >,
+  epicId: string,
+): EpicWorkspaceHint | null {
+  for (const tab of Object.values(tabsById)) {
+    if (tab === undefined || tab.epicId !== epicId) continue;
+    const stamp = tab.projectWorkspace;
+    if (stamp === undefined || stamp === null) continue;
+    if (hintPrimaryPath(stamp) === null) continue;
+    return stamp;
+  }
+  return null;
+}
+
+export function workspaceHintFromHistoryItem(
+  item: Pick<HistoryItem, "linkedWorkspaces" | "worktreePaths">,
+): EpicWorkspaceHint {
+  return {
+    worktreePaths: item.worktreePaths,
+    linkedWorkspaces: item.linkedWorkspaces,
+    primaryPath:
+      item.linkedWorkspaces[0]?.workspacePath ?? item.worktreePaths[0] ?? null,
+  };
+}
+
+export function workspaceHintFromSnapshotFolders(
+  folders: ReadonlyArray<{
+    readonly hostId: string;
+    readonly workspacePath: string;
+  }>,
+): EpicWorkspaceHint | null {
+  if (folders.length === 0) return null;
+  return {
+    worktreePaths: [],
+    linkedWorkspaces: folders.map((folder) => ({
+      hostId: folder.hostId,
+      workspacePath: folder.workspacePath,
+    })),
+    primaryPath: folders[0]?.workspacePath ?? null,
+  };
+}
+
+function epicOwnedByProfile(
+  epicId: string,
+  hint: EpicWorkspaceHint | null,
+  profile: ProjectProfile,
+): boolean {
+  const primary = hintPrimaryPath(hint);
+  if (primary === null) return profile.epicIds.includes(epicId);
+  return historyItemMatchesProject(
+    {
+      epicId: "",
+      linkedWorkspaces: primary.includes(TRAYCER_WORKTREES_MARKER)
+        ? []
+        : [{ hostId: "", workspacePath: primary }],
+      worktreePaths: primary.includes(TRAYCER_WORKTREES_MARKER) ? [primary] : [],
+    },
+    { ...profile, epicIds: [] },
+  );
+}
 
 export function headerTabMatchesProject(
   tab: ProjectScopedHeaderTab,
@@ -21,14 +116,27 @@ export function headerTabMatchesProject(
 ): boolean {
   if (profile === null) return true;
   if (tab.kind !== "epic") return true;
-  return historyItemMatchesProject(
-    {
-      epicId: tab.epicId,
-      worktreePaths: hint?.worktreePaths ?? [],
-      linkedWorkspaces: hint?.linkedWorkspaces ?? [],
-    },
-    profile,
+  return epicOwnedByProfile(tab.epicId, hint, profile);
+}
+
+export function resolveOwningProjectProfile(
+  profiles: ReadonlyArray<ProjectProfile>,
+  epicId: string,
+  hint: EpicWorkspaceHint | null,
+): ProjectProfile | null {
+  const owners = profiles.filter((profile) =>
+    epicOwnedByProfile(epicId, hint, profile),
   );
+  return owners.length === 1 ? owners[0] : null;
+}
+
+export function headerTabProjectBadge(
+  activeProfile: ProjectProfile | null,
+  owner: ProjectProfile | null,
+): { readonly color: ProjectProfile["color"]; readonly name: string } | null {
+  if (activeProfile !== null) return null;
+  if (owner === null) return null;
+  return { color: owner.color, name: owner.name };
 }
 
 export function filterHeaderStripItemIdsForProject(input: {

--- a/clients/gui-app/src/lib/workspace/header-tab-matches-project.ts
+++ b/clients/gui-app/src/lib/workspace/header-tab-matches-project.ts
@@ -1,7 +1,10 @@
 import type { HistoryItem } from "@/components/home/data/home-page.data";
 import type { SplitSide, StripItem } from "@/stores/tabs/layout";
 import type { ProjectProfile } from "@/stores/workspace/project-profiles-store";
-import { historyItemMatchesProject } from "@/lib/workspace/history-item-matches-project";
+import {
+  claimedProfileIdForEpic,
+  historyItemMatchesProject,
+} from "@/lib/workspace/history-item-matches-project";
 
 export type ProjectScopedHeaderTab =
   | { readonly kind: "epic"; readonly epicId: string }
@@ -127,9 +130,12 @@ function epicOwnedByProfile(
   epicId: string,
   hint: EpicWorkspaceHint | null,
   profile: ProjectProfile,
+  profiles: ReadonlyArray<ProjectProfile>,
 ): boolean {
+  const claimedId = claimedProfileIdForEpic(profiles, epicId);
+  if (claimedId !== null) return claimedId === profile.id;
   const paths = hintWorkspacePaths(hint);
-  if (paths.length === 0) return profile.epicIds.includes(epicId);
+  if (paths.length === 0) return false;
   return paths.every((path) => pathOwnedByProfile(path, profile));
 }
 
@@ -137,10 +143,12 @@ export function headerTabMatchesProject(
   tab: ProjectScopedHeaderTab,
   profile: ProjectProfile | null,
   hint: EpicWorkspaceHint | null,
+  profiles: ReadonlyArray<ProjectProfile> = profile === null ? [] : [profile],
 ): boolean {
   if (profile === null) return true;
   if (tab.kind !== "epic") return true;
-  return epicOwnedByProfile(tab.epicId, hint, profile);
+  const list = profiles.length > 0 ? profiles : [profile];
+  return epicOwnedByProfile(tab.epicId, hint, profile, list);
 }
 
 export function resolveOwningProjectProfile(
@@ -148,8 +156,12 @@ export function resolveOwningProjectProfile(
   epicId: string,
   hint: EpicWorkspaceHint | null,
 ): ProjectProfile | null {
+  const claimedId = claimedProfileIdForEpic(profiles, epicId);
+  if (claimedId !== null) {
+    return profiles.find((profile) => profile.id === claimedId) ?? null;
+  }
   const owners = profiles.filter((profile) =>
-    epicOwnedByProfile(epicId, hint, profile),
+    epicOwnedByProfile(epicId, hint, profile, profiles),
   );
   return owners.length === 1 ? owners[0] : null;
 }
@@ -182,11 +194,13 @@ export function filterHeaderStripItemIdsForProject(input: {
   readonly itemIds: ReadonlyArray<string>;
   readonly items: ReadonlyArray<StripItem>;
   readonly profile: ProjectProfile | null;
+  readonly profiles?: ReadonlyArray<ProjectProfile>;
   readonly epicIdForTabId: (tabId: string) => string | null;
   readonly workspaceHintForEpic: (epicId: string) => EpicWorkspaceHint | null;
 }): ReadonlyArray<string> {
   const profile = input.profile;
   if (profile === null) return input.itemIds;
+  const profiles = input.profiles ?? [profile];
   const byId = new Map(input.items.map((item) => [item.id, item]));
   return input.itemIds.filter((itemId) => {
     const item = byId.get(itemId);
@@ -194,6 +208,7 @@ export function filterHeaderStripItemIdsForProject(input: {
     return stripItemMatchesProject(
       item,
       profile,
+      profiles,
       input.epicIdForTabId,
       input.workspaceHintForEpic,
     );
@@ -203,6 +218,7 @@ export function filterHeaderStripItemIdsForProject(input: {
 function stripItemMatchesProject(
   item: StripItem,
   profile: ProjectProfile,
+  profiles: ReadonlyArray<ProjectProfile>,
   epicIdForTabId: (tabId: string) => string | null,
   workspaceHintForEpic: (epicId: string) => EpicWorkspaceHint | null,
 ): boolean {
@@ -211,6 +227,7 @@ function stripItemMatchesProject(
       item.ref.kind,
       item.ref.id,
       profile,
+      profiles,
       epicIdForTabId,
       workspaceHintForEpic,
     );
@@ -219,12 +236,14 @@ function stripItemMatchesProject(
     sideMatchesProject(
       item.left,
       profile,
+      profiles,
       epicIdForTabId,
       workspaceHintForEpic,
     ) &&
     sideMatchesProject(
       item.right,
       profile,
+      profiles,
       epicIdForTabId,
       workspaceHintForEpic,
     )
@@ -234,6 +253,7 @@ function stripItemMatchesProject(
 function sideMatchesProject(
   side: SplitSide,
   profile: ProjectProfile,
+  profiles: ReadonlyArray<ProjectProfile>,
   epicIdForTabId: (tabId: string) => string | null,
   workspaceHintForEpic: (epicId: string) => EpicWorkspaceHint | null,
 ): boolean {
@@ -242,6 +262,7 @@ function sideMatchesProject(
     side.ref.kind,
     side.ref.id,
     profile,
+    profiles,
     epicIdForTabId,
     workspaceHintForEpic,
   );
@@ -251,11 +272,17 @@ function tabRefMatchesProject(
   kind: string,
   tabId: string,
   profile: ProjectProfile,
+  profiles: ReadonlyArray<ProjectProfile>,
   epicIdForTabId: (tabId: string) => string | null,
   workspaceHintForEpic: (epicId: string) => EpicWorkspaceHint | null,
 ): boolean {
   if (kind !== "epic") {
-    return headerTabMatchesProject({ kind: scopedKind(kind) }, profile, null);
+    return headerTabMatchesProject(
+      { kind: scopedKind(kind) },
+      profile,
+      null,
+      profiles,
+    );
   }
   const epicId = epicIdForTabId(tabId);
   if (epicId === null) return false;
@@ -263,6 +290,7 @@ function tabRefMatchesProject(
     { kind: "epic", epicId },
     profile,
     workspaceHintForEpic(epicId),
+    profiles,
   );
 }
 
@@ -278,11 +306,22 @@ export function headerTabRecordMatchesProject(
   tab: { readonly kind: string; readonly epicId?: string },
   profile: ProjectProfile | null,
   hint: EpicWorkspaceHint | null,
+  profiles: ReadonlyArray<ProjectProfile> = profile === null ? [] : [profile],
 ): boolean {
   if (tab.kind === "epic") {
     const epicId = tab.epicId;
     if (epicId === undefined) return false;
-    return headerTabMatchesProject({ kind: "epic", epicId }, profile, hint);
+    return headerTabMatchesProject(
+      { kind: "epic", epicId },
+      profile,
+      hint,
+      profiles,
+    );
   }
-  return headerTabMatchesProject({ kind: scopedKind(tab.kind) }, profile, hint);
+  return headerTabMatchesProject(
+    { kind: scopedKind(tab.kind) },
+    profile,
+    hint,
+    profiles,
+  );
 }

--- a/clients/gui-app/src/lib/workspace/hidden-active-tab-fallback.ts
+++ b/clients/gui-app/src/lib/workspace/hidden-active-tab-fallback.ts
@@ -1,0 +1,29 @@
+export type HiddenActiveTabFallback =
+  | { readonly kind: "keep" }
+  | { readonly kind: "activate"; readonly itemId: string }
+  | { readonly kind: "new-draft" };
+
+/**
+ * Where to send the window when the active strip item is gone or hidden.
+ *
+ * `/` is a signed-in black void (RootLandingPage returns null). Never go
+ * there when a visible tab exists — All projects after a Titanos-empty
+ * switch was landing on `/` and staying black. An empty first-run landing
+ * stays put so `/` → `/draft/new` does not double-mint.
+ */
+export function hiddenActiveTabFallback(input: {
+  readonly isLandingPage: boolean;
+  readonly activeItemId: string | null;
+  readonly visibleItemIds: ReadonlyArray<string>;
+}): HiddenActiveTabFallback {
+  const firstVisible = input.visibleItemIds[0];
+  const activeIsVisible =
+    input.activeItemId !== null &&
+    input.visibleItemIds.includes(input.activeItemId);
+  if (activeIsVisible) return { kind: "keep" };
+  if (firstVisible !== undefined) {
+    return { kind: "activate", itemId: firstVisible };
+  }
+  if (input.isLandingPage) return { kind: "keep" };
+  return { kind: "new-draft" };
+}

--- a/clients/gui-app/src/lib/workspace/history-item-matches-project.ts
+++ b/clients/gui-app/src/lib/workspace/history-item-matches-project.ts
@@ -5,40 +5,42 @@ import { workspaceFolderName } from "@/lib/worktree/workspace-folder-name";
 const TRAYCER_WORKTREES_MARKER = "/.traycer/worktrees/";
 
 /**
- * An existing chat belongs to a project when it was claimed, when one of
- * its originating workspace paths is that project's folder, or when a
- * leftover Traycer worktree was created from that folder's repo slug.
+ * An existing chat belongs to a project when every workspace path sits
+ * inside that project's folders (or a documented Traycer worktree of
+ * them). Claim wins only when there is no path. Fan-out that also
+ * touched another repo is not this project's History row.
  */
 export function historyItemMatchesProject(
   item: Pick<HistoryItem, "epicId" | "worktreePaths" | "linkedWorkspaces">,
   profile: ProjectProfile,
 ): boolean {
-  if (profile.epicIds.includes(item.epicId)) return true;
-  if (profile.folderPaths.length === 0) return false;
+  if (profile.folderPaths.length === 0) {
+    return profile.epicIds.includes(item.epicId);
+  }
   const folders = profile.folderPaths.map(normalizePathSeparators);
-  if (
-    item.linkedWorkspaces.some((workspace) =>
+  if (item.linkedWorkspaces.length > 0) {
+    return item.linkedWorkspaces.every((workspace) =>
       folders.some((folder) =>
         pathIsInsideFolder(
           normalizePathSeparators(workspace.workspacePath),
           folder,
         ),
       ),
-    )
-  ) {
-    return true;
+    );
   }
   // When the cloud row already named its folders, do not also guess from
   // worktree basenames — two checkouts named Titanos would collide.
-  if (item.linkedWorkspaces.length > 0) return false;
-  return item.worktreePaths.some((worktreePath) =>
-    folders.some((folder) =>
-      isDocumentedTraycerWorktreeOfFolder(
-        normalizePathSeparators(worktreePath),
-        folder,
+  if (item.worktreePaths.length > 0) {
+    return item.worktreePaths.every((worktreePath) =>
+      folders.some((folder) =>
+        isDocumentedTraycerWorktreeOfFolder(
+          normalizePathSeparators(worktreePath),
+          folder,
+        ),
       ),
-    ),
-  );
+    );
+  }
+  return profile.epicIds.includes(item.epicId);
 }
 
 export function filterHistoryItemsForProject<

--- a/clients/gui-app/src/lib/workspace/history-item-matches-project.ts
+++ b/clients/gui-app/src/lib/workspace/history-item-matches-project.ts
@@ -2,26 +2,47 @@ import type { HistoryItem } from "@/components/home/data/home-page.data";
 import type { ProjectProfile } from "@/stores/workspace/project-profiles-store";
 import { workspaceFolderName } from "@/lib/worktree/workspace-folder-name";
 
+const TRAYCER_WORKTREES_MARKER = "/.traycer/worktrees/";
+
 /**
- * An existing chat belongs to a project when it was claimed, or when one of
- * its worktrees is that project's folder (or a Traycer worktree of it).
- * Fan-out chats still match the project they actually touched.
+ * An existing chat belongs to a project when it was claimed, when one of
+ * its originating workspace paths is that project's folder, or when a
+ * leftover Traycer worktree was created from that folder's repo slug.
  */
 export function historyItemMatchesProject(
-  item: Pick<HistoryItem, "epicId" | "worktreePaths">,
+  item: Pick<HistoryItem, "epicId" | "worktreePaths" | "linkedWorkspaces">,
   profile: ProjectProfile,
 ): boolean {
   if (profile.epicIds.includes(item.epicId)) return true;
   if (profile.folderPaths.length === 0) return false;
+  const folders = profile.folderPaths.map(normalizePathSeparators);
+  if (
+    item.linkedWorkspaces.some((workspace) =>
+      folders.some((folder) =>
+        pathIsInsideFolder(
+          normalizePathSeparators(workspace.workspacePath),
+          folder,
+        ),
+      ),
+    )
+  ) {
+    return true;
+  }
+  // When the cloud row already named its folders, do not also guess from
+  // worktree basenames — two checkouts named Titanos would collide.
+  if (item.linkedWorkspaces.length > 0) return false;
   return item.worktreePaths.some((worktreePath) =>
-    profile.folderPaths.some((folder) =>
-      worktreeTouchesProjectFolder(worktreePath, folder),
+    folders.some((folder) =>
+      isDocumentedTraycerWorktreeOfFolder(
+        normalizePathSeparators(worktreePath),
+        folder,
+      ),
     ),
   );
 }
 
 export function filterHistoryItemsForProject<
-  T extends Pick<HistoryItem, "epicId" | "worktreePaths">,
+  T extends Pick<HistoryItem, "epicId" | "worktreePaths" | "linkedWorkspaces">,
 >(
   items: ReadonlyArray<T>,
   profile: ProjectProfile | null,
@@ -30,23 +51,27 @@ export function filterHistoryItemsForProject<
   return items.filter((item) => historyItemMatchesProject(item, profile));
 }
 
-function worktreeTouchesProjectFolder(
+function isDocumentedTraycerWorktreeOfFolder(
   worktreePath: string,
   folder: string,
 ): boolean {
   if (pathIsInsideFolder(worktreePath, folder)) return true;
-  const name = workspaceFolderName(folder).toLowerCase();
-  if (name.length === 0) return false;
+  const slug = workspaceFolderName(folder).toLowerCase();
+  if (slug.length === 0) return false;
   const haystack = worktreePath.toLowerCase();
-  return (
-    haystack.includes(`__${name}/`) ||
-    haystack.includes(`/${name}/`) ||
-    haystack.endsWith(`/${name}`)
-  );
+  const markerAt = haystack.indexOf(TRAYCER_WORKTREES_MARKER);
+  if (markerAt < 0) return false;
+  const repoSeg = haystack
+    .slice(markerAt + TRAYCER_WORKTREES_MARKER.length)
+    .split("/")[0];
+  return repoSeg.endsWith(`__${slug}`);
 }
 
 function pathIsInsideFolder(path: string, folder: string): boolean {
   if (path === folder) return true;
-  const prefix = folder.endsWith("/") ? folder : `${folder}/`;
-  return path.startsWith(prefix);
+  return path.startsWith(`${folder}/`);
+}
+
+function normalizePathSeparators(path: string): string {
+  return path.replace(/\\/g, "/").replace(/\/+$/, "");
 }

--- a/clients/gui-app/src/lib/workspace/history-item-matches-project.ts
+++ b/clients/gui-app/src/lib/workspace/history-item-matches-project.ts
@@ -4,18 +4,35 @@ import { workspaceFolderName } from "@/lib/worktree/workspace-folder-name";
 
 const TRAYCER_WORKTREES_MARKER = "/.traycer/worktrees/";
 
+export function claimedProfileIdForEpic(
+  profiles: ReadonlyArray<ProjectProfile>,
+  epicId: string,
+): string | null {
+  let claimed: string | null = null;
+  for (const profile of profiles) {
+    if (!profile.epicIds.includes(epicId)) continue;
+    if (claimed !== null && claimed !== profile.id) return claimed;
+    claimed = profile.id;
+  }
+  return claimed;
+}
+
 /**
  * An existing chat belongs to a project when every workspace path sits
  * inside that project's folders (or a documented Traycer worktree of
- * them). Claim wins only when there is no path. Fan-out that also
- * touched another repo is not this project's History row.
+ * them). An explicit Move-to-project claim wins over path matching.
+ * Fan-out that also touched another repo is not this project's History
+ * row unless the user claimed it.
  */
 export function historyItemMatchesProject(
   item: Pick<HistoryItem, "epicId" | "worktreePaths" | "linkedWorkspaces">,
   profile: ProjectProfile,
+  profiles: ReadonlyArray<ProjectProfile> = [profile],
 ): boolean {
+  const claimedId = claimedProfileIdForEpic(profiles, item.epicId);
+  if (claimedId !== null) return claimedId === profile.id;
   if (profile.folderPaths.length === 0) {
-    return profile.epicIds.includes(item.epicId);
+    return false;
   }
   const folders = profile.folderPaths.map(normalizePathSeparators);
   if (item.linkedWorkspaces.length > 0) {
@@ -40,7 +57,7 @@ export function historyItemMatchesProject(
       ),
     );
   }
-  return profile.epicIds.includes(item.epicId);
+  return false;
 }
 
 export function filterHistoryItemsForProject<
@@ -48,9 +65,12 @@ export function filterHistoryItemsForProject<
 >(
   items: ReadonlyArray<T>,
   profile: ProjectProfile | null,
+  profiles: ReadonlyArray<ProjectProfile> = profile === null ? [] : [profile],
 ): ReadonlyArray<T> {
   if (profile === null) return items;
-  return items.filter((item) => historyItemMatchesProject(item, profile));
+  return items.filter((item) =>
+    historyItemMatchesProject(item, profile, profiles),
+  );
 }
 
 export type HistoryListEmptyState =

--- a/clients/gui-app/src/lib/workspace/history-item-matches-project.ts
+++ b/clients/gui-app/src/lib/workspace/history-item-matches-project.ts
@@ -73,5 +73,13 @@ function pathIsInsideFolder(path: string, folder: string): boolean {
 }
 
 function normalizePathSeparators(path: string): string {
-  return path.replace(/\\/g, "/").replace(/\/+$/, "");
+  const withSlashes = path.replace(/\\/g, "/").replace(/\/+$/, "");
+  if (isWindowsDrivePath(withSlashes)) {
+    return withSlashes.toLowerCase();
+  }
+  return withSlashes;
+}
+
+function isWindowsDrivePath(path: string): boolean {
+  return /^[A-Za-z]:(?:\/|$)/.test(path);
 }

--- a/clients/gui-app/src/lib/workspace/history-item-matches-project.ts
+++ b/clients/gui-app/src/lib/workspace/history-item-matches-project.ts
@@ -51,6 +51,31 @@ export function filterHistoryItemsForProject<
   return items.filter((item) => historyItemMatchesProject(item, profile));
 }
 
+export type HistoryListEmptyState =
+  | "no-tasks"
+  | "no-filter-matches"
+  | "hidden-by-active-project";
+
+/**
+ * Which empty copy the history list shows. When a project profile hides every
+ * row while chats still exist outside it, the list must say so - the plain
+ * "No tasks yet" copy reads as if the chats were deleted. `preProjectFilterCount`
+ * is the list size BEFORE the project filter (search filters still applied),
+ * so a search that matches only outside the project also gets the project copy.
+ */
+export function historyListEmptyState(input: {
+  readonly visibleCount: number;
+  readonly preProjectFilterCount: number;
+  readonly hasActiveFilters: boolean;
+  readonly projectFilterActive: boolean;
+}): HistoryListEmptyState | null {
+  if (input.visibleCount > 0) return null;
+  if (input.projectFilterActive && input.preProjectFilterCount > 0) {
+    return "hidden-by-active-project";
+  }
+  return input.hasActiveFilters ? "no-filter-matches" : "no-tasks";
+}
+
 function isDocumentedTraycerWorktreeOfFolder(
   worktreePath: string,
   folder: string,

--- a/clients/gui-app/src/lib/workspace/history-item-matches-project.ts
+++ b/clients/gui-app/src/lib/workspace/history-item-matches-project.ts
@@ -101,12 +101,20 @@ function pathIsInsideFolder(path: string, folder: string): boolean {
 
 function normalizePathSeparators(path: string): string {
   const withSlashes = path.replace(/\\/g, "/").replace(/\/+$/, "");
-  if (isWindowsDrivePath(withSlashes)) {
+  if (isCaseInsensitiveWindowsPath(withSlashes)) {
     return withSlashes.toLowerCase();
   }
   return withSlashes;
 }
 
+function isCaseInsensitiveWindowsPath(path: string): boolean {
+  return isWindowsDrivePath(path) || isWindowsUncPath(path);
+}
+
 function isWindowsDrivePath(path: string): boolean {
   return /^[A-Za-z]:(?:\/|$)/.test(path);
+}
+
+function isWindowsUncPath(path: string): boolean {
+  return /^\/\/[^/]+/.test(path);
 }

--- a/clients/gui-app/src/lib/workspace/history-item-matches-project.ts
+++ b/clients/gui-app/src/lib/workspace/history-item-matches-project.ts
@@ -1,0 +1,52 @@
+import type { HistoryItem } from "@/components/home/data/home-page.data";
+import type { ProjectProfile } from "@/stores/workspace/project-profiles-store";
+import { workspaceFolderName } from "@/lib/worktree/workspace-folder-name";
+
+/**
+ * An existing chat belongs to a project when it was claimed, or when one of
+ * its worktrees is that project's folder (or a Traycer worktree of it).
+ * Fan-out chats still match the project they actually touched.
+ */
+export function historyItemMatchesProject(
+  item: Pick<HistoryItem, "epicId" | "worktreePaths">,
+  profile: ProjectProfile,
+): boolean {
+  if (profile.epicIds.includes(item.epicId)) return true;
+  if (profile.folderPaths.length === 0) return false;
+  return item.worktreePaths.some((worktreePath) =>
+    profile.folderPaths.some((folder) =>
+      worktreeTouchesProjectFolder(worktreePath, folder),
+    ),
+  );
+}
+
+export function filterHistoryItemsForProject<
+  T extends Pick<HistoryItem, "epicId" | "worktreePaths">,
+>(
+  items: ReadonlyArray<T>,
+  profile: ProjectProfile | null,
+): ReadonlyArray<T> {
+  if (profile === null) return items;
+  return items.filter((item) => historyItemMatchesProject(item, profile));
+}
+
+function worktreeTouchesProjectFolder(
+  worktreePath: string,
+  folder: string,
+): boolean {
+  if (pathIsInsideFolder(worktreePath, folder)) return true;
+  const name = workspaceFolderName(folder).toLowerCase();
+  if (name.length === 0) return false;
+  const haystack = worktreePath.toLowerCase();
+  return (
+    haystack.includes(`__${name}/`) ||
+    haystack.includes(`/${name}/`) ||
+    haystack.endsWith(`/${name}`)
+  );
+}
+
+function pathIsInsideFolder(path: string, folder: string): boolean {
+  if (path === folder) return true;
+  const prefix = folder.endsWith("/") ? folder : `${folder}/`;
+  return path.startsWith(prefix);
+}

--- a/clients/gui-app/src/lib/workspace/new-conversation-workspace-seed.ts
+++ b/clients/gui-app/src/lib/workspace/new-conversation-workspace-seed.ts
@@ -1,0 +1,65 @@
+import type { ResolvedWorkspaceFolder } from "@traycer/protocol/host/epic/snapshot-meta";
+import type { LandingDraftWorkspaceSnapshot } from "@/stores/home/landing-draft-store";
+import { emptyLandingDraftWorkspaceSnapshot } from "@/stores/home/landing-draft-store";
+import type { WorkspaceFolderInfo } from "@/stores/workspace/workspace-folders-store";
+import { workspaceFolderName } from "@/lib/worktree/workspace-folder-name";
+
+/**
+ * The new-conversation modal's workspace seed for an EXISTING epic. The
+ * fallback chain is deliberately closed over in-epic sources only:
+ *
+ * 1. The latest conversation's own seed (its binding / staged intent), when
+ *    the caller resolved one.
+ * 2. The epic's stored workspace folders (`snapshotMeta.workspaceFolders`,
+ *    resolved to on-disk checkouts by the serving host) that live on the
+ *    host the conversation will be created on. This mirrors the host's own
+ *    send-time fallback (`deriveProviderDirectories` falls back to the epic
+ *    workspace context when a chat carries no binding), so the modal seeds
+ *    the same folders the created chat would run against.
+ * 3. Empty folders. A folderless epic submits with a `null` intent and the
+ *    host runs it folderless - the modal never invents one.
+ *
+ * The active-project overlay (`selectEffectiveWorkspaceFoldersBucket`) is
+ * NOT a tier here: it answers "which folders does the user have selected
+ * right now", which is the landing/new-epic question. For an existing epic
+ * it would silently re-home the new conversation into whatever project the
+ * header switcher last selected (e.g. a CRM epic's chat born in Titanos).
+ *
+ * A null `hostId` (no active host resolved yet) matches no folders: the
+ * paths are stamped with the host that resolved them, so without a create
+ * host their on-disk validity cannot be established - and submit bails
+ * hostless anyway. The hook reseeds once the host arrives.
+ */
+export function resolveNewConversationWorkspaceSeed(args: {
+  readonly latestWorkspace: LandingDraftWorkspaceSnapshot | null;
+  readonly epicWorkspaceFolders: readonly ResolvedWorkspaceFolder[];
+  readonly hostId: string | null;
+}): LandingDraftWorkspaceSnapshot {
+  if (args.latestWorkspace !== null) return args.latestWorkspace;
+  const folders =
+    args.hostId === null
+      ? []
+      : args.epicWorkspaceFolders.filter(
+          (folder) => folder.hostId === args.hostId,
+        );
+  if (folders.length === 0) return emptyLandingDraftWorkspaceSnapshot();
+  const folderInfoByPath = folders.reduce<Record<string, WorkspaceFolderInfo>>(
+    (accumulator, folder) => ({
+      ...accumulator,
+      [folder.workspacePath]: {
+        path: folder.workspacePath,
+        name: workspaceFolderName(folder.workspacePath),
+        repoIdentifier: folder.repoIdentifier,
+        hostId: folder.hostId,
+      },
+    }),
+    {},
+  );
+  return {
+    folders: folders.map((folder) => folder.workspacePath),
+    folderInfoByPath,
+    // The stored set carries no primary marker; first entry wins, matching
+    // `buildForkWorkspaceSeedFromWorkspaceFolders`'s convention.
+    primaryPath: folders[0].workspacePath,
+  };
+}

--- a/clients/gui-app/src/lib/workspace/next-active-profile-after-delete.ts
+++ b/clients/gui-app/src/lib/workspace/next-active-profile-after-delete.ts
@@ -1,0 +1,29 @@
+import type { ProjectProfile } from "@/stores/workspace/project-profiles-store";
+
+export function nextActiveProfileIdAfterDelete(input: {
+  readonly profiles: ReadonlyArray<Pick<ProjectProfile, "id">>;
+  readonly activeProfileId: string | null;
+  readonly deletedProfileId: string;
+}): string | null {
+  const remaining = input.profiles.filter(
+    (profile) => profile.id !== input.deletedProfileId,
+  );
+  if (remaining.length === 0) return null;
+  if (
+    input.activeProfileId !== null &&
+    input.activeProfileId !== input.deletedProfileId &&
+    remaining.some((profile) => profile.id === input.activeProfileId)
+  ) {
+    return input.activeProfileId;
+  }
+  const deletedIndex = input.profiles.findIndex(
+    (profile) => profile.id === input.deletedProfileId,
+  );
+  const nextByIndex =
+    deletedIndex >= 0 && deletedIndex < remaining.length
+      ? remaining[deletedIndex]
+      : undefined;
+  if (nextByIndex !== undefined) return nextByIndex.id;
+  const last = remaining[remaining.length - 1];
+  return last === undefined ? null : last.id;
+}

--- a/clients/gui-app/src/lib/workspace/project-profile-seed.ts
+++ b/clients/gui-app/src/lib/workspace/project-profile-seed.ts
@@ -35,9 +35,19 @@ export function folderSeedForNewProfile(
   const chosen =
     projectFolderPath !== null && catalog.folders.includes(projectFolderPath)
       ? projectFolderPath
-      : resolvePrimaryPath(catalog.folders, catalog.primaryPath);
+      : null;
   if (chosen === null) {
     return { folderPaths: [], primaryPath: null };
   }
   return { folderPaths: [chosen], primaryPath: chosen };
+}
+
+export function canConfirmNewProject(input: {
+  readonly name: string;
+  readonly seed: ProjectProfileSeed;
+  readonly pickedFolder: string | null;
+}): boolean {
+  if (input.name.trim().length === 0) return false;
+  if (input.seed === "folder" && input.pickedFolder === null) return false;
+  return true;
 }

--- a/clients/gui-app/src/lib/workspace/project-profile-seed.ts
+++ b/clients/gui-app/src/lib/workspace/project-profile-seed.ts
@@ -1,0 +1,36 @@
+import type { WorkspaceFoldersHostBucket } from "@/stores/workspace/workspace-folders-store";
+import { resolvePrimaryPath } from "@/lib/worktree/resolve-primary-path";
+
+export const PROJECT_PROFILE_SEEDS = ["primary", "all", "empty"] as const;
+
+export type ProjectProfileSeed = (typeof PROJECT_PROFILE_SEEDS)[number];
+
+export interface ProjectProfileFolderSeed {
+  readonly folderPaths: ReadonlyArray<string>;
+  readonly primaryPath: string | null;
+}
+
+/**
+ * What a new profile should own. `primary` is the isolation default: one
+ * folder, the one the picker already treats as primary. `all` copies the
+ * current multi-repo set. `empty` starts with no folders.
+ */
+export function folderSeedForNewProfile(
+  catalog: WorkspaceFoldersHostBucket,
+  seed: ProjectProfileSeed,
+): ProjectProfileFolderSeed {
+  if (seed === "empty" || catalog.folders.length === 0) {
+    return { folderPaths: [], primaryPath: null };
+  }
+  if (seed === "all") {
+    return {
+      folderPaths: [...catalog.folders],
+      primaryPath: resolvePrimaryPath(catalog.folders, catalog.primaryPath),
+    };
+  }
+  const primary = resolvePrimaryPath(catalog.folders, catalog.primaryPath);
+  if (primary === null) {
+    return { folderPaths: [], primaryPath: null };
+  }
+  return { folderPaths: [primary], primaryPath: primary };
+}

--- a/clients/gui-app/src/lib/workspace/project-profile-seed.ts
+++ b/clients/gui-app/src/lib/workspace/project-profile-seed.ts
@@ -1,7 +1,7 @@
 import type { WorkspaceFoldersHostBucket } from "@/stores/workspace/workspace-folders-store";
 import { resolvePrimaryPath } from "@/lib/worktree/resolve-primary-path";
 
-export const PROJECT_PROFILE_SEEDS = ["primary", "all", "empty"] as const;
+export const PROJECT_PROFILE_SEEDS = ["folder", "all", "empty"] as const;
 
 export type ProjectProfileSeed = (typeof PROJECT_PROFILE_SEEDS)[number];
 
@@ -11,26 +11,33 @@ export interface ProjectProfileFolderSeed {
 }
 
 /**
- * What a new profile should own. `primary` is the isolation default: one
- * folder, the one the picker already treats as primary. `all` copies the
- * current multi-repo set. `empty` starts with no folders.
+ * What a new profile should own. `folder` is one explicit project folder
+ * (that project's main). `all` copies the current multi-repo set. `empty`
+ * starts with no folders.
  */
 export function folderSeedForNewProfile(
   catalog: WorkspaceFoldersHostBucket,
   seed: ProjectProfileSeed,
+  projectFolderPath: string | null,
 ): ProjectProfileFolderSeed {
-  if (seed === "empty" || catalog.folders.length === 0) {
+  if (seed === "empty") {
     return { folderPaths: [], primaryPath: null };
   }
   if (seed === "all") {
+    if (catalog.folders.length === 0) {
+      return { folderPaths: [], primaryPath: null };
+    }
     return {
       folderPaths: [...catalog.folders],
       primaryPath: resolvePrimaryPath(catalog.folders, catalog.primaryPath),
     };
   }
-  const primary = resolvePrimaryPath(catalog.folders, catalog.primaryPath);
-  if (primary === null) {
+  const chosen =
+    projectFolderPath !== null && catalog.folders.includes(projectFolderPath)
+      ? projectFolderPath
+      : resolvePrimaryPath(catalog.folders, catalog.primaryPath);
+  if (chosen === null) {
     return { folderPaths: [], primaryPath: null };
   }
-  return { folderPaths: [primary], primaryPath: primary };
+  return { folderPaths: [chosen], primaryPath: chosen };
 }

--- a/clients/gui-app/src/lib/workspace/sync-active-profile-folders.ts
+++ b/clients/gui-app/src/lib/workspace/sync-active-profile-folders.ts
@@ -1,0 +1,38 @@
+import {
+  selectActiveProjectProfile,
+  useProjectProfilesStore,
+} from "@/stores/workspace/project-profiles-store";
+
+/**
+ * When a Project Profile is active, picker edits belong to THAT project.
+ * The host catalog stays a library: add writes metadata there, remove/primary
+ * stay on the profile so All projects and sibling profiles are not rewritten.
+ */
+export function syncActiveProfileFolders(args: {
+  readonly hostId: string | null;
+  readonly addPaths: ReadonlyArray<string>;
+  readonly removePath: string | null;
+  readonly primaryPath: string | null;
+}): void {
+  if (args.hostId === null) return;
+  const store = useProjectProfilesStore.getState();
+  const profile = selectActiveProjectProfile(store, args.hostId);
+  if (profile === null) return;
+  for (const path of args.addPaths) {
+    store.addProfileFolder(args.hostId, profile.id, path);
+  }
+  if (args.removePath !== null) {
+    store.removeProfileFolder(args.hostId, profile.id, args.removePath);
+  }
+  if (args.primaryPath !== null) {
+    store.setProfilePrimary(args.hostId, profile.id, args.primaryPath);
+  }
+}
+
+export function activeProfileOwnsPickerEdits(hostId: string | null): boolean {
+  if (hostId === null) return false;
+  return (
+    selectActiveProjectProfile(useProjectProfilesStore.getState(), hostId) !==
+    null
+  );
+}

--- a/clients/gui-app/src/lib/worktree/seeded-launch-worktree-intent.ts
+++ b/clients/gui-app/src/lib/worktree/seeded-launch-worktree-intent.ts
@@ -1,9 +1,6 @@
 import type { WorktreeIntent } from "@traycer/protocol/host/worktree-schemas";
 import type { LandingDraftWorkspaceSnapshot } from "@/stores/home/landing-draft-store";
-import {
-  selectWorkspaceFoldersBucket,
-  useWorkspaceFoldersStore,
-} from "@/stores/workspace/workspace-folders-store";
+import { readEffectiveWorkspaceSnapshot } from "@/lib/workspace/effective-workspace-folders";
 import {
   readStagedWorktreeIntent,
   type WorktreeStagingKey,
@@ -55,10 +52,7 @@ export function readSeededLaunchWorkspace(args: {
 function readGlobalWorkspaceSnapshot(
   hostId: string | null,
 ): LandingDraftWorkspaceSnapshot {
-  const bucket = selectWorkspaceFoldersBucket(
-    useWorkspaceFoldersStore.getState(),
-    hostId,
-  );
+  const bucket = readEffectiveWorkspaceSnapshot(hostId);
   return {
     folders: bucket.folders,
     folderInfoByPath: bucket.folderInfoByPath,

--- a/clients/gui-app/src/stores/epics/canvas/__tests__/canvas-persistence-surface-mode.test.ts
+++ b/clients/gui-app/src/stores/epics/canvas/__tests__/canvas-persistence-surface-mode.test.ts
@@ -24,4 +24,36 @@ describe("canvas Phase-migration persistence", () => {
       phaseId: "phase-1",
     });
   });
+
+  it("restores the persisted project workspace stamp on an epic tab", () => {
+    const state = sanitizePersistedCanvasState({
+      tabsById: {
+        "epic-tab": {
+          tabId: "epic-tab",
+          epicId: "epic-1",
+          name: "Issue 1180",
+          projectWorkspace: {
+            primaryPath: "/Users/g/work/Titanos",
+            linkedWorkspaces: [
+              { hostId: "host-a", workspacePath: "/Users/g/work/Titanos" },
+            ],
+            worktreePaths: [],
+          },
+        },
+      },
+      canvasByTabId: {},
+      openTabOrder: ["epic-tab"],
+      activeTabId: "epic-tab",
+      mostRecentTabIdByEpicId: { "epic-1": "epic-tab" },
+      artifactTreeByEpicId: {},
+    });
+
+    expect(state.tabsById["epic-tab"]?.projectWorkspace).toEqual({
+      primaryPath: "/Users/g/work/Titanos",
+      linkedWorkspaces: [
+        { hostId: "host-a", workspacePath: "/Users/g/work/Titanos" },
+      ],
+      worktreePaths: [],
+    });
+  });
 });

--- a/clients/gui-app/src/stores/epics/canvas/__tests__/store.test.ts
+++ b/clients/gui-app/src/stores/epics/canvas/__tests__/store.test.ts
@@ -387,6 +387,32 @@ describe("epic canvas store header tabs", () => {
     expect(state.canvasByTabId["tab-invalid"]).toEqual(createEmptyCanvas());
   });
 
+  it("stamps project workspace onto existing and newly opened epic tabs", () => {
+    const store = useEpicCanvasStore.getState();
+    const tabId = store.openEpicTab("epic-titanos", "Titanos chat");
+    store.stampEpicWorkspaceHint("epic-titanos", {
+      worktreePaths: [],
+      linkedWorkspaces: [
+        { hostId: "host-a", workspacePath: "/Users/g/work/Titanos" },
+      ],
+      primaryPath: "/Users/g/work/Titanos",
+    });
+    expect(
+      useEpicCanvasStore.getState().tabsById[tabId]?.projectWorkspace,
+    ).toEqual({
+      primaryPath: "/Users/g/work/Titanos",
+      linkedWorkspaces: [
+        { hostId: "host-a", workspacePath: "/Users/g/work/Titanos" },
+      ],
+      worktreePaths: [],
+    });
+    const nextId = store.openEpicTab("epic-titanos", "Titanos chat 2");
+    expect(
+      useEpicCanvasStore.getState().tabsById[nextId]?.projectWorkspace
+        ?.primaryPath,
+    ).toBe("/Users/g/work/Titanos");
+  });
+
   it("persists pane activation history through canvasByTabId local storage", async () => {
     const store = useEpicCanvasStore.getState();
     const tabId = store.openEpicTab("epic-history", "History");

--- a/clients/gui-app/src/stores/epics/canvas/canvas-persistence.ts
+++ b/clients/gui-app/src/stores/epics/canvas/canvas-persistence.ts
@@ -118,12 +118,62 @@ function parsePersistedEpicViewTab(value: unknown): EpicViewTab | null {
   // `lastSeenAt` in persisted data is ignored - the field was removed (it was
   // write-only; restore ordering uses `mostRecentTabIdByEpicId`).
   const surfaceMode = parsePersistedSurfaceMode(value.surfaceMode);
+  const projectWorkspace = parsePersistedProjectWorkspace(
+    value.projectWorkspace,
+  );
   return {
     tabId: value.tabId,
     epicId: value.epicId,
     name: value.name,
     ...(surfaceMode === undefined ? {} : { surfaceMode }),
+    ...(projectWorkspace === undefined ? {} : { projectWorkspace }),
   };
+}
+
+function parsePersistedProjectWorkspace(
+  value: unknown,
+): EpicViewTab["projectWorkspace"] {
+  if (!isRecord(value)) return undefined;
+  const primaryPath =
+    typeof value.primaryPath === "string" && value.primaryPath.length > 0
+      ? value.primaryPath
+      : null;
+  const linkedWorkspaces = parsePersistedLinkedWorkspaces(
+    value.linkedWorkspaces,
+  );
+  const worktreePaths = parsePersistedPathList(value.worktreePaths);
+  if (
+    primaryPath === null &&
+    linkedWorkspaces.length === 0 &&
+    worktreePaths.length === 0
+  ) {
+    return undefined;
+  }
+  return { primaryPath, linkedWorkspaces, worktreePaths };
+}
+
+function parsePersistedLinkedWorkspaces(
+  value: unknown,
+): NonNullable<EpicViewTab["projectWorkspace"]>["linkedWorkspaces"] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((entry) => {
+    if (!isRecord(entry)) return [];
+    if (
+      typeof entry.hostId !== "string" ||
+      typeof entry.workspacePath !== "string" ||
+      entry.workspacePath.length === 0
+    ) {
+      return [];
+    }
+    return [{ hostId: entry.hostId, workspacePath: entry.workspacePath }];
+  });
+}
+
+function parsePersistedPathList(value: unknown): ReadonlyArray<string> {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((entry) =>
+    typeof entry === "string" && entry.length > 0 ? [entry] : [],
+  );
 }
 
 function parsePersistedSurfaceMode(value: unknown): EpicViewTab["surfaceMode"] {

--- a/clients/gui-app/src/stores/epics/canvas/store.ts
+++ b/clients/gui-app/src/stores/epics/canvas/store.ts
@@ -28,6 +28,7 @@ import {
   type NestedFocusTarget,
 } from "@/lib/epic-nested-focus-route";
 import { UNTITLED_EPIC_TITLE } from "@/lib/display-title";
+import type { EpicWorkspaceHint } from "@/lib/workspace/header-tab-matches-project";
 import { createEpicName } from "@/lib/epic-name";
 import {
   Analytics,
@@ -111,6 +112,7 @@ import {
   type EpicCanvasTileRef,
   type EpicCanvasState,
   type CommGraphTileViewState,
+  type EpicTabProjectWorkspace,
   type EpicViewTab,
   type GitDiffTileViewState,
   type PrDiffTileViewState,
@@ -393,6 +395,14 @@ export interface EpicCanvasStore {
    */
   setActiveTab: (tabId: string) => void;
   renameTab: (tabId: string, name: string) => void;
+  /**
+   * Stamp owner folders on every tab of this epic so project-profile filtering
+   * survives a cold session / app restart.
+   */
+  stampEpicWorkspaceHint: (
+    epicId: string,
+    hint: EpicWorkspaceHint,
+  ) => void;
   /**
    * Permanently delete a tab record and its canvas state. This is for true
    * discard flows such as moving a tab to another desktop window or rejecting
@@ -856,8 +866,50 @@ export function resolveTabIdForPhaseMigration(
 function createEpicViewTab(
   epicId: string,
   name: string | undefined,
+  tabsById: Readonly<Record<string, EpicViewTab | undefined>>,
 ): EpicViewTab {
-  return { tabId: uuidv4(), epicId, name: name ?? UNTITLED_EPIC_TITLE };
+  return withEpicWorkspaceStamp(
+    { tabId: uuidv4(), epicId, name: name ?? UNTITLED_EPIC_TITLE },
+    tabsById,
+  );
+}
+
+const pendingEpicWorkspaceHints = new Map<string, EpicTabProjectWorkspace>();
+
+function withEpicWorkspaceStamp(
+  tab: EpicViewTab,
+  tabsById: Readonly<Record<string, EpicViewTab | undefined>>,
+): EpicViewTab {
+  if (tab.projectWorkspace !== undefined) return tab;
+  const pending = pendingEpicWorkspaceHints.get(tab.epicId);
+  if (pending !== undefined) return { ...tab, projectWorkspace: pending };
+  for (const existing of Object.values(tabsById)) {
+    if (existing === undefined || existing.epicId !== tab.epicId) continue;
+    if (existing.projectWorkspace === undefined) continue;
+    return { ...tab, projectWorkspace: existing.projectWorkspace };
+  }
+  return tab;
+}
+
+function toProjectWorkspaceStamp(
+  hint: EpicWorkspaceHint,
+): EpicTabProjectWorkspace {
+  return {
+    primaryPath:
+      hint.primaryPath ??
+      hint.linkedWorkspaces[0]?.workspacePath ??
+      hint.worktreePaths[0] ??
+      null,
+    linkedWorkspaces: hint.linkedWorkspaces,
+    worktreePaths: hint.worktreePaths,
+  };
+}
+
+function workspaceStampsMatch(
+  left: EpicTabProjectWorkspace | undefined,
+  right: EpicTabProjectWorkspace,
+): boolean {
+  return (left?.primaryPath ?? null) === (right.primaryPath ?? null);
 }
 
 /**
@@ -1389,7 +1441,7 @@ export const useEpicCanvasStore = create<EpicCanvasStore>()(
         pendingChatTitles: {},
 
         openEpicTab: (epicId, name) => {
-          const tab = createEpicViewTab(epicId, name);
+          const tab = createEpicViewTab(epicId, name, get().tabsById);
           set((state) => ({
             ...appendedEpicTabState(state, tab),
             activeTabId: tab.tabId,
@@ -1408,11 +1460,14 @@ export const useEpicCanvasStore = create<EpicCanvasStore>()(
             get().setActiveTab(tabId);
             return tabId;
           }
-          const tab: EpicViewTab = {
-            tabId,
-            epicId,
-            name: name ?? UNTITLED_EPIC_TITLE,
-          };
+          const tab = withEpicWorkspaceStamp(
+            {
+              tabId,
+              epicId,
+              name: name ?? UNTITLED_EPIC_TITLE,
+            },
+            get().tabsById,
+          );
           set((state) => ({
             ...appendedEpicTabState(state, tab),
             activeTabId: tab.tabId,
@@ -1455,7 +1510,7 @@ export const useEpicCanvasStore = create<EpicCanvasStore>()(
             );
             return existing;
           }
-          const tab = createEpicViewTab(epicId, name);
+          const tab = createEpicViewTab(epicId, name, get().tabsById);
           // activeTabId is intentionally left untouched - the tab opens behind
           // the current surface and never steals focus.
           set((current) => appendedEpicTabState(current, tab));
@@ -1608,11 +1663,17 @@ export const useEpicCanvasStore = create<EpicCanvasStore>()(
           const siblingNames = epicTabNames(state.tabsById, source.epicId);
           const sourceCanvas =
             state.canvasByTabId[tabId] ?? createEmptyCanvas();
-          const newTab: EpicViewTab = {
-            tabId: newId,
-            epicId: source.epicId,
-            name: nextCopyName(source.name, siblingNames),
-          };
+          const newTab = withEpicWorkspaceStamp(
+            {
+              tabId: newId,
+              epicId: source.epicId,
+              name: nextCopyName(source.name, siblingNames),
+              ...(source.projectWorkspace === undefined
+                ? {}
+                : { projectWorkspace: source.projectWorkspace }),
+            },
+            state.tabsById,
+          );
           set((current) => {
             const insertAt = current.openTabOrder.indexOf(tabId) + 1;
             return {
@@ -1647,11 +1708,14 @@ export const useEpicCanvasStore = create<EpicCanvasStore>()(
             sourceTab === null
               ? node.name
               : nextCopyName(sourceTab.name, siblingNames);
-          const tab: EpicViewTab = {
-            tabId,
-            epicId,
-            name: tabName,
-          };
+          const tab = withEpicWorkspaceStamp(
+            {
+              tabId,
+              epicId,
+              name: tabName,
+            },
+            state.tabsById,
+          );
           set((current) => {
             const insertAt =
               insertIndex === null
@@ -1801,6 +1865,24 @@ export const useEpicCanvasStore = create<EpicCanvasStore>()(
                 [tabId]: { ...tab, name: trimmed },
               },
             };
+          });
+        },
+
+        stampEpicWorkspaceHint: (epicId, hint) => {
+          const stamp = toProjectWorkspaceStamp(hint);
+          pendingEpicWorkspaceHints.set(epicId, stamp);
+          set((state) => {
+            let changed = false;
+            const tabsById: Record<string, EpicViewTab | undefined> = {
+              ...state.tabsById,
+            };
+            for (const [tabId, tab] of Object.entries(state.tabsById)) {
+              if (tab === undefined || tab.epicId !== epicId) continue;
+              if (workspaceStampsMatch(tab.projectWorkspace, stamp)) continue;
+              tabsById[tabId] = { ...tab, projectWorkspace: stamp };
+              changed = true;
+            }
+            return changed ? { tabsById } : state;
           });
         },
 

--- a/clients/gui-app/src/stores/epics/canvas/types.ts
+++ b/clients/gui-app/src/stores/epics/canvas/types.ts
@@ -692,6 +692,15 @@ export interface EpicCanvasState {
  * - header-strip / command-palette consumers that read only tab metadata must
  * not re-render on every tile open/switch.
  */
+export interface EpicTabProjectWorkspace {
+  readonly primaryPath: string | null;
+  readonly linkedWorkspaces: ReadonlyArray<{
+    readonly hostId: string;
+    readonly workspacePath: string;
+  }>;
+  readonly worktreePaths: ReadonlyArray<string>;
+}
+
 export interface EpicViewTab {
   readonly tabId: string;
   readonly epicId: string;
@@ -699,4 +708,9 @@ export interface EpicViewTab {
   readonly surfaceMode?:
     | { readonly kind: "epic" }
     | { readonly kind: "phase-migration"; readonly phaseId: string };
+  /**
+   * Durable owner folders for project-profile tab filtering. Survives a cold
+   * session / restart because the live registry peek is not persisted.
+   */
+  readonly projectWorkspace?: EpicTabProjectWorkspace;
 }

--- a/clients/gui-app/src/stores/home/__tests__/landing-draft-store.test.ts
+++ b/clients/gui-app/src/stores/home/__tests__/landing-draft-store.test.ts
@@ -65,6 +65,7 @@ import {
   useWorkspaceFoldersStore,
   type WorkspaceFolderInfo,
 } from "@/stores/workspace/workspace-folders-store";
+import { useProjectProfilesStore } from "@/stores/workspace/project-profiles-store";
 import { useSettingsStore } from "@/stores/settings/settings-store";
 import type {
   DesktopJsonValue,
@@ -130,6 +131,7 @@ function resetStore(): void {
     activeDraftId: null,
   });
   useWorkspaceFoldersStore.setState({ byHost: {} });
+  useProjectProfilesStore.setState({ byHost: {} });
   useSettingsStore.setState({
     composerMode: "chat",
   });
@@ -461,6 +463,78 @@ describe("useLandingDraftStore", () => {
     expect(useLandingDraftStore.getState().activeDraftId).toBe(preMintedId);
     expect(useLandingDraftStore.getState().drafts).toHaveLength(1);
     expect(useLandingDraftStore.getState().drafts[0].id).toBe(preMintedId);
+  });
+
+  it("createDraft snapshots only the active project profile's folders", () => {
+    useWorkspaceFoldersStore.getState().addResolvedFolders(HOST_A, [
+      { ...WORKSPACE_A, hostId: HOST_A },
+      { ...WORKSPACE_B, hostId: HOST_A },
+    ]);
+    const profileId = useProjectProfilesStore.getState().createProfile(HOST_A, {
+      name: "Titanos",
+      color: "orange",
+      folderPaths: [WORKSPACE_A.path],
+      primaryPath: WORKSPACE_A.path,
+    });
+    useProjectProfilesStore.getState().setActiveProfile(HOST_A, profileId);
+
+    const id = useLandingDraftStore.getState().createDraft(null);
+    const draft = useLandingDraftStore
+      .getState()
+      .drafts.find((entry) => entry.id === id);
+    expect(draft?.workspace.folders).toEqual([WORKSPACE_A.path]);
+    expect(draft?.workspace.primaryPath).toBe(WORKSPACE_A.path);
+  });
+
+  it("replaceActiveDraftWorkspaceFromStores narrows an already-open draft", () => {
+    useWorkspaceFoldersStore.getState().addResolvedFolders(HOST_A, [
+      { ...WORKSPACE_A, hostId: HOST_A },
+      { ...WORKSPACE_B, hostId: HOST_A },
+    ]);
+    const id = useLandingDraftStore.getState().createDraft(null);
+    expect(
+      useLandingDraftStore.getState().drafts.find((entry) => entry.id === id)
+        ?.workspace.folders,
+    ).toEqual([WORKSPACE_A.path, WORKSPACE_B.path]);
+
+    const profileId = useProjectProfilesStore.getState().createProfile(HOST_A, {
+      name: "Titanos",
+      color: "orange",
+      folderPaths: [WORKSPACE_A.path],
+      primaryPath: WORKSPACE_A.path,
+    });
+    useProjectProfilesStore.getState().setActiveProfile(HOST_A, profileId);
+    useLandingDraftStore.getState().replaceActiveDraftWorkspaceFromStores();
+
+    expect(
+      useLandingDraftStore.getState().drafts.find((entry) => entry.id === id)
+        ?.workspace.folders,
+    ).toEqual([WORKSPACE_A.path]);
+  });
+
+  it("replaceActiveDraftWorkspaceFromStores mints a draft when none is active", () => {
+    useWorkspaceFoldersStore.getState().addResolvedFolders(HOST_A, [
+      { ...WORKSPACE_A, hostId: HOST_A },
+      { ...WORKSPACE_B, hostId: HOST_A },
+    ]);
+    const profileId = useProjectProfilesStore.getState().createProfile(HOST_A, {
+      name: "Titanos",
+      color: "orange",
+      folderPaths: [WORKSPACE_A.path],
+      primaryPath: WORKSPACE_A.path,
+    });
+    useProjectProfilesStore.getState().setActiveProfile(HOST_A, profileId);
+    expect(useLandingDraftStore.getState().activeDraftId).toBeNull();
+
+    useLandingDraftStore.getState().replaceActiveDraftWorkspaceFromStores();
+
+    const activeId = useLandingDraftStore.getState().activeDraftId;
+    expect(activeId).not.toBeNull();
+    expect(
+      useLandingDraftStore
+        .getState()
+        .drafts.find((entry) => entry.id === activeId)?.workspace.folders,
+    ).toEqual([WORKSPACE_A.path]);
   });
 
   it("setDraftContent stores content on the target draft and bails on no-op writes", () => {

--- a/clients/gui-app/src/stores/home/__tests__/landing-draft-store.test.ts
+++ b/clients/gui-app/src/stores/home/__tests__/landing-draft-store.test.ts
@@ -512,7 +512,7 @@ describe("useLandingDraftStore", () => {
     ).toEqual([WORKSPACE_A.path]);
   });
 
-  it("replaceActiveDraftWorkspaceFromStores mints a draft when none is active", () => {
+  it("replaceActiveDraftWorkspaceFromStores does not mint a Start Page when none is active", () => {
     useWorkspaceFoldersStore.getState().addResolvedFolders(HOST_A, [
       { ...WORKSPACE_A, hostId: HOST_A },
       { ...WORKSPACE_B, hostId: HOST_A },
@@ -528,13 +528,8 @@ describe("useLandingDraftStore", () => {
 
     useLandingDraftStore.getState().replaceActiveDraftWorkspaceFromStores();
 
-    const activeId = useLandingDraftStore.getState().activeDraftId;
-    expect(activeId).not.toBeNull();
-    expect(
-      useLandingDraftStore
-        .getState()
-        .drafts.find((entry) => entry.id === activeId)?.workspace.folders,
-    ).toEqual([WORKSPACE_A.path]);
+    expect(useLandingDraftStore.getState().activeDraftId).toBeNull();
+    expect(useLandingDraftStore.getState().drafts).toEqual([]);
   });
 
   it("setDraftContent stores content on the target draft and bails on no-op writes", () => {

--- a/clients/gui-app/src/stores/home/landing-draft-store.ts
+++ b/clients/gui-app/src/stores/home/landing-draft-store.ts
@@ -14,10 +14,11 @@ import { extractPlainTextFromComposerJSONContent } from "@/lib/composer/tiptap-j
 import { isMobileApp } from "@/lib/mobile-app";
 import type { DraftSelection } from "@/stores/composer/composer-draft-store";
 import {
-  selectWorkspaceFoldersBucket,
   useWorkspaceFoldersStore,
 } from "@/stores/workspace/workspace-folders-store";
 import { activeHostIdOrNull } from "@/lib/host/runtime";
+import { useProjectProfilesStore } from "@/stores/workspace/project-profiles-store";
+import { selectEffectiveWorkspaceFoldersBucket } from "@/lib/workspace/effective-workspace-folders";
 import type { WorkspaceFolderInfo } from "@/stores/workspace/workspace-folders-store";
 import { useSettingsStore } from "@/stores/settings/settings-store";
 import {
@@ -131,6 +132,12 @@ interface LandingDraftStoreState {
   ) => ReadonlyArray<string>;
   removeDraftFolder: (id: string, folderPath: string) => void;
   setDraftWorkspacePrimary: (id: string, folderPath: string) => void;
+  /**
+   * Re-snapshot the active draft from the effective (profile-narrowed)
+   * workspace. Used when the user switches Project Profile so the next
+   * send cannot inherit folders from another project.
+   */
+  replaceActiveDraftWorkspaceFromStores: () => void;
 }
 
 export const LANDING_DRAFT_PERSIST_KEY = persistKey(STORE_KEYS.landingDraft);
@@ -549,6 +556,23 @@ export const useLandingDraftStore = create<LandingDraftStoreState>()(
           ),
         );
       },
+
+      replaceActiveDraftWorkspaceFromStores: () => {
+        // Isolation applies at profile switch (this method) and at new-draft
+        // create. A background draft keeps the folder set it was minted with —
+        // activating it does not re-snapshot, so in-progress folder edits
+        // survive a profile change.
+        const id = get().activeDraftId;
+        if (id === null) {
+          get().createDraft(null);
+          return;
+        }
+        set((state) =>
+          updateDraftWorkspace(state, id, () =>
+            readCurrentLandingDraftWorkspaceSnapshot(),
+          ),
+        );
+      },
     }),
     {
       ...basePersistOptions(LANDING_DRAFT_PERSIST_KEY),
@@ -846,9 +870,12 @@ function readCurrentLandingDraftWorkspaceSnapshot(): LandingDraftWorkspaceSnapsh
   // app-wide effective host - snapshot THAT host's folder bucket, not another
   // machine's paths. Through the shared reader: the spine stopped carrying an
   // identity at P4.2, so asking it here selected the unresolved-host bucket
-  // and silently dropped the real host's folders.
-  const bucket = selectWorkspaceFoldersBucket(
+  // and silently dropped the real host's folders. An active Project Profile
+  // then narrows that bucket so a Titanos chat cannot inherit every
+  // remembered repo.
+  const bucket = selectEffectiveWorkspaceFoldersBucket(
     useWorkspaceFoldersStore.getState(),
+    useProjectProfilesStore.getState(),
     activeHostIdOrNull(),
   );
   return normalizeLandingDraftWorkspace({

--- a/clients/gui-app/src/stores/home/landing-draft-store.ts
+++ b/clients/gui-app/src/stores/home/landing-draft-store.ts
@@ -561,12 +561,10 @@ export const useLandingDraftStore = create<LandingDraftStoreState>()(
         // Isolation applies at profile switch (this method) and at new-draft
         // create. A background draft keeps the folder set it was minted with —
         // activating it does not re-snapshot, so in-progress folder edits
-        // survive a profile change.
+        // survive a profile change. Switching while no Start Page is active
+        // must not mint a tab — that stacked duplicate Start Pages.
         const id = get().activeDraftId;
-        if (id === null) {
-          get().createDraft(null);
-          return;
-        }
+        if (id === null) return;
         set((state) =>
           updateDraftWorkspace(state, id, () =>
             readCurrentLandingDraftWorkspaceSnapshot(),

--- a/clients/gui-app/src/stores/tabs/use-header-tabs.ts
+++ b/clients/gui-app/src/stores/tabs/use-header-tabs.ts
@@ -21,6 +21,13 @@ import {
   subscribeTabStructuralLocks,
 } from "@/stores/tabs/tab-structural-lock";
 import { getOpenEpicRegistry } from "@/lib/registries/epic-session-registry";
+import { useAddressableHostId } from "@/hooks/host/use-addressable-host-id";
+import { activeHostIdOrNull } from "@/lib/host/runtime";
+import { scopeHeaderTabsToActiveProject } from "@/hooks/workspace/use-project-scoped-header-strip";
+import {
+  selectActiveProjectProfile,
+  useProjectProfilesStore,
+} from "@/stores/workspace/project-profiles-store";
 
 /**
  * Revision over "which host serves which open epic".
@@ -85,6 +92,10 @@ export function useHeaderTabs(): ReadonlyArray<HeaderTab> {
   );
   const draftTabs = useLandingDraftStore(useShallow((s) => s.drafts));
   const systemTabs = useTabsStore(useShallow((s) => s.systemTabs));
+  const hostId = useAddressableHostId();
+  const activeProfileId = useProjectProfilesStore(
+    (state) => selectActiveProjectProfile(state, hostId)?.id ?? null,
+  );
 
   const epicTabsById = useMemo(
     () => new Map<string, EpicViewTab>(epicTabs.map((t) => [t.tabId, t])),
@@ -98,19 +109,24 @@ export function useHeaderTabs(): ReadonlyArray<HeaderTab> {
 
   return useMemo<ReadonlyArray<HeaderTab>>(
     () =>
-      stripOrder.flatMap<HeaderTab>((ref) =>
-        resolveRef(ref, {
-          epicTabsById,
-          draftTabsById,
-          systemTabs,
-          structuralLockRevision,
-          epicSessionHostRevision: epicSessionHostRevisionValue,
-        }),
+      scopeHeaderTabsToActiveProject(
+        stripOrder.flatMap<HeaderTab>((ref) =>
+          resolveRef(ref, {
+            epicTabsById,
+            draftTabsById,
+            systemTabs,
+            structuralLockRevision,
+            epicSessionHostRevision: epicSessionHostRevisionValue,
+          }),
+        ),
+        hostId,
       ),
     [
+      activeProfileId,
       draftTabsById,
       epicSessionHostRevisionValue,
       epicTabsById,
+      hostId,
       stripOrder,
       structuralLockRevision,
       systemTabs,
@@ -486,13 +502,16 @@ export function getHeaderTabs(): ReadonlyArray<HeaderTab> {
   const draftTabsById = new Map<string, LandingDraftTab>(
     draftTabs.map((t) => [t.id, t]),
   );
-  return stripOrder.flatMap((ref) =>
-    resolveRef(ref, {
-      epicTabsById,
-      draftTabsById,
-      systemTabs,
-      structuralLockRevision: getTabStructuralLockRevision(),
-      epicSessionHostRevision: getEpicSessionHostRevision(),
-    }),
+  return scopeHeaderTabsToActiveProject(
+    stripOrder.flatMap((ref) =>
+      resolveRef(ref, {
+        epicTabsById,
+        draftTabsById,
+        systemTabs,
+        structuralLockRevision: getTabStructuralLockRevision(),
+        epicSessionHostRevision: getEpicSessionHostRevision(),
+      }),
+    ),
+    activeHostIdOrNull(),
   );
 }

--- a/clients/gui-app/src/stores/workspace/__tests__/project-profiles-store.test.ts
+++ b/clients/gui-app/src/stores/workspace/__tests__/project-profiles-store.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  EMPTY_PROJECT_PROFILES_BUCKET,
+  PROJECT_PROFILE_COLORS,
+  selectActiveProjectProfile,
+  selectProjectProfilesBucket,
+  useProjectProfilesStore,
+} from "../project-profiles-store";
+
+const HOST_A = "host-a";
+const HOST_B = "host-b";
+
+function bucket(hostId: string | null) {
+  return selectProjectProfilesBucket(useProjectProfilesStore.getState(), hostId);
+}
+
+function create(
+  hostId: string | null,
+  name: string,
+  folderPaths: ReadonlyArray<string>,
+  primaryPath: string | null,
+): string | null {
+  return useProjectProfilesStore.getState().createProfile(hostId, {
+    name,
+    color: "orange",
+    folderPaths,
+    primaryPath,
+  });
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+  useProjectProfilesStore.setState({ byHost: {} });
+});
+
+afterEach(() => {
+  window.localStorage.clear();
+});
+
+describe("useProjectProfilesStore", () => {
+  it("starts empty and treats a missing host as the shared empty bucket", () => {
+    expect(bucket(HOST_A)).toBe(EMPTY_PROJECT_PROFILES_BUCKET);
+    expect(bucket(null)).toBe(EMPTY_PROJECT_PROFILES_BUCKET);
+    expect(selectActiveProjectProfile(useProjectProfilesStore.getState(), HOST_A)).toBeNull();
+  });
+
+  it("creates a host-scoped profile and leaves other hosts untouched", () => {
+    const id = create(HOST_A, "Titanos", ["/titanos"], "/titanos");
+    expect(id).toEqual(expect.any(String));
+    expect(create(null, "Nope", [], null)).toBeNull();
+    expect(create(HOST_A, "   ", [], null)).toBeNull();
+
+    const created = bucket(HOST_A).profiles[0];
+    expect(created).toMatchObject({
+      id,
+      name: "Titanos",
+      color: "orange",
+      folderPaths: ["/titanos"],
+      primaryPath: "/titanos",
+    });
+    expect(bucket(HOST_B).profiles).toEqual([]);
+  });
+
+  it("trims the name, drops empty folder paths, and resolves primary to a member", () => {
+    const id = create(HOST_A, "  Titanos  ", ["", "/titanos", "/titanos", "/crm"], "/missing");
+    expect(id).not.toBeNull();
+    const created = bucket(HOST_A).profiles[0];
+    expect(created.name).toBe("Titanos");
+    expect(created.folderPaths).toEqual(["/titanos", "/crm"]);
+    expect(created.primaryPath).toBe("/titanos");
+  });
+
+  it("activates a profile on its own host only; unknown ids are a no-op", () => {
+    const id = create(HOST_A, "Titanos", ["/titanos"], "/titanos");
+    useProjectProfilesStore.getState().setActiveProfile(HOST_A, id);
+    useProjectProfilesStore.getState().setActiveProfile(HOST_A, "missing");
+    expect(bucket(HOST_A).activeProfileId).toBe(id);
+    expect(selectActiveProjectProfile(useProjectProfilesStore.getState(), HOST_A)?.name).toBe(
+      "Titanos",
+    );
+
+    useProjectProfilesStore.getState().setActiveProfile(HOST_B, id);
+    expect(bucket(HOST_B).activeProfileId).toBeNull();
+  });
+
+  it("renames, recolors, and rewrites folders without leaking across hosts", () => {
+    const id = create(HOST_A, "Titanos", ["/titanos"], "/titanos");
+    useProjectProfilesStore.getState().renameProfile(HOST_A, id ?? "", "  Ads  ");
+    useProjectProfilesStore.getState().setProfileColor(HOST_A, id ?? "", "blue");
+    useProjectProfilesStore.getState().setProfileFolders(HOST_A, id ?? "", ["/titanos", "/mcp"], "/mcp");
+    useProjectProfilesStore.getState().renameProfile(HOST_B, id ?? "", "Leak");
+
+    const updated = bucket(HOST_A).profiles[0];
+    expect(updated.name).toBe("Ads");
+    expect(updated.color).toBe("blue");
+    expect(updated.folderPaths).toEqual(["/titanos", "/mcp"]);
+    expect(updated.primaryPath).toBe("/mcp");
+    expect(bucket(HOST_B).profiles).toEqual([]);
+  });
+
+  it("adds and removes folders on the active profile without touching another host", () => {
+    const id = create(HOST_A, "Titanos", ["/titanos"], "/titanos");
+    useProjectProfilesStore.getState().addProfileFolder(HOST_A, id ?? "", "/crm");
+    useProjectProfilesStore.getState().setProfilePrimary(HOST_A, id ?? "", "/crm");
+    useProjectProfilesStore.getState().removeProfileFolder(HOST_A, id ?? "", "/titanos");
+
+    const updated = bucket(HOST_A).profiles[0];
+    expect(updated.folderPaths).toEqual(["/crm"]);
+    expect(updated.primaryPath).toBe("/crm");
+  });
+
+  it("deleting the active profile returns the host to All projects", () => {
+    const id = create(HOST_A, "Titanos", ["/titanos"], "/titanos");
+    useProjectProfilesStore.getState().setActiveProfile(HOST_A, id);
+    useProjectProfilesStore.getState().deleteProfile(HOST_A, id ?? "");
+    expect(bucket(HOST_A).profiles).toEqual([]);
+    expect(bucket(HOST_A).activeProfileId).toBeNull();
+  });
+
+  it("rejects an unknown color and keeps the catalog closed", () => {
+    expect(PROJECT_PROFILE_COLORS).toContain("orange");
+    const id = create(HOST_A, "Titanos", [], null);
+    useProjectProfilesStore
+      .getState()
+      .setProfileColor(HOST_A, id ?? "", "not-a-color" as "orange");
+    expect(bucket(HOST_A).profiles[0].color).toBe("orange");
+  });
+
+  it("rehydration drops a bad color, a stale active id, and empty host keys", async () => {
+    window.localStorage.setItem(
+      "traycer-gui-app:project-profiles",
+      JSON.stringify({
+        state: {
+          byHost: {
+            "": {
+              profiles: [
+                {
+                  id: "ghost",
+                  name: "Ghost",
+                  color: "orange",
+                  folderPaths: ["/x"],
+                  primaryPath: "/x",
+                },
+              ],
+              activeProfileId: "ghost",
+            },
+            [HOST_A]: {
+              profiles: [
+                {
+                  id: "p1",
+                  name: "Titanos",
+                  color: "orange",
+                  folderPaths: ["/titanos"],
+                  primaryPath: "/titanos",
+                },
+                {
+                  id: "p2",
+                  name: "Bad",
+                  color: "nope",
+                  folderPaths: ["/x"],
+                  primaryPath: "/x",
+                },
+              ],
+              activeProfileId: "missing",
+            },
+          },
+        },
+        version: 1,
+      }),
+    );
+    await useProjectProfilesStore.persist.rehydrate();
+    expect(bucket("").profiles).toEqual([]);
+    expect(bucket(HOST_A).profiles.map((profile) => profile.id)).toEqual(["p1"]);
+    expect(bucket(HOST_A).activeProfileId).toBeNull();
+  });
+});

--- a/clients/gui-app/src/stores/workspace/__tests__/project-profiles-store.test.ts
+++ b/clients/gui-app/src/stores/workspace/__tests__/project-profiles-store.test.ts
@@ -117,6 +117,15 @@ describe("useProjectProfilesStore", () => {
     expect(bucket(HOST_A).activeProfileId).toBeNull();
   });
 
+  it("deleting the active profile activates a remaining sibling", () => {
+    const titanos = create(HOST_A, "Titanos", ["/titanos"], "/titanos");
+    const crm = create(HOST_A, "CRM", ["/crm"], "/crm");
+    useProjectProfilesStore.getState().setActiveProfile(HOST_A, titanos);
+    useProjectProfilesStore.getState().deleteProfile(HOST_A, titanos ?? "");
+    expect(bucket(HOST_A).profiles.map((profile) => profile.id)).toEqual([crm]);
+    expect(bucket(HOST_A).activeProfileId).toBe(crm);
+  });
+
   it("rejects an unknown color and keeps the catalog closed", () => {
     expect(PROJECT_PROFILE_COLORS).toContain("orange");
     const id = create(HOST_A, "Titanos", [], null);

--- a/clients/gui-app/src/stores/workspace/project-profiles-store.ts
+++ b/clients/gui-app/src/stores/workspace/project-profiles-store.ts
@@ -24,6 +24,7 @@ export interface ProjectProfile {
   readonly color: ProjectProfileColor;
   readonly folderPaths: ReadonlyArray<string>;
   readonly primaryPath: string | null;
+  readonly epicIds: ReadonlyArray<string>;
 }
 
 export interface ProjectProfileCreateInput {
@@ -80,10 +81,21 @@ interface ProjectProfilesStore {
     profileId: string,
     folderPath: string,
   ) => void;
+  addProfileEpics: (
+    hostId: string | null,
+    profileId: string,
+    epicIds: ReadonlyArray<string>,
+  ) => void;
+  removeProfileEpic: (
+    hostId: string | null,
+    profileId: string,
+    epicId: string,
+  ) => void;
 }
 
 const MAX_PROFILES_PER_HOST = 20;
 const MAX_FOLDERS_PER_PROFILE = 50;
+const MAX_EPICS_PER_PROFILE = 200;
 
 export const EMPTY_PROJECT_PROFILES_BUCKET: ProjectProfilesHostBucket = {
   profiles: [],
@@ -130,6 +142,7 @@ export const useProjectProfilesStore = create<ProjectProfilesStore>()(
           color: input.color,
           folderPaths: input.folderPaths,
           primaryPath: input.primaryPath,
+          epicIds: [],
         });
         set((state) => ({
           byHost: {
@@ -237,6 +250,20 @@ export const useProjectProfilesStore = create<ProjectProfilesStore>()(
           return { ...profile, primaryPath: folderPath };
         });
       },
+      addProfileEpics: (hostId, profileId, epicIds) => {
+        updateProfile(set, get, { hostId, profileId }, (profile) =>
+          mergeProfileEpicIds(profile, epicIds),
+        );
+      },
+      removeProfileEpic: (hostId, profileId, epicId) => {
+        updateProfile(set, get, { hostId, profileId }, (profile) => {
+          if (!profile.epicIds.includes(epicId)) return profile;
+          return {
+            ...profile,
+            epicIds: profile.epicIds.filter((id) => id !== epicId),
+          };
+        });
+      },
     }),
     {
       ...basePersistOptions(persistKey(STORE_KEYS.projectProfiles)),
@@ -301,7 +328,33 @@ function normalizeProfile(input: ProjectProfile): ProjectProfile {
     color: input.color,
     folderPaths: trimmed,
     primaryPath: resolvePrimaryPath(trimmed, input.primaryPath),
+    epicIds: normalizeEpicIds(input.epicIds),
   };
+}
+
+function mergeProfileEpicIds(
+  profile: ProjectProfile,
+  epicIds: ReadonlyArray<string>,
+): ProjectProfile {
+  const next = normalizeEpicIds([...profile.epicIds, ...epicIds]);
+  if (next.length === profile.epicIds.length) {
+    const same = next.every((id, index) => id === profile.epicIds[index]);
+    if (same) return profile;
+  }
+  return { ...profile, epicIds: next };
+}
+
+function normalizeEpicIds(raw: ReadonlyArray<string>): ReadonlyArray<string> {
+  const seen = new Set<string>();
+  const epicIds: string[] = [];
+  for (const value of raw) {
+    const id = value.trim();
+    if (id.length === 0 || seen.has(id)) continue;
+    seen.add(id);
+    epicIds.push(id);
+    if (epicIds.length >= MAX_EPICS_PER_PROFILE) break;
+  }
+  return epicIds;
 }
 
 function parsePersistedByHost(
@@ -343,6 +396,7 @@ function parsePersistedProfiles(value: unknown): ReadonlyArray<ProjectProfile> {
         folderPaths: parsePersistedFolderPaths(raw.folderPaths),
         primaryPath:
           typeof raw.primaryPath === "string" ? raw.primaryPath : null,
+        epicIds: parsePersistedEpicIds(raw.epicIds),
       }),
     );
     if (profiles.length >= MAX_PROFILES_PER_HOST) break;
@@ -351,6 +405,13 @@ function parsePersistedProfiles(value: unknown): ReadonlyArray<ProjectProfile> {
 }
 
 function parsePersistedFolderPaths(value: unknown): ReadonlyArray<string> {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((entry) =>
+    typeof entry === "string" && entry.trim().length > 0 ? [entry] : [],
+  );
+}
+
+function parsePersistedEpicIds(value: unknown): ReadonlyArray<string> {
   if (!Array.isArray(value)) return [];
   return value.flatMap((entry) =>
     typeof entry === "string" && entry.trim().length > 0 ? [entry] : [],

--- a/clients/gui-app/src/stores/workspace/project-profiles-store.ts
+++ b/clients/gui-app/src/stores/workspace/project-profiles-store.ts
@@ -1,0 +1,379 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import { v4 as uuidv4 } from "uuid";
+import { basePersistOptions, persistKey, STORE_KEYS } from "@/lib/persist";
+import {
+  resolvePrimaryPath,
+  trimFoldersPreservingPrimary,
+} from "@/lib/worktree/resolve-primary-path";
+
+export const PROJECT_PROFILE_COLORS = [
+  "orange",
+  "blue",
+  "green",
+  "purple",
+  "rose",
+  "amber",
+] as const;
+
+export type ProjectProfileColor = (typeof PROJECT_PROFILE_COLORS)[number];
+
+export interface ProjectProfile {
+  readonly id: string;
+  readonly name: string;
+  readonly color: ProjectProfileColor;
+  readonly folderPaths: ReadonlyArray<string>;
+  readonly primaryPath: string | null;
+}
+
+export interface ProjectProfileCreateInput {
+  readonly name: string;
+  readonly color: ProjectProfileColor;
+  readonly folderPaths: ReadonlyArray<string>;
+  readonly primaryPath: string | null;
+}
+
+export interface ProjectProfilesHostBucket {
+  readonly profiles: ReadonlyArray<ProjectProfile>;
+  readonly activeProfileId: string | null;
+}
+
+interface ProjectProfilesStore {
+  byHost: Readonly<Record<string, ProjectProfilesHostBucket>>;
+  createProfile: (
+    hostId: string | null,
+    input: ProjectProfileCreateInput,
+  ) => string | null;
+  renameProfile: (
+    hostId: string | null,
+    profileId: string,
+    name: string,
+  ) => void;
+  setProfileColor: (
+    hostId: string | null,
+    profileId: string,
+    color: ProjectProfileColor,
+  ) => void;
+  deleteProfile: (hostId: string | null, profileId: string) => void;
+  setActiveProfile: (
+    hostId: string | null,
+    profileId: string | null,
+  ) => void;
+  setProfileFolders: (
+    hostId: string | null,
+    profileId: string,
+    folderPaths: ReadonlyArray<string>,
+    primaryPath: string | null,
+  ) => void;
+  addProfileFolder: (
+    hostId: string | null,
+    profileId: string,
+    folderPath: string,
+  ) => void;
+  removeProfileFolder: (
+    hostId: string | null,
+    profileId: string,
+    folderPath: string,
+  ) => void;
+  setProfilePrimary: (
+    hostId: string | null,
+    profileId: string,
+    folderPath: string,
+  ) => void;
+}
+
+const MAX_PROFILES_PER_HOST = 20;
+const MAX_FOLDERS_PER_PROFILE = 50;
+
+export const EMPTY_PROJECT_PROFILES_BUCKET: ProjectProfilesHostBucket = {
+  profiles: [],
+  activeProfileId: null,
+};
+
+export function selectProjectProfilesBucket(
+  state: Pick<ProjectProfilesStore, "byHost">,
+  hostId: string | null,
+): ProjectProfilesHostBucket {
+  if (hostId === null || !Object.hasOwn(state.byHost, hostId)) {
+    return EMPTY_PROJECT_PROFILES_BUCKET;
+  }
+  return state.byHost[hostId];
+}
+
+export function selectActiveProjectProfile(
+  state: Pick<ProjectProfilesStore, "byHost">,
+  hostId: string | null,
+): ProjectProfile | null {
+  const bucket = selectProjectProfilesBucket(state, hostId);
+  if (bucket.activeProfileId === null) return null;
+  return (
+    bucket.profiles.find((profile) => profile.id === bucket.activeProfileId) ??
+    null
+  );
+}
+
+export const useProjectProfilesStore = create<ProjectProfilesStore>()(
+  persist(
+    (set, get) => ({
+      byHost: {},
+      createProfile: (hostId, input) => {
+        if (hostId === null) return null;
+        const name = input.name.trim();
+        if (name.length === 0) return null;
+        if (!isProjectProfileColor(input.color)) return null;
+        const bucket = selectProjectProfilesBucket(get(), hostId);
+        if (bucket.profiles.length >= MAX_PROFILES_PER_HOST) return null;
+        const id = uuidv4();
+        const profile = normalizeProfile({
+          id,
+          name,
+          color: input.color,
+          folderPaths: input.folderPaths,
+          primaryPath: input.primaryPath,
+        });
+        set((state) => ({
+          byHost: {
+            ...state.byHost,
+            [hostId]: {
+              profiles: [...bucket.profiles, profile],
+              activeProfileId: bucket.activeProfileId,
+            },
+          },
+        }));
+        return id;
+      },
+      renameProfile: (hostId, profileId, name) => {
+        const trimmed = name.trim();
+        if (trimmed.length === 0) return;
+        updateProfile(set, get, { hostId, profileId }, (profile) =>
+          profile.name === trimmed ? profile : { ...profile, name: trimmed },
+        );
+      },
+      setProfileColor: (hostId, profileId, color) => {
+        if (!isProjectProfileColor(color)) return;
+        updateProfile(set, get, { hostId, profileId }, (profile) =>
+          profile.color === color ? profile : { ...profile, color },
+        );
+      },
+      deleteProfile: (hostId, profileId) => {
+        if (hostId === null) return;
+        set((state) => {
+          const bucket = selectProjectProfilesBucket(state, hostId);
+          if (!bucket.profiles.some((profile) => profile.id === profileId)) {
+            return state;
+          }
+          return {
+            byHost: {
+              ...state.byHost,
+              [hostId]: {
+                profiles: bucket.profiles.filter(
+                  (profile) => profile.id !== profileId,
+                ),
+                activeProfileId:
+                  bucket.activeProfileId === profileId
+                    ? null
+                    : bucket.activeProfileId,
+              },
+            },
+          };
+        });
+      },
+      setActiveProfile: (hostId, profileId) => {
+        if (hostId === null) return;
+        set((state) => {
+          const bucket = selectProjectProfilesBucket(state, hostId);
+          if (profileId !== null) {
+            const exists = bucket.profiles.some(
+              (profile) => profile.id === profileId,
+            );
+            if (!exists) return state;
+          }
+          if (bucket.activeProfileId === profileId) return state;
+          return {
+            byHost: {
+              ...state.byHost,
+              [hostId]: { ...bucket, activeProfileId: profileId },
+            },
+          };
+        });
+      },
+      setProfileFolders: (hostId, profileId, folderPaths, primaryPath) => {
+        updateProfile(set, get, { hostId, profileId }, (profile) =>
+          normalizeProfile({
+            ...profile,
+            folderPaths,
+            primaryPath,
+          }),
+        );
+      },
+      addProfileFolder: (hostId, profileId, folderPath) => {
+        const path = folderPath.trim();
+        if (path.length === 0) return;
+        updateProfile(set, get, { hostId, profileId }, (profile) => {
+          if (profile.folderPaths.includes(path)) return profile;
+          return normalizeProfile({
+            ...profile,
+            folderPaths: [...profile.folderPaths, path],
+            primaryPath: profile.primaryPath,
+          });
+        });
+      },
+      removeProfileFolder: (hostId, profileId, folderPath) => {
+        updateProfile(set, get, { hostId, profileId }, (profile) => {
+          if (!profile.folderPaths.includes(folderPath)) return profile;
+          return normalizeProfile({
+            ...profile,
+            folderPaths: profile.folderPaths.filter(
+              (path) => path !== folderPath,
+            ),
+            primaryPath: profile.primaryPath,
+          });
+        });
+      },
+      setProfilePrimary: (hostId, profileId, folderPath) => {
+        updateProfile(set, get, { hostId, profileId }, (profile) => {
+          if (!profile.folderPaths.includes(folderPath)) return profile;
+          if (profile.primaryPath === folderPath) return profile;
+          return { ...profile, primaryPath: folderPath };
+        });
+      },
+    }),
+    {
+      ...basePersistOptions(persistKey(STORE_KEYS.projectProfiles)),
+      merge: (persistedState, currentState) => {
+        const persisted: Record<string, unknown> = isRecord(persistedState)
+          ? persistedState
+          : {};
+        return {
+          ...currentState,
+          byHost: parsePersistedByHost(persisted.byHost),
+        };
+      },
+    },
+  ),
+);
+
+function updateProfile(
+  set: (partial: {
+    byHost: Readonly<Record<string, ProjectProfilesHostBucket>>;
+  }) => void,
+  get: () => ProjectProfilesStore,
+  target: { readonly hostId: string | null; readonly profileId: string },
+  update: (profile: ProjectProfile) => ProjectProfile,
+): void {
+  const { hostId, profileId } = target;
+  if (hostId === null) return;
+  const bucket = selectProjectProfilesBucket(get(), hostId);
+  const current = bucket.profiles.find((profile) => profile.id === profileId);
+  if (current === undefined) return;
+  const next = update(current);
+  if (next === current) return;
+  set({
+    byHost: {
+      ...get().byHost,
+      [hostId]: {
+        ...bucket,
+        profiles: bucket.profiles.map((profile) =>
+          profile.id === profileId ? next : profile,
+        ),
+      },
+    },
+  });
+}
+
+function normalizeProfile(input: ProjectProfile): ProjectProfile {
+  const seen = new Set<string>();
+  const folderPaths: string[] = [];
+  for (const raw of input.folderPaths) {
+    const path = raw.trim();
+    if (path.length === 0 || seen.has(path)) continue;
+    seen.add(path);
+    folderPaths.push(path);
+  }
+  const trimmed = trimFoldersPreservingPrimary(
+    folderPaths,
+    input.primaryPath,
+    MAX_FOLDERS_PER_PROFILE,
+  );
+  return {
+    id: input.id,
+    name: input.name,
+    color: input.color,
+    folderPaths: trimmed,
+    primaryPath: resolvePrimaryPath(trimmed, input.primaryPath),
+  };
+}
+
+function parsePersistedByHost(
+  value: unknown,
+): Readonly<Record<string, ProjectProfilesHostBucket>> {
+  if (!isRecord(value)) return {};
+  return Object.fromEntries(
+    Object.entries(value).flatMap(([hostId, rawBucket]) => {
+      if (!isRecord(rawBucket) || hostId.length === 0) return [];
+      const profiles = parsePersistedProfiles(rawBucket.profiles);
+      const activeProfileId = parsePersistedActiveId(
+        rawBucket.activeProfileId,
+        profiles,
+      );
+      if (profiles.length === 0 && activeProfileId === null) return [];
+      return [[hostId, { profiles, activeProfileId }]];
+    }),
+  );
+}
+
+function parsePersistedProfiles(value: unknown): ReadonlyArray<ProjectProfile> {
+  if (!Array.isArray(value)) return [];
+  const profiles: ProjectProfile[] = [];
+  const seenIds = new Set<string>();
+  for (const raw of value) {
+    if (!isRecord(raw)) continue;
+    if (typeof raw.id !== "string" || raw.id.length === 0) continue;
+    if (seenIds.has(raw.id)) continue;
+    if (typeof raw.name !== "string") continue;
+    const name = raw.name.trim();
+    if (name.length === 0) continue;
+    if (!isProjectProfileColor(raw.color)) continue;
+    seenIds.add(raw.id);
+    profiles.push(
+      normalizeProfile({
+        id: raw.id,
+        name,
+        color: raw.color,
+        folderPaths: parsePersistedFolderPaths(raw.folderPaths),
+        primaryPath:
+          typeof raw.primaryPath === "string" ? raw.primaryPath : null,
+      }),
+    );
+    if (profiles.length >= MAX_PROFILES_PER_HOST) break;
+  }
+  return profiles;
+}
+
+function parsePersistedFolderPaths(value: unknown): ReadonlyArray<string> {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((entry) =>
+    typeof entry === "string" && entry.trim().length > 0 ? [entry] : [],
+  );
+}
+
+function parsePersistedActiveId(
+  value: unknown,
+  profiles: ReadonlyArray<ProjectProfile>,
+): string | null {
+  if (typeof value !== "string" || value.length === 0) return null;
+  return profiles.some((profile) => profile.id === value) ? value : null;
+}
+
+export function isProjectProfileColor(
+  value: unknown,
+): value is ProjectProfileColor {
+  return (
+    typeof value === "string" &&
+    (PROJECT_PROFILE_COLORS as readonly string[]).includes(value)
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/clients/gui-app/src/stores/workspace/project-profiles-store.ts
+++ b/clients/gui-app/src/stores/workspace/project-profiles-store.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import { v4 as uuidv4 } from "uuid";
 import { basePersistOptions, persistKey, STORE_KEYS } from "@/lib/persist";
+import { nextActiveProfileIdAfterDelete } from "@/lib/workspace/next-active-profile-after-delete";
 import {
   resolvePrimaryPath,
   trimFoldersPreservingPrimary,
@@ -182,10 +183,11 @@ export const useProjectProfilesStore = create<ProjectProfilesStore>()(
                 profiles: bucket.profiles.filter(
                   (profile) => profile.id !== profileId,
                 ),
-                activeProfileId:
-                  bucket.activeProfileId === profileId
-                    ? null
-                    : bucket.activeProfileId,
+                activeProfileId: nextActiveProfileIdAfterDelete({
+                  profiles: bucket.profiles,
+                  activeProfileId: bucket.activeProfileId,
+                  deletedProfileId: profileId,
+                }),
               },
             },
           };


### PR DESCRIPTION
## Summary

New chats were creating a worktree + branch for **every** folder in the persisted picker. Opening a Titanos-only issue forked 8 repos at once. Anyone who has used Traycer with more than one repo already has this leftover set.

This is the first slice of #1113 (Project Profiles).

### New chats (stop the fan-out)

- A host-scoped Project Profile owns a folder set. An active profile narrows launch snapshots so only those folders get worktrees.
- Zero profiles / **All projects** keeps today's multi-repo behavior.
- Empty Start Page: **Add project** opens the folder picker, names the project after the folder, and isolates it in one step.
- **New project** in the header lists remembered folders (or **Choose folder**) so each project picks **its own** main folder. **All current folders** and **Empty** stay behind **Advanced**.
- The switcher sits flush against the first tab (no title-bar drag hole between them). Window drag stays on the spacer after the tab strip.

### Open tabs and delete

- With a project active, the tab strip shows only tabs **owned** by that project: primary workspace folder, or a claim with no primary. A fan-out chat that only *touched* Titanos is not a Titanos tab.
- Workspace folders are stamped on the epic tab (and persisted) so a cold session or app restart does not hide the tab and bounce Home.
- **All projects** shows every tab, with the owning project's color dot and name in the tooltip.
- If the current tab is hidden, the app goes Home.
- Deleting a project asks for confirmation, then activates a sibling. Last project falls back to **All projects**.

### Existing chats (orphans)

Chats created before this change already have worktrees in every remembered repo. We do **not** delete those worktrees (that would trash in-flight work).

Instead, with a project active, History keeps chats that:

- already have a worktree under that project's folder (including fan-out chats that touched Titanos *and* CRM), or
- were explicitly claimed on the profile.

History may still list “touched” orphans. The tab strip does not. New messages in those old chats still run in the worktrees they already have. Only **new** chats are isolated.

### Not #786 / #803

#803 is a persistent picker: saved folder library + pin + per-chat checkboxes. Useful, but a chat can still launch with several folders selected, so the 8-repo fan-out remains possible.

This PR is a different cut: a named profile is the launch overlay. One project active → only that folder set gets worktrees. The two should not be merged into one PR.

### Implementation notes

- Persist `project-profiles` through the existing catalog, bucketed by `hostId`.
- One overlay (`selectEffectiveWorkspaceFoldersBucket`) used by landing draft, new-conversation modal, seeded launch, home picker, and the resolved-folder query.
- Picker add/remove/primary while a profile is active updates that profile only. The catalog stays a library.
- Tab ownership uses `EpicViewTab.projectWorkspace` (durable) merged with a live session peek (does not bump LRU).

Out of scope here: rewriting existing worktree bindings.

## Related issue

Implements the folder-isolation slice of #1113 (does not close it).

## Validation

- Targeted gui-app tests for profiles, seed, history match, claim, tab ownership, durable workspace stamp, delete fallback, and empty History copy
- `nx run traycer-clients-gui-app:compile`
- Local desktop dogfood (create project from a folder; new chat stays on that folder)

## Checklist

- [x] Pre-commit static checks pass (hook ran on commit)
- [ ] Separate CI test checks pass
- [x] Tests added/updated where it makes sense
- [x] Commits are signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#developer-certificate-of-origin-dco)
