### PR TITLE
fix(notifications): carry host.operation.finished on the cloud feed via @1.1

### DIFF
--- a/clients/gui-app/src/lib/notifications/notification-display.ts
+++ b/clients/gui-app/src/lib/notifications/notification-display.ts
@@ -16,7 +16,7 @@ import {
 import type { AppLocalNotificationEntry } from "@/stores/notifications/app-local-notifications-store";
 import type {
   HostNotificationEntryV21,
-  HostNotificationsCloudFeedRow,
+  HostNotificationsCloudFeedRowV11,
 } from "@traycer/protocol/host/notifications/contracts";
 import {
   notificationEntityFromHostEntry,
@@ -441,7 +441,7 @@ export function displayHostChannelEmission(
  * unlike a v1 channel batch, one snapshot can contain entries from several
  * hosts and every native activation envelope must retain the correct one. */
 export function displayCloudSnapshotArrivals(
-  entries: ReadonlyArray<HostNotificationsCloudFeedRow>,
+  entries: ReadonlyArray<HostNotificationsCloudFeedRowV11>,
   target: NotificationDisplayTarget,
 ): void {
   const focused = readFocusedHostNotificationPresence();

--- a/clients/gui-app/src/stores/notifications/cloud-notifications-store.ts
+++ b/clients/gui-app/src/stores/notifications/cloud-notifications-store.ts
@@ -5,8 +5,8 @@ import type {
 } from "@traycer-clients/shared/host-transport/i-stream-session";
 import type { IHostStreamClient } from "@traycer-clients/shared/host-transport/host-stream-client";
 import {
-  hostNotificationsCloudFeedSubscribeServerFrameSchemaV10,
-  type HostNotificationsCloudFeedRow,
+  hostNotificationsCloudFeedSubscribeServerFrameSchemaV11,
+  type HostNotificationsCloudFeedRowV11,
   type HostNotificationsCloudFeedSummary,
   type HostNotificationsEntityRef,
 } from "@traycer/protocol/host/notifications/contracts";
@@ -34,7 +34,7 @@ export interface CloudNotificationsState {
    * activation still asks for it.
    */
   readonly rows: Readonly<
-    Partial<Record<string, HostNotificationsCloudFeedRow>>
+    Partial<Record<string, HostNotificationsCloudFeedRowV11>>
   >;
   readonly summary: HostNotificationsCloudFeedSummary | null;
   /** The cloud's per-user change sequence, as of the last snapshot. This is
@@ -69,10 +69,10 @@ export interface CloudNotificationsState {
   >;
   readonly connectionState: CloudNotificationsConnectionState;
   applySnapshot(input: {
-    readonly rows: ReadonlyArray<HostNotificationsCloudFeedRow>;
+    readonly rows: ReadonlyArray<HostNotificationsCloudFeedRowV11>;
     readonly summary: HostNotificationsCloudFeedSummary;
     readonly version: number;
-  }): ReadonlyArray<HostNotificationsCloudFeedRow> | null;
+  }): ReadonlyArray<HostNotificationsCloudFeedRowV11> | null;
   /** Optimistic set-once marker application. A later authoritative snapshot
    * reconciles the row, but the common successful mutation never waits on a
    * wake or the relay's correctness poll to look read. */
@@ -187,11 +187,13 @@ export function cloudNotificationFeedId(entryId: string): string {
   return `cloud:${encodeURIComponent(entryId)}`;
 }
 
-function rowKey(row: Pick<HostNotificationsCloudFeedRow, "entryId">): string {
+function rowKey(
+  row: Pick<HostNotificationsCloudFeedRowV11, "entryId">,
+): string {
   return cloudNotificationFeedId(row.entryId);
 }
 
-function isUnreadAttention(row: HostNotificationsCloudFeedRow): boolean {
+function isUnreadAttention(row: HostNotificationsCloudFeedRowV11): boolean {
   return (
     (row.entry.severity === "needs_action" ||
       row.entry.severity === "failure") &&
@@ -215,9 +217,10 @@ export const useCloudNotificationsStore = create<CloudNotificationsState>()(
       // uses accepted snapshots to drive cross-plane completion reconciliation.
       if (currentVersion !== null && input.version < currentVersion)
         return null;
-      const arrivals: HostNotificationsCloudFeedRow[] = [];
+      const arrivals: HostNotificationsCloudFeedRowV11[] = [];
       set((state) => {
-        const rows: Partial<Record<string, HostNotificationsCloudFeedRow>> = {};
+        const rows: Partial<Record<string, HostNotificationsCloudFeedRowV11>> =
+          {};
         for (const row of input.rows) {
           const key = rowKey(row);
           rows[key] = row;
@@ -379,8 +382,8 @@ export function openCloudNotificationsStream(
   onEntitlementDenied: (() => void) | null,
   onSnapshot:
     | ((input: {
-        readonly rows: ReadonlyArray<HostNotificationsCloudFeedRow>;
-        readonly arrivals: ReadonlyArray<HostNotificationsCloudFeedRow>;
+        readonly rows: ReadonlyArray<HostNotificationsCloudFeedRowV11>;
+        readonly arrivals: ReadonlyArray<HostNotificationsCloudFeedRowV11>;
       }) => void)
     | null,
 ): () => void {
@@ -423,7 +426,7 @@ export function openCloudNotificationsStream(
         return;
       }
       const parsed =
-        hostNotificationsCloudFeedSubscribeServerFrameSchemaV10.safeParse(
+        hostNotificationsCloudFeedSubscribeServerFrameSchemaV11.safeParse(
           envelope,
         );
       if (!parsed.success) {

--- a/clients/gui-app/src/stores/notifications/merged-notifications.ts
+++ b/clients/gui-app/src/stores/notifications/merged-notifications.ts
@@ -76,7 +76,7 @@ import {
   type HostNotificationSeverity,
   type HostNotificationsAttentionCursor,
   type HostNotificationsChronologicalCursor,
-  type HostNotificationsCloudFeedRow,
+  type HostNotificationsCloudFeedRowV11,
   type HostNotificationsCloudFeedEntryRequest,
   type HostNotificationsCloudFeedMarkAllReadRequest,
   type HostNotificationsCloudFeedClearAllRequest,
@@ -252,7 +252,7 @@ function useMergedNotificationRows(): ReadonlyArray<MergedNotificationRow> {
       const rows: MergedNotificationRow[] = [
         ...Object.values(cloudRows)
           .filter(
-            (row): row is HostNotificationsCloudFeedRow => row !== undefined,
+            (row): row is HostNotificationsCloudFeedRowV11 => row !== undefined,
           )
           .filter((row) => !isAutomaticAgentRecovery(row.entry))
           .map(rowFromCloudFeedRow),
@@ -445,7 +445,7 @@ function rowFromLocalFeedId(input: {
 
 function rowFromCloudFeedId(input: {
   readonly feedMode: "local" | "cloud" | "upgrade-required";
-  readonly cloudRow: HostNotificationsCloudFeedRow | undefined;
+  readonly cloudRow: HostNotificationsCloudFeedRowV11 | undefined;
 }): MergedNotificationRow | null {
   if (
     input.feedMode !== "cloud" ||
@@ -1096,7 +1096,7 @@ export function useMergedNotificationsActions(): MergedNotificationsActions {
           if (cloudState.version !== cloudVersion) return;
           const fallbackEntryIds = Object.values(cloudState.rows)
             .filter(
-              (row): row is HostNotificationsCloudFeedRow =>
+              (row): row is HostNotificationsCloudFeedRowV11 =>
                 row !== undefined && row.entry.readAt === null,
             )
             .map((row) => row.entryId);
@@ -1400,7 +1400,7 @@ export function rowFromGlobalEntry(
 }
 
 export function rowFromCloudFeedRow(
-  row: HostNotificationsCloudFeedRow,
+  row: HostNotificationsCloudFeedRowV11,
 ): MergedNotificationRow {
   const fallback = formatHostNotificationPresentation(row.entry);
   const title =

--- a/clients/gui-app/src/stores/notifications/notification-indicator-state.ts
+++ b/clients/gui-app/src/stores/notifications/notification-indicator-state.ts
@@ -1,6 +1,6 @@
 import type {
-  HostNotificationEntry,
-  HostNotificationsCloudFeedRow,
+  HostNotificationEntryV21,
+  HostNotificationsCloudFeedRowV11,
   HostNotificationsEntityRef,
   HostNotificationsIndicatorState,
   HostNotificationsIndicatorStateResponse,
@@ -171,7 +171,7 @@ function selectHostIndicatorState(
  * stable.
  */
 export function selectCloudNotificationIndicators(
-  rows: Readonly<Partial<Record<string, HostNotificationsCloudFeedRow>>>,
+  rows: Readonly<Partial<Record<string, HostNotificationsCloudFeedRowV11>>>,
   epicIds: ReadonlyArray<string>,
   chatIds: ReadonlyArray<string>,
 ): HostNotificationsIndicatorStateResponse {
@@ -187,7 +187,7 @@ export interface CloudNotificationIndicatorProjection {
 }
 
 export function selectCloudNotificationIndicatorProjection(
-  rows: Readonly<Partial<Record<string, HostNotificationsCloudFeedRow>>>,
+  rows: Readonly<Partial<Record<string, HostNotificationsCloudFeedRowV11>>>,
   epicIds: ReadonlyArray<string>,
   chatIds: ReadonlyArray<string>,
 ): CloudNotificationIndicatorProjection {
@@ -235,7 +235,7 @@ export function selectCloudNotificationIndicatorProjection(
 }
 
 function cloudIndicatorEntryIsWanted(
-  row: HostNotificationsCloudFeedRow,
+  row: HostNotificationsCloudFeedRowV11,
   wantedEpicIds: ReadonlySet<string>,
   wantedChatIds: ReadonlySet<string>,
 ): boolean {
@@ -294,14 +294,14 @@ interface CloudIndicatorAccumulator {
 /** Exact entity -> origin host -> latest terminal entry in causal write order. */
 type CloudTerminalCandidate = {
   readonly entryId: string;
-  readonly entry: HostNotificationEntry;
+  readonly entry: HostNotificationEntryV21;
 };
 
 type CloudTerminalWinners = Map<string, Map<string, CloudTerminalCandidate>>;
 
 function collectCloudIndicatorEntry(
   accumulator: CloudIndicatorAccumulator,
-  row: HostNotificationsCloudFeedRow,
+  row: HostNotificationsCloudFeedRowV11,
 ): void {
   const { entry, originHostId } = row;
   const contribution = indicatorContribution(entry);
@@ -341,7 +341,7 @@ function collectCloudIndicatorEntry(
 /** `null` when the entry lights nothing, so an entity with only quiet rows is
  * never allocated an all-false record. */
 function indicatorContribution(
-  entry: HostNotificationEntry,
+  entry: HostNotificationEntryV21,
 ): HostNotificationsIndicatorState | null {
   const pendingApproval =
     entry.kind === "approval.requested" && entry.resolvedAt === null;
@@ -375,7 +375,7 @@ function retainLatestTerminal(input: {
   readonly entityId: string;
   readonly originHostId: string;
   readonly entryId: string;
-  readonly candidate: HostNotificationEntry;
+  readonly candidate: HostNotificationEntryV21;
 }): void {
   if (!isTerminalEntry(input.candidate)) return;
   const originWinners = terminalWinnersForEntity(input.winners, input.entityId);
@@ -410,7 +410,7 @@ function terminalCandidateSupersedes(
   return terminalEntryIsNewer(candidate, current);
 }
 
-function isAutomaticRecoveryEntry(entry: HostNotificationEntry): boolean {
+function isAutomaticRecoveryEntry(entry: HostNotificationEntryV21): boolean {
   return (
     entry.kind === "agent.stopped" &&
     "automaticRecovery" in entry.payload &&
@@ -420,19 +420,19 @@ function isAutomaticRecoveryEntry(entry: HostNotificationEntry): boolean {
 
 function terminalEntriesForEpic(
   winners: CloudTerminalWinners,
-): ReadonlyArray<HostNotificationEntry> {
+): ReadonlyArray<HostNotificationEntryV21> {
   return [...winners.values()].flatMap(terminalEntriesForOrigins);
 }
 
 function terminalEntriesForOrigins(
   winners: Map<string, CloudTerminalCandidate>,
-): ReadonlyArray<HostNotificationEntry> {
+): ReadonlyArray<HostNotificationEntryV21> {
   return [...winners.values()].map((candidate) => candidate.entry);
 }
 
 function mergeTerminalContributions(
   current: HostNotificationsIndicatorState | undefined,
-  entries: ReadonlyArray<HostNotificationEntry>,
+  entries: ReadonlyArray<HostNotificationEntryV21>,
 ): HostNotificationsIndicatorState | undefined {
   return entries.reduce<HostNotificationsIndicatorState | undefined>(
     (merged, entry) => {
@@ -456,7 +456,7 @@ function terminalWinnersForEntity(
   return created;
 }
 
-function isTerminalEntry(entry: HostNotificationEntry): boolean {
+function isTerminalEntry(entry: HostNotificationEntryV21): boolean {
   return entry.severity === "failure" || entry.severity === "done";
 }
 
@@ -475,7 +475,7 @@ function terminalEntryIsNewer(
 }
 
 function terminalIndicatorContribution(
-  entry: HostNotificationEntry,
+  entry: HostNotificationEntryV21,
 ): HostNotificationsIndicatorState | null {
   if (entry.readAt !== null || !isTerminalEntry(entry)) return null;
   return {

--- a/protocol/src/host/notifications/__tests__/host-operation-finished-compat.test.ts
+++ b/protocol/src/host/notifications/__tests__/host-operation-finished-compat.test.ts
@@ -11,6 +11,10 @@ import {
   hiddenHostNotificationKinds,
   hostNotificationEntrySchema,
   hostNotificationEntrySchemaV21,
+  hostNotificationsCloudFeedSubscribeServerFrameSchemaV10,
+  hostNotificationsCloudFeedSubscribeServerFrameSchemaV11,
+  hostNotificationsCloudFeedSubscribeV10,
+  hostNotificationsCloudFeedSubscribeV11,
   hostNotificationsFeedSubscribeV10,
   hostNotificationsFeedSubscribeV11,
   hostNotificationsListDowngradeV21ToV10,
@@ -169,6 +173,37 @@ describe("released schemas stay frozen", () => {
     ).toBe(false);
   });
 
+  it("leaves the cloud feed @1.0 frame unable to carry the new arm, @1.1 able", () => {
+    const snapshot = (rows: unknown[]): unknown => ({
+      kind: "snapshot",
+      hasBinaryPayload: false,
+      connectionState: "connected",
+      version: 3,
+      rows,
+      summary: { totalCount: rows.length, unreadCount: 1, attentionCount: 0 },
+    });
+    const row = {
+      entryId: "0195a1f0-0001-7000-8000-00000000000a",
+      originHostId: "host-a",
+      coalesceKey: "worktree.deletion:wt-1",
+      entry: OPERATION_FINISHED_ENTRY,
+      presentation: { epicTitle: null, chatTitle: null },
+    };
+    // The live bug this pins against: the cloud relay validated every row
+    // against the frozen V1 union, so this exact row was silently dropped
+    // AFTER being counted into the badge.
+    expect(
+      hostNotificationsCloudFeedSubscribeServerFrameSchemaV10.safeParse(
+        snapshot([row]),
+      ).success,
+    ).toBe(false);
+    expect(
+      hostNotificationsCloudFeedSubscribeServerFrameSchemaV11.safeParse(
+        snapshot([row]),
+      ).success,
+    ).toBe(true);
+  });
+
   it("keeps the released contracts byte-identical to their frozen sources", () => {
     const dump = (schema: z.ZodType): unknown =>
       z.toJSONSchema(schema, { unrepresentable: "any" });
@@ -183,6 +218,18 @@ describe("released schemas stay frozen", () => {
     expect(
       dump(hostNotificationsFeedSubscribeV10.serverFrameSchema),
     ).not.toEqual(dump(hostNotificationsFeedSubscribeV11.serverFrameSchema));
+    // Same discipline for the cloud feed's own minor pair.
+    expect(
+      dump(hostNotificationsCloudFeedSubscribeV10.openRequestSchema),
+    ).toEqual(dump(hostNotificationsCloudFeedSubscribeV11.openRequestSchema));
+    expect(
+      dump(hostNotificationsCloudFeedSubscribeV10.clientFrameSchema),
+    ).toEqual(dump(hostNotificationsCloudFeedSubscribeV11.clientFrameSchema));
+    expect(
+      dump(hostNotificationsCloudFeedSubscribeV10.serverFrameSchema),
+    ).not.toEqual(
+      dump(hostNotificationsCloudFeedSubscribeV11.serverFrameSchema),
+    );
     // Requests are untouched by the response widening.
     expect(dump(hostNotificationsListV20.requestSchema)).toEqual(
       dump(hostNotificationsListV21.requestSchema),
@@ -215,6 +262,18 @@ describe("registry wiring", () => {
     const line = hostStreamRpcRegistry["host.notifications.subscribe"][1];
     expect(line.latestMinor).toBe(0);
     expect(Object.keys(line.versions)).toEqual(["0"]);
+  });
+
+  it("advertises cloud feed @1.1 with @1.0 still installed for older peers", () => {
+    const line =
+      hostStreamRpcRegistry["host.notifications.cloudFeed.subscribe"][1];
+    expect(line.latestMinor).toBe(1);
+    expect(line.versions[0].contract).toBe(
+      hostNotificationsCloudFeedSubscribeV10,
+    );
+    expect(line.versions[1].contract).toBe(
+      hostNotificationsCloudFeedSubscribeV11,
+    );
   });
 });
 
@@ -255,6 +314,16 @@ describe("negotiated-version visibility projection", () => {
         version: { major: 1, minor: 0 },
         sees: false,
       },
+      {
+        surface: { method: "host.notifications.cloudFeed.subscribe" },
+        version: { major: 1, minor: 0 },
+        sees: false,
+      },
+      {
+        surface: { method: "host.notifications.cloudFeed.subscribe" },
+        version: { major: 1, minor: 1 },
+        sees: true,
+      },
     ];
     for (const { surface, version, sees } of cases) {
       const visible = visibleHostNotificationKinds(surface, version);
@@ -280,6 +349,7 @@ describe("negotiated-version visibility projection", () => {
       { method: "host.notifications.list" } as const,
       { method: "host.notifications.feed.subscribe" } as const,
       { method: "host.notifications.subscribe" } as const,
+      { method: "host.notifications.cloudFeed.subscribe" } as const,
     ]) {
       for (const version of [
         { major: 3, minor: 0 },

--- a/protocol/src/host/notifications/__tests__/notification-kind-surface-conformance.test.ts
+++ b/protocol/src/host/notifications/__tests__/notification-kind-surface-conformance.test.ts
@@ -1,0 +1,298 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import {
+  hostRpcRegistry,
+  hostStreamRpcRegistry,
+} from "@traycer/protocol/host/registry";
+import {
+  ALL_HOST_NOTIFICATION_KINDS,
+  visibleHostNotificationKinds,
+  type HostNotificationKind,
+  type HostNotificationsSurface,
+} from "@traycer/protocol/host/notifications/contracts";
+
+/**
+ * Cross-surface conformance: for EVERY registered serving path and EVERY
+ * installed version of it, every notification kind is either representable by
+ * that version's wire schema or excluded by the central
+ * `visibleHostNotificationKinds` projection - never neither, never both.
+ *
+ * This is the tripwire the `host.operation.finished` cloud-feed bug proved
+ * missing. The kind shipped with a complete LOCAL compat ladder on 2026-07-28;
+ * the cloud feed shipped two days later pinning the frozen V1 union, and no
+ * test tied "kinds the enum knows" to "kinds each read path can carry" - so
+ * for a month the relay counted rows into the badge that no client could
+ * render. The invariant this file pins is exactly the one that broke:
+ *
+ *   representable(surface, version, kind) ⇔ visible(surface, version, kind)
+ *
+ * A kind a version cannot parse must be centrally hidden from it (so the
+ * serving side filters rows AND summaries in one place), and a kind a version
+ * CAN parse must not be hidden (a silent exclusion is a row the user never
+ * sees on a client that could have shown it).
+ *
+ * Everything below is derived from the registries, not hand-listed:
+ * - The set of entry-carrying methods is DETECTED by scanning every
+ *   `host.notifications.*` registry contract's wire schemas for entry-kind
+ *   literals. A new read path that carries entries joins the matrix or fails
+ *   the completeness check - it cannot sit out, which is how the cloud feed
+ *   sat out.
+ * - The versions per method come from the registry's installed
+ *   (major, minor) set, so a new minor is exercised the moment it is
+ *   registered.
+ * - The kinds come from `ALL_HOST_NOTIFICATION_KINDS`, and a fixture-coverage
+ *   check makes a new kind fail here until it gets a representative entry.
+ */
+
+// ---- representative entries, one per kind ------------------------------- //
+
+const ENTRY_BASE = {
+  id: "conformance-entry-1",
+  updatedAt: 1_700_000_000_000,
+  readAt: null,
+  sourceRef: "conformance-source",
+  epicId: "epic-1",
+  chatId: "chat-1",
+};
+
+/** Minimal VALID entry per kind on the widest union. Arm-specific fields
+ * (outcome nullability, resolvedAt, strict payloads) matter: an invalid
+ * fixture would read as "not representable" and corrupt the matrix. */
+const REPRESENTATIVE_ENTRIES: Readonly<
+  Record<HostNotificationKind, Record<string, unknown>>
+> = {
+  "agent.stopped": {
+    ...ENTRY_BASE,
+    kind: "agent.stopped",
+    severity: "done",
+    outcome: "completed",
+    payload: { outcome: "completed" },
+  },
+  "agent.stalled": {
+    ...ENTRY_BASE,
+    kind: "agent.stalled",
+    severity: "failure",
+    outcome: "errored",
+    payload: {},
+  },
+  "workspace.operation.failed": {
+    ...ENTRY_BASE,
+    kind: "workspace.operation.failed",
+    severity: "failure",
+    outcome: "errored",
+    payload: {},
+  },
+  "approval.requested": {
+    ...ENTRY_BASE,
+    kind: "approval.requested",
+    severity: "needs_action",
+    outcome: null,
+    resolvedAt: null,
+    payload: {},
+  },
+  "interview.requested": {
+    ...ENTRY_BASE,
+    kind: "interview.requested",
+    severity: "needs_action",
+    outcome: null,
+    resolvedAt: null,
+    payload: {},
+  },
+  "host.operation.finished": {
+    ...ENTRY_BASE,
+    kind: "host.operation.finished",
+    epicId: null,
+    chatId: null,
+    severity: "done",
+    outcome: "completed",
+    payload: { title: "Deleted a worktree", message: "Removed cleanly." },
+  },
+};
+
+// ---- per-method wire embedding ------------------------------------------ //
+
+/** How one representative entry rides each method's wire, and which schema
+ * of the registered contract validates that shape. The embedding SHAPE is
+ * per method; the entry union inside it is whatever the negotiated version's
+ * schema says - which is exactly what the matrix probes. */
+type ServingPath = {
+  readonly registry: "rpc" | "stream";
+  readonly embed: (entry: Record<string, unknown>) => unknown;
+};
+
+const SERVING_PATHS: Readonly<Record<string, ServingPath>> = {
+  "host.notifications.list": {
+    registry: "rpc",
+    embed: (entry) => ({ entries: [entry], nextCursor: null }),
+  },
+  "host.notifications.subscribe": {
+    registry: "stream",
+    embed: (entry) => ({
+      kind: "upserted",
+      hasBinaryPayload: false,
+      entry,
+    }),
+  },
+  "host.notifications.feed.subscribe": {
+    registry: "stream",
+    embed: (entry) => ({
+      kind: "upserted",
+      hasBinaryPayload: false,
+      entry,
+      removedIds: [],
+      summary: { unreadCount: 0, attentionCount: 0 },
+    }),
+  },
+  "host.notifications.cloudFeed.subscribe": {
+    registry: "stream",
+    embed: (entry) => ({
+      kind: "snapshot",
+      hasBinaryPayload: false,
+      connectionState: "connected",
+      version: 1,
+      rows: [
+        {
+          entryId: "0195a1f0-0001-7000-8000-00000000000a",
+          originHostId: "host-a",
+          coalesceKey: "conformance:key",
+          entry,
+          presentation: { epicTitle: null, chatTitle: null },
+        },
+      ],
+      summary: { totalCount: 1, unreadCount: 0, attentionCount: 0 },
+    }),
+  },
+};
+
+// ---- registry introspection --------------------------------------------- //
+
+type InstalledVersion = {
+  readonly major: number;
+  readonly minor: number;
+  readonly wireSchema: z.ZodType;
+};
+
+function installedVersions(
+  method: string,
+  path: ServingPath,
+): InstalledVersion[] {
+  const line = (
+    path.registry === "rpc" ? hostRpcRegistry : hostStreamRpcRegistry
+  )[method as never] as Record<
+    string,
+    { versions: Record<string, { contract: unknown }> }
+  >;
+  const versions: InstalledVersion[] = [];
+  for (const [majorKey, majorLine] of Object.entries(line)) {
+    const major = Number(majorKey);
+    if (!Number.isInteger(major)) continue; // skips `degrade`
+    for (const [minorKey, entry] of Object.entries(majorLine.versions)) {
+      const contract = entry.contract as {
+        responseSchema?: z.ZodType;
+        serverFrameSchema?: z.ZodType;
+      };
+      const wireSchema =
+        path.registry === "rpc"
+          ? contract.responseSchema
+          : contract.serverFrameSchema;
+      if (wireSchema === undefined) {
+        throw new Error(`no wire schema on ${method}@${major}.${minorKey}`);
+      }
+      versions.push({ major, minor: Number(minorKey), wireSchema });
+    }
+  }
+  return versions;
+}
+
+/** A contract carries notification entries iff its wire schemas mention an
+ * entry-kind literal. Dump-based on purpose: it inspects what is actually on
+ * the wire, so a new method cannot opt out by simply not being hand-listed. */
+function carriesNotificationEntries(contract: unknown): boolean {
+  const schemas = Object.entries(contract as Record<string, unknown>).filter(
+    ([, value]) => value instanceof z.ZodType,
+  );
+  return schemas.some(([, schema]) => {
+    const dump = JSON.stringify(
+      z.toJSONSchema(schema as z.ZodType, { unrepresentable: "any" }),
+    );
+    return ALL_HOST_NOTIFICATION_KINDS.some((kind) =>
+      dump.includes(`"${kind}"`),
+    );
+  });
+}
+
+function detectedEntryCarryingMethods(): string[] {
+  const methods: string[] = [];
+  for (const [registryName, registry] of [
+    ["rpc", hostRpcRegistry],
+    ["stream", hostStreamRpcRegistry],
+  ] as const) {
+    for (const [method, line] of Object.entries(registry)) {
+      if (!method.startsWith("host.notifications.")) continue;
+      const carries = Object.entries(
+        line as Record<
+          string,
+          { versions?: Record<string, { contract: unknown }> }
+        >,
+      ).some(
+        ([majorKey, majorLine]) =>
+          Number.isInteger(Number(majorKey)) &&
+          Object.values(majorLine.versions ?? {}).some((entry) =>
+            carriesNotificationEntries(entry.contract),
+          ),
+      );
+      if (carries) methods.push(`${registryName}:${method}`);
+    }
+  }
+  return methods.sort();
+}
+
+// ---- the conformance matrix --------------------------------------------- //
+
+describe("notification kind ↔ surface conformance", () => {
+  it("has a representative entry for every kind the enum knows", () => {
+    expect(Object.keys(REPRESENTATIVE_ENTRIES).sort()).toEqual(
+      [...ALL_HOST_NOTIFICATION_KINDS].sort(),
+    );
+  });
+
+  it("covers exactly the entry-carrying methods the registries actually serve", () => {
+    // Detected from the wire schemas, not hand-listed. A new
+    // `host.notifications.*` method that carries entries fails here until it
+    // gets an embedding above AND a `HostNotificationsSurface` arm - the two
+    // things the cloud feed shipped without.
+    const expected = Object.entries(SERVING_PATHS)
+      .map(([method, path]) => `${path.registry}:${method}`)
+      .sort();
+    expect(detectedEntryCarryingMethods()).toEqual(expected);
+  });
+
+  it("every kind is representable exactly where the central projection says it is visible", () => {
+    for (const [method, path] of Object.entries(SERVING_PATHS)) {
+      const surface = { method } as HostNotificationsSurface;
+      for (const { major, minor, wireSchema } of installedVersions(
+        method,
+        path,
+      )) {
+        const visible = visibleHostNotificationKinds(surface, {
+          major,
+          minor,
+        });
+        for (const kind of ALL_HOST_NOTIFICATION_KINDS) {
+          const candidate = path.embed(REPRESENTATIVE_ENTRIES[kind]);
+          const representable = wireSchema.safeParse(candidate).success;
+          // The one line the cloud-feed bug would have tripped:
+          // `cloudFeed.subscribe@1.0` could not represent
+          // `host.operation.finished`, but nothing hid the kind from that
+          // surface, so it was counted, then silently dropped.
+          expect
+            .soft(
+              representable,
+              `${method}@${major}.${minor} kind=${kind}: representable=${representable} but centrally visible=${visible.includes(kind)}`,
+            )
+            .toBe(visible.includes(kind));
+        }
+      }
+    }
+  });
+});

--- a/protocol/src/host/notifications/host-notifications.ts
+++ b/protocol/src/host/notifications/host-notifications.ts
@@ -235,7 +235,8 @@ export const ALL_HOST_NOTIFICATION_KINDS: readonly HostNotificationKind[] = [
 export type HostNotificationsSurface =
   | { readonly method: "host.notifications.list" }
   | { readonly method: "host.notifications.feed.subscribe" }
-  | { readonly method: "host.notifications.subscribe" };
+  | { readonly method: "host.notifications.subscribe" }
+  | { readonly method: "host.notifications.cloudFeed.subscribe" };
 
 /**
  * Enumerated per SUPPORTED major, never `major > N`.
@@ -272,6 +273,17 @@ export function visibleHostNotificationKinds(
     // The frozen host-v1.1.7 stream has no successor minor and never will.
     case "host.notifications.subscribe":
       return RELEASED_HOST_NOTIFICATION_KINDS;
+    // The cloud relay serves every subscriber from one shared replica, so this
+    // projection is what keeps a `@1.0` subscriber's rows AND summary closed
+    // over the arms its parser can represent - the relay derives its
+    // compatibility buckets from here rather than re-deciding `minor >= 1`.
+    case "host.notifications.cloudFeed.subscribe":
+      if (schemaVersion.major === 1) {
+        return schemaVersion.minor >= 1
+          ? ALL_HOST_NOTIFICATION_KINDS
+          : RELEASED_HOST_NOTIFICATION_KINDS;
+      }
+      return RELEASED_HOST_NOTIFICATION_KINDS;
   }
 }
 
@@ -298,6 +310,9 @@ export function streamCarriesChannelEmissionFrame(
       return schemaVersion.major === 1 && schemaVersion.minor === 0;
     // Unary: no frames at all.
     case "host.notifications.list":
+      return false;
+    // Snapshot/connectionState/pong only, on both installed minors.
+    case "host.notifications.cloudFeed.subscribe":
       return false;
   }
 }
@@ -1153,6 +1168,58 @@ export const hostNotificationsCloudFeedSubscribeV10 = defineStreamRpcContract({
   schemaVersion: { major: 1, minor: 0 } as const,
   openRequestSchema: hostNotificationsCloudFeedSubscribeOpenRequestSchemaV10,
   serverFrameSchema: hostNotificationsCloudFeedSubscribeServerFrameSchemaV10,
+  clientFrameSchema: hostNotificationsCloudFeedSubscribeClientFrameSchemaV10,
+});
+
+/**
+ * Additive minor of the cloud feed row: identical envelope, entry slot widened
+ * to the `@2.1` union so a `host.operation.finished` occurrence is
+ * representable. V10 stays frozen - its closed union is a released parser's
+ * contract, and one new arm reaching it is treated as connection corruption
+ * (see `hostNotificationEntrySchema`'s doc), never a cosmetic failure.
+ *
+ * A V11 frame is a strict superset of a V10 frame, so one client-side parser
+ * (the V11 one) reads both minors; which ROWS it receives is decided
+ * host-side by `visibleHostNotificationKinds` for the negotiated version.
+ */
+export const hostNotificationsCloudFeedRowSchemaV11 = z.object({
+  ...hostNotificationsCloudFeedRowSchema.shape,
+  entry: hostNotificationEntrySchemaV21,
+});
+export type HostNotificationsCloudFeedRowV11 = z.infer<
+  typeof hostNotificationsCloudFeedRowSchemaV11
+>;
+
+export const hostNotificationsCloudFeedSubscribeServerFrameSchemaV11 =
+  z.discriminatedUnion("kind", [
+    z.object({
+      kind: z.literal("snapshot"),
+      ...textFrameFields,
+      connectionState: z.literal("connected"),
+      version: z.number().int().nonnegative(),
+      rows: z.array(hostNotificationsCloudFeedRowSchemaV11),
+      summary: hostNotificationsCloudFeedSummarySchema,
+    }),
+    z.object({
+      kind: z.literal("connectionState"),
+      ...textFrameFields,
+      connectionState: z.literal("reconnecting"),
+    }),
+    z.object({
+      kind: z.literal("pong"),
+      ...textFrameFields,
+    }),
+  ]);
+export type HostNotificationsCloudFeedSubscribeServerFrameV11 = z.infer<
+  typeof hostNotificationsCloudFeedSubscribeServerFrameSchemaV11
+>;
+
+/** Additive minor: same open request and client frames, widened entry union. */
+export const hostNotificationsCloudFeedSubscribeV11 = defineStreamRpcContract({
+  method: "host.notifications.cloudFeed.subscribe",
+  schemaVersion: { major: 1, minor: 1 } as const,
+  openRequestSchema: hostNotificationsCloudFeedSubscribeOpenRequestSchemaV10,
+  serverFrameSchema: hostNotificationsCloudFeedSubscribeServerFrameSchemaV11,
   clientFrameSchema: hostNotificationsCloudFeedSubscribeClientFrameSchemaV10,
 });
 

--- a/protocol/src/host/registry.ts
+++ b/protocol/src/host/registry.ts
@@ -515,6 +515,7 @@ import {
   hostNotificationsFeedSubscribeV10,
   hostNotificationsFeedSubscribeV11,
   hostNotificationsCloudFeedSubscribeV10,
+  hostNotificationsCloudFeedSubscribeV11,
   hostNotificationsCloudFeedMarkRead,
   hostNotificationsCloudFeedMarkAllRead,
   hostNotificationsCloudFeedResolve,
@@ -8482,10 +8483,13 @@ const HOST_STREAM_RPC_REGISTRY_OTHER_DEFINITION = {
   },
   "host.notifications.cloudFeed.subscribe": {
     1: {
-      latestMinor: 0,
+      latestMinor: 1,
       versions: {
         0: {
           contract: hostNotificationsCloudFeedSubscribeV10,
+        },
+        1: {
+          contract: hostNotificationsCloudFeedSubscribeV11,
         },
       },
     },


### PR DESCRIPTION
## Problem

The cloud feed's row contract (`hostNotificationsCloudFeedRowSchema.entry`) was pinned to the frozen V1 entry union. `host.operation.finished` passed the kind enum but failed the union parse in the host relay, so every such occurrence was silently dropped from the wire **after** being counted into the badge summary. Observed live on Windows prod: badge = 8, panel = 1 rendered attention row — the 7 hidden rows were unread worktree-deletion failures.

The kind shipped 2026-07-28 (#768) with a complete local compat ladder (list @2.1, feed @1.1, old-client summary exclusion). The cloud feed shipped two days later (#813) framed as a transport for the frozen v1 contract, was never registered as a `HostNotificationsSurface`, and no test tied surfaces to read paths — so it sat out the ladder.

## Change

- **@1.1 cloud feed contract**: `hostNotificationsCloudFeedRowSchemaV11` (entry slot widened to `hostNotificationEntrySchemaV21`), matching server frame and stream contract, registered beside the untouched @1.0 (`latestMinor: 1`).
- **Central visibility**: `host.notifications.cloudFeed.subscribe` is now a `HostNotificationsSurface` arm; `visibleHostNotificationKinds` decides which kinds each negotiated version observes (released at @1.0, all at @1.1). The host relay derives its per-subscriber projection from this (paired traycer-internal PR).
- **GUI**: parses the @1.1 superset frame (valid for both negotiated minors) and carries the V21 entry type through the cloud store, merged projection, display helpers, and indicator state. The renderer already had a `host.operation.finished` branch — only the wire was starving it.
- **Guardrail**: new `notification-kind-surface-conformance.test.ts` pins `representable(surface, version, kind) ⇔ visible(surface, version, kind)` for every installed version of every entry-carrying `host.notifications.*` method. The method set is **detected** from the registries' wire schemas (a new entry-carrying read path cannot sit out), versions are enumerated from the registries, and a fixture-coverage check breaks on a new kind until it gets a representative entry. Mutation-tested: restoring the pre-fix visibility fails with `cloudFeed.subscribe@1.0 kind=host.operation.finished` — the live bug's exact signature.
- Extended the existing `host-operation-finished-compat` tripwires (frozen-contract dumps, registry wiring, visibility matrix) to the cloud feed.

## Compatibility

| Client | Host | Result |
| --- | --- | --- |
| old GUI | new host | @1.0: kind hidden from rows AND summary — badge consistent |
| new GUI | new host | @1.1: kind rendered and counted |
| new GUI | old host | @1.0 negotiated: kind unavailable, still consistent |

@1.0 frames are byte-identical to before; an old GUI never sees the new arm (its parser treats an unknown arm as connection corruption and reconnect-loops, which is why @1.0 is not widened in place).

## Testing

- `host-operation-finished-compat.test.ts` 25/25, `host-notifications.test.ts` 41/41, new conformance test 3/3, `tsgo --noEmit` clean.
- gui-app: `tsc -b` clean; notifications store/popover suites 267/267.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
