### PR TITLE
fix(gui,protocol): stop reading an absence as evidence, twice

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/chat-tile-session-state.test.ts
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/chat-tile-session-state.test.ts
@@ -929,9 +929,11 @@ describe("findUnanswerableInterviews", () => {
     ];
 
     expect(
-      findUnanswerableInterviews(messages, [
-        { blockId: "settled-block", requestedAt: 10 },
-      ]),
+      findUnanswerableInterviews(
+        messages,
+        [{ blockId: "settled-block", requestedAt: 10 }],
+        null,
+      ),
     ).toEqual([{ blockId: "settled-block", requestedAt: 10 }]);
   });
 
@@ -940,6 +942,7 @@ describe("findUnanswerableInterviews", () => {
       findUnanswerableInterviews(
         [],
         [{ blockId: "ghost-block", requestedAt: 7 }],
+        null,
       ),
     ).toEqual([{ blockId: "ghost-block", requestedAt: 7 }]);
   });
@@ -954,7 +957,7 @@ describe("findUnanswerableInterviews", () => {
 
     // The two derivations partition the host's pending set - a block routed to
     // the card must never also raise the escape hatch.
-    expect(findUnanswerableInterviews(messages, pending)).toEqual([]);
+    expect(findUnanswerableInterviews(messages, pending, null)).toEqual([]);
     expect(
       findPendingInterview(messages, (id) => id === "streaming-block")?.blockId,
     ).toBe("streaming-block");
@@ -971,10 +974,14 @@ describe("findUnanswerableInterviews", () => {
     ];
 
     expect(
-      findUnanswerableInterviews(messages, [
-        { blockId: "settled-block", requestedAt: 10 },
-        { blockId: "streaming-block", requestedAt: 20 },
-      ]),
+      findUnanswerableInterviews(
+        messages,
+        [
+          { blockId: "settled-block", requestedAt: 10 },
+          { blockId: "streaming-block", requestedAt: 20 },
+        ],
+        null,
+      ),
     ).toEqual([{ blockId: "settled-block", requestedAt: 10 }]);
   });
 
@@ -986,6 +993,7 @@ describe("findUnanswerableInterviews", () => {
           { blockId: "newer-block", requestedAt: 20 },
           { blockId: "older-block", requestedAt: 10 },
         ],
+        null,
       ).map((interview) => interview.blockId),
     ).toEqual(["older-block", "newer-block"]);
   });
@@ -993,7 +1001,7 @@ describe("findUnanswerableInterviews", () => {
   it("returns one stable empty reference so the composer memo cannot churn", () => {
     // `renderedMessages` changes on every streaming token; a fresh `[]` here
     // would re-identify the composer's props each token.
-    const first = findUnanswerableInterviews([], []);
+    const first = findUnanswerableInterviews([], [], null);
     const second = findUnanswerableInterviews(
       [
         interviewMessage("m-1", [
@@ -1001,10 +1009,95 @@ describe("findUnanswerableInterviews", () => {
         ]),
       ],
       [{ blockId: "streaming-block", requestedAt: 10 }],
+      null,
     );
 
     expect(first).toEqual([]);
     expect(second).toBe(first);
+  });
+
+  /**
+   * The windowed line, where "not in `messages`" stopped being evidence.
+   *
+   * The three cases below are the three states the host's judgement can be in
+   * for a pending id, and only ONE of them may reach the dismiss affordance.
+   * The other two are a question the reader can still answer.
+   */
+  describe("on the windowed line", () => {
+    it("does not offer to dismiss a question the host placed at an ordinal", () => {
+      // The bug this fixes. The block is answerable and merely cold - its row
+      // outside the retained window - so the rendered scan misses it, and
+      // before the host's answer this offered to settle it as errored.
+      expect(
+        findUnanswerableInterviews(
+          [],
+          [{ blockId: "cold-block", requestedAt: 10 }],
+          [{ blockId: "cold-block", ordinal: 7 }],
+        ),
+      ).toEqual([]);
+    });
+
+    it("offers to dismiss a question the host says no row renders", () => {
+      // `ordinal: null` is a judgement, not an absence: the host walked the
+      // whole transcript and found nothing that could ever draw a card. This
+      // is the phantom-interview case, and suppressing the notice here would
+      // leave the chat wedged with no way out.
+      expect(
+        findUnanswerableInterviews(
+          [],
+          [{ blockId: "stuck-block", requestedAt: 10 }],
+          [{ blockId: "stuck-block", ordinal: null }],
+        ),
+      ).toEqual([{ blockId: "stuck-block", requestedAt: 10 }]);
+    });
+
+    it("does not offer to dismiss a question the host has not judged", () => {
+      // An id that became pending AFTER the snapshot: `interviewRequested`
+      // publishes it, and the block delta that would have rendered it was
+      // dropped because its row is evicted. Absent from the judgement is
+      // "unjudged", never "unrenderable" - the next snapshot decides.
+      expect(
+        findUnanswerableInterviews(
+          [],
+          [{ blockId: "fresh-block", requestedAt: 10 }],
+          [{ blockId: "other-block", ordinal: null }],
+        ),
+      ).toEqual([]);
+    });
+
+    it("still keeps a rendered streaming block out of the notice", () => {
+      // The rendered scan is not replaced by the judgement, it is narrowed by
+      // it: a block this client can already draw needs no host opinion.
+      const messages = [
+        interviewMessage("m-1", [
+          { blockId: "live-block", status: "streaming" },
+        ]),
+      ];
+
+      expect(
+        findUnanswerableInterviews(
+          messages,
+          [{ blockId: "live-block", requestedAt: 10 }],
+          [{ blockId: "live-block", ordinal: null }],
+        ),
+      ).toEqual([]);
+    });
+
+    it("separates a cold question from a genuinely stuck one in the same chat", () => {
+      expect(
+        findUnanswerableInterviews(
+          [],
+          [
+            { blockId: "stuck-block", requestedAt: 10 },
+            { blockId: "cold-block", requestedAt: 20 },
+          ],
+          [
+            { blockId: "stuck-block", ordinal: null },
+            { blockId: "cold-block", ordinal: 3 },
+          ],
+        ),
+      ).toEqual([{ blockId: "stuck-block", requestedAt: 10 }]);
+    });
   });
 });
 
@@ -1096,6 +1189,8 @@ function windowedLine(input: {
       pinnedTaskTodoItems: [],
       latestForkableAssistantMessageId: null,
       restorableSetupInterruption: null,
+      interviewAnswerability: [],
+      latestAssistantAuthFailureTurnKey: null,
     },
   };
 }
@@ -1379,5 +1474,7 @@ function derivedWith(
     pinnedTaskTodoItems: [],
     latestForkableAssistantMessageId: null,
     restorableSetupInterruption: null,
+    interviewAnswerability: [],
+    latestAssistantAuthFailureTurnKey: null,
   };
 }

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/chat-tile-setup.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/chat-tile-setup.test.tsx
@@ -262,6 +262,8 @@ function emitWindowedSnapshot(
         pinnedTaskTodoItems: [],
         latestForkableAssistantMessageId: null,
         restorableSetupInterruption,
+        interviewAnswerability: [],
+        latestAssistantAuthFailureTurnKey: null,
       },
     },
   });

--- a/clients/gui-app/src/components/epic-canvas/renderers/chat-tile-session-state.ts
+++ b/clients/gui-app/src/components/epic-canvas/renderers/chat-tile-session-state.ts
@@ -5,6 +5,7 @@ import type {
   ChatRunSettings,
   ChatRunStatus,
 } from "@traycer/protocol/host/agent/gui/subscribe";
