### PR TITLE
feat(gui): unify opener trees with sidebar views

### DIFF
--- a/clients/gui-app/src/components/command-palette/__tests__/palette-tree-keyboard.test.tsx
+++ b/clients/gui-app/src/components/command-palette/__tests__/palette-tree-keyboard.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { Command, CommandList } from "@/components/ui/command";
+import { Command, CommandInput, CommandList } from "@/components/ui/command";
 import { SubpageView } from "@/components/command-palette/palette-cmdk";
 import type {
   CommandContext,
@@ -130,6 +130,7 @@ function renderTree(id: "open:agents" | "open:artifacts"): void {
   };
   render(
     <Command>
+      <CommandInput aria-label="Search" />
       <CommandList>
         <SubpageView
           subpage={subpage}
@@ -149,11 +150,11 @@ describe.each(["open:agents", "open:artifacts"] as const)(
     it("expands with ArrowRight and collapses with ArrowLeft", () => {
       renderTree(id);
       expect(screen.queryByText("Grandchild")).toBeNull();
-      const childRow = screen.getByText("Child").closest('[role="option"]');
-      if (childRow === null) throw new Error("missing child option");
-      fireEvent.keyDown(childRow, { key: "ArrowRight" });
+      const input = screen.getByRole("combobox");
+      fireEvent.keyDown(input, { key: "ArrowDown" });
+      fireEvent.keyDown(input, { key: "ArrowRight" });
       expect(screen.getByText("Grandchild")).toBeTruthy();
-      fireEvent.keyDown(childRow, { key: "ArrowLeft" });
+      fireEvent.keyDown(input, { key: "ArrowLeft" });
       expect(screen.queryByText("Grandchild")).toBeNull();
     });
   },

--- a/clients/gui-app/src/components/command-palette/__tests__/palette-tree-keyboard.test.tsx
+++ b/clients/gui-app/src/components/command-palette/__tests__/palette-tree-keyboard.test.tsx
@@ -168,3 +168,52 @@ it("scopes tree arrows to the command surface receiving the key", () => {
   fireEvent.keyDown(firstInput, { key: "ArrowRight" });
   expect(screen.getAllByText("Grandchild")).toHaveLength(1);
 });
+
+it("expands an actionable path branch from the command input", () => {
+  const parent = {
+    ...baseItem("parent", "Spec"),
+    pathTreeRow: {
+      treeId: "artifacts",
+      nodeId: "parent",
+      depth: 0,
+      ancestorIds: [],
+      hasChildren: true,
+      kind: "file" as const,
+      path: "parent",
+      displayPath: "Spec",
+    },
+  };
+  const child = {
+    ...baseItem("child", "Ticket"),
+    pathTreeRow: {
+      treeId: "artifacts",
+      nodeId: "child",
+      depth: 1,
+      ancestorIds: ["parent"],
+      hasChildren: false,
+      kind: "file" as const,
+      path: "parent/child",
+      displayPath: "Spec / Ticket",
+    },
+  };
+  const subpage: CommandSubpage = {
+    id: "open:files:artifacts",
+    title: "Artifacts",
+    useItems: () => [parent, child],
+  };
+  render(
+    <Command>
+      <CommandInput />
+      <CommandList>
+        <SubpageView
+          subpage={subpage}
+          ctx={context}
+          onSelect={() => undefined}
+        />
+      </CommandList>
+    </Command>,
+  );
+  expect(screen.queryByText("Ticket")).toBeNull();
+  fireEvent.keyDown(screen.getByRole("combobox"), { key: "ArrowRight" });
+  expect(screen.getByText("Ticket")).toBeTruthy();
+});

--- a/clients/gui-app/src/components/command-palette/__tests__/palette-tree-keyboard.test.tsx
+++ b/clients/gui-app/src/components/command-palette/__tests__/palette-tree-keyboard.test.tsx
@@ -1,0 +1,160 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { Command, CommandList } from "@/components/ui/command";
+import { SubpageView } from "@/components/command-palette/palette-cmdk";
+import type {
+  CommandContext,
+  CommandItem,
+  CommandSubpage,
+} from "@/lib/commands/types";
+import type { KeybindingRouter } from "@/lib/keybindings/dispatch";
+
+const router: KeybindingRouter = {
+  getPathname: () => "/",
+  navigateHome: () => undefined,
+  navigateSettings: () => undefined,
+  navigateToEpic: () => undefined,
+  navigateToEpicTab: () => undefined,
+  navigateToEpicList: () => undefined,
+  navigateSettingsSection: () => undefined,
+  navigateToTabIntent: () => undefined,
+  goBack: () => undefined,
+  goForward: () => undefined,
+  isHistoryNavAvailable: () => false,
+  canGoBack: () => false,
+  canGoForward: () => false,
+  navigateNestedFocus: () => null,
+};
+
+const context: CommandContext = {
+  pathname: "/",
+  router,
+  activeTabId: "tab-1",
+  activeEpicId: "epic-1",
+  focusedComposerKind: null,
+  targetGroupId: "group-1",
+};
+
+function baseItem(id: string, label: string): CommandItem {
+  return {
+    id,
+    label,
+    description: null,
+    keywords: [label],
+    group: "open",
+    scope: "actions",
+    shortcut: null,
+    actionId: null,
+    subpage: null,
+    run: () => undefined,
+  };
+}
+
+function renderTree(id: "open:agents" | "open:artifacts"): void {
+  const items: ReadonlyArray<CommandItem> =
+    id === "open:agents"
+      ? [
+          {
+            ...baseItem("root", "Root"),
+            agentTreeRow: {
+              nodeId: "root",
+              depth: 0,
+              ancestorIds: [],
+              hasChildren: true,
+              interface: "chat",
+              activity: "idle",
+            },
+          },
+          {
+            ...baseItem("child", "Child"),
+            agentTreeRow: {
+              nodeId: "child",
+              depth: 1,
+              ancestorIds: ["root"],
+              hasChildren: true,
+              interface: "chat",
+              activity: "idle",
+            },
+          },
+          {
+            ...baseItem("grandchild", "Grandchild"),
+            agentTreeRow: {
+              nodeId: "grandchild",
+              depth: 2,
+              ancestorIds: ["root", "child"],
+              hasChildren: false,
+              interface: "chat",
+              activity: "idle",
+            },
+          },
+        ]
+      : [
+          {
+            ...baseItem("root", "Root"),
+            artifactTreeRow: {
+              nodeId: "root",
+              depth: 0,
+              ancestorIds: [],
+              hasChildren: true,
+              kind: "story",
+              status: 1,
+            },
+          },
+          {
+            ...baseItem("child", "Child"),
+            artifactTreeRow: {
+              nodeId: "child",
+              depth: 1,
+              ancestorIds: ["root"],
+              hasChildren: true,
+              kind: "story",
+              status: 1,
+            },
+          },
+          {
+            ...baseItem("grandchild", "Grandchild"),
+            artifactTreeRow: {
+              nodeId: "grandchild",
+              depth: 2,
+              ancestorIds: ["root", "child"],
+              hasChildren: false,
+              kind: "ticket",
+              status: 0,
+            },
+          },
+        ];
+  const subpage: CommandSubpage = {
+    id,
+    title: "Tree",
+    useItems: () => items,
+  };
+  render(
+    <Command>
+      <CommandList>
+        <SubpageView
+          subpage={subpage}
+          ctx={context}
+          onSelect={() => undefined}
+        />
+      </CommandList>
+    </Command>,
+  );
+}
+
+afterEach(() => cleanup());
+
+describe.each(["open:agents", "open:artifacts"] as const)(
+  "%s keyboard tree navigation",
+  (id) => {
+    it("expands with ArrowRight and collapses with ArrowLeft", () => {
+      renderTree(id);
+      expect(screen.queryByText("Grandchild")).toBeNull();
+      const childRow = screen.getByText("Child").closest('[role="option"]');
+      if (childRow === null) throw new Error("missing child option");
+      fireEvent.keyDown(childRow, { key: "ArrowRight" });
+      expect(screen.getByText("Grandchild")).toBeTruthy();
+      fireEvent.keyDown(childRow, { key: "ArrowLeft" });
+      expect(screen.queryByText("Grandchild")).toBeNull();
+    });
+  },
+);

--- a/clients/gui-app/src/components/command-palette/__tests__/palette-tree-keyboard.test.tsx
+++ b/clients/gui-app/src/components/command-palette/__tests__/palette-tree-keyboard.test.tsx
@@ -159,3 +159,12 @@ describe.each(["open:agents", "open:artifacts"] as const)(
     });
   },
 );
+
+it("scopes tree arrows to the command surface receiving the key", () => {
+  renderTree("open:agents");
+  renderTree("open:agents");
+  const [firstInput] = screen.getAllByRole("combobox");
+  fireEvent.keyDown(firstInput, { key: "ArrowDown" });
+  fireEvent.keyDown(firstInput, { key: "ArrowRight" });
+  expect(screen.getAllByText("Grandchild")).toHaveLength(1);
+});

