### PR TITLE
fix(cli): enforce the readonly agent surface at runtime, not in help

### DIFF
--- a/clients/traycer-cli/src/agent-surface.ts
+++ b/clients/traycer-cli/src/agent-surface.ts
@@ -4,8 +4,10 @@ import { cliError, CLI_ERROR_CODES, type CliError } from "./runner/errors";
  * Which slice of the agent-facing CLI a session is allowed to drive.
  *
  * `readonly` is set by the host (`TRAYCER_AGENT_CLI_SURFACE=readonly`) for
- * sessions that may inspect Traycer state but must not change it. `full` is
- * everything else, including a human typing `traycer` in their own terminal.
+ * sessions that may inspect Traycer state but must not change it. `full` is an
+ * absent/empty variable - a human typing `traycer` in their own terminal, and
+ * every session the host chose not to restrict - or the exact string `full`.
+ * Anything else resolves to `readonly`; see `resolveAgentCliSurface`.
  *
  * WHAT THIS IS, AND IS NOT. The signal is an environment variable in the
  * session's own environment, so an agent holding that shell can unset or

--- a/clients/traycer-cli/src/agent-surface.ts
+++ b/clients/traycer-cli/src/agent-surface.ts
@@ -1,0 +1,174 @@
+import { cliError, CLI_ERROR_CODES, type CliError } from "./runner/errors";
+
+/**
+ * Which slice of the agent-facing CLI a session is allowed to drive.
+ *
+ * `readonly` is set by the host (`TRAYCER_AGENT_CLI_SURFACE=readonly`) for
+ * sessions that may inspect Traycer state but must not change it. `full` is
+ * everything else, including a human typing `traycer` in their own terminal.
+ *
+ * WHAT THIS IS, AND IS NOT. The signal is an environment variable in the
+ * session's own environment, so an agent holding that shell can unset or
+ * overwrite it. This is therefore a client-side capability RAIL - it makes the
+ * restricted surface behave as it is documented to behave, for a caller that
+ * does not go out of its way - and NOT an authorization boundary against the
+ * agent it restricts. Real authorization has to come from the host: a
+ * host-side check, or a scoped credential the session cannot swap out. Until
+ * that exists, do not let this file's presence be read as "mutations are
+ * prevented"; it means "mutations are refused unless the caller tampers with
+ * its own environment".
+ *
+ * Lives in this leaf module - not in `index.ts` - so the policy table below can
+ * be imported by a command without pulling in the whole program builder (and
+ * closing an import cycle).
+ */
+export type AgentCliSurface = "full" | "readonly";
+
+/**
+ * Resolve the surface, failing CLOSED on anything unrecognised.
+ *
+ * Only an absent/empty variable and the exact string `full` open the full
+ * surface. Every other value - a host spelling drift, a casing difference, a
+ * surface name a newer host knows and this CLI does not - resolves to
+ * `readonly`.
+ *
+ * The alternative (unknown means `full`) is how the restriction silently
+ * evaporates: one typo on the host side and a session the host believes is
+ * restricted quietly regains every mutation, with nothing failing to signal
+ * it. Failing closed instead costs a newer-host/older-CLI pairing some gated
+ * commands, which is visible, recoverable, and refuses rather than acts.
+ */
+export function resolveAgentCliSurface(
+  env: Readonly<Record<string, string | undefined>>,
+): AgentCliSurface {
+  const declared = env.TRAYCER_AGENT_CLI_SURFACE;
+  // Unset or empty is the ordinary case: a human's own terminal, and every
+  // session the host chose not to restrict.
+  if (declared === undefined || declared.length === 0) return "full";
+  if (declared === "full") return "full";
+  return "readonly";
+}
+
+/**
+ * Every command path the readonly surface REFUSES at runtime, keyed by the
+ * space-joined path under `traycer` and mapped to the recovery sentence its
+ * refusal ends with.
+ *
+ * This table is the capability check. Commander's `hidden` flag is not:
+ * hiding a command only keeps it out of `--help`, and an agent that types the
+ * subcommand anyway still reaches the action. Hiding is also a WIDER set than
+ * this one - the readonly surface hides the whole agent-to-agent surface,
+ * reads included (`agent inbox`, `agent selection-guide`, the harness/profile
+ * catalogs), because none of it is useful to a session that cannot act. Those
+ * reads stay runnable; only the mutations below are refused.
+ *
+ * Enforcement is centralised in `withRunner` (see `index.ts`), which looks up
+ * the invoked command's path here on every runner-backed action. So adding a
+ * mutating command to this table is the whole change - there is no second
+ * per-command opt-in to forget.
+ *
+ * `traycer monitor` is deliberately absent; see `MONITOR_SURFACE_NOTE`.
+ */
+export const READONLY_REFUSED_COMMANDS: Readonly<Record<string, string>> = {
+  "agent create":
+    "this session can inspect agents but cannot create or change them.",
+  "agent fork":
+    "this session can inspect agents but cannot create or change them.",
+  "agent configure":
+    "this session can inspect agents but cannot change how they run.",
+  "agent stop": "this session can inspect agents but cannot stop their work.",
+  "agent archive":
+    "this session can inspect agents but cannot change their archive state.",
+  "agent send":
+    "this session can inspect agents but cannot message them - report the message to the user instead.",
+  "agent role claim": "this session can list role claims but cannot make one.",
+  "agent role relinquish":
+    "this session can list role claims but cannot release one.",
+  "worktree delete":
+    "remove worktrees from Settings ▸ Worktrees, or run this from a full-surface session.",
+};
+
+/**
+ * Why the long-running inbox monitor is NOT in the table above, kept next to it
+ * so the omission reads as a decision rather than an oversight.
+ *
+ * `traycer monitor` does mutate: it durably acknowledges the messages it prints
+ * (`agent.inbox.ack` from the negotiated `@1.2`; on an older host the CLI has
+ * no event id and the host retires the row itself), rotates and persists this
+ * machine's stored credentials while it runs, and may provision a delegated
+ * host credential. Those are disclosed in its description and in
+ * `commands/monitor.ts`.
+ *
+ * It is an EXPLICIT EXCEPTION, not a command that happens to be out of reach.
+ * It is normally the delivery daemon the Traycer plugin spawns for a session,
+ * but it is also a registered command an agent can type, with its own
+ * `--agent-id` - so leaving it ungated does leave a mutation reachable, and
+ * the exception is granted with that understood. Two things decide it:
+ *
+ *  - Refusing it would break at-least-once delivery for any session the host
+ *    DOES spawn a monitor for. Whether that happens is a host-side fact this
+ *    repo cannot check, and the failure would be silent redelivery loops.
+ *  - Refusing it would buy little even against a caller trying to get around
+ *    the restriction, because this whole mechanism is an environment-variable
+ *    rail (see `AgentCliSurface`): the same caller can clear the variable and
+ *    run anything. The rail's job is to make the documented surface behave as
+ *    documented, and monitor's documented behaviour is that it runs.
+ *
+ * Flipping this needs the host-side fact, and then one entry in the table
+ * above.
+ *
+ * The same reasoning keeps the internal `agent *-from-hook` commands out of the
+ * table: a provider hook firing on turn/session lifecycle is the harness
+ * reporting what this session just did, not the agent asking for a change, and
+ * refusing them would only desynchronise the host's record of a session it is
+ * already running.
+ *
+ * Not in scope of that reasoning, and not gated today because the readonly
+ * surface has never hidden them either: `comments set-status` and
+ * `worktree create` are both agent-typed mutations that a readonly session can
+ * still run. Whether the surface should cover them is a contract question for
+ * the host, not something this table should decide unilaterally.
+ */
+export const MONITOR_SURFACE_NOTE =
+  "traycer monitor is an explicit readonly-surface exception: refusing the delivery daemon would break inbox delivery rather than remove a capability";
+
+/**
+ * The refusal every gated command shares. `FORBIDDEN` (not `INVALID_ARGUMENT`)
+ * so a caller can switch on the code: the invocation was well-formed, this
+ * session just may not perform it.
+ */
+export function readonlySurfaceRefusal(
+  commandPath: string,
+  hint: string,
+): CliError {
+  return cliError({
+    code: CLI_ERROR_CODES.FORBIDDEN,
+    message: `traycer: ${commandPath} is not available in the readonly agent surface - ${hint}`,
+    details: null,
+    exitCode: 1,
+  });
+}
+
+/**
+ * The capability check itself. Throws before the gated command is even built,
+ * so ahead of every RPC, dial, and write that command would do. It is NOT
+ * ahead of the runner's own generic setup: `runCommand` has already resolved
+ * the runtime and opened the CLI log by the time this runs, and the installed
+ * entrypoint may have refreshed the well-known CLI slot before Commander
+ * parsed anything. Nothing gated happens; some ordinary process bookkeeping
+ * does.
+ *
+ * A no-op both on the full surface and for any command the table does not
+ * list.
+ */
+export function assertCommandAllowedOnSurface(
+  commandPath: string,
+  surface: AgentCliSurface,
+): void {
+  if (surface !== "readonly") return;
+  if (!Object.hasOwn(READONLY_REFUSED_COMMANDS, commandPath)) return;
+  throw readonlySurfaceRefusal(
+    commandPath,
+    READONLY_REFUSED_COMMANDS[commandPath],
+  );
+}

