### PR TITLE
feat(gui-app): worktree rebind as a draft with teardown disclosure (T10)

### DIFF
--- a/clients/gui-app/src/components/chat/segments/setup-card-segment.tsx
+++ b/clients/gui-app/src/components/chat/segments/setup-card-segment.tsx
@@ -165,7 +165,7 @@ export function SetupCardSegment(props: {
   const focusTerminal = useFocusEpicTerminalSession(viewTabId);
   const tabClient = useTabHostClient();
   const retrySetup = useWorktreeRetrySetupFor(tabClient);
-  const worktreeCreate = useWorktreeCreateForClient(tabClient);
+  const worktreeCreate = useWorktreeCreateForClient(tabClient, undefined);
   const terminalList = useTerminalListFor(tabClient, {
     kind: "epic",
     epicId: aggregate.epicId,

--- a/clients/gui-app/src/components/epic-canvas/__tests__/chat-tile.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/chat-tile.test.tsx
@@ -921,7 +921,11 @@ function renderSwitchableChatTile() {
   };
 }
 
-function chatTileTestTree(queryClient: QueryClient, chatVisible: boolean) {
+function chatTileTestTree(
+  queryClient: QueryClient,
+  chatVisible: boolean,
+  node: typeof CHAT_ARTIFACT = CHAT_ARTIFACT,
+) {
   return (
     <TestRouterProvider>
       <QueryClientProvider client={queryClient}>
@@ -942,11 +946,7 @@ function chatTileTestTree(queryClient: QueryClient, chatVisible: boolean) {
             <TestEpicSessionWrapper epicId={EPIC_ID}>
               <TabHostProvider hostId={CHAT_ARTIFACT.hostId}>
                 {chatVisible ? (
-                  <ChatTile
-                    node={CHAT_ARTIFACT}
-                    viewTabId="tab-test"
-                    isActive
-                  />
+                  <ChatTile node={node} viewTabId="tab-test" isActive />
                 ) : null}
               </TabHostProvider>
             </TestEpicSessionWrapper>
@@ -3483,6 +3483,75 @@ describe("<ChatTile />", () => {
       kind: "import",
       worktreePath: "/wt/b",
     });
+  });
+
+  it("drops an armed send when the tile repoints to another chat", async () => {
+    stageChatWorktreeDraft("/wt/a");
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+    const rendered = render(chatTileTestTree(queryClient, true));
+    await waitForChatTileLoaded();
+    act(() => {
+      emitChatSnapshotWithMessages({
+        callbacks: chatHarness.callbacks(),
+        access: "owner",
+        queueItems: [],
+        settings: SESSION_SETTINGS,
+        messages: [hostUserMessage()],
+        activeTurn: null,
+        managedCommands: [runningShellOnProject()],
+      });
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+    expect(await screen.findByTestId("teardown-commit-dialog")).toBeTruthy();
+
+    rendered.rerender(
+      chatTileTestTree(queryClient, true, {
+        ...CHAT_ARTIFACT,
+        id: "chat-2",
+        instanceId: "inst-chat-2",
+        name: "Chat 2",
+      }),
+    );
+    expect(screen.queryByTestId("teardown-commit-dialog")).toBeNull();
+    expect(chatHarness.sent).toHaveLength(0);
+  });
+
+  it("re-discloses when the holder set changes under an armed chat send", async () => {
+    stageChatWorktreeDraft("/wt/a");
+    await loadChatWithDroppedShell();
+
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+    expect(await screen.findByTestId("teardown-commit-dialog")).toBeTruthy();
+
+    act(() => {
+      emitChatSnapshotWithMessages({
+        callbacks: chatHarness.callbacks(),
+        access: "owner",
+        queueItems: [],
+        settings: SESSION_SETTINGS,
+        messages: [hostUserMessage()],
+        activeTurn: null,
+        managedCommands: [
+          runningShellOnProject(),
+          {
+            ...runningShellOnProject(),
+            id: "sh-other",
+            command: "sleep 1",
+          },
+        ],
+      });
+    });
+    fireEvent.click(screen.getByTestId("teardown-commit-immediate"));
+    expect(await screen.findByTestId("teardown-commit-dialog")).toBeTruthy();
+    expect(chatHarness.sent).toHaveLength(0);
+    expect(screen.getByTestId("teardown-disclosure").textContent).toContain(
+      "sleep 1",
+    );
+
+    fireEvent.click(screen.getByTestId("teardown-commit-immediate"));
+    expect(chatHarness.sent).toHaveLength(1);
   });
 
   // The composer render-count proof lives in `chat-tile-composer-rerender.test.tsx`

--- a/clients/gui-app/src/components/epic-canvas/__tests__/chat-tile.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/chat-tile.test.tsx
@@ -312,7 +312,12 @@ import type {
   ChatRunStatus,
   ChatSubscribeClientFrame,
 } from "@traycer/protocol/host/agent/gui/subscribe";
-import type { WorktreeBinding } from "@traycer/protocol/host/worktree-schemas";
+import type { ManagedCommand } from "@traycer/protocol/host/managed-command/unary-schemas";
+import type {
+  WorktreeBinding,
+  WorktreeFolderIntent,
+} from "@traycer/protocol/host/worktree-schemas";
+import { useWorktreeIntentStagingStore } from "@/stores/worktree/worktree-intent-staging-store";
 import {
   getFocusedComposerControls,
   resetFocusedComposerControlsForTests,
@@ -548,6 +553,7 @@ function emitChatSnapshotWithMessages(input: {
   readonly events?: ReadonlyArray<ChatEvent>;
   readonly activeTurn: ChatActiveTurn | null;
   readonly pendingInterviews?: ReadonlyArray<ChatPendingInterviewState>;
+  readonly managedCommands?: ReadonlyArray<ManagedCommand>;
 }): void {
   input.callbacks.onSnapshot({
     kind: "snapshot",
@@ -587,7 +593,7 @@ function emitChatSnapshotWithMessages(input: {
       missingWorktreePaths: [],
       pendingFileEditApprovals: [],
       accumulatedFileChanges: [],
-      managedCommands: [],
+      managedCommands: [...(input.managedCommands ?? [])],
       heldUpdates: [],
     },
   });
@@ -1067,6 +1073,7 @@ describe("<ChatTile />", () => {
     harness.install(seedDocWithChat, "editor");
     chatHarness.install("owner", []);
     useInitialChatHandoffStore.getState().resetForTests();
+    useWorktreeIntentStagingStore.getState().resetForTests();
     resetFocusedComposerControlsForTests();
     cloudChatListTestState.knownChatIds.clear();
   });
@@ -1085,6 +1092,7 @@ describe("<ChatTile />", () => {
     });
     useComposerRunSettingsStore.getState().resetForTests();
     useComposerHarnessMemoryStore.getState().resetForTests();
+    useWorktreeIntentStagingStore.getState().resetForTests();
     useAuthStore.setState({
       status: "signed-out",
       profile: null,
@@ -3356,6 +3364,129 @@ describe("<ChatTile />", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  function stageChatWorktreeDraft(worktreePath: string): void {
+    const entry: WorktreeFolderIntent = {
+      kind: "import",
+      workspacePath: "/Users/test/project",
+      repoIdentifier: null,
+      isPrimary: true,
+      worktreePath,
+    };
+    useWorktreeIntentStagingStore.getState().stageIntent(
+      {
+        surface: "owner",
+        hostId: HOST_ID,
+        epicId: EPIC_ID,
+        ownerKind: "chat",
+        ownerId: CHAT_ARTIFACT.id,
+      },
+      { entries: [entry] },
+    );
+  }
+
+  function runningShellOnProject(): ManagedCommand {
+    return {
+      id: "sh-dropped",
+      monitoring: false,
+      description: "watch",
+      command: "npm run dev",
+      cwd: "/Users/test/project/apps",
+      cadence: null,
+      status: { state: "running", pid: 42, startedAtMs: 1 },
+      chatId: CHAT_ARTIFACT.id,
+      createdAtMs: 1,
+      updatedAtMs: 1,
+    };
+  }
+
+  async function loadChatWithDroppedShell(): Promise<void> {
+    renderChatTile();
+    await waitForChatTileLoaded();
+    act(() => {
+      emitChatSnapshotWithMessages({
+        callbacks: chatHarness.callbacks(),
+        access: "owner",
+        queueItems: [],
+        settings: SESSION_SETTINGS,
+        messages: [hostUserMessage()],
+        activeTurn: null,
+        managedCommands: [runningShellOnProject()],
+      });
+    });
+  }
+
+  it("consumes an armed send confirmation so a later submit re-discloses", async () => {
+    stageChatWorktreeDraft("/wt/a");
+    await loadChatWithDroppedShell();
+
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+    expect(await screen.findByTestId("teardown-commit-dialog")).toBeTruthy();
+    expect(screen.getByTestId("teardown-disclosure").textContent).toContain(
+      "npm run dev",
+    );
+    expect(chatHarness.sent).toHaveLength(0);
+
+    act(() => {
+      emitChatSnapshotWithMessages({
+        callbacks: chatHarness.callbacks(),
+        access: "viewer",
+        queueItems: [],
+        settings: SESSION_SETTINGS,
+        messages: [hostUserMessage()],
+        activeTurn: null,
+        managedCommands: [runningShellOnProject()],
+      });
+    });
+    fireEvent.click(screen.getByTestId("teardown-commit-immediate"));
+    expect(chatHarness.sent).toHaveLength(0);
+    expect(screen.queryByTestId("teardown-commit-dialog")).toBeNull();
+
+    act(() => {
+      emitChatSnapshotWithMessages({
+        callbacks: chatHarness.callbacks(),
+        access: "owner",
+        queueItems: [],
+        settings: SESSION_SETTINGS,
+        messages: [hostUserMessage()],
+        activeTurn: null,
+        managedCommands: [runningShellOnProject()],
+      });
+    });
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Send" })).not.toBeNull();
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+    expect(await screen.findByTestId("teardown-commit-dialog")).toBeTruthy();
+    expect(chatHarness.sent).toHaveLength(0);
+  });
+
+  it("re-discloses when staging mutates under an armed chat send", async () => {
+    stageChatWorktreeDraft("/wt/a");
+    await loadChatWithDroppedShell();
+
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+    expect(await screen.findByTestId("teardown-commit-dialog")).toBeTruthy();
+
+    act(() => {
+      stageChatWorktreeDraft("/wt/b");
+    });
+    fireEvent.click(screen.getByTestId("teardown-commit-immediate"));
+
+    expect(await screen.findByTestId("teardown-commit-dialog")).toBeTruthy();
+    expect(chatHarness.sent).toHaveLength(0);
+
+    fireEvent.click(screen.getByTestId("teardown-commit-immediate"));
+    expect(chatHarness.sent).toHaveLength(1);
+    const frame = chatHarness.sent[0];
+    if (frame.kind !== "send") {
+      throw new Error("expected send frame");
+    }
+    expect(frame.worktreeIntent?.entries[0]).toMatchObject({
+      kind: "import",
+      worktreePath: "/wt/b",
+    });
   });
 
   // The composer render-count proof lives in `chat-tile-composer-rerender.test.tsx`

--- a/clients/gui-app/src/components/epic-canvas/__tests__/chat-tile.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/chat-tile.test.tsx
@@ -3417,15 +3417,12 @@ describe("<ChatTile />", () => {
     });
   }
 
-  it("consumes an armed send confirmation so a later submit re-discloses", async () => {
+  it("keeps the send confirmation open with a reason when it cannot proceed", async () => {
     stageChatWorktreeDraft("/wt/a");
     await loadChatWithDroppedShell();
 
     fireEvent.click(screen.getByRole("button", { name: "Send" }));
     expect(await screen.findByTestId("teardown-commit-dialog")).toBeTruthy();
-    expect(screen.getByTestId("teardown-disclosure").textContent).toContain(
-      "npm run dev",
-    );
     expect(chatHarness.sent).toHaveLength(0);
 
     act(() => {
@@ -3441,7 +3438,10 @@ describe("<ChatTile />", () => {
     });
     fireEvent.click(screen.getByTestId("teardown-commit-immediate"));
     expect(chatHarness.sent).toHaveLength(0);
-    expect(screen.queryByTestId("teardown-commit-dialog")).toBeNull();
+    expect(screen.getByTestId("teardown-commit-dialog")).toBeTruthy();
+    expect(screen.getByTestId("teardown-commit-refusal").textContent).toBe(
+      "You don't have permission to send.",
+    );
 
     act(() => {
       emitChatSnapshotWithMessages({
@@ -3454,12 +3454,8 @@ describe("<ChatTile />", () => {
         managedCommands: [runningShellOnProject()],
       });
     });
-    await waitFor(() => {
-      expect(screen.getByRole("button", { name: "Send" })).not.toBeNull();
-    });
-    fireEvent.click(screen.getByRole("button", { name: "Send" }));
-    expect(await screen.findByTestId("teardown-commit-dialog")).toBeTruthy();
-    expect(chatHarness.sent).toHaveLength(0);
+    fireEvent.click(screen.getByTestId("teardown-commit-immediate"));
+    expect(chatHarness.sent).toHaveLength(1);
   });
 
   it("re-discloses when staging mutates under an armed chat send", async () => {

--- a/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
@@ -64,9 +64,16 @@ import { SteerSettingsConflictDialog } from "@/components/chat/segments/steer-se
 import { TeardownCommitDialog } from "@/components/worktree/teardown-commit-dialog";
 import type { WorktreeBusyHolder } from "@traycer/protocol/framework/worktree-busy-holders";
 import { droppedRunDirectoriesFromDraft } from "@/lib/worktree/owner-teardown-snapshot";
+import {
+  takeArmedTeardownSubmit,
+  worktreeCommitCaptureIsStale,
+  type ArmedTeardownSubmit,
+  type WorktreeCommitCapture,
+} from "@/lib/worktree/worktree-commit-capture";
 import { useOwnerTeardownSnapshot } from "@/hooks/worktree/use-owner-teardown-snapshot";
 import {
   readStagedWorktreeIntent,
+  stagedWorktreeIntentRevision,
   type WorktreeStagingKey,
 } from "@/stores/worktree/worktree-intent-staging-store";
 import { accumulatedFileChangesFromMessages } from "@/lib/chat/accumulated-file-changes-from-messages";
@@ -1944,10 +1951,10 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
   const [teardownDialog, setTeardownDialog] = useState<{
     readonly holders: readonly WorktreeBusyHolder[];
   } | null>(null);
-  const pendingSubmitRef = useRef<ChatComposerSubmitInput | null>(null);
-  const teardownConfirmedRef = useRef(false);
+  const pendingSubmitRef =
+    useRef<ArmedTeardownSubmit<ChatComposerSubmitInput> | null>(null);
 
-  const submitMessage = useCallback(
+  const dispatchUserSend = useCallback(
     (input: ChatComposerSubmitInput): boolean => {
       if (!canAct) return false;
       if (profile === null) return false;
@@ -1955,6 +1962,45 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
         type: "user",
         userId: profile.userId,
       };
+      const expectedTitle = state.chat?.title ?? node.name;
+      const shouldMarkTitlePending = shouldGenerateChatTitleForSubmittedMessage(
+        {
+          chat: state.chat,
+          messages: state.messages,
+          pendingUserMessages: state.pendingUserMessages,
+          content: input.content,
+        },
+      );
+      const sent = chatActions.sendMessage(
+        input.content,
+        sender,
+        input.settings,
+        input.deliveryPolicy,
+      );
+      if (sent === null) return false;
+      if (shouldMarkTitlePending) {
+        useEpicCanvasStore
+          .getState()
+          .markChatTitlePending(node.id, expectedTitle);
+      }
+      return true;
+    },
+    [
+      canAct,
+      chatActions,
+      node.id,
+      node.name,
+      profile,
+      state.chat,
+      state.messages,
+      state.pendingUserMessages,
+    ],
+  );
+
+  const submitMessage = useCallback(
+    (input: ChatComposerSubmitInput): boolean => {
+      if (!canAct) return false;
+      if (profile === null) return false;
       if (activeEditingQueueItemId !== null) {
         const actionId = chatActions.queueEdit(
           activeEditingQueueItemId,
@@ -1985,53 +2031,32 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
         dispatchUi({ type: "setEditingQueueItemId", editingQueueItemId: null });
         return true;
       }
-      const expectedTitle = state.chat?.title ?? node.name;
-      const shouldMarkTitlePending = shouldGenerateChatTitleForSubmittedMessage(
-        {
-          chat: state.chat,
-          messages: state.messages,
-          pendingUserMessages: state.pendingUserMessages,
-          content: input.content,
-        },
+      const stagedKey: WorktreeStagingKey = {
+        surface: "owner",
+        hostId: activeHostId,
+        epicId: currentEpicId,
+        ownerKind: "chat",
+        ownerId: node.id,
+      };
+      const capture: WorktreeCommitCapture = {
+        draft: readStagedWorktreeIntent(stagedKey),
+        revision: stagedWorktreeIntentRevision(stagedKey),
+        binding: state.worktreeBinding,
+        removedWorkspacePaths: [],
+      };
+      const holders = snapshotTeardownHolders(
+        droppedRunDirectoriesFromDraft({
+          binding: capture.binding,
+          draft: capture.draft,
+          removedWorkspacePaths: capture.removedWorkspacePaths,
+        }),
       );
-      if (!teardownConfirmedRef.current) {
-        const stagedKey: WorktreeStagingKey = {
-          surface: "owner",
-          hostId: activeHostId,
-          epicId: currentEpicId,
-          ownerKind: "chat",
-          ownerId: node.id,
-        };
-        const staged = readStagedWorktreeIntent(stagedKey);
-        const holders =
-          staged === null
-            ? []
-            : snapshotTeardownHolders(
-                droppedRunDirectoriesFromDraft({
-                  binding: state.worktreeBinding,
-                  draft: staged,
-                }),
-              );
-        if (holders.length > 0) {
-          pendingSubmitRef.current = input;
-          setTeardownDialog({ holders });
-          return false;
-        }
+      if (holders.length > 0) {
+        pendingSubmitRef.current = { input, capture };
+        setTeardownDialog({ holders });
+        return false;
       }
-      teardownConfirmedRef.current = false;
-      const sent = chatActions.sendMessage(
-        input.content,
-        sender,
-        input.settings,
-        input.deliveryPolicy,
-      );
-      if (sent === null) return false;
-      if (shouldMarkTitlePending) {
-        useEpicCanvasStore
-          .getState()
-          .markChatTitlePending(node.id, expectedTitle);
-      }
-      return true;
+      return dispatchUserSend(input);
     },
     [
       activeEditingQueueItemId,
@@ -2040,14 +2065,11 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
       chatActions,
       currentEpicId,
       dispatchUi,
+      dispatchUserSend,
       node.id,
-      node.name,
       profile,
       snapshotTeardownHolders,
       state.worktreeBinding,
-      state.chat,
-      state.messages,
-      state.pendingUserMessages,
     ],
   );
   const canSendNextStep =
@@ -2277,6 +2299,7 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
       activeHostId,
       currentEpicId,
       node.id,
+      node.name,
       state.worktreeBinding,
       effectiveMissingPaths,
       state.snapshotLoaded,
@@ -2570,12 +2593,38 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
       choice: "submit" as const,
       holders: teardownDialog?.holders ?? [],
       onImmediate: () => {
-        const pending = pendingSubmitRef.current;
-        pendingSubmitRef.current = null;
+        const armed = takeArmedTeardownSubmit(pendingSubmitRef);
         setTeardownDialog(null);
-        if (pending === null) return;
-        teardownConfirmedRef.current = true;
-        submitMessage(pending);
+        if (armed === null) return;
+        if (!canAct || profile === null) return;
+        const stagedKey: WorktreeStagingKey = {
+          surface: "owner",
+          hostId: activeHostId,
+          epicId: currentEpicId,
+          ownerKind: "chat",
+          ownerId: node.id,
+        };
+        const live: WorktreeCommitCapture = {
+          draft: readStagedWorktreeIntent(stagedKey),
+          revision: stagedWorktreeIntentRevision(stagedKey),
+          binding: state.worktreeBinding,
+          removedWorkspacePaths: [],
+        };
+        if (worktreeCommitCaptureIsStale(armed.capture, live)) {
+          const holders = snapshotTeardownHolders(
+            droppedRunDirectoriesFromDraft({
+              binding: live.binding,
+              draft: live.draft,
+              removedWorkspacePaths: live.removedWorkspacePaths,
+            }),
+          );
+          if (holders.length > 0) {
+            pendingSubmitRef.current = { input: armed.input, capture: live };
+            setTeardownDialog({ holders });
+            return;
+          }
+        }
+        dispatchUserSend(armed.input);
       },
       onDismiss: () => {
         pendingSubmitRef.current = null;

--- a/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
@@ -61,6 +61,14 @@ import { ContextUsageChip } from "@/components/chat/context-usage-chip";
 import { ChatRestoreProvider } from "@/components/chat/chat-restore-context";
 import { RevertOnEditDialog } from "@/components/chat/segments/revert-on-edit-dialog";
 import { SteerSettingsConflictDialog } from "@/components/chat/segments/steer-settings-conflict-dialog";
+import { TeardownCommitDialog } from "@/components/worktree/teardown-commit-dialog";
+import type { WorktreeBusyHolder } from "@traycer/protocol/framework/worktree-busy-holders";
+import { droppedRunDirectoriesFromDraft } from "@/lib/worktree/owner-teardown-snapshot";
+import { useOwnerTeardownSnapshot } from "@/hooks/worktree/use-owner-teardown-snapshot";
+import {
+  readStagedWorktreeIntent,
+  type WorktreeStagingKey,
+} from "@/stores/worktree/worktree-intent-staging-store";
 import { accumulatedFileChangesFromMessages } from "@/lib/chat/accumulated-file-changes-from-messages";
 import type { ChatRestoreContextValue } from "@/components/chat/chat-restore-context-core";
 import { buildPinnedTodoRenderState } from "@/components/chat/chat-pinned-todos";
@@ -1192,6 +1200,14 @@ export function ChatTileSessionView(props: ChatTileSessionViewProps) {
               onRestart={view.steerRestart.onRestart}
               changed={view.steerRestart.changed}
             />
+            <TeardownCommitDialog
+              open={view.teardownCommit.open}
+              choice={view.teardownCommit.choice}
+              holders={view.teardownCommit.holders}
+              onImmediate={view.teardownCommit.onImmediate}
+              onDefer={view.teardownCommit.onDismiss}
+              onDismiss={view.teardownCommit.onDismiss}
+            />
             <ChatForkDialog
               open={view.fork.open}
               target={view.fork.target}
@@ -1916,6 +1932,21 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
     [composerActiveTurnStatus, forkAtAssistantMessage, latestForkBoundaryId],
   );
 
+  const snapshotTeardownHolders = useOwnerTeardownSnapshot({
+    epicId: currentEpicId,
+    hostId: activeHostId,
+    ownerKind: "chat",
+    ownerId: node.id,
+    ownerLabel: node.name,
+    hasActiveTurn: composerActiveTurnStatus !== null,
+    ptyLive: false,
+  });
+  const [teardownDialog, setTeardownDialog] = useState<{
+    readonly holders: readonly WorktreeBusyHolder[];
+  } | null>(null);
+  const pendingSubmitRef = useRef<ChatComposerSubmitInput | null>(null);
+  const teardownConfirmedRef = useRef(false);
+
   const submitMessage = useCallback(
     (input: ChatComposerSubmitInput): boolean => {
       if (!canAct) return false;
@@ -1963,6 +1994,31 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
           content: input.content,
         },
       );
+      if (!teardownConfirmedRef.current) {
+        const stagedKey: WorktreeStagingKey = {
+          surface: "owner",
+          hostId: activeHostId,
+          epicId: currentEpicId,
+          ownerKind: "chat",
+          ownerId: node.id,
+        };
+        const staged = readStagedWorktreeIntent(stagedKey);
+        const holders =
+          staged === null
+            ? []
+            : snapshotTeardownHolders(
+                droppedRunDirectoriesFromDraft({
+                  binding: state.worktreeBinding,
+                  draft: staged,
+                }),
+              );
+        if (holders.length > 0) {
+          pendingSubmitRef.current = input;
+          setTeardownDialog({ holders });
+          return false;
+        }
+      }
+      teardownConfirmedRef.current = false;
       const sent = chatActions.sendMessage(
         input.content,
         sender,
@@ -1979,12 +2035,16 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
     },
     [
       activeEditingQueueItemId,
+      activeHostId,
       canAct,
       chatActions,
+      currentEpicId,
       dispatchUi,
       node.id,
       node.name,
       profile,
+      snapshotTeardownHolders,
+      state.worktreeBinding,
       state.chat,
       state.messages,
       state.pendingUserMessages,
@@ -2205,6 +2265,7 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
           // because of visible background work, not a turn the "stop" wording
           // would make sense for.
           hasActiveTurn: composerActiveTurnStatus !== null,
+          ownerLabel: node.name,
           missingWorktreePaths: effectiveMissingPaths,
           bindingResolved: state.snapshotLoaded,
           onBindingCommitted: clearMissingPathsAfterBindingCommit,
@@ -2504,6 +2565,23 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
     todo: pinnedTodoRenderState.todo,
     revertOnEdit,
     steerRestart,
+    teardownCommit: {
+      open: teardownDialog !== null,
+      choice: "submit" as const,
+      holders: teardownDialog?.holders ?? [],
+      onImmediate: () => {
+        const pending = pendingSubmitRef.current;
+        pendingSubmitRef.current = null;
+        setTeardownDialog(null);
+        if (pending === null) return;
+        teardownConfirmedRef.current = true;
+        submitMessage(pending);
+      },
+      onDismiss: () => {
+        pendingSubmitRef.current = null;
+        setTeardownDialog(null);
+      },
+    },
     fork: {
       open: forkTarget !== null,
       target: forkTarget,

--- a/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
@@ -1211,6 +1211,8 @@ export function ChatTileSessionView(props: ChatTileSessionViewProps) {
               open={view.teardownCommit.open}
               choice={view.teardownCommit.choice}
               holders={view.teardownCommit.holders}
+              immediateDisabled={view.teardownCommit.immediateDisabled}
+              refusalReason={view.teardownCommit.refusalReason}
               onImmediate={view.teardownCommit.onImmediate}
               onDefer={view.teardownCommit.onDismiss}
               onDismiss={view.teardownCommit.onDismiss}
@@ -1232,6 +1234,16 @@ export function ChatTileSessionView(props: ChatTileSessionViewProps) {
 // Aggregates the full chat-tile view model (session handle, ui reducer, derived
 // run/permission/handoff state). The branch count reflects the number of
 // independent UI concerns surfaced for one tile, not reducible nesting.
+// eslint-disable-next-line complexity
+function teardownSendRefusalReason(
+  canAct: boolean,
+  signedIn: boolean,
+): string | undefined {
+  if (!canAct) return "You don't have permission to send.";
+  if (!signedIn) return "Sign in to send this message.";
+  return undefined;
+}
+
 // eslint-disable-next-line complexity
 function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
   const { handle, node, viewTabId, isActive, currentEpicId } = props;
@@ -2038,22 +2050,23 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
         ownerKind: "chat",
         ownerId: node.id,
       };
+      const snapshot = snapshotTeardownHolders(
+        droppedRunDirectoriesFromDraft({
+          binding: state.worktreeBinding,
+          draft: readStagedWorktreeIntent(stagedKey),
+          removedWorkspacePaths: [],
+        }),
+      );
       const capture: WorktreeCommitCapture = {
         draft: readStagedWorktreeIntent(stagedKey),
         revision: stagedWorktreeIntentRevision(stagedKey),
         binding: state.worktreeBinding,
         removedWorkspacePaths: [],
+        stopTargets: snapshot.stopTargets,
       };
-      const holders = snapshotTeardownHolders(
-        droppedRunDirectoriesFromDraft({
-          binding: capture.binding,
-          draft: capture.draft,
-          removedWorkspacePaths: capture.removedWorkspacePaths,
-        }),
-      );
-      if (holders.length > 0) {
+      if (snapshot.holders.length > 0) {
         pendingSubmitRef.current = { input, capture };
-        setTeardownDialog({ holders });
+        setTeardownDialog({ holders: snapshot.holders });
         return false;
       }
       return dispatchUserSend(input);
@@ -2592,11 +2605,19 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
       open: teardownDialog !== null,
       choice: "submit" as const,
       holders: teardownDialog?.holders ?? [],
+      immediateDisabled: !canAct || profile === null,
+      refusalReason: teardownSendRefusalReason(canAct, profile !== null),
       onImmediate: () => {
+        if (!canAct) {
+          toast("You don't have permission to send.");
+          return;
+        }
+        if (profile === null) {
+          toast("Sign in to send this message.");
+          return;
+        }
         const armed = takeArmedTeardownSubmit(pendingSubmitRef);
-        setTeardownDialog(null);
         if (armed === null) return;
-        if (!canAct || profile === null) return;
         const stagedKey: WorktreeStagingKey = {
           surface: "owner",
           hostId: activeHostId,
@@ -2604,26 +2625,28 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
           ownerKind: "chat",
           ownerId: node.id,
         };
+        const liveSnapshot = snapshotTeardownHolders(
+          droppedRunDirectoriesFromDraft({
+            binding: state.worktreeBinding,
+            draft: readStagedWorktreeIntent(stagedKey),
+            removedWorkspacePaths: [],
+          }),
+        );
         const live: WorktreeCommitCapture = {
           draft: readStagedWorktreeIntent(stagedKey),
           revision: stagedWorktreeIntentRevision(stagedKey),
           binding: state.worktreeBinding,
           removedWorkspacePaths: [],
+          stopTargets: liveSnapshot.stopTargets,
         };
         if (worktreeCommitCaptureIsStale(armed.capture, live)) {
-          const holders = snapshotTeardownHolders(
-            droppedRunDirectoriesFromDraft({
-              binding: live.binding,
-              draft: live.draft,
-              removedWorkspacePaths: live.removedWorkspacePaths,
-            }),
-          );
-          if (holders.length > 0) {
+          if (liveSnapshot.holders.length > 0) {
             pendingSubmitRef.current = { input: armed.input, capture: live };
-            setTeardownDialog({ holders });
+            setTeardownDialog({ holders: liveSnapshot.holders });
             return;
           }
         }
+        setTeardownDialog(null);
         dispatchUserSend(armed.input);
       },
       onDismiss: () => {

--- a/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
@@ -63,7 +63,10 @@ import { RevertOnEditDialog } from "@/components/chat/segments/revert-on-edit-di
 import { SteerSettingsConflictDialog } from "@/components/chat/segments/steer-settings-conflict-dialog";
 import { TeardownCommitDialog } from "@/components/worktree/teardown-commit-dialog";
 import type { WorktreeBusyHolder } from "@traycer/protocol/framework/worktree-busy-holders";
-import { droppedRunDirectoriesFromDraft } from "@/lib/worktree/owner-teardown-snapshot";
+import {
+  droppedRunDirectoriesFromDraft,
+  teardownHolderSetDrifted,
+} from "@/lib/worktree/owner-teardown-snapshot";
 import {
   takeArmedTeardownSubmit,
   worktreeCommitCaptureIsStale,
@@ -1965,6 +1968,14 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
   } | null>(null);
   const pendingSubmitRef =
     useRef<ArmedTeardownSubmit<ChatComposerSubmitInput> | null>(null);
+  const [teardownOwnerId, setTeardownOwnerId] = useState(node.id);
+  if (node.id !== teardownOwnerId) {
+    setTeardownOwnerId(node.id);
+    setTeardownDialog(null);
+  }
+  useEffect(() => {
+    pendingSubmitRef.current = null;
+  }, [node.id]);
 
   const dispatchUserSend = useCallback(
     (input: ChatComposerSubmitInput): boolean => {
@@ -2065,7 +2076,11 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
         stopTargets: snapshot.stopTargets,
       };
       if (snapshot.holders.length > 0) {
-        pendingSubmitRef.current = { input, capture };
+        pendingSubmitRef.current = {
+          input,
+          capture,
+          ownerId: node.id,
+        };
         setTeardownDialog({ holders: snapshot.holders });
         return false;
       }
@@ -2618,6 +2633,10 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
         }
         const armed = takeArmedTeardownSubmit(pendingSubmitRef);
         if (armed === null) return;
+        if (armed.ownerId !== node.id) {
+          setTeardownDialog(null);
+          return;
+        }
         const stagedKey: WorktreeStagingKey = {
           surface: "owner",
           hostId: activeHostId,
@@ -2639,12 +2658,18 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
           removedWorkspacePaths: [],
           stopTargets: liveSnapshot.stopTargets,
         };
-        if (worktreeCommitCaptureIsStale(armed.capture, live)) {
-          if (liveSnapshot.holders.length > 0) {
-            pendingSubmitRef.current = { input: armed.input, capture: live };
-            setTeardownDialog({ holders: liveSnapshot.holders });
-            return;
-          }
+        const disclosedHolders = teardownDialog?.holders ?? [];
+        const drifted =
+          worktreeCommitCaptureIsStale(armed.capture, live) ||
+          teardownHolderSetDrifted(disclosedHolders, liveSnapshot.holders);
+        if (drifted && liveSnapshot.holders.length > 0) {
+          pendingSubmitRef.current = {
+            input: armed.input,
+            capture: live,
+            ownerId: node.id,
+          };
+          setTeardownDialog({ holders: liveSnapshot.holders });
+          return;
         }
         setTeardownDialog(null);
         dispatchUserSend(armed.input);

--- a/clients/gui-app/src/components/epic-canvas/renderers/tui-agent-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/tui-agent-tile.tsx
@@ -937,6 +937,7 @@ function TerminalAgentPreLaunchToolbar(
           // signal to distinguish - this field is unread for this surface kind
           // (the notice text is fixed regardless), kept equal for consistency.
           hasActiveTurn: props.isOwnerActive,
+          ownerLabel: props.agent.title,
           // Surfaced on the chip as a per-folder "missing on disk" indicator.
           // The host-computed signal on `worktree.getBinding` — the actual
           // launch gate is the `prepareLaunch` WORKTREE_MISSING reject, but this

--- a/clients/gui-app/src/components/home/host-workspace-selector/__tests__/folder-controls.test.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/__tests__/folder-controls.test.tsx
@@ -1105,6 +1105,21 @@ describe("WorkspaceFolderRows", () => {
 });
 
 describe("WorkspaceSummaryTrigger", () => {
+  it("shows a pending indicator for an uncommitted draft", () => {
+    render(
+      <TooltipProvider>
+        <WorkspaceSummaryTrigger
+          items={[item({})]}
+          readOnly={false}
+          bindingResolved
+          draftPending
+        />
+      </TooltipProvider>,
+    );
+    expect(screen.getByTestId("workspace-summary-draft")).toBeTruthy();
+    expect(screen.getByLabelText("Uncommitted workspace draft")).toBeTruthy();
+  });
+
   it("summarizes the primary folder and extra count", () => {
     render(
       <TooltipProvider>

--- a/clients/gui-app/src/components/home/host-workspace-selector/__tests__/in-epic-surface-primary-readonly.test.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/__tests__/in-epic-surface-primary-readonly.test.tsx
@@ -567,6 +567,19 @@ function shellHolder(
   };
 }
 
+function chatTurnHolder(label: string): WorktreeBusyHolder {
+  return {
+    ownerRef: {
+      epicId: "epic-1",
+      ownerKind: "chat",
+      ownerId: "owner-1",
+    },
+    holdKind: "chat-turn",
+    activity: "working",
+    label,
+  };
+}
+
 function shellSnapshot(
   label: string,
   commandId = "sh-1",
@@ -871,6 +884,97 @@ it("keeps a newer TUI draft after an in-flight commit of an older capture", asyn
       ]?.entries[0],
     ).toMatchObject({ branch: { name: "feat-b" } });
   });
+});
+
+it("stops a chat turn once and does not re-stop expanded agent.stop-consequence shells", async () => {
+  seedResolvedBindingMetadata();
+  const turn = chatTurnHolder(
+    "Owner is working. Stopping the agent also stops its background shells and clears queued messages",
+  );
+  const shell = shellHolder("sleep 1", "chat");
+  teardownMocks.snapshot.mockImplementation(() => ({
+    holders: [turn, shell],
+    stopTargets: [
+      {
+        kind: "chat-turn",
+        holderKey: teardownHolderKey(turn),
+      },
+    ],
+  }));
+  useWorktreeIntentStagingStore.getState().stageIntent(TERMINAL_STAGING_KEY, {
+    entries: [newWorktreeIntent("/repo/alpha", "feat-a")],
+  });
+
+  await openTerminalFolderPopover();
+  fireEvent.click(await screen.findByRole("button", { name: "Update" }));
+  expect(await screen.findByTestId("teardown-commit-dialog")).toBeTruthy();
+  expect(screen.getByTestId("teardown-disclosure").textContent).toContain(
+    "sleep 1",
+  );
+  fireEvent.click(screen.getByTestId("teardown-commit-immediate"));
+
+  await waitFor(() => {
+    expect(teardownStopMocks.stopAgent).toHaveBeenCalledTimes(1);
+  });
+  expect(teardownStopMocks.stopShell).not.toHaveBeenCalled();
+  await waitFor(() => {
+    expect(mutationMocks.createWorktree).toHaveBeenCalledTimes(1);
+  });
+});
+
+it("does not apply a cancelled teardown after a newer confirm starts", async () => {
+  seedResolvedBindingMetadata();
+  teardownMocks.snapshot.mockImplementation(() => shellSnapshot("npm run dev"));
+  useWorktreeIntentStagingStore.getState().stageIntent(TERMINAL_STAGING_KEY, {
+    entries: [newWorktreeIntent("/repo/alpha", "feat-a")],
+  });
+  const stopResolvers: Array<(value: unknown) => void> = [];
+  teardownStopMocks.stopShell.mockImplementation(
+    () =>
+      new Promise((resolve) => {
+        stopResolvers.push(resolve);
+      }),
+  );
+
+  await openTerminalFolderPopover();
+  fireEvent.click(await screen.findByRole("button", { name: "Update" }));
+  fireEvent.click(await screen.findByTestId("teardown-commit-immediate"));
+  await waitFor(() => {
+    expect(teardownStopMocks.stopShell).toHaveBeenCalledTimes(1);
+  });
+  fireEvent.click(screen.getByTestId("teardown-commit-cancel"));
+
+  act(() => {
+    useWorktreeIntentStagingStore.getState().stageIntent(TERMINAL_STAGING_KEY, {
+      entries: [newWorktreeIntent("/repo/alpha", "feat-b")],
+    });
+  });
+  fireEvent.click(screen.getByRole("button", { name: /^beta/ }));
+  await screen.findAllByTestId("folder-row");
+  fireEvent.click(await screen.findByRole("button", { name: "Update" }));
+  fireEvent.click(await screen.findByTestId("teardown-commit-immediate"));
+  await waitFor(() => {
+    expect(teardownStopMocks.stopShell).toHaveBeenCalledTimes(2);
+  });
+
+  await act(async () => {
+    stopResolvers[0]?.({});
+    await Promise.resolve();
+  });
+  expect(mutationMocks.createWorktree).not.toHaveBeenCalled();
+
+  act(() => {
+    stopResolvers[1]?.({});
+  });
+  await waitFor(() => {
+    expect(mutationMocks.createWorktree).toHaveBeenCalledTimes(1);
+  });
+  const createArg = mutationMocks.createWorktree.mock.calls[0]?.[0] as {
+    readonly entries: ReadonlyArray<{
+      readonly branch?: { readonly name?: string };
+    }>;
+  };
+  expect(createArg.entries[0]?.branch?.name).toBe("feat-b");
 });
 
 it("does not apply remove or create if the user cancels during in-flight teardown", async () => {

--- a/clients/gui-app/src/components/home/host-workspace-selector/__tests__/in-epic-surface-primary-readonly.test.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/__tests__/in-epic-surface-primary-readonly.test.tsx
@@ -543,6 +543,13 @@ const TERMINAL_STAGING_KEY = {
   ownerKind: "terminal-agent" as const,
   ownerId: "owner-1",
 };
+const CHAT_STAGING_KEY = {
+  surface: "owner" as const,
+  hostId: "host-test",
+  epicId: "epic-1",
+  ownerKind: "chat" as const,
+  ownerId: "owner-1",
+};
 
 function shellHolder(
   label: string,
@@ -863,5 +870,114 @@ it("keeps a newer TUI draft after an in-flight commit of an older capture", asyn
         worktreeStagingKeyString(TERMINAL_STAGING_KEY)
       ]?.entries[0],
     ).toMatchObject({ branch: { name: "feat-b" } });
+  });
+});
+
+it("does not apply remove or create if the user cancels during in-flight teardown", async () => {
+  seedResolvedBindingMetadata();
+  teardownMocks.snapshot.mockImplementation(() => shellSnapshot("npm run dev"));
+  useWorktreeIntentStagingStore.getState().stageIntent(TERMINAL_STAGING_KEY, {
+    entries: [newWorktreeIntent("/repo/alpha", "feat-a")],
+  });
+  let releaseStop: ((value: unknown) => void) | null = null;
+  teardownStopMocks.stopShell.mockImplementation(
+    () =>
+      new Promise((resolve) => {
+        releaseStop = resolve;
+      }),
+  );
+
+  await openTerminalFolderPopover();
+  fireEvent.click(await screen.findByRole("button", { name: "Update" }));
+  fireEvent.click(await screen.findByTestId("teardown-commit-immediate"));
+  await waitFor(() => {
+    expect(teardownStopMocks.stopShell).toHaveBeenCalled();
+  });
+  fireEvent.click(screen.getByTestId("teardown-commit-cancel"));
+  act(() => {
+    releaseStop?.({});
+  });
+  await Promise.resolve();
+  expect(mutationMocks.createWorktree).not.toHaveBeenCalled();
+  expect(mutationMocks.removeBindingFolder).not.toHaveBeenCalled();
+  expect(
+    useWorktreeIntentStagingStore.getState().intentByKey[
+      worktreeStagingKeyString(TERMINAL_STAGING_KEY)
+    ]?.entries[0],
+  ).toMatchObject({ branch: { name: "feat-a" } });
+});
+
+it("applies only the disclosed folder removal and leaves a staged draft intact", async () => {
+  teardownMocks.snapshot.mockImplementation((dropped: readonly string[]) =>
+    dropped.includes("/repo/beta")
+      ? shellSnapshot("npm run dev", "sh-1", "chat")
+      : { holders: [], stopTargets: [] },
+  );
+  useWorktreeIntentStagingStore.getState().stageIntent(CHAT_STAGING_KEY, {
+    entries: [newWorktreeIntent("/repo/alpha", "feat-a")],
+  });
+
+  renderBoundSurface("chat", true);
+  fireEvent.click(screen.getByRole("button", { name: /^beta/ }));
+  fireEvent.click(
+    (
+      await screen.findAllByRole("button", {
+        name: /^(?:Move|Remove) beta(?: to Recent)?$/,
+      })
+    )[0],
+  );
+  expect(await screen.findByTestId("teardown-commit-dialog")).toBeTruthy();
+  fireEvent.click(screen.getByTestId("teardown-commit-immediate"));
+
+  await waitFor(() => {
+    expect(mutationMocks.removeBindingFolder).toHaveBeenCalledWith({
+      epicId: "epic-1",
+      ownerId: "owner-1",
+      ownerKind: "chat",
+      workspacePath: "/repo/beta",
+    });
+  });
+  expect(mutationMocks.createWorktree).not.toHaveBeenCalled();
+  expect(
+    useWorktreeIntentStagingStore.getState().intentByKey[
+      worktreeStagingKeyString(CHAT_STAGING_KEY)
+    ]?.entries[0],
+  ).toMatchObject({
+    workspacePath: "/repo/alpha",
+    branch: { name: "feat-a" },
+  });
+});
+
+it("restores a same-folder draft when a removal disclosure is dismissed", async () => {
+  teardownMocks.snapshot.mockImplementation((dropped: readonly string[]) =>
+    dropped.includes("/repo/alpha")
+      ? shellSnapshot("npm run dev", "sh-1", "chat")
+      : { holders: [], stopTargets: [] },
+  );
+  useWorktreeIntentStagingStore.getState().stageIntent(CHAT_STAGING_KEY, {
+    entries: [newWorktreeIntent("/repo/alpha", "feat-a")],
+  });
+
+  renderBoundSurface("chat", true);
+  fireEvent.click(screen.getByRole("button", { name: /^beta/ }));
+  fireEvent.click(
+    (
+      await screen.findAllByRole("button", {
+        name: /^(?:Move|Remove) alpha(?: to Recent)?$/,
+      })
+    )[0],
+  );
+  expect(await screen.findByTestId("teardown-commit-dialog")).toBeTruthy();
+  expect(screen.queryByTestId("teardown-commit-defer")).toBeNull();
+  fireEvent.click(screen.getByTestId("teardown-commit-cancel"));
+
+  expect(mutationMocks.removeBindingFolder).not.toHaveBeenCalled();
+  expect(
+    useWorktreeIntentStagingStore.getState().intentByKey[
+      worktreeStagingKeyString(CHAT_STAGING_KEY)
+    ]?.entries[0],
+  ).toMatchObject({
+    workspacePath: "/repo/alpha",
+    branch: { name: "feat-a" },
   });
 });

--- a/clients/gui-app/src/components/home/host-workspace-selector/__tests__/in-epic-surface-primary-readonly.test.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/__tests__/in-epic-surface-primary-readonly.test.tsx
@@ -31,7 +31,7 @@ const FAKE_CLIENT = {
 };
 const mutationMocks = vi.hoisted(() => ({
   addBindingFolder: vi.fn(),
-  createWorktree: vi.fn(),
+  createWorktree: vi.fn().mockResolvedValue({ perEntry: [] }),
   recordRecent: vi.fn(),
   removeBindingFolder: vi.fn(),
 }));
@@ -102,6 +102,7 @@ vi.mock("@/hooks/worktree/use-worktree-import-mutation", () => ({
 vi.mock("@/hooks/worktree/use-worktree-create-mutation", () => ({
   useWorktreeCreateForClient: () => ({
     mutate: mutationMocks.createWorktree,
+    mutateAsync: mutationMocks.createWorktree,
     isPending: false,
   }),
 }));
@@ -270,6 +271,7 @@ function renderBoundSurface(
             binding: BINDING,
             isOwnerActive: false,
             hasActiveTurn: false,
+            ownerLabel: "Owner",
             missingWorktreePaths: [],
             bindingResolved,
             onBindingCommitted: null,

--- a/clients/gui-app/src/components/home/host-workspace-selector/__tests__/in-epic-surface-primary-readonly.test.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/__tests__/in-epic-surface-primary-readonly.test.tsx
@@ -10,6 +10,8 @@ import {
 } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { WorktreeBusyHolder } from "@traycer/protocol/framework/worktree-busy-holders";
+import type { OwnerTeardownSnapshot } from "@/lib/worktree/owner-teardown-snapshot";
+import { teardownHolderKey } from "@/lib/worktree/owner-teardown-snapshot";
 import type {
   WorktreeBinding,
   WorktreeBindingEntry,
@@ -44,9 +46,14 @@ const recentMocks = vi.hoisted(() => ({
   recordRecentAsync: vi.fn(),
 }));
 const teardownMocks = vi.hoisted(() => ({
-  snapshot: vi.fn(
-    (_dropped: readonly string[]): readonly WorktreeBusyHolder[] => [],
-  ),
+  snapshot: vi.fn((_dropped: readonly string[]): OwnerTeardownSnapshot => ({
+    holders: [],
+    stopTargets: [],
+  })),
+}));
+const teardownStopMocks = vi.hoisted(() => ({
+  stopShell: vi.fn().mockResolvedValue({}),
+  stopAgent: vi.fn().mockResolvedValue({ stoppedAgentIds: [] }),
 }));
 const listByPathsMocks = vi.hoisted(() => ({
   workspaces: [] as WorktreeWorkspaceSummaryV15[],
@@ -94,6 +101,24 @@ vi.mock("@/hooks/worktree/use-worktree-list-by-workspace-paths-query", () => ({
 }));
 vi.mock("@/hooks/worktree/use-owner-teardown-snapshot", () => ({
   useOwnerTeardownSnapshot: () => teardownMocks.snapshot,
+}));
+vi.mock(
+  "@/hooks/managed-command/use-managed-command-lifecycle-mutations",
+  async (importOriginal) => ({
+    ...(await importOriginal<
+      typeof import("@/hooks/managed-command/use-managed-command-lifecycle-mutations")
+    >()),
+    useManagedCommandStop: () => ({
+      mutateAsync: teardownStopMocks.stopShell,
+      isPending: false,
+    }),
+  }),
+);
+vi.mock("@/hooks/agent/use-stop-agent-mutation", () => ({
+  useAgentStop: () => ({
+    mutateAsync: teardownStopMocks.stopAgent,
+    isPending: false,
+  }),
 }));
 vi.mock("@/hooks/worktree/use-worktree-workspaces-refresh", () => ({
   useWorktreeWorkspacesRefresh: () => ({
@@ -304,7 +329,12 @@ beforeEach(() => {
   recentMocks.recordRecentAsync.mockResolvedValue({});
   mutationMocks.createWorktree.mockResolvedValue({ perEntry: [] });
   mutationMocks.removeBindingFolder.mockResolvedValue({});
-  teardownMocks.snapshot.mockImplementation(() => []);
+  teardownStopMocks.stopShell.mockResolvedValue({});
+  teardownStopMocks.stopAgent.mockResolvedValue({ stoppedAgentIds: [] });
+  teardownMocks.snapshot.mockImplementation(() => ({
+    holders: [],
+    stopTargets: [],
+  }));
 });
 
 afterEach(() => {
@@ -313,6 +343,8 @@ afterEach(() => {
   mutationMocks.createWorktree.mockReset();
   mutationMocks.recordRecent.mockReset();
   mutationMocks.removeBindingFolder.mockReset();
+  teardownStopMocks.stopShell.mockReset();
+  teardownStopMocks.stopAgent.mockReset();
   teardownMocks.snapshot.mockReset();
   listByPathsMocks.workspaces = [];
   recentMocks.prepareRecent.mockReset();
@@ -512,16 +544,37 @@ const TERMINAL_STAGING_KEY = {
   ownerId: "owner-1",
 };
 
-function shellHolder(label: string): WorktreeBusyHolder {
+function shellHolder(
+  label: string,
+  ownerKind: WorktreeBusyHolder["ownerRef"]["ownerKind"] = "terminal-agent",
+): WorktreeBusyHolder {
   return {
     ownerRef: {
       epicId: "epic-1",
-      ownerKind: "terminal-agent",
+      ownerKind,
       ownerId: "owner-1",
     },
     holdKind: "supervised-shell",
     activity: "working",
     label,
+  };
+}
+
+function shellSnapshot(
+  label: string,
+  commandId = "sh-1",
+  ownerKind: WorktreeBusyHolder["ownerRef"]["ownerKind"] = "terminal-agent",
+): OwnerTeardownSnapshot {
+  const holder = shellHolder(label, ownerKind);
+  return {
+    holders: [holder],
+    stopTargets: [
+      {
+        kind: "supervised-shell",
+        commandId,
+        holderKey: teardownHolderKey(holder),
+      },
+    ],
   };
 }
 
@@ -581,7 +634,9 @@ async function openTerminalFolderPopover(): Promise<void> {
 
 it("stages a TUI folder removal and discloses a shell under it on Update", async () => {
   teardownMocks.snapshot.mockImplementation((dropped: readonly string[]) =>
-    dropped.includes("/repo/alpha") ? [shellHolder("npm run dev")] : [],
+    dropped.includes("/repo/alpha")
+      ? shellSnapshot("npm run dev")
+      : { holders: [], stopTargets: [] },
   );
 
   await openTerminalFolderPopover();
@@ -615,7 +670,7 @@ it("stages a TUI folder removal and discloses a shell under it on Update", async
 
 it("re-discloses when TUI staging mutates under an open confirmation", async () => {
   seedResolvedBindingMetadata();
-  teardownMocks.snapshot.mockImplementation(() => [shellHolder("npm run dev")]);
+  teardownMocks.snapshot.mockImplementation(() => shellSnapshot("npm run dev"));
   useWorktreeIntentStagingStore.getState().stageIntent(TERMINAL_STAGING_KEY, {
     entries: [newWorktreeIntent("/repo/alpha", "feat-a")],
   });
@@ -650,7 +705,7 @@ it("re-discloses when TUI staging mutates under an open confirmation", async () 
 
 it("commits the disclosed TUI draft when staging is unchanged", async () => {
   seedResolvedBindingMetadata();
-  teardownMocks.snapshot.mockImplementation(() => [shellHolder("npm run dev")]);
+  teardownMocks.snapshot.mockImplementation(() => shellSnapshot("npm run dev"));
   useWorktreeIntentStagingStore.getState().stageIntent(TERMINAL_STAGING_KEY, {
     entries: [newWorktreeIntent("/repo/alpha", "feat-a")],
   });
@@ -670,4 +725,143 @@ it("commits the disclosed TUI draft when staging is unchanged", async () => {
     }>;
   };
   expect(createArg.entries[0]?.branch?.name).toBe("feat-a");
+});
+
+it("awaits a disclosed shell stop before worktree.create", async () => {
+  seedResolvedBindingMetadata();
+  teardownMocks.snapshot.mockImplementation(() => shellSnapshot("npm run dev"));
+  useWorktreeIntentStagingStore.getState().stageIntent(TERMINAL_STAGING_KEY, {
+    entries: [newWorktreeIntent("/repo/alpha", "feat-a")],
+  });
+  let releaseStop: ((value: unknown) => void) | null = null;
+  teardownStopMocks.stopShell.mockImplementation(
+    () =>
+      new Promise((resolve) => {
+        releaseStop = resolve;
+      }),
+  );
+
+  await openTerminalFolderPopover();
+  fireEvent.click(await screen.findByRole("button", { name: "Update" }));
+  fireEvent.click(await screen.findByTestId("teardown-commit-immediate"));
+
+  await waitFor(() => {
+    expect(teardownStopMocks.stopShell).toHaveBeenCalledWith({
+      hostId: "host-test",
+      epicId: "epic-1",
+      commandId: "sh-1",
+    });
+  });
+  expect(mutationMocks.createWorktree).not.toHaveBeenCalled();
+
+  act(() => {
+    releaseStop?.({});
+  });
+  await waitFor(() => {
+    expect(mutationMocks.createWorktree).toHaveBeenCalledTimes(1);
+  });
+});
+
+it("keeps the dialog open and skips create when a disclosed stop fails", async () => {
+  seedResolvedBindingMetadata();
+  teardownMocks.snapshot.mockImplementation(() => shellSnapshot("npm run dev"));
+  useWorktreeIntentStagingStore.getState().stageIntent(TERMINAL_STAGING_KEY, {
+    entries: [newWorktreeIntent("/repo/alpha", "feat-a")],
+  });
+  teardownStopMocks.stopShell.mockRejectedValue(
+    new Error("shell still running"),
+  );
+
+  await openTerminalFolderPopover();
+  fireEvent.click(await screen.findByRole("button", { name: "Update" }));
+  fireEvent.click(await screen.findByTestId("teardown-commit-immediate"));
+
+  expect(
+    (await screen.findByTestId("teardown-holder-failure")).textContent,
+  ).toBe("shell still running");
+  expect(mutationMocks.createWorktree).not.toHaveBeenCalled();
+});
+
+it("discloses idle-chat folder removal when a live shell is under the folder", async () => {
+  teardownMocks.snapshot.mockImplementation((dropped: readonly string[]) =>
+    dropped.includes("/repo/alpha")
+      ? shellSnapshot("npm run dev", "sh-1", "chat")
+      : { holders: [], stopTargets: [] },
+  );
+
+  renderBoundSurface("chat", true);
+  fireEvent.click(screen.getByRole("button", { name: /^beta/ }));
+  fireEvent.click(
+    (
+      await screen.findAllByRole("button", {
+        name: /^(?:Move|Remove) alpha(?: to Recent)?$/,
+      })
+    )[0],
+  );
+
+  expect(await screen.findByTestId("teardown-commit-dialog")).toBeTruthy();
+  expect(screen.getByTestId("teardown-disclosure").textContent).toContain(
+    "npm run dev",
+  );
+  expect(mutationMocks.removeBindingFolder).not.toHaveBeenCalled();
+
+  fireEvent.click(screen.getByTestId("teardown-commit-immediate"));
+  await waitFor(() => {
+    expect(teardownStopMocks.stopShell).toHaveBeenCalled();
+  });
+  await waitFor(() => {
+    expect(mutationMocks.removeBindingFolder).toHaveBeenCalledWith({
+      epicId: "epic-1",
+      ownerId: "owner-1",
+      ownerKind: "chat",
+      workspacePath: "/repo/alpha",
+    });
+  });
+});
+
+it("keeps a newer TUI draft after an in-flight commit of an older capture", async () => {
+  seedResolvedBindingMetadata();
+  let releaseCreate: ((value: unknown) => void) | null = null;
+  mutationMocks.createWorktree.mockImplementation(
+    () =>
+      new Promise((resolve) => {
+        releaseCreate = resolve;
+      }),
+  );
+  useWorktreeIntentStagingStore.getState().stageIntent(TERMINAL_STAGING_KEY, {
+    entries: [newWorktreeIntent("/repo/alpha", "feat-a")],
+  });
+
+  await openTerminalFolderPopover();
+  fireEvent.click(await screen.findByRole("button", { name: "Update" }));
+  await waitFor(() => {
+    expect(mutationMocks.createWorktree).toHaveBeenCalledTimes(1);
+  });
+
+  act(() => {
+    useWorktreeIntentStagingStore.getState().stageIntent(TERMINAL_STAGING_KEY, {
+      entries: [newWorktreeIntent("/repo/alpha", "feat-b")],
+    });
+  });
+  act(() => {
+    releaseCreate?.({
+      perEntry: [
+        {
+          workspacePath: "/repo/alpha",
+          ok: true,
+          worktreePath: "/wt/alpha",
+          branch: "feat-a",
+          errorMessage: null,
+        },
+      ],
+    });
+  });
+
+  await waitFor(() => {
+    expect(
+      useWorktreeIntentStagingStore.getState().intentByKey[
+        worktreeStagingKeyString(TERMINAL_STAGING_KEY)
+      ]?.entries[0],
+    ).toMatchObject({ branch: { name: "feat-b" } });
+  });
 });

--- a/clients/gui-app/src/components/home/host-workspace-selector/__tests__/in-epic-surface-primary-readonly.test.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/__tests__/in-epic-surface-primary-readonly.test.tsx
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import userEvent from "@testing-library/user-event";
 import {
+  act,
   cleanup,
   fireEvent,
   render,
@@ -8,9 +9,12 @@ import {
   waitFor,
 } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { WorktreeBusyHolder } from "@traycer/protocol/framework/worktree-busy-holders";
 import type {
   WorktreeBinding,
   WorktreeBindingEntry,
+  WorktreeFolderIntent,
+  WorktreeWorkspaceSummaryV15,
 } from "@traycer/protocol/host/worktree-schemas";
 import type { PreparedWorkspaceFolder } from "@traycer/protocol/host/epic/unary-schemas";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -33,11 +37,19 @@ const mutationMocks = vi.hoisted(() => ({
   addBindingFolder: vi.fn(),
   createWorktree: vi.fn().mockResolvedValue({ perEntry: [] }),
   recordRecent: vi.fn(),
-  removeBindingFolder: vi.fn(),
+  removeBindingFolder: vi.fn().mockResolvedValue({}),
 }));
 const recentMocks = vi.hoisted(() => ({
   prepareRecent: vi.fn(),
   recordRecentAsync: vi.fn(),
+}));
+const teardownMocks = vi.hoisted(() => ({
+  snapshot: vi.fn(
+    (_dropped: readonly string[]): readonly WorktreeBusyHolder[] => [],
+  ),
+}));
+const listByPathsMocks = vi.hoisted(() => ({
+  workspaces: [] as WorktreeWorkspaceSummaryV15[],
 }));
 
 const RECENT_FOLDER: PreparedWorkspaceFolder = {
@@ -75,10 +87,13 @@ vi.mock("@/hooks/host/use-host-directory-list-query", () => ({
 }));
 vi.mock("@/hooks/worktree/use-worktree-list-by-workspace-paths-query", () => ({
   useWorktreeListByWorkspacePathsForClient: () => ({
-    data: { workspaces: [] },
+    data: { workspaces: listByPathsMocks.workspaces },
     isFetching: false,
     isLoading: false,
   }),
+}));
+vi.mock("@/hooks/worktree/use-owner-teardown-snapshot", () => ({
+  useOwnerTeardownSnapshot: () => teardownMocks.snapshot,
 }));
 vi.mock("@/hooks/worktree/use-worktree-workspaces-refresh", () => ({
   useWorktreeWorkspacesRefresh: () => ({
@@ -111,6 +126,7 @@ vi.mock(
   () => ({
     useWorkspaceBindingRemoveEntryForClient: () => ({
       mutate: mutationMocks.removeBindingFolder,
+      mutateAsync: mutationMocks.removeBindingFolder,
       isPending: false,
     }),
     usePendingRemoveBindingEntryPaths: () => new Set<string>(),
@@ -286,6 +302,9 @@ function renderBoundSurface(
 beforeEach(() => {
   recentMocks.prepareRecent.mockResolvedValue({ folders: [RECENT_FOLDER] });
   recentMocks.recordRecentAsync.mockResolvedValue({});
+  mutationMocks.createWorktree.mockResolvedValue({ perEntry: [] });
+  mutationMocks.removeBindingFolder.mockResolvedValue({});
+  teardownMocks.snapshot.mockImplementation(() => []);
 });
 
 afterEach(() => {
@@ -294,6 +313,8 @@ afterEach(() => {
   mutationMocks.createWorktree.mockReset();
   mutationMocks.recordRecent.mockReset();
   mutationMocks.removeBindingFolder.mockReset();
+  teardownMocks.snapshot.mockReset();
+  listByPathsMocks.workspaces = [];
   recentMocks.prepareRecent.mockReset();
   recentMocks.recordRecentAsync.mockReset();
   useWorktreeIntentStagingStore.getState().resetForTests();
@@ -481,4 +502,172 @@ it("refuses terminal Update when metadata regresses to unresolved", async () => 
       worktreeStagingKeyString(key)
     ],
   ).toBeDefined();
+});
+
+const TERMINAL_STAGING_KEY = {
+  surface: "owner" as const,
+  hostId: "host-test",
+  epicId: "epic-1",
+  ownerKind: "terminal-agent" as const,
+  ownerId: "owner-1",
+};
+
+function shellHolder(label: string): WorktreeBusyHolder {
+  return {
+    ownerRef: {
+      epicId: "epic-1",
+      ownerKind: "terminal-agent",
+      ownerId: "owner-1",
+    },
+    holdKind: "supervised-shell",
+    activity: "working",
+    label,
+  };
+}
+
+function newWorktreeIntent(
+  workspacePath: string,
+  branchName: string,
+): WorktreeFolderIntent {
+  return {
+    kind: "worktree",
+    scripts: null,
+    workspacePath,
+    repoIdentifier: null,
+    isPrimary: false,
+    branch: {
+      type: "new",
+      name: branchName,
+      source: "main",
+      carryUncommittedChanges: false,
+    },
+  };
+}
+
+function resolvedSummary(workspacePath: string): WorktreeWorkspaceSummaryV15 {
+  return {
+    workspacePath,
+    isGitRepo: true,
+    repoIdentifier: { owner: "acme", repo: "app" },
+    mainBranch: "main",
+    worktrees: [
+      {
+        worktreePath: workspacePath,
+        branch: "main",
+        head: null,
+        isMain: true,
+        isLocked: false,
+      },
+    ],
+    scripts: null,
+    repoBranchPrefix: { status: "absent" },
+    resolvedAt: 1,
+    presence: "present",
+  };
+}
+
+function seedResolvedBindingMetadata(): void {
+  listByPathsMocks.workspaces = [
+    resolvedSummary("/repo/alpha"),
+    resolvedSummary("/repo/beta"),
+  ];
+}
+
+async function openTerminalFolderPopover(): Promise<void> {
+  renderBoundSurface("terminal-agent", true);
+  fireEvent.click(screen.getByRole("button", { name: /^beta/ }));
+  await screen.findAllByTestId("folder-row");
+}
+
+it("stages a TUI folder removal and discloses a shell under it on Update", async () => {
+  teardownMocks.snapshot.mockImplementation((dropped: readonly string[]) =>
+    dropped.includes("/repo/alpha") ? [shellHolder("npm run dev")] : [],
+  );
+
+  await openTerminalFolderPopover();
+  fireEvent.click(screen.getByRole("button", { name: "Remove alpha" }));
+
+  expect(mutationMocks.removeBindingFolder).not.toHaveBeenCalled();
+
+  fireEvent.click(await screen.findByRole("button", { name: "Update" }));
+
+  expect(await screen.findByTestId("teardown-commit-dialog")).toBeTruthy();
+  expect(screen.getByTestId("teardown-disclosure").textContent).toContain(
+    "npm run dev",
+  );
+  expect(screen.getByTestId("teardown-disclosure").textContent).toContain(
+    "Shell",
+  );
+  expect(teardownMocks.snapshot).toHaveBeenCalledWith(["/repo/alpha"]);
+
+  fireEvent.click(screen.getByTestId("teardown-commit-immediate"));
+
+  await waitFor(() => {
+    expect(mutationMocks.removeBindingFolder).toHaveBeenCalledWith({
+      epicId: "epic-1",
+      ownerId: "owner-1",
+      ownerKind: "terminal-agent",
+      workspacePath: "/repo/alpha",
+    });
+  });
+  expect(mutationMocks.createWorktree).not.toHaveBeenCalled();
+});
+
+it("re-discloses when TUI staging mutates under an open confirmation", async () => {
+  seedResolvedBindingMetadata();
+  teardownMocks.snapshot.mockImplementation(() => [shellHolder("npm run dev")]);
+  useWorktreeIntentStagingStore.getState().stageIntent(TERMINAL_STAGING_KEY, {
+    entries: [newWorktreeIntent("/repo/alpha", "feat-a")],
+  });
+
+  await openTerminalFolderPopover();
+  fireEvent.click(await screen.findByRole("button", { name: "Update" }));
+  expect(await screen.findByTestId("teardown-commit-dialog")).toBeTruthy();
+
+  act(() => {
+    useWorktreeIntentStagingStore.getState().stageIntent(TERMINAL_STAGING_KEY, {
+      entries: [newWorktreeIntent("/repo/alpha", "feat-b")],
+    });
+  });
+
+  fireEvent.click(screen.getByTestId("teardown-commit-immediate"));
+
+  expect(await screen.findByTestId("teardown-commit-dialog")).toBeTruthy();
+  expect(mutationMocks.createWorktree).not.toHaveBeenCalled();
+
+  fireEvent.click(screen.getByTestId("teardown-commit-immediate"));
+
+  await waitFor(() => {
+    expect(mutationMocks.createWorktree).toHaveBeenCalledTimes(1);
+  });
+  const createArg = mutationMocks.createWorktree.mock.calls[0]?.[0] as {
+    readonly entries: ReadonlyArray<{
+      readonly branch?: { readonly name?: string };
+    }>;
+  };
+  expect(createArg.entries[0]?.branch?.name).toBe("feat-b");
+});
+
+it("commits the disclosed TUI draft when staging is unchanged", async () => {
+  seedResolvedBindingMetadata();
+  teardownMocks.snapshot.mockImplementation(() => [shellHolder("npm run dev")]);
+  useWorktreeIntentStagingStore.getState().stageIntent(TERMINAL_STAGING_KEY, {
+    entries: [newWorktreeIntent("/repo/alpha", "feat-a")],
+  });
+
+  await openTerminalFolderPopover();
+  fireEvent.click(await screen.findByRole("button", { name: "Update" }));
+  expect(await screen.findByTestId("teardown-commit-dialog")).toBeTruthy();
+
+  fireEvent.click(screen.getByTestId("teardown-commit-immediate"));
+
+  await waitFor(() => {
+    expect(mutationMocks.createWorktree).toHaveBeenCalledTimes(1);
+  });
+  const createArg = mutationMocks.createWorktree.mock.calls[0]?.[0] as {
+    readonly entries: ReadonlyArray<{
+      readonly branch?: { readonly name?: string };
+    }>;
+  };
+  expect(createArg.entries[0]?.branch?.name).toBe("feat-a");
 });

--- a/clients/gui-app/src/components/home/host-workspace-selector/__tests__/in-epic-surface-primary-readonly.test.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/__tests__/in-epic-surface-primary-readonly.test.tsx
@@ -587,7 +587,7 @@ function shellSnapshot(
 ): OwnerTeardownSnapshot {
   const holder = shellHolder(label, ownerKind);
   return {
-    holders: [holder],
+    holders: [{ ...holder, holderKey: teardownHolderKey(holder) }],
     stopTargets: [
       {
         kind: "supervised-shell",
@@ -907,7 +907,10 @@ it("stops a chat turn once and does not re-stop expanded agent.stop-consequence 
   );
   const shell = shellHolder("sleep 1", "chat");
   teardownMocks.snapshot.mockImplementation(() => ({
-    holders: [turn, shell],
+    holders: [
+      { ...turn, holderKey: teardownHolderKey(turn) },
+      { ...shell, holderKey: teardownHolderKey(shell) },
+    ],
     stopTargets: [
       {
         kind: "chat-turn",

--- a/clients/gui-app/src/components/home/host-workspace-selector/__tests__/in-epic-surface-primary-readonly.test.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/__tests__/in-epic-surface-primary-readonly.test.tsx
@@ -747,19 +747,33 @@ it("commits the disclosed TUI draft when staging is unchanged", async () => {
   expect(createArg.entries[0]?.branch?.name).toBe("feat-a");
 });
 
+function deferredValue(): {
+  readonly promise: Promise<unknown>;
+  readonly resolve: (value: unknown) => void;
+} {
+  let resolve!: (value: unknown) => void;
+  const promise = new Promise((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+async function drainMicrotasks(): Promise<void> {
+  await act(async () => {
+    for (let i = 0; i < 8; i += 1) {
+      await Promise.resolve();
+    }
+  });
+}
+
 it("awaits a disclosed shell stop before worktree.create", async () => {
   seedResolvedBindingMetadata();
   teardownMocks.snapshot.mockImplementation(() => shellSnapshot("npm run dev"));
   useWorktreeIntentStagingStore.getState().stageIntent(TERMINAL_STAGING_KEY, {
     entries: [newWorktreeIntent("/repo/alpha", "feat-a")],
   });
-  let releaseStop: ((value: unknown) => void) | null = null;
-  teardownStopMocks.stopShell.mockImplementation(
-    () =>
-      new Promise((resolve) => {
-        releaseStop = resolve;
-      }),
-  );
+  const stop = deferredValue();
+  teardownStopMocks.stopShell.mockImplementation(() => stop.promise);
 
   await openTerminalFolderPopover();
   fireEvent.click(await screen.findByRole("button", { name: "Update" }));
@@ -775,7 +789,7 @@ it("awaits a disclosed shell stop before worktree.create", async () => {
   expect(mutationMocks.createWorktree).not.toHaveBeenCalled();
 
   act(() => {
-    releaseStop?.({});
+    stop.resolve({});
   });
   await waitFor(() => {
     expect(mutationMocks.createWorktree).toHaveBeenCalledTimes(1);
@@ -928,13 +942,11 @@ it("does not apply a cancelled teardown after a newer confirm starts", async () 
   useWorktreeIntentStagingStore.getState().stageIntent(TERMINAL_STAGING_KEY, {
     entries: [newWorktreeIntent("/repo/alpha", "feat-a")],
   });
-  const stopResolvers: Array<(value: unknown) => void> = [];
-  teardownStopMocks.stopShell.mockImplementation(
-    () =>
-      new Promise((resolve) => {
-        stopResolvers.push(resolve);
-      }),
-  );
+  const firstStop = deferredValue();
+  const secondStop = deferredValue();
+  teardownStopMocks.stopShell
+    .mockImplementationOnce(() => firstStop.promise)
+    .mockImplementationOnce(() => secondStop.promise);
 
   await openTerminalFolderPopover();
   fireEvent.click(await screen.findByRole("button", { name: "Update" }));
@@ -957,14 +969,14 @@ it("does not apply a cancelled teardown after a newer confirm starts", async () 
     expect(teardownStopMocks.stopShell).toHaveBeenCalledTimes(2);
   });
 
-  await act(async () => {
-    stopResolvers[0]?.({});
-    await Promise.resolve();
+  act(() => {
+    firstStop.resolve({});
   });
+  await drainMicrotasks();
   expect(mutationMocks.createWorktree).not.toHaveBeenCalled();
 
   act(() => {
-    stopResolvers[1]?.({});
+    secondStop.resolve({});
   });
   await waitFor(() => {
     expect(mutationMocks.createWorktree).toHaveBeenCalledTimes(1);
@@ -977,19 +989,36 @@ it("does not apply a cancelled teardown after a newer confirm starts", async () 
   expect(createArg.entries[0]?.branch?.name).toBe("feat-b");
 });
 
+it("does not stop holders when a staged create cannot apply after confirm", async () => {
+  seedResolvedBindingMetadata();
+  teardownMocks.snapshot.mockImplementation(() => shellSnapshot("npm run dev"));
+  useWorktreeIntentStagingStore.getState().stageIntent(TERMINAL_STAGING_KEY, {
+    entries: [newWorktreeIntent("/repo/alpha", "feat-a")],
+  });
+
+  await openTerminalFolderPopover();
+  fireEvent.click(await screen.findByRole("button", { name: "Update" }));
+  expect(await screen.findByTestId("teardown-commit-dialog")).toBeTruthy();
+  act(() => {
+    useWorktreeIntentStagingStore
+      .getState()
+      .setSuspendedWorkspacePaths(TERMINAL_STAGING_KEY, ["/repo/alpha"]);
+  });
+  fireEvent.click(screen.getByTestId("teardown-commit-immediate"));
+
+  expect(await screen.findByTestId("teardown-commit-refusal")).toBeTruthy();
+  expect(teardownStopMocks.stopShell).not.toHaveBeenCalled();
+  expect(mutationMocks.createWorktree).not.toHaveBeenCalled();
+});
+
 it("does not apply remove or create if the user cancels during in-flight teardown", async () => {
   seedResolvedBindingMetadata();
   teardownMocks.snapshot.mockImplementation(() => shellSnapshot("npm run dev"));
   useWorktreeIntentStagingStore.getState().stageIntent(TERMINAL_STAGING_KEY, {
     entries: [newWorktreeIntent("/repo/alpha", "feat-a")],
   });
-  let releaseStop: ((value: unknown) => void) | null = null;
-  teardownStopMocks.stopShell.mockImplementation(
-    () =>
-      new Promise((resolve) => {
-        releaseStop = resolve;
-      }),
-  );
+  const stop = deferredValue();
+  teardownStopMocks.stopShell.mockImplementation(() => stop.promise);
 
   await openTerminalFolderPopover();
   fireEvent.click(await screen.findByRole("button", { name: "Update" }));
@@ -999,9 +1028,9 @@ it("does not apply remove or create if the user cancels during in-flight teardow
   });
   fireEvent.click(screen.getByTestId("teardown-commit-cancel"));
   act(() => {
-    releaseStop?.({});
+    stop.resolve({});
   });
-  await Promise.resolve();
+  await drainMicrotasks();
   expect(mutationMocks.createWorktree).not.toHaveBeenCalled();
   expect(mutationMocks.removeBindingFolder).not.toHaveBeenCalled();
   expect(

--- a/clients/gui-app/src/components/home/host-workspace-selector/host-workspace-selector.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/host-workspace-selector.tsx
@@ -130,12 +130,18 @@ import { workspaceFolderName } from "@/lib/worktree/workspace-folder-name";
 import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 import { trackUserInitiatedWorktreeWrite } from "@/lib/worktree/user-worktree-analytics";
 import { droppedRunDirectoriesFromDraft } from "@/lib/worktree/owner-teardown-snapshot";
+import {
+  failuresByHolderKey,
+  runGuiComposedTeardown,
+} from "@/lib/worktree/gui-composed-teardown";
 import { isWorktreeRebindBlocked } from "@/lib/worktree/is-worktree-rebind-blocked";
 import {
   worktreeCommitCaptureIsStale,
   type WorktreeCommitCapture,
 } from "@/lib/worktree/worktree-commit-capture";
 import { useOwnerTeardownSnapshot } from "@/hooks/worktree/use-owner-teardown-snapshot";
+import { useManagedCommandStop } from "@/hooks/managed-command/use-managed-command-lifecycle-mutations";
+import { useAgentStop } from "@/hooks/agent/use-stop-agent-mutation";
 import {
   TeardownCommitDialog,
   type TeardownCommitChoice,
@@ -1735,6 +1741,7 @@ type FolderEditorAction =
       readonly workspacePaths: ReadonlyArray<string>;
     }
   | { readonly type: "stageRemoval"; readonly workspacePath: string }
+  | { readonly type: "unstageRemoval"; readonly workspacePath: string }
   | { readonly type: "resumed" };
 function folderEditorReducer(
   state: FolderEditorState,
@@ -1760,6 +1767,12 @@ function folderEditorReducer(
           action.workspacePath,
         ]),
       };
+    }
+    case "unstageRemoval": {
+      if (!state.pendingRemovedPaths.has(action.workspacePath)) return state;
+      const next = new Set(state.pendingRemovedPaths);
+      next.delete(action.workspacePath);
+      return { ...state, pendingRemovedPaths: next };
     }
     case "resumed":
       return {
@@ -1803,7 +1816,7 @@ function InEpicSurface(props: InEpicSurfaceProps) {
     "WORKTREE_REBIND_BLOCKED",
   ]);
   const worktreeCreatePending = worktreeCreateMutation.isPending;
-  const snapshotTeardownHolders = useOwnerTeardownSnapshot({
+  const snapshotOwnerTeardown = useOwnerTeardownSnapshot({
     epicId: surface.epicId,
     hostId: surface.hostId,
     ownerKind,
@@ -1812,11 +1825,16 @@ function InEpicSurface(props: InEpicSurfaceProps) {
     hasActiveTurn: surface.hasActiveTurn,
     ptyLive: surface.kind === "terminal-agent" && surface.isOwnerActive,
   });
+  const stopManagedCommand = useManagedCommandStop();
+  const stopAgent = useAgentStop();
   const [teardownDialog, setTeardownDialog] = useState<{
     readonly choice: TeardownCommitChoice;
     readonly holders: readonly WorktreeBusyHolder[];
     readonly capture: WorktreeCommitCapture;
+    readonly failures: Readonly<Record<string, string>>;
+    readonly restoreRemovalOnDismiss: string | null;
   } | null>(null);
+  const [teardownCommitPending, setTeardownCommitPending] = useState(false);
   const removeBindingEntryMutation = useWorkspaceBindingRemoveEntryForClient(
     props.hostClient,
   );
@@ -1926,8 +1944,8 @@ function InEpicSurface(props: InEpicSurfaceProps) {
   const unstageWorktreeEntry = useWorktreeIntentStagingStore(
     (s) => s.unstageEntry,
   );
-  const clearStagedWorktreeIntent = useWorktreeIntentStagingStore(
-    (s) => s.clear,
+  const releaseIntentForDispatch = useWorktreeIntentStagingStore(
+    (s) => s.releaseIntentForDispatch,
   );
   const stagedKey = useMemo<WorktreeStagingKey>(
     () => ({
@@ -2030,13 +2048,28 @@ function InEpicSurface(props: InEpicSurfaceProps) {
     changedWorkspacePathsSinceResume,
   );
   const readLiveCommitCapture = useCallback((): WorktreeCommitCapture => {
+    const draft = readStagedWorktreeIntent(stagedKey);
+    const removedWorkspacePaths = [...editor.pendingRemovedPaths];
+    const snapshot = snapshotOwnerTeardown(
+      droppedRunDirectoriesFromDraft({
+        binding: surface.binding,
+        draft,
+        removedWorkspacePaths,
+      }),
+    );
     return {
-      draft: readStagedWorktreeIntent(stagedKey),
+      draft,
       revision: stagedWorktreeIntentRevision(stagedKey),
       binding: surface.binding,
-      removedWorkspacePaths: [...editor.pendingRemovedPaths],
+      removedWorkspacePaths,
+      stopTargets: snapshot.stopTargets,
     };
-  }, [editor.pendingRemovedPaths, stagedKey, surface.binding]);
+  }, [
+    editor.pendingRemovedPaths,
+    snapshotOwnerTeardown,
+    stagedKey,
+    surface.binding,
+  ]);
   const applyStagedFoldersAndResume = useCallback(
     (capture: WorktreeCommitCapture): void => {
       if (stagedWorktreeIntentIsSuspended(stagedKey)) return;
@@ -2061,7 +2094,7 @@ function InEpicSurface(props: InEpicSurfaceProps) {
         ]),
       );
       const finishAndResume = (): void => {
-        clearStagedWorktreeIntent(stagedKey);
+        releaseIntentForDispatch(stagedKey, capture.revision);
         dispatchEditor({ type: "resumed" });
         handleBindingCommitted(changedWorkspacePaths);
       };
@@ -2106,10 +2139,13 @@ function InEpicSurface(props: InEpicSurfaceProps) {
               draft: live.draft,
               removedWorkspacePaths: live.removedWorkspacePaths,
             });
+            const blocked = snapshotOwnerTeardown(dropped);
             setTeardownDialog({
               choice: "blocked",
-              holders: snapshotTeardownHolders(dropped),
-              capture: live,
+              holders: blocked.holders,
+              capture: { ...live, stopTargets: blocked.stopTargets },
+              failures: {},
+              restoreRemovalOnDismiss: null,
             });
           });
       };
@@ -2148,29 +2184,36 @@ function InEpicSurface(props: InEpicSurfaceProps) {
       surface.ownerId,
       ownerKind,
       stagedKey,
-      clearStagedWorktreeIntent,
+      releaseIntentForDispatch,
       unstageWorktreeEntry,
       handleBindingCommitted,
-      snapshotTeardownHolders,
+      snapshotOwnerTeardown,
     ],
   );
   const requestStagedFolderCommit = useCallback((): void => {
     const capture = readLiveCommitCapture();
-    const dropped = droppedRunDirectoriesFromDraft({
-      binding: capture.binding,
-      draft: capture.draft,
-      removedWorkspacePaths: capture.removedWorkspacePaths,
-    });
-    const holders = snapshotTeardownHolders(dropped);
-    if (holders.length === 0) {
+    const snapshot = snapshotOwnerTeardown(
+      droppedRunDirectoriesFromDraft({
+        binding: capture.binding,
+        draft: capture.draft,
+        removedWorkspacePaths: capture.removedWorkspacePaths,
+      }),
+    );
+    if (snapshot.holders.length === 0) {
       applyStagedFoldersAndResume(capture);
       return;
     }
-    setTeardownDialog({ choice: "commit", holders, capture });
+    setTeardownDialog({
+      choice: "commit",
+      holders: snapshot.holders,
+      capture: { ...capture, stopTargets: snapshot.stopTargets },
+      failures: {},
+      restoreRemovalOnDismiss: null,
+    });
   }, [
     applyStagedFoldersAndResume,
     readLiveCommitCapture,
-    snapshotTeardownHolders,
+    snapshotOwnerTeardown,
   ]);
   // Terminal-agent add/remove commit to the binding but deliberately do NOT
   // resume — only the explicit "Update" does. Mark the binding dirty so
@@ -2189,6 +2232,58 @@ function InEpicSurface(props: InEpicSurfaceProps) {
     },
     [stagedKey, unstageWorktreeEntry],
   );
+  // Phase-1 GUI-composed teardown: stop disclosed owner-scoped holders
+  // (managed-command stop, agent.stop) before removeBindingEntry /
+  // worktree.create. create has no commitIntent (protocol frozen behind
+  // the pin). Upgrade with listHolders + create-with-intent in the same
+  // follow-up as the snapshot provider.
+  const confirmImmediateCommit = useCallback(async (): Promise<void> => {
+    const dialog = teardownDialog;
+    if (dialog === null || teardownCommitPending) return;
+    const live = readLiveCommitCapture();
+    if (worktreeCommitCaptureIsStale(dialog.capture, live)) {
+      setTeardownDialog(null);
+      requestStagedFolderCommit();
+      return;
+    }
+    setTeardownCommitPending(true);
+    const failures = await runGuiComposedTeardown({
+      stopTargets: dialog.capture.stopTargets,
+      stopShell: (commandId) =>
+        stopManagedCommand.mutateAsync({
+          hostId: surface.hostId,
+          epicId: surface.epicId,
+          commandId,
+        }),
+      stopTurn: () =>
+        stopAgent.mutateAsync({
+          epicId: surface.epicId,
+          agentId: surface.ownerId,
+          cascade: false,
+        }),
+    });
+    setTeardownCommitPending(false);
+    if (failures.length > 0) {
+      setTeardownDialog({
+        ...dialog,
+        failures: failuresByHolderKey(failures),
+      });
+      return;
+    }
+    setTeardownDialog(null);
+    applyStagedFoldersAndResume(dialog.capture);
+  }, [
+    applyStagedFoldersAndResume,
+    readLiveCommitCapture,
+    requestStagedFolderCommit,
+    stopAgent,
+    stopManagedCommand,
+    surface.epicId,
+    surface.hostId,
+    surface.ownerId,
+    teardownCommitPending,
+    teardownDialog,
+  ]);
   const removeFolderNow = useCallback(
     (workspacePath: string): void => {
       removeBindingEntryMutation.mutate(
@@ -2221,6 +2316,42 @@ function InEpicSurface(props: InEpicSurfaceProps) {
       surface.kind,
       surface.ownerId,
       unstageWorktreeEntry,
+    ],
+  );
+  const requestChatFolderRemoval = useCallback(
+    (workspacePath: string): void => {
+      const snapshot = snapshotOwnerTeardown(
+        droppedRunDirectoriesFromDraft({
+          binding: surface.binding,
+          draft: null,
+          removedWorkspacePaths: [workspacePath],
+        }),
+      );
+      if (snapshot.holders.length === 0) {
+        removeFolderNow(workspacePath);
+        return;
+      }
+      stageFolderRemoval(workspacePath);
+      setTeardownDialog({
+        choice: "commit",
+        holders: snapshot.holders,
+        capture: {
+          draft: readStagedWorktreeIntent(stagedKey),
+          revision: stagedWorktreeIntentRevision(stagedKey),
+          binding: surface.binding,
+          removedWorkspacePaths: [workspacePath],
+          stopTargets: snapshot.stopTargets,
+        },
+        failures: {},
+        restoreRemovalOnDismiss: workspacePath,
+      });
+    },
+    [
+      removeFolderNow,
+      snapshotOwnerTeardown,
+      stageFolderRemoval,
+      stagedKey,
+      surface.binding,
     ],
   );
   useEffect(() => {
@@ -2638,7 +2769,7 @@ function InEpicSurface(props: InEpicSurfaceProps) {
                   stageFolderRemoval(ws.workspacePath);
                   return;
                 }
-                removeFolderNow(ws.workspacePath);
+                requestChatFolderRemoval(ws.workspacePath);
               },
             };
           }
@@ -2712,7 +2843,7 @@ function InEpicSurface(props: InEpicSurfaceProps) {
                 stageFolderRemoval(ws.workspacePath);
                 return;
               }
-              removeFolderNow(ws.workspacePath);
+              requestChatFolderRemoval(ws.workspacePath);
             },
           };
         }),
@@ -2726,7 +2857,7 @@ function InEpicSurface(props: InEpicSurfaceProps) {
       handleBindingCommitted,
       markBindingDirtyWithoutResume,
       remainingVisibleFolders,
-      removeFolderNow,
+      requestChatFolderRemoval,
       stageFolderRemoval,
       stagedKey,
       unstageWorktreeEntry,
@@ -2951,21 +3082,29 @@ function InEpicSurface(props: InEpicSurfaceProps) {
         open={teardownDialog !== null}
         choice={teardownDialog?.choice ?? null}
         holders={teardownDialog?.holders ?? []}
+        failures={teardownDialog?.failures}
+        immediatePending={teardownCommitPending}
         onImmediate={() => {
-          const dialog = teardownDialog;
-          setTeardownDialog(null);
-          if (dialog === null) return;
-          const live = readLiveCommitCapture();
-          if (worktreeCommitCaptureIsStale(dialog.capture, live)) {
-            requestStagedFolderCommit();
-            return;
-          }
-          applyStagedFoldersAndResume(dialog.capture);
+          void confirmImmediateCommit();
         }}
         onDefer={() => {
+          const restore = teardownDialog?.restoreRemovalOnDismiss;
+          if (restore !== null && restore !== undefined) {
+            dispatchEditor({
+              type: "unstageRemoval",
+              workspacePath: restore,
+            });
+          }
           setTeardownDialog(null);
         }}
         onDismiss={() => {
+          const restore = teardownDialog?.restoreRemovalOnDismiss;
+          if (restore !== null && restore !== undefined) {
+            dispatchEditor({
+              type: "unstageRemoval",
+              workspacePath: restore,
+            });
+          }
           setTeardownDialog(null);
         }}
       />

--- a/clients/gui-app/src/components/home/host-workspace-selector/host-workspace-selector.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/host-workspace-selector.tsx
@@ -128,6 +128,14 @@ import { applyWorktreeCreateResult } from "@/lib/worktree/apply-worktree-create-
 import { workspaceFolderName } from "@/lib/worktree/workspace-folder-name";
 import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 import { trackUserInitiatedWorktreeWrite } from "@/lib/worktree/user-worktree-analytics";
+import { droppedRunDirectoriesFromDraft } from "@/lib/worktree/owner-teardown-snapshot";
+import { isWorktreeRebindBlocked } from "@/lib/worktree/is-worktree-rebind-blocked";
+import { useOwnerTeardownSnapshot } from "@/hooks/worktree/use-owner-teardown-snapshot";
+import {
+  TeardownCommitDialog,
+  type TeardownCommitChoice,
+} from "@/components/worktree/teardown-commit-dialog";
+import type { WorktreeBusyHolder } from "@traycer/protocol/framework/worktree-busy-holders";
 import { useRecentWorkspaces } from "./use-recent-workspaces";
 import { RecentWorkspacesSection } from "./recent-workspaces-section";
 
@@ -166,6 +174,8 @@ type BoundOwnerSurface = {
   // `isOwnerActive` still decides whether removal is disabled at all (a live
   // background process could still be touching the folder either way).
   readonly hasActiveTurn: boolean;
+  /** Display name used in teardown copy (agent title, chat title). */
+  readonly ownerLabel: string;
   // The `workspacePath`s whose bound directory is gone on disk (host-computed,
   // delivered on the chat snapshot / `worktreeStateChanged` for chat and on
   // `worktree.getBinding` for terminal-agents). Drives the per-folder "missing"
@@ -1768,9 +1778,23 @@ function InEpicSurface(props: InEpicSurfaceProps) {
     props.hostClient,
   );
   const importMutation = useWorktreeImportForClient(props.hostClient);
-  const worktreeCreateMutation = useWorktreeCreateForClient(props.hostClient);
-  const createWorktree = worktreeCreateMutation.mutate;
+  const worktreeCreateMutation = useWorktreeCreateForClient(props.hostClient, [
+    "WORKTREE_REBIND_BLOCKED",
+  ]);
   const worktreeCreatePending = worktreeCreateMutation.isPending;
+  const snapshotTeardownHolders = useOwnerTeardownSnapshot({
+    epicId: surface.epicId,
+    hostId: surface.hostId,
+    ownerKind,
+    ownerId: surface.ownerId,
+    ownerLabel: surface.ownerLabel,
+    hasActiveTurn: surface.hasActiveTurn,
+    ptyLive: surface.kind === "terminal-agent" && surface.isOwnerActive,
+  });
+  const [teardownDialog, setTeardownDialog] = useState<{
+    readonly choice: TeardownCommitChoice;
+    readonly holders: readonly WorktreeBusyHolder[];
+  } | null>(null);
   const removeBindingEntryMutation = useWorkspaceBindingRemoveEntryForClient(
     props.hostClient,
   );
@@ -2014,50 +2038,50 @@ function InEpicSurface(props: InEpicSurfaceProps) {
       finishAndResume();
       return;
     }
-    createWorktree(
-      {
+    void worktreeCreateMutation
+      .mutateAsync({
         epicId: surface.epicId,
         ownerId: surface.ownerId,
         ownerKind,
         entries: worktreeCreateEntries(stagedEntries),
-      },
-      {
-        onSuccess: (result) => {
-          // The RPC resolves per-entry: on a mixed outcome the failed
-          // folders keep their staged intent (popover stays open) so Update
-          // can re-apply just the failed subset, while the succeeded folders
-          // commit + unstage normally. The commit signal for the successes
-          // still fires - the host already applied them to the binding, and
-          // a live terminal surface must re-sync its PTY to that partially
-          // updated binding rather than keep running against stale folders.
-          applyWorktreeCreateResult({
-            stagedEntries,
-            changedWorkspacePaths,
-            perEntry: result.perEntry,
-            actions: {
-              finishAndResume,
-              unstageEntry: (workspacePath) =>
-                unstageWorktreeEntry(stagedKey, workspacePath),
-              commitPaths: handleBindingCommitted,
-              showPartialFailure: (message) =>
-                reportableErrorToast(message, undefined, {
-                  title: "Workspace update incomplete",
-                  message: null,
-                  code: null,
-                  source: "Worktree update",
-                }),
-            },
-          });
-          // Telemetry runs strictly after the product work; it is an
-          // observer and never part of the mutation chain (and it already
-          // gates each event on per-entry success).
-          trackUserInitiatedWorktreeWrite(stagedEntries, result);
-        },
-      },
-    );
+      })
+      .then((result) => {
+        applyWorktreeCreateResult({
+          stagedEntries,
+          changedWorkspacePaths,
+          perEntry: result.perEntry,
+          actions: {
+            finishAndResume,
+            unstageEntry: (workspacePath) =>
+              unstageWorktreeEntry(stagedKey, workspacePath),
+            commitPaths: handleBindingCommitted,
+            showPartialFailure: (message) =>
+              reportableErrorToast(message, undefined, {
+                title: "Workspace update incomplete",
+                message: null,
+                code: null,
+                source: "Worktree update",
+              }),
+          },
+        });
+        trackUserInitiatedWorktreeWrite(stagedEntries, result);
+      })
+      .catch((error: unknown) => {
+        if (!isWorktreeRebindBlocked(error)) return;
+        const draft = readStagedWorktreeIntent(stagedKey);
+        const dropped = droppedRunDirectoriesFromDraft({
+          binding: surface.binding,
+          draft,
+        });
+        setTeardownDialog({
+          choice: "blocked",
+          holders: snapshotTeardownHolders(dropped),
+        });
+      });
   }, [
     editor.dirtyPathsSinceResume,
-    createWorktree,
+    worktreeCreateMutation,
+    surface.binding,
     surface.epicId,
     surface.ownerId,
     ownerKind,
@@ -2065,6 +2089,25 @@ function InEpicSurface(props: InEpicSurfaceProps) {
     clearStagedWorktreeIntent,
     unstageWorktreeEntry,
     handleBindingCommitted,
+    snapshotTeardownHolders,
+  ]);
+  const requestStagedFolderCommit = useCallback((): void => {
+    const staged = readStagedWorktreeIntent(stagedKey);
+    const dropped = droppedRunDirectoriesFromDraft({
+      binding: surface.binding,
+      draft: staged,
+    });
+    const holders = snapshotTeardownHolders(dropped);
+    if (holders.length === 0) {
+      applyStagedFoldersAndResume();
+      return;
+    }
+    setTeardownDialog({ choice: "commit", holders });
+  }, [
+    applyStagedFoldersAndResume,
+    snapshotTeardownHolders,
+    stagedKey,
+    surface.binding,
   ]);
   // Terminal-agent add/remove commit to the binding but deliberately do NOT
   // resume — only the explicit "Update" does. Mark the binding dirty so
@@ -2075,16 +2118,6 @@ function InEpicSurface(props: InEpicSurfaceProps) {
     },
     [],
   );
-  // Closing the picker without Update discards the staged (un-applied) edits so
-  // the rows revert to the live binding. Terminal-agent only: chat staged
-  // worktree intents ride the next message send and must survive the popover.
-  // A committed add/remove (`editor.dirtyPathsSinceResume`) is intentionally NOT
-  // discarded here — it is already in the binding and can only be cleared by a
-  // resume, so "Update" must stay available after a close-without-apply.
-  const discardStagedFoldersOnClose = useCallback((): void => {
-    clearStagedWorktreeIntent(stagedKey);
-  }, [clearStagedWorktreeIntent, stagedKey]);
-
   useEffect(() => {
     const pending = pendingDefaultPathsRef.current;
     if (pending.size === 0) return;
@@ -2236,14 +2269,13 @@ function InEpicSurface(props: InEpicSurfaceProps) {
         // Persist the per-folder choice immediately (not at send) so it survives
         // a reload and seeds future adds of this folder.
         setFolderIntent(intent, Date.now());
-        if (surface.kind === "terminal-agent") {
-          // Live terminal agent: stage every location/branch edit locally - no
-          // host write and no PTY restart yet. The explicit "Update" button
-          // applies the staged intent set via worktree.create and resumes the
-          // PTY once, so changing several folders is a single resume rather than
-          // one restart per edit. Closing the picker without Update discards the
-          // staged edits. `stageIntent` merges by workspacePath, so re-picking a
-          // folder replaces its prior staged choice.
+        if (
+          surface.kind === "terminal-agent" ||
+          (surface.kind === "chat" && surface.isOwnerActive)
+        ) {
+          // Draft: no host write. Terminal-agent commits via Update;
+          // a busy chat rides the next send. `stageIntent` merges by
+          // workspacePath, so re-picking a folder replaces its prior choice.
           stageWorktreeIntent(stagedKey, { entries: [intent] });
           return;
         }
@@ -2305,6 +2337,7 @@ function InEpicSurface(props: InEpicSurfaceProps) {
       stageWorktreeIntent,
       surface.binding,
       surface.epicId,
+      surface.isOwnerActive,
       surface.kind,
       surface.ownerId,
       unstageWorktreeEntry,
@@ -2538,9 +2571,9 @@ function InEpicSurface(props: InEpicSurfaceProps) {
           makePrimaryDisabled: false,
           makePrimaryDisabledReason: null,
           hostClient: props.hostClient,
-          modeDisabled: activeRunLocksBinding || rowMetadataPending,
+          modeDisabled: rowMetadataPending,
           modeDisabledReason: modeDisabledReasonFor(
-            activeRunLocksBinding,
+            false,
             activeRunNotice,
             rowMetadataPending,
           ),
@@ -2797,18 +2830,15 @@ function InEpicSurface(props: InEpicSurfaceProps) {
             onAddFolder={addFoldersToOwnerBinding}
             onUpdate={
               surface.kind === "terminal-agent"
-                ? applyStagedFoldersAndResume
+                ? requestStagedFolderCommit
                 : null
             }
+            draftPending={hasStagedFolderChanges}
             updateEnabled={
               hasStagedFolderChanges || editor.dirtyPathsSinceResume.size > 0
             }
             updatePending={worktreeCreatePending}
-            onDiscardStaged={
-              surface.kind === "terminal-agent"
-                ? discardStagedFoldersOnClose
-                : null
-            }
+            onDiscardStaged={null}
             onEditEnvironment={handleEditEnvironment}
             refresh={summariesRefresh}
             popoverTestId="workspace-rows-popover"
@@ -2830,6 +2860,21 @@ function InEpicSurface(props: InEpicSurfaceProps) {
         context={scriptsContext}
         onOpenChange={(nextOpen) => {
           if (!nextOpen) setScriptsTargetPath(null);
+        }}
+      />
+      <TeardownCommitDialog
+        open={teardownDialog !== null}
+        choice={teardownDialog?.choice ?? null}
+        holders={teardownDialog?.holders ?? []}
+        onImmediate={() => {
+          setTeardownDialog(null);
+          applyStagedFoldersAndResume();
+        }}
+        onDefer={() => {
+          setTeardownDialog(null);
+        }}
+        onDismiss={() => {
+          setTeardownDialog(null);
         }}
       />
     </>

--- a/clients/gui-app/src/components/home/host-workspace-selector/host-workspace-selector.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/host-workspace-selector.tsx
@@ -1836,7 +1836,7 @@ function InEpicSurface(props: InEpicSurfaceProps) {
     readonly restoreDraftOnDismiss: WorktreeFolderIntent | null;
   } | null>(null);
   const [teardownCommitPending, setTeardownCommitPending] = useState(false);
-  const teardownAbortRef = useRef(false);
+  const teardownRunIdRef = useRef(0);
   const removeBindingEntryMutation = useWorkspaceBindingRemoveEntryForClient(
     props.hostClient,
   );
@@ -2269,9 +2269,9 @@ function InEpicSurface(props: InEpicSurfaceProps) {
       requestStagedFolderCommit();
       return;
     }
-    teardownAbortRef.current = false;
+    const runId = ++teardownRunIdRef.current;
     setTeardownCommitPending(true);
-    const isCancelled = (): boolean => teardownAbortRef.current;
+    const isCancelled = (): boolean => teardownRunIdRef.current !== runId;
     const failures = await runGuiComposedTeardown({
       stopTargets: dialog.capture.stopTargets,
       stopShell: (commandId) =>
@@ -2289,7 +2289,6 @@ function InEpicSurface(props: InEpicSurfaceProps) {
       isCancelled,
     });
     if (isCancelled()) {
-      setTeardownCommitPending(false);
       return;
     }
     setTeardownCommitPending(false);
@@ -3121,7 +3120,7 @@ function InEpicSurface(props: InEpicSurfaceProps) {
           void confirmImmediateCommit();
         }}
         onDefer={() => {
-          teardownAbortRef.current = true;
+          teardownRunIdRef.current += 1;
           setTeardownCommitPending(false);
           const restore = teardownDialog?.restoreRemovalOnDismiss;
           if (restore !== null && restore !== undefined) {
@@ -3137,7 +3136,7 @@ function InEpicSurface(props: InEpicSurfaceProps) {
           setTeardownDialog(null);
         }}
         onDismiss={() => {
-          teardownAbortRef.current = true;
+          teardownRunIdRef.current += 1;
           setTeardownCommitPending(false);
           const restore = teardownDialog?.restoreRemovalOnDismiss;
           if (restore !== null && restore !== undefined) {

--- a/clients/gui-app/src/components/home/host-workspace-selector/host-workspace-selector.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/host-workspace-selector.tsx
@@ -1833,8 +1833,10 @@ function InEpicSurface(props: InEpicSurfaceProps) {
     readonly capture: WorktreeCommitCapture;
     readonly failures: Readonly<Record<string, string>>;
     readonly restoreRemovalOnDismiss: string | null;
+    readonly restoreDraftOnDismiss: WorktreeFolderIntent | null;
   } | null>(null);
   const [teardownCommitPending, setTeardownCommitPending] = useState(false);
+  const teardownAbortRef = useRef(false);
   const removeBindingEntryMutation = useWorkspaceBindingRemoveEntryForClient(
     props.hostClient,
   );
@@ -2071,8 +2073,17 @@ function InEpicSurface(props: InEpicSurfaceProps) {
     surface.binding,
   ]);
   const applyStagedFoldersAndResume = useCallback(
-    (capture: WorktreeCommitCapture): void => {
-      if (stagedWorktreeIntentIsSuspended(stagedKey)) return;
+    (
+      capture: WorktreeCommitCapture,
+      isCancelled: () => boolean = () => false,
+    ): void => {
+      if (isCancelled()) return;
+      if (
+        capture.draft !== null &&
+        stagedWorktreeIntentIsSuspended(stagedKey)
+      ) {
+        return;
+      }
       const stagedEntries = capture.draft?.entries ?? [];
       const removedWorkspacePaths = capture.removedWorkspacePaths;
       // A just-added git folder may still be waiting for metadata so the default
@@ -2094,11 +2105,15 @@ function InEpicSurface(props: InEpicSurfaceProps) {
         ]),
       );
       const finishAndResume = (): void => {
-        releaseIntentForDispatch(stagedKey, capture.revision);
+        if (isCancelled()) return;
+        if (capture.draft !== null) {
+          releaseIntentForDispatch(stagedKey, capture.revision);
+        }
         dispatchEditor({ type: "resumed" });
         handleBindingCommitted(changedWorkspacePaths);
       };
       const createThenResume = (): void => {
+        if (isCancelled()) return;
         if (stagedEntries.length === 0) {
           finishAndResume();
           return;
@@ -2146,6 +2161,7 @@ function InEpicSurface(props: InEpicSurfaceProps) {
               capture: { ...live, stopTargets: blocked.stopTargets },
               failures: {},
               restoreRemovalOnDismiss: null,
+              restoreDraftOnDismiss: null,
             });
           });
       };
@@ -2156,8 +2172,9 @@ function InEpicSurface(props: InEpicSurfaceProps) {
       void removedWorkspacePaths
         .reduce(
           (prior, workspacePath) =>
-            prior.then(() =>
-              removeBindingEntryMutation
+            prior.then(() => {
+              if (isCancelled()) return;
+              return removeBindingEntryMutation
                 .mutateAsync({
                   epicId: surface.epicId,
                   ownerId: surface.ownerId,
@@ -2165,13 +2182,15 @@ function InEpicSurface(props: InEpicSurfaceProps) {
                   workspacePath,
                 })
                 .then(() => {
+                  if (isCancelled()) return;
                   pendingDefaultPathsRef.current.delete(workspacePath);
                   unstageWorktreeEntry(stagedKey, workspacePath);
-                }),
-            ),
+                });
+            }),
           Promise.resolve(),
         )
         .then(() => {
+          if (isCancelled()) return;
           createThenResume();
         });
     },
@@ -2209,6 +2228,7 @@ function InEpicSurface(props: InEpicSurfaceProps) {
       capture: { ...capture, stopTargets: snapshot.stopTargets },
       failures: {},
       restoreRemovalOnDismiss: null,
+      restoreDraftOnDismiss: null,
     });
   }, [
     applyStagedFoldersAndResume,
@@ -2241,12 +2261,17 @@ function InEpicSurface(props: InEpicSurfaceProps) {
     const dialog = teardownDialog;
     if (dialog === null || teardownCommitPending) return;
     const live = readLiveCommitCapture();
-    if (worktreeCommitCaptureIsStale(dialog.capture, live)) {
+    if (
+      dialog.choice !== "remove" &&
+      worktreeCommitCaptureIsStale(dialog.capture, live)
+    ) {
       setTeardownDialog(null);
       requestStagedFolderCommit();
       return;
     }
+    teardownAbortRef.current = false;
     setTeardownCommitPending(true);
+    const isCancelled = (): boolean => teardownAbortRef.current;
     const failures = await runGuiComposedTeardown({
       stopTargets: dialog.capture.stopTargets,
       stopShell: (commandId) =>
@@ -2261,7 +2286,12 @@ function InEpicSurface(props: InEpicSurfaceProps) {
           agentId: surface.ownerId,
           cascade: false,
         }),
+      isCancelled,
     });
+    if (isCancelled()) {
+      setTeardownCommitPending(false);
+      return;
+    }
     setTeardownCommitPending(false);
     if (failures.length > 0) {
       setTeardownDialog({
@@ -2271,7 +2301,7 @@ function InEpicSurface(props: InEpicSurfaceProps) {
       return;
     }
     setTeardownDialog(null);
-    applyStagedFoldersAndResume(dialog.capture);
+    applyStagedFoldersAndResume(dialog.capture, isCancelled);
   }, [
     applyStagedFoldersAndResume,
     readLiveCommitCapture,
@@ -2331,12 +2361,13 @@ function InEpicSurface(props: InEpicSurfaceProps) {
         removeFolderNow(workspacePath);
         return;
       }
+      const priorDraft = stagedEntryByPath.get(workspacePath) ?? null;
       stageFolderRemoval(workspacePath);
       setTeardownDialog({
-        choice: "commit",
+        choice: "remove",
         holders: snapshot.holders,
         capture: {
-          draft: readStagedWorktreeIntent(stagedKey),
+          draft: null,
           revision: stagedWorktreeIntentRevision(stagedKey),
           binding: surface.binding,
           removedWorkspacePaths: [workspacePath],
@@ -2344,12 +2375,14 @@ function InEpicSurface(props: InEpicSurfaceProps) {
         },
         failures: {},
         restoreRemovalOnDismiss: workspacePath,
+        restoreDraftOnDismiss: priorDraft,
       });
     },
     [
       removeFolderNow,
       snapshotOwnerTeardown,
       stageFolderRemoval,
+      stagedEntryByPath,
       stagedKey,
       surface.binding,
     ],
@@ -3088,6 +3121,8 @@ function InEpicSurface(props: InEpicSurfaceProps) {
           void confirmImmediateCommit();
         }}
         onDefer={() => {
+          teardownAbortRef.current = true;
+          setTeardownCommitPending(false);
           const restore = teardownDialog?.restoreRemovalOnDismiss;
           if (restore !== null && restore !== undefined) {
             dispatchEditor({
@@ -3095,15 +3130,25 @@ function InEpicSurface(props: InEpicSurfaceProps) {
               workspacePath: restore,
             });
           }
+          const restoreDraft = teardownDialog?.restoreDraftOnDismiss;
+          if (restoreDraft !== null && restoreDraft !== undefined) {
+            stageWorktreeIntent(stagedKey, { entries: [restoreDraft] });
+          }
           setTeardownDialog(null);
         }}
         onDismiss={() => {
+          teardownAbortRef.current = true;
+          setTeardownCommitPending(false);
           const restore = teardownDialog?.restoreRemovalOnDismiss;
           if (restore !== null && restore !== undefined) {
             dispatchEditor({
               type: "unstageRemoval",
               workspacePath: restore,
             });
+          }
+          const restoreDraft = teardownDialog?.restoreDraftOnDismiss;
+          if (restoreDraft !== null && restoreDraft !== undefined) {
+            stageWorktreeIntent(stagedKey, { entries: [restoreDraft] });
           }
           setTeardownDialog(null);
         }}

--- a/clients/gui-app/src/components/home/host-workspace-selector/host-workspace-selector.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/host-workspace-selector.tsx
@@ -1834,6 +1834,7 @@ function InEpicSurface(props: InEpicSurfaceProps) {
     readonly failures: Readonly<Record<string, string>>;
     readonly restoreRemovalOnDismiss: string | null;
     readonly restoreDraftOnDismiss: WorktreeFolderIntent | null;
+    readonly refusalReason?: string;
   } | null>(null);
   const [teardownCommitPending, setTeardownCommitPending] = useState(false);
   const teardownRunIdRef = useRef(0);
@@ -2269,6 +2270,16 @@ function InEpicSurface(props: InEpicSurfaceProps) {
       requestStagedFolderCommit();
       return;
     }
+    const refusal = stagedCommitRefusalReason({
+      capture: dialog.capture,
+      stagedKey,
+      pendingDefaultPathCount: pendingDefaultPathsRef.current.size,
+      dirtyPathCount: editor.dirtyPathsSinceResume.size,
+    });
+    if (refusal !== null) {
+      setTeardownDialog({ ...dialog, refusalReason: refusal });
+      return;
+    }
     const runId = ++teardownRunIdRef.current;
     setTeardownCommitPending(true);
     const isCancelled = (): boolean => teardownRunIdRef.current !== runId;
@@ -2312,6 +2323,8 @@ function InEpicSurface(props: InEpicSurfaceProps) {
     surface.ownerId,
     teardownCommitPending,
     teardownDialog,
+    stagedKey,
+    editor.dirtyPathsSinceResume,
   ]);
   const removeFolderNow = useCallback(
     (workspacePath: string): void => {
@@ -3116,6 +3129,10 @@ function InEpicSurface(props: InEpicSurfaceProps) {
         holders={teardownDialog?.holders ?? []}
         failures={teardownDialog?.failures}
         immediatePending={teardownCommitPending}
+        refusalReason={teardownDialog?.refusalReason}
+        deferContext={
+          surface.kind === "terminal-agent" ? "update" : "message"
+        }
         onImmediate={() => {
           void confirmImmediateCommit();
         }}
@@ -3160,6 +3177,32 @@ function InEpicSurface(props: InEpicSurfaceProps) {
 // default (new worktree); a non-git folder can only be Local. The seeding effect
 // stages a pick shortly after mount, so this is the transient pre-seed state. A
 // supported staged entry's own kind wins.
+function stagedCommitRefusalReason(input: {
+  readonly capture: WorktreeCommitCapture;
+  readonly stagedKey: WorktreeStagingKey;
+  readonly pendingDefaultPathCount: number;
+  readonly dirtyPathCount: number;
+}): string | null {
+  if (
+    input.capture.draft !== null &&
+    stagedWorktreeIntentIsSuspended(input.stagedKey)
+  ) {
+    return "This folder change is waiting on unresolved workspace setup.";
+  }
+  if (input.pendingDefaultPathCount > 0) {
+    return "Wait for folder setup to finish before updating.";
+  }
+  const stagedEntries = input.capture.draft?.entries ?? [];
+  if (
+    stagedEntries.length === 0 &&
+    input.dirtyPathCount === 0 &&
+    input.capture.removedWorkspacePaths.length === 0
+  ) {
+    return "Nothing to apply.";
+  }
+  return null;
+}
+
 function deriveHomeRowMode(
   capturedEntry: WorktreeFolderIntent | null,
   isGitRepo: boolean,

--- a/clients/gui-app/src/components/home/host-workspace-selector/host-workspace-selector.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/host-workspace-selector.tsx
@@ -3130,9 +3130,7 @@ function InEpicSurface(props: InEpicSurfaceProps) {
         failures={teardownDialog?.failures}
         immediatePending={teardownCommitPending}
         refusalReason={teardownDialog?.refusalReason}
-        deferContext={
-          surface.kind === "terminal-agent" ? "update" : "message"
-        }
+        deferContext={surface.kind === "terminal-agent" ? "update" : "message"}
         onImmediate={() => {
           void confirmImmediateCommit();
         }}

--- a/clients/gui-app/src/components/home/host-workspace-selector/host-workspace-selector.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/host-workspace-selector.tsx
@@ -69,6 +69,7 @@ import {
 import {
   readStagedWorktreeIntent,
   stagedWorktreeIntentIsSuspended,
+  stagedWorktreeIntentRevision,
   useWorktreeIntentStagingStore,
   worktreeStagingKeyString,
   type WorktreeStagingKey,
@@ -130,6 +131,10 @@ import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 import { trackUserInitiatedWorktreeWrite } from "@/lib/worktree/user-worktree-analytics";
 import { droppedRunDirectoriesFromDraft } from "@/lib/worktree/owner-teardown-snapshot";
 import { isWorktreeRebindBlocked } from "@/lib/worktree/is-worktree-rebind-blocked";
+import {
+  worktreeCommitCaptureIsStale,
+  type WorktreeCommitCapture,
+} from "@/lib/worktree/worktree-commit-capture";
 import { useOwnerTeardownSnapshot } from "@/hooks/worktree/use-owner-teardown-snapshot";
 import {
   TeardownCommitDialog,
@@ -1722,12 +1727,14 @@ function branchForSummary(
 // `WorkspaceFolderSummaryControl`.
 type FolderEditorState = {
   readonly dirtyPathsSinceResume: ReadonlySet<string>;
+  readonly pendingRemovedPaths: ReadonlySet<string>;
 };
 type FolderEditorAction =
   | {
       readonly type: "markDirty";
       readonly workspacePaths: ReadonlyArray<string>;
     }
+  | { readonly type: "stageRemoval"; readonly workspacePath: string }
   | { readonly type: "resumed" };
 function folderEditorReducer(
   state: FolderEditorState,
@@ -1742,10 +1749,23 @@ function folderEditorReducer(
       ]);
       return next.size === state.dirtyPathsSinceResume.size
         ? state
-        : { dirtyPathsSinceResume: next };
+        : { ...state, dirtyPathsSinceResume: next };
+    }
+    case "stageRemoval": {
+      if (state.pendingRemovedPaths.has(action.workspacePath)) return state;
+      return {
+        ...state,
+        pendingRemovedPaths: new Set([
+          ...state.pendingRemovedPaths,
+          action.workspacePath,
+        ]),
+      };
     }
     case "resumed":
-      return { dirtyPathsSinceResume: new Set<string>() };
+      return {
+        dirtyPathsSinceResume: new Set<string>(),
+        pendingRemovedPaths: new Set<string>(),
+      };
   }
 }
 interface InEpicSurfaceProps {
@@ -1771,6 +1791,7 @@ function InEpicSurface(props: InEpicSurfaceProps) {
         ];
   const [editor, dispatchEditor] = useReducer(folderEditorReducer, {
     dirtyPathsSinceResume: new Set<string>(),
+    pendingRemovedPaths: new Set<string>(),
   });
   const ownerKind: WorktreeBindingOwnerKind =
     surface.kind === "chat" ? "chat" : "terminal-agent";
@@ -1794,6 +1815,7 @@ function InEpicSurface(props: InEpicSurfaceProps) {
   const [teardownDialog, setTeardownDialog] = useState<{
     readonly choice: TeardownCommitChoice;
     readonly holders: readonly WorktreeBusyHolder[];
+    readonly capture: WorktreeCommitCapture;
   } | null>(null);
   const removeBindingEntryMutation = useWorkspaceBindingRemoveEntryForClient(
     props.hostClient,
@@ -2007,107 +2029,148 @@ function InEpicSurface(props: InEpicSurfaceProps) {
     surface.missingWorktreePaths,
     changedWorkspacePathsSinceResume,
   );
-  const applyStagedFoldersAndResume = useCallback((): void => {
-    if (stagedWorktreeIntentIsSuspended(stagedKey)) return;
-    const staged = readStagedWorktreeIntent(stagedKey);
-    const stagedEntries = staged?.entries ?? [];
-    // A just-added git folder may still be waiting for metadata so the default
-    // new-worktree seed can be staged. Keep Update enabled, but don't resume
-    // until those pending defaults either stage or resolve as no-op.
-    if (pendingDefaultPathsRef.current.size > 0) return;
-    // Defensive: the button is already gated on the same condition, but guard
-    // against an empty apply (nothing staged AND no committed add/remove).
-    if (stagedEntries.length === 0 && editor.dirtyPathsSinceResume.size === 0) {
-      return;
-    }
-    const changedWorkspacePaths = Array.from(
-      new Set([
-        ...editor.dirtyPathsSinceResume,
-        ...stagedEntries.map((entry) => entry.workspacePath),
-      ]),
-    );
-    const finishAndResume = (): void => {
-      clearStagedWorktreeIntent(stagedKey);
-      // Closes the popover AND clears dirty in one update.
-      dispatchEditor({ type: "resumed" });
-      handleBindingCommitted(changedWorkspacePaths);
-    };
-    // Only add/remove happened — already committed to the binding, so there is
-    // nothing to create; just resume the PTY against the updated binding.
-    if (stagedEntries.length === 0) {
-      finishAndResume();
-      return;
-    }
-    void worktreeCreateMutation
-      .mutateAsync({
-        epicId: surface.epicId,
-        ownerId: surface.ownerId,
-        ownerKind,
-        entries: worktreeCreateEntries(stagedEntries),
-      })
-      .then((result) => {
-        applyWorktreeCreateResult({
-          stagedEntries,
-          changedWorkspacePaths,
-          perEntry: result.perEntry,
-          actions: {
-            finishAndResume,
-            unstageEntry: (workspacePath) =>
-              unstageWorktreeEntry(stagedKey, workspacePath),
-            commitPaths: handleBindingCommitted,
-            showPartialFailure: (message) =>
-              reportableErrorToast(message, undefined, {
-                title: "Workspace update incomplete",
-                message: null,
-                code: null,
-                source: "Worktree update",
-              }),
-          },
-        });
-        trackUserInitiatedWorktreeWrite(stagedEntries, result);
-      })
-      .catch((error: unknown) => {
-        if (!isWorktreeRebindBlocked(error)) return;
-        const draft = readStagedWorktreeIntent(stagedKey);
-        const dropped = droppedRunDirectoriesFromDraft({
-          binding: surface.binding,
-          draft,
-        });
-        setTeardownDialog({
-          choice: "blocked",
-          holders: snapshotTeardownHolders(dropped),
-        });
-      });
-  }, [
-    editor.dirtyPathsSinceResume,
-    worktreeCreateMutation,
-    surface.binding,
-    surface.epicId,
-    surface.ownerId,
-    ownerKind,
-    stagedKey,
-    clearStagedWorktreeIntent,
-    unstageWorktreeEntry,
-    handleBindingCommitted,
-    snapshotTeardownHolders,
-  ]);
-  const requestStagedFolderCommit = useCallback((): void => {
-    const staged = readStagedWorktreeIntent(stagedKey);
-    const dropped = droppedRunDirectoriesFromDraft({
+  const readLiveCommitCapture = useCallback((): WorktreeCommitCapture => {
+    return {
+      draft: readStagedWorktreeIntent(stagedKey),
+      revision: stagedWorktreeIntentRevision(stagedKey),
       binding: surface.binding,
-      draft: staged,
+      removedWorkspacePaths: [...editor.pendingRemovedPaths],
+    };
+  }, [editor.pendingRemovedPaths, stagedKey, surface.binding]);
+  const applyStagedFoldersAndResume = useCallback(
+    (capture: WorktreeCommitCapture): void => {
+      if (stagedWorktreeIntentIsSuspended(stagedKey)) return;
+      const stagedEntries = capture.draft?.entries ?? [];
+      const removedWorkspacePaths = capture.removedWorkspacePaths;
+      // A just-added git folder may still be waiting for metadata so the default
+      // new-worktree seed can be staged. Keep Update enabled, but don't resume
+      // until those pending defaults either stage or resolve as no-op.
+      if (pendingDefaultPathsRef.current.size > 0) return;
+      if (
+        stagedEntries.length === 0 &&
+        editor.dirtyPathsSinceResume.size === 0 &&
+        removedWorkspacePaths.length === 0
+      ) {
+        return;
+      }
+      const changedWorkspacePaths = Array.from(
+        new Set([
+          ...editor.dirtyPathsSinceResume,
+          ...stagedEntries.map((entry) => entry.workspacePath),
+          ...removedWorkspacePaths,
+        ]),
+      );
+      const finishAndResume = (): void => {
+        clearStagedWorktreeIntent(stagedKey);
+        dispatchEditor({ type: "resumed" });
+        handleBindingCommitted(changedWorkspacePaths);
+      };
+      const createThenResume = (): void => {
+        if (stagedEntries.length === 0) {
+          finishAndResume();
+          return;
+        }
+        void worktreeCreateMutation
+          .mutateAsync({
+            epicId: surface.epicId,
+            ownerId: surface.ownerId,
+            ownerKind,
+            entries: worktreeCreateEntries(stagedEntries),
+          })
+          .then((result) => {
+            applyWorktreeCreateResult({
+              stagedEntries,
+              changedWorkspacePaths,
+              perEntry: result.perEntry,
+              actions: {
+                finishAndResume,
+                unstageEntry: (workspacePath) =>
+                  unstageWorktreeEntry(stagedKey, workspacePath),
+                commitPaths: handleBindingCommitted,
+                showPartialFailure: (message) =>
+                  reportableErrorToast(message, undefined, {
+                    title: "Workspace update incomplete",
+                    message: null,
+                    code: null,
+                    source: "Worktree update",
+                  }),
+              },
+            });
+            trackUserInitiatedWorktreeWrite(stagedEntries, result);
+          })
+          .catch((error: unknown) => {
+            if (!isWorktreeRebindBlocked(error)) return;
+            const live = readLiveCommitCapture();
+            const dropped = droppedRunDirectoriesFromDraft({
+              binding: live.binding,
+              draft: live.draft,
+              removedWorkspacePaths: live.removedWorkspacePaths,
+            });
+            setTeardownDialog({
+              choice: "blocked",
+              holders: snapshotTeardownHolders(dropped),
+              capture: live,
+            });
+          });
+      };
+      if (removedWorkspacePaths.length === 0) {
+        createThenResume();
+        return;
+      }
+      void removedWorkspacePaths
+        .reduce(
+          (prior, workspacePath) =>
+            prior.then(() =>
+              removeBindingEntryMutation
+                .mutateAsync({
+                  epicId: surface.epicId,
+                  ownerId: surface.ownerId,
+                  ownerKind,
+                  workspacePath,
+                })
+                .then(() => {
+                  pendingDefaultPathsRef.current.delete(workspacePath);
+                  unstageWorktreeEntry(stagedKey, workspacePath);
+                }),
+            ),
+          Promise.resolve(),
+        )
+        .then(() => {
+          createThenResume();
+        });
+    },
+    [
+      editor.dirtyPathsSinceResume,
+      worktreeCreateMutation,
+      removeBindingEntryMutation,
+      readLiveCommitCapture,
+      surface.epicId,
+      surface.ownerId,
+      ownerKind,
+      stagedKey,
+      clearStagedWorktreeIntent,
+      unstageWorktreeEntry,
+      handleBindingCommitted,
+      snapshotTeardownHolders,
+    ],
+  );
+  const requestStagedFolderCommit = useCallback((): void => {
+    const capture = readLiveCommitCapture();
+    const dropped = droppedRunDirectoriesFromDraft({
+      binding: capture.binding,
+      draft: capture.draft,
+      removedWorkspacePaths: capture.removedWorkspacePaths,
     });
     const holders = snapshotTeardownHolders(dropped);
     if (holders.length === 0) {
-      applyStagedFoldersAndResume();
+      applyStagedFoldersAndResume(capture);
       return;
     }
-    setTeardownDialog({ choice: "commit", holders });
+    setTeardownDialog({ choice: "commit", holders, capture });
   }, [
     applyStagedFoldersAndResume,
+    readLiveCommitCapture,
     snapshotTeardownHolders,
-    stagedKey,
-    surface.binding,
   ]);
   // Terminal-agent add/remove commit to the binding but deliberately do NOT
   // resume — only the explicit "Update" does. Mark the binding dirty so
@@ -2117,6 +2180,48 @@ function InEpicSurface(props: InEpicSurfaceProps) {
       dispatchEditor({ type: "markDirty", workspacePaths });
     },
     [],
+  );
+  const stageFolderRemoval = useCallback(
+    (workspacePath: string): void => {
+      pendingDefaultPathsRef.current.delete(workspacePath);
+      unstageWorktreeEntry(stagedKey, workspacePath);
+      dispatchEditor({ type: "stageRemoval", workspacePath });
+    },
+    [stagedKey, unstageWorktreeEntry],
+  );
+  const removeFolderNow = useCallback(
+    (workspacePath: string): void => {
+      removeBindingEntryMutation.mutate(
+        {
+          epicId: surface.epicId,
+          ownerId: surface.ownerId,
+          ownerKind,
+          workspacePath,
+        },
+        {
+          onSuccess: () => {
+            pendingDefaultPathsRef.current.delete(workspacePath);
+            unstageWorktreeEntry(stagedKey, workspacePath);
+            if (surface.kind === "terminal-agent") {
+              markBindingDirtyWithoutResume([workspacePath]);
+              return;
+            }
+            handleBindingCommitted([workspacePath]);
+          },
+        },
+      );
+    },
+    [
+      handleBindingCommitted,
+      markBindingDirtyWithoutResume,
+      ownerKind,
+      removeBindingEntryMutation,
+      stagedKey,
+      surface.epicId,
+      surface.kind,
+      surface.ownerId,
+      unstageWorktreeEntry,
+    ],
   );
   useEffect(() => {
     const pending = pendingDefaultPathsRef.current;
@@ -2269,10 +2374,7 @@ function InEpicSurface(props: InEpicSurfaceProps) {
         // Persist the per-folder choice immediately (not at send) so it survives
         // a reload and seeds future adds of this folder.
         setFolderIntent(intent, Date.now());
-        if (
-          surface.kind === "terminal-agent" ||
-          (surface.kind === "chat" && surface.isOwnerActive)
-        ) {
+        if (surface.kind === "terminal-agent" || surface.isOwnerActive) {
           // Draft: no host write. Terminal-agent commits via Update;
           // a busy chat rides the next send. `stageIntent` merges by
           // workspacePath, so re-picking a folder replaces its prior choice.
@@ -2408,245 +2510,224 @@ function InEpicSurface(props: InEpicSurfaceProps) {
     ],
   );
 
+  const remainingVisibleFolders = bindingEntries.filter(
+    (entry) => !editor.pendingRemovedPaths.has(entry.workspacePath),
+  ).length;
   const workspaceRunItems = useMemo<ReadonlyArray<WorkspaceRunItem>>(
     () =>
-      workspaces.map((ws) => {
-        const {
-          currentMode,
-          modeLabel,
-          removePending,
-          isPrimary,
-          currentIntent,
-          defaultNewBranchName,
-          branchPrefixWarning,
-          currentBranch,
-          rowMetadataPending,
-          rowIsGitRepo,
-          branchLabel,
-          emit,
-        } = deriveInEpicRowState(ws);
-        // Presence is per-(host, path) display state — never stored on the
-        // binding. An absent path is not a non-git folder; Locate REPLACes
-        // the dead path with a picked one (add-only left it blocking).
-        // Handlers that close over pendingDefaultPathsRef are attached AFTER
-        // unresolvedWorkspaceRunItem returns — passing them as arguments is
-        // flagged by react-hooks/refs as "ref access during render".
-        if (ws.presence === "absent" && ws.resolvedAt !== null) {
-          const base = unresolvedWorkspaceRunItem({
-            path: ws.workspacePath,
-            name: workspaceFolderName(ws.workspacePath),
-            repoIdentifier: ws.repoIdentifier,
-            hostLabel: props.hostLabel,
+      workspaces
+        .filter((ws) => !editor.pendingRemovedPaths.has(ws.workspacePath))
+        .map((ws) => {
+          const {
+            currentMode,
+            modeLabel,
+            removePending,
             isPrimary,
-            onLocate: () => undefined,
-            onMakePrimary: () => undefined,
-            onRemove: () => undefined,
-          });
+            currentIntent,
+            defaultNewBranchName,
+            branchPrefixWarning,
+            currentBranch,
+            rowMetadataPending,
+            rowIsGitRepo,
+            branchLabel,
+            emit,
+          } = deriveInEpicRowState(ws);
+          // Presence is per-(host, path) display state — never stored on the
+          // binding. An absent path is not a non-git folder; Locate REPLACes
+          // the dead path with a picked one (add-only left it blocking).
+          // Handlers that close over pendingDefaultPathsRef are attached AFTER
+          // unresolvedWorkspaceRunItem returns — passing them as arguments is
+          // flagged by react-hooks/refs as "ref access during render".
+          if (ws.presence === "absent" && ws.resolvedAt !== null) {
+            const base = unresolvedWorkspaceRunItem({
+              path: ws.workspacePath,
+              name: workspaceFolderName(ws.workspacePath),
+              repoIdentifier: ws.repoIdentifier,
+              hostLabel: props.hostLabel,
+              isPrimary,
+              onLocate: () => undefined,
+              onMakePrimary: () => undefined,
+              onRemove: () => undefined,
+            });
+            return {
+              ...base,
+              // Bound owner rows have no set-primary RPC.
+              canChangePrimary: false,
+              // An absent row is still a BOUND row: Locate adds and removes
+              // binding entries exactly like the normal controls, so it takes
+              // the same active-run lock. Without this the one row that mutates
+              // the binding hardest stayed live while an owner turn was running,
+              // and `unresolvedWorkspaceRunItem`'s `removeDisabled: false` came
+              // through the spread untouched. The lock clears with the turn and
+              // the row is retryable again - nothing about it is one-shot.
+              removeDisabled:
+                activeRunLocksBinding ||
+                removePending ||
+                remainingVisibleFolders <= 1,
+              removeDisabledReason: removeDisabledReasonFor(
+                activeRunLocksBinding,
+                activeRunNotice,
+              ),
+              onLocate: activeRunLocksBinding
+                ? null
+                : () => {
+                    // Locate REPLACes only after ≥1 DISTINCT add succeeds — never
+                    // delete-first (empty pick / all-adds-fail would drop the entry).
+                    // Cancel and zero-success leave the binding untouched.
+                    void (async (): Promise<void> => {
+                      const result =
+                        await folderActions.pickAndPrepareFolders(false);
+                      const outcome = await locateReplaceBoundFolder({
+                        absentPath: ws.workspacePath,
+                        pick: result,
+                        add: async (workspacePath) => {
+                          try {
+                            await addFolderMutation.mutateAsync({
+                              epicId: surface.epicId,
+                              ownerId: surface.ownerId,
+                              ownerKind,
+                              workspacePath,
+                            });
+                            pendingDefaultPathsRef.current.add(workspacePath);
+                            return true;
+                          } catch {
+                            return false;
+                          }
+                        },
+                        remove: async (workspacePath) => {
+                          try {
+                            await removeBindingEntryMutation.mutateAsync({
+                              epicId: surface.epicId,
+                              ownerId: surface.ownerId,
+                              ownerKind,
+                              workspacePath,
+                            });
+                            pendingDefaultPathsRef.current.delete(
+                              workspacePath,
+                            );
+                            unstageWorktreeEntry(stagedKey, workspacePath);
+                            return true;
+                          } catch {
+                            return false;
+                          }
+                        },
+                      });
+                      if (
+                        outcome.kind !== "replaced" &&
+                        outcome.kind !== "replaced-stale-entry"
+                      ) {
+                        return;
+                      }
+                      // A retained path is still bound, so it is not "touched" by a
+                      // commit that did not move it - the absent row stays put and
+                      // stays retryable. The adds are real either way.
+                      const touchedPaths =
+                        outcome.kind === "replaced"
+                          ? [outcome.removedPath, ...outcome.addedPaths]
+                          : [...outcome.addedPaths];
+                      if (surface.kind === "terminal-agent") {
+                        markBindingDirtyWithoutResume(touchedPaths);
+                      } else {
+                        handleBindingCommitted(touchedPaths);
+                      }
+                    })();
+                  },
+              onRemove: () => {
+                if (activeRunLocksBinding || removePending) return;
+                if (surface.kind === "terminal-agent") {
+                  stageFolderRemoval(ws.workspacePath);
+                  return;
+                }
+                removeFolderNow(ws.workspacePath);
+              },
+            };
+          }
           return {
-            ...base,
-            // Bound owner rows have no set-primary RPC.
+            key: ws.workspacePath,
+            displayName: workspaceFolderName(ws.workspacePath),
+            displayPath: ws.workspacePath,
+            unresolved: false,
+            metadataPending: rowMetadataPending,
+            missing: visibleMissingWorktreePaths.includes(ws.workspacePath),
+            isGitRepo: rowIsGitRepo,
+            mode: currentMode,
+            branchLabel:
+              currentMode === "local"
+                ? (currentBranch ?? modeLabel)
+                : branchLabel,
+            summary: ws,
+            currentIntent,
+            defaultNewBranchName,
+            branchPrefixWarning,
+            repoIdentifier: ws.repoIdentifier,
+            isPrimary,
+            // Bound owner rows (chat / terminal-agent) have no atomic
+            // set-primary RPC yet - the badge renders read-only here; switching
+            // stays scoped to not-yet-created pickers (landing, fork dialogs,
+            // the new-conversation modal, the terminal-agent launcher).
             canChangePrimary: false,
-            // An absent row is still a BOUND row: Locate adds and removes
-            // binding entries exactly like the normal controls, so it takes
-            // the same active-run lock. Without this the one row that mutates
-            // the binding hardest stayed live while an owner turn was running,
-            // and `unresolvedWorkspaceRunItem`'s `removeDisabled: false` came
-            // through the spread untouched. The lock clears with the turn and
-            // the row is retryable again - nothing about it is one-shot.
-            removeDisabled: activeRunLocksBinding || removePending,
+            makePrimaryDisabled: false,
+            makePrimaryDisabledReason: null,
+            hostClient: props.hostClient,
+            modeDisabled: rowMetadataPending,
+            modeDisabledReason: modeDisabledReasonFor(
+              false,
+              activeRunNotice,
+              rowMetadataPending,
+            ),
+            removeDisabled:
+              activeRunLocksBinding ||
+              removePending ||
+              remainingVisibleFolders <= 1,
             removeDisabledReason: removeDisabledReasonFor(
               activeRunLocksBinding,
               activeRunNotice,
             ),
-            onLocate: activeRunLocksBinding
-              ? null
-              : () => {
-                  // Locate REPLACes only after ≥1 DISTINCT add succeeds — never
-                  // delete-first (empty pick / all-adds-fail would drop the entry).
-                  // Cancel and zero-success leave the binding untouched.
-                  void (async (): Promise<void> => {
-                    const result =
-                      await folderActions.pickAndPrepareFolders(false);
-                    const outcome = await locateReplaceBoundFolder({
-                      absentPath: ws.workspacePath,
-                      pick: result,
-                      add: async (workspacePath) => {
-                        try {
-                          await addFolderMutation.mutateAsync({
-                            epicId: surface.epicId,
-                            ownerId: surface.ownerId,
-                            ownerKind,
-                            workspacePath,
-                          });
-                          pendingDefaultPathsRef.current.add(workspacePath);
-                          return true;
-                        } catch {
-                          return false;
-                        }
-                      },
-                      remove: async (workspacePath) => {
-                        try {
-                          await removeBindingEntryMutation.mutateAsync({
-                            epicId: surface.epicId,
-                            ownerId: surface.ownerId,
-                            ownerKind,
-                            workspacePath,
-                          });
-                          pendingDefaultPathsRef.current.delete(workspacePath);
-                          unstageWorktreeEntry(stagedKey, workspacePath);
-                          return true;
-                        } catch {
-                          return false;
-                        }
-                      },
-                    });
-                    if (
-                      outcome.kind !== "replaced" &&
-                      outcome.kind !== "replaced-stale-entry"
-                    ) {
-                      return;
-                    }
-                    // A retained path is still bound, so it is not "touched" by a
-                    // commit that did not move it - the absent row stays put and
-                    // stays retryable. The adds are real either way.
-                    const touchedPaths =
-                      outcome.kind === "replaced"
-                        ? [outcome.removedPath, ...outcome.addedPaths]
-                        : [...outcome.addedPaths];
-                    if (surface.kind === "terminal-agent") {
-                      markBindingDirtyWithoutResume(touchedPaths);
-                    } else {
-                      handleBindingCommitted(touchedPaths);
-                    }
-                  })();
-                },
+            removePending,
+            onEmit: emit,
+            onMakePrimary: () => undefined,
+            onSelectMode: (nextMode) => {
+              // Unresolved rows (`resolvedAt === null`) have no verified git
+              // facts yet - the mode switch itself is disabled for them
+              // (`modeDisabled` above), but guard here too since this closure
+              // outlives that render.
+              if (ws.resolvedAt === null) return;
+              emitRowMode({
+                currentBranch,
+                currentIntent,
+                defaultNewBranchName,
+                emit,
+                isGitRepo: rowIsGitRepo,
+                isPrimary,
+                mode: currentMode,
+                nextMode,
+                repoIdentifier: ws.repoIdentifier,
+                workspacePath: ws.workspacePath,
+              });
+            },
+            onLocate: null,
             onRemove: () => {
-              if (activeRunLocksBinding || removePending) return;
-              removeBindingEntryMutation.mutate(
-                {
-                  epicId: surface.epicId,
-                  ownerId: surface.ownerId,
-                  ownerKind,
-                  workspacePath: ws.workspacePath,
-                },
-                {
-                  onSuccess: () => {
-                    pendingDefaultPathsRef.current.delete(ws.workspacePath);
-                    unstageWorktreeEntry(stagedKey, ws.workspacePath);
-                    if (surface.kind === "terminal-agent") {
-                      markBindingDirtyWithoutResume([ws.workspacePath]);
-                      return;
-                    }
-                    handleBindingCommitted([ws.workspacePath]);
-                  },
-                },
-              );
+              if (removePending) return;
+              if (surface.kind === "terminal-agent") {
+                stageFolderRemoval(ws.workspacePath);
+                return;
+              }
+              removeFolderNow(ws.workspacePath);
             },
           };
-        }
-        return {
-          key: ws.workspacePath,
-          displayName: workspaceFolderName(ws.workspacePath),
-          displayPath: ws.workspacePath,
-          unresolved: false,
-          metadataPending: rowMetadataPending,
-          missing: visibleMissingWorktreePaths.includes(ws.workspacePath),
-          isGitRepo: rowIsGitRepo,
-          mode: currentMode,
-          branchLabel:
-            currentMode === "local"
-              ? (currentBranch ?? modeLabel)
-              : branchLabel,
-          summary: ws,
-          currentIntent,
-          defaultNewBranchName,
-          branchPrefixWarning,
-          repoIdentifier: ws.repoIdentifier,
-          isPrimary,
-          // Bound owner rows (chat / terminal-agent) have no atomic
-          // set-primary RPC yet - the badge renders read-only here; switching
-          // stays scoped to not-yet-created pickers (landing, fork dialogs,
-          // the new-conversation modal, the terminal-agent launcher).
-          canChangePrimary: false,
-          makePrimaryDisabled: false,
-          makePrimaryDisabledReason: null,
-          hostClient: props.hostClient,
-          modeDisabled: rowMetadataPending,
-          modeDisabledReason: modeDisabledReasonFor(
-            false,
-            activeRunNotice,
-            rowMetadataPending,
-          ),
-          removeDisabled: activeRunLocksBinding || removePending,
-          removeDisabledReason: removeDisabledReasonFor(
-            activeRunLocksBinding,
-            activeRunNotice,
-          ),
-          removePending,
-          onEmit: emit,
-          onMakePrimary: () => undefined,
-          onSelectMode: (nextMode) => {
-            // Unresolved rows (`resolvedAt === null`) have no verified git
-            // facts yet - the mode switch itself is disabled for them
-            // (`modeDisabled` above), but guard here too since this closure
-            // outlives that render.
-            if (ws.resolvedAt === null) return;
-            emitRowMode({
-              currentBranch,
-              currentIntent,
-              defaultNewBranchName,
-              emit,
-              isGitRepo: rowIsGitRepo,
-              isPrimary,
-              mode: currentMode,
-              nextMode,
-              repoIdentifier: ws.repoIdentifier,
-              workspacePath: ws.workspacePath,
-            });
-          },
-          onLocate: null,
-          onRemove: () => {
-            if (removePending) return;
-            removeBindingEntryMutation.mutate(
-              {
-                epicId: surface.epicId,
-                ownerId: surface.ownerId,
-                ownerKind,
-                workspacePath: ws.workspacePath,
-              },
-              {
-                // Terminal-agent: remove from the binding but don't resume —
-                // only "Update" does. Chat: no PTY to resume (no-op callback).
-                onSuccess: () => {
-                  // A folder removed before its metadata resolved has nothing
-                  // to seed - its summary never arrives, so left in place the
-                  // path would pin the pending-defaults guard and block
-                  // Update's resume forever.
-                  pendingDefaultPathsRef.current.delete(ws.workspacePath);
-                  // And if metadata DID resolve first, the seeding effect may
-                  // already have staged a default worktree intent for this
-                  // path - unstage it, or the next Update would call
-                  // worktree.create for a folder no longer in the binding.
-                  unstageWorktreeEntry(stagedKey, ws.workspacePath);
-                  if (surface.kind === "terminal-agent") {
-                    markBindingDirtyWithoutResume([ws.workspacePath]);
-                    return;
-                  }
-                  handleBindingCommitted([ws.workspacePath]);
-                },
-              },
-            );
-          },
-        };
-      }),
+        }),
     [
       activeRunNotice,
       activeRunLocksBinding,
       addFolderMutation,
       deriveInEpicRowState,
       folderActions,
+      editor.pendingRemovedPaths,
       handleBindingCommitted,
       markBindingDirtyWithoutResume,
+      remainingVisibleFolders,
+      removeFolderNow,
+      stageFolderRemoval,
       stagedKey,
       unstageWorktreeEntry,
       props.hostClient,
@@ -2833,9 +2914,13 @@ function InEpicSurface(props: InEpicSurfaceProps) {
                 ? requestStagedFolderCommit
                 : null
             }
-            draftPending={hasStagedFolderChanges}
+            draftPending={
+              hasStagedFolderChanges || editor.pendingRemovedPaths.size > 0
+            }
             updateEnabled={
-              hasStagedFolderChanges || editor.dirtyPathsSinceResume.size > 0
+              hasStagedFolderChanges ||
+              editor.dirtyPathsSinceResume.size > 0 ||
+              editor.pendingRemovedPaths.size > 0
             }
             updatePending={worktreeCreatePending}
             onDiscardStaged={null}
@@ -2867,8 +2952,15 @@ function InEpicSurface(props: InEpicSurfaceProps) {
         choice={teardownDialog?.choice ?? null}
         holders={teardownDialog?.holders ?? []}
         onImmediate={() => {
+          const dialog = teardownDialog;
           setTeardownDialog(null);
-          applyStagedFoldersAndResume();
+          if (dialog === null) return;
+          const live = readLiveCommitCapture();
+          if (worktreeCommitCaptureIsStale(dialog.capture, live)) {
+            requestStagedFolderCommit();
+            return;
+          }
+          applyStagedFoldersAndResume(dialog.capture);
         }}
         onDefer={() => {
           setTeardownDialog(null);

--- a/clients/gui-app/src/components/home/host-workspace-selector/workspace-folder-summary-control.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/workspace-folder-summary-control.tsx
@@ -145,6 +145,8 @@ export function WorkspaceFolderSummaryControl(props: {
   readonly onUpdate: (() => void) | null;
   readonly updateEnabled: boolean;
   readonly updatePending: boolean;
+  /** Uncommitted workspace draft on the summary chip. */
+  readonly draftPending?: boolean;
   readonly onDiscardStaged: (() => void) | null;
   readonly onEditEnvironment: (workspacePath: string) => void;
   /**
@@ -260,6 +262,7 @@ export function WorkspaceFolderSummaryControl(props: {
         items={props.items}
         readOnly
         bindingResolved={props.bindingResolved}
+        draftPending={props.draftPending === true}
         className="max-w-full"
       />
     );
@@ -305,6 +308,7 @@ export function WorkspaceFolderSummaryControl(props: {
       items={props.items}
       readOnly={false}
       bindingResolved={props.bindingResolved}
+      draftPending={props.draftPending === true}
       className="justify-start overflow-hidden"
     />
   );

--- a/clients/gui-app/src/components/home/host-workspace-selector/workspace-summary-trigger.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/workspace-summary-trigger.tsx
@@ -31,10 +31,19 @@ export function WorkspaceSummaryTrigger(
     readonly items: ReadonlyArray<WorkspaceRunItem>;
     readonly readOnly: boolean;
     readonly bindingResolved: boolean;
+    readonly draftPending?: boolean;
     readonly ref?: Ref<HTMLButtonElement>;
   },
 ) {
-  const { items, readOnly, bindingResolved, className, ref, ...rest } = props;
+  const {
+    items,
+    readOnly,
+    bindingResolved,
+    draftPending,
+    className,
+    ref,
+    ...rest
+  } = props;
   // Resolve by the marked `isPrimary` row, not array order: the host
   // normalizes binding flags without reordering entries, so the collapsed
   // chip must agree with the primary pin/row rather than always reading
@@ -92,6 +101,13 @@ export function WorkspaceSummaryTrigger(
             <span className="shrink-0 rounded-md bg-foreground/7 px-1.5 py-0.5 text-overline font-medium text-current">
               +{extraCount}
             </span>
+          ) : null}
+          {draftPending === true ? (
+            <span
+              className="size-1.5 shrink-0 rounded-full bg-foreground"
+              data-testid="workspace-summary-draft"
+              aria-label="Uncommitted workspace draft"
+            />
           ) : null}
         </>
       )}

--- a/clients/gui-app/src/components/worktree/__tests__/teardown-commit-dialog.test.tsx
+++ b/clients/gui-app/src/components/worktree/__tests__/teardown-commit-dialog.test.tsx
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { WorktreeBusyHolder } from "@traycer/protocol/framework/worktree-busy-holders";
+import { TeardownCommitDialog } from "@/components/worktree/teardown-commit-dialog";
+
+const HOLDER: WorktreeBusyHolder = {
+  ownerRef: {
+    epicId: "epic-1",
+    ownerKind: "chat",
+    ownerId: "chat-1",
+  },
+  holdKind: "chat-turn",
+  activity: "working",
+  label: "Planner is working",
+};
+
+describe("TeardownCommitDialog", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("offers stop-now and apply-later on the commit gesture", () => {
+    const onImmediate = vi.fn();
+    const onDefer = vi.fn();
+    render(
+      <TeardownCommitDialog
+        open
+        choice="commit"
+        holders={[HOLDER]}
+        onImmediate={onImmediate}
+        onDefer={onDefer}
+        onDismiss={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("teardown-commit-immediate"));
+    expect(onImmediate).toHaveBeenCalledTimes(1);
+    fireEvent.click(screen.getByTestId("teardown-commit-defer"));
+    expect(onDefer).toHaveBeenCalledTimes(1);
+  });
+
+  it("pivots a blocked envelope into apply-on-next-message only", () => {
+    render(
+      <TeardownCommitDialog
+        open
+        choice="blocked"
+        holders={[]}
+        onImmediate={vi.fn()}
+        onDefer={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("teardown-commit-defer")).toBeTruthy();
+    expect(screen.queryByTestId("teardown-commit-immediate")).toBeNull();
+  });
+});

--- a/clients/gui-app/src/components/worktree/__tests__/teardown-commit-dialog.test.tsx
+++ b/clients/gui-app/src/components/worktree/__tests__/teardown-commit-dialog.test.tsx
@@ -36,6 +36,9 @@ describe("TeardownCommitDialog", () => {
     expect(onImmediate).toHaveBeenCalledTimes(1);
     fireEvent.click(screen.getByTestId("teardown-commit-defer"));
     expect(onDefer).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId("teardown-commit-defer").textContent).toBe(
+      "Apply on next Update",
+    );
   });
 
   it("pivots a blocked envelope into apply-on-next-message only", () => {
@@ -67,5 +70,26 @@ describe("TeardownCommitDialog", () => {
     expect(screen.getByTestId("teardown-commit-immediate")).toBeTruthy();
     expect(screen.getByTestId("teardown-commit-cancel")).toBeTruthy();
     expect(screen.queryByTestId("teardown-commit-defer")).toBeNull();
+    expect(screen.getByTestId("teardown-commit-immediate").textContent).toBe(
+      "Stop and remove now",
+    );
+    expect(screen.getByText(/if you remove it/)).toBeTruthy();
+  });
+
+  it("labels terminal-agent defer as apply on next Update", () => {
+    render(
+      <TeardownCommitDialog
+        open
+        choice="blocked"
+        holders={[]}
+        deferContext="update"
+        onImmediate={vi.fn()}
+        onDefer={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("teardown-commit-defer").textContent).toBe(
+      "Apply on next Update",
+    );
   });
 });

--- a/clients/gui-app/src/components/worktree/__tests__/teardown-commit-dialog.test.tsx
+++ b/clients/gui-app/src/components/worktree/__tests__/teardown-commit-dialog.test.tsx
@@ -52,4 +52,20 @@ describe("TeardownCommitDialog", () => {
     expect(screen.getByTestId("teardown-commit-defer")).toBeTruthy();
     expect(screen.queryByTestId("teardown-commit-immediate")).toBeNull();
   });
+
+  it("offers stop-now and cancel only on a removal gesture", () => {
+    render(
+      <TeardownCommitDialog
+        open
+        choice="remove"
+        holders={[HOLDER]}
+        onImmediate={vi.fn()}
+        onDefer={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("teardown-commit-immediate")).toBeTruthy();
+    expect(screen.getByTestId("teardown-commit-cancel")).toBeTruthy();
+    expect(screen.queryByTestId("teardown-commit-defer")).toBeNull();
+  });
 });

--- a/clients/gui-app/src/components/worktree/__tests__/teardown-disclosure.test.tsx
+++ b/clients/gui-app/src/components/worktree/__tests__/teardown-disclosure.test.tsx
@@ -47,18 +47,18 @@ describe("TeardownDisclosure", () => {
         ]}
       />,
     );
-    expect(screen.getByTestId("teardown-disclosure-working").textContent).toContain(
-      "Planner is working",
-    );
-    expect(screen.getByTestId("teardown-disclosure-working").textContent).toContain(
-      "1 agent is still working",
-    );
-    expect(screen.getByTestId("teardown-disclosure-idle").textContent).toContain(
-      "1 background process will be stopped",
-    );
-    expect(screen.getByTestId("teardown-disclosure-idle").textContent).toContain(
-      "npm test",
-    );
+    expect(
+      screen.getByTestId("teardown-disclosure-working").textContent,
+    ).toContain("Planner is working");
+    expect(
+      screen.getByTestId("teardown-disclosure-working").textContent,
+    ).toContain("1 agent is still working");
+    expect(
+      screen.getByTestId("teardown-disclosure-idle").textContent,
+    ).toContain("1 background process will be stopped");
+    expect(
+      screen.getByTestId("teardown-disclosure-idle").textContent,
+    ).toContain("npm test");
   });
 
   it("labels each holder kind instead of saying busy", () => {
@@ -81,5 +81,25 @@ describe("TeardownDisclosure", () => {
     expect(screen.getByText("Terminal")).toBeTruthy();
     expect(screen.getByText("Shell")).toBeTruthy();
     expect(screen.queryByText(/busy/i)).toBeNull();
+  });
+
+  it("names a stop failure on the matching holder row", () => {
+    const shell = holder({
+      holdKind: "supervised-shell",
+      activity: "working",
+      label: "npm run dev",
+    });
+    render(
+      <TeardownDisclosure
+        holders={[shell]}
+        failures={{
+          "terminal-agent:tui-1:supervised-shell:npm run dev":
+            "shell still running",
+        }}
+      />,
+    );
+    expect(screen.getByTestId("teardown-holder-failure").textContent).toBe(
+      "shell still running",
+    );
   });
 });

--- a/clients/gui-app/src/components/worktree/__tests__/teardown-disclosure.test.tsx
+++ b/clients/gui-app/src/components/worktree/__tests__/teardown-disclosure.test.tsx
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { cleanup, render, screen } from "@testing-library/react";
 import type { WorktreeBusyHolder } from "@traycer/protocol/framework/worktree-busy-holders";
 import { TeardownDisclosure } from "@/components/worktree/teardown-disclosure";
+import { teardownHolderKey } from "@/lib/worktree/owner-teardown-snapshot";
 
 const OWNER: WorktreeBusyHolder["ownerRef"] = {
   epicId: "epic-1",
@@ -93,13 +94,54 @@ describe("TeardownDisclosure", () => {
       <TeardownDisclosure
         holders={[shell]}
         failures={{
-          "terminal-agent:tui-1:supervised-shell:npm run dev":
-            "shell still running",
+          [teardownHolderKey(shell)]: "shell still running",
         }}
       />,
     );
     expect(screen.getByTestId("teardown-holder-failure").textContent).toBe(
       "shell still running",
     );
+  });
+
+  it("paints a stop failure only on the matching same-label shell", () => {
+    const first = {
+      ...holder({
+        holdKind: "supervised-shell",
+        activity: "working",
+        label: "npm run dev",
+      }),
+      holderKey: teardownHolderKey(
+        holder({
+          holdKind: "supervised-shell",
+          activity: "working",
+          label: "npm run dev",
+        }),
+        "sh-1",
+      ),
+    };
+    const second = {
+      ...holder({
+        holdKind: "supervised-shell",
+        activity: "working",
+        label: "npm run dev",
+      }),
+      holderKey: teardownHolderKey(
+        holder({
+          holdKind: "supervised-shell",
+          activity: "working",
+          label: "npm run dev",
+        }),
+        "sh-2",
+      ),
+    };
+    render(
+      <TeardownDisclosure
+        holders={[first, second]}
+        failures={{ [first.holderKey]: "shell still running" }}
+      />,
+    );
+    const rows = screen.getAllByText("npm run dev");
+    expect(rows).toHaveLength(2);
+    expect(screen.getAllByTestId("teardown-holder-failure")).toHaveLength(1);
   });
 });

--- a/clients/gui-app/src/components/worktree/__tests__/teardown-disclosure.test.tsx
+++ b/clients/gui-app/src/components/worktree/__tests__/teardown-disclosure.test.tsx
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import type { WorktreeBusyHolder } from "@traycer/protocol/framework/worktree-busy-holders";
+import { TeardownDisclosure } from "@/components/worktree/teardown-disclosure";
+
+const OWNER: WorktreeBusyHolder["ownerRef"] = {
+  epicId: "epic-1",
+  ownerKind: "terminal-agent",
+  ownerId: "tui-1",
+};
+
+function holder(
+  overrides: Partial<WorktreeBusyHolder> &
+    Pick<WorktreeBusyHolder, "holdKind" | "activity" | "label">,
+): WorktreeBusyHolder {
+  return {
+    ownerRef: OWNER,
+    ...overrides,
+  };
+}
+
+describe("TeardownDisclosure", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders nothing for an empty holder list", () => {
+    const { container } = render(<TeardownDisclosure holders={[]} />);
+    expect(container.innerHTML).toBe("");
+    expect(screen.queryByTestId("teardown-disclosure")).toBeNull();
+  });
+
+  it("calls out working holders loudly and lists idle holders plainly", () => {
+    render(
+      <TeardownDisclosure
+        holders={[
+          holder({
+            holdKind: "chat-turn",
+            activity: "working",
+            label: "Planner is working",
+          }),
+          holder({
+            holdKind: "supervised-shell",
+            activity: "idle",
+            label: "npm test",
+          }),
+        ]}
+      />,
+    );
+    expect(screen.getByTestId("teardown-disclosure-working").textContent).toContain(
+      "Planner is working",
+    );
+    expect(screen.getByTestId("teardown-disclosure-working").textContent).toContain(
+      "1 agent is still working",
+    );
+    expect(screen.getByTestId("teardown-disclosure-idle").textContent).toContain(
+      "1 background process will be stopped",
+    );
+    expect(screen.getByTestId("teardown-disclosure-idle").textContent).toContain(
+      "npm test",
+    );
+  });
+
+  it("labels each holder kind instead of saying busy", () => {
+    render(
+      <TeardownDisclosure
+        holders={[
+          holder({
+            holdKind: "terminal-agent-pty",
+            activity: "working",
+            label: "Claude will restart in the new folder",
+          }),
+          holder({
+            holdKind: "supervised-shell",
+            activity: "working",
+            label: "npm run dev",
+          }),
+        ]}
+      />,
+    );
+    expect(screen.getByText("Terminal")).toBeTruthy();
+    expect(screen.getByText("Shell")).toBeTruthy();
+    expect(screen.queryByText(/busy/i)).toBeNull();
+  });
+});

--- a/clients/gui-app/src/components/worktree/teardown-commit-dialog.tsx
+++ b/clients/gui-app/src/components/worktree/teardown-commit-dialog.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/components/ui/dialog";
 import { TeardownDisclosure } from "@/components/worktree/teardown-disclosure";
 
-export type TeardownCommitChoice = "commit" | "submit" | "blocked";
+export type TeardownCommitChoice = "commit" | "submit" | "blocked" | "remove";
 
 /**
  * Gesture-time confirm for a worktree commit that would tear holders down.
@@ -31,6 +31,8 @@ export function TeardownCommitDialog(props: {
 }) {
   const blocked = props.choice === "blocked";
   const submit = props.choice === "submit";
+  const removeOnly = props.choice === "remove";
+  const pending = props.immediatePending === true;
   const title = dialogTitle(props.choice);
   const description = dialogDescription(props.choice);
   return (
@@ -71,14 +73,16 @@ export function TeardownCommitDialog(props: {
             variant="ghost"
             size="sm"
             onClick={props.onDismiss}
+            data-testid="teardown-commit-cancel"
           >
             Cancel
           </Button>
-          {submit || blocked ? null : (
+          {submit || blocked || removeOnly ? null : (
             <Button
               type="button"
               variant="outline"
               size="sm"
+              disabled={pending}
               onClick={props.onDefer}
               data-testid="teardown-commit-defer"
             >
@@ -100,10 +104,7 @@ export function TeardownCommitDialog(props: {
               type="button"
               variant="default"
               size="sm"
-              disabled={
-                props.immediateDisabled === true ||
-                props.immediatePending === true
-              }
+              disabled={props.immediateDisabled === true || pending}
               onClick={props.onImmediate}
               data-testid="teardown-commit-immediate"
             >
@@ -121,6 +122,7 @@ function dialogTitle(choice: TeardownCommitChoice | null): string {
     return "Apply this folder change on the next message?";
   }
   if (choice === "submit") return "Send in the new folder?";
+  if (choice === "remove") return "Remove this folder?";
   return "Switch workspace?";
 }
 

--- a/clients/gui-app/src/components/worktree/teardown-commit-dialog.tsx
+++ b/clients/gui-app/src/components/worktree/teardown-commit-dialog.tsx
@@ -21,6 +21,10 @@ export function TeardownCommitDialog(props: {
   readonly open: boolean;
   readonly choice: TeardownCommitChoice | null;
   readonly holders: readonly WorktreeBusyHolder[];
+  readonly failures?: Readonly<Record<string, string>>;
+  readonly immediateDisabled?: boolean;
+  readonly immediatePending?: boolean;
+  readonly refusalReason?: string;
   readonly onImmediate: () => void;
   readonly onDefer: () => void;
   readonly onDismiss: () => void;
@@ -45,9 +49,21 @@ export function TeardownCommitDialog(props: {
         <DialogHeader className="space-y-1 px-6 pt-6 pb-2">
           <DialogTitle className="text-base font-semibold">{title}</DialogTitle>
           <DialogDescription>{description}</DialogDescription>
+          {props.refusalReason === undefined ||
+          props.refusalReason.length === 0 ? null : (
+            <p
+              className="text-ui-sm text-destructive"
+              data-testid="teardown-commit-refusal"
+            >
+              {props.refusalReason}
+            </p>
+          )}
         </DialogHeader>
         <div className="px-6 py-2">
-          <TeardownDisclosure holders={props.holders} />
+          <TeardownDisclosure
+            holders={props.holders}
+            failures={props.failures}
+          />
         </div>
         <DialogFooter className="mx-0 mb-0 mt-2 gap-2 rounded-b-xl border-t border-border/40 bg-foreground/2 px-6 py-4">
           <Button
@@ -84,6 +100,10 @@ export function TeardownCommitDialog(props: {
               type="button"
               variant="default"
               size="sm"
+              disabled={
+                props.immediateDisabled === true ||
+                props.immediatePending === true
+              }
               onClick={props.onImmediate}
               data-testid="teardown-commit-immediate"
             >

--- a/clients/gui-app/src/components/worktree/teardown-commit-dialog.tsx
+++ b/clients/gui-app/src/components/worktree/teardown-commit-dialog.tsx
@@ -27,16 +27,8 @@ export function TeardownCommitDialog(props: {
 }) {
   const blocked = props.choice === "blocked";
   const submit = props.choice === "submit";
-  const title = blocked
-    ? "Apply this folder change on the next message?"
-    : submit
-      ? "Send in the new folder?"
-      : "Switch workspace?";
-  const description = blocked
-    ? "This host will not switch folders while the agent is running. The draft stays local until the next message."
-    : submit
-      ? "Sending this message will switch folders and stop the processes below."
-      : "These processes run in the current folder and will stop if you switch now.";
+  const title = dialogTitle(props.choice);
+  const description = dialogDescription(props.choice);
   return (
     <Dialog
       open={props.open}
@@ -102,4 +94,22 @@ export function TeardownCommitDialog(props: {
       </DialogContent>
     </Dialog>
   );
+}
+
+function dialogTitle(choice: TeardownCommitChoice | null): string {
+  if (choice === "blocked") {
+    return "Apply this folder change on the next message?";
+  }
+  if (choice === "submit") return "Send in the new folder?";
+  return "Switch workspace?";
+}
+
+function dialogDescription(choice: TeardownCommitChoice | null): string {
+  if (choice === "blocked") {
+    return "This host will not switch folders while the agent is running. The draft stays local until the next message.";
+  }
+  if (choice === "submit") {
+    return "Sending this message will switch folders and stop the processes below.";
+  }
+  return "These processes run in the current folder and will stop if you switch now.";
 }

--- a/clients/gui-app/src/components/worktree/teardown-commit-dialog.tsx
+++ b/clients/gui-app/src/components/worktree/teardown-commit-dialog.tsx
@@ -1,0 +1,105 @@
+import type { WorktreeBusyHolder } from "@traycer/protocol/framework/worktree-busy-holders";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { TeardownDisclosure } from "@/components/worktree/teardown-disclosure";
+
+export type TeardownCommitChoice = "commit" | "submit" | "blocked";
+
+/**
+ * Gesture-time confirm for a worktree commit that would tear holders down.
+ * `immediate` is "stop and switch now"; `defer` is "apply on next message";
+ * `blocked` is the legacy-host WORKTREE_REBIND_BLOCKED pivot (defer only).
+ */
+export function TeardownCommitDialog(props: {
+  readonly open: boolean;
+  readonly choice: TeardownCommitChoice | null;
+  readonly holders: readonly WorktreeBusyHolder[];
+  readonly onImmediate: () => void;
+  readonly onDefer: () => void;
+  readonly onDismiss: () => void;
+}) {
+  const blocked = props.choice === "blocked";
+  const submit = props.choice === "submit";
+  const title = blocked
+    ? "Apply this folder change on the next message?"
+    : submit
+      ? "Send in the new folder?"
+      : "Switch workspace?";
+  const description = blocked
+    ? "This host will not switch folders while the agent is running. The draft stays local until the next message."
+    : submit
+      ? "Sending this message will switch folders and stop the processes below."
+      : "These processes run in the current folder and will stop if you switch now.";
+  return (
+    <Dialog
+      open={props.open}
+      onOpenChange={(open) => {
+        if (!open) props.onDismiss();
+      }}
+    >
+      <DialogContent
+        className="w-full min-w-0 gap-0 overflow-hidden p-0"
+        style={{ maxWidth: "min(92vw, 34rem)" }}
+        showCloseButton={false}
+        data-testid="teardown-commit-dialog"
+      >
+        <DialogHeader className="space-y-1 px-6 pt-6 pb-2">
+          <DialogTitle className="text-base font-semibold">{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+        <div className="px-6 py-2">
+          <TeardownDisclosure holders={props.holders} />
+        </div>
+        <DialogFooter className="mx-0 mb-0 mt-2 gap-2 rounded-b-xl border-t border-border/40 bg-foreground/2 px-6 py-4">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={props.onDismiss}
+          >
+            Cancel
+          </Button>
+          {submit || blocked ? null : (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={props.onDefer}
+              data-testid="teardown-commit-defer"
+            >
+              Apply on next message
+            </Button>
+          )}
+          {blocked ? (
+            <Button
+              type="button"
+              variant="default"
+              size="sm"
+              onClick={props.onDefer}
+              data-testid="teardown-commit-defer"
+            >
+              Apply on next message
+            </Button>
+          ) : (
+            <Button
+              type="button"
+              variant="default"
+              size="sm"
+              onClick={props.onImmediate}
+              data-testid="teardown-commit-immediate"
+            >
+              {submit ? "Send and switch" : "Stop and switch now"}
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/clients/gui-app/src/components/worktree/teardown-commit-dialog.tsx
+++ b/clients/gui-app/src/components/worktree/teardown-commit-dialog.tsx
@@ -25,6 +25,7 @@ export function TeardownCommitDialog(props: {
   readonly immediateDisabled?: boolean;
   readonly immediatePending?: boolean;
   readonly refusalReason?: string;
+  readonly deferContext?: "message" | "update";
   readonly onImmediate: () => void;
   readonly onDefer: () => void;
   readonly onDismiss: () => void;
@@ -33,8 +34,11 @@ export function TeardownCommitDialog(props: {
   const submit = props.choice === "submit";
   const removeOnly = props.choice === "remove";
   const pending = props.immediatePending === true;
+  const deferContext = props.deferContext ?? "message";
   const title = dialogTitle(props.choice);
-  const description = dialogDescription(props.choice);
+  const description = dialogDescription(props.choice, deferContext);
+  const deferLabel = deferButtonLabel(props.choice, deferContext);
+  const immediateLabel = immediateButtonLabel(props.choice);
   return (
     <Dialog
       open={props.open}
@@ -86,7 +90,7 @@ export function TeardownCommitDialog(props: {
               onClick={props.onDefer}
               data-testid="teardown-commit-defer"
             >
-              Apply on next message
+              {deferLabel}
             </Button>
           )}
           {blocked ? (
@@ -97,7 +101,7 @@ export function TeardownCommitDialog(props: {
               onClick={props.onDefer}
               data-testid="teardown-commit-defer"
             >
-              Apply on next message
+              {deferLabel}
             </Button>
           ) : (
             <Button
@@ -108,13 +112,29 @@ export function TeardownCommitDialog(props: {
               onClick={props.onImmediate}
               data-testid="teardown-commit-immediate"
             >
-              {submit ? "Send and switch" : "Stop and switch now"}
+              {immediateLabel}
             </Button>
           )}
         </DialogFooter>
       </DialogContent>
     </Dialog>
   );
+}
+
+function deferButtonLabel(
+  choice: TeardownCommitChoice | null,
+  deferContext: "message" | "update",
+): string {
+  if (deferContext === "update" || choice === "commit") {
+    return "Apply on next Update";
+  }
+  return "Apply on next message";
+}
+
+function immediateButtonLabel(choice: TeardownCommitChoice | null): string {
+  if (choice === "submit") return "Send and switch";
+  if (choice === "remove") return "Stop and remove now";
+  return "Stop and switch now";
 }
 
 function dialogTitle(choice: TeardownCommitChoice | null): string {
@@ -126,12 +146,20 @@ function dialogTitle(choice: TeardownCommitChoice | null): string {
   return "Switch workspace?";
 }
 
-function dialogDescription(choice: TeardownCommitChoice | null): string {
+function dialogDescription(
+  choice: TeardownCommitChoice | null,
+  deferContext: "message" | "update",
+): string {
   if (choice === "blocked") {
-    return "This host will not switch folders while the agent is running. The draft stays local until the next message.";
+    return deferContext === "update"
+      ? "This host will not switch folders while the agent is running. The draft stays local until you click Update."
+      : "This host will not switch folders while the agent is running. The draft stays local until the next message.";
   }
   if (choice === "submit") {
     return "Sending this message will switch folders and stop the processes below.";
+  }
+  if (choice === "remove") {
+    return "These processes run in this folder and will stop if you remove it.";
   }
   return "These processes run in the current folder and will stop if you switch now.";
 }

--- a/clients/gui-app/src/components/worktree/teardown-disclosure.tsx
+++ b/clients/gui-app/src/components/worktree/teardown-disclosure.tsx
@@ -1,5 +1,6 @@
 import type { WorktreeBusyHolder } from "@traycer/protocol/framework/worktree-busy-holders";
 import { cn } from "@/lib/utils";
+import { teardownHolderKey } from "@/lib/worktree/owner-teardown-snapshot";
 
 /**
  * Renders a T2 holder list as "what will be stopped". Source-agnostic: the
@@ -8,6 +9,7 @@ import { cn } from "@/lib/utils";
  */
 export function TeardownDisclosure(props: {
   readonly holders: readonly WorktreeBusyHolder[];
+  readonly failures?: Readonly<Record<string, string>>;
 }) {
   if (props.holders.length === 0) return null;
   const working = props.holders.filter(
@@ -25,6 +27,7 @@ export function TeardownDisclosure(props: {
           heading={workingHeading(working)}
           holders={working}
           tone="working"
+          failures={props.failures}
         />
       ) : null}
       {idle.length > 0 ? (
@@ -33,6 +36,7 @@ export function TeardownDisclosure(props: {
           heading={idleHeading(idle)}
           holders={idle}
           tone="idle"
+          failures={props.failures}
         />
       ) : null}
     </div>
@@ -44,6 +48,7 @@ function HolderGroup(props: {
   readonly heading: string;
   readonly holders: readonly WorktreeBusyHolder[];
   readonly tone: "working" | "idle";
+  readonly failures: Readonly<Record<string, string>> | undefined;
 }) {
   return (
     <section
@@ -61,22 +66,38 @@ function HolderGroup(props: {
         {props.heading}
       </p>
       <ul className="m-0 flex list-none flex-col gap-0.5 p-0">
-        {props.holders.map((holder) => (
-          <li
-            key={holderKey(holder)}
-            className={cn(
-              "flex min-w-0 items-baseline gap-2 rounded-md px-2 py-1 text-ui-sm",
-              props.tone === "working" ? "bg-foreground/8" : "bg-foreground/3",
-            )}
-          >
-            <span className="min-w-0 flex-1 truncate text-foreground">
-              {holder.label}
-            </span>
-            <span className="shrink-0 text-ui-xs text-muted-foreground">
-              {holdKindLabel(holder.holdKind)}
-            </span>
-          </li>
-        ))}
+        {props.holders.map((holder) => {
+          const key = teardownHolderKey(holder);
+          const failure = props.failures?.[key];
+          return (
+            <li
+              key={key}
+              className={cn(
+                "flex min-w-0 flex-col gap-0.5 rounded-md px-2 py-1 text-ui-sm",
+                props.tone === "working"
+                  ? "bg-foreground/8"
+                  : "bg-foreground/3",
+              )}
+            >
+              <div className="flex min-w-0 items-baseline gap-2">
+                <span className="min-w-0 flex-1 truncate text-foreground">
+                  {holder.label}
+                </span>
+                <span className="shrink-0 text-ui-xs text-muted-foreground">
+                  {holdKindLabel(holder.holdKind)}
+                </span>
+              </div>
+              {failure === undefined ? null : (
+                <span
+                  className="text-ui-xs text-destructive"
+                  data-testid="teardown-holder-failure"
+                >
+                  {failure}
+                </span>
+              )}
+            </li>
+          );
+        })}
       </ul>
     </section>
   );
@@ -115,8 +136,4 @@ function idleHeading(holders: readonly WorktreeBusyHolder[]): string {
   return holders.length === 1
     ? "1 background process will be stopped"
     : `${holders.length} background processes will be stopped`;
-}
-
-function holderKey(holder: WorktreeBusyHolder): string {
-  return `${holder.ownerRef.ownerKind}:${holder.ownerRef.ownerId}:${holder.holdKind}:${holder.label}`;
 }

--- a/clients/gui-app/src/components/worktree/teardown-disclosure.tsx
+++ b/clients/gui-app/src/components/worktree/teardown-disclosure.tsx
@@ -46,11 +46,16 @@ function HolderGroup(props: {
   readonly tone: "working" | "idle";
 }) {
   return (
-    <section className="flex min-w-0 flex-col gap-1.5" data-testid={props.testId}>
+    <section
+      className="flex min-w-0 flex-col gap-1.5"
+      data-testid={props.testId}
+    >
       <p
         className={cn(
           "text-ui-sm font-medium",
-          props.tone === "working" ? "text-foreground" : "text-muted-foreground",
+          props.tone === "working"
+            ? "text-foreground"
+            : "text-muted-foreground",
         )}
       >
         {props.heading}
@@ -77,9 +82,7 @@ function HolderGroup(props: {
   );
 }
 
-export function holdKindLabel(
-  holdKind: WorktreeBusyHolder["holdKind"],
-): string {
+function holdKindLabel(holdKind: WorktreeBusyHolder["holdKind"]): string {
   if (holdKind === "chat-turn") return "Turn";
   if (holdKind === "terminal-agent-pty") return "Terminal";
   if (holdKind === "supervised-shell") return "Shell";

--- a/clients/gui-app/src/components/worktree/teardown-disclosure.tsx
+++ b/clients/gui-app/src/components/worktree/teardown-disclosure.tsx
@@ -1,6 +1,6 @@
 import type { WorktreeBusyHolder } from "@traycer/protocol/framework/worktree-busy-holders";
 import { cn } from "@/lib/utils";
-import { teardownHolderKey } from "@/lib/worktree/owner-teardown-snapshot";
+import { teardownHolderRowKey } from "@/lib/worktree/owner-teardown-snapshot";
 
 /**
  * Renders a T2 holder list as "what will be stopped". Source-agnostic: the
@@ -67,7 +67,7 @@ function HolderGroup(props: {
       </p>
       <ul className="m-0 flex list-none flex-col gap-0.5 p-0">
         {props.holders.map((holder) => {
-          const key = teardownHolderKey(holder);
+          const key = teardownHolderRowKey(holder);
           const failure = props.failures?.[key];
           return (
             <li

--- a/clients/gui-app/src/components/worktree/teardown-disclosure.tsx
+++ b/clients/gui-app/src/components/worktree/teardown-disclosure.tsx
@@ -1,0 +1,119 @@
+import type { WorktreeBusyHolder } from "@traycer/protocol/framework/worktree-busy-holders";
+import { cn } from "@/lib/utils";
+
+/**
+ * Renders a T2 holder list as "what will be stopped". Source-agnostic: the
+ * list may come from the phase-1 client-local snapshot or, later, the host
+ * `listHolders` read. Empty renders nothing.
+ */
+export function TeardownDisclosure(props: {
+  readonly holders: readonly WorktreeBusyHolder[];
+}) {
+  if (props.holders.length === 0) return null;
+  const working = props.holders.filter(
+    (holder) => holder.activity === "working",
+  );
+  const idle = props.holders.filter((holder) => holder.activity === "idle");
+  return (
+    <div
+      className="flex w-full min-w-0 flex-col gap-3"
+      data-testid="teardown-disclosure"
+    >
+      {working.length > 0 ? (
+        <HolderGroup
+          testId="teardown-disclosure-working"
+          heading={workingHeading(working)}
+          holders={working}
+          tone="working"
+        />
+      ) : null}
+      {idle.length > 0 ? (
+        <HolderGroup
+          testId="teardown-disclosure-idle"
+          heading={idleHeading(idle)}
+          holders={idle}
+          tone="idle"
+        />
+      ) : null}
+    </div>
+  );
+}
+
+function HolderGroup(props: {
+  readonly testId: string;
+  readonly heading: string;
+  readonly holders: readonly WorktreeBusyHolder[];
+  readonly tone: "working" | "idle";
+}) {
+  return (
+    <section className="flex min-w-0 flex-col gap-1.5" data-testid={props.testId}>
+      <p
+        className={cn(
+          "text-ui-sm font-medium",
+          props.tone === "working" ? "text-foreground" : "text-muted-foreground",
+        )}
+      >
+        {props.heading}
+      </p>
+      <ul className="m-0 flex list-none flex-col gap-0.5 p-0">
+        {props.holders.map((holder) => (
+          <li
+            key={holderKey(holder)}
+            className={cn(
+              "flex min-w-0 items-baseline gap-2 rounded-md px-2 py-1 text-ui-sm",
+              props.tone === "working" ? "bg-foreground/8" : "bg-foreground/3",
+            )}
+          >
+            <span className="min-w-0 flex-1 truncate text-foreground">
+              {holder.label}
+            </span>
+            <span className="shrink-0 text-ui-xs text-muted-foreground">
+              {holdKindLabel(holder.holdKind)}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+export function holdKindLabel(
+  holdKind: WorktreeBusyHolder["holdKind"],
+): string {
+  if (holdKind === "chat-turn") return "Turn";
+  if (holdKind === "terminal-agent-pty") return "Terminal";
+  if (holdKind === "supervised-shell") return "Shell";
+  return "Run directory";
+}
+
+function workingHeading(holders: readonly WorktreeBusyHolder[]): string {
+  const agents = holders.filter(
+    (holder) =>
+      holder.holdKind === "chat-turn" ||
+      holder.holdKind === "terminal-agent-pty",
+  ).length;
+  const shells = holders.filter(
+    (holder) => holder.holdKind === "supervised-shell",
+  ).length;
+  const parts: string[] = [];
+  if (agents === 1) parts.push("1 agent is still working");
+  if (agents > 1) parts.push(`${agents} agents are still working`);
+  if (shells === 1) parts.push("1 shell is running");
+  if (shells > 1) parts.push(`${shells} shells are running`);
+  if (parts.length === 0) {
+    return holders.length === 1
+      ? "1 process is still working"
+      : `${holders.length} processes are still working`;
+  }
+  return parts.join(" · ");
+}
+
+function idleHeading(holders: readonly WorktreeBusyHolder[]): string {
+  return holders.length === 1
+    ? "1 background process will be stopped"
+    : `${holders.length} background processes will be stopped`;
+}
+
+function holderKey(holder: WorktreeBusyHolder): string {
+  return `${holder.ownerRef.ownerKind}:${holder.ownerRef.ownerId}:${holder.holdKind}:${holder.label}`;
+}

--- a/clients/gui-app/src/hooks/agent/use-create-tui-agent.ts
+++ b/clients/gui-app/src/hooks/agent/use-create-tui-agent.ts
@@ -241,7 +241,7 @@ export function useCreateTuiAgentForClient(
 } {
   const startSession = useAgentStartTerminalSession(hostClient);
   const createTuiAgent = useEpicCreateTuiAgentForClient(hostClient);
-  const worktreeCreate = useWorktreeCreateForClient(hostClient);
+  const worktreeCreate = useWorktreeCreateForClient(hostClient, undefined);
   const validateForkProfile = useValidateTuiForkProfile(hostClient);
   const forkProfilePreflightSupported =
     useTuiForkProfileSupported(placeholderHostId);

--- a/clients/gui-app/src/hooks/host/use-host-scoped-mutation.ts
+++ b/clients/gui-app/src/hooks/host/use-host-scoped-mutation.ts
@@ -53,6 +53,11 @@ interface UseHostScopedMutationArgs<
         variables: RequestOfMethod<HostRpcRegistry, Method>,
       ) => void)
     | undefined;
+  /**
+   * Codes the caller handles inline (a confirm dialog). The default toast is
+   * skipped so the user is not told to "stop the run" AND asked to confirm.
+   */
+  readonly silentCodes?: readonly HostRpcError["code"][];
 }
 
 /**
@@ -106,6 +111,7 @@ export function useHostScopedMutationForClient<
         }
       },
       onError: (error) => {
+        if (args.silentCodes?.includes(error.code) === true) return;
         toastFromHostError(error, args.errorMessage);
       },
     },

--- a/clients/gui-app/src/hooks/worktree/use-owner-teardown-snapshot.ts
+++ b/clients/gui-app/src/hooks/worktree/use-owner-teardown-snapshot.ts
@@ -51,6 +51,15 @@ export function useOwnerTeardownSnapshot(
           ptyLive,
         }),
         droppedRunDirectories,
+        ...collectOwnerAgentStopEvidence({
+          epicId,
+          hostId,
+          ownerKind,
+          ownerId,
+          ownerLabel,
+          hasActiveTurn,
+          ptyLive,
+        }),
       }),
     [epicId, hasActiveTurn, hostId, ownerId, ownerKind, ownerLabel, ptyLive],
   );
@@ -80,4 +89,23 @@ function collectOwnerShells(
     }
   }
   return [...byId.values()];
+}
+
+function collectOwnerAgentStopEvidence(args: OwnerTeardownSnapshotArgs): {
+  readonly queuedMessageCount: number;
+  readonly backgroundItemCount: number;
+} {
+  if (args.ownerKind !== "chat") {
+    return { queuedMessageCount: 0, backgroundItemCount: 0 };
+  }
+  const handle = getChatSessionRegistry().peek(
+    args.epicId,
+    args.ownerId,
+    args.hostId,
+  );
+  const state = handle?.store.getState();
+  return {
+    queuedMessageCount: state?.queue.items.length ?? 0,
+    backgroundItemCount: state?.backgroundItems?.length ?? 0,
+  };
 }

--- a/clients/gui-app/src/hooks/worktree/use-owner-teardown-snapshot.ts
+++ b/clients/gui-app/src/hooks/worktree/use-owner-teardown-snapshot.ts
@@ -1,10 +1,10 @@
 import { useCallback } from "react";
-import type { WorktreeBusyHolder } from "@traycer/protocol/framework/worktree-busy-holders";
 import type { WorktreeBindingOwnerKind } from "@traycer/protocol/host/worktree-schemas";
 import { getChatSessionRegistry } from "@/lib/registries/chat-session-registry";
 import {
-  snapshotOwnerTeardownHolders,
+  snapshotOwnerTeardown,
   type OwnerTeardownShell,
+  type OwnerTeardownSnapshot,
 } from "@/lib/worktree/owner-teardown-snapshot";
 
 export type OwnerTeardownSnapshotArgs = {
@@ -24,7 +24,7 @@ export type OwnerTeardownSnapshotArgs = {
  */
 export function useOwnerTeardownSnapshot(
   args: OwnerTeardownSnapshotArgs,
-): (droppedRunDirectories: readonly string[]) => readonly WorktreeBusyHolder[] {
+): (droppedRunDirectories: readonly string[]) => OwnerTeardownSnapshot {
   const {
     epicId,
     hostId,
@@ -36,7 +36,7 @@ export function useOwnerTeardownSnapshot(
   } = args;
   return useCallback(
     (droppedRunDirectories: readonly string[]) =>
-      snapshotOwnerTeardownHolders({
+      snapshotOwnerTeardown({
         ownerRef: { epicId, ownerKind, ownerId },
         ownerLabel,
         hasActiveTurn,

--- a/clients/gui-app/src/hooks/worktree/use-owner-teardown-snapshot.ts
+++ b/clients/gui-app/src/hooks/worktree/use-owner-teardown-snapshot.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from "react";
+import { useCallback } from "react";
 import type { WorktreeBusyHolder } from "@traycer/protocol/framework/worktree-busy-holders";
 import type { WorktreeBindingOwnerKind } from "@traycer/protocol/host/worktree-schemas";
 import { getChatSessionRegistry } from "@/lib/registries/chat-session-registry";
@@ -6,7 +6,6 @@ import {
   snapshotOwnerTeardownHolders,
   type OwnerTeardownShell,
 } from "@/lib/worktree/owner-teardown-snapshot";
-import { resourcesRegistry } from "@/stores/resources/resources-registry";
 
 export type OwnerTeardownSnapshotArgs = {
   readonly epicId: string;
@@ -19,30 +18,42 @@ export type OwnerTeardownSnapshotArgs = {
 };
 
 /**
- * Gesture-time snapshot getter. Reads live stores at call time (not render
- * time / picker-open time) so disclosure content is never stale relative to
- * the click.
+ * Gesture-time snapshot getter. Shells are read from live stores at call
+ * time (not picker-open time) so disclosure content is never stale relative
+ * to the click.
  */
 export function useOwnerTeardownSnapshot(
   args: OwnerTeardownSnapshotArgs,
 ): (droppedRunDirectories: readonly string[]) => readonly WorktreeBusyHolder[] {
-  const argsRef = useRef(args);
-  argsRef.current = args;
-  return useCallback((droppedRunDirectories: readonly string[]) => {
-    const live = argsRef.current;
-    return snapshotOwnerTeardownHolders({
-      ownerRef: {
-        epicId: live.epicId,
-        ownerKind: live.ownerKind,
-        ownerId: live.ownerId,
-      },
-      ownerLabel: live.ownerLabel,
-      hasActiveTurn: live.hasActiveTurn,
-      ptyLive: live.ptyLive,
-      shells: collectOwnerShells(live),
-      droppedRunDirectories,
-    });
-  }, []);
+  const {
+    epicId,
+    hostId,
+    ownerKind,
+    ownerId,
+    ownerLabel,
+    hasActiveTurn,
+    ptyLive,
+  } = args;
+  return useCallback(
+    (droppedRunDirectories: readonly string[]) =>
+      snapshotOwnerTeardownHolders({
+        ownerRef: { epicId, ownerKind, ownerId },
+        ownerLabel,
+        hasActiveTurn,
+        ptyLive,
+        shells: collectOwnerShells({
+          epicId,
+          hostId,
+          ownerKind,
+          ownerId,
+          ownerLabel,
+          hasActiveTurn,
+          ptyLive,
+        }),
+        droppedRunDirectories,
+      }),
+    [epicId, hasActiveTurn, hostId, ownerId, ownerKind, ownerLabel, ptyLive],
+  );
 }
 
 function collectOwnerShells(
@@ -67,23 +78,6 @@ function collectOwnerShells(
         live,
       });
     }
-  }
-  const resourceOwners =
-    resourcesRegistry.get(args.epicId)?.store.getState().owners ??
-    new Map();
-  for (const snapshot of resourceOwners.values()) {
-    if (snapshot.owner.kind !== "managed-command") continue;
-    const managed = snapshot.managedCommand;
-    if (managed === null) continue;
-    if (managed.createdByAgentId !== args.ownerId) continue;
-    if (byId.has(managed.commandId)) continue;
-    byId.set(managed.commandId, {
-      id: managed.commandId,
-      description: managed.description,
-      command: null,
-      cwd: null,
-      live: true,
-    });
   }
   return [...byId.values()];
 }

--- a/clients/gui-app/src/hooks/worktree/use-owner-teardown-snapshot.ts
+++ b/clients/gui-app/src/hooks/worktree/use-owner-teardown-snapshot.ts
@@ -1,0 +1,89 @@
+import { useCallback, useRef } from "react";
+import type { WorktreeBusyHolder } from "@traycer/protocol/framework/worktree-busy-holders";
+import type { WorktreeBindingOwnerKind } from "@traycer/protocol/host/worktree-schemas";
+import { getChatSessionRegistry } from "@/lib/registries/chat-session-registry";
+import {
+  snapshotOwnerTeardownHolders,
+  type OwnerTeardownShell,
+} from "@/lib/worktree/owner-teardown-snapshot";
+import { resourcesRegistry } from "@/stores/resources/resources-registry";
+
+export type OwnerTeardownSnapshotArgs = {
+  readonly epicId: string;
+  readonly hostId: string;
+  readonly ownerKind: WorktreeBindingOwnerKind;
+  readonly ownerId: string;
+  readonly ownerLabel: string;
+  readonly hasActiveTurn: boolean;
+  readonly ptyLive: boolean;
+};
+
+/**
+ * Gesture-time snapshot getter. Reads live stores at call time (not render
+ * time / picker-open time) so disclosure content is never stale relative to
+ * the click.
+ */
+export function useOwnerTeardownSnapshot(
+  args: OwnerTeardownSnapshotArgs,
+): (droppedRunDirectories: readonly string[]) => readonly WorktreeBusyHolder[] {
+  const argsRef = useRef(args);
+  argsRef.current = args;
+  return useCallback((droppedRunDirectories: readonly string[]) => {
+    const live = argsRef.current;
+    return snapshotOwnerTeardownHolders({
+      ownerRef: {
+        epicId: live.epicId,
+        ownerKind: live.ownerKind,
+        ownerId: live.ownerId,
+      },
+      ownerLabel: live.ownerLabel,
+      hasActiveTurn: live.hasActiveTurn,
+      ptyLive: live.ptyLive,
+      shells: collectOwnerShells(live),
+      droppedRunDirectories,
+    });
+  }, []);
+}
+
+function collectOwnerShells(
+  args: OwnerTeardownSnapshotArgs,
+): readonly OwnerTeardownShell[] {
+  const byId = new Map<string, OwnerTeardownShell>();
+  if (args.ownerKind === "chat") {
+    const handle = getChatSessionRegistry().peek(
+      args.epicId,
+      args.ownerId,
+      args.hostId,
+    );
+    for (const command of handle?.store.getState().managedCommands ?? []) {
+      const live =
+        command.status.state === "running" ||
+        command.status.state === "interrupted";
+      byId.set(command.id, {
+        id: command.id,
+        description: command.description,
+        command: command.command,
+        cwd: command.cwd,
+        live,
+      });
+    }
+  }
+  const resourceOwners =
+    resourcesRegistry.get(args.epicId)?.store.getState().owners ??
+    new Map();
+  for (const snapshot of resourceOwners.values()) {
+    if (snapshot.owner.kind !== "managed-command") continue;
+    const managed = snapshot.managedCommand;
+    if (managed === null) continue;
+    if (managed.createdByAgentId !== args.ownerId) continue;
+    if (byId.has(managed.commandId)) continue;
+    byId.set(managed.commandId, {
+      id: managed.commandId,
+      description: managed.description,
+      command: null,
+      cwd: null,
+      live: true,
+    });
+  }
+  return [...byId.values()];
+}

--- a/clients/gui-app/src/hooks/worktree/use-worktree-create-mutation.ts
+++ b/clients/gui-app/src/hooks/worktree/use-worktree-create-mutation.ts
@@ -12,20 +12,27 @@ import { WORKTREE_BINDING_INVALIDATIONS } from "@/hooks/worktree/invalidations";
 
 export function useWorktreeCreateForClient(
   client: HostClient<HostRpcRegistry> | null,
+  silentCodes: readonly HostRpcError["code"][] | undefined,
 ): UseMutationResult<
   ResponseOfMethod<HostRpcRegistry, "worktree.create">,
   HostRpcError,
   RequestOfMethod<HostRpcRegistry, "worktree.create">,
   { readonly hostId: string | null }
 > {
-  return useHostScopedMutationForClient(client, worktreeCreateMutationArgs());
+  return useHostScopedMutationForClient(
+    client,
+    worktreeCreateMutationArgs(silentCodes),
+  );
 }
 
-function worktreeCreateMutationArgs() {
+function worktreeCreateMutationArgs(
+  silentCodes: readonly HostRpcError["code"][] | undefined,
+) {
   return {
     method: "worktree.create",
     mutationKey: worktreeMutationKeys.create(),
     errorMessage: "Couldn't create worktree.",
     invalidateMethods: WORKTREE_BINDING_INVALIDATIONS,
+    silentCodes,
   } as const;
 }

--- a/clients/gui-app/src/lib/path/cross-platform-path.ts
+++ b/clients/gui-app/src/lib/path/cross-platform-path.ts
@@ -177,6 +177,30 @@ function normalizePosixPreservingBackslashes(path: string): string {
   return joined.length > 0 ? joined : ".";
 }
 
+/**
+ * True when `candidate` is `root` or a descendant. Browser-safe: folds
+ * Windows separators, trailing seps, relative segments, and drive-letter
+ * case. POSIX paths keep literal backslashes so a `\` filename is not a
+ * separator.
+ */
+export function pathContainsDirectory(
+  root: string,
+  candidate: string,
+): boolean {
+  return (
+    stripRootPrefix(
+      stripTrailingSeparators(root),
+      stripTrailingSeparators(candidate),
+    ) !== null
+  );
+}
+
+function stripTrailingSeparators(path: string): string {
+  if (path === "/" || path === "\\") return path;
+  if (/^[A-Za-z]:[/\\]$/.test(path)) return path;
+  return path.replace(/[/\\]+$/, "");
+}
+
 function stripRootPrefix(root: string, path: string): string | null {
   const windowsLike = isWindowsLikePath(root) || isWindowsLikePath(path);
   const normalizedRoot = windowsLike

--- a/clients/gui-app/src/lib/worktree/__tests__/gui-composed-teardown.test.ts
+++ b/clients/gui-app/src/lib/worktree/__tests__/gui-composed-teardown.test.ts
@@ -22,6 +22,7 @@ describe("runGuiComposedTeardown", () => {
       ],
       stopShell,
       stopTurn: vi.fn(),
+      isCancelled: () => false,
     });
     expect(failures).toEqual([]);
     expect(stopShell).toHaveBeenCalledWith("sh-1");
@@ -48,6 +49,7 @@ describe("runGuiComposedTeardown", () => {
       ],
       stopShell,
       stopTurn: vi.fn(),
+      isCancelled: () => false,
     });
     expect(failures).toEqual([
       {
@@ -69,9 +71,37 @@ describe("runGuiComposedTeardown", () => {
       ],
       stopShell: vi.fn(),
       stopTurn,
+      isCancelled: () => false,
     });
     expect(failures).toEqual([]);
     expect(stopTurn).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops further targets once cancelled", async () => {
+    let cancelled = false;
+    const stopShell = vi.fn(() => {
+      cancelled = true;
+      return Promise.resolve();
+    });
+    const failures = await runGuiComposedTeardown({
+      stopTargets: [
+        {
+          kind: "supervised-shell",
+          commandId: "sh-1",
+          holderKey: "chat:c1:supervised-shell:npm run dev",
+        },
+        {
+          kind: "supervised-shell",
+          commandId: "sh-2",
+          holderKey: "chat:c1:supervised-shell:watch",
+        },
+      ],
+      stopShell,
+      stopTurn: vi.fn(),
+      isCancelled: () => cancelled,
+    });
+    expect(failures).toEqual([]);
+    expect(stopShell).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/clients/gui-app/src/lib/worktree/__tests__/gui-composed-teardown.test.ts
+++ b/clients/gui-app/src/lib/worktree/__tests__/gui-composed-teardown.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  failuresByHolderKey,
+  runGuiComposedTeardown,
+  teardownErrorMessage,
+} from "../gui-composed-teardown";
+
+describe("runGuiComposedTeardown", () => {
+  it("awaits each disclosed shell stop before returning", async () => {
+    const order: string[] = [];
+    const stopShell = vi.fn((commandId: string) => {
+      order.push(`stop:${commandId}`);
+      return Promise.resolve();
+    });
+    const failures = await runGuiComposedTeardown({
+      stopTargets: [
+        {
+          kind: "supervised-shell",
+          commandId: "sh-1",
+          holderKey: "chat:c1:supervised-shell:npm run dev",
+        },
+      ],
+      stopShell,
+      stopTurn: vi.fn(),
+    });
+    expect(failures).toEqual([]);
+    expect(stopShell).toHaveBeenCalledWith("sh-1");
+    expect(order).toEqual(["stop:sh-1"]);
+  });
+
+  it("names a failed stop and still attempts later targets", async () => {
+    const stopShell = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("shell still running"))
+      .mockResolvedValueOnce({});
+    const failures = await runGuiComposedTeardown({
+      stopTargets: [
+        {
+          kind: "supervised-shell",
+          commandId: "sh-1",
+          holderKey: "chat:c1:supervised-shell:npm run dev",
+        },
+        {
+          kind: "supervised-shell",
+          commandId: "sh-2",
+          holderKey: "chat:c1:supervised-shell:watch",
+        },
+      ],
+      stopShell,
+      stopTurn: vi.fn(),
+    });
+    expect(failures).toEqual([
+      {
+        holderKey: "chat:c1:supervised-shell:npm run dev",
+        message: "shell still running",
+      },
+    ]);
+    expect(stopShell).toHaveBeenCalledTimes(2);
+    expect(
+      failuresByHolderKey(failures)["chat:c1:supervised-shell:npm run dev"],
+    ).toBe("shell still running");
+  });
+
+  it("awaits a chat-turn stop", async () => {
+    const stopTurn = vi.fn(() => Promise.resolve());
+    const failures = await runGuiComposedTeardown({
+      stopTargets: [
+        { kind: "chat-turn", holderKey: "chat:c1:chat-turn:working" },
+      ],
+      stopShell: vi.fn(),
+      stopTurn,
+    });
+    expect(failures).toEqual([]);
+    expect(stopTurn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("teardownErrorMessage", () => {
+  it("reads an Error message and falls back otherwise", () => {
+    expect(teardownErrorMessage(new Error("nope"))).toBe("nope");
+    expect(teardownErrorMessage("nope")).toBe("Couldn't stop it.");
+  });
+});

--- a/clients/gui-app/src/lib/worktree/__tests__/owner-teardown-snapshot.test.ts
+++ b/clients/gui-app/src/lib/worktree/__tests__/owner-teardown-snapshot.test.ts
@@ -209,8 +209,8 @@ describe("snapshotOwnerTeardownHolders", () => {
     ).toEqual([]);
   });
 
-  it("includes a live shell on a retained path when a chat-turn will call agent.stop", () => {
-    const holders = snapshotOwnerTeardownHolders(
+  it("discloses a retained-path shell under agent.stop without a shell stop target", () => {
+    const snapshot = snapshotOwnerTeardown(
       input({
         hasActiveTurn: true,
         droppedRunDirectories: ["/wt/old"],
@@ -225,9 +225,45 @@ describe("snapshotOwnerTeardownHolders", () => {
         ],
       }),
     );
-    expect(holders.map((holder) => holder.label)).toEqual([
+    expect(snapshot.holders.map((holder) => holder.label)).toEqual([
       "Planner is working. Stopping the agent also stops its background shells and clears queued messages",
       "sleep 1",
+    ]);
+    expect(snapshot.stopTargets).toEqual([
+      {
+        kind: "chat-turn",
+        holderKey:
+          "chat:chat-1:chat-turn:Planner is working. Stopping the agent also stops its background shells and clears queued messages",
+      },
+    ]);
+  });
+
+  it("does not attach a dropped-path shell stop target when agent.stop covers the owner", () => {
+    const snapshot = snapshotOwnerTeardown(
+      input({
+        hasActiveTurn: true,
+        droppedRunDirectories: ["/wt/old"],
+        shells: [
+          {
+            id: "sh-old",
+            description: "watch",
+            command: "npm run dev",
+            cwd: "/wt/old",
+            live: true,
+          },
+        ],
+      }),
+    );
+    expect(snapshot.holders.map((holder) => holder.holdKind)).toEqual([
+      "chat-turn",
+      "supervised-shell",
+    ]);
+    expect(snapshot.stopTargets).toEqual([
+      {
+        kind: "chat-turn",
+        holderKey:
+          "chat:chat-1:chat-turn:Planner is working. Stopping the agent also stops its background shells and clears queued messages",
+      },
     ]);
   });
 

--- a/clients/gui-app/src/lib/worktree/__tests__/owner-teardown-snapshot.test.ts
+++ b/clients/gui-app/src/lib/worktree/__tests__/owner-teardown-snapshot.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from "vitest";
+import type { WorktreeBusyHolder } from "@traycer/protocol/framework/worktree-busy-holders";
+import type {
+  WorktreeBinding,
+  WorktreeBindingEntry,
+  WorktreeIntent,
+} from "@traycer/protocol/host/worktree-schemas";
+import {
+  droppedRunDirectoriesFromDraft,
+  pathContainsDirectory,
+  snapshotOwnerTeardownHolders,
+  type OwnerTeardownSnapshotInput,
+} from "../owner-teardown-snapshot";
+
+const OWNER: WorktreeBusyHolder["ownerRef"] = {
+  epicId: "epic-1",
+  ownerKind: "chat",
+  ownerId: "chat-1",
+};
+
+function bindingEntry(
+  workspacePath: string,
+  worktreePath: string | null,
+): WorktreeBindingEntry {
+  return {
+    workspacePath,
+    mode: worktreePath === null ? "local" : "worktree",
+    repoIdentifier: null,
+    worktreePath,
+    branch: worktreePath === null ? null : "feat",
+    isPrimary: true,
+    isImported: worktreePath !== null,
+    setupState: "not_required",
+    setupTerminalSessionId: null,
+    setupExitCode: null,
+    setupFailedAt: null,
+    createdAt: 0,
+  };
+}
+
+function binding(entries: readonly WorktreeBindingEntry[]): WorktreeBinding {
+  return { entries: [...entries] };
+}
+
+function input(
+  overrides: Partial<OwnerTeardownSnapshotInput>,
+): OwnerTeardownSnapshotInput {
+  return {
+    ownerRef: OWNER,
+    ownerLabel: "Planner",
+    hasActiveTurn: false,
+    ptyLive: false,
+    shells: [],
+    droppedRunDirectories: [],
+    ...overrides,
+  };
+}
+
+describe("snapshotOwnerTeardownHolders", () => {
+  it("returns nothing when the owner is idle with no shells", () => {
+    expect(snapshotOwnerTeardownHolders(input({}))).toEqual([]);
+  });
+
+  it("names a working chat turn", () => {
+    expect(snapshotOwnerTeardownHolders(input({ hasActiveTurn: true }))).toEqual(
+      [
+        {
+          ownerRef: OWNER,
+          holdKind: "chat-turn",
+          activity: "working",
+          label: "Planner is working",
+        },
+      ],
+    );
+  });
+
+  it("discloses a live PTY as a restart, not a loss", () => {
+    expect(snapshotOwnerTeardownHolders(input({ ptyLive: true }))).toEqual([
+      {
+        ownerRef: OWNER,
+        holdKind: "terminal-agent-pty",
+        activity: "working",
+        label: "Planner will restart in the new folder",
+      },
+    ]);
+  });
+
+  it("names a live shell on a dropped path by its command", () => {
+    const holders = snapshotOwnerTeardownHolders(
+      input({
+        droppedRunDirectories: ["/wt/old"],
+        shells: [
+          {
+            id: "sh-1",
+            description: "watch",
+            command: "npm run dev",
+            cwd: "/wt/old/apps",
+            live: true,
+          },
+          {
+            id: "sh-2",
+            description: "other",
+            command: "sleep 1",
+            cwd: "/wt/keep",
+            live: true,
+          },
+        ],
+      }),
+    );
+    expect(holders).toEqual([
+      {
+        ownerRef: OWNER,
+        holdKind: "supervised-shell",
+        activity: "working",
+        label: "npm run dev",
+      },
+    ]);
+  });
+
+  it("omits shells when the draft drops no run directories", () => {
+    expect(
+      snapshotOwnerTeardownHolders(
+        input({
+          shells: [
+            {
+              id: "sh-1",
+              description: "watch",
+              command: "npm run dev",
+              cwd: null,
+              live: true,
+            },
+          ],
+        }),
+      ),
+    ).toEqual([]);
+  });
+});
+
+describe("droppedRunDirectoriesFromDraft", () => {
+  it("drops the previous worktree when the draft switches to local", () => {
+    const draft: WorktreeIntent = {
+      entries: [
+        {
+          kind: "local",
+          workspacePath: "/src/app",
+          repoIdentifier: null,
+          isPrimary: true,
+        },
+      ],
+    };
+    expect(
+      droppedRunDirectoriesFromDraft({
+        binding: binding([bindingEntry("/src/app", "/wt/old")]),
+        draft,
+      }),
+    ).toEqual(["/wt/old"]);
+  });
+
+  it("returns empty when the draft keeps the same run directory", () => {
+    const draft: WorktreeIntent = {
+      entries: [
+        {
+          kind: "import",
+          workspacePath: "/src/app",
+          repoIdentifier: null,
+          isPrimary: true,
+          worktreePath: "/wt/old",
+        },
+      ],
+    };
+    expect(
+      droppedRunDirectoriesFromDraft({
+        binding: binding([bindingEntry("/src/app", "/wt/old")]),
+        draft,
+      }),
+    ).toEqual([]);
+  });
+});
+
+describe("pathContainsDirectory", () => {
+  it("treats equal and descendant paths as contained", () => {
+    expect(pathContainsDirectory("/wt/a", "/wt/a")).toBe(true);
+    expect(pathContainsDirectory("/wt/a", "/wt/a/src")).toBe(true);
+    expect(pathContainsDirectory("/wt/a", "/wt/ab")).toBe(false);
+  });
+});

--- a/clients/gui-app/src/lib/worktree/__tests__/owner-teardown-snapshot.test.ts
+++ b/clients/gui-app/src/lib/worktree/__tests__/owner-teardown-snapshot.test.ts
@@ -54,6 +54,8 @@ function input(
     ptyLive: false,
     shells: [],
     droppedRunDirectories: [],
+    queuedMessageCount: 0,
+    backgroundItemCount: 0,
     ...overrides,
   };
 }
@@ -63,7 +65,7 @@ describe("snapshotOwnerTeardownHolders", () => {
     expect(snapshotOwnerTeardownHolders(input({}))).toEqual([]);
   });
 
-  it("names a working chat turn", () => {
+  it("names a working chat turn and the agent.stop consequence", () => {
     expect(
       snapshotOwnerTeardownHolders(input({ hasActiveTurn: true })),
     ).toEqual([
@@ -71,7 +73,8 @@ describe("snapshotOwnerTeardownHolders", () => {
         ownerRef: OWNER,
         holdKind: "chat-turn",
         activity: "working",
-        label: "Planner is working",
+        label:
+          "Planner is working. Stopping the agent also stops its background shells and clears queued messages",
       },
     ]);
   });
@@ -192,7 +195,8 @@ describe("snapshotOwnerTeardownHolders", () => {
     ).toEqual([
       {
         kind: "chat-turn",
-        holderKey: "chat:chat-1:chat-turn:Planner is working",
+        holderKey:
+          "chat:chat-1:chat-turn:Planner is working. Stopping the agent also stops its background shells and clears queued messages",
       },
     ]);
     expect(
@@ -203,6 +207,36 @@ describe("snapshotOwnerTeardownHolders", () => {
         }),
       ).stopTargets,
     ).toEqual([]);
+  });
+
+  it("includes a live shell on a retained path when a chat-turn will call agent.stop", () => {
+    const holders = snapshotOwnerTeardownHolders(
+      input({
+        hasActiveTurn: true,
+        droppedRunDirectories: ["/wt/old"],
+        shells: [
+          {
+            id: "sh-keep",
+            description: "keep",
+            command: "sleep 1",
+            cwd: "/wt/keep",
+            live: true,
+          },
+        ],
+      }),
+    );
+    expect(holders.map((holder) => holder.label)).toEqual([
+      "Planner is working. Stopping the agent also stops its background shells and clears queued messages",
+      "sleep 1",
+    ]);
+  });
+
+  it("names queued work on the chat-turn row when evidence exists", () => {
+    expect(
+      snapshotOwnerTeardownHolders(
+        input({ hasActiveTurn: true, queuedMessageCount: 2 }),
+      )[0]?.label,
+    ).toBe("Planner is working. Stopping it also clears 2 queued messages");
   });
 
   it("includes a shell under a pending-removed folder in the teardown set", () => {

--- a/clients/gui-app/src/lib/worktree/__tests__/owner-teardown-snapshot.test.ts
+++ b/clients/gui-app/src/lib/worktree/__tests__/owner-teardown-snapshot.test.ts
@@ -8,7 +8,9 @@ import type {
 import {
   droppedRunDirectoriesFromDraft,
   pathContainsDirectory,
+  snapshotOwnerTeardown,
   snapshotOwnerTeardownHolders,
+  teardownHolderKey,
   type OwnerTeardownSnapshotInput,
 } from "../owner-teardown-snapshot";
 
@@ -151,6 +153,55 @@ describe("snapshotOwnerTeardownHolders", () => {
           ],
         }),
       ),
+    ).toEqual([]);
+  });
+
+  it("attaches a stop target with the shell id for GUI-composed teardown", () => {
+    const snapshot = snapshotOwnerTeardown(
+      input({
+        droppedRunDirectories: ["/wt/old"],
+        shells: [
+          {
+            id: "sh-1",
+            description: "watch",
+            command: "npm run dev",
+            cwd: "/wt/old",
+            live: true,
+          },
+        ],
+      }),
+    );
+    expect(snapshot.holders).toHaveLength(1);
+    expect(snapshot.stopTargets).toEqual([
+      {
+        kind: "supervised-shell",
+        commandId: "sh-1",
+        holderKey: teardownHolderKey({
+          ownerRef: OWNER,
+          holdKind: "supervised-shell",
+          activity: "working",
+          label: "npm run dev",
+        }),
+      },
+    ]);
+  });
+
+  it("attaches a chat-turn stop target only for chat owners", () => {
+    expect(
+      snapshotOwnerTeardown(input({ hasActiveTurn: true })).stopTargets,
+    ).toEqual([
+      {
+        kind: "chat-turn",
+        holderKey: "chat:chat-1:chat-turn:Planner is working",
+      },
+    ]);
+    expect(
+      snapshotOwnerTeardown(
+        input({
+          ownerRef: { ...OWNER, ownerKind: "terminal-agent" },
+          hasActiveTurn: true,
+        }),
+      ).stopTargets,
     ).toEqual([]);
   });
 

--- a/clients/gui-app/src/lib/worktree/__tests__/owner-teardown-snapshot.test.ts
+++ b/clients/gui-app/src/lib/worktree/__tests__/owner-teardown-snapshot.test.ts
@@ -11,6 +11,7 @@ import {
   snapshotOwnerTeardown,
   snapshotOwnerTeardownHolders,
   teardownHolderKey,
+  teardownHolderSetDrifted,
   type OwnerTeardownSnapshotInput,
 } from "../owner-teardown-snapshot";
 
@@ -68,7 +69,7 @@ describe("snapshotOwnerTeardownHolders", () => {
   it("names a working chat turn and the agent.stop consequence", () => {
     expect(
       snapshotOwnerTeardownHolders(input({ hasActiveTurn: true })),
-    ).toEqual([
+    ).toMatchObject([
       {
         ownerRef: OWNER,
         holdKind: "chat-turn",
@@ -80,14 +81,16 @@ describe("snapshotOwnerTeardownHolders", () => {
   });
 
   it("discloses a live PTY as a restart, not a loss", () => {
-    expect(snapshotOwnerTeardownHolders(input({ ptyLive: true }))).toEqual([
-      {
-        ownerRef: OWNER,
-        holdKind: "terminal-agent-pty",
-        activity: "working",
-        label: "Planner will restart in the new folder",
-      },
-    ]);
+    expect(snapshotOwnerTeardownHolders(input({ ptyLive: true }))).toMatchObject(
+      [
+        {
+          ownerRef: OWNER,
+          holdKind: "terminal-agent-pty",
+          activity: "working",
+          label: "Planner will restart in the new folder",
+        },
+      ],
+    );
   });
 
   it("names a live shell on a dropped path by its command", () => {
@@ -112,7 +115,7 @@ describe("snapshotOwnerTeardownHolders", () => {
         ],
       }),
     );
-    expect(holders).toEqual([
+    expect(holders).toMatchObject([
       {
         ownerRef: OWNER,
         holdKind: "supervised-shell",
@@ -179,12 +182,15 @@ describe("snapshotOwnerTeardownHolders", () => {
       {
         kind: "supervised-shell",
         commandId: "sh-1",
-        holderKey: teardownHolderKey({
-          ownerRef: OWNER,
-          holdKind: "supervised-shell",
-          activity: "working",
-          label: "npm run dev",
-        }),
+        holderKey: teardownHolderKey(
+          {
+            ownerRef: OWNER,
+            holdKind: "supervised-shell",
+            activity: "working",
+            label: "npm run dev",
+          },
+          "sh-1",
+        ),
       },
     ]);
   });
@@ -267,6 +273,68 @@ describe("snapshotOwnerTeardownHolders", () => {
     ]);
   });
 
+  it("gives each same-label shell a distinct holder key", () => {
+    const snapshot = snapshotOwnerTeardown(
+      input({
+        droppedRunDirectories: ["/wt/old"],
+        shells: [
+          {
+            id: "sh-1",
+            description: "watch",
+            command: "npm run dev",
+            cwd: "/wt/old",
+            live: true,
+          },
+          {
+            id: "sh-2",
+            description: "watch",
+            command: "npm run dev",
+            cwd: "/wt/old/apps",
+            live: true,
+          },
+        ],
+      }),
+    );
+    const keys = snapshot.holders.map((holder) => holder.holderKey);
+    expect(new Set(keys).size).toBe(2);
+    expect(snapshot.stopTargets.map((target) => target.holderKey)).toEqual(
+      keys,
+    );
+  });
+
+  it("includes a live Windows-cwd shell on a dropped Windows run directory", () => {
+    const snapshot = snapshotOwnerTeardown(
+      input({
+        droppedRunDirectories: ["C:\\wt\\old"],
+        shells: [
+          {
+            id: "sh-win",
+            description: "watch",
+            command: "npm run dev",
+            cwd: "C:\\wt\\old\\apps",
+            live: true,
+          },
+        ],
+      }),
+    );
+    expect(snapshot.holders).toHaveLength(1);
+    expect(snapshot.stopTargets).toEqual([
+      {
+        kind: "supervised-shell",
+        commandId: "sh-win",
+        holderKey: teardownHolderKey(
+          {
+            ownerRef: OWNER,
+            holdKind: "supervised-shell",
+            activity: "working",
+            label: "npm run dev",
+          },
+          "sh-win",
+        ),
+      },
+    ]);
+  });
+
   it("names queued work on the chat-turn row when evidence exists", () => {
     expect(
       snapshotOwnerTeardownHolders(
@@ -300,7 +368,7 @@ describe("snapshotOwnerTeardownHolders", () => {
           ],
         }),
       ),
-    ).toEqual([
+    ).toMatchObject([
       {
         ownerRef: OWNER,
         holdKind: "supervised-shell",
@@ -308,6 +376,48 @@ describe("snapshotOwnerTeardownHolders", () => {
         label: "npm run dev",
       },
     ]);
+  });
+});
+
+describe("teardownHolderSetDrifted", () => {
+  it("detects a holder appearing after disclosure", () => {
+    const disclosed = snapshotOwnerTeardown(
+      input({
+        droppedRunDirectories: ["/wt/old"],
+        shells: [
+          {
+            id: "sh-1",
+            description: "watch",
+            command: "npm run dev",
+            cwd: "/wt/old",
+            live: true,
+          },
+        ],
+      }),
+    ).holders;
+    const live = snapshotOwnerTeardown(
+      input({
+        droppedRunDirectories: ["/wt/old"],
+        shells: [
+          {
+            id: "sh-1",
+            description: "watch",
+            command: "npm run dev",
+            cwd: "/wt/old",
+            live: true,
+          },
+          {
+            id: "sh-2",
+            description: "watch",
+            command: "sleep 1",
+            cwd: "/wt/old",
+            live: true,
+          },
+        ],
+      }),
+    ).holders;
+    expect(teardownHolderSetDrifted(disclosed, disclosed)).toBe(false);
+    expect(teardownHolderSetDrifted(disclosed, live)).toBe(true);
   });
 });
 
@@ -359,5 +469,19 @@ describe("pathContainsDirectory", () => {
     expect(pathContainsDirectory("/wt/a", "/wt/a")).toBe(true);
     expect(pathContainsDirectory("/wt/a", "/wt/a/src")).toBe(true);
     expect(pathContainsDirectory("/wt/a", "/wt/ab")).toBe(false);
+  });
+
+  it("contains Windows-separator descendants after normalizing drive case and trailing seps", () => {
+    expect(pathContainsDirectory("C:\\wt\\old", "C:\\wt\\old\\apps")).toBe(
+      true,
+    );
+    expect(pathContainsDirectory("C:\\wt\\old\\", "C:\\wt\\old")).toBe(true);
+    expect(pathContainsDirectory("c:\\wt\\old", "C:\\wt\\old\\apps")).toBe(
+      true,
+    );
+    expect(pathContainsDirectory("C:\\wt\\old", "C:\\wt\\other")).toBe(false);
+    expect(
+      pathContainsDirectory("C:\\wt\\old", "C:\\wt\\old\\..\\other"),
+    ).toBe(false);
   });
 });

--- a/clients/gui-app/src/lib/worktree/__tests__/owner-teardown-snapshot.test.ts
+++ b/clients/gui-app/src/lib/worktree/__tests__/owner-teardown-snapshot.test.ts
@@ -62,16 +62,16 @@ describe("snapshotOwnerTeardownHolders", () => {
   });
 
   it("names a working chat turn", () => {
-    expect(snapshotOwnerTeardownHolders(input({ hasActiveTurn: true }))).toEqual(
-      [
-        {
-          ownerRef: OWNER,
-          holdKind: "chat-turn",
-          activity: "working",
-          label: "Planner is working",
-        },
-      ],
-    );
+    expect(
+      snapshotOwnerTeardownHolders(input({ hasActiveTurn: true })),
+    ).toEqual([
+      {
+        ownerRef: OWNER,
+        holdKind: "chat-turn",
+        activity: "working",
+        label: "Planner is working",
+      },
+    ]);
   });
 
   it("discloses a live PTY as a restart, not a loss", () => {
@@ -134,6 +134,60 @@ describe("snapshotOwnerTeardownHolders", () => {
       ),
     ).toEqual([]);
   });
+
+  it("excludes a live shell whose cwd is unknown even when paths are dropped", () => {
+    expect(
+      snapshotOwnerTeardownHolders(
+        input({
+          droppedRunDirectories: ["/wt/old"],
+          shells: [
+            {
+              id: "sh-unknown",
+              description: "watch",
+              command: "npm run dev",
+              cwd: null,
+              live: true,
+            },
+          ],
+        }),
+      ),
+    ).toEqual([]);
+  });
+
+  it("includes a shell under a pending-removed folder in the teardown set", () => {
+    const dropped = droppedRunDirectoriesFromDraft({
+      binding: binding([
+        bindingEntry("/src/a", "/wt/a"),
+        bindingEntry("/src/b", "/wt/b"),
+      ]),
+      draft: null,
+      removedWorkspacePaths: ["/src/b"],
+    });
+    expect(dropped).toEqual(["/wt/b"]);
+    expect(
+      snapshotOwnerTeardownHolders(
+        input({
+          droppedRunDirectories: dropped,
+          shells: [
+            {
+              id: "sh-b",
+              description: "watch",
+              command: "npm run dev",
+              cwd: "/wt/b/apps",
+              live: true,
+            },
+          ],
+        }),
+      ),
+    ).toEqual([
+      {
+        ownerRef: OWNER,
+        holdKind: "supervised-shell",
+        activity: "working",
+        label: "npm run dev",
+      },
+    ]);
+  });
 });
 
 describe("droppedRunDirectoriesFromDraft", () => {
@@ -152,6 +206,7 @@ describe("droppedRunDirectoriesFromDraft", () => {
       droppedRunDirectoriesFromDraft({
         binding: binding([bindingEntry("/src/app", "/wt/old")]),
         draft,
+        removedWorkspacePaths: [],
       }),
     ).toEqual(["/wt/old"]);
   });
@@ -172,6 +227,7 @@ describe("droppedRunDirectoriesFromDraft", () => {
       droppedRunDirectoriesFromDraft({
         binding: binding([bindingEntry("/src/app", "/wt/old")]),
         draft,
+        removedWorkspacePaths: [],
       }),
     ).toEqual([]);
   });

--- a/clients/gui-app/src/lib/worktree/__tests__/owner-teardown-snapshot.test.ts
+++ b/clients/gui-app/src/lib/worktree/__tests__/owner-teardown-snapshot.test.ts
@@ -81,16 +81,16 @@ describe("snapshotOwnerTeardownHolders", () => {
   });
 
   it("discloses a live PTY as a restart, not a loss", () => {
-    expect(snapshotOwnerTeardownHolders(input({ ptyLive: true }))).toMatchObject(
-      [
-        {
-          ownerRef: OWNER,
-          holdKind: "terminal-agent-pty",
-          activity: "working",
-          label: "Planner will restart in the new folder",
-        },
-      ],
-    );
+    expect(
+      snapshotOwnerTeardownHolders(input({ ptyLive: true })),
+    ).toMatchObject([
+      {
+        ownerRef: OWNER,
+        holdKind: "terminal-agent-pty",
+        activity: "working",
+        label: "Planner will restart in the new folder",
+      },
+    ]);
   });
 
   it("names a live shell on a dropped path by its command", () => {
@@ -480,8 +480,8 @@ describe("pathContainsDirectory", () => {
       true,
     );
     expect(pathContainsDirectory("C:\\wt\\old", "C:\\wt\\other")).toBe(false);
-    expect(
-      pathContainsDirectory("C:\\wt\\old", "C:\\wt\\old\\..\\other"),
-    ).toBe(false);
+    expect(pathContainsDirectory("C:\\wt\\old", "C:\\wt\\old\\..\\other")).toBe(
+      false,
+    );
   });
 });

--- a/clients/gui-app/src/lib/worktree/__tests__/worktree-commit-capture.test.ts
+++ b/clients/gui-app/src/lib/worktree/__tests__/worktree-commit-capture.test.ts
@@ -44,7 +44,7 @@ function capture(
 describe("takeArmedTeardownSubmit", () => {
   it("consumes the armed payload so a later take cannot reuse it", () => {
     const slot: { current: ArmedTeardownSubmit<string> | null } = {
-      current: { input: "send-a", capture: capture({}) },
+      current: { input: "send-a", capture: capture({}), ownerId: "chat-1" },
     };
     expect(takeArmedTeardownSubmit(slot)?.input).toBe("send-a");
     expect(takeArmedTeardownSubmit(slot)).toBeNull();

--- a/clients/gui-app/src/lib/worktree/__tests__/worktree-commit-capture.test.ts
+++ b/clients/gui-app/src/lib/worktree/__tests__/worktree-commit-capture.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import type { WorktreeIntent } from "@traycer/protocol/host/worktree-schemas";
+import {
+  takeArmedTeardownSubmit,
+  worktreeCommitCaptureIsStale,
+  type ArmedTeardownSubmit,
+  type WorktreeCommitCapture,
+} from "../worktree-commit-capture";
+
+const draftA: WorktreeIntent = {
+  entries: [
+    {
+      kind: "local",
+      workspacePath: "/src/a",
+      repoIdentifier: null,
+      isPrimary: true,
+    },
+  ],
+};
+const draftB: WorktreeIntent = {
+  entries: [
+    {
+      kind: "local",
+      workspacePath: "/src/b",
+      repoIdentifier: null,
+      isPrimary: true,
+    },
+  ],
+};
+
+function capture(
+  overrides: Partial<WorktreeCommitCapture>,
+): WorktreeCommitCapture {
+  return {
+    draft: draftA,
+    revision: 1,
+    binding: { entries: [] },
+    removedWorkspacePaths: [],
+    ...overrides,
+  };
+}
+
+describe("takeArmedTeardownSubmit", () => {
+  it("consumes the armed payload so a later take cannot reuse it", () => {
+    const slot: { current: ArmedTeardownSubmit<string> | null } = {
+      current: { input: "send-a", capture: capture({}) },
+    };
+    expect(takeArmedTeardownSubmit(slot)?.input).toBe("send-a");
+    expect(takeArmedTeardownSubmit(slot)).toBeNull();
+  });
+});
+
+describe("worktreeCommitCaptureIsStale", () => {
+  it("is stale when staging mutates to a different draft after disclosure", () => {
+    expect(
+      worktreeCommitCaptureIsStale(
+        capture({ draft: draftA, revision: 1 }),
+        capture({ draft: draftB, revision: 2 }),
+      ),
+    ).toBe(true);
+  });
+
+  it("is stale when a folder is removed after disclosure", () => {
+    expect(
+      worktreeCommitCaptureIsStale(
+        capture({ removedWorkspacePaths: [] }),
+        capture({ removedWorkspacePaths: ["/src/b"] }),
+      ),
+    ).toBe(true);
+  });
+
+  it("is current when draft, revision, binding, and removals match", () => {
+    const value = capture({
+      draft: draftA,
+      revision: 4,
+      removedWorkspacePaths: ["/src/b"],
+    });
+    expect(worktreeCommitCaptureIsStale(value, { ...value })).toBe(false);
+  });
+});

--- a/clients/gui-app/src/lib/worktree/__tests__/worktree-commit-capture.test.ts
+++ b/clients/gui-app/src/lib/worktree/__tests__/worktree-commit-capture.test.ts
@@ -36,6 +36,7 @@ function capture(
     revision: 1,
     binding: { entries: [] },
     removedWorkspacePaths: [],
+    stopTargets: [],
     ...overrides,
   };
 }

--- a/clients/gui-app/src/lib/worktree/gui-composed-teardown.ts
+++ b/clients/gui-app/src/lib/worktree/gui-composed-teardown.ts
@@ -1,0 +1,55 @@
+import type { TeardownStopTarget } from "@/lib/worktree/owner-teardown-snapshot";
+
+/**
+ * Phase-1 GUI-composed teardown. `worktree.create` has no `commitIntent`
+ * (protocol is frozen behind the pin), so the GUI stops exactly the
+ * owner-scoped holders it disclosed — managed-command stop for supervised
+ * shells, `agent.stop` for a chat turn — then mutates the binding. Upgrade
+ * with `listHolders` + create-with-intent in the same follow-up as the
+ * snapshot provider.
+ *
+ * Partial failure is consequential: if any stop fails, the caller must not
+ * proceed with remove/create, and must name the failure on that holder row.
+ */
+export type HolderTeardownFailure = {
+  readonly holderKey: string;
+  readonly message: string;
+};
+
+export function failuresByHolderKey(
+  failures: readonly HolderTeardownFailure[],
+): Readonly<Record<string, string>> {
+  const record: Record<string, string> = {};
+  for (const failure of failures) {
+    record[failure.holderKey] = failure.message;
+  }
+  return record;
+}
+
+export function teardownErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message.length > 0) return error.message;
+  return "Couldn't stop it.";
+}
+
+export async function runGuiComposedTeardown(input: {
+  readonly stopTargets: readonly TeardownStopTarget[];
+  readonly stopShell: (commandId: string) => Promise<unknown>;
+  readonly stopTurn: () => Promise<unknown>;
+}): Promise<readonly HolderTeardownFailure[]> {
+  const failures: HolderTeardownFailure[] = [];
+  for (const target of input.stopTargets) {
+    try {
+      if (target.kind === "supervised-shell") {
+        await input.stopShell(target.commandId);
+      } else {
+        await input.stopTurn();
+      }
+    } catch (error: unknown) {
+      failures.push({
+        holderKey: target.holderKey,
+        message: teardownErrorMessage(error),
+      });
+    }
+  }
+  return failures;
+}

--- a/clients/gui-app/src/lib/worktree/gui-composed-teardown.ts
+++ b/clients/gui-app/src/lib/worktree/gui-composed-teardown.ts
@@ -35,9 +35,11 @@ export async function runGuiComposedTeardown(input: {
   readonly stopTargets: readonly TeardownStopTarget[];
   readonly stopShell: (commandId: string) => Promise<unknown>;
   readonly stopTurn: () => Promise<unknown>;
+  readonly isCancelled: () => boolean;
 }): Promise<readonly HolderTeardownFailure[]> {
   const failures: HolderTeardownFailure[] = [];
   for (const target of input.stopTargets) {
+    if (input.isCancelled()) return failures;
     try {
       if (target.kind === "supervised-shell") {
         await input.stopShell(target.commandId);
@@ -50,6 +52,7 @@ export async function runGuiComposedTeardown(input: {
         message: teardownErrorMessage(error),
       });
     }
+    if (input.isCancelled()) return failures;
   }
   return failures;
 }

--- a/clients/gui-app/src/lib/worktree/is-worktree-rebind-blocked.ts
+++ b/clients/gui-app/src/lib/worktree/is-worktree-rebind-blocked.ts
@@ -1,0 +1,7 @@
+import { HostRpcError } from "@traycer-clients/shared/host-transport/host-messenger";
+
+export function isWorktreeRebindBlocked(error: unknown): boolean {
+  return (
+    error instanceof HostRpcError && error.code === "WORKTREE_REBIND_BLOCKED"
+  );
+}

--- a/clients/gui-app/src/lib/worktree/owner-teardown-snapshot.ts
+++ b/clients/gui-app/src/lib/worktree/owner-teardown-snapshot.ts
@@ -1,0 +1,145 @@
+import type { WorktreeBusyHolder } from "@traycer/protocol/framework/worktree-busy-holders";
+import type {
+  WorktreeBinding,
+  WorktreeBindingEntry,
+  WorktreeFolderIntent,
+  WorktreeIntent,
+} from "@traycer/protocol/host/worktree-schemas";
+
+/**
+ * Phase-1 (client-local) owner-scoped teardown snapshot.
+ *
+ * Synthesizes the T2 `WorktreeBusyHolder` shape so `TeardownDisclosure` does
+ * not know where the list came from. When the host-authoritative
+ * `listHolders` minor lands (path-scoped with optional owner filter), only
+ * this provider changes.
+ *
+ * Known gaps vs the T6 inventory, acceptable at gesture time because neither
+ * is a user-stoppable thing here:
+ * - host-only `active-run-cwd` marks after a partial rebind
+ * - grace-window PTYs (no live session in the terminal store)
+ */
+export type OwnerTeardownShell = {
+  readonly id: string;
+  readonly description: string;
+  readonly command: string | null;
+  readonly cwd: string | null;
+  readonly live: boolean;
+};
+
+export type OwnerTeardownSnapshotInput = {
+  readonly ownerRef: WorktreeBusyHolder["ownerRef"];
+  readonly ownerLabel: string;
+  readonly hasActiveTurn: boolean;
+  readonly ptyLive: boolean;
+  readonly shells: readonly OwnerTeardownShell[];
+  readonly droppedRunDirectories: readonly string[];
+};
+
+export function runDirectoryOfBindingEntry(
+  entry: WorktreeBindingEntry,
+): string {
+  return entry.worktreePath ?? entry.workspacePath;
+}
+
+export function runDirectoryOfFolderIntent(
+  entry: WorktreeFolderIntent,
+): string | null {
+  if (entry.kind === "import") return entry.worktreePath;
+  if (entry.kind === "local") return entry.workspacePath;
+  return null;
+}
+
+/**
+ * Run directories the draft would leave: each staged folder whose next run
+ * directory differs from the live binding. Staged intent is a sparse overlay
+ * (changed folders only), so unstaged binding entries are not dropped.
+ */
+export function droppedRunDirectoriesFromDraft(input: {
+  readonly binding: WorktreeBinding | null;
+  readonly draft: WorktreeIntent | null;
+}): readonly string[] {
+  if (input.draft === null) return [];
+  const previousByWorkspace = new Map(
+    (input.binding?.entries ?? []).map((entry) => [
+      entry.workspacePath,
+      runDirectoryOfBindingEntry(entry),
+    ]),
+  );
+  const dropped: string[] = [];
+  const seen = new Set<string>();
+  for (const entry of input.draft.entries) {
+    const previous = previousByWorkspace.get(entry.workspacePath);
+    if (previous === undefined) continue;
+    const next = runDirectoryOfFolderIntent(entry);
+    if (next === previous) continue;
+    if (seen.has(previous)) continue;
+    seen.add(previous);
+    dropped.push(previous);
+  }
+  return dropped;
+}
+
+export function pathContainsDirectory(
+  root: string,
+  candidate: string,
+): boolean {
+  const normalizedRoot = root.replace(/\/+$/, "");
+  const normalizedCandidate = candidate.replace(/\/+$/, "");
+  return (
+    normalizedCandidate === normalizedRoot ||
+    normalizedCandidate.startsWith(`${normalizedRoot}/`)
+  );
+}
+
+export function snapshotOwnerTeardownHolders(
+  input: OwnerTeardownSnapshotInput,
+): readonly WorktreeBusyHolder[] {
+  const holders: WorktreeBusyHolder[] = [];
+  if (input.hasActiveTurn) {
+    holders.push({
+      ownerRef: input.ownerRef,
+      holdKind: "chat-turn",
+      activity: "working",
+      label: `${input.ownerLabel} is working`,
+    });
+  }
+  if (input.ptyLive) {
+    holders.push({
+      ownerRef: input.ownerRef,
+      holdKind: "terminal-agent-pty",
+      activity: "working",
+      label: `${input.ownerLabel} will restart in the new folder`,
+    });
+  }
+  for (const shell of input.shells) {
+    if (!shell.live) continue;
+    if (!shellBelongsToDroppedPaths(shell, input.droppedRunDirectories)) {
+      continue;
+    }
+    holders.push({
+      ownerRef: input.ownerRef,
+      holdKind: "supervised-shell",
+      activity: "working",
+      label: shellLabel(shell),
+    });
+  }
+  return holders;
+}
+
+function shellBelongsToDroppedPaths(
+  shell: OwnerTeardownShell,
+  droppedRunDirectories: readonly string[],
+): boolean {
+  if (droppedRunDirectories.length === 0) return false;
+  if (shell.cwd === null) return true;
+  return droppedRunDirectories.some((root) =>
+    pathContainsDirectory(root, shell.cwd ?? ""),
+  );
+}
+
+function shellLabel(shell: OwnerTeardownShell): string {
+  if (shell.command !== null && shell.command.length > 0) return shell.command;
+  if (shell.description.length > 0) return shell.description;
+  return "Background shell";
+}

--- a/clients/gui-app/src/lib/worktree/owner-teardown-snapshot.ts
+++ b/clients/gui-app/src/lib/worktree/owner-teardown-snapshot.ts
@@ -39,6 +39,26 @@ export type OwnerTeardownSnapshotInput = {
   readonly droppedRunDirectories: readonly string[];
 };
 
+export type TeardownStopTarget =
+  | {
+      readonly kind: "supervised-shell";
+      readonly commandId: string;
+      readonly holderKey: string;
+    }
+  | {
+      readonly kind: "chat-turn";
+      readonly holderKey: string;
+    };
+
+export type OwnerTeardownSnapshot = {
+  readonly holders: readonly WorktreeBusyHolder[];
+  readonly stopTargets: readonly TeardownStopTarget[];
+};
+
+export function teardownHolderKey(holder: WorktreeBusyHolder): string {
+  return `${holder.ownerRef.ownerKind}:${holder.ownerRef.ownerId}:${holder.holdKind}:${holder.label}`;
+}
+
 export function runDirectoryOfBindingEntry(
   entry: WorktreeBindingEntry,
 ): string {
@@ -107,17 +127,25 @@ export function pathContainsDirectory(
   );
 }
 
-export function snapshotOwnerTeardownHolders(
+export function snapshotOwnerTeardown(
   input: OwnerTeardownSnapshotInput,
-): readonly WorktreeBusyHolder[] {
+): OwnerTeardownSnapshot {
   const holders: WorktreeBusyHolder[] = [];
+  const stopTargets: TeardownStopTarget[] = [];
   if (input.hasActiveTurn) {
-    holders.push({
+    const holder: WorktreeBusyHolder = {
       ownerRef: input.ownerRef,
       holdKind: "chat-turn",
       activity: "working",
       label: `${input.ownerLabel} is working`,
-    });
+    };
+    holders.push(holder);
+    if (input.ownerRef.ownerKind === "chat") {
+      stopTargets.push({
+        kind: "chat-turn",
+        holderKey: teardownHolderKey(holder),
+      });
+    }
   }
   if (input.ptyLive) {
     holders.push({
@@ -132,14 +160,26 @@ export function snapshotOwnerTeardownHolders(
     if (!shellBelongsToDroppedPaths(shell, input.droppedRunDirectories)) {
       continue;
     }
-    holders.push({
+    const holder: WorktreeBusyHolder = {
       ownerRef: input.ownerRef,
       holdKind: "supervised-shell",
       activity: "working",
       label: shellLabel(shell),
+    };
+    holders.push(holder);
+    stopTargets.push({
+      kind: "supervised-shell",
+      commandId: shell.id,
+      holderKey: teardownHolderKey(holder),
     });
   }
-  return holders;
+  return { holders, stopTargets };
+}
+
+export function snapshotOwnerTeardownHolders(
+  input: OwnerTeardownSnapshotInput,
+): readonly WorktreeBusyHolder[] {
+  return snapshotOwnerTeardown(input).holders;
 }
 
 function shellBelongsToDroppedPaths(

--- a/clients/gui-app/src/lib/worktree/owner-teardown-snapshot.ts
+++ b/clients/gui-app/src/lib/worktree/owner-teardown-snapshot.ts
@@ -14,10 +14,13 @@ import type {
  * `listHolders` minor lands (path-scoped with optional owner filter), only
  * this provider changes.
  *
- * Known gaps vs the T6 inventory, acceptable at gesture time because neither
- * is a user-stoppable thing here:
+ * Known gaps vs the T6 inventory, acceptable at gesture time because they
+ * are not a user-stoppable thing here, or cannot be proven from GUI state:
  * - host-only `active-run-cwd` marks after a partial rebind
  * - grace-window PTYs (no live session in the terminal store)
+ * - TUI-owned (and any other) supervised shells whose host or cwd is
+ *   unproven — the resource projection has no cwd and is not
+ *   host-attributed, so those rows are omitted rather than over-matched
  */
 export type OwnerTeardownShell = {
   readonly id: string;
@@ -52,14 +55,16 @@ export function runDirectoryOfFolderIntent(
 
 /**
  * Run directories the draft would leave: each staged folder whose next run
- * directory differs from the live binding. Staged intent is a sparse overlay
- * (changed folders only), so unstaged binding entries are not dropped.
+ * directory differs from the live binding, plus each pending-removed folder's
+ * current run directory. Staged intent is a sparse overlay (changed folders
+ * only), so unstaged binding entries are not dropped unless listed in
+ * `removedWorkspacePaths`.
  */
 export function droppedRunDirectoriesFromDraft(input: {
   readonly binding: WorktreeBinding | null;
   readonly draft: WorktreeIntent | null;
+  readonly removedWorkspacePaths: readonly string[];
 }): readonly string[] {
-  if (input.draft === null) return [];
   const previousByWorkspace = new Map(
     (input.binding?.entries ?? []).map((entry) => [
       entry.workspacePath,
@@ -68,14 +73,24 @@ export function droppedRunDirectoriesFromDraft(input: {
   );
   const dropped: string[] = [];
   const seen = new Set<string>();
-  for (const entry of input.draft.entries) {
-    const previous = previousByWorkspace.get(entry.workspacePath);
+  const pushDropped = (path: string): void => {
+    if (seen.has(path)) return;
+    seen.add(path);
+    dropped.push(path);
+  };
+  if (input.draft !== null) {
+    for (const entry of input.draft.entries) {
+      const previous = previousByWorkspace.get(entry.workspacePath);
+      if (previous === undefined) continue;
+      const next = runDirectoryOfFolderIntent(entry);
+      if (next === previous) continue;
+      pushDropped(previous);
+    }
+  }
+  for (const workspacePath of input.removedWorkspacePaths) {
+    const previous = previousByWorkspace.get(workspacePath);
     if (previous === undefined) continue;
-    const next = runDirectoryOfFolderIntent(entry);
-    if (next === previous) continue;
-    if (seen.has(previous)) continue;
-    seen.add(previous);
-    dropped.push(previous);
+    pushDropped(previous);
   }
   return dropped;
 }
@@ -132,10 +147,9 @@ function shellBelongsToDroppedPaths(
   droppedRunDirectories: readonly string[],
 ): boolean {
   if (droppedRunDirectories.length === 0) return false;
-  if (shell.cwd === null) return true;
-  return droppedRunDirectories.some((root) =>
-    pathContainsDirectory(root, shell.cwd ?? ""),
-  );
+  const cwd = shell.cwd;
+  if (cwd === null) return false;
+  return droppedRunDirectories.some((root) => pathContainsDirectory(root, cwd));
 }
 
 function shellLabel(shell: OwnerTeardownShell): string {

--- a/clients/gui-app/src/lib/worktree/owner-teardown-snapshot.ts
+++ b/clients/gui-app/src/lib/worktree/owner-teardown-snapshot.ts
@@ -173,11 +173,17 @@ export function snapshotOwnerTeardown(
       label: shellLabel(shell),
     };
     holders.push(holder);
-    stopTargets.push({
-      kind: "supervised-shell",
-      commandId: shell.id,
-      holderKey: teardownHolderKey(holder),
-    });
+    // agent.stop already awaits stopCommandsForAgent for every owner
+    // shell. Expanded consequence rows are disclosure-only so a
+    // follow-up managedCommand.stop cannot reject after teardown
+    // succeeded and block the binding commit.
+    if (!agentStopClearsOwner) {
+      stopTargets.push({
+        kind: "supervised-shell",
+        commandId: shell.id,
+        holderKey: teardownHolderKey(holder),
+      });
+    }
   }
   return { holders, stopTargets };
 }

--- a/clients/gui-app/src/lib/worktree/owner-teardown-snapshot.ts
+++ b/clients/gui-app/src/lib/worktree/owner-teardown-snapshot.ts
@@ -5,6 +5,7 @@ import type {
   WorktreeFolderIntent,
   WorktreeIntent,
 } from "@traycer/protocol/host/worktree-schemas";
+import { pathContainsDirectory as pathIsUnderRoot } from "@/lib/path/cross-platform-path";
 
 /**
  * Phase-1 (client-local) owner-scoped teardown snapshot.
@@ -52,13 +53,38 @@ export type TeardownStopTarget =
       readonly holderKey: string;
     };
 
+export type DisclosedTeardownHolder = WorktreeBusyHolder & {
+  readonly holderKey: string;
+};
+
 export type OwnerTeardownSnapshot = {
-  readonly holders: readonly WorktreeBusyHolder[];
+  readonly holders: readonly DisclosedTeardownHolder[];
   readonly stopTargets: readonly TeardownStopTarget[];
 };
 
-export function teardownHolderKey(holder: WorktreeBusyHolder): string {
-  return `${holder.ownerRef.ownerKind}:${holder.ownerRef.ownerId}:${holder.holdKind}:${holder.label}`;
+export function teardownHolderKey(
+  holder: WorktreeBusyHolder,
+  uniqueId: string | undefined = undefined,
+): string {
+  const base = `${holder.ownerRef.ownerKind}:${holder.ownerRef.ownerId}:${holder.holdKind}:${holder.label}`;
+  return uniqueId === undefined ? base : `${base}:${uniqueId}`;
+}
+
+export function teardownHolderRowKey(holder: WorktreeBusyHolder): string {
+  if ("holderKey" in holder) {
+    return (holder as DisclosedTeardownHolder).holderKey;
+  }
+  return teardownHolderKey(holder);
+}
+
+export function teardownHolderSetDrifted(
+  disclosed: readonly WorktreeBusyHolder[],
+  live: readonly WorktreeBusyHolder[],
+): boolean {
+  if (disclosed.length !== live.length) return true;
+  const left = disclosed.map(teardownHolderRowKey).sort();
+  const right = live.map(teardownHolderRowKey).sort();
+  return left.some((key, index) => key !== right[index]);
 }
 
 export function runDirectoryOfBindingEntry(
@@ -121,42 +147,39 @@ export function pathContainsDirectory(
   root: string,
   candidate: string,
 ): boolean {
-  const normalizedRoot = root.replace(/\/+$/, "");
-  const normalizedCandidate = candidate.replace(/\/+$/, "");
-  return (
-    normalizedCandidate === normalizedRoot ||
-    normalizedCandidate.startsWith(`${normalizedRoot}/`)
-  );
+  return pathIsUnderRoot(root, candidate);
 }
 
 export function snapshotOwnerTeardown(
   input: OwnerTeardownSnapshotInput,
 ): OwnerTeardownSnapshot {
-  const holders: WorktreeBusyHolder[] = [];
+  const holders: DisclosedTeardownHolder[] = [];
   const stopTargets: TeardownStopTarget[] = [];
   const agentStopClearsOwner = chatTurnWillCallAgentStop(input);
   if (input.hasActiveTurn) {
-    const holder: WorktreeBusyHolder = {
+    const holder = disclosedHolder({
       ownerRef: input.ownerRef,
       holdKind: "chat-turn",
       activity: "working",
       label: chatTurnHolderLabel(input, agentStopClearsOwner),
-    };
+    });
     holders.push(holder);
     if (agentStopClearsOwner) {
       stopTargets.push({
         kind: "chat-turn",
-        holderKey: teardownHolderKey(holder),
+        holderKey: holder.holderKey,
       });
     }
   }
   if (input.ptyLive) {
-    holders.push({
-      ownerRef: input.ownerRef,
-      holdKind: "terminal-agent-pty",
-      activity: "working",
-      label: `${input.ownerLabel} will restart in the new folder`,
-    });
+    holders.push(
+      disclosedHolder({
+        ownerRef: input.ownerRef,
+        holdKind: "terminal-agent-pty",
+        activity: "working",
+        label: `${input.ownerLabel} will restart in the new folder`,
+      }),
+    );
   }
   for (const shell of input.shells) {
     if (!shell.live) continue;
@@ -166,12 +189,15 @@ export function snapshotOwnerTeardown(
     ) {
       continue;
     }
-    const holder: WorktreeBusyHolder = {
-      ownerRef: input.ownerRef,
-      holdKind: "supervised-shell",
-      activity: "working",
-      label: shellLabel(shell),
-    };
+    const holder = disclosedHolder(
+      {
+        ownerRef: input.ownerRef,
+        holdKind: "supervised-shell",
+        activity: "working",
+        label: shellLabel(shell),
+      },
+      shell.id,
+    );
     holders.push(holder);
     // agent.stop already awaits stopCommandsForAgent for every owner
     // shell. Expanded consequence rows are disclosure-only so a
@@ -181,11 +207,18 @@ export function snapshotOwnerTeardown(
       stopTargets.push({
         kind: "supervised-shell",
         commandId: shell.id,
-        holderKey: teardownHolderKey(holder),
+        holderKey: holder.holderKey,
       });
     }
   }
   return { holders, stopTargets };
+}
+
+function disclosedHolder(
+  holder: WorktreeBusyHolder,
+  uniqueId: string | undefined = undefined,
+): DisclosedTeardownHolder {
+  return { ...holder, holderKey: teardownHolderKey(holder, uniqueId) };
 }
 
 export function snapshotOwnerTeardownHolders(

--- a/clients/gui-app/src/lib/worktree/owner-teardown-snapshot.ts
+++ b/clients/gui-app/src/lib/worktree/owner-teardown-snapshot.ts
@@ -37,6 +37,8 @@ export type OwnerTeardownSnapshotInput = {
   readonly ptyLive: boolean;
   readonly shells: readonly OwnerTeardownShell[];
   readonly droppedRunDirectories: readonly string[];
+  readonly queuedMessageCount: number;
+  readonly backgroundItemCount: number;
 };
 
 export type TeardownStopTarget =
@@ -132,15 +134,16 @@ export function snapshotOwnerTeardown(
 ): OwnerTeardownSnapshot {
   const holders: WorktreeBusyHolder[] = [];
   const stopTargets: TeardownStopTarget[] = [];
+  const agentStopClearsOwner = chatTurnWillCallAgentStop(input);
   if (input.hasActiveTurn) {
     const holder: WorktreeBusyHolder = {
       ownerRef: input.ownerRef,
       holdKind: "chat-turn",
       activity: "working",
-      label: `${input.ownerLabel} is working`,
+      label: chatTurnHolderLabel(input, agentStopClearsOwner),
     };
     holders.push(holder);
-    if (input.ownerRef.ownerKind === "chat") {
+    if (agentStopClearsOwner) {
       stopTargets.push({
         kind: "chat-turn",
         holderKey: teardownHolderKey(holder),
@@ -157,7 +160,10 @@ export function snapshotOwnerTeardown(
   }
   for (const shell of input.shells) {
     if (!shell.live) continue;
-    if (!shellBelongsToDroppedPaths(shell, input.droppedRunDirectories)) {
+    if (
+      !agentStopClearsOwner &&
+      !shellBelongsToDroppedPaths(shell, input.droppedRunDirectories)
+    ) {
       continue;
     }
     const holder: WorktreeBusyHolder = {
@@ -180,6 +186,31 @@ export function snapshotOwnerTeardownHolders(
   input: OwnerTeardownSnapshotInput,
 ): readonly WorktreeBusyHolder[] {
   return snapshotOwnerTeardown(input).holders;
+}
+
+function chatTurnWillCallAgentStop(input: OwnerTeardownSnapshotInput): boolean {
+  return input.hasActiveTurn && input.ownerRef.ownerKind === "chat";
+}
+
+function chatTurnHolderLabel(
+  input: OwnerTeardownSnapshotInput,
+  agentStopClearsOwner: boolean,
+): string {
+  const base = `${input.ownerLabel} is working`;
+  if (!agentStopClearsOwner) return base;
+  const named: string[] = [];
+  if (input.queuedMessageCount === 1) named.push("1 queued message");
+  if (input.queuedMessageCount > 1) {
+    named.push(`${input.queuedMessageCount} queued messages`);
+  }
+  if (input.backgroundItemCount === 1) named.push("1 background item");
+  if (input.backgroundItemCount > 1) {
+    named.push(`${input.backgroundItemCount} background items`);
+  }
+  if (named.length > 0) {
+    return `${base}. Stopping it also clears ${named.join(" and ")}`;
+  }
+  return `${base}. Stopping the agent also stops its background shells and clears queued messages`;
 }
 
 function shellBelongsToDroppedPaths(

--- a/clients/gui-app/src/lib/worktree/worktree-commit-capture.ts
+++ b/clients/gui-app/src/lib/worktree/worktree-commit-capture.ts
@@ -21,6 +21,7 @@ export type WorktreeCommitCapture = {
 export type ArmedTeardownSubmit<T> = {
   readonly input: T;
   readonly capture: WorktreeCommitCapture;
+  readonly ownerId: string;
 };
 
 export function takeArmedTeardownSubmit<T>(slot: {

--- a/clients/gui-app/src/lib/worktree/worktree-commit-capture.ts
+++ b/clients/gui-app/src/lib/worktree/worktree-commit-capture.ts
@@ -2,16 +2,20 @@ import type {
   WorktreeBinding,
   WorktreeIntent,
 } from "@traycer/protocol/host/worktree-schemas";
+import type { TeardownStopTarget } from "@/lib/worktree/owner-teardown-snapshot";
 
 /**
  * Gesture-time snapshot of the draft a disclosure was computed from. Confirm
  * must apply this capture (or re-disclose) — never a later staging mutation.
+ * `stopTargets` are the GUI-composed teardown actions for the holders shown
+ * at disclosure time (phase-1; see `runGuiComposedTeardown`).
  */
 export type WorktreeCommitCapture = {
   readonly draft: WorktreeIntent | null;
   readonly revision: number;
   readonly binding: WorktreeBinding | null;
   readonly removedWorkspacePaths: readonly string[];
+  readonly stopTargets: readonly TeardownStopTarget[];
 };
 
 export type ArmedTeardownSubmit<T> = {

--- a/clients/gui-app/src/lib/worktree/worktree-commit-capture.ts
+++ b/clients/gui-app/src/lib/worktree/worktree-commit-capture.ts
@@ -1,0 +1,79 @@
+import type {
+  WorktreeBinding,
+  WorktreeIntent,
+} from "@traycer/protocol/host/worktree-schemas";
+
+/**
+ * Gesture-time snapshot of the draft a disclosure was computed from. Confirm
+ * must apply this capture (or re-disclose) — never a later staging mutation.
+ */
+export type WorktreeCommitCapture = {
+  readonly draft: WorktreeIntent | null;
+  readonly revision: number;
+  readonly binding: WorktreeBinding | null;
+  readonly removedWorkspacePaths: readonly string[];
+};
+
+export type ArmedTeardownSubmit<T> = {
+  readonly input: T;
+  readonly capture: WorktreeCommitCapture;
+};
+
+export function takeArmedTeardownSubmit<T>(slot: {
+  current: ArmedTeardownSubmit<T> | null;
+}): ArmedTeardownSubmit<T> | null {
+  const armed = slot.current;
+  slot.current = null;
+  return armed;
+}
+
+export function worktreeCommitCaptureIsStale(
+  capture: WorktreeCommitCapture,
+  live: WorktreeCommitCapture,
+): boolean {
+  if (capture.revision !== live.revision) return true;
+  if (!samePathSet(capture.removedWorkspacePaths, live.removedWorkspacePaths)) {
+    return true;
+  }
+  if (!sameBinding(capture.binding, live.binding)) return true;
+  return !sameDraft(capture.draft, live.draft);
+}
+
+function samePathSet(
+  left: readonly string[],
+  right: readonly string[],
+): boolean {
+  if (left.length !== right.length) return false;
+  const rightSet = new Set(right);
+  return left.every((path) => rightSet.has(path));
+}
+
+function sameBinding(
+  left: WorktreeBinding | null,
+  right: WorktreeBinding | null,
+): boolean {
+  if (left === right) return true;
+  if (left === null || right === null) return false;
+  if (left.entries.length !== right.entries.length) return false;
+  return left.entries.every((entry, index) => {
+    const other = right.entries[index];
+    return (
+      entry.workspacePath === other.workspacePath &&
+      entry.worktreePath === other.worktreePath &&
+      entry.mode === other.mode
+    );
+  });
+}
+
+function sameDraft(
+  left: WorktreeIntent | null,
+  right: WorktreeIntent | null,
+): boolean {
+  if (left === right) return true;
+  if (left === null || right === null) return false;
+  if (left.entries.length !== right.entries.length) return false;
+  return left.entries.every((entry, index) => {
+    const other = right.entries[index];
+    return entry.workspacePath === other.workspacePath;
+  });
+}


### PR DESCRIPTION
## What

The GUI half of "switch worktrees while the agent is busy" (host half: traycer-internal #5275, merged).

- **Draft picker:** the composer's worktree location/branch selection is always editable — a changed-but-uncommitted selection is a visible draft (pending indicator, survives popover close, zero cost, zero warnings). No more hard gate on agent busyness.
- **Gesture 1 — the folder picker's Update/refresh:** commits now. When teardown is implied, a `TeardownDisclosure` dialog (new shared component, consumed by the force-delete flow next) shows exactly what stops — evidence-named per holder — with "apply on next message" vs "stop and switch now".
- **Gesture 2 — message send with a changed draft:** the workspace intent rides the send (existing `worktreeIntent` field); disclosure at submit from a fresh owner-scoped snapshot.
- **Phase-1 snapshot + teardown are GUI-composed** (documented in-code): the client's own turn/PTY/shells synthesized into the typed holder shape, and "stop and switch now" stops exactly the disclosed set (managed-command stop + agent-stop, awaited; failure keeps the dialog open naming the holder). Upgraded to host-authoritative `listHolders` + create-with-intent when those wire paths land (the listHolders half is in flight in #1494-adjacent work).
- **Disclosure honesty invariants**, each regression-tested red-first across 5 adversarial review rounds: the disclosed set and the stopped set are identical (agent.stop's owner-wide consequence is disclosed, its shells subsumed not double-stopped); confirm commits exactly the disclosed draft (capture-pinned, re-discloses on staleness); a cancelled in-flight teardown can never apply (per-run generation); folder removals route through disclosure when holders exist; legacy hosts get the blocked-envelope → "apply on next message" pivot.

## Tests

171 across 8 suites, StrictMode-safe; oxlint `--deny-warnings` + eslint `--max-warnings 0` green; five adversarial review rounds (Codex ultra), final verdict APPROVE with the full teardown matrix verified across active-chat / idle-chat / terminal-agent owner shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
