### PR TITLE
feat(cli): add safe file and stdin inputs to agent send

### DIFF
--- a/clients/traycer-cli/README.md
+++ b/clients/traycer-cli/README.md
@@ -89,9 +89,16 @@ Traycer-launched agent sessions receive environment variables such as `TRAYCER_A
 traycer agent list
 traycer agent inbox
 traycer agent send --to <agent-id> --message "Can you review this change?"
+traycer agent send --to <agent-id> --message-file ./prompt.txt
+printf '%s' "$PROMPT" | traycer agent send --to <agent-id> --stdin
 traycer workspace list
 traycer worktree create --workspace /path/to/repo --branch my-feature
 ```
+
+`agent send` requires exactly one prompt source: `--message`,
+`--message-file`, or `--stdin`.
+For sensitive prompts, prefer `--stdin` or `--message-file`: the legacy
+`--message` spelling remains visible in process argv and may enter shell history.
 
 These commands are mainly intended for Traycer-managed automation, but they are regular CLI commands and can be scripted when the host is running and the required IDs are supplied.
 

--- a/clients/traycer-cli/src/commands/__tests__/agent-send.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/agent-send.test.ts
@@ -90,6 +90,7 @@ function buildCommand(
 function stubStdin(value: {
   readonly isTTY: boolean;
   readonly chunks?: readonly (Buffer | string)[];
+  readonly onChunkRead?: (index: number) => void;
   readonly reject?: boolean;
 }): Mock {
   const destroy = vi.fn();
@@ -99,7 +100,8 @@ function stubStdin(value: {
       isTTY: value.isTTY,
       destroy,
       async *[Symbol.asyncIterator]() {
-        for (const chunk of value.chunks ?? []) {
+        for (const [index, chunk] of (value.chunks ?? []).entries()) {
+          value.onChunkRead?.(index);
           yield Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
         }
         if (value.reject === true) throw new Error("private stream failure");
@@ -253,7 +255,12 @@ describe("agent send prompt sources", () => {
       Buffer.from(privatePrefix),
       Buffer.alloc(A2A_MESSAGE_MAX_UTF8_BYTES + 1 - privatePrefix.length, 0x73),
     ]);
-    const destroy = stubStdin({ isTTY: false, chunks: [prompt] });
+    const onChunkRead = vi.fn();
+    const destroy = stubStdin({
+      isTTY: false,
+      chunks: [prompt, "sentinel chunk must not be consumed"],
+      onChunkRead,
+    });
 
     const error = await captureError(buildCommand({ stdin: true }));
 
@@ -263,6 +270,8 @@ describe("agent send prompt sources", () => {
       details: null,
     });
     expect(destroy).toHaveBeenCalledTimes(1);
+    expect(onChunkRead).toHaveBeenCalledTimes(1);
+    expect(onChunkRead).toHaveBeenCalledWith(0);
     expect(rpcMock).not.toHaveBeenCalled();
     expectNoPromptLeak(privatePrefix, error);
   });

--- a/clients/traycer-cli/src/commands/__tests__/agent-send.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/agent-send.test.ts
@@ -209,6 +209,31 @@ describe("agent send prompt sources", () => {
     expectNoPromptLeak(privatePrefix, error);
   });
 
+  it("rejects malformed UTF-8 from --message-file without echoing content or path", async () => {
+    const privatePrefix = "private malformed file prompt";
+    const directory = await mkdtemp(join(tmpdir(), "traycer-agent-send-"));
+    tempDirs.push(directory);
+    const privatePath = join(directory, "private-prompt-name.txt");
+    await writeFile(
+      privatePath,
+      Buffer.concat([Buffer.from(privatePrefix), Buffer.from([0xc3, 0x28])]),
+    );
+
+    const error = await captureError(
+      buildCommand({ messageFile: privatePath }),
+    );
+
+    expect(error).toMatchObject({
+      code: CLI_ERROR_CODES.INVALID_ARGUMENT,
+      message: "traycer agent send: --message-file must contain valid UTF-8.",
+      details: null,
+      exitCode: 1,
+    });
+    expect(rpcMock).not.toHaveBeenCalled();
+    expectNoPromptLeak(privatePrefix, error);
+    expectNoPromptLeak(privatePath, error);
+  });
+
   it("reads --stdin exactly and does not return or log its prompt", async () => {
     const prompt = "piped prompt\nwith formatting";
     stubStdin({ isTTY: false, chunks: ["piped ", "prompt\nwith formatting"] });
@@ -257,6 +282,30 @@ describe("agent send prompt sources", () => {
     const prompt = lastSentPrompt();
     expect(prompt.endsWith("é")).toBe(true);
     expect(utf8ByteLength(prompt)).toBe(A2A_MESSAGE_MAX_UTF8_BYTES);
+  });
+
+  it("rejects malformed UTF-8 split across stdin chunks without echoing content", async () => {
+    const privatePrefix = "private malformed stdin prompt";
+    stubStdin({
+      isTTY: false,
+      chunks: [
+        Buffer.from(privatePrefix),
+        Buffer.from([0xe2]),
+        Buffer.from([0x28, 0xa1]),
+      ],
+    });
+
+    const error = await captureError(buildCommand({ stdin: true }));
+
+    expect(error).toMatchObject({
+      code: CLI_ERROR_CODES.INVALID_ARGUMENT,
+      message:
+        "traycer agent send: the prompt from stdin must contain valid UTF-8.",
+      details: null,
+      exitCode: 1,
+    });
+    expect(rpcMock).not.toHaveBeenCalled();
+    expectNoPromptLeak(privatePrefix, error);
   });
 
   it("rejects a multibyte character that crosses the byte limit", async () => {

--- a/clients/traycer-cli/src/commands/__tests__/agent-send.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/agent-send.test.ts
@@ -236,6 +236,19 @@ describe("agent send prompt sources", () => {
     expectNoPromptLeak(privatePath, error);
   });
 
+  it("preserves a leading UTF-8 BOM from --message-file", async () => {
+    const prompt = "\uFEFFprompt whose leading marker must survive";
+    const directory = await mkdtemp(join(tmpdir(), "traycer-agent-send-"));
+    tempDirs.push(directory);
+    const path = join(directory, "prompt.txt");
+    await writeFile(path, prompt, "utf8");
+
+    const result = await buildCommand({ messageFile: path })(makeCtx());
+
+    expect(lastSentPrompt()).toBe(prompt);
+    expectNoPromptLeak(prompt, result);
+  });
+
   it("reads --stdin exactly and does not return or log its prompt", async () => {
     const prompt = "piped prompt\nwith formatting";
     stubStdin({ isTTY: false, chunks: ["piped ", "prompt\nwith formatting"] });

--- a/clients/traycer-cli/src/commands/__tests__/agent-send.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/agent-send.test.ts
@@ -1,0 +1,362 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type Mock,
+} from "vitest";
+import {
+  A2A_MESSAGE_MAX_UTF8_BYTES,
+  utf8ByteLength,
+} from "@traycer/protocol/host/agent/shared";
+import { buildAgentSendCommand } from "../agent-send";
+import { callHostRpc } from "../../internal/host-rpc";
+import { noopLogger } from "../../logger";
+import { CLI_ERROR_CODES, CliError } from "../../runner/errors";
+import type { CommandContext, CommandFn } from "../../runner/runner";
+
+const loggerMock = vi.hoisted(() => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock("../../logger", () => ({
+  createCliLogger: () => loggerMock,
+  errorFromUnknown: (value: unknown) =>
+    value instanceof Error ? value : new Error(String(value)),
+  noopLogger: loggerMock,
+}));
+
+vi.mock("../../internal/host-rpc", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../internal/host-rpc")
+  >("../../internal/host-rpc");
+  return { ...actual, callHostRpc: vi.fn() };
+});
+
+const rpcMock = vi.mocked(callHostRpc);
+const realStdin = Object.getOwnPropertyDescriptor(process, "stdin");
+const tempDirs: string[] = [];
+
+function makeCtx(): CommandContext {
+  return {
+    runtime: {
+      json: false,
+      quiet: false,
+      noProgress: false,
+      noBootstrap: false,
+      nonInteractive: false,
+      environment: "production",
+      logger: noopLogger,
+    },
+    output: {
+      progress: vi.fn(),
+      human: vi.fn(),
+      humanRequired: vi.fn(),
+      emitResult: vi.fn(),
+      emitError: vi.fn(),
+    },
+    progress: vi.fn(),
+  };
+}
+
+function buildCommand(
+  prompt: Partial<{
+    readonly message: string | null;
+    readonly messageFile: string | null;
+    readonly stdin: boolean;
+  }>,
+) {
+  return buildAgentSendCommand({
+    epicId: "epic-1",
+    senderAgentId: "agent-sender",
+    to: "agent-receiver",
+    message: null,
+    messageFile: null,
+    stdin: false,
+    expectReply: false,
+    responseId: null,
+    ...prompt,
+  });
+}
+
+function stubStdin(value: {
+  readonly isTTY: boolean;
+  readonly chunks?: readonly (Buffer | string)[];
+  readonly reject?: boolean;
+}): Mock {
+  const destroy = vi.fn();
+  Object.defineProperty(process, "stdin", {
+    configurable: true,
+    value: {
+      isTTY: value.isTTY,
+      destroy,
+      async *[Symbol.asyncIterator]() {
+        for (const chunk of value.chunks ?? []) {
+          yield Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+        }
+        if (value.reject === true) throw new Error("private stream failure");
+      },
+    },
+  });
+  return destroy;
+}
+
+async function captureError(command: CommandFn): Promise<CliError> {
+  const error = await command(makeCtx()).catch((value: unknown) => value);
+  expect(error).toBeInstanceOf(CliError);
+  if (!(error instanceof CliError)) throw new Error("unreachable");
+  return error;
+}
+
+function expectNoPromptLeak(prompt: string, value: unknown): void {
+  expect(String(value)).not.toContain(prompt);
+  expect(JSON.stringify(value)).not.toContain(prompt);
+  expect(
+    JSON.stringify(Object.values(loggerMock).map((mock) => mock.mock.calls)),
+  ).not.toContain(prompt);
+}
+
+function lastSentPrompt(): string {
+  const request: unknown = rpcMock.mock.lastCall?.[1];
+  if (typeof request !== "object" || request === null) {
+    throw new Error("agent.sendMessage request was not recorded");
+  }
+  const prompt = Reflect.get(request, "prompt");
+  if (typeof prompt !== "string") {
+    throw new Error("agent.sendMessage request has no prompt");
+  }
+  return prompt;
+}
+
+const TOO_LARGE_MESSAGE = `traycer agent send: prompt exceeds the ${A2A_MESSAGE_MAX_UTF8_BYTES}-byte UTF-8 limit.`;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  rpcMock.mockResolvedValue({ responseId: null });
+});
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  if (realStdin !== undefined)
+    Object.defineProperty(process, "stdin", realStdin);
+  await Promise.all(
+    tempDirs
+      .splice(0)
+      .map((path) => rm(path, { recursive: true, force: true })),
+  );
+});
+
+describe("agent send prompt sources", () => {
+  it("preserves the existing --message request without returning or logging the prompt", async () => {
+    const prompt = "inline prompt: do not disclose";
+    const result = await buildCommand({ message: prompt })(makeCtx());
+
+    expect(rpcMock).toHaveBeenCalledWith("agent.sendMessage", {
+      senderAgentId: "agent-sender",
+      epicId: "epic-1",
+      receiverAgentId: "agent-receiver",
+      prompt,
+      responseId: null,
+      expectReply: false,
+    });
+    expect(result).toEqual({
+      data: { responseId: null },
+      human: "sent to agent-receiver",
+      exitCode: 0,
+    });
+    expectNoPromptLeak(prompt, result);
+  });
+
+  it("accepts a --message-file exactly at the canonical UTF-8 byte limit", async () => {
+    const prompt = "f".repeat(A2A_MESSAGE_MAX_UTF8_BYTES);
+    const directory = await mkdtemp(join(tmpdir(), "traycer-agent-send-"));
+    tempDirs.push(directory);
+    const path = join(directory, "prompt.txt");
+    await writeFile(path, prompt, "utf8");
+
+    const result = await buildCommand({ messageFile: path })(makeCtx());
+
+    expect(utf8ByteLength(lastSentPrompt())).toBe(A2A_MESSAGE_MAX_UTF8_BYTES);
+    expectNoPromptLeak(prompt, result);
+  });
+
+  it("stops and rejects a --message-file at limit plus one byte", async () => {
+    const privatePrefix = "private file prompt";
+    const prompt = `${privatePrefix}${"f".repeat(
+      A2A_MESSAGE_MAX_UTF8_BYTES + 1 - privatePrefix.length,
+    )}`;
+    const directory = await mkdtemp(join(tmpdir(), "traycer-agent-send-"));
+    tempDirs.push(directory);
+    const path = join(directory, "prompt.txt");
+    await writeFile(path, prompt, "utf8");
+
+    const error = await captureError(buildCommand({ messageFile: path }));
+
+    expect(error).toMatchObject({
+      code: CLI_ERROR_CODES.INVALID_ARGUMENT,
+      message: TOO_LARGE_MESSAGE,
+      details: null,
+    });
+    expect(rpcMock).not.toHaveBeenCalled();
+    expectNoPromptLeak(privatePrefix, error);
+  });
+
+  it("reads --stdin exactly and does not return or log its prompt", async () => {
+    const prompt = "piped prompt\nwith formatting";
+    stubStdin({ isTTY: false, chunks: ["piped ", "prompt\nwith formatting"] });
+
+    const result = await buildCommand({ stdin: true })(makeCtx());
+
+    expect(rpcMock).toHaveBeenCalledWith(
+      "agent.sendMessage",
+      expect.objectContaining({ prompt }),
+    );
+    expectNoPromptLeak(prompt, result);
+  });
+
+  it("stops and rejects --stdin at limit plus one byte", async () => {
+    const privatePrefix = "private stdin prompt";
+    const prompt = Buffer.concat([
+      Buffer.from(privatePrefix),
+      Buffer.alloc(A2A_MESSAGE_MAX_UTF8_BYTES + 1 - privatePrefix.length, 0x73),
+    ]);
+    const destroy = stubStdin({ isTTY: false, chunks: [prompt] });
+
+    const error = await captureError(buildCommand({ stdin: true }));
+
+    expect(error).toMatchObject({
+      code: CLI_ERROR_CODES.INVALID_ARGUMENT,
+      message: TOO_LARGE_MESSAGE,
+      details: null,
+    });
+    expect(destroy).toHaveBeenCalledTimes(1);
+    expect(rpcMock).not.toHaveBeenCalled();
+    expectNoPromptLeak(privatePrefix, error);
+  });
+
+  it("accepts a multibyte character split across chunks at the exact byte limit", async () => {
+    stubStdin({
+      isTTY: false,
+      chunks: [
+        Buffer.alloc(A2A_MESSAGE_MAX_UTF8_BYTES - 2, 0x61),
+        Buffer.from([0xc3]),
+        Buffer.from([0xa9]),
+      ],
+    });
+
+    await buildCommand({ stdin: true })(makeCtx());
+
+    const prompt = lastSentPrompt();
+    expect(prompt.endsWith("é")).toBe(true);
+    expect(utf8ByteLength(prompt)).toBe(A2A_MESSAGE_MAX_UTF8_BYTES);
+  });
+
+  it("rejects a multibyte character that crosses the byte limit", async () => {
+    const destroy = stubStdin({
+      isTTY: false,
+      chunks: [
+        Buffer.alloc(A2A_MESSAGE_MAX_UTF8_BYTES - 1, 0x61),
+        Buffer.from([0xc3]),
+        Buffer.from([0xa9]),
+      ],
+    });
+
+    const error = await captureError(buildCommand({ stdin: true }));
+
+    expect(error).toMatchObject({
+      code: CLI_ERROR_CODES.INVALID_ARGUMENT,
+      message: TOO_LARGE_MESSAGE,
+      details: null,
+    });
+    expect(destroy).toHaveBeenCalledTimes(1);
+    expect(rpcMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["no source", {}],
+    [
+      "message and file",
+      { message: "private-inline", messageFile: "/private-file" },
+    ],
+    ["message and stdin", { message: "private-inline", stdin: true }],
+    ["file and stdin", { messageFile: "/private-file", stdin: true }],
+    [
+      "all sources",
+      { message: "private-inline", messageFile: "/private-file", stdin: true },
+    ],
+  ])(
+    "rejects %s before reading input or calling the host",
+    async (_label, prompt) => {
+      const iterator = vi.fn(() => {
+        throw new Error("stdin must not be read");
+      });
+      Object.defineProperty(process, "stdin", {
+        configurable: true,
+        value: { isTTY: false, [Symbol.asyncIterator]: iterator },
+      });
+
+      const error = await captureError(buildCommand(prompt));
+
+      expect(error).toMatchObject({
+        code: CLI_ERROR_CODES.INVALID_ARGUMENT,
+        message:
+          "traycer agent send: exactly one of --message, --message-file, or --stdin is required.",
+        details: null,
+        exitCode: 1,
+      });
+      expect(iterator).not.toHaveBeenCalled();
+      expect(rpcMock).not.toHaveBeenCalled();
+      expectNoPromptLeak("private-inline", error);
+    },
+  );
+
+  it("reports an unreadable message file without echoing its path", async () => {
+    const privatePath = "/missing/private-prompt-name";
+
+    const error = await captureError(
+      buildCommand({ messageFile: privatePath }),
+    );
+
+    expect(error).toMatchObject({
+      code: CLI_ERROR_CODES.INVALID_ARGUMENT,
+      message: "traycer agent send: could not read --message-file.",
+      details: null,
+    });
+    expect(rpcMock).not.toHaveBeenCalled();
+    expectNoPromptLeak(privatePath, error);
+  });
+
+  it("refuses a TTY for --stdin instead of waiting interactively", async () => {
+    stubStdin({ isTTY: true });
+
+    const error = await captureError(buildCommand({ stdin: true }));
+
+    expect(error).toMatchObject({
+      code: CLI_ERROR_CODES.INVALID_ARGUMENT,
+      message: "traycer agent send: --stdin requires piped input.",
+    });
+    expect(rpcMock).not.toHaveBeenCalled();
+  });
+
+  it("maps stdin stream failures to a prompt-free error", async () => {
+    const partialPrompt = "partially read private prompt";
+    stubStdin({ isTTY: false, chunks: [partialPrompt], reject: true });
+
+    const error = await captureError(buildCommand({ stdin: true }));
+
+    expect(error).toMatchObject({
+      code: CLI_ERROR_CODES.INVALID_ARGUMENT,
+      message: "traycer agent send: could not read the prompt from stdin.",
+    });
+    expectNoPromptLeak(partialPrompt, error);
+    expect(rpcMock).not.toHaveBeenCalled();
+  });
+});

--- a/clients/traycer-cli/src/commands/__tests__/cli-entrypoint-registration.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/cli-entrypoint-registration.test.ts
@@ -36,6 +36,16 @@ const mocks = vi.hoisted(() => ({
   }>,
   serviceControllerCalls: [] as string[],
   progressEvents: [] as ProgressInfo[],
+  agentSendCalls: [] as Array<{
+    readonly epicId: string | null;
+    readonly senderAgentId: string | null;
+    readonly to: string;
+    readonly message: string | null;
+    readonly messageFile: string | null;
+    readonly stdin: boolean;
+    readonly expectReply: boolean;
+    readonly responseId: string | null;
+  }>,
 }));
 
 // `host free-port-and-restart`'s handler calls `createServiceController().restart(...)`
@@ -231,6 +241,17 @@ vi.mock("../../commands/config-env-list", () => ({
     human: null,
     exitCode: 0,
   }),
+}));
+
+// Keep Commander and index.ts's option mapping real while stopping the two
+// agent-send wiring tests below before they read stdin/a file or dial a host.
+vi.mock("../../commands/agent-send", () => ({
+  buildAgentSendCommand:
+    (opts: (typeof mocks.agentSendCalls)[number]): CommandFn =>
+    async () => {
+      mocks.agentSendCalls.push(opts);
+      return { data: { responseId: null }, human: null, exitCode: 0 };
+    },
 }));
 
 // Replaces only `runCommand` (which owns `process.exit` - see
@@ -1256,6 +1277,49 @@ describe("traycer CLI entrypoint registration", () => {
     const required = cmd.options.filter((o) => o.mandatory).map((o) => o.long);
     expect(required).toContain("--agent-id");
   });
+
+  it.each([
+    [
+      "--message-file",
+      ["--message-file", "/private/prompt.txt"],
+      { messageFile: "/private/prompt.txt", stdin: false },
+    ],
+    ["--stdin", ["--stdin"], { messageFile: null, stdin: true }],
+  ] as const)(
+    "parses and forwards agent send %s through the real Commander tree",
+    async (_spelling, inputArgs, expected) => {
+      const originalSurface = process.env.TRAYCER_AGENT_CLI_SURFACE;
+      process.env.TRAYCER_AGENT_CLI_SURFACE = "full";
+      mocks.agentSendCalls.length = 0;
+      try {
+        const program = buildProgram();
+        program.exitOverride();
+        await program.parseAsync(
+          ["agent", "send", "--to", "agent-receiver", ...inputArgs],
+          { from: "user" },
+        );
+
+        expect(mocks.agentSendCalls).toEqual([
+          {
+            epicId: null,
+            senderAgentId: null,
+            to: "agent-receiver",
+            message: null,
+            messageFile: expected.messageFile,
+            stdin: expected.stdin,
+            expectReply: false,
+            responseId: null,
+          },
+        ]);
+      } finally {
+        if (originalSurface === undefined) {
+          delete process.env.TRAYCER_AGENT_CLI_SURFACE;
+        } else {
+          process.env.TRAYCER_AGENT_CLI_SURFACE = originalSurface;
+        }
+      }
+    },
+  );
 
   it("limits readonly agent CLI help to inspection commands", () => {
     const originalSurface = process.env.TRAYCER_AGENT_CLI_SURFACE;

--- a/clients/traycer-cli/src/commands/__tests__/rendered-help.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/rendered-help.test.ts
@@ -870,10 +870,12 @@ const EXPECTED_PUBLIC_SURFACE: readonly ExpectedSurfaceEntry[] = [
     options: [
       { flags: "--expect-reply", mandatory: false },
       { flags: "--json", mandatory: false },
-      { flags: "--message <text>", mandatory: true },
+      { flags: "--message <text>", mandatory: false },
+      { flags: "--message-file <path>", mandatory: false },
       { flags: "--no-progress", mandatory: false },
       { flags: "--quiet", mandatory: false },
       { flags: "--response-id <id>", mandatory: false },
+      { flags: "--stdin", mandatory: false },
       { flags: "--to <agentId>", mandatory: true },
     ],
     args: [],

--- a/clients/traycer-cli/src/commands/agent-send.ts
+++ b/clients/traycer-cli/src/commands/agent-send.ts
@@ -179,7 +179,7 @@ async function readBoundedPrompt(input: BoundedPromptInput): Promise<string> {
   if (oversized) throw promptTooLargeError();
   let prompt: string;
   try {
-    prompt = new TextDecoder("utf-8", { fatal: true }).decode(
+    prompt = new TextDecoder("utf-8", { fatal: true, ignoreBOM: true }).decode(
       captured.subarray(0, capturedBytes),
     );
   } catch {

--- a/clients/traycer-cli/src/commands/agent-send.ts
+++ b/clients/traycer-cli/src/commands/agent-send.ts
@@ -1,7 +1,10 @@
 import {
+  A2A_MESSAGE_MAX_UTF8_BYTES,
   sendAgentMessageRequestSchema,
   sendAgentMessageResponseSchema,
+  utf8ByteLength,
 } from "@traycer/protocol/host/agent/shared";
+import { createReadStream } from "node:fs";
 import {
   callHostRpc,
   parseCanonicalHostResponse,
@@ -9,7 +12,20 @@ import {
   toAgentCliError,
 } from "../internal/host-rpc";
 import { resolveEpicId, resolveSenderAgentId } from "../internal/agent-context";
+import { cliError, CLI_ERROR_CODES } from "../runner/errors";
 import type { CommandFn } from "../runner/runner";
+
+interface AgentSendPromptOptions {
+  readonly message: string | null;
+  readonly messageFile: string | null;
+  readonly stdin: boolean;
+}
+
+interface BoundedPromptInput {
+  readonly stream: AsyncIterable<Buffer | string>;
+  readonly stop: () => void;
+  readonly readErrorMessage: string;
+}
 
 /**
  * `traycer agent send` - hand a prompt to another agent
@@ -26,16 +42,19 @@ export function buildAgentSendCommand(opts: {
   readonly epicId: string | null;
   readonly senderAgentId: string | null;
   readonly to: string;
-  readonly message: string;
+  readonly message: string | null;
+  readonly messageFile: string | null;
+  readonly stdin: boolean;
   readonly expectReply: boolean;
   readonly responseId: string | null;
 }): CommandFn {
   return async () => {
+    const prompt = await resolvePrompt(opts);
     const request = parseUserInput(sendAgentMessageRequestSchema, {
       senderAgentId: resolveSenderAgentId(opts.senderAgentId),
       epicId: resolveEpicId(opts.epicId),
       receiverAgentId: opts.to,
-      prompt: opts.message,
+      prompt,
       responseId: opts.responseId,
       expectReply: opts.expectReply,
     });
@@ -53,4 +72,123 @@ export function buildAgentSendCommand(opts: {
         : `sent to ${opts.to} (responseId: ${responseId})`;
     return { data: { responseId }, human, exitCode: 0 };
   };
+}
+
+async function resolvePrompt(opts: AgentSendPromptOptions): Promise<string> {
+  const sourceCount = [
+    opts.message !== null,
+    opts.messageFile !== null,
+    opts.stdin,
+  ].filter(Boolean).length;
+  if (sourceCount !== 1) {
+    throw cliError({
+      code: CLI_ERROR_CODES.INVALID_ARGUMENT,
+      message:
+        "traycer agent send: exactly one of --message, --message-file, or --stdin is required.",
+      details: null,
+      exitCode: 1,
+    });
+  }
+
+  if (opts.message !== null) return validatePromptSize(opts.message);
+  if (opts.messageFile !== null) {
+    const stream = createReadStream(opts.messageFile, {
+      // `end` is inclusive: this caps the read at limit + 1 bytes, which is
+      // enough to distinguish an accepted prompt from an oversized one.
+      end: A2A_MESSAGE_MAX_UTF8_BYTES,
+    });
+    return readBoundedPrompt({
+      stream,
+      stop: () => stream.destroy(),
+      readErrorMessage: "traycer agent send: could not read --message-file.",
+    });
+  }
+  return readPromptFromStdin();
+}
+
+async function readPromptFromStdin(): Promise<string> {
+  if (process.stdin.isTTY === true) {
+    throw cliError({
+      code: CLI_ERROR_CODES.INVALID_ARGUMENT,
+      message: "traycer agent send: --stdin requires piped input.",
+      details: null,
+      exitCode: 1,
+    });
+  }
+
+  return readBoundedPrompt({
+    stream: process.stdin,
+    stop: () => process.stdin.destroy(),
+    readErrorMessage:
+      "traycer agent send: could not read the prompt from stdin.",
+  });
+}
+
+async function readBoundedPrompt(input: BoundedPromptInput): Promise<string> {
+  const captureLimit = A2A_MESSAGE_MAX_UTF8_BYTES + 1;
+  let captured = Buffer.allocUnsafe(Math.min(64 * 1024, captureLimit));
+  let capturedBytes = 0;
+  let oversized = false;
+  try {
+    for await (const chunk of input.stream) {
+      const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      const targetBytes = Math.min(captureLimit, capturedBytes + bytes.length);
+      if (targetBytes > captured.length) {
+        // Grow geometrically so a producer yielding tiny chunks cannot create
+        // millions of retained Buffer objects before reaching the byte limit.
+        let nextCapacity = captured.length;
+        while (nextCapacity < targetBytes) {
+          nextCapacity = Math.min(captureLimit, nextCapacity * 2);
+        }
+        const grown = Buffer.allocUnsafe(nextCapacity);
+        captured.copy(grown, 0, 0, capturedBytes);
+        captured = grown;
+      }
+      capturedBytes += bytes.copy(
+        captured,
+        capturedBytes,
+        0,
+        targetBytes - capturedBytes,
+      );
+      if (capturedBytes > A2A_MESSAGE_MAX_UTF8_BYTES) {
+        oversized = true;
+        try {
+          input.stop();
+        } catch {
+          // Best effort: the overflow result still wins over cleanup failure.
+        }
+        break;
+      }
+    }
+  } catch {
+    if (!oversized) {
+      throw cliError({
+        code: CLI_ERROR_CODES.INVALID_ARGUMENT,
+        message: input.readErrorMessage,
+        details: null,
+        exitCode: 1,
+      });
+    }
+  }
+
+  if (oversized) throw promptTooLargeError();
+  return validatePromptSize(
+    captured.subarray(0, capturedBytes).toString("utf8"),
+  );
+}
+
+function validatePromptSize(prompt: string): string {
+  if (utf8ByteLength(prompt) > A2A_MESSAGE_MAX_UTF8_BYTES) {
+    throw promptTooLargeError();
+  }
+  return prompt;
+}
+
+function promptTooLargeError() {
+  return cliError({
+    code: CLI_ERROR_CODES.INVALID_ARGUMENT,
+    message: `traycer agent send: prompt exceeds the ${A2A_MESSAGE_MAX_UTF8_BYTES}-byte UTF-8 limit.`,
+    details: null,
+    exitCode: 1,
+  });
 }

--- a/clients/traycer-cli/src/commands/agent-send.ts
+++ b/clients/traycer-cli/src/commands/agent-send.ts
@@ -25,6 +25,7 @@ interface BoundedPromptInput {
   readonly stream: AsyncIterable<Buffer | string>;
   readonly stop: () => void;
   readonly readErrorMessage: string;
+  readonly invalidUtf8Message: string;
 }
 
 /**
@@ -101,6 +102,8 @@ async function resolvePrompt(opts: AgentSendPromptOptions): Promise<string> {
       stream,
       stop: () => stream.destroy(),
       readErrorMessage: "traycer agent send: could not read --message-file.",
+      invalidUtf8Message:
+        "traycer agent send: --message-file must contain valid UTF-8.",
     });
   }
   return readPromptFromStdin();
@@ -121,6 +124,8 @@ async function readPromptFromStdin(): Promise<string> {
     stop: () => process.stdin.destroy(),
     readErrorMessage:
       "traycer agent send: could not read the prompt from stdin.",
+    invalidUtf8Message:
+      "traycer agent send: the prompt from stdin must contain valid UTF-8.",
   });
 }
 
@@ -172,9 +177,20 @@ async function readBoundedPrompt(input: BoundedPromptInput): Promise<string> {
   }
 
   if (oversized) throw promptTooLargeError();
-  return validatePromptSize(
-    captured.subarray(0, capturedBytes).toString("utf8"),
-  );
+  let prompt: string;
+  try {
+    prompt = new TextDecoder("utf-8", { fatal: true }).decode(
+      captured.subarray(0, capturedBytes),
+    );
+  } catch {
+    throw cliError({
+      code: CLI_ERROR_CODES.INVALID_ARGUMENT,
+      message: input.invalidUtf8Message,
+      details: null,
+      exitCode: 1,
+    });
+  }
+  return validatePromptSize(prompt);
 }
 
 function validatePromptSize(prompt: string): string {

--- a/clients/traycer-cli/src/index.ts
+++ b/clients/traycer-cli/src/index.ts
@@ -2848,7 +2848,18 @@ function registerAgentCommands(
       .command("send", readonlyHidden)
       .description("Send a prompt to another agent")
       .requiredOption("--to <agentId>", "Receiver agent id")
-      .requiredOption("--message <text>", "Prompt to deliver")
+      .option(
+        "--message <text>",
+        "Prompt to deliver (choose exactly one prompt source)",
+      )
+      .option(
+        "--message-file <path>",
+        "Read the prompt from a UTF-8 file (choose exactly one prompt source)",
+      )
+      .option(
+        "--stdin",
+        "Read the prompt from stdin (choose exactly one prompt source)",
+      )
       .option(
         "--expect-reply",
         "Open or reuse a reply thread; the host returns a responseId. Without it the peer processes your message and never reports back.",
@@ -2862,7 +2873,10 @@ function registerAgentCommands(
         epicId: null,
         senderAgentId: null,
         to: typeof opts.to === "string" ? opts.to : "",
-        message: typeof opts.message === "string" ? opts.message : "",
+        message: typeof opts.message === "string" ? opts.message : null,
+        messageFile:
+          typeof opts.messageFile === "string" ? opts.messageFile : null,
+        stdin: opts.stdin === true,
         expectReply: opts.expectReply === true,
         responseId:
           typeof opts.responseId === "string" ? opts.responseId : null,


### PR DESCRIPTION
## Summary

- Add `--message-file <path>` and explicit `--stdin` prompt sources to `traycer agent send`, while preserving the existing `--message <text>` interface.
- Require exactly one prompt source and avoid including prompt contents in validation errors or command results.
- Bound file and streaming-stdin ingestion to the protocol canonical 16 MiB UTF-8 message limit, stopping reads as soon as overflow is detected.
- Document that `--message` remains visible in process arguments and shell history, and recommend file/stdin transport for sensitive or multiline prompts.

## Related issue

None.

## Testing

- Focused Traycer CLI Vitest suite: 4 files, 162 tests passed
- `pre-commit run --from-ref origin/main --to-ref HEAD`

## Checklist

- [x] Pre-commit static checks pass
- [x] Separate focused CLI tests pass
- [x] Tests added or updated where appropriate
- [x] Commit is signed off per the DCO