--- a/clients/gui-app/src/components/command-palette/palette-cmdk.tsx
+++ b/clients/gui-app/src/components/command-palette/palette-cmdk.tsx
@@ -569,7 +569,10 @@ function OpenerDeepRows(props: OpenerDeepRowsProps) {
               disabled={item.disabled === true}
               onSelect={() => onSelect(item)}
             >
-              <DeepPathLabel path={path} label={item.label} />
+              <DeepPathLabel
+                path={path}
+                label={item.pathTreeRow?.displayPath ?? item.label}
+              />
               {item.statusBadge !== undefined ? (
                 <RowStatusBadge>{item.statusBadge}</RowStatusBadge>
               ) : null}

--- a/clients/gui-app/src/components/command-palette/palette-cmdk.tsx
+++ b/clients/gui-app/src/components/command-palette/palette-cmdk.tsx
@@ -509,6 +509,8 @@ function PathSubpageRows(props: {
   const expandedPaths = useOpenerFileTreeExpandedPaths(treeId);
   const togglePath = useOpenerFileTreeStore((state) => state.toggle);
   const search = useCommandState((state) => state.search);
+  const selectedValue = useCommandState((state) => state.value);
+  const ownerMarkerRef = useRef<HTMLSpanElement>(null);
   const isExpanded = (row: NonNullable<CommandItemShape["pathTreeRow"]>) =>
     expandedPaths.includes(`${row.path}/`);
   const rowByNodeId = new Map(
@@ -521,6 +523,35 @@ function PathSubpageRows(props: {
   const toggle = (row: NonNullable<CommandItemShape["pathTreeRow"]>) => {
     togglePath(row.treeId, `${row.path}/`);
   };
+  useEffect(() => {
+    const onKeyDown = (event: globalThis.KeyboardEvent) => {
+      const ownerRoot = ownerMarkerRef.current?.closest("[cmdk-root]");
+      if (
+        !(event.target instanceof Element) ||
+        ownerRoot === null ||
+        ownerRoot === undefined ||
+        event.target.closest("[cmdk-root]") !== ownerRoot
+      ) {
+        return;
+      }
+      const item = props.items.find(
+        (candidate) => buildCmdkValue(candidate) === selectedValue,
+      );
+      const row = item?.pathTreeRow;
+      if (row?.hasChildren !== true) return;
+      const expanded = isExpanded(row);
+      if (
+        (event.key === "ArrowRight" && !expanded) ||
+        (event.key === "ArrowLeft" && expanded)
+      ) {
+        event.preventDefault();
+        event.stopPropagation();
+        toggle(row);
+      }
+    };
+    document.addEventListener("keydown", onKeyDown, true);
+    return () => document.removeEventListener("keydown", onKeyDown, true);
+  });
   const visibleItems =
     search.length > 0
       ? props.items
@@ -532,7 +563,7 @@ function PathSubpageRows(props: {
               return ancestor !== undefined && isExpanded(ancestor);
             }),
         );
-  return visibleItems.map((item) => {
+  const rows = visibleItems.map((item) => {
     const row = item.pathTreeRow;
     const expanded = row !== undefined && isExpanded(row);
     return (
@@ -562,6 +593,12 @@ function PathSubpageRows(props: {
       </PaletteItemRow>
     );
   });
+  return (
+    <>
+      <span ref={ownerMarkerRef} className="hidden" />
+      {rows}
+    </>
+  );
 }
 
 function RowStatusBadge({ children }: { readonly children: string }) {
@@ -685,36 +722,39 @@ function OpenerDeepRows(props: OpenerDeepRowsProps) {
     <>
       {items
         .filter((item) => item.pathTreeRow?.kind !== "directory")
-        .map((item) => (
-          <Fragment key={item.id}>
-            <PaletteItemRow
-              value={buildCmdkValue(item)}
-              keywords={[
-                ...item.keywords,
-                ...path.map((segment) => segment.toLowerCase()),
-              ]}
-              aria-label={deepRowName(path, item.label, item.statusBadge)}
-              disabled={item.disabled === true}
-              onSelect={() => onSelect(item)}
-            >
-              <DeepPathLabel
-                path={path}
-                label={item.pathTreeRow?.displayPath ?? item.label}
-              />
-              {item.statusBadge !== undefined ? (
-                <RowStatusBadge>{item.statusBadge}</RowStatusBadge>
+        .map((item) => {
+          const rowIdentity = `${subpage.id}:${item.id}`;
+          return (
+            <Fragment key={rowIdentity}>
+              <PaletteItemRow
+                value={`${rowIdentity} ${buildCmdkValue(item)}`}
+                keywords={[
+                  ...item.keywords,
+                  ...path.map((segment) => segment.toLowerCase()),
+                ]}
+                aria-label={deepRowName(path, item.label, item.statusBadge)}
+                disabled={item.disabled === true}
+                onSelect={() => onSelect(item)}
+              >
+                <DeepPathLabel
+                  path={path}
+                  label={item.pathTreeRow?.displayPath ?? item.label}
+                />
+                {item.statusBadge !== undefined ? (
+                  <RowStatusBadge>{item.statusBadge}</RowStatusBadge>
+                ) : null}
+              </PaletteItemRow>
+              {item.subpage !== null && path.length < OPENER_DEEP_MAX_DEPTH ? (
+                <OpenerDeepRows
+                  subpage={item.subpage}
+                  ctx={ctx}
+                  path={[...path, item.label]}
+                  onSelect={onSelect}
+                />
               ) : null}
-            </PaletteItemRow>
-            {item.subpage !== null && path.length < OPENER_DEEP_MAX_DEPTH ? (
-              <OpenerDeepRows
-                subpage={item.subpage}
-                ctx={ctx}
-                path={[...path, item.label]}
-                onSelect={onSelect}
-              />
-            ) : null}
-          </Fragment>
-        ))}
+            </Fragment>
+          );
+        })}
     </>
   );
 }

--- a/clients/gui-app/src/components/command-palette/palette-cmdk.tsx
+++ b/clients/gui-app/src/components/command-palette/palette-cmdk.tsx
@@ -148,6 +148,23 @@ function AgentSubpageRows(props: {
   const isExpanded = (row: NonNullable<CommandItemShape["agentTreeRow"]>) =>
     !userCollapsedIds.has(row.nodeId) &&
     (row.depth === 0 || userExpandedIds.has(row.nodeId));
+  const setRowExpanded = (
+    row: NonNullable<CommandItemShape["agentTreeRow"]>,
+    expanded: boolean,
+  ) => {
+    setUserExpandedIds((ids) => {
+      const next = new Set(ids);
+      if (expanded) next.add(row.nodeId);
+      else next.delete(row.nodeId);
+      return next;
+    });
+    setUserCollapsedIds((ids) => {
+      const next = new Set(ids);
+      if (expanded) next.delete(row.nodeId);
+      else next.add(row.nodeId);
+      return next;
+    });
+  };
   const rowByNodeId = new Map(
     props.items.flatMap((item) =>
       item.agentTreeRow === undefined
@@ -176,6 +193,18 @@ function AgentSubpageRows(props: {
         keywords={[...item.keywords]}
         disabled={item.disabled === true}
         onSelect={() => props.onSelect(item)}
+        onKeyDown={(event) => {
+          if (row?.hasChildren !== true) return;
+          if (event.key === "ArrowRight" && !expanded) {
+            event.preventDefault();
+            event.stopPropagation();
+            setRowExpanded(row, true);
+          } else if (event.key === "ArrowLeft" && expanded) {
+            event.preventDefault();
+            event.stopPropagation();
+            setRowExpanded(row, false);
+          }
+        }}
       >
         <AgentTreeItemLabel
           item={item}
@@ -185,21 +214,7 @@ function AgentSubpageRows(props: {
               ? (event) => {
                   event.preventDefault();
                   event.stopPropagation();
-                  if (expanded) {
-                    setUserExpandedIds((ids) => {
-                      const next = new Set(ids);
-                      next.delete(row.nodeId);
-                      return next;
-                    });
-                    setUserCollapsedIds((ids) => new Set(ids).add(row.nodeId));
-                  } else {
-                    setUserCollapsedIds((ids) => {
-                      const next = new Set(ids);
-                      next.delete(row.nodeId);
-                      return next;
-                    });
-                    setUserExpandedIds((ids) => new Set(ids).add(row.nodeId));
-                  }
+                  setRowExpanded(row, !expanded);
                 }
               : undefined
           }
@@ -269,6 +284,23 @@ function ArtifactSubpageRows(props: {
   const isExpanded = (row: NonNullable<CommandItemShape["artifactTreeRow"]>) =>
     !userCollapsedIds.has(row.nodeId) &&
     (row.depth === 0 || userExpandedIds.has(row.nodeId));
+  const setRowExpanded = (
+    row: NonNullable<CommandItemShape["artifactTreeRow"]>,
+    expanded: boolean,
+  ) => {
+    setUserExpandedIds((ids) => {
+      const next = new Set(ids);
+      if (expanded) next.add(row.nodeId);
+      else next.delete(row.nodeId);
+      return next;
+    });
+    setUserCollapsedIds((ids) => {
+      const next = new Set(ids);
+      if (expanded) next.delete(row.nodeId);
+      else next.add(row.nodeId);
+      return next;
+    });
+  };
   const rowByNodeId = new Map(
     props.items.flatMap((item) =>
       item.artifactTreeRow === undefined
@@ -297,6 +329,18 @@ function ArtifactSubpageRows(props: {
         keywords={[...item.keywords]}
         disabled={item.disabled === true}
         onSelect={() => props.onSelect(item)}
+        onKeyDown={(event) => {
+          if (row?.hasChildren !== true) return;
+          if (event.key === "ArrowRight" && !expanded) {
+            event.preventDefault();
+            event.stopPropagation();
+            setRowExpanded(row, true);
+          } else if (event.key === "ArrowLeft" && expanded) {
+            event.preventDefault();
+            event.stopPropagation();
+            setRowExpanded(row, false);
+          }
+        }}
       >
         <ArtifactTreeItemLabel
           item={item}
@@ -306,21 +350,7 @@ function ArtifactSubpageRows(props: {
               ? (event) => {
                   event.preventDefault();
                   event.stopPropagation();
-                  if (expanded) {
-                    setUserExpandedIds((ids) => {
-                      const next = new Set(ids);
-                      next.delete(row.nodeId);
-                      return next;
-                    });
-                    setUserCollapsedIds((ids) => new Set(ids).add(row.nodeId));
-                  } else {
-                    setUserCollapsedIds((ids) => {
-                      const next = new Set(ids);
-                      next.delete(row.nodeId);
-                      return next;
-                    });
-                    setUserExpandedIds((ids) => new Set(ids).add(row.nodeId));
-                  }
+                  setRowExpanded(row, !expanded);
                 }
               : undefined
           }
@@ -363,7 +393,10 @@ function PathTreeItemLabel(props: {
             tone={gitStyle.tone}
             label={gitStyle.label}
             withTooltip
-            className="ml-auto h-4 min-w-4 px-0.5"
+            className={cn(
+              "ml-auto h-4 min-w-4 px-0.5",
+              gitStyle.tone === "muted" && "bg-foreground/8",
+            )}
           />
         )}
       </span>

--- a/clients/gui-app/src/components/command-palette/palette-cmdk.tsx
+++ b/clients/gui-app/src/components/command-palette/palette-cmdk.tsx
@@ -8,6 +8,7 @@
 import {
   Fragment,
   useEffect,
+  useRef,
   useState,
   type MouseEvent,
   type ReactNode,
@@ -174,6 +175,7 @@ function AgentSubpageRows(props: {
   );
   const search = useCommandState((state) => state.search);
   const selectedValue = useCommandState((state) => state.value);
+  const ownerMarkerRef = useRef<HTMLSpanElement>(null);
   const isExpanded = (row: NonNullable<CommandItemShape["agentTreeRow"]>) =>
     !userCollapsedIds.has(row.nodeId) &&
     (row.depth === 0 || userExpandedIds.has(row.nodeId));
@@ -203,9 +205,12 @@ function AgentSubpageRows(props: {
   );
   useEffect(() => {
     const onKeyDown = (event: globalThis.KeyboardEvent) => {
+      const ownerRoot = ownerMarkerRef.current?.closest("[cmdk-root]");
       if (
         !(event.target instanceof Element) ||
-        event.target.closest("[cmdk-root]") === null
+        ownerRoot === null ||
+        ownerRoot === undefined ||
+        event.target.closest("[cmdk-root]") !== ownerRoot
       ) {
         return;
       }
@@ -243,7 +248,7 @@ function AgentSubpageRows(props: {
               return ancestor !== undefined && isExpanded(ancestor);
             }),
         );
-  return visibleItems.map((item) => {
+  const rows = visibleItems.map((item) => {
     const row = item.agentTreeRow;
     const expanded = row !== undefined && isExpanded(row);
     return (
@@ -276,6 +281,12 @@ function AgentSubpageRows(props: {
       </PaletteItemRow>
     );
   });
+  return (
+    <>
+      <span ref={ownerMarkerRef} className="hidden" />
+      {rows}
+    </>
+  );
 }
 
 function ArtifactTreeItemLabel(props: {
@@ -333,6 +344,7 @@ function ArtifactSubpageRows(props: {
   );
   const search = useCommandState((state) => state.search);
   const selectedValue = useCommandState((state) => state.value);
+  const ownerMarkerRef = useRef<HTMLSpanElement>(null);
   const isExpanded = (row: NonNullable<CommandItemShape["artifactTreeRow"]>) =>
     !userCollapsedIds.has(row.nodeId) &&
     (row.depth === 0 || userExpandedIds.has(row.nodeId));
@@ -362,9 +374,12 @@ function ArtifactSubpageRows(props: {
   );
   useEffect(() => {
     const onKeyDown = (event: globalThis.KeyboardEvent) => {
+      const ownerRoot = ownerMarkerRef.current?.closest("[cmdk-root]");
       if (
         !(event.target instanceof Element) ||
-        event.target.closest("[cmdk-root]") === null
+        ownerRoot === null ||
+        ownerRoot === undefined ||
+        event.target.closest("[cmdk-root]") !== ownerRoot
       ) {
         return;
       }
@@ -402,7 +417,7 @@ function ArtifactSubpageRows(props: {
               return ancestor !== undefined && isExpanded(ancestor);
             }),
         );
-  return visibleItems.map((item) => {
+  const rows = visibleItems.map((item) => {
     const row = item.artifactTreeRow;
     const expanded = row !== undefined && isExpanded(row);
     return (
@@ -432,6 +447,12 @@ function ArtifactSubpageRows(props: {
       </PaletteItemRow>
     );
   });
+  return (
+    <>
+      <span ref={ownerMarkerRef} className="hidden" />
+      {rows}
+    </>
+  );
 }
 
 function PathTreeItemLabel(props: {

--- a/clients/gui-app/src/components/command-palette/palette-cmdk.tsx
+++ b/clients/gui-app/src/components/command-palette/palette-cmdk.tsx
@@ -5,8 +5,28 @@
  * opener root view. Non-component helpers (filter, row value, controller hook)
  * live in `palette-cmdk-controller.ts`.
  */
-import { Fragment } from "react";
+import { Fragment, useState, type MouseEvent, type ReactNode } from "react";
+import { useCommandState } from "cmdk";
+import { Bot, Folder, FolderOpen, MessageSquare } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
+import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
+import { BackgroundActivityGlyph } from "@/components/notifications/background-activity-glyph";
+import { TreeChevron, TreeChevronSpacer } from "@/components/ui/tree-chevron";
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
+import { EPIC_NODE_ICONS } from "@/lib/artifacts/node-display";
+import {
+  STATUS_DOT_CLASSES,
+  STATUS_LABELS,
+  computeArtifactNodeStatusDot,
+} from "@/components/epic-canvas/sidebar/epic-sidebar-tree-shared";
+import { cn } from "@/lib/utils";
+import { MaterialFileIcon } from "@/components/material-file-icon";
+import { GitStatusBadge } from "@/components/epic-canvas/git-diff/git-status-badge";
+import { statusBadgeStyle } from "@/lib/git/status-icon";
+import {
+  useOpenerFileTreeExpandedPaths,
+  useOpenerFileTreeStore,
+} from "@/stores/file-tree/opener-file-tree-store";
 import { CommandEmpty, CommandGroup } from "@/components/ui/command";
 import { PaletteItemRow } from "@/components/command-palette/palette-item-row";
 import { buildCmdkValue } from "@/components/command-palette/palette-cmdk-controller";
@@ -38,6 +58,384 @@ function SubpageItemLabel({ label }: { label: string }) {
   );
 }
 
+function AgentTreeIndent(props: {
+  readonly depth: number;
+  readonly children: ReactNode;
+}) {
+  if (props.depth === 0) return props.children;
+  return (
+    <span className="flex min-w-0 border-l border-border/60 pl-3">
+      <AgentTreeIndent depth={props.depth - 1}>
+        {props.children}
+      </AgentTreeIndent>
+    </span>
+  );
+}
+
+function AgentTreeItemLabel(props: {
+  readonly item: CommandItemShape;
+  readonly expanded: boolean;
+  readonly onToggle: ((event: MouseEvent<HTMLSpanElement>) => void) | undefined;
+}) {
+  const row = props.item.agentTreeRow;
+  if (row === undefined) return <SubpageItemLabel label={props.item.label} />;
+  let statusLabel = "Agent idle";
+  let icon =
+    row.interface === "chat" ? (
+      <MessageSquare aria-hidden className="size-3.5 text-muted-foreground" />
+    ) : (
+      <Bot aria-hidden className="size-3.5 text-muted-foreground" />
+    );
+  if (row.activity === "turn") {
+    statusLabel = "Agent in progress";
+    icon = (
+      <AgentSpinningDots
+        className="size-3.5 text-primary"
+        testId={`agent-opener-running-${props.item.id}`}
+        variant="dots2"
+      />
+    );
+  } else if (row.activity === "background") {
+    statusLabel = "Agent working in background";
+    icon = (
+      <BackgroundActivityGlyph
+        testId={`agent-opener-background-${props.item.id}`}
+      />
+    );
+  }
+  return (
+    <AgentTreeIndent depth={row.depth}>
+      <span className="flex min-w-0 items-center gap-2">
+        {row.hasChildren ? (
+          <TreeChevron expanded={props.expanded} onToggle={props.onToggle} />
+        ) : (
+          <TreeChevronSpacer />
+        )}
+        <TooltipWrapper
+          label={statusLabel}
+          side="right"
+          sideOffset={undefined}
+          align={undefined}
+        >
+          <span
+            className="flex size-4 shrink-0 items-center justify-center"
+            role="status"
+            aria-label={statusLabel}
+          >
+            {icon}
+          </span>
+        </TooltipWrapper>
+        <SubpageItemLabel label={props.item.label} />
+      </span>
+    </AgentTreeIndent>
+  );
+}
+
+function AgentSubpageRows(props: {
+  readonly items: ReadonlyArray<CommandItemShape>;
+  readonly onSelect: (item: CommandItemShape) => void;
+}) {
+  // Expansion belongs to this picker instance. It deliberately does not use
+  // the sidebar expansion store: collapsing here must not rearrange the user's
+  // persistent left-panel tree (and vice versa).
+  const [userExpandedIds, setUserExpandedIds] = useState<ReadonlySet<string>>(
+    () => new Set<string>(),
+  );
+  const [userCollapsedIds, setUserCollapsedIds] = useState<ReadonlySet<string>>(
+    () => new Set<string>(),
+  );
+  const search = useCommandState((state) => state.search);
+  const isExpanded = (row: NonNullable<CommandItemShape["agentTreeRow"]>) =>
+    !userCollapsedIds.has(row.nodeId) &&
+    (row.depth === 0 || userExpandedIds.has(row.nodeId));
+  const rowByNodeId = new Map(
+    props.items.flatMap((item) =>
+      item.agentTreeRow === undefined
+        ? []
+        : [[item.agentTreeRow.nodeId, item.agentTreeRow] as const],
+    ),
+  );
+  const visibleItems =
+    search.length > 0
+      ? props.items
+      : props.items.filter(
+          (item) =>
+            item.agentTreeRow === undefined ||
+            item.agentTreeRow.ancestorIds.every((id) => {
+              const ancestor = rowByNodeId.get(id);
+              return ancestor !== undefined && isExpanded(ancestor);
+            }),
+        );
+  return visibleItems.map((item) => {
+    const row = item.agentTreeRow;
+    const expanded = row !== undefined && isExpanded(row);
+    return (
+      <PaletteItemRow
+        key={item.id}
+        value={buildCmdkValue(item)}
+        keywords={[...item.keywords]}
+        disabled={item.disabled === true}
+        onSelect={() => props.onSelect(item)}
+      >
+        <AgentTreeItemLabel
+          item={item}
+          expanded={expanded}
+          onToggle={
+            row?.hasChildren === true
+              ? (event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  if (expanded) {
+                    setUserExpandedIds((ids) => {
+                      const next = new Set(ids);
+                      next.delete(row.nodeId);
+                      return next;
+                    });
+                    setUserCollapsedIds((ids) => new Set(ids).add(row.nodeId));
+                  } else {
+                    setUserCollapsedIds((ids) => {
+                      const next = new Set(ids);
+                      next.delete(row.nodeId);
+                      return next;
+                    });
+                    setUserExpandedIds((ids) => new Set(ids).add(row.nodeId));
+                  }
+                }
+              : undefined
+          }
+        />
+        {item.hostBadge !== undefined ? (
+          <RowStatusBadge>{item.hostBadge}</RowStatusBadge>
+        ) : null}
+      </PaletteItemRow>
+    );
+  });
+}
+
+function ArtifactTreeItemLabel(props: {
+  readonly item: CommandItemShape;
+  readonly expanded: boolean;
+  readonly onToggle: ((event: MouseEvent<HTMLSpanElement>) => void) | undefined;
+}) {
+  const row = props.item.artifactTreeRow;
+  if (row === undefined) return <SubpageItemLabel label={props.item.label} />;
+  const Icon = EPIC_NODE_ICONS[row.kind];
+  const showStatus = computeArtifactNodeStatusDot(row.kind, row.status);
+  const statusLabel =
+    row.status === null ? null : (STATUS_LABELS[row.status] ?? "Unknown");
+  return (
+    <AgentTreeIndent depth={row.depth}>
+      <span className="flex min-w-0 items-center gap-2">
+        {row.hasChildren ? (
+          <TreeChevron expanded={props.expanded} onToggle={props.onToggle} />
+        ) : (
+          <TreeChevronSpacer />
+        )}
+        <Icon aria-hidden className="size-3.5 shrink-0 text-muted-foreground" />
+        <SubpageItemLabel label={props.item.label} />
+        {showStatus && row.status !== null ? (
+          <TooltipWrapper
+            label={statusLabel ?? "Unknown"}
+            side="right"
+            sideOffset={undefined}
+            align={undefined}
+          >
+            <span
+              aria-label={statusLabel ?? undefined}
+              className={cn(
+                "size-2 shrink-0 rounded-full",
+                STATUS_DOT_CLASSES[row.status] ?? "bg-slate-400",
+              )}
+              role="status"
+            />
+          </TooltipWrapper>
+        ) : null}
+      </span>
+    </AgentTreeIndent>
+  );
+}
+
+function ArtifactSubpageRows(props: {
+  readonly items: ReadonlyArray<CommandItemShape>;
+  readonly onSelect: (item: CommandItemShape) => void;
+}) {
+  const [userExpandedIds, setUserExpandedIds] = useState<ReadonlySet<string>>(
+    () => new Set<string>(),
+  );
+  const [userCollapsedIds, setUserCollapsedIds] = useState<ReadonlySet<string>>(
+    () => new Set<string>(),
+  );
+  const search = useCommandState((state) => state.search);
+  const isExpanded = (row: NonNullable<CommandItemShape["artifactTreeRow"]>) =>
+    !userCollapsedIds.has(row.nodeId) &&
+    (row.depth === 0 || userExpandedIds.has(row.nodeId));
+  const rowByNodeId = new Map(
+    props.items.flatMap((item) =>
+      item.artifactTreeRow === undefined
+        ? []
+        : [[item.artifactTreeRow.nodeId, item.artifactTreeRow] as const],
+    ),
+  );
+  const visibleItems =
+    search.length > 0
+      ? props.items
+      : props.items.filter(
+          (item) =>
+            item.artifactTreeRow === undefined ||
+            item.artifactTreeRow.ancestorIds.every((id) => {
+              const ancestor = rowByNodeId.get(id);
+              return ancestor !== undefined && isExpanded(ancestor);
+            }),
+        );
+  return visibleItems.map((item) => {
+    const row = item.artifactTreeRow;
+    const expanded = row !== undefined && isExpanded(row);
+    return (
+      <PaletteItemRow
+        key={item.id}
+        value={buildCmdkValue(item)}
+        keywords={[...item.keywords]}
+        disabled={item.disabled === true}
+        onSelect={() => props.onSelect(item)}
+      >
+        <ArtifactTreeItemLabel
+          item={item}
+          expanded={expanded}
+          onToggle={
+            row?.hasChildren === true
+              ? (event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  if (expanded) {
+                    setUserExpandedIds((ids) => {
+                      const next = new Set(ids);
+                      next.delete(row.nodeId);
+                      return next;
+                    });
+                    setUserCollapsedIds((ids) => new Set(ids).add(row.nodeId));
+                  } else {
+                    setUserCollapsedIds((ids) => {
+                      const next = new Set(ids);
+                      next.delete(row.nodeId);
+                      return next;
+                    });
+                    setUserExpandedIds((ids) => new Set(ids).add(row.nodeId));
+                  }
+                }
+              : undefined
+          }
+        />
+      </PaletteItemRow>
+    );
+  });
+}
+
+function PathTreeItemLabel(props: {
+  readonly item: CommandItemShape;
+  readonly expanded: boolean;
+  readonly onToggle: ((event: MouseEvent<HTMLSpanElement>) => void) | undefined;
+}) {
+  const row = props.item.pathTreeRow;
+  if (row === undefined) return <SubpageItemLabel label={props.item.label} />;
+  const FolderIcon = props.expanded ? FolderOpen : Folder;
+  const gitStyle =
+    row.gitStatus === undefined ? null : statusBadgeStyle(row.gitStatus);
+  return (
+    <AgentTreeIndent depth={row.depth}>
+      <span className="flex min-w-0 items-center gap-2">
+        {row.hasChildren ? (
+          <TreeChevron expanded={props.expanded} onToggle={props.onToggle} />
+        ) : (
+          <TreeChevronSpacer />
+        )}
+        {row.kind === "directory" ? (
+          <FolderIcon
+            aria-hidden
+            className="size-3.5 shrink-0 text-muted-foreground"
+          />
+        ) : (
+          <MaterialFileIcon filename={row.path} className="size-4 shrink-0" />
+        )}
+        <SubpageItemLabel label={props.item.label} />
+        {gitStyle === null ? null : (
+          <GitStatusBadge
+            letter={gitStyle.letter}
+            tone={gitStyle.tone}
+            label={gitStyle.label}
+            withTooltip
+            className="ml-auto h-4 min-w-4 px-0.5"
+          />
+        )}
+      </span>
+    </AgentTreeIndent>
+  );
+}
+
+function PathSubpageRows(props: {
+  readonly items: ReadonlyArray<CommandItemShape>;
+  readonly onSelect: (item: CommandItemShape) => void;
+}) {
+  const treeId =
+    props.items.find((item) => item.pathTreeRow !== undefined)?.pathTreeRow
+      ?.treeId ?? "";
+  const expandedPaths = useOpenerFileTreeExpandedPaths(treeId);
+  const togglePath = useOpenerFileTreeStore((state) => state.toggle);
+  const search = useCommandState((state) => state.search);
+  const isExpanded = (row: NonNullable<CommandItemShape["pathTreeRow"]>) =>
+    expandedPaths.includes(`${row.path}/`);
+  const rowByNodeId = new Map(
+    props.items.flatMap((item) =>
+      item.pathTreeRow === undefined
+        ? []
+        : [[item.pathTreeRow.nodeId, item.pathTreeRow] as const],
+    ),
+  );
+  const toggle = (row: NonNullable<CommandItemShape["pathTreeRow"]>) => {
+    togglePath(row.treeId, `${row.path}/`);
+  };
+  const visibleItems =
+    search.length > 0
+      ? props.items
+      : props.items.filter(
+          (item) =>
+            item.pathTreeRow === undefined ||
+            item.pathTreeRow.ancestorIds.every((id) => {
+              const ancestor = rowByNodeId.get(id);
+              return ancestor !== undefined && isExpanded(ancestor);
+            }),
+        );
+  return visibleItems.map((item) => {
+    const row = item.pathTreeRow;
+    const expanded = row !== undefined && isExpanded(row);
+    return (
+      <PaletteItemRow
+        key={item.id}
+        value={buildCmdkValue(item)}
+        keywords={[...item.keywords]}
+        disabled={item.disabled === true}
+        onSelect={() => {
+          if (row?.kind === "directory") toggle(row);
+          else props.onSelect(item);
+        }}
+      >
+        <PathTreeItemLabel
+          item={item}
+          expanded={expanded}
+          onToggle={
+            row?.hasChildren === true
+              ? (event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  toggle(row);
+                }
+              : undefined
+          }
+        />
+      </PaletteItemRow>
+    );
+  });
+}
+
 function RowStatusBadge({ children }: { readonly children: string }) {
   return (
     <Badge
@@ -58,30 +456,38 @@ interface SubpageViewProps {
 export function SubpageView(props: SubpageViewProps) {
   const { subpage, ctx, onSelect } = props;
   const items = subpage.useItems(ctx);
+  let rows: ReactNode;
+  if (subpage.id === "open:agents") {
+    rows = <AgentSubpageRows items={items} onSelect={onSelect} />;
+  } else if (subpage.id === "open:artifacts") {
+    rows = <ArtifactSubpageRows items={items} onSelect={onSelect} />;
+  } else if (items.some((item) => item.pathTreeRow !== undefined)) {
+    rows = <PathSubpageRows items={items} onSelect={onSelect} />;
+  } else {
+    rows = items.map((item) => (
+      <PaletteItemRow
+        key={item.id}
+        value={buildCmdkValue(item)}
+        keywords={[...item.keywords]}
+        disabled={item.disabled === true}
+        onSelect={() => onSelect(item)}
+      >
+        <SubpageItemLabel label={item.label} />
+        {item.hostBadge !== undefined ? (
+          <RowStatusBadge>{item.hostBadge}</RowStatusBadge>
+        ) : null}
+        {item.statusBadge !== undefined ? (
+          <RowStatusBadge>{item.statusBadge}</RowStatusBadge>
+        ) : null}
+      </PaletteItemRow>
+    ));
+  }
   return (
     <>
       {items.length === 0 ? (
         <CommandEmpty>Nothing available.</CommandEmpty>
       ) : null}
-      <CommandGroup heading={subpage.title}>
-        {items.map((item) => (
-          <PaletteItemRow
-            key={item.id}
-            value={buildCmdkValue(item)}
-            keywords={[...item.keywords]}
-            disabled={item.disabled === true}
-            onSelect={() => onSelect(item)}
-          >
-            <SubpageItemLabel label={item.label} />
-            {item.hostBadge !== undefined ? (
-              <RowStatusBadge>{item.hostBadge}</RowStatusBadge>
-            ) : null}
-            {item.statusBadge !== undefined ? (
-              <RowStatusBadge>{item.statusBadge}</RowStatusBadge>
-            ) : null}
-          </PaletteItemRow>
-        ))}
-      </CommandGroup>
+      <CommandGroup heading={subpage.title}>{rows}</CommandGroup>
     </>
   );
 }
@@ -149,33 +555,35 @@ function OpenerDeepRows(props: OpenerDeepRowsProps) {
   const items = subpage.useItems(ctx);
   return (
     <>
-      {items.map((item) => (
-        <Fragment key={item.id}>
-          <PaletteItemRow
-            value={buildCmdkValue(item)}
-            keywords={[
-              ...item.keywords,
-              ...path.map((segment) => segment.toLowerCase()),
-            ]}
-            aria-label={deepRowName(path, item.label, item.statusBadge)}
-            disabled={item.disabled === true}
-            onSelect={() => onSelect(item)}
-          >
-            <DeepPathLabel path={path} label={item.label} />
-            {item.statusBadge !== undefined ? (
-              <RowStatusBadge>{item.statusBadge}</RowStatusBadge>
+      {items
+        .filter((item) => item.pathTreeRow?.kind !== "directory")
+        .map((item) => (
+          <Fragment key={item.id}>
+            <PaletteItemRow
+              value={buildCmdkValue(item)}
+              keywords={[
+                ...item.keywords,
+                ...path.map((segment) => segment.toLowerCase()),
+              ]}
+              aria-label={deepRowName(path, item.label, item.statusBadge)}
+              disabled={item.disabled === true}
+              onSelect={() => onSelect(item)}
+            >
+              <DeepPathLabel path={path} label={item.label} />
+              {item.statusBadge !== undefined ? (
+                <RowStatusBadge>{item.statusBadge}</RowStatusBadge>
+              ) : null}
+            </PaletteItemRow>
+            {item.subpage !== null && path.length < OPENER_DEEP_MAX_DEPTH ? (
+              <OpenerDeepRows
+                subpage={item.subpage}
+                ctx={ctx}
+                path={[...path, item.label]}
+                onSelect={onSelect}
+              />
             ) : null}
-          </PaletteItemRow>
-          {item.subpage !== null && path.length < OPENER_DEEP_MAX_DEPTH ? (
-            <OpenerDeepRows
-              subpage={item.subpage}
-              ctx={ctx}
-              path={[...path, item.label]}
-              onSelect={onSelect}
-            />
-          ) : null}
-        </Fragment>
-      ))}
+          </Fragment>
+        ))}
     </>
   );
 }

--- a/clients/gui-app/src/components/command-palette/palette-cmdk.tsx
+++ b/clients/gui-app/src/components/command-palette/palette-cmdk.tsx
@@ -5,7 +5,13 @@
  * opener root view. Non-component helpers (filter, row value, controller hook)
  * live in `palette-cmdk-controller.ts`.
  */
-import { Fragment, useState, type MouseEvent, type ReactNode } from "react";
+import {
+  Fragment,
+  useEffect,
+  useState,
+  type MouseEvent,
+  type ReactNode,
+} from "react";
 import { useCommandState } from "cmdk";
 import { Bot, Folder, FolderOpen, MessageSquare } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
@@ -70,6 +76,28 @@ function AgentTreeIndent(props: {
       </AgentTreeIndent>
     </span>
   );
+}
+
+function treeDescendantKeywords(
+  items: ReadonlyArray<CommandItemShape>,
+  getRow: (
+    item: CommandItemShape,
+  ) =>
+    | { readonly nodeId: string; readonly ancestorIds: ReadonlyArray<string> }
+    | undefined,
+): ReadonlyMap<string, ReadonlyArray<string>> {
+  const keywords = new Map<string, string[]>();
+  for (const item of items) {
+    const row = getRow(item);
+    if (row === undefined) continue;
+    const searchable = [item.label, ...item.keywords];
+    for (const ancestorId of row.ancestorIds) {
+      const existing = keywords.get(ancestorId) ?? [];
+      existing.push(...searchable);
+      keywords.set(ancestorId, existing);
+    }
+  }
+  return keywords;
 }
 
 function AgentTreeItemLabel(props: {
@@ -145,6 +173,7 @@ function AgentSubpageRows(props: {
     () => new Set<string>(),
   );
   const search = useCommandState((state) => state.search);
+  const selectedValue = useCommandState((state) => state.value);
   const isExpanded = (row: NonNullable<CommandItemShape["agentTreeRow"]>) =>
     !userCollapsedIds.has(row.nodeId) &&
     (row.depth === 0 || userExpandedIds.has(row.nodeId));
@@ -172,6 +201,37 @@ function AgentSubpageRows(props: {
         : [[item.agentTreeRow.nodeId, item.agentTreeRow] as const],
     ),
   );
+  useEffect(() => {
+    const onKeyDown = (event: globalThis.KeyboardEvent) => {
+      if (
+        !(event.target instanceof Element) ||
+        event.target.closest("[cmdk-root]") === null
+      ) {
+        return;
+      }
+      const item = props.items.find(
+        (candidate) => buildCmdkValue(candidate) === selectedValue,
+      );
+      const row = item?.agentTreeRow;
+      if (row?.hasChildren !== true) return;
+      const expanded = isExpanded(row);
+      if (event.key === "ArrowRight" && !expanded) {
+        event.preventDefault();
+        event.stopPropagation();
+        setRowExpanded(row, true);
+      } else if (event.key === "ArrowLeft" && expanded) {
+        event.preventDefault();
+        event.stopPropagation();
+        setRowExpanded(row, false);
+      }
+    };
+    document.addEventListener("keydown", onKeyDown, true);
+    return () => document.removeEventListener("keydown", onKeyDown, true);
+  });
+  const descendantKeywords = treeDescendantKeywords(
+    props.items,
+    (item) => item.agentTreeRow,
+  );
   const visibleItems =
     search.length > 0
       ? props.items
@@ -190,21 +250,12 @@ function AgentSubpageRows(props: {
       <PaletteItemRow
         key={item.id}
         value={buildCmdkValue(item)}
-        keywords={[...item.keywords]}
+        keywords={[
+          ...item.keywords,
+          ...(descendantKeywords.get(row?.nodeId ?? "") ?? []),
+        ]}
         disabled={item.disabled === true}
         onSelect={() => props.onSelect(item)}
-        onKeyDown={(event) => {
-          if (row?.hasChildren !== true) return;
-          if (event.key === "ArrowRight" && !expanded) {
-            event.preventDefault();
-            event.stopPropagation();
-            setRowExpanded(row, true);
-          } else if (event.key === "ArrowLeft" && expanded) {
-            event.preventDefault();
-            event.stopPropagation();
-            setRowExpanded(row, false);
-          }
-        }}
       >
         <AgentTreeItemLabel
           item={item}
@@ -281,6 +332,7 @@ function ArtifactSubpageRows(props: {
     () => new Set<string>(),
   );
   const search = useCommandState((state) => state.search);
+  const selectedValue = useCommandState((state) => state.value);
   const isExpanded = (row: NonNullable<CommandItemShape["artifactTreeRow"]>) =>
     !userCollapsedIds.has(row.nodeId) &&
     (row.depth === 0 || userExpandedIds.has(row.nodeId));
@@ -308,6 +360,37 @@ function ArtifactSubpageRows(props: {
         : [[item.artifactTreeRow.nodeId, item.artifactTreeRow] as const],
     ),
   );
+  useEffect(() => {
+    const onKeyDown = (event: globalThis.KeyboardEvent) => {
+      if (
+        !(event.target instanceof Element) ||
+        event.target.closest("[cmdk-root]") === null
+      ) {
+        return;
+      }
+      const item = props.items.find(
+        (candidate) => buildCmdkValue(candidate) === selectedValue,
+      );
+      const row = item?.artifactTreeRow;
+      if (row?.hasChildren !== true) return;
+      const expanded = isExpanded(row);
+      if (event.key === "ArrowRight" && !expanded) {
+        event.preventDefault();
+        event.stopPropagation();
+        setRowExpanded(row, true);
+      } else if (event.key === "ArrowLeft" && expanded) {
+        event.preventDefault();
+        event.stopPropagation();
+        setRowExpanded(row, false);
+      }
+    };
+    document.addEventListener("keydown", onKeyDown, true);
+    return () => document.removeEventListener("keydown", onKeyDown, true);
+  });
+  const descendantKeywords = treeDescendantKeywords(
+    props.items,
+    (item) => item.artifactTreeRow,
+  );
   const visibleItems =
     search.length > 0
       ? props.items
@@ -326,21 +409,12 @@ function ArtifactSubpageRows(props: {
       <PaletteItemRow
         key={item.id}
         value={buildCmdkValue(item)}
-        keywords={[...item.keywords]}
+        keywords={[
+          ...item.keywords,
+          ...(descendantKeywords.get(row?.nodeId ?? "") ?? []),
+        ]}
         disabled={item.disabled === true}
         onSelect={() => props.onSelect(item)}
-        onKeyDown={(event) => {
-          if (row?.hasChildren !== true) return;
-          if (event.key === "ArrowRight" && !expanded) {
-            event.preventDefault();
-            event.stopPropagation();
-            setRowExpanded(row, true);
-          } else if (event.key === "ArrowLeft" && expanded) {
-            event.preventDefault();
-            event.stopPropagation();
-            setRowExpanded(row, false);
-          }
-        }}
       >
         <ArtifactTreeItemLabel
           item={item}

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-file-tree.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-file-tree.tsx
@@ -222,6 +222,7 @@ function useFileTreeSource(args: {
     hostId: args.hostId,
     workspacePath: args.workspacePath,
     enabled: !useUnaryFallback,
+    streamClient: undefined,
     expandedPathsOverride: null,
     onPrunedOverride: null,
   });

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-file-tree.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-file-tree.tsx
@@ -222,6 +222,8 @@ function useFileTreeSource(args: {
     hostId: args.hostId,
     workspacePath: args.workspacePath,
     enabled: !useUnaryFallback,
+    expandedPathsOverride: null,
+    onPrunedOverride: null,
   });
   const search = useHostPathSearch({
     epicId: args.epicId,

--- a/clients/gui-app/src/hooks/workspace/__tests__/use-workspace-file-list-subscription.test.tsx
+++ b/clients/gui-app/src/hooks/workspace/__tests__/use-workspace-file-list-subscription.test.tsx
@@ -190,6 +190,7 @@ function renderSubscription(
         hostId: HOST_ID,
         workspacePath: WORKSPACE_PATH,
         enabled: true,
+        streamClient: undefined,
         expandedPathsOverride: null,
         onPrunedOverride: null,
       }),

--- a/clients/gui-app/src/hooks/workspace/__tests__/use-workspace-file-list-subscription.test.tsx
+++ b/clients/gui-app/src/hooks/workspace/__tests__/use-workspace-file-list-subscription.test.tsx
@@ -190,6 +190,8 @@ function renderSubscription(
         hostId: HOST_ID,
         workspacePath: WORKSPACE_PATH,
         enabled: true,
+        expandedPathsOverride: null,
+        onPrunedOverride: null,
       }),
     { wrapper },
   );

--- a/clients/gui-app/src/hooks/workspace/use-workspace-file-list-subscription.ts
+++ b/clients/gui-app/src/hooks/workspace/use-workspace-file-list-subscription.ts
@@ -160,6 +160,11 @@ export function useWorkspaceFileListSubscription(args: {
   readonly hostId: string | null;
   readonly workspacePath: string | null;
   readonly enabled: boolean;
+  /** Explicit host-bound transport; `undefined` uses the ambient sidebar client. */
+  readonly streamClient:
+    | IHostStreamClient<HostStreamRpcRegistry>
+    | null
+    | undefined;
   /** Null uses the persistent sidebar expansion store. */
   readonly expandedPathsOverride: ReadonlyArray<string> | null;
   readonly onPrunedOverride:
@@ -167,7 +172,9 @@ export function useWorkspaceFileListSubscription(args: {
     | null;
 }): WorkspaceFileListSubscriptionResult {
   const queryClient = useQueryClient();
-  const wsStreamClient = useWsStreamClient();
+  const ambientStreamClient = useWsStreamClient();
+  const wsStreamClient =
+    args.streamClient === undefined ? ambientStreamClient : args.streamClient;
   const pruneExpandedPaths = useFileTreeStore((s) => s.pruneExpandedPaths);
   const storedExpandedPaths = useFileTreeExpandedPaths(
     args.epicId,

--- a/clients/gui-app/src/hooks/workspace/use-workspace-file-list-subscription.ts
+++ b/clients/gui-app/src/hooks/workspace/use-workspace-file-list-subscription.ts
@@ -160,18 +160,24 @@ export function useWorkspaceFileListSubscription(args: {
   readonly hostId: string | null;
   readonly workspacePath: string | null;
   readonly enabled: boolean;
+  /** Null uses the persistent sidebar expansion store. */
+  readonly expandedPathsOverride: ReadonlyArray<string> | null;
+  readonly onPrunedOverride:
+    | ((directoryPaths: ReadonlyArray<string>) => void)
+    | null;
 }): WorkspaceFileListSubscriptionResult {
   const queryClient = useQueryClient();
   const wsStreamClient = useWsStreamClient();
   const pruneExpandedPaths = useFileTreeStore((s) => s.pruneExpandedPaths);
-  const expandedPaths = useFileTreeExpandedPaths(
+  const storedExpandedPaths = useFileTreeExpandedPaths(
     args.epicId,
     args.hostId,
     args.workspacePath,
   );
+  const expandedPaths = args.expandedPathsOverride ?? storedExpandedPaths;
   const [consumerId] = useState(() => Symbol("workspace-file-list-consumer"));
 
-  const { epicId, hostId, workspacePath, enabled } = args;
+  const { epicId, hostId, workspacePath, enabled, onPrunedOverride } = args;
   const watchPaths = useMemo(
     () => selectWatchableDirectoryPaths(expandedPaths),
     [expandedPaths],
@@ -208,7 +214,11 @@ export function useWorkspaceFileListSubscription(args: {
 
     shared.refCount += 1;
     shared.pruneListeners.set(consumerId, (directoryPaths) => {
-      pruneExpandedPaths(epicId, hostId, workspacePath, directoryPaths);
+      if (onPrunedOverride !== null) {
+        onPrunedOverride(directoryPaths);
+      } else {
+        pruneExpandedPaths(epicId, hostId, workspacePath, directoryPaths);
+      }
     });
     // A joining consumer may find a GC-collected query slot (the listings
     // themselves live on the shared entry, and an idle workspace produces no
@@ -237,6 +247,7 @@ export function useWorkspaceFileListSubscription(args: {
     epicId,
     hostId,
     pruneExpandedPaths,
+    onPrunedOverride,
     queryClient,
     workspacePath,
     wsStreamClient,

--- a/clients/gui-app/src/lib/commands/sources/open/__tests__/artifact-display-index.test.ts
+++ b/clients/gui-app/src/lib/commands/sources/open/__tests__/artifact-display-index.test.ts
@@ -63,6 +63,7 @@ describe("buildArtifactDisplayPathIndex", () => {
     expect(index.get("tickets/one")).toMatchObject({
       id: "c",
       title: "First",
+      titleSegments: ["Tickets", "First"],
       titlePath: "Tickets / First",
     });
   });

--- a/clients/gui-app/src/lib/commands/sources/open/__tests__/artifact-display-index.test.ts
+++ b/clients/gui-app/src/lib/commands/sources/open/__tests__/artifact-display-index.test.ts
@@ -64,6 +64,7 @@ describe("buildArtifactDisplayPathIndex", () => {
       id: "c",
       title: "First",
       titleSegments: ["Tickets", "First"],
+      idSegments: ["p", "c"],
       titlePath: "Tickets / First",
     });
   });

--- a/clients/gui-app/src/lib/commands/sources/open/__tests__/open-files-diff.test.tsx
+++ b/clients/gui-app/src/lib/commands/sources/open/__tests__/open-files-diff.test.tsx
@@ -566,9 +566,9 @@ describe("Files opener sub-page (Artifacts step)", () => {
       "Notes",
     ]);
     expect(items.map((i) => i.id)).toEqual([
-      "open:files:artifacts:epic-1:directory:Parent%20A",
+      "open:files:artifacts:epic-1:directory:p1",
       "open:files:artifacts:c1",
-      "open:files:artifacts:epic-1:directory:Parent%20B",
+      "open:files:artifacts:epic-1:directory:p2",
       "open:files:artifacts:c2",
     ]);
   });
@@ -586,6 +586,32 @@ describe("Files opener sub-page (Artifacts step)", () => {
     const items = artifactStepItems();
     expect(items.map((item) => item.label)).toEqual(["API / UI"]);
     expect(items[0].pathTreeRow?.depth).toBe(0);
+  });
+
+  it("keeps duplicate-titled artifact branches separate by identity", () => {
+    state.projection = projectionOf([
+      { id: "p1", folderName: "one", title: "Area", parentId: null },
+      { id: "c1", folderName: "notes", title: "Notes", parentId: "p1" },
+      { id: "p2", folderName: "two", title: "Area", parentId: null },
+      { id: "c2", folderName: "notes", title: "Notes", parentId: "p2" },
+    ]);
+    state.searchResults = [
+      fileResult("one/notes", "index.md"),
+      fileResult("two/notes", "index.md"),
+    ];
+    const items = artifactStepItems();
+    expect(items.map((item) => item.id)).toEqual([
+      "open:files:artifacts:epic-1:directory:p1",
+      "open:files:artifacts:c1",
+      "open:files:artifacts:epic-1:directory:p2",
+      "open:files:artifacts:c2",
+    ]);
+    expect(items.map((item) => item.label)).toEqual([
+      "Area",
+      "Notes",
+      "Area",
+      "Notes",
+    ]);
   });
 
   it("drops a stale/deleted artifact whose path is not in authoritative state", () => {

--- a/clients/gui-app/src/lib/commands/sources/open/__tests__/open-files-diff.test.tsx
+++ b/clients/gui-app/src/lib/commands/sources/open/__tests__/open-files-diff.test.tsx
@@ -96,6 +96,28 @@ vi.mock("@/hooks/workspace/use-workspace-search-paths-query", async () => {
     }),
   };
 });
+vi.mock("@/hooks/workspace/use-workspace-file-list-subscription", () => ({
+  useWorkspaceFileListSubscription: () => {
+    const files = state.searchResults.flatMap((result) =>
+      result.kind === "file" ? [[result.relPath, result.name] as const] : [],
+    );
+    const directories = new Set<string>();
+    for (const [path] of files) {
+      const segments = path.split("/");
+      for (let index = 1; index < segments.length; index += 1) {
+        directories.add(`${segments.slice(0, index).join("/")}/`);
+      }
+    }
+    return {
+      paths: [...directories, ...files.map(([path]) => path)],
+      fileNameByPath: new Map(files),
+      ignoredPaths: [],
+      truncated: state.searchTruncated,
+      isPending: false,
+      error: null,
+    };
+  },
+}));
 
 function buildSearchResponse(
   source: WorkspaceSearchSource,
@@ -130,6 +152,9 @@ vi.mock("@/hooks/git/use-git-list-changed-files-subscription", () => ({
 vi.mock("@/stores/command-palette/command-palette-store", () => ({
   useCommandPaletteStore: (selector: (s: { query: string }) => unknown) =>
     selector({ query: state.query }),
+}));
+vi.mock("@/lib/commands/palette-query-context", () => ({
+  usePaletteLiveQuery: () => state.query,
 }));
 
 import { useFilesOpenerItems } from "@/lib/commands/sources/open/files-subpage";
@@ -371,8 +396,19 @@ describe("Files opener sub-page (code root step)", () => {
     state.searchResults = [fileResult("src/a.ts", "a.ts")];
     const fileItems = codeStepItems("/ws/only");
     expect(fileItems.map((i) => i.id)).toEqual([
+      "open:files:default-host:/ws/only:directory:src",
       "open:files:/ws/only:src/a.ts",
     ]);
+    expect(fileItems[0].pathTreeRow).toMatchObject({
+      kind: "directory",
+      depth: 0,
+      hasChildren: true,
+    });
+    expect(fileItems[1].pathTreeRow).toMatchObject({
+      kind: "file",
+      depth: 1,
+      ancestorIds: ["open:files:default-host:/ws/only:directory:src"],
+    });
     runById(fileItems, "open:files:/ws/only:src/a.ts");
     const opened = lastTileOpen();
     expect(opened.groupId).toBe("group-1");
@@ -386,12 +422,14 @@ describe("Files opener sub-page (code root step)", () => {
     state.searchTruncated = true;
     const fileItems = codeStepItems("/ws/only");
     expect(fileItems.map((i) => i.id)).toEqual([
+      "open:files:default-host:/ws/only:directory:src",
       "open:files:/ws/only:src/a.ts",
       "open:files:truncated",
     ]);
   });
 
   it("shows a distinct notice when the workspace root is unavailable", () => {
+    state.query = "missing";
     state.searchRootUnavailable = true;
     const fileItems = codeStepItems("/ws/only");
     expect(fileItems.map((i) => i.id)).toEqual([
@@ -401,6 +439,7 @@ describe("Files opener sub-page (code root step)", () => {
   });
 
   it("shows a distinct notice when the host lacks the search RPC", () => {
+    state.query = "a";
     state.searchIsError = true;
     const fileItems = codeStepItems("/ws/only");
     expect(fileItems.map((i) => i.id)).toEqual([
@@ -409,6 +448,7 @@ describe("Files opener sub-page (code root step)", () => {
   });
 
   it("returns no rows for a ready-but-empty search (distinct from unavailable)", () => {
+    state.query = "missing";
     state.searchResults = [];
     state.searchRootUnavailable = false;
     const fileItems = codeStepItems("/ws/only");
@@ -416,6 +456,7 @@ describe("Files opener sub-page (code root step)", () => {
   });
 
   it("drops a late reply echoing a different root (stale-selection guard)", () => {
+    state.query = "a";
     state.searchResults = [fileResult("src/a.ts", "a.ts")];
     state.echoRootOverride = "/ws/some-previous-workspace";
     const fileItems = codeStepItems("/ws/only");
@@ -469,11 +510,15 @@ describe("Files opener sub-page (Artifacts step)", () => {
     ];
     const items = artifactStepItems();
     expect(items.map((i) => i.label)).toEqual([
-      "Parent A / Notes",
-      "Parent B / Notes",
+      "Parent A",
+      "Notes",
+      "Parent B",
+      "Notes",
     ]);
     expect(items.map((i) => i.id)).toEqual([
+      "open:files:artifacts:epic-1:directory:Parent A",
       "open:files:artifacts:c1",
+      "open:files:artifacts:epic-1:directory:Parent B",
       "open:files:artifacts:c2",
     ]);
   });
@@ -567,6 +612,7 @@ describe("Diff opener sub-page", () => {
     state.changedFiles = [changedFile("src/x.ts")];
     const items = renderItems(useDiffOpenerItems);
     expect(items.map((i) => i.id)).toEqual([
+      "open:diff:default-host:/ws/only:directory:src",
       "open:diff:/ws/only:src/x.ts:unstaged",
     ]);
     runById(items, "open:diff:/ws/only:src/x.ts:unstaged");

--- a/clients/gui-app/src/lib/commands/sources/open/__tests__/open-files-diff.test.tsx
+++ b/clients/gui-app/src/lib/commands/sources/open/__tests__/open-files-diff.test.tsx
@@ -43,6 +43,11 @@ const state = vi.hoisted(() => ({
   searchRootUnavailable: false,
   searchTruncated: false,
   searchIsError: false,
+  streamSupport: "supported" as "supported" | "unsupported",
+  streamClientAvailable: true,
+  streamIsPending: false,
+  streamError: null as string | null,
+  streamEnabledCalls: [] as boolean[],
   // Force the echoed source to a different root, to exercise the stale-reply
   // guard (a late response for a workspace the user has since left).
   echoRootOverride: null as string | null,
@@ -65,6 +70,19 @@ vi.mock("@/hooks/worktree/use-worktree-list-bindings-for-epic-query", () => ({
 vi.mock("@/lib/host", () => ({ useHostClient: () => ({}) }));
 vi.mock("@/hooks/host/use-host-client-for-host-id", () => ({
   useHostClientForHostId: (hostId: string | null) => ({ mockHostId: hostId }),
+}));
+vi.mock("@/hooks/host/use-host-directory-entry", () => ({
+  useHostDirectoryEntry: (hostId: string) => ({ hostId }),
+}));
+vi.mock("@/hooks/host/use-host-stream-client-for", () => ({
+  useHostStreamClientFor: () =>
+    state.streamClientAvailable ? { instanceId: "test-stream" } : null,
+}));
+vi.mock("@/lib/host/stream-auth-revalidator", () => ({
+  useStreamAuthRevalidator: () => null,
+}));
+vi.mock("@/lib/host/stream-runtime-context", () => ({
+  useStreamMethodSupportFor: () => state.streamSupport,
 }));
 vi.mock("@/hooks/host/use-addressable-host-id", () => ({
   useAddressableHostId: () => state.defaultHostId,
@@ -97,7 +115,8 @@ vi.mock("@/hooks/workspace/use-workspace-search-paths-query", async () => {
   };
 });
 vi.mock("@/hooks/workspace/use-workspace-file-list-subscription", () => ({
-  useWorkspaceFileListSubscription: () => {
+  useWorkspaceFileListSubscription: (args: { readonly enabled: boolean }) => {
+    state.streamEnabledCalls.push(args.enabled);
     const files = state.searchResults.flatMap((result) =>
       result.kind === "file" ? [[result.relPath, result.name] as const] : [],
     );
@@ -113,8 +132,8 @@ vi.mock("@/hooks/workspace/use-workspace-file-list-subscription", () => ({
       fileNameByPath: new Map(files),
       ignoredPaths: [],
       truncated: state.searchTruncated,
-      isPending: false,
-      error: null,
+      isPending: state.streamIsPending,
+      error: state.streamError,
     };
   },
 }));
@@ -278,6 +297,11 @@ beforeEach(() => {
   state.searchRootUnavailable = false;
   state.searchTruncated = false;
   state.searchIsError = false;
+  state.streamSupport = "supported";
+  state.streamClientAvailable = true;
+  state.streamIsPending = false;
+  state.streamError = null;
+  state.streamEnabledCalls = [];
   state.echoRootOverride = null;
   state.projection = null;
   state.defaultHostId = "default-host";
@@ -396,7 +420,7 @@ describe("Files opener sub-page (code root step)", () => {
     state.searchResults = [fileResult("src/a.ts", "a.ts")];
     const fileItems = codeStepItems("/ws/only");
     expect(fileItems.map((i) => i.id)).toEqual([
-      "open:files:default-host:/ws/only:directory:src",
+      "open:files:default-host:%2Fws%2Fonly:directory:src",
       "open:files:/ws/only:src/a.ts",
     ]);
     expect(fileItems[0].pathTreeRow).toMatchObject({
@@ -407,7 +431,7 @@ describe("Files opener sub-page (code root step)", () => {
     expect(fileItems[1].pathTreeRow).toMatchObject({
       kind: "file",
       depth: 1,
-      ancestorIds: ["open:files:default-host:/ws/only:directory:src"],
+      ancestorIds: ["open:files:default-host:%2Fws%2Fonly:directory:src"],
     });
     runById(fileItems, "open:files:/ws/only:src/a.ts");
     const opened = lastTileOpen();
@@ -422,7 +446,7 @@ describe("Files opener sub-page (code root step)", () => {
     state.searchTruncated = true;
     const fileItems = codeStepItems("/ws/only");
     expect(fileItems.map((i) => i.id)).toEqual([
-      "open:files:default-host:/ws/only:directory:src",
+      "open:files:default-host:%2Fws%2Fonly:directory:src",
       "open:files:/ws/only:src/a.ts",
       "open:files:truncated",
     ]);
@@ -444,6 +468,32 @@ describe("Files opener sub-page (code root step)", () => {
     const fileItems = codeStepItems("/ws/only");
     expect(fileItems.map((i) => i.id)).toEqual([
       "open:files:ws:/ws/only:unsupported",
+    ]);
+  });
+
+  it("does not open a live file stream while host search is active", () => {
+    state.query = "a";
+    state.searchResults = [fileResult("src/a.ts", "a.ts")];
+    codeStepItems("/ws/only");
+    expect(state.streamEnabledCalls.at(-1)).toBe(false);
+  });
+
+  it("surfaces unsupported, pending, and failed browse states", () => {
+    state.streamSupport = "unsupported";
+    expect(codeStepItems("/ws/only").map((item) => item.label)).toEqual([
+      "File browsing is unavailable on this host",
+    ]);
+
+    state.streamSupport = "supported";
+    state.streamIsPending = true;
+    expect(codeStepItems("/ws/only").map((item) => item.label)).toEqual([
+      "Loading files…",
+    ]);
+
+    state.streamIsPending = false;
+    state.streamError = "stream failed";
+    expect(codeStepItems("/ws/only").map((item) => item.label)).toEqual([
+      "Files could not be loaded",
     ]);
   });
 
@@ -516,11 +566,26 @@ describe("Files opener sub-page (Artifacts step)", () => {
       "Notes",
     ]);
     expect(items.map((i) => i.id)).toEqual([
-      "open:files:artifacts:epic-1:directory:Parent A",
+      "open:files:artifacts:epic-1:directory:Parent%20A",
       "open:files:artifacts:c1",
-      "open:files:artifacts:epic-1:directory:Parent B",
+      "open:files:artifacts:epic-1:directory:Parent%20B",
       "open:files:artifacts:c2",
     ]);
+  });
+
+  it("keeps slashes inside artifact titles instead of fabricating ancestors", () => {
+    state.projection = projectionOf([
+      {
+        id: "a1",
+        folderName: "api-ui",
+        title: "API / UI",
+        parentId: null,
+      },
+    ]);
+    state.searchResults = [fileResult("api-ui", "index.md")];
+    const items = artifactStepItems();
+    expect(items.map((item) => item.label)).toEqual(["API / UI"]);
+    expect(items[0].pathTreeRow?.depth).toBe(0);
   });
 
   it("drops a stale/deleted artifact whose path is not in authoritative state", () => {
@@ -612,7 +677,7 @@ describe("Diff opener sub-page", () => {
     state.changedFiles = [changedFile("src/x.ts")];
     const items = renderItems(useDiffOpenerItems);
     expect(items.map((i) => i.id)).toEqual([
-      "open:diff:default-host:/ws/only:directory:src",
+      "open:diff:default-host:%2Fws%2Fonly:directory:src",
       "open:diff:/ws/only:src/x.ts:unstaged",
     ]);
     runById(items, "open:diff:/ws/only:src/x.ts:unstaged");

--- a/clients/gui-app/src/lib/commands/sources/open/__tests__/open-subpages.test.tsx
+++ b/clients/gui-app/src/lib/commands/sources/open/__tests__/open-subpages.test.tsx
@@ -125,11 +125,12 @@ function chat(
   id: string,
   title: string,
   hostId: string | null,
+  parentId: string | null,
 ): ChatProjection {
   return {
     id,
     title,
-    parentId: null,
+    parentId,
     createdAt: 0,
     updatedAt: 0,
     userId: null,
@@ -162,17 +163,23 @@ function agent(id: string, title: string): TuiAgentProjection {
     terminalShellArgs: null,
   };
 }
-function artifact(id: string, title: string): ArtifactProjection {
+function artifact(args: {
+  readonly id: string;
+  readonly title: string;
+  readonly kind: "spec" | "ticket" | "story" | "review";
+  readonly parentId: string | null;
+  readonly status: number | null;
+}): ArtifactProjection {
   return {
-    id,
-    kind: "spec",
-    title,
+    id: args.id,
+    kind: args.kind,
+    title: args.title,
     folderName: "",
-    parentId: null,
+    parentId: args.parentId,
     artifactRoomId: null,
     createdAt: 0,
     updatedAt: 0,
-    status: null,
+    status: args.status,
     createdManually: false,
   };
 }
@@ -184,16 +191,34 @@ const FAKE_PROJECTION: EpicProjectedSlices = {
     byId: {
       // Lives on a different host than the active one ("default-host") -
       // should carry a host badge.
-      c1: chat("c1", "Chat One", "chat-host"),
+      c1: chat("c1", "Chat One", "chat-host", null),
       // Lives on the active host - no badge.
-      c2: chat("c2", "Chat Two", "default-host"),
+      c2: chat("c2", "Chat Two", "default-host", "c1"),
       // Lives on a directory-listed host whose label is blank - the badge
       // must fall back to the raw hostId, not render an empty chip.
-      c3: chat("c3", "Chat Three", "blank-label-host"),
+      c3: chat("c3", "Chat Three", "blank-label-host", "c1"),
     },
   },
   tuiAgents: { allIds: ["a1"], byId: { a1: agent("a1", "Agent One") } },
-  artifacts: { allIds: ["s1"], byId: { s1: artifact("s1", "Spec One") } },
+  artifacts: {
+    allIds: ["s1", "t1"],
+    byId: {
+      s1: artifact({
+        id: "s1",
+        title: "Spec One",
+        kind: "spec",
+        parentId: null,
+        status: null,
+      }),
+      t1: artifact({
+        id: "t1",
+        title: "Ticket One",
+        kind: "ticket",
+        parentId: "s1",
+        status: 1,
+      }),
+    },
+  },
 };
 
 vi.mock("@/lib/commands/actions", () => ({
@@ -457,7 +482,7 @@ afterEach(() => {
 });
 
 describe("Agents opener sub-page", () => {
-  it("leads with both interfaces' creation leaves, then every Agent record", () => {
+  it("leads with creation leaves, then follows the canonical nested Agent tree", () => {
     const items = renderItems(useAgentsOpenerItems);
     // Creation for both interfaces sits at the top; records follow as one list
     // rather than two interface-grouped collections.
@@ -471,6 +496,30 @@ describe("Agents opener sub-page", () => {
     const ids = items.map((i) => i.id);
     expect(ids).toContain("open:chats:c1");
     expect(ids).toContain("open:tui:a1");
+    expect(ids.indexOf("open:chats:c2")).toBeGreaterThan(
+      ids.indexOf("open:chats:c1"),
+    );
+    expect(ids.indexOf("open:chats:c3")).toBeGreaterThan(
+      ids.indexOf("open:chats:c1"),
+    );
+    expect(
+      items.find((item) => item.id === "open:chats:c1")?.agentTreeRow,
+    ).toMatchObject({
+      depth: 0,
+      ancestorIds: [],
+      hasChildren: true,
+      interface: "chat",
+      activity: "idle",
+    });
+    expect(
+      items.find((item) => item.id === "open:chats:c2")?.agentTreeRow,
+    ).toMatchObject({
+      depth: 1,
+      ancestorIds: ["c1"],
+      hasChildren: false,
+      interface: "chat",
+      activity: "idle",
+    });
   });
 
   it("preserves the leaf id prefixes the palette keys analytics off", () => {
@@ -910,9 +959,26 @@ describe("Terminals opener sub-page", () => {
 });
 
 describe("Artifacts opener sub-page", () => {
-  it("lists existing artifacts and opens them into the target", () => {
+  it("lists the nested artifact tree with status metadata and opens a node", () => {
     const items = renderItems(useArtifactsOpenerItems);
-    expect(items.map((i) => i.id)).toEqual(["open:artifacts:s1"]);
+    expect(items.map((i) => i.id)).toEqual([
+      "open:artifacts:s1",
+      "open:artifacts:t1",
+    ]);
+    expect(items[0].artifactTreeRow).toMatchObject({
+      depth: 0,
+      ancestorIds: [],
+      hasChildren: true,
+      kind: "spec",
+      status: null,
+    });
+    expect(items[1].artifactTreeRow).toMatchObject({
+      depth: 1,
+      ancestorIds: ["s1"],
+      hasChildren: false,
+      kind: "ticket",
+      status: 1,
+    });
     runById(items, "open:artifacts:s1");
     const opened = lastTileOpen();
     expect(opened.groupId).toBe("group-1");

--- a/clients/gui-app/src/lib/commands/sources/open/__tests__/open-subpages.test.tsx
+++ b/clients/gui-app/src/lib/commands/sources/open/__tests__/open-subpages.test.tsx
@@ -187,7 +187,7 @@ function artifact(args: {
 const FAKE_PROJECTION: EpicProjectedSlices = {
   ...EMPTY_PROJECTED_SLICES,
   chats: {
-    allIds: ["c1", "c2", "c3"],
+    allIds: ["c1", "c2", "c3", "c:colon"],
     byId: {
       // Lives on a different host than the active one ("default-host") -
       // should carry a host badge.
@@ -197,6 +197,7 @@ const FAKE_PROJECTION: EpicProjectedSlices = {
       // Lives on a directory-listed host whose label is blank - the badge
       // must fall back to the raw hostId, not render an empty chip.
       c3: chat("c3", "Chat Three", "blank-label-host", "c1"),
+      "c:colon": chat("c:colon", "Colon Chat", "default-host", null),
     },
   },
   tuiAgents: { allIds: ["a1"], byId: { a1: agent("a1", "Agent One") } },
@@ -496,6 +497,7 @@ describe("Agents opener sub-page", () => {
     const ids = items.map((i) => i.id);
     expect(ids).toContain("open:chats:c1");
     expect(ids).toContain("open:tui:a1");
+    expect(ids).toContain("open:chats:c:colon");
     expect(ids.indexOf("open:chats:c2")).toBeGreaterThan(
       ids.indexOf("open:chats:c1"),
     );

--- a/clients/gui-app/src/lib/commands/sources/open/__tests__/path-tree-items.test.ts
+++ b/clients/gui-app/src/lib/commands/sources/open/__tests__/path-tree-items.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from "vitest";
+import type { CommandItem } from "@/lib/commands/types";
+import { buildPathTreeItems } from "@/lib/commands/sources/open/path-tree-items";
+
+function item(id: string, label: string): CommandItem {
+  return {
+    id,
+    label,
+    description: null,
+    keywords: [label],
+    group: "open",
+    scope: "actions",
+    shortcut: null,
+    actionId: null,
+    subpage: null,
+    run: vi.fn(),
+  };
+}
+
+describe("buildPathTreeItems", () => {
+  it("coalesces an actionable parent leaf with its directory node", () => {
+    const parent = item("parent", "Spec");
+    const child = item("child", "Ticket");
+    const rows = buildPathTreeItems(
+      "artifacts",
+      [
+        {
+          item: parent,
+          path: "parent",
+          displaySegments: ["Spec"],
+          structuralSegments: ["parent"],
+          gitStatus: undefined,
+        },
+        {
+          item: child,
+          path: "child",
+          displaySegments: ["Spec", "Ticket"],
+          structuralSegments: ["parent", "child"],
+          gitStatus: undefined,
+        },
+      ],
+      [],
+    );
+
+    expect(rows.map((row) => row.id)).toEqual(["parent", "child"]);
+    expect(rows[0]?.pathTreeRow).toMatchObject({
+      kind: "file",
+      hasChildren: true,
+      nodeId: "parent",
+    });
+    expect(rows[0]?.run).toBe(parent.run);
+    expect(rows[1]?.pathTreeRow?.ancestorIds).toEqual(["parent"]);
+  });
+});

--- a/clients/gui-app/src/lib/commands/sources/open/agents-subpage.ts
+++ b/clients/gui-app/src/lib/commands/sources/open/agents-subpage.ts
@@ -54,7 +54,10 @@ export function useAgentsOpenerItems(
   );
   const itemByNodeId = new Map<string, CommandItem>();
   for (const item of [...chat.existing, ...terminal.existing]) {
-    const nodeId = item.id.slice(item.id.lastIndexOf(":") + 1);
+    const prefix = item.id.startsWith("open:chats:")
+      ? "open:chats:"
+      : "open:tui:";
+    const nodeId = item.id.slice(prefix.length);
     itemByNodeId.set(nodeId, item);
   }
   const existing: CommandItem[] = [];

--- a/clients/gui-app/src/lib/commands/sources/open/agents-subpage.ts
+++ b/clients/gui-app/src/lib/commands/sources/open/agents-subpage.ts
@@ -6,19 +6,22 @@
  * agents" categories restated the interface as an entity collection, so the two
  * are merged here into one category listing every Agent in the Task.
  *
- * Layout: both creation leaves first (each naming its interface, so starting a
- * Terminal Agent stays one keystroke away), then every existing Agent -
- * chat-interface records before terminal-interface ones, matching the order the
- * mention picker's `epicAgentMentionEntriesFromEpic` projection uses.
+ * Layout: both creation leaves first, then the canonical mixed-interface Agent
+ * tree from the Epic projection. This is the same parent/child structure and
+ * default ordering used by the sidebar, so a child remains findable beneath
+ * the Agent that spawned it instead of disappearing into a long flat list.
  *
  * Composition, not reimplementation: the per-interface hooks still own their
  * own leaves, so `open:chats:*` / `open:tui:*` ids (and therefore the
  * `open_chat` / `open_terminal` analytics routing keyed on those prefixes in
  * `palette-cmdk-controller.ts`) are untouched by the merge.
  */
-import { useMemo } from "react";
+import { agentActivityTiers } from "@/lib/agent-activity";
+import { useEpicAgentActivity } from "@/stores/agent-activity-store";
 import { useChatsOpenerItems } from "@/lib/commands/sources/open/chats-subpage";
 import { useTuiOpenerItems } from "@/lib/commands/sources/open/tui-subpage";
+import { useActiveEpicProjection } from "@/lib/commands/sources/open/use-active-epic-projection";
+import { projectTreeSlice } from "@/stores/epics/open-epic/projection-helpers";
 import type { CommandContext, CommandItem } from "@/lib/commands/types";
 
 /**
@@ -36,13 +39,48 @@ export function useAgentsOpenerItems(
 ): ReadonlyArray<CommandItem> {
   const chat = useChatsOpenerItems(ctx);
   const terminal = useTuiOpenerItems(ctx);
-  return useMemo<ReadonlyArray<CommandItem>>(
-    () => [
-      chat.create,
-      terminal.create,
-      ...chat.existing,
-      ...terminal.existing,
-    ],
-    [chat, terminal],
+  const projection = useActiveEpicProjection(ctx.activeEpicId);
+  const activity = agentActivityTiers(useEpicAgentActivity(ctx.activeEpicId));
+  if (projection === null) return [chat.create, terminal.create];
+  // The command palette subscribes to the passive registry projection outside
+  // EpicSessionProvider. Its independently cached `tree` index can briefly be
+  // empty while the record slices are already populated (the sidebar, inside
+  // the provider, does not have that gap). Derive from the authoritative live
+  // records here so opening the Agents page never collapses to creation-only.
+  const tree = projectTreeSlice(
+    projection.artifacts,
+    projection.chats,
+    projection.tuiAgents,
   );
+  const itemByNodeId = new Map<string, CommandItem>();
+  for (const item of [...chat.existing, ...terminal.existing]) {
+    const nodeId = item.id.slice(item.id.lastIndexOf(":") + 1);
+    itemByNodeId.set(nodeId, item);
+  }
+  const existing: CommandItem[] = [];
+  const append = (nodeId: string, ancestorIds: ReadonlyArray<string>): void => {
+    const node = tree.nodeById[nodeId];
+    const item = itemByNodeId.get(nodeId);
+    if (
+      item !== undefined &&
+      (node.type === "chat" || node.type === "terminal-agent")
+    ) {
+      existing.push({
+        ...item,
+        agentTreeRow: {
+          nodeId,
+          depth: ancestorIds.length,
+          ancestorIds,
+          hasChildren: tree.childrenByParent[nodeId].length > 0,
+          interface: node.type === "chat" ? "chat" : "terminal",
+          activity: activity.get(nodeId) ?? "idle",
+        },
+      });
+    }
+    for (const childId of tree.childrenByParent[nodeId] ?? []) {
+      append(childId, [...ancestorIds, nodeId]);
+    }
+  };
+  for (const rootId of tree.rootIds) append(rootId, []);
+  return [chat.create, terminal.create, ...existing];
 }

--- a/clients/gui-app/src/lib/commands/sources/open/agents-subpage.ts
+++ b/clients/gui-app/src/lib/commands/sources/open/agents-subpage.ts
@@ -61,6 +61,9 @@ export function useAgentsOpenerItems(
   const append = (nodeId: string, ancestorIds: ReadonlyArray<string>): void => {
     const node = tree.nodeById[nodeId];
     const item = itemByNodeId.get(nodeId);
+    const childIds = Object.hasOwn(tree.childrenByParent, nodeId)
+      ? tree.childrenByParent[nodeId]
+      : [];
     if (
       item !== undefined &&
       (node.type === "chat" || node.type === "terminal-agent")
@@ -71,13 +74,13 @@ export function useAgentsOpenerItems(
           nodeId,
           depth: ancestorIds.length,
           ancestorIds,
-          hasChildren: tree.childrenByParent[nodeId].length > 0,
+          hasChildren: childIds.length > 0,
           interface: node.type === "chat" ? "chat" : "terminal",
           activity: activity.get(nodeId) ?? "idle",
         },
       });
     }
-    for (const childId of tree.childrenByParent[nodeId] ?? []) {
+    for (const childId of childIds) {
       append(childId, [...ancestorIds, nodeId]);
     }
   };

--- a/clients/gui-app/src/lib/commands/sources/open/artifact-display-index.ts
+++ b/clients/gui-app/src/lib/commands/sources/open/artifact-display-index.ts
@@ -24,6 +24,8 @@ export interface ArtifactPathEntry {
   readonly title: string;
   /** Structured ancestor-to-leaf titles; separators inside titles stay data. */
   readonly titleSegments: ReadonlyArray<string>;
+  /** Stable ancestor-to-leaf artifact IDs parallel to `titleSegments`. */
+  readonly idSegments: ReadonlyArray<string>;
   /**
    * Ancestor-to-leaf display titles joined by " / ". Distinguishes duplicate
    * leaf titles by their parent context and reads better than the folder slug
@@ -40,15 +42,37 @@ export function buildArtifactDisplayPathIndex(
   const index = new Map<string, ArtifactPathEntry>();
   for (const [logicalPath, resolved] of resolution) {
     const titleSegments = artifactTitleSegments(tree, artifacts, resolved.id);
+    const idSegments = artifactIdSegments(tree, artifacts, resolved.id);
     index.set(logicalPath, {
       id: resolved.id,
       kind: resolved.kind,
       title: displayTitle(resolved.title, resolved.kind),
       titleSegments,
+      idSegments,
       titlePath: titleSegments.join(" / "),
     });
   }
   return index;
+}
+
+/** Root-to-leaf artifact IDs parallel to the display-title segments. */
+function artifactIdSegments(
+  tree: TreeSlice,
+  artifacts: ArtifactsSlice,
+  artifactId: string,
+): ReadonlyArray<string> {
+  const ids: string[] = [];
+  const visited = new Set<string>();
+  let current: string | null = artifactId;
+  while (current !== null) {
+    if (visited.has(current)) break;
+    visited.add(current);
+    if (Object.hasOwn(artifacts.byId, current)) ids.unshift(current);
+    current = Object.hasOwn(tree.nodeById, current)
+      ? tree.nodeById[current].parentId
+      : null;
+  }
+  return ids;
 }
 
 /** Root-to-leaf display titles for `artifactId`, kept as structured segments. */

--- a/clients/gui-app/src/lib/commands/sources/open/artifact-display-index.ts
+++ b/clients/gui-app/src/lib/commands/sources/open/artifact-display-index.ts
@@ -22,6 +22,8 @@ export interface ArtifactPathEntry {
   readonly kind: EpicArtifactKind;
   /** Display title of the leaf artifact (host-independent, user-renamed). */
   readonly title: string;
+  /** Structured ancestor-to-leaf titles; separators inside titles stay data. */
+  readonly titleSegments: ReadonlyArray<string>;
   /**
    * Ancestor-to-leaf display titles joined by " / ". Distinguishes duplicate
    * leaf titles by their parent context and reads better than the folder slug
@@ -37,22 +39,24 @@ export function buildArtifactDisplayPathIndex(
   const resolution = buildArtifactPathIndex(tree, artifacts);
   const index = new Map<string, ArtifactPathEntry>();
   for (const [logicalPath, resolved] of resolution) {
+    const titleSegments = artifactTitleSegments(tree, artifacts, resolved.id);
     index.set(logicalPath, {
       id: resolved.id,
       kind: resolved.kind,
       title: displayTitle(resolved.title, resolved.kind),
-      titlePath: artifactTitlePath(tree, artifacts, resolved.id),
+      titleSegments,
+      titlePath: titleSegments.join(" / "),
     });
   }
   return index;
 }
 
-/** Root-to-leaf display titles for `artifactId`, joined by " / ". */
-function artifactTitlePath(
+/** Root-to-leaf display titles for `artifactId`, kept as structured segments. */
+function artifactTitleSegments(
   tree: TreeSlice,
   artifacts: ArtifactsSlice,
   artifactId: string,
-): string {
+): ReadonlyArray<string> {
   const titles: string[] = [];
   const visited = new Set<string>();
   let current: string | null = artifactId;
@@ -67,7 +71,7 @@ function artifactTitlePath(
       ? tree.nodeById[current].parentId
       : null;
   }
-  return titles.join(" / ");
+  return titles;
 }
 
 /** Strip leading/trailing slashes so client + host path forms compare equal. */

--- a/clients/gui-app/src/lib/commands/sources/open/artifacts-subpage.ts
+++ b/clients/gui-app/src/lib/commands/sources/open/artifacts-subpage.ts
@@ -59,6 +59,9 @@ export function useArtifactsOpenerItems(
   const append = (nodeId: string, ancestorIds: ReadonlyArray<string>): void => {
     const node = tree.nodeById[nodeId];
     const item = itemByNodeId.get(nodeId);
+    const childIds = Object.hasOwn(tree.childrenByParent, nodeId)
+      ? tree.childrenByParent[nodeId]
+      : [];
     if (
       item !== undefined &&
       node.type !== "chat" &&
@@ -70,13 +73,13 @@ export function useArtifactsOpenerItems(
           nodeId,
           depth: ancestorIds.length,
           ancestorIds,
-          hasChildren: tree.childrenByParent[nodeId].length > 0,
+          hasChildren: childIds.length > 0,
           kind: node.type,
           status: node.status,
         },
       });
     }
-    for (const childId of tree.childrenByParent[nodeId] ?? []) {
+    for (const childId of childIds) {
       append(childId, [...ancestorIds, nodeId]);
     }
   };

--- a/clients/gui-app/src/lib/commands/sources/open/artifacts-subpage.ts
+++ b/clients/gui-app/src/lib/commands/sources/open/artifacts-subpage.ts
@@ -4,7 +4,6 @@
  * instance into the target group. Artifact projections carry no hostId, so
  * they bind to the default host (matching the sidebar's fallback).
  */
-import { useMemo } from "react";
 import { v4 as uuidv4 } from "uuid";
 import { UNKNOWN_HOST_PLACEHOLDER } from "@/lib/host/constants";
 import { openerExistingLeaf } from "@/lib/commands/sources/open/open-leaf";
@@ -14,6 +13,7 @@ import {
 } from "@/lib/commands/sources/open/use-active-epic-projection";
 import type { CommandContext, CommandItem } from "@/lib/commands/types";
 import { isOpenableEpicNodeKind } from "@/stores/epics/canvas/types";
+import { projectTreeSlice } from "@/stores/epics/open-epic/projection-helpers";
 
 export function useArtifactsOpenerItems(
   ctx: CommandContext,
@@ -24,30 +24,62 @@ export function useArtifactsOpenerItems(
     useActiveEpicHostId(ctx.activeEpicId) ?? UNKNOWN_HOST_PLACEHOLDER;
   const projection = useActiveEpicProjection(ctx.activeEpicId);
 
-  return useMemo<ReadonlyArray<CommandItem>>(() => {
-    if (projection === null) return [];
-    return projection.artifacts.allIds.flatMap((id) => {
-      const artifact = projection.artifacts.byId[id];
-      if (!isOpenableEpicNodeKind(artifact.kind)) return [];
-      return [
-        openerExistingLeaf(
-          "artifacts",
-          ctx,
-          {
-            id: artifact.id,
-            instanceId: uuidv4(),
-            type: artifact.kind,
-            name:
-              artifact.title.length > 0
-                ? artifact.title
-                : `Untitled ${artifact.kind}`,
-            hostId: defaultHostId,
-          },
-          // Artifacts carry no per-item hostId (verified host-agnostic, audit
-          // G3) - never badged.
-          null,
-        ),
-      ];
-    });
-  }, [ctx, projection, defaultHostId]);
+  if (projection === null) return [];
+  const tree = projectTreeSlice(
+    projection.artifacts,
+    projection.chats,
+    projection.tuiAgents,
+  );
+  const itemByNodeId = new Map<string, CommandItem>();
+  for (const id of projection.artifacts.allIds) {
+    const artifact = projection.artifacts.byId[id];
+    if (!isOpenableEpicNodeKind(artifact.kind)) continue;
+    itemByNodeId.set(
+      id,
+      openerExistingLeaf(
+        "artifacts",
+        ctx,
+        {
+          id: artifact.id,
+          instanceId: uuidv4(),
+          type: artifact.kind,
+          name:
+            artifact.title.length > 0
+              ? artifact.title
+              : `Untitled ${artifact.kind}`,
+          hostId: defaultHostId,
+        },
+        // Artifacts carry no per-item hostId (verified host-agnostic, audit
+        // G3) - never badged.
+        null,
+      ),
+    );
+  }
+  const items: CommandItem[] = [];
+  const append = (nodeId: string, ancestorIds: ReadonlyArray<string>): void => {
+    const node = tree.nodeById[nodeId];
+    const item = itemByNodeId.get(nodeId);
+    if (
+      item !== undefined &&
+      node.type !== "chat" &&
+      node.type !== "terminal-agent"
+    ) {
+      items.push({
+        ...item,
+        artifactTreeRow: {
+          nodeId,
+          depth: ancestorIds.length,
+          ancestorIds,
+          hasChildren: tree.childrenByParent[nodeId].length > 0,
+          kind: node.type,
+          status: node.status,
+        },
+      });
+    }
+    for (const childId of tree.childrenByParent[nodeId] ?? []) {
+      append(childId, [...ancestorIds, nodeId]);
+    }
+  };
+  for (const rootId of tree.rootIds) append(rootId, []);
+  return items;
 }

--- a/clients/gui-app/src/lib/commands/sources/open/diff-subpage.ts
+++ b/clients/gui-app/src/lib/commands/sources/open/diff-subpage.ts
@@ -36,7 +36,10 @@ import type {
   CommandItem,
   CommandSubpage,
 } from "@/lib/commands/types";
-import { buildPathTreeItems } from "@/lib/commands/sources/open/path-tree-items";
+import {
+  buildPathTreeItems,
+  openerPathTreeId,
+} from "@/lib/commands/sources/open/path-tree-items";
 
 interface ChangedFileLeavesArgs {
   readonly ctx: CommandContext;
@@ -54,6 +57,7 @@ function changedFileLeaves(
   const shown = matched.slice(0, OPENER_RESULT_CAP);
   const leaves = shown.map((file) => ({
     path: file.path,
+    displaySegments: null,
     gitStatus: file.status,
     item: openerActionLeaf({
       id: `open:diff:${workspacePath}:${file.path}:${file.stage}`,
@@ -76,7 +80,7 @@ function changedFileLeaves(
     }),
   }));
   const treeItems = buildPathTreeItems(
-    `open:diff:${hostId}:${workspacePath}`,
+    openerPathTreeId("diff", hostId, workspacePath),
     leaves,
     [],
   );

--- a/clients/gui-app/src/lib/commands/sources/open/diff-subpage.ts
+++ b/clients/gui-app/src/lib/commands/sources/open/diff-subpage.ts
@@ -37,6 +37,7 @@ import type {
   CommandSubpage,
 } from "@/lib/commands/types";
 import {
+  buildRankedPathItems,
   buildPathTreeItems,
   openerPathTreeId,
 } from "@/lib/commands/sources/open/path-tree-items";
@@ -80,11 +81,11 @@ function changedFileLeaves(
         }),
     }),
   }));
-  const treeItems = buildPathTreeItems(
-    openerPathTreeId("diff", hostId, workspacePath),
-    leaves,
-    [],
-  );
+  const treeId = openerPathTreeId("diff", hostId, workspacePath);
+  const treeItems =
+    query.trim().length > 0
+      ? buildRankedPathItems(treeId, leaves)
+      : buildPathTreeItems(treeId, leaves, []);
   if (matched.length > shown.length) {
     return [...treeItems, openerTruncatedHint("diff", shown.length)];
   }

--- a/clients/gui-app/src/lib/commands/sources/open/diff-subpage.ts
+++ b/clients/gui-app/src/lib/commands/sources/open/diff-subpage.ts
@@ -36,6 +36,7 @@ import type {
   CommandItem,
   CommandSubpage,
 } from "@/lib/commands/types";
+import { buildPathTreeItems } from "@/lib/commands/sources/open/path-tree-items";
 
 interface ChangedFileLeavesArgs {
   readonly ctx: CommandContext;
@@ -51,8 +52,10 @@ function changedFileLeaves(
   const { ctx, hostId, workspacePath, files, query } = args;
   const matched = files.filter((file) => matchesPathQuery(query, file.path));
   const shown = matched.slice(0, OPENER_RESULT_CAP);
-  const leaves = shown.map((file) =>
-    openerActionLeaf({
+  const leaves = shown.map((file) => ({
+    path: file.path,
+    gitStatus: file.status,
+    item: openerActionLeaf({
       id: `open:diff:${workspacePath}:${file.path}:${file.stage}`,
       // Workspace-relative path (not just the basename) so duplicate filenames
       // are distinguishable; the row dims the directory, emphasizes the name.
@@ -71,11 +74,16 @@ function changedFileLeaves(
           navigateNestedFocus: ctx.router.navigateNestedFocus,
         }),
     }),
+  }));
+  const treeItems = buildPathTreeItems(
+    `open:diff:${hostId}:${workspacePath}`,
+    leaves,
+    [],
   );
   if (matched.length > shown.length) {
-    return [...leaves, openerTruncatedHint("diff", shown.length)];
+    return [...treeItems, openerTruncatedHint("diff", shown.length)];
   }
-  return leaves;
+  return treeItems;
 }
 
 function useDiffStepItems(

--- a/clients/gui-app/src/lib/commands/sources/open/diff-subpage.ts
+++ b/clients/gui-app/src/lib/commands/sources/open/diff-subpage.ts
@@ -58,6 +58,7 @@ function changedFileLeaves(
   const leaves = shown.map((file) => ({
     path: file.path,
     displaySegments: null,
+    structuralSegments: null,
     gitStatus: file.status,
     item: openerActionLeaf({
       id: `open:diff:${workspacePath}:${file.path}:${file.stage}`,

--- a/clients/gui-app/src/lib/commands/sources/open/files-subpage.ts
+++ b/clients/gui-app/src/lib/commands/sources/open/files-subpage.ts
@@ -62,6 +62,7 @@ import type {
 } from "@/lib/commands/types";
 import type { EpicArtifactRef } from "@/stores/epics/canvas/types";
 import {
+  buildRankedPathItems,
   buildPathTreeItems,
   openerPathTreeId,
 } from "@/lib/commands/sources/open/path-tree-items";
@@ -97,6 +98,7 @@ function openerNotice(id: string, label: string): CommandItem {
     shortcut: null,
     actionId: null,
     subpage: null,
+    disabled: true,
     run: () => undefined,
   };
 }
@@ -164,10 +166,9 @@ function codeFileLeaves(args: CodeFileLeavesArgs): ReadonlyArray<CommandItem> {
       },
     ];
   });
-  const treeItems = buildPathTreeItems(
+  const treeItems = buildRankedPathItems(
     openerPathTreeId("files", hostId, workspacePath),
     leaves,
-    [],
   );
   return view.truncated
     ? [...treeItems, openerTruncatedHint("files", leaves.length)]
@@ -331,10 +332,11 @@ interface ArtifactLeavesArgs {
   readonly view: WorkspaceSearchPathsView | null;
   readonly isError: boolean;
   readonly pathIndex: ReadonlyMap<string, ArtifactPathEntry>;
+  readonly isSearching: boolean;
 }
 
 function artifactLeaves(args: ArtifactLeavesArgs): ReadonlyArray<CommandItem> {
-  const { ctx, defaultHostId, view, isError, pathIndex } = args;
+  const { ctx, defaultHostId, view, isError, pathIndex, isSearching } = args;
   if (isError) {
     return [
       openerNotice(
@@ -390,11 +392,10 @@ function artifactLeaves(args: ArtifactLeavesArgs): ReadonlyArray<CommandItem> {
       },
     ];
   });
-  const treeItems = buildPathTreeItems(
-    `open:files:artifacts:${ctx.activeEpicId ?? ""}`,
-    leaves,
-    [],
-  );
+  const treeId = `open:files:artifacts:${ctx.activeEpicId ?? ""}`;
+  const treeItems = isSearching
+    ? buildRankedPathItems(treeId, leaves)
+    : buildPathTreeItems(treeId, leaves, []);
   return view.truncated
     ? [...treeItems, openerTruncatedHint("files-artifacts", leaves.length)]
     : treeItems;
@@ -409,6 +410,7 @@ function useArtifactsStepItems(
   const client = useHostClientForHostId(activeEpicHostId);
   const defaultHostId = activeEpicHostId ?? UNKNOWN_HOST_PLACEHOLDER;
   const query = usePaletteLiveQuery();
+  const isSearching = query.trim().length > 0;
   const debouncedQuery = useDebouncedValue(query, FILES_SEARCH_DEBOUNCE_MS);
   const epicId = ctx.activeEpicId ?? "";
   const projection = useActiveEpicProjection(ctx.activeEpicId);
@@ -434,8 +436,16 @@ function useArtifactsStepItems(
     [projection],
   );
   return useMemo<ReadonlyArray<CommandItem>>(
-    () => artifactLeaves({ ctx, defaultHostId, view, isError, pathIndex }),
-    [ctx, defaultHostId, view, isError, pathIndex],
+    () =>
+      artifactLeaves({
+        ctx,
+        defaultHostId,
+        view,
+        isError,
+        pathIndex,
+        isSearching,
+      }),
+    [ctx, defaultHostId, view, isError, pathIndex, isSearching],
   );
 }
 

--- a/clients/gui-app/src/lib/commands/sources/open/files-subpage.ts
+++ b/clients/gui-app/src/lib/commands/sources/open/files-subpage.ts
@@ -137,6 +137,7 @@ function codeFileLeaves(args: CodeFileLeavesArgs): ReadonlyArray<CommandItem> {
       {
         path: result.relPath,
         displaySegments: null,
+        structuralSegments: null,
         gitStatus: undefined,
         item: openerActionLeaf({
           id: `open:files:${workspacePath}:${result.relPath}`,
@@ -185,6 +186,7 @@ function liveCodeFileLeaves(args: {
   const leaves = [...args.fileNameByPath].map(([path, name]) => ({
     path,
     displaySegments: null,
+    structuralSegments: null,
     gitStatus: undefined,
     item: openerActionLeaf({
       id: `open:files:${args.workspacePath}:${path}`,
@@ -360,6 +362,7 @@ function artifactLeaves(args: ArtifactLeavesArgs): ReadonlyArray<CommandItem> {
       {
         path: entry.id,
         displaySegments: entry.titleSegments,
+        structuralSegments: entry.idSegments,
         gitStatus: undefined,
         item: openerActionLeaf({
           id: `open:files:artifacts:${entry.id}`,

--- a/clients/gui-app/src/lib/commands/sources/open/files-subpage.ts
+++ b/clients/gui-app/src/lib/commands/sources/open/files-subpage.ts
@@ -57,6 +57,12 @@ import type {
   CommandSubpage,
 } from "@/lib/commands/types";
 import type { EpicArtifactRef } from "@/stores/epics/canvas/types";
+import { buildPathTreeItems } from "@/lib/commands/sources/open/path-tree-items";
+import { useWorkspaceFileListSubscription } from "@/hooks/workspace/use-workspace-file-list-subscription";
+import {
+  useOpenerFileTreeExpandedPaths,
+  useOpenerFileTreeStore,
+} from "@/stores/file-tree/opener-file-tree-store";
 
 const FILES_SEARCH_DEBOUNCE_MS = 150;
 
@@ -120,33 +126,82 @@ function codeFileLeaves(args: CodeFileLeavesArgs): ReadonlyArray<CommandItem> {
   const leaves = view.results.flatMap((result) => {
     if (result.kind !== "file") return [];
     return [
-      openerActionLeaf({
-        id: `open:files:${workspacePath}:${result.relPath}`,
-        // Workspace-relative path so duplicate basenames are distinguishable,
-        // and so the host-searched text is what cmdk re-filters on.
-        label: result.relPath,
-        keywords: [result.relPath, result.name],
-        run: () => {
-          const ref = workspaceFileRefFromTreePath(
-            hostId,
-            workspacePath,
-            result.relPath,
-            result.name,
-          );
-          if (ref === null) return;
-          openTileIntoTargetGroup({
-            tabId: ctx.activeTabId,
-            groupId: ctx.targetGroupId,
-            ref,
-            navigateNestedFocus: ctx.router.navigateNestedFocus,
-          });
-        },
-      }),
+      {
+        path: result.relPath,
+        gitStatus: undefined,
+        item: openerActionLeaf({
+          id: `open:files:${workspacePath}:${result.relPath}`,
+          // Workspace-relative path so duplicate basenames are distinguishable,
+          // and so the host-searched text is what cmdk re-filters on.
+          label: result.relPath,
+          keywords: [result.relPath, result.name],
+          run: () => {
+            const ref = workspaceFileRefFromTreePath(
+              hostId,
+              workspacePath,
+              result.relPath,
+              result.name,
+            );
+            if (ref === null) return;
+            openTileIntoTargetGroup({
+              tabId: ctx.activeTabId,
+              groupId: ctx.targetGroupId,
+              ref,
+              navigateNestedFocus: ctx.router.navigateNestedFocus,
+            });
+          },
+        }),
+      },
     ];
   });
+  const treeItems = buildPathTreeItems(
+    `open:files:${hostId}:${workspacePath}`,
+    leaves,
+    [],
+  );
   return view.truncated
-    ? [...leaves, openerTruncatedHint("files", leaves.length)]
-    : leaves;
+    ? [...treeItems, openerTruncatedHint("files", leaves.length)]
+    : treeItems;
+}
+
+function liveCodeFileLeaves(args: {
+  readonly ctx: CommandContext;
+  readonly hostId: string;
+  readonly workspacePath: string;
+  readonly paths: ReadonlyArray<string>;
+  readonly fileNameByPath: ReadonlyMap<string, string>;
+  readonly truncated: boolean;
+}): ReadonlyArray<CommandItem> {
+  const treeId = `open:files:${args.hostId}:${args.workspacePath}`;
+  const leaves = [...args.fileNameByPath].map(([path, name]) => ({
+    path,
+    gitStatus: undefined,
+    item: openerActionLeaf({
+      id: `open:files:${args.workspacePath}:${path}`,
+      label: path,
+      keywords: [path, name],
+      run: () => {
+        const ref = workspaceFileRefFromTreePath(
+          args.hostId,
+          args.workspacePath,
+          path,
+          name,
+        );
+        if (ref === null) return;
+        openTileIntoTargetGroup({
+          tabId: args.ctx.activeTabId,
+          groupId: args.ctx.targetGroupId,
+          ref,
+          navigateNestedFocus: args.ctx.router.navigateNestedFocus,
+        });
+      },
+    }),
+  }));
+  const directories = args.paths.filter((path) => path.endsWith("/"));
+  const items = buildPathTreeItems(treeId, leaves, directories);
+  return args.truncated
+    ? [...items, openerTruncatedHint("files", leaves.length)]
+    : items;
 }
 
 function useCodeRootStepItems(
@@ -163,27 +218,47 @@ function useCodeRootStepItems(
     () => ({ root: row.runningDir }),
     [row.runningDir],
   );
+  const treeId = `open:files:${row.hostId}:${row.runningDir}`;
+  const expandedPaths = useOpenerFileTreeExpandedPaths(treeId);
+  const prune = useOpenerFileTreeStore((state) => state.prune);
+  const onPruned = (directoryPaths: ReadonlyArray<string>) => {
+    prune(treeId, directoryPaths);
+  };
+  const live = useWorkspaceFileListSubscription({
+    epicId,
+    hostId: row.hostId,
+    workspacePath: row.runningDir,
+    enabled: ctx.activeEpicId !== null,
+    expandedPathsOverride: expandedPaths,
+    onPrunedOverride: onPruned,
+  });
   const search = useWorkspaceSearchPathsForSource({
     client,
     epicId,
     source,
     query: debouncedQuery,
     kinds: "files",
-    enabled: ctx.activeEpicId !== null,
+    enabled: ctx.activeEpicId !== null && query.trim().length > 0,
   });
   const view = readSearchPathsResponseForSource(search.data, epicId, source);
   const isError = search.isError;
-  return useMemo<ReadonlyArray<CommandItem>>(
-    () =>
-      codeFileLeaves({
-        ctx,
-        hostId: row.hostId,
-        workspacePath: row.runningDir,
-        view,
-        isError,
-      }),
-    [ctx, row.hostId, row.runningDir, view, isError],
-  );
+  if (query.trim().length > 0) {
+    return codeFileLeaves({
+      ctx,
+      hostId: row.hostId,
+      workspacePath: row.runningDir,
+      view,
+      isError,
+    });
+  }
+  return liveCodeFileLeaves({
+    ctx,
+    hostId: row.hostId,
+    workspacePath: row.runningDir,
+    paths: live.paths,
+    fileNameByPath: live.fileNameByPath,
+    truncated: live.truncated,
+  });
 }
 
 function makeCodeRootStepSubpage(
@@ -232,34 +307,46 @@ function artifactLeaves(args: ArtifactLeavesArgs): ReadonlyArray<CommandItem> {
     const entry = pathIndex.get(normalizeArtifactLogicalPath(result.relPath));
     if (entry === undefined) return [];
     return [
-      openerActionLeaf({
-        id: `open:files:artifacts:${entry.id}`,
-        // Ancestor-title path distinguishes duplicate leaf titles and reads
-        // better than the folder slug; the slug path rides in keywords so the
-        // host match survives cmdk's re-filter.
-        label: entry.titlePath.length > 0 ? entry.titlePath : entry.title,
-        keywords: [result.relPath, result.name, entry.title, entry.titlePath],
-        run: () => {
-          const ref: EpicArtifactRef = {
-            id: entry.id,
-            instanceId: uuidv4(),
-            type: entry.kind,
-            name: entry.title,
-            hostId: defaultHostId,
-          };
-          openTileIntoTargetGroup({
-            tabId: ctx.activeTabId,
-            groupId: ctx.targetGroupId,
-            ref,
-            navigateNestedFocus: ctx.router.navigateNestedFocus,
-          });
-        },
-      }),
+      {
+        path:
+          entry.titlePath.length > 0
+            ? entry.titlePath.replaceAll(" / ", "/")
+            : entry.title,
+        gitStatus: undefined,
+        item: openerActionLeaf({
+          id: `open:files:artifacts:${entry.id}`,
+          // Ancestor-title path distinguishes duplicate leaf titles and reads
+          // better than the folder slug; the slug path rides in keywords so the
+          // host match survives cmdk's re-filter.
+          label: entry.titlePath.length > 0 ? entry.titlePath : entry.title,
+          keywords: [result.relPath, result.name, entry.title, entry.titlePath],
+          run: () => {
+            const ref: EpicArtifactRef = {
+              id: entry.id,
+              instanceId: uuidv4(),
+              type: entry.kind,
+              name: entry.title,
+              hostId: defaultHostId,
+            };
+            openTileIntoTargetGroup({
+              tabId: ctx.activeTabId,
+              groupId: ctx.targetGroupId,
+              ref,
+              navigateNestedFocus: ctx.router.navigateNestedFocus,
+            });
+          },
+        }),
+      },
     ];
   });
+  const treeItems = buildPathTreeItems(
+    `open:files:artifacts:${ctx.activeEpicId ?? ""}`,
+    leaves,
+    [],
+  );
   return view.truncated
-    ? [...leaves, openerTruncatedHint("files-artifacts", leaves.length)]
-    : leaves;
+    ? [...treeItems, openerTruncatedHint("files-artifacts", leaves.length)]
+    : treeItems;
 }
 
 function useArtifactsStepItems(

--- a/clients/gui-app/src/lib/commands/sources/open/files-subpage.ts
+++ b/clients/gui-app/src/lib/commands/sources/open/files-subpage.ts
@@ -21,6 +21,10 @@ import type { WorktreeBindingSelectorRow } from "@traycer/protocol/host";
 import type { WorkspaceSearchSource } from "@traycer/protocol/host/workspace/unary-schemas";
 import { getBasename } from "@/lib/path/cross-platform-path";
 import { useHostClientForHostId } from "@/hooks/host/use-host-client-for-host-id";
+import { useHostDirectoryEntry } from "@/hooks/host/use-host-directory-entry";
+import { useHostStreamClientFor } from "@/hooks/host/use-host-stream-client-for";
+import { useStreamAuthRevalidator } from "@/lib/host/stream-auth-revalidator";
+import { useStreamMethodSupportFor } from "@/lib/host/stream-runtime-context";
 import { UNKNOWN_HOST_PLACEHOLDER } from "@/lib/host/constants";
 import { useDebouncedValue } from "@/hooks/ui/use-debounced-value";
 import {
@@ -57,7 +61,10 @@ import type {
   CommandSubpage,
 } from "@/lib/commands/types";
 import type { EpicArtifactRef } from "@/stores/epics/canvas/types";
-import { buildPathTreeItems } from "@/lib/commands/sources/open/path-tree-items";
+import {
+  buildPathTreeItems,
+  openerPathTreeId,
+} from "@/lib/commands/sources/open/path-tree-items";
 import { useWorkspaceFileListSubscription } from "@/hooks/workspace/use-workspace-file-list-subscription";
 import {
   useOpenerFileTreeExpandedPaths,
@@ -65,6 +72,7 @@ import {
 } from "@/stores/file-tree/opener-file-tree-store";
 
 const FILES_SEARCH_DEBOUNCE_MS = 150;
+const WORKSPACE_FILE_LIST_METHOD = "workspace.subscribeFileList";
 
 // A stable source object so the search hook's query key is stable across
 // renders (the host derives the mirror root from the request `epicId`).
@@ -128,6 +136,7 @@ function codeFileLeaves(args: CodeFileLeavesArgs): ReadonlyArray<CommandItem> {
     return [
       {
         path: result.relPath,
+        displaySegments: null,
         gitStatus: undefined,
         item: openerActionLeaf({
           id: `open:files:${workspacePath}:${result.relPath}`,
@@ -155,7 +164,7 @@ function codeFileLeaves(args: CodeFileLeavesArgs): ReadonlyArray<CommandItem> {
     ];
   });
   const treeItems = buildPathTreeItems(
-    `open:files:${hostId}:${workspacePath}`,
+    openerPathTreeId("files", hostId, workspacePath),
     leaves,
     [],
   );
@@ -172,9 +181,10 @@ function liveCodeFileLeaves(args: {
   readonly fileNameByPath: ReadonlyMap<string, string>;
   readonly truncated: boolean;
 }): ReadonlyArray<CommandItem> {
-  const treeId = `open:files:${args.hostId}:${args.workspacePath}`;
+  const treeId = openerPathTreeId("files", args.hostId, args.workspacePath);
   const leaves = [...args.fileNameByPath].map(([path, name]) => ({
     path,
+    displaySegments: null,
     gitStatus: undefined,
     item: openerActionLeaf({
       id: `open:files:${args.workspacePath}:${path}`,
@@ -212,13 +222,24 @@ function useCodeRootStepItems(
   // runs there, on the same host the leaves below bind their tiles to.
   const client = useHostClientForHostId(row.hostId);
   const query = usePaletteLiveQuery();
+  const isBrowsing = query.trim().length === 0;
+  const hostEntry = useHostDirectoryEntry(row.hostId);
+  const streamAuth = useStreamAuthRevalidator();
+  const streamClient = useHostStreamClientFor(
+    isBrowsing ? hostEntry : null,
+    streamAuth,
+  );
+  const streamSupport = useStreamMethodSupportFor(
+    streamClient,
+    WORKSPACE_FILE_LIST_METHOD,
+  );
   const debouncedQuery = useDebouncedValue(query, FILES_SEARCH_DEBOUNCE_MS);
   const epicId = ctx.activeEpicId ?? "";
   const source = useMemo<WorkspaceSearchSource>(
     () => ({ root: row.runningDir }),
     [row.runningDir],
   );
-  const treeId = `open:files:${row.hostId}:${row.runningDir}`;
+  const treeId = openerPathTreeId("files", row.hostId, row.runningDir);
   const expandedPaths = useOpenerFileTreeExpandedPaths(treeId);
   const prune = useOpenerFileTreeStore((state) => state.prune);
   const onPruned = (directoryPaths: ReadonlyArray<string>) => {
@@ -228,7 +249,12 @@ function useCodeRootStepItems(
     epicId,
     hostId: row.hostId,
     workspacePath: row.runningDir,
-    enabled: ctx.activeEpicId !== null,
+    enabled:
+      ctx.activeEpicId !== null &&
+      isBrowsing &&
+      streamClient !== null &&
+      streamSupport !== "unsupported",
+    streamClient,
     expandedPathsOverride: expandedPaths,
     onPrunedOverride: onPruned,
   });
@@ -250,6 +276,30 @@ function useCodeRootStepItems(
       view,
       isError,
     });
+  }
+  if (streamClient === null || streamSupport === "unsupported") {
+    return [
+      openerNotice(
+        `open:files:ws:${row.runningDir}:browse-unavailable`,
+        "File browsing is unavailable on this host",
+      ),
+    ];
+  }
+  if (live.error !== null) {
+    return [
+      openerNotice(
+        `open:files:ws:${row.runningDir}:browse-error`,
+        "Files could not be loaded",
+      ),
+    ];
+  }
+  if (live.isPending) {
+    return [
+      openerNotice(
+        `open:files:ws:${row.runningDir}:browse-loading`,
+        "Loading files…",
+      ),
+    ];
   }
   return liveCodeFileLeaves({
     ctx,
@@ -308,10 +358,8 @@ function artifactLeaves(args: ArtifactLeavesArgs): ReadonlyArray<CommandItem> {
     if (entry === undefined) return [];
     return [
       {
-        path:
-          entry.titlePath.length > 0
-            ? entry.titlePath.replaceAll(" / ", "/")
-            : entry.title,
+        path: entry.id,
+        displaySegments: entry.titleSegments,
         gitStatus: undefined,
         item: openerActionLeaf({
           id: `open:files:artifacts:${entry.id}`,

--- a/clients/gui-app/src/lib/commands/sources/open/path-tree-items.ts
+++ b/clients/gui-app/src/lib/commands/sources/open/path-tree-items.ts
@@ -17,6 +17,7 @@ interface DirectoryNode {
   readonly displayPath: string;
   readonly childDirectories: Map<string, DirectoryNode>;
   readonly leaves: PathTreeLeaf[];
+  actionLeaf: PathTreeLeaf | null;
 }
 
 export function buildPathTreeItems(
@@ -30,6 +31,7 @@ export function buildPathTreeItems(
     displayPath: "",
     childDirectories: new Map(),
     leaves: [],
+    actionLeaf: null,
   };
   for (const directoryPath of explicitDirectoryPaths) {
     const segments = directoryPath
@@ -48,6 +50,7 @@ export function buildPathTreeItems(
           displayPath: path,
           childDirectories: new Map(),
           leaves: [],
+          actionLeaf: null,
         };
         directory.childDirectories.set(segment, child);
       }
@@ -80,6 +83,7 @@ export function buildPathTreeItems(
           displayPath,
           childDirectories: new Map(),
           leaves: [],
+          actionLeaf: null,
         };
         directory.childDirectories.set(segment, child);
       }
@@ -88,6 +92,31 @@ export function buildPathTreeItems(
     directory.leaves.push(leaf);
   }
 
+  const structuralPath = (leaf: PathTreeLeaf): string => {
+    const displaySegments =
+      leaf.displaySegments ??
+      leaf.path.split("/").filter((segment) => segment.length > 0);
+    const structuralSegments = leaf.structuralSegments ?? displaySegments;
+    return (
+      leaf.displaySegments === null
+        ? structuralSegments
+        : structuralSegments.map((segment) => encodeURIComponent(segment))
+    ).join("/");
+  };
+  const coalesceActionableDirectories = (directory: DirectoryNode): void => {
+    for (const child of directory.childDirectories.values()) {
+      const leafIndex = directory.leaves.findIndex(
+        (leaf) => structuralPath(leaf) === child.path,
+      );
+      if (leafIndex !== -1) {
+        child.actionLeaf = directory.leaves[leafIndex] ?? null;
+        directory.leaves.splice(leafIndex, 1);
+      }
+      coalesceActionableDirectories(child);
+    }
+  };
+  coalesceActionableDirectories(root);
+
   const items: CommandItem[] = [];
   const appendDirectory = (
     directory: DirectoryNode,
@@ -95,29 +124,35 @@ export function buildPathTreeItems(
   ): void => {
     const nodeId = `${namespace}:directory:${directory.path}`;
     const label = directory.label;
+    const item = directory.actionLeaf?.item;
+    const effectiveNodeId = item?.id ?? nodeId;
     items.push({
-      id: nodeId,
+      ...(item ?? {
+        id: nodeId,
+        description: null,
+        keywords: [directory.path, label],
+        group: "open" as const,
+        scope: "actions" as const,
+        shortcut: null,
+        actionId: null,
+        subpage: null,
+        run: () => undefined,
+      }),
+      id: effectiveNodeId,
       label,
       description: null,
-      keywords: [directory.path, label],
-      group: "open",
-      scope: "actions",
-      shortcut: null,
-      actionId: null,
-      subpage: null,
-      run: () => undefined,
       pathTreeRow: {
         treeId: namespace,
-        nodeId,
+        nodeId: effectiveNodeId,
         depth: ancestorIds.length,
         ancestorIds,
         hasChildren: true,
-        kind: "directory",
+        kind: item === undefined ? "directory" : "file",
         path: directory.path,
         displayPath: directory.displayPath,
       },
     });
-    const nextAncestors = [...ancestorIds, nodeId];
+    const nextAncestors = [...ancestorIds, effectiveNodeId];
     for (const child of directory.childDirectories.values()) {
       appendDirectory(child, nextAncestors);
     }

--- a/clients/gui-app/src/lib/commands/sources/open/path-tree-items.ts
+++ b/clients/gui-app/src/lib/commands/sources/open/path-tree-items.ts
@@ -6,6 +6,8 @@ export interface PathTreeLeaf {
   readonly path: string;
   /** Structured display segments when `/` inside a label is not a separator. */
   readonly displaySegments: ReadonlyArray<string> | null;
+  /** Stable structural identity for each display segment, when not path-based. */
+  readonly structuralSegments: ReadonlyArray<string> | null;
   readonly gitStatus: GitFileStatus | undefined;
 }
 
@@ -56,10 +58,11 @@ export function buildPathTreeItems(
     const displaySegments =
       leaf.displaySegments ??
       leaf.path.split("/").filter((segment) => segment.length > 0);
+    const structuralSegments = leaf.structuralSegments ?? displaySegments;
     const segments =
       leaf.displaySegments === null
-        ? displaySegments
-        : displaySegments.map((segment) => encodeURIComponent(segment));
+        ? structuralSegments
+        : structuralSegments.map((segment) => encodeURIComponent(segment));
     let directory = root;
     for (const [index, segment] of segments.slice(0, -1).entries()) {
       const path =

--- a/clients/gui-app/src/lib/commands/sources/open/path-tree-items.ts
+++ b/clients/gui-app/src/lib/commands/sources/open/path-tree-items.ts
@@ -4,11 +4,15 @@ import type { CommandItem } from "@/lib/commands/types";
 export interface PathTreeLeaf {
   readonly item: CommandItem;
   readonly path: string;
+  /** Structured display segments when `/` inside a label is not a separator. */
+  readonly displaySegments: ReadonlyArray<string> | null;
   readonly gitStatus: GitFileStatus | undefined;
 }
 
 interface DirectoryNode {
   readonly path: string;
+  readonly label: string;
+  readonly displayPath: string;
   readonly childDirectories: Map<string, DirectoryNode>;
   readonly leaves: PathTreeLeaf[];
 }
@@ -20,6 +24,8 @@ export function buildPathTreeItems(
 ): ReadonlyArray<CommandItem> {
   const root: DirectoryNode = {
     path: "",
+    label: "",
+    displayPath: "",
     childDirectories: new Map(),
     leaves: [],
   };
@@ -34,23 +40,44 @@ export function buildPathTreeItems(
         directory.path.length === 0 ? segment : `${directory.path}/${segment}`;
       let child = directory.childDirectories.get(segment);
       if (child === undefined) {
-        child = { path, childDirectories: new Map(), leaves: [] };
+        child = {
+          path,
+          label: segment,
+          displayPath: path,
+          childDirectories: new Map(),
+          leaves: [],
+        };
         directory.childDirectories.set(segment, child);
       }
       directory = child;
     }
   }
   for (const leaf of leaves) {
-    const segments = leaf.path
-      .split("/")
-      .filter((segment) => segment.length > 0);
+    const displaySegments =
+      leaf.displaySegments ??
+      leaf.path.split("/").filter((segment) => segment.length > 0);
+    const segments =
+      leaf.displaySegments === null
+        ? displaySegments
+        : displaySegments.map((segment) => encodeURIComponent(segment));
     let directory = root;
-    for (const segment of segments.slice(0, -1)) {
+    for (const [index, segment] of segments.slice(0, -1).entries()) {
       const path =
         directory.path.length === 0 ? segment : `${directory.path}/${segment}`;
       let child = directory.childDirectories.get(segment);
       if (child === undefined) {
-        child = { path, childDirectories: new Map(), leaves: [] };
+        const label = displaySegments[index] ?? segment;
+        const displayPath =
+          directory.displayPath.length === 0
+            ? label
+            : `${directory.displayPath} / ${label}`;
+        child = {
+          path,
+          label,
+          displayPath,
+          childDirectories: new Map(),
+          leaves: [],
+        };
         directory.childDirectories.set(segment, child);
       }
       directory = child;
@@ -64,7 +91,7 @@ export function buildPathTreeItems(
     ancestorIds: ReadonlyArray<string>,
   ): void => {
     const nodeId = `${namespace}:directory:${directory.path}`;
-    const label = directory.path.slice(directory.path.lastIndexOf("/") + 1);
+    const label = directory.label;
     items.push({
       id: nodeId,
       label,
@@ -84,6 +111,7 @@ export function buildPathTreeItems(
         hasChildren: true,
         kind: "directory",
         path: directory.path,
+        displayPath: directory.displayPath,
       },
     });
     const nextAncestors = [...ancestorIds, nodeId];
@@ -99,7 +127,9 @@ export function buildPathTreeItems(
     for (const leaf of directoryLeaves) {
       items.push({
         ...leaf.item,
-        label: leaf.path.slice(leaf.path.lastIndexOf("/") + 1),
+        label:
+          leaf.displaySegments?.at(-1) ??
+          leaf.path.slice(leaf.path.lastIndexOf("/") + 1),
         pathTreeRow: {
           treeId: namespace,
           nodeId: leaf.item.id,
@@ -108,6 +138,10 @@ export function buildPathTreeItems(
           hasChildren: false,
           kind: "file",
           path: leaf.path,
+          displayPath:
+            leaf.displaySegments === null
+              ? leaf.path
+              : leaf.displaySegments.join(" / "),
           gitStatus: leaf.gitStatus,
         },
       });
@@ -118,4 +152,12 @@ export function buildPathTreeItems(
   }
   appendLeaves(root.leaves, []);
   return items;
+}
+
+export function openerPathTreeId(
+  kind: "files" | "diff",
+  hostId: string,
+  workspacePath: string,
+): string {
+  return `open:${kind}:${encodeURIComponent(hostId)}:${encodeURIComponent(workspacePath)}`;
 }

--- a/clients/gui-app/src/lib/commands/sources/open/path-tree-items.ts
+++ b/clients/gui-app/src/lib/commands/sources/open/path-tree-items.ts
@@ -157,6 +157,34 @@ export function buildPathTreeItems(
   return items;
 }
 
+/** Preserve an authoritative search order while retaining file-row visuals. */
+export function buildRankedPathItems(
+  namespace: string,
+  leaves: ReadonlyArray<PathTreeLeaf>,
+): ReadonlyArray<CommandItem> {
+  return leaves.map((leaf) => ({
+    ...leaf.item,
+    label:
+      leaf.displaySegments === null
+        ? leaf.path
+        : leaf.displaySegments.join(" / "),
+    pathTreeRow: {
+      treeId: namespace,
+      nodeId: leaf.item.id,
+      depth: 0,
+      ancestorIds: [],
+      hasChildren: false,
+      kind: "file",
+      path: leaf.path,
+      displayPath:
+        leaf.displaySegments === null
+          ? leaf.path
+          : leaf.displaySegments.join(" / "),
+      gitStatus: leaf.gitStatus,
+    },
+  }));
+}
+
 export function openerPathTreeId(
   kind: "files" | "diff",
   hostId: string,

--- a/clients/gui-app/src/lib/commands/sources/open/path-tree-items.ts
+++ b/clients/gui-app/src/lib/commands/sources/open/path-tree-items.ts
@@ -1,0 +1,121 @@
+import type { GitFileStatus } from "@traycer/protocol/host";
+import type { CommandItem } from "@/lib/commands/types";
+
+export interface PathTreeLeaf {
+  readonly item: CommandItem;
+  readonly path: string;
+  readonly gitStatus: GitFileStatus | undefined;
+}
+
+interface DirectoryNode {
+  readonly path: string;
+  readonly childDirectories: Map<string, DirectoryNode>;
+  readonly leaves: PathTreeLeaf[];
+}
+
+export function buildPathTreeItems(
+  namespace: string,
+  leaves: ReadonlyArray<PathTreeLeaf>,
+  explicitDirectoryPaths: ReadonlyArray<string>,
+): ReadonlyArray<CommandItem> {
+  const root: DirectoryNode = {
+    path: "",
+    childDirectories: new Map(),
+    leaves: [],
+  };
+  for (const directoryPath of explicitDirectoryPaths) {
+    const segments = directoryPath
+      .replace(/\/$/, "")
+      .split("/")
+      .filter((segment) => segment.length > 0);
+    let directory = root;
+    for (const segment of segments) {
+      const path =
+        directory.path.length === 0 ? segment : `${directory.path}/${segment}`;
+      let child = directory.childDirectories.get(segment);
+      if (child === undefined) {
+        child = { path, childDirectories: new Map(), leaves: [] };
+        directory.childDirectories.set(segment, child);
+      }
+      directory = child;
+    }
+  }
+  for (const leaf of leaves) {
+    const segments = leaf.path
+      .split("/")
+      .filter((segment) => segment.length > 0);
+    let directory = root;
+    for (const segment of segments.slice(0, -1)) {
+      const path =
+        directory.path.length === 0 ? segment : `${directory.path}/${segment}`;
+      let child = directory.childDirectories.get(segment);
+      if (child === undefined) {
+        child = { path, childDirectories: new Map(), leaves: [] };
+        directory.childDirectories.set(segment, child);
+      }
+      directory = child;
+    }
+    directory.leaves.push(leaf);
+  }
+
+  const items: CommandItem[] = [];
+  const appendDirectory = (
+    directory: DirectoryNode,
+    ancestorIds: ReadonlyArray<string>,
+  ): void => {
+    const nodeId = `${namespace}:directory:${directory.path}`;
+    const label = directory.path.slice(directory.path.lastIndexOf("/") + 1);
+    items.push({
+      id: nodeId,
+      label,
+      description: null,
+      keywords: [directory.path, label],
+      group: "open",
+      scope: "actions",
+      shortcut: null,
+      actionId: null,
+      subpage: null,
+      run: () => undefined,
+      pathTreeRow: {
+        treeId: namespace,
+        nodeId,
+        depth: ancestorIds.length,
+        ancestorIds,
+        hasChildren: true,
+        kind: "directory",
+        path: directory.path,
+      },
+    });
+    const nextAncestors = [...ancestorIds, nodeId];
+    for (const child of directory.childDirectories.values()) {
+      appendDirectory(child, nextAncestors);
+    }
+    appendLeaves(directory.leaves, nextAncestors);
+  };
+  const appendLeaves = (
+    directoryLeaves: ReadonlyArray<PathTreeLeaf>,
+    ancestorIds: ReadonlyArray<string>,
+  ): void => {
+    for (const leaf of directoryLeaves) {
+      items.push({
+        ...leaf.item,
+        label: leaf.path.slice(leaf.path.lastIndexOf("/") + 1),
+        pathTreeRow: {
+          treeId: namespace,
+          nodeId: leaf.item.id,
+          depth: ancestorIds.length,
+          ancestorIds,
+          hasChildren: false,
+          kind: "file",
+          path: leaf.path,
+          gitStatus: leaf.gitStatus,
+        },
+      });
+    }
+  };
+  for (const directory of root.childDirectories.values()) {
+    appendDirectory(directory, []);
+  }
+  appendLeaves(root.leaves, []);
+  return items;
+}

--- a/clients/gui-app/src/lib/commands/types.ts
+++ b/clients/gui-app/src/lib/commands/types.ts
@@ -133,6 +133,7 @@ export interface CommandItem {
     readonly hasChildren: boolean;
     readonly kind: "directory" | "file";
     readonly path: string;
+    readonly displayPath: string;
     readonly gitStatus?:
       | "modified"
       | "added"

--- a/clients/gui-app/src/lib/commands/types.ts
+++ b/clients/gui-app/src/lib/commands/types.ts
@@ -106,6 +106,42 @@ export interface CommandItem {
    * Prevent selection in cmdk while retaining the row as contextual feedback.
    */
   readonly disabled?: boolean;
+  /** Agent-tree presentation metadata used by the unified Agents opener. */
+  readonly agentTreeRow?: {
+    readonly nodeId: string;
+    readonly depth: number;
+    readonly ancestorIds: ReadonlyArray<string>;
+    readonly hasChildren: boolean;
+    readonly interface: "chat" | "terminal";
+    readonly activity: "turn" | "background" | "idle";
+  };
+  /** Artifact-tree presentation metadata used by the Artifacts opener. */
+  readonly artifactTreeRow?: {
+    readonly nodeId: string;
+    readonly depth: number;
+    readonly ancestorIds: ReadonlyArray<string>;
+    readonly hasChildren: boolean;
+    readonly kind: "spec" | "ticket" | "story" | "review";
+    readonly status: number | null;
+  };
+  /** Directory/file presentation metadata for Files and Git Diff results. */
+  readonly pathTreeRow?: {
+    readonly treeId: string;
+    readonly nodeId: string;
+    readonly depth: number;
+    readonly ancestorIds: ReadonlyArray<string>;
+    readonly hasChildren: boolean;
+    readonly kind: "directory" | "file";
+    readonly path: string;
+    readonly gitStatus?:
+      | "modified"
+      | "added"
+      | "deleted"
+      | "renamed"
+      | "copied"
+      | "untracked"
+      | "conflicted";
+  };
 }
 
 /**

--- a/clients/gui-app/src/stores/file-tree/opener-file-tree-store.ts
+++ b/clients/gui-app/src/stores/file-tree/opener-file-tree-store.ts
@@ -1,0 +1,56 @@
+import { create } from "zustand";
+import { isWithinDirectory } from "@/lib/workspace/workspace-file-list-tree";
+
+interface OpenerFileTreeState {
+  readonly expandedPathsByTree: Readonly<Record<string, ReadonlyArray<string>>>;
+  readonly toggle: (treeId: string, directoryPath: string) => void;
+  readonly prune: (
+    treeId: string,
+    directoryPaths: ReadonlyArray<string>,
+  ) => void;
+}
+
+const EMPTY_EXPANDED_PATHS: ReadonlyArray<string> = Object.freeze([]);
+
+export const useOpenerFileTreeStore = create<OpenerFileTreeState>()((set) => ({
+  expandedPathsByTree: {},
+  toggle: (treeId, directoryPath) => {
+    set((state) => {
+      const current = state.expandedPathsByTree[treeId] ?? [];
+      const next = current.includes(directoryPath)
+        ? current.filter((path) => path !== directoryPath)
+        : [...current, directoryPath];
+      return {
+        expandedPathsByTree: {
+          ...state.expandedPathsByTree,
+          [treeId]: next,
+        },
+      };
+    });
+  },
+  prune: (treeId, directoryPaths) => {
+    if (directoryPaths.length === 0) return;
+    set((state) => {
+      const current = state.expandedPathsByTree[treeId] ?? [];
+      return {
+        expandedPathsByTree: {
+          ...state.expandedPathsByTree,
+          [treeId]: current.filter(
+            (path) =>
+              !directoryPaths.some((directoryPath) =>
+                isWithinDirectory(path, directoryPath),
+              ),
+          ),
+        },
+      };
+    });
+  },
+}));
+
+export function useOpenerFileTreeExpandedPaths(
+  treeId: string,
+): ReadonlyArray<string> {
+  return useOpenerFileTreeStore(
+    (state) => state.expandedPathsByTree[treeId] ?? EMPTY_EXPANDED_PATHS,
+  );
+}


### PR DESCRIPTION
## Summary

- add shared nested tree rows with independent expand/collapse state in opener tiles
- mirror agent hierarchy, activity status, and artifact hierarchy/status from the sidebar
- browse files lazily through `workspace.subscribeFileList`, watching folders only as they expand
- render Git diff paths as a matching tree and keep file rows opening the selected file

## Commit boundaries

Each surface remains isolated for cherry-pick or revert:

- `df727039` shared opener tree presentation
- `aa1b6cf9` agents hierarchy and status
- `01ee3cae` artifacts hierarchy and status
- `3094e0e5` files/diff tree and lazy subscription

## Validation

- commit hooks: affected build, compile, lint, format
- focused file-list subscription tests
- focused Files/Diff opener tests
- React Doctor
- dev-app HMR smoke check