### PR TITLE
fix(gui-app): reveal full paths on hover in the folder pickers

### DIFF
--- a/clients/gui-app/src/components/__tests__/remote-folder-picker-dialog.test.tsx
+++ b/clients/gui-app/src/components/__tests__/remote-folder-picker-dialog.test.tsx
@@ -22,6 +22,7 @@ import { modLabel } from "@/lib/keybindings/platform";
 import { RemoteFolderPickerDialog } from "@/components/remote-folder-picker-dialog";
 import { useRemoteFolderPickerStore } from "@/stores/workspace/remote-folder-picker-store";
 import type { NegotiatedMethodVersion } from "@/hooks/host/use-host-negotiated-method-version";
+import { tooltipTextFor } from "@/components/ui/__tests__/tooltip-probe";
 
 interface FakeQueryState {
   readonly data: WorkspaceBrowseFoldersResponseV11 | undefined;
@@ -1407,6 +1408,54 @@ describe("<RemoteFolderPickerDialog />", () => {
       } finally {
         vi.useRealTimers();
       }
+    });
+  });
+
+  describe("hover reveals the absolute path", () => {
+    // Long-press is touch-only (`useLongPress`), so a mouse user's only route
+    // to the same absolute path is hover - this is the pointer half of the
+    // two long-press tests above.
+    it("a recent row keeps its short name visible but hovers to the full path", async () => {
+      // Two entries under a shared base, same as the "offers the host's
+      // recent workspaces" fixture above - a single entry has no base to
+      // collapse against and would render its full path as the label too,
+      // which is not the pairing this test is about.
+      recentEntries = [
+        { path: "/srv/app", lastOpenedAt: "2026-08-01T00:00:00.000Z" },
+        { path: "/srv/api", lastOpenedAt: "2026-07-30T00:00:00.000Z" },
+      ];
+      render(<RemoteFolderPickerDialog />);
+      void useRemoteFolderPickerStore.getState().requestPick(makeClient());
+      const [chip] = await screen.findAllByTestId(
+        "remote-folder-picker-recent",
+      );
+      // The pairing this change is about: the row still reads as the short,
+      // tilde/relative-collapsed name...
+      expect(chip.textContent).toBe("app");
+      // ...while hover carries the full absolute path, matching what
+      // long-press has always shown.
+      expect(tooltipTextFor(chip)).toBe("/srv/app");
+    });
+
+    it("a directory row hovers to its full absolute path", async () => {
+      render(<RemoteFolderPickerDialog />);
+      void useRemoteFolderPickerStore.getState().requestPick(makeClient());
+      const [row] = await screen.findAllByTestId("remote-folder-picker-row");
+      expect(row.textContent).toBe("code");
+      expect(tooltipTextFor(row)).toBe("/Users/tester/code");
+    });
+
+    it("the .. row hovers to the parent path", async () => {
+      render(<RemoteFolderPickerDialog />);
+      void useRemoteFolderPickerStore.getState().requestPick(makeClient());
+      fireEvent.click(
+        (await screen.findAllByTestId("remote-folder-picker-row"))[0],
+      );
+      // Now inside /Users/tester/code, whose parent is /Users/tester - the
+      // ".." row names no path itself, so hover is the only thing that says
+      // where it goes.
+      const upRow = screen.getByTestId("remote-folder-picker-up-row");
+      expect(tooltipTextFor(upRow)).toBe("/Users/tester");
     });
   });
 });

--- a/clients/gui-app/src/components/__tests__/remote-folder-picker-dialog.test.tsx
+++ b/clients/gui-app/src/components/__tests__/remote-folder-picker-dialog.test.tsx
@@ -1457,5 +1457,32 @@ describe("<RemoteFolderPickerDialog />", () => {
       const upRow = screen.getByTestId("remote-folder-picker-up-row");
       expect(tooltipTextFor(upRow)).toBe("/Users/tester");
     });
