### PR TITLE
fix(traycer-cli): parse canonical RPC response schemas (CLI-023)

### DIFF
--- a/clients/traycer-cli/src/commands/__tests__/terminal-commands.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/terminal-commands.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { CanonicalTerminalSessionInfoWithCurrentCwd } from "@traycer/protocol/host/terminal/unary-schemas";
+import { listTerminalsResponseSchemaV23 } from "@traycer/protocol/host/terminal/unary-schemas";
+import type { CanonicalTerminalSessionInfoWithLifecycleOwner } from "@traycer/protocol/host/terminal/unary-schemas";
 import {
   buildTerminalListCommand,
   formatTerminalListTable,
@@ -50,8 +51,8 @@ afterEach(() => {
 });
 
 function session(
-  overrides: Partial<CanonicalTerminalSessionInfoWithCurrentCwd>,
-): CanonicalTerminalSessionInfoWithCurrentCwd {
+  overrides: Partial<CanonicalTerminalSessionInfoWithLifecycleOwner>,
+): CanonicalTerminalSessionInfoWithLifecycleOwner {
   return {
     sessionId: "term-1",
     scope: { kind: "epic", epicId: "epic-1" },
@@ -68,6 +69,7 @@ function session(
     createdAt: 1_700_000_000_000,
     title: "build",
     activeProcessName: "vitest",
+    lifecycleOwner: "registry",
     ...overrides,
   };
 }
@@ -187,6 +189,19 @@ describe("buildTerminalListCommand", () => {
     const result = await buildTerminalListCommand({ epicId: null })(ctx);
 
     expect(result.data).toMatchObject({ terminals: [{ title: "api" }] });
+  });
+
+  it("parses a v2.3 terminal.list payload without stripping lifecycleOwner", () => {
+    // The v1.4-equivalent regression for this method: a stale v2.2 schema
+    // strips the additive `lifecycleOwner` field silently (Zod discards
+    // unknown keys). The canonical v2.3 parse must keep it, even though the
+    // CLI's own row shape does not currently surface it downstream.
+    const wireSession = session({ lifecycleOwner: "manager" });
+    const parsed = listTerminalsResponseSchemaV23.parse({
+      sessions: [wireSession],
+      homeCwd: "/home/dev",
+    });
+    expect(parsed.sessions[0]?.lifecycleOwner).toBe("manager");
   });
 });
 

