### PR TITLE
fix(gui-app): add the deliberately aimed remote folder

### DIFF
--- a/clients/gui-app/src/components/__tests__/remote-folder-picker-dialog.test.tsx
+++ b/clients/gui-app/src/components/__tests__/remote-folder-picker-dialog.test.tsx
@@ -465,6 +465,95 @@ describe("<RemoteFolderPickerDialog />", () => {
     expect(pathInput().value).toBe("/Users/tester/code/");
   });
 
+  it("Add picks the directory deliberately aimed with an arrow", async () => {
+    render(<RemoteFolderPickerDialog />);
+    const pick = useRemoteFolderPickerStore
+      .getState()
+      .requestPick(makeClient());
+    await screen.findAllByTestId("remote-folder-picker-row");
+
+    // The initial `..` highlight is only a visual default. Moving down is the
+    // first explicit aim, and Add must commit that row without requiring the
+    // user to open it first.
+    fireEvent.keyDown(pathInput(), { key: "ArrowDown" });
+    fireEvent.click(screen.getByTestId("remote-folder-picker-add"));
+
+    await expect(pick).resolves.toBe("/Users/tester/code");
+    expect(recordedRecents).toEqual(["/Users/tester/code"]);
+  });
+
+  it("ctrl+Enter picks the same deliberately aimed directory as Add", async () => {
+    render(<RemoteFolderPickerDialog />);
+    const pick = useRemoteFolderPickerStore
+      .getState()
+      .requestPick(makeClient());
+    await screen.findAllByTestId("remote-folder-picker-row");
+
+    fireEvent.keyDown(pathInput(), { key: "ArrowDown" });
+    fireEvent.keyDown(pathInput(), { key: "Enter", ctrlKey: true });
+
+    await expect(pick).resolves.toBe("/Users/tester/code");
+  });
+
+  it("keeps a typed path authoritative after arrow navigation", async () => {
+    render(<RemoteFolderPickerDialog />);
+    const pick = useRemoteFolderPickerStore
+      .getState()
+      .requestPick(makeClient());
+    await screen.findAllByTestId("remote-folder-picker-row");
+
+    fireEvent.change(pathInput(), {
+      target: { value: "/Users/tester/co" },
+    });
+    // `code` and `consulting` are both visible, so this is a real movement to
+    // a directory row rather than a boundary keypress. The typed path still
+    // wins because editing the field established the user's source of truth.
+    fireEvent.keyDown(pathInput(), { key: "ArrowDown" });
+    fireEvent.click(screen.getByTestId("remote-folder-picker-add"));
+
+    await expect(pick).resolves.toBe("/Users/tester/co");
+  });
+
+  it("clears an aimed directory when the selection moves back to ..", async () => {
+    render(<RemoteFolderPickerDialog />);
+    const pick = useRemoteFolderPickerStore
+      .getState()
+      .requestPick(makeClient());
+    await screen.findAllByTestId("remote-folder-picker-row");
+
+    fireEvent.keyDown(pathInput(), { key: "ArrowDown" });
+    fireEvent.keyDown(pathInput(), { key: "ArrowUp" });
+    fireEvent.click(screen.getByTestId("remote-folder-picker-add"));
+
+    await expect(pick).resolves.toBe("/Users/tester");
+  });
+
+  it("does not promote an auto-highlighted root entry without movement", async () => {
+    queryByPath.set(
+      pathKey(null),
+      readyLevel({
+        directoryPath: "/",
+        parentPath: null,
+        entries: [
+          { path: "/apps", name: "apps" },
+          { path: "/code", name: "code" },
+        ],
+      }),
+    );
+    render(<RemoteFolderPickerDialog />);
+    const pick = useRemoteFolderPickerStore
+      .getState()
+      .requestPick(makeClient());
+    await screen.findAllByTestId("remote-folder-picker-row");
+
+    // Row zero is highlighted because the listbox needs an active option, not
+    // because the user aimed at `/apps`.
+    fireEvent.keyDown(pathInput(), { key: "ArrowUp" });
+    fireEvent.click(screen.getByTestId("remote-folder-picker-add"));
+
+    await expect(pick).resolves.toBe("/");
+  });
+
   it("relative input shows a hint, not a loading state", async () => {
     render(<RemoteFolderPickerDialog />);
     void useRemoteFolderPickerStore.getState().requestPick(makeClient());

--- a/clients/gui-app/src/components/remote-folder-picker-dialog.tsx
+++ b/clients/gui-app/src/components/remote-folder-picker-dialog.tsx
@@ -90,6 +90,11 @@ function RemoteFolderPickerBody(): ReactNode {
   // null = not edited yet; the field then shows the host home once known.
   const [rawInput, setRawInput] = useState<string | null>(null);
   const [selectedIndex, setSelectedIndex] = useState(0);
+  // A highlighted row is only an Add target after the user actually moved to
+  // it with the arrow keys. The initial highlight remains presentational.
+  const [keyboardAimedPath, setKeyboardAimedPath] = useState<string | null>(
+    null,
+  );
   // The host's home, learned from the root (null-path) response; anchors `~`.
   const [homePath, setHomePath] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement | null>(null);
@@ -160,12 +165,18 @@ function RemoteFolderPickerBody(): ReactNode {
   );
   const upPath = readUpPath(data, parsed);
   // Row 0 is the ".." row whenever there is somewhere to go up to.
-  const rowCount = (upPath !== null ? 1 : 0) + filteredEntries.length;
+  const entryRowOffset = upPath !== null ? 1 : 0;
+  const rowCount = entryRowOffset + filteredEntries.length;
   const clampedIndex = Math.min(selectedIndex, Math.max(rowCount - 1, 0));
+  const selectedEntry = readDirectoryEntryAtRow(
+    filteredEntries,
+    clampedIndex - entryRowOffset,
+  );
 
   const setPath = (path: string): void => {
     setRawInput(path);
     setSelectedIndex(0);
+    setKeyboardAimedPath(null);
   };
 
   const enterEntry = (entry: WorkspaceBrowseFolderEntry): void => {
@@ -176,7 +187,15 @@ function RemoteFolderPickerBody(): ReactNode {
     if (upPath !== null) setPath(withTrailingSeparator(upPath));
   };
 
-  const addTarget = readAddTarget(rawInput, effectiveHome, data);
+  // Keep the aimed path coupled to the row still highlighted. If a live
+  // listing changes underneath the picker, a stale path must not silently win.
+  const aimedAddTarget = readKeyboardAimedAddTarget(
+    rawInput,
+    selectedEntry,
+    keyboardAimedPath,
+  );
+  const addTarget =
+    aimedAddTarget ?? readAddTarget(rawInput, effectiveHome, data);
 
   const addCurrent = (): void => {
     if (addTarget === null) return;
@@ -192,8 +211,7 @@ function RemoteFolderPickerBody(): ReactNode {
       goUp();
       return;
     }
-    const entry = filteredEntries.at(clampedIndex - (upPath !== null ? 1 : 0));
-    if (entry !== undefined) enterEntry(entry);
+    if (selectedEntry !== undefined) enterEntry(selectedEntry);
   };
 
   const moveSelection = (delta: number): void => {
@@ -202,6 +220,14 @@ function RemoteFolderPickerBody(): ReactNode {
       Math.max(rowCount - 1, 0),
     );
     setSelectedIndex(next);
+    setKeyboardAimedPath((currentAimedPath) => {
+      if (next === clampedIndex) return currentAimedPath;
+      if (rawInput !== null) return null;
+      return (
+        readDirectoryEntryAtRow(filteredEntries, next - entryRowOffset)?.path ??
+        null
+      );
+    });
     const option = document.getElementById(pickerOptionId(next));
     if (option !== null && typeof option.scrollIntoView === "function") {
       option.scrollIntoView({ block: "nearest" });
@@ -242,6 +268,7 @@ function RemoteFolderPickerBody(): ReactNode {
           onChange={(event) => {
             setRawInput(event.target.value);
             setSelectedIndex(0);
+            setKeyboardAimedPath(null);
           }}
           onKeyDown={(event) => {
             handlePickerFieldKeys(event, {
@@ -602,11 +629,31 @@ function pickerOptionId(index: number): string {
   return `remote-folder-picker-option-${String(index)}`;
 }
 
+function readDirectoryEntryAtRow(
+  entries: ReadonlyArray<WorkspaceBrowseFolderEntry>,
+  entryIndex: number,
+): WorkspaceBrowseFolderEntry | undefined {
+  if (entryIndex < 0) return undefined;
+  return entries.at(entryIndex);
+}
+
+function readKeyboardAimedAddTarget(
+  rawInput: string | null,
+  selectedEntry: WorkspaceBrowseFolderEntry | undefined,
+  keyboardAimedPath: string | null,
+): string | null {
+  if (rawInput !== null || selectedEntry?.path !== keyboardAimedPath) {
+    return null;
+  }
+  return keyboardAimedPath;
+}
+
 /**
  * Keyboard model on the path field (the dialog auto-focuses it): arrows move
  * the row selection, Enter opens the selected row, cmd/ctrl+Enter adds the
- * current path. Backspace needs no handler - deleting characters past a `/`
- * IS up-navigation, because the field is the source of truth.
+ * deliberately aimed directory or the authoritative field path. Backspace
+ * needs no handler - deleting characters past a `/` IS up-navigation, because
+ * an edited field remains the source of truth.
  */
 function handlePickerFieldKeys(
   event: KeyboardEvent<HTMLInputElement>,
@@ -865,10 +912,11 @@ function filterEntries(
 }
 
 /**
- * What Add picks: exactly what the field shows (with `~` expanded and any
- * trailing `/` dropped), whether or not that folder was ever listed -
- * selecting a folder needs no read. An unedited field picks the home the
- * field displays; a field the user explicitly cleared picks nothing.
+ * What the field contributes to Add: exactly what it shows (with `~` expanded
+ * and any trailing `/` dropped), whether or not that folder was ever listed.
+ * An unedited field contributes the home it displays, while a field the user
+ * explicitly cleared contributes nothing. The component may supersede this
+ * fallback with a directory the user deliberately aimed at using arrow keys.
  */
 function readAddTarget(
   rawInput: string | null,


### PR DESCRIPTION
## Summary

- make Add and Cmd/Ctrl+Enter commit a directory deliberately targeted with the arrow keys
- keep the initial highlight presentational and preserve typed paths as the source of truth
- clear the keyboard target when navigation returns to `..`, the field is edited, or pointer navigation changes the path

## Root cause

The picker tracked `selectedIndex` for highlighting and Enter navigation, but Add always called `readAddTarget` using only the path field. On a pristine picker that field resolves to the current directory, so arrowing to a child and pressing Add silently selected the parent instead.

The fix records a path only after a real keyboard selection move and validates that it still matches the highlighted directory before using it.

## Validation

- remote folder picker suite: 53 tests passed
- ESLint on both changed files passed with zero warnings
- GUI compile and build passed on Node 24
- Prettier and `git diff --check` passed
- React Doctor found no issues in the changed files

Fixes #1084
