### PR TITLE
fix(gui-app): pin the manual link-code button's label color on the hero

### DIFF
--- a/clients/gui-app/src/components/layout/__tests__/sign-in-button.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/sign-in-button.test.tsx
@@ -542,7 +542,11 @@ describe("link-code entry is gated on the mobile-app PRODUCT signal", () => {
       scan.compareDocumentPosition(signIn) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
     // Manual code entry stays reachable as a tertiary link.
-    expect(screen.getByTestId("link-code-signin-manual")).toBeTruthy();
+    const manual = screen.getByTestId("link-code-signin-manual");
+    expect(manual).toBeTruthy();
+    // The hero's inherited white text must not reach this outline button's
+    // light surface - the label pins its own foreground.
+    expect(manual.className).toContain("text-foreground");
     mobile.cleanupClient();
   });
 

--- a/clients/gui-app/src/components/layout/header/sign-in/link-code-sign-in.tsx
+++ b/clients/gui-app/src/components/layout/header/sign-in/link-code-sign-in.tsx
@@ -294,7 +294,10 @@ export function LinkCodeSignIn(props: {
             {noticeLine}
             {/* A real button in the hero's stack, not a bare text line
                 wedged between two buttons — outline keeps it clearly
-                subordinate to the Scan primary. */}
+                subordinate to the Scan primary. The hero paints white text
+                over its backdrop while `outline` sets a surface with no text
+                color of its own, so the label pins its foreground - otherwise
+                it inherits the hero's white onto the light surface. */}
             <Button
               type="button"
               size="lg"
@@ -303,7 +306,7 @@ export function LinkCodeSignIn(props: {
               onClick={() => {
                 setOpen(true);
               }}
-              className="w-full cursor-pointer"
+              className="w-full cursor-pointer text-foreground"
             >
               Enter code manually
             </Button>


### PR DESCRIPTION
## Summary

On the mobile sign-in hero, the "Enter code manually" button rendered white text on its light surface — invisible (screenshot-reported on device). Mechanism: the hero paints white text over its backdrop, and the `outline` button variant supplies a surface (`bg-background`) with **no text color of its own**, so the label inherited the hero's white. The two sibling buttons carry explicit text colors and were unaffected.

Fix at the call-site: the label pins `text-foreground`. A variant-level default was considered and rejected — it would touch every `outline` call-site in the app for a defect only white-text contexts can produce.

## Validation

- New assertion in `sign-in-button.test.tsx` (mobile hero case): the manual button's class list pins its foreground — red if the fix is reverted.
- Committed `--no-verify` from a fresh worktree without node_modules; CI runs the full workspace gate on this PR.