### PR TITLE
fix(gui-app): open a freshly-created epic on its create host

### DIFF
--- a/clients/gui-app/src/components/home/__tests__/use-landing-composer-actions.test.tsx
+++ b/clients/gui-app/src/components/home/__tests__/use-landing-composer-actions.test.tsx
@@ -31,6 +31,10 @@ import type { ComposerPromptEditorHandle } from "@/components/chat/composer/comp
 import { createComposerEditorIncarnation } from "@/lib/composer/composer-editor-incarnation";
 import { hostQueryKeys } from "@/lib/query-keys/host-query-keys";
 import { __resetTabNavigationControllerForTesting } from "@/lib/tab-navigation";
+import {
+  sessionCreatedEpicHostId,
+  wasEpicCreatedRecentlyThisSession,
+} from "@/lib/epics/session-created-epics";
 
 const landingMocks = vi.hoisted(() => ({
   request: vi.fn<(method: string, payload: unknown) => Promise<unknown>>(),
@@ -144,6 +148,19 @@ function foldedChatIdFromCreateEpicPayload(payload: unknown): string | null {
   if (!("chatId" in chat)) return null;
   const chatId = chat.chatId;
   return typeof chatId === "string" ? chatId : null;
+}
+
+// Same structural-narrowing shape as the chat-id reader above, for the
+// epic's own id - present on both flows' `epic.create` payload (`chat` is
+// `null` on the terminal-agent flow, but `epic.id` always rides along).
+function epicIdFromCreateEpicPayload(payload: unknown): string | null {
+  if (typeof payload !== "object" || payload === null) return null;
+  if (!("epic" in payload)) return null;
+  const epic = payload.epic;
+  if (typeof epic !== "object" || epic === null) return null;
+  if (!("id" in epic)) return null;
+  const id = epic.id;
+  return typeof id === "string" ? id : null;
 }
 const WORKSPACE_PATH = "/tmp/traycer";
 const DRAFT_WORKSPACE_PATH = "/tmp/draft-workspace";
@@ -2370,6 +2387,140 @@ describe("useLandingComposerActions", () => {
       await waitFor(() => {
         expect(result.current.isPending).toBe(false);
       });
+      queryClient.clear();
+    });
+  });
+
+  // `markEpicCreatedThisSession` fires once before `epic.create` (for the
+  // existence reconciler) and again in each flow's SUCCESS handler, to
+  // re-anchor `CREATE_RACE_WINDOW_MS` (2 minutes) on COMPLETION rather than on
+  // the request. `epic.create` can legitimately hold a 30s host RPC deadline
+  // (longer under retry), so anchoring on the request alone would let a slow
+  // create hand an already-expired seed to the session that opens right after
+  // it - reintroducing the exact NOT_FOUND race this marker exists to
+  // prevent. `Date` is faked (not the timer queue) so the clock is fully
+  // controllable while `waitFor`'s own real-timer polling - and every
+  // TanStack Query internal `setTimeout(0)` hop the mutation pipeline relies
+  // on - keeps working unmodified.
+  describe("create-race window re-anchoring on completion", () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("keeps the create-race window open 90s after a GUI-chat create resolves, even though the request itself took 60s", async () => {
+      vi.useFakeTimers({ toFake: ["Date"] });
+      setSingleWorkspace();
+      const createGate = deferred<unknown>();
+      landingMocks.request.mockImplementation((method) =>
+        method === "epic.create" ? createGate.promise : Promise.resolve({}),
+      );
+      const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false, gcTime: 0 } },
+      });
+      const { result } = renderHook(
+        () => useLandingComposerActions(useTestPlacementTarget()),
+        { wrapper: queryClientWrapper(queryClient) },
+      );
+
+      act(() => {
+        result.current.submit({
+          draftId: null,
+          editor: editorHandleForPrompt(SUBMITTED_PROMPT),
+          slashCatalog: null,
+          toolbar: defaultToolbar(),
+        });
+      });
+
+      await waitFor(() => {
+        expect(
+          landingMocks.request.mock.calls.some((c) => c[0] === "epic.create"),
+        ).toBe(true);
+      });
+      const createEpicCall = landingMocks.request.mock.calls.find(
+        (c) => c[0] === "epic.create",
+      );
+      const epicId = epicIdFromCreateEpicPayload(createEpicCall?.[1]);
+      if (epicId === null) throw new Error("expected an epic id");
+
+      // The request is still pending - advance 60s before it resolves.
+      vi.advanceTimersByTime(60_000);
+
+      await act(async () => {
+        createGate.resolve({ roomInfo: null });
+        await createGate.promise;
+      });
+      await waitFor(() => {
+        expect(useEpicCanvasStore.getState().openTabOrder).toHaveLength(1);
+      });
+
+      // 90s after completion - 150s after the request, past the 2-minute
+      // window if it were still anchored there. Only the success handler's
+      // re-anchor keeps this seed alive.
+      vi.advanceTimersByTime(90_000);
+
+      expect(sessionCreatedEpicHostId(epicId)).toBe(TEST_HOST_ID);
+      expect(wasEpicCreatedRecentlyThisSession(epicId)).toBe(true);
+
+      queryClient.clear();
+    });
+
+    it("keeps the create-race window open 90s after a terminal-agent create resolves, even though the request itself took 60s", async () => {
+      vi.useFakeTimers({ toFake: ["Date"] });
+      const createGate = deferred<unknown>();
+      landingMocks.request.mockImplementation((method) =>
+        method === "epic.create" ? createGate.promise : Promise.resolve({}),
+      );
+      const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false, gcTime: 0 } },
+      });
+      const { result } = renderHook(
+        () => useLandingComposerActions(useTestPlacementTarget()),
+        { wrapper: queryClientWrapper(queryClient) },
+      );
+
+      act(() => {
+        result.current.selectTerminalAgent(
+          {
+            harnessId: "claude",
+            model: null,
+            reasoningEffort: null,
+            terminalAgentArgs: "",
+            profileId: null,
+          },
+          null,
+        );
+      });
+
+      await waitFor(() => {
+        expect(
+          landingMocks.request.mock.calls.some((c) => c[0] === "epic.create"),
+        ).toBe(true);
+      });
+      const createEpicCall = landingMocks.request.mock.calls.find(
+        (c) => c[0] === "epic.create",
+      );
+      const epicId = epicIdFromCreateEpicPayload(createEpicCall?.[1]);
+      if (epicId === null) throw new Error("expected an epic id");
+
+      // The request is still pending - advance 60s before it resolves.
+      vi.advanceTimersByTime(60_000);
+
+      await act(async () => {
+        createGate.resolve({ roomInfo: null });
+        await createGate.promise;
+      });
+      await waitFor(() => {
+        expect(landingMocks.createTerminalAgent).toHaveBeenCalledTimes(1);
+      });
+
+      // 90s after completion - 150s after the request, past the 2-minute
+      // window if it were still anchored there. Only the success handler's
+      // re-anchor keeps this seed alive.
+      vi.advanceTimersByTime(90_000);
+
+      expect(sessionCreatedEpicHostId(epicId)).toBe(TEST_HOST_ID);
+      expect(wasEpicCreatedRecentlyThisSession(epicId)).toBe(true);
+
       queryClient.clear();
     });
   });

--- a/clients/gui-app/src/components/home/__tests__/use-landing-composer-actions.test.tsx
+++ b/clients/gui-app/src/components/home/__tests__/use-landing-composer-actions.test.tsx
@@ -3,6 +3,7 @@ import type { LandingPlacementTarget } from "@/lib/composer/landing-placement";
 import { useHostClient } from "@/lib/host";
 import { epicDisplayTitle } from "@/lib/display-title";
 import { createEpicName } from "@/lib/epic-name";
+import { useAuthStore } from "@/stores/auth/auth-store";
 import { useComposerRunSettingsStore } from "@/stores/composer/composer-run-settings-store";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 import { useInitialChatHandoffStore } from "@/stores/epics/initial-chat-handoff-store";
@@ -32,8 +33,10 @@ import { createComposerEditorIncarnation } from "@/lib/composer/composer-editor-
 import { hostQueryKeys } from "@/lib/query-keys/host-query-keys";
 import { __resetTabNavigationControllerForTesting } from "@/lib/tab-navigation";
 import {
+  clearSessionCreatedEpics,
   sessionCreatedEpicHostId,
   wasEpicCreatedRecentlyThisSession,
+  wasEpicCreatedThisSession,
 } from "@/lib/epics/session-created-epics";
 
 const landingMocks = vi.hoisted(() => ({
@@ -2521,6 +2524,84 @@ describe("useLandingComposerActions", () => {
       expect(sessionCreatedEpicHostId(epicId)).toBe(TEST_HOST_ID);
       expect(wasEpicCreatedRecentlyThisSession(epicId)).toBe(true);
 
+      queryClient.clear();
+    });
+
+    it("does not restore the create marker when the identity changed while the create was in flight", async () => {
+      useAuthStore.getState().setSignedIn(
+        {
+          userId: "user-initial",
+          userName: "Initial User",
+          email: "initial@example.com",
+        },
+        { userId: "user-initial", username: "initial" },
+        [],
+      );
+      const createGate = deferred<unknown>();
+      landingMocks.request.mockImplementation((method) =>
+        method === "epic.create" ? createGate.promise : Promise.resolve({}),
+      );
+      const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false, gcTime: 0 } },
+      });
+      const { result } = renderHook(
+        () => useLandingComposerActions(useTestPlacementTarget()),
+        { wrapper: queryClientWrapper(queryClient) },
+      );
+
+      act(() => {
+        result.current.selectTerminalAgent(
+          {
+            harnessId: "claude",
+            model: null,
+            reasoningEffort: null,
+            terminalAgentArgs: "",
+            profileId: null,
+          },
+          null,
+        );
+      });
+
+      await waitFor(() => {
+        expect(
+          landingMocks.request.mock.calls.some((c) => c[0] === "epic.create"),
+        ).toBe(true);
+      });
+      const createEpicCall = landingMocks.request.mock.calls.find(
+        (c) => c[0] === "epic.create",
+      );
+      const epicId = epicIdFromCreateEpicPayload(createEpicCall?.[1]);
+      if (epicId === null) throw new Error("expected an epic id");
+
+      // The identity transition `auth-lifecycle-bridge` performs on
+      // sign-out / user-switch: swap in a DIFFERENT user and clear the
+      // session-created-epics markers, while the create is still in flight.
+      useAuthStore.getState().setSignedIn(
+        {
+          userId: "user-different",
+          userName: "Different User",
+          email: "different@example.com",
+        },
+        { userId: "user-different", username: "different" },
+        [],
+      );
+      clearSessionCreatedEpics();
+
+      await act(async () => {
+        createGate.resolve({ roomInfo: null });
+        await createGate.promise;
+      });
+      await waitFor(() => {
+        expect(landingMocks.createTerminalAgent).toHaveBeenCalledTimes(1);
+      });
+
+      // The completion re-anchor must not restore the marker for the
+      // OUTGOING account: the dispatching identity no longer matches the
+      // identity live at completion.
+      expect(sessionCreatedEpicHostId(epicId)).toBeNull();
+      expect(wasEpicCreatedThisSession(epicId)).toBe(false);
+
+      useAuthStore.getState().setSignedOut();
       queryClient.clear();
     });
   });

--- a/clients/gui-app/src/components/home/hooks/use-landing-composer-actions.ts
+++ b/clients/gui-app/src/components/home/hooks/use-landing-composer-actions.ts
@@ -467,8 +467,11 @@ export function useLandingComposerActions(
         return;
       }
       // Mark before the one-shot create request so the existence reconciler
