### PR TITLE
fix(gui-app): keep shadow-rooted tree scrollers touch-scrollable in modal sheets

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/git-diff/__tests__/file-tree-navigation.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/__tests__/file-tree-navigation.test.tsx
@@ -150,10 +150,10 @@ describe("<FileTree /> nested focus navigation", () => {
   });
 
   /**
-   * The same wrapper also carries `useShadowScrollerTouchShield`'s ref (see
-   * `use-shadow-scroller-touch-shield.ts`), which stops a `touchmove`
+   * The tree's light-DOM wrapper carries `useShadowScrollerTouchShield`'s ref
+   * (see `use-shadow-scroller-touch-shield.ts`), which stops a `touchmove`
    * bubbling out of Pierre's shadow-rooted scroller before it reaches a
-   * document-level listener - the modal scroll lock a vaul drawer registers
+   * document BUBBLE listener - the modal scroll lock a vaul drawer registers
    * while open. jsdom has no `TouchEvent`, so a plain bubbling `Event` stands
    * in; the hook only calls `stopPropagation()`, which does not care about
    * the event's concrete type. `touchstart` is the control: it is untouched

--- a/clients/gui-app/src/components/epic-canvas/git-diff/__tests__/file-tree-navigation.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/__tests__/file-tree-navigation.test.tsx
@@ -148,4 +148,36 @@ describe("<FileTree /> nested focus navigation", () => {
       expect.any(Function),
     );
   });
+
+  /**
+   * The same wrapper also carries `useShadowScrollerTouchShield`'s ref (see
+   * `use-shadow-scroller-touch-shield.ts`), which stops a `touchmove`
+   * bubbling out of Pierre's shadow-rooted scroller before it reaches a
+   * document-level listener - the modal scroll lock a vaul drawer registers
+   * while open. jsdom has no `TouchEvent`, so a plain bubbling `Event` stands
+   * in; the hook only calls `stopPropagation()`, which does not care about
+   * the event's concrete type. `touchstart` is the control: it is untouched
+   * by this hook, so it must still reach the document. Deleting
+   * `ref={touchShieldRef}` from the wrapper must fail this test.
+   */
+  it("shields a bubbling touchmove from the pierre tree so it never reaches the document", () => {
+    const tabId = useEpicCanvasStore.getState().openEpicTab("epic-1", "Epic 1");
+    renderTree(tabId);
+
+    const documentTouchMove = vi.fn();
+    const documentTouchStart = vi.fn();
+    document.addEventListener("touchmove", documentTouchMove);
+    document.addEventListener("touchstart", documentTouchStart);
+    try {
+      const tree = screen.getByTestId("git-pierre-file-tree");
+      tree.dispatchEvent(new Event("touchmove", { bubbles: true }));
+      tree.dispatchEvent(new Event("touchstart", { bubbles: true }));
+
+      expect(documentTouchMove).not.toHaveBeenCalled();
+      expect(documentTouchStart).toHaveBeenCalledTimes(1);
+    } finally {
+      document.removeEventListener("touchmove", documentTouchMove);
+      document.removeEventListener("touchstart", documentTouchStart);
+    }
+  });
 });

--- a/clients/gui-app/src/components/epic-canvas/git-diff/file-tree.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/file-tree.tsx
@@ -14,6 +14,7 @@ import { GIT_PANEL_PIERRE_FILE_TREE_THEME_STYLE } from "@/components/epic-canvas
 import { extractPierreItemPathFromEvent } from "@/components/epic-canvas/pierre-tree-adapter";
 import { usePierreCanvasDragBridge } from "@/components/epic-canvas/dnd/use-pierre-canvas-drag-bridge";
 import { useEpicNestedFocusNavigation } from "@/hooks/epic/use-epic-nested-focus-navigation";
+import { useShadowScrollerTouchShield } from "@/hooks/ui/use-shadow-scroller-touch-shield";
 import {
   GIT_DIFF_TILE_DND_TYPE,
   getGitDiffTileDragId,
@@ -266,9 +267,17 @@ function GitTreeSectionBody(props: GitTreeSectionBodyProps): ReactNode {
     id: getGitDiffTileDragId(`tree:${props.viewTabId}:${props.group}`),
     resolveSourceData: resolveDragSourceData,
   });
