### PR TITLE
feat(gui-app): default sharing to editor, hide artifact search on read-only Epics

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/panels/epic-sharing/__tests__/panel.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/panels/epic-sharing/__tests__/panel.test.tsx
@@ -365,12 +365,12 @@ describe("<SharingPanel />", () => {
             {
               identifier: "sharm@gmail.com",
               identifierType: "email",
-              role: "viewer",
+              role: "editor",
             },
             {
               identifier: "asjnfakjsnf",
               identifierType: "github_handle",
-              role: "viewer",
+              role: "editor",
             },
           ],
         }),
@@ -487,7 +487,7 @@ describe("<SharingPanel />", () => {
         input: {
           kind: "team",
           teamId: "team-2",
-          role: "viewer",
+          role: "editor",
         },
       },
       expect.objectContaining({}),

--- a/clients/gui-app/src/components/epic-canvas/panels/epic-sharing/access-lists.tsx
+++ b/clients/gui-app/src/components/epic-canvas/panels/epic-sharing/access-lists.tsx
@@ -152,7 +152,7 @@ export function TeamsAccess(props: TeamsAccessProps) {
           isSharePending={props.pending.shareTeamId === row.teamId}
           isRoleUpdatePending={props.pending.roleTeamId === row.teamId}
           isRevokePending={props.pending.revokeTeamId === row.teamId}
-          pendingRole={props.teamRolesById[row.teamId] ?? "viewer"}
+          pendingRole={props.teamRolesById[row.teamId] ?? "editor"}
           onPendingRoleChange={(role) => {
             props.onPendingTeamRoleChange(row.teamId, role);
           }}

--- a/clients/gui-app/src/components/epic-canvas/panels/epic-sharing/use-controller.ts
+++ b/clients/gui-app/src/components/epic-canvas/panels/epic-sharing/use-controller.ts
@@ -81,7 +81,7 @@ type SharingPanelAction =
 
 const INITIAL_SHARING_PANEL_STATE: SharingPanelState = {
   inviteInput: "",
-  selectedRole: "viewer",
+  selectedRole: "editor",
   queuedInvites: [],
   teamRolesById: {},
   revokeTarget: null,
@@ -288,7 +288,7 @@ export function useEpicSharingPanelController(
   const handleShareTeam = (team: TeamRow) => {
     if (!isOwner) return;
     if (team.kind !== "unshared") return;
-    const role = state.teamRolesById[team.teamId] ?? "viewer";
+    const role = state.teamRolesById[team.teamId] ?? "editor";
     dispatch({
       type: "set-pending-action",
       pendingAction: {

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/artifact-search-availability.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/artifact-search-availability.test.tsx
@@ -49,6 +49,10 @@ function openStore(): OpenEpicStoreHandle {
     userId: null,
     onAuthError: null,
   });
+  // A writable role, the way the host's meta/permission frames would set it:
+  // the gate also withholds search from viewers (and from a not-yet-known
+  // role), so the artifact-count cases below need write access as a given.
+  handle.store.setState({ permissionRole: "editor" });
   opened = handle;
   return handle;
 }
@@ -154,5 +158,41 @@ describe("useArtifactSearchAvailable against a real Epic store", () => {
 
     // Emptiness is the gate, not a count: one survivor still offers search.
     expect(availability()).toBe("yes");
+  });
+
+  it("answers no for a viewer even when artifacts exist", () => {
+    const handle = openStore();
+    act(() => {
+      seedArtifact(handle.doc, "art-1");
+    });
+    render(
+      <EpicSessionContext.Provider value={handle}>
+        <AvailabilityProbe />
+      </EpicSessionContext.Provider>,
+    );
+    expect(availability()).toBe("yes");
+
+    // A read-only device never runs epic file sync, so the search RPC's disk
+    // mirror never materializes; the gate hides search rather than offering a
+    // permanently "still syncing" dead end.
+    act(() => {
+      handle.store.setState({ permissionRole: "viewer" });
+    });
+
+    expect(availability()).toBe("no");
+  });
+
+  it("answers no while the role is not yet known", () => {
+    const handle = openStore();
+    act(() => {
+      seedArtifact(handle.doc, "art-1");
+      handle.store.setState({ permissionRole: null });
+    });
+    render(
+      <EpicSessionContext.Provider value={handle}>
+        <AvailabilityProbe />
+      </EpicSessionContext.Provider>,
+    );
+    expect(availability()).toBe("no");
   });
 });

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-artifact-search.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-artifact-search.test.tsx
@@ -106,6 +106,10 @@ vi.mock("@/hooks/epic/use-epic-tile-navigation", () => ({
 }));
 vi.mock("@/lib/epic-selectors", () => ({
   epicNodeRefForNodeId: () => harness.epicNodeRef,
+  // Writable role: the availability gate withholds search from viewers, and
+  // this suite covers the shell/box behaviour, not the role gate (that lives
+  // in artifact-search-availability.test.tsx).
+  useEpicPermissionRole: () => "editor",
 }));
 vi.mock("@/hooks/use-epic-store", () => ({
   useEpicStore: (selector: (s: unknown) => unknown) =>

--- a/clients/gui-app/src/components/epic-canvas/sidebar/artifact-search-availability.ts
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/artifact-search-availability.ts
@@ -7,9 +7,11 @@
  * components, for Fast Refresh).
  */
 import { useEpicStore } from "@/hooks/use-epic-store";
+import { useEpicPermissionRole } from "@/lib/epic-selectors";
+import { isEditableRole } from "@/lib/epic-permissions";
 
 /**
- * The gate is EMPTINESS, not size.
+ * The gate is EMPTINESS plus WRITE ACCESS, not size.
  *
  * This used to require ten artifacts, on the theory that scanning a short tree
  * beats filtering it. That threshold hid the affordance from most Epics, where
@@ -23,7 +25,17 @@ import { useEpicStore } from "@/hooks/use-epic-store";
  * query returns nothing. That case is common (every Epic starts there) and is
  * already answered by the panel's own "No artifacts yet." empty state, so
  * offering to search it is a dead end the header should not advertise.
+ *
+ * Read-only access is a dead end of a different kind: the host only runs epic
+ * file sync (which writes the on-disk artifact mirror the search RPC greps)
+ * for writable roles, so on a viewer's device `epic.searchArtifacts` reports
+ * `mirror-unavailable` forever - the "still syncing" empty state would be a
+ * permanent lie. Until search works without the mirror, withhold the
+ * affordance entirely for viewers (a null, not-yet-known role counts as
+ * read-only rather than briefly advertising a search that may then vanish).
  */
 export function useArtifactSearchAvailable(): boolean {
-  return useEpicStore((s) => s.artifacts.allIds.length > 0);
+  const hasArtifacts = useEpicStore((s) => s.artifacts.allIds.length > 0);
+  const writable = isEditableRole(useEpicPermissionRole());
+  return hasArtifacts && writable;
 }

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar.tsx
@@ -2215,9 +2215,9 @@ function ArtifactHeaderMoreMenu(props: {
         avoidCollisions={false}
         className="w-[var(--radix-dropdown-menu-content-available-width)] min-w-0 max-w-52"
       >
-        {/* Hidden only when the Epic has NO artifacts - see
-            `useArtifactSearchAvailable` for why emptiness gates this and a size
-            threshold does not. */}
+        {/* Hidden when the Epic has NO artifacts or is open read-only - see
+            `useArtifactSearchAvailable` for why emptiness and write access gate
+            this and a size threshold does not. */}
         {searchAvailable && !props.searching ? (
           <DropdownMenuItem
             onSelect={() => openSearch(props.tabId, "artifacts", "")}


### PR DESCRIPTION
## Summary

Two independent defaults, both about what a shared Epic offers.

**Sharing now proposes `editor`, not `viewer`.** Three places the panel picks a role for you: the invite card's initial selection, the fallback when a team is shared without touching its role select (`use-controller.ts`), and the pending role an unshared team row displays (`access-lists.tsx`). Inviting someone to collaborate and having them land unable to collaborate was the wrong default; the select still offers viewer for the cases that want it.

**Artifact search is withheld entirely from a read-only Epic.** The host only runs epic file sync — which writes the on-disk artifact mirror the search RPC greps — for writable roles (`epic-stream-resolver.ts` gates `startFileSync` on `isRoleAtLeast(role, "editor")`). So on a viewer's device `epic.searchArtifacts` answers `mirror-unavailable` forever, and the panel's "Artifact search isn't ready yet. / This Epic's artifacts are still syncing to this device." empty state was a permanent lie rather than a transient one.

`useArtifactSearchAvailable` is the single gate behind both entry points (the header overflow menu item and type-to-filter in the tree), so requiring write access there closes both. The shell's existing close-on-unavailable effect already kicks a user out of an open search when the gate flips, so a live role downgrade is handled. A not-yet-known (`null`) role counts as read-only, so the affordance never appears and then vanishes.

This is a client-side gate only — the RPC still answers viewers truthfully. Search without the mirror (title/path ranking off the authoritative Y.Doc index, which viewers *do* hold) stays possible later; this just stops advertising a dead end in the meantime.

## Related issue

<!-- none -->

## Checklist

- [x] Pre-commit static checks pass
- [x] Separate CI test checks pass
- [x] Tests added/updated where it makes sense
- [x] Commits are signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#developer-certificate-of-origin-dco)

### Tests

- `artifact-search-availability.test.tsx` — added a viewer-with-artifacts case and a null-role case; existing artifact-count cases now seed an editor role. This suite mocks nothing and drives a real `createOpenEpicStore`, so the role transition is exercised end to end.
- `epic-sidebar-artifact-search.test.tsx` — its `@/lib/epic-selectors` mock now supplies a writable `useEpicPermissionRole`.
- `epic-sharing/__tests__/panel.test.tsx` — the two expectations that encoded the old default (queued-invite payload, team-grant payload) now expect `editor`.

Locally: 208 tests pass across the six affected suites (availability, artifact search, sharing panel, sidebar selection mode, sidebar column, epic shell).

🤖 Generated with [Claude Code](https://claude.com/claude-code)