### PR TITLE
fix(gui): keep fresh shell output at live tail

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/managed-command-output-tile.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/managed-command-output-tile.test.tsx
@@ -45,8 +45,12 @@ const boundHostSupport = vi.hoisted<{ value: StreamMethodSupport }>(() => ({
   value: "supported",
 }));
 
-const virtualizerConfig = vi.hoisted<{ useFlushSync: boolean | null }>(() => ({
+const virtualizerConfig = vi.hoisted<{
+  useFlushSync: boolean | null;
+  anchorTo: "start" | "end" | null;
+}>(() => ({
   useFlushSync: null,
+  anchorTo: null,
 }));
 
 vi.mock("@tanstack/react-virtual", async (importOriginal) => {
@@ -56,6 +60,7 @@ vi.mock("@tanstack/react-virtual", async (importOriginal) => {
     ...actual,
     useVirtualizer: (options: Parameters<typeof actual.useVirtualizer>[0]) => {
       virtualizerConfig.useFlushSync = options.useFlushSync ?? null;
+      virtualizerConfig.anchorTo = options.anchorTo ?? null;
       return actual.useVirtualizer(options);
     },
   };
@@ -340,6 +345,7 @@ beforeEach(() => {
   defaultHostSupport.value = "supported";
   boundHostSupport.value = "supported";
   virtualizerConfig.useFlushSync = null;
+  virtualizerConfig.anchorTo = null;
   sentFrames = [];
   useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
   useEpicCanvasStore.setState({
@@ -431,6 +437,10 @@ describe("managed-command output window", () => {
     expect(mountedRows.length).toBeGreaterThan(0);
     expect(mountedRows.length).toBeLessThan(100);
     expect(virtualizerConfig.useFlushSync).toBe(false);
+    // A fresh window first reaches an estimated tail. End anchoring is what
+    // keeps it there when wrapped rows are measured and enlarge the document;
+    // without this option the viewport can settle in the middle of the log.
+    expect(virtualizerConfig.anchorTo).toBe("end");
   });
 
   it("floats live status over the log instead of titling itself", () => {

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/managed-command-output-tile.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/managed-command-output-tile.test.tsx
@@ -291,13 +291,12 @@ const STREAM_FAILED: FatalErrorDetails = {
 /**
  * jsdom has no layout, so the scroll geometry a follow-mode decision reads has
  * to be stated outright. `scrollHeight` is installed as a getter over a box the
- * test owns, because prepend compensation is only meaningful when the document
- * can actually grow between two reads.
+ * test owns so individual interactions can change the viewport geometry.
  */
 function setScrollGeometry(
   element: HTMLElement,
   geometry: { scrollTop: number; scrollHeight: number; clientHeight: number },
-): { setScrollHeight: (value: number) => void } {
+): void {
   const box = { scrollHeight: geometry.scrollHeight };
   Object.defineProperty(element, "scrollHeight", {
     configurable: true,
@@ -308,11 +307,6 @@ function setScrollGeometry(
     value: geometry.clientHeight,
   });
   element.scrollTop = geometry.scrollTop;
-  return {
-    setScrollHeight: (value: number) => {
-      box.scrollHeight = value;
-    },
-  };
 }
 
 function timeline(): HTMLElement {
@@ -641,89 +635,6 @@ describe("managed-command output window", () => {
     expect(
       sentFrames[0].kind === "loadOlder" ? sentFrames[0].before : null,
     ).toEqual({ segmentId: "seg-2", byteOffset: 40 });
-  });
-
-  it("holds the reading position when a page of older lines is prepended", () => {
-    const stub = installOutputStub();
-    renderTile();
-    openAtTail(stub.emit, [line("stdout", "tail")]);
-
-    const view = timeline();
-    const geometry = setScrollGeometry(view, {
-      scrollTop: 10,
-      scrollHeight: 4_000,
-      clientHeight: 400,
-    });
-    fireEvent.scroll(view);
-    const request = sentFrames[0];
-    if (request.kind !== "loadOlder") throw new Error("expected loadOlder");
-
-    // The page lands and the document grows by 5,000px ABOVE the viewport.
-    geometry.setScrollHeight(9_000);
-    act(() => {
-      stub.emit().onOlder({
-        requestId: request.requestId,
-        lines: [line("stdout", "older-1"), line("stdout", "older-2")],
-        start: { segmentId: "seg-1", byteOffset: 0 },
-        reachedStart: false,
-      });
-    });
-
-    // Without compensation the viewport stays at 10 and the line the human was
-    // reading is 5,000px below - the whole point of scrolling up is lost.
-    // Chromium's native scroll anchoring cannot save this: the spec disables it
-    // at the very top, which is exactly where a load-older fires.
-    expect(view.scrollTop).toBe(5_010);
-  });
-
-  it("includes a changed history-marker prefix when a terminal page also evicts the tail", () => {
-    const stub = installOutputStub();
-    renderTile();
-    openAtTail(stub.emit, [line("stdout", "tail-1"), line("stdout", "tail-2")]);
-
-    const view = timeline();
-    setScrollGeometry(view, {
-      scrollTop: 10,
-      scrollHeight: 4_000,
-      clientHeight: 400,
-    });
-    const list = screen.getByTestId("managed-command-output-virtual-list");
-    let listOffsetTop = 16;
-    Object.defineProperty(list, "offsetTop", {
-      configurable: true,
-      get: () => listOffsetTop,
-    });
-
-    // Thirty-nine valid pages leave the quiet command just below the cap.
-    // The fortieth both crosses it (evicting the stale tail) and declares the
-    // retained start, replacing the loading prefix with the terminal marker.
-    for (let page = 0; page < 40; page += 1) {
-      view.scrollTop = 10;
-      fireEvent.scroll(view);
-      const request = sentFrames.at(-1);
-      if (request?.kind !== "loadOlder") {
-        throw new Error("expected loadOlder");
-      }
-      const finalPage = page === 39;
-      // Exaggerated deliberately: TanStack adapts its unmeasured-row estimate
-      // from measured rows, so a distinctive prefix delta isolates the term
-      // this regression owns without coupling to virtualizer internals.
-      if (finalPage) listOffsetTop = 100_016;
-      act(() => {
-        stub.emit().onOlder({
-          requestId: request.requestId,
-          lines: Array.from({ length: 500 }, (_, index) =>
-            line("stdout", `older-${page}-${index}`),
-          ),
-          start: { segmentId: `seg-history-${page}`, byteOffset: 0 },
-          reachedStart: finalPage,
-        });
-      });
-    }
-
-    expect(view.scrollTop).toBeGreaterThan(100_000);
-    expect(screen.getByText("Start of the retained log")).not.toBeNull();
-    expect(screen.queryByText("tail-1")).toBeNull();
   });
 
   it("pauses live output while reading history and resnapshots on return to live", () => {

--- a/clients/gui-app/src/components/epic-canvas/renderers/managed-command-output-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/managed-command-output-tile.tsx
@@ -344,7 +344,6 @@ function ManagedCommandOutputTileBody(props: {
     [readingIdentity],
   );
   const viewRef = useRef<HTMLDivElement>(null);
-  const outputListRef = useRef<HTMLDivElement>(null);
   const lastReadingAnchorRef = useRef<ManagedCommandReadingAnchor | null>(
     restoredReadingAnchor,
   );
@@ -389,23 +388,6 @@ function ManagedCommandOutputTileBody(props: {
   const virtualRows = outputVirtualizer.getVirtualItems();
   const outputVirtualizerRef = useRef(outputVirtualizer);
   outputVirtualizerRef.current = outputVirtualizer;
-  // What the timeline looked like at the last moment we could measure it:
-  // the oldest row's identity, and how tall the document was. A page of older
-  // lines prepends content ABOVE the viewport, which slides everything the
-  // human is reading down by exactly the height added.
-  const anchorRef = useRef<{
-    readonly firstSeq: number | null;
-    readonly lastSeq: number | null;
-    readonly scrollHeight: number;
-    readonly scrollTop: number;
-    readonly listOffsetTop: number;
-  }>({
-    firstSeq: null,
-    lastSeq: null,
-    scrollHeight: 0,
-    scrollTop: 0,
-    listOffsetTop: 0,
-  });
   const lastTimelineGenerationRef = useRef(timelineGeneration);
 
   const scrollToNewest = useCallback(() => {
@@ -510,53 +492,6 @@ function ManagedCommandOutputTileBody(props: {
     restoredReadingPositionRef.current = true;
   }, [captureReadingPosition, lines.length, readingIdentity, visible]);
 
-  // Runs before paint, so the correction is never a visible jump. Browsers do
-  // have native scroll anchoring, but the spec suppresses it at scrollTop 0 -
-  // precisely where a load-older fires - so the position has to be held here.
-  useLayoutEffect(() => {
-    const view = viewRef.current;
-    if (view === null) return;
-    const firstSeq = lines.length > 0 ? lines[0].seq : null;
-    const lastSeq = lines.length > 0 ? lines[lines.length - 1].seq : null;
-    const previous = anchorRef.current;
-    const listOffsetTop = outputListRef.current?.offsetTop ?? 0;
-    const prepended =
-      previous.firstSeq !== null &&
-      firstSeq !== null &&
-      firstSeq < previous.firstSeq;
-    if (prepended) {
-      const tailWasEvicted =
-        previous.lastSeq !== null && lastSeq !== previous.lastSeq;
-      const previousFirstIndex = lines.findIndex(
-        (line) => line.seq === previous.firstSeq,
-      );
-      const previousFirstOffset =
-        previousFirstIndex < 0
-          ? undefined
-          : outputVirtualizer.getOffsetForIndex(
-              previousFirstIndex,
-              "start",
-            )?.[0];
-      // Paging while detached can prepend old rows and evict stale tail rows
-      // in the same update, so total scroll-height delta is not the prepend
-      // height. Anchor to the row that used to begin the document instead.
-      view.scrollTop =
-        !tailWasEvicted || previousFirstOffset === undefined
-          ? view.scrollTop + view.scrollHeight - previous.scrollHeight
-          : previousFirstOffset +
-            previous.scrollTop +
-            listOffsetTop -
-            previous.listOffsetTop;
-    }
-    anchorRef.current = {
-      firstSeq,
-      lastSeq,
-      scrollHeight: view.scrollHeight,
-      scrollTop: view.scrollTop,
-      listOffsetTop,
-    };
-  }, [lines, outputVirtualizer]);
-
   // The first snapshot participates in reading-position restore. Every later
   // snapshot is a deliberate rebase (resnapshot or reconnect), so it restores
   // the live latch and pins the replacement tail before paint.
@@ -576,22 +511,12 @@ function ManagedCommandOutputTileBody(props: {
     scrollToNewest();
   }, [following, lines, resyncPending, scrollToNewest]);
 
-  // A Terminal typography change resizes every row at once, so the geometry
-  // both the follow latch and the prepend correction were measured against is
-  // wrong the moment it lands - and no line arrived to trigger the effects that
-  // normally re-measure. Re-pin before paint instead of leaving the reader
-  // somewhere they did not scroll to.
+  // A Terminal typography change resizes every row at once. Re-pin before
+  // paint instead of leaving a tailing reader somewhere they did not scroll to.
   useLayoutEffect(() => {
     const view = viewRef.current;
     if (view === null) return;
     if (following && !resyncPending) view.scrollTop = view.scrollHeight;
-    anchorRef.current = {
-      firstSeq: anchorRef.current.firstSeq,
-      lastSeq: anchorRef.current.lastSeq,
-      scrollHeight: view.scrollHeight,
-      scrollTop: view.scrollTop,
-      listOffsetTop: outputListRef.current?.offsetTop ?? 0,
-    };
   }, [
     following,
     resyncPending,
@@ -602,15 +527,6 @@ function ManagedCommandOutputTileBody(props: {
   const onScroll = useCallback(() => {
     const view = viewRef.current;
     if (view === null) return;
-    // Keep the anchor honest between renders: the human scrolling is the other
-    // way the measurable geometry changes.
-    anchorRef.current = {
-      firstSeq: anchorRef.current.firstSeq,
-      lastSeq: anchorRef.current.lastSeq,
-      scrollHeight: view.scrollHeight,
-      scrollTop: view.scrollTop,
-      listOffsetTop: outputListRef.current?.offsetTop ?? 0,
-    };
     if (resyncPending) return;
     const distanceFromBottom =
       view.scrollHeight - view.scrollTop - view.clientHeight;
@@ -801,7 +717,6 @@ function ManagedCommandOutputTileBody(props: {
           ) : null}
           {lines.length === 0 ? null : (
             <div
-              ref={outputListRef}
               data-testid="managed-command-output-virtual-list"
               className="relative w-full"
               style={{ height: `${outputVirtualizer.getTotalSize()}px` }}

--- a/clients/gui-app/src/components/epic-canvas/renderers/managed-command-output-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/managed-command-output-tile.tsx
@@ -372,6 +372,13 @@ function ManagedCommandOutputTileBody(props: {
     getItemKey: getOutputRowKey,
     overscan: OUTPUT_VIRTUAL_OVERSCAN,
     initialRect: OUTPUT_VIRTUAL_INITIAL_RECT,
+    // The first snapshot scrolls to an estimated tail. Wrapped rows at that
+    // tail are measured after the scroll and can grow the virtual document;
+    // end anchoring carries that growth into scrollTop so the fresh window
+    // stays live. This does not turn every focus into "jump to live": TanStack
+    // applies the end correction only while the viewport is already at the
+    // end, so a restored reader parked in history keeps their position.
+    anchorTo: "end",
     // Row measurement can land while the follow/prepend layout effects are
     // committing. TanStack's synchronous default calls React `flushSync` from
     // that ResizeObserver path, which React rejects and which turns a burst of


### PR DESCRIPTION
## Summary

- keep a newly opened Monitor/Shell output window anchored at its live tail while virtualized rows receive measured heights
- preserve the existing remembered position when refocusing an output window
- cover the virtualizer end-anchor configuration with the managed-command output test

## Related issue

- None

## Checklist

- [ ] Pre-commit static checks pass (`pre-commit run --all-files` was not run)
- [ ] Separate CI test checks pass (pending CI)
- [x] Tests added/updated where it makes sense
- [x] Commits are signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#developer-certificate-of-origin-dco)

## Validation

- `node node_modules/vitest/vitest.mjs run --config vitest.config.ts src/components/epic-canvas/renderers/__tests__/managed-command-output-tile.test.tsx` � 28 passed