### PR TITLE
fix(gui-app): supersede deferred sticky-scroll end corrections on reader scroll

### DIFF
--- a/clients/gui-app/src/components/chat/__tests__/chat-timeline-follow-latch.test.ts
+++ b/clients/gui-app/src/components/chat/__tests__/chat-timeline-follow-latch.test.ts
@@ -405,6 +405,60 @@ describe("useChatTimelineFollowLatch", () => {
     expect(onFollowIntentChange).toHaveBeenLastCalledWith(false);
   });
 
+  it("supersedes a deferred end correction before its coalesced strict-bottom report", () => {
+    const node = shim.makeNode({
+      scrollTop: 1000,
+      scrollHeight: 1500,
+      clientHeight: 500,
+    });
+    const listRef = makeFakeListRef(node);
+    const onFollowIntentChange = vi.fn();
+    let runDeferredEnd = (): void => undefined;
+    listRef.scrollToEnd.mockImplementation(
+      () =>
+        new Promise<void>(() => {
+          runDeferredEnd = (): void => {
+            shim.setGeometry(node, { scrollTop: 1000 });
+            fireNativeScroll(node);
+          };
+        }),
+    );
+    listRef.scrollToOffset.mockImplementation(({ offset }): Promise<void> => {
+      runDeferredEnd = (): void => undefined;
+      shim.setGeometry(node, { scrollTop: offset });
+      return Promise.resolve();
+    });
+    const { result } = renderHook(() =>
+      useChatTimelineFollowLatch(listRef, true, true, {
+        onFollowIntentChange,
+        onReaderGesture: undefined,
+        isCorrectionSuppressed: undefined,
+        resolveSuppressedEndLanding: undefined,
+      }),
+    );
+
+    shim.setGeometry(node, { scrollTop: 900 });
+    result.current.followEndIfPermitted();
+    expect(listRef.scrollToEnd).toHaveBeenCalledTimes(1);
+
+    // Native scroll delivery is still queued; the compositor has already
+    // parked the reader away from the tail.
+    shim.setGeometry(node, { scrollTop: 467 });
+    node.dispatchEvent(new WheelEvent("wheel", { deltaY: -120 }));
+
+    // If the pending LegendList token is still live, this restores the
+    // strict edge and coalesces as a native strict-bottom report, which
+    // would re-latch follow. Arm-time supersede must cancel it first.
+    runDeferredEnd();
+    fireNativeScroll(node);
+    expect(node.scrollTop).toBe(467);
+    expect(onFollowIntentChange).toHaveBeenLastCalledWith(false);
+
+    shim.setGeometry(node, { scrollHeight: 1700 });
+    result.current.followEndIfPermitted();
+    expect(listRef.scrollToEnd).toHaveBeenCalledTimes(1);
+  });
+
   it("ends a bounded correction burst without inventing reader departure", () => {
     const node = shim.makeNode({
       scrollTop: 1200,

--- a/clients/gui-app/src/components/chat/__tests__/chat-timeline-follow-latch.test.ts
+++ b/clients/gui-app/src/components/chat/__tests__/chat-timeline-follow-latch.test.ts
@@ -207,10 +207,17 @@ const DEFAULT_FOLLOW_LATCH_OPTIONS = {
 interface FakeListRef {
   readonly current: LegendListRef;
   readonly scrollToEnd: Mock<() => Promise<void>>;
+  readonly scrollToOffset: Mock<
+    (params: {
+      readonly offset: number;
+      readonly animated?: boolean;
+    }) => Promise<void>
+  >;
 }
 
 function makeFakeListRef(node: HTMLDivElement): FakeListRef {
   const scrollToEnd = vi.fn((): Promise<void> => Promise.resolve());
+  const scrollToOffset = vi.fn((): Promise<void> => Promise.resolve());
   const current: LegendListRef = {
     clearCaches: notImplemented,
     flashScrollIndicators: notImplemented,
@@ -225,12 +232,12 @@ function makeFakeListRef(node: HTMLDivElement): FakeListRef {
     scrollToEnd,
     scrollToIndex: notImplemented,
     scrollToItem: notImplemented,
-    scrollToOffset: notImplemented,
+    scrollToOffset,
     setItemSize: notImplemented,
     setScrollProcessingEnabled: notImplemented,
     setVisibleContentAnchorOffset: notImplemented,
   };
-  return { current, scrollToEnd };
+  return { current, scrollToEnd, scrollToOffset };
 }
 
 describe("useChatTimelineFollowLatch", () => {
@@ -347,6 +354,55 @@ describe("useChatTimelineFollowLatch", () => {
     shim.setGeometry(node, { scrollHeight: 1800 });
     result.current.followEndIfPermitted();
     expect(listRef.scrollToEnd).toHaveBeenCalledTimes(3);
+  });
+
+  it("supersedes a deferred end correction when the reader scrolls away", () => {
+    const node = shim.makeNode({
+      scrollTop: 1000,
+      scrollHeight: 1500,
+      clientHeight: 500,
+    });
+    const listRef = makeFakeListRef(node);
+    const onFollowIntentChange = vi.fn();
+    let runDeferredEnd = (): void => undefined;
+    listRef.scrollToEnd.mockImplementation(
+      () =>
+        new Promise<void>(() => {
+          runDeferredEnd = (): void => {
+            shim.setGeometry(node, { scrollTop: 1000 });
+            fireNativeScroll(node);
+          };
+        }),
+    );
+    listRef.scrollToOffset.mockImplementation(({ offset }): Promise<void> => {
+      runDeferredEnd = (): void => undefined;
+      shim.setGeometry(node, { scrollTop: offset });
+      return Promise.resolve();
+    });
+    const { result } = renderHook(() =>
+      useChatTimelineFollowLatch(listRef, true, true, {
+        onFollowIntentChange,
+        onReaderGesture: undefined,
+        isCorrectionSuppressed: undefined,
+        resolveSuppressedEndLanding: undefined,
+      }),
+    );
+
+    // LegendList can queue this correction while a data/layout pass settles.
+    shim.setGeometry(node, { scrollTop: 900 });
+    result.current.followEndIfPermitted();
+    expect(listRef.scrollToEnd).toHaveBeenCalledTimes(1);
+    shim.setGeometry(node, { scrollTop: 1000 });
+
+    node.dispatchEvent(new WheelEvent("wheel", { deltaY: -120 }));
+    shim.setGeometry(node, { scrollTop: 467 });
+    fireNativeScroll(node);
+    expect(onFollowIntentChange).toHaveBeenLastCalledWith(false);
+
+    // A stale queued end command must not execute after the reader has parked.
+    runDeferredEnd();
+    expect(node.scrollTop).toBe(467);
+    expect(onFollowIntentChange).toHaveBeenLastCalledWith(false);
   });
 
   it("ends a bounded correction burst without inventing reader departure", () => {

--- a/clients/gui-app/src/components/chat/chat-timeline-follow-latch.ts
+++ b/clients/gui-app/src/components/chat/chat-timeline-follow-latch.ts
@@ -52,7 +52,8 @@ export interface ChatTimelineFollowLatch {
   readonly followEndIfPermitted: () => void;
   /** Explicit controller transition (pill click / navigation fallback). */
   readonly setFollowIntent: (isFollowing: boolean) => void;
-  /** Cancels any app-owned correction before a real reader gesture. */
+  /** Cancels any app-owned correction and supersedes a pending LegendList
+   *  end command before a real reader gesture. */
   readonly noteReaderGesture: (intent: ChatTimelineReaderGestureIntent) => void;
   /** Owns an explicit animated/non-animated "go live" operation. */
   readonly beginOwnedEndNavigation: () => void;
@@ -173,10 +174,12 @@ function canReaderGestureMove(
  *   Its intermediate non-bottom scroll reports cannot revoke permission;
  *   validation reissues after two-frame measurement windows with a bounded
  *   retry budget. Wheel/touch/key/pointer intent cancels ownership before its
- *   scroll report. Scroll direction during an owned correction is never used
- *   as reader-intent evidence because MVCP, ResizeObserver delivery, browser
- *   clamping, and content-inset compensation can all move `scrollTop` in the
- *   opposite direction without reader input.
+ *   scroll report. A movable publishing gesture also supersedes any pending
+ *   LegendList `scrollToEnd` at the live offset so a queued end command cannot
+ *   restore the tail before that report. Scroll direction during an owned
+ *   correction is never used as reader-intent evidence because MVCP,
+ *   ResizeObserver delivery, browser clamping, and content-inset compensation
+ *   can all move `scrollTop` in the opposite direction without reader input.
  * - `followEndIfPermitted` is the one automatic path that turns permission
  *   into an actual scroll. Explicit go-live navigation declares its own
  *   ownership through the same latch and uses the same fresh-DOM authority.
@@ -232,6 +235,23 @@ export function useChatTimelineFollowLatch(
     activeCorrectionRef.current = null;
   }, []);
 
+  const supersedePendingEndCorrection = useCallback(
+    (offset: number): void => {
+      if (pendingEndCorrectionScrollRef.current === null) return;
+      // LegendList queues scrollToEnd behind data/layout readiness and
+      // invalidates that command only when a newer imperative scroll starts.
+      // Clearing retry bookkeeping is not enough: bump the library token with
+      // the reader's live offset so a stale end command cannot restore the
+      // tail after this gesture has already moved scrollTop.
+      pendingEndCorrectionScrollRef.current = null;
+      void listRef.current?.scrollToOffset({
+        offset,
+        animated: false,
+      });
+    },
+    [listRef],
+  );
+
   const setFollowIntent = useCallback(
     (isFollowing: boolean): void => {
       if (!isFollowing) cancelActiveCorrection();
@@ -256,6 +276,10 @@ export function useChatTimelineFollowLatch(
       cancelActiveCorrection();
       const node = listRef.current?.getScrollableNode();
       const geometry = node ? readScrollGeometry(node) : null;
+      const blocksAutomaticCorrection =
+        geometry === null ||
+        !isChatTimelineGeometryMeasurable(geometry) ||
+        canReaderGestureMove(geometry, intent.direction);
       armedReaderDepartureRef.current = intent.publishesReaderPosition
         ? {
             source: "gesture",
@@ -263,10 +287,7 @@ export function useChatTimelineFollowLatch(
             // Unknown/hidden geometry cannot safely prove a no-op. When it is
             // measurable, an edge-directed gesture that cannot move must not
             // strand follow if no native scroll event is emitted.
-            blocksAutomaticCorrection:
-              geometry === null ||
-              !isChatTimelineGeometryMeasurable(geometry) ||
-              canReaderGestureMove(geometry, intent.direction),
+            blocksAutomaticCorrection,
           }
         : null;
       readerEndCandidateRef.current =
@@ -281,9 +302,17 @@ export function useChatTimelineFollowLatch(
               ),
             }
           : null;
+      if (
+        intent.publishesReaderPosition &&
+        blocksAutomaticCorrection &&
+        geometry !== null &&
+        isChatTimelineGeometryMeasurable(geometry)
+      ) {
+        supersedePendingEndCorrection(geometry.scrollTop);
+      }
       onReaderGestureRef.current?.(intent);
     },
-    [cancelActiveCorrection, listRef],
+    [cancelActiveCorrection, listRef, supersedePendingEndCorrection],
   );
 
   const createActiveCorrection = useCallback((): ActiveEndCorrection => {
@@ -477,18 +506,10 @@ export function useChatTimelineFollowLatch(
     if (!permissionRef.current) return;
     const armedDeparture = armedReaderDepartureRef.current;
     if (armedDeparture !== null) {
-      if (
-        armedDeparture.source === "gesture" &&
-        pendingEndCorrectionScrollRef.current !== null
-      ) {
-        // LegendList may still be waiting for data/layout readiness before it
-        // executes an already-issued scrollToEnd. Supersede that stale command
-        // with the reader's landed offset before publishing free-scrolling.
-        pendingEndCorrectionScrollRef.current = null;
-        void listRef.current?.scrollToOffset({
-          offset: geometry.scrollTop,
-          animated: false,
-        });
+      if (armedDeparture.source === "gesture") {
+        // Backstop if arm-time geometry was unmeasurable or a later native
+        // report is the first moment the reader's offset is known.
+        supersedePendingEndCorrection(geometry.scrollTop);
       }
       armedReaderDepartureRef.current = null;
       setFollowIntent(false);
@@ -507,6 +528,7 @@ export function useChatTimelineFollowLatch(
     reconcileStrictBottom,
     setFollowIntent,
     startEndCorrection,
+    supersedePendingEndCorrection,
     tryReattachReader,
   ]);
 

--- a/clients/gui-app/src/components/chat/chat-timeline-follow-latch.ts
+++ b/clients/gui-app/src/components/chat/chat-timeline-follow-latch.ts
@@ -212,6 +212,7 @@ export function useChatTimelineFollowLatch(
   const readerGestureGenerationRef = useRef(0);
   const armedReaderDepartureRef = useRef<ArmedReaderDeparture>(null);
   const activeCorrectionRef = useRef<ActiveEndCorrection | null>(null);
+  const pendingEndCorrectionScrollRef = useRef<Promise<void> | null>(null);
   const readerEndCandidateRef = useRef<ReaderEndCandidate | null>(null);
   const lastTouchClientYRef = useRef<number | null>(null);
 
@@ -345,7 +346,14 @@ export function useChatTimelineFollowLatch(
           return;
         }
         correction.attempts += 1;
-        void list.scrollToEnd({ animated: false });
+        const pendingScroll = list.scrollToEnd({ animated: false });
+        pendingEndCorrectionScrollRef.current = pendingScroll;
+        const clearPendingScroll = (): void => {
+          if (pendingEndCorrectionScrollRef.current === pendingScroll) {
+            pendingEndCorrectionScrollRef.current = null;
+          }
+        };
+        void pendingScroll.then(clearPendingScroll, clearPendingScroll);
         scheduleValidation();
       };
 
@@ -467,7 +475,21 @@ export function useChatTimelineFollowLatch(
     }
     if (tryReattachReader(node, geometry)) return;
     if (!permissionRef.current) return;
-    if (armedReaderDepartureRef.current !== null) {
+    const armedDeparture = armedReaderDepartureRef.current;
+    if (armedDeparture !== null) {
+      if (
+        armedDeparture.source === "gesture" &&
+        pendingEndCorrectionScrollRef.current !== null
+      ) {
+        // LegendList may still be waiting for data/layout readiness before it
+        // executes an already-issued scrollToEnd. Supersede that stale command
+        // with the reader's landed offset before publishing free-scrolling.
+        pendingEndCorrectionScrollRef.current = null;
+        void listRef.current?.scrollToOffset({
+          offset: geometry.scrollTop,
+          animated: false,
+        });
+      }
       armedReaderDepartureRef.current = null;
       setFollowIntent(false);
       return;


### PR DESCRIPTION
## Summary
- track the Promise returned by app-issued LegendList scrollToEnd() corrections
- when a confirmed reader gesture departs, supersede any stale queued command with a non-animated scrollToOffset() at the landed offset before publishing free-scroll

LegendList 3.3.4 can defer scrollToEnd() while data/layout settles. Without this guard, reader input could appear to park and then snap back to the bottom.

## Validation
- pre-commit hooks passed: build, compile, lint, format, whitespace/EOF, large-file, shebang, private-key, line-ending, conflict, and DCO checks
- targeted latch regression and both latch unit/integration suites passed locally (58 tests plus React compiler variants)
- git diff --check passed

Task scope is limited to the follow-latch implementation and its regression test.