+import type { InterviewAnswerability } from "@traycer/protocol/host/agent/gui/subscribe-windowed";
 import type { RestoreResultEntry } from "@traycer/protocol/persistence/epic/checkpoint-manifests";
 import type {
   Message,
@@ -683,15 +684,39 @@ const NO_UNANSWERABLE_INTERVIEWS: ReadonlyArray<UnanswerableInterviewView> = [];
  * over the host's pending set: every id here has no streaming block, so the two
  * can never name the same block.
  *
- * There is no transient window to debounce. The host broadcasts an interview's
- * `blockDelta` before the `interviewRequested` frame that makes it pending
- * (chat-session-manager `handleRuntimeEvent`), and hydration surfaces detached
- * waits in the same snapshot that carries their persisted blocks - so a pending
- * id without a streaming block is genuinely stuck, not mid-arrival.
+ * There is no transient window to debounce ON THE LEGACY LINE. The host
+ * broadcasts an interview's `blockDelta` before the `interviewRequested` frame
+ * that makes it pending (chat-session-manager `handleRuntimeEvent`), and
+ * hydration surfaces detached waits in the same snapshot that carries their
+ * persisted blocks - so a pending id without a streaming block is genuinely
+ * stuck, not mid-arrival.
+ *
+ * ## Why the windowed line needs `hostAnswerability`
+ *
+ * That whole argument rests on the transcript being WHOLE. Once `messages` is
+ * the hydrated window, "no streaming block here" stops meaning "no streaming
+ * block": the question can be perfectly answerable and merely cold - its row
+ * past the inline tail, or a detached wait the eager range has not reached -
+ * and this would offer to error out a question the user could have answered.
+ * A block delta arriving for an EVICTED row is dropped rather than seated, so
+ * even the flush-before-publish ordering above stops closing the gap.
+ *
+ * So on that line the host judges it, and the three states are distinct:
+ *
+ * - **an entry with an ordinal** - answerable, merely cold. Not listed here;
+ *   the store hydrates that row and the card appears.
+ * - **an entry with `ordinal: null`** - no row renders it. Genuinely stuck,
+ *   listed, and dismissal is the right affordance.
+ * - **no entry** - the host has not judged this id (it became pending after
+ *   the snapshot). Not listed: an unjudged question is not evidence of one.
+ *
+ * @param hostAnswerability The host's judgement, or `null` on the legacy line -
+ * where absence in `messages` IS the answer and no second opinion exists.
  */
 export function findUnanswerableInterviews(
   messages: ReadonlyArray<ChatMessageModel>,
   hostPendingInterviews: ReadonlyArray<ChatPendingInterviewState>,
+  hostAnswerability: ReadonlyArray<InterviewAnswerability> | null,
 ): ReadonlyArray<UnanswerableInterviewView> {
   if (hostPendingInterviews.length === 0) return NO_UNANSWERABLE_INTERVIEWS;
   const streamingBlockIds = new Set<string>();
@@ -702,9 +727,22 @@ export function findUnanswerableInterviews(
       streamingBlockIds.add(segment.id);
     }
   }
+  // Only the ids the host judged UNRENDERABLE. Both other states - judged and
+  // placeable, or not judged at all - fall outside this set, which is why the
+  // check below is membership rather than a lookup with a default.
+  const hostStuckBlockIds =
+    hostAnswerability === null
+      ? null
+      : new Set(
+          hostAnswerability
+            .filter((entry) => entry.ordinal === null)
+            .map((entry) => entry.blockId),
+        );
   const unanswerable: UnanswerableInterviewView[] = [];
   for (const interview of hostPendingInterviews) {
     if (streamingBlockIds.has(interview.blockId)) continue;
+    if (hostStuckBlockIds !== null && !hostStuckBlockIds.has(interview.blockId))
+      continue;
     unanswerable.push({
       blockId: interview.blockId,
       requestedAt: interview.requestedAt,

--- a/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
@@ -1888,9 +1888,20 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
   // Host-pending blocks this transcript renders no card for. Yields a stable
   // empty array whenever nothing is stuck, so the composer memo chain below
   // does not churn per streaming token.
+  //
+  // On the windowed line the rendered scan is a scan of a SUBSET, so the host's
+  // judgement decides which of its misses are real - see the function's own
+  // doc. `null` is the legacy line, where absence in the transcript is proof.
   const unanswerableInterviews = useMemo(
-    () => findUnanswerableInterviews(renderedMessages, state.pendingInterviews),
-    [renderedMessages, state.pendingInterviews],
+    () =>
+      findUnanswerableInterviews(
+        renderedMessages,
+        state.pendingInterviews,
+        state.transcriptDerived === null
+          ? null
+          : state.transcriptDerived.interviewAnswerability,
+      ),
+    [renderedMessages, state.pendingInterviews, state.transcriptDerived],
   );
   const unanswerableInterviewsBusy = unanswerableInterviews.some((interview) =>
     interviewActionBlockIds.has(interview.blockId),

--- a/clients/gui-app/src/stores/chats/__tests__/chat-session-store-viewport-hydration.test.ts
+++ b/clients/gui-app/src/stores/chats/__tests__/chat-session-store-viewport-hydration.test.ts
@@ -111,6 +111,8 @@ function snapshot(input: {
     pinnedTaskTodoItems: [],
     latestForkableAssistantMessageId: null,
     restorableSetupInterruption: null,
+    interviewAnswerability: [],
+    latestAssistantAuthFailureTurnKey: null,
   };
   return {
     kind: "snapshot",

--- a/clients/gui-app/src/stores/chats/__tests__/chat-session-store.test.ts
+++ b/clients/gui-app/src/stores/chats/__tests__/chat-session-store.test.ts
@@ -10966,6 +10966,8 @@ describe("createChatSessionStore", () => {
             clientActionId: "send-1",
             messageId: "queued-msg",
           },
+          interviewAnswerability: [],
+          latestAssistantAuthFailureTurnKey: null,
         },
       }),
     ).toMatchObject({
@@ -10998,6 +11000,8 @@ describe("createChatSessionStore", () => {
           pinnedTaskTodoItems: [],
           latestForkableAssistantMessageId: null,
           restorableSetupInterruption: null,
+          interviewAnswerability: [],
+          latestAssistantAuthFailureTurnKey: null,
         },
       }),
     ).toBeNull();

--- a/clients/gui-app/src/stores/chats/__tests__/transcript-window.test.ts
+++ b/clients/gui-app/src/stores/chats/__tests__/transcript-window.test.ts
@@ -552,7 +552,7 @@ describe("range responses", () => {
     expect(seated.invalidated).toBe(true);
     // And the planner now asks for a resnapshot rather than the same range.
     expect(
-      planTranscriptHydration(seated, { fromOrdinal: 0, toOrdinal: 4 }),
+      planTranscriptHydration(seated, { fromOrdinal: 0, toOrdinal: 4 }, []),
     ).toBeNull();
   });
 
@@ -685,7 +685,7 @@ describe("gaps and what to request next", () => {
       rowCount: 40,
       tail: { fromOrdinal: 40, messages: [], events: [] },
     });
-    expect(planTranscriptHydration(window, null)).toEqual({
+    expect(planTranscriptHydration(window, null, [])).toEqual({
       fromOrdinal: 20,
       toOrdinal: 40,
     });
@@ -705,9 +705,9 @@ describe("gaps and what to request next", () => {
         messages: [userMessage("m-20", 20)],
       }),
     );
-    expect(planTranscriptHydration(window, null)).toBeNull();
+    expect(planTranscriptHydration(window, null, [])).toBeNull();
     expect(
-      planTranscriptHydration(window, { fromOrdinal: 0, toOrdinal: 10 }),
+      planTranscriptHydration(window, { fromOrdinal: 0, toOrdinal: 10 }, []),
     ).toEqual({ fromOrdinal: 0, toOrdinal: 10 });
   });
 
@@ -718,8 +718,103 @@ describe("gaps and what to request next", () => {
       changes: [{ type: "reindexed" }],
     });
     expect(
-      planTranscriptHydration(window, { fromOrdinal: 0, toOrdinal: 5 }),
+      planTranscriptHydration(window, { fromOrdinal: 0, toOrdinal: 5 }, []),
     ).toBeNull();
+  });
+
+  /**
+   * The third obligation: rows something other than the viewport is blocked on.
+   *
+   * Today that is a pending interview's question, whose card renders in the
+   * COMPOSER - so no amount of scrolling will ever bring its row into view and
+   * viewport-driven hydration would never fetch it. Without this the client
+   * correctly stops offering to dismiss a cold question and then renders
+   * nothing at all, which is a chat blocked with no affordance.
+   */
+  describe("required ordinals", () => {
+    /** A 40-row window whose eager tail is hydrated and nothing else. */
+    function tailHydrated(): TranscriptWindow {
+      return applyRangeResponse(
+        applyWindowedSnapshot(emptyTranscriptWindow(), {
+          epoch: 1,
+          rowCount: 40,
+          tail: { fromOrdinal: 40, messages: [], events: [] },
+        }),
+        rangeResponse({
+          epoch: 1,
+          fromOrdinal: 20,
+          rowIds: Array.from({ length: 20 }, (_u, i) => `row-${20 + i}`),
+          messages: [userMessage("m-20", 20)],
+        }),
+      );
+    }
+
+    it("asks for a required row the window does not hold, one row wide", () => {
+      // One row, not the gap around it: the host always serves the first
+      // requested row whatever it costs, so a single-row ask cannot be
+      // squeezed out by scrollback nobody asked for.
+      expect(planTranscriptHydration(tailHydrated(), null, [4])).toEqual({
+        fromOrdinal: 4,
+        toOrdinal: 5,
+      });
+    });
+
+    it("outranks the visible span", () => {
+      // A reader scrolled elsewhere must not starve the row the chat is
+      // blocked on - the viewport keeps re-planning itself every frame.
+      expect(
+        planTranscriptHydration(
+          tailHydrated(),
+          { fromOrdinal: 0, toOrdinal: 3 },
+          [9],
+        ),
+      ).toEqual({ fromOrdinal: 9, toOrdinal: 10 });
+    });
+
+    it("yields to the missing tail, which is the cheaper way to the same row", () => {
+      const noTail = applyWindowedSnapshot(emptyTranscriptWindow(), {
+        epoch: 1,
+        rowCount: 40,
+        tail: { fromOrdinal: 40, messages: [], events: [] },
+      });
+      expect(planTranscriptHydration(noTail, null, [4])).toEqual({
+        fromOrdinal: 20,
+        toOrdinal: 40,
+      });
+    });
+
+    it("skips a required row the window already holds", () => {
+      // Ordinal 25 is inside the hydrated tail. Re-asking for it would put the
+      // planner in a loop that never reaches the viewport.
+      expect(
+        planTranscriptHydration(
+          tailHydrated(),
+          { fromOrdinal: 0, toOrdinal: 3 },
+          [25],
+        ),
+      ).toEqual({ fromOrdinal: 0, toOrdinal: 3 });
+    });
+
+    it("takes the lowest required ordinal first", () => {
+      expect(planTranscriptHydration(tailHydrated(), null, [12, 4, 9])).toEqual(
+        {
+          fromOrdinal: 4,
+          toOrdinal: 5,
+        },
+      );
+    });
+
+    it("ignores an ordinal outside the transcript", () => {
+      // A judgement carried across a `rowCount` change names a row that does
+      // not exist, and a range framed against it comes back empty forever - a
+      // hydration loop with nothing on the other end. There is no bounds check
+      // for this: `transcriptHydrationGaps` clamps, so an absent row reports
+      // itself hydrated. This pins the COMPOSED behaviour, which is what a
+      // second bound here would have restated.
+      expect(
+        planTranscriptHydration(tailHydrated(), null, [40, 99, -1]),
+      ).toBeNull();
+    });
   });
 });
 
@@ -759,6 +854,7 @@ describe("eviction", () => {
       window,
       window.hydratedBytes - 1,
       null,
+      [],
     );
     expect(evicted.spans.map((span) => span.fromOrdinal)).toEqual([10, 28]);
   });
@@ -785,7 +881,7 @@ describe("eviction", () => {
         messages: [userMessage("warmer", 0)],
       }),
     );
-    const evicted = evictTranscriptWindowToBudget(window, 1, null);
+    const evicted = evictTranscriptWindowToBudget(window, 1, null, []);
     expect(evicted.spans.map((span) => span.fromOrdinal)).toEqual([18]);
   });
 
@@ -836,6 +932,7 @@ describe("eviction", () => {
       touched,
       touched.hydratedBytes - 1,
       null,
+      [],
     );
     // The now-untouched span at 10 is the coldest, so it goes instead of 0.
     expect(evicted.spans.map((span) => span.fromOrdinal)).toEqual([0, 28]);
@@ -897,14 +994,46 @@ describe("eviction protects the visible span", () => {
     // row whatever it costs, so evicting the visible span here would only
     // re-request it and evict it again, forever - while the cold span (0),
     // which nothing is looking at, is fair game.
-    const evicted = evictTranscriptWindowToBudget(window, 1, {
-      fromOrdinal: 10,
-      toOrdinal: 12,
-    });
+    const evicted = evictTranscriptWindowToBudget(
+      window,
+      1,
+      { fromOrdinal: 10, toOrdinal: 12 },
+      [],
+    );
     expect(evicted.spans.map((span) => span.fromOrdinal)).toEqual([10, 28]);
     // The budget is SOFT against the protected spans: the result stays over
     // budget rather than sacrificing them.
     expect(evicted.hydratedBytes).toBeGreaterThan(1);
+  });
+
+  it("never evicts a span holding a required row", () => {
+    // The same re-fetch loop as the visible span, in its purest form: a
+    // required ordinal is re-planned with no viewport to scroll away from, so
+    // evicting its span means fetching that one row forever.
+    let window = windowWithSkeleton(30);
+    window = applyRangeResponse(
+      window,
+      rangeResponse({
+        epoch: 1,
+        fromOrdinal: 0,
+        rowIds: ["row-0", "row-1"],
+        messages: [userMessage("question", 0)],
+      }),
+    );
+    window = applyRangeResponse(
+      window,
+      rangeResponse({
+        epoch: 1,
+        fromOrdinal: 10,
+        rowIds: ["row-10", "row-11"],
+        messages: [userMessage("cold", 10)],
+      }),
+    );
+
+    // Nothing visible, so only the tail rule and the required rule can save a
+    // span - and ordinal 0's span is the coldest by insertion order.
+    const evicted = evictTranscriptWindowToBudget(window, 1, null, [0]);
+    expect(evicted.spans.map((span) => span.fromOrdinal)).toEqual([0]);
   });
 });
 
