### PR TITLE
fix(gui): flag edge whitespace in an env override instead of trimming it

### DIFF
--- a/clients/gui-app/src/components/settings/panels/__tests__/env-override-editor.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/env-override-editor.test.tsx
@@ -95,4 +95,80 @@ describe("EnvOverrideEditor", () => {
 
     expect(onDelete).toHaveBeenCalledWith("OPENAI_API_KEY");
   });
+
+  it("flags edge whitespace in a value rather than silently trimming it", () => {
+    const onCommit = vi.fn<EnvCommit>();
+    const onDelete = vi.fn<EnvDelete>();
+
+    renderEditor({
+      overrides: [{ key: "KIMI_CODE_HOME", value: " /workspace/kimi " }],
+      onCommit,
+      onDelete,
+    });
+
+    // Rendering alone must not rewrite the value. The spawned CLI receives it
+    // byte for byte and the providers disagree about what a padded value MEANS
+    // - most treat it as a relative path, a few strip it and call it unset - so
+    // the editor states the consequence and leaves the choice with the user.
+    expect(
+      screen.queryByText(/Leading or trailing spaces are part of this value/),
+    ).not.toBeNull();
+    expect(onCommit).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Trim spaces" }));
+
+    expect(onCommit).toHaveBeenCalledWith(
+      "KIMI_CODE_HOME",
+      "KIMI_CODE_HOME",
+      "/workspace/kimi",
+    );
+  });
+
+  it("says nothing about a value with no edge whitespace", () => {
+    const onCommit = vi.fn<EnvCommit>();
+    const onDelete = vi.fn<EnvDelete>();
+
+    renderEditor({
+      overrides: [{ key: "KIMI_CODE_HOME", value: "/workspace/kimi" }],
+      onCommit,
+      onDelete,
+    });
+
+    // Interior spaces are ordinary in a path and are NOT what diverges - only
+    // the edges are, so a notice here would be noise on a correct value.
+    expect(screen.queryByRole("button", { name: "Trim spaces" })).toBeNull();
+  });
+
+  it("flags edge whitespace on the staged add row without committing it", () => {
+    const onCommit = vi.fn<EnvCommit>();
+    const onDelete = vi.fn<EnvDelete>();
+
+    renderEditor({ overrides: [], onCommit, onDelete });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Add environment variable" }),
+    );
+    fireEvent.change(screen.getByLabelText("New environment variable name"), {
+      target: { value: "COPILOT_HOME" },
+    });
+    const valueField = screen.getByLabelText("New environment variable value");
+    fireEvent.change(valueField, { target: { value: "  /workspace/copilot" } });
+
+    fireEvent.click(screen.getByRole("button", { name: "Trim spaces" }));
+
+    // Staged, not written: the add row commits on Apply alone, so trimming here
+    // must edit the draft and nothing else.
+    expect(onCommit).not.toHaveBeenCalled();
+    expect((valueField as HTMLInputElement).value).toBe("/workspace/copilot");
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Apply environment variable" }),
+    );
+
+    expect(onCommit).toHaveBeenCalledWith(
+      "",
+      "COPILOT_HOME",
+      "/workspace/copilot",
+    );
+  });
 });

--- a/clients/gui-app/src/components/settings/panels/env-override-editor.tsx
+++ b/clients/gui-app/src/components/settings/panels/env-override-editor.tsx
@@ -56,6 +56,68 @@ function isEnvMode(value: string): value is EnvMode {
   return value === "set" || value === "unset";
 }
 