+
+    it("the group header hovers to the absolute base, not the ~ it displays", async () => {
+      // A base UNDER the host's home is the case the two collapse steps can
+      // silently agree on: if the header were handed an already-collapsed
+      // base, hover would repeat `~/code` and reveal nothing.
+      recentEntries = [
+        {
+          path: "/Users/tester/code/app",
+          lastOpenedAt: "2026-08-01T00:00:00.000Z",
+        },
+        {
+          path: "/Users/tester/code/api",
+          lastOpenedAt: "2026-07-30T00:00:00.000Z",
+        },
+      ];
+      render(<RemoteFolderPickerDialog />);
+      void useRemoteFolderPickerStore.getState().requestPick(makeClient());
+      const header = await screen.findByTestId(
+        "remote-folder-picker-group-header",
+      );
+      expect(header.textContent).toContain("~/code");
+      // The header's label sits outside the trigger, so the tooltip hangs off
+      // the path span within it rather than off the line itself.
+      const trigger = header.querySelector('[data-slot="tooltip-trigger"]');
+      if (trigger === null) throw new Error("group header has no tooltip");
+      expect(tooltipTextFor(trigger)).toBe("/Users/tester/code");
+    });
   });
 });

--- a/clients/gui-app/src/components/folder-picker-path-view.tsx
+++ b/clients/gui-app/src/components/folder-picker-path-view.tsx
@@ -1,6 +1,5 @@
 import type { ReactNode } from "react";
 import { Sheet, SheetContent, SheetTitle } from "@/components/ui/sheet";
