### PR TITLE
fix(gui-app): drop the status pill tooltip below the title bar

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/panels/epic-connection-pill.tsx
+++ b/clients/gui-app/src/components/epic-canvas/panels/epic-connection-pill.tsx
@@ -97,11 +97,18 @@ export function EpicConnectionPill(props: EpicConnectionPillProps) {
 
   return (
     <>
+      {/*
+       * Below the pill, like every other control in this row. The status row
+       * is the topmost content row in the window, so a `top` tooltip has
+       * nowhere to go but up into the title bar, where it covers the
+       * minimize/maximize/close buttons. `end` alignment keeps the wider
+       * multi-plane copy from running off the right edge.
+       */}
       <TooltipWrapper
         label={tooltipFor(rawSelected)}
-        side="top"
+        side="bottom"
         sideOffset={undefined}
-        align={undefined}
+        align="end"
       >
         <button
           type="button"


### PR DESCRIPTION
## Problem

The Epic status row is the topmost content row in the window. `EpicConnectionPill` asked for `side="top"`, so Radix had nowhere to put its tooltip but up into the title bar — directly over the minimize/maximize/close buttons.

## Fix

Flip the pill to `side="bottom"`, matching `EpicUsageEntryPoint` and `EpicSweepAction` — the pill's two neighbours in the same row, both of which already open downward. `align="end"` keeps the wider multi-plane copy (the `alsoDegraded` list) from running off the right edge.

## Verification

- `bun run compile` (gui-app tsc -b) — clean
- `vitest run src/components/epic-canvas/__tests__/epic-connection-pill.test.tsx` — 44/44 pass
- `eslint` on the changed file with `--max-warnings 0` — clean

No test asserted tooltip placement, so this is a behaviour-only change to the rendered side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)