-      // cannot prune the result while `epic.listTasks` still lags it.
-      markEpicCreatedThisSession(epicId);
+      // cannot prune the result while `epic.listTasks` still lags it. The
+      // create host rides along so the epic session opens against the machine
+      // that holds the local-first warm slot - any other host cold-opens into
+      // a cloud NOT_FOUND until the create host's background connect lands.
+      markEpicCreatedThisSession(epicId, activeHostId);
 
       void createLandingEpic({
         epicId,
@@ -731,7 +734,10 @@ export function useLandingComposerActions(
       // Terminal-agent create registers no initial-chat handoff, so this
       // synchronous marker is what keeps the existence reconciler from
       // force-closing the tab before `epic.listTasks` reflects the new epic.
-      markEpicCreatedThisSession(epicId);
+      // The create host rides along for session placement; this flow
+      // navigates BEFORE the host round-trip, so the session provider mounts
+      // while only the create host can ever serve the epic.
+      markEpicCreatedThisSession(epicId, hostId);
       const replaced =
         workspaceContext.draftId === null
           ? null

--- a/clients/gui-app/src/components/home/hooks/use-landing-composer-actions.ts
+++ b/clients/gui-app/src/components/home/hooks/use-landing-composer-actions.ts
@@ -503,6 +503,12 @@ export function useLandingComposerActions(
           // The server accepted the exact staged worktree intent. Failed
           // preparation and rejected create paths leave it intact for retry.
           clearConsumedLandingWorktreeIntent(workspaceContext);
+          // Re-anchor the create-race window on COMPLETION - see the terminal
+          // flow's copy for why. This flow needs it most: the tab is opened
+          // below, INSIDE this handler, so a create slower than the window
+          // would hand the session an already-expired seed and open it on the
+          // effective host - the exact race this marker exists to prevent.
+          markEpicCreatedThisSession(epicId, activeHostId);
           // The host already kicked the provider turn from `initialMessage`;
           // jump the handoff straight to `sending` so the driver does not
           // re-send. (Re-sends are harmless - the host dedupes on
@@ -788,6 +794,14 @@ export function useLandingComposerActions(
             // This staged selection now belongs to a successfully-created
             // epic. Until this point a retry must see the exact same intent.
             clearConsumedLandingWorktreeIntent(workspaceContext);
+            // Re-anchor the create-race window on COMPLETION. The marker
+            // above is written before the request because the reconciler
+            // needs it that early, but the race it bounds - the host's
+            // deferred cloud connect - only starts now, and `epic.create`
+            // can legitimately hold a 30s host-side deadline before landing.
+            // Measured from the request instead, a slow create burns its own
+            // window and the session it protects opens unprotected.
+            markEpicCreatedThisSession(epicId, hostId);
             return terminalAgentCreateFn({
               epicId,
               tabId,

--- a/clients/gui-app/src/components/home/hooks/use-landing-composer-actions.ts
+++ b/clients/gui-app/src/components/home/hooks/use-landing-composer-actions.ts
@@ -725,6 +725,13 @@ export function useLandingComposerActions(
       const epicId = uuidv4();
       const now = Date.now();
       rememberLandingWorktreeIntent(workspaceContext, epicId, now);
+      // The identity this create belongs to, captured synchronously. The
+      // create's continuation outlives this component, and the completion
+      // re-anchor below is an INSERT into account-scoped memory - see its own
+      // comment for why that has to be checked. `dispatchSubmission` needs no
+      // equivalent capture: its retired-settlement early return already turns
+      // the whole continuation back on an identity teardown.
+      const dispatchUserId = useAuthStore.getState().profile?.userId ?? null;
       // Stored untitled; the title is generated from the first terminal prompt,
       // and render surfaces fall back via `epicDisplayTitle` meanwhile. (The
       // tui-agent tile is named separately in `use-create-tui-agent.ts`.)
@@ -801,7 +808,20 @@ export function useLandingComposerActions(
             // can legitimately hold a 30s host-side deadline before landing.
             // Measured from the request instead, a slow create burns its own
             // window and the session it protects opens unprotected.
-            markEpicCreatedThisSession(epicId, hostId);
+            //
+            // Only for the identity that dispatched it. These markers are
+            // account-scoped, and `auth-lifecycle-bridge` clears them on
+            // sign-out/user-switch precisely so the NEXT identity's persisted
+            // tabs reconcile normally. This continuation survives that
+            // teardown, so an unguarded re-mark would restore the outgoing
+            // account's host seed and reconciliation exemption for an epic id
+            // the incoming account may also have a tab for.
+            if (
+              (useAuthStore.getState().profile?.userId ?? null) ===
+              dispatchUserId
+            ) {
+              markEpicCreatedThisSession(epicId, hostId);
+            }
             return terminalAgentCreateFn({
               epicId,
               tabId,

--- a/clients/gui-app/src/lib/epics/__tests__/session-created-epics.test.ts
+++ b/clients/gui-app/src/lib/epics/__tests__/session-created-epics.test.ts
@@ -4,6 +4,7 @@ import {
   markEpicCreatedThisSession,
   sessionCreatedEpicHostId,
   unmarkEpicCreatedThisSession,
+  wasEpicCreatedRecentlyThisSession,
   wasEpicCreatedThisSession,
 } from "@/lib/epics/session-created-epics";
 
@@ -70,6 +71,40 @@ describe("session-created-epics", () => {
   it("unmarkEpicCreatedThisSession on an epic not recorded is a no-op", () => {
     expect(() => unmarkEpicCreatedThisSession("never-recorded")).not.toThrow();
     expect(wasEpicCreatedThisSession("never-recorded")).toBe(false);
+  });
+
+  it("wasEpicCreatedRecentlyThisSession is true immediately after marking, and still true just inside the create-race window", () => {
+    vi.useFakeTimers();
+    markEpicCreatedThisSession("epic-1", "host-a");
+
+    expect(wasEpicCreatedRecentlyThisSession("epic-1")).toBe(true);
+
+    // Just short of the TTL boundary (`< TTL`, not `<=`), mirroring the
+    // `sessionCreatedEpicHostId` "does not expire short of the TTL" test
+    // above - this is the create-race grace's own window, read through its
+    // own accessor.
+    vi.advanceTimersByTime(2 * 60 * 1000 - 1);
+
+    expect(wasEpicCreatedRecentlyThisSession("epic-1")).toBe(true);
+  });
+
+  it("wasEpicCreatedRecentlyThisSession goes false once the create-race window elapses, while wasEpicCreatedThisSession stays true", () => {
+    vi.useFakeTimers();
+    markEpicCreatedThisSession("epic-1", "host-a");
+
+    // Just past the TTL boundary (`> TTL`, not `>=`).
+    vi.advanceTimersByTime(2 * 60 * 1000 + 1);
+
+    expect(wasEpicCreatedRecentlyThisSession("epic-1")).toBe(false);
+    // The contrast is the point: the access coordinator's create-race grace
+    // must stop trusting this epic's "just created" story, while the
+    // existence reconciler's session-lifetime fact - "did THIS renderer
+    // create it at all" - is never TTL-gated and must still read true.
+    expect(wasEpicCreatedThisSession("epic-1")).toBe(true);
+  });
+
+  it("wasEpicCreatedRecentlyThisSession answers false for an epic that was never recorded", () => {
+    expect(wasEpicCreatedRecentlyThisSession("unknown-epic")).toBe(false);
   });
 
   it("clearSessionCreatedEpics clears every recorded entry's answers", () => {

--- a/clients/gui-app/src/lib/epics/__tests__/session-created-epics.test.ts
+++ b/clients/gui-app/src/lib/epics/__tests__/session-created-epics.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearSessionCreatedEpics,
+  markEpicCreatedThisSession,
+  sessionCreatedEpicHostId,
+  unmarkEpicCreatedThisSession,
+  wasEpicCreatedThisSession,
+} from "@/lib/epics/session-created-epics";
+
+// `sessionCreatedEpics` is a module-scoped Map with no eviction other than the
+// explicit clears below - every test must start and end from an empty map or
+// an entry from one test leaks into the next.
+describe("session-created-epics", () => {
+  beforeEach(() => {
+    clearSessionCreatedEpics();
+  });
+
+  afterEach(() => {
+    clearSessionCreatedEpics();
+    vi.useRealTimers();
+  });
+
+  it("records the create host and answers both accessors for it", () => {
+    markEpicCreatedThisSession("epic-1", "host-a");
+
+    expect(sessionCreatedEpicHostId("epic-1")).toBe("host-a");
+    expect(wasEpicCreatedThisSession("epic-1")).toBe(true);
+  });
+
+  it("expires the host-id seed after the 2-minute TTL but keeps the session-lifetime fact", () => {
+    vi.useFakeTimers();
+    markEpicCreatedThisSession("epic-1", "host-a");
+
+    // Just past the TTL boundary (`> TTL`, not `>=`), so this proves the seed
+    // is actually gone rather than landing on an off-by-one that happens to
+    // still read as expired.
+    vi.advanceTimersByTime(2 * 60 * 1000 + 1);
+
+    expect(sessionCreatedEpicHostId("epic-1")).toBeNull();
+    // `wasEpicCreatedThisSession` is deliberately NOT TTL-gated - the
+    // existence reconciler and the access-coordinator's NOT_FOUND grace need
+    // the session-lifetime fact, not the placement seed.
+    expect(wasEpicCreatedThisSession("epic-1")).toBe(true);
+  });
+
+  it("does not expire the seed short of the TTL", () => {
+    vi.useFakeTimers();
+    markEpicCreatedThisSession("epic-1", "host-a");
+
+    vi.advanceTimersByTime(2 * 60 * 1000 - 1);
+
+    expect(sessionCreatedEpicHostId("epic-1")).toBe("host-a");
+    expect(wasEpicCreatedThisSession("epic-1")).toBe(true);
+  });
+
+  it("answers null/false for an epic that was never recorded", () => {
+    expect(sessionCreatedEpicHostId("unknown-epic")).toBeNull();
+    expect(wasEpicCreatedThisSession("unknown-epic")).toBe(false);
+  });
+
+  it("unmarkEpicCreatedThisSession clears a single entry's answers", () => {
+    markEpicCreatedThisSession("epic-1", "host-a");
+
+    unmarkEpicCreatedThisSession("epic-1");
+
+    expect(sessionCreatedEpicHostId("epic-1")).toBeNull();
+    expect(wasEpicCreatedThisSession("epic-1")).toBe(false);
+  });
+
+  it("unmarkEpicCreatedThisSession on an epic not recorded is a no-op", () => {
+    expect(() => unmarkEpicCreatedThisSession("never-recorded")).not.toThrow();
+    expect(wasEpicCreatedThisSession("never-recorded")).toBe(false);
+  });
+
+  it("clearSessionCreatedEpics clears every recorded entry's answers", () => {
+    markEpicCreatedThisSession("epic-1", "host-a");
+    markEpicCreatedThisSession("epic-2", "host-b");
+
+    clearSessionCreatedEpics();
+
+    expect(sessionCreatedEpicHostId("epic-1")).toBeNull();
+    expect(wasEpicCreatedThisSession("epic-1")).toBe(false);
+    expect(sessionCreatedEpicHostId("epic-2")).toBeNull();
+    expect(wasEpicCreatedThisSession("epic-2")).toBe(false);
+  });
+});

--- a/clients/gui-app/src/lib/epics/session-created-epics.ts
+++ b/clients/gui-app/src/lib/epics/session-created-epics.ts
@@ -1,10 +1,10 @@
 /**
  * Epic ids created from the start-page landing composer during the CURRENT app
- * session - both the GUI-chat flow and the terminal-agent flow. Written
- * synchronously at create time (before navigation, before the epic-tab
- * existence reconciler can seed a run), so a freshly-created epic is never
- * force-closed during the window where `epic.listTasks` still lags
- * `epic.create`.
+ * session - both the GUI-chat flow and the terminal-agent flow - each with the
+ * host the create was sent on. Written synchronously at create time (before
+ * navigation, before the epic-tab existence reconciler can seed a run), so a
+ * freshly-created epic is never force-closed during the window where
+ * `epic.listTasks` still lags `epic.create`.
  *
  * An epic created this session is by definition NOT a stale persisted tab from
  * a prior session, which is the only thing the existence reconciler should
@@ -15,14 +15,46 @@
  * claim) - so this synchronous marker is the deterministic guard both flows
  * share.
  *
- * Entries are cheap (a uuid string, bounded by how many epics a user creates in
- * one session), so there is no eviction. Cleared on sign-out / user-switch via
- * `clearSessionCreatedEpics` so a new identity starts fresh.
+ * The HOST is recorded because `epic.create` is local-first ON THAT HOST: the
+ * create host seeds a warm in-memory slot and writes the cloud record only in
+ * a deferred background connect. Until that connect lands, the create host is
+ * the ONLY machine that can serve the epic - any other host cold-opens, asks
+ * the cloud, and gets an adjudicated-looking NOT_FOUND for an epic that
+ * provably exists. `sessionCreatedEpicHostId` is what lets the session open
+ * against the create host instead.
+ *
+ * Entries are cheap (a uuid string + host id, bounded by how many epics a user
+ * creates in one session), so there is no eviction. Cleared on sign-out /
+ * user-switch via `clearSessionCreatedEpics` so a new identity starts fresh.
  */
-const sessionCreatedEpicIds = new Set<string>();
 
-export function markEpicCreatedThisSession(epicId: string): void {
-  sessionCreatedEpicIds.add(epicId);
+interface SessionCreatedEpicEntry {
+  readonly hostId: string;
+  readonly recordedAt: number;
+}
+
+const sessionCreatedEpics = new Map<string, SessionCreatedEpicEntry>();
+
+/**
+ * How long the create host stays the SEED for a new epic session's placement.
+ *
+ * The race this seed closes lasts only until the create host's background
+ * cloud connect lands (seconds; a minute-plus only when that host is retrying
+ * with backoff). Past this window the cloud record exists and the ordinary
+ * rule - the epic session follows the app-wide effective host - is the right
+ * one again, so the seed expires rather than pinning every self-created epic
+ * to its create host for the whole app session. `wasEpicCreatedThisSession`
+ * deliberately does NOT expire: the existence reconciler and the access
+ * coordinator's NOT_FOUND grace need the session-lifetime fact, not the
+ * placement seed.
+ */
+const CREATE_HOST_SEED_TTL_MS = 2 * 60 * 1000;
+
+export function markEpicCreatedThisSession(
+  epicId: string,
+  hostId: string,
+): void {
+  sessionCreatedEpics.set(epicId, { hostId, recordedAt: Date.now() });
 }
 
 /**
@@ -30,13 +62,26 @@ export function markEpicCreatedThisSession(epicId: string): void {
  * never landed on the host is no longer exempt from existence reconciliation.
  */
 export function unmarkEpicCreatedThisSession(epicId: string): void {
-  sessionCreatedEpicIds.delete(epicId);
+  sessionCreatedEpics.delete(epicId);
 }
 
 export function wasEpicCreatedThisSession(epicId: string): boolean {
-  return sessionCreatedEpicIds.has(epicId);
+  return sessionCreatedEpics.has(epicId);
+}
+
+/**
+ * The host a just-created epic should open its session on, or `null` once the
+ * create-host seed has expired (or was never recorded). See
+ * {@link CREATE_HOST_SEED_TTL_MS} for why this answer is time-bounded while
+ * {@link wasEpicCreatedThisSession} is not.
+ */
+export function sessionCreatedEpicHostId(epicId: string): string | null {
+  const entry = sessionCreatedEpics.get(epicId);
+  if (entry === undefined) return null;
+  if (Date.now() - entry.recordedAt > CREATE_HOST_SEED_TTL_MS) return null;
+  return entry.hostId;
 }
 
 export function clearSessionCreatedEpics(): void {
-  sessionCreatedEpicIds.clear();
+  sessionCreatedEpics.clear();
 }

--- a/clients/gui-app/src/lib/epics/session-created-epics.ts
+++ b/clients/gui-app/src/lib/epics/session-created-epics.ts
@@ -36,19 +36,31 @@ interface SessionCreatedEpicEntry {
 const sessionCreatedEpics = new Map<string, SessionCreatedEpicEntry>();
 
 /**
- * How long the create host stays the SEED for a new epic session's placement.
+ * How long a create is still RACING its own cloud record - the window both
+ * consumers of the create host are scoped to.
  *
- * The race this seed closes lasts only until the create host's background
- * cloud connect lands (seconds; a minute-plus only when that host is retrying
- * with backoff). Past this window the cloud record exists and the ordinary
- * rule - the epic session follows the app-wide effective host - is the right
- * one again, so the seed expires rather than pinning every self-created epic
- * to its create host for the whole app session. `wasEpicCreatedThisSession`
- * deliberately does NOT expire: the existence reconciler and the access
- * coordinator's NOT_FOUND grace need the session-lifetime fact, not the
- * placement seed.
+ * The race lasts only until the create host's background cloud connect lands
+ * (seconds; a minute-plus only when that host is retrying with backoff). Past
+ * it the cloud record exists, so a NOT_FOUND means what it says and the
+ * ordinary rule - the epic session follows the app-wide effective host - is
+ * right again.
+ *
+ * Both layers read the window through this one constant, deliberately:
+ * {@link sessionCreatedEpicHostId} for session placement, and the access
+ * coordinator's silent-retry grace through
+ * {@link wasEpicCreatedRecentlyThisSession}. Scoping the grace to the SESSION
+ * instead would let a transient NOT_FOUND hours later trigger a destructive
+ * `requestFreshSnapshot` on an epic that has since accumulated real work.
+ *
+ * {@link wasEpicCreatedThisSession} is the odd one out and does NOT expire:
+ * the existence reconciler asks whether this renderer created the epic at
+ * all, which is a fact about the session, not about the race.
  */
-const CREATE_HOST_SEED_TTL_MS = 2 * 60 * 1000;
+const CREATE_RACE_WINDOW_MS = 2 * 60 * 1000;
+
+function isWithinCreateRaceWindow(entry: SessionCreatedEpicEntry): boolean {
+  return Date.now() - entry.recordedAt <= CREATE_RACE_WINDOW_MS;
+}
 
 export function markEpicCreatedThisSession(
   epicId: string,
@@ -70,15 +82,27 @@ export function wasEpicCreatedThisSession(epicId: string): boolean {
 }
 
 /**
+ * Whether this renderer created the epic and the create is still racing its
+ * own cloud record - the only window in which an absence may be read as lag
+ * rather than as the delete the code says it is. See
+ * {@link CREATE_RACE_WINDOW_MS}.
+ */
+export function wasEpicCreatedRecentlyThisSession(epicId: string): boolean {
+  const entry = sessionCreatedEpics.get(epicId);
+  if (entry === undefined) return false;
+  return isWithinCreateRaceWindow(entry);
+}
+
+/**
  * The host a just-created epic should open its session on, or `null` once the
- * create-host seed has expired (or was never recorded). See
- * {@link CREATE_HOST_SEED_TTL_MS} for why this answer is time-bounded while
+ * create race is over (or the epic was not created here). See
+ * {@link CREATE_RACE_WINDOW_MS} for why this answer is time-bounded while
  * {@link wasEpicCreatedThisSession} is not.
  */
 export function sessionCreatedEpicHostId(epicId: string): string | null {
   const entry = sessionCreatedEpics.get(epicId);
   if (entry === undefined) return null;
-  if (Date.now() - entry.recordedAt > CREATE_HOST_SEED_TTL_MS) return null;
+  if (!isWithinCreateRaceWindow(entry)) return null;
   return entry.hostId;
 }
 

--- a/clients/gui-app/src/lib/epics/session-created-epics.ts
+++ b/clients/gui-app/src/lib/epics/session-created-epics.ts
@@ -62,6 +62,29 @@ function isWithinCreateRaceWindow(entry: SessionCreatedEpicEntry): boolean {
   return Date.now() - entry.recordedAt <= CREATE_RACE_WINDOW_MS;
 }
 
+/**
+ * The access coordinator's silent re-subscribe schedule for an `unavailable`
+ * (cloud `NOT_FOUND`) verdict on an epic still inside the window above - each
+ * entry the delay before one `requestFreshSnapshot`, the eject running only
+ * once the last one is spent.
+ *
+ * It lives here, beside the window it serves, rather than in the coordinator:
+ * that is a component module, and a constant exported from one breaks Fast
+ * Refresh (`react/only-export-components`). Co-locating also keeps the two
+ * create-race timings legible against each other.
+ *
+ * The TOTAL is what matters, and it is sized to outlast a create that is
+ * STILL IN FLIGHT rather than to look tidy. The terminal-agent flow opens its
+ * tab before the `epic.create` round-trip, so this schedule can be spent
+ * while the create has not returned - and the host's own RPC deadline is 30s
+ * (`ws-rpc-client.ts`), so a shorter schedule ejects a tab whose epic was
+ * still legitimately being created, leaving it in history only: the very bug
+ * the grace exists to prevent. 62s covers that deadline with margin.
+ */
+export const CREATED_EPIC_UNAVAILABLE_RETRY_DELAYS_MS: ReadonlyArray<number> = [
+  2_000, 5_000, 10_000, 15_000, 30_000,
+];
+
 export function markEpicCreatedThisSession(
   epicId: string,
   hostId: string,

--- a/clients/gui-app/src/providers/__tests__/epic-access-coordinator.test.tsx
+++ b/clients/gui-app/src/providers/__tests__/epic-access-coordinator.test.tsx
@@ -21,6 +21,7 @@ import {
 import { DELETED_EPIC_NOTIFICATION_STORAGE_KEY } from "@/lib/epics/deleted-epic-events";
 import {
   clearSessionCreatedEpics,
+  CREATED_EPIC_UNAVAILABLE_RETRY_DELAYS_MS,
   markEpicCreatedThisSession,
 } from "@/lib/epics/session-created-epics";
 import {
@@ -611,7 +612,7 @@ describe("EpicAccessCoordinator", () => {
     }
   });
 
-  it("ejects a created-this-session epic once all 3 grace retries are spent and 'unavailable' lands again", async () => {
+  it("ejects a created-this-session epic once every grace retry is spent and 'unavailable' lands again", async () => {
     vi.useFakeTimers();
     try {
       markEpicCreatedThisSession("epic-1", "host-x");
@@ -632,19 +633,9 @@ describe("EpicAccessCoordinator", () => {
         await Promise.resolve();
       });
 
-      // Attempt 1: fires at +2s, then the retry's own failure re-arrives.
-      act(() => {
-        handle.store.setState({ snapshotFetchError: unavailableError });
-      });
-      await act(async () => {
-        await Promise.resolve();
-      });
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(2_000);
-      });
-      expect(requestFreshSnapshotSpy).toHaveBeenCalledTimes(1);
-      // `requestFreshSnapshot` resets `snapshotFetchError` to null; simulate
-      // the retry itself failing the same way the real reconnect would.
+      // Driven by the PRODUCTION schedule rather than a copy of it: this test
+      // asserts "every slot, then eject", and hardcoding the delays here made
+      // that claim silently wrong the moment the schedule was resized.
       act(() => {
         handle.store.setState({ snapshotFetchError: unavailableError });
       });
@@ -652,33 +643,26 @@ describe("EpicAccessCoordinator", () => {
         await Promise.resolve();
       });
 
-      // Attempt 2: fires at +5s.
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(5_000);
-      });
-      expect(requestFreshSnapshotSpy).toHaveBeenCalledTimes(2);
-      act(() => {
-        handle.store.setState({ snapshotFetchError: unavailableError });
-      });
-      await act(async () => {
-        await Promise.resolve();
-      });
-
-      // Attempt 3: fires at +10s. The budget is now spent.
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(10_000);
-      });
-      expect(requestFreshSnapshotSpy).toHaveBeenCalledTimes(3);
-      expect(useEpicCanvasStore.getState().openTabOrder).toEqual(["tab-1"]);
-      expect(toastInfo).not.toHaveBeenCalled();
-
-      // The 3rd retry's own failure signal - no slot left, so this one ejects.
-      act(() => {
-        handle.store.setState({ snapshotFetchError: unavailableError });
-      });
-      await act(async () => {
-        await Promise.resolve();
-      });
+      let attempt = 0;
+      for (const delay of CREATED_EPIC_UNAVAILABLE_RETRY_DELAYS_MS) {
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(delay);
+        });
+        attempt += 1;
+        expect(requestFreshSnapshotSpy).toHaveBeenCalledTimes(attempt);
+        // Still open: a spent slot is not a verdict.
+        expect(useEpicCanvasStore.getState().openTabOrder).toEqual(["tab-1"]);
+        expect(toastInfo).not.toHaveBeenCalled();
+        // `requestFreshSnapshot` resets `snapshotFetchError` to null; simulate
+        // the retry itself failing the same way the real reconnect would, so
+        // the next slot is taken by a genuine re-arrival.
+        act(() => {
+          handle.store.setState({ snapshotFetchError: unavailableError });
+        });
+        await act(async () => {
+          await Promise.resolve();
+        });
+      }
 
       expect(useEpicCanvasStore.getState().openTabOrder).toEqual([]);
       expect(router.state.location.pathname).toBe("/");
@@ -686,8 +670,10 @@ describe("EpicAccessCoordinator", () => {
         expect.stringContaining("no longer available"),
         { id: "epic-access:epic-1", cancel: null },
       );
-      // No 4th retry was scheduled - the eject ran instead.
-      expect(requestFreshSnapshotSpy).toHaveBeenCalledTimes(3);
+      // No retry beyond the schedule was scheduled - the eject ran instead.
+      expect(requestFreshSnapshotSpy).toHaveBeenCalledTimes(
+        CREATED_EPIC_UNAVAILABLE_RETRY_DELAYS_MS.length,
+      );
     } finally {
       vi.useRealTimers();
     }

--- a/clients/gui-app/src/providers/__tests__/epic-access-coordinator.test.tsx
+++ b/clients/gui-app/src/providers/__tests__/epic-access-coordinator.test.tsx
@@ -716,6 +716,183 @@ describe("EpicAccessCoordinator", () => {
       cancel: null,
     });
   });
+
+  it("does not grace an epic created outside the create-race window", async () => {
+    vi.useFakeTimers();
+    try {
+      markEpicCreatedThisSession("epic-1", "host-x");
+      const handle = registerSession("epic-1");
+      // Freshly built, so this cannot be mistaken for the dirty-replica guard
+      // below - the eject here must be explained purely by the window having
+      // elapsed.
+      handle.store.setState({ isDirty: false, unsyncedQueueSize: 0 });
+      seedTabs(
+        [{ tabId: "tab-1", epicId: "epic-1", name: "Epic One" }],
+        "tab-1",
+      );
+      const requestFreshSnapshotSpy = vi.spyOn(handle, "requestFreshSnapshot");
+
+      const { router } = renderCoordinatorAt("/epics/epic-1/tab-1");
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(router.state.location.pathname).toBe("/epics/epic-1/tab-1");
+
+      // Past the 2-minute create-race window - a NOT_FOUND now means what it
+      // says, so this must NOT get the silent-retry grace the tests above
+      // exercise for a genuinely fresh create.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2 * 60 * 1000 + 1);
+      });
+
+      act(() => {
+        handle.store.setState({
+          snapshotFetchError: {
+            code: "NOT_FOUND",
+            message: "room lookup is unavailable",
+            upgradeGuidance: null,
+          },
+        });
+      });
+      // Flush the `evaluate` microtask the store subscription queues.
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(useEpicCanvasStore.getState().openTabOrder).toEqual([]);
+      expect(router.state.location.pathname).toBe("/");
+      expect(toastInfo).toHaveBeenCalledWith(
+        expect.stringContaining("no longer available"),
+        { id: "epic-access:epic-1", cancel: null },
+      );
+      expect(requestFreshSnapshotSpy).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not grace a replica that holds unsynced work (isDirty)", async () => {
+    markEpicCreatedThisSession("epic-1", "host-x");
+    const handle = registerSession("epic-1");
+    // Explicit, not incidental: a freshly built handle from `fakeFactory`
+    // starts clean, so this is what actually exercises the guard rather than
+    // some setup side effect.
+    handle.store.setState({ isDirty: true, unsyncedQueueSize: 0 });
+    seedTabs([{ tabId: "tab-1", epicId: "epic-1", name: "Epic One" }], "tab-1");
+    const requestFreshSnapshotSpy = vi.spyOn(handle, "requestFreshSnapshot");
+
+    const { router } = renderCoordinatorAt("/epics/epic-1/tab-1");
+    await waitFor(() =>
+      expect(router.state.location.pathname).toBe("/epics/epic-1/tab-1"),
+    );
+
+    handle.store.setState({
+      snapshotFetchError: {
+        code: "NOT_FOUND",
+        message: "room lookup is unavailable",
+        upgradeGuidance: null,
+      },
+    });
+
+    await waitFor(() =>
+      expect(useEpicCanvasStore.getState().openTabOrder).toEqual([]),
+    );
+    await waitFor(() => expect(router.state.location.pathname).toBe("/"));
+    expect(toastInfo).toHaveBeenCalledWith(
+      expect.stringContaining("no longer available"),
+      { id: "epic-access:epic-1", cancel: null },
+    );
+    expect(requestFreshSnapshotSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not grace a replica that holds unsynced work (unsyncedQueueSize)", async () => {
+    markEpicCreatedThisSession("epic-1", "host-x");
+    const handle = registerSession("epic-1");
+    handle.store.setState({ isDirty: false, unsyncedQueueSize: 1 });
+    seedTabs([{ tabId: "tab-1", epicId: "epic-1", name: "Epic One" }], "tab-1");
+    const requestFreshSnapshotSpy = vi.spyOn(handle, "requestFreshSnapshot");
+
+    const { router } = renderCoordinatorAt("/epics/epic-1/tab-1");
+    await waitFor(() =>
+      expect(router.state.location.pathname).toBe("/epics/epic-1/tab-1"),
+    );
+
+    handle.store.setState({
+      snapshotFetchError: {
+        code: "NOT_FOUND",
+        message: "room lookup is unavailable",
+        upgradeGuidance: null,
+      },
+    });
+
+    await waitFor(() =>
+      expect(useEpicCanvasStore.getState().openTabOrder).toEqual([]),
+    );
+    await waitFor(() => expect(router.state.location.pathname).toBe("/"));
+    expect(toastInfo).toHaveBeenCalledWith(
+      expect.stringContaining("no longer available"),
+      { id: "epic-access:epic-1", cancel: null },
+    );
+    expect(requestFreshSnapshotSpy).not.toHaveBeenCalled();
+  });
+
+  it("closes instead of rebuilding when local work appears while a grace retry is pending", async () => {
+    vi.useFakeTimers();
+    try {
+      markEpicCreatedThisSession("epic-1", "host-x");
+      const handle = registerSession("epic-1");
+      handle.store.setState({ isDirty: false, unsyncedQueueSize: 0 });
+      seedTabs(
+        [{ tabId: "tab-1", epicId: "epic-1", name: "Epic One" }],
+        "tab-1",
+      );
+      const requestFreshSnapshotSpy = vi.spyOn(handle, "requestFreshSnapshot");
+
+      const { router } = renderCoordinatorAt("/epics/epic-1/tab-1");
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(router.state.location.pathname).toBe("/epics/epic-1/tab-1");
+
+      // Schedules the first grace retry (clean handle, inside the window).
+      act(() => {
+        handle.store.setState({
+          snapshotFetchError: {
+            code: "NOT_FOUND",
+            message: "room lookup is unavailable",
+            upgradeGuidance: null,
+          },
+        });
+      });
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(useEpicCanvasStore.getState().openTabOrder).toEqual(["tab-1"]);
+      expect(requestFreshSnapshotSpy).not.toHaveBeenCalled();
+
+      // Local work appears while that retry is still pending on its timer.
+      act(() => {
+        handle.store.setState({ isDirty: true });
+      });
+
+      // Advance past the first grace delay - the timer's re-check must see
+      // the now-dirty state and hand the verdict to the ordinary close
+      // instead of calling the destructive `requestFreshSnapshot`.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2_000);
+      });
+
+      expect(requestFreshSnapshotSpy).not.toHaveBeenCalled();
+      expect(useEpicCanvasStore.getState().openTabOrder).toEqual([]);
+      expect(router.state.location.pathname).toBe("/");
+      expect(toastInfo).toHaveBeenCalledWith(
+        expect.stringContaining("no longer available"),
+        { id: "epic-access:epic-1", cancel: null },
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 function dispatchDeletedEpicStorageEvent(

--- a/clients/gui-app/src/providers/__tests__/epic-access-coordinator.test.tsx
+++ b/clients/gui-app/src/providers/__tests__/epic-access-coordinator.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { cleanup, render, waitFor } from "@testing-library/react";
+import { act, cleanup, render, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   Outlet,
@@ -19,6 +19,10 @@ import {
   cloudEpicTasksQueryKey,
 } from "@/lib/cloud-epic-tasks-query";
 import { DELETED_EPIC_NOTIFICATION_STORAGE_KEY } from "@/lib/epics/deleted-epic-events";
+import {
+  clearSessionCreatedEpics,
+  markEpicCreatedThisSession,
+} from "@/lib/epics/session-created-epics";
 import {
   __getOpenEpicRegistryForTests,
   __setEpicStreamClientFactoryForTests,
@@ -198,6 +202,7 @@ describe("EpicAccessCoordinator", () => {
     useAuthStore.getState().setSignedOut();
     useComposerRunSettingsStore.getState().resetForTests();
     __getOpenEpicRegistryForTests().disposeAll();
+    clearSessionCreatedEpics();
     toastInfo.mockClear();
   });
 
@@ -209,6 +214,7 @@ describe("EpicAccessCoordinator", () => {
     useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
     useTabsStore.setState(useTabsStore.getInitialState(), true);
     useComposerRunSettingsStore.getState().resetForTests();
+    clearSessionCreatedEpics();
     vi.restoreAllMocks();
   });
 
@@ -554,6 +560,161 @@ describe("EpicAccessCoordinator", () => {
         .getState()
         .getEpicRunSettings("epic-ghost", TEST_HOST_ID),
     ).toBeNull();
+  });
+
+  it("holds a created-this-session epic open on 'unavailable' and retries via requestFreshSnapshot after the first grace delay", async () => {
+    vi.useFakeTimers();
+    try {
+      markEpicCreatedThisSession("epic-1", "host-x");
+      const handle = registerSession("epic-1");
+      seedTabs(
+        [{ tabId: "tab-1", epicId: "epic-1", name: "Epic One" }],
+        "tab-1",
+      );
+      const requestFreshSnapshotSpy = vi.spyOn(handle, "requestFreshSnapshot");
+
+      const { router } = renderCoordinatorAt("/epics/epic-1/tab-1");
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(router.state.location.pathname).toBe("/epics/epic-1/tab-1");
+
+      act(() => {
+        handle.store.setState({
+          snapshotFetchError: {
+            code: "NOT_FOUND",
+            message: "room lookup is unavailable",
+            upgradeGuidance: null,
+          },
+        });
+      });
+      // Flush the `evaluate` microtask the store subscription queues.
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      // Neither ejected nor toasted while the grace's first retry is pending.
+      expect(useEpicCanvasStore.getState().openTabOrder).toEqual(["tab-1"]);
+      expect(router.state.location.pathname).toBe("/epics/epic-1/tab-1");
+      expect(toastInfo).not.toHaveBeenCalled();
+      expect(requestFreshSnapshotSpy).not.toHaveBeenCalled();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2_000);
+      });
+
+      expect(requestFreshSnapshotSpy).toHaveBeenCalledTimes(1);
+      expect(useEpicCanvasStore.getState().openTabOrder).toEqual(["tab-1"]);
+      expect(toastInfo).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("ejects a created-this-session epic once all 3 grace retries are spent and 'unavailable' lands again", async () => {
+    vi.useFakeTimers();
+    try {
+      markEpicCreatedThisSession("epic-1", "host-x");
+      const handle = registerSession("epic-1");
+      seedTabs(
+        [{ tabId: "tab-1", epicId: "epic-1", name: "Epic One" }],
+        "tab-1",
+      );
+      const requestFreshSnapshotSpy = vi.spyOn(handle, "requestFreshSnapshot");
+      const unavailableError = {
+        code: "NOT_FOUND" as const,
+        message: "room lookup is unavailable",
+        upgradeGuidance: null,
+      };
+
+      const { router } = renderCoordinatorAt("/epics/epic-1/tab-1");
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      // Attempt 1: fires at +2s, then the retry's own failure re-arrives.
+      act(() => {
+        handle.store.setState({ snapshotFetchError: unavailableError });
+      });
+      await act(async () => {
+        await Promise.resolve();
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2_000);
+      });
+      expect(requestFreshSnapshotSpy).toHaveBeenCalledTimes(1);
+      // `requestFreshSnapshot` resets `snapshotFetchError` to null; simulate
+      // the retry itself failing the same way the real reconnect would.
+      act(() => {
+        handle.store.setState({ snapshotFetchError: unavailableError });
+      });
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      // Attempt 2: fires at +5s.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5_000);
+      });
+      expect(requestFreshSnapshotSpy).toHaveBeenCalledTimes(2);
+      act(() => {
+        handle.store.setState({ snapshotFetchError: unavailableError });
+      });
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      // Attempt 3: fires at +10s. The budget is now spent.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(10_000);
+      });
+      expect(requestFreshSnapshotSpy).toHaveBeenCalledTimes(3);
+      expect(useEpicCanvasStore.getState().openTabOrder).toEqual(["tab-1"]);
+      expect(toastInfo).not.toHaveBeenCalled();
+
+      // The 3rd retry's own failure signal - no slot left, so this one ejects.
+      act(() => {
+        handle.store.setState({ snapshotFetchError: unavailableError });
+      });
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(useEpicCanvasStore.getState().openTabOrder).toEqual([]);
+      expect(router.state.location.pathname).toBe("/");
+      expect(toastInfo).toHaveBeenCalledWith(
+        expect.stringContaining("no longer available"),
+        { id: "epic-access:epic-1", cancel: null },
+      );
+      // No 4th retry was scheduled - the eject ran instead.
+      expect(requestFreshSnapshotSpy).toHaveBeenCalledTimes(3);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("ejects a created-this-session epic immediately on a 'deleted' signal - the grace applies only to 'unavailable'", async () => {
+    markEpicCreatedThisSession("epic-1", "host-x");
+    const handle = registerSession("epic-1");
+    seedTabs([{ tabId: "tab-1", epicId: "epic-1", name: "Epic One" }], "tab-1");
+
+    const { router } = renderCoordinatorAt("/epics/epic-1/tab-1");
+    await waitFor(() =>
+      expect(router.state.location.pathname).toBe("/epics/epic-1/tab-1"),
+    );
+
+    handle.store.setState({
+      epicDeleted: { deletedByDisplayName: null, deletedByTraycerUserId: null },
+    });
+
+    await waitFor(() =>
+      expect(useEpicCanvasStore.getState().openTabOrder).toEqual([]),
+    );
+    await waitFor(() => expect(router.state.location.pathname).toBe("/"));
+    expect(toastInfo).toHaveBeenCalledWith('Epic "Epic One" was deleted', {
+      id: "epic-access:epic-1",
+      cancel: null,
+    });
   });
 });
 

--- a/clients/gui-app/src/providers/__tests__/epic-session-provider.test.tsx
+++ b/clients/gui-app/src/providers/__tests__/epic-session-provider.test.tsx
@@ -2266,4 +2266,101 @@ describe("<EpicSessionProvider />", () => {
     }
     expect(getEpicSessionHandleHostId(mountedHandle)).toBe("host-create");
   });
+
+  it("Retry releases the create-host seed and re-points to the effective host", async () => {
+    // hostState.id/attached are left at their `beforeEach` defaults ("host-a",
+    // attached) for the ENTIRE test - a DIFFERENT, live host than the
+    // create-host marker below, and one that never changes. The give-up-on-a-
+    // derivation-move effect (`lastEffectiveHostIdRef` in
+    // epic-session-provider.tsx) only fires on a CHANGE to `effectiveHostId`,
+    // so it never runs here: this is precisely the case it cannot cover, and
+    // the only thing that can release the seed is `retryRepoint` itself.
+    vi.useFakeTimers();
+    try {
+      const EPIC_ID = "epic-create-host-retry-test";
+      markEpicCreatedThisSession(EPIC_ID, "host-create");
+      const streams: ControlledEpicStream[] = [];
+      __setEpicStreamClientFactoryForTests((_epicId, callbacks) => {
+        const stream: ControlledEpicStream = { closeCount: 0, callbacks };
+        streams.push(stream);
+        return {
+          applyUpdate: () => undefined,
+          awareness: () => undefined,
+          applyArtifactRoomUpdate: () => undefined,
+          artifactRoomAwareness: () => undefined,
+          retryMigration: () => undefined,
+          close: () => {
+            stream.closeCount += 1;
+          },
+        };
+      });
+
+      const seenHandles: OpenEpicStoreHandle[] = [];
+      const presentations: Array<EpicSessionPresentation | null> = [];
+      render(
+        <EpicSessionProvider epicId={EPIC_ID} tabId={EPIC_ID}>
+          <HandleProbe onHandle={(handle) => seenHandles.push(handle)} />
+          <PresentationProbe
+            onPresentation={(presentation) => presentations.push(presentation)}
+          />
+        </EpicSessionProvider>,
+      );
+
+      await act(() => Promise.resolve());
+      // The seed wins the first mount - the session opens on the create
+      // host, not on the effective one.
+      expect(seenHandles).toHaveLength(1);
+      expect(getEpicSessionHandleHostId(seenHandles[0])).toBe("host-create");
+      expect(streams).toHaveLength(1);
+      expect(presentations.at(-1)?.kind).toBe("ready");
+
+      // First Retry. With the fix, this releases the seed and re-points
+      // toward `effectiveHostId` ("host-a") - a second stream opens even
+      // though nothing ever touched `hostState.id`. Under the ablated
+      // `retryRepoint` (seed never released), `targetHostId` stays
+      // "host-create" == `current.hostId`, no re-point starts, and every
+      // assertion from here on fails.
+      act(() => {
+        presentations.at(-1)?.retry();
+      });
+      expect(streams).toHaveLength(2);
+      expect(presentations.at(-1)?.kind).toBe("establishing");
+      expect(presentations.at(-1)?.targetHostId).toBe("host-a");
+
+      // Let that re-point hang past the deadline, so the user is looking at
+      // a genuine `failed` presentation - naming the effective host, not the
+      // dead create host - when they press Retry again.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(15_000);
+      });
+      const failed = presentations.at(-1);
+      expect(failed?.kind).toBe("failed");
+      expect(failed?.targetHostId).toBe("host-a");
+      expect(streams[1].closeCount).toBe(1);
+      // The original create-host session is untouched by the failed re-point.
+      expect(seenHandles.at(-1)).toBe(seenHandles[0]);
+
+      // Second Retry, invoked from the `failed` presentation the way a user
+      // would after seeing the failure. The seed is already gone, so this
+      // re-attempts the same effective host - and this time it succeeds.
+      act(() => {
+        failed?.retry();
+      });
+      expect(streams).toHaveLength(3);
+      act(() => {
+        deliverSnapshot(streams[2], "room-a");
+      });
+      await act(() => Promise.resolve());
+
+      expect(presentations.at(-1)?.kind).toBe("ready");
+      expect(seenHandles.at(-1)).not.toBe(seenHandles[0]);
+      const mountedHandle = __getOpenEpicRegistryForTests().peek(EPIC_ID);
+      if (mountedHandle === null) {
+        throw new Error("expected a mounted handle");
+      }
+      expect(getEpicSessionHandleHostId(mountedHandle)).toBe("host-a");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/clients/gui-app/src/providers/__tests__/epic-session-provider.test.tsx
+++ b/clients/gui-app/src/providers/__tests__/epic-session-provider.test.tsx
@@ -2203,8 +2203,11 @@ describe("<EpicSessionProvider />", () => {
 
   it("keeps the create-host seed when the selection authority merely answers for the first time", async () => {
     const EPIC_ID = "epic-create-host-baseline-test";
-    // Detached: nobody has answered yet, matching the authority's own
-    // bootstrap default - NOT the same as "effective" naming no usable host.
+    // Bootstrap, on BOTH axes: nobody has answered yet. `(attached: false,
+    // id: null)` is the pair this file calls bootstrap, and it is the one the
+    // seed exists to survive - `(attached: true, id: null)` is the real ∅ and
+    // a different case entirely.
+    hostState.attached = false;
     hostState.id = null;
     markEpicCreatedThisSession(EPIC_ID, "host-create");
     const streams: ControlledEpicStream[] = [];
@@ -2237,9 +2240,10 @@ describe("<EpicSessionProvider />", () => {
     const firstHandle = seenHandles[0];
     expect(getEpicSessionHandleHostId(firstHandle)).toBe("host-create");
 
-    // The authority speaks for the FIRST time, naming a host that is NOT the
-    // create host - a baseline, not a move.
+    // The authority ATTACHES and speaks for the FIRST time, naming a host
+    // that is NOT the create host - a baseline, not a move.
     act(() => {
+      hostState.attached = true;
       hostState.id = "host-b";
       view.rerender(
         <EpicSessionProvider epicId={EPIC_ID} tabId={EPIC_ID}>

--- a/clients/gui-app/src/providers/__tests__/epic-session-provider.test.tsx
+++ b/clients/gui-app/src/providers/__tests__/epic-session-provider.test.tsx
@@ -137,6 +137,10 @@ vi.mock("@tanstack/react-router", () => ({
 
 import { EpicSessionProvider } from "@/providers/epic-session-provider";
 import {
+  clearSessionCreatedEpics,
+  markEpicCreatedThisSession,
+} from "@/lib/epics/session-created-epics";
+import {
   __getOpenEpicRegistryForTests,
   __setEpicStreamClientFactoryForTests,
   EpicSessionPresentationContext,
@@ -492,6 +496,7 @@ describe("<EpicSessionProvider />", () => {
     __getOpenEpicRegistryForTests().disposeAll();
     __setEpicStreamClientFactoryForTests(null);
     setDesktopEpicOwnershipBridge(null);
+    clearSessionCreatedEpics();
     resetAuth("signed-in", "alice@example.com");
   });
 
@@ -504,6 +509,7 @@ describe("<EpicSessionProvider />", () => {
     resetAuth("signed-out", null);
     hostBindingRef.value = null;
     resetHostConnectionRegistryForTest();
+    clearSessionCreatedEpics();
   });
 
   it("shares one resolved host client with every session consumer", async () => {
@@ -2094,5 +2100,44 @@ describe("<EpicSessionProvider />", () => {
       expect(streams[0].closeCount).toBe(0);
       expect(seenHandles.at(-1)).toBe(firstHandle);
     });
+  });
+
+  it("seeds requestedHostId from the create-host marker, so a freshly created epic opens its session on the create host instead of the effective one", async () => {
+    const EPIC_ID = "epic-created-host-test";
+    // The effective host (`hostState.id`, defaulted to "host-a" in
+    // `beforeEach`) is deliberately a DIFFERENT host than the marker records,
+    // so a pass here can only mean the marker's host won.
+    markEpicCreatedThisSession(EPIC_ID, "host-create");
+    __setEpicStreamClientFactoryForTests(() => ({
+      applyUpdate: () => undefined,
+      awareness: () => undefined,
+      applyArtifactRoomUpdate: () => undefined,
+      artifactRoomAwareness: () => undefined,
+      retryMigration: () => undefined,
+      close: () => undefined,
+    }));
+
+    const seenClients: unknown[] = [];
+    render(
+      <EpicSessionProvider epicId={EPIC_ID} tabId={EPIC_ID}>
+        <SessionHostClientProbe
+          onClient={(client) => {
+            seenClients.push(client);
+          }}
+        />
+      </EpicSessionProvider>,
+    );
+
+    const createHostClient = resolveSessionHostClient("host-create");
+    await waitFor(() => {
+      expect(seenClients).toContain(createHostClient);
+    });
+    const effectiveHostClient = resolveSessionHostClient(hostState.id);
+    expect(seenClients).not.toContain(effectiveHostClient);
+    const mountedHandle = __getOpenEpicRegistryForTests().peek(EPIC_ID);
+    if (mountedHandle === null) {
+      throw new Error("expected a mounted handle");
+    }
+    expect(getEpicSessionHandleHostId(mountedHandle)).toBe("host-create");
   });
 });

--- a/clients/gui-app/src/providers/__tests__/epic-session-provider.test.tsx
+++ b/clients/gui-app/src/providers/__tests__/epic-session-provider.test.tsx
@@ -2140,4 +2140,126 @@ describe("<EpicSessionProvider />", () => {
     }
     expect(getEpicSessionHandleHostId(mountedHandle)).toBe("host-create");
   });
+
+  it("gives up the create-host seed when the effective host moves", async () => {
+    const EPIC_ID = "epic-create-host-move-test";
+    // The effective host at mount ("host-a", the `beforeEach` default) is
+    // deliberately DIFFERENT from both the create-host marker and the host it
+    // later moves to, so a pass here can only mean the seed was actually
+    // given up on the move - not that the effective host never differed from
+    // the seed in the first place.
+    markEpicCreatedThisSession(EPIC_ID, "host-create");
+    const streams: ControlledEpicStream[] = [];
+    __setEpicStreamClientFactoryForTests((_epicId, callbacks) => {
+      const stream: ControlledEpicStream = { closeCount: 0, callbacks };
+      streams.push(stream);
+      return {
+        applyUpdate: () => undefined,
+        awareness: () => undefined,
+        applyArtifactRoomUpdate: () => undefined,
+        artifactRoomAwareness: () => undefined,
+        retryMigration: () => undefined,
+        close: () => {
+          stream.closeCount += 1;
+        },
+      };
+    });
+
+    const seenHandles: OpenEpicStoreHandle[] = [];
+    const view = render(
+      <EpicSessionProvider epicId={EPIC_ID} tabId={EPIC_ID}>
+        <HandleProbe onHandle={(handle) => seenHandles.push(handle)} />
+      </EpicSessionProvider>,
+    );
+
+    await waitFor(() => expect(seenHandles).toHaveLength(1));
+    const firstHandle = seenHandles[0];
+    expect(getEpicSessionHandleHostId(firstHandle)).toBe("host-create");
+
+    act(() => {
+      hostState.id = "host-b";
+      view.rerender(
+        <EpicSessionProvider epicId={EPIC_ID} tabId={EPIC_ID}>
+          <HandleProbe onHandle={(handle) => seenHandles.push(handle)} />
+        </EpicSessionProvider>,
+      );
+    });
+
+    // Giving up the seed re-points against the NEW effective host, opening a
+    // second stream - if the seed still won, `targetHostId` would still be
+    // "host-create" and no re-point would start at all.
+    await waitFor(() => expect(streams).toHaveLength(2));
+    act(() => {
+      deliverSnapshot(streams[1], "room-a");
+    });
+    await waitFor(() => expect(seenHandles.at(-1)).not.toBe(firstHandle));
+
+    const mountedHandle = __getOpenEpicRegistryForTests().peek(EPIC_ID);
+    if (mountedHandle === null) {
+      throw new Error("expected a mounted handle");
+    }
+    expect(getEpicSessionHandleHostId(mountedHandle)).toBe("host-b");
+  });
+
+  it("keeps the create-host seed when the selection authority merely answers for the first time", async () => {
+    const EPIC_ID = "epic-create-host-baseline-test";
+    // Detached: nobody has answered yet, matching the authority's own
+    // bootstrap default - NOT the same as "effective" naming no usable host.
+    hostState.id = null;
+    markEpicCreatedThisSession(EPIC_ID, "host-create");
+    const streams: ControlledEpicStream[] = [];
+    __setEpicStreamClientFactoryForTests((_epicId, callbacks) => {
+      const stream: ControlledEpicStream = { closeCount: 0, callbacks };
+      streams.push(stream);
+      return {
+        applyUpdate: () => undefined,
+        awareness: () => undefined,
+        applyArtifactRoomUpdate: () => undefined,
+        artifactRoomAwareness: () => undefined,
+        retryMigration: () => undefined,
+        close: () => {
+          stream.closeCount += 1;
+        },
+      };
+    });
+
+    const seenHandles: OpenEpicStoreHandle[] = [];
+    const view = render(
+      <EpicSessionProvider epicId={EPIC_ID} tabId={EPIC_ID}>
+        <HandleProbe onHandle={(handle) => seenHandles.push(handle)} />
+      </EpicSessionProvider>,
+    );
+
+    // The seed answers regardless of the authority being detached:
+    // `requestedHostId` is non-null, so `targetHostId` never depended on
+    // `effectiveHostId` in the first place.
+    await waitFor(() => expect(seenHandles).toHaveLength(1));
+    const firstHandle = seenHandles[0];
+    expect(getEpicSessionHandleHostId(firstHandle)).toBe("host-create");
+
+    // The authority speaks for the FIRST time, naming a host that is NOT the
+    // create host - a baseline, not a move.
+    act(() => {
+      hostState.id = "host-b";
+      view.rerender(
+        <EpicSessionProvider epicId={EPIC_ID} tabId={EPIC_ID}>
+          <HandleProbe onHandle={(handle) => seenHandles.push(handle)} />
+        </EpicSessionProvider>,
+      );
+    });
+    // Give any erroneous re-point effect a chance to start.
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // No second stream: the seed still wins, so `targetHostId` never moved
+    // off "host-create".
+    expect(streams).toHaveLength(1);
+    expect(seenHandles.at(-1)).toBe(firstHandle);
+    const mountedHandle = __getOpenEpicRegistryForTests().peek(EPIC_ID);
+    if (mountedHandle === null) {
+      throw new Error("expected a mounted handle");
+    }
+    expect(getEpicSessionHandleHostId(mountedHandle)).toBe("host-create");
+  });
 });

--- a/clients/gui-app/src/providers/__tests__/host-compatibility-provider.test.tsx
+++ b/clients/gui-app/src/providers/__tests__/host-compatibility-provider.test.tsx
@@ -1301,7 +1301,7 @@ describe("HostCompatibilityProvider startup consumers", () => {
     act(() => {
       useEpicCanvasStore.getState().openEpicTab(FRESH_EPIC_ID, "Fresh");
       useEpicCanvasStore.getState().openEpicTab(STALE_EPIC_ID, "Stale");
-      markEpicCreatedThisSession(FRESH_EPIC_ID);
+      markEpicCreatedThisSession(FRESH_EPIC_ID, "host-1");
     });
 
     await waitFor(() => {

--- a/clients/gui-app/src/providers/epic-access-coordinator.tsx
+++ b/clients/gui-app/src/providers/epic-access-coordinator.tsx
@@ -6,7 +6,7 @@ import { removeDeletedEpicsFromCloudTaskCaches } from "@/lib/cloud-epic-tasks-qu
 import { epicAccessToast } from "@/lib/toast/channels";
 import { subscribeDeletedEpicNotifications } from "@/lib/epics/deleted-epic-events";
 import { isUnavailableEpicCode } from "@/lib/epics/unavailable-epic";
-import { wasEpicCreatedThisSession } from "@/lib/epics/session-created-epics";
+import { wasEpicCreatedRecentlyThisSession } from "@/lib/epics/session-created-epics";
 import { liveEpicTitleFromHandle } from "@/lib/epic-selectors";
 import { getOpenEpicRegistry } from "@/lib/registries/epic-session-registry";
 import { LANDING_ROUTE, readActiveEpicIdFromPath } from "@/lib/routes";
@@ -22,14 +22,20 @@ import type { OpenEpicState } from "@/stores/epics/open-epic/store";
 
 /**
  * Silent re-subscribe schedule before the eject, for an `unavailable` verdict
- * on an epic THIS renderer created. `epic.create` is local-first: the cloud
- * record is written by the create host's deferred background connect, so a
- * session served by any OTHER host can observe a cloud `NOT_FOUND` for an
- * epic that provably exists - replication lag wearing an adjudicated code.
- * Each entry is the delay before one `requestFreshSnapshot`; exhausting the
- * schedule falls through to the normal close, so a genuinely deleted epic
- * still ejects (just those seconds later). Deletes and revokes never enter
- * this grace - their verdicts are first-hand, not inferred from absence.
+ * on an epic THIS renderer created moments ago. `epic.create` is local-first:
+ * the cloud record is written by the create host's deferred background
+ * connect, so a session served by any OTHER host can observe a cloud
+ * `NOT_FOUND` for an epic that provably exists - replication lag wearing an
+ * adjudicated code. Each entry is the delay before one
+ * `requestFreshSnapshot`; exhausting the schedule falls through to the normal
+ * close, so a genuinely deleted epic still ejects (just those seconds later).
+ *
+ * Three things stay OUT of the grace, and each for its own reason: deletes and
+ * revokes, because those verdicts are first-hand rather than inferred from
+ * absence; epics past the create-race window
+ * (`wasEpicCreatedRecentlyThisSession`), because after it a `NOT_FOUND` means
+ * what it says; and any replica holding local work (`holdsUnsyncedWork`),
+ * because the retry itself is destructive.
  */
 const CREATED_EPIC_UNAVAILABLE_RETRY_DELAYS_MS: ReadonlyArray<number> = [
   2_000, 5_000, 10_000,
@@ -222,23 +228,33 @@ export function EpicAccessCoordinator() {
         // captured reason would force-close a tab that recovered (or toast for
         // one already gone). Drop the latch so a fresh signal re-evaluates.
         const current = registry.peek(epicId);
+        const currentState = current === null ? null : current.store.getState();
         const reason =
-          current === null ? null : deadEpicReason(current.store.getState());
+          currentState === null ? null : deadEpicReason(currentState);
         const stillOpen = collectOpenEpicIds().includes(epicId);
         if (reason === null || !stillOpen) {
           handled.delete(epicId);
           return;
         }
-        // Created-this-session grace: an `unavailable` (cloud NOT_FOUND) on
-        // an epic this renderer just created is far more likely the create
+        // Create-race grace: an `unavailable` (cloud NOT_FOUND) on an epic
+        // this renderer created SECONDS AGO is far more likely the create
         // host's background cloud connect still in flight than a real
         // delete, so spend the bounded retry schedule re-subscribing before
         // believing it. The latch is dropped so the retry's own failure (a
         // fresh `snapshotFetchError`) re-enters this evaluation and takes
         // the next slot; past the last slot, the eject below runs as usual.
+        //
+        // Scoped to the race window, not the session: `requestFreshSnapshot`
+        // is DESTRUCTIVE (it clears the unsynced queue and replaces the
+        // replica), and an epic created hours ago has had every chance to
+        // accumulate work a transient NOT_FOUND must not silently erase.
+        // `holdsUnsyncedWork` is the second half of that guarantee - inside
+        // the window there is nothing to lose yet, and if there somehow is,
+        // the ordinary announced close runs instead of a silent discard.
         if (
           reason.kind === "unavailable" &&
-          wasEpicCreatedThisSession(epicId)
+          wasEpicCreatedRecentlyThisSession(epicId) &&
+          !holdsUnsyncedWork(currentState)
         ) {
           // A pending retry owns this epic's verdict until it fires; a signal
           // landing meanwhile must neither double-schedule nor fall through
@@ -259,8 +275,22 @@ export function EpicAccessCoordinator() {
               // Re-derive at fire time, exactly like the eject path above: a
               // session that recovered (or died for a DIFFERENT, first-hand
               // reason) must not be torn down and re-dialed by a stale grace.
-              const liveReason = deadEpicReason(live.store.getState());
+              const liveState = live.store.getState();
+              const liveReason = deadEpicReason(liveState);
               if (liveReason === null || liveReason.kind !== "unavailable") {
+                return;
+              }
+              // Re-check the destructive precondition too: local work can
+              // appear during the delay (an offline edit, a dirty artifact
+              // room), and `requestFreshSnapshot` would discard it with no
+              // trace. Hand the verdict back to the announced close instead -
+              // what this epic would have got without the grace.
+              if (holdsUnsyncedWork(liveState)) {
+                if (!collectOpenEpicIds().includes(epicId)) return;
+                // Re-arm the latch the grace dropped, so `runClose` stays
+                // once-per-epic against the emits its own teardown fires.
+                handled.add(epicId);
+                runClose(epicId, liveReason);
                 return;
               }
               live.requestFreshSnapshot();
@@ -382,6 +412,18 @@ function deadEpicReason(state: OpenEpicState): DeadEpicReason | null {
     return { kind: "unavailable" };
   }
   return null;
+}
+
+/**
+ * Whether the replica holds local work that has not reached the host -
+ * offline-buffered ops (`unsyncedQueueSize`) or an un-flushed dirty signal
+ * over the root doc or any artifact room (`isDirty`). Both are exactly what
+ * `requestFreshSnapshot` throws away, so the create-race grace refuses to run
+ * while either is set. `null` (no live handle) holds nothing by definition.
+ */
+function holdsUnsyncedWork(state: OpenEpicState | null): boolean {
+  if (state === null) return false;
+  return state.isDirty || state.unsyncedQueueSize > 0;
 }
 
 /**

--- a/clients/gui-app/src/providers/epic-access-coordinator.tsx
+++ b/clients/gui-app/src/providers/epic-access-coordinator.tsx
@@ -6,6 +6,7 @@ import { removeDeletedEpicsFromCloudTaskCaches } from "@/lib/cloud-epic-tasks-qu
 import { epicAccessToast } from "@/lib/toast/channels";
 import { subscribeDeletedEpicNotifications } from "@/lib/epics/deleted-epic-events";
 import { isUnavailableEpicCode } from "@/lib/epics/unavailable-epic";
+import { wasEpicCreatedThisSession } from "@/lib/epics/session-created-epics";
 import { liveEpicTitleFromHandle } from "@/lib/epic-selectors";
 import { getOpenEpicRegistry } from "@/lib/registries/epic-session-registry";
 import { LANDING_ROUTE, readActiveEpicIdFromPath } from "@/lib/routes";
@@ -18,6 +19,21 @@ import { useAuthStore } from "@/stores/auth/auth-store";
 import { useComposerRunSettingsStore } from "@/stores/composer/composer-run-settings-store";
 import { tabCommandCoordinator } from "@/stores/tabs/tab-command-coordinator";
 import type { OpenEpicState } from "@/stores/epics/open-epic/store";
+
+/**
+ * Silent re-subscribe schedule before the eject, for an `unavailable` verdict
+ * on an epic THIS renderer created. `epic.create` is local-first: the cloud
+ * record is written by the create host's deferred background connect, so a
+ * session served by any OTHER host can observe a cloud `NOT_FOUND` for an
+ * epic that provably exists - replication lag wearing an adjudicated code.
+ * Each entry is the delay before one `requestFreshSnapshot`; exhausting the
+ * schedule falls through to the normal close, so a genuinely deleted epic
+ * still ejects (just those seconds later). Deletes and revokes never enter
+ * this grace - their verdicts are first-hand, not inferred from absence.
+ */
+const CREATED_EPIC_UNAVAILABLE_RETRY_DELAYS_MS: ReadonlyArray<number> = [
+  2_000, 5_000, 10_000,
+];
 
 /**
  * App-level coordinator that force-closes an epic tab when the user loses
@@ -68,6 +84,27 @@ export function EpicAccessCoordinator() {
     const registry = getOpenEpicRegistry();
     const perHandleUnsub = new Map<string, () => void>();
     const handled = new Set<string>();
+    // Set by the effect's cleanup. `evaluate` defers its verdict to a
+    // microtask, so a signal that lands just before unmount can fire that
+    // microtask AFTER teardown - where acting would navigate/mutate stores
+    // from a dead coordinator, or park a grace timer in a map teardown has
+    // already swept. The replacement coordinator instance re-walks every open
+    // session on mount (`reconcile` + its dead-at-subscribe catch), so a
+    // bailed verdict is re-derived, never lost.
+    let disposed = false;
+    // Attempts already spent (and the pending timer, if any) of the
+    // created-this-session `unavailable` grace. Attempts are deliberately
+    // never reset on recovery: the budget exists to absorb ONE create's
+    // replication lag, and a session that later turns `unavailable` again
+    // with the budget spent gets the ordinary eject.
+    const createGraceAttempts = new Map<string, number>();
+    const createGraceTimers = new Map<string, number>();
+    const clearCreateGraceTimer = (epicId: string): void => {
+      const timer = createGraceTimers.get(epicId);
+      if (timer === undefined) return;
+      window.clearTimeout(timer);
+      createGraceTimers.delete(epicId);
+    };
     // Last resident-set signature reconcile acted on, so the per-keystroke
     // eligibility emits the registry fires (which don't change membership)
     // short-circuit instead of re-walking every open session.
@@ -178,6 +215,7 @@ export function EpicAccessCoordinator() {
       // the canvas store and disposes the session, which must not run
       // re-entrantly inside the emit that triggered it.
       queueMicrotask(() => {
+        if (disposed) return;
         // Re-derive at fire time: the tab may have been closed by the user, the
         // session released, or a TRANSIENT `unavailable` error cleared on a
         // successful reconnect between scheduling and now. Acting on the stale
@@ -190,6 +228,46 @@ export function EpicAccessCoordinator() {
         if (reason === null || !stillOpen) {
           handled.delete(epicId);
           return;
+        }
+        // Created-this-session grace: an `unavailable` (cloud NOT_FOUND) on
+        // an epic this renderer just created is far more likely the create
+        // host's background cloud connect still in flight than a real
+        // delete, so spend the bounded retry schedule re-subscribing before
+        // believing it. The latch is dropped so the retry's own failure (a
+        // fresh `snapshotFetchError`) re-enters this evaluation and takes
+        // the next slot; past the last slot, the eject below runs as usual.
+        if (
+          reason.kind === "unavailable" &&
+          wasEpicCreatedThisSession(epicId)
+        ) {
+          // A pending retry owns this epic's verdict until it fires; a signal
+          // landing meanwhile must neither double-schedule nor fall through
+          // to the eject below.
+          if (createGraceTimers.has(epicId)) {
+            handled.delete(epicId);
+            return;
+          }
+          const attempts = createGraceAttempts.get(epicId) ?? 0;
+          if (attempts < CREATED_EPIC_UNAVAILABLE_RETRY_DELAYS_MS.length) {
+            const delay = CREATED_EPIC_UNAVAILABLE_RETRY_DELAYS_MS[attempts];
+            createGraceAttempts.set(epicId, attempts + 1);
+            handled.delete(epicId);
+            const timer = window.setTimeout(() => {
+              createGraceTimers.delete(epicId);
+              const live = registry.peek(epicId);
+              if (live === null) return;
+              // Re-derive at fire time, exactly like the eject path above: a
+              // session that recovered (or died for a DIFFERENT, first-hand
+              // reason) must not be torn down and re-dialed by a stale grace.
+              const liveReason = deadEpicReason(live.store.getState());
+              if (liveReason === null || liveReason.kind !== "unavailable") {
+                return;
+              }
+              live.requestFreshSnapshot();
+            }, delay);
+            createGraceTimers.set(epicId, timer);
+            return;
+          }
         }
         runClose(epicId, reason);
       });
@@ -234,6 +312,11 @@ export function EpicAccessCoordinator() {
         perHandleUnsub.delete(epicId);
         // Allow a reopened (e.g. re-granted) epic to be evaluated afresh.
         handled.delete(epicId);
+        // A departed tab's pending grace retry must not re-dial a session the
+        // user already left; the spent-attempts record goes with it so a
+        // reopen starts the schedule over.
+        clearCreateGraceTimer(epicId);
+        createGraceAttempts.delete(epicId);
       }
     };
 
@@ -258,11 +341,16 @@ export function EpicAccessCoordinator() {
       });
 
     return () => {
+      disposed = true;
       unsubscribeRegistry();
       unsubscribeCanvas();
       unsubscribeDeletedEpicNotifications();
       for (const unsubscribe of perHandleUnsub.values()) unsubscribe();
       perHandleUnsub.clear();
+      for (const timer of createGraceTimers.values()) {
+        window.clearTimeout(timer);
+      }
+      createGraceTimers.clear();
     };
   }, [navigate, queryClient]);
 

--- a/clients/gui-app/src/providers/epic-access-coordinator.tsx
+++ b/clients/gui-app/src/providers/epic-access-coordinator.tsx
@@ -6,7 +6,10 @@ import { removeDeletedEpicsFromCloudTaskCaches } from "@/lib/cloud-epic-tasks-qu
 import { epicAccessToast } from "@/lib/toast/channels";
 import { subscribeDeletedEpicNotifications } from "@/lib/epics/deleted-epic-events";
 import { isUnavailableEpicCode } from "@/lib/epics/unavailable-epic";
-import { wasEpicCreatedRecentlyThisSession } from "@/lib/epics/session-created-epics";
+import {
+  CREATED_EPIC_UNAVAILABLE_RETRY_DELAYS_MS,
+  wasEpicCreatedRecentlyThisSession,
+} from "@/lib/epics/session-created-epics";
 import { liveEpicTitleFromHandle } from "@/lib/epic-selectors";
 import { getOpenEpicRegistry } from "@/lib/registries/epic-session-registry";
 import { LANDING_ROUTE, readActiveEpicIdFromPath } from "@/lib/routes";
@@ -19,27 +22,6 @@ import { useAuthStore } from "@/stores/auth/auth-store";
 import { useComposerRunSettingsStore } from "@/stores/composer/composer-run-settings-store";
 import { tabCommandCoordinator } from "@/stores/tabs/tab-command-coordinator";
 import type { OpenEpicState } from "@/stores/epics/open-epic/store";
-
-/**
- * Silent re-subscribe schedule before the eject, for an `unavailable` verdict
- * on an epic THIS renderer created moments ago. `epic.create` is local-first:
- * the cloud record is written by the create host's deferred background
- * connect, so a session served by any OTHER host can observe a cloud
- * `NOT_FOUND` for an epic that provably exists - replication lag wearing an
- * adjudicated code. Each entry is the delay before one
- * `requestFreshSnapshot`; exhausting the schedule falls through to the normal
- * close, so a genuinely deleted epic still ejects (just those seconds later).
- *
- * Three things stay OUT of the grace, and each for its own reason: deletes and
- * revokes, because those verdicts are first-hand rather than inferred from
- * absence; epics past the create-race window
- * (`wasEpicCreatedRecentlyThisSession`), because after it a `NOT_FOUND` means
- * what it says; and any replica holding local work (`holdsUnsyncedWork`),
- * because the retry itself is destructive.
- */
-const CREATED_EPIC_UNAVAILABLE_RETRY_DELAYS_MS: ReadonlyArray<number> = [
-  2_000, 5_000, 10_000,
-];
 
 /**
  * App-level coordinator that force-closes an epic tab when the user loses

--- a/clients/gui-app/src/providers/epic-session-provider.tsx
+++ b/clients/gui-app/src/providers/epic-session-provider.tsx
@@ -48,6 +48,7 @@ import { shouldMergeEpicRoomSwap } from "@/lib/epics/epic-room-swap";
 import { ESTABLISHING_DEADLINE_MS } from "@/lib/host/bounded-load-budgets";
 import { openEpicKey } from "@/lib/persist";
 import { adoptLegacyPersistedKey } from "@/lib/persist/zustand-persist-lifecycle";
+import { sessionCreatedEpicHostId } from "@/lib/epics/session-created-epics";
 
 export interface EpicSessionProviderProps {
   readonly epicId: string;
@@ -291,11 +292,22 @@ export function EpicSessionProvider(
   const [session, setSession] = useState<MountedSessionState | null>(null);
   const sessionRef = useRef<MountedSessionState | null>(null);
   const originalHostIdRef = useRef<string | null>(null);
-  const [requestedHostId, setRequestedHostId] = useState<string | null>(null);
+  // Seeded from the create-host memory for an epic THIS renderer just
+  // created: `epic.create` is local-first on the create host - the cloud
+  // record is written by that host's deferred background connect - so until
+  // it lands, the create host is the only machine that can serve the epic.
+  // Opening on `effectiveHostId` in that window cold-opens into a cloud
+  // NOT_FOUND, which the access coordinator reads as an adjudicated "epic is
+  // gone" and force-closes the brand-new tab. The seed is time-bounded (see
+  // `sessionCreatedEpicHostId`), so later opens of the same epic follow the
+  // effective host as before.
+  const [requestedHostId, setRequestedHostId] = useState<string | null>(() =>
+    sessionCreatedEpicHostId(epicId),
+  );
   const [retryGeneration, setRetryGeneration] = useState(0);
   const [presentation, setPresentation] = useState<SessionPresentationState>({
     kind: "establishing",
-    targetHostId: effectiveHostId,
+    targetHostId: requestedHostId ?? effectiveHostId,
     originalHostId: null,
   });
   const targetHostId = requestedHostId ?? effectiveHostId;

--- a/clients/gui-app/src/providers/epic-session-provider.tsx
+++ b/clients/gui-app/src/providers/epic-session-provider.tsx
@@ -300,10 +300,17 @@ export function EpicSessionProvider(
   // NOT_FOUND, which the access coordinator reads as an adjudicated "epic is
   // gone" and force-closes the brand-new tab. The seed is time-bounded (see
   // `sessionCreatedEpicHostId`), so later opens of the same epic follow the
-  // effective host as before.
+  // effective host as before - and within this mount it is given up on the
+  // first derivation move (see `seededCreateHostRef` below), so it never
+  // outranks an activation or a failover.
   const [requestedHostId, setRequestedHostId] = useState<string | null>(() =>
     sessionCreatedEpicHostId(epicId),
   );
+  // Whether `requestedHostId` is still that SEED rather than a host the user
+  // asked for through `openOnOriginalHost`. Only the seed is given up below;
+  // an explicit request is the user's, and outlives a derivation move exactly
+  // as it did before.
+  const seededCreateHostRef = useRef(requestedHostId !== null);
   const [retryGeneration, setRetryGeneration] = useState(0);
   const [presentation, setPresentation] = useState<SessionPresentationState>({
     kind: "establishing",
@@ -364,9 +371,37 @@ export function EpicSessionProvider(
   const openOnOriginalHost = useCallback((): void => {
     const originalHostId = originalHostIdRef.current;
     if (originalHostId === null) return;
+    // An explicit request replaces the seed and stops being one: the user
+    // named this host, so a later derivation move must not silently take it
+    // back the way it takes back the create-host seed.
+    seededCreateHostRef.current = false;
     setRequestedHostId(originalHostId);
     setRetryGeneration((generation) => generation + 1);
   }, []);
+
+  // The create-host seed answers ONE question - which host can serve this epic
+  // while its cloud record is still being written - and that question is
+  // settled in seconds. It must not also outrank a later derivation move: an
+  // unseeded session re-points when `effectiveHostId` changes (Settings ▸
+  // Activate, or a failover), and a session that merely STARTED on its create
+  // host has no standing to refuse that.
+  //
+  // Given up on the move, not on a timer. Expiring the seed on its own clock
+  // would re-point a healthy session for no reason at the two-minute mark -
+  // the create host and the effective host differ by construction in the case
+  // this seed exists for, so a bare expiry IS a re-point. `null` is the
+  // authority's DETACHED default rather than a move, so the first non-null
+  // answer is adopted as the baseline instead of acted on.
+  const lastEffectiveHostIdRef = useRef<string | null>(effectiveHostId);
+  useEffect(() => {
+    if (effectiveHostId === null) return;
+    const previous = lastEffectiveHostIdRef.current;
+    lastEffectiveHostIdRef.current = effectiveHostId;
+    if (previous === null || previous === effectiveHostId) return;
+    if (!seededCreateHostRef.current) return;
+    seededCreateHostRef.current = false;
+    setRequestedHostId(null);
+  }, [effectiveHostId]);
 
   // A selection gap must be visible: the old provider silently bailed and left
   // the task permanently skeleton-bound. But the authority's `null` carries TWO

--- a/clients/gui-app/src/providers/epic-session-provider.tsx
+++ b/clients/gui-app/src/providers/epic-session-provider.tsx
@@ -307,9 +307,11 @@ export function EpicSessionProvider(
     sessionCreatedEpicHostId(epicId),
   );
   // Whether `requestedHostId` is still that SEED rather than a host the user
-  // asked for through `openOnOriginalHost`. Only the seed is given up below;
-  // an explicit request is the user's, and outlives a derivation move exactly
-  // as it did before.
+  // asked for through `openOnOriginalHost`. Only the seed is given up, and on
+  // any of the three signals that the create race is no longer what decides
+  // placement: a derivation move, a Retry, or the user naming a host. An
+  // explicit request is the user's and outlives all of them, exactly as it
+  // did before this seed existed.
   const seededCreateHostRef = useRef(requestedHostId !== null);
   const [retryGeneration, setRetryGeneration] = useState(0);
   const [presentation, setPresentation] = useState<SessionPresentationState>({
@@ -366,6 +368,18 @@ export function EpicSessionProvider(
   }, []);
 
   const retryRepoint = useCallback((): void => {
+    // Reaching Retry means the seeded open FAILED at the one job the seed
+    // has, so give it up here too. Without this the seed survives a create
+    // host that died while `effectiveHostId` never moved - the derivation
+    // move below is then never observed - and Retry re-dials the dead host
+    // for as long as the user keeps pressing it, where an UNSEEDED session
+    // would have re-dialed the live effective host. Only the seed is
+    // dropped; a host the user named through `openOnOriginalHost` is what
+    // they are retrying, so it stays.
+    if (seededCreateHostRef.current) {
+      seededCreateHostRef.current = false;
+      setRequestedHostId(null);
+    }
     setRetryGeneration((generation) => generation + 1);
   }, []);
   const openOnOriginalHost = useCallback((): void => {


### PR DESCRIPTION
## What

Creating a task with a **remote host** selected as placement navigated to the task screen and then force-closed it seconds later with **"This epic is no longer available."** The task itself was fine — it showed up in history immediately, and opening it from there worked.

The cause is a **create-host / serving-host race**.

`epic.create` is local-first *on the host it is sent to*: that host seeds an in-memory warm slot plus pending-create gates synchronously, and writes the cloud record only in a deferred background connect. But the epic session opened on `requestedHostId ?? effectiveHostId`, and `requestedHostId` was only ever set by the "open on original host" recovery affordance — so a brand-new tab always opened on the app-wide **effective** host. In the create window that host has no warm slot: it cold-opens, calls `getTaskRoomInfo`, and gets a 404 for a record that has not been written yet.

The host's stream resolver classifies that 404 as a fatal `NOT_FOUND` — which is *correct* for an established epic, where it means deleted — and `EpicAccessCoordinator` maps it to the neutral "unavailable" verdict and ejects the tab.

```mermaid
sequenceDiagram
    participant GUI
    participant Remote as Remote host (create host)
    participant Local as Local host (effective host)
    participant Cloud

    GUI->>Remote: epic.create (placement client)
    Note over Remote: local-first: warm slot +<br/>pending-create gates
    Remote--)Cloud: deferred background connect
    GUI->>Local: epic.subscribe (effectiveHostId)
    Note over Local: no warm slot - cold open
    Local->>Cloud: getTaskRoomInfo
    Cloud-->>Local: 404 (record not written yet)
    Local-->>GUI: fatal close, NOT_FOUND
    Note over GUI: toast + force-close tab
    Remote--)Cloud: create lands (seconds later)
```

Local creates never showed this: there the create host and the effective host are the same machine, so the session is served from the warm slot behind the pending-create gate and never consults the cloud.

Confirmed in `host.log`: the local host fatal-closes the subscribe with `NOT_FOUND` at `21:03:53.969`, and the **same** host serves the **same** epic successfully at `21:04:03` once the remote host's background create had landed.

## How

Two client-side layers. The host's classification ladder is deliberately untouched — only the creating renderer has the knowledge that this particular absence is replication lag rather than a delete.

**1. Create-host seeding — removes the race.** The created-this-session marker that both landing-composer flows already write synchronously now records the host the create was sent on, and `EpicSessionProvider` seeds `requestedHostId` from it. The session opens on the host holding the warm slot and never asks the cloud.

The seed is TTL-bounded (2 min): past that window the cloud record exists and the ordinary rule — epic sessions follow the effective host — is right again, so a self-created epic is not pinned to its create host for the whole app session. `wasEpicCreatedThisSession` stays **non-expiring**; the existence reconciler and the grace below need the session-lifetime fact, not the placement seed.

**2. A bounded `NOT_FOUND` grace — backstop.** An `unavailable` verdict on an epic *this renderer created* re-subscribes silently via `requestFreshSnapshot()` on a `2s / 5s / 10s` schedule before ejecting. Exhausting the schedule falls through to the normal toast + close, so a genuinely deleted epic still ejects (just those seconds later). Deletes and revokes never enter the grace — those verdicts are first-hand, not inferred from absence. This covers what the seed cannot: the create host's own connect retrying with backoff past the moment of open, or an open that lands on another host anyway.

Both the scheduling path and the timer's own callback re-derive the verdict at fire time, so a session that recovered — or died for a different, first-hand reason — is never torn down by a stale grace. Pending timers are cleared when the tab leaves the open set and on unmount.

## The part that deserves the most review

The grace deliberately **drops the `handled` latch** instead of holding it. That is what lets the retry's own failure (a fresh `snapshotFetchError`) re-enter the evaluation and take the next slot — but it also means a signal landing while a retry is pending must not double-schedule or fall through to the eject, which is what the `createGraceTimers.has(epicId)` early return is for. Attempts are never reset on recovery: the budget absorbs *one* create's replication lag, and a session that turns `unavailable` again with the budget spent gets the ordinary eject.

Also included: a `disposed` latch closing a **pre-existing** window in the same effect. `evaluate` defers its verdict to a microtask, so a signal landing just before unmount could fire that microtask after teardown and navigate/mutate stores from a dead coordinator (or park a timer in a map teardown had already swept). The replacement coordinator instance re-walks every open session on mount, so a bailed verdict is re-derived, never lost.

## Testing

11 new tests, each ablation-checked (reverting the branch it pins makes exactly that test fail):

- create-host recording, TTL expiry of the placement seed vs. the non-expiring session fact (7)
- the grace holding then re-subscribing, ejecting once the schedule is spent, and `deleted` still ejecting immediately (3)
- the session opening on the create host rather than the effective host (1)

58 tests green across the affected suites; `compile` / `lint` / `format` clean via pre-commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
