### PR TITLE
fix(traycer-cli): repair help surface and human-readable output (CLI-002/005/020/022)

### DIFF
--- a/clients/traycer-cli/README.md
+++ b/clients/traycer-cli/README.md
@@ -74,7 +74,7 @@ Most commands support `--json`, which emits structured NDJSON events suitable fo
 
 ## Agent and Workspace Commands
 
-Traycer-launched agent sessions receive environment variables such as `TRAYCER_AGENT_ID` and `TRAYCER_EPIC_ID`. In that context, the CLI can inspect the current epic, communicate with other agents, and create worktrees:
+Traycer-launched agent sessions receive environment variables such as `TRAYCER_AGENT_ID` and `TRAYCER_EPIC_ID`. In that context, the CLI can inspect the current Task, communicate with other agents, and create worktrees:
 
 ```sh
 traycer agent list

--- a/clients/traycer-cli/src/commands/__tests__/cli-entrypoint-registration.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/cli-entrypoint-registration.test.ts
@@ -34,8 +34,40 @@ const mocks = vi.hoisted(() => ({
     readonly port: number;
     readonly commandName: string;
   }>,
+  serviceControllerCalls: [] as string[],
   progressEvents: [] as ProgressInfo[],
 }));
+
+// `host free-port-and-restart`'s handler calls `createServiceController().restart(...)`
+// once its two guards clear. Mocked so a real (both-flags) parse in this
+// file's "genuinely exercise the index.ts guard" tests below never reaches
+// an actual OS service manager - the restart/lock/attestation plumbing past
+// the guards is exercised for real in `host-free-port-and-restart.test.ts`.
+vi.mock("../../service", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../service")>();
+  return {
+    ...actual,
+    createServiceController: () => ({
+      install: async () => undefined,
+      uninstall: async () => undefined,
+      status: async () => ({
+        state: "stopped" as const,
+        version: null,
+        listenUrl: null,
+        pid: null,
+      }),
+      stop: async () => {
+        mocks.serviceControllerCalls.push("stop");
+      },
+      start: async () => {
+        mocks.serviceControllerCalls.push("start");
+      },
+      restart: async () => {
+        mocks.serviceControllerCalls.push("restart");
+      },
+    }),
+  };
+});
 
 vi.mock("../../installer/download-stage", () => ({
   downloadAndStageHost: async (opts: {
@@ -1133,6 +1165,78 @@ describe("traycer CLI entrypoint registration", () => {
       thrown = err;
     }
     expect(thrown).toMatchObject({ code: "E_INVALID_ARGUMENT" });
+  });
+
+  // `host free-port-and-restart` went public because `host doctor` prints
+  // this exact command line as the fix for a port conflict - a half-typed
+  // `--port` alone used to skip the kill entirely, restart the host, and
+  // still exit 0 as if the conflict had been resolved. These four route
+  // through the REAL registered command (`program.parseAsync`, not the
+  // handler in isolation) so the guard added in `index.ts` is genuinely
+  // exercised - `host-free-port-and-restart.test.ts` covers the deeper
+  // lock/kill/restart wiring once the guards clear.
+  it("host free-port-and-restart rejects --port without --pid, naming --pid in the message", async () => {
+    const program = buildProgram();
+    program.exitOverride();
+    let thrown: unknown = null;
+    try {
+      await program.parseAsync(
+        ["host", "free-port-and-restart", "--port", "51820"],
+        { from: "user" },
+      );
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toMatchObject({
+      code: "E_INVALID_ARGUMENT",
+      message: expect.stringContaining("--pid"),
+    });
+  });
+
+  it("host free-port-and-restart still rejects --pid without --port (pre-existing handler guard, not regressed)", async () => {
+    const program = buildProgram();
+    program.exitOverride();
+    let thrown: unknown = null;
+    try {
+      await program.parseAsync(
+        ["host", "free-port-and-restart", "--pid", "4242"],
+        { from: "user" },
+      );
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toMatchObject({ code: "E_INVALID_ARGUMENT" });
+  });
+
+  it("host free-port-and-restart parses and forwards both --pid and --port as integers when both are given", async () => {
+    mocks.freePortKillCalls.length = 0;
+    mocks.serviceControllerCalls.length = 0;
+
+    const program = buildProgram();
+    program.exitOverride();
+    await program.parseAsync(
+      ["host", "free-port-and-restart", "--pid", "4242", "--port", "51820"],
+      { from: "user" },
+    );
+
+    expect(mocks.freePortKillCalls).toEqual([
+      { pid: 4242, port: 51820, commandName: "host free-port-and-restart" },
+    ]);
+    expect(mocks.serviceControllerCalls).toEqual(["restart"]);
+  });
+
+  it("host free-port-and-restart parses fine with neither --pid nor --port (Desktop's bare machine call)", async () => {
+    mocks.freePortKillCalls.length = 0;
+    mocks.serviceControllerCalls.length = 0;
+
+    const program = buildProgram();
+    program.exitOverride();
+    await program.parseAsync(["host", "free-port-and-restart"], {
+      from: "user",
+    });
+
+    expect(mocks.freePortKillCalls).toEqual([]);
+    expect(mocks.serviceControllerCalls).toEqual(["restart"]);
   });
 
   it.each([

--- a/clients/traycer-cli/src/commands/__tests__/comments-artifact-path.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/comments-artifact-path.test.ts
@@ -1,0 +1,213 @@
+import path from "node:path";
+import fs from "node:fs";
+import os from "node:os";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  buildCommentsListCommand,
+  buildCommentsSetStatusCommand,
+} from "../comments";
+import { callHostRpc } from "../../internal/host-rpc";
+import type { CommandContext } from "../../runner/runner";
+
+const loggerMock = vi.hoisted(() => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock("../../logger", () => ({
+  createCliLogger: () => loggerMock,
+  errorFromUnknown: (value: unknown) =>
+    value instanceof Error ? value : new Error(String(value)),
+  noopLogger: loggerMock,
+}));
+
+vi.mock("../../internal/host-rpc", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../internal/host-rpc")
+  >("../../internal/host-rpc");
+  return {
+    ...actual,
+    callHostRpc: vi.fn(),
+  };
+});
+
+const rpcMock = vi.mocked(callHostRpc);
+const PREV_EPIC_ENV = process.env.TRAYCER_EPIC_ID;
+
+function fakeCtx(): CommandContext {
+  return {
+    runtime: {
+      json: false,
+      quiet: false,
+      noProgress: false,
+      noBootstrap: false,
+      nonInteractive: false,
+      environment: "production",
+      logger: {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      },
+    },
+    output: {
+      progress: vi.fn(),
+      human: vi.fn(),
+      humanRequired: vi.fn(),
+      emitResult: vi.fn(),
+      emitError: vi.fn(),
+    },
+    progress: vi.fn(),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.TRAYCER_EPIC_ID = "epic_test";
+  rpcMock.mockResolvedValue({ artifacts: [] });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+  if (PREV_EPIC_ENV === undefined) delete process.env.TRAYCER_EPIC_ID;
+  else process.env.TRAYCER_EPIC_ID = PREV_EPIC_ENV;
+});
+
+describe("comments list artifact path normalization (CLI-022)", () => {
+  it("forwards an absolute path unchanged", async () => {
+    const absolute = path.resolve("/tmp/artifacts/spec/index.md");
+    await buildCommentsListCommand({
+      epicId: null,
+      artifactPaths: [absolute],
+      status: null,
+    })(fakeCtx());
+
+    expect(rpcMock).toHaveBeenCalledWith("comments.listThreads", {
+      epicId: "epic_test",
+      artifactPaths: [absolute],
+      status: "all",
+    });
+  });
+
+  it("resolves a relative path that does not exist on disk against process.cwd() (the regression)", async () => {
+    const relative = "does-not-exist/spec/index.md";
+    await buildCommentsListCommand({
+      epicId: null,
+      artifactPaths: [relative],
+      status: null,
+    })(fakeCtx());
+
+    expect(rpcMock).toHaveBeenCalledWith("comments.listThreads", {
+      epicId: "epic_test",
+      artifactPaths: [path.resolve(relative)],
+      status: "all",
+    });
+  });
+
+  it("resolves a relative path that DOES exist on disk to the same absolute form", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "traycer-comments-"));
+    const existingFile = path.join(tmpDir, "index.md");
+    fs.writeFileSync(existingFile, "# artifact");
+    try {
+      const originalCwd = process.cwd();
+      process.chdir(tmpDir);
+      try {
+        await buildCommentsListCommand({
+          epicId: null,
+          artifactPaths: ["index.md"],
+          status: null,
+        })(fakeCtx());
+      } finally {
+        process.chdir(originalCwd);
+      }
+
+      expect(rpcMock).toHaveBeenCalledWith("comments.listThreads", {
+        epicId: "epic_test",
+        artifactPaths: [existingFile],
+        status: "all",
+      });
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("sends artifactPaths: null when no paths are given", async () => {
+    await buildCommentsListCommand({
+      epicId: null,
+      artifactPaths: [],
+      status: null,
+    })(fakeCtx());
+
+    expect(rpcMock).toHaveBeenCalledWith("comments.listThreads", {
+      epicId: "epic_test",
+      artifactPaths: null,
+      status: "all",
+    });
+  });
+
+  it("collapses '.' and '..' segments via path.resolve", async () => {
+    const messy = "docs/../docs/./spec.md";
+    await buildCommentsListCommand({
+      epicId: null,
+      artifactPaths: [messy],
+      status: null,
+    })(fakeCtx());
+
+    expect(rpcMock).toHaveBeenCalledWith("comments.listThreads", {
+      epicId: "epic_test",
+      artifactPaths: [path.resolve(messy)],
+      status: "all",
+    });
+  });
+});
+
+describe("comments set-status artifact path normalization (CLI-022)", () => {
+  beforeEach(() => {
+    rpcMock.mockResolvedValue({ updated: [], failed: [] });
+  });
+
+  it("resolves a relative --artifact against process.cwd() before the request", async () => {
+    const relative = "docs/spec.md";
+    await buildCommentsSetStatusCommand({
+      epicId: null,
+      artifactPath: relative,
+      threadIds: ["t1"],
+      status: "resolved",
+    })(fakeCtx());
+
+    expect(rpcMock).toHaveBeenCalledWith("comments.setThreadStatus", {
+      epicId: "epic_test",
+      updates: [
+        {
+          artifactPath: path.resolve(relative),
+          threadIds: ["t1"],
+          status: "resolved",
+        },
+      ],
+    });
+  });
+
+  it("forwards an absolute --artifact unchanged", async () => {
+    const absolute = path.resolve("/tmp/docs/spec.md");
+    await buildCommentsSetStatusCommand({
+      epicId: null,
+      artifactPath: absolute,
+      threadIds: ["t1", "t2"],
+      status: "open",
+    })(fakeCtx());
+
+    expect(rpcMock).toHaveBeenCalledWith("comments.setThreadStatus", {
+      epicId: "epic_test",
+      updates: [
+        {
+          artifactPath: absolute,
+          threadIds: ["t1", "t2"],
+          status: "open",
+        },
+      ],
+    });
+  });
+});

--- a/clients/traycer-cli/src/commands/__tests__/rendered-help.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/rendered-help.test.ts
@@ -221,175 +221,271 @@ const NAMED_PARENT_PATHS: ReadonlyArray<readonly string[]> = [
   ["agent", "role"],
 ];
 
+interface ExpectedOption {
+  readonly flags: string;
+  readonly mandatory: boolean;
+}
+
 interface ExpectedSurfaceEntry {
   readonly path: string;
-  readonly options: readonly string[];
+  readonly options: readonly ExpectedOption[];
   readonly args: readonly ExpectedArgument[];
 }
 
 // The full public command surface under `buildProgramWithAgentRoles(true)` -
 // every visible command path (`""` is the root itself; parents are listed
 // too, so deleting a whole subtree is caught, not just a leaf), each
-// command's own visible options as their FULL rendered flags term (short
-// alias included, e.g. `"-a, --all"`, not reduced to the long flag - see
-// `parseOptionRowFlagTerms`), and each command's registered arguments as
-// their full name/required/variadic signature (see `ExpectedArgument`
-// above) rather than just a name.
+// command's own visible options as their FULL rendered flags term PLUS
+// mandatory-ness (short alias included, e.g. `"-a, --all"`, not reduced to
+// the long flag - see `parseOptionRowFlagTerms`; `.requiredOption(...)` vs
+// `.option(...)` renders the IDENTICAL flags term and row, so mandatory-ness
+// has to be tracked as its own fact or a required flag silently becoming
+// optional - or vice versa - passes with nothing to disagree), and each
+// command's registered arguments as their full name/required/variadic
+// signature (see `ExpectedArgument` above) rather than just a name.
 //
 // THIS LITERAL IS MEANT TO BE EDITED whenever the public surface
 // legitimately changes - a new command, a renamed/added/removed flag or
-// alias, a new positional argument, a changed arity. That edit is the
-// enforcement mechanism, not a maintenance cost to route around: unlike
-// everything else in this file, nothing here is derived from `cmd`, so it
-// is the one check that can prove something disappeared.
+// alias, a flag becoming required/optional, a new positional argument, a
+// changed arity. That edit is the enforcement mechanism, not a maintenance
+// cost to route around: unlike everything else in this file, nothing here
+// is derived from `cmd`, so it is the one check that can prove something
+// disappeared or silently changed shape.
 const EXPECTED_PUBLIC_SURFACE: readonly ExpectedSurfaceEntry[] = [
   {
     path: "",
-    options: ["--json", "--no-progress", "--quiet", "-V, --version"],
+    options: [
+      { flags: "--json", mandatory: false },
+      { flags: "--no-progress", mandatory: false },
+      { flags: "--quiet", mandatory: false },
+      { flags: "-V, --version", mandatory: false },
+    ],
     args: [],
   },
-  { path: "login", options: ["--json", "--no-progress", "--quiet"], args: [] },
-  { path: "logout", options: ["--json", "--no-progress", "--quiet"], args: [] },
-  { path: "whoami", options: ["--json", "--no-progress", "--quiet"], args: [] },
+  {
+    path: "login",
+    options: [
+      { flags: "--json", mandatory: false },
+      { flags: "--no-progress", mandatory: false },
+      { flags: "--quiet", mandatory: false },
+    ],
+    args: [],
+  },
+  {
+    path: "logout",
+    options: [
+      { flags: "--json", mandatory: false },
+      { flags: "--no-progress", mandatory: false },
+      { flags: "--quiet", mandatory: false },
+    ],
+    args: [],
+  },
+  {
+    path: "whoami",
+    options: [
+      { flags: "--json", mandatory: false },
+      { flags: "--no-progress", mandatory: false },
+      { flags: "--quiet", mandatory: false },
+    ],
+    args: [],
+  },
   {
     path: "link-phone",
-    options: ["--json", "--no-progress", "--no-qr", "--quiet"],
+    options: [
+      { flags: "--json", mandatory: false },
+      { flags: "--no-progress", mandatory: false },
+      { flags: "--no-qr", mandatory: false },
+      { flags: "--quiet", mandatory: false },
+    ],
     args: [],
   },
   { path: "host", options: [], args: [] },
   {
     path: "host start",
-    options: ["--cwd <path>", "--json", "--no-progress", "--quiet"],
+    options: [
+      { flags: "--cwd <path>", mandatory: false },
+      { flags: "--json", mandatory: false },
+      { flags: "--no-progress", mandatory: false },
+      { flags: "--quiet", mandatory: false },
+    ],
     args: [],
   },
   {
     path: "host capabilities",
-    options: ["--has <capability>", "--json"],
+    options: [
+      { flags: "--has <capability>", mandatory: false },
+      { flags: "--json", mandatory: false },
+    ],
     args: [],
   },
   {
     path: "host status",
-    options: ["--json", "--no-progress", "--quiet"],
+    options: [
+      { flags: "--json", mandatory: false },
+      { flags: "--no-progress", mandatory: false },
+      { flags: "--quiet", mandatory: false },
+    ],
     args: [],
   },
   {
     path: "host doctor",
-    options: ["--json", "--no-progress", "--quiet"],
+    options: [
+      { flags: "--json", mandatory: false },
+      { flags: "--no-progress", mandatory: false },
+      { flags: "--quiet", mandatory: false },
+    ],
     args: [],
   },
   {
     path: "host restart",
-    options: ["--force", "--json", "--no-progress", "--quiet"],
+    options: [
+      { flags: "--force", mandatory: false },
+      { flags: "--json", mandatory: false },
+      { flags: "--no-progress", mandatory: false },
+      { flags: "--quiet", mandatory: false },
+    ],
     args: [],
   },
   {
     path: "host stop",
-    options: ["--force", "--json", "--no-progress", "--quiet"],
+    options: [
+      { flags: "--force", mandatory: false },
+      { flags: "--json", mandatory: false },
+      { flags: "--no-progress", mandatory: false },
+      { flags: "--quiet", mandatory: false },
+    ],
     args: [],
   },
   { path: "host service", options: [], args: [] },
   {
     path: "host service install",
     options: [
-      "--allow-self-invocation",
-      "--json",
-      "--no-linger",
-      "--no-progress",
-      "--quiet",
-      "--takeover",
+      { flags: "--allow-self-invocation", mandatory: false },
+      { flags: "--json", mandatory: false },
+      { flags: "--no-linger", mandatory: false },
+      { flags: "--no-progress", mandatory: false },
+      { flags: "--quiet", mandatory: false },
+      { flags: "--takeover", mandatory: false },
     ],
     args: [],
   },
   {
     path: "host service status",
-    options: ["--json", "--no-progress", "--quiet"],
+    options: [
+      { flags: "--json", mandatory: false },
+      { flags: "--no-progress", mandatory: false },
+      { flags: "--quiet", mandatory: false },
+    ],
     args: [],
   },
   {
     path: "host service uninstall",
-    options: ["--json", "--no-progress", "--quiet"],
+    options: [
+      { flags: "--json", mandatory: false },
+      { flags: "--no-progress", mandatory: false },
+      { flags: "--quiet", mandatory: false },
+    ],
     args: [],
   },
   {
     path: "host install",
     options: [
-      "--allow-self-invocation",
-      "--force",
-      "--from <path>",
-      "--json",
-      "--no-linger",
-      "--no-progress",
-      "--no-service-register",
-      "--quiet",
-      "--release <version>",
+      { flags: "--allow-self-invocation", mandatory: false },
+      { flags: "--force", mandatory: false },
+      { flags: "--from <path>", mandatory: false },
+      { flags: "--json", mandatory: false },
+      { flags: "--no-linger", mandatory: false },
+      { flags: "--no-progress", mandatory: false },
+      { flags: "--no-service-register", mandatory: false },
+      { flags: "--quiet", mandatory: false },
+      { flags: "--release <version>", mandatory: false },
     ],
     args: [],
   },
   {
     path: "host ensure",
     options: [
-      "--allow-self-invocation",
-      "--force",
-      "--from <path>",
-      "--json",
-      "--no-linger",
-      "--no-progress",
-      "--no-service-register",
-      "--quiet",
-      "--release <version>",
+      { flags: "--allow-self-invocation", mandatory: false },
+      { flags: "--force", mandatory: false },
+      { flags: "--from <path>", mandatory: false },
+      { flags: "--json", mandatory: false },
+      { flags: "--no-linger", mandatory: false },
+      { flags: "--no-progress", mandatory: false },
+      { flags: "--no-service-register", mandatory: false },
+      { flags: "--quiet", mandatory: false },
+      { flags: "--release <version>", mandatory: false },
     ],
     args: [],
   },
   {
     path: "host apply",
-    options: ["--force", "--json", "--no-progress", "--quiet"],
+    options: [
+      { flags: "--force", mandatory: false },
+      { flags: "--json", mandatory: false },
+      { flags: "--no-progress", mandatory: false },
+      { flags: "--quiet", mandatory: false },
+    ],
     args: [],
   },
   {
     path: "host update",
-    options: ["--force", "--json", "--no-progress", "--quiet"],
+    options: [
+      { flags: "--force", mandatory: false },
+      { flags: "--json", mandatory: false },
+      { flags: "--no-progress", mandatory: false },
+      { flags: "--quiet", mandatory: false },
+    ],
     args: [],
   },
   {
     path: "host download",
-    options: ["--json", "--no-progress", "--quiet"],
+    options: [
+      { flags: "--json", mandatory: false },
+      { flags: "--no-progress", mandatory: false },
+      { flags: "--quiet", mandatory: false },
+    ],
     args: [{ name: "version", required: false, variadic: false }],
   },
   {
     path: "host uninstall",
-    options: ["--all", "--json", "--no-progress", "--quiet"],
+    options: [
+      { flags: "--all", mandatory: false },
+      { flags: "--json", mandatory: false },
+      { flags: "--no-progress", mandatory: false },
+      { flags: "--quiet", mandatory: false },
+    ],
     args: [],
   },
   {
     path: "host available",
     options: [
-      "--include-pre-releases",
-      "--json",
-      "--no-include-pre-releases",
-      "--no-progress",
-      "--quiet",
+      { flags: "--include-pre-releases", mandatory: false },
+      { flags: "--json", mandatory: false },
+      { flags: "--no-include-pre-releases", mandatory: false },
+      { flags: "--no-progress", mandatory: false },
+      { flags: "--quiet", mandatory: false },
     ],
     args: [],
   },
   {
     path: "host logs",
     options: [
-      "--follow",
-      "--json",
-      "--no-progress",
-      "--quiet",
-      "--tail <lines>",
+      { flags: "--follow", mandatory: false },
+      { flags: "--json", mandatory: false },
+      { flags: "--no-progress", mandatory: false },
+      { flags: "--quiet", mandatory: false },
+      { flags: "--tail <lines>", mandatory: false },
     ],
     args: [],
   },
   {
     path: "host free-port-and-restart",
     options: [
-      "--json",
-      "--no-progress",
-      "--pid <pid>",
-      "--port <port>",
-      "--quiet",
+      { flags: "--json", mandatory: false },
+      { flags: "--no-progress", mandatory: false },
+      { flags: "--pid <pid>", mandatory: false },
+      { flags: "--port <port>", mandatory: false },
+      { flags: "--quiet", mandatory: false },
     ],
     args: [],
   },
@@ -397,22 +493,22 @@ const EXPECTED_PUBLIC_SURFACE: readonly ExpectedSurfaceEntry[] = [
   {
     path: "cli upgrade",
     options: [
-      "--dry-run",
-      "--json",
-      "--no-progress",
-      "--quiet",
-      "--target <version>",
+      { flags: "--dry-run", mandatory: false },
+      { flags: "--json", mandatory: false },
+      { flags: "--no-progress", mandatory: false },
+      { flags: "--quiet", mandatory: false },
+      { flags: "--target <version>", mandatory: false },
     ],
     args: [],
   },
   {
     path: "cli re-anchor",
     options: [
-      "--binary-path <path>",
-      "--installed-version <version>",
-      "--json",
-      "--no-progress",
-      "--quiet",
+      { flags: "--binary-path <path>", mandatory: true },
+      { flags: "--installed-version <version>", mandatory: true },
+      { flags: "--json", mandatory: false },
+      { flags: "--no-progress", mandatory: false },
+      { flags: "--quiet", mandatory: false },
     ],
     args: [],
   },
@@ -420,309 +516,417 @@ const EXPECTED_PUBLIC_SURFACE: readonly ExpectedSurfaceEntry[] = [
   { path: "config shell", options: [], args: [] },
   {
     path: "config shell get",
-    options: ["--json", "--no-progress", "--quiet"],
+    options: [
+      { flags: "--json", mandatory: false },
+      { flags: "--no-progress", mandatory: false },
+      { flags: "--quiet", mandatory: false },
+    ],
     args: [],
   },
   {
     path: "config shell list",
-    options: ["--json", "--no-progress", "--quiet"],
+    options: [
+      { flags: "--json", mandatory: false },
+      { flags: "--no-progress", mandatory: false },
+      { flags: "--quiet", mandatory: false },
+    ],
     args: [],
   },
   {
     path: "config shell set",
     options: [
-      "--clear-args",
-      "--json",
-      "--no-progress",
-      "--path <path>",
-      "--quiet",
+      { flags: "--clear-args", mandatory: false },
+      { flags: "--json", mandatory: false },
+      { flags: "--no-progress", mandatory: false },
+      { flags: "--path <path>", mandatory: false },
+      { flags: "--quiet", mandatory: false },
     ],
     args: [{ name: "shellArgs", required: false, variadic: true }],
   },
   {
     path: "config shell add",
-    options: ["--json", "--no-progress", "--path <path>", "--quiet"],
+    options: [
+      { flags: "--json", mandatory: false },
+      { flags: "--no-progress", mandatory: false },
+      { flags: "--path <path>", mandatory: true },
+      { flags: "--quiet", mandatory: false },
+    ],
     args: [],
   },
   {
     path: "config shell remove",
-    options: ["--json", "--no-progress", "--path <path>", "--quiet"],
+    options: [
+      { flags: "--json", mandatory: false },
+      { flags: "--no-progress", mandatory: false },
+      { flags: "--path <path>", mandatory: true },
+      { flags: "--quiet", mandatory: false },
+    ],
     args: [],
   },
   {
     path: "config shell revert-args",
-    options: ["--json", "--no-progress", "--path <path>", "--quiet"],
+    options: [
+      { flags: "--json", mandatory: false },
+      { flags: "--no-progress", mandatory: false },
+      { flags: "--path <path>", mandatory: true },
+      { flags: "--quiet", mandatory: false },
+    ],
     args: [],
   },
   {
     path: "config shell reset",
-    options: ["--json", "--no-progress", "--quiet"],
+    options: [
+      { flags: "--json", mandatory: false },
+      { flags: "--no-progress", mandatory: false },
+      { flags: "--quiet", mandatory: false },
+    ],
     args: [],
   },
   { path: "config env", options: [], args: [] },
   {
     path: "config env list",
-    options: ["--json", "--no-progress", "--quiet"],
+    options: [
+      { flags: "--json", mandatory: false },
+      { flags: "--no-progress", mandatory: false },
+      { flags: "--quiet", mandatory: false },
+    ],
     args: [],
   },
   {
     path: "config env get",
-    options: ["--json", "--key <key>", "--no-progress", "--quiet"],
+    options: [
+      { flags: "--json", mandatory: false },
+      { flags: "--key <key>", mandatory: true },
+      { flags: "--no-progress", mandatory: false },
+      { flags: "--quiet", mandatory: false },
+    ],
     args: [],
   },
   {
     path: "config env set",
     options: [
-      "--json",
-      "--key <key>",
-      "--no-progress",
-      "--quiet",
-      "--value <value>",
+      { flags: "--json", mandatory: false },
+      { flags: "--key <key>", mandatory: true },
+      { flags: "--no-progress", mandatory: false },
+      { flags: "--quiet", mandatory: false },
+      { flags: "--value <value>", mandatory: true },
     ],
     args: [],
   },
   {
     path: "config env unset",
-    options: ["--json", "--key <key>", "--no-progress", "--quiet"],
+    options: [
+      { flags: "--json", mandatory: false },
+      { flags: "--key <key>", mandatory: true },
+      { flags: "--no-progress", mandatory: false },
+      { flags: "--quiet", mandatory: false },
+    ],
     args: [],
   },
   {
     path: "config env delete",
-    options: ["--json", "--key <key>", "--no-progress", "--quiet"],
+    options: [
+      { flags: "--json", mandatory: false },
+      { flags: "--key <key>", mandatory: true },
+      { flags: "--no-progress", mandatory: false },
+      { flags: "--quiet", mandatory: false },
+    ],
     args: [],
   },
   { path: "comments", options: [], args: [] },
   {
     path: "comments list",
-    options: ["--json", "--no-progress", "--quiet", "--status <status>"],
+    options: [
+      { flags: "--json", mandatory: false },
+      { flags: "--no-progress", mandatory: false },
+      { flags: "--quiet", mandatory: false },
+      { flags: "--status <status>", mandatory: false },
+    ],
     args: [{ name: "artifactPaths", required: false, variadic: true }],
   },
   {
     path: "comments set-status",
     options: [
-      "--artifact <path>",
-      "--json",
-      "--no-progress",
-      "--quiet",
-      "--status <status>",
+      { flags: "--artifact <path>", mandatory: true },
+      { flags: "--json", mandatory: false },
+      { flags: "--no-progress", mandatory: false },
+      { flags: "--quiet", mandatory: false },
+      { flags: "--status <status>", mandatory: true },
     ],
     args: [{ name: "threadIds", required: true, variadic: true }],
   },
   { path: "terminal", options: [], args: [] },
   {
     path: "terminal list",
-    options: ["--json", "--no-progress", "--quiet"],
+    options: [
+      { flags: "--json", mandatory: false },
+      { flags: "--no-progress", mandatory: false },
+      { flags: "--quiet", mandatory: false },
+    ],
     args: [],
   },
   {
     path: "terminal output",
-    options: ["--json", "--no-progress", "--quiet"],
+    options: [
+      { flags: "--json", mandatory: false },
+      { flags: "--no-progress", mandatory: false },
+      { flags: "--quiet", mandatory: false },
+    ],
     args: [{ name: "terminal-id", required: true, variadic: false }],
   },
   { path: "workspace", options: [], args: [] },
   {
     path: "workspace list",
-    options: ["--json", "--no-progress", "--quiet"],
+    options: [
+      { flags: "--json", mandatory: false },
+      { flags: "--no-progress", mandatory: false },
+      { flags: "--quiet", mandatory: false },
+    ],
     args: [],
   },
   { path: "worktree", options: [], args: [] },
   {
     path: "worktree list",
     options: [
-      "--cursor <worktreePath>",
-      "--include-activity",
-      "--json",
-      "--limit <n>",
-      "--no-progress",
-      "--quiet",
+      { flags: "--cursor <worktreePath>", mandatory: false },
+      { flags: "--include-activity", mandatory: false },
+      { flags: "--json", mandatory: false },
+      { flags: "--limit <n>", mandatory: false },
+      { flags: "--no-progress", mandatory: false },
+      { flags: "--quiet", mandatory: false },
     ],
     args: [],
   },
   {
     path: "worktree delete",
-    options: ["--json", "--no-progress", "--path <path>", "--quiet"],
+    options: [
+      { flags: "--json", mandatory: false },
+      { flags: "--no-progress", mandatory: false },
+      { flags: "--path <path>", mandatory: true },
+      { flags: "--quiet", mandatory: false },
+    ],
     args: [],
   },
   {
     path: "worktree create",
     options: [
-      "--branch <branch>",
-      "--carry-uncommitted",
-      "--existing <branch>",
-      "--json",
-      "--no-progress",
-      "--quiet",
-      "--source-branch <branch>",
-      "--workspace <path>",
+      { flags: "--branch <branch>", mandatory: false },
+      { flags: "--carry-uncommitted", mandatory: false },
+      { flags: "--existing <branch>", mandatory: false },
+      { flags: "--json", mandatory: false },
+      { flags: "--no-progress", mandatory: false },
+      { flags: "--quiet", mandatory: false },
+      { flags: "--source-branch <branch>", mandatory: false },
+      { flags: "--workspace <path>", mandatory: true },
     ],
     args: [],
   },
   { path: "agent", options: [], args: [] },
   {
     path: "agent list",
-    options: ["--json", "--no-progress", "--quiet", "-a, --all"],
+    options: [
+      { flags: "--json", mandatory: false },
+      { flags: "--no-progress", mandatory: false },
+      { flags: "--quiet", mandatory: false },
+      { flags: "-a, --all", mandatory: false },
+    ],
     args: [],
   },
   {
     path: "agent create",
     options: [
-      "--cwd <path>",
-      "--fast",
-      "--harness <id>",
-      "--json",
-      "--model <id>",
-      "--name <name>",
-      "--no-progress",
-      "--permission-mode <mode>",
-      "--profile <ambient|id>",
-      "--quiet",
-      "--reasoning-effort <effort>",
-      "--surface <surface>",
-      "--workspace-entry <workspace=path>",
-      "--workspace-path <path>",
+      { flags: "--cwd <path>", mandatory: false },
+      { flags: "--fast", mandatory: false },
+      { flags: "--harness <id>", mandatory: false },
+      { flags: "--json", mandatory: false },
+      { flags: "--model <id>", mandatory: false },
+      { flags: "--name <name>", mandatory: false },
+      { flags: "--no-progress", mandatory: false },
+      { flags: "--permission-mode <mode>", mandatory: false },
+      { flags: "--profile <ambient|id>", mandatory: false },
+      { flags: "--quiet", mandatory: false },
+      { flags: "--reasoning-effort <effort>", mandatory: false },
+      { flags: "--surface <surface>", mandatory: false },
+      { flags: "--workspace-entry <workspace=path>", mandatory: false },
+      { flags: "--workspace-path <path>", mandatory: false },
     ],
     args: [],
   },
   {
     path: "agent fork",
     options: [
-      "--agent-id <id>",
-      "--cwd <path>",
-      "--json",
-      "--name <name>",
-      "--no-progress",
-      "--permission-mode <mode>",
-      "--profile <ambient|id>",
-      "--quiet",
-      "--workspace-entry <workspace=path>",
-      "--workspace-path <path>",
+      { flags: "--agent-id <id>", mandatory: true },
+      { flags: "--cwd <path>", mandatory: false },
+      { flags: "--json", mandatory: false },
+      { flags: "--name <name>", mandatory: false },
+      { flags: "--no-progress", mandatory: false },
+      { flags: "--permission-mode <mode>", mandatory: false },
+      { flags: "--profile <ambient|id>", mandatory: false },
+      { flags: "--quiet", mandatory: false },
+      { flags: "--workspace-entry <workspace=path>", mandatory: false },
+      { flags: "--workspace-path <path>", mandatory: false },
     ],
     args: [],
   },
   {
     path: "agent selection-guide",
-    options: ["--json", "--no-progress", "--quiet"],
+    options: [
+      { flags: "--json", mandatory: false },
+      { flags: "--no-progress", mandatory: false },
+      { flags: "--quiet", mandatory: false },
+    ],
     args: [],
   },
   {
     path: "agent list-harnesses",
-    options: ["--json", "--no-progress", "--quiet"],
+    options: [
+      { flags: "--json", mandatory: false },
+      { flags: "--no-progress", mandatory: false },
+      { flags: "--quiet", mandatory: false },
+    ],
     args: [],
   },
   {
     path: "agent list-harness-models",
-    options: ["--json", "--no-progress", "--quiet"],
+    options: [
+      { flags: "--json", mandatory: false },
+      { flags: "--no-progress", mandatory: false },
+      { flags: "--quiet", mandatory: false },
+    ],
     args: [{ name: "harness", required: true, variadic: false }],
   },
   {
     path: "agent list-profiles",
-    options: ["--json", "--no-progress", "--quiet"],
+    options: [
+      { flags: "--json", mandatory: false },
+      { flags: "--no-progress", mandatory: false },
+      { flags: "--quiet", mandatory: false },
+    ],
     args: [{ name: "harness", required: true, variadic: false }],
   },
   {
     path: "agent profile-rate-limits",
-    options: ["--json", "--no-progress", "--profile <ambient|id>", "--quiet"],
+    options: [
+      { flags: "--json", mandatory: false },
+      { flags: "--no-progress", mandatory: false },
+      { flags: "--profile <ambient|id>", mandatory: true },
+      { flags: "--quiet", mandatory: false },
+    ],
     args: [{ name: "harness", required: true, variadic: false }],
   },
   {
     path: "agent configure",
     options: [
-      "--agent-id <id>",
-      "--fast",
-      "--harness <id>",
-      "--json",
-      "--model <id>",
-      "--no-progress",
-      "--permission-mode <mode>",
-      "--profile <ambient|id>",
-      "--quiet",
-      "--reasoning-effort <effort>",
+      { flags: "--agent-id <id>", mandatory: true },
+      { flags: "--fast", mandatory: false },
+      { flags: "--harness <id>", mandatory: true },
+      { flags: "--json", mandatory: false },
+      { flags: "--model <id>", mandatory: true },
+      { flags: "--no-progress", mandatory: false },
+      { flags: "--permission-mode <mode>", mandatory: false },
+      { flags: "--profile <ambient|id>", mandatory: true },
+      { flags: "--quiet", mandatory: false },
+      { flags: "--reasoning-effort <effort>", mandatory: false },
     ],
     args: [],
   },
   {
     path: "agent stop",
     options: [
-      "--agent-id <id>",
-      "--cascade",
-      "--json",
-      "--no-progress",
-      "--quiet",
+      { flags: "--agent-id <id>", mandatory: true },
+      { flags: "--cascade", mandatory: false },
+      { flags: "--json", mandatory: false },
+      { flags: "--no-progress", mandatory: false },
+      { flags: "--quiet", mandatory: false },
     ],
     args: [],
   },
   {
     path: "agent archive",
     options: [
-      "--agent-id <id>",
-      "--json",
-      "--no-progress",
-      "--quiet",
-      "--unarchive",
+      { flags: "--agent-id <id>", mandatory: true },
+      { flags: "--json", mandatory: false },
+      { flags: "--no-progress", mandatory: false },
+      { flags: "--quiet", mandatory: false },
+      { flags: "--unarchive", mandatory: false },
     ],
     args: [],
   },
   {
     path: "agent send",
     options: [
-      "--expect-reply",
-      "--json",
-      "--message <text>",
-      "--no-progress",
-      "--quiet",
-      "--response-id <id>",
-      "--to <agentId>",
+      { flags: "--expect-reply", mandatory: false },
+      { flags: "--json", mandatory: false },
+      { flags: "--message <text>", mandatory: true },
+      { flags: "--no-progress", mandatory: false },
+      { flags: "--quiet", mandatory: false },
+      { flags: "--response-id <id>", mandatory: false },
+      { flags: "--to <agentId>", mandatory: true },
     ],
     args: [],
   },
   {
     path: "agent transcript",
-    options: ["--agent-id <id>", "--json", "--no-progress", "--quiet"],
+    options: [
+      { flags: "--agent-id <id>", mandatory: true },
+      { flags: "--json", mandatory: false },
+      { flags: "--no-progress", mandatory: false },
+      { flags: "--quiet", mandatory: false },
+    ],
     args: [],
   },
   { path: "agent role", options: [], args: [] },
   {
     path: "agent role claim",
     options: [
-      "--agent-id <id>",
-      "--json",
-      "--no-progress",
-      "--quiet",
-      "--role <name>",
-      "--scope <scope>",
+      { flags: "--agent-id <id>", mandatory: false },
+      { flags: "--json", mandatory: false },
+      { flags: "--no-progress", mandatory: false },
+      { flags: "--quiet", mandatory: false },
+      { flags: "--role <name>", mandatory: true },
+      { flags: "--scope <scope>", mandatory: true },
     ],
     args: [],
   },
   {
     path: "agent role list",
-    options: ["--json", "--no-progress", "--quiet"],
+    options: [
+      { flags: "--json", mandatory: false },
+      { flags: "--no-progress", mandatory: false },
+      { flags: "--quiet", mandatory: false },
+    ],
     args: [],
   },
   {
     path: "agent role relinquish",
     options: [
-      "--agent-id <id>",
-      "--claim-id <id>",
-      "--json",
-      "--no-progress",
-      "--quiet",
+      { flags: "--agent-id <id>", mandatory: false },
+      { flags: "--claim-id <id>", mandatory: true },
+      { flags: "--json", mandatory: false },
+      { flags: "--no-progress", mandatory: false },
+      { flags: "--quiet", mandatory: false },
     ],
     args: [],
   },
   {
     path: "agent inbox",
     options: [
-      "--after <createdAt:eventId>",
-      "--agent-id <id>",
-      "--json",
-      "--no-progress",
-      "--quiet",
+      { flags: "--after <createdAt:eventId>", mandatory: false },
+      { flags: "--agent-id <id>", mandatory: false },
+      { flags: "--json", mandatory: false },
+      { flags: "--no-progress", mandatory: false },
+      { flags: "--quiet", mandatory: false },
     ],
     args: [],
   },
   {
     path: "monitor",
-    options: ["--agent-id <id>", "--json", "--no-progress", "--quiet"],
+    options: [
+      { flags: "--agent-id <id>", mandatory: false },
+      { flags: "--json", mandatory: false },
+      { flags: "--no-progress", mandatory: false },
+      { flags: "--quiet", mandatory: false },
+    ],
     args: [],
   },
 ];
@@ -777,13 +981,13 @@ describe("rendered root/parent/leaf --help (CLI command audit regression suite)"
       // Full flags TERM (short alias included, e.g. "-a, --all"), not
       // reduced to the long flag - a deleted `-a` alias with `--all` still
       // registered must show up as a mismatch here.
-      const actualOptions = new Set(parseOptionRowFlagTerms(help));
-      const expectedOptions = new Set(entry.options);
-      const missingOptions = [...expectedOptions].filter(
-        (f) => !actualOptions.has(f),
+      const renderedOptionTerms = new Set(parseOptionRowFlagTerms(help));
+      const expectedFlagTerms = new Set(entry.options.map((o) => o.flags));
+      const missingOptions = [...expectedFlagTerms].filter(
+        (f) => !renderedOptionTerms.has(f),
       );
-      const unexpectedOptions = [...actualOptions].filter(
-        (f) => !expectedOptions.has(f),
+      const unexpectedOptions = [...renderedOptionTerms].filter(
+        (f) => !expectedFlagTerms.has(f),
       );
       expect(
         missingOptions,
@@ -792,6 +996,31 @@ describe("rendered root/parent/leaf --help (CLI command audit regression suite)"
       expect(
         unexpectedOptions,
         `${label}: undocumented new rendered option(s) - add to EXPECTED_PUBLIC_SURFACE if intentional: ${unexpectedOptions.join(", ")}`,
+      ).toEqual([]);
+
+      // Mandatory-ness has NO rendered representation at all -
+      // `.requiredOption("--artifact <path>", ...)` and
+      // `.option("--artifact <path>", ...)` produce the byte-identical
+      // Options: row, so this can only be checked against the live `Option`
+      // object's public `.mandatory` field, never parsed from text. Flipping
+      // a required flag to optional (or vice versa) changes the public CLI
+      // contract with nothing in rendered help to disagree - for
+      // `--artifact` specifically it would let the `opts.artifact ?? ""`
+      // empty-string fallback in `index.ts` reach the RPC.
+      const mandatoryMismatches = entry.options
+        .map((expectedOption) => {
+          const actualOption = cmd.options.find(
+            (option) => option.flags === expectedOption.flags,
+          );
+          return actualOption === undefined ||
+            actualOption.mandatory === expectedOption.mandatory
+            ? null
+            : `${expectedOption.flags} (expected mandatory=${expectedOption.mandatory}, actual=${actualOption.mandatory})`;
+        })
+        .filter((entryLabel): entryLabel is string => entryLabel !== null);
+      expect(
+        mandatoryMismatches,
+        `${label}: option mandatory-ness changed: ${mandatoryMismatches.join(", ")}`,
       ).toEqual([]);
 
       // Full argument SIGNATURE (name + required + variadic), not just the

--- a/clients/traycer-cli/src/commands/__tests__/rendered-help.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/rendered-help.test.ts
@@ -128,7 +128,7 @@ describe("rendered root/parent/leaf --help (CLI command audit regression suite)"
     );
   });
 
-  it("prints every non-hidden option's flags in that command's own rendered help", () => {
+  it("prints every non-hidden option's flags, and every registered argument's name, in that command's own rendered help", () => {
     const program = freshProgram();
     for (const { path, cmd } of allCommands(program)) {
       const help = cmd.helpInformation();
@@ -146,6 +146,15 @@ describe("rendered root/parent/leaf --help (CLI command audit regression suite)"
             `${pathLabel(path)}: rendered help is missing '${option.short}'`,
           ).toBe(true);
         }
+      }
+      // Commander's `Arguments:` section lists the BARE name (no `<>`/`[]`/
+      // `...`), e.g. `artifactPaths`, not `[artifactPaths...]` - confirmed by
+      // inspecting `helpInformation()` output directly rather than guessing.
+      for (const argument of cmd.registeredArguments) {
+        expect(
+          help.includes(argument.name()),
+          `${pathLabel(path)}: rendered help is missing registered argument '${argument.name()}'`,
+        ).toBe(true);
       }
     }
   });
@@ -292,7 +301,7 @@ describe("rendered root/parent/leaf --help (CLI command audit regression suite)"
     ).toBe(false);
   });
 
-  it("keeps internal vocabulary out of every visible command's description and its visible options' descriptions", () => {
+  it("keeps internal vocabulary out of every visible command's description, its visible options' descriptions, and its registered arguments' descriptions", () => {
     const program = freshProgram();
     // Deliberately does NOT blocklist "bootstrap" (host start's description
     // is owned by another in-flight PR) or "NDJSON" (a real format name).
@@ -319,6 +328,20 @@ describe("rendered root/parent/leaf --help (CLI command audit regression suite)"
           expect(
             pattern.test(option.description),
             `${pathLabel(path)} ${option.long}: description leaks '${label}': "${option.description}"`,
+          ).toBe(false);
+        }
+      }
+      // Positional argument descriptions are rendered help text too
+      // (`comments list [artifactPaths...]`, `terminal output <terminal-id>`,
+      // etc.) - a regression here (e.g. "this epic" instead of "this Task")
+      // is exactly as user-visible as one in an option description, so it
+      // gets the same blocklist. `registeredArguments` is commander's public
+      // accessor for this - not an internal field.
+      for (const argument of cmd.registeredArguments) {
+        for (const [pattern, label] of banned) {
+          expect(
+            pattern.test(argument.description),
+            `${pathLabel(path)} ${argument.name()}: description leaks '${label}': "${argument.description}"`,
           ).toBe(false);
         }
       }
@@ -418,6 +441,27 @@ describe("rendered root/parent/leaf --help (CLI command audit regression suite)"
         "relative to the current directory (resolved before the request)";
       expect(list).toContain(expectedWording);
       expect(setStatus).toContain(expectedWording);
+    });
+
+    // Belt-and-braces duplicate of the generic internal-vocabulary sweep
+    // above: this is a proven regression (CLI-005 walked right back in via
+    // `comments list`'s `[artifactPaths...]` argument description reverting
+    // to "this epic"), and the generic sweep's failure message names the
+    // command path but not what the wording SHOULD say. This one points
+    // straight at the finding.
+    it("comments list's [artifactPaths...] argument says 'this Task', never 'epic' (CLI-005 regression)", () => {
+      const program = freshProgram();
+      const list = findByPath(program, ["comments", "list"]);
+      const argument = list.registeredArguments.find(
+        (candidate) => candidate.name() === "artifactPaths",
+      );
+      expect(
+        argument,
+        "expected 'comments list' to register an 'artifactPaths' argument",
+      ).toBeDefined();
+      const description = argument?.description ?? "";
+      expect(description).toContain("this Task");
+      expect(description).not.toMatch(/\bepics?\b/i);
     });
   });
 });

--- a/clients/traycer-cli/src/commands/__tests__/rendered-help.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/rendered-help.test.ts
@@ -1,0 +1,423 @@
+import { describe, expect, it, vi } from "vitest";
+import { Command } from "commander";
+import { buildProgramWithAgentRoles } from "../../index";
+
+// Regression suite for the CLI command audit's "Help audit checklist"
+// (epics/.../artifacts/cli-command-audit/index.md): rendered root/parent/leaf
+// `--help` output must match the inventory - every supported flag/command
+// visible, every internal one hidden and undocumented in user-facing text,
+// and parent help enumerating exactly its intended public children.
+//
+// Built once per test via `buildProgramWithAgentRoles(true)` (the full agent
+// surface, agent roles enabled) so `agent role` and every non-readonly-gated
+// command are present.
+
+interface TreeEntry {
+  readonly path: readonly string[];
+  readonly cmd: Command;
+}
+
+function walk(cmd: Command, path: readonly string[], acc: TreeEntry[]): void {
+  acc.push({ path, cmd });
+  for (const child of cmd.commands) {
+    walk(child, [...path, child.name()], acc);
+  }
+}
+
+function allCommands(root: Command): TreeEntry[] {
+  const acc: TreeEntry[] = [];
+  walk(root, [], acc);
+  return acc;
+}
+
+function pathLabel(path: readonly string[]): string {
+  return path.length === 0 ? "traycer" : `traycer ${path.join(" ")}`;
+}
+
+function findByPath(root: Command, path: readonly string[]): Command {
+  let cursor = root;
+  for (const segment of path) {
+    const next = cursor.commands.find((child) => child.name() === segment);
+    if (next === undefined) {
+      throw new Error(`command not found: ${pathLabel(path)}`);
+    }
+    cursor = next;
+  }
+  return cursor;
+}
+
+// Public Help API - `createHelp().visibleCommands(cmd)` is what commander's
+// own help renderer calls to decide what to list, so it's the supported way
+// to ask "is this subcommand hidden" rather than reading `Command`'s private
+// `_hidden` field. `Option#hidden` (used below) is a public field already -
+// no equivalent workaround needed for options.
+function hiddenChildren(cmd: Command): Command[] {
+  const visible = cmd.createHelp().visibleCommands(cmd);
+  return cmd.commands.filter((child) => !visible.includes(child));
+}
+
+function visibleChildren(cmd: Command): Command[] {
+  const visible = cmd.createHelp().visibleCommands(cmd);
+  return cmd.commands.filter((child) => visible.includes(child));
+}
+
+function isHiddenCommand(root: Command, path: readonly string[]): boolean {
+  if (path.length === 0) return false;
+  const parent = findByPath(root, path.slice(0, -1));
+  return hiddenChildren(parent).includes(findByPath(root, path));
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+// Boundary-safe "is this command name listed" check. A bare `.includes()`
+// would let `free-port` (hidden) false-match inside `free-port-and-restart`
+// (visible) - exactly the trap the audit's spot check calls out.
+function helpListsCommandName(help: string, name: string): boolean {
+  return new RegExp(`(^|\\s)${escapeRegExp(name)}(\\s|\\[|$)`, "m").test(help);
+}
+
+// Real-render helper: `helpInformation()` renders only commander's built-in
+// sections and omits `addHelpText` blocks entirely (e.g. `host update`'s
+// public `--version <version>` spelling, which exists ONLY as addHelpText
+// because the registered option would collide with root `--version`). Used
+// for the root, every named parent, and `host update` below, per the task's
+// rendering caveat; `helpInformation()` is used for the bulk per-leaf sweep,
+// where no addHelpText content is in play.
+function renderHelp(cmd: Command): string {
+  const write = vi
+    .spyOn(process.stdout, "write")
+    .mockImplementation(() => true);
+  try {
+    cmd.outputHelp();
+    return write.mock.calls.map(([chunk]) => String(chunk)).join("");
+  } finally {
+    write.mockRestore();
+  }
+}
+
+function freshProgram(): Command {
+  return buildProgramWithAgentRoles(true);
+}
+
+const NAMED_PARENT_PATHS: ReadonlyArray<readonly string[]> = [
+  ["host"],
+  ["host", "service"],
+  ["cli"],
+  ["config"],
+  ["config", "shell"],
+  ["config", "env"],
+  ["comments"],
+  ["terminal"],
+  ["workspace"],
+  ["worktree"],
+  ["agent"],
+  ["agent", "role"],
+];
+
+describe("rendered root/parent/leaf --help (CLI command audit regression suite)", () => {
+  it("cross-checks the hidden-command helper against a known-hidden and a known-visible command", () => {
+    const program = freshProgram();
+    const host = findByPath(program, ["host"]);
+    expect(hiddenChildren(host).map((c) => c.name())).toContain("purge-stage");
+    expect(visibleChildren(host).map((c) => c.name())).toContain("status");
+    expect(hiddenChildren(host).map((c) => c.name())).not.toContain("status");
+    expect(visibleChildren(host).map((c) => c.name())).not.toContain(
+      "purge-stage",
+    );
+  });
+
+  it("prints every non-hidden option's flags in that command's own rendered help", () => {
+    const program = freshProgram();
+    for (const { path, cmd } of allCommands(program)) {
+      const help = cmd.helpInformation();
+      for (const option of cmd.options) {
+        if (option.hidden) continue;
+        if (option.long) {
+          expect(
+            help.includes(option.long),
+            `${pathLabel(path)}: rendered help is missing '${option.long}'`,
+          ).toBe(true);
+        }
+        if (option.short) {
+          expect(
+            help.includes(option.short),
+            `${pathLabel(path)}: rendered help is missing '${option.short}'`,
+          ).toBe(true);
+        }
+      }
+    }
+  });
+
+  it("lists every visible subcommand and none of the hidden ones, per named parent", () => {
+    const program = freshProgram();
+    for (const path of NAMED_PARENT_PATHS) {
+      const parent = findByPath(program, path);
+      const help = parent.helpInformation();
+      for (const child of visibleChildren(parent)) {
+        expect(
+          helpListsCommandName(help, child.name()),
+          `${pathLabel(path)}: rendered help is missing visible subcommand '${child.name()}'`,
+        ).toBe(true);
+      }
+      for (const child of hiddenChildren(parent)) {
+        expect(
+          helpListsCommandName(help, child.name()),
+          `${pathLabel(path)}: rendered help leaks hidden subcommand '${child.name()}'`,
+        ).toBe(false);
+      }
+    }
+  });
+
+  it("real --help render for the root and every named parent agrees with the subcommand listing", () => {
+    const program = freshProgram();
+    for (const path of [[], ...NAMED_PARENT_PATHS] as ReadonlyArray<
+      readonly string[]
+    >) {
+      const cmd = findByPath(program, path);
+      const real = renderHelp(cmd);
+      for (const child of visibleChildren(cmd)) {
+        expect(
+          helpListsCommandName(real, child.name()),
+          `${pathLabel(path)}: real --help render is missing visible subcommand '${child.name()}'`,
+        ).toBe(true);
+      }
+      for (const child of hiddenChildren(cmd)) {
+        expect(
+          helpListsCommandName(real, child.name()),
+          `${pathLabel(path)}: real --help render leaks hidden subcommand '${child.name()}'`,
+        ).toBe(false);
+      }
+    }
+  });
+
+  it("host update --help (real render) shows the public '--version <version>' spelling and never the internal '--host-update-version' spelling", () => {
+    const program = freshProgram();
+    const hostUpdate = findByPath(program, ["host", "update"]);
+    const help = renderHelp(hostUpdate);
+    expect(help).toContain("--version <version>");
+    expect(help).toContain("Update to this exact registry version");
+    expect(help).not.toContain("--host-update-version");
+  });
+
+  // Encodes the standing user policy: every supported user-facing/invocable
+  // command and flag must appear in rendered help. Hidden visibility must
+  // not paper over confusing public behavior - genuinely machine-only
+  // callbacks and service-manager entrypoints may stay hidden ONLY when
+  // they are explicitly unsupported for direct users and are
+  // tested/documented as machine contracts (which is exactly what every
+  // entry below is). THIS TEST MUST BE UPDATED whenever the hidden surface
+  // legitimately changes - that update is the enforcement mechanism, not a
+  // maintenance cost to route around.
+  it("hides exactly the allowlisted commands - nothing more, nothing less", () => {
+    const program = freshProgram();
+    const hiddenCommandPaths = allCommands(program)
+      .filter(({ path }) => isHiddenCommand(program, path))
+      .map(({ path }) => path.join(" "))
+      .sort();
+
+    expect(hiddenCommandPaths).toEqual(
+      [
+        "host purge-stage",
+        "host stamp-runtime",
+        "host free-port",
+        "cli mark-source",
+        "cli finalize-upgrade",
+        "agent title-from-hook",
+        "agent activity-from-hook",
+        "agent turn-ended-from-hook",
+        "agent session-observed-from-hook",
+      ].sort(),
+    );
+  });
+
+  it("hides exactly the allowlisted options on visible commands (--no-bootstrap aside)", () => {
+    const program = freshProgram();
+    const hiddenOptionEntries = allCommands(program)
+      .flatMap(({ path, cmd }) =>
+        cmd.options
+          .filter((option) => option.hidden && option.long !== "--no-bootstrap")
+          .map((option) => `${pathLabel(path)} ${option.long}`),
+      )
+      .sort();
+
+    expect(hiddenOptionEntries).toEqual(
+      [
+        "traycer login --token",
+        "traycer host start --service-label",
+        "traycer host start --transition-id",
+        "traycer host start --probe-nonce",
+        "traycer host restart --if-idle",
+        "traycer host install --if-idle",
+        "traycer host apply --expected-stage-fingerprint",
+        "traycer host apply --no-service",
+        "traycer host update --host-update-version",
+        "traycer host download --automatic",
+      ].sort(),
+    );
+  });
+
+  it("hides --no-bootstrap on the root and on every runner-backed leaf, and nowhere else", () => {
+    const program = freshProgram();
+    const allEntries = allCommands(program);
+
+    // "Runner-backed" is derived programmatically as "carries the shared
+    // --json flag", with `host capabilities` carved out: its --json is a
+    // distinct raw machine-contract flag registered directly (not via
+    // `addRunnerFlags`), so it never gets --no-bootstrap either.
+    const runnerBackedPaths = allEntries
+      .filter(
+        ({ path, cmd }) =>
+          cmd.options.some((option) => option.long === "--json") &&
+          pathLabel(path) !== "traycer host capabilities",
+      )
+      .map(({ path }) => pathLabel(path))
+      .sort();
+
+    const noBootstrapPaths = allEntries
+      .filter(({ cmd }) =>
+        cmd.options.some(
+          (option) => option.long === "--no-bootstrap" && option.hidden,
+        ),
+      )
+      .map(({ path }) => pathLabel(path))
+      .sort();
+
+    expect(noBootstrapPaths).toEqual(runnerBackedPaths);
+    expect(
+      findByPath(program, ["host", "capabilities"]).options.some(
+        (option) => option.long === "--no-bootstrap",
+      ),
+    ).toBe(false);
+  });
+
+  it("keeps internal vocabulary out of every visible command's description and its visible options' descriptions", () => {
+    const program = freshProgram();
+    // Deliberately does NOT blocklist "bootstrap" (host start's description
+    // is owned by another in-flight PR) or "NDJSON" (a real format name).
+    const banned: ReadonlyArray<readonly [RegExp, string]> = [
+      [/Internal:/, "Internal:"],
+      [/config surface/i, "config surface"],
+      [/host supervisor/i, "host supervisor"],
+      [/calling agent/i, "calling agent"],
+      [/\bepics?\b/i, "epic(s)"],
+    ];
+
+    for (const { path, cmd } of allCommands(program)) {
+      if (isHiddenCommand(program, path)) continue;
+      const description = cmd.description();
+      for (const [pattern, label] of banned) {
+        expect(
+          pattern.test(description),
+          `${pathLabel(path)}: description leaks '${label}': "${description}"`,
+        ).toBe(false);
+      }
+      for (const option of cmd.options) {
+        if (option.hidden) continue;
+        for (const [pattern, label] of banned) {
+          expect(
+            pattern.test(option.description),
+            `${pathLabel(path)} ${option.long}: description leaks '${label}': "${option.description}"`,
+          ).toBe(false);
+        }
+      }
+    }
+  });
+
+  describe("public-surface spot checks", () => {
+    it("root --help never advertises --no-bootstrap", () => {
+      const program = freshProgram();
+      const help = renderHelp(program);
+      expect(help).not.toContain("--no-bootstrap");
+    });
+
+    it("--no-bootstrap still parses even though it is hidden (Desktop's discoverCli() slot depends on this)", async () => {
+      const program = freshProgram();
+      program.exitOverride();
+      // Override the real action so this stays a parse-layer assertion -
+      // it must not dial a host in this test process. If --no-bootstrap
+      // were an unknown option, commander would throw before this action
+      // ever runs.
+      const hostStatus = findByPath(program, ["host", "status"]);
+      let actionRan = false;
+      hostStatus.action(() => {
+        actionRan = true;
+      });
+      await program.parseAsync(["host", "status", "--no-bootstrap"], {
+        from: "user",
+      });
+      expect(actionRan).toBe(true);
+    });
+
+    it("login --help omits --token while the option itself is still registered (the Desktop contract survives)", () => {
+      const program = freshProgram();
+      const login = findByPath(program, ["login"]);
+      expect(login.helpInformation()).not.toContain("--token");
+      expect(login.options.some((option) => option.long === "--token")).toBe(
+        true,
+      );
+    });
+
+    it("host --help lists 'free-port-and-restart' and not the bare 'free-port' (false-match guard)", () => {
+      const program = freshProgram();
+      const help = renderHelp(findByPath(program, ["host"]));
+      expect(help).toContain("free-port-and-restart");
+      expect(help).not.toContain("free-port ");
+    });
+
+    it("the root and named-parent descriptions use the new user-language wording", () => {
+      const program = freshProgram();
+      expect(program.description()).toContain(
+        "sign in, run the Traycer host on this machine",
+      );
+      expect(findByPath(program, ["host"]).description()).toContain(
+        "Install, run, update, and troubleshoot the Traycer host",
+      );
+      expect(findByPath(program, ["host", "service"]).description()).toContain(
+        "background registration that keeps the host running",
+      );
+      expect(findByPath(program, ["cli"]).description()).toContain(
+        "Update the 'traycer' command itself",
+      );
+      expect(findByPath(program, ["config"]).description()).toContain(
+        "Read or change the Traycer settings stored on this machine",
+      );
+      expect(findByPath(program, ["config", "shell"]).description()).toContain(
+        "Choose the shell Traycer uses",
+      );
+      expect(findByPath(program, ["config", "env"]).description()).toContain(
+        "Environment variables Traycer adds",
+      );
+      expect(findByPath(program, ["workspace"]).description()).toContain(
+        "Show the folders an agent in this Task can work in",
+      );
+      expect(findByPath(program, ["agent"]).description()).toContain(
+        "List, inspect, message, and manage the other agents in this Task",
+      );
+      expect(findByPath(program, ["agent", "role"]).description()).toContain(
+        "Claim, list, and relinquish the named roles",
+      );
+    });
+
+    it("comments list/set-status --help say relative artifact paths are resolved against the current directory", () => {
+      const program = freshProgram();
+      // Commander word-wraps long option/argument descriptions across
+      // lines, so the sentence can be split by a newline in the rendered
+      // text even though it reads as one line in source - collapse
+      // whitespace before matching rather than asserting on a raw
+      // multi-line substring.
+      const normalize = (text: string): string => text.replace(/\s+/g, " ");
+      const list = normalize(
+        renderHelp(findByPath(program, ["comments", "list"])),
+      );
+      const setStatus = normalize(
+        renderHelp(findByPath(program, ["comments", "set-status"])),
+      );
+      const expectedWording =
+        "relative to the current directory (resolved before the request)";
+      expect(list).toContain(expectedWording);
+      expect(setStatus).toContain(expectedWording);
+    });
+  });
+});

--- a/clients/traycer-cli/src/commands/__tests__/rendered-help.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/rendered-help.test.ts
@@ -161,14 +161,17 @@ function parseSectionRows(
 
 // Every option row's leading term is commander's own `option.flags` string
 // verbatim (e.g. "-a, --all", "--workspace <path>") - confirmed by reading
-// `Option#flags` against real rendered rows, not assumed. Reduced here to
-// just the long flag for comparison against the plain-long-flag inventory;
-// the auto-added `-h, --help` is excluded uniformly rather than tracked per
-// command.
-function parseOptionRowLongFlags(help: string): string[] {
-  return parseSectionRows(help, "Options", ["Commands"])
-    .map((term) => term.match(/--[a-zA-Z0-9-]+/)?.[0])
-    .filter((flag): flag is string => flag !== undefined && flag !== "--help");
+// `Option#flags` against real rendered rows, not assumed. Returned AS THE
+// FULL TERM, not reduced to the bare long flag: reducing to `--all` would
+// let the public `-a` alias on `agent list` be deleted with nothing to
+// disagree - `parseOptionRowFlagTerms(...)` would still report `--all`
+// present, and a caller of `traycer agent list -a` breaks with no test
+// failure. The auto-added `-h, --help` is excluded uniformly rather than
+// tracked per command.
+function parseOptionRowFlagTerms(help: string): string[] {
+  return parseSectionRows(help, "Options", ["Commands"]).filter(
+    (term) => term !== "-h, --help",
+  );
 }
 
 // The "Arguments:" section lists the bare argument name (no `<>`/`[]`/
@@ -180,6 +183,27 @@ function parseOptionRowLongFlags(help: string): string[] {
 // inventory's argument check.
 function parseArgumentRowNames(help: string): string[] {
   return parseSectionRows(help, "Arguments", ["Options", "Commands"]);
+}
+
+interface ExpectedArgument {
+  readonly name: string;
+  readonly required: boolean;
+  readonly variadic: boolean;
+}
+
+// Commander renders the SAME bare row name for `[artifactPaths]`,
+// `[artifactPaths...]`, and `<artifactPaths...>` in the "Arguments:"
+// section - the name alone can't tell them apart, so a name-only inventory
+// entry cannot catch `comments list` silently losing its variadic (only one
+// path accepted) or becoming required (breaking a no-args invocation). Both
+// `.required` and `.variadic` are public fields on commander's `Argument`
+// (confirmed by reading `argument.js`, not assumed).
+function actualArgumentSignature(cmd: Command): readonly ExpectedArgument[] {
+  return cmd.registeredArguments.map((argument) => ({
+    name: argument.name(),
+    required: argument.required,
+    variadic: argument.variadic,
+  }));
 }
 
 const NAMED_PARENT_PATHS: ReadonlyArray<readonly string[]> = [
@@ -200,25 +224,28 @@ const NAMED_PARENT_PATHS: ReadonlyArray<readonly string[]> = [
 interface ExpectedSurfaceEntry {
   readonly path: string;
   readonly options: readonly string[];
-  readonly args: readonly string[];
+  readonly args: readonly ExpectedArgument[];
 }
 
 // The full public command surface under `buildProgramWithAgentRoles(true)` -
 // every visible command path (`""` is the root itself; parents are listed
 // too, so deleting a whole subtree is caught, not just a leaf), each
-// command's own visible long flags (auto-added `-h, --help` excluded
-// uniformly), and each command's registered positional argument names.
+// command's own visible options as their FULL rendered flags term (short
+// alias included, e.g. `"-a, --all"`, not reduced to the long flag - see
+// `parseOptionRowFlagTerms`), and each command's registered arguments as
+// their full name/required/variadic signature (see `ExpectedArgument`
+// above) rather than just a name.
 //
 // THIS LITERAL IS MEANT TO BE EDITED whenever the public surface
-// legitimately changes - a new command, a renamed/added/removed flag, a new
-// positional argument. That edit is the enforcement mechanism, not a
-// maintenance cost to route around: unlike everything else in this file,
-// nothing here is derived from `cmd`, so it is the one check that can prove
-// something disappeared.
+// legitimately changes - a new command, a renamed/added/removed flag or
+// alias, a new positional argument, a changed arity. That edit is the
+// enforcement mechanism, not a maintenance cost to route around: unlike
+// everything else in this file, nothing here is derived from `cmd`, so it
+// is the one check that can prove something disappeared.
 const EXPECTED_PUBLIC_SURFACE: readonly ExpectedSurfaceEntry[] = [
   {
     path: "",
-    options: ["--json", "--no-progress", "--quiet", "--version"],
+    options: ["--json", "--no-progress", "--quiet", "-V, --version"],
     args: [],
   },
   { path: "login", options: ["--json", "--no-progress", "--quiet"], args: [] },
@@ -232,10 +259,14 @@ const EXPECTED_PUBLIC_SURFACE: readonly ExpectedSurfaceEntry[] = [
   { path: "host", options: [], args: [] },
   {
     path: "host start",
-    options: ["--cwd", "--json", "--no-progress", "--quiet"],
+    options: ["--cwd <path>", "--json", "--no-progress", "--quiet"],
     args: [],
   },
-  { path: "host capabilities", options: ["--has", "--json"], args: [] },
+  {
+    path: "host capabilities",
+    options: ["--has <capability>", "--json"],
+    args: [],
+  },
   {
     path: "host status",
     options: ["--json", "--no-progress", "--quiet"],
@@ -284,13 +315,13 @@ const EXPECTED_PUBLIC_SURFACE: readonly ExpectedSurfaceEntry[] = [
     options: [
       "--allow-self-invocation",
       "--force",
-      "--from",
+      "--from <path>",
       "--json",
       "--no-linger",
       "--no-progress",
       "--no-service-register",
       "--quiet",
-      "--release",
+      "--release <version>",
     ],
     args: [],
   },
@@ -299,13 +330,13 @@ const EXPECTED_PUBLIC_SURFACE: readonly ExpectedSurfaceEntry[] = [
     options: [
       "--allow-self-invocation",
       "--force",
-      "--from",
+      "--from <path>",
       "--json",
       "--no-linger",
       "--no-progress",
       "--no-service-register",
       "--quiet",
-      "--release",
+      "--release <version>",
     ],
     args: [],
   },
@@ -322,7 +353,7 @@ const EXPECTED_PUBLIC_SURFACE: readonly ExpectedSurfaceEntry[] = [
   {
     path: "host download",
     options: ["--json", "--no-progress", "--quiet"],
-    args: ["version"],
+    args: [{ name: "version", required: false, variadic: false }],
   },
   {
     path: "host uninstall",
@@ -342,25 +373,43 @@ const EXPECTED_PUBLIC_SURFACE: readonly ExpectedSurfaceEntry[] = [
   },
   {
     path: "host logs",
-    options: ["--follow", "--json", "--no-progress", "--quiet", "--tail"],
+    options: [
+      "--follow",
+      "--json",
+      "--no-progress",
+      "--quiet",
+      "--tail <lines>",
+    ],
     args: [],
   },
   {
     path: "host free-port-and-restart",
-    options: ["--json", "--no-progress", "--pid", "--port", "--quiet"],
+    options: [
+      "--json",
+      "--no-progress",
+      "--pid <pid>",
+      "--port <port>",
+      "--quiet",
+    ],
     args: [],
   },
   { path: "cli", options: [], args: [] },
   {
     path: "cli upgrade",
-    options: ["--dry-run", "--json", "--no-progress", "--quiet", "--target"],
+    options: [
+      "--dry-run",
+      "--json",
+      "--no-progress",
+      "--quiet",
+      "--target <version>",
+    ],
     args: [],
   },
   {
     path: "cli re-anchor",
     options: [
-      "--binary-path",
-      "--installed-version",
+      "--binary-path <path>",
+      "--installed-version <version>",
       "--json",
       "--no-progress",
       "--quiet",
@@ -381,22 +430,28 @@ const EXPECTED_PUBLIC_SURFACE: readonly ExpectedSurfaceEntry[] = [
   },
   {
     path: "config shell set",
-    options: ["--clear-args", "--json", "--no-progress", "--path", "--quiet"],
-    args: ["shellArgs"],
+    options: [
+      "--clear-args",
+      "--json",
+      "--no-progress",
+      "--path <path>",
+      "--quiet",
+    ],
+    args: [{ name: "shellArgs", required: false, variadic: true }],
   },
   {
     path: "config shell add",
-    options: ["--json", "--no-progress", "--path", "--quiet"],
+    options: ["--json", "--no-progress", "--path <path>", "--quiet"],
     args: [],
   },
   {
     path: "config shell remove",
-    options: ["--json", "--no-progress", "--path", "--quiet"],
+    options: ["--json", "--no-progress", "--path <path>", "--quiet"],
     args: [],
   },
   {
     path: "config shell revert-args",
-    options: ["--json", "--no-progress", "--path", "--quiet"],
+    options: ["--json", "--no-progress", "--path <path>", "--quiet"],
     args: [],
   },
   {
@@ -412,34 +467,46 @@ const EXPECTED_PUBLIC_SURFACE: readonly ExpectedSurfaceEntry[] = [
   },
   {
     path: "config env get",
-    options: ["--json", "--key", "--no-progress", "--quiet"],
+    options: ["--json", "--key <key>", "--no-progress", "--quiet"],
     args: [],
   },
   {
     path: "config env set",
-    options: ["--json", "--key", "--no-progress", "--quiet", "--value"],
+    options: [
+      "--json",
+      "--key <key>",
+      "--no-progress",
+      "--quiet",
+      "--value <value>",
+    ],
     args: [],
   },
   {
     path: "config env unset",
-    options: ["--json", "--key", "--no-progress", "--quiet"],
+    options: ["--json", "--key <key>", "--no-progress", "--quiet"],
     args: [],
   },
   {
     path: "config env delete",
-    options: ["--json", "--key", "--no-progress", "--quiet"],
+    options: ["--json", "--key <key>", "--no-progress", "--quiet"],
     args: [],
   },
   { path: "comments", options: [], args: [] },
   {
     path: "comments list",
-    options: ["--json", "--no-progress", "--quiet", "--status"],
-    args: ["artifactPaths"],
+    options: ["--json", "--no-progress", "--quiet", "--status <status>"],
+    args: [{ name: "artifactPaths", required: false, variadic: true }],
   },
   {
     path: "comments set-status",
-    options: ["--artifact", "--json", "--no-progress", "--quiet", "--status"],
-    args: ["threadIds"],
+    options: [
+      "--artifact <path>",
+      "--json",
+      "--no-progress",
+      "--quiet",
+      "--status <status>",
+    ],
+    args: [{ name: "threadIds", required: true, variadic: true }],
   },
   { path: "terminal", options: [], args: [] },
   {
@@ -450,7 +517,7 @@ const EXPECTED_PUBLIC_SURFACE: readonly ExpectedSurfaceEntry[] = [
   {
     path: "terminal output",
     options: ["--json", "--no-progress", "--quiet"],
-    args: ["terminal-id"],
+    args: [{ name: "terminal-id", required: true, variadic: false }],
   },
   { path: "workspace", options: [], args: [] },
   {
@@ -462,10 +529,10 @@ const EXPECTED_PUBLIC_SURFACE: readonly ExpectedSurfaceEntry[] = [
   {
     path: "worktree list",
     options: [
-      "--cursor",
+      "--cursor <worktreePath>",
       "--include-activity",
       "--json",
-      "--limit",
+      "--limit <n>",
       "--no-progress",
       "--quiet",
     ],
@@ -473,62 +540,62 @@ const EXPECTED_PUBLIC_SURFACE: readonly ExpectedSurfaceEntry[] = [
   },
   {
     path: "worktree delete",
-    options: ["--json", "--no-progress", "--path", "--quiet"],
+    options: ["--json", "--no-progress", "--path <path>", "--quiet"],
     args: [],
   },
   {
     path: "worktree create",
     options: [
-      "--branch",
+      "--branch <branch>",
       "--carry-uncommitted",
-      "--existing",
+      "--existing <branch>",
       "--json",
       "--no-progress",
       "--quiet",
-      "--source-branch",
-      "--workspace",
+      "--source-branch <branch>",
+      "--workspace <path>",
     ],
     args: [],
   },
   { path: "agent", options: [], args: [] },
   {
     path: "agent list",
-    options: ["--all", "--json", "--no-progress", "--quiet"],
+    options: ["--json", "--no-progress", "--quiet", "-a, --all"],
     args: [],
   },
   {
     path: "agent create",
     options: [
-      "--cwd",
+      "--cwd <path>",
       "--fast",
-      "--harness",
+      "--harness <id>",
       "--json",
-      "--model",
-      "--name",
+      "--model <id>",
+      "--name <name>",
       "--no-progress",
-      "--permission-mode",
-      "--profile",
+      "--permission-mode <mode>",
+      "--profile <ambient|id>",
       "--quiet",
-      "--reasoning-effort",
-      "--surface",
-      "--workspace-entry",
-      "--workspace-path",
+      "--reasoning-effort <effort>",
+      "--surface <surface>",
+      "--workspace-entry <workspace=path>",
+      "--workspace-path <path>",
     ],
     args: [],
   },
   {
     path: "agent fork",
     options: [
-      "--agent-id",
-      "--cwd",
+      "--agent-id <id>",
+      "--cwd <path>",
       "--json",
-      "--name",
+      "--name <name>",
       "--no-progress",
-      "--permission-mode",
-      "--profile",
+      "--permission-mode <mode>",
+      "--profile <ambient|id>",
       "--quiet",
-      "--workspace-entry",
-      "--workspace-path",
+      "--workspace-entry <workspace=path>",
+      "--workspace-path <path>",
     ],
     args: [],
   },
@@ -545,43 +612,49 @@ const EXPECTED_PUBLIC_SURFACE: readonly ExpectedSurfaceEntry[] = [
   {
     path: "agent list-harness-models",
     options: ["--json", "--no-progress", "--quiet"],
-    args: ["harness"],
+    args: [{ name: "harness", required: true, variadic: false }],
   },
   {
     path: "agent list-profiles",
     options: ["--json", "--no-progress", "--quiet"],
-    args: ["harness"],
+    args: [{ name: "harness", required: true, variadic: false }],
   },
   {
     path: "agent profile-rate-limits",
-    options: ["--json", "--no-progress", "--profile", "--quiet"],
-    args: ["harness"],
+    options: ["--json", "--no-progress", "--profile <ambient|id>", "--quiet"],
+    args: [{ name: "harness", required: true, variadic: false }],
   },
   {
     path: "agent configure",
     options: [
-      "--agent-id",
+      "--agent-id <id>",
       "--fast",
-      "--harness",
+      "--harness <id>",
       "--json",
-      "--model",
+      "--model <id>",
       "--no-progress",
-      "--permission-mode",
-      "--profile",
+      "--permission-mode <mode>",
+      "--profile <ambient|id>",
       "--quiet",
-      "--reasoning-effort",
+      "--reasoning-effort <effort>",
     ],
     args: [],
   },
   {
     path: "agent stop",
-    options: ["--agent-id", "--cascade", "--json", "--no-progress", "--quiet"],
+    options: [
+      "--agent-id <id>",
+      "--cascade",
+      "--json",
+      "--no-progress",
+      "--quiet",
+    ],
     args: [],
   },
   {
     path: "agent archive",
     options: [
-      "--agent-id",
+      "--agent-id <id>",
       "--json",
       "--no-progress",
       "--quiet",
@@ -594,29 +667,29 @@ const EXPECTED_PUBLIC_SURFACE: readonly ExpectedSurfaceEntry[] = [
     options: [
       "--expect-reply",
       "--json",
-      "--message",
+      "--message <text>",
       "--no-progress",
       "--quiet",
-      "--response-id",
-      "--to",
+      "--response-id <id>",
+      "--to <agentId>",
     ],
     args: [],
   },
   {
     path: "agent transcript",
-    options: ["--agent-id", "--json", "--no-progress", "--quiet"],
+    options: ["--agent-id <id>", "--json", "--no-progress", "--quiet"],
     args: [],
   },
   { path: "agent role", options: [], args: [] },
   {
     path: "agent role claim",
     options: [
-      "--agent-id",
+      "--agent-id <id>",
       "--json",
       "--no-progress",
       "--quiet",
-      "--role",
-      "--scope",
+      "--role <name>",
+      "--scope <scope>",
     ],
     args: [],
   },
@@ -627,17 +700,29 @@ const EXPECTED_PUBLIC_SURFACE: readonly ExpectedSurfaceEntry[] = [
   },
   {
     path: "agent role relinquish",
-    options: ["--agent-id", "--claim-id", "--json", "--no-progress", "--quiet"],
+    options: [
+      "--agent-id <id>",
+      "--claim-id <id>",
+      "--json",
+      "--no-progress",
+      "--quiet",
+    ],
     args: [],
   },
   {
     path: "agent inbox",
-    options: ["--after", "--agent-id", "--json", "--no-progress", "--quiet"],
+    options: [
+      "--after <createdAt:eventId>",
+      "--agent-id <id>",
+      "--json",
+      "--no-progress",
+      "--quiet",
+    ],
     args: [],
   },
   {
     path: "monitor",
-    options: ["--agent-id", "--json", "--no-progress", "--quiet"],
+    options: ["--agent-id <id>", "--json", "--no-progress", "--quiet"],
     args: [],
   },
 ];
@@ -689,7 +774,10 @@ describe("rendered root/parent/leaf --help (CLI command audit regression suite)"
       const label = pathLabel(splitPath(entry.path));
       const help = cmd.helpInformation();
 
-      const actualOptions = new Set(parseOptionRowLongFlags(help));
+      // Full flags TERM (short alias included, e.g. "-a, --all"), not
+      // reduced to the long flag - a deleted `-a` alias with `--all` still
+      // registered must show up as a mismatch here.
+      const actualOptions = new Set(parseOptionRowFlagTerms(help));
       const expectedOptions = new Set(entry.options);
       const missingOptions = [...expectedOptions].filter(
         (f) => !actualOptions.has(f),
@@ -706,19 +794,29 @@ describe("rendered root/parent/leaf --help (CLI command audit regression suite)"
         `${label}: undocumented new rendered option(s) - add to EXPECTED_PUBLIC_SURFACE if intentional: ${unexpectedOptions.join(", ")}`,
       ).toEqual([]);
 
-      const actualArgs = new Set(parseArgumentRowNames(help));
-      const expectedArgs = new Set(entry.args);
+      // Full argument SIGNATURE (name + required + variadic), not just the
+      // name - commander renders the identical bare row name for
+      // `[artifactPaths]`, `[artifactPaths...]`, and `<artifactPaths...>`,
+      // so a name-only comparison can't catch an arity change (e.g.
+      // `comments list` silently losing its "many paths" variadic, or
+      // becoming required). Compared via a canonical string key so a
+      // mismatch reports which exact signature is missing/unexpected
+      // rather than just a name.
+      const argumentKey = (arg: ExpectedArgument): string =>
+        `${arg.name} (required=${arg.required}, variadic=${arg.variadic})`;
+      const actualArgs = new Set(actualArgumentSignature(cmd).map(argumentKey));
+      const expectedArgs = new Set(entry.args.map(argumentKey));
       const missingArgs = [...expectedArgs].filter((a) => !actualArgs.has(a));
       const unexpectedArgs = [...actualArgs].filter(
         (a) => !expectedArgs.has(a),
       );
       expect(
         missingArgs,
-        `${label}: argument row(s) removed from rendered help: ${missingArgs.join(", ")}`,
+        `${label}: argument signature(s) removed or changed from rendered help: ${missingArgs.join(", ")}`,
       ).toEqual([]);
       expect(
         unexpectedArgs,
-        `${label}: undocumented new rendered argument(s) - add to EXPECTED_PUBLIC_SURFACE if intentional: ${unexpectedArgs.join(", ")}`,
+        `${label}: undocumented new/changed rendered argument signature(s) - add to EXPECTED_PUBLIC_SURFACE if intentional: ${unexpectedArgs.join(", ")}`,
       ).toEqual([]);
     }
   });

--- a/clients/traycer-cli/src/commands/__tests__/rendered-help.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/rendered-help.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { Command } from "commander";
 import { buildProgramWithAgentRoles } from "../../index";
+import { extractRunnerFlags } from "../../runner/commander-flags";
 
 // Regression suite for the CLI command audit's "Help audit checklist"
 // (epics/.../artifacts/cli-command-audit/index.md): rendered root/parent/leaf
@@ -11,6 +12,18 @@ import { buildProgramWithAgentRoles } from "../../index";
 // Built once per test via `buildProgramWithAgentRoles(true)` (the full agent
 // surface, agent roles enabled) so `agent role` and every non-readonly-gated
 // command are present.
+//
+// IMPORTANT - anti-tautology note: several checks below walk the LIVE
+// command tree (`cmd.options`, `cmd.registeredArguments`) and verify it
+// against its OWN rendered help. Those checks are real and worth having, but
+// they cannot by themselves catch a flag or command that was DELETED from
+// registration entirely - there is nothing left in the live tree to iterate
+// once it's gone, so a walk-and-check-yourself test stays green through a
+// silent removal. That is exactly what an independent review proved: deleting
+// `worktree create --branch` passed the whole suite. `EXPECTED_PUBLIC_SURFACE`
+// below exists specifically to close that hole - it is a hand-maintained
+// literal that does NOT come from `cmd`, so removing something public has
+// something fixed to disagree with.
 
 interface TreeEntry {
   readonly path: readonly string[];
@@ -32,6 +45,10 @@ function allCommands(root: Command): TreeEntry[] {
 
 function pathLabel(path: readonly string[]): string {
   return path.length === 0 ? "traycer" : `traycer ${path.join(" ")}`;
+}
+
+function splitPath(path: string): readonly string[] {
+  return path === "" ? [] : path.split(" ");
 }
 
 function findByPath(root: Command, path: readonly string[]): Command {
@@ -82,9 +99,9 @@ function helpListsCommandName(help: string, name: string): boolean {
 // sections and omits `addHelpText` blocks entirely (e.g. `host update`'s
 // public `--version <version>` spelling, which exists ONLY as addHelpText
 // because the registered option would collide with root `--version`). Used
-// for the root, every named parent, and `host update` below, per the task's
-// rendering caveat; `helpInformation()` is used for the bulk per-leaf sweep,
-// where no addHelpText content is in play.
+// for the root, every named parent, `host update`, and the full-render
+// vocabulary sweep below; `helpInformation()` is used where no addHelpText
+// content is in play.
 function renderHelp(cmd: Command): string {
   const write = vi
     .spyOn(process.stdout, "write")
@@ -99,6 +116,70 @@ function renderHelp(cmd: Command): string {
 
 function freshProgram(): Command {
   return buildProgramWithAgentRoles(true);
+}
+
+function expectRecordDefined(
+  value: Record<string, unknown> | null,
+  message: string,
+): Record<string, unknown> {
+  if (value === null) throw new Error(message);
+  return value;
+}
+
+// Commander's help sections ("Arguments:", "Options:", "Commands:") list one
+// ROW per item, indented by EXACTLY two spaces before the row's own content.
+// A word-wrapped CONTINUATION of a row's description is indented to the
+// description column instead, which is always deeper than two spaces - so
+// matching only lines with precisely a two-space indent isolates real rows
+// from wrapped text. This is what makes flag/argument presence checks
+// EXACT: a name only counts as "rendered" if some row's own content
+// contains it, never because the string happens to appear inside a
+// DIFFERENT row's flags or description - e.g. "--branch" is a literal
+// substring of "--source-branch"'s own flags and of both its and
+// "--carry-uncommitted"'s description text in the real `worktree create`
+// help, which is exactly the false-positive an independent review caught a
+// naive `help.includes("--branch")` check missing.
+function parseSectionRows(
+  help: string,
+  heading: string,
+  stopHeadings: readonly string[],
+): string[] {
+  const startIndex = help.indexOf(`${heading}:`);
+  if (startIndex === -1) return [];
+  let section = help.slice(startIndex + heading.length + 1);
+  for (const stop of stopHeadings) {
+    const stopIndex = section.indexOf(`\n${stop}:`);
+    if (stopIndex !== -1) section = section.slice(0, stopIndex);
+  }
+  const rows: string[] = [];
+  for (const line of section.split("\n")) {
+    const match = /^ {2}(\S.*?)(?: {2,}|$)/.exec(line);
+    if (match !== null) rows.push(match[1]);
+  }
+  return rows;
+}
+
+// Every option row's leading term is commander's own `option.flags` string
+// verbatim (e.g. "-a, --all", "--workspace <path>") - confirmed by reading
+// `Option#flags` against real rendered rows, not assumed. Reduced here to
+// just the long flag for comparison against the plain-long-flag inventory;
+// the auto-added `-h, --help` is excluded uniformly rather than tracked per
+// command.
+function parseOptionRowLongFlags(help: string): string[] {
+  return parseSectionRows(help, "Options", ["Commands"])
+    .map((term) => term.match(/--[a-zA-Z0-9-]+/)?.[0])
+    .filter((flag): flag is string => flag !== undefined && flag !== "--help");
+}
+
+// The "Arguments:" section lists the bare argument name (no `<>`/`[]`/
+// `...`), e.g. `artifactPaths`, `terminal-id` - confirmed against real
+// rendered output, not guessed. Commander OMITS the entire "Arguments:"
+// heading whenever no registered argument has a non-empty description
+// (`Help#visibleArguments`), so a blanked description silently removes the
+// whole section - exactly the mutation verified below for the fixed
+// inventory's argument check.
+function parseArgumentRowNames(help: string): string[] {
+  return parseSectionRows(help, "Arguments", ["Options", "Commands"]);
 }
 
 const NAMED_PARENT_PATHS: ReadonlyArray<readonly string[]> = [
@@ -116,6 +197,451 @@ const NAMED_PARENT_PATHS: ReadonlyArray<readonly string[]> = [
   ["agent", "role"],
 ];
 
+interface ExpectedSurfaceEntry {
+  readonly path: string;
+  readonly options: readonly string[];
+  readonly args: readonly string[];
+}
+
+// The full public command surface under `buildProgramWithAgentRoles(true)` -
+// every visible command path (`""` is the root itself; parents are listed
+// too, so deleting a whole subtree is caught, not just a leaf), each
+// command's own visible long flags (auto-added `-h, --help` excluded
+// uniformly), and each command's registered positional argument names.
+//
+// THIS LITERAL IS MEANT TO BE EDITED whenever the public surface
+// legitimately changes - a new command, a renamed/added/removed flag, a new
+// positional argument. That edit is the enforcement mechanism, not a
+// maintenance cost to route around: unlike everything else in this file,
+// nothing here is derived from `cmd`, so it is the one check that can prove
+// something disappeared.
+const EXPECTED_PUBLIC_SURFACE: readonly ExpectedSurfaceEntry[] = [
+  {
+    path: "",
+    options: ["--json", "--no-progress", "--quiet", "--version"],
+    args: [],
+  },
+  { path: "login", options: ["--json", "--no-progress", "--quiet"], args: [] },
+  { path: "logout", options: ["--json", "--no-progress", "--quiet"], args: [] },
+  { path: "whoami", options: ["--json", "--no-progress", "--quiet"], args: [] },
+  {
+    path: "link-phone",
+    options: ["--json", "--no-progress", "--no-qr", "--quiet"],
+    args: [],
+  },
+  { path: "host", options: [], args: [] },
+  {
+    path: "host start",
+    options: ["--cwd", "--json", "--no-progress", "--quiet"],
+    args: [],
+  },
+  { path: "host capabilities", options: ["--has", "--json"], args: [] },
+  {
+    path: "host status",
+    options: ["--json", "--no-progress", "--quiet"],
+    args: [],
+  },
+  {
+    path: "host doctor",
+    options: ["--json", "--no-progress", "--quiet"],
+    args: [],
+  },
+  {
+    path: "host restart",
+    options: ["--force", "--json", "--no-progress", "--quiet"],
+    args: [],
+  },
+  {
+    path: "host stop",
+    options: ["--force", "--json", "--no-progress", "--quiet"],
+    args: [],
+  },
+  { path: "host service", options: [], args: [] },
+  {
+    path: "host service install",
+    options: [
+      "--allow-self-invocation",
+      "--json",
+      "--no-linger",
+      "--no-progress",
+      "--quiet",
+      "--takeover",
+    ],
+    args: [],
+  },
+  {
+    path: "host service status",
+    options: ["--json", "--no-progress", "--quiet"],
+    args: [],
+  },
+  {
+    path: "host service uninstall",
+    options: ["--json", "--no-progress", "--quiet"],
+    args: [],
+  },
+  {
+    path: "host install",
+    options: [
+      "--allow-self-invocation",
+      "--force",
+      "--from",
+      "--json",
+      "--no-linger",
+      "--no-progress",
+      "--no-service-register",
+      "--quiet",
+      "--release",
+    ],
+    args: [],
+  },
+  {
+    path: "host ensure",
+    options: [
+      "--allow-self-invocation",
+      "--force",
+      "--from",
+      "--json",
+      "--no-linger",
+      "--no-progress",
+      "--no-service-register",
+      "--quiet",
+      "--release",
+    ],
+    args: [],
+  },
+  {
+    path: "host apply",
+    options: ["--force", "--json", "--no-progress", "--quiet"],
+    args: [],
+  },
+  {
+    path: "host update",
+    options: ["--force", "--json", "--no-progress", "--quiet"],
+    args: [],
+  },
+  {
+    path: "host download",
+    options: ["--json", "--no-progress", "--quiet"],
+    args: ["version"],
+  },
+  {
+    path: "host uninstall",
+    options: ["--all", "--json", "--no-progress", "--quiet"],
+    args: [],
+  },
+  {
+    path: "host available",
+    options: [
+      "--include-pre-releases",
+      "--json",
+      "--no-include-pre-releases",
+      "--no-progress",
+      "--quiet",
+    ],
+    args: [],
+  },
+  {
+    path: "host logs",
+    options: ["--follow", "--json", "--no-progress", "--quiet", "--tail"],
+    args: [],
+  },
+  {
+    path: "host free-port-and-restart",
+    options: ["--json", "--no-progress", "--pid", "--port", "--quiet"],
+    args: [],
+  },
+  { path: "cli", options: [], args: [] },
+  {
+    path: "cli upgrade",
+    options: ["--dry-run", "--json", "--no-progress", "--quiet", "--target"],
+    args: [],
+  },
+  {
+    path: "cli re-anchor",
+    options: [
+      "--binary-path",
+      "--installed-version",
+      "--json",
+      "--no-progress",
+      "--quiet",
+    ],
+    args: [],
+  },
+  { path: "config", options: [], args: [] },
+  { path: "config shell", options: [], args: [] },
+  {
+    path: "config shell get",
+    options: ["--json", "--no-progress", "--quiet"],
+    args: [],
+  },
+  {
+    path: "config shell list",
+    options: ["--json", "--no-progress", "--quiet"],
+    args: [],
+  },
+  {
+    path: "config shell set",
+    options: ["--clear-args", "--json", "--no-progress", "--path", "--quiet"],
+    args: ["shellArgs"],
+  },
+  {
+    path: "config shell add",
+    options: ["--json", "--no-progress", "--path", "--quiet"],
+    args: [],
+  },
+  {
+    path: "config shell remove",
+    options: ["--json", "--no-progress", "--path", "--quiet"],
+    args: [],
+  },
+  {
+    path: "config shell revert-args",
+    options: ["--json", "--no-progress", "--path", "--quiet"],
+    args: [],
+  },
+  {
+    path: "config shell reset",
+    options: ["--json", "--no-progress", "--quiet"],
+    args: [],
+  },
+  { path: "config env", options: [], args: [] },
+  {
+    path: "config env list",
+    options: ["--json", "--no-progress", "--quiet"],
+    args: [],
+  },
+  {
+    path: "config env get",
+    options: ["--json", "--key", "--no-progress", "--quiet"],
+    args: [],
+  },
+  {
+    path: "config env set",
+    options: ["--json", "--key", "--no-progress", "--quiet", "--value"],
+    args: [],
+  },
+  {
+    path: "config env unset",
+    options: ["--json", "--key", "--no-progress", "--quiet"],
+    args: [],
+  },
+  {
+    path: "config env delete",
+    options: ["--json", "--key", "--no-progress", "--quiet"],
+    args: [],
+  },
+  { path: "comments", options: [], args: [] },
+  {
+    path: "comments list",
+    options: ["--json", "--no-progress", "--quiet", "--status"],
+    args: ["artifactPaths"],
+  },
+  {
+    path: "comments set-status",
+    options: ["--artifact", "--json", "--no-progress", "--quiet", "--status"],
+    args: ["threadIds"],
+  },
+  { path: "terminal", options: [], args: [] },
+  {
+    path: "terminal list",
+    options: ["--json", "--no-progress", "--quiet"],
+    args: [],
+  },
+  {
+    path: "terminal output",
+    options: ["--json", "--no-progress", "--quiet"],
+    args: ["terminal-id"],
+  },
+  { path: "workspace", options: [], args: [] },
+  {
+    path: "workspace list",
+    options: ["--json", "--no-progress", "--quiet"],
+    args: [],
+  },
+  { path: "worktree", options: [], args: [] },
+  {
+    path: "worktree list",
+    options: [
+      "--cursor",
+      "--include-activity",
+      "--json",
+      "--limit",
+      "--no-progress",
+      "--quiet",
+    ],
+    args: [],
+  },
+  {
+    path: "worktree delete",
+    options: ["--json", "--no-progress", "--path", "--quiet"],
+    args: [],
+  },
+  {
+    path: "worktree create",
+    options: [
+      "--branch",
+      "--carry-uncommitted",
+      "--existing",
+      "--json",
+      "--no-progress",
+      "--quiet",
+      "--source-branch",
+      "--workspace",
+    ],
+    args: [],
+  },
+  { path: "agent", options: [], args: [] },
+  {
+    path: "agent list",
+    options: ["--all", "--json", "--no-progress", "--quiet"],
+    args: [],
+  },
+  {
+    path: "agent create",
+    options: [
+      "--cwd",
+      "--fast",
+      "--harness",
+      "--json",
+      "--model",
+      "--name",
+      "--no-progress",
+      "--permission-mode",
+      "--profile",
+      "--quiet",
+      "--reasoning-effort",
+      "--surface",
+      "--workspace-entry",
+      "--workspace-path",
+    ],
+    args: [],
+  },
+  {
+    path: "agent fork",
+    options: [
+      "--agent-id",
+      "--cwd",
+      "--json",
+      "--name",
+      "--no-progress",
+      "--permission-mode",
+      "--profile",
+      "--quiet",
+      "--workspace-entry",
+      "--workspace-path",
+    ],
+    args: [],
+  },
+  {
+    path: "agent selection-guide",
+    options: ["--json", "--no-progress", "--quiet"],
+    args: [],
+  },
+  {
+    path: "agent list-harnesses",
+    options: ["--json", "--no-progress", "--quiet"],
+    args: [],
+  },
+  {
+    path: "agent list-harness-models",
+    options: ["--json", "--no-progress", "--quiet"],
+    args: ["harness"],
+  },
+  {
+    path: "agent list-profiles",
+    options: ["--json", "--no-progress", "--quiet"],
+    args: ["harness"],
+  },
+  {
+    path: "agent profile-rate-limits",
+    options: ["--json", "--no-progress", "--profile", "--quiet"],
+    args: ["harness"],
+  },
+  {
+    path: "agent configure",
+    options: [
+      "--agent-id",
+      "--fast",
+      "--harness",
+      "--json",
+      "--model",
+      "--no-progress",
+      "--permission-mode",
+      "--profile",
+      "--quiet",
+      "--reasoning-effort",
+    ],
+    args: [],
+  },
+  {
+    path: "agent stop",
+    options: ["--agent-id", "--cascade", "--json", "--no-progress", "--quiet"],
+    args: [],
+  },
+  {
+    path: "agent archive",
+    options: [
+      "--agent-id",
+      "--json",
+      "--no-progress",
+      "--quiet",
+      "--unarchive",
+    ],
+    args: [],
+  },
+  {
+    path: "agent send",
+    options: [
+      "--expect-reply",
+      "--json",
+      "--message",
+      "--no-progress",
+      "--quiet",
+      "--response-id",
+      "--to",
+    ],
+    args: [],
+  },
+  {
+    path: "agent transcript",
+    options: ["--agent-id", "--json", "--no-progress", "--quiet"],
+    args: [],
+  },
+  { path: "agent role", options: [], args: [] },
+  {
+    path: "agent role claim",
+    options: [
+      "--agent-id",
+      "--json",
+      "--no-progress",
+      "--quiet",
+      "--role",
+      "--scope",
+    ],
+    args: [],
+  },
+  {
+    path: "agent role list",
+    options: ["--json", "--no-progress", "--quiet"],
+    args: [],
+  },
+  {
+    path: "agent role relinquish",
+    options: ["--agent-id", "--claim-id", "--json", "--no-progress", "--quiet"],
+    args: [],
+  },
+  {
+    path: "agent inbox",
+    options: ["--after", "--agent-id", "--json", "--no-progress", "--quiet"],
+    args: [],
+  },
+  {
+    path: "monitor",
+    options: ["--agent-id", "--json", "--no-progress", "--quiet"],
+    args: [],
+  },
+];
+
 describe("rendered root/parent/leaf --help (CLI command audit regression suite)", () => {
   it("cross-checks the hidden-command helper against a known-hidden and a known-visible command", () => {
     const program = freshProgram();
@@ -128,32 +654,104 @@ describe("rendered root/parent/leaf --help (CLI command audit regression suite)"
     );
   });
 
-  it("prints every non-hidden option's flags, and every registered argument's name, in that command's own rendered help", () => {
+  // Anti-tautology check (see the file-level comment). Set equality both
+  // ways against `EXPECTED_PUBLIC_SURFACE`, with separate MISSING vs
+  // UNEXPECTED messages because they call for different reactions: missing
+  // means something public disappeared (fix the regression); unexpected
+  // means something new needs documenting in the literal above (update the
+  // inventory) - or, if it was never meant to be public, hiding it.
+  it("matches the fixed public-surface inventory exactly - nothing removed, nothing undocumented added", () => {
+    const program = freshProgram();
+
+    const actualPaths = new Set(
+      allCommands(program)
+        .filter(({ path }) => !isHiddenCommand(program, path))
+        .map(({ path }) => path.join(" ")),
+    );
+    const expectedPaths = new Set(EXPECTED_PUBLIC_SURFACE.map((e) => e.path));
+
+    const missingPaths = [...expectedPaths].filter((p) => !actualPaths.has(p));
+    const unexpectedPaths = [...actualPaths].filter(
+      (p) => !expectedPaths.has(p),
+    );
+    expect(
+      missingPaths,
+      `command path(s) removed or newly hidden from the public surface: ${missingPaths.join(", ")}`,
+    ).toEqual([]);
+    expect(
+      unexpectedPaths,
+      `undocumented new public command path(s) - add to EXPECTED_PUBLIC_SURFACE if intentional: ${unexpectedPaths.join(", ")}`,
+    ).toEqual([]);
+
+    for (const entry of EXPECTED_PUBLIC_SURFACE) {
+      if (!actualPaths.has(entry.path)) continue; // already reported above
+      const cmd = findByPath(program, splitPath(entry.path));
+      const label = pathLabel(splitPath(entry.path));
+      const help = cmd.helpInformation();
+
+      const actualOptions = new Set(parseOptionRowLongFlags(help));
+      const expectedOptions = new Set(entry.options);
+      const missingOptions = [...expectedOptions].filter(
+        (f) => !actualOptions.has(f),
+      );
+      const unexpectedOptions = [...actualOptions].filter(
+        (f) => !expectedOptions.has(f),
+      );
+      expect(
+        missingOptions,
+        `${label}: option row(s) removed or newly hidden from rendered help: ${missingOptions.join(", ")}`,
+      ).toEqual([]);
+      expect(
+        unexpectedOptions,
+        `${label}: undocumented new rendered option(s) - add to EXPECTED_PUBLIC_SURFACE if intentional: ${unexpectedOptions.join(", ")}`,
+      ).toEqual([]);
+
+      const actualArgs = new Set(parseArgumentRowNames(help));
+      const expectedArgs = new Set(entry.args);
+      const missingArgs = [...expectedArgs].filter((a) => !actualArgs.has(a));
+      const unexpectedArgs = [...actualArgs].filter(
+        (a) => !expectedArgs.has(a),
+      );
+      expect(
+        missingArgs,
+        `${label}: argument row(s) removed from rendered help: ${missingArgs.join(", ")}`,
+      ).toEqual([]);
+      expect(
+        unexpectedArgs,
+        `${label}: undocumented new rendered argument(s) - add to EXPECTED_PUBLIC_SURFACE if intentional: ${unexpectedArgs.join(", ")}`,
+      ).toEqual([]);
+    }
+  });
+
+  // Defense-in-depth alongside the fixed inventory above: this walks the
+  // LIVE tree (so it also covers anything not yet added to
+  // EXPECTED_PUBLIC_SURFACE) but checks EXACT row membership rather than
+  // substring presence anywhere in the text - `option.flags` / an
+  // argument's `.name()` must appear as some row's own content, not merely
+  // somewhere in the rendered string. A bare `help.includes(...)` check
+  // (the prior version of this test) is fooled by "--branch" appearing
+  // inside "--source-branch"'s own flags/description, and by an argument
+  // name that's already present in the auto-generated `Usage:` line even
+  // when its "Arguments:" row is gone.
+  it("renders every non-hidden option and every registered argument as an actual row - not merely present somewhere in the text", () => {
     const program = freshProgram();
     for (const { path, cmd } of allCommands(program)) {
       const help = cmd.helpInformation();
+      const renderedOptionTerms = parseSectionRows(help, "Options", [
+        "Commands",
+      ]);
       for (const option of cmd.options) {
         if (option.hidden) continue;
-        if (option.long) {
-          expect(
-            help.includes(option.long),
-            `${pathLabel(path)}: rendered help is missing '${option.long}'`,
-          ).toBe(true);
-        }
-        if (option.short) {
-          expect(
-            help.includes(option.short),
-            `${pathLabel(path)}: rendered help is missing '${option.short}'`,
-          ).toBe(true);
-        }
+        expect(
+          renderedOptionTerms.includes(option.flags),
+          `${pathLabel(path)}: no OPTION ROW for '${option.flags}' (a substring match elsewhere in the help text does not count)`,
+        ).toBe(true);
       }
-      // Commander's `Arguments:` section lists the BARE name (no `<>`/`[]`/
-      // `...`), e.g. `artifactPaths`, not `[artifactPaths...]` - confirmed by
-      // inspecting `helpInformation()` output directly rather than guessing.
+      const renderedArgumentNames = parseArgumentRowNames(help);
       for (const argument of cmd.registeredArguments) {
         expect(
-          help.includes(argument.name()),
-          `${pathLabel(path)}: rendered help is missing registered argument '${argument.name()}'`,
+          renderedArgumentNames.includes(argument.name()),
+          `${pathLabel(path)}: no ARGUMENT ROW for '${argument.name()}' (its presence in 'Usage:' does not count)`,
         ).toBe(true);
       }
     }
@@ -301,7 +899,18 @@ describe("rendered root/parent/leaf --help (CLI command audit regression suite)"
     ).toBe(false);
   });
 
-  it("keeps internal vocabulary out of every visible command's description, its visible options' descriptions, and its registered arguments' descriptions", () => {
+  // Full-render vocabulary sweep (not field-by-field): `renderHelp(cmd)` is
+  // the REAL `--help` output, which naturally covers descriptions, option
+  // descriptions, argument descriptions, commander-generated content, AND
+  // `addHelpText` blocks in one pass - a field-by-field scan of
+  // `cmd.description()`/`option.description`/`argument.description` misses
+  // addHelpText entirely (confirmed: banned text added to `host update`'s
+  // addHelpText block passes a field-by-field scan silently). Hidden
+  // commands' text is absent from a render by construction (nothing to
+  // render), so this stays correct without a separate skip list beyond the
+  // `isHiddenCommand` filter already needed to know which commands are
+  // public.
+  it("keeps internal vocabulary out of every visible command's FULL rendered --help", () => {
     const program = freshProgram();
     // Deliberately does NOT blocklist "bootstrap" (host start's description
     // is owned by another in-flight PR) or "NDJSON" (a real format name).
@@ -315,35 +924,12 @@ describe("rendered root/parent/leaf --help (CLI command audit regression suite)"
 
     for (const { path, cmd } of allCommands(program)) {
       if (isHiddenCommand(program, path)) continue;
-      const description = cmd.description();
+      const rendered = renderHelp(cmd);
       for (const [pattern, label] of banned) {
         expect(
-          pattern.test(description),
-          `${pathLabel(path)}: description leaks '${label}': "${description}"`,
+          pattern.test(rendered),
+          `${pathLabel(path)}: rendered --help leaks '${label}'`,
         ).toBe(false);
-      }
-      for (const option of cmd.options) {
-        if (option.hidden) continue;
-        for (const [pattern, label] of banned) {
-          expect(
-            pattern.test(option.description),
-            `${pathLabel(path)} ${option.long}: description leaks '${label}': "${option.description}"`,
-          ).toBe(false);
-        }
-      }
-      // Positional argument descriptions are rendered help text too
-      // (`comments list [artifactPaths...]`, `terminal output <terminal-id>`,
-      // etc.) - a regression here (e.g. "this epic" instead of "this Task")
-      // is exactly as user-visible as one in an option description, so it
-      // gets the same blocklist. `registeredArguments` is commander's public
-      // accessor for this - not an internal field.
-      for (const argument of cmd.registeredArguments) {
-        for (const [pattern, label] of banned) {
-          expect(
-            pattern.test(argument.description),
-            `${pathLabel(path)} ${argument.name()}: description leaks '${label}': "${argument.description}"`,
-          ).toBe(false);
-        }
       }
     }
   });
@@ -371,6 +957,33 @@ describe("rendered root/parent/leaf --help (CLI command audit regression suite)"
         from: "user",
       });
       expect(actionRan).toBe(true);
+    });
+
+    // The compatibility vector `--no-bootstrap`'s own comment describes:
+    // Desktop's `discoverCli()` may place the flag BEFORE the subcommand
+    // (`traycer --no-bootstrap host status`), binding to the root's global
+    // copy rather than the leaf's own. The prior test only covers the
+    // after-command spelling and only proves the action ran - this asserts
+    // the actual runtime signal (`optsWithGlobals()` /
+    // `extractRunnerFlags(...)`) a real command body reads.
+    it("--no-bootstrap placed BEFORE the subcommand binds through the root's global copy", async () => {
+      const program = freshProgram();
+      program.exitOverride();
+      const hostStatus = findByPath(program, ["host", "status"]);
+      let observedOpts: Record<string, unknown> | null = null;
+      hostStatus.action((...actionArgs: unknown[]) => {
+        const command = actionArgs[actionArgs.length - 1] as Command;
+        observedOpts = command.optsWithGlobals() as Record<string, unknown>;
+      });
+      await program.parseAsync(["--no-bootstrap", "host", "status"], {
+        from: "user",
+      });
+      const opts = expectRecordDefined(
+        observedOpts,
+        "expected 'host status' action to run and capture opts",
+      );
+      expect(opts.bootstrap).toBe(false);
+      expect(extractRunnerFlags(opts).noBootstrap).toBe(true);
     });
 
     it("login --help omits --token while the option itself is still registered (the Desktop contract survives)", () => {

--- a/clients/traycer-cli/src/commands/__tests__/workspace-list.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/workspace-list.test.ts
@@ -1,0 +1,277 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { WorktreeBindingSelectorRow } from "@traycer/protocol/host";
+import {
+  buildWorkspaceListCommand,
+  formatWorkspaceListTable,
+} from "../workspace-list";
+import { callHostRpc } from "../../internal/host-rpc";
+import type { CommandContext } from "../../runner/runner";
+
+const loggerMock = vi.hoisted(() => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock("../../logger", () => ({
+  createCliLogger: () => loggerMock,
+  errorFromUnknown: (value: unknown) =>
+    value instanceof Error ? value : new Error(String(value)),
+  noopLogger: loggerMock,
+}));
+
+vi.mock("../../internal/host-rpc", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../internal/host-rpc")
+  >("../../internal/host-rpc");
+  return {
+    ...actual,
+    callHostRpc: vi.fn(),
+  };
+});
+
+const rpcMock = vi.mocked(callHostRpc);
+const PREV_EPIC_ENV = process.env.TRAYCER_EPIC_ID;
+
+function fakeCtx(): CommandContext {
+  return {
+    runtime: {
+      json: false,
+      quiet: false,
+      noProgress: false,
+      noBootstrap: false,
+      nonInteractive: false,
+      environment: "production",
+      logger: {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      },
+    },
+    output: {
+      progress: vi.fn(),
+      human: vi.fn(),
+      humanRequired: vi.fn(),
+      emitResult: vi.fn(),
+      emitError: vi.fn(),
+    },
+    progress: vi.fn(),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.TRAYCER_EPIC_ID = "epic_test";
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+  if (PREV_EPIC_ENV === undefined) delete process.env.TRAYCER_EPIC_ID;
+  else process.env.TRAYCER_EPIC_ID = PREV_EPIC_ENV;
+});
+
+function row(
+  overrides: Partial<WorktreeBindingSelectorRow>,
+): WorktreeBindingSelectorRow {
+  return {
+    hostId: "host_1",
+    runningDir: "/Users/dev/src/acme-web",
+    workspacePath: "/Users/dev/src/acme-web",
+    worktreePath: null,
+    mode: "local",
+    isGitRepo: true,
+    repoIdentifier: { owner: "acme", repo: "web" },
+    branch: "main",
+    isPrimary: true,
+    isImported: false,
+    setupState: "not_required",
+    disabledReason: null,
+    sources: [],
+    ...overrides,
+  };
+}
+
+describe("formatWorkspaceListTable", () => {
+  it("shows the empty-state message and create hint when there are no rows", () => {
+    const table = formatWorkspaceListTable([]);
+    expect(table).toContain("No workspace folders are bound to this Task.");
+    expect(table).toContain(
+      "traycer worktree create --workspace <path> --branch <name>",
+    );
+    expect(table).toContain("traycer agent create --cwd <path>");
+  });
+
+  it("renders a header row and correct cells for a local row and a worktree row", () => {
+    const localRow = row({
+      mode: "local",
+      workspacePath: "/Users/dev/src/acme-web",
+      runningDir: "/Users/dev/src/acme-web",
+      branch: "main",
+      sources: [
+        {
+          ownerKind: "chat",
+          ownerId: "c1",
+          workspacePath: "/Users/dev/src/acme-web",
+          isPrimary: true,
+          mode: "local",
+        },
+      ],
+    });
+    const worktreeRow = row({
+      mode: "worktree",
+      workspacePath: "/Users/dev/src/acme-web",
+      worktreePath: "/Users/dev/.traycer/worktrees/acme__web/feature-x",
+      runningDir: "/Users/dev/.traycer/worktrees/acme__web/feature-x",
+      branch: "feature/x",
+      sources: [],
+    });
+    const table = formatWorkspaceListTable([localRow, worktreeRow]);
+    const lines = table.split("\n");
+
+    expect(lines[0]).toContain("REPO");
+    expect(lines[0]).toContain("MODE");
+    expect(lines[0]).toContain("BRANCH");
+    expect(lines[0]).toContain("GIT");
+    expect(lines[0]).toContain("STATE");
+    expect(lines[0]).toContain("AGENTS");
+    expect(lines[0]).toContain("DIRECTORY");
+
+    expect(lines[1]).toContain("acme/web");
+    expect(lines[1]).toContain("local");
+    expect(lines[1]).toContain("main");
+    expect(lines[1]).toContain("yes");
+    expect(lines[1]).toContain("ready");
+    expect(lines[1]).toContain("1");
+    expect(lines[1]).toContain("/Users/dev/src/acme-web");
+
+    // DIRECTORY must show `runningDir`, not `workspacePath` - for the
+    // worktree row those differ.
+    expect(lines[2]).toContain("worktree");
+    expect(lines[2]).toContain(
+      "/Users/dev/.traycer/worktrees/acme__web/feature-x",
+    );
+    expect(lines[2]).not.toMatch(/\/Users\/dev\/src\/acme-web\s*$/);
+  });
+
+  it("renders a dash for a null repoIdentifier and a null branch", () => {
+    const table = formatWorkspaceListTable([
+      row({ repoIdentifier: null, branch: null }),
+    ]);
+    const line = table.split("\n")[1];
+    // Split on runs of 2+ spaces (the column separator) rather than
+    // asserting `toContain("-")` on the whole line - a bare substring check
+    // would also match a hyphen inside the DIRECTORY path or a repo name.
+    // Column order is REPO, MODE, BRANCH, GIT, STATE, AGENTS, DIRECTORY.
+    const cells = line.split(/\s{2,}/);
+    expect(cells[0]).toBe("-"); // REPO
+    expect(cells[2]).toBe("-"); // BRANCH
+  });
+
+  it.each([
+    [null, "ready"],
+    ["setup_pending", "setup pending"],
+    ["setup_running", "setup running"],
+    ["setup_failed", "setup failed"],
+    ["setup_cancelled", "setup cancelled"],
+    ["missing_worktree_path", "missing on disk"],
+  ] as const)(
+    "renders disabledReason %j as %j in the STATE column",
+    (disabledReason, label) => {
+      const table = formatWorkspaceListTable([row({ disabledReason })]);
+      const line = table.split("\n")[1];
+      expect(line).toContain(label);
+    },
+  );
+
+  it("aligns every non-final column to a consistent start offset across header and rows", () => {
+    const table = formatWorkspaceListTable([
+      row({
+        repoIdentifier: { owner: "acme", repo: "web" },
+        mode: "local",
+        branch: "main",
+        isGitRepo: true,
+        disabledReason: null,
+        sources: [
+          {
+            ownerKind: "chat",
+            ownerId: "c1",
+            workspacePath: "/x",
+            isPrimary: true,
+            mode: "local",
+          },
+        ],
+        runningDir: "/short",
+      }),
+      row({
+        repoIdentifier: { owner: "acme", repo: "a-much-longer-repo-name" },
+        mode: "worktree",
+        branch: "feature-x",
+        isGitRepo: false,
+        disabledReason: "setup_failed",
+        sources: [],
+        runningDir: "/a/much/longer/directory/path",
+      }),
+    ]);
+    const [header, row1, row2] = table.split("\n");
+
+    // Every non-final column's content begins at the same character offset
+    // on the header line and on every data row - proof the padEnd widths
+    // are computed consistently across the whole column, not per-row.
+    const modeStart = header.indexOf("MODE");
+    expect(row1.indexOf("local")).toBe(modeStart);
+    expect(row2.indexOf("worktree")).toBe(modeStart);
+
+    const branchStart = header.indexOf("BRANCH");
+    expect(row1.indexOf("main")).toBe(branchStart);
+    expect(row2.indexOf("feature-x")).toBe(branchStart);
+
+    const gitStart = header.indexOf("GIT");
+    expect(row1.indexOf("yes")).toBe(gitStart);
+    expect(row2.indexOf("no")).toBe(gitStart);
+
+    const stateStart = header.indexOf("STATE");
+    expect(row1.indexOf("ready")).toBe(stateStart);
+    expect(row2.indexOf("setup failed")).toBe(stateStart);
+
+    // AGENTS is a bare digit ("1"/"0"), so this only isolates the right
+    // column because no earlier cell in either row happens to contain that
+    // digit (no digits in the mode/branch/git/state text, and the chosen
+    // `runningDir` fixtures below are digit-free) - keep it that way rather
+    // than "improving" the fixture with a path that has a stray digit.
+    const agentsStart = header.indexOf("AGENTS");
+    expect(row1.indexOf("1")).toBe(agentsStart);
+    expect(row2.indexOf("0")).toBe(agentsStart);
+
+    // The final DIRECTORY column is never right-padded: no rendered line
+    // has trailing whitespace.
+    for (const line of table.split("\n")) {
+      expect(line).toBe(line.trimEnd());
+    }
+  });
+
+  it("includes the trailing hint lines", () => {
+    const table = formatWorkspaceListTable([row({})]);
+    expect(table).toContain(
+      "Run an agent in one with `traycer agent create --cwd <directory>`.",
+    );
+    expect(table).toContain("Run with --json for the full binding records.");
+  });
+});
+
+describe("buildWorkspaceListCommand", () => {
+  it("preserves --json: data is the raw parsed host response", async () => {
+    const rows = [row({})];
+    rpcMock.mockResolvedValue({ rows });
+
+    const result = await buildWorkspaceListCommand({ epicId: null })(fakeCtx());
+
+    expect(rpcMock).toHaveBeenCalledWith("worktree.listBindingsForEpic", {
+      epicId: "epic_test",
+    });
+    expect(result.data).toEqual({ rows });
+    expect(result.exitCode).toBe(0);
+  });
+});

--- a/clients/traycer-cli/src/commands/__tests__/workspace-list.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/workspace-list.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { WorktreeBindingSelectorRow } from "@traycer/protocol/host";
+import type { WorktreeBindingSelectorRowV12 } from "@traycer/protocol/host";
 import {
   buildWorkspaceListCommand,
   formatWorkspaceListTable,
@@ -74,8 +74,8 @@ afterEach(() => {
 });
 
 function row(
-  overrides: Partial<WorktreeBindingSelectorRow>,
-): WorktreeBindingSelectorRow {
+  overrides: Partial<WorktreeBindingSelectorRowV12>,
+): WorktreeBindingSelectorRowV12 {
   return {
     hostId: "host_1",
     runningDir: "/Users/dev/src/acme-web",
@@ -90,6 +90,7 @@ function row(
     setupState: "not_required",
     disabledReason: null,
     sources: [],
+    isGitResolvePending: false,
     ...overrides,
   };
 }
@@ -186,6 +187,54 @@ describe("formatWorkspaceListTable", () => {
     },
   );
 
+  it("REGRESSION: a pending row's missing_worktree_path reason is not reported as 'missing on disk' - it renders 'checking' with GIT '?'", () => {
+    const table = formatWorkspaceListTable([
+      row({
+        isGitResolvePending: true,
+        disabledReason: "missing_worktree_path",
+      }),
+    ]);
+    const line = table.split("\n")[1];
+    const cells = line.split(/\s{2,}/);
+    expect(cells[3]).toBe("?"); // GIT
+    expect(cells[4]).toBe("checking"); // STATE
+    expect(line).not.toContain("missing on disk");
+  });
+
+  it("a pending row that is otherwise selectable reports STATE 'ready' but GIT stays '?'", () => {
+    const table = formatWorkspaceListTable([
+      row({ isGitResolvePending: true, disabledReason: null }),
+    ]);
+    const line = table.split("\n")[1];
+    const cells = line.split(/\s{2,}/);
+    expect(cells[3]).toBe("?"); // GIT
+    expect(cells[4]).toBe("ready"); // STATE
+  });
+
+  it("a pending row with a resolved setup reason is NOT masked by the pending git marker", () => {
+    const table = formatWorkspaceListTable([
+      row({ isGitResolvePending: true, disabledReason: "setup_failed" }),
+    ]);
+    const line = table.split("\n")[1];
+    const cells = line.split(/\s{2,}/);
+    expect(cells[3]).toBe("?"); // GIT
+    expect(cells[4]).toBe("setup failed"); // STATE
+  });
+
+  it("isGitResolvePending: false keeps the existing yes/no GIT rendering and reason-derived STATE, unchanged", () => {
+    const table = formatWorkspaceListTable([
+      row({
+        isGitResolvePending: false,
+        isGitRepo: false,
+        disabledReason: "missing_worktree_path",
+      }),
+    ]);
+    const line = table.split("\n")[1];
+    const cells = line.split(/\s{2,}/);
+    expect(cells[3]).toBe("no"); // GIT
+    expect(cells[4]).toBe("missing on disk"); // STATE
+  });
+
   it("aligns every non-final column to a consistent start offset across header and rows", () => {
     const table = formatWorkspaceListTable([
       row({
@@ -262,16 +311,17 @@ describe("formatWorkspaceListTable", () => {
 });
 
 describe("buildWorkspaceListCommand", () => {
-  it("preserves --json: data is the raw parsed host response", async () => {
-    const rows = [row({})];
-    rpcMock.mockResolvedValue({ rows });
+  it("preserves --json: data is the raw parsed v1.2 host response, including folderlessCwd and isGitResolvePending", async () => {
+    const rows = [row({ isGitResolvePending: true })];
+    const v12Response = { rows, folderlessCwd: null };
+    rpcMock.mockResolvedValue(v12Response);
 
     const result = await buildWorkspaceListCommand({ epicId: null })(fakeCtx());
 
     expect(rpcMock).toHaveBeenCalledWith("worktree.listBindingsForEpic", {
       epicId: "epic_test",
     });
-    expect(result.data).toEqual({ rows });
+    expect(result.data).toEqual(v12Response);
     expect(result.exitCode).toBe(0);
   });
 });

--- a/clients/traycer-cli/src/commands/__tests__/workspace-list.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/workspace-list.test.ts
@@ -171,10 +171,16 @@ describe("formatWorkspaceListTable", () => {
     expect(cells[2]).toBe("-"); // BRANCH
   });
 
+  // The default fixture is `mode: "local"`, so a legacy `setup_*`
+  // `disabledReason` never trips the blocking check below (that only
+  // applies to `mode === "worktree" && !isGitRepo`) and falls through to
+  // the setup-lifecycle branch, matching the GUI's
+  // `worktreeFolderRowBadge` labels exactly - "setup_running" now reads
+  // "setting up", not "setup running".
   it.each([
     [null, "ready"],
     ["setup_pending", "setup pending"],
-    ["setup_running", "setup running"],
+    ["setup_running", "setting up"],
     ["setup_failed", "setup failed"],
     ["setup_cancelled", "setup cancelled"],
     ["missing_worktree_path", "missing on disk"],
@@ -186,6 +192,67 @@ describe("formatWorkspaceListTable", () => {
       expect(line).toContain(label);
     },
   );
+
+  // Regression coverage for the "creation is the selector gate" fix: once a
+  // worktree exists, setup progress/outcomes live in `setupState` with
+  // `disabledReason: null`, so `formatState` must read `setupState` too -
+  // keying on `disabledReason` alone reported a worktree whose setup script
+  // FAILED as plain "ready".
+  it.each([
+    ["failed", "setup failed"],
+    ["running", "setting up"],
+    ["pending", "setup pending"],
+    ["cancelled", "setup cancelled"],
+    ["succeeded", "ready"],
+    ["not_required", "ready"],
+  ] as const)(
+    "REGRESSION: setupState %j with disabledReason: null renders %j (not masked by a null reason)",
+    (setupState, label) => {
+      const table = formatWorkspaceListTable([
+        row({ setupState, disabledReason: null }),
+      ]);
+      const line = table.split("\n")[1];
+      const cells = line.split(/\s{2,}/);
+      expect(cells[4]).toBe(label); // STATE
+    },
+  );
+
+  it("a legacy host's setup_failed reason on a mode: 'local' row is not blocking - it reports 'setup failed'", () => {
+    const table = formatWorkspaceListTable([
+      row({ mode: "local", disabledReason: "setup_failed" }),
+    ]);
+    const line = table.split("\n")[1];
+    const cells = line.split(/\s{2,}/);
+    expect(cells[4]).toBe("setup failed"); // STATE
+  });
+
+  it("a legacy host's setup_failed reason on a mode: 'worktree' row with isGitRepo: false IS blocking - it reports 'missing on disk'", () => {
+    const table = formatWorkspaceListTable([
+      row({
+        mode: "worktree",
+        isGitRepo: false,
+        disabledReason: "setup_failed",
+        isGitResolvePending: false,
+      }),
+    ]);
+    const line = table.split("\n")[1];
+    const cells = line.split(/\s{2,}/);
+    expect(cells[4]).toBe("missing on disk"); // STATE
+  });
+
+  it("a legacy host's setup_failed reason on a mode: 'worktree' row with isGitRepo: false reports 'checking' while resolve is pending", () => {
+    const table = formatWorkspaceListTable([
+      row({
+        mode: "worktree",
+        isGitRepo: false,
+        disabledReason: "setup_failed",
+        isGitResolvePending: true,
+      }),
+    ]);
+    const line = table.split("\n")[1];
+    const cells = line.split(/\s{2,}/);
+    expect(cells[4]).toBe("checking"); // STATE
+  });
 
   it("REGRESSION: a pending row's missing_worktree_path reason is not reported as 'missing on disk' - it renders 'checking' with GIT '?'", () => {
     const table = formatWorkspaceListTable([
@@ -259,7 +326,13 @@ describe("formatWorkspaceListTable", () => {
         mode: "worktree",
         branch: "feature-x",
         isGitRepo: false,
-        disabledReason: "setup_failed",
+        // A worktree row (isGitRepo: false) with a legacy `setup_failed`
+        // REASON is now blocking ("missing on disk") under the production
+        // fix - use the canonical `setupState` spelling instead, which
+        // `hasBlockingReason` never inspects, so this row stays a plain
+        // "setup failed" STATE for the column-alignment check below.
+        disabledReason: null,
+        setupState: "failed",
         sources: [],
         runningDir: "/a/much/longer/directory/path",
       }),

--- a/clients/traycer-cli/src/commands/__tests__/worktree-create.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/worktree-create.test.ts
@@ -392,6 +392,73 @@ describe("formatWorktreeCreateResult", () => {
     expect(summary).not.toContain("Uncommitted changes");
   });
 
+  // Regression: `entry.branch` is nullable
+  // (`worktreeCreatedPathEntrySchema`), and the requested name used to fill
+  // the gap dressed as an observed outcome - "(new branch, forked from x)"
+  // even though the host never said the branch materialized. A null is the
+  // host DECLINING to state the result, not "same as requested".
+  it("REGRESSION: new-branch success with entry.branch: null reports the request was made, not an assumed outcome", () => {
+    const branch = newBranchSelection({ name: "feature/x", source: "main" });
+    const response = createResponse({
+      entries: [
+        {
+          workspacePath: WORKSPACE,
+          path: "/Users/dev/.traycer/worktrees/acme__web/feature-x",
+          mode: "worktree",
+          repoIdentifier: { owner: "acme", repo: "web" },
+          branch: null,
+        },
+      ],
+      perEntry: [
+        {
+          workspacePath: WORKSPACE,
+          ok: true,
+          worktreePath: "/Users/dev/.traycer/worktrees/acme__web/feature-x",
+          branch: null,
+          errorMessage: null,
+        },
+      ],
+    });
+
+    const summary = formatWorktreeCreateResult(response, branch);
+
+    expect(summary).toContain(
+      "feature/x (requested; the host did not report the resulting branch)",
+    );
+    expect(summary).not.toContain("new branch, forked from");
+  });
+
+  it("REGRESSION: existing-branch success with entry.branch: null reports the request was made, not an assumed outcome", () => {
+    const branch = existingBranchSelection("release/1.0");
+    const response = createResponse({
+      entries: [
+        {
+          workspacePath: WORKSPACE,
+          path: "/Users/dev/.traycer/worktrees/acme__web/release-1.0",
+          mode: "worktree",
+          repoIdentifier: { owner: "acme", repo: "web" },
+          branch: null,
+        },
+      ],
+      perEntry: [
+        {
+          workspacePath: WORKSPACE,
+          ok: true,
+          worktreePath: "/Users/dev/.traycer/worktrees/acme__web/release-1.0",
+          branch: null,
+          errorMessage: null,
+        },
+      ],
+    });
+
+    const summary = formatWorktreeCreateResult(response, branch);
+
+    expect(summary).toContain(
+      "release/1.0 (requested; the host did not report the resulting branch)",
+    );
+    expect(summary).not.toContain("checked out; the branch already existed");
+  });
+
   it("repoIdentifier: null renders the no-parseable-remote wording", () => {
     const branch = newBranchSelection({});
     const response = createResponse({

--- a/clients/traycer-cli/src/commands/__tests__/worktree-create.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/worktree-create.test.ts
@@ -1,7 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { resolveWorktreeBranchSelection } from "../worktree-create";
+import type {
+  WorktreeBranchSelection,
+  WorktreeCreatePathsResponse,
+} from "@traycer/protocol/host";
+import {
+  buildWorktreeCreateCommand,
+  formatWorktreeCreateResult,
+  resolveWorktreeBranchSelection,
+} from "../worktree-create";
 import { callHostRpc } from "../../internal/host-rpc";
 import { CliError, CLI_ERROR_CODES } from "../../runner/errors";
+import type { CommandContext } from "../../runner/runner";
 
 const loggerMock = vi.hoisted(() => ({
   debug: vi.fn(),
@@ -196,5 +205,368 @@ describe("resolveWorktreeBranchSelection", () => {
       }),
     ).rejects.toMatchObject({ code: CLI_ERROR_CODES.INVALID_ARGUMENT });
     expect(rpcMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects combining --carry-uncommitted with --existing instead of silently dropping it", async () => {
+    await expect(
+      resolveWorktreeBranchSelection({
+        workspacePath: WORKSPACE,
+        newBranch: null,
+        existingBranch: "release/1.0",
+        sourceBranch: null,
+        carryUncommittedChanges: true,
+      }),
+    ).rejects.toMatchObject({
+      code: CLI_ERROR_CODES.INVALID_ARGUMENT,
+      message: expect.stringContaining("--carry-uncommitted"),
+    });
+    await expect(
+      resolveWorktreeBranchSelection({
+        workspacePath: WORKSPACE,
+        newBranch: null,
+        existingBranch: "release/1.0",
+        sourceBranch: null,
+        carryUncommittedChanges: true,
+      }),
+    ).rejects.toMatchObject({
+      message: expect.stringContaining("--existing"),
+    });
+    expect(rpcMock).not.toHaveBeenCalled();
+  });
+
+  it("still resolves the existing variant when --carry-uncommitted is explicitly false", async () => {
+    const branch = await resolveWorktreeBranchSelection({
+      workspacePath: WORKSPACE,
+      newBranch: null,
+      existingBranch: "release/1.0",
+      sourceBranch: null,
+      carryUncommittedChanges: false,
+    });
+
+    expect(branch).toEqual({ type: "existing", name: "release/1.0" });
+    expect(rpcMock).not.toHaveBeenCalled();
+  });
+});
+
+// The `new` selection is itself a two-arm union - `collision?: "fail"` carries
+// no `retryIdentity`, `collision: "random"` requires one - so a bare
+// `Extract<…, { type: "new" }>` keeps both arms and TS resolves the spread
+// against the wrong one. Dropping the random arm leaves the single shape
+// `resolveWorktreeBranchSelection` actually produces, which lets this use the
+// same `Partial<…>` override idiom as `createResponse` below. (Extracting on
+// `collision: "fail"` directly yields `never` - it is OPTIONAL on that arm, so
+// the arm is not assignable to a required-property matcher.)
+type NewBranchSelection = Exclude<
+  Extract<WorktreeBranchSelection, { readonly type: "new" }>,
+  { readonly collision: "random" }
+>;
+
+function newBranchSelection(
+  overrides: Partial<NewBranchSelection>,
+): WorktreeBranchSelection {
+  return {
+    type: "new",
+    name: "feature/x",
+    source: "main",
+    carryUncommittedChanges: false,
+    collision: "fail",
+    ...overrides,
+  };
+}
+
+function existingBranchSelection(name: string): WorktreeBranchSelection {
+  return { type: "existing", name };
+}
+
+function createResponse(
+  overrides: Partial<WorktreeCreatePathsResponse>,
+): WorktreeCreatePathsResponse {
+  return {
+    entries: [],
+    perEntry: [],
+    ...overrides,
+  };
+}
+
+describe("formatWorktreeCreateResult", () => {
+  it("new-branch success: created path, branch/source/repo/mode, and the carry row when carrying", () => {
+    const branch = newBranchSelection({
+      name: "feature/x",
+      source: "main",
+      carryUncommittedChanges: true,
+    });
+    const response = createResponse({
+      entries: [
+        {
+          workspacePath: WORKSPACE,
+          path: "/Users/dev/.traycer/worktrees/acme__web/feature-x",
+          mode: "worktree",
+          repoIdentifier: { owner: "acme", repo: "web" },
+          branch: "feature/x",
+        },
+      ],
+      perEntry: [
+        {
+          workspacePath: WORKSPACE,
+          ok: true,
+          worktreePath: "/Users/dev/.traycer/worktrees/acme__web/feature-x",
+          branch: "feature/x",
+          errorMessage: null,
+        },
+      ],
+    });
+
+    const summary = formatWorktreeCreateResult(response, branch);
+
+    expect(summary).toContain(
+      "Created worktree /Users/dev/.traycer/worktrees/acme__web/feature-x",
+    );
+    expect(summary).toContain("feature/x (new branch, forked from main)");
+    expect(summary).toContain(WORKSPACE);
+    expect(summary).toContain("acme/web");
+    expect(summary).toContain("worktree");
+    expect(summary).toContain("carried from the source workspace when valid");
+  });
+
+  it("new-branch success: the carry row reads 'left in the source workspace' when not carrying", () => {
+    const branch = newBranchSelection({ carryUncommittedChanges: false });
+    const response = createResponse({
+      entries: [
+        {
+          workspacePath: WORKSPACE,
+          path: "/Users/dev/.traycer/worktrees/acme__web/feature-x",
+          mode: "worktree",
+          repoIdentifier: { owner: "acme", repo: "web" },
+          branch: "feature/x",
+        },
+      ],
+      perEntry: [
+        {
+          workspacePath: WORKSPACE,
+          ok: true,
+          worktreePath: "/Users/dev/.traycer/worktrees/acme__web/feature-x",
+          branch: "feature/x",
+          errorMessage: null,
+        },
+      ],
+    });
+
+    const summary = formatWorktreeCreateResult(response, branch);
+
+    expect(summary).toContain("left in the source workspace");
+  });
+
+  it("existing-branch success: '(checked out; the branch already existed)', Source/Repo/Mode rows, and no Uncommitted changes row", () => {
+    const branch = existingBranchSelection("release/1.0");
+    const response = createResponse({
+      entries: [
+        {
+          workspacePath: WORKSPACE,
+          path: "/Users/dev/.traycer/worktrees/acme__web/release-1.0",
+          mode: "worktree",
+          repoIdentifier: { owner: "acme", repo: "web" },
+          branch: "release/1.0",
+        },
+      ],
+      perEntry: [
+        {
+          workspacePath: WORKSPACE,
+          ok: true,
+          worktreePath: "/Users/dev/.traycer/worktrees/acme__web/release-1.0",
+          branch: "release/1.0",
+          errorMessage: null,
+        },
+      ],
+    });
+
+    const summary = formatWorktreeCreateResult(response, branch);
+
+    expect(summary).toContain(
+      "release/1.0 (checked out; the branch already existed)",
+    );
+    expect(summary).toContain(WORKSPACE);
+    expect(summary).toContain("acme/web");
+    expect(summary).toContain("worktree");
+    expect(summary).not.toContain("Uncommitted changes");
+  });
+
+  it("repoIdentifier: null renders the no-parseable-remote wording", () => {
+    const branch = newBranchSelection({});
+    const response = createResponse({
+      entries: [
+        {
+          workspacePath: WORKSPACE,
+          path: "/Users/dev/.traycer/worktrees/local/feature-x",
+          mode: "worktree",
+          repoIdentifier: null,
+          branch: "feature/x",
+        },
+      ],
+      perEntry: [
+        {
+          workspacePath: WORKSPACE,
+          ok: true,
+          worktreePath: "/Users/dev/.traycer/worktrees/local/feature-x",
+          branch: "feature/x",
+          errorMessage: null,
+        },
+      ],
+    });
+
+    const summary = formatWorktreeCreateResult(response, branch);
+
+    expect(summary).toContain(
+      "(no parseable Git remote - filed under a local path)",
+    );
+  });
+
+  it("a failed perEntry reports 'Could not create a worktree for' with the host's errorMessage", () => {
+    const branch = newBranchSelection({});
+    const response = createResponse({
+      entries: [],
+      perEntry: [
+        {
+          workspacePath: WORKSPACE,
+          ok: false,
+          worktreePath: null,
+          branch: null,
+          errorMessage: "branch already checked out elsewhere",
+        },
+      ],
+    });
+
+    const summary = formatWorktreeCreateResult(response, branch);
+
+    expect(summary).toContain(`Could not create a worktree for ${WORKSPACE}`);
+    expect(summary).toContain("branch already checked out elsewhere");
+  });
+
+  it("a failed perEntry with errorMessage: null falls back to 'The host reported no reason.'", () => {
+    const branch = newBranchSelection({});
+    const response = createResponse({
+      entries: [],
+      perEntry: [
+        {
+          workspacePath: WORKSPACE,
+          ok: false,
+          worktreePath: null,
+          branch: null,
+          errorMessage: null,
+        },
+      ],
+    });
+
+    const summary = formatWorktreeCreateResult(response, branch);
+
+    expect(summary).toContain("The host reported no reason.");
+  });
+
+  it("perEntry all ok but entries empty: reports the host contradicting itself", () => {
+    const branch = newBranchSelection({});
+    const response = createResponse({
+      entries: [],
+      perEntry: [
+        {
+          workspacePath: WORKSPACE,
+          ok: true,
+          worktreePath: "/Users/dev/.traycer/worktrees/acme__web/feature-x",
+          branch: "feature/x",
+          errorMessage: null,
+        },
+      ],
+    });
+
+    const summary = formatWorktreeCreateResult(response, branch);
+
+    expect(summary).toContain("reported success but returned no worktree path");
+  });
+});
+
+function fakeCtx(): CommandContext {
+  return {
+    runtime: {
+      json: false,
+      quiet: false,
+      noProgress: false,
+      noBootstrap: false,
+      nonInteractive: false,
+      environment: "production",
+      logger: {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      },
+    },
+    output: {
+      progress: vi.fn(),
+      human: vi.fn(),
+      humanRequired: vi.fn(),
+      emitResult: vi.fn(),
+      emitError: vi.fn(),
+    },
+    progress: vi.fn(),
+  };
+}
+
+describe("buildWorktreeCreateCommand", () => {
+  it("preserves --json (data is the raw parsed protocol response) and sets exitCode from perEntry.ok", async () => {
+    const successResponse: WorktreeCreatePathsResponse = {
+      entries: [
+        {
+          workspacePath: WORKSPACE,
+          path: "/Users/dev/.traycer/worktrees/acme__web/feature-x",
+          mode: "worktree",
+          repoIdentifier: { owner: "acme", repo: "web" },
+          branch: "feature/x",
+        },
+      ],
+      perEntry: [
+        {
+          workspacePath: WORKSPACE,
+          ok: true,
+          worktreePath: "/Users/dev/.traycer/worktrees/acme__web/feature-x",
+          branch: "feature/x",
+          errorMessage: null,
+        },
+      ],
+    };
+    rpcMock.mockResolvedValue(successResponse);
+
+    const successResult = await buildWorktreeCreateCommand({
+      workspacePath: WORKSPACE,
+      newBranch: "feature/x",
+      existingBranch: null,
+      sourceBranch: "main",
+      carryUncommittedChanges: false,
+    })(fakeCtx());
+
+    expect(successResult.data).toEqual(successResponse);
+    expect(successResult.exitCode).toBe(0);
+
+    const failureResponse: WorktreeCreatePathsResponse = {
+      entries: [],
+      perEntry: [
+        {
+          workspacePath: WORKSPACE,
+          ok: false,
+          worktreePath: null,
+          branch: null,
+          errorMessage: "conflict",
+        },
+      ],
+    };
+    rpcMock.mockResolvedValue(failureResponse);
+
+    const failureResult = await buildWorktreeCreateCommand({
+      workspacePath: WORKSPACE,
+      newBranch: "feature/y",
+      existingBranch: null,
+      sourceBranch: "main",
+      carryUncommittedChanges: false,
+    })(fakeCtx());
+
+    expect(failureResult.data).toEqual(failureResponse);
+    expect(failureResult.exitCode).toBe(1);
   });
 });

--- a/clients/traycer-cli/src/commands/__tests__/worktree-create.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/worktree-create.test.ts
@@ -325,7 +325,9 @@ describe("formatWorktreeCreateResult", () => {
     expect(summary).toContain(WORKSPACE);
     expect(summary).toContain("acme/web");
     expect(summary).toContain("worktree");
-    expect(summary).toContain("carried from the source workspace when valid");
+    expect(summary).toContain(
+      "carry requested - best effort, confirm in the new worktree",
+    );
   });
 
   it("new-branch success: the carry row reads 'left in the source workspace' when not carrying", () => {

--- a/clients/traycer-cli/src/commands/comments.ts
+++ b/clients/traycer-cli/src/commands/comments.ts
@@ -1,4 +1,3 @@
-import { existsSync } from "node:fs";
 import path from "node:path";
 import {
   commentThreadStatusFilterSchema,
@@ -96,8 +95,22 @@ export function buildCommentsSetStatusCommand(opts: {
   };
 }
 
+/**
+ * Absolute in, absolute out - unconditionally.
+ *
+ * This used to resolve a relative path only when the result existed on disk,
+ * and otherwise forwarded the caller's relative string untouched. That made the
+ * request shape depend on the filesystem: the same `comments list docs/a.md`
+ * sent an absolute path when the file was there and a relative one when it was
+ * not, and the host has no way to resolve the second - it does not know the
+ * caller's working directory. A typo'd path therefore failed as "no threads"
+ * rather than as the missing artifact it is.
+ *
+ * Resolving every relative path against `process.cwd()` is also what the help
+ * text now promises, so the declared contract and the wire shape agree. No
+ * existence check: whether an artifact exists is the host's answer to give, and
+ * asking here would only reintroduce a filesystem-dependent request.
+ */
 function normalizeCliArtifactPath(value: string): string {
-  if (path.isAbsolute(value)) return value;
-  const resolved = path.resolve(value);
-  return existsSync(resolved) ? resolved : value;
+  return path.resolve(value);
 }

--- a/clients/traycer-cli/src/commands/workspace-list.ts
+++ b/clients/traycer-cli/src/commands/workspace-list.ts
@@ -116,34 +116,65 @@ function formatRepo(row: WorktreeBindingSelectorRowV12): string {
 }
 
 /**
- * One word for "can an agent be pointed here right now". `disabledReason` is
- * the host's own answer to that - the same field the GUI picker greys a row on
- * - so a null reason is `ready` and a non-null one is named rather than
- * re-derived from `setupState` (which would have to repeat the host's rules and
- * could disagree with them).
+ * What this row's state actually is, mirroring the precedence in the GUI
+ * pickers (`clients/gui-app/src/lib/worktree/worktree-folder-disabled-reason.ts`
+ * — `worktreeFolderRowBadge`), which is the canonical derivation.
  *
- * `isGitResolvePending` wins over the reason, and only over the git-derived
- * one. The host emits `missing_worktree_path` off an `isGitRepo` it has not
- * verified yet, so reporting "missing on disk" for such a row states as fact
- * something the next refresh may retract - the GUI pickers render these as
- * "checking" for the same reason. A genuine setup-state reason is already
- * resolved and is reported as-is even while git facts are pending.
+ * Keying on `disabledReason` ALONE was wrong, and wrong in the direction that
+ * hides bad news. The current host treats creation as the selector gate: once a
+ * worktree exists, setup progress and outcomes stay in `setupState` and the row
+ * is left selectable with `disabledReason: null`. Reading only the reason
+ * therefore reported a worktree whose setup script FAILED as plain `ready`.
+ * Older hosts projected the same lifecycle as `setup_*` reasons, so both
+ * spellings are accepted — which is also why a legacy `setup_*` reason is not
+ * treated as blocking unless disk truth (`mode === "worktree" && !isGitRepo`)
+ * says the worktree is not actually there.
+ *
+ * Setup states are deliberately NOT "unavailable": the GUI renders them
+ * `disabled: false`, because a worktree with a failed setup script is still a
+ * directory an agent can work in. They are reported so the user knows why it
+ * may be half-configured, not to warn them off it.
+ *
+ * Ideally this lives in `clients/shared` beside `classifyWorktreeTier`, so CLI
+ * and GUI cannot drift; that consolidation is a separate change from this one.
  */
 function formatState(row: WorktreeBindingSelectorRowV12): string {
-  if (row.isGitResolvePending && row.disabledReason === "missing_worktree_path")
-    return "checking";
+  if (hasBlockingReason(row)) {
+    // The host derives `missing_worktree_path` from an `isGitRepo` it has not
+    // verified yet, so naming it "missing" states as fact something the next
+    // sweep may retract. The pickers render these as "checking" for exactly
+    // this reason.
+    return row.isGitResolvePending ? "checking" : "missing on disk";
+  }
+  if (row.setupState === "pending" || row.disabledReason === "setup_pending")
+    return "setup pending";
+  if (row.setupState === "running" || row.disabledReason === "setup_running")
+    return "setting up";
+  if (row.setupState === "failed" || row.disabledReason === "setup_failed")
+    return "setup failed";
+  if (
+    row.setupState === "cancelled" ||
+    row.disabledReason === "setup_cancelled"
+  )
+    return "setup cancelled";
+  return "ready";
+}
+
+/**
+ * Mirrors `hasBlockingWorktreeSelectorReason`. A `setup_*` reason from an older
+ * host is relaxed once the worktree demonstrably exists; anything else with a
+ * reason (today only `missing_worktree_path`) genuinely blocks.
+ */
+function hasBlockingReason(row: WorktreeBindingSelectorRowV12): boolean {
   switch (row.disabledReason) {
     case null:
-      return "ready";
+      return false;
     case "setup_pending":
-      return "setup pending";
     case "setup_running":
-      return "setup running";
     case "setup_failed":
-      return "setup failed";
     case "setup_cancelled":
-      return "setup cancelled";
+      return row.mode === "worktree" && !row.isGitRepo;
     case "missing_worktree_path":
-      return "missing on disk";
+      return true;
   }
 }

--- a/clients/traycer-cli/src/commands/workspace-list.ts
+++ b/clients/traycer-cli/src/commands/workspace-list.ts
@@ -1,5 +1,5 @@
-import { worktreeListBindingsForEpicResponseSchema } from "@traycer/protocol/host";
-import type { WorktreeBindingSelectorRow } from "@traycer/protocol/host";
+import { worktreeListBindingsForEpicResponseSchemaV12 } from "@traycer/protocol/host";
+import type { WorktreeBindingSelectorRowV12 } from "@traycer/protocol/host";
 import {
   callHostRpc,
   parseHostResponse,
@@ -15,6 +15,16 @@ import type { CommandFn } from "../runner/runner";
  * Human mode renders a scannable table; `--json` still hands back the host's
  * `worktree.listBindingsForEpic` rows verbatim, which is what a caller parsing
  * this wants and what the human table deliberately is not.
+ *
+ * Parses the CANONICAL v1.2 response, not the v1.0 base schema this used to
+ * read. Zod strips unknown keys, so the old parse silently discarded
+ * `isGitResolvePending` - the host's authoritative "these git facts are still
+ * an unverified placeholder" marker - and the table then reported a resolving
+ * row as `not git` / `missing on disk`, which is the one thing the protocol
+ * says a client must not do with a pending row. A pre-v1.2 host is bridged up
+ * transparently (every row stamped `isGitResolvePending: false`, which is
+ * correct: an old host has no pending concept and never sends a signal that
+ * would clear it), the same way `worktree list` reads its v1.4 schema.
  */
 export function buildWorkspaceListCommand(opts: {
   readonly epicId: string | null;
@@ -25,7 +35,7 @@ export function buildWorkspaceListCommand(opts: {
       callHostRpc("worktree.listBindingsForEpic", { epicId }),
     );
     const parsed = parseHostResponse(
-      worktreeListBindingsForEpicResponseSchema,
+      worktreeListBindingsForEpicResponseSchemaV12,
       result,
     );
     return {
@@ -55,7 +65,7 @@ const COLUMNS = [
  * still in the `--json` payload for anyone who needs the pair.
  */
 export function formatWorkspaceListTable(
-  rows: ReadonlyArray<WorktreeBindingSelectorRow>,
+  rows: ReadonlyArray<WorktreeBindingSelectorRowV12>,
 ): string {
   if (rows.length === 0) {
     return [
@@ -68,7 +78,10 @@ export function formatWorkspaceListTable(
     formatRepo(row),
     row.mode,
     row.branch ?? "-",
-    row.isGitRepo ? "yes" : "no",
+    // `isGitRepo` is part of the placeholder a pending row carries, so it gets
+    // the same "not answered yet" treatment as STATE rather than a confident
+    // "no" the next refresh may contradict.
+    row.isGitResolvePending ? "?" : row.isGitRepo ? "yes" : "no",
     formatState(row),
     String(row.sources.length),
     row.runningDir,
@@ -97,7 +110,7 @@ export function formatWorkspaceListTable(
   ].join("\n");
 }
 
-function formatRepo(row: WorktreeBindingSelectorRow): string {
+function formatRepo(row: WorktreeBindingSelectorRowV12): string {
   const identifier = row.repoIdentifier;
   return identifier === null ? "-" : `${identifier.owner}/${identifier.repo}`;
 }
@@ -108,8 +121,17 @@ function formatRepo(row: WorktreeBindingSelectorRow): string {
  * - so a null reason is `ready` and a non-null one is named rather than
  * re-derived from `setupState` (which would have to repeat the host's rules and
  * could disagree with them).
+ *
+ * `isGitResolvePending` wins over the reason, and only over the git-derived
+ * one. The host emits `missing_worktree_path` off an `isGitRepo` it has not
+ * verified yet, so reporting "missing on disk" for such a row states as fact
+ * something the next refresh may retract - the GUI pickers render these as
+ * "checking" for the same reason. A genuine setup-state reason is already
+ * resolved and is reported as-is even while git facts are pending.
  */
-function formatState(row: WorktreeBindingSelectorRow): string {
+function formatState(row: WorktreeBindingSelectorRowV12): string {
+  if (row.isGitResolvePending && row.disabledReason === "missing_worktree_path")
+    return "checking";
   switch (row.disabledReason) {
     case null:
       return "ready";

--- a/clients/traycer-cli/src/commands/workspace-list.ts
+++ b/clients/traycer-cli/src/commands/workspace-list.ts
@@ -2,7 +2,7 @@ import { worktreeListBindingsForEpicResponseSchemaV12 } from "@traycer/protocol/
 import type { WorktreeBindingSelectorRowV12 } from "@traycer/protocol/host";
 import {
   callHostRpc,
-  parseHostResponse,
+  parseCanonicalHostResponse,
   toAgentCliError,
 } from "../internal/host-rpc";
 import { resolveEpicId } from "../internal/agent-context";
@@ -34,7 +34,8 @@ export function buildWorkspaceListCommand(opts: {
     const result = await toAgentCliError(
       callHostRpc("worktree.listBindingsForEpic", { epicId }),
     );
-    const parsed = parseHostResponse(
+    const parsed = parseCanonicalHostResponse(
+      "worktree.listBindingsForEpic",
       worktreeListBindingsForEpicResponseSchemaV12,
       result,
     );

--- a/clients/traycer-cli/src/commands/workspace-list.ts
+++ b/clients/traycer-cli/src/commands/workspace-list.ts
@@ -1,4 +1,5 @@
 import { worktreeListBindingsForEpicResponseSchema } from "@traycer/protocol/host";
+import type { WorktreeBindingSelectorRow } from "@traycer/protocol/host";
 import {
   callHostRpc,
   parseHostResponse,
@@ -7,6 +8,14 @@ import {
 import { resolveEpicId } from "../internal/agent-context";
 import type { CommandFn } from "../runner/runner";
 
+/**
+ * `traycer workspace list` - the folders and Git worktrees bound to this Task,
+ * which is the set an agent here can be pointed at.
+ *
+ * Human mode renders a scannable table; `--json` still hands back the host's
+ * `worktree.listBindingsForEpic` rows verbatim, which is what a caller parsing
+ * this wants and what the human table deliberately is not.
+ */
 export function buildWorkspaceListCommand(opts: {
   readonly epicId: string | null;
 }): CommandFn {
@@ -21,8 +30,98 @@ export function buildWorkspaceListCommand(opts: {
     );
     return {
       data: parsed,
-      human: JSON.stringify(parsed, null, 2),
+      human: formatWorkspaceListTable(parsed.rows),
       exitCode: 0,
     };
   };
+}
+
+const COLUMNS = [
+  "REPO",
+  "MODE",
+  "BRANCH",
+  "GIT",
+  "STATE",
+  "AGENTS",
+  "DIRECTORY",
+] as const;
+
+/**
+ * Fixed-width column table, pure so the layout is testable without a host.
+ *
+ * DIRECTORY is `runningDir` - the directory Git and a shell actually run in -
+ * rather than `workspacePath`, because for a worktree row those differ and only
+ * the former answers "where would my agent be working". The source workspace is
+ * still in the `--json` payload for anyone who needs the pair.
+ */
+export function formatWorkspaceListTable(
+  rows: ReadonlyArray<WorktreeBindingSelectorRow>,
+): string {
+  if (rows.length === 0) {
+    return [
+      "No workspace folders are bound to this Task.",
+      "",
+      "Create one with `traycer worktree create --workspace <path> --branch <name>`, then bind it with `traycer agent create --cwd <path>`.",
+    ].join("\n");
+  }
+  const cells = rows.map((row) => [
+    formatRepo(row),
+    row.mode,
+    row.branch ?? "-",
+    row.isGitRepo ? "yes" : "no",
+    formatState(row),
+    String(row.sources.length),
+    row.runningDir,
+  ]);
+  const widths = COLUMNS.map((header, column) =>
+    cells.reduce(
+      (max, row) => Math.max(max, row[column].length),
+      header.length,
+    ),
+  );
+  const renderRow = (row: ReadonlyArray<string>): string =>
+    row
+      .map((cell, column) =>
+        // The final column (DIRECTORY) stays unpadded so a long path never
+        // trails a wall of spaces.
+        column === COLUMNS.length - 1 ? cell : cell.padEnd(widths[column]),
+      )
+      .join("  ")
+      .trimEnd();
+  return [
+    renderRow(COLUMNS),
+    ...cells.map(renderRow),
+    "",
+    "Run an agent in one with `traycer agent create --cwd <directory>`.",
+    "Run with --json for the full binding records.",
+  ].join("\n");
+}
+
+function formatRepo(row: WorktreeBindingSelectorRow): string {
+  const identifier = row.repoIdentifier;
+  return identifier === null ? "-" : `${identifier.owner}/${identifier.repo}`;
+}
+
+/**
+ * One word for "can an agent be pointed here right now". `disabledReason` is
+ * the host's own answer to that - the same field the GUI picker greys a row on
+ * - so a null reason is `ready` and a non-null one is named rather than
+ * re-derived from `setupState` (which would have to repeat the host's rules and
+ * could disagree with them).
+ */
+function formatState(row: WorktreeBindingSelectorRow): string {
+  switch (row.disabledReason) {
+    case null:
+      return "ready";
+    case "setup_pending":
+      return "setup pending";
+    case "setup_running":
+      return "setup running";
+    case "setup_failed":
+      return "setup failed";
+    case "setup_cancelled":
+      return "setup cancelled";
+    case "missing_worktree_path":
+      return "missing on disk";
+  }
 }

--- a/clients/traycer-cli/src/commands/worktree-create.ts
+++ b/clients/traycer-cli/src/commands/worktree-create.ts
@@ -6,7 +6,7 @@ import {
 } from "@traycer/protocol/host";
 import {
   callHostRpc,
-  parseHostResponse,
+  parseCanonicalHostResponse,
   parseUserInput,
   toAgentCliError,
 } from "../internal/host-rpc";
@@ -150,7 +150,11 @@ export function buildWorktreeCreateCommand(
     const result = await toAgentCliError(
       callHostRpc("worktree.createPaths", request),
     );
-    const parsed = parseHostResponse(worktreeCreatePathsResponseSchema, result);
+    const parsed = parseCanonicalHostResponse(
+      "worktree.createPaths",
+      worktreeCreatePathsResponseSchema,
+      result,
+    );
     return {
       data: parsed,
       human: formatWorktreeCreateResult(parsed, branch),

--- a/clients/traycer-cli/src/commands/worktree-create.ts
+++ b/clients/traycer-cli/src/commands/worktree-create.ts
@@ -211,13 +211,23 @@ export function formatWorktreeCreateResult(
         // `resolveWorktreeBranchSelection` rejects `--carry-uncommitted`
         // alongside `--existing`, so an `existing` create has nothing to
         // report here rather than a "no" a reader would have to interpret.
+        //
+        // The carrying case is reported as INTENT, not as an outcome, and the
+        // distinction is load-bearing. The response says a worktree was
+        // created; it does not say whether any WIP came with it. Carry is
+        // best-effort on the host - an unresolvable carry root, a failed stash
+        // replay, an unreadable untracked file - and none of those turn the
+        // create into a failed `perEntry`. Printing "carried" off the request
+        // flag would state as fact something this command cannot observe, which
+        // is the class of false human status CLI-020 exists to remove. The
+        // not-carrying case IS certain: nothing was asked for, so nothing moved.
         ...(branch.type === "existing"
           ? []
           : ([
               [
                 "Uncommitted changes",
                 branch.carryUncommittedChanges
-                  ? "carried from the source workspace when valid"
+                  ? "carry requested - best effort, confirm in the new worktree"
                   : "left in the source workspace",
               ],
             ] satisfies [string, string][])),

--- a/clients/traycer-cli/src/commands/worktree-create.ts
+++ b/clients/traycer-cli/src/commands/worktree-create.ts
@@ -1,5 +1,6 @@
 import {
   type WorktreeBranchSelection,
+  type WorktreeCreatePathsResponse,
   worktreeCreatePathsRequestSchema,
   worktreeCreatePathsResponseSchema,
 } from "@traycer/protocol/host";
@@ -56,6 +57,19 @@ export async function resolveWorktreeBranchSelection(
         code: CLI_ERROR_CODES.INVALID_ARGUMENT,
         message:
           "traycer: --source-branch only applies to --branch (creating a new branch); it cannot be combined with --existing.",
+        details: null,
+        exitCode: 1,
+      });
+    }
+    // Same rule, same reason: the `existing` selection carries no
+    // `carryUncommittedChanges` field, so this flag had been accepted and then
+    // silently dropped - the user asked for their work to come along and it
+    // did not. Refuse rather than quietly do nothing.
+    if (opts.carryUncommittedChanges) {
+      throw cliError({
+        code: CLI_ERROR_CODES.INVALID_ARGUMENT,
+        message:
+          "traycer: --carry-uncommitted only applies to --branch (creating a new branch); it cannot be combined with --existing.",
         details: null,
         exitCode: 1,
       });
@@ -139,8 +153,96 @@ export function buildWorktreeCreateCommand(
     const parsed = parseHostResponse(worktreeCreatePathsResponseSchema, result);
     return {
       data: parsed,
-      human: JSON.stringify(parsed, null, 2),
+      human: formatWorktreeCreateResult(parsed, branch),
       exitCode: parsed.perEntry.every((entry) => entry.ok) ? 0 : 1,
     };
   };
+}
+
+/**
+ * Human summary of a create. Pure so the layout is testable without a host, and
+ * deliberately not the response object: `--json` still returns the protocol
+ * shape verbatim for anyone parsing this, while a person gets the four facts
+ * they came for - where it landed, on which branch, from what, and what to do
+ * with it.
+ *
+ * The `branch` selection is threaded in rather than read back off the response
+ * because it is the only place the *intent* survives: the wire response reports
+ * a branch name, not whether that branch was created or checked out, nor
+ * whether uncommitted changes were carried along.
+ */
+export function formatWorktreeCreateResult(
+  response: WorktreeCreatePathsResponse,
+  branch: WorktreeBranchSelection,
+): string {
+  const failures = response.perEntry.filter((entry) => !entry.ok);
+  if (failures.length > 0) {
+    return failures
+      .map((entry) =>
+        [
+          `Could not create a worktree for ${entry.workspacePath}`,
+          `  ${entry.errorMessage ?? "The host reported no reason."}`,
+        ].join("\n"),
+      )
+      .join("\n\n");
+  }
+  if (response.entries.length === 0) {
+    // `perEntry` says every entry succeeded, so an empty `entries` is the host
+    // contradicting itself. Say so plainly instead of printing a confident
+    // summary of nothing.
+    return "The host reported success but returned no worktree path. Run with --json to see the full response.";
+  }
+  const lines: string[] = [];
+  for (const entry of response.entries) {
+    if (lines.length > 0) lines.push("");
+    lines.push(`Created worktree ${entry.path}`);
+    lines.push(
+      ...kvBlock([
+        ["Branch", formatBranch(entry.branch, branch)],
+        ["Source", entry.workspacePath],
+        [
+          "Repo",
+          entry.repoIdentifier === null
+            ? "(no parseable Git remote - filed under a local path)"
+            : `${entry.repoIdentifier.owner}/${entry.repoIdentifier.repo}`,
+        ],
+        ["Mode", entry.mode],
+        // Only the `new` selection can carry work across, and
+        // `resolveWorktreeBranchSelection` rejects `--carry-uncommitted`
+        // alongside `--existing`, so an `existing` create has nothing to
+        // report here rather than a "no" a reader would have to interpret.
+        ...(branch.type === "existing"
+          ? []
+          : ([
+              [
+                "Uncommitted changes",
+                branch.carryUncommittedChanges
+                  ? "carried from the source workspace when valid"
+                  : "left in the source workspace",
+              ],
+            ] satisfies [string, string][])),
+      ]),
+    );
+  }
+  lines.push("");
+  lines.push("Run an agent in it with `traycer agent create --cwd <path>`.");
+  return lines.join("\n");
+}
+
+function formatBranch(
+  created: string | null,
+  branch: WorktreeBranchSelection,
+): string {
+  const name = created ?? branch.name;
+  return branch.type === "existing"
+    ? `${name} (checked out; the branch already existed)`
+    : `${name} (new branch, forked from ${branch.source})`;
+}
+
+function kvBlock(rows: readonly [string, string][]): string[] {
+  const keyWidth = rows.reduce(
+    (width, [key]) => Math.max(width, key.length),
+    0,
+  );
+  return rows.map(([key, value]) => `  ${key.padEnd(keyWidth)}  ${value}`);
 }

--- a/clients/traycer-cli/src/commands/worktree-create.ts
+++ b/clients/traycer-cli/src/commands/worktree-create.ts
@@ -239,14 +239,29 @@ export function formatWorktreeCreateResult(
   return lines.join("\n");
 }
 
+/**
+ * The host's `branch` when it reported one, and an explicit "it did not" when
+ * it did not.
+ *
+ * This used to fall back to `branch.name` - the name we ASKED for - and then
+ * describe it with the same "(new branch, forked from x)" / "(checked out)"
+ * confidence as a reported one. `worktreeCreatedPathEntrySchema` makes the
+ * returned branch nullable, so a null is the host declining to state the
+ * outcome, and echoing the request back dressed as a result is the same
+ * false-status defect this file already fixed for the carry row. The requested
+ * name is still shown, because it is the useful thing to print - it is just
+ * labelled as the request rather than as what happened.
+ */
 function formatBranch(
   created: string | null,
   branch: WorktreeBranchSelection,
 ): string {
-  const name = created ?? branch.name;
+  if (created === null) {
+    return `${branch.name} (requested; the host did not report the resulting branch)`;
+  }
   return branch.type === "existing"
-    ? `${name} (checked out; the branch already existed)`
-    : `${name} (new branch, forked from ${branch.source})`;
+    ? `${created} (checked out; the branch already existed)`
+    : `${created} (new branch, forked from ${branch.source})`;
 }
 
 function kvBlock(rows: readonly [string, string][]): string[] {

--- a/clients/traycer-cli/src/index.ts
+++ b/clients/traycer-cli/src/index.ts
@@ -1290,6 +1290,27 @@ function registerHostCommands(program: Command): void {
           exitCode: 1,
         });
       }
+      // Both or neither. The handler already refuses `--pid` without `--port`
+      // (it cannot verify ownership without the port), but `--port` alone used
+      // to fall through to a bare restart: no kill attempted, exit 0, and human
+      // output reporting a successful restart. That was survivable while this
+      // command was hidden and only Desktop's controller drove it - it passes
+      // both flags or neither - but `host doctor` now prints this spelling for
+      // a person to type, and a half-typed line must not report success for a
+      // repair it never attempted.
+      //
+      // Bare (neither flag) stays legal: Desktop's `HostController` appends
+      // `--pid`/`--port` conditionally, so `["host","free-port-and-restart"]`
+      // is a live machine call.
+      if (pid === null && port !== null) {
+        throw cliError({
+          code: CLI_ERROR_CODES.INVALID_ARGUMENT,
+          message:
+            "host free-port-and-restart: --port requires --pid - the PID is what gets terminated, and it is re-checked against the port first. Run 'traycer host doctor' for the filled-in command, or pass neither flag (or use 'traycer host restart') to restart without killing anything.",
+          details: { pid: null, port },
+          exitCode: 1,
+        });
+      }
       return buildHostFreePortAndRestartCommand({
         pid,
         port,

--- a/clients/traycer-cli/src/index.ts
+++ b/clients/traycer-cli/src/index.ts
@@ -813,8 +813,15 @@ function registerHostCommands(program: Command): void {
       // command can replace the `traycer` binary itself. Someone restarting the
       // host to clear a hang deserves to know that before their CLI version
       // changes under them.
+      //
+      // "attempts"/"may" rather than "completes", because the finalize is
+      // explicitly non-fatal: a missing staged binary, a still-locked binary on
+      // a read-only install, or a Windows helper that only gets SCHEDULED all
+      // return exit 0 with the pending upgrade retained. Promising completion
+      // would be the same false-status defect this PR removes elsewhere; the
+      // human result already reports which of those actually happened.
       .description(
-        "Restart the host service. If a CLI self-upgrade is waiting to be applied, this completes it too, replacing the 'traycer' binary.",
+        "Restart the host service. If a CLI self-upgrade is waiting to be applied, this also attempts to finalize it, which may replace the 'traycer' binary.",
       )
       // Hidden: the CLI-owned activation mode (desktop controller's
       // idle-gated restart cycle), not a user-facing switch - see

--- a/clients/traycer-cli/src/index.ts
+++ b/clients/traycer-cli/src/index.ts
@@ -435,7 +435,9 @@ export function buildProgramWithAgentRoles(
   // positional/global-option parsing.
   program
     .name("traycer")
-    .description("Traycer CLI - auth, host supervisor, and config surface")
+    .description(
+      "Traycer CLI - sign in, run the Traycer host on this machine, and work with the agents in a Task",
+    )
     .version(cliVersion);
 
   // Global runner flags so `traycer --json <subcommand>` works even when
@@ -634,9 +636,16 @@ function registerAuthCommands(program: Command): void {
     program
       .command("login")
       .description("Sign in to Traycer via your browser")
-      .option(
-        "--token <token>",
-        "Internal: seed credentials from a JSON `{ token, refreshToken }` payload piped on stdin (pass '-'). Used by the desktop app after sign-in; not for interactive use.",
+      // Hidden per the house convention for `"Internal:"` options: the payload
+      // is produced by the Traycer Desktop app's own sign-in and piped on
+      // stdin, so there is nothing a person at a terminal can usefully type
+      // here. Its contract is pinned by `commands/__tests__/login-token.test.ts`
+      // rather than by help text.
+      .addOption(
+        new Option(
+          "--token <token>",
+          "Internal: seed credentials from a JSON `{ token, refreshToken }` payload piped on stdin (pass '-'). Used by the desktop app after sign-in; not for interactive use.",
+        ).hideHelp(),
       ),
     (opts) =>
       buildLoginCommand({
@@ -667,7 +676,14 @@ function registerAuthCommands(program: Command): void {
 }
 
 function registerHostCommands(program: Command): void {
-  const host = program.command("host").description("Manage the local host");
+  // Names what the group actually spans, because the children differ enormously
+  // in consequence: reads (status, logs, available) sit beside commands that
+  // download and swap bytes, register an OS service, or kill a running host.
+  const host = program
+    .command("host")
+    .description(
+      "Install, run, update, and troubleshoot the Traycer host on this machine",
+    );
 
   // `host start` is the long-running supervisor invoked by service
   // manifests (launchd / systemd-user / Windows Scheduled Task) as
@@ -744,7 +760,13 @@ function registerHostCommands(program: Command): void {
   // see host/capabilities.ts.
   host
     .command("capabilities")
-    .description("Print the capability tokens this CLI supports")
+    // Says out loud that `--json` means something different here. Every other
+    // command's `--json` is the runner's NDJSON event stream; this one prints a
+    // single JSON document, because its readers are a /bin/sh script and a
+    // VBScript launcher rather than an event consumer.
+    .description(
+      "Print the capability tokens this CLI supports. Raw output for scripts: plain text or a single JSON document plus an exit code, not the NDJSON event stream other commands emit with --json.",
+    )
     .option("--json", "Print the capability document as JSON")
     .option(
       "--has <capability>",
@@ -786,7 +808,14 @@ function registerHostCommands(program: Command): void {
   withRunner(
     host
       .command("restart")
-      .description("Restart the host service")
+      // The CLI-upgrade clause is not padding: a restart is where a pending
+      // self-upgrade is finalised (`upgrade/finalize-helper.ts`), so this host
+      // command can replace the `traycer` binary itself. Someone restarting the
+      // host to clear a hang deserves to know that before their CLI version
+      // changes under them.
+      .description(
+        "Restart the host service. If a CLI self-upgrade is waiting to be applied, this completes it too, replacing the 'traycer' binary.",
+      )
       // Hidden: the CLI-owned activation mode (desktop controller's
       // idle-gated restart cycle), not a user-facing switch - see
       // commands/host-restart.ts.
@@ -1222,12 +1251,22 @@ function registerHostCommands(program: Command): void {
 
   withRunner(
     host
-      .command("free-port-and-restart", { hidden: true })
+      // Public, unlike its kill-only sibling below: `host doctor` prints this
+      // exact command line - PID and port filled in - as the fix for a port
+      // conflict, so a user is asked to type it. A command the CLI tells
+      // people to run has to be in the CLI's own help.
+      .command("free-port-and-restart")
       .description(
-        "Terminate a foreign PID holding the host port and restart the service (internal - invoked by Doctor)",
+        "Kill the process holding the host's port, then restart the host - the fix 'traycer host doctor' prints for a port conflict. Pass --pid and --port together; the PID is re-checked against the port and nothing is killed if it no longer owns it. With neither flag this only restarts the host.",
       )
-      .option("--pid <pid>", "PID of the conflicting process to terminate")
-      .option("--port <port>", "Port the foreign process is bound to"),
+      .option(
+        "--pid <pid>",
+        "PID of the process holding the port, as reported by 'traycer host doctor'. Requires --port.",
+      )
+      .option(
+        "--port <port>",
+        "Port that PID is holding, as reported by 'traycer host doctor'. Requires --pid.",
+      ),
     (opts) => {
       const pid =
         typeof opts.pid === "string" ? parsePositiveIntegerArg(opts.pid) : null;
@@ -1260,9 +1299,14 @@ function registerHostCommands(program: Command): void {
 
   withRunner(
     host
+      // Stays hidden where `free-port-and-restart` above went public, and the
+      // difference is who is asked to run it: nothing prints this spelling for
+      // a person to type. It is the half-repair Desktop's host controller
+      // drives when it owns the restart itself, and leaving the port freed but
+      // the host down is not an outcome to hand a user.
       .command("free-port", { hidden: true })
       .description(
-        "Terminate a foreign PID holding the host port, without restarting the service (internal - invoked by Doctor)",
+        "Internal: terminate a foreign PID holding the host port WITHOUT restarting the host. Machine contract for Desktop's host controller; people use 'traycer host free-port-and-restart'.",
       )
       .requiredOption(
         "--pid <pid>",
@@ -1348,10 +1392,14 @@ export function hostStartOptionsFromCommand(input: {
 }
 
 function registerServiceCommands(host: Command): void {
+  // "status" belongs in the summary because it is a third of this group, and
+  // "starts/stops it" because registering or deregistering is never only a
+  // bookkeeping edit - the OS starts the host on install and stops it on
+  // uninstall.
   const service = host
     .command("service")
     .description(
-      "Register / deregister the OS service that supervises the host",
+      "Set up, check, or remove the background registration that keeps the host running (registering starts it; deregistering stops it)",
     );
 
   withRunner(
@@ -1396,7 +1444,9 @@ function registerServiceCommands(host: Command): void {
 function registerCliCommands(program: Command): void {
   const cli = program
     .command("cli")
-    .description("Manage the installed CLI binary (upgrade, re-anchor)");
+    .description(
+      "Update the 'traycer' command itself, or point it at a binary you installed by hand",
+    );
 
   withRunner(
     cli
@@ -1491,11 +1541,13 @@ function registerCliCommands(program: Command): void {
 function registerConfigCommands(program: Command): void {
   const config = program
     .command("config")
-    .description("Read or write Traycer's machine-local config");
+    .description("Read or change the Traycer settings stored on this machine");
 
   const shell = config
     .command("shell")
-    .description("Shell used for host bootstrap and terminal tabs");
+    .description(
+      "Choose the shell Traycer uses to start the host and to open terminal tabs",
+    );
   withRunner(
     shell
       .command("get")
@@ -1618,7 +1670,9 @@ function registerConfigCommands(program: Command): void {
 
   const env = config
     .command("env")
-    .description("Env vars layered on top of host + terminal env");
+    .description(
+      "Environment variables Traycer adds when it starts the host and opens terminal tabs",
+    );
   withRunner(
     env.command("list").description("List env overrides"),
     () => async (ctx) => buildConfigEnvListCommand()(ctx),
@@ -1683,12 +1737,14 @@ function collectRepeatedOption(
 function registerWorkspaceCommands(program: Command): void {
   const workspace = program
     .command("workspace")
-    .description("Inspect workspace folders");
+    .description("Show the folders an agent in this Task can work in");
 
   withRunner(
     workspace
       .command("list")
-      .description("List workspace folders and Git worktrees for an epic"),
+      .description(
+        "List the folders and Git worktrees bound to this Task, and which agents hold each one",
+      ),
     () => buildWorkspaceListCommand({ epicId: null }),
   );
 }
@@ -1739,8 +1795,14 @@ function registerCommentsCommands(program: Command): void {
       .description(
         "List artifact comment threads. Read them after reading an artifact, so human-authored feedback is visible before editing or responding. A thread may quote the artifact text it refers to: anchor=present means that quote is still located in the current artifact, while anchor=missing or anchor=unavailable means the quote is context only - verify it against the artifact before acting on it.",
       )
-      .argument("[artifactPaths...]", "Absolute artifact paths")
-      .option("--status <status>", "Thread status: all, open, or resolved"),
+      .argument(
+        "[artifactPaths...]",
+        "Artifact paths to list threads for. Absolute, or relative to the current directory (resolved before the request). Omit to list every artifact in this Task.",
+      )
+      .option(
+        "--status <status>",
+        "Thread status: all, open, or resolved (defaults to all)",
+      ),
     (opts, args) =>
       buildCommentsListCommand({
         epicId: null,
@@ -1757,7 +1819,10 @@ function registerCommentsCommands(program: Command): void {
       .description(
         "Set artifact comment threads to open or resolved after addressing or reopening feedback. Prefer telling the user which threads look addressed and letting them decide, unless they have already asked you to resolve threads yourself.",
       )
-      .requiredOption("--artifact <path>", "Absolute artifact path")
+      .requiredOption(
+        "--artifact <path>",
+        "Artifact the threads belong to. Absolute, or relative to the current directory (resolved before the request).",
+      )
       .requiredOption("--status <status>", "Thread status: open or resolved")
       .argument("<threadIds...>", "Thread ids to update"),
     (opts, args) =>
@@ -1785,7 +1850,9 @@ function registerWorktreeCommands(program: Command): void {
   };
   const worktree = program
     .command("worktree")
-    .description("Create, inspect, and remove Git worktree paths");
+    .description(
+      "Create, list, and remove the Git worktrees Traycer manages on this machine",
+    );
 
   withRunner(
     worktree
@@ -1845,7 +1912,7 @@ function registerWorktreeCommands(program: Command): void {
       )
       .option(
         "--carry-uncommitted",
-        "Carry tracked and untracked changes from the source workspace when valid",
+        "Carry tracked and untracked changes from the source workspace when valid. Only with --branch; rejected with --existing.",
       ),
     (opts) =>
       buildWorktreeCreateCommand({
@@ -1889,15 +1956,17 @@ function registerAgentCommands(
     "Provider profile: 'ambient' for the provider's CLI login, or a managed profile id from 'traycer agent list-profiles <harness>'. Omit to inherit the source agent's own profile.";
   const agent = program
     .command("agent")
-    .description("Agent inspection and communication for the calling agent");
+    .description(
+      "List, inspect, message, and manage the other agents in this Task",
+    );
 
   withRunner(
     agent
       .command("list")
-      .description("List every agent in the epic")
+      .description("List every agent in this Task")
       .option(
         "-a, --all",
-        "List all agents in the epic, not just agents belonging to this user",
+        "List all agents in this Task, not just agents belonging to this user",
       ),
     (opts) =>
       buildAgentListCommand({
@@ -2222,14 +2291,14 @@ function registerAgentCommands(
     const role = agent
       .command("role")
       .description(
-        "Claim, list, and relinquish durable Task-local roles for the calling agent",
+        "Claim, list, and relinquish the named roles that record which agent owns what in this Task",
       );
 
     withRunner(
       role
         .command("claim", readonlyHidden)
         .description(
-          "Claim a durable role for the calling agent in this Task's role registry",
+          "Claim a named role for yourself in this Task, so other agents can see who owns what",
         )
         .requiredOption(
           "--role <name>",
@@ -2267,7 +2336,7 @@ function registerAgentCommands(
     withRunner(
       role
         .command("relinquish", readonlyHidden)
-        .description("Relinquish a role claim held by the calling agent")
+        .description("Give up a role you are currently holding in this Task")
         .requiredOption(
           "--claim-id <id>",
           "Claim id to relinquish (see 'traycer agent role list')",

--- a/clients/traycer-cli/src/internal/__tests__/host-rpc.test.ts
+++ b/clients/traycer-cli/src/internal/__tests__/host-rpc.test.ts
@@ -494,13 +494,15 @@ describe("parseCanonicalHostResponse", () => {
 });
 
 describe("parseHostResponse creep guard", () => {
-  // `worktree-create.ts` and `workspace-list.ts` are owned by open PR #1505;
-  // this allowlist is the enforcement mechanism and is expected to shrink to
-  // empty once that PR lands. Do not add to it without justification - use
-  // `parseCanonicalHostResponse` instead.
-  const ALLOWLIST = new Set(["workspace-list.ts", "worktree-create.ts"]);
+  // Empty, as intended: #1508 carved out `workspace-list.ts` and
+  // `worktree-create.ts` while PR #1505 held them, and #1505 converted both to
+  // `parseCanonicalHostResponse` on landing. Do not add to it without
+  // justification - use `parseCanonicalHostResponse` instead. A call site that
+  // genuinely means a specific historical version (monitor.ts's frame decode)
+  // lives outside this directory.
+  const ALLOWLIST = new Set<string>([]);
 
-  it("only PR #1505's carved-out files still call the un-canonical parseHostResponse", () => {
+  it("no command calls the un-canonical parseHostResponse", () => {
     const offenders: string[] = [];
     for (const file of readdirSync(COMMANDS_DIR)) {
       if (!file.endsWith(".ts") || ALLOWLIST.has(file)) continue;

--- a/clients/traycer-cli/src/runner/commander-flags.ts
+++ b/clients/traycer-cli/src/runner/commander-flags.ts
@@ -1,4 +1,4 @@
-import { Command } from "commander";
+import { Command, Option } from "commander";
 import type { RawRunnerFlags } from "./runtime";
 
 // Commander-side adapter for the runner's global flags. Every
@@ -18,9 +18,29 @@ export function addRunnerFlags(cmd: Command): Command {
     )
     .option("--quiet", "Suppress non-essential human output")
     .option("--no-progress", "Suppress progress events / progress lines")
-    .option(
-      "--no-bootstrap",
-      "Skip implicit bootstrap actions (e.g. auto-start)",
+    .addOption(
+      // A compatibility token, not a user-facing switch, so it is hidden
+      // rather than advertised on every runner-backed leaf.
+      //
+      // It opts out of the implicit install/register/start that `host status`
+      // performs before reading state - the ONLY command that has ever read
+      // it, which is why advertising it on every runner-backed leaf was
+      // misleading. That implicit provisioning is itself being removed (the
+      // explicit verb is `traycer host ensure`), after which the flag reads as
+      // a plain no-op everywhere.
+      //
+      // The TOKEN still has to parse. Desktop calls
+      // `traycer host status --no-bootstrap` through `discoverCli()`
+      // (manifest -> PATH -> bundled), which is deliberately NOT version-matched
+      // with Desktop - an installed older Desktop can drive a newer CLI slot.
+      // Deleting the option would turn that call into commander's
+      // `unknown option` failure and cost the renderer's host-failure card its
+      // bootstrap.log tail on exactly the machines that are already broken.
+      // Delete the token only once that compatibility window has closed.
+      new Option(
+        "--no-bootstrap",
+        "Deprecated no-op, accepted so older callers keep parsing",
+      ).hideHelp(),
     );
 }
 

--- a/clients/traycer-cli/src/runner/commander-flags.ts
+++ b/clients/traycer-cli/src/runner/commander-flags.ts
@@ -37,9 +37,14 @@ export function addRunnerFlags(cmd: Command): Command {
       // `unknown option` failure and cost the renderer's host-failure card its
       // bootstrap.log tail on exactly the machines that are already broken.
       // Delete the token only once that compatibility window has closed.
+      // Describes what it does TODAY, not what it is expected to become.
+      // `host status` still reads `runtime.noBootstrap`, so calling this a
+      // no-op here would contradict the live contract in the one place a
+      // maintainer looks to learn it - and the removal it anticipates is on
+      // another branch and may not land first.
       new Option(
         "--no-bootstrap",
-        "Deprecated no-op, accepted so older callers keep parsing",
+        "Compatibility option for older callers: skips the implicit provisioning 'host status' performs. No effect on any other command; becomes a no-op everywhere once that provisioning is removed.",
       ).hideHelp(),
     );
 }


### PR DESCRIPTION
## Summary

Repairs the help-surface and human-output findings from the CLI command and behavior audit: **CLI-002, CLI-005, CLI-020, CLI-022**, plus the audit's cross-cutting rendered-help regression pass, plus **CLI-023** (found by Codex's review of this PR — see below).

One rule runs through all of it: **help must describe what a command actually does, in the words a user would use, and every command a user is asked to run must be in help.**

## CLI-002 — `--no-bootstrap` advertised an internal execution concern everywhere

`addRunnerFlags` put it on the root and every runner-backed leaf, but `host status` is the only command that has ever read it.

It is now `.hideHelp()` and described as a compatibility option — gone from `traycer --help` and every leaf's help. **The token still parses everywhere it used to**, deliberately:

> `clients/desktop/.../traycer-cli-ipc.ts` runs `traycer host status --no-bootstrap`, resolving the binary through `discoverCli()` (manifest → PATH → bundled). That resolution is *not* version-matched with Desktop — `runBundledTraycerCliJson` is the version-matched one — and the CLI slot is independently replaceable, so an already-installed older Desktop can drive a newer CLI. Deleting the option would turn that call into commander's `unknown option` failure, costing the renderer's host-failure card its `bootstrap.log` tail on precisely the machines that are already broken.

**Deliberately not done here:** dropping the flag from the Desktop call site. It is still load-bearing until CLI-001 makes `host status` observational — removing it first would make every Desktop `host status` on a clean machine run the full install + service-registration pipeline. That edit belongs to the CLI-001 branch and its owner has taken it.

## CLI-005 — parent descriptions written in implementation language

Rewrote the root and every parent (`host`, `host service`, `cli`, `config`, `config shell`, `config env`, `workspace`, `worktree`, `agent`, `agent role`) in terms of what the user gets. "host supervisor", "config surface" and "calling agent" are gone.

Also removed **"epic"** from visible help — the user-facing word is **Task**, already the convention in `terminal list`, `comments`, and the A2A tool descriptions. `TRAYCER_EPIC_ID` stays; it is an env-var name.

## CLI-020 — `workspace list` / `worktree create` printed raw RPC JSON

Both now render like their neighbours (`terminal list`, `worktree list`): a pure exported formatter, fixed-width columns with the long path last and unpadded, an explicit empty state, and a trailing hint naming the next command.

```
REPO      MODE      BRANCH     GIT  STATE          AGENTS  DIRECTORY
acme/web  local     main       yes  ready          1       /home/dev/code/web
acme/web  worktree  feature-x  yes  setup running  2       /home/dev/.traycer/worktrees/acme__web/feature-x
```

```
Created worktree /home/dev/.traycer/worktrees/acme__web/feature-x
  Branch               feature-x (new branch, forked from main)
  Source               /home/dev/code/web
  Repo                 acme/web
  Mode                 worktree
  Uncommitted changes  carry requested - best effort, confirm in the new worktree
```

`--json` keeps returning the parsed host response; see the CLI-023 note below for the one way its payload changed.

Knock-on: anything scraping `worktree create`'s *human* stdout for a path was reading pretty-printed JSON and now reads `Created worktree <path>`. `--json` is the stable surface for that and always was.

## CLI-022 — the declared path contract disagreed with the request shape

`normalizeCliArtifactPath` resolved a relative path only when the resolved path *existed on disk*, and otherwise forwarded the caller's relative string unchanged. The request shape therefore depended on the filesystem: the same `comments list docs/a.md` sent an absolute path when the file was there and a relative one when it was not — and the host cannot resolve the second, having no idea of the caller's working directory. A typo'd path failed as "no threads" rather than as the missing artifact it is.

Now unconditionally `path.resolve`, and the help says so.

## CLI-023 — `workspace list` silently dropped the host's "still resolving" marker

**Found by Codex's automated review of this PR, and a defect this PR's own change made visible.**

The handler parsed the **v1.0** `worktree.listBindingsForEpic` response for a method the protocol registers at **v1.2**. Zod strips unknown keys, so `isGitResolvePending` — documented at `worktree-schemas.ts:1455` as the host's *authoritative* signal that a row's `isGitRepo`, and the `missing_worktree_path` reason derived from it, are an unverified placeholder it is still resolving — was discarded before rendering. The new table then reported a still-resolving worktree as `no` / `missing on disk`: an observational surface asserting a state the host had explicitly said it had not established.

The old raw-JSON output was equally missing the field, but it did not editorialise. Rendering a confident STATE word turned a silent omission into an active misstatement, which is why this is fixed here rather than deferred.

Now parses the canonical v1.2 response:
- pending rows render GIT `?` and STATE `checking`;
- only the git-derived `missing_worktree_path` reason is masked — a setup-state reason is already resolved and is reported as-is;
- a pre-v1.2 host bridges up transparently with every row stamped `isGitResolvePending: false`, which is correct: an old host has no pending concept and never sends a signal that would clear it, so stamping `true` would strand its rows as perpetually "checking".

**`--json` change:** `data` gains `folderlessCwd` (v1.1) and per-row `isGitResolvePending` (v1.2). Additive, and strictly more faithful to what the host actually sent. This is the only way the JSON payload differs anywhere in this PR.

The general hazard — any CLI command pinned to an older `…Schema` silently dropping fields a newer host sends — is recorded as its own audit finding and is being swept in a separate workstream. **This PR fixes only the `workspace list` instance.**

## Visibility

Applying the rule that hidden is only for genuinely machine-only contracts that are explicitly unsupported for direct users:

- **`host free-port-and-restart` is now public.** It was `{ hidden: true }`, yet `host doctor` prints `fix: traycer host free-port-and-restart --pid N --port P` for a person to type.
- **`host free-port` (kill-only) stays hidden.** Nothing prints that spelling for a human; it is the half-repair Desktop's controller drives when it owns the restart itself, and "port freed, host still down" is not an outcome to hand a user.
- **`login --token` is now hidden.** The payload is produced by Desktop's own sign-in and piped on stdin — nothing a person at a terminal can type. Its contract is pinned by `login-token.test.ts`.

The test for "genuinely machine-only" is **who is asked to run it**, not how dangerous it is.

Making that command public also meant honouring the contract its help states. Codex caught that **`--port` without `--pid` skipped the kill, restarted the host, and exited 0** — reporting success for a repair it never attempted, while the help said `--port` requires `--pid`. Guarded now. Bare invocation stays legal: Desktop's `HostController` appends both flags or neither, so `["host","free-port-and-restart"]` is a live machine call. (A sibling branch adds the same guard in the handler, which is the better home and will supersede this one on its rebase.)

## Regression coverage

New `rendered-help.test.ts` walks the whole command tree and asserts:

1. **No flag goes missing** — every non-hidden option's flags appear in that command's rendered help.
2. **Every visible child is listed by its parent, and no hidden one leaks** — with a boundary-safe name match, so `free-port` cannot false-match inside `free-port-and-restart`.
3. **The hidden surface is an explicit allowlist**, commands and options. A new hidden entry fails until someone justifies it as a machine contract. This test is *meant* to be edited when the surface legitimately changes — that edit is the enforcement mechanism.
4. **No internal vocabulary in visible help** — `Internal:`, "config surface", "host supervisor", "calling agent", "epic" — across command descriptions, option descriptions, **and registered-argument descriptions**.
5. Spot checks: `--no-bootstrap` absent from root help but still parsing; `login --help` without `--token` while the option stays registered; `host update --help` still showing the public `--version <version>` spelling — asserted against a real render, since it exists only as `addHelpText` and `helpInformation()` omits those blocks.

Argument descriptions are in that list because **the suite initially missed them, and it was proven rather than theorised**: an independent reviewer mutation-tested the branch by flipping `comments list`'s `[artifactPaths...]` description from "this Task" back to "this epic", and the whole suite stayed green. Seven commands carry user-facing text in positionals. The coverage now walks `cmd.registeredArguments[].description`, verified red-then-green against that exact mutation.

Hidden-command detection goes through the public `createHelp().visibleCommands(cmd)` — the same method commander's own help renderer calls — rather than a private `_hidden` field, and the helper is cross-checked against a known-hidden and a known-visible command in its own test.

Plus unit tests for both new formatters and for the artifact-path normalization.

## What independent review changed

Two rounds of review (Codex on the PR, plus a cold read) found five real defects. Worth stating what they were, because two were introduced *by this PR* and one was in the regression suite that is this PR's headline deliverable.

**Three were the same mistake: reporting as fact something the CLI never observed.**

| Surface | Claimed | Actually |
| --- | --- | --- |
| `workspace list` STATE | `missing on disk` | The host had said `isGitResolvePending` — "I have not verified this row's git facts yet". A v1.0 parse was stripping the field. |
| `worktree create` carry row | `carried from the source workspace` | The response says a worktree was created, never whether WIP came with it. Carry is best-effort; an unresolvable carry root or failed stash replay still returns success. |
| `host restart` help | "this **completes** it too, replacing the 'traycer' binary" | The finalize is explicitly non-fatal. Missing staged binary, still-locked binary, or a Windows helper merely *scheduled* all return exit 0 with the upgrade pending. |

Now: `checking`, `carry requested - best effort, confirm in the new worktree`, and `also attempts to finalize ... may replace`.

The pattern is worth naming because CLI-020 reads like a formatting ticket, and formatting is how it bites: **raw JSON omits a field silently, but a rendered word asserts.** Replacing a dump with a summary raises what the command is claiming on the host's behalf.

A fourth: `--no-bootstrap`'s hidden description called itself a "deprecated no-op" while `host status` still reads it — premature, since the removal is on another branch that may not land first.

**The fifth was the regression suite itself, and it could not fail.**

Its expectations were derived from the same command model under test. The reviewer demonstrated three passing mutations: deleting `worktree create --branch` outright; keeping an option registered but omitting its rendered row (`help.includes("--branch")` was satisfied by `--source-branch`'s *description*); and deleting commander's entire `Arguments:` section (satisfied by the `Usage:` line). A fourth, found the same way, was the argument-description vocabulary hole — flipping `comments list`'s positional back to "epic" left all 15 tests green.

An expectation derived from the artifact under test catches corruption but never omission. Fixed with `EXPECTED_PUBLIC_SURFACE`, a hand-maintained inventory of every visible command path, rendered option flag and rendered argument name, compared both directions with distinct MISSING vs UNEXPECTED messages; section-anchored row parsing instead of substring matching; and the vocabulary blocklist now running over the full rendered help so `addHelpText` blocks are covered.

**Every new assertion is verified by mutation, not by a green run.** Deleting `worktree create --branch` now fails with `option row(s) removed or newly hidden from rendered help: --branch`. A banned word inside `host update`'s `addHelpText` now fails with `rendered --help leaks 'epic(s)'`. Both passed silently before.

Review also cleared the two risks I considered most likely to be real: `hideHelp()` genuinely does not touch parsing (both flag positions verified, plus `optsWithGlobals()` and `extractRunnerFlags`), and no Windows path shape regresses under unconditional `path.resolve` — `C:\foo`, UNC and extended paths resolve to the same target, and `C:foo` / `/foo` become explicit rather than ambiguous.

## Behavior changes (three, all small)

1. **`worktree create --carry-uncommitted` is now rejected with `--existing`** instead of silently dropped. The `existing` branch-selection variant has no `carryUncommittedChanges` field, so the flag was accepted and then discarded — the user asked for their work to come along and it did not. This mirrors the `--source-branch` + `--existing` rejection already in that function, added for exactly the same reason. (Audit help-checklist item 7.)
2. **`host free-port-and-restart` rejects `--port` without `--pid`** (above).
3. A relative path to a *nonexistent* artifact now reaches the host absolute instead of relative. Both forms failed before; the absolute one fails informatively.

## Adjacent help-only fixes

Two undisclosed behaviours from the audit's cross-cutting checklist that no other workstream claimed. One-line description changes, no code paths touched:

- **`host restart`** now says it also completes a pending CLI self-upgrade, replacing the `traycer` binary (`upgrade/finalize-helper.ts`). Someone restarting the host to clear a hang deserves to know their CLI version may change under them.
- **`host capabilities`** now says its output is raw — plain text or a single JSON document plus an exit code, not the NDJSON event stream every other command emits with `--json`. Its readers are a `/bin/sh` script and a VBScript launcher. (Checklist item 6.)

## Test status

All new and adjacent CLI tests pass. The package additionally has **40 pre-existing failures across 7 files** (`well-known-cli`, `cli-mark-source`, `cli-version`, `host-restart-finalize`, `pending-upgrade`, `cli-manifest-system-marker`, `registry/client`) that are unrelated to this branch — verified by stashing these changes and running the same suite at `main`, which fails identically. None of those files is touched here. They are filesystem/mtime-timing sensitive in this environment; CI is the real signal, and CI was green 30/30 on the first commit.

## Coordination

Part of the CLI audit fix series; `index.ts` edits are scoped to stay narrow.

- **CLI-001/006/007/011** (`fix/cli-host-repair-audit`) owns `host status`'s description, the `terminalCommand`-parses test, and the Desktop `--no-bootstrap` call-site removal. It also carries the header-comment correction in `commands/host-free-port-and-restart.ts`, which still reads "Hidden from `--help`" here — that file is deliberately untouched on this branch to avoid a guaranteed conflict on a comment.
- **CLI-019/021** (`fix/cli-readonly-capabilities`): `monitor`, `agent inbox`, and the readonly-gated agent leaf descriptions are untouched. The hidden allowlist is computed under the **full** agent surface — readonly-surface hiding is a separate axis and is unaffected.
- **CLI-004/012** (`fix/cli-host-lifecycle-audit`): `host start` and `host update --version` untouched.

## Checklist

- [x] Pre-commit static checks pass (`pre-commit` ran build, compile, lint, format on each commit)
- [ ] Separate CI test checks pass
- [x] Tests added/updated where it makes sense
- [x] Commits are signed off (`git commit -s`) per the DCO

🤖 Generated with [Claude Code](https://claude.com/claude-code)