-import { cn } from "@/lib/utils";
 import type { FuzzyRange } from "@/lib/fuzzy-folder-match";
 
 /**
@@ -46,32 +45,10 @@ export function HighlightedName(props: {
 }
 
 /**
- * A path that loses its FRONT when it will not fit, never its end: the leaf
- * is the identity of the row and the prefix is the noise, so the end is what
- * has to survive.
- *
- * CSS truncation always eats the end of the line, so the line is laid out
- * right-to-left — which moves the overflow, and the ellipsis with it, to the
- * start — while the text inside is isolated back to left-to-right so the path
- * itself still reads normally. Doing it in CSS rather than by counting
- * characters means the cut lands exactly at the available width, at whatever
- * size the row happens to be.
- */
-export function TailAnchoredPath(props: {
-  readonly path: string;
-  readonly className: string | undefined;
-}): ReactNode {
-  return (
-    <span dir="rtl" className={cn("block truncate text-left", props.className)}>
-      <bdi dir="ltr">{props.path}</bdi>
-    </span>
-  );
-}
-
-/**
- * The escape hatch for every abbreviation above: the untouched absolute path,
- * selectable, one long-press away. Abbreviating is safe precisely because
- * this exists.
+ * The escape hatch for every abbreviation above, on touch: the untouched
+ * absolute path, selectable, one long-press away. A pointer reaches the same
+ * path through the rows' hover tooltip. Abbreviating is safe precisely
+ * because both exist.
  */
 export function FullPathSheet(props: {
   readonly path: string | null;

--- a/clients/gui-app/src/components/home/host-workspace-selector/folder-location-control.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/folder-location-control.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/components/ui/input-group";
 import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 import { StartTruncatedText } from "@/components/ui/start-truncated-text";
+import { FilePathTooltip } from "@/components/file-path-tooltip";
 import {
   worktreeImportRows,
   type UnifiedPickerWorktreeRow,
@@ -402,9 +403,11 @@ function ExistingWorktreeList(props: {
                   <span className="truncate">
                     {row.branch ?? workspaceFolderName(row.worktreePath)}
                   </span>
-                  <StartTruncatedText className="block text-ui-xs text-muted-foreground">
-                    {row.worktreePath}
-                  </StartTruncatedText>
+                  <FilePathTooltip content={row.worktreePath} side="bottom">
+                    <StartTruncatedText className="block text-ui-xs text-muted-foreground">
+                      {row.worktreePath}
+                    </StartTruncatedText>
+                  </FilePathTooltip>
                 </span>
                 {uncommitted !== undefined && uncommitted > 0 ? (
                   <span className="shrink-0 text-ui-xs text-muted-foreground">

--- a/clients/gui-app/src/components/home/terminal-panel/landing-terminal-directory-picker.tsx
+++ b/clients/gui-app/src/components/home/terminal-panel/landing-terminal-directory-picker.tsx
@@ -17,6 +17,8 @@ import {
   CommandList,
 } from "@/components/ui/command";
 import { InputGroupButton } from "@/components/ui/input-group";
+import { StartTruncatedText } from "@/components/ui/start-truncated-text";
+import { FilePathTooltip } from "@/components/file-path-tooltip";
 import { registerPrimaryFocusEndpoint } from "@/lib/focus/primary-focus-coordinator";
 import { workspaceFolderName } from "@/lib/worktree/workspace-folder-name";
 
@@ -144,9 +146,11 @@ export function LandingTerminalDirectoryPicker(
                       </Badge>
                     ) : null}
                   </span>
-                  <span className="block truncate text-ui-xs text-muted-foreground">
-                    {workspacePath}
-                  </span>
+                  <FilePathTooltip content={workspacePath} side="bottom">
+                    <StartTruncatedText className="block text-ui-xs text-muted-foreground">
+                      {workspacePath}
+                    </StartTruncatedText>
+                  </FilePathTooltip>
                 </span>
               </CommandItem>
             ))}

--- a/clients/gui-app/src/components/home/terminal-panel/landing-terminal-directory-picker.tsx
+++ b/clients/gui-app/src/components/home/terminal-panel/landing-terminal-directory-picker.tsx
@@ -146,8 +146,11 @@ export function LandingTerminalDirectoryPicker(
                       </Badge>
                     ) : null}
                   </span>
+                  {/* Same reason as the worktree list: these rows disable
+                      themselves while a launch is in flight, and a disabled
+                      CommandItem drops pointer events for the whole row. */}
                   <FilePathTooltip content={workspacePath} side="bottom">
-                    <StartTruncatedText className="block text-ui-xs text-muted-foreground">
+                    <StartTruncatedText className="pointer-events-auto block text-ui-xs text-muted-foreground">
                       {workspacePath}
                     </StartTruncatedText>
                   </FilePathTooltip>

--- a/clients/gui-app/src/components/remote-folder-picker-dialog.tsx
+++ b/clients/gui-app/src/components/remote-folder-picker-dialog.tsx
@@ -597,7 +597,15 @@ function RemoteFolderPickerFooter(props: {
  */
 function PathGroupHeader(props: {
   readonly label: string;
+  /**
+   * The ABSOLUTE shared base. Collapsing happens here rather than in the
+   * caller so the tooltip keeps the raw path while the line abbreviates it —
+   * handing this component an already-collapsed base would make the hover
+   * repeat the visible text and reveal nothing.
+   */
   readonly basePath: string | null;
+  /** Where `~` points, for the visible line only. */
+  readonly homePath: string | null;
   readonly fallback: string;
 }): ReactNode {
   return (
@@ -612,7 +620,7 @@ function PathGroupHeader(props: {
           <span className="shrink-0">{props.label}</span>
           <FilePathTooltip content={props.basePath} side="bottom">
             <StartTruncatedText className="min-w-0 flex-1 font-mono">
-              {props.basePath}
+              {tildeCollapse(props.basePath, props.homePath)}
             </StartTruncatedText>
           </FilePathTooltip>
         </>
@@ -726,7 +734,8 @@ function RemoteFolderPickerRecents(props: {
     <div data-testid="remote-folder-picker-recents" className="pb-3">
       <PathGroupHeader
         label="Recent, under"
-        basePath={base === null ? null : tildeCollapse(base, props.homePath)}
+        basePath={base}
+        homePath={props.homePath}
         fallback="Recent"
       />
       <ul className="flex flex-col">

--- a/clients/gui-app/src/components/remote-folder-picker-dialog.tsx
+++ b/clients/gui-app/src/components/remote-folder-picker-dialog.tsx
@@ -36,10 +36,11 @@ import { hostQueryKeys } from "@/lib/query-keys";
 import { useRunnerHostOrNull } from "@/providers/use-runner-host";
 import { Switch } from "@/components/ui/switch";
 import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
+import { StartTruncatedText } from "@/components/ui/start-truncated-text";
+import { FilePathTooltip } from "@/components/file-path-tooltip";
 import {
   FullPathSheet,
   HighlightedName,
-  TailAnchoredPath,
 } from "@/components/folder-picker-path-view";
 import { RemoteFolderPickerHeader } from "@/components/remote-folder-picker-header";
 import { useCoarsePointer } from "@/hooks/ui/use-coarse-pointer";
@@ -322,7 +323,7 @@ function RemoteFolderPickerBody(): ReactNode {
           isPending={parsed.valid ? browseQuery.isPending : false}
           error={listingError}
           matches={data === undefined ? undefined : matches}
-          upPresent={upRowPresent}
+          upPath={upRowPresent ? upPath : null}
           selectedIndex={clampedIndex}
           filtering={parsed.filter !== ""}
           homePath={effectiveHome}
@@ -609,10 +610,11 @@ function PathGroupHeader(props: {
       ) : (
         <>
           <span className="shrink-0">{props.label}</span>
-          <TailAnchoredPath
-            path={props.basePath}
-            className="min-w-0 flex-1 font-mono"
-          />
+          <FilePathTooltip content={props.basePath} side="bottom">
+            <StartTruncatedText className="min-w-0 flex-1 font-mono">
+              {props.basePath}
+            </StartTruncatedText>
+          </FilePathTooltip>
         </>
       )}
     </p>
@@ -626,11 +628,21 @@ function PathGroupHeader(props: {
  * inside one folder every such line repeats the same prefix, so a column of
  * them is duplication rather than information, and each row truncating at a
  * different character makes the block read as noise. The heading above states
- * the location once; long-press produces the absolute path on demand.
+ * the location once; hover (or long-press on touch) produces the absolute
+ * path on demand.
  */
 function PickerRow(props: {
   readonly name: string;
   readonly ranges: ReadonlyArray<FuzzyRange>;
+  /** Absolute path the row stands for: what hover and long-press both reveal. */
+  readonly fullPath: string;
+  /**
+   * Which end survives when the label will not fit. A recent shows a PATH,
+   * whose leaf is its identity and whose prefix repeats down the column, so it
+   * loses its front; a directory shows a bare folder name, which reads from
+   * the front like any other word.
+   */
+  readonly truncateFrom: "start" | "end";
   /** Listbox options carry an id and selection; the recents strip does not. */
   readonly option: { readonly id: string; readonly selected: boolean } | null;
   readonly testId: string;
@@ -643,38 +655,49 @@ function PickerRow(props: {
     disabled: false,
   });
   return (
-    <Button
-      type="button"
-      variant="ghost"
-      tabIndex={-1}
-      role={props.option === null ? undefined : "option"}
-      id={props.option?.id}
-      aria-selected={props.option?.selected}
-      className={cn(
-        "h-10 w-full justify-start gap-2 px-2 hover:bg-foreground/8",
-        props.option?.selected === true &&
-          "bg-foreground/8 hover:bg-foreground/8",
-      )}
-      data-testid={props.testId}
-      // Keep focus (and the keyboard model) on the combobox field.
-      onMouseDown={(event) => {
-        event.preventDefault();
-      }}
-      {...longPress.handlers}
-      onClick={() => {
-        // The long-press already answered this gesture; picking as well
-        // would move the user off the row they were inspecting.
-        if (longPress.consumedTap()) return;
-        props.onOpen();
-      }}
-    >
-      {props.icon}
-      <HighlightedName
-        name={props.name}
-        ranges={props.ranges}
-        className="min-w-0 flex-1 truncate text-left font-normal"
-      />
-    </Button>
+    // Hover is the pointer's half of the long-press: `useLongPress` is touch
+    // only by design, so without this a mouse has no way at all to reach the
+    // absolute path behind an abbreviated row.
+    <FilePathTooltip content={props.fullPath} side="bottom">
+      <Button
+        type="button"
+        variant="ghost"
+        tabIndex={-1}
+        role={props.option === null ? undefined : "option"}
+        id={props.option?.id}
+        aria-selected={props.option?.selected}
+        className={cn(
+          "h-10 w-full justify-start gap-2 px-2 hover:bg-foreground/8",
+          props.option?.selected === true &&
+            "bg-foreground/8 hover:bg-foreground/8",
+        )}
+        data-testid={props.testId}
+        // Keep focus (and the keyboard model) on the combobox field.
+        onMouseDown={(event) => {
+          event.preventDefault();
+        }}
+        {...longPress.handlers}
+        onClick={() => {
+          // The long-press already answered this gesture; picking as well
+          // would move the user off the row they were inspecting.
+          if (longPress.consumedTap()) return;
+          props.onOpen();
+        }}
+      >
+        {props.icon}
+        {props.truncateFrom === "start" ? (
+          <StartTruncatedText className="min-w-0 flex-1 font-normal">
+            {props.name}
+          </StartTruncatedText>
+        ) : (
+          <HighlightedName
+            name={props.name}
+            ranges={props.ranges}
+            className="min-w-0 flex-1 truncate text-left font-normal"
+          />
+        )}
+      </Button>
+    </FilePathTooltip>
   );
 }
 
@@ -716,6 +739,8 @@ function RemoteFolderPickerRecents(props: {
               <PickerRow
                 name={relative ?? tildeCollapse(entry.path, props.homePath)}
                 ranges={[]}
+                fullPath={entry.path}
+                truncateFrom="start"
                 option={null}
                 testId="remote-folder-picker-recent"
                 icon={
@@ -743,7 +768,12 @@ function RemoteFolderPickerListing(props: {
   readonly matches:
     | ReadonlyArray<FuzzyMatch<WorkspaceBrowseFolderEntryV11>>
     | undefined;
-  readonly upPresent: boolean;
+  /**
+   * Where `..` leads, or null when there is no up row. One nullable prop
+   * rather than a path beside a boolean: the row and its destination appear
+   * and disappear together, so a present row with no path is not a state.
+   */
+  readonly upPath: string | null;
   readonly selectedIndex: number;
   readonly filtering: boolean;
   readonly homePath: string | null;
@@ -761,37 +791,41 @@ function RemoteFolderPickerListing(props: {
   // The <li> wrappers are therefore `role="presentation"` - a listbox must own
   // its options directly, and an <li> sitting between the two is an invalid
   // owned-element hop.
-  if (props.upPresent) {
+  if (props.upPath !== null) {
     rows.push(
       <li key=".." role="presentation">
-        <Button
-          type="button"
-          variant="ghost"
-          tabIndex={-1}
-          role="option"
-          id={pickerOptionId(0)}
-          aria-selected={props.selectedIndex === 0}
-          className={cn(
-            "h-10 w-full justify-start gap-2 px-2 hover:bg-foreground/8",
-            props.selectedIndex === 0 &&
-              "bg-foreground/8 hover:bg-foreground/8",
-          )}
-          data-testid="remote-folder-picker-up-row"
-          // Keep focus (and the keyboard model) on the combobox field.
-          onMouseDown={(event) => {
-            event.preventDefault();
-          }}
-          onClick={props.onUp}
-        >
-          <CornerLeftUp className="size-4 shrink-0 text-muted-foreground" />
-          <span className="min-w-0 flex-1 truncate text-left font-normal">
-            ..
-          </span>
-        </Button>
+        {/* `..` is the one label that names no path at all, so the hover is
+            the only thing that says where the row goes. */}
+        <FilePathTooltip content={props.upPath} side="bottom">
+          <Button
+            type="button"
+            variant="ghost"
+            tabIndex={-1}
+            role="option"
+            id={pickerOptionId(0)}
+            aria-selected={props.selectedIndex === 0}
+            className={cn(
+              "h-10 w-full justify-start gap-2 px-2 hover:bg-foreground/8",
+              props.selectedIndex === 0 &&
+                "bg-foreground/8 hover:bg-foreground/8",
+            )}
+            data-testid="remote-folder-picker-up-row"
+            // Keep focus (and the keyboard model) on the combobox field.
+            onMouseDown={(event) => {
+              event.preventDefault();
+            }}
+            onClick={props.onUp}
+          >
+            <CornerLeftUp className="size-4 shrink-0 text-muted-foreground" />
+            <span className="min-w-0 flex-1 truncate text-left font-normal">
+              ..
+            </span>
+          </Button>
+        </FilePathTooltip>
       </li>,
     );
   }
-  const offset = props.upPresent ? 1 : 0;
+  const offset = props.upPath === null ? 0 : 1;
   (props.error === null ? (props.matches ?? []) : []).forEach(
     (match, index) => {
       rows.push(
@@ -799,6 +833,8 @@ function RemoteFolderPickerListing(props: {
           <PickerRow
             name={match.item.name}
             ranges={match.ranges}
+            fullPath={match.item.path}
+            truncateFrom="end"
             option={{
               id: pickerOptionId(index + offset),
               selected: props.selectedIndex === index + offset,

--- a/clients/gui-app/src/components/worktree/worktree-folder-list.tsx
+++ b/clients/gui-app/src/components/worktree/worktree-folder-list.tsx
@@ -116,8 +116,15 @@ export function WorktreeFolderList(props: WorktreeFolderListProps): ReactNode {
                     className="min-w-0 flex-1"
                   >
                     <div className="truncate font-medium">{label}</div>
+                    {/* `pointer-events-auto` re-opens the one hole this row
+                        needs. A disabled CommandItem takes
+                        `pointer-events-none` for the whole row, and a
+                        `checking`/`missing` worktree - still visible, and the
+                        row whose location someone most wants to read - would
+                        otherwise have no reachable trigger. Selection stays
+                        shut: `onSelect` returns early while disabled. */}
                     <FilePathTooltip content={secondary} side="bottom">
-                      <StartTruncatedText className="block min-w-0 text-ui-xs text-muted-foreground">
+                      <StartTruncatedText className="pointer-events-auto block min-w-0 text-ui-xs text-muted-foreground">
                         {secondary}
                       </StartTruncatedText>
                     </FilePathTooltip>

--- a/clients/gui-app/src/components/worktree/worktree-folder-list.tsx
+++ b/clients/gui-app/src/components/worktree/worktree-folder-list.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/ui/command";
 import { DropdownMenuLabel } from "@/components/ui/dropdown-menu";
 import { StartTruncatedText } from "@/components/ui/start-truncated-text";
+import { FilePathTooltip } from "@/components/file-path-tooltip";
 import { formatGitWorktreeLabel } from "@/lib/git/worktree-label";
 import { cn } from "@/lib/utils";
 import { worktreeRowKey } from "@/lib/worktree/worktree-row-key";
@@ -115,9 +116,11 @@ export function WorktreeFolderList(props: WorktreeFolderListProps): ReactNode {
                     className="min-w-0 flex-1"
                   >
                     <div className="truncate font-medium">{label}</div>
-                    <StartTruncatedText className="block min-w-0 text-ui-xs text-muted-foreground">
-                      {secondary}
-                    </StartTruncatedText>
+                    <FilePathTooltip content={secondary} side="bottom">
+                      <StartTruncatedText className="block min-w-0 text-ui-xs text-muted-foreground">
+                        {secondary}
+                      </StartTruncatedText>
+                    </FilePathTooltip>
                   </div>
                   {badge === null ? null : (
                     <WorktreeRowStatusBadge


### PR DESCRIPTION
## Summary

The remote folder picker abbreviates every row — a directory shows its leaf name, a recent shows a path relative to the group's shared base — and `FullPathSheet` is the escape hatch that makes abbreviating safe. Only a long-press opened it, and `useLongPress` is touch-only by design ("a mouse already has a right-click and a long left-click there is an interrupted drag rather than an intent"), so a pointer had **no way at all** to reach the absolute path.

Reported from a remote-host session, where recents span two machines' roots and every row renders its whole path.

## Changes

**Hover reveals the path.** Rows are wrapped in `FilePathTooltip`, the app's existing path-hover component, carrying the same absolute path long-press already showed. The `..` row gets one too — it is the one label that names no destination.

**Recents truncated the wrong way.** When entries share no common base, `commonBasePath` returns null, the heading falls back to a plain "Recent" and each row renders its whole path. End-truncation then drops the leaf that identifies the row while keeping the prefix every row repeats. Recents now truncate from the front, like every other path in the app.

**One implementation of path display.** `TailAnchoredPath` is dropped for the shared `StartTruncatedText` — identical rtl-outer/ltr-inner mechanism, just inline styles instead of Tailwind classes.

**Three sibling surfaces** were missing the same hover, each verified by tracing its parents rather than grepping the component alone:

| Surface | Path | Also fixed |
| --- | --- | --- |
| Worktree dropdown (`folder-location-control`) | `row.worktreePath` | — |
| Terminal directory picker | `workspacePath` | end-truncated a path |
| Worktree folder list | per-row path | — |

Those tooltips are scoped to the path text rather than the whole row: safe inside both cmdk and Radix menu items, and matching how `folder-row.tsx` already scopes its own tooltip in that neighbourhood.

## Deliberately not changed

`worktree-picker-trigger` shows a path with no tooltip, but it is shared by two callers that disagree — the diff panel's repo switcher already wraps it in a tooltip whose text includes a `Path:` line, while the epic-canvas sidebar wraps it in nothing. A tooltip inside the component would double up on hover in the diff panel. Left for a separate change.

## Validation

- `bun run --filter @traycer-clients/gui-app compile` — clean
- 225 tests pass across the 7 suites touching these files, including 3 new ones asserting the short-name/full-path pairing (a recent row shows `app` while its tooltip carries `/srv/app`)
- Pre-commit: build · compile · lint · format (nx affected) — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)