--- a/clients/traycer-cli/src/commands/__tests__/readonly-surface-gate.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/readonly-surface-gate.test.ts
@@ -1,0 +1,394 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Command } from "commander";
+import type { CommandContext, CommandFn } from "../../runner/runner";
+import { CLI_ERROR_CODES } from "../../runner/errors";
+
+// This suite proves the CLI-019 capability boundary itself - not the wiring
+// underneath it. Every command listed in `READONLY_REFUSED_COMMANDS` must be
+// refused with E_FORBIDDEN *before* its body runs when driven end-to-end
+// through the real program under `TRAYCER_AGENT_CLI_SURFACE=readonly`, and
+// must NOT be refused on the full surface. The table is iterated directly
+// (not copied into a parallel literal here) so a new gated entry without a
+// working gate fails this suite rather than silently shipping unguarded.
+
+// Hoisted so the mock factory below can reference it, and so every `it` can
+// assert on call counts (not just the thrown error) - proof the gate ran
+// BEFORE the command body did anything, not merely that the body failed for
+// some other reason downstream.
+const mocks = vi.hoisted(() => ({
+  resolveHostAuthMock: vi.fn(async () => null),
+}));
+
+vi.mock("../../internal/host-auth", () => ({
+  // Every gated command (and every read command exercised here) bottoms out
+  // in `callHostRpc`/`resolveHostAuth` (or, for `worktree delete`, calls
+  // `resolveHostAuth` directly) before it does anything else. Forcing "not
+  // signed in" here is the single deepest-dependency mock that stops every
+  // command short of a real network call, while still producing a distinct,
+  // non-FORBIDDEN error on the full surface that proves the body was reached.
+  resolveHostAuth: mocks.resolveHostAuthMock,
+}));
+
+beforeEach(() => {
+  mocks.resolveHostAuthMock.mockClear();
+});
+
+vi.mock("../../runner/runner", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../runner/runner")>();
+  return {
+    ...actual,
+    runCommand: async (fn: CommandFn) => {
+      const ctx: CommandContext = {
+        runtime: {
+          json: false,
+          quiet: false,
+          noProgress: false,
+          noBootstrap: false,
+          nonInteractive: true,
+          environment: "production",
+          logger: {
+            debug: () => undefined,
+            info: () => undefined,
+            warn: () => undefined,
+            error: () => undefined,
+          },
+        },
+        output: {
+          progress: () => undefined,
+          human: () => undefined,
+          humanRequired: () => undefined,
+          emitResult: () => undefined,
+          emitError: () => undefined,
+        },
+        progress: () => undefined,
+      };
+      await fn(ctx);
+    },
+  };
+});
+
+import { buildProgramWithAgentRoles, commanderCommandPath } from "../../index";
+import {
+  assertCommandAllowedOnSurface,
+  MONITOR_SURFACE_NOTE,
+  READONLY_REFUSED_COMMANDS,
+  resolveAgentCliSurface,
+} from "../../agent-surface";
+
+// Fixture values for the agent/epic context the `agent *` commands resolve
+// from env when their own `--agent-id`/`epicId` opts are omitted (see
+// `resolveEpicId`/`resolveSenderAgentId` in `internal/agent-context.ts`).
+// Pinned here rather than inherited from the ambient environment: this suite
+// runs inside a live Traycer agent session, which already has
+// `TRAYCER_AGENT_ID`/`TRAYCER_EPIC_ID` set - so without this override, a
+// command reaching "resolve context from env" would silently succeed here
+// and then throw "no context" in CI (or any shell without those vars),
+// short-circuiting BEFORE `resolveHostAuth` and invalidating the
+// `toHaveBeenCalled()` assertions below for the wrong reason. Pinning fixed
+// values makes the suite's outcome independent of what happens to be running
+// it.
+const FIXTURE_AGENT_ID = "agent-fixture";
+const FIXTURE_EPIC_ID = "epic-fixture";
+
+const ENV_VARS_UNDER_TEST = [
+  "TRAYCER_AGENT_CLI_SURFACE",
+  "TRAYCER_AGENT_ID",
+  "TRAYCER_EPIC_ID",
+] as const;
+
+// `await`s `run()` itself (rather than returning it from inside try/finally)
+// so the env restoration in `finally` cannot race ahead of `run`'s own
+// internal awaits - `run` drives a real `program.parseAsync(...)`, whose
+// action dispatch is not guaranteed to complete synchronously, so restoring
+// the env on the tick after the *call* to `run()` (rather than after it
+// actually settles) could hand the in-flight command a clean environment
+// mid-flight.
+//
+// `envValue` is the literal `TRAYCER_AGENT_CLI_SURFACE` value to set
+// (`undefined` unsets it entirely) rather than a closed `"readonly" | "full"`
+// union, so this same helper can drive the fail-closed matrix below with
+// arbitrary/unrecognised values (e.g. `"restricted"`) without a second
+// save/restore implementation.
+async function withEnvSurface<T>(
+  envValue: string | undefined,
+  run: () => Promise<T> | T,
+): Promise<T> {
+  const originals = Object.fromEntries(
+    ENV_VARS_UNDER_TEST.map((name) => [name, process.env[name]]),
+  ) as Record<(typeof ENV_VARS_UNDER_TEST)[number], string | undefined>;
+  if (envValue === undefined) {
+    delete process.env.TRAYCER_AGENT_CLI_SURFACE;
+  } else {
+    process.env.TRAYCER_AGENT_CLI_SURFACE = envValue;
+  }
+  process.env.TRAYCER_AGENT_ID = FIXTURE_AGENT_ID;
+  process.env.TRAYCER_EPIC_ID = FIXTURE_EPIC_ID;
+  try {
+    return await run();
+  } finally {
+    for (const name of ENV_VARS_UNDER_TEST) {
+      const original = originals[name];
+      if (original === undefined) {
+        delete process.env[name];
+      } else {
+        process.env[name] = original;
+      }
+    }
+  }
+}
+
+function findSubcommand(parent: Command, name: string): Command | null {
+  for (const child of parent.commands) {
+    if (child.name() === name) return child;
+  }
+  return null;
+}
+
+function resolveCommand(
+  program: Command,
+  path: readonly string[],
+): Command | null {
+  let cursor: Command = program;
+  for (const segment of path) {
+    const next = findSubcommand(cursor, segment);
+    if (next === null) return null;
+    cursor = next;
+  }
+  return cursor;
+}
+
+async function parseAndCapture(
+  program: Command,
+  argv: readonly string[],
+): Promise<unknown> {
+  program.exitOverride();
+  program.configureOutput({
+    writeErr: () => undefined,
+    writeOut: () => undefined,
+  });
+  try {
+    await program.parseAsync(argv, { from: "user" });
+    return null;
+  } catch (err) {
+    return err;
+  }
+}
+
+// Extra argv tokens (Commander options, not the command path itself) needed
+// so `program.parseAsync` reaches the action for every gated command. Every
+// key in `READONLY_REFUSED_COMMANDS` must have an entry here or the suite
+// fails loudly below - this is deliberately kept separate from the policy
+// table itself, since it encodes "what does Commander require to parse", not
+// "what is refused".
+const REQUIRED_ARGS: Readonly<Record<string, readonly string[]>> = {
+  "agent create": [],
+  "agent fork": ["--agent-id", "agent-1"],
+  "agent configure": [
+    "--agent-id",
+    "agent-1",
+    "--harness",
+    "claude",
+    "--model",
+    "model-1",
+    "--profile",
+    "ambient",
+  ],
+  "agent stop": ["--agent-id", "agent-1"],
+  "agent archive": ["--agent-id", "agent-1"],
+  "agent send": ["--to", "agent-1", "--message", "hi"],
+  "agent role claim": ["--role", "role-1", "--scope", "scope-1"],
+  // `claimId` is validated as a UUID by the protocol request schema before
+  // any transport (see agent-role.ts) - an arbitrary string never reaches
+  // `callHostRpc`/`resolveHostAuth` at all, which would fail the full-surface
+  // "reaches the body" assertion below for the wrong reason.
+  "agent role relinquish": [
+    "--claim-id",
+    "11111111-1111-4111-8111-111111111111",
+  ],
+  "worktree delete": ["--path", "/tmp/some-worktree"],
+};
+
+// Reads that stay runnable on the readonly surface: hidden from `--help`
+// (a WIDER set than the capability boundary - see `agent-surface.ts`) but
+// never refused at runtime.
+const UNGATED_READS: ReadonlyArray<{
+  readonly path: readonly string[];
+  readonly args: readonly string[];
+}> = [
+  { path: ["agent", "list"], args: [] },
+  { path: ["agent", "transcript"], args: ["--agent-id", "agent-1"] },
+  { path: ["agent", "inbox"], args: [] },
+  { path: ["agent", "role", "list"], args: [] },
+  { path: ["worktree", "list"], args: [] },
+];
+
+describe("readonly-surface gate: table coverage is complete", () => {
+  it("has a REQUIRED_ARGS entry for every key in READONLY_REFUSED_COMMANDS", () => {
+    for (const commandPath of Object.keys(READONLY_REFUSED_COMMANDS)) {
+      expect(
+        Object.hasOwn(REQUIRED_ARGS, commandPath),
+        `readonly-surface-gate.test.ts's REQUIRED_ARGS is missing an entry for '${commandPath}' - add one so this suite actually drives it`,
+      ).toBe(true);
+    }
+  });
+
+  it("resolves every READONLY_REFUSED_COMMANDS key to a registered command", () => {
+    const program = buildProgramWithAgentRoles(true);
+    for (const commandPath of Object.keys(READONLY_REFUSED_COMMANDS)) {
+      const cmd = resolveCommand(program, commandPath.split(" "));
+      expect(
+        cmd,
+        `'${commandPath}' is a READONLY_REFUSED_COMMANDS key but is not a registered command - a rename here would silently disable enforcement`,
+      ).not.toBeNull();
+    }
+  });
+});
+
+describe("readonly-surface gate: refuses every table entry before the body runs", () => {
+  for (const commandPath of Object.keys(READONLY_REFUSED_COMMANDS)) {
+    it(`refuses '${commandPath}' with E_FORBIDDEN under the readonly surface, before the body runs`, async () => {
+      await withEnvSurface("readonly", async () => {
+        const program = buildProgramWithAgentRoles(true);
+        const argv = [...commandPath.split(" "), ...REQUIRED_ARGS[commandPath]];
+        const thrown = await parseAndCapture(program, argv);
+        expect(thrown).toMatchObject({ code: CLI_ERROR_CODES.FORBIDDEN });
+        // The load-bearing assertion: the command body's own deepest
+        // dependency was never reached, so the refusal happened ahead of it
+        // rather than merely producing the same-looking error downstream.
+        expect(mocks.resolveHostAuthMock).not.toHaveBeenCalled();
+      });
+    });
+
+    it(`does not refuse '${commandPath}' on the full surface (reaches the command body)`, async () => {
+      await withEnvSurface("full", async () => {
+        const program = buildProgramWithAgentRoles(true);
+        const argv = [...commandPath.split(" "), ...REQUIRED_ARGS[commandPath]];
+        const thrown = await parseAndCapture(program, argv);
+        // Every gated command bottoms out in the mocked `resolveHostAuth`
+        // returning null, which throws AUTH_NO_CREDENTIALS - proof the body
+        // was reached rather than refused. Assert on "not E_FORBIDDEN" (per
+        // the task) rather than the exact code, so this stays robust to
+        // which specific downstream error a given command surfaces first.
+        expect(thrown).not.toBeNull();
+        expect(thrown).not.toMatchObject({ code: CLI_ERROR_CODES.FORBIDDEN });
+        // Positive proof: the body actually ran far enough to call its
+        // deepest dependency, not just "failed with a different code".
+        expect(mocks.resolveHostAuthMock).toHaveBeenCalled();
+      });
+    });
+  }
+});
+
+describe("readonly-surface gate: hidden-but-ungated reads stay runnable", () => {
+  for (const { path, args } of UNGATED_READS) {
+    it(`does not refuse '${path.join(" ")}' under the readonly surface`, async () => {
+      await withEnvSurface("readonly", async () => {
+        const program = buildProgramWithAgentRoles(true);
+        const thrown = await parseAndCapture(program, [...path, ...args]);
+        // Reached the body (mocked resolveHostAuth -> AUTH_NO_CREDENTIALS),
+        // not refused by the capability gate.
+        expect(thrown).not.toBeNull();
+        expect(thrown).not.toMatchObject({ code: CLI_ERROR_CODES.FORBIDDEN });
+        // Positive proof it reached the body, same as the full-surface case
+        // above - these reads must stay runnable under readonly, not merely
+        // fail with a code that happens not to be FORBIDDEN.
+        expect(mocks.resolveHostAuthMock).toHaveBeenCalled();
+      });
+    });
+  }
+});
+
+describe("readonly-surface gate: traycer monitor is deliberately not gated", () => {
+  it("is absent from READONLY_REFUSED_COMMANDS", () => {
+    expect(Object.keys(READONLY_REFUSED_COMMANDS)).not.toContain("monitor");
+  });
+
+  it("assertCommandAllowedOnSurface does not refuse 'monitor' on the readonly surface", () => {
+    // Pins the decision in MONITOR_SURFACE_NOTE (CLI-021): monitor bypasses
+    // `withRunner` entirely (so this gate never runs for it in practice), but
+    // this asserts the same outcome directly against the policy function so a
+    // future flip - adding "monitor" to the table without also routing it
+    // through the runner - is caught here rather than only in production.
+    expect(() =>
+      assertCommandAllowedOnSurface("monitor", "readonly"),
+    ).not.toThrow();
+    expect(MONITOR_SURFACE_NOTE.length).toBeGreaterThan(0);
+  });
+
+  it("monitor's registered description discloses delivery acknowledgement and credential maintenance", () => {
+    const program = buildProgramWithAgentRoles(true);
+    const monitor = resolveCommand(program, ["monitor"]);
+    expect(monitor).not.toBeNull();
+    const description = monitor?.description() ?? "";
+    expect(description).toContain("acknowledged as delivered");
+    expect(description).toContain("stored Traycer credentials");
+  });
+});
+
+describe("resolveAgentCliSurface: fails closed on any unrecognised value", () => {
+  // Fail-closed, not fail-open. The prior implementation was
+  // `declared === "readonly" ? "readonly" : "full"` - so a host spelling
+  // drift, different casing, or a surface name a newer host knows and this
+  // CLI does not would silently resolve to "full" and the whole restriction
+  // would evaporate with nothing signalling it. Only the two spellings that
+  // actually mean "unrestricted" - absent/empty, and the explicit "full" -
+  // resolve to full; every other string, however plausible-looking, is
+  // treated as a request to restrict: an unknown value must never quietly
+  // re-open the mutating surface.
+  it.each([
+    [undefined, "full"],
+    ["", "full"],
+    ["full", "full"],
+    ["readonly", "readonly"],
+    // Casing is not normalised - these fail closed rather than matching.
+    ["Readonly", "readonly"],
+    ["READONLY", "readonly"],
+    ["read-only", "readonly"],
+    // An unknown future surface name this CLI has never heard of.
+    ["limited", "readonly"],
+    // Not trimmed - pins the current behaviour so a later trim is a
+    // deliberate, reviewed change rather than an accidental one.
+    [" full ", "readonly"],
+  ] as const)(
+    "TRAYCER_AGENT_CLI_SURFACE=%j resolves to %s",
+    (declared, expected) => {
+      expect(
+        resolveAgentCliSurface({ TRAYCER_AGENT_CLI_SURFACE: declared }),
+      ).toBe(expected);
+    },
+  );
+});
+
+describe("readonly-surface gate: fails closed end-to-end on an unrecognised surface value", () => {
+  it("refuses 'agent stop' with E_FORBIDDEN before the body runs when TRAYCER_AGENT_CLI_SURFACE is unrecognised", async () => {
+    await withEnvSurface("restricted", async () => {
+      const program = buildProgramWithAgentRoles(true);
+      const thrown = await parseAndCapture(program, [
+        "agent",
+        "stop",
+        "--agent-id",
+        "agent-1",
+      ]);
+      expect(thrown).toMatchObject({ code: CLI_ERROR_CODES.FORBIDDEN });
+      expect(mocks.resolveHostAuthMock).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe("commanderCommandPath", () => {
+  it("returns the space-joined path for a nested command", () => {
+    const program = buildProgramWithAgentRoles(true);
+    const claim = resolveCommand(program, ["agent", "role", "claim"]);
+    expect(claim).not.toBeNull();
+    if (claim === null) throw new Error("unreachable");
+    expect(commanderCommandPath(claim)).toBe("agent role claim");
+  });
+
+  it("returns the single segment for a top-level command", () => {
+    const program = buildProgramWithAgentRoles(true);
+    const monitor = resolveCommand(program, ["monitor"]);
+    expect(monitor).not.toBeNull();
+    if (monitor === null) throw new Error("unreachable");
+    expect(commanderCommandPath(monitor)).toBe("monitor");
+  });
+});

--- a/clients/traycer-cli/src/commands/__tests__/worktree-delete.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/worktree-delete.test.ts
@@ -158,33 +158,21 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-describe("buildWorktreeDeleteCommand readonly guard", () => {
-  it("refuses in the readonly surface before any auth/endpoint/stream work", async () => {
-    await expect(
-      buildWorktreeDeleteCommand({
-        worktreePath: "/wt/x",
-        readonlySurface: true,
-      })(ctx),
-    ).rejects.toMatchObject({ code: CLI_ERROR_CODES.FORBIDDEN });
-
-    expect(resolveHostAuthMock).not.toHaveBeenCalled();
-    expect(resolveEndpointMock).not.toHaveBeenCalled();
-    expect(hoisted.subscribeMock).not.toHaveBeenCalled();
-  });
-});
+// The readonly-surface refusal moved out of this command: `worktree delete` is
+// now one entry in `READONLY_REFUSED_COMMANDS`, enforced for every gated
+// command in `withRunner` before the body runs. Its coverage lives with that
+// gate, in `__tests__/readonly-surface-gate.test.ts`.
 
 describe("buildWorktreeDeleteCommand input validation", () => {
   it("rejects an empty --path before any network call", async () => {
     await expect(
       buildWorktreeDeleteCommand({
         worktreePath: "   ",
-        readonlySurface: false,
       })(ctx),
     ).rejects.toBeInstanceOf(CliError);
     await expect(
       buildWorktreeDeleteCommand({
         worktreePath: "",
-        readonlySurface: false,
       })(ctx),
     ).rejects.toMatchObject({ code: CLI_ERROR_CODES.INVALID_ARGUMENT });
 
@@ -197,7 +185,6 @@ describe("buildWorktreeDeleteCommand command shape", () => {
   it("opens ONE start-mode command carrying a uuid and the single target", async () => {
     const pending = buildWorktreeDeleteCommand({
       worktreePath: "/wt/x",
-      readonlySurface: false,
     })(ctx);
 
     await waitForSessions(1);
@@ -228,7 +215,6 @@ describe("buildWorktreeDeleteCommand command shape", () => {
     const recorded: ProgressInfo[] = [];
     const pending = buildWorktreeDeleteCommand({
       worktreePath: "/wt/x",
-      readonlySurface: false,
     })(jsonCtx(recorded));
 
     await waitForSessions(1);
@@ -293,7 +279,6 @@ describe("buildWorktreeDeleteCommand stream-drop safety", () => {
   it("fails non-zero on a drop before a terminal frame, with no re-subscribe", async () => {
     const pending = buildWorktreeDeleteCommand({
       worktreePath: "/wt/x",
-      readonlySurface: false,
     })(ctx);
 
     await waitForSessions(1);
@@ -335,7 +320,6 @@ describe("buildWorktreeDeleteCommand terminal outcomes", () => {
   it("resolves deleted=true on a target.complete frame", async () => {
     const pending = buildWorktreeDeleteCommand({
       worktreePath: "/wt/x",
-      readonlySurface: false,
     })(ctx);
 
     await waitForSessions(1);
@@ -356,7 +340,6 @@ describe("buildWorktreeDeleteCommand terminal outcomes", () => {
   it("resolves deleted=false with a non-zero exit when the host removed nothing", async () => {
     const pending = buildWorktreeDeleteCommand({
       worktreePath: "/wt/x",
-      readonlySurface: false,
     })(ctx);
 
     await waitForSessions(1);
@@ -375,7 +358,6 @@ describe("buildWorktreeDeleteCommand terminal outcomes", () => {
   it("maps a target.failed frame to a CliError carrying the host's reason", async () => {
     const pending = buildWorktreeDeleteCommand({
       worktreePath: "/wt/x",
-      readonlySurface: false,
     })(ctx);
 
     await waitForSessions(1);
@@ -396,7 +378,6 @@ describe("buildWorktreeDeleteCommand terminal outcomes", () => {
   it("maps a command.failed frame to a CliError carrying the host's reason", async () => {
     const pending = buildWorktreeDeleteCommand({
       worktreePath: "/wt/x",
-      readonlySurface: false,
     })(ctx);
 
     await waitForSessions(1);
@@ -418,7 +399,6 @@ describe("buildWorktreeDeleteCommand terminal outcomes", () => {
     // per-target frames are replayed, so the counts are the whole answer.
     const pending = buildWorktreeDeleteCommand({
       worktreePath: "/wt/x",
-      readonlySurface: false,
     })(ctx);
 
     await waitForSessions(1);
@@ -438,7 +418,6 @@ describe("buildWorktreeDeleteCommand terminal outcomes", () => {
   it("maps an UNAUTHORIZED fatal close to an auth-rejected CliError", async () => {
     const pending = buildWorktreeDeleteCommand({
       worktreePath: "/wt/x",
-      readonlySurface: false,
     })(ctx);
 
     await waitForSessions(1);
@@ -461,7 +440,6 @@ describe("buildWorktreeDeleteCommand terminal outcomes", () => {
   it("maps an INCOMPATIBLE fatal close to a host-incompatible CliError", async () => {
     const pending = buildWorktreeDeleteCommand({
       worktreePath: "/wt/x",
-      readonlySurface: false,
     })(ctx);
 
     await waitForSessions(1);
@@ -487,7 +465,6 @@ describe("buildWorktreeDeleteCommand older-host fallback", () => {
     hoisted.state.methodSupport = "unsupported";
     const pending = buildWorktreeDeleteCommand({
       worktreePath: "/wt/x",
-      readonlySurface: false,
     })(ctx);
 
     await waitForSessions(1);
@@ -523,7 +500,6 @@ describe("buildWorktreeDeleteCommand older-host fallback", () => {
   it("does not fall back after a fatal close that is not an unsupported method", async () => {
     const pending = buildWorktreeDeleteCommand({
       worktreePath: "/wt/x",
-      readonlySurface: false,
     })(ctx);
 
     await waitForSessions(1);

--- a/clients/traycer-cli/src/commands/monitor.ts
+++ b/clients/traycer-cli/src/commands/monitor.ts
@@ -68,6 +68,25 @@ import { CLI_CLIENT_IDENTITY } from "../cli-version";
  *
  * stdout carries inbox messages only; all connection/diagnostic noise goes to
  * stderr so it never pollutes the agent-facing stream.
+ *
+ * NOT read-only, despite "stream" (CLI-021). Three durable effects, all of them
+ * required for the stream to be correct rather than incidental:
+ *
+ *  1. Delivery acknowledgement - a message confirmed onto stdout advances the
+ *     agent's inbox server-side, so the at-least-once inbox stops redelivering
+ *     it on reconnect. From the negotiated `@1.2` this CLI enqueues the
+ *     `agent.inbox.ack` itself; below that there is no event id on the frame
+ *     and the host retires the row on its own (see `handleServerFrame`).
+ *  2. Credential maintenance - the store-backed revalidator rotates and
+ *     PERSISTS this machine's credentials, proactively before expiry and
+ *     reactively on `UNAUTHORIZED`. A rotation spends a single-use refresh
+ *     token, which is why it goes through the locked store.
+ *  3. Host-credential provisioning - a host reporting `missing` gets a
+ *     delegated credential minted for it, so it keeps serving after this
+ *     process exits.
+ *
+ * On the readonly agent surface this command is hidden but NOT refused; see
+ * `MONITOR_SURFACE_NOTE` in `../agent-surface.ts` for that decision.
  */
 const SUBSCRIBE_METHOD = "agent.inbox.subscribe" as const;
 const OPEN_ACK_TIMEOUT_MS = 10_000;

--- a/clients/traycer-cli/src/commands/worktree-delete.ts
+++ b/clients/traycer-cli/src/commands/worktree-delete.ts
@@ -48,12 +48,6 @@ const MAX_BACKOFF_MS = 30_000;
 
 export interface WorktreeDeleteCommandOpts {
   readonly worktreePath: string;
-  // The delete is destructive, so it is a capability boundary - not merely a
-  // hidden command - in the readonly agent surface. Commander's `hidden` flag
-  // still runs the action when the subcommand is typed explicitly, so the
-  // command itself refuses up front (before any network/stream work) when this
-  // is true. Resolved from `TRAYCER_AGENT_CLI_SURFACE` at registration.
-  readonly readonlySurface: boolean;
 }
 
 /**
@@ -61,8 +55,14 @@ export interface WorktreeDeleteCommandOpts {
  * (busy-check -> teardown script -> `git worktree remove`). Teardown/remove
  * output is relayed live as it streams; the terminal frame carries the final
  * `deleted` flag, and a failure (busy path, unexpected host error) surfaces as
- * a clean non-zero CliError. Hidden in the `readonly` CLI surface (registered
- * like `agent create`).
+ * a clean non-zero CliError.
+ *
+ * The delete is destructive, so it is a capability boundary in the readonly
+ * agent surface, not merely a hidden command. That refusal is no longer made
+ * here: `READONLY_REFUSED_COMMANDS` lists `worktree delete`, and `withRunner`
+ * enforces the whole table before any command body runs (CLI-019). One
+ * mechanism covers this command and every gated agent mutation, so nothing
+ * reaches this function on a readonly surface.
  *
  * On a host that has `worktree.deleteBatchByPath` this runs as a ONE-TARGET
  * command, so the CLI's delete queues on the same host-wide scheduler as every
@@ -73,15 +73,6 @@ export function buildWorktreeDeleteCommand(
   opts: WorktreeDeleteCommandOpts,
 ): CommandFn {
   return async (ctx) => {
-    if (opts.readonlySurface) {
-      throw cliError({
-        code: CLI_ERROR_CODES.FORBIDDEN,
-        message:
-          "traycer: worktree delete is not available in the readonly agent surface - remove worktrees from Settings ▸ Worktrees, or run this from a full-surface session.",
-        details: null,
-        exitCode: 1,
-      });
-    }
     const worktreePath = opts.worktreePath.trim();
     if (worktreePath.length === 0) {
       throw cliError({

--- a/clients/traycer-cli/src/index.ts
+++ b/clients/traycer-cli/src/index.ts
@@ -2425,11 +2425,15 @@ function registerAgentCommands(
 // the shared globals still parse if present.
 //
 // Because it bypasses the runner, it also bypasses the readonly capability
-// gate `withRunner` applies - deliberately, and it is absent from
-// `READONLY_REFUSED_COMMANDS` for the reason recorded in `MONITOR_SURFACE_NOTE`
-// (CLI-021): it is the host-spawned delivery daemon, not a mutation an agent
-// asks for, and refusing it would break delivery rather than remove a
-// capability. It stays hidden on the readonly surface, as before.
+// check `withRunner` applies - and it is absent from
+// `READONLY_REFUSED_COMMANDS` as an EXPLICIT EXCEPTION, for the reason
+// recorded in `MONITOR_SURFACE_NOTE` (CLI-021). Not because it is out of
+// reach: this is a registered command an agent can type, with its own
+// `--agent-id`, so leaving it open does leave a mutation reachable. It is
+// granted because refusing it would break inbox delivery for any session the
+// host spawns a monitor for, and would buy little against a caller who can
+// clear the surface variable anyway. It stays hidden on the readonly surface,
+// as before.
 //
 // It is not read-only, and the description now says so: printing a message
 // durably acknowledges it, and the process maintains this machine's stored

--- a/clients/traycer-cli/src/index.ts
+++ b/clients/traycer-cli/src/index.ts
@@ -15,6 +15,10 @@ import { A2A_PERMISSION_MODE_INSTRUCTION } from "@traycer/protocol/agent/agent-s
 import { AGENT_FACING_HARNESS_ID_LIST } from "@traycer/protocol/host/agent/shared";
 import { readFeatureSettingsSync } from "@traycer/protocol/config/store";
 import { config } from "./config";
+import {
+  assertCommandAllowedOnSurface,
+  resolveAgentCliSurface,
+} from "./agent-surface";
 import { resolveCliVersion } from "./cli-version";
 import { cliFinalizeUpgradeCommand } from "./commands/cli-finalize-upgrade";
 import { buildCliMarkSourceCommand } from "./commands/cli-mark-source";
@@ -153,6 +157,24 @@ function parsePortArg(value: string): number | null {
   return parsed !== null && parsed <= 65_535 ? parsed : null;
 }
 
+/**
+ * The invoked command's path under the root program, space-joined
+ * (`agent role claim`). Built from Commander's own parent chain rather than the
+ * argv the user typed, so an alias or an abbreviated path still resolves to the
+ * canonical name the capability table is keyed by.
+ */
+export function commanderCommandPath(command: CommanderCommand): string {
+  const segments: string[] = [];
+  let cursor: CommanderCommand | null = command;
+  // Stop at the root program: it contributes the binary name, not a path
+  // segment (`traycer agent create` is keyed as `agent create`).
+  while (cursor !== null && cursor.parent !== null) {
+    segments.unshift(cursor.name());
+    cursor = cursor.parent;
+  }
+  return segments.join(" ");
+}
+
 function withRunner(
   cmd: CommanderCommand,
   build: (
@@ -164,8 +186,35 @@ function withRunner(
     const command = actionArgs[actionArgs.length - 1] as CommanderCommand;
     const positionals = extractActionPositionals(actionArgs);
     const optsBag = command.optsWithGlobals() as Record<string, unknown>;
-    const fn = build(optsBag, positionals);
-    await runCommand(fn, extractRunnerFlags(optsBag));
+    const commandPath = commanderCommandPath(command);
+    // THE capability check for every runner-backed command (CLI-019).
+    //
+    // It runs here, once, rather than in each mutating handler: hiding a
+    // command on the readonly surface is presentation only - Commander still
+    // runs the action when the subcommand is typed explicitly - and a
+    // per-handler guard is a check every new command has to remember. Keyed by
+    // command path off `READONLY_REFUSED_COMMANDS`, so no Commander route to a
+    // gated action skips it.
+    //
+    // A rail, not an authorization boundary: the surface is a variable in the
+    // caller's own environment, so this constrains a cooperative caller, not
+    // one that clears it. See `AgentCliSurface` in `agent-surface.ts`.
+    //
+    // The surface is read at invocation (not at registration) so it reflects
+    // the environment this process was actually launched with, and the check
+    // is wrapped INSIDE the CommandFn so a refusal renders through the runner's
+    // normal error path: NDJSON envelope under `--json`, stderr otherwise, and
+    // a non-zero exit either way. Building `fn` lazily keeps the refusal ahead
+    // of any argument parsing the builder does, so a readonly session is told
+    // it may not do this rather than which flag it also got wrong.
+    const guarded: CommandFn = async (ctx) => {
+      assertCommandAllowedOnSurface(
+        commandPath,
+        resolveAgentCliSurface(readonlyEnv()),
+      );
+      return build(optsBag, positionals)(ctx);
+    };
+    await runCommand(guarded, extractRunnerFlags(optsBag));
   });
 }
 
@@ -194,13 +243,15 @@ export function isTraycerCliEntrypoint(argv1: string | undefined): boolean {
 // existing caller and test looks for them.
 export { LOCAL_CLI_VERSION, resolveCliVersion } from "./cli-version";
 
-export type AgentCliSurface = "full" | "readonly";
-
-export function resolveAgentCliSurface(
-  env: Readonly<Record<string, string | undefined>>,
-): AgentCliSurface {
-  return env.TRAYCER_AGENT_CLI_SURFACE === "readonly" ? "readonly" : "full";
-}
+// The surface type, its resolver, and the readonly capability table live in
+// the leaf `agent-surface.ts` so a command can import the policy without
+// importing this module (which builds the whole program and would close a
+// cycle). Re-exported here because this is where existing callers look.
+export {
+  READONLY_REFUSED_COMMANDS,
+  resolveAgentCliSurface,
+  type AgentCliSurface,
+} from "./agent-surface";
 
 // Construct the full commander program. Exported as a builder so tests
 // can assert command registration (subject of the
@@ -1724,11 +1775,14 @@ function registerCommentsCommands(program: Command): void {
 function registerWorktreeCommands(program: Command): void {
   // `worktree delete` mutates on-disk state, so it is a capability boundary in
   // the readonly agent surface: hidden from help (like `agent create`) AND
-  // guarded at runtime, because Commander's `hidden` flag still runs the action
-  // when the subcommand is typed explicitly. `worktree list` is a read and
-  // stays available in both surfaces.
-  const readonlySurface = resolveAgentCliSurface(readonlyEnv()) === "readonly";
-  const deleteHidden = { hidden: readonlySurface };
+  // refused at runtime, because Commander's `hidden` flag still runs the action
+  // when the subcommand is typed explicitly. The refusal is the shared one -
+  // `worktree delete` is a `READONLY_REFUSED_COMMANDS` entry that `withRunner`
+  // enforces - so only the hiding is decided here. `worktree list` is a read
+  // and stays available in both surfaces.
+  const deleteHidden = {
+    hidden: resolveAgentCliSurface(readonlyEnv()) === "readonly",
+  };
   const worktree = program
     .command("worktree")
     .description("Create, inspect, and remove Git worktree paths");
@@ -1769,7 +1823,6 @@ function registerWorktreeCommands(program: Command): void {
     (opts) =>
       buildWorktreeDeleteCommand({
         worktreePath: typeof opts.path === "string" ? opts.path : "",
-        readonlySurface,
       }),
   );
 
@@ -1811,8 +1864,15 @@ function registerAgentCommands(
   program: Command,
   agentRolesEnabled: boolean,
 ): void {
-  const cliSurface = resolveAgentCliSurface(readonlyEnv());
-  const readonlyHidden = { hidden: cliSurface === "readonly" };
+  // Presentation only, and a WIDER set than the capability boundary: the
+  // readonly surface hides the whole agent-to-agent surface, reads included, so
+  // a session that cannot act is not offered the vocabulary to try. What a
+  // readonly session may not RUN is decided by `READONLY_REFUSED_COMMANDS` and
+  // enforced in `withRunner`, so the hidden reads below stay runnable and the
+  // hidden mutations are refused whether or not they were ever listed.
+  const readonlyHidden = {
+    hidden: resolveAgentCliSurface(readonlyEnv()) === "readonly",
+  };
   const harnessHelp = `Harness id: ${AGENT_FACING_HARNESS_ID_LIST}`;
   // Deliberately spells out what OMITTING the option does: omission is its own
   // selection (the remembered last-used profile), not a synonym for 'ambient'.
@@ -2102,7 +2162,7 @@ function registerAgentCommands(
     agent
       .command("archive", readonlyHidden)
       .description(
-        "Archive or unarchive a GUI chat or terminal agent. Archived agents stay addressable - any later message to them auto-unarchives the record. Archiving a still-working agent is refused; stop it first with 'traycer agent stop', or wait for it to settle. Unarchiving is never gated.",
+        "Archive or unarchive a GUI chat or terminal agent. Archived agents stay addressable - any later message to them auto-unarchives the record. Archiving a still-working agent is refused; stop it first with 'traycer agent stop', or wait for it to settle. That busy check never blocks unarchiving.",
       )
       .requiredOption(
         "--agent-id <id>",
@@ -2363,13 +2423,26 @@ function registerAgentCommands(
 // spawns. Like `host start` it owns its own lifecycle and does NOT go
 // through the shared NDJSON runner - `addRunnerFlags` is applied only so
 // the shared globals still parse if present.
+//
+// Because it bypasses the runner, it also bypasses the readonly capability
+// gate `withRunner` applies - deliberately, and it is absent from
+// `READONLY_REFUSED_COMMANDS` for the reason recorded in `MONITOR_SURFACE_NOTE`
+// (CLI-021): it is the host-spawned delivery daemon, not a mutation an agent
+// asks for, and refusing it would break delivery rather than remove a
+// capability. It stays hidden on the readonly surface, as before.
+//
+// It is not read-only, and the description now says so: printing a message
+// durably acknowledges it, and the process maintains this machine's stored
+// credentials for as long as it runs.
 function registerMonitorCommand(program: Command): void {
   addRunnerFlags(
     program
       .command("monitor", {
         hidden: resolveAgentCliSurface(readonlyEnv()) === "readonly",
       })
-      .description("Stream this agent's inter-agent inbox messages to stdout.")
+      .description(
+        "Stream this agent's inter-agent inbox messages to stdout. Long-running: each message it prints is acknowledged as delivered on the host, and it refreshes this machine's stored Traycer credentials (and provisions a host credential if one is missing) while it runs.",
+      )
       .option(
         "--agent-id <id>",
         "Agent to monitor (defaults to $TRAYCER_AGENT_ID)",


### PR DESCRIPTION
## Summary

CLI audit findings **CLI-019** (high) and **CLI-021** (medium).

Hiding a command on `TRAYCER_AGENT_CLI_SURFACE=readonly` was never a capability check — Commander runs a hidden subcommand's action when it is typed explicitly. So `agent create`, `fork`, `configure`, `stop`, `archive`, `send` and role `claim`/`relinquish` all still executed on a readonly surface. `worktree delete` was the only command that refused, via a guard of its own.

This centralizes the check: `clients/traycer-cli/src/agent-surface.ts` owns a policy table keyed by canonical command path, and `withRunner` consults it for every runner-backed command. A gated command cannot be reached through any Commander route without passing it, and adding a mutating command to the table is the whole change — there is no per-registration opt-in to forget, which is what let this drift in the first place.

| | Mechanism | Scope |
| --- | --- | --- |
| **Presentation** | Commander `hidden` | The whole agent-to-agent surface, **reads included** — unchanged by this PR |
| **Capability** | `READONLY_REFUSED_COMMANDS`, enforced in `withRunner` | Agent-typed mutations only |

Hiding is deliberately the wider set: the readonly surface hides reads (`agent inbox`, `selection-guide`, the harness/profile catalogs) because they are not useful to a session that cannot act. Those reads stay runnable, and this PR changes no command's visibility.

### What is in the table

`agent create` · `agent fork` · `agent configure` · `agent stop` · `agent archive` · `agent send` · `agent role claim` · `agent role relinquish` · `worktree delete`

`worktree delete` moved off its bespoke guard onto the shared table; its user-facing message is byte-for-byte unchanged.

### Fails closed

`resolveAgentCliSurface` used to be `=== "readonly" ? "readonly" : "full"`, so any value that was not exactly `readonly` — a host spelling drift, a casing difference, a surface name a newer host knows and this CLI does not — silently meant `full` and the restriction evaporated with nothing signalling it. Now only an absent/empty variable and the exact string `full` open the full surface; everything else resolves to `readonly`.

**This is the one host-observable behavior change in the PR.** If the host ever writes a value other than lowercase `full`/`readonly` for a session meant to be unrestricted, that session now loses the gated commands. Evidence it is safe: the CLI has only ever recognised lowercase `readonly`, a live session's ambient value is lowercase `full`, and this CLI is the variable's only consumer — a third value would be one no client understands. The failure mode is a visible refusal rather than a silent grant.

### A rail, not an authorization boundary

The surface is an environment variable in the session's own environment, so an agent holding that shell can clear it. This makes the restricted surface behave as documented for a caller that does not go out of its way; it does not stop one that does. That is a real improvement over hiding — which stopped nothing, including an agent that simply typed a command it saw in a transcript — but the ceiling is set by where the signal lives. **A genuine boundary has to be host-side** (an authorization check on the RPC, or a scoped credential the session cannot swap). The code now says this plainly instead of implying more than it does.

### CLI-021: monitor

`traycer monitor` is not read-only, and nothing said so. Its description and module contract now disclose all three durable effects: delivery acknowledgement (the CLI enqueues `agent.inbox.ack` from the negotiated `@1.2`; below that the frame carries no event id and the host retires the row server-side), credential rotation/persistence, and host-credential provisioning.

It stays **ungated**, as a knowing exception rather than an oversight — it is also a registered command an agent can type, with its own `--agent-id`, so leaving it open does leave a mutation reachable. Two things decide it: refusing it would break at-least-once delivery for any session the host does spawn a monitor for (a host-side fact this repo cannot check, whose symptom is silent redelivery loops), and it would buy little against a caller who can clear the variable anyway. Flipping it later is one table entry.

## Notable side effect

Building the inner command lazily means a builder-side throw now renders through the runner with its real code and message, instead of being flattened to `E_UNEXPECTED` by the entrypoint's catch. Better fidelity, user-visible on those edge paths.

## Test plan

- New `clients/traycer-cli/src/commands/__tests__/readonly-surface-gate.test.ts` (40 tests). It iterates `READONLY_REFUSED_COMMANDS` itself rather than a copied literal, so a future gated entry without a working gate fails the suite. Per entry: refused with `E_FORBIDDEN` under readonly **and** the deepest dependency never called (proof the body was not entered), plus the full-surface counterpart reaching the body. Also covers hidden-but-ungated reads staying runnable, the fail-closed resolution matrix (casing, unknown values, whitespace), an end-to-end fail-closed case, that every table key resolves to a registered command (a rename would otherwise silently disable enforcement), the monitor exception, and `commanderCommandPath`.
- [x] Full `@traycer-clients/traycer-cli` suite green in a CI-like environment: **153 files, 1914 passed, 0 failed**. (Run with `TRAYCER_CLI_VERSION`/`TRAYCER_CLI_DISTRIBUTION`/agent-context vars scrubbed — those ambient values make 31 unrelated version/packaging suites fail locally.)
- [x] `nx run @traycer-clients/traycer-cli:compile`
- [x] Manual, real binary: under readonly, `agent stop --json` returns the `E_FORBIDDEN` envelope with exit 1 and `worktree delete` prints the unchanged message; on the full surface `agent stop` reaches the body (`E_AUTH_NO_CREDENTIALS`).
- Independently reviewed by a separate agent; all five findings (fail-open resolution, the monitor rationale, an overstated side-effect claim, contradictory `agent archive` help, and the ack mechanism on pre-`@1.2` hosts) are addressed in this PR.

## Out of scope

`comments set-status` and `worktree create` are agent-typed mutations a readonly session can still run. They have never been hidden on the readonly surface either, so widening the contract to cover them is a host-side product decision, not a table edit to make unilaterally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)