@@ -976,10 +1105,12 @@ describe("reading a long chat upward from the tail", () => {
     expect(window.hydratedBytes).toBeGreaterThan(budget);
 
     // The reader is at the tail; everything behind it is fair game.
-    const evicted = evictTranscriptWindowToBudget(window, budget, {
-      fromOrdinal: 18,
-      toOrdinal: 20,
-    });
+    const evicted = evictTranscriptWindowToBudget(
+      window,
+      budget,
+      { fromOrdinal: 18, toOrdinal: 20 },
+      [],
+    );
 
     expect(evicted.hydratedBytes).toBeLessThan(window.hydratedBytes);
     expect(evicted.spans.length).toBeLessThan(window.spans.length);
@@ -1212,7 +1343,7 @@ describe("the streaming row's byte charge", () => {
     // Under the STALE figure this window fits, so nothing would be dropped.
     expect(streamed.hydratedBytes).toBeLessThan(budget);
 
-    const evicted = evictTranscriptWindowToBudget(streamed, budget, null);
+    const evicted = evictTranscriptWindowToBudget(streamed, budget, null, []);
     // The tail is exempt, so the cold span is what has to go.
     expect(evicted.spans.map((span) => span.fromOrdinal)).toEqual([29]);
   });
@@ -1228,6 +1359,7 @@ describe("the streaming row's byte charge", () => {
       streamed,
       TRANSCRIPT_WINDOW_MAX_BYTES,
       null,
+      [],
     );
     expect(evicted.spans.map((span) => span.fromOrdinal)).toEqual([0, 29]);
     // Settled on the way through, so the next read costs nothing.
@@ -1381,7 +1513,11 @@ describe("what an overlap keeps", () => {
     });
     expect(reconnected.spans).toHaveLength(0);
     expect(
-      planTranscriptHydration(reconnected, { fromOrdinal: 0, toOrdinal: 3 }),
+      planTranscriptHydration(
+        reconnected,
+        { fromOrdinal: 0, toOrdinal: 3 },
+        [],
+      ),
     ).not.toBeNull();
   });
 

--- a/clients/gui-app/src/stores/chats/__tests__/windowed-session-binding.test.ts
+++ b/clients/gui-app/src/stores/chats/__tests__/windowed-session-binding.test.ts
@@ -4,6 +4,7 @@ import type { Message } from "@traycer/protocol/persistence/epic/schemas";
 import type {
   ChatAccumulatedFileChangeSummary,
   ChatLoadRangeRequest,
+  InterviewAnswerability,
 } from "@traycer/protocol/host/agent/gui/subscribe-windowed";
 import type { ChatStreamCallbacks } from "@traycer-clients/shared/host-transport/chat-stream-client";
 import { createImageResolutionUpdatedFrame } from "@traycer/protocol/host/agent/gui/subscribe";
@@ -12,7 +13,10 @@ import {
   type ChatSessionStoreHandle,
 } from "@/stores/chats/chat-session-store";
 import { IMMEDIATE_STREAM_FLUSH_COORDINATOR } from "@/stores/chats/stream-flush-coordinator";
-import { isTailHydrated } from "@/stores/chats/transcript-window";
+import {
+  isTailHydrated,
+  TRANSCRIPT_WINDOW_MAX_BYTES,
+} from "@/stores/chats/transcript-window";
 
 /**
  * # The wait-for-tail rule
@@ -74,6 +78,40 @@ function userMessage(messageId: string, timestamp: number): Message {
     messageId,
     sender: { type: "user", userId: OWNER_ID },
     message: { kind: "user", content: CONTENT },
+    timestamp,
+    sessionAnchor: null,
+  };
+}
+
+/**
+ * One row larger than the whole window budget.
+ *
+ * A legal response: the host's range read always serves the FIRST requested row
+ * whatever it costs (`read-range.ts`), so a single oversized row is exactly how
+ * a window ends up over budget with nothing else to blame.
+ */
+function oversizedMessage(messageId: string, timestamp: number): Message {
+  return {
+    role: "user",
+    messageId,
+    sender: { type: "user", userId: OWNER_ID },
+    message: {
+      kind: "user",
+      content: {
+        type: "doc",
+        content: [
+          {
+            type: "paragraph",
+            content: [
+              {
+                type: "text",
+                text: "x".repeat(TRANSCRIPT_WINDOW_MAX_BYTES + 1),
+              },
+            ],
+          },
+        ],
+      },
+    },
     timestamp,
     sessionAnchor: null,
   };
@@ -186,11 +224,19 @@ interface WindowedHarness {
    * that is a frame the host has no reason to send.
    */
   lastRangeRequestId(): string;
+  /**
+   * How many times the store asked the app to refetch `providers.list`.
+   *
+   * The re-auth banner's only trigger on a snapshot path, and on this line it
+   * can no longer be read out of the published records.
+   */
+  providerAuthNudgeCount(): number;
 }
 
 function createWindowedHarness(): WindowedHarness {
   const rangeRequests: ChatLoadRangeRequest[] = [];
   let resnapshots = 0;
+  let providerAuthNudges = 0;
   let callbacks: ChatStreamCallbacks | null = null;
   const handle = createChatSessionStore({
     hostId: "host-a",
@@ -198,7 +244,9 @@ function createWindowedHarness(): WindowedHarness {
     chatId: CHAT_ID,
     userId: OWNER_ID,
     onAuthError: null,
-    onProviderAuthError: null,
+    onProviderAuthError: () => {
+      providerAuthNudges += 1;
+    },
     streamFlushCoordinator: IMMEDIATE_STREAM_FLUSH_COORDINATOR,
     streamClientFactory: (_epicId, _chatId, nextCallbacks) => {
       callbacks = nextCallbacks;
@@ -227,6 +275,62 @@ function createWindowedHarness(): WindowedHarness {
       const last = rangeRequests.at(-1);
       if (last === undefined) throw new Error("Expected an outstanding range");
       return last.requestId;
+    },
+    providerAuthNudgeCount: () => providerAuthNudges,
+  };
+}
+
+type WindowedSnapshotFrame = Parameters<
+  ChatStreamCallbacks["onWindowedSnapshot"]
+>[0];
+
+/**
+ * Overlay the two aux/derived fields the answers below travel on.
+ *
+ * A patch rather than more parameters on {@link windowedSnapshot}: these are
+ * read by two suites out of a dozen, and threading them through every call site
+ * would say they are part of what a snapshot IS rather than something a
+ * particular case sets.
+ */
+function withPendingQuestion(
+  frame: WindowedSnapshotFrame,
+  input: {
+    readonly pendingInterviews: ReadonlyArray<{
+      readonly blockId: string;
+      readonly requestedAt: number;
+    }>;
+    readonly interviewAnswerability: ReadonlyArray<InterviewAnswerability>;
+  },
+): WindowedSnapshotFrame {
+  return {
+    ...frame,
+    snapshot: {
+      ...frame.snapshot,
+      pendingInterviews: input.pendingInterviews.map((interview) => ({
+        ...interview,
+      })),
+      derived: {
+        ...frame.snapshot.derived,
+        interviewAnswerability: input.interviewAnswerability.map((entry) => ({
+          ...entry,
+        })),
+      },
+    },
+  };
+}
+
+function withAuthFailure(
+  frame: WindowedSnapshotFrame,
+  latestAssistantAuthFailureTurnKey: string | null,
+): WindowedSnapshotFrame {
+  return {
+    ...frame,
+    snapshot: {
+      ...frame.snapshot,
+      derived: {
+        ...frame.snapshot.derived,
+        latestAssistantAuthFailureTurnKey,
+      },
     },
   };
 }
@@ -285,6 +389,8 @@ function windowedSnapshot(input: {
         pinnedTaskTodoItems: [],
         latestForkableAssistantMessageId: "assistant-9",
         restorableSetupInterruption: null,
+        interviewAnswerability: [],
+        latestAssistantAuthFailureTurnKey: null,
       },
     },
   };
@@ -319,6 +425,274 @@ describe("windowed snapshot with a hydrated tail", () => {
       expect(state.accumulatedFileChangeCount).toBe(7);
       // Nothing missing, so nothing asked for.
       expect(harness.rangeRequests).toEqual([]);
+    } finally {
+      harness.handle.dispose();
+    }
+  });
+});
+
+/**
+ * The two answers a windowed client can no longer read out of an ABSENCE.
+ *
+ * Both consumers used to take an irreversible action on "I cannot find it in
+ * `messages`" - one offers to error out a question, the other declines to
+ * invalidate a stale provider query - and on this line that array is the
+ * hydrated subset.
+ */
+describe("host answers a windowed client cannot derive", () => {
+  it("hydrates the row a cold pending question lives on", () => {
+    // The tail is complete, the reader is looking at nothing in particular,
+    // and ordinal 4 is far outside the window. No scroll would ever ask for
+    // it - the answer card renders in the COMPOSER - so without the required
+    // obligation the chat sits blocked with the question invisible.
+    const harness = createWindowedHarness();
+    try {
+      harness.callbacks().onWindowedSnapshot(
+        withPendingQuestion(
+          windowedSnapshot({
+            epoch: 4,
+            rowCount: 30,
+            tailFromOrdinal: 29,
+            tailMessages: [userMessage("m-29", 29)],
+            accumulatedFileChangeCount: 0,
+          }),
+          {
+            pendingInterviews: [{ blockId: "ask-1", requestedAt: 10 }],
+            interviewAnswerability: [{ blockId: "ask-1", ordinal: 4 }],
+          },
+        ),
+      );
+
+      expect(harness.rangeRequests).toHaveLength(1);
+      const request = harness.rangeRequests[0];
+      expect(request.epoch).toBe(4);
+      expect(request.fromOrdinal).toBe(4);
+      // Inclusive on the wire, so one row is `[4, 4]`.
+      expect(request.toOrdinal).toBe(4);
+    } finally {
+      harness.handle.dispose();
+    }
+  });
+
+  it("asks for nothing when the host says no row renders the question", () => {
+    // `ordinal: null` is the genuinely-stuck judgement. There is no row to
+    // fetch, and the composer's dismiss notice is the correct affordance -
+    // fetching anything here would be a request with no answer.
+    const harness = createWindowedHarness();
+    try {
+      harness.callbacks().onWindowedSnapshot(
+        withPendingQuestion(
+          windowedSnapshot({
+            epoch: 4,
+            rowCount: 30,
+            tailFromOrdinal: 29,
+            tailMessages: [userMessage("m-29", 29)],
+            accumulatedFileChangeCount: 0,
+          }),
+          {
+            pendingInterviews: [{ blockId: "ask-1", requestedAt: 10 }],
+            interviewAnswerability: [{ blockId: "ask-1", ordinal: null }],
+          },
+        ),
+      );
+
+      expect(harness.rangeRequests).toEqual([]);
+    } finally {
+      harness.handle.dispose();
+    }
+  });
+
+  it("asks for nothing for a placed question that is no longer pending", () => {
+    // The judgement and the pending set are one pair at the snapshot that
+    // produced them, and they diverge afterwards: an interview settled by a
+    // live frame leaves `pendingInterviews` immediately while the derived
+    // payload keeps naming its row until the next snapshot. Fetching that row
+    // is work with nothing on the other end of it.
+    //
+    // ANOTHER question stays pending on purpose. With an empty pending list
+    // this would pass on the store's "nothing is pending" early return and
+    // assert nothing about the intersection - which is exactly what the first
+    // version of this test did.
+    const harness = createWindowedHarness();
+    try {
+      harness.callbacks().onWindowedSnapshot(
+        withPendingQuestion(
+          windowedSnapshot({
+            epoch: 4,
+            rowCount: 30,
+            tailFromOrdinal: 29,
+            tailMessages: [userMessage("m-29", 29)],
+            accumulatedFileChangeCount: 0,
+          }),
+          {
+            pendingInterviews: [{ blockId: "ask-2", requestedAt: 20 }],
+            interviewAnswerability: [
+              { blockId: "ask-1", ordinal: 4 },
+              { blockId: "ask-2", ordinal: null },
+            ],
+          },
+        ),
+      );
+
+      expect(harness.rangeRequests).toEqual([]);
+    } finally {
+      harness.handle.dispose();
+    }
+  });
+
+  it("never evicts the question's row, on either path that runs the budget", () => {
+    // The re-fetch loop in its purest form. A required ordinal is re-planned
+    // with NO viewport to scroll away from, so a required span evicted as
+    // coldest is re-requested immediately, evicted again, and the client
+    // fetches one row forever. Both callers of the budget have to know:
+    // `onRange`, which seats it, and `onWindowedSnapshot`, which runs on every
+    // history mutation.
+    //
+    // One oversized row puts the window over budget on its own - a legal
+    // response, since the host always serves the first requested row whatever
+    // it costs - and nothing is visible throughout, so only the required rule
+    // can save the span.
+    const harness = createWindowedHarness();
+    try {
+      const callbacks = harness.callbacks();
+      const question = {
+        pendingInterviews: [{ blockId: "ask-1", requestedAt: 10 }],
+        interviewAnswerability: [{ blockId: "ask-1", ordinal: 0 }],
+      };
+      const snapshot = (): Parameters<
+        ChatStreamCallbacks["onWindowedSnapshot"]
+      >[0] =>
+        withPendingQuestion(
+          windowedSnapshot({
+            epoch: 4,
+            rowCount: 30,
+            tailFromOrdinal: 29,
+            tailMessages: [userMessage("m-29", 29)],
+            accumulatedFileChangeCount: 0,
+          }),
+          question,
+        );
+
+      callbacks.onWindowedSnapshot(snapshot());
+      // The tail is complete and nothing is visible, so this request exists
+      // only because ordinal 0 is required.
+      expect(harness.rangeRequests).toHaveLength(1);
+      expect(harness.rangeRequests[0]?.fromOrdinal).toBe(0);
+
+      callbacks.onRange({
+        kind: "range",
+        hasBinaryPayload: false,
+        epicId: EPIC_ID,
+        chatId: CHAT_ID,
+        range: {
+          requestId: harness.lastRangeRequestId(),
+          epoch: 4,
+          fromOrdinal: 0,
+          rowIds: ["row-0"],
+          messages: [oversizedMessage("m-0", 0)],
+          events: [],
+          rowContext: {},
+          reachedStart: true,
+          reachedEnd: false,
+        },
+      });
+      // Survived `onRange`'s eviction, and nothing was asked for again.
+      expect(
+        harness.handle.store
+          .getState()
+          .transcriptWindow.spans.map((span) => span.fromOrdinal),
+      ).toContain(0);
+      expect(harness.rangeRequests).toHaveLength(1);
+
+      // And survives the next snapshot's, which reads the FRAME's pair
+      // because the store has not been given this one yet.
+      callbacks.onWindowedSnapshot(snapshot());
+      expect(
+        harness.handle.store
+          .getState()
+          .transcriptWindow.spans.map((span) => span.fromOrdinal),
+      ).toContain(0);
+      expect(harness.rangeRequests).toHaveLength(1);
+    } finally {
+      harness.handle.dispose();
+    }
+  });
+
+  it("nudges the provider query for a failure outside the hydrated tail", () => {
+    // The exact shape the scan cannot see: the tail holds one user row and no
+    // assistant record at all, so a backwards scan over `state.messages`
+    // answers "no failure" and the re-auth banner never mounts.
+    const harness = createWindowedHarness();
+    try {
+      harness.callbacks().onWindowedSnapshot(
+        withAuthFailure(
+          windowedSnapshot({
+            epoch: 4,
+            rowCount: 30,
+            tailFromOrdinal: 29,
+            tailMessages: [userMessage("m-29", 29)],
+            accumulatedFileChangeCount: 0,
+          }),
+          "turn-failed",
+        ),
+      );
+
+      expect(
+        harness.handle.store
+          .getState()
+          .messages.some((message) => message.role === "assistant"),
+      ).toBe(false);
+      expect(harness.providerAuthNudgeCount()).toBe(1);
+    } finally {
+      harness.handle.dispose();
+    }
+  });
+
+  it("nudges once per failure, not once per snapshot carrying it", () => {
+    // Every aux-only re-broadcast - a queue change, an approval - re-sends the
+    // whole snapshot with the same derived key. A nudge per frame would
+    // refetch `providers.list` on every chat event for as long as the failure
+    // is the latest turn.
+    const harness = createWindowedHarness();
+    try {
+      const frame = withAuthFailure(
+        windowedSnapshot({
+          epoch: 4,
+          rowCount: 30,
+          tailFromOrdinal: 29,
+          tailMessages: [userMessage("m-29", 29)],
+          accumulatedFileChangeCount: 0,
+        }),
+        "turn-failed",
+      );
+      harness.callbacks().onWindowedSnapshot(frame);
+      harness.callbacks().onWindowedSnapshot(frame);
+      expect(harness.providerAuthNudgeCount()).toBe(1);
+
+      // A LATER failure is a different key, and must nudge again: the user may
+      // already have re-authed the first one.
+      harness
+        .callbacks()
+        .onWindowedSnapshot(withAuthFailure(frame, "turn-failed-again"));
+      expect(harness.providerAuthNudgeCount()).toBe(2);
+    } finally {
+      harness.handle.dispose();
+    }
+  });
+
+  it("does not nudge when the host reports no failure", () => {
+    const harness = createWindowedHarness();
+    try {
+      harness.callbacks().onWindowedSnapshot(
+        windowedSnapshot({
+          epoch: 4,
+          rowCount: 3,
+          tailFromOrdinal: 1,
+          tailMessages: [userMessage("m-1", 1), userMessage("m-2", 2)],
+          accumulatedFileChangeCount: 0,
+        }),
+      );
+      expect(harness.providerAuthNudgeCount()).toBe(0);
     } finally {
       harness.handle.dispose();
     }

--- a/clients/gui-app/src/stores/chats/chat-session-store.ts
+++ b/clients/gui-app/src/stores/chats/chat-session-store.ts
@@ -34,6 +34,7 @@ import type {
   ChatIndexChange,
   ChatRangeResponse,
   ChatTranscriptDerived,
+  InterviewAnswerability,
 } from "@traycer/protocol/host/agent/gui/subscribe-windowed";
 import {
   applyIndexChange,
@@ -143,7 +144,6 @@ import type {
   TokenUsage,
 } from "@traycer/protocol/persistence/epic/foundation";
 import type {
-  AssistantMessage,
   Chat,
   ChatEvent,
   ContentBlock,
@@ -152,6 +152,7 @@ import type {
   Message,
   UserMessageSender,
 } from "@traycer/protocol/persistence/epic/schemas";
+import { latestAssistantAuthFailureTurnKey } from "@traycer/protocol/persistence/chat-transcript/provider-auth-failure";
 import { v4 as uuidv4 } from "uuid";
 import { create, type StoreApi, type UseBoundStore } from "zustand";
 
@@ -1912,20 +1913,24 @@ export function createChatSessionStoreWithNotificationDependencies(
     // harmless refetch either way (the gate is a pure predicate).
     let nudgedAuthErrorTurnId: string | null = null;
 
-    const nudgeProviderAuthFromPersistedError = (
-      messages: ReadonlyArray<Message>,
-    ): void => {
+    /**
+     * Act on the whole-transcript answer, whichever line produced it.
+     *
+     * The SELECTION moved to `provider-auth-failure.ts` and the two lines get
+     * it from different places - the legacy caller runs it over the snapshot's
+     * full record array, the windowed caller reads the host's scalar. What
+     * stays here is the dedupe, because the marker it compares against is also
+     * written by the live `blockDelta` path below and neither line can see
+     * that.
+     *
+     * `null` means "the latest turn did not fail on a credential", on both
+     * lines. It never means "could not tell": that ambiguity is precisely what
+     * the derived scalar exists to remove.
+     */
+    const nudgeProviderAuthFailure = (turnKey: string | null): void => {
       if (options.onProviderAuthError === null) return;
-      const lastAssistant = messages.findLast(
-        (message): message is AssistantMessage => message.role === "assistant",
-      );
-      if (lastAssistant === undefined) return;
-      const turnKey = lastAssistant.turnId ?? lastAssistant.messageId;
+      if (turnKey === null) return;
       if (nudgedAuthErrorTurnId === turnKey) return;
-      const hasAuthError = lastAssistant.blocks.some(
-        (block) => block.type === "error" && block.code === AUTH_ERROR_CODE,
-      );
-      if (!hasAuthError) return;
       nudgedAuthErrorTurnId = turnKey;
       options.onProviderAuthError();
     };
@@ -2009,15 +2014,24 @@ export function createChatSessionStoreWithNotificationDependencies(
      * that judgement about a legitimate new row. The legacy caller passes
      * either `null` or the windowed-state RESET (a downgrade is the same
      * atomicity argument in reverse).
+     *
+     * `authFailureTurnKey` is passed in rather than scanned from `frame`
+     * because THIS is the one question the adaptation cannot carry: the
+     * windowed caller's `frame.snapshot.chat.messages` is the hydrated subset,
+     * so a scan here would answer "no failure" for a failure that is merely
+     * cold. Each caller supplies the whole-transcript answer its own line has -
+     * the legacy scan, or the host's scalar - and the two agree by running the
+     * same selection.
      */
     const applyAuthoritativeSnapshot = (
       frame: ChatSnapshotFrame,
       extra: Partial<ChatSessionState> | null,
+      authFailureTurnKey: string | null,
     ): void => {
       if (disposed || !matchesChat(options, frame.epicId, frame.chatId)) {
         return;
       }
-      nudgeProviderAuthFromPersistedError(frame.snapshot.chat.messages);
+      nudgeProviderAuthFailure(authFailureTurnKey);
       flushBlockDeltas();
       // Pendings dispatched on an earlier connection never see their ack, so
       // the snapshot drops them (below). Computed here, before the set, so a
@@ -2731,9 +2745,10 @@ export function createChatSessionStoreWithNotificationDependencies(
     const requestPlannedHydration = (): void => {
       const client = streamClient;
       if (client === null) return;
+      const state = get();
       // NOT named `window`: the timeout below is armed off the global one, and
       // a local of that name would shadow it.
-      const transcriptWindow = get().transcriptWindow;
+      const transcriptWindow = state.transcriptWindow;
       if (transcriptWindow.invalidated) {
         // A void index cannot be repaired by a range: every ordinal it would
         // name belongs to a coordinate space this client has left.
@@ -2743,6 +2758,7 @@ export function createChatSessionStoreWithNotificationDependencies(
       const next = planTranscriptHydration(
         transcriptWindow,
         visibleTranscriptRange,
+        pendingInterviewOrdinalsOf(state),
       );
       if (next === null) return;
       const inFlight = inFlightHydrationRequest;
@@ -3155,13 +3171,23 @@ export function createChatSessionStoreWithNotificationDependencies(
           ...aux,
           transcriptRowContext: hydratedRowContext(window),
         },
+        // The HOST's answer, not a scan of the adapted frame: those records are
+        // the hydrated subset, and a failure several user rows back is exactly
+        // the shape that falls outside the inline tail.
+        frame.snapshot.derived.latestAssistantAuthFailureTurnKey,
       );
     };
 
     const callbacks: ChatStreamCallbacks = {
       onSnapshot: (frame) => {
         if (!windowedLine) {
-          applyAuthoritativeSnapshot(frame, null);
+          // The legacy line's `messages` IS the transcript, so the scan is the
+          // whole-transcript answer here and needs no host help.
+          applyAuthoritativeSnapshot(
+            frame,
+            null,
+            latestAssistantAuthFailureTurnKey(frame.snapshot.chat.messages),
+          );
           return;
         }
         if (disposed || !matchesChat(options, frame.epicId, frame.chatId)) {
@@ -3185,16 +3211,22 @@ export function createChatSessionStoreWithNotificationDependencies(
         forgetOutstandingHydration();
         clearResnapshotRequest();
         forgetDeferredWindowedSnapshot();
-        applyAuthoritativeSnapshot(frame, {
-          transcriptWindow: emptyTranscriptWindow(),
-          transcriptDerived: null,
-          // The rest of the windowed line's aux state, back to its initial
-          // values: nothing reads either once `transcriptDerived` is null,
-          // but a LATER re-upgrade must start from the same blank state a
-          // fresh store does.
-          accumulatedFileChangeCount: 0,
-          accumulatedFileChangeSummaries: [],
-        });
+        applyAuthoritativeSnapshot(
+          frame,
+          {
+            transcriptWindow: emptyTranscriptWindow(),
+            transcriptDerived: null,
+            // The rest of the windowed line's aux state, back to its initial
+            // values: nothing reads either once `transcriptDerived` is null,
+            // but a LATER re-upgrade must start from the same blank state a
+            // fresh store does.
+            accumulatedFileChangeCount: 0,
+            accumulatedFileChangeSummaries: [],
+          },
+          // A downgrade frame is a LEGACY snapshot - full records - so the
+          // scan is again the whole-transcript answer.
+          latestAssistantAuthFailureTurnKey(frame.snapshot.chat.messages),
+        );
       },
       onWorktreeStateChanged: (frame) => {
         if (disposed || !matchesChat(options, frame.epicId, frame.chatId)) {
@@ -3270,6 +3302,14 @@ export function createChatSessionStoreWithNotificationDependencies(
           }),
           TRANSCRIPT_WINDOW_MAX_BYTES,
           visibleTranscriptRange,
+          // The FRAME's pair, not the store's: this runs before the snapshot's
+          // judgement and pending list are published, and protecting the rows
+          // the PREVIOUS snapshot was blocked on would protect the wrong ones
+          // for exactly the beat that matters.
+          pendingInterviewOrdinals(
+            frame.snapshot.derived.interviewAnswerability,
+            frame.snapshot.pendingInterviews,
+          ),
         );
         // The window and the snapshot's aux ride the fold's own `set` (or the
         // deferral's single `set`) rather than being published here first - a
@@ -3394,6 +3434,9 @@ export function createChatSessionStoreWithNotificationDependencies(
           // function's own doc for the oversized-row re-fetch loop this
           // forecloses.
           visibleTranscriptRange,
+          // And the row a pending question lives on, which is re-planned with
+          // no viewport to scroll away from and would loop hardest of all.
+          pendingInterviewOrdinalsOf(get()),
         );
         // Rides the same `set` as the rows it describes, so no consumer can
         // observe the rows without the fact that a range delivered them.
@@ -6394,6 +6437,59 @@ export function isWindowedTranscript<
   state: T,
 ): state is T & { readonly transcriptDerived: ChatTranscriptDerived } {
   return state.transcriptDerived !== null;
+}
+
+/**
+ * Rows the chat is BLOCKED on - the hydration obligation the viewport cannot
+ * express.
+ *
+ * A pending interview's answer card renders in the composer slot, off a
+ * `streaming` interview block found by walking the rendered rows. Scrolling
+ * never brings it into view, so viewport-driven hydration will not fetch it,
+ * and a chat whose question sits outside the retained window has no affordance
+ * at all: the card cannot render, and the dismiss notice is (correctly) held
+ * back because the host says the question is answerable. Naming the ordinal is
+ * what closes that.
+ *
+ * Intersected with the store's OWN pending list rather than taken from the
+ * host's judgement wholesale. The two are the same set at the snapshot that
+ * produced them, and they diverge afterwards in exactly one direction that
+ * matters: an interview settled by a live frame is dropped from `state`
+ * immediately, and re-fetching a row for a question already answered would be
+ * work with nothing on the other end of it.
+ *
+ * Empty on the legacy line, where `transcriptDerived` is null and the whole
+ * transcript is materialized anyway.
+ */
+function pendingInterviewOrdinals(
+  answerability: ReadonlyArray<InterviewAnswerability> | null,
+  pendingInterviews: ReadonlyArray<ChatPendingInterviewState>,
+): ReadonlyArray<number> {
+  if (answerability === null) return [];
+  if (pendingInterviews.length === 0) return [];
+  const pending = new Set(
+    pendingInterviews.map((interview) => interview.blockId),
+  );
+  const ordinals: number[] = [];
+  for (const entry of answerability) {
+    // `null` is "no row renders it" - genuinely stuck, and nothing to fetch.
+    if (entry.ordinal === null) continue;
+    if (!pending.has(entry.blockId)) continue;
+    ordinals.push(entry.ordinal);
+  }
+  return ordinals;
+}
+
+/** The pair as the STORE currently holds it, for every caller but a snapshot. */
+function pendingInterviewOrdinalsOf(
+  state: ChatSessionState,
+): ReadonlyArray<number> {
+  return pendingInterviewOrdinals(
+    state.transcriptDerived === null
+      ? null
+      : state.transcriptDerived.interviewAnswerability,
+    state.pendingInterviews,
+  );
 }
 
 /**

--- a/clients/gui-app/src/stores/chats/transcript-window.ts
+++ b/clients/gui-app/src/stores/chats/transcript-window.ts
@@ -1549,7 +1549,7 @@ export function unhydratedRowCount(window: TranscriptWindow): number {
 /**
  * What to fetch next, or `null` when the window is already sufficient.
  *
- * Two obligations, in priority order:
+ * Three obligations, in priority order:
  *
  * 1. **The tail, when the LAST ROW is not hydrated.** A snapshot whose
  *    `rowCount` is positive and whose tail seated nothing means the host's tail
@@ -1563,16 +1563,29 @@ export function unhydratedRowCount(window: TranscriptWindow): number {
  *    rows above it as an outstanding obligation would prefetch scrollback the
  *    reader may never reach on every single snapshot. Once the tail is in,
  *    hydration is the viewport's business.
- * 2. **The visible span**, whichever part of it is not hydrated.
+ * 2. **`required`** - rows something OTHER than the viewport is blocked on.
+ *    Today that is exactly one thing: a row carrying a pending interview's
+ *    question, which no scroll will ever bring into view because the card
+ *    renders in the composer. A chat blocked on a question nobody can see is
+ *    stuck, so this outranks scrollback the reader may never reach; it sits
+ *    below the tail only because the tail is where the answer usually already
+ *    is, and asking for it is the cheaper way to get there.
+ * 3. **The visible span**, whichever part of it is not hydrated.
  *
  * An invalidated window returns `null`: no range can repair a void index, and
  * issuing one against a coordinate space the client has left would seat bodies
  * under the wrong rows. The caller owes a `resnapshot` instead, which is a
  * different frame and a different decision.
+ *
+ * @param required Ordinals that must be hydrated regardless of the viewport.
+ * An ordinal outside the transcript selects itself out - see
+ * {@link firstRequiredGap} - so a judgement carried across a `rowCount` change
+ * cannot plan a request the host would answer with nothing.
  */
 export function planTranscriptHydration(
   window: TranscriptWindow,
   visible: OrdinalRange | null,
+  required: readonly number[],
 ): OrdinalRange | null {
   if (window.invalidated) return null;
   if (window.rowCount === 0) return null;
@@ -1586,8 +1599,45 @@ export function planTranscriptHydration(
     const lastTailGap = tailGaps.at(-1);
     if (lastTailGap !== undefined) return lastTailGap;
   }
+  const requiredGap = firstRequiredGap(window, required);
+  if (requiredGap !== null) return requiredGap;
   if (visible === null) return null;
   return transcriptHydrationGaps(window, visible)[0] ?? null;
+}
+
+/**
+ * The lowest required ordinal this window does not hold, as a ONE-ROW range.
+ *
+ * One row rather than the gap around it because the caller wants that row and
+ * nothing else: the host serves the first requested row whatever it costs
+ * (`read-range.ts`), so a single-row ask always succeeds, while widening it to
+ * the enclosing gap could spend the whole frame budget on scrollback nobody
+ * asked for and still stop short of the row that matters.
+ *
+ * Lowest first so a chat blocked on several questions works through them in
+ * transcript order, which is the order the notice lists them in.
+ *
+ * An ordinal outside the transcript needs no guard of its own, and deliberately
+ * does not have one. {@link transcriptHydrationGaps} clamps to `[0, rowCount)`
+ * and answers an empty range with no gap, so a row that does not exist reports
+ * itself hydrated and is skipped by the same line that skips a row the window
+ * already holds. A second bound here would be a restatement of that clamp -
+ * correct today, and one more place to disagree with it later.
+ */
+function firstRequiredGap(
+  window: TranscriptWindow,
+  required: readonly number[],
+): OrdinalRange | null {
+  let lowest: number | null = null;
+  for (const ordinal of required) {
+    if (lowest !== null && ordinal >= lowest) continue;
+    const range = { fromOrdinal: ordinal, toOrdinal: ordinal + 1 };
+    if (transcriptHydrationGaps(window, range).length === 0) continue;
+    lowest = ordinal;
+  }
+  return lowest === null
+    ? null
+    : { fromOrdinal: lowest, toOrdinal: lowest + 1 };
 }
 
 /**
@@ -1615,11 +1665,19 @@ export function planTranscriptHydration(
  * hydrates/evicts/re-fetches that row forever while it never renders once.
  * Protecting what the reader is looking at bounds the overage by one
  * viewport's spans and ends when they scroll away.
+ *
+ * `required` is protected for the SAME reason and would otherwise reintroduce
+ * that loop in its purest form. Those rows are re-planned unconditionally -
+ * they are not gated on a viewport that could scroll away - so a required span
+ * evicted as coldest is re-requested on the next plan, evicted again, and the
+ * client fetches one row forever. It ends the way the viewport's does: when the
+ * question settles and the ordinal stops being required.
  */
 export function evictTranscriptWindowToBudget(
   input: TranscriptWindow,
   maxBytes: number,
   visible: OrdinalRange | null,
+  required: readonly number[],
 ): TranscriptWindow {
   // The one place the byte figure is READ, and therefore the one place it has
   // to be true. Settling FIRST rather than after the early return is the whole
@@ -1629,6 +1687,13 @@ export function evictTranscriptWindowToBudget(
   if (window.hydratedBytes <= maxBytes) return window;
   const isProtected = (span: HydratedSpan): boolean => {
     if (spanEnd(span) >= window.rowCount && window.rowCount > 0) return true;
+    if (
+      required.some(
+        (ordinal) => span.fromOrdinal <= ordinal && spanEnd(span) > ordinal,
+      )
+    ) {
+      return true;
+    }
     return (
       visible !== null &&
       span.fromOrdinal < visible.toOrdinal &&

--- a/clients/shared/host-transport/__tests__/chat-stream-client.test.ts
+++ b/clients/shared/host-transport/__tests__/chat-stream-client.test.ts
@@ -1126,6 +1126,8 @@ function windowedSnapshotFrame(): StreamFrameEnvelope {
         pinnedTaskTodoItems: [],
         latestForkableAssistantMessageId: null,
         restorableSetupInterruption: null,
+        interviewAnswerability: [],
+        latestAssistantAuthFailureTurnKey: null,
       },
     },
   };

--- a/protocol/src/host/agent/gui/__tests__/subscribe-windowed-line.test.ts
+++ b/protocol/src/host/agent/gui/__tests__/subscribe-windowed-line.test.ts
@@ -80,6 +80,8 @@ function baseWindowedSnapshot(): Record<string, unknown> {
       pinnedTaskTodoItems: [],
       latestForkableAssistantMessageId: null,
       restorableSetupInterruption: null,
+      interviewAnswerability: [],
+      latestAssistantAuthFailureTurnKey: null,
     },
   };
 }

--- a/protocol/src/host/agent/gui/subscribe-windowed.ts
+++ b/protocol/src/host/agent/gui/subscribe-windowed.ts
@@ -19,6 +19,12 @@ import {
 } from "@traycer/protocol/persistence/chat-transcript/row-skeleton";
 import { transcriptRowContextSchema } from "@traycer/protocol/persistence/chat-transcript/row-context";
 import {
+  interviewAnswerabilitySchema,
+  judgeInterviewAnswerability,
+  type InterviewAnswerability,
+} from "@traycer/protocol/persistence/chat-transcript/interview-answerability";
+import { latestAssistantAuthFailureTurnKey } from "@traycer/protocol/persistence/chat-transcript/provider-auth-failure";
+import {
   restorableSetupInterruptionSchema,
   selectRestorableSetupInterruption,
   type RestorableSetupInterruption,
@@ -320,6 +326,25 @@ export {
   type RestorableSetupInterruption,
 };
 
+/**
+ * The two answers a windowed client would otherwise read out of an ABSENCE.
+ *
+ * Both back a destructive consumer. `findUnanswerableInterviews` offers to
+ * error out a question whose block it cannot find, and the store's persisted
+ * auth nudge declines to mount the re-auth banner for a failure it cannot see -
+ * one destroys an answer, the other leaves a chat sending against a credential
+ * the host has already poisoned. Their derivations and the reasoning live in
+ * `persistence/chat-transcript/`, beside the row projection they read; they are
+ * re-exported here for the same reason the setup interruption is, so a producer
+ * reads this module alone.
+ */
+export {
+  interviewAnswerabilitySchema,
+  judgeInterviewAnswerability,
+  latestAssistantAuthFailureTurnKey,
+  type InterviewAnswerability,
+};
+
 export const chatTranscriptDerivedSchema = z.object({
   /**
    * The most recent assistant usage report, for the context chip. Nullable
@@ -392,6 +417,33 @@ export const chatTranscriptDerivedSchema = z.object({
    * that space needs its own carriage.
    */
   restorableSetupInterruption: restorableSetupInterruptionSchema.nullable(),
+  /**
+   * Where each host-pending interview's answer card would render.
+   *
+   * One entry per id in the same snapshot's own `pendingInterviews` (see
+   * `chatWindowedSnapshotSchema`), so the two are read as a pair: an `ordinal`
+   * says the card is merely cold and names the row to hydrate, a `null` ordinal
+   * says no row can ever draw it, and a pending id with no entry at all says
+   * the host has not judged it yet. The dismiss affordance is gated on the
+   * second of those three and nothing else - see `interview-answerability.ts`
+   * for why the third is a real state on this line and not on the legacy one.
+   *
+   * Empty for the overwhelming majority of snapshots, because it is bounded by
+   * a pending set that is usually empty.
+   */
+  interviewAnswerability: z.array(interviewAnswerabilitySchema),
+  /**
+   * The nudge key of the latest assistant turn when that turn ended in a
+   * recoverable provider-auth failure, `null` when it did not.
+   *
+   * `null` is the ordinary state and means "the last turn did not fail on a
+   * credential" - never "not hydrated". That distinction is the whole point:
+   * the store's own backwards scan cannot tell the two apart once `messages` is
+   * a window, and it resolves the ambiguity by staying silent, so a headless
+   * failure followed by a few user rows silently stops mounting the re-auth
+   * banner. See `provider-auth-failure.ts`, which both lines call.
+   */
+  latestAssistantAuthFailureTurnKey: z.string().nullable(),
 });
 export type ChatTranscriptDerived = z.infer<typeof chatTranscriptDerivedSchema>;
 

--- a/protocol/src/persistence/chat-transcript/__tests__/interview-answerability.test.ts
+++ b/protocol/src/persistence/chat-transcript/__tests__/interview-answerability.test.ts
@@ -1,0 +1,316 @@
+import { describe, expect, it } from "vitest";
+import {
+  interviewBlockSchema,
+  type ContentBlock,
+} from "@traycer/protocol/persistence/epic/content-blocks";
+import { judgeInterviewAnswerability } from "@traycer/protocol/persistence/chat-transcript/interview-answerability";
+import { contentBlocksById } from "@traycer/protocol/persistence/chat-transcript/pinned-todo-fold";
+import {
+  projectTranscriptRows,
+  type TranscriptRowDescriptor,
+} from "@traycer/protocol/persistence/chat-transcript/row-projection";
+import type { ChatEvent } from "@traycer/protocol/persistence/epic/chat-events";
+import {
+  assistantMessageSchema,
+  userMessageSchema,
+  type AssistantMessage,
+  type Message,
+  type UserMessage,
+} from "@traycer/protocol/persistence/epic/messages";
+
+/**
+ * The host's answer to "is this pending question askable, and where".
+ *
+ * What is worth pinning here is every way the answer can be WRONG in the
+ * direction that hurts: a `null` ordinal is what re-enables the destructive
+ * dismiss affordance, so each of these asserts which of the three states the
+ * judgement lands in - placed, unrenderable, or (by omission) unjudged.
+ */
+
+const AGENT_SENDER = {
+  type: "agent" as const,
+  harnessId: "claude",
+  agentId: "agent-1",
+  displayName: "Claude",
+};
+
+const USER_SENDER = { type: "user" as const, userId: "user-1" };
+
+const NO_EVENTS: readonly ChatEvent[] = [];
+
+function interviewBlock(
+  blockId: string,
+  status: "streaming" | "completed" | "errored",
+): ContentBlock {
+  return interviewBlockSchema.parse({
+    blockId,
+    status,
+    timestamp: 1,
+    type: "interview",
+    toolName: "AskUserQuestion",
+    title: "Pick one",
+    description: null,
+    questions: [],
+    answers: [],
+    error: null,
+    metadata: null,
+  });
+}
+
+function steerBlock(blockId: string, timestamp: number): ContentBlock {
+  return {
+    blockId,
+    status: "completed" as const,
+    timestamp,
+    type: "steer" as const,
+    queueItemId: `q-${blockId}`,
+    messageId: `m-${blockId}`,
+    content: { type: "doc" },
+    mode: "safe_point" as const,
+    sender: null,
+  };
+}
+
+function assistantMessage(input: {
+  messageId: string;
+  timestamp: number;
+  turnId: string;
+  blocks: ReadonlyArray<ContentBlock>;
+}): AssistantMessage {
+  return assistantMessageSchema.parse({
+    role: "assistant",
+    messageId: input.messageId,
+    sender: AGENT_SENDER,
+    blocks: input.blocks,
+    startedAt: input.timestamp,
+    timestamp: input.timestamp,
+    turnId: input.turnId,
+    usage: null,
+  });
+}
+
+function userMessage(messageId: string, timestamp: number): UserMessage {
+  return userMessageSchema.parse({
+    role: "user",
+    messageId,
+    sender: USER_SENDER,
+    message: { kind: "user", content: { type: "doc" } },
+    timestamp,
+    sessionAnchor: null,
+  });
+}
+
+/**
+ * The projection the host feeds this judgement, built the way
+ * `chat-transcript-view.ts` builds it.
+ *
+ * Going through `projectTranscriptRows` rather than hand-writing descriptors is
+ * the point: the ORDINALS these tests assert are the projection's own indices,
+ * so a change to how a turn splits into rows moves them here too.
+ */
+function rowsFor(
+  messages: readonly Message[],
+  activeTurnId: string | null,
+): readonly TranscriptRowDescriptor[] {
+  return projectTranscriptRows({
+    messages,
+    events: NO_EVENTS,
+    activeTurnId,
+    chatId: "chat-1",
+  });
+}
+
+describe("judgeInterviewAnswerability", () => {
+  it("names the ordinal of the row that renders a streaming question", () => {
+    const messages = [
+      userMessage("u-1", 1),
+      assistantMessage({
+        messageId: "a-1",
+        timestamp: 2,
+        turnId: "turn-1",
+        blocks: [interviewBlock("ask-1", "streaming")],
+      }),
+    ];
+
+    expect(
+      judgeInterviewAnswerability(
+        rowsFor(messages, "turn-1"),
+        contentBlocksById(messages),
+        ["ask-1"],
+      ),
+    ).toEqual([{ blockId: "ask-1", ordinal: 1 }]);
+  });
+
+  it("reports a settled block as unrenderable, which is the phantom-interview shape", () => {
+    // The harness errored the AskUserQuestion and the block persisted as
+    // `errored`, but the pending wait was rebuilt from a dangling
+    // `interview.requested`. Nothing will ever draw a card, and the dismiss
+    // affordance is the only way out of the chat - so this MUST stay `null`.
+    const messages = [
+      assistantMessage({
+        messageId: "a-1",
+        timestamp: 2,
+        turnId: "turn-1",
+        blocks: [interviewBlock("ask-1", "errored")],
+      }),
+    ];
+
+    expect(
+      judgeInterviewAnswerability(
+        rowsFor(messages, null),
+        contentBlocksById(messages),
+        ["ask-1"],
+      ),
+    ).toEqual([{ blockId: "ask-1", ordinal: null }]);
+  });
+
+  it("reports a block the transcript never recorded as unrenderable", () => {
+    // The hard-crash shape: the row never persisted, so the question exists
+    // only as a pending wait.
+    expect(
+      judgeInterviewAnswerability(rowsFor([], null), new Map(), ["ghost"]),
+    ).toEqual([{ blockId: "ghost", ordinal: null }]);
+  });
+
+  it("reports a streaming block NO ROW declares as unrenderable", () => {
+    // The contract that makes the row walk load-bearing rather than a stylistic
+    // choice: an ordinal is only ever returned for a row that names the block,
+    // so a block present in the RECORDS but declared by no row is `null`. A
+    // records walk would call it answerable and hand the client an id it has
+    // nowhere to send - hydration is addressed by ordinal, and there is none.
+    //
+    // The rows are hand-built rather than projected precisely because this pins
+    // the function's own contract; whether today's projection can produce such
+    // a block is a separate question, and the client is stuck either way.
+    const messages = [
+      assistantMessage({
+        messageId: "a-1",
+        timestamp: 2,
+        turnId: "turn-1",
+        blocks: [interviewBlock("ask-1", "streaming")],
+      }),
+    ];
+    const rowsWithoutTheBlock: readonly TranscriptRowDescriptor[] = rowsFor(
+      messages,
+      null,
+    ).map((row) =>
+      row.source.kind === "assistant-slice"
+        ? { ...row, source: { ...row.source, blockIds: [] } }
+        : row,
+    );
+
+    expect(
+      judgeInterviewAnswerability(
+        rowsWithoutTheBlock,
+        contentBlocksById(messages),
+        ["ask-1"],
+      ),
+    ).toEqual([{ blockId: "ask-1", ordinal: null }]);
+  });
+
+  it("never names a row that does not declare the block", () => {
+    // The same contract stated as an invariant over a realistic projection: a
+    // returned ordinal must be a row the client can hydrate INTO a card.
+    const messages = [
+      userMessage("u-1", 1),
+      assistantMessage({
+        messageId: "a-1",
+        timestamp: 2,
+        turnId: "turn-1",
+        blocks: [
+          steerBlock("steer-1", 2),
+          interviewBlock("ask-1", "streaming"),
+        ],
+      }),
+    ];
+    const rows = rowsFor(messages, null);
+
+    for (const entry of judgeInterviewAnswerability(
+      rows,
+      contentBlocksById(messages),
+      ["ask-1"],
+    )) {
+      if (entry.ordinal === null) continue;
+      const source = rows[entry.ordinal]?.source;
+      expect(source?.kind).toBe("assistant-slice");
+      expect(
+        source?.kind === "assistant-slice" ? source.blockIds : [],
+      ).toContain(entry.blockId);
+    }
+  });
+
+  it("returns one entry per pending id, in the order it was given them", () => {
+    // The client reads a MISSING entry as "not judged", so the result has to
+    // cover the whole pending set even when most of it is unrenderable.
+    const messages = [
+      assistantMessage({
+        messageId: "a-1",
+        timestamp: 2,
+        turnId: "turn-1",
+        blocks: [interviewBlock("ask-1", "streaming")],
+      }),
+      userMessage("u-1", 3),
+      assistantMessage({
+        messageId: "a-2",
+        timestamp: 4,
+        turnId: "turn-2",
+        blocks: [interviewBlock("ask-2", "streaming")],
+      }),
+    ];
+
+    expect(
+      judgeInterviewAnswerability(
+        rowsFor(messages, null),
+        contentBlocksById(messages),
+        ["ask-2", "missing", "ask-1"],
+      ),
+    ).toEqual([
+      { blockId: "ask-2", ordinal: 2 },
+      { blockId: "missing", ordinal: null },
+      { blockId: "ask-1", ordinal: 0 },
+    ]);
+  });
+
+  it("judges nothing when nothing is pending", () => {
+    // The overwhelmingly common case, and the one that must not walk the
+    // transcript: this runs on every snapshot of every chat.
+    const messages = [
+      assistantMessage({
+        messageId: "a-1",
+        timestamp: 2,
+        turnId: "turn-1",
+        blocks: [interviewBlock("ask-1", "streaming")],
+      }),
+    ];
+
+    expect(
+      judgeInterviewAnswerability(
+        rowsFor(messages, null),
+        contentBlocksById(messages),
+        [],
+      ),
+    ).toEqual([]);
+  });
+
+  it("ignores a pending id that names a block of another type", () => {
+    // Not defensive noise: block ids are unique across the transcript, so a
+    // pending interview id colliding with a `steer` block would otherwise
+    // resolve to that block's row and hydrate the wrong ordinal.
+    const messages = [
+      assistantMessage({
+        messageId: "a-1",
+        timestamp: 2,
+        turnId: "turn-1",
+        blocks: [steerBlock("ask-1", 2)],
+      }),
+    ];
+
+    expect(
+      judgeInterviewAnswerability(
+        rowsFor(messages, null),
+        contentBlocksById(messages),
+        ["ask-1"],
+      ),
+    ).toEqual([{ blockId: "ask-1", ordinal: null }]);
+  });
+});

--- a/protocol/src/persistence/chat-transcript/__tests__/provider-auth-failure.test.ts
+++ b/protocol/src/persistence/chat-transcript/__tests__/provider-auth-failure.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from "vitest";
+import { AUTH_ERROR_CODE } from "@traycer/protocol/host/agent/gui/agent-runtime";
+import { latestAssistantAuthFailureTurnKey } from "@traycer/protocol/persistence/chat-transcript/provider-auth-failure";
+import type { ContentBlock } from "@traycer/protocol/persistence/epic/content-blocks";
+import {
+  assistantMessageSchema,
+  userMessageSchema,
+  type AssistantMessage,
+  type UserMessage,
+} from "@traycer/protocol/persistence/epic/messages";
+
+/**
+ * The selection BOTH lines run - the renderer over a legacy peer's full record
+ * array, the host over the whole transcript - so a chat mounts the re-auth
+ * banner identically whichever host serves it.
+ *
+ * These pin the shape of the answer, not just its truth value: the key is what
+ * the store dedupes on, and getting it wrong turns "nudge once per failure"
+ * into either a nudge storm or a single nudge for the lifetime of the store.
+ */
+
+const AGENT_SENDER = {
+  type: "agent" as const,
+  harnessId: "claude",
+  agentId: "agent-1",
+  displayName: "Claude",
+};
+
+const USER_SENDER = { type: "user" as const, userId: "user-1" };
+
+function errorBlock(blockId: string, code: string | null): ContentBlock {
+  return {
+    blockId,
+    status: "completed" as const,
+    timestamp: 1,
+    type: "error" as const,
+    message: "boom",
+    recoverable: true,
+    code,
+  };
+}
+
+function textBlock(blockId: string): ContentBlock {
+  return {
+    blockId,
+    status: "completed" as const,
+    timestamp: 1,
+    type: "text" as const,
+    text: "hi",
+    providerNotice: null,
+  };
+}
+
+function assistantMessage(input: {
+  messageId: string;
+  timestamp: number;
+  turnId: string | null;
+  blocks: ReadonlyArray<ContentBlock>;
+}): AssistantMessage {
+  return assistantMessageSchema.parse({
+    role: "assistant",
+    messageId: input.messageId,
+    sender: AGENT_SENDER,
+    blocks: input.blocks,
+    startedAt: input.timestamp,
+    timestamp: input.timestamp,
+    turnId: input.turnId,
+    usage: null,
+  });
+}
+
+function userMessage(messageId: string, timestamp: number): UserMessage {
+  return userMessageSchema.parse({
+    role: "user",
+    messageId,
+    sender: USER_SENDER,
+    message: { kind: "user", content: { type: "doc" } },
+    timestamp,
+    sessionAnchor: null,
+  });
+}
+
+describe("latestAssistantAuthFailureTurnKey", () => {
+  it("returns the failed turn's id", () => {
+    expect(
+      latestAssistantAuthFailureTurnKey([
+        userMessage("u-1", 1),
+        assistantMessage({
+          messageId: "a-1",
+          timestamp: 2,
+          turnId: "turn-1",
+          blocks: [errorBlock("b-1", AUTH_ERROR_CODE)],
+        }),
+      ]),
+    ).toBe("turn-1");
+  });
+
+  it("is not hidden by trailing user rows", () => {
+    // The exact shape the windowed line breaks on: the failing assistant
+    // record sits several rows back, so it is the first thing an inline tail
+    // drops - and the legacy suite already covers it, which is why the two
+    // lines have to answer the same.
+    expect(
+      latestAssistantAuthFailureTurnKey([
+        assistantMessage({
+          messageId: "a-1",
+          timestamp: 1,
+          turnId: "turn-1",
+          blocks: [errorBlock("b-1", AUTH_ERROR_CODE)],
+        }),
+        userMessage("u-1", 2),
+        userMessage("u-2", 3),
+      ]),
+    ).toBe("turn-1");
+  });
+
+  it("is silent when a LATER turn succeeded", () => {
+    // A recovered chat keeps its failure rows forever. What decides whether
+    // the credential is broken now is the most recent turn.
+    expect(
+      latestAssistantAuthFailureTurnKey([
+        assistantMessage({
+          messageId: "a-1",
+          timestamp: 1,
+          turnId: "turn-1",
+          blocks: [errorBlock("b-1", AUTH_ERROR_CODE)],
+        }),
+        assistantMessage({
+          messageId: "a-2",
+          timestamp: 2,
+          turnId: "turn-2",
+          blocks: [textBlock("b-2")],
+        }),
+      ]),
+    ).toBeNull();
+  });
+
+  it("ignores an error block with another code", () => {
+    expect(
+      latestAssistantAuthFailureTurnKey([
+        assistantMessage({
+          messageId: "a-1",
+          timestamp: 1,
+          turnId: "turn-1",
+          blocks: [errorBlock("b-1", "rate_limit")],
+        }),
+      ]),
+    ).toBeNull();
+  });
+
+  it("ignores an error block whose code is null", () => {
+    expect(
+      latestAssistantAuthFailureTurnKey([
+        assistantMessage({
+          messageId: "a-1",
+          timestamp: 1,
+          turnId: "turn-1",
+          blocks: [errorBlock("b-1", null)],
+        }),
+      ]),
+    ).toBeNull();
+  });
+
+  it("falls back to the record id for a turnId-less record", () => {
+    // NOT `assistantTurnKey`'s `ts:<timestamp>` fallback. The key exists to
+    // dedupe against the LIVE path's marker, which is the turn the runtime
+    // named; a record that never had one dedupes by identity instead.
+    expect(
+      latestAssistantAuthFailureTurnKey([
+        assistantMessage({
+          messageId: "a-1",
+          timestamp: 1,
+          turnId: null,
+          blocks: [errorBlock("b-1", AUTH_ERROR_CODE)],
+        }),
+      ]),
+    ).toBe("a-1");
+  });
+
+  it("is silent for a transcript with no assistant record", () => {
+    expect(
+      latestAssistantAuthFailureTurnKey([userMessage("u-1", 1)]),
+    ).toBeNull();
+    expect(latestAssistantAuthFailureTurnKey([])).toBeNull();
+  });
+});

--- a/protocol/src/persistence/chat-transcript/interview-answerability.ts
+++ b/protocol/src/persistence/chat-transcript/interview-answerability.ts
@@ -1,0 +1,134 @@
+import { z } from "zod";
+
+import type { TranscriptRowDescriptor } from "@traycer/protocol/persistence/chat-transcript/row-projection";
+import type { ContentBlock } from "@traycer/protocol/persistence/epic/schemas";
+
+/**
+ * # "Is this pending question askable, and where?"
+ *
+ * The GUI renders an interview's answer card only for a `streaming` interview
+ * block it can find in the transcript. A host-pending interview with no such
+ * block is a question nobody can answer while the host keeps rejecting every
+ * send, so the composer offers to settle it as errored - a DESTRUCTIVE action,
+ * and the only escape from a chat wedged that way.
+ *
+ * `findUnanswerableInterviews` decides that from the absence of a rendered
+ * block, and on the legacy line absence is proof: the client holds the whole
+ * transcript. On the windowed line it is not. The block can be perfectly
+ * answerable and merely COLD - its row outside the inline tail because the
+ * turn's last row exceeded the tail budget, or a detached wait sitting far
+ * enough back that the eager range has not reached it - and the notice appears
+ * with its Dismiss button before hydration has had a chance to contradict it.
+ * A user who takes the offer errors out a question they could have answered.
+ *
+ * So the host answers it from the whole transcript, and the client stops
+ * reading absence as evidence.
+ *
+ * ## Why this is indexed by the PENDING set
+ *
+ * Every other value on `chatTranscriptDerived` is a function of the transcript
+ * alone. This one is too - "does a row render an answerable block for id X" is
+ * a whole-transcript fact - but the SET of ids worth answering it for is the
+ * host's pending set, which is the same set the client already has and is small
+ * by construction (it is what the runtime is actually blocked on). Shipping
+ * every streaming interview block in the transcript instead would be unbounded:
+ * a hard crash leaves its block `streaming` forever, so a long-lived chat
+ * accumulates them, and the client would filter them all back down to the
+ * pending set anyway.
+ *
+ * The cost is that the derivation is no longer keyed on the transcript alone -
+ * see `ChatTranscriptDerivedCache`, whose key had to grow with it.
+ *
+ * ## Why a MISSING entry is not the same as `ordinal: null`
+ *
+ * The list has one entry per interview the host had pending when it built the
+ * snapshot, so the two absences are different facts and the client needs both:
+ *
+ * - **`ordinal: null`** - judged, and no row renders an answerable block. The
+ *   question is genuinely stuck and Dismiss is the right affordance.
+ * - **no entry at all** - the id became pending AFTER this snapshot, so the
+ *   host has not judged it. The client must not offer Dismiss for it yet.
+ *
+ * That second case is real on this line and is not on the legacy one. The store
+ * flushes an interview's `blockDelta` before publishing its pending id, which
+ * is what makes "pending with no rendered block" mean "stuck" today - but a
+ * delta targeting an EVICTED row is dropped rather than seated, so on a
+ * windowed client the flush can leave nothing behind. The next snapshot carries
+ * both halves and settles it; until then, unjudged.
+ */
+
+export const interviewAnswerabilitySchema = z.object({
+  blockId: z.string(),
+  /**
+   * The ordinal of the row that renders this question's card, or `null` when
+   * no row does.
+   *
+   * The ordinal is what makes the answer actionable rather than merely
+   * non-destructive: the client hydrates it, the row seats, the card appears
+   * and the question can be answered. Without it a cold question would only
+   * stop being mis-reported as stuck - it would still render nothing, and the
+   * chat would sit blocked with no affordance at all.
+   */
+  ordinal: z.number().int().nonnegative().nullable(),
+});
+export type InterviewAnswerability = z.infer<
+  typeof interviewAnswerabilitySchema
+>;
+
+/**
+ * Where each pending interview's answer card would render, one entry per id.
+ *
+ * ## Why it walks ROWS rather than the records
+ *
+ * Because of what the client does with the answer. The question is not "does
+ * this block exist" - a records walk answers that - it is "which ordinal do I
+ * hydrate to make a card appear", and only the projection knows. Hydration is
+ * addressed by ordinal, so a records walk could report the question answerable
+ * and leave the client with nowhere to send the request.
+ *
+ * That makes the `null` here structural rather than defensive: this returns an
+ * ordinal only for a row that DECLARES the block, so an id no row declares is
+ * reported unrenderable and the dismiss affordance stays available. Whether the
+ * projection can currently produce such a block is not the point - the client
+ * would be stuck either way, and the affordance is the only escape.
+ *
+ * @param rows The projected transcript rows, in canonical order - the array
+ * whose indices ARE the ordinals.
+ * @param blocksById The transcript's content blocks, as `contentBlocksById`
+ * builds them. Passed in rather than rebuilt because the caller already has one
+ * for the pinned-todo fold, and two passes over every block of every record is
+ * the kind of cost this line exists to remove.
+ * @param pendingBlockIds The host's pending interview ids. The result has one
+ * entry per id, in the same order.
+ */
+export function judgeInterviewAnswerability(
+  rows: readonly TranscriptRowDescriptor[],
+  blocksById: ReadonlyMap<string, ContentBlock>,
+  pendingBlockIds: readonly string[],
+): InterviewAnswerability[] {
+  if (pendingBlockIds.length === 0) return [];
+  const pending = new Set(pendingBlockIds);
+  const ordinalByBlockId = new Map<string, number>();
+  for (let ordinal = 0; ordinal < rows.length; ordinal += 1) {
+    const source = rows[ordinal].source;
+    if (source.kind !== "assistant-slice") continue;
+    for (const blockId of source.blockIds) {
+      if (!pending.has(blockId)) continue;
+      // First row wins. A block belongs to exactly one slice, so this cannot
+      // fire today - guarded rather than asserted because the split rule is
+      // `planAssistantTurnRows`'s to change, and the failure it would cause
+      // here is a card hydrated at the wrong ordinal.
+      if (ordinalByBlockId.has(blockId)) continue;
+      const block = blocksById.get(blockId);
+      if (block === undefined || block.type !== "interview") continue;
+      // The renderer's own condition for drawing an answer card, verbatim: a
+      // settled block renders as history, not as a question.
+      if (block.status !== "streaming") continue;
+      ordinalByBlockId.set(blockId, ordinal);
+    }
+  }
+  return pendingBlockIds.map((blockId) => ({
+    blockId,
+    ordinal: ordinalByBlockId.get(blockId) ?? null,
+  }));
+}

--- a/protocol/src/persistence/chat-transcript/provider-auth-failure.ts
+++ b/protocol/src/persistence/chat-transcript/provider-auth-failure.ts
@@ -1,0 +1,83 @@
+import { AUTH_ERROR_CODE } from "@traycer/protocol/host/agent/gui/agent-runtime";
+import type { AssistantMessage } from "@traycer/protocol/persistence/epic/messages";
+import type { Message } from "@traycer/protocol/persistence/epic/schemas";
+
+/**
+ * # "Did this chat's last turn fail on a provider credential?"
+ *
+ * The question the store asks on every authoritative snapshot so a failure that
+ * happened with no live subscriber - a headless A2A turn, a turn that ran while
+ * the tab was closed - still invalidates the stale `providers.list` query and
+ * mounts the re-auth banner when the user comes back.
+ *
+ * ## Why it is a whole-transcript derivation
+ *
+ * The store answered it by scanning the snapshot's records backwards for the
+ * last assistant one. That is sound only while `messages` IS the transcript. On
+ * the windowed line it is the hydrated subset, and the failing turn is outside
+ * it in exactly the case the legacy suite already covers: a headless failure
+ * followed by user rows, which pushes the assistant record out of the inline
+ * tail. The scan then finds a LATER assistant record with no error block - or
+ * none at all - and reports "no failure", permanently, because nothing re-sends
+ * a snapshot to correct it. The banner never mounts and the composer keeps
+ * sending against a credential the host has already poisoned.
+ *
+ * So the answer travels as a scalar on `chatTranscriptDerived`, and the
+ * selection lives here because BOTH lines run it: the renderer against a legacy
+ * peer's full array, the host against the whole transcript. Two copies that
+ * agreed by inspection would drift on the first change to what counts as a
+ * failure, and the drift would be invisible - a banner that mounts against one
+ * host version and not another reads as a flaky host, not as a code defect.
+ *
+ * ## Why the answer is a KEY rather than a boolean
+ *
+ * The nudge is deduped by the failed turn, not once per store lifetime: a
+ * reconnect can surface a NEW headless failure after the user has already
+ * re-authed the previous one, and that later snapshot must still invalidate the
+ * query. A boolean cannot distinguish "the same failure again" from "another
+ * one", so the derivation returns the marker the store compares.
+ */
+
+/**
+ * The nudge key of the latest assistant record when THAT record carries a
+ * recoverable provider-auth error block; `null` when it does not, or when the
+ * transcript has no assistant record at all.
+ *
+ * ## Why the LATEST record and not "any record with an auth error"
+ *
+ * A recovered chat still holds its old failure rows forever. What decides
+ * whether the credential is broken NOW is whether the most recent turn ended
+ * that way, which is the condition the store has always used - preserved here
+ * verbatim rather than improved, because the two lines have to agree and the
+ * legacy line is the one already in the field.
+ *
+ * ## Why RECORD order rather than display order
+ *
+ * `upsertEntry` appends an unseen record at the array tail, so a checkpoint
+ * restore re-adds an older record after newer ones while its display position
+ * stays historical - the drift `fork-boundary.ts` documents. This walks the raw
+ * array anyway, because the value being preserved is the LEGACY store's answer
+ * and that is what the legacy store computes. Switching to canonical order here
+ * would make the same chat mount the banner on one host version and not on
+ * another, which is the exact failure this module exists to prevent. If that
+ * ordering is wrong it is wrong on both lines, and it is one change to both.
+ *
+ * The key mirrors the store's own marker so the live `blockDelta` path and this
+ * one dedupe against each other: `turnId` when the record has one, and the
+ * record id otherwise. Note this is deliberately NOT `assistantTurnKey`, whose
+ * fallback is the timestamp - a record dedupes against the live path by the
+ * turn the runtime named, and a record with no `turnId` never had one.
+ */
+export function latestAssistantAuthFailureTurnKey(
+  messages: readonly Message[],
+): string | null {
+  const lastAssistant = messages.findLast(
+    (message): message is AssistantMessage => message.role === "assistant",
+  );
+  if (lastAssistant === undefined) return null;
+  const hasAuthError = lastAssistant.blocks.some(
+    (block) => block.type === "error" && block.code === AUTH_ERROR_CODE,
+  );
+  if (!hasAuthError) return null;
+  return lastAssistant.turnId ?? lastAssistant.messageId;
+}


### PR DESCRIPTION
Stacked on [#1459](https://github.com/traycerai/traycer/pull/1459) — base is `traycer/eager-walrus`, because everything here is about the windowed `chat.subscribe@1.8` line that PR introduces. Retarget to `main` once #1459 lands.

## What this fixes

Two consumers take an **irreversible** action when they cannot find something in `state.messages`. On the windowed line that array is the *hydrated window*, not the transcript, so "cannot find" stopped being evidence.

| Consumer | What it does on a miss | Why the miss is now wrong |
|---|---|---|
| `findUnanswerableInterviews` | Offers to settle a host-pending interview **as errored** | The question can be answerable and merely cold — its row past the inline tail, or a detached wait the eager range has not reached. A reader who takes the offer destroys an answer. |
| `nudgeProviderAuthFromPersistedError` | Declines to invalidate the stale `providers.list` query | A headless failure followed by user rows is exactly what the inline tail drops. The re-auth banner never mounts and the composer keeps sending against a credential the host has already poisoned. The legacy suite explicitly covers that shape. |

Codex opened both on #1459 (`chat-session-store.ts:2946`, `:3081`). They are the two members of the `state.messages` sweep that *destroy* rather than degrade.

## The shape

Host-side answers on `chatTranscriptDerived`, as `pinnedTodo` and `latestForkableAssistantMessageId` already are.

**`interviewAnswerability`** — one entry per host-pending id, carrying the **ordinal** of the row that would render its card, or `null` when no row can. Three states, and the client needs all three:

| State | Meaning | Dismiss offered? |
|---|---|---|
| `ordinal: <n>` | Answerable, merely cold — hydrate row *n* | No |
| `ordinal: null` | No row can ever draw it (phantom interview) | **Yes** |
| *no entry* | Became pending after this snapshot; unjudged | No |

That third state is real on this line and not on the legacy one: a block delta targeting an **evicted** row is dropped rather than seated, so `interviewRequested` can publish an id whose block never landed. The store's flush-before-publish ordering stops closing the gap, so "unjudged" has to be distinguishable from "unrenderable".

**`latestAssistantAuthFailureTurnKey`** — the nudge key, or `null`. `null` means "the last turn did not fail on a credential", never "not hydrated". The selection moved to shared protocol code that **both** lines call, so a chat mounts the banner identically whichever host version serves it.

## Making the first answer actionable

Carrying the ordinal is what turns "stop mis-reporting a cold question" into "render it":

- `planTranscriptHydration` grows a third obligation, between the tail and the viewport. An interview card renders in the **composer**, so no scroll ever brings its row into view and viewport-driven hydration would never fetch it. Without this the chat stops offering a wrong Dismiss and then sits blocked with no affordance at all.
- `evictTranscriptWindowToBudget` protects those spans, for the same reason it protects the visible span. A required span evicted as coldest is re-requested with **no viewport to scroll away from**, so the client would fetch one row forever.
- `ChatTranscriptDerivedCache`'s key grows the pending ids. An `interviewRequested` re-broadcasts the snapshot against an *unchanged* view, so a view-keyed answer would report every newly pending question unjudged forever — the one moment the answer has to move.

## Companion change

The host half (`buildChatTranscriptDerived`, the cache key, `emitWindowedSnapshotToSubscriber`) lives in the internal repo and ships alongside. Without it `interviewAnswerability` is always `[]` and `latestAssistantAuthFailureTurnKey` always `null`, and both fixes are inert.

## Validation

- `bun run compile --skip-nx-cache` — 6 projects green
- `bun run lint` + `bun run format` — clean
- protocol `chat-transcript` suites: 160 pass · gui-app `stores/chats` + tile suites: 776 pass · `clients/shared` chat-stream-client: 10 pass
- host `chat-transcript-derived`: 9 pass

**20 ablations, each killing a named test.** Two survivors on the first pass were real findings:

- a bounds check in `firstRequiredGap` that `transcriptHydrationGaps`'s *documented* clamp already made unreachable — removed rather than shipped, with the test rewritten to pin the composed behaviour;
- two store tests that passed on the "nothing is pending" early return instead of the intersection they claimed to cover — rewritten to keep another question pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)