+  const touchShieldRef = useShadowScrollerTouchShield();
 
   return (
-    <div {...bridge.wrapperProps} className="flex h-full min-h-0 flex-col">
+    // Pierre's scroller lives in a shadow root; inside the mobile switcher
+    // sheet the modal scroll lock would keep it from ever touch-scrolling.
+    // See `useShadowScrollerTouchShield`.
+    <div
+      {...bridge.wrapperProps}
+      ref={touchShieldRef}
+      className="flex h-full min-h-0 flex-col"
+    >
       <PierreFileTree
         className="h-full min-h-0"
         model={model}

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-file-tree-source.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-file-tree-source.test.tsx
@@ -631,10 +631,10 @@ describe("sidebar file tree source selection", () => {
   });
 
   /**
-   * The same wrapper also carries `useShadowScrollerTouchShield`'s ref (see
-   * `use-shadow-scroller-touch-shield.ts`), which stops a `touchmove`
+   * The tree's light-DOM wrapper carries `useShadowScrollerTouchShield`'s ref
+   * (see `use-shadow-scroller-touch-shield.ts`), which stops a `touchmove`
    * bubbling out of Pierre's shadow-rooted scroller before it reaches a
-   * document-level listener - the modal scroll lock a vaul drawer registers
+   * document BUBBLE listener - the modal scroll lock a vaul drawer registers
    * while open. jsdom has no `TouchEvent`, so a plain bubbling `Event` stands
    * in; the hook only calls `stopPropagation()`, which does not care about
    * the event's concrete type. `touchstart` is the control: it is untouched

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-file-tree-source.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-file-tree-source.test.tsx
@@ -630,6 +630,37 @@ describe("sidebar file tree source selection", () => {
     expect(ambient.subscribedMethods).toEqual([]);
   });
 
+  /**
+   * The same wrapper also carries `useShadowScrollerTouchShield`'s ref (see
+   * `use-shadow-scroller-touch-shield.ts`), which stops a `touchmove`
+   * bubbling out of Pierre's shadow-rooted scroller before it reaches a
+   * document-level listener - the modal scroll lock a vaul drawer registers
+   * while open. jsdom has no `TouchEvent`, so a plain bubbling `Event` stands
+   * in; the hook only calls `stopPropagation()`, which does not care about
+   * the event's concrete type. `touchstart` is the control: it is untouched
+   * by this hook, so it must still reach the document. Deleting
+   * `ref={touchShieldRef}` from the wrapper must fail this test.
+   */
+  it("shields a bubbling touchmove from the pierre tree so it never reaches the document", () => {
+    renderPanel(new MockWsStreamClient("unknown"));
+
+    const documentTouchMove = vi.fn();
+    const documentTouchStart = vi.fn();
+    document.addEventListener("touchmove", documentTouchMove);
+    document.addEventListener("touchstart", documentTouchStart);
+    try {
+      const tree = screen.getByTestId("pierre-file-tree-stub");
+      tree.dispatchEvent(new Event("touchmove", { bubbles: true }));
+      tree.dispatchEvent(new Event("touchstart", { bubbles: true }));
+
+      expect(documentTouchMove).not.toHaveBeenCalled();
+      expect(documentTouchStart).toHaveBeenCalledTimes(1);
+    } finally {
+      document.removeEventListener("touchmove", documentTouchMove);
+      document.removeEventListener("touchstart", documentTouchStart);
+    }
+  });
+
   it("builds the tree from the live stream and leaves the unary path disabled", async () => {
     const client = new MockWsStreamClient("unknown");
     renderPanel(client);

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-file-tree.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-file-tree.tsx
@@ -65,6 +65,7 @@ import { ReportIssueAction } from "@/components/report-issue/report-issue-action
 import { useEpicNestedFocusNavigation } from "@/hooks/epic/use-epic-nested-focus-navigation";
 import { useGitListChangedFilesSubscription } from "@/hooks/git/use-git-list-changed-files-subscription";
 import { useDebouncedValue } from "@/hooks/ui/use-debounced-value";
+import { useShadowScrollerTouchShield } from "@/hooks/ui/use-shadow-scroller-touch-shield";
 import { useWorkspaceListFileTree } from "@/hooks/workspace/use-list-file-tree-query";
 import {
   useWorkspaceFileListSubscription,
@@ -776,6 +777,7 @@ function FileTreeBodyForResolvedHost(
     ),
     resolveSourceData: resolveDragSourceData,
   });
+  const touchShieldRef = useShadowScrollerTouchShield();
 
   return (
     <div
@@ -802,7 +804,14 @@ function FileTreeBodyForResolvedHost(
           className="h-7"
         />
       </div>
-      <div {...bridge.wrapperProps} className="relative min-h-0 flex-1">
+      {/* Pierre's scroller lives in a shadow root; inside the mobile switcher
+          sheet the modal scroll lock would keep it from ever touch-scrolling.
+          See `useShadowScrollerTouchShield`. */}
+      <div
+        {...bridge.wrapperProps}
+        ref={touchShieldRef}
+        className="relative min-h-0 flex-1"
+      >
         {/* `invisible`, not unmount: the model keeps its DOM/state for the
             instant the query changes to something that does match. */}
         <div className={cn("h-full", noMatches && "invisible")}>

--- a/clients/gui-app/src/hooks/__tests__/use-shadow-scroller-touch-shield.test.tsx
+++ b/clients/gui-app/src/hooks/__tests__/use-shadow-scroller-touch-shield.test.tsx
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { useShadowScrollerTouchShield } from "@/hooks/ui/use-shadow-scroller-touch-shield";
+
+/**
+ * jsdom has no `TouchEvent` constructor, so these dispatch plain `Event`
+ * instances named "touchmove" / "touchstart" - the hook only ever reads
+ * `stopPropagation()`, never a Touch-specific payload, so a bubbling plain
+ * `Event` exercises the same code path.
+ */
+function dispatchBubbling(target: Element, type: string): void {
+  target.dispatchEvent(new Event(type, { bubbles: true }));
+}
+
+function TouchShieldHarness(props: { readonly shielded: boolean }) {
+  const touchShieldRef = useShadowScrollerTouchShield();
+  return (
+    <div data-testid="outer">
+      <div data-testid="wrapper" ref={props.shielded ? touchShieldRef : null}>
+        <div data-testid="child" />
+      </div>
+    </div>
+  );
+}
+
+describe("useShadowScrollerTouchShield", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("stops a bubbling touchmove from a descendant reaching the document", () => {
+    render(<TouchShieldHarness shielded />);
+    const documentTouchMove = vi.fn();
+    document.addEventListener("touchmove", documentTouchMove);
+    try {
+      dispatchBubbling(screen.getByTestId("child"), "touchmove");
+      expect(documentTouchMove).not.toHaveBeenCalled();
+    } finally {
+      document.removeEventListener("touchmove", documentTouchMove);
+    }
+  });
+
+  it("still lets a listener on the touched element itself see the touchmove", () => {
+    render(<TouchShieldHarness shielded />);
+    const child = screen.getByTestId("child");
+    const childTouchMove = vi.fn();
+    child.addEventListener("touchmove", childTouchMove);
+    try {
+      dispatchBubbling(child, "touchmove");
+      expect(childTouchMove).toHaveBeenCalledTimes(1);
+    } finally {
+      child.removeEventListener("touchmove", childTouchMove);
+    }
+  });
+
+  it("leaves touchstart alone - only touchmove is shielded", () => {
+    render(<TouchShieldHarness shielded />);
+    const documentTouchStart = vi.fn();
+    document.addEventListener("touchstart", documentTouchStart);
+    try {
+      dispatchBubbling(screen.getByTestId("child"), "touchstart");
+      expect(documentTouchStart).toHaveBeenCalledTimes(1);
+    } finally {
+      document.removeEventListener("touchstart", documentTouchStart);
+    }
+  });
+
+  it("stops shielding once the ref detaches, letting touchmove reach the document again", () => {
+    const { rerender } = render(<TouchShieldHarness shielded />);
+    rerender(<TouchShieldHarness shielded={false} />);
+
+    const documentTouchMove = vi.fn();
+    document.addEventListener("touchmove", documentTouchMove);
+    try {
+      dispatchBubbling(screen.getByTestId("child"), "touchmove");
+      expect(documentTouchMove).toHaveBeenCalledTimes(1);
+    } finally {
+      document.removeEventListener("touchmove", documentTouchMove);
+    }
+  });
+});

--- a/clients/gui-app/src/hooks/ui/use-shadow-scroller-touch-shield.ts
+++ b/clients/gui-app/src/hooks/ui/use-shadow-scroller-touch-shield.ts
@@ -1,0 +1,48 @@
+import { useCallback, useRef } from "react";
+
+/**
+ * Keeps touch scrolling alive for a scroller that lives inside a shadow root
+ * when the surface hosting it also mounts a modal scroll lock.
+ *
+ * On iOS WKWebView, a non-passive document-level `touchmove` listener (the
+ * scroll-lock layer of a modal drawer/dialog registers one while open) makes
+ * the engine defer its native-scroll decision until the event has finished
+ * dispatching. A touch inside a shadow root retargets to the light-DOM host
+ * for that document-level dispatch, and the deferred decision resolves
+ * against the host's light-DOM chain — which contains no scroller — so the
+ * native pan never starts: every `touchmove` flows uncancelled, no `scroll`
+ * event fires, and the rows sit frozen under the finger. Light-DOM scrollers
+ * are unaffected, and programmatic `scrollTop` writes still work, which is
+ * what makes the failure look like a hit-testing bug rather than what it is.
+ *
+ * Stopping `touchmove` propagation at the light-DOM wrapper keeps those
+ * touches out of the document-level dispatch, and the engine engages the
+ * native pan for the shadow-internal scroller directly. Bubble phase, not
+ * capture: the scroller's own shadow-internal listeners must still see the
+ * gesture. The listener is inert wherever no document-level `touchmove`
+ * consumer is mounted (desktop, and sheets without scroll locks).
+ *
+ * Attach the returned ref to the nearest light-DOM wrapper of the
+ * shadow-rooted scroller. The wrapper must not itself need `touchmove` to
+ * reach ancestors — drawer drag-to-dismiss decisions ride pointer events and
+ * are unaffected.
+ */
+export function useShadowScrollerTouchShield(): (
+  node: HTMLElement | null,
+) => void {
+  const cleanupRef = useRef<(() => void) | null>(null);
+  return useCallback((node: HTMLElement | null) => {
+    if (cleanupRef.current !== null) {
+      cleanupRef.current();
+      cleanupRef.current = null;
+    }
+    if (node === null) return;
+    const stopTouchMove = (event: TouchEvent): void => {
+      event.stopPropagation();
+    };
+    node.addEventListener("touchmove", stopTouchMove);
+    cleanupRef.current = () => {
+      node.removeEventListener("touchmove", stopTouchMove);
+    };
+  }, []);
+}

--- a/clients/gui-app/src/hooks/ui/use-shadow-scroller-touch-shield.ts
+++ b/clients/gui-app/src/hooks/ui/use-shadow-scroller-touch-shield.ts
@@ -16,16 +16,23 @@ import { useCallback, useRef } from "react";
  * what makes the failure look like a hit-testing bug rather than what it is.
  *
  * Stopping `touchmove` propagation at the light-DOM wrapper keeps those
- * touches out of the document-level dispatch, and the engine engages the
- * native pan for the shadow-internal scroller directly. Bubble phase, not
- * capture: the scroller's own shadow-internal listeners must still see the
- * gesture. The listener is inert wherever no document-level `touchmove`
- * consumer is mounted (desktop, and sheets without scroll locks).
+ * touches away from document BUBBLE listeners — capture-phase listeners on
+ * document or window still run, since capture descends before the wrapper's
+ * bubble position — and the engine engages the native pan for the
+ * shadow-internal scroller directly. Bubble phase, not capture: listeners at
+ * and below the touched element (the scroller's own shadow-internal ones
+ * included) have already run by the time the wrapper's bubble listener
+ * stops the event. The listener is inert wherever no document-level
+ * `touchmove` consumer is mounted (desktop, and sheets without scroll locks).
  *
  * Attach the returned ref to the nearest light-DOM wrapper of the
  * shadow-rooted scroller. The wrapper must not itself need `touchmove` to
  * reach ancestors — drawer drag-to-dismiss decisions ride pointer events and
- * are unaffected.
+ * are unaffected. The flip side is a standing constraint: any bubble-phase
+ * `touchmove` listener above the wrapper — native or React synthetic — is
+ * deaf to tree gestures. Nothing above listens for `touchmove` today; a
+ * future listener that must hear these gestures needs a capture-phase
+ * registration.
  */
 export function useShadowScrollerTouchShield(): (
   node: HTMLElement | null,


### PR DESCRIPTION
## Problem

On the phone, the workspace file tree inside the mobile tab switcher sheet does not scroll under a finger: rows sit frozen while the same sheet's light-DOM lists (Agents, Artifacts) scroll normally. Instrumented on device: every `touchmove` reaches the page cancelable and unprevented, zero `scroll` events fire, and programmatic `scrollTop` writes work — the native pan simply never starts.

## Mechanism

The sheet is a modal drawer, and its scroll-lock layer keeps a non-passive document-level `touchmove` listener registered while open. With that listener in the dispatch path, WKWebView defers its native-scroll decision until the event finishes dispatching — and for a touch inside a shadow root, that deferred decision resolves against the retargeted light-DOM ancestor chain, which contains no scroller. Pierre's tree renders its scroller inside a shadow root, so the pan never engages. Light-DOM scrollers in the same sheet are unaffected.

Two properties confirmed on device explain why this defect was intermittent across sessions: the first successful pan on a given scroller latches (later gestures scroll even with the listener back in path), and a layer rebuild (e.g. `position` change on the sheet) resets the latch.

## Fix

`useShadowScrollerTouchShield`: a bubble-phase `touchmove` `stopPropagation()` listener attached to each tree's light-DOM wrapper. Bubble, not capture, so the scroller's own shadow-internal listeners still see the gesture; drawer drag-to-dismiss rides pointer events and is untouched. Wired into the workspace sidebar tree and the git-diff tree — a sweep of all shadow-DOM components in the app found these two are the only shadow-internal vertical scrollers reachable inside a modal sheet (the diffs viewer scrolls horizontally within its root and mounts outside modal contexts). Inert wherever no document-level `touchmove` consumer is mounted, including desktop.

## Device verification (iPhone simulator, real finger)

- Controlled A/B in the open sheet: an unshielded shadow-rooted scroller was dead across fresh sheet instances while an identical light-DOM twin scrolled; with the shield attached from mount, the shadow scroller scrolled from the first flick on four consecutive fresh sheet instances (rubber-band overshoot both ends).
- The real workspace file tree scrolls under a finger with this fix served (tester-confirmed).
- Sheet open/dismiss-by-gesture cycles remained functional throughout the session (four cycles observed in telemetry).
- Soft-confirmed under the tester's overall pass rather than itemized: row taps (the shield only touches `touchmove` propagation), and the git-diff tree (same shield, same wrapper pattern; renders in the sheet only under the tree list layout).

On phones the trees also need the sheet's scroll-lock opt-out from #1476; this change is orthogonal and was device-verified atop that head.

## Tests

- Hook unit suite: touchmove stopped before document, same-element listeners still fire, touchstart unaffected, cleanup restores propagation.
- One arm per tree component: a bubbling `touchmove` from the (stubbed) pierre tree must not reach a document listener, with a `touchstart` control — deleting the `ref` wire in either component fails its own suite.

## Standing constraint

Any bubble-phase `touchmove` listener above the tree wrappers — native or React synthetic — will not hear tree gestures while the shield is mounted. Nothing above listens for `touchmove` today; a future listener that must hear them needs a capture-phase registration. (Also stated in the hook's doc comment.)
