### PR TITLE
fix(gui-app): publish the landing terminal toggle only on the surface it acts on

### DIFF
--- a/clients/gui-app/src/components/home/terminal-panel/__tests__/landing-terminal-panel.test.tsx
+++ b/clients/gui-app/src/components/home/terminal-panel/__tests__/landing-terminal-panel.test.tsx
@@ -714,6 +714,26 @@ describe("<LandingTerminalPanel />", () => {
       expect(useMobileHeaderStore.getState().rightActions).toBeNull();
     });
 
+    // The panel outlives its page's activation to keep its PTYs warm - it stays
+    // mounted behind an epic tab, History or Settings so its PTYs survive - so
+    // being mounted is not a claim on the header. The header belongs to the
+    // surface on screen: a toggle published from behind another surface would
+    // act on a terminal panel the user cannot see.
+    it("publishes no toggle while another surface is presented", async () => {
+      seedTabsLayout([PANEL_DRAFT_TAB, PANEL_EPIC_TAB], PANEL_EPIC_TAB.id);
+      render(
+        <>
+          {panelUi()}
+          <MobileHeaderSlotProbe />
+        </>,
+      );
+      await screen.findByTestId("landing-terminal-panel");
+
+      expect(useMobileHeaderStore.getState().rightActions).toBeNull();
+      expect(useMobileHeaderStore.getState().rightActionsOwner).toBeNull();
+      expect(screen.queryByTestId("landing-terminal-toggle")).toBeNull();
+    });
+
     // Launching a task from this page replaces it with the epic it created,
     // and the epic's surface claims the header slot while this panel is still
     // mounted: its existence follows the pane ANCHOR, which unregisters a

--- a/clients/gui-app/src/components/home/terminal-panel/landing-terminal-panel.tsx
+++ b/clients/gui-app/src/components/home/terminal-panel/landing-terminal-panel.tsx
@@ -1652,10 +1652,18 @@ function LandingTerminalHeaderToggle(props: {
 }
 
 /**
- * Publishes the reveal toggle into the mobile header while the landing terminal
- * panel is mounted, and clears it on unmount so it cannot leak into History,
- * Settings or the epic view. Rendered from the panel contents, so it inherits
- * the availability guard above - no toggle appears where no terminal can run.
+ * Publishes the reveal toggle into the mobile header while the landing surface
+ * is the one on screen. Rendered from the panel contents, so it inherits the
+ * availability guard above - no toggle appears where no terminal can run.
+ *
+ * Gated on the surface rather than on being mounted, because the panel
+ * deliberately OUTLIVES its page's activation: its existence follows the
+ * hosting page's pane anchor, not tab focus, so it stays mounted behind an epic
+ * tab, History or Settings to keep its PTYs warm. The header belongs to the
+ * surface the phone is presenting, so a toggle published from behind one of
+ * those would act on a terminal panel the user cannot see - the same reason the
+ * panel's other outward-facing behavior (chords, focus grabs) gates on this
+ * selector instead of on being rendered.
  */
 function MobileLandingTerminalActionBinder(props: {
   readonly landingPageId: string;
@@ -1666,8 +1674,10 @@ function MobileLandingTerminalActionBinder(props: {
   const clearRightActions = useMobileHeaderStore(
     (state) => state.clearRightActions,
   );
+  const surfaceActive = useLandingTerminalSurfaceActive();
   const owner = `landing-terminal:${props.landingPageId}`;
   useEffect(() => {
+    if (!surfaceActive) return;
     // Re-baked whenever the focused landing page changes, so the slotted node
     // always toggles the layout of the page actually on screen.
     setRightActions(
@@ -1677,7 +1687,13 @@ function MobileLandingTerminalActionBinder(props: {
     return () => {
       clearRightActions(owner);
     };
-  }, [clearRightActions, owner, setRightActions, props.landingPageId]);
+  }, [
+    clearRightActions,
+    owner,
+    setRightActions,
+    surfaceActive,
+    props.landingPageId,
+  ]);
   return null;
 }
 


### PR DESCRIPTION
> Follow-up to #1511 (merged as `7861433d`), now rebased onto `main` as a single commit. It depends on that PR's owner-scoped release: without it, gating this binder would just relocate the same clobber onto the epic tab's trigger.

## What was wrong

With a start page open, **History and Settings carried the start page's terminal-panel toggle in the mobile header**. Tapping it opened or collapsed a terminal panel belonging to a surface the user could not see.

Confirmed on the iOS Simulator (before):

```
on landing draft:              [... , landing-terminal-toggle]   title: null
on History (draft still open): [... , landing-terminal-toggle]   title: "History"
```

## Mechanism

`MobileLandingTerminalActionBinder` published for as long as the **panel** was mounted. That stopped meaning "this page is on screen" when the panel began outliving its page's activation — its existence follows the hosting page's pane anchor rather than tab focus (`landing-terminal-host.tsx`: *"Existence follows the hosting page's ANCHOR, never the focused tab"*), precisely so its PTYs survive a tab switch. Being mounted is therefore not a claim on the header.

The binder's own doc still asserted the opposite — that it "clears it on unmount so it cannot leak into History, Settings or the epic view". That guarantee predates panel retention and nothing had enforced it since; this PR corrects the comment along with the behaviour.

## The fix

Gate the publish on the landing surface actually being presented, via `useLandingTerminalSurfaceActive()` — the same selector the panel's other outward-facing behaviour (chords, focus grabs) already uses, for the same reason: what the panel may do *outside its own pane* depends on whether it owns the screen, not on whether it exists.

Leaving the surface releases the cell through the owner-scoped clear from #1511, so it hands back without disturbing whichever surface has since claimed it.

## Verification

Simulator, same rig, after:

| | before | after |
| --- | --- | --- |
| header on landing draft | toggle present | toggle present |
| header on History, draft still open | **toggle present** | **toggle absent** |

And it is still a working control, not just an absent one — on the landing page: tap → swaps to collapse, tap collapse → swaps back to the toggle; and it reappears after leaving to History and returning.

Tests: `landing-terminal-panel` 82 green, re-run after the rebase onto `main`. The new case (`publishes no toggle while another surface is presented`) is mutation-checked — it fails with the gate removed.

A note on the test's shape: an earlier version drove the transition by re-seeding the tab layout *after* mount, and it passed with the gate removed — in that harness the panel is rebound to a different page id on focus change, so the slot cleared for an unrelated reason. It was replaced with one that seeds the other surface before mount, which is faithful to the leak and actually discriminating. The mounted-then-switched path is covered on the Simulator instead, where the panel genuinely stays bound.