### PR TITLE
fix(mobile,android): raise minSdk to 26 for the barcode scanner, sync plugin wiring

### DIFF
--- a/clients/mobile/android/app/capacitor.build.gradle
+++ b/clients/mobile/android/app/capacitor.build.gradle
@@ -9,7 +9,10 @@ android {
 
 apply from: "../capacitor-cordova-android-plugins/cordova.variables.gradle"
 dependencies {
+    implementation project(':capacitor-app')
     implementation project(':capacitor-app-launcher')
+    implementation project(':capacitor-barcode-scanner')
+    implementation project(':capacitor-device')
     implementation project(':capacitor-keyboard')
     implementation project(':capacitor-push-notifications')
     implementation project(':capacitor-native-settings')

--- a/clients/mobile/android/capacitor.settings.gradle
+++ b/clients/mobile/android/capacitor.settings.gradle
@@ -2,8 +2,17 @@
 include ':capacitor-android'
 project(':capacitor-android').projectDir = new File('../../../node_modules/.bun/@capacitor+android@8.4.2+f68449e264960a74/node_modules/@capacitor/android/capacitor')
 
+include ':capacitor-app'
+project(':capacitor-app').projectDir = new File('../../../node_modules/.bun/@capacitor+app@8.1.1+f68449e264960a74/node_modules/@capacitor/app/android')
+
 include ':capacitor-app-launcher'
 project(':capacitor-app-launcher').projectDir = new File('../../../node_modules/.bun/@capacitor+app-launcher@8.0.1+f68449e264960a74/node_modules/@capacitor/app-launcher/android')
+
+include ':capacitor-barcode-scanner'
+project(':capacitor-barcode-scanner').projectDir = new File('../../../node_modules/.bun/@capacitor+barcode-scanner@3.1.0+f68449e264960a74/node_modules/@capacitor/barcode-scanner/android')
+
+include ':capacitor-device'
+project(':capacitor-device').projectDir = new File('../../../node_modules/.bun/@capacitor+device@8.0.0+f68449e264960a74/node_modules/@capacitor/device/android')
 
 include ':capacitor-keyboard'
 project(':capacitor-keyboard').projectDir = new File('../../../node_modules/.bun/@capacitor+keyboard@8.0.5+f68449e264960a74/node_modules/@capacitor/keyboard/android')

--- a/clients/mobile/android/variables.gradle
+++ b/clients/mobile/android/variables.gradle
@@ -1,5 +1,7 @@
 ext {
-    minSdkVersion = 24
+    // 26 (Android 8.0) is the floor @capacitor/barcode-scanner's native
+    // library (ionbarcode-android) declares; 24 fails the manifest merge.
+    minSdkVersion = 26
     compileSdkVersion = 36
     targetSdkVersion = 36
     androidxActivityVersion = '1.11.0'


### PR DESCRIPTION
## Why

Every Android release build has failed since the QR link-login feature landed: `@capacitor/barcode-scanner`'s native library (`ionbarcode-android:2.1.0`) declares `minSdk 26`, and our app declared `24`, so the manifest merge aborts (`mobile-staging-v1.0.19` / `v1.0.20` in the internal repo). iOS is unaffected.

## What

- `variables.gradle`: `minSdkVersion` 24 → 26 (Android 8.0, 2017 — drops Android 7 only). The alternative, `tools:overrideLibrary`, would pass the build and crash at runtime when the scanner opens.
- `capacitor.settings.gradle` / `app/capacitor.build.gradle`: regenerated by `cap sync` — the same feature added the `app`, `barcode-scanner` and `device` plugins without re-syncing the tracked files, so a fresh clone could not run Gradle. Same install-layout hashes as the committed lines.

## Verified

`./gradlew :app:processReleaseMainManifest` (the exact step CI fails on) passes; the merged manifest carries `minSdkVersion="26"`. A full signed staging AAB was also built from this tree and uploaded to Play internal testing by hand.

Internal follow-up: `traycerai/traycer-internal` PR for the Android release-lane split (Play upload + staging/prod identities) will repin to this commit once merged.