### PR TITLE
feat(gui): redesign remote folder picker

### DIFF
--- a/clients/gui-app/src/components/__tests__/remote-folder-picker-dialog.test.tsx
+++ b/clients/gui-app/src/components/__tests__/remote-folder-picker-dialog.test.tsx
@@ -225,10 +225,16 @@ describe("<RemoteFolderPickerDialog />", () => {
     const dialogClasses = dialog.className.split(" ");
     expect(dialogClasses).toContain("top-[18svh]");
     expect(dialogClasses).toContain("translate-y-0");
-    expect(dialogClasses).toContain("h-[min(80dvh,36rem)]");
+    expect(dialogClasses).toContain(
+      "h-[min(80dvh,36rem,calc(100dvh-18svh-var(--safe-area-inset-bottom)))]",
+    );
     expect(dialogClasses).not.toContain("max-h-[min(80dvh,36rem)]");
-    expect(dialogClasses).toContain("max-w-[min(90vw,40rem)]");
-    expect(dialogClasses).toContain("sm:max-w-[min(90vw,40rem)]");
+    expect(dialogClasses).toContain(
+      "max-w-[min(90vw,40rem,var(--safe-area-width))]",
+    );
+    expect(dialogClasses).toContain(
+      "sm:max-w-[min(90vw,40rem,var(--safe-area-width))]",
+    );
     expect(dialogClasses).not.toContain("top-safe-center-y");
     expect(dialogClasses).not.toContain("-translate-y-1/2");
     expect(dialogClasses).not.toContain("sm:max-w-sm");

--- a/clients/gui-app/src/components/__tests__/remote-folder-picker-dialog.test.tsx
+++ b/clients/gui-app/src/components/__tests__/remote-folder-picker-dialog.test.tsx
@@ -157,41 +157,13 @@ const CODE_RESPONSE: WorkspaceBrowseFoldersResponseV11 = {
   entries: [],
 };
 
-/**
- * The raw absolute-path field. It is no longer the resting presentation of
- * the location - a dimmed heading is - so reaching it means tapping that
- * heading first, exactly as a user does. Tests about PATH semantics
- * (expansion, separators, whitespace) drive this field; tests about finding
- * a folder drive `searchInput()`.
- */
+/** The always-visible path combobox. */
 function pathInput(): HTMLInputElement {
-  if (screen.queryByTestId("remote-folder-picker-path") === null) {
-    fireEvent.click(screen.getByTestId("remote-folder-picker-location"));
-  }
   const element = screen.getByTestId("remote-folder-picker-path");
   if (!(element instanceof HTMLInputElement)) {
     throw new Error("path field is not an input");
   }
   return element;
-}
-
-/**
- * The search field: filters the CURRENT folder, never navigates. Located the
- * way a screen reader would - by role and accessible name - so the query also
- * asserts that the combobox is still announced as one.
- */
-function searchInput(): HTMLInputElement {
-  const element = screen.getByRole("combobox", { name: "Search folders" });
-  if (!(element instanceof HTMLInputElement)) {
-    throw new Error("search field is not an input");
-  }
-  return element;
-}
-
-/** Text of the dimmed location heading, without its leading "in". */
-function locationText(): string {
-  const element = screen.getByTestId("remote-folder-picker-location");
-  return element.textContent.replace(/^in/, "");
 }
 
 function rowNames(): string[] {
@@ -244,6 +216,94 @@ describe("<RemoteFolderPickerDialog />", () => {
   it("stays unmounted until a pick is requested", () => {
     render(<RemoteFolderPickerDialog />);
     expect(screen.queryByTestId("remote-folder-picker-dialog")).toBeNull();
+  });
+
+  it("keeps a stable height and single-row footer across directory levels", async () => {
+    render(<RemoteFolderPickerDialog />);
+    void useRemoteFolderPickerStore.getState().requestPick(makeClient());
+    const dialog = await screen.findByTestId("remote-folder-picker-dialog");
+    const dialogClasses = dialog.className.split(" ");
+    expect(dialogClasses).toContain("top-[18svh]");
+    expect(dialogClasses).toContain("translate-y-0");
+    expect(dialogClasses).toContain("h-[min(80dvh,36rem)]");
+    expect(dialogClasses).not.toContain("max-h-[min(80dvh,36rem)]");
+    expect(dialogClasses).toContain("max-w-[min(90vw,40rem)]");
+    expect(dialogClasses).toContain("sm:max-w-[min(90vw,40rem)]");
+    expect(dialogClasses).not.toContain("top-safe-center-y");
+    expect(dialogClasses).not.toContain("-translate-y-1/2");
+    expect(dialogClasses).not.toContain("sm:max-w-sm");
+    const addButton = screen.getByTestId("remote-folder-picker-add");
+    expect(addButton.dataset.variant).toBe("outline");
+    const addKeycaps = [...addButton.querySelectorAll('[data-slot="kbd"]')];
+    expect(addKeycaps).toHaveLength(2);
+    for (const keycap of addKeycaps) {
+      expect(keycap.className).toContain("bg-foreground/8");
+      expect(keycap.className).toContain("text-muted-foreground");
+      expect(keycap.className.split(" ")).not.toContain("text-current");
+    }
+    expect(screen.getByRole("button", { name: "Up one folder" })).toBeTruthy();
+    expect(pathInput().parentElement?.className).not.toContain(
+      "bg-foreground/8",
+    );
+    expect(pathInput().parentElement?.parentElement?.className).toContain(
+      "flex-1",
+    );
+    expect(pathInput().className).not.toMatch(/border|ring/);
+    expect(screen.getByText("Directories")).toBeTruthy();
+
+    const footer = screen
+      .getByRole("button", { name: "Folder picker settings" })
+      .closest(".border-t");
+    expect(footer).not.toBeNull();
+    expect(footer?.querySelector(".flex-wrap")).toBeNull();
+  });
+
+  it("keeps the editable path visible through navigation and creation", async () => {
+    render(<RemoteFolderPickerDialog />);
+    void useRemoteFolderPickerStore.getState().requestPick(makeClient());
+    const field = await screen.findByRole("combobox", { name: "Folder path" });
+    expect(field).toBeInstanceOf(HTMLInputElement);
+    expect(
+      screen.queryByRole("combobox", { name: "Search folders" }),
+    ).toBeNull();
+    expect(pathInput().value).toBe("/Users/tester/");
+
+    Object.defineProperty(pathInput(), "scrollWidth", {
+      configurable: true,
+      value: 400,
+    });
+    pathInput().scrollLeft = 0;
+    pathInput().setSelectionRange(0, 0);
+    fireEvent.click(
+      (await screen.findAllByTestId("remote-folder-picker-row"))[0],
+    );
+    expect(pathInput().value).toBe("/Users/tester/code/");
+    expect(pathInput().selectionStart).toBe(pathInput().value.length);
+    expect(pathInput().scrollLeft).toBe(400);
+    pathInput().scrollLeft = 100;
+    fireEvent.change(pathInput(), {
+      target: { value: "/Users/tester/code/new-folder" },
+    });
+    expect(pathInput().scrollLeft).toBe(100);
+    expect(
+      screen.getByTestId("remote-folder-picker-add").textContent,
+    ).toContain("Create & Add");
+  });
+
+  it("keeps a selected fuzzy match visible on hover", async () => {
+    render(<RemoteFolderPickerDialog />);
+    void useRemoteFolderPickerStore.getState().requestPick(makeClient());
+    await screen.findAllByTestId("remote-folder-picker-row");
+    fireEvent.change(pathInput(), {
+      target: { value: "/Users/tester/cod" },
+    });
+    const row = screen.getByTestId("remote-folder-picker-row");
+    expect(row.className.split(" ")).toEqual(
+      expect.arrayContaining(["bg-foreground/8", "hover:bg-foreground/8"]),
+    );
+    expect(
+      row.querySelector("[data-testid='folder-picker-name-hit']")?.className,
+    ).toContain("group-aria-selected/button:text-foreground");
   });
 
   it("seeds the field with the host home; hidden folders stay hidden unfiltered", async () => {
@@ -300,7 +360,7 @@ describe("<RemoteFolderPickerDialog />", () => {
     expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy();
   });
 
-  it("Retry hands focus back to the search field", async () => {
+  it("Retry hands focus back to the path field", async () => {
     queryByPath.set(pathKey("/Users/tester/Desktop"), {
       data: undefined,
       isPending: false,
@@ -321,9 +381,9 @@ describe("<RemoteFolderPickerDialog />", () => {
     await act(async () => {
       await Promise.resolve();
     });
-    // The search field is the combobox now, so that is where the keyboard
-    // has to land - Retry disappears when it succeeds.
-    expect(document.activeElement).toBe(searchInput());
+    // Retry disappears when it succeeds, so the keyboard returns to the
+    // combobox that owns path editing and row navigation.
+    expect(document.activeElement).toBe(pathInput());
   });
 
   it("a too-old host shows upgrade guidance without Retry", async () => {
@@ -403,7 +463,7 @@ describe("<RemoteFolderPickerDialog />", () => {
       target: { value: "/Users/tester/code/" },
     });
     expect(requestedPaths.at(-1)).toBe("/Users/tester/code");
-    // Empty folder: only the ".." row remains (matching T3's layout).
+    // Empty folder: only the ".." row remains.
     expect(rowNames()).toEqual([]);
     expect(screen.getByTestId("remote-folder-picker-up-row")).toBeTruthy();
   });
@@ -523,19 +583,45 @@ describe("<RemoteFolderPickerDialog />", () => {
     // is where the selection RESTS before any key is pressed. "Go up" is a
     // poor default for Enter, and on touch the resting fill is all the
     // highlight communicates.
-    expect(searchInput().getAttribute("aria-activedescendant")).toBe(
+    expect(pathInput().getAttribute("aria-activedescendant")).toBe(
       "remote-folder-picker-option-1",
     );
     expect(screen.getAllByRole("option")[1].getAttribute("aria-selected")).toBe(
       "true",
     );
-    fireEvent.keyDown(searchInput(), { key: "ArrowDown" });
-    expect(searchInput().getAttribute("aria-activedescendant")).toBe(
+    fireEvent.keyDown(pathInput(), { key: "ArrowDown" });
+    expect(pathInput().getAttribute("aria-activedescendant")).toBe(
       "remote-folder-picker-option-2",
     );
-    fireEvent.keyDown(searchInput(), { key: "Enter" });
-    // The heading presents the location, so it reads tilde-collapsed.
-    expect(locationText()).toBe("~/consulting");
+    fireEvent.keyDown(pathInput(), { key: "Enter" });
+    expect(pathInput().value).toBe("/Users/tester/consulting/");
+  });
+
+  it("keeps the parent row active while repeatedly ascending with Enter", async () => {
+    queryByPath.set(
+      pathKey("/Users"),
+      readyLevel({
+        directoryPath: "/Users",
+        parentPath: "/",
+        entries: [{ path: "/Users/tester", name: "tester", hidden: false }],
+      }),
+    );
+    render(<RemoteFolderPickerDialog />);
+    void useRemoteFolderPickerStore.getState().requestPick(makeClient());
+    await screen.findAllByTestId("remote-folder-picker-row");
+
+    fireEvent.keyDown(pathInput(), { key: "Enter" });
+    expect(pathInput().value).toBe("/Users/tester/code/");
+    expect(pathInput().getAttribute("aria-activedescendant")).toBe(
+      "remote-folder-picker-option-0",
+    );
+    fireEvent.keyDown(pathInput(), { key: "Enter" });
+    expect(pathInput().value).toBe("/Users/tester/");
+    expect(pathInput().getAttribute("aria-activedescendant")).toBe(
+      "remote-folder-picker-option-0",
+    );
+    fireEvent.keyDown(pathInput(), { key: "Enter" });
+    expect(pathInput().value).toBe("/Users/");
   });
 
   it("relative input shows a hint, not a loading state", async () => {
@@ -633,13 +719,13 @@ describe("<RemoteFolderPickerDialog />", () => {
     // The stale "api" row is not rendered, so it must not be addressable:
     // ".." is the only option, and ArrowDown has nowhere past it to go.
     expect(rowNames()).toEqual([]);
-    fireEvent.keyDown(searchInput(), { key: "ArrowDown" });
-    expect(searchInput().getAttribute("aria-activedescendant")).toBe(
+    fireEvent.keyDown(pathInput(), { key: "ArrowDown" });
+    expect(pathInput().getAttribute("aria-activedescendant")).toBe(
       "remote-folder-picker-option-0",
     );
     // Enter therefore backs out, instead of opening a folder nothing showed.
-    fireEvent.keyDown(searchInput(), { key: "Enter" });
-    expect(locationText()).toBe("~");
+    fireEvent.keyDown(pathInput(), { key: "Enter" });
+    expect(pathInput().value).toBe("/Users/tester/");
   });
 
   it("navigates up via the up row", async () => {
@@ -743,8 +829,7 @@ describe("<RemoteFolderPickerDialog />", () => {
     expect(document.activeElement).toBe(chip);
     fireEvent.click(chip);
     expect(screen.queryAllByTestId("remote-folder-picker-recent")).toEqual([]);
-    // The search field is the combobox the keyboard model lives on.
-    expect(document.activeElement).toBe(searchInput());
+    expect(document.activeElement).toBe(pathInput());
   });
 
   it("treats a backslash as an ordinary character in a POSIX folder name", async () => {
@@ -876,7 +961,7 @@ describe("<RemoteFolderPickerDialog />", () => {
     const pick = useRemoteFolderPickerStore
       .getState()
       .requestPick(makeClient());
-    await screen.findByTestId("remote-folder-picker-location");
+    await screen.findByTestId("remote-folder-picker-path");
     expect(pathInput().value).toBe("/Users/tester/");
     expect(
       screen.getByTestId("remote-folder-picker-add").hasAttribute("disabled"),
@@ -905,7 +990,7 @@ describe("<RemoteFolderPickerDialog />", () => {
     const pick = useRemoteFolderPickerStore
       .getState()
       .requestPick(makeClient());
-    await screen.findByTestId("remote-folder-picker-location");
+    await screen.findByTestId("remote-folder-picker-path");
     fireEvent.change(pathInput(), { target: { value: "~/code" } });
     fireEvent.click(screen.getByTestId("remote-folder-picker-add"));
     await expect(pick).resolves.toEqual({
@@ -1030,16 +1115,12 @@ describe("<RemoteFolderPickerDialog />", () => {
       });
     });
 
-    it("keeps the drive root's separator in the heading", async () => {
-      // Dropping it would leave `C:`, which names the drive-RELATIVE current
-      // directory rather than the drive itself, so the heading would quietly
-      // claim a different location than the one being browsed.
+    it("keeps the drive root's separator in the field", async () => {
       render(<RemoteFolderPickerDialog />);
       void useRemoteFolderPickerStore.getState().requestPick(makeClient());
       await screen.findAllByTestId("remote-folder-picker-row");
       fireEvent.change(pathInput(), { target: { value: "C:\\" } });
-      fireEvent.blur(screen.getByTestId("remote-folder-picker-path"));
-      expect(locationText()).toBe("C:\\");
+      expect(pathInput().value).toBe("C:\\");
     });
 
     it("expands ~ against the Windows home", async () => {
@@ -1142,51 +1223,50 @@ describe("<RemoteFolderPickerDialog />", () => {
       expect(screen.getByTestId("remote-folder-picker-invalid")).toBeTruthy();
     });
   });
-  describe("search and the location heading", () => {
-    it("searches the CURRENT folder and never leaves it", async () => {
+  describe("path filtering", () => {
+    it("filters the current folder from the final path segment", async () => {
       render(<RemoteFolderPickerDialog />);
       void useRemoteFolderPickerStore.getState().requestPick(makeClient());
       await screen.findAllByTestId("remote-folder-picker-row");
-      fireEvent.change(searchInput(), { target: { value: "co" } });
+      fireEvent.change(pathInput(), {
+        target: { value: "/Users/tester/co" },
+      });
       expect(rowNames()).toEqual(["code", "consulting"]);
-      // Filtering is a client-side pass over rows already in hand: it asks
-      // the host about no directory other than the one already open, and the
-      // location is untouched. (The fake records one entry per render, so
-      // the DISTINCT set is the meaningful assertion, not the count.)
-      expect([...new Set(requestedPaths)]).toEqual([null]);
-      expect(locationText()).toBe("~");
+      expect(requestedPaths.at(-1)).toBe("/Users/tester");
+      expect(pathInput().value).toBe("/Users/tester/co");
     });
 
     it("ranks by match strength, not by listing order", async () => {
-      queryByPath.set(
-        pathKey(null),
-        readyLevel({
-          directoryPath: "/Users/tester",
-          parentPath: "/Users",
-          entries: [
-            {
-              path: "/Users/tester/my-prototype",
-              name: "my-prototype",
-              hidden: false,
-            },
-            {
-              path: "/Users/tester/mp-tools",
-              name: "mp-tools",
-              hidden: false,
-            },
-            {
-              path: "/Users/tester/old-mpt-runner",
-              name: "old-mpt-runner",
-              hidden: false,
-            },
-            { path: "/Users/tester/mpt", name: "mpt", hidden: false },
-          ],
-        }),
-      );
+      const level = readyLevel({
+        directoryPath: "/Users/tester",
+        parentPath: "/Users",
+        entries: [
+          {
+            path: "/Users/tester/my-prototype",
+            name: "my-prototype",
+            hidden: false,
+          },
+          {
+            path: "/Users/tester/mp-tools",
+            name: "mp-tools",
+            hidden: false,
+          },
+          {
+            path: "/Users/tester/old-mpt-runner",
+            name: "old-mpt-runner",
+            hidden: false,
+          },
+          { path: "/Users/tester/mpt", name: "mpt", hidden: false },
+        ],
+      });
+      queryByPath.set(pathKey(null), level);
+      queryByPath.set(pathKey("/Users/tester"), level);
       render(<RemoteFolderPickerDialog />);
       void useRemoteFolderPickerStore.getState().requestPick(makeClient());
       await screen.findAllByTestId("remote-folder-picker-row");
-      fireEvent.change(searchInput(), { target: { value: "mpt" } });
+      fireEvent.change(pathInput(), {
+        target: { value: "/Users/tester/mpt" },
+      });
       // Prefix, then substring, then scattered subsequence - and within the
       // subsequence tier the tighter run first ("mp-tools" spans 4
       // characters, "my-prototype" spans 7). Listing order does not survive.
@@ -1206,9 +1286,13 @@ describe("<RemoteFolderPickerDialog />", () => {
       void useRemoteFolderPickerStore.getState().requestPick(makeClient());
       await screen.findAllByTestId("remote-folder-picker-row");
       expect(screen.getByTestId("remote-folder-picker-up-row")).toBeTruthy();
-      fireEvent.change(searchInput(), { target: { value: "co" } });
+      fireEvent.change(pathInput(), {
+        target: { value: "/Users/tester/co" },
+      });
       expect(screen.queryByTestId("remote-folder-picker-up-row")).toBeNull();
-      fireEvent.click(screen.getByTestId("remote-folder-picker-filter-clear"));
+      fireEvent.change(pathInput(), {
+        target: { value: "/Users/tester/" },
+      });
       expect(screen.getByTestId("remote-folder-picker-up-row")).toBeTruthy();
     });
 
@@ -1216,7 +1300,9 @@ describe("<RemoteFolderPickerDialog />", () => {
       render(<RemoteFolderPickerDialog />);
       void useRemoteFolderPickerStore.getState().requestPick(makeClient());
       await screen.findAllByTestId("remote-folder-picker-row");
-      fireEvent.change(searchInput(), { target: { value: "zzz" } });
+      fireEvent.change(pathInput(), {
+        target: { value: "/Users/tester/zzz" },
+      });
       expect(screen.getByText("Nothing here matches.")).toBeTruthy();
     });
 
@@ -1224,7 +1310,9 @@ describe("<RemoteFolderPickerDialog />", () => {
       render(<RemoteFolderPickerDialog />);
       void useRemoteFolderPickerStore.getState().requestPick(makeClient());
       await screen.findAllByTestId("remote-folder-picker-row");
-      fireEvent.change(searchInput(), { target: { value: "cod" } });
+      fireEvent.change(pathInput(), {
+        target: { value: "/Users/tester/cod" },
+      });
       const [row] = screen.getAllByTestId("remote-folder-picker-row");
       // The hit is marked in place; the rest of the name still renders.
       expect(row.textContent).toBe("code");
@@ -1234,34 +1322,25 @@ describe("<RemoteFolderPickerDialog />", () => {
       ).toBe("cod");
     });
 
-    it("moving to another folder drops the search with it", async () => {
+    it("opening a filtered row appends it to the field", async () => {
       render(<RemoteFolderPickerDialog />);
       void useRemoteFolderPickerStore.getState().requestPick(makeClient());
       await screen.findAllByTestId("remote-folder-picker-row");
-      fireEvent.change(searchInput(), { target: { value: "code" } });
+      fireEvent.change(pathInput(), {
+        target: { value: "/Users/tester/code" },
+      });
       fireEvent.click(screen.getAllByTestId("remote-folder-picker-row")[0]);
-      // A search that survived the move would hide the rows the move was
-      // made to look at.
-      expect(searchInput().value).toBe("");
-      expect(locationText()).toBe("~/code");
+      expect(pathInput().value).toBe("/Users/tester/code/");
     });
 
-    it("shows the location as a heading, with the raw path one tap behind", async () => {
+    it("shows the editable absolute path without a disclosure step", async () => {
       render(<RemoteFolderPickerDialog />);
       void useRemoteFolderPickerStore.getState().requestPick(makeClient());
       await screen.findAllByTestId("remote-folder-picker-row");
-      // Resting state: a heading, not a field. The search box is the only
-      // input on show, and it holds no path.
-      expect(screen.queryByTestId("remote-folder-picker-path")).toBeNull();
-      expect(locationText()).toBe("~");
-      expect(searchInput().value).toBe("");
-      fireEvent.click(screen.getByTestId("remote-folder-picker-location"));
-      // Tapping swaps in the absolute path, unabbreviated and editable.
-      const field = screen.getByTestId("remote-folder-picker-path");
-      expect(field).toBeInstanceOf(HTMLInputElement);
+      expect(screen.getByRole("combobox", { name: "Folder path" })).toBe(
+        pathInput(),
+      );
       expect(pathInput().value).toBe("/Users/tester/");
-      fireEvent.blur(field);
-      expect(screen.queryByTestId("remote-folder-picker-path")).toBeNull();
     });
 
     it("long-pressing a row reveals its full path verbatim", async () => {
@@ -1288,7 +1367,7 @@ describe("<RemoteFolderPickerDialog />", () => {
         expect(screen.getByText("/Users/tester/code")).toBeTruthy();
         // And the press must not ALSO pick the row it was inspecting.
         fireEvent.click(row);
-        expect(locationText()).toBe("~");
+        expect(pathInput().value).toBe("/Users/tester/");
       } finally {
         vi.useRealTimers();
       }

--- a/clients/gui-app/src/components/folder-picker-path-view.tsx
+++ b/clients/gui-app/src/components/folder-picker-path-view.tsx
@@ -32,7 +32,7 @@ export function HighlightedName(props: {
       <span
         key={`hit-${String(index)}`}
         data-testid="folder-picker-name-hit"
-        className="font-semibold text-primary underline decoration-primary/40 underline-offset-2"
+        className="font-semibold text-primary underline decoration-primary/40 underline-offset-2 group-aria-selected/button:text-foreground group-aria-selected/button:decoration-current/40"
       >
         {props.name.slice(range.start, range.end)}
       </span>,

--- a/clients/gui-app/src/components/remote-folder-picker-dialog.tsx
+++ b/clients/gui-app/src/components/remote-folder-picker-dialog.tsx
@@ -100,7 +100,7 @@ export function RemoteFolderPickerDialog(): ReactNode {
       }}
     >
       <DialogContent
-        className="flex max-h-[min(80dvh,36rem)] w-[min(92vw,34rem)] max-w-[min(92vw,34rem)] flex-col gap-0 p-0"
+        className="top-[18svh] flex h-[min(80dvh,36rem)] w-full max-w-[min(90vw,40rem)] translate-y-0 flex-col gap-0 overflow-hidden p-0 sm:max-w-[min(90vw,40rem)]"
         data-testid="remote-folder-picker-dialog"
         // Phone-facing portal outside HomePage's touch scope: re-apply the
         // coarse-pointer hit-slop rules (home-touch-targets.css) so every
@@ -139,26 +139,18 @@ function RemoteFolderPickerBody(): ReactNode {
   // null = not edited yet; the field then shows the host home once known.
   const [rawInput, setRawInput] = useState<string | null>(null);
   const [selectedIndex, setSelectedIndex] = useState(UNSET_SELECTION);
-  /**
-   * Type-to-filter over the CURRENT listing, separate from the location.
-   * Splitting them is what lets the location be presented (short, relative,
-   * non-editable) instead of being a raw path field the filter has to share.
-   */
-  const [filter, setFilter] = useState("");
-  /** The location line is a button until tapped; then it is the raw field. */
-  const [editingPath, setEditingPath] = useState(false);
   /** Long-press target: the one path shown in full, verbatim. */
   const [fullPath, setFullPath] = useState<string | null>(null);
   // The host's home, learned from the root (null-path) response; anchors `~`.
   const [homePath, setHomePath] = useState<string | null>(null);
-  /** Bumped to pull focus back to the search field; see the header. */
-  const [focusSearchToken, setFocusSearchToken] = useState(0);
+  /** Bumped to pull focus back to the path field; see the header. */
+  const [focusPathToken, setFocusPathToken] = useState(0);
   // Mount focus is for a keyboard, not a thumb: on a phone it raises the
   // on-screen keyboard over the listing the dialog was opened to read.
   const coarsePointer = useCoarsePointer();
 
-  const requestSearchFocus = (): void => {
-    setFocusSearchToken((token) => token + 1);
+  const requestPathFocus = (): void => {
+    setFocusPathToken((token) => token + 1);
   };
 
   // Both are conveniences that must never gate browsing: each fails closed
@@ -209,22 +201,19 @@ function RemoteFolderPickerBody(): ReactNode {
   const recentEntries = readRecentShortcuts(rawInput, recentsQuery.data);
 
   const shownInput = readShownInput(rawInput, data, effectiveHome);
-  // One query, whichever affordance produced it: the dedicated filter field,
-  // or a partial segment typed into the location field while editing it.
-  const query = filter !== "" ? filter : parsed.filter;
   const matches = useMemo(
     () =>
       matchEntries(
         listingError !== null ? undefined : data?.entries,
-        filter !== "" ? filter : parsed.filter,
+        parsed.filter,
         showHiddenFolders,
       ),
-    [listingError, data?.entries, filter, parsed.filter, showHiddenFolders],
+    [listingError, data?.entries, parsed.filter, showHiddenFolders],
   );
   const upPath = readUpPath(data, parsed);
-  // `..` is navigation, not a result: while a search is running the rows are
-  // answers to the query, and a parent directory is not one.
-  const upRowPresent = upPath !== null && query === "";
+  // `..` is navigation, not a result: while the path's final segment is
+  // filtering rows, a parent directory is not one of those results.
+  const upRowPresent = upPath !== null && parsed.filter === "";
   const { rowCount, clampedIndex } = readRowSelection({
     selectedIndex,
     upRowPresent,
@@ -234,9 +223,6 @@ function RemoteFolderPickerBody(): ReactNode {
   const setPath = (path: string): void => {
     setRawInput(path);
     setSelectedIndex(UNSET_SELECTION);
-    // Moving is not filtering: a filter that survived a directory change
-    // would hide the rows the move was made to see.
-    setFilter("");
   };
 
   const enterEntry = (entry: WorkspaceBrowseFolderEntryV11): void => {
@@ -244,7 +230,9 @@ function RemoteFolderPickerBody(): ReactNode {
   };
 
   const goUp = (): void => {
-    if (upPath !== null) setPath(withTrailingSeparator(upPath));
+    if (upPath === null) return;
+    setRawInput(withTrailingSeparator(upPath));
+    setSelectedIndex(0);
   };
 
   const { addTarget, createDirectory } = readFolderPickerAddState({
@@ -288,38 +276,21 @@ function RemoteFolderPickerBody(): ReactNode {
   };
 
   return (
-    <div className="flex min-h-0 flex-col">
+    <div className="flex min-h-0 flex-1 flex-col">
       <RemoteFolderPickerHeader
-        filter={filter}
-        onFilterChange={(next) => {
-          setFilter(next);
-          setSelectedIndex(UNSET_SELECTION);
-        }}
         activeOptionId={rowCount > 0 ? pickerOptionId(clampedIndex) : undefined}
         addDisabled={addTarget === null}
         addLabel={createDirectory ? "Create & Add" : "Add"}
         onAdd={addCurrent}
-        editingPath={editingPath}
-        onBeginEditPath={() => {
-          setEditingPath(true);
-        }}
-        onEndEditPath={() => {
-          setEditingPath(false);
-        }}
+        upDisabled={upPath === null}
+        onUp={goUp}
         pathValue={shownInput}
         onPathChange={(next) => {
           setRawInput(next);
           setSelectedIndex(UNSET_SELECTION);
         }}
-        // Trailing separator dropped for display only: the field still
-        // carries it, but on screen it pushes the leaf - the one segment
-        // that identifies this folder - a character further from the edge
-        // that truncation eats toward.
-        displayPath={dropTrailingSeparator(
-          tildeCollapse(shownInput, effectiveHome),
-        )}
-        focusSearchToken={focusSearchToken}
-        autoFocusSearch={!coarsePointer}
+        focusPathToken={focusPathToken}
+        autoFocusPath={!coarsePointer}
         onFieldKeyDown={(event) => {
           handlePickerFieldKeys(event, {
             addCurrent,
@@ -340,13 +311,12 @@ function RemoteFolderPickerBody(): ReactNode {
             // (Enter/Space) never triggers that, so focus would land nowhere
             // and the field would stop accepting typing, arrows and cmd+Enter.
             setPath(path);
-            requestSearchFocus();
+            requestPathFocus();
           }}
         />
-        {/* No group header here: the location line at the top of the dialog
-            IS the base every row shares, and the filter never reaches outside
-            the folder that line names. A second copy would state the same
-            path twice on one screen. */}
+        <p className="px-2 pb-1 text-ui-xs text-muted-foreground">
+          Directories
+        </p>
         <RemoteFolderPickerListing
           invalid={!parsed.valid}
           isPending={parsed.valid ? browseQuery.isPending : false}
@@ -354,7 +324,7 @@ function RemoteFolderPickerBody(): ReactNode {
           matches={data === undefined ? undefined : matches}
           upPresent={upRowPresent}
           selectedIndex={clampedIndex}
-          filtering={query !== ""}
+          filtering={parsed.filter !== ""}
           homePath={effectiveHome}
           onUp={goUp}
           onEnter={enterEntry}
@@ -363,7 +333,7 @@ function RemoteFolderPickerBody(): ReactNode {
             // Retry receives focus and disappears when it succeeds - hand
             // the keyboard back to the combobox field either way.
             void browseQuery.refetch().finally(() => {
-              requestSearchFocus();
+              requestPathFocus();
             });
           }}
         />
@@ -530,7 +500,7 @@ function RemoteFolderPickerFooter(props: {
   return (
     <div className="flex shrink-0 items-center gap-3 border-t border-border/60 px-3 py-2 text-ui-xs text-muted-foreground">
       <ShortcutHint>
-        <div className="hidden min-w-0 flex-wrap items-center gap-x-3 gap-y-1 min-[36rem]:flex">
+        <div className="hidden min-w-0 items-center gap-x-3 min-[42rem]:flex">
           {props.rowCount > 0 ? (
             <span className="inline-flex items-center gap-1">
               <Kbd>↑</Kbd>
@@ -681,8 +651,9 @@ function PickerRow(props: {
       id={props.option?.id}
       aria-selected={props.option?.selected}
       className={cn(
-        "h-10 w-full justify-start gap-2 px-2",
-        props.option?.selected === true && "bg-accent",
+        "h-10 w-full justify-start gap-2 px-2 hover:bg-foreground/8",
+        props.option?.selected === true &&
+          "bg-foreground/8 hover:bg-foreground/8",
       )}
       data-testid={props.testId}
       // Keep focus (and the keyboard model) on the combobox field.
@@ -800,8 +771,9 @@ function RemoteFolderPickerListing(props: {
           id={pickerOptionId(0)}
           aria-selected={props.selectedIndex === 0}
           className={cn(
-            "h-10 w-full justify-start gap-2 px-2",
-            props.selectedIndex === 0 && "bg-accent",
+            "h-10 w-full justify-start gap-2 px-2 hover:bg-foreground/8",
+            props.selectedIndex === 0 &&
+              "bg-foreground/8 hover:bg-foreground/8",
           )}
           data-testid="remote-folder-picker-up-row"
           // Keep focus (and the keyboard model) on the combobox field.
@@ -1099,18 +1071,6 @@ const INVALID_INPUT: ParsedBrowseInput = {
   directoryPath: null,
   filter: "",
 };
-
-/**
- * Display-only inverse of `withTrailingSeparator`. A ROOT keeps its own
- * separator: `C:\\` without it is `C:`, which names the drive-relative
- * current directory rather than the drive, so the heading would read `in C:`
- * and mean something else entirely.
- */
-function dropTrailingSeparator(path: string): string {
-  const separator = separatorOf(path);
-  if (path.length <= rootLengthOf(path)) return path;
-  return path.endsWith(separator) ? path.slice(0, -1) : path;
-}
 
 /** Descending appends a separator; a root already ends in one. */
 function withTrailingSeparator(path: string): string {

--- a/clients/gui-app/src/components/remote-folder-picker-dialog.tsx
+++ b/clients/gui-app/src/components/remote-folder-picker-dialog.tsx
@@ -100,7 +100,7 @@ export function RemoteFolderPickerDialog(): ReactNode {
       }}
     >
       <DialogContent
-        className="top-[18svh] flex h-[min(80dvh,36rem)] w-full max-w-[min(90vw,40rem)] translate-y-0 flex-col gap-0 overflow-hidden p-0 sm:max-w-[min(90vw,40rem)]"
+        className="top-[18svh] flex h-[min(80dvh,36rem,calc(100dvh-18svh-var(--safe-area-inset-bottom)))] w-full max-w-[min(90vw,40rem,var(--safe-area-width))] translate-y-0 flex-col gap-0 overflow-hidden p-0 sm:max-w-[min(90vw,40rem,var(--safe-area-width))]"
         data-testid="remote-folder-picker-dialog"
         // Phone-facing portal outside HomePage's touch scope: re-apply the
         // coarse-pointer hit-slop rules (home-touch-targets.css) so every

--- a/clients/gui-app/src/components/remote-folder-picker-header.tsx
+++ b/clients/gui-app/src/components/remote-folder-picker-header.tsx
@@ -1,166 +1,117 @@
-import { useEffect, useRef, type KeyboardEvent, type ReactNode } from "react";
-import { Search, X } from "lucide-react";
+import {
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  type KeyboardEvent,
+  type ReactNode,
+} from "react";
+import { ArrowLeft } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { PrimaryActionShortcutHint } from "@/components/ui/primary-action-shortcut-hint";
-import { TailAnchoredPath } from "@/components/folder-picker-path-view";
+import { Kbd, KbdGroup } from "@/components/ui/kbd";
+import { ShortcutHint } from "@/components/ui/shortcut-hint";
+import { modLabel } from "@/lib/keybindings/platform";
 
 export interface RemoteFolderPickerHeaderProps {
-  /** Current search text; "" is the browse state. */
-  readonly filter: string;
-  readonly onFilterChange: (next: string) => void;
+  /** Raw absolute path, exactly as browsing and Add will read it. */
+  readonly pathValue: string;
+  readonly onPathChange: (next: string) => void;
   /** Id of the highlighted row, or undefined when the listing is empty. */
   readonly activeOptionId: string | undefined;
   readonly addDisabled: boolean;
   readonly addLabel: string;
   readonly onAdd: () => void;
-  /** True while the location heading is swapped for the raw path field. */
-  readonly editingPath: boolean;
-  readonly onBeginEditPath: () => void;
-  readonly onEndEditPath: () => void;
-  /** Raw field contents - the absolute path, exactly as it will be read. */
-  readonly pathValue: string;
-  readonly onPathChange: (next: string) => void;
-  /** Presentation of the same location: tilde-collapsed, no trailing slash. */
-  readonly displayPath: string;
+  readonly upDisabled: boolean;
+  readonly onUp: () => void;
   /**
-   * Bump to hand the keyboard back to the search field after an action
+   * Bump to hand the keyboard back to the path field after an action
    * elsewhere took focus. A token rather than a ref: the element belongs to
    * this component, so nothing outside it needs to hold a handle on the DOM.
    */
-  readonly focusSearchToken: number;
-  /** Focus the search input on mount (fine pointers only - see the dialog). */
-  readonly autoFocusSearch: boolean;
+  readonly focusPathToken: number;
+  /** Focus the path input on mount (fine pointers only - see the dialog). */
+  readonly autoFocusPath: boolean;
   readonly onFieldKeyDown: (event: KeyboardEvent<HTMLInputElement>) => void;
 }
 
 /**
- * Search field, Add, and the one line in this dialog that renders a location.
- *
- * Two decisions are load-bearing here and are easy to undo by accident:
- *
- * **Search and location are separate controls.** A single field that held the
- * path AND filtered on the segment after its last `/` meant that on a phone
- * the segment naming the folder was the part that fell off the end, and that
- * searching meant editing a path. Splitting them is what lets the location be
- * presented instead of typed.
- *
- * **There is no back arrow.** Up-navigation is the `..` row and only that
- * row: an arrow in a dialog's top-left corner reads as "close", not as
- * "parent folder", and two affordances for one move means the ambiguous one
- * gets tapped. The accepted cost is that going up while a search is active
- * means clearing the search first, since `..` is not a search result.
+ * The editable path is the stable header and the combobox input. Its final
+ * segment filters the current listing; opening a row appends to the same
+ * value, so the path never moves behind a secondary affordance.
  */
 export function RemoteFolderPickerHeader(
   props: RemoteFolderPickerHeaderProps,
 ): ReactNode {
-  const searchRef = useRef<HTMLInputElement | null>(null);
-  const { focusSearchToken, autoFocusSearch } = props;
+  const pathRef = useRef<HTMLInputElement | null>(null);
+  const changedByInputRef = useRef(false);
+  const { focusPathToken, autoFocusPath, pathValue } = props;
   useEffect(() => {
     // 0 is "never asked"; every later value is one explicit request.
-    if (focusSearchToken === 0) return;
-    searchRef.current?.focus();
-  }, [focusSearchToken]);
+    if (focusPathToken === 0) return;
+    pathRef.current?.focus();
+  }, [focusPathToken]);
   useEffect(() => {
-    if (!autoFocusSearch) return;
-    searchRef.current?.focus();
-  }, [autoFocusSearch]);
+    if (!autoFocusPath) return;
+    pathRef.current?.focus();
+  }, [autoFocusPath]);
+  useLayoutEffect(() => {
+    if (changedByInputRef.current) {
+      changedByInputRef.current = false;
+      return;
+    }
+    const input = pathRef.current;
+    if (input !== null) input.scrollLeft = input.scrollWidth;
+  }, [pathValue]);
   return (
-    <div className="flex shrink-0 flex-col gap-2 border-b border-border/60 px-3 py-3">
-      <div className="flex items-center gap-2">
-        <div className="flex min-w-0 flex-1 items-center gap-2 rounded-md bg-foreground/8 px-2">
-          <Search className="size-4 shrink-0 text-muted-foreground" />
-          <input
-            className="min-w-0 flex-1 bg-transparent py-2 text-ui-sm outline-none placeholder:text-muted-foreground"
-            ref={searchRef}
-            role="combobox"
-            aria-label="Search folders"
-            aria-controls="remote-folder-picker-listbox"
-            // The listbox popup is always presented while the dialog is open
-            // (it may be empty); only the active option comes and goes.
-            aria-expanded
-            aria-activedescendant={props.activeOptionId}
-            data-testid="remote-folder-picker-filter"
-            value={props.filter}
-            placeholder="Search this folder"
-            spellCheck={false}
-            autoCapitalize="off"
-            autoCorrect="off"
-            onChange={(event) => {
-              props.onFilterChange(event.target.value);
-            }}
-            onKeyDown={props.onFieldKeyDown}
-          />
-          {props.filter === "" ? null : (
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon-sm"
-              aria-label="Clear search"
-              data-testid="remote-folder-picker-filter-clear"
-              onClick={() => {
-                props.onFilterChange("");
-              }}
-            >
-              <X className="size-4" />
-            </Button>
-          )}
-        </div>
-        <Button
-          type="button"
-          size="sm"
-          data-testid="remote-folder-picker-add"
-          disabled={props.addDisabled}
-          onClick={props.onAdd}
-        >
-          {props.addLabel}
-          <PrimaryActionShortcutHint />
-        </Button>
-      </div>
-      {/* Pinned rather than scrolled with the rows: it is the only statement
-          of where these rows come from, so it may not leave the screen. */}
-      {props.editingPath ? (
-        <input
-          // The raw absolute path, one tap behind the heading. Reachable,
-          // never the resting presentation.
-          className="w-full min-w-0 bg-transparent font-mono text-ui-xs outline-none placeholder:text-muted-foreground"
-          // Mounts only when the heading is tapped, so taking focus IS the
-          // response to that tap. A callback ref rather than `autoFocus`:
-          // the attribute is a page-load behaviour with real accessibility
-          // costs, while this fires only on a mount the user just asked for.
-          ref={focusOnMount}
-          aria-label="Folder path"
-          data-testid="remote-folder-picker-path"
-          value={props.pathValue}
-          placeholder="/path/on/the/host"
-          spellCheck={false}
-          autoCapitalize="off"
-          autoCorrect="off"
-          onBlur={props.onEndEditPath}
-          onChange={(event) => {
-            props.onPathChange(event.target.value);
-          }}
-          onKeyDown={props.onFieldKeyDown}
-        />
-      ) : (
-        <button
-          type="button"
-          className="flex w-full min-w-0 items-baseline gap-1 text-left text-ui-xs text-muted-foreground"
-          data-testid="remote-folder-picker-location"
-          aria-label="Edit folder path"
-          onClick={props.onBeginEditPath}
-        >
-          <span className="shrink-0">in</span>
-          <TailAnchoredPath
-            path={props.displayPath}
-            className="min-w-0 flex-1 font-mono"
-          />
-        </button>
-      )}
+    <div className="flex shrink-0 items-center gap-2 border-b border-border/60 px-3 py-3">
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-sm"
+        aria-label="Up one folder"
+        data-testid="remote-folder-picker-up"
+        disabled={props.upDisabled}
+        onClick={props.onUp}
+      >
+        <ArrowLeft aria-hidden className="size-4" />
+      </Button>
+      <input
+        className="min-w-0 flex-1 bg-transparent py-1 font-mono text-ui-sm outline-none placeholder:text-muted-foreground"
+        ref={pathRef}
+        role="combobox"
+        aria-label="Folder path"
+        aria-controls="remote-folder-picker-listbox"
+        // The listbox popup is always presented while the dialog is open
+        // (it may be empty); only the active option comes and goes.
+        aria-expanded
+        aria-activedescendant={props.activeOptionId}
+        data-testid="remote-folder-picker-path"
+        value={pathValue}
+        placeholder="/path/on/the/host"
+        spellCheck={false}
+        autoCapitalize="off"
+        autoCorrect="off"
+        onChange={(event) => {
+          changedByInputRef.current = true;
+          props.onPathChange(event.target.value);
+        }}
+        onKeyDown={props.onFieldKeyDown}
+      />
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        data-testid="remote-folder-picker-add"
+        disabled={props.addDisabled}
+        onClick={props.onAdd}
+      >
+        {props.addLabel}
+        <ShortcutHint>
+          <KbdGroup aria-hidden>
+            <Kbd>{modLabel()}</Kbd>
+            <Kbd>↵</Kbd>
+          </KbdGroup>
+        </ShortcutHint>
+      </Button>
     </div>
   );
-}
-
-/** Take focus as soon as the element exists. */
-function focusOnMount(element: HTMLInputElement | null): void {
-  element?.focus();
 }


### PR DESCRIPTION
## Summary
- keep the remote folder picker at a stable height with an internally scrolling listing
- make the path field the single navigation/filter control
- preserve the parent-row selection for repeated Enter navigation
- update focused coverage for layout, navigation, and path filtering

## Validation
- `bun run test -- src/components/__tests__/remote-folder-picker-dialog.test.tsx`
- signed commit hook: lint, format, compile, build, DCO

The picker interaction and visual design are finalized for this change.