### PR TITLE
fix(gui): use official Reasonix icon

### DIFF
--- a/clients/gui-app/src/components/home/pickers/harness-icons.tsx
+++ b/clients/gui-app/src/components/home/pickers/harness-icons.tsx
@@ -126,45 +126,17 @@ export const OmpIcon: HarnessIcon = (props) => (
   </svg>
 );
 
-// Reasonix (esengine/DeepSeek-Reasonix) has no lobehub entry and publishes no
-// brand asset, so this is a hand-rolled mark: a premise node fanning out to two
-// conclusion nodes — an inference step, which is what the product is named for.
-//
-// Deliberately NOT DeepSeek's whale, even though `@lobehub/icons` ships one and
-// the upstream repo carries "DeepSeek" in its name. Reasonix is a third-party
-// CLI whose backend is user-configured: its shipped presets cover Kimi, GLM/Z.AI,
-// Qwen, MiniMax, StepFun, LongCat and Nvidia alongside DeepSeek, and Kimi and
-// Qwen are already their own rows here with their own marks. A vendor mark on
-// this row would claim a backend the user may not be running — the same
-// mis-identification hazard the checklist records for reusing a sibling's icon,
-// arriving from the model side instead of the sibling side.
-//
-// Monochrome `currentColor` so it follows `text-foreground` like the other
-// hand-rolled marks; there is no brand accent to keep literal.
+// Reasonix's official app badge, from the upstream website favicon. Keep the
+// literal brand blue and white glyph: unlike the monochrome harness marks, the
+// blue rounded square is part of Reasonix's identity and remains legible in
+// both themes.
 export const ReasonixIcon: HarnessIcon = (props) => (
-  <svg
-    {...props}
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="1.8"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-  >
-    {/* Premise → two conclusions */}
-    <path d="M8 12h3.5l3 -5.5" />
-    <path d="M11.5 12l3 5.5" />
-    <rect
-      x="2.6"
-      y="9.4"
-      width="5.2"
-      height="5.2"
-      rx="1.4"
-      fill="currentColor"
-      stroke="none"
+  <svg {...props} viewBox="0 0 64 64" fill="none">
+    <rect width="64" height="64" rx="20.22" fill="#0153e5" />
+    <path
+      fill="#fff"
+      d="M40.53 37.67c2.26-.67 4.24-1.86 5.83-3.59 1.73-1.94 2.82-4.29 3.2-6.87.86-5.64-1.94-10.79-7.21-12.97-1.85-.74-3.76-1.06-5.78-1.04h-19.6v37.56h9.64V38.08c1.05.34 2.16.52 3.29.52l3.15 4.35 5.73 7.83 11.44-.02-9.7-13.1Zm-.39-1.73c-1.31.43-2.72.37-4.06-.02-2.3-1.74-3.55-3.6-5.52-5.37-2.52-2.27-5.84-3.84-9.25-3.69.27-.74.66-1.45 1.17-2.11 1.76-2.2 4.16-2.9 6.92-2.51 1.02.14 2.11-1.05 4.18-.82.14.02.28.12.29.2.05.28-.75.44-.75 1.21 0 .32.15.7.45.92 1.06.74 1.97 1.57 2.93 2.43.47.42 2.04 1.59 2.44.64.24-.56.39-1.14.54-1.74.08-.29-.09-.47-.32-.61-1.63-.96-2.24-2.97-1.6-4.75.06-.17.22-.25.36-.26.55-.02.25.99 1.61 1.4 1.28.4 1.32 1.46 1.94 1.04 1.45-.99 1.97-.18 3.32-1.45.14-.13.38-.14.52-.04.09.06.17.22.16.41-.04 1.07-.46 2.1-1.19 2.88-1.39 1.49-2.55.77-2.62 1.82-.22 3.06-1.22 6.11-3.39 8.33-.07.07-.11.17-.1.24.01.07.1.14.19.17l1.83.62c.26.09.45.32.41.57-.03.22-.2.41-.45.49Z"
     />
-    <circle cx="17.6" cy="6" r="2.6" fill="currentColor" stroke="none" />
-    <circle cx="17.6" cy="18" r="2.6" />
   </svg>
 );
 


### PR DESCRIPTION
## Summary

- replace the hand-drawn Reasonix placeholder with the official upstream app badge
- preserve the official `#0153e5` blue plate and white Reasonix glyph in both themes
- source the vector geometry from Reasonix’s published website favicon

Official source: https://github.com/esengine/DeepSeek-Reasonix/blob/main-v2/site/public/favicon.svg

## Related issue

None.

## Checklist

- [ ] Pre-commit static checks pass (`pre-commit run --all-files` for an explicit full-repo run)
- [ ] Separate CI test checks pass
- [x] Tests added/updated where it makes sense (visual asset replacement; no behavioral test needed)
- [x] Commits are signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#developer-certificate-of-origin-dco)