+/**
+ * Whether a SET value carries leading or trailing whitespace.
+ *
+ * Surfaced rather than stripped, and the distinction is load-bearing. This
+ * value is handed to the spawned CLI byte for byte, and the providers each read
+ * it their own way: most treat `"   "` as SET and resolve a directory literally
+ * named three spaces under their own cwd, while a few (`claude-code`, `hermes`,
+ * reasonix's `REASONIX_HOME`) strip it themselves and treat it as unset. The
+ * host models each of those individually so a probe looks where the CLI looks.
+ * Normalizing here would make this editor disagree with all of them at once and
+ * hide the difference from the only person who can say which they meant - a
+ * pasted path with a stray space and a deliberately padded value look identical
+ * once trimmed. So: say what will happen, and put the fix one click away.
+ */
+function hasEdgeWhitespace(value: string): boolean {
+  return value !== value.trim();
+}
+
+/**
+ * The one line below a row: a blocking error if there is one, otherwise the
+ * whitespace notice. Shared by the edit row and the add row so the precedence
+ * is stated once.
+ */
+function EnvRowFooter(props: {
+  readonly draft: Draft;
+  readonly disabled: boolean;
+  readonly onTrim: () => void;
+}) {
+  const { draft, disabled, onTrim } = props;
+  if (draft.error !== null) {
+    return <p className="text-ui-xs text-destructive">{draft.error}</p>;
+  }
+  if (draft.mode !== "set" || !hasEdgeWhitespace(draft.value)) return null;
+  return <EnvValueWhitespaceNotice disabled={disabled} onTrim={onTrim} />;
+}
+
+function EnvValueWhitespaceNotice(props: {
+  readonly disabled: boolean;
+  readonly onTrim: () => void;
+}) {
+  const { disabled, onTrim } = props;
+  return (
+    <p className="flex flex-wrap items-center gap-x-2 gap-y-0.5 text-ui-xs text-[var(--term-ansi-yellow)]">
+      <span>
+        Leading or trailing spaces are part of this value — the CLI receives it
+        exactly as written.
+      </span>
+      <button
+        type="button"
+        disabled={disabled}
+        // Keep focus in the field: a blur here would commit the untrimmed value
+        // first and this would trim it in a second write.
+        onMouseDown={(event) => event.preventDefault()}
+        onClick={onTrim}
+        className="underline underline-offset-2 hover:no-underline disabled:opacity-50"
+      >
+        Trim spaces
+      </button>
+    </p>
+  );
+}
+
 function draftError(key: string, otherKeys: readonly string[]): string | null {
   if (!ENV_KEY_PATTERN.test(key)) {
     return "Name must match /^[A-Za-z_][A-Za-z0-9_]*$/.";
@@ -189,9 +251,8 @@ function EnvOverrideRow(props: {
     onCommitRef.current = onCommit;
   }, [onCommit]);
 
-  const commit = (): void => {
+  const commitValue = (nextValue: string | null): void => {
     const nextKey = draft.key.trim();
-    const nextValue = draft.mode === "unset" ? null : draft.value;
     const error = draftError(nextKey, otherKeys);
     if (error !== null) {
       setDraft((current) => ({ ...current, key: entry.key, error }));
@@ -201,6 +262,15 @@ function EnvOverrideRow(props: {
     if (nextKey !== entry.key || nextValue !== entry.value) {
       onCommit(entry.key, nextKey, nextValue);
     }
+  };
+
+  const commit = (): void =>
+    commitValue(draft.mode === "unset" ? null : draft.value);
+
+  const trimValue = (): void => {
+    const nextValue = draft.value.trim();
+    setDraft((current) => ({ ...current, value: nextValue }));
+    commitValue(nextValue);
   };
 
   useEffect(() => {
@@ -261,9 +331,7 @@ function EnvOverrideRow(props: {
           <Trash2 className="size-4" />
         </button>
       </div>
-      {draft.error !== null ? (
-        <p className="text-ui-xs text-destructive">{draft.error}</p>
-      ) : null}
+      <EnvRowFooter draft={draft} disabled={disabled} onTrim={trimValue} />
     </li>
   );
 }
@@ -342,9 +410,13 @@ function EnvOverrideAddRow(props: {
           </Button>
         </div>
       </div>
-      {draft.error !== null ? (
-        <p className="text-ui-xs text-destructive">{draft.error}</p>
-      ) : null}
+      <EnvRowFooter
+        draft={draft}
+        disabled={disabled}
+        onTrim={() =>
+          setDraft((current) => ({ ...current, value: current.value.trim() }))
+        }
+      />
     </div>
   );
 }


### PR DESCRIPTION
An env-override row trims the KEY before committing it and leaves the VALUE
untouched, and nothing downstream trims it either. So Traycer's own settings UI
is a source of padded provider env values — the exact malformed input the host
has been spending review rounds learning to handle.

**This does not trim the value**, deliberately:

- The value's contract is that the spawned CLI receives it byte for byte.
  Trimming here makes the GUI and the host disagree about what the user
  configured, with the GUI winning invisibly.
- Providers disagree about what a padded value *means*. Most read it verbatim,
  so `"   "` is SET and resolves a directory literally named three spaces;
  claude-code, hermes and reasonix's `REASONIX_HOME` strip it themselves and
  call it unset. One normalization cannot be right for all of them.
- It would not close the class anyway — padded values still arrive from the
  login-shell capture, hand-edited `cli/config.json`, managed profiles, and the
  win32 registry.

So the editor states the consequence and puts the fix one click away: a notice
in the established `--term-ansi-yellow` validation tone plus a "Trim spaces"
action. Only EDGE whitespace is flagged — interior spaces are ordinary in a
path and are not what diverges.

Two details worth calling out:

- The trim button suppresses the field's blur (`onMouseDown` preventDefault),
  or the untrimmed value would commit first and then be rewritten.
- On the staged add row, trimming edits the draft only. That row commits on
  Apply alone, and a trim must not turn into a write.

Three tests, ablated by forcing `hasEdgeWhitespace` false: both "flags" tests
fail and the negative test correctly still passes.