--- a/clients/traycer-cli/src/commands/__tests__/worktree-delete.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/worktree-delete.test.ts
@@ -532,10 +532,7 @@ async function startLegacyFallback(): Promise<{
   readonly legacy: FakeSession;
 }> {
   hoisted.state.methodSupport = "unsupported";
-  const pending = buildWorktreeDeleteCommand({
-    worktreePath: "/wt/x",
-    readonlySurface: false,
-  })(ctx);
+  const pending = buildWorktreeDeleteCommand({ worktreePath: "/wt/x" })(ctx);
 
   await waitForSessions(1);
   commandSession().statusHandler?.("closed", {

--- a/clients/traycer-cli/src/commands/__tests__/worktree-delete.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/worktree-delete.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { buildWorktreeDeleteCommand } from "../worktree-delete";
 import { CliError, CLI_ERROR_CODES } from "../../runner/errors";
-import type { CommandContext } from "../../runner/runner";
+import type { CommandContext, CommandResult } from "../../runner/runner";
 import type { ProgressInfo } from "../../runner/output";
 import type { StreamCloseReason } from "../../../../shared/host-transport/i-stream-session";
 import type { StreamMethodSupport } from "../../../../shared/host-transport/ws-stream-client";
@@ -543,5 +543,104 @@ describe("buildWorktreeDeleteCommand older-host fallback", () => {
     // Exactly one subscribe: a delete that may have half-happened is never
     // re-issued on the older method.
     expect(hoisted.state.sessions).toHaveLength(1);
+  });
+});
+
+/**
+ * Drives the command past the `worktree.deleteBatchByPath` compatibility
+ * check into the released `worktree.deleteByPath@1.1` fallback stream and
+ * returns that session, mirroring the "older-host fallback" setup above.
+ */
+async function startLegacyFallback(): Promise<{
+  readonly pending: Promise<CommandResult>;
+  readonly legacy: FakeSession;
+}> {
+  hoisted.state.methodSupport = "unsupported";
+  const pending = buildWorktreeDeleteCommand({
+    worktreePath: "/wt/x",
+    readonlySurface: false,
+  })(ctx);
+
+  await waitForSessions(1);
+  commandSession().statusHandler?.("closed", {
+    kind: "fatalError",
+    details: {
+      code: "INCOMPATIBLE",
+      reason: "host does not offer worktree.deleteBatchByPath",
+      incompatibleMethods: null,
+      upgradeGuidance: null,
+    },
+  });
+  await waitForSessions(2);
+  return { pending, legacy: hoisted.state.sessions[1]! };
+}
+
+describe("buildWorktreeDeleteCommand legacy stream v1.1 holders", () => {
+  // The v1.0 -> v1.1 diff on `worktree.deleteByPath` is an OPTIONAL `holders`
+  // field added to the `failed` arm - `worktreeBusyHoldersWireFieldSchema` is
+  // `.optional().catch(undefined)`, so a stale v1.0 decode does not fail, it
+  // silently drops the field. A busy refusal kept its prose `reason` and lost
+  // the only actionable part. Because the difference is optional-on-one-arm,
+  // a `ZodType<...>` compile-time constraint alone would NOT have caught a
+  // call site still naming the v1.0 schema - this is exactly the case the
+  // runtime canonical-identity backstop exists for (see
+  // `host-rpc.test.ts`'s "canonical stream frame pairing" suite).
+  it("surfaces holders from a v1.1 failed frame in details and the human message", async () => {
+    const { pending, legacy } = await startLegacyFallback();
+
+    legacy.frameHandler?.({
+      kind: "failed",
+      reason: "worktree is busy",
+      holders: [
+        {
+          ownerRef: { epicId: "e1", ownerKind: "chat", ownerId: "c1" },
+          holdKind: "chat-turn",
+          activity: "working",
+          label: "Chat: fix flaky test",
+        },
+        {
+          ownerRef: {
+            epicId: "e1",
+            ownerKind: "terminal-agent",
+            ownerId: "t1",
+          },
+          holdKind: "terminal-agent-pty",
+          activity: "idle",
+          label: "Terminal agent: refactor",
+        },
+      ],
+      hasBinaryPayload: false,
+    });
+
+    await expect(pending).rejects.toMatchObject({
+      code: CLI_ERROR_CODES.UNEXPECTED,
+      exitCode: 1,
+      message: expect.stringContaining(
+        "Held by Chat: fix flaky test, Terminal agent: refactor.",
+      ),
+      details: {
+        holders: [
+          expect.objectContaining({ label: "Chat: fix flaky test" }),
+          expect.objectContaining({ label: "Terminal agent: refactor" }),
+        ],
+      },
+    });
+  });
+
+  it("keeps today's back-compat wording when an older host's failed frame omits holders", async () => {
+    const { pending, legacy } = await startLegacyFallback();
+
+    legacy.frameHandler?.({
+      kind: "failed",
+      reason: "worktree is busy",
+      hasBinaryPayload: false,
+    });
+
+    await expect(pending).rejects.toMatchObject({
+      code: CLI_ERROR_CODES.UNEXPECTED,
+      exitCode: 1,
+      message: "traycer: worktree delete failed - worktree is busy",
+      details: null,
+    });
   });
 });

--- a/clients/traycer-cli/src/commands/__tests__/worktree-list.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/worktree-list.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { WorktreeHostEntryV14 } from "@traycer/protocol/host";
+import type { WorktreeHostEntryV16 } from "@traycer/protocol/host";
 import type { WorktreeTier } from "@traycer-clients/shared/worktree/classify-worktree";
 import {
   buildWorktreeListCommand,
@@ -7,6 +7,7 @@ import {
   parseWorktreeListLimit,
   type WorktreeListRow,
 } from "../worktree-list";
+import { worktreeListAllForHostResponseSchemaV16 } from "@traycer/protocol/host";
 import { callHostRpc } from "../../internal/host-rpc";
 import type { CommandContext } from "../../runner/runner";
 import { CLI_ERROR_CODES } from "../../runner/errors";
@@ -46,7 +47,7 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
-function entry(overrides: Partial<WorktreeHostEntryV14>): WorktreeHostEntryV14 {
+function entry(overrides: Partial<WorktreeHostEntryV16>): WorktreeHostEntryV16 {
   return {
     worktreePath: "/Users/dev/.traycer/worktrees/acme__web/feature-x",
     repoLabel: "acme/web",
@@ -67,12 +68,14 @@ function entry(overrides: Partial<WorktreeHostEntryV14>): WorktreeHostEntryV14 {
     submodules: [],
     atBaseCommit: false,
     resolvedAt: 1,
+    presence: "present",
+    gitUnreadable: false,
     ...overrides,
   };
 }
 
 function row(
-  overrides: Partial<WorktreeHostEntryV14>,
+  overrides: Partial<WorktreeHostEntryV16>,
   tier: WorktreeTier | null,
 ): WorktreeListRow {
   return { ...entry(overrides), tier };
@@ -265,6 +268,49 @@ describe("buildWorktreeListCommand", () => {
       ],
       nextCursor: null,
     });
+  });
+
+  it("classifies a gitUnreadable row as review, not orphaned - the v1.4 regression this canonical parse fixes", async () => {
+    // The real host pairs `gitUnreadable: true` with `gitRemovable: false`
+    // (git can neither read the pointed-at repo nor prove it removable). A
+    // stale v1.4 parse strips `gitUnreadable`, so `classifyWorktreeTier` falls
+    // through to rung 2 (`!gitRemovable`) and mislabels the row "orphaned" -
+    // a forced-cleanup reading this shape must never get, since its branch
+    // and dirty count are unknowable, not proven empty.
+    rpcMock.mockResolvedValue({
+      worktrees: [entry({ gitUnreadable: true, gitRemovable: false })],
+      nextCursor: null,
+    });
+
+    const result = await buildWorktreeListCommand(defaultOpts)(ctx);
+
+    expect(result.data).toEqual({
+      worktrees: [
+        {
+          ...entry({ gitUnreadable: true, gitRemovable: false }),
+          tier: "review",
+        },
+      ],
+      nextCursor: null,
+    });
+    const listedWorktrees = (result.data as { worktrees: WorktreeListRow[] })
+      .worktrees;
+    expect(listedWorktrees[0]?.tier).toBe("review");
+    expect(listedWorktrees[0]?.tier).not.toBe("orphaned");
+    // `--json` callers read these two fields straight off the row; a stale
+    // schema silently drops both.
+    expect(listedWorktrees[0]?.gitUnreadable).toBe(true);
+    expect(listedWorktrees[0]?.presence).toBe("present");
+  });
+
+  it("round-trips gitUnreadable and presence through the canonical v1.6 response parse", () => {
+    const wireEntry = entry({ gitUnreadable: true, presence: "absent" });
+    const parsed = worktreeListAllForHostResponseSchemaV16.parse({
+      worktrees: [wireEntry],
+      nextCursor: null,
+    });
+    expect(parsed.worktrees[0]?.gitUnreadable).toBe(true);
+    expect(parsed.worktrees[0]?.presence).toBe("absent");
   });
 
   it("emits tier null without --include-activity (unprobed entries are never classified)", async () => {

--- a/clients/traycer-cli/src/commands/agent-activity-from-hook.ts
+++ b/clients/traycer-cli/src/commands/agent-activity-from-hook.ts
@@ -12,7 +12,7 @@ import {
 } from "@traycer/protocol/host/agent/shared";
 import {
   callHostRpcFastFail,
-  parseHostResponse,
+  parseCanonicalHostResponse,
   parseUserInput,
   toAgentCliError,
 } from "../internal/host-rpc";
@@ -189,7 +189,8 @@ async function submitPrompt(identity: HookActivityIdentity) {
     };
   }
 
-  const { accepted, pendingPromptContext } = parseHostResponse(
+  const { accepted, pendingPromptContext } = parseCanonicalHostResponse(
+    "agent.tui.promptSubmitted",
     tuiAgentPromptSubmittedResponseSchema,
     rpcResult,
   );
@@ -231,7 +232,11 @@ async function callRecordActivity(
     throw err;
   });
   if (rpcResult === "host-unreachable") return "host-unreachable";
-  return parseHostResponse(recordTuiAgentActivityResponseSchema, rpcResult);
+  return parseCanonicalHostResponse(
+    "agent.tui.recordActivity",
+    recordTuiAgentActivityResponseSchema,
+    rpcResult,
+  );
 }
 
 function userPromptSubmitEnvelope(additionalContext: string): string {

--- a/clients/traycer-cli/src/commands/agent-archive.ts
+++ b/clients/traycer-cli/src/commands/agent-archive.ts
@@ -4,7 +4,7 @@ import {
 } from "@traycer/protocol/host/epic/unary-schemas";
 import {
   callHostRpc,
-  parseHostResponse,
+  parseCanonicalHostResponse,
   parseUserInput,
   toAgentCliError,
 } from "../internal/host-rpc";
@@ -53,7 +53,8 @@ export function buildAgentArchiveCommand(opts: {
     ).catch((err: unknown) => {
       throw remapArchiveError(err, opts.agentId);
     });
-    const { updated } = parseHostResponse(
+    const { updated } = parseCanonicalHostResponse(
+      "epic.setChatArchived",
       setChatArchivedResponseSchema,
       result,
     );

--- a/clients/traycer-cli/src/commands/agent-configure.ts
+++ b/clients/traycer-cli/src/commands/agent-configure.ts
@@ -5,7 +5,7 @@ import {
 } from "@traycer/protocol/host/agent/profiles";
 import {
   callHostRpc,
-  parseHostResponse,
+  parseCanonicalHostResponse,
   parseUserInput,
   toAgentCliError,
 } from "../internal/host-rpc";
@@ -53,7 +53,11 @@ export function buildAgentConfigureCommand(opts: {
     const result = await toAgentCliError(
       callHostRpc("agent.configure", request),
     );
-    const response = parseHostResponse(agentConfigureResponseSchema, result);
+    const response = parseCanonicalHostResponse(
+      "agent.configure",
+      agentConfigureResponseSchema,
+      result,
+    );
     return {
       data: response,
       human: formatAgentConfigureResponse(opts.agentId, response),

--- a/clients/traycer-cli/src/commands/agent-create.ts
+++ b/clients/traycer-cli/src/commands/agent-create.ts
@@ -6,7 +6,7 @@ import {
 } from "@traycer/protocol/host/agent/shared";
 import {
   callHostRpc,
-  parseHostResponse,
+  parseCanonicalHostResponse,
   parseUserInput,
   toAgentCliError,
 } from "../internal/host-rpc";
@@ -83,7 +83,8 @@ export function buildAgentCreateCommand(opts: {
       profileSelection: parseCreateProfileSelection(opts.profile),
     });
     const result = await toAgentCliError(callHostRpc("agent.create", request));
-    const { agentId, warnings } = parseHostResponse(
+    const { agentId, warnings } = parseCanonicalHostResponse(
+      "agent.create",
       createAgentResponseSchema,
       result,
     );

--- a/clients/traycer-cli/src/commands/agent-fork.ts
+++ b/clients/traycer-cli/src/commands/agent-fork.ts
@@ -4,7 +4,7 @@ import {
 } from "@traycer/protocol/host/agent/shared";
 import {
   callHostRpc,
-  parseHostResponse,
+  parseCanonicalHostResponse,
   parseUserInput,
   toAgentCliError,
 } from "../internal/host-rpc";
@@ -64,7 +64,11 @@ export function buildAgentForkCommand(opts: {
       profileSelection: parseForkProfileSelection(opts.profile),
     });
     const result = await toAgentCliError(callHostRpc("agent.fork", request));
-    const response = parseHostResponse(forkAgentResponseSchema, result);
+    const response = parseCanonicalHostResponse(
+      "agent.fork",
+      forkAgentResponseSchema,
+      result,
+    );
     const lines = [
       response.agentId,
       `Forked from: ${response.sourceAgentId}`,

--- a/clients/traycer-cli/src/commands/agent-inbox.ts
+++ b/clients/traycer-cli/src/commands/agent-inbox.ts
@@ -2,7 +2,7 @@ import { formatAgentMessageSenderLabel } from "@traycer/protocol/agent/a2a-messa
 import { agentInboxReadResponseSchemaV20 } from "@traycer/protocol/host/agent/inbox";
 import {
   callHostRpc,
-  parseHostResponse,
+  parseCanonicalHostResponse,
   toAgentCliError,
 } from "../internal/host-rpc";
 import { resolveEpicId, resolveSenderAgentId } from "../internal/agent-context";
@@ -34,7 +34,8 @@ export function buildAgentInboxCommand(opts: {
     const result = await toAgentCliError(
       callHostRpc("agent.inbox.read", { epicId, agentId, after }),
     );
-    const { messages, nextCursor } = parseHostResponse(
+    const { messages, nextCursor } = parseCanonicalHostResponse(
+      "agent.inbox.read",
       agentInboxReadResponseSchemaV20,
       result,
     );

--- a/clients/traycer-cli/src/commands/agent-list-harness-models.ts
+++ b/clients/traycer-cli/src/commands/agent-list-harness-models.ts
@@ -5,7 +5,7 @@ import {
 } from "@traycer/protocol/host/agent/shared";
 import {
   callHostRpc,
-  parseHostResponse,
+  parseCanonicalHostResponse,
   parseUserInput,
   toAgentCliError,
 } from "../internal/host-rpc";
@@ -46,5 +46,9 @@ async function listSingleHarnessModels(
   const result = await toAgentCliError(
     callHostRpc("agent.listHarnessModels", request),
   );
-  return parseHostResponse(listHarnessModelsResponseSchema, result);
+  return parseCanonicalHostResponse(
+    "agent.listHarnessModels",
+    listHarnessModelsResponseSchema,
+    result,
+  );
 }

--- a/clients/traycer-cli/src/commands/agent-list-harnesses.ts
+++ b/clients/traycer-cli/src/commands/agent-list-harnesses.ts
@@ -9,7 +9,7 @@ import {
 } from "@traycer/protocol/host/agent/gui/unary-schemas";
 import {
   callHostRpc,
-  parseHostResponse,
+  parseCanonicalHostResponse,
   parseUserInput,
   toAgentCliError,
 } from "../internal/host-rpc";
@@ -23,7 +23,11 @@ export function buildAgentListHarnessesCommand(): CommandFn {
         parseUserInput(listGuiHarnessesRequestSchema, {}),
       ),
     );
-    const catalog = parseHostResponse(listGuiHarnessesResponseSchema, result);
+    const catalog = parseCanonicalHostResponse(
+      "agent.gui.listHarnesses",
+      listGuiHarnessesResponseSchema,
+      result,
+    );
     const response = {
       harnesses: catalog.harnesses
         .filter((harness) => harness.enabled)

--- a/clients/traycer-cli/src/commands/agent-list-profiles.ts
+++ b/clients/traycer-cli/src/commands/agent-list-profiles.ts
@@ -5,7 +5,7 @@ import {
 } from "@traycer/protocol/host/agent/profiles";
 import {
   callHostRpc,
-  parseHostResponse,
+  parseCanonicalHostResponse,
   parseUserInput,
   toAgentCliError,
 } from "../internal/host-rpc";
@@ -37,7 +37,8 @@ export function buildAgentListProfilesCommand(opts: {
     const result = await toAgentCliError(
       callHostRpc("agent.listProviderProfiles", request),
     );
-    const response = parseHostResponse(
+    const response = parseCanonicalHostResponse(
+      "agent.listProviderProfiles",
       agentListProviderProfilesResponseSchema,
       result,
     );

--- a/clients/traycer-cli/src/commands/agent-list.ts
+++ b/clients/traycer-cli/src/commands/agent-list.ts
@@ -2,7 +2,7 @@ import { listAgentsResponseSchema } from "@traycer/protocol/host/agent/shared";
 import { formatAgentListResponse } from "@traycer/protocol/agent/agent-list-format";
 import {
   callHostRpc,
-  parseHostResponse,
+  parseCanonicalHostResponse,
   toAgentCliError,
 } from "../internal/host-rpc";
 import { resolveEpicId, resolveSenderAgentId } from "../internal/agent-context";
@@ -29,7 +29,11 @@ export function buildAgentListCommand(opts: {
         scope: opts.all ? ("all" as const) : ("user" as const),
       }),
     );
-    const response = parseHostResponse(listAgentsResponseSchema, result);
+    const response = parseCanonicalHostResponse(
+      "agent.list",
+      listAgentsResponseSchema,
+      result,
+    );
     return {
       data: response,
       human: formatAgentListResponse(response),

--- a/clients/traycer-cli/src/commands/agent-profile-rate-limits.ts
+++ b/clients/traycer-cli/src/commands/agent-profile-rate-limits.ts
@@ -1,11 +1,11 @@
 import { formatAgentProviderProfileRateLimitsResponse } from "@traycer/protocol/agent/agent-profile-format";
 import {
   agentGetProviderProfileRateLimitsRequestSchema,
-  agentGetProviderProfileRateLimitsResponseSchema,
+  agentGetProviderProfileRateLimitsResponseSchemaV5,
 } from "@traycer/protocol/host/agent/profiles";
 import {
   callHostRpc,
-  parseHostResponse,
+  parseCanonicalHostResponse,
   parseUserInput,
   toAgentCliError,
 } from "../internal/host-rpc";
@@ -44,8 +44,14 @@ export function buildAgentProfileRateLimitsCommand(opts: {
     const result = await toAgentCliError(
       callHostRpc("agent.getProviderProfileRateLimits", request),
     );
-    const response = parseHostResponse(
-      agentGetProviderProfileRateLimitsResponseSchema,
+    // The explicit v5.0 schema, not the base `...ResponseSchema` name this
+    // used to read. That name is the LIVE line's alias: identical to v5.0
+    // today, but it is redefined onto each new major as the previous one is
+    // frozen, so it only tracks canonical by coincidence of timing. Naming the
+    // version pins the contract and lets `parseCanonicalHostResponse` prove it.
+    const response = parseCanonicalHostResponse(
+      "agent.getProviderProfileRateLimits",
+      agentGetProviderProfileRateLimitsResponseSchemaV5,
       result,
     );
     return {

--- a/clients/traycer-cli/src/commands/agent-role.ts
+++ b/clients/traycer-cli/src/commands/agent-role.ts
@@ -13,7 +13,7 @@ import {
 } from "@traycer/protocol/agent/agent-roles-format";
 import {
   callHostRpc,
-  parseHostResponse,
+  parseCanonicalHostResponse,
   parseUserInput,
   toAgentCliError,
 } from "../internal/host-rpc";
@@ -50,7 +50,11 @@ export function buildAgentRoleClaimCommand(opts: {
     const result = await toAgentCliError(
       callHostRpc("agent.roles.claim", request),
     );
-    const response = parseHostResponse(claimAgentRoleResponseSchemaV11, result);
+    const response = parseCanonicalHostResponse(
+      "agent.roles.claim",
+      claimAgentRoleResponseSchemaV11,
+      result,
+    );
     return {
       data: response,
       human: formatClaimRoleResponseV11(response),
@@ -69,7 +73,11 @@ export function buildAgentRoleListCommand(opts: {
     const result = await toAgentCliError(
       callHostRpc("agent.roles.list", request),
     );
-    const response = parseHostResponse(listAgentRolesResponseSchema, result);
+    const response = parseCanonicalHostResponse(
+      "agent.roles.list",
+      listAgentRolesResponseSchema,
+      result,
+    );
     return {
       data: response,
       human: formatListRolesResponse(response),
@@ -92,7 +100,8 @@ export function buildAgentRoleRelinquishCommand(opts: {
     const result = await toAgentCliError(
       callHostRpc("agent.roles.relinquish", request),
     );
-    const response = parseHostResponse(
+    const response = parseCanonicalHostResponse(
+      "agent.roles.relinquish",
       relinquishAgentRoleResponseSchemaV11,
       result,
     );

--- a/clients/traycer-cli/src/commands/agent-selection-guide.ts
+++ b/clients/traycer-cli/src/commands/agent-selection-guide.ts
@@ -8,7 +8,7 @@ import {
 } from "@traycer/protocol/agent/agent-selection-guide-format";
 import {
   callHostRpc,
-  parseHostResponse,
+  parseCanonicalHostResponse,
   parseUserInput,
   toAgentCliError,
 } from "../internal/host-rpc";
@@ -29,7 +29,8 @@ export function buildAgentSelectionGuideCommand(opts: {
     const result = await toAgentCliError(
       callHostRpc("agent.selectionGuide", request),
     );
-    const response = parseHostResponse(
+    const response = parseCanonicalHostResponse(
+      "agent.selectionGuide",
       agentSelectionGuideResponseSchema,
       result,
     );

--- a/clients/traycer-cli/src/commands/agent-send.ts
+++ b/clients/traycer-cli/src/commands/agent-send.ts
@@ -4,7 +4,7 @@ import {
 } from "@traycer/protocol/host/agent/shared";
 import {
   callHostRpc,
-  parseHostResponse,
+  parseCanonicalHostResponse,
   parseUserInput,
   toAgentCliError,
 } from "../internal/host-rpc";
@@ -42,7 +42,8 @@ export function buildAgentSendCommand(opts: {
     const result = await toAgentCliError(
       callHostRpc("agent.sendMessage", request),
     );
-    const { responseId } = parseHostResponse(
+    const { responseId } = parseCanonicalHostResponse(
+      "agent.sendMessage",
       sendAgentMessageResponseSchema,
       result,
     );

--- a/clients/traycer-cli/src/commands/agent-session-observed-from-hook.ts
+++ b/clients/traycer-cli/src/commands/agent-session-observed-from-hook.ts
@@ -6,7 +6,7 @@ import { tuiHarnessIdSchema } from "@traycer/protocol/host/agent/shared";
 import {
   callHostRpcFastFail,
   isRequestVersionProjectionError,
-  parseHostResponse,
+  parseCanonicalHostResponse,
   parseUserInput,
   toAgentCliError,
 } from "../internal/host-rpc";
@@ -119,7 +119,8 @@ export function buildAgentSessionObservedFromHookCommand(opts: {
       return noop("host-unreachable");
     }
 
-    const { accepted } = parseHostResponse(
+    const { accepted } = parseCanonicalHostResponse(
+      "agent.tui.recordActivity",
       recordTuiAgentActivityResponseSchema,
       rpcResult,
     );

--- a/clients/traycer-cli/src/commands/agent-stop.ts
+++ b/clients/traycer-cli/src/commands/agent-stop.ts
@@ -4,7 +4,7 @@ import {
 } from "@traycer/protocol/host/agent/shared";
 import {
   callHostRpc,
-  parseHostResponse,
+  parseCanonicalHostResponse,
   parseUserInput,
   toAgentCliError,
 } from "../internal/host-rpc";
@@ -39,7 +39,8 @@ export function buildAgentStopCommand(opts: {
       cascade: opts.cascade,
     });
     const result = await toAgentCliError(callHostRpc("agent.stop", request));
-    const { stoppedAgentIds } = parseHostResponse(
+    const { stoppedAgentIds } = parseCanonicalHostResponse(
+      "agent.stop",
       stopAgentResponseSchema,
       result,
     );

--- a/clients/traycer-cli/src/commands/agent-title-from-hook.ts
+++ b/clients/traycer-cli/src/commands/agent-title-from-hook.ts
@@ -7,7 +7,7 @@ import { tuiHarnessIdSchema } from "@traycer/protocol/host/agent/shared";
 import { GENERATE_TITLE_SOURCE_TEXT_MAX_CHARS } from "@traycer/protocol/host/epic/unary-schemas";
 import {
   callHostRpcFastFail,
-  parseHostResponse,
+  parseCanonicalHostResponse,
   parseUserInput,
   toAgentCliError,
 } from "../internal/host-rpc";
@@ -125,7 +125,8 @@ export function buildAgentTitleFromHookCommand(opts: {
       return noop("host-unreachable");
     }
 
-    const { accepted } = parseHostResponse(
+    const { accepted } = parseCanonicalHostResponse(
+      "agent.tui.generateTitle",
       generateTuiAgentTitleResponseSchema,
       rpcResult,
     );

--- a/clients/traycer-cli/src/commands/agent-transcript.ts
+++ b/clients/traycer-cli/src/commands/agent-transcript.ts
@@ -1,7 +1,7 @@
 import { getAgentTranscriptResponseSchema } from "@traycer/protocol/host/agent/shared";
 import {
   callHostRpc,
-  parseHostResponse,
+  parseCanonicalHostResponse,
   toAgentCliError,
 } from "../internal/host-rpc";
 import { resolveEpicId } from "../internal/agent-context";
@@ -27,7 +27,8 @@ export function buildAgentTranscriptCommand(opts: {
         agentId: opts.agentId,
       }),
     );
-    const { transcript } = parseHostResponse(
+    const { transcript } = parseCanonicalHostResponse(
+      "agent.getTranscript",
       getAgentTranscriptResponseSchema,
       result,
     );

--- a/clients/traycer-cli/src/commands/agent-turn-ended-from-hook.ts
+++ b/clients/traycer-cli/src/commands/agent-turn-ended-from-hook.ts
@@ -5,7 +5,7 @@ import {
 import { tuiHarnessIdSchema } from "@traycer/protocol/host/agent/shared";
 import {
   callHostRpc,
-  parseHostResponse,
+  parseCanonicalHostResponse,
   parseUserInput,
   toAgentCliError,
 } from "../internal/host-rpc";
@@ -72,7 +72,8 @@ export function buildAgentTurnEndedFromHookCommand(opts: {
       return noop("host-unreachable");
     }
 
-    const { accepted } = parseHostResponse(
+    const { accepted } = parseCanonicalHostResponse(
+      "agent.tui.turnEnded",
       tuiAgentTurnEndedResponseSchema,
       rpcResult,
     );

--- a/clients/traycer-cli/src/commands/comments.ts
+++ b/clients/traycer-cli/src/commands/comments.ts
@@ -12,7 +12,7 @@ import {
 } from "@traycer/protocol/comments/comments-xml-formatting";
 import {
   callHostRpc,
-  parseHostResponse,
+  parseCanonicalHostResponse,
   parseUserInput,
   toAgentCliError,
 } from "../internal/host-rpc";
@@ -41,7 +41,11 @@ export function buildCommentsListCommand(opts: {
         status,
       }),
     );
-    const parsed = parseHostResponse(commentsListThreadsResponseSchema, result);
+    const parsed = parseCanonicalHostResponse(
+      "comments.listThreads",
+      commentsListThreadsResponseSchema,
+      result,
+    );
     return {
       data: parsed,
       human: formatCommentsListThreadsXml({
@@ -79,7 +83,8 @@ export function buildCommentsSetStatusCommand(opts: {
         ],
       }),
     );
-    const parsed = parseHostResponse(
+    const parsed = parseCanonicalHostResponse(
+      "comments.setThreadStatus",
       commentsSetThreadStatusResponseSchema,
       result,
     );

--- a/clients/traycer-cli/src/commands/terminal-list.ts
+++ b/clients/traycer-cli/src/commands/terminal-list.ts
@@ -1,8 +1,8 @@
-import { listTerminalsResponseSchemaV22 } from "@traycer/protocol/host/terminal/unary-schemas";
-import type { CanonicalTerminalSessionInfoWithCurrentCwd } from "@traycer/protocol/host/terminal/unary-schemas";
+import { listTerminalsResponseSchemaV23 } from "@traycer/protocol/host/terminal/unary-schemas";
+import type { CanonicalTerminalSessionInfoWithLifecycleOwner } from "@traycer/protocol/host/terminal/unary-schemas";
 import {
   callHostRpc,
-  parseHostResponse,
+  parseCanonicalHostResponse,
   toAgentCliError,
 } from "../internal/host-rpc";
 import { resolveEpicId } from "../internal/agent-context";
@@ -27,8 +27,9 @@ export function buildTerminalListCommand(opts: {
         scope: { kind: "epic", epicId },
       }),
     );
-    const { sessions } = parseHostResponse(
-      listTerminalsResponseSchemaV22,
+    const { sessions } = parseCanonicalHostResponse(
+      "terminal.list",
+      listTerminalsResponseSchemaV23,
       result,
     );
     const terminals = sessions
@@ -54,7 +55,7 @@ export type TerminalListRow = {
 };
 
 function summarizeTerminal(
-  session: CanonicalTerminalSessionInfoWithCurrentCwd,
+  session: CanonicalTerminalSessionInfoWithLifecycleOwner,
 ): TerminalListRow {
   return {
     terminalId: session.sessionId,
@@ -75,7 +76,7 @@ function summarizeTerminal(
  * TITLE names the same directory the row's DIRECTORY column shows.
  */
 function terminalTitle(
-  session: CanonicalTerminalSessionInfoWithCurrentCwd,
+  session: CanonicalTerminalSessionInfoWithLifecycleOwner,
 ): string {
   if (session.title !== null && session.title.length > 0) return session.title;
   const directory =

--- a/clients/traycer-cli/src/commands/terminal-output.ts
+++ b/clients/traycer-cli/src/commands/terminal-output.ts
@@ -2,7 +2,7 @@ import { formatTerminalOutputPointer } from "@traycer/protocol/host/terminal/out
 import { readTerminalOutputResponseSchema } from "@traycer/protocol/host/terminal/unary-schemas";
 import {
   callHostRpc,
-  parseHostResponse,
+  parseCanonicalHostResponse,
   toAgentCliError,
 } from "../internal/host-rpc";
 import { resolveEpicId } from "../internal/agent-context";
@@ -34,7 +34,8 @@ export function buildTerminalOutputCommand(opts: {
         sessionId: opts.terminalId,
       }),
     );
-    const { path } = parseHostResponse(
+    const { path } = parseCanonicalHostResponse(
+      "terminal.readOutput",
       readTerminalOutputResponseSchema,
       result,
     );

--- a/clients/traycer-cli/src/commands/worktree-delete.ts
+++ b/clients/traycer-cli/src/commands/worktree-delete.ts
@@ -4,9 +4,10 @@ import {
   type HostStreamRpcRegistry,
 } from "@traycer/protocol/host/registry";
 import {
-  worktreeDeleteByPathServerFrameSchema,
+  worktreeDeleteByPathServerFrameSchemaV11,
   type WorktreeDeleteOutputChannel,
 } from "@traycer/protocol/host/worktree-delete-stream";
+import type { WorktreeBusyHolders } from "@traycer/protocol/framework/worktree-busy-holders";
 import type {
   WorktreeDeleteBatchOutputChannel,
   WorktreeDeleteBatchPhase,
@@ -250,7 +251,7 @@ function runDeleteCommand(
           finish({
             kind: "settled",
             deleted: false,
-            error: deleteFailedCliError(reason),
+            error: deleteFailedCliError(reason, null),
           }),
         // With one target this normally arrives after its terminal frame and
         // is a no-op under the settled guard. It matters when it does NOT: an
@@ -266,7 +267,7 @@ function runDeleteCommand(
           finish({
             kind: "settled",
             deleted: false,
-            error: deleteFailedCliError(reason),
+            error: deleteFailedCliError(reason, null),
           }),
         onUnsupported: () => finish({ kind: "unsupported" }),
         onConnectionStatus: (
@@ -328,7 +329,15 @@ async function runLegacyDeleteStream(
       act();
     };
     session.onServerFrame((envelope) => {
-      const parsed = worktreeDeleteByPathServerFrameSchema.safeParse(envelope);
+      // The CANONICAL v1.1 frame, not the v1.0 base schema. v1.1 added
+      // `holders` to the `failed` arm - the typed inventory naming which chats
+      // and terminal agents still hold the worktree. It is declared
+      // `.optional().catch(undefined)` so that adding it could never reject an
+      // older envelope, which also means a v1.0 decode drops it silently
+      // instead of failing: the busy refusal kept its prose `reason` and lost
+      // the one part a caller could act on.
+      const parsed =
+        worktreeDeleteByPathServerFrameSchemaV11.safeParse(envelope);
       if (!parsed.success) return;
       const frame = parsed.data;
       switch (frame.kind) {
@@ -350,7 +359,9 @@ async function runLegacyDeleteStream(
           finish(() => resolve(frame.deleted));
           return;
         case "failed":
-          finish(() => reject(deleteFailedCliError(frame.reason)));
+          finish(() =>
+            reject(deleteFailedCliError(frame.reason, frame.holders ?? null)),
+          );
           return;
         case "pong":
           return;
@@ -437,11 +448,25 @@ function relayOutput(
 }
 
 /** The host reported this delete as failed, with a displayable reason. */
-function deleteFailedCliError(reason: string): CliError {
+/**
+ * `holders` is the host's typed inventory of what still holds the worktree,
+ * present only on a busy refusal from a v1.1+ host (`null` otherwise). It rides
+ * `details` so `--json` callers get the structured list, and the human message
+ * names the holders rather than leaving "worktree is busy" for the user to
+ * investigate by hand.
+ */
+function deleteFailedCliError(
+  reason: string,
+  holders: WorktreeBusyHolders | null,
+): CliError {
+  const named =
+    holders === null || holders.length === 0
+      ? ""
+      : ` Held by ${holders.map((holder) => holder.label).join(", ")}.`;
   return cliError({
     code: CLI_ERROR_CODES.UNEXPECTED,
-    message: `traycer: worktree delete failed - ${reason}`,
-    details: null,
+    message: `traycer: worktree delete failed - ${reason}${named}`,
+    details: holders === null ? null : { holders },
     exitCode: 1,
   });
 }

--- a/clients/traycer-cli/src/commands/worktree-list.ts
+++ b/clients/traycer-cli/src/commands/worktree-list.ts
@@ -1,8 +1,8 @@
 import {
-  worktreeListAllForHostRequestSchemaV14,
-  worktreeListAllForHostResponseSchemaV14,
+  worktreeListAllForHostRequestSchemaV16,
+  worktreeListAllForHostResponseSchemaV16,
 } from "@traycer/protocol/host";
-import type { WorktreeHostEntryV14 } from "@traycer/protocol/host";
+import type { WorktreeHostEntryV16 } from "@traycer/protocol/host";
 import {
   WORKTREE_TIER_LABEL,
   classifyWorktreeTier,
@@ -10,7 +10,7 @@ import {
 } from "@traycer-clients/shared/worktree/classify-worktree";
 import {
   callHostRpc,
-  parseHostResponse,
+  parseCanonicalHostResponse,
   parseUserInput,
   toAgentCliError,
 } from "../internal/host-rpc";
@@ -31,7 +31,7 @@ const DEFAULT_WORKTREE_LIST_PAGE_LIMIT = 32;
  * feed the greens, so classifying unprobed entries would misread every worktree
  * as Review. Null mirrors the probe-skipped semantics of the other fields.
  */
-export type WorktreeListRow = WorktreeHostEntryV14 & {
+export type WorktreeListRow = WorktreeHostEntryV16 & {
   readonly tier: WorktreeTier | null;
 };
 
@@ -52,12 +52,30 @@ interface WorktreeListPage {
 
 /**
  * `traycer worktree list` - host-wide listing of every Traycer-managed
- * worktree under `~/.traycer/worktrees/`. Calls `worktree.listAllForHost@1.4`;
- * the canonical (latest) request carries `includeActivity`, so a v1.0 host is
- * bridged up transparently (enriched fields default to empty `owners` / `null`
- * timestamps). Human mode renders a scannable table; `--json` hands the
- * enriched entries to the caller (the skill), each carrying the shared
- * classifier's computed `tier` (null without `--include-activity`).
+ * worktree under `~/.traycer/worktrees/`. Calls `worktree.listAllForHost` at
+ * the CANONICAL v1.6 contract; the request carries `includeActivity`, so a
+ * v1.0 host is bridged up transparently (enriched fields default to empty
+ * `owners` / `null` timestamps). Human mode renders a scannable table;
+ * `--json` hands the enriched entries to the caller (the skill), each carrying
+ * the shared classifier's computed `tier` (null without `--include-activity`).
+ *
+ * The canonical parse is load-bearing, not tidiness. This read used to decode
+ * the v1.4 response, and Zod strips unknown keys, so two facts a current host
+ * sends were dropped before anything saw them:
+ *
+ *   - `gitUnreadable` (v1.6) - git cannot resolve the repository the worktree's
+ *     gitlink points at, so its branch and `uncommittedCount` are placeholders.
+ *     `classifyWorktreeTier` reads it at rung 1b and returns `review`
+ *     specifically so such a row does NOT read as an fs-only cleanup. Stripped,
+ *     the row fell through to rung 2 (`!gitRemovable`) and rendered `Orphaned`,
+ *     whose whole meaning is "forced cleanup, nothing to lose" - the one
+ *     reading the ladder is written to prevent, and the `traycer-housekeeping`
+ *     skill takes `tier` verbatim.
+ *   - `presence` (v1.5) - never consumed here, but it is part of the `--json`
+ *     contract the skill reads.
+ *
+ * The classifier tolerates the field's absence (older hosts omit it), which is
+ * why the loss was silent rather than a parse failure.
  */
 export function buildWorktreeListCommand(
   opts: WorktreeListCommandOpts,
@@ -128,7 +146,7 @@ async function requestWorktreeListPage(
   cursor: string | null,
   limit: number | null,
 ): Promise<WorktreeListPage> {
-  const request = parseUserInput(worktreeListAllForHostRequestSchemaV14, {
+  const request = parseUserInput(worktreeListAllForHostRequestSchemaV16, {
     includeActivity,
     // The CLI is a paged-listing caller, never a GUI per-selection probe.
     activityPaths: null,
@@ -141,8 +159,9 @@ async function requestWorktreeListPage(
   const result = await toAgentCliError(
     callHostRpc("worktree.listAllForHost", request),
   );
-  const parsed = parseHostResponse(
-    worktreeListAllForHostResponseSchemaV14,
+  const parsed = parseCanonicalHostResponse(
+    "worktree.listAllForHost",
+    worktreeListAllForHostResponseSchemaV16,
     result,
   );
   return {

--- a/clients/traycer-cli/src/internal/__tests__/host-rpc.test.ts
+++ b/clients/traycer-cli/src/internal/__tests__/host-rpc.test.ts
@@ -1,11 +1,55 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { callHostRpc, callHostRpcFastFail, toAgentCliError } from "../host-rpc";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  callHostRpc,
+  callHostRpcFastFail,
+  canonicalResponseSchemaFor,
+  parseCanonicalHostResponse,
+  toAgentCliError,
+} from "../host-rpc";
 import { resolveHostAuth } from "../host-auth";
 import { readHostPidMetadata } from "../../host/pid-metadata";
 import { HostRpcError } from "../../../../shared/host-transport/host-messenger";
 import { createCliCredentialsStore } from "../../store/credentials-store";
 import type { CredentialsMutationStore } from "@traycer/protocol/config/credentials-mutation";
 import { CLI_ERROR_CODES } from "../../runner/errors";
+import {
+  hostRpcRegistry,
+  hostStreamRpcRegistry,
+} from "@traycer/protocol/host/registry";
+import { getLatestContract } from "@traycer/protocol/framework/versioned-rpc";
+import type {
+  StreamMethodVersionRegistry,
+  UncheckedStreamMethodVersionRegistry,
+} from "@traycer/protocol/framework/versioned-stream-rpc";
+import type { ZodType } from "zod";
+import {
+  agentGetProviderProfileRateLimitsResponseSchema,
+  agentGetProviderProfileRateLimitsResponseSchemaV5,
+} from "@traycer/protocol/host/agent/profiles";
+import { worktreeListAllForHostResponseSchemaV16 } from "@traycer/protocol/host";
+import { listTerminalsResponseSchemaV23 } from "@traycer/protocol/host/terminal/unary-schemas";
+import { worktreeDeleteByPathServerFrameSchemaV11 } from "@traycer/protocol/host/worktree-delete-stream";
+
+/**
+ * Mirrors `getLatestContract`'s traversal (highest major -> its
+ * `latestMinor`) for a stream method registry - there is no shared helper
+ * because `hostStreamRpcRegistry`'s validated shape carries no
+ * `downgradePathsFromLatest`, so it fails `getLatestContract`'s
+ * `MethodVersionRegistry` constraint outright.
+ */
+function latestStreamServerFrameSchema<
+  Registry extends UncheckedStreamMethodVersionRegistry,
+>(registry: StreamMethodVersionRegistry<Registry>): ZodType {
+  const highestMajor = Math.max(
+    ...Object.keys(registry)
+      .map(Number)
+      .filter((candidate) => Number.isInteger(candidate)),
+  );
+  const majorLine = registry[highestMajor];
+  return majorLine.versions[majorLine.latestMinor].contract.serverFrameSchema;
+}
 
 // Mock the WS transport + the credentials-store FACTORY; exercise the real
 // store-backed revalidator + withCommitRetry + shared auth-aware wrapper so this
@@ -373,5 +417,145 @@ describe("callHostRpc", () => {
       message: "traycer: Message exceeds the maximum size.",
       details: null,
     });
+  });
+});
+
+const COMMANDS_DIR = join(__dirname, "..", "..", "commands");
+
+describe("canonicalResponseSchemaFor", () => {
+  it("returns exactly the registry's latest contract response schema for a spread of methods", () => {
+    const methods: ReadonlyArray<keyof typeof hostRpcRegistry & string> = [
+      "worktree.listAllForHost",
+      "terminal.list",
+      "agent.getProviderProfileRateLimits",
+      "agent.list",
+    ];
+    for (const method of methods) {
+      expect(canonicalResponseSchemaFor(method)).toBe(
+        getLatestContract(hostRpcRegistry[method], undefined).responseSchema,
+      );
+    }
+  });
+
+  it("agrees with the concrete canonical schemas the fixed call sites parse against", () => {
+    expect(canonicalResponseSchemaFor("worktree.listAllForHost")).toBe(
+      worktreeListAllForHostResponseSchemaV16,
+    );
+    expect(canonicalResponseSchemaFor("terminal.list")).toBe(
+      listTerminalsResponseSchemaV23,
+    );
+    expect(
+      canonicalResponseSchemaFor("agent.getProviderProfileRateLimits"),
+    ).toBe(agentGetProviderProfileRateLimitsResponseSchemaV5);
+  });
+});
+
+describe("parseCanonicalHostResponse", () => {
+  it("returns the parsed data on the canonical-pairing happy path", () => {
+    const value = {
+      rateLimits: { provider: "codex", available: false, reason: "timeout" },
+      usageUpdatedAt: null,
+    };
+    const parsed = parseCanonicalHostResponse(
+      "agent.getProviderProfileRateLimits",
+      agentGetProviderProfileRateLimitsResponseSchemaV5,
+      value,
+    );
+    expect(parsed).toEqual(value);
+  });
+
+  // This is the one case the type system cannot catch: `...Schema` (no
+  // version suffix) is the LIVE-line alias, redefined onto each new major as
+  // the previous one freezes. It is STRUCTURALLY IDENTICAL to `...SchemaV5`
+  // today, so it satisfies `ZodType<ResponseOfMethod<...>>` and compiles at
+  // the call site - but it is a DIFFERENT object, free to stop tracking
+  // canonical the moment a v6 line ships. Only the runtime identity check in
+  // `assertCanonicalResponseSchema` catches that drift; a type-level
+  // assertion would pass this call unchanged.
+  it("throws when handed a schema that is structurally identical to canonical but not the same object (the runtime backstop)", () => {
+    const value = {
+      rateLimits: { provider: "codex", available: false, reason: "timeout" },
+      usageUpdatedAt: null,
+    };
+    // Sanity: the base alias really does accept the same payload as V5 today -
+    // otherwise this test would be catching a type/shape bug, not the
+    // identity backstop it exists to prove.
+    expect(
+      agentGetProviderProfileRateLimitsResponseSchema.safeParse(value).success,
+    ).toBe(true);
+    expect(() =>
+      parseCanonicalHostResponse(
+        "agent.getProviderProfileRateLimits",
+        agentGetProviderProfileRateLimitsResponseSchema,
+        value,
+      ),
+    ).toThrow(/non-canonical response schema/);
+  });
+});
+
+describe("parseHostResponse creep guard", () => {
+  // `worktree-create.ts` and `workspace-list.ts` are owned by open PR #1505;
+  // this allowlist is the enforcement mechanism and is expected to shrink to
+  // empty once that PR lands. Do not add to it without justification - use
+  // `parseCanonicalHostResponse` instead.
+  const ALLOWLIST = new Set(["workspace-list.ts", "worktree-create.ts"]);
+
+  it("only PR #1505's carved-out files still call the un-canonical parseHostResponse", () => {
+    const offenders: string[] = [];
+    for (const file of readdirSync(COMMANDS_DIR)) {
+      if (!file.endsWith(".ts") || ALLOWLIST.has(file)) continue;
+      const source = readFileSync(join(COMMANDS_DIR, file), "utf8");
+      if (/\bparseHostResponse\(/.test(source)) offenders.push(file);
+    }
+    expect(
+      offenders,
+      `${offenders.join(", ")} call parseHostResponse() directly. Use ` +
+        "parseCanonicalHostResponse(method, schema, value) instead - naming " +
+        "the method lets the compiler and the runtime identity check both " +
+        "prove the schema is canonical. If this call site genuinely needs a " +
+        "specific historical version (like monitor.ts's frame decode), " +
+        "justify it in this test's allowlist instead of failing silently.",
+    ).toEqual([]);
+  });
+});
+
+describe("canonical stream frame pairing (worktree.deleteByPath)", () => {
+  it("worktreeDeleteByPathServerFrameSchemaV11 is the canonical serverFrameSchema for worktree.deleteByPath", () => {
+    expect(
+      latestStreamServerFrameSchema(
+        hostStreamRpcRegistry["worktree.deleteByPath"],
+      ),
+    ).toBe(worktreeDeleteByPathServerFrameSchemaV11);
+  });
+
+  // The v1.0 -> v1.1 diff on this method is an OPTIONAL field
+  // (`worktreeBusyHoldersWireFieldSchema` is `.optional().catch(undefined)`)
+  // added to one arm of a discriminated union, not a new required field on
+  // the whole response. A `ZodType<...>` compile-time constraint would not
+  // reject the v1.0 schema in that shape, so this identity check (mirroring
+  // `canonicalResponseSchemaFor`'s unary-registry traversal, but over
+  // `hostStreamRpcRegistry`) is the only thing that would have caught this
+  // specific skew.
+  it("scans commands/*.ts for hand-picked ServerFrameSchemaV<N> usage outside the negotiated-dispatch allowlist", () => {
+    // `monitor.ts` parses agentInboxSubscribeServerFrameSchemaV10/V11/V12 (plus
+    // the base envelope) ON PURPOSE - that is per-connection negotiated-version
+    // dispatch (try newest, fall back), not a stale call site. `worktree-delete.ts`
+    // names `worktreeDeleteByPathServerFrameSchemaV11` explicitly, verified
+    // canonical by the assertion above.
+    const ALLOWLIST = new Set(["monitor.ts", "worktree-delete.ts"]);
+    const versionedFrameSchemaPattern = /[A-Za-z]+ServerFrameSchemaV\d+/;
+    const offenders: string[] = [];
+    for (const file of readdirSync(COMMANDS_DIR)) {
+      if (!file.endsWith(".ts") || ALLOWLIST.has(file)) continue;
+      const source = readFileSync(join(COMMANDS_DIR, file), "utf8");
+      if (versionedFrameSchemaPattern.test(source)) offenders.push(file);
+    }
+    expect(
+      offenders,
+      `${offenders.join(", ")} reference a versioned *ServerFrameSchemaV<N> ` +
+        "directly. Confirm it is the registry's canonical latest for that " +
+        "stream method (see the identity assertion above) or justify the " +
+        "addition in this allowlist.",
+    ).toEqual([]);
   });
 });

--- a/clients/traycer-cli/src/internal/host-rpc.ts
+++ b/clients/traycer-cli/src/internal/host-rpc.ts
@@ -5,6 +5,7 @@ import {
   hostRpcRegistry,
   type HostRpcRegistry,
 } from "@traycer/protocol/host/registry";
+import { getLatestContract } from "@traycer/protocol/framework/versioned-rpc";
 import { MutableBearerLease } from "../../../shared/auth/bearer-source";
 import { createAuthAwareMessenger } from "../../../shared/host-transport/auth-aware-messenger";
 import {
@@ -429,6 +430,84 @@ export function parseHostResponse<T>(schema: ZodType<T>, value: unknown): T {
     details: null,
     exitCode: 1,
   });
+}
+
+/**
+ * Validate a host response against the CANONICAL (latest installed) response
+ * schema for `method`, resolved from the same `hostRpcRegistry` the transport
+ * negotiates against. Prefer this over {@link parseHostResponse} everywhere the
+ * payload is just "the response to the call we made".
+ *
+ * Why this exists rather than each call site naming a schema: the transport
+ * hands back a payload already at the client's canonical version - either the
+ * host spoke it directly (returned unvalidated, so this parse IS the validation
+ * boundary) or `upgradeResponseAlongChain` bridged an older host's reply up to
+ * it. A call site that names an older `...SchemaVNN` therefore validates the
+ * wrong contract AND, because Zod strips unknown keys, silently discards every
+ * field added since - turning a host fact the CLI was told into one it never
+ * saw. That skew is invisible to the type checker, because `parseHostResponse`
+ * takes `value: unknown` and returns whatever the schema it was handed infers.
+ *
+ * Naming the METHOD alongside the schema is what closes that hole. The schema
+ * parameter is typed as the method's canonical `ResponseOfMethod` - the same
+ * type `callHostRpc` already promises for the value being parsed - so handing
+ * it a stale `...SchemaVNN` is a compile error at the call site instead of a
+ * silent field drop at runtime. When a protocol minor lands, every CLI call
+ * site on that method stops compiling until someone decides what the new field
+ * means here, which is the loud, reviewable moment the old signature never had.
+ * `assertCanonicalResponseSchema` covers the residue the types cannot see.
+ *
+ * {@link parseHostResponse} stays for the callers that genuinely mean a
+ * specific historical version - the streaming frame bridge in `monitor.ts`
+ * decodes v1.0/v1.1/v1.2 envelopes on purpose.
+ */
+export function parseCanonicalHostResponse<
+  Method extends keyof HostRpcRegistry & string,
+>(
+  method: Method,
+  schema: ZodType<ResponseOfMethod<HostRpcRegistry, Method>>,
+  value: unknown,
+): ResponseOfMethod<HostRpcRegistry, Method> {
+  assertCanonicalResponseSchema(method, schema);
+  return parseHostResponse(schema, value);
+}
+
+/**
+ * The canonical (latest installed) response schema the registry declares for
+ * `method` - the contract the transport negotiates and therefore the only one a
+ * plain response parse may use. Exported so a test can assert the pairing for
+ * every method without re-deriving the traversal.
+ */
+export function canonicalResponseSchemaFor(
+  method: keyof HostRpcRegistry & string,
+): ZodType<unknown> {
+  return getLatestContract(hostRpcRegistry[method], undefined).responseSchema;
+}
+
+/**
+ * Backstop for the drift the signature alone cannot catch. The
+ * `ZodType<ResponseOfMethod<...>>` parameter rejects a stale schema whenever the
+ * versions differ by a REQUIRED field - which is what an additive protocol minor
+ * normally adds, since its upgrade path has to supply a value for older hosts.
+ * It does not reject a schema that merely differs by an optional field, and it
+ * cannot see a base-name alias that tracks the latest line today but is free to
+ * stop doing so (`agentGetProviderProfileRateLimitsResponseSchema` is exactly
+ * that shape).
+ *
+ * So compare identity against the registry as well. This is an O(1) property
+ * walk against a call that just crossed a WebSocket, and it fails as a plain
+ * `Error`, not a `CliError`: reaching it means the CLI was built with a
+ * mismatched pairing, which is a bug in this repo rather than anything the user
+ * or the host did.
+ */
+function assertCanonicalResponseSchema(
+  method: keyof HostRpcRegistry & string,
+  schema: ZodType<unknown>,
+): void {
+  if (canonicalResponseSchemaFor(method) === schema) return;
+  throw new Error(
+    `traycer: internal error - '${method}' is parsed with a non-canonical response schema. Parse the latest contract in the versioned-RPC registry; an older '...SchemaVNN' silently strips every field added since.`,
+  );
 }
 
 function hostRpcToCliError(err: unknown): unknown {


### PR DESCRIPTION
## Summary

Repo-wide sweep for CLI RPC handlers parsing a **non-canonical** response schema, prompted by **CLI-023** (found in PR #1505: `workspace list` read the v1.0 base schema while `worktree.listBindingsForEpic` was at v1.2). #1505 fixes that one instance; this PR fixes the rest of the class and makes recurrence loud.

## Why the class exists

The transport hands a command a payload **already at the client's canonical version** — either the host spoke it directly, in which case `WsRpcClient` returns it **unvalidated**, or `upgradeResponseAlongChain` bridged an older host's reply up to it. So the command's own parse *is* the validation boundary.

A call site naming an older `…SchemaVNN` therefore validates the wrong contract, and since Zod strips unknown keys it **silently discards every field added since**. A host fact the CLI was told becomes one it never saw — no error anywhere.

It was invisible to the type checker because `parseHostResponse(schema, value: unknown)` infers its return from whatever schema it is handed.

## Audit method

Every CLI parse site was compared against the registry's latest contract by **reference identity** *and* **JSON-schema fingerprint** — 29 unary sites via `parseHostResponse`, plus the direct stream-frame `safeParse` sites. 25 were already canonical.

| # | Command | Method | Was | Canonical | Silently dropped |
|---|---|---|---|---|---|
| 1 | `worktree list` | `worktree.listAllForHost` | v1.4 | **v1.6** | `presence`, `gitUnreadable` |
| 2 | `terminal list` | `terminal.list` | v2.2 | **v2.3** | `lifecycleOwner` |
| 3 | `worktree delete` | `worktree.deleteByPath` *(stream)* | v1.0 | **v1.1** | `holders` on `failed` |
| 4 | `workspace list` | `worktree.listBindingsForEpic` | v1.0 | v1.2 | — **PR #1505 owns this** |

I verified every affected method has a **complete upgrade chain** (no missing `upgradeFromPreviousVersion`), so an older host is still bridged rather than failing to parse.

### #1 `worktree list` — the consequential one

`classifyWorktreeTier` reads `gitUnreadable` at **rung 1b** and returns `review`, deliberately placed *before* the `orphaned` rung with the comment that such a row "must not read as an fs-only cleanup with nothing to lose" — its branch and dirty count are placeholders.

With the field stripped the row fell through to rung 2 (`!gitRemovable`) and rendered **`Orphaned`**, whose tooltip is precisely *"deleting it uses a forced cleanup"*. The `traycer-housekeeping` skill takes `tier` **verbatim** and leads its report with the removal set. `presence` (v1.5) was dropped from the `--json` contract too.

The classifier tolerates the field's absence (older hosts omit it), which is why the loss was silent rather than a parse failure.

### #3 `worktree delete` — the subtlest, and the one that shaped the fix

v1.1 added `holders` to the `failed` frame: the typed inventory naming which chats and terminal agents still hold the worktree — the same disclosure the GUI got in T7/T8 (#1498, #1497). The busy refusal kept its prose `reason` and dropped the only actionable part. It now rides the CliError `details` for `--json` and names the holders in the human message.

Critically: `worktreeBusyHoldersWireFieldSchema` is `.optional().catch(undefined)`, and an **optional** field on one arm of a discriminated union is *not* a type error. This is the case a compile-time constraint alone cannot catch — which is why the fix has a runtime half.

### #2 `terminal list`

Dropped `lifecycleOwner`. Latent: never rendered, and `--json` emits a projected row, so nothing downstream had observed it yet.

### Not a defect, but hardened

`agent profile-rate-limits` parsed `agentGetProviderProfileRateLimitsResponseSchema`, the **live-line alias**. Structurally identical to v5.0 today, so nothing was lost — but that base name is redefined onto each new major as the previous one freezes, so it tracks canonical only by coincidence of timing. Pinned to the explicit `…SchemaV5`.

## Prevention

`parseCanonicalHostResponse(method, schema, value)` in `internal/host-rpc.ts`:

- **Compile time** — `schema` is typed `ZodType<ResponseOfMethod<HostRpcRegistry, Method>>`, the same type `callHostRpc` already promises for the value. A stale schema is a type error *at the call site*. (Verified: the old V22 produced `error TS2345` before I fixed it.) When a protocol minor lands, every CLI call site on that method stops compiling until someone decides what the new field means there.
- **Runtime backstop** — `assertCanonicalResponseSchema` compares by reference against the registry, covering the residue types cannot see: a minor that adds only an *optional* field (#3), and the base-name alias above. O(1) property walk against a call that just crossed a WebSocket.
- **Escape hatch preserved** — `parseHostResponse` stays for callers that genuinely mean a specific historical version. `monitor.ts` decodes v1.0/v1.1/v1.2 envelopes as negotiated-version dispatch; that is not skew and is not banned.

27 call sites converted. Two **creep guards** scan `commands/*.ts` and fail on new un-canonical parses outside an explicit allowlist — editing that allowlist is the enforcement mechanism, and its failure message says what to do instead.

## Scope notes

- **`workspace-list.ts` and `worktree-create.ts` are untouched** — open PR #1505 owns both. They are allowlisted in the creep guard, which is expected to shrink to empty once it lands. I deliberately did not duplicate #1505's CLI-023 fix.
- **`gui-app` / `desktop` are clean** — zero unary re-parsing; they consume the transport's typed return directly. Their only versioned `…SchemaVNN.safeParse` calls are stream/subscription frame bridges decoding historical envelopes on purpose. This was a CLI-only pattern; the fix aligns the CLI with how the GUI already worked.

## Follow-up owed (after #1505 lands)

#1505's new `workspace-list.ts` docstring ends *"…the same way `worktree list` reads its v1.4 schema"* — citing defect #1 as the model to follow. That sentence needs correcting, and both carved-out files converting, which empties the allowlist.

## Test status

`worktree-list`, `worktree-delete`, `terminal-commands`, `host-rpc`: **69 passed**. New coverage: the `gitUnreadable` row classifying `review` not `orphaned`; `presence`/`gitUnreadable` surviving into `--json`; `lifecycleOwner` not stripped; holders surfaced on a busy refusal *and* the no-holders older-host path unchanged; the runtime backstop firing on the structurally-identical alias; both creep guards; and canonical-identity assertions against the unary and stream registries.

Full `@traycer-clients/traycer-cli:test`: the same 7 pre-existing failing files as `main` (`cli-version`, `cli-mark-source`, `host-restart-finalize`, `pending-upgrade`, `cli-manifest-system-marker`, `registry/client`, `well-known-cli`) and nothing else. None is touched here.

## Checklist

- [x] Pre-commit static checks pass (build, compile, lint, format)
- [ ] Separate CI test checks pass
- [x] Tests added/updated where it makes sense
- [x] Commits are signed off (`git commit -s`) per the DCO

🤖 Generated with [Claude Code](https://claude.com/claude-code)
