### PR TITLE
fix(gui-app): preserve file names at browser zoom

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/pierre-tree-theme.ts
+++ b/clients/gui-app/src/components/epic-canvas/pierre-tree-theme.ts
@@ -34,6 +34,24 @@ export const GIT_PANEL_PIERRE_FILE_TREE_THEME_STYLE = {
   "--trees-selected-fg-override": "var(--accent-foreground)",
 } as CSSProperties;
 
+/**
+ * Scoped CSS to preserve file names in the workspace file tree when browser zoom exceeds 100%.
+ *
+ * Pierre's content lane defaults to `flex: 0 auto`, which lets adjacent lanes consume its inline
+ * space as text metrics scale. At high zoom, this causes the filename to shrink until only an
+ * ellipsis marker remains. This override gives the content lane an explicit `flex: 1 1 0` basis
+ * and `max-width: none`, so it takes the remaining row width instead of being squeezed out.
+ *
+ * The CSS is intentionally scoped to Pierre's shadow root through the `unsafeCSS` option,
+ * preventing interference with the git-diff tree that shares the same theme constants.
+ */
+export const WORKSPACE_FILE_TREE_UNSAFE_CSS = `
+[data-item-section="content"] {
+  flex: 1 1 0;
+  max-width: none;
+}
+`;
+
 export const GIT_PANEL_PIERRE_FILE_TREE_UNSAFE_CSS = `
 [data-item-type="file"] [data-item-section="icon"] {
   opacity: 0.9;

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-file-tree-source.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-file-tree-source.test.tsx
@@ -209,6 +209,10 @@ let capturedOnSelectionChange: ((paths: ReadonlyArray<string>) => void) | null =
 // reads its options once, at construction, and the model exposes no getter the
 // panel could be asked afterwards.
 let capturedItemHeight: number | undefined = undefined;
+// The workspace tree renders its rows inside Pierre's shadow root, so a
+// high-zoom layout correction must be passed through its deliberate CSS escape
+// hatch rather than an app-level selector that cannot reach the rows.
+let capturedUnsafeCSS: string | undefined = undefined;
 
 function notifyModel(): void {
   for (const listener of modelListeners) listener();
@@ -353,11 +357,22 @@ vi.mock("@pierre/trees/react", () => ({
   FileTree: () => <div data-testid="pierre-file-tree-stub" />,
   useFileTreeSearch: () =>
     useSyncExternalStore(subscribeToSearchSnapshot, getSearchSnapshot),
+  /**
+   * Mock of Pierre's `useFileTree` hook for the workspace tree tests.
+   *
+   * Real hook reads `options.onSelectionChange`, `options.itemHeight`, and
+   * `options.unsafeCSS` once at construction and returns a stable model
+   * object. Mirror that contract here so the test can assert exactly the
+   * options the real component passes (selection change, row height, and
+   * the workspace file-tree CSS override).
+   */
   useFileTree: (options: {
     readonly onSelectionChange: (paths: ReadonlyArray<string>) => void;
     readonly itemHeight: number | undefined;
+    readonly unsafeCSS: string | undefined;
   }) => {
     capturedOnSelectionChange = options.onSelectionChange;
+    capturedUnsafeCSS = options.unsafeCSS;
     // Mount-captured, exactly like the real hook's `useState(() => new
     // FileTree(options))`. Recording it per RENDER instead would make the row
     // geometry look reactive here when it is not, and the viewport-transition
@@ -628,6 +643,15 @@ describe("sidebar file tree source selection", () => {
 
     expect(pinned.subscribedMethods).toEqual(["workspace.subscribeFileList"]);
     expect(ambient.subscribedMethods).toEqual([]);
+  });
+
+  it("keeps the content lane flexible at browser zoom", () => {
+    const client = new MockWsStreamClient("unknown");
+    renderPanel(client);
+
+    expect(capturedUnsafeCSS).toContain('[data-item-section="content"]');
+    expect(capturedUnsafeCSS).toContain("flex: 1 1 0");
+    expect(capturedUnsafeCSS).toContain("max-width: none");
   });
 
   it("builds the tree from the live stream and leaves the unary path disabled", async () => {

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-file-tree.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-file-tree.tsx
@@ -58,7 +58,10 @@ import {
 } from "@/components/epic-canvas/dnd/dnd";
 import { usePierreCanvasDragBridge } from "@/components/epic-canvas/dnd/use-pierre-canvas-drag-bridge";
 import { extractPierreItemPathFromEvent } from "@/components/epic-canvas/pierre-tree-adapter";
-import { PIERRE_FILE_TREE_THEME_STYLE } from "@/components/epic-canvas/pierre-tree-theme";
+import {
+  PIERRE_FILE_TREE_THEME_STYLE,
+  WORKSPACE_FILE_TREE_UNSAFE_CSS,
+} from "@/components/epic-canvas/pierre-tree-theme";
 import { workspaceFileRefFromTreePath } from "@/components/epic-canvas/workspace-file/workspace-file-ref";
 import { getBasename } from "@/lib/path/cross-platform-path";
 import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
@@ -644,6 +647,10 @@ function FileTreeBodyForResolvedHost(
     icons: "complete",
     stickyFolders: true,
     gitStatus,
+    // Rows live in Pierre's shadow DOM. Keep the filename's flex lane from
+    // collapsing to its ellipsis marker when browser zoom increases text and
+    // fixed adjacent lanes together.
+    unsafeCSS: WORKSPACE_FILE_TREE_UNSAFE_CSS,
     // `hide-non-matches`: the filter input below drops every row whose
     // name does not match, keeping only matches and their parents.
     fileTreeSearchMode: "hide-non-matches",


### PR DESCRIPTION
## Summary
- keep the workspace file-tree content lane flexible inside Pierre's shadow DOM
- prevent filename rows from collapsing to an ellipsis marker at browser zoom above 100%
- cover the layout override passed to the FileTree model

Fixes #1371

## Validation
- `bunx vitest run --config vitest.config.ts src/components/epic-canvas/sidebar/__tests__/epic-sidebar-file-tree-source.test.tsx` (24 passed)
- `npx -y react-doctor@latest . --verbose --diff upstream/main --offline --no-score` (no issues found)

## Risk
Scoped to the workspace tree's shadow-root CSS. Git-diff tree styling is unchanged.