### PR TITLE
fix(gui-app): apply an appended index delta whose rows the snapshot already counted

### DIFF
--- a/clients/gui-app/src/stores/chats/__tests__/transcript-window.test.ts
+++ b/clients/gui-app/src/stores/chats/__tests__/transcript-window.test.ts
@@ -437,6 +437,43 @@ describe("index deltas", () => {
     expect(appended.skeleton[101]?.rowId).toBe("row-101");
   });
 
+  it("applies an append whose rows a snapshot already counted, at the frame's own ordinals", () => {
+    // The host's append republish emits the bounded snapshot FIRST - stamped
+    // with the post-append `rowCount` and the subscriber's pre-delta
+    // `indexRevision` - and the delta for the same append right behind it. So
+    // the delta lands on a window whose `rowCount` already includes its rows.
+    // Read against `window.rowCount`, that has the `0 !== appendedRows`
+    // signature of a lost frame; voiding on it blanked the transcript and
+    // forced a resnapshot on EVERY append for the life of a turn, which is an
+    // empty chat under an active stream. The frame is self-consistent - its
+    // entries occupy `[rowCount - appended, rowCount)` - so it must apply, and
+    // seat at the frame-derived base rather than one past it.
+    const seeded = applyWindowedSnapshot(emptyTranscriptWindow(), {
+      epoch: 0,
+      rowCount: 1,
+      indexRevision: 0,
+      tail: {
+        fromOrdinal: 0,
+        messages: [userMessage("m-0", 0)],
+        events: [],
+      },
+    });
+    expect(seeded.rowCount).toBe(1);
+
+    const appended = applyIndexChange(seeded, {
+      epoch: 0,
+      rowCount: 1,
+      indexRevision: 1,
+      changes: [{ type: "appended", entries: [skeletonEntry("m-0", 0)] }],
+    });
+
+    expect(appended.invalidated).toBe(false);
+    expect(appended.rowCount).toBe(1);
+    // At ordinal 0 - the ordinal the frame names - not at `window.rowCount`.
+    expect(appended.skeleton[0]?.rowId).toBe("m-0");
+    expect(appended.skeleton[1]).toBeUndefined();
+  });
+
   it("drops the whole span containing a row that was rewritten in place", () => {
     // The whole span, not the row: a span's records are a DEDUPLICATED union
     // across its rows, so the client cannot say which records belong to the

--- a/clients/gui-app/src/stores/chats/__tests__/transcript-window.test.ts
+++ b/clients/gui-app/src/stores/chats/__tests__/transcript-window.test.ts
@@ -472,6 +472,45 @@ describe("index deltas", () => {
     // At ordinal 0 - the ordinal the frame names - not at `window.rowCount`.
     expect(appended.skeleton[0]?.rowId).toBe("m-0");
     expect(appended.skeleton[1]).toBeUndefined();
+    // And the same baseline governs the stream prefix. The snapshot moved
+    // `rowCount` to 1 while the prefix was still 0, so an equality against
+    // `window.rowCount` never holds again: the prefix freezes below `rowCount`
+    // for the rest of the epoch, `skeletonComplete` can never be re-established
+    // from it, and the completion watchdog reads a healthy stream as stalled.
+    expect(appended.skeletonStreamCoveredThrough).toBe(1);
+    expect(appended.skeletonComplete).toBe(true);
+  });
+
+  it("leaves the skeleton incomplete when the append does not fill what the snapshot got ahead by", () => {
+    // The negative that keeps the assertion above from passing for the wrong
+    // reason: re-establishing completeness is conditional on the append
+    // actually accounting for what the snapshot got ahead by, not on the frame
+    // being an append. Here the snapshot moved `rowCount` by three and the
+    // delta names only the last of them, so ordinals 0 and 1 are undelivered -
+    // whatever the cause - and the client must keep saying so.
+    const seeded = applyWindowedSnapshot(emptyTranscriptWindow(), {
+      epoch: 0,
+      rowCount: 3,
+      indexRevision: 0,
+      tail: {
+        fromOrdinal: 0,
+        messages: [userMessage("m-0", 0)],
+        events: [],
+      },
+    });
+
+    const appended = applyIndexChange(seeded, {
+      epoch: 0,
+      rowCount: 3,
+      indexRevision: 1,
+      changes: [{ type: "appended", entries: [skeletonEntry("m-2", 2)] }],
+    });
+
+    expect(appended.invalidated).toBe(false);
+    expect(appended.skeleton[2]?.rowId).toBe("m-2");
+    expect(appended.skeleton[1]).toBeUndefined();
+    expect(appended.skeletonStreamCoveredThrough).toBe(0);
+    expect(appended.skeletonComplete).toBe(false);
   });
 
   it("drops the whole span containing a row that was rewritten in place", () => {
@@ -1697,6 +1736,38 @@ describe("what an overlap keeps", () => {
     // And the span survives - adopting is not the same as contradicting.
     expect(hydratedRecords(described).messages.map((m) => m.messageId)).toEqual(
       ["row-2"],
+    );
+  });
+
+  it("fills them from an appended delta when no chunk will reach them again", () => {
+    // The other authority, and the only one for a row appended AFTER the
+    // skeleton stream finished: a chunk backfilled the tail above, but nothing
+    // re-streams for a row the delta itself introduces. Left unadopted the span
+    // keeps `""` at that ordinal, `transcriptListRows` finds no model with that
+    // id and suppresses the ordinal, and then drops the real model as one the
+    // skeleton has already placed - so the row renders nowhere at all.
+    const seeded = applyWindowedSnapshot(emptyTranscriptWindow(), {
+      epoch: 1,
+      rowCount: 1,
+      indexRevision: 0,
+      tail: {
+        fromOrdinal: 0,
+        messages: [userMessage("row-0", 1)],
+        events: [],
+      },
+    });
+    expect(seeded.spans[0].rowIds).toEqual([""]);
+
+    const described = applyIndexChange(seeded, {
+      epoch: 1,
+      rowCount: 1,
+      indexRevision: 1,
+      changes: [{ type: "appended", entries: [skeletonEntry("row-0", 0)] }],
+    });
+
+    expect(described.spans[0].rowIds).toEqual(["row-0"]);
+    expect(hydratedRecords(described).messages.map((m) => m.messageId)).toEqual(
+      ["row-0"],
     );
   });
 

--- a/clients/gui-app/src/stores/chats/__tests__/windowed-append-republish.test.ts
+++ b/clients/gui-app/src/stores/chats/__tests__/windowed-append-republish.test.ts
@@ -1,10 +1,11 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { JsonContent } from "@traycer/protocol/common/registry";
 import type { Message } from "@traycer/protocol/persistence/epic/schemas";
 import type { RowSkeletonEntry } from "@traycer/protocol/persistence/chat-transcript/row-skeleton";
 import type { ChatStreamCallbacks } from "@traycer-clients/shared/host-transport/chat-stream-client";
 import {
   createChatSessionStore,
+  STREAM_COMPLETION_TIMEOUT_MS,
   type ChatSessionStoreHandle,
 } from "@/stores/chats/chat-session-store";
 import { IMMEDIATE_STREAM_FLUSH_COORDINATOR } from "@/stores/chats/stream-flush-coordinator";
@@ -24,9 +25,10 @@ import { IMMEDIATE_STREAM_FLUSH_COORDINATOR } from "@/stores/chats/stream-flush-
  * that misreading once: it voided the window and requested a resnapshot on
  * EVERY append, which under an active turn is a transcript that is blank for
  * as long as the stream keeps appending - the "launch a task, see an empty
- * chat" regression. These fixtures replay the host's real emission order
- * (captured from a live `ChatSessionManager` running the launch flow) and pin
- * that the window survives it.
+ * chat" regression. The first fixture replays the host's real emission order,
+ * captured from a live `ChatSessionManager` running the launch flow, and pins
+ * that the window survives it; the second holds that order and varies only the
+ * one field the wire lets a producer omit.
  */
 
 const EPIC_ID = "epic-r";
@@ -117,12 +119,19 @@ type WindowedSnapshotFrame = Parameters<
 /**
  * A snapshot as the append republish stamps it: the CURRENT `rowCount` and
  * tail, at the subscriber's held (pre-delta) `indexRevision`.
+ *
+ * `tailRowIds` is what the host actually sends - `chat-session-manager.ts`
+ * always names the tail's rows - and it is passed explicitly here rather than
+ * derived, so a fixture cannot quietly drift onto the positional fallback the
+ * live producer never uses. The one case that DOES omit it is the fallback's
+ * own test below, which says so.
  */
 function republishSnapshot(input: {
   readonly epoch: number;
   readonly rowCount: number;
   readonly indexRevision: number | null;
   readonly tailMessages: readonly Message[];
+  readonly tailRowIds: readonly string[] | undefined;
 }): WindowedSnapshotFrame {
   return {
     kind: "snapshot",
@@ -163,6 +172,8 @@ function republishSnapshot(input: {
       indexRevision: input.indexRevision,
       tail: {
         fromOrdinal: 0,
+        rowIds:
+          input.tailRowIds === undefined ? undefined : [...input.tailRowIds],
         messages: [...input.tailMessages],
         events: [],
       },
@@ -227,6 +238,13 @@ function createHarness(): Harness {
 
 describe("the append republish interleave (bootstrap → accept → snapshot → delta)", () => {
   it("keeps the transcript through a launch-flow turn instead of voiding on every append", () => {
+    // Fake timers throughout, because "the transcript survived" is only half
+    // the claim: the window must also come out of the interleave declaring the
+    // skeleton COMPLETE. It does not travel through `state.messages`, so
+    // nothing above would notice it staying false - but
+    // `chunkedDeliveryIncomplete()` reads it, and the completion watchdog then
+    // spends its per-epoch restream budget resnapshotting a healthy stream.
+    vi.useFakeTimers();
     const harness = createHarness();
     try {
       const cb = harness.callbacks();
@@ -239,6 +257,7 @@ describe("the append republish interleave (bootstrap → accept → snapshot →
           rowCount: 0,
           indexRevision: null,
           tailMessages: [],
+          tailRowIds: [],
         }),
       );
       cb.onSkeletonChunk({
@@ -265,6 +284,7 @@ describe("the append republish interleave (bootstrap → accept → snapshot →
           rowCount: 1,
           indexRevision: 0,
           tailMessages: [userMessage("m-1", 2)],
+          tailRowIds: ["m-1"],
         }),
       );
       cb.onIndexChanged({
@@ -290,6 +310,10 @@ describe("the append republish interleave (bootstrap → accept → snapshot →
         "m-1",
       ]);
       expect(afterUser.transcriptWindow.skeleton[0]?.rowId).toBe("m-1");
+      // The snapshot declared the skeleton short - correctly, at the instant it
+      // landed - and this delta is what fills the ordinal it was short by.
+      expect(afterUser.transcriptWindow.skeletonComplete).toBe(true);
+      expect(afterUser.transcriptWindow.skeletonStreamCoveredThrough).toBe(1);
 
       // 3. The assistant row lands the same way one broadcast later.
       cb.onWindowedSnapshot(
@@ -298,6 +322,7 @@ describe("the append republish interleave (bootstrap → accept → snapshot →
           rowCount: 2,
           indexRevision: 1,
           tailMessages: [userMessage("m-1", 2), assistantMessage("a-1", 3)],
+          tailRowIds: ["m-1", "a-1"],
         }),
       );
       cb.onIndexChanged({
@@ -325,6 +350,93 @@ describe("the append republish interleave (bootstrap → accept → snapshot →
       ).toEqual(["m-1", "a-1"]);
       expect(afterAssistant.transcriptWindow.skeleton[0]?.rowId).toBe("m-1");
       expect(afterAssistant.transcriptWindow.skeleton[1]?.rowId).toBe("a-1");
+      expect(afterAssistant.transcriptWindow.skeletonComplete).toBe(true);
+      expect(afterAssistant.transcriptWindow.skeletonStreamCoveredThrough).toBe(
+        2,
+      );
+
+      // 4. And the stream goes quiet, as a turn does between tokens. A window
+      //    that came out of the interleave still calling its skeleton
+      //    incomplete asks for a full resnapshot here - once per idle window,
+      //    up to `MAX_WATCHDOG_RESTREAMS_PER_EPOCH` - having lost nothing.
+      vi.advanceTimersByTime(STREAM_COMPLETION_TIMEOUT_MS + 1);
+      expect(harness.resnapshotCount()).toBe(0);
+    } finally {
+      harness.handle.dispose();
+      vi.useRealTimers();
+    }
+  });
+
+  it("names the rows it appends to a tail seated without ids", () => {
+    // The positional fallback: `tail.rowIds` is optional on the wire, and a
+    // host that sends none leaves the tail seated with the empty string at
+    // every ordinal (`tailRowIdsFor`). The skeleton stream is what normally
+    // backfills those - but a row appended AFTER that stream finished is one
+    // no chunk will ever revisit, so the delta is the last authority to reach
+    // it. Left unadopted the span keeps `""`, and `transcriptListRows` renders
+    // neither the ordinal (no model is named `""`) nor the model (the skeleton
+    // now names it) - a row the client holds, drawn nowhere.
+    const harness = createHarness();
+    try {
+      const cb = harness.callbacks();
+
+      cb.onWindowedSnapshot(
+        republishSnapshot({
+          epoch: 0,
+          rowCount: 0,
+          indexRevision: null,
+          tailMessages: [],
+          tailRowIds: undefined,
+        }),
+      );
+      cb.onSkeletonChunk({
+        kind: "skeletonChunk",
+        hasBinaryPayload: false,
+        epicId: EPIC_ID,
+        chatId: CHAT_ID,
+        chunk: { epoch: 0, fromOrdinal: 0, entries: [], isFinal: true },
+      });
+      cb.onMessageAccepted({
+        kind: "messageAccepted",
+        hasBinaryPayload: false,
+        epicId: EPIC_ID,
+        chatId: CHAT_ID,
+        message: acceptedUserMessage("m-1", 2),
+      });
+      cb.onWindowedSnapshot(
+        republishSnapshot({
+          epoch: 0,
+          rowCount: 1,
+          indexRevision: 0,
+          tailMessages: [userMessage("m-1", 2)],
+          tailRowIds: undefined,
+        }),
+      );
+      // Seated positionally, with nothing yet to name it.
+      expect(
+        harness.handle.store.getState().transcriptWindow.spans[0]?.rowIds,
+      ).toEqual([""]);
+
+      cb.onIndexChanged({
+        kind: "indexChanged",
+        hasBinaryPayload: false,
+        epicId: EPIC_ID,
+        chatId: CHAT_ID,
+        epoch: 0,
+        rowCount: 1,
+        indexRevision: 1,
+        changes: [
+          { type: "appended", entries: [skeletonEntry("m-1", 0, "user")] },
+        ],
+      });
+
+      const state = harness.handle.store.getState();
+      expect(state.transcriptWindow.spans[0]?.rowIds).toEqual(["m-1"]);
+      // Adopting is not contradicting: the body survives with its identity.
+      expect(state.messages.map((message) => message.messageId)).toEqual([
+        "m-1",
+      ]);
+      expect(harness.resnapshotCount()).toBe(0);
     } finally {
       harness.handle.dispose();
     }

--- a/clients/gui-app/src/stores/chats/__tests__/windowed-append-republish.test.ts
+++ b/clients/gui-app/src/stores/chats/__tests__/windowed-append-republish.test.ts
@@ -1,0 +1,308 @@
+import { describe, expect, it } from "vitest";
+import type { JsonContent } from "@traycer/protocol/common/registry";
+import type { Message } from "@traycer/protocol/persistence/epic/schemas";
+import type { RowSkeletonEntry } from "@traycer/protocol/persistence/chat-transcript/row-skeleton";
+import type { ChatStreamCallbacks } from "@traycer-clients/shared/host-transport/chat-stream-client";
+import {
+  createChatSessionStore,
+  type ChatSessionStoreHandle,
+} from "@/stores/chats/chat-session-store";
+import { IMMEDIATE_STREAM_FLUSH_COORDINATOR } from "@/stores/chats/stream-flush-coordinator";
+
+/**
+ * # The append republish interleave
+ *
+ * The host's append broadcast emits, in one synchronous pass and in this
+ * order: the shared frames (`messageAccepted` / `eventAppended`), then the
+ * bounded SNAPSHOT - stamped with the post-append `rowCount` but the
+ * subscriber's PRE-delta `indexRevision` - and then the `indexChanged` delta
+ * for that same append. So the delta always lands on a window whose
+ * `rowCount` already includes its rows.
+ *
+ * Read naively against `window.rowCount`, every such delta has the
+ * `0 !== appendedRows` signature of a lost frame. The client shipped exactly
+ * that misreading once: it voided the window and requested a resnapshot on
+ * EVERY append, which under an active turn is a transcript that is blank for
+ * as long as the stream keeps appending - the "launch a task, see an empty
+ * chat" regression. These fixtures replay the host's real emission order
+ * (captured from a live `ChatSessionManager` running the launch flow) and pin
+ * that the window survives it.
+ */
+
+const EPIC_ID = "epic-r";
+const CHAT_ID = "chat-r";
+const OWNER_ID = "owner-1";
+
+const CONTENT: JsonContent = {
+  type: "doc",
+  content: [{ type: "paragraph", content: [{ type: "text", text: "hi" }] }],
+};
+
+function userMessage(messageId: string, timestamp: number): Message {
+  return {
+    role: "user",
+    messageId,
+    sender: { type: "user", userId: OWNER_ID },
+    message: { kind: "user", content: CONTENT, browserAnnotations: [] },
+    timestamp,
+    sessionAnchor: null,
+  };
+}
+
+function assistantMessage(messageId: string, timestamp: number): Message {
+  return {
+    role: "assistant",
+    messageId,
+    sender: {
+      type: "agent",
+      harnessId: "claude",
+      agentId: "claude",
+      displayName: "Claude",
+      reply: { expectsReply: false },
+      inReplyTo: null,
+    },
+    blocks: [],
+    startedAt: timestamp,
+    timestamp,
+    turnId: "turn-1",
+    usage: null,
+    reasoningEffort: null,
+    serviceTier: null,
+    imageResolutions: [],
+  };
+}
+
+function skeletonEntry(
+  rowId: string,
+  ordinal: number,
+  role: "user" | "assistant",
+): RowSkeletonEntry {
+  return {
+    rowId,
+    createdAt: 1000 + ordinal,
+    role,
+    byteLength: 128,
+    bodyDigest: `d-${rowId}`,
+  };
+}
+
+type WindowedSnapshotFrame = Parameters<
+  ChatStreamCallbacks["onWindowedSnapshot"]
+>[0];
+
+/**
+ * A snapshot as the append republish stamps it: the CURRENT `rowCount` and
+ * tail, at the subscriber's held (pre-delta) `indexRevision`.
+ */
+function republishSnapshot(input: {
+  readonly epoch: number;
+  readonly rowCount: number;
+  readonly indexRevision: number | null;
+  readonly tailMessages: readonly Message[];
+}): WindowedSnapshotFrame {
+  return {
+    kind: "snapshot",
+    hasBinaryPayload: false,
+    epicId: EPIC_ID,
+    chatId: CHAT_ID,
+    snapshot: {
+      chat: {
+        id: CHAT_ID,
+        parentId: null,
+        userId: OWNER_ID,
+        hostId: "host-a",
+        title: "Chat",
+        createdAt: 1,
+        updatedAt: 1,
+        isTitleEditedByUser: false,
+        settings: null,
+        archivedAt: null,
+        lastDeliveredRolesDigest: null,
+        activeSessionChain: null,
+        claudePendingWakes: [],
+        pinnedUserProviderHandle: null,
+      },
+      access: { role: "owner", ownerUserId: OWNER_ID, canAct: true },
+      queue: { status: "idle", items: [] },
+      runStatus: "running",
+      activeTurn: null,
+      pendingApprovals: [],
+      pendingInterviews: [],
+      worktreeBinding: null,
+      missingWorktreePaths: [],
+      pendingFileEditApprovals: [],
+      accumulatedFileChangeCount: 0,
+      managedCommands: [],
+      heldUpdates: [],
+      transcriptEpoch: input.epoch,
+      rowCount: input.rowCount,
+      indexRevision: input.indexRevision,
+      tail: {
+        fromOrdinal: 0,
+        messages: [...input.tailMessages],
+        events: [],
+      },
+      derived: {
+        latestAssistantUsage: null,
+        pinnedTodo: null,
+        pinnedTaskTodoItems: [],
+        latestForkableAssistantMessageId: null,
+        restorableSetupInterruption: null,
+        interviewAnswerability: [],
+        latestAssistantAuthFailureTurnKey: null,
+        setupCardWindows: [],
+      },
+    },
+  };
+}
+
+interface Harness {
+  readonly handle: ChatSessionStoreHandle;
+  readonly resnapshotCount: () => number;
+  readonly rangeRequestCount: () => number;
+  callbacks(): ChatStreamCallbacks;
+}
+
+function createHarness(): Harness {
+  let resnapshots = 0;
+  let rangeRequests = 0;
+  let callbacks: ChatStreamCallbacks | null = null;
+  const handle = createChatSessionStore({
+    hostId: "host-a",
+    epicId: EPIC_ID,
+    chatId: CHAT_ID,
+    userId: OWNER_ID,
+    onAuthError: null,
+    onProviderAuthError: () => {},
+    streamFlushCoordinator: IMMEDIATE_STREAM_FLUSH_COORDINATOR,
+    streamClientFactory: (_epicId, _chatId, nextCallbacks) => {
+      callbacks = nextCallbacks;
+      return {
+        sendAction: () => undefined,
+        sameTurnSteeringProtocolSupported: () => true,
+        requestTranscriptRange: () => {
+          rangeRequests += 1;
+        },
+        requestResnapshot: () => {
+          resnapshots += 1;
+        },
+        close: () => undefined,
+      };
+    },
+  });
+  return {
+    handle,
+    resnapshotCount: () => resnapshots,
+    rangeRequestCount: () => rangeRequests,
+    callbacks: () => {
+      if (callbacks === null) throw new Error("Expected callbacks");
+      return callbacks;
+    },
+  };
+}
+
+describe("the append republish interleave (bootstrap → accept → snapshot → delta)", () => {
+  it("keeps the transcript through a launch-flow turn instead of voiding on every append", () => {
+    const harness = createHarness();
+    try {
+      const cb = harness.callbacks();
+
+      // 1. Bootstrap: the chat exists but the initial message has not been
+      //    accepted yet - the subscriber attached mid-`startInitialTurn`.
+      cb.onWindowedSnapshot(
+        republishSnapshot({
+          epoch: 0,
+          rowCount: 0,
+          indexRevision: null,
+          tailMessages: [],
+        }),
+      );
+      cb.onSkeletonChunk({
+        kind: "skeletonChunk",
+        hasBinaryPayload: false,
+        epicId: EPIC_ID,
+        chatId: CHAT_ID,
+        chunk: { epoch: 0, fromOrdinal: 0, entries: [], isFinal: true },
+      });
+
+      // 2. The initial message is accepted...
+      cb.onMessageAccepted({
+        kind: "messageAccepted",
+        hasBinaryPayload: false,
+        epicId: EPIC_ID,
+        chatId: CHAT_ID,
+        message: userMessage("m-1", 2),
+      });
+      // ...and its append republish follows: snapshot at the NEW rowCount but
+      // the held revision, then the delta for the very same append.
+      cb.onWindowedSnapshot(
+        republishSnapshot({
+          epoch: 0,
+          rowCount: 1,
+          indexRevision: 0,
+          tailMessages: [userMessage("m-1", 2)],
+        }),
+      );
+      cb.onIndexChanged({
+        kind: "indexChanged",
+        hasBinaryPayload: false,
+        epicId: EPIC_ID,
+        chatId: CHAT_ID,
+        epoch: 0,
+        rowCount: 1,
+        indexRevision: 1,
+        changes: [
+          {
+            type: "appended",
+            entries: [skeletonEntry("m-1", 0, "user")],
+          },
+        ],
+      });
+
+      const afterUser = harness.handle.store.getState();
+      expect(afterUser.transcriptWindow.invalidated).toBe(false);
+      expect(harness.resnapshotCount()).toBe(0);
+      expect(afterUser.messages.map((message) => message.messageId)).toEqual([
+        "m-1",
+      ]);
+      expect(afterUser.transcriptWindow.skeleton[0]?.rowId).toBe("m-1");
+
+      // 3. The assistant row lands the same way one broadcast later.
+      cb.onWindowedSnapshot(
+        republishSnapshot({
+          epoch: 0,
+          rowCount: 2,
+          indexRevision: 1,
+          tailMessages: [userMessage("m-1", 2), assistantMessage("a-1", 3)],
+        }),
+      );
+      cb.onIndexChanged({
+        kind: "indexChanged",
+        hasBinaryPayload: false,
+        epicId: EPIC_ID,
+        chatId: CHAT_ID,
+        epoch: 0,
+        rowCount: 2,
+        indexRevision: 2,
+        changes: [
+          {
+            type: "appended",
+            entries: [skeletonEntry("a-1", 1, "assistant")],
+          },
+        ],
+      });
+
+      const afterAssistant = harness.handle.store.getState();
+      expect(afterAssistant.transcriptWindow.invalidated).toBe(false);
+      expect(harness.resnapshotCount()).toBe(0);
+      expect(harness.rangeRequestCount()).toBe(0);
+      expect(
+        afterAssistant.messages.map((message) => message.messageId),
+      ).toEqual(["m-1", "a-1"]);
+      expect(afterAssistant.transcriptWindow.skeleton[0]?.rowId).toBe("m-1");
+      expect(afterAssistant.transcriptWindow.skeleton[1]?.rowId).toBe("a-1");
+    } finally {
+      harness.handle.dispose();
+    }
+  });
+});

--- a/clients/gui-app/src/stores/chats/__tests__/windowed-append-republish.test.ts
+++ b/clients/gui-app/src/stores/chats/__tests__/windowed-append-republish.test.ts
@@ -49,6 +49,30 @@ function userMessage(messageId: string, timestamp: number): Message {
   };
 }
 
+/**
+ * The `messageAccepted` frame's own message type. NOT the `Message` above:
+ * the two are structurally identical and nominally distinct (the frame's
+ * resolves through the subscribe union's schema instance), so a fixture typed
+ * as one cannot be passed where the other is expected.
+ */
+type AcceptedMessage = Parameters<
+  ChatStreamCallbacks["onMessageAccepted"]
+>[0]["message"];
+
+function acceptedUserMessage(
+  messageId: string,
+  timestamp: number,
+): AcceptedMessage {
+  return {
+    role: "user",
+    messageId,
+    sender: { type: "user", userId: OWNER_ID },
+    message: { kind: "user", content: CONTENT, browserAnnotations: [] },
+    timestamp,
+    sessionAnchor: null,
+  };
+}
+
 function assistantMessage(messageId: string, timestamp: number): Message {
   return {
     role: "assistant",
@@ -231,7 +255,7 @@ describe("the append republish interleave (bootstrap → accept → snapshot →
         hasBinaryPayload: false,
         epicId: EPIC_ID,
         chatId: CHAT_ID,
-        message: userMessage("m-1", 2),
+        message: acceptedUserMessage("m-1", 2),
       });
       // ...and its append republish follows: snapshot at the NEW rowCount but
       // the held revision, then the delta for the very same append.

--- a/clients/gui-app/src/stores/chats/__tests__/windowed-session-binding.test.ts
+++ b/clients/gui-app/src/stores/chats/__tests__/windowed-session-binding.test.ts
@@ -1524,9 +1524,10 @@ describe("accumulated-change chunks", () => {
         state.accumulatedFileChangeCount -
           state.accumulatedFileChangeSummaries.length,
       ).toBe(3);
-      // Dropping alone would strand the panel: the host streams these chunks
-      // only while rebuilding an index, so nothing on the ordinary path sends
-      // them again. The resnapshot is the restart.
+      // Dropping alone would strand the panel: the host records the set it
+      // just sent, so a chunk lost in transit leaves it believing this
+      // subscriber holds that generation - ordinary traffic over an unchanged
+      // set sends nothing. The resnapshot is the restart.
       expect(harness.resnapshotCount()).toBe(1);
     } finally {
       harness.handle.dispose();
@@ -1535,11 +1536,11 @@ describe("accumulated-change chunks", () => {
 
   /**
    * An aux-only re-broadcast - a queue change, an approval - re-sends the
-   * snapshot against an unchanged skeleton, and the host emits accumulated
-   * chunks only while REBUILDING a subscriber's index. So a snapshot is not
-   * proof that a re-stream is coming, and clearing the assembled summaries on
-   * one empties the panel for the rest of the session while the header goes on
-   * counting files it can no longer list.
+   * snapshot against summaries the host has already sent, and it never re-sends
+   * an unchanged set. So a snapshot is not proof that a re-stream is coming,
+   * and clearing the assembled summaries on one empties the panel for the rest
+   * of the session while the header goes on counting files it can no longer
+   * list.
    */
   it("keeps the assembled summaries across an aux-only snapshot re-broadcast", () => {
     const harness = createWindowedHarness();

--- a/clients/gui-app/src/stores/chats/chat-session-store.ts
+++ b/clients/gui-app/src/stores/chats/chat-session-store.ts
@@ -3705,12 +3705,14 @@ export function createChatSessionStoreWithNotificationDependencies(
           // the new total and no entry of a previous set can outlive it.
           //
           // And a snapshot is NOT proof that a re-stream is coming. The host
-          // emits the summaries only while rebuilding a subscriber's index;
-          // an aux-only re-broadcast - a queue change, an approval - re-sends
-          // the snapshot against an unchanged skeleton and sends no chunks at
-          // all. Clearing here would empty the panel on the next approval and
-          // leave it empty, with the header still counting the files it can no
-          // longer list.
+          // re-streams the summaries whenever they CHANGED - the reconcile runs
+          // ahead of every index branch, so a turn that replaces them while
+          // leaving every ordinal intact still delivers them - but it compares
+          // what this subscriber was last sent by identity, so an UNCHANGED set
+          // is never re-sent. An aux-only re-broadcast - a queue change, an
+          // approval - therefore carries no chunks at all, and clearing here
+          // would empty the panel on the next approval and leave it empty, with
+          // the header still counting the files it can no longer list.
         });
         // An aux-only re-broadcast - a queue change, an approval - clears the
         // resnapshot latch and `invalidated` while sending no chunks at all
@@ -3928,12 +3930,13 @@ export function createChatSessionStoreWithNotificationDependencies(
           // it, and the panel's rows are then attributed to the wrong files.
           //
           // Dropped rather than seated at the wrong offset - but dropping
-          // alone is not a recovery. The host streams these chunks only while
-          // REBUILDING a subscriber's index, so nothing on the ordinary path
-          // will send them again: the panel would stay permanently short, with
-          // "Review all" held back, for the rest of the connection. A
-          // resnapshot is what restarts the stream, and it is the same
-          // recovery a void index uses.
+          // alone is not a recovery. The host re-streams these chunks when the
+          // summaries CHANGE, and it records the set it just sent: a chunk lost
+          // in transit leaves the host believing this subscriber holds that
+          // generation, so ordinary traffic over an unchanged set sends nothing
+          // and the panel stays short - "Review all" held back - for the rest
+          // of the connection. A resnapshot is what restarts the stream, and it
+          // is the same recovery a void index uses.
           if (frame.chunk.fromIndex > assembled.length) {
             requestSummaryRestream();
             return {};

--- a/clients/gui-app/src/stores/chats/transcript-window.ts
+++ b/clients/gui-app/src/stores/chats/transcript-window.ts
@@ -1332,7 +1332,11 @@ export function applySkeletonChunk(
     invalidated: window.invalidated || lost,
     clock: window.clock + 1,
   };
-  return reconcileSpansWithSkeleton(next, chunk);
+  return reconcileSpansWithSkeleton(
+    next,
+    chunk.fromOrdinal,
+    chunk.fromOrdinal + chunk.entries.length,
+  );
 }
 
 /**
@@ -1353,31 +1357,37 @@ function coversEveryOrdinal(
 }
 
 /**
- * Reconcile the spans a skeleton chunk now has authority over.
+ * Reconcile the spans an index delivery now has authority over, across
+ * `[fromOrdinal, toOrdinal)`.
  *
- * Two things, because the chunk answers both at once for the same rows. A span
- * whose held ids CONTRADICT the chunk is dropped - that body belongs to a
- * different row. A span holding UNVERIFIED ids (the empty string, which only
+ * Two things, because the delivery answers both at once for the same rows. A
+ * span whose held ids CONTRADICT the skeleton is dropped - that body belongs to
+ * a different row. A span holding UNVERIFIED ids (the empty string, which only
  * the inline tail produces) adopts them.
  *
  * The adopt half is not cosmetic. The tail is seated by the snapshot, which is
  * emitted BEFORE the skeleton streams, so on a fresh session every tail row's
- * id is empty; this chunk is the first authority to reach them. Left empty,
+ * id is empty; this delivery is the first authority to reach them. Left empty,
  * `transcriptListRows` cannot match those ordinals to their rendered models,
  * suppresses the ordinals, and re-emits the models as ordinal-less live rows -
  * so the inline tail never participates in viewport reporting or row-height
  * memory, on every windowed session, for exactly the rows the reader starts on.
+ *
+ * Both callers owe this, and by ordinal range rather than by frame shape: the
+ * skeleton stream reaches a fresh session's tail ({@link applySkeletonChunk}),
+ * and an `appended` delta reaches the rows that arrive AFTER that stream
+ * finished ({@link applyIndexChange}) - which no chunk will ever revisit.
  */
 function reconcileSpansWithSkeleton(
   window: TranscriptWindow,
-  chunk: ChatSkeletonChunk,
+  fromOrdinal: number,
+  toOrdinal: number,
 ): TranscriptWindow {
-  const chunkEnd = chunk.fromOrdinal + chunk.entries.length;
   let changed = false;
   const kept: HydratedSpan[] = [];
   for (const span of window.spans) {
     const disjoint =
-      spanEnd(span) <= chunk.fromOrdinal || span.fromOrdinal >= chunkEnd;
+      spanEnd(span) <= fromOrdinal || span.fromOrdinal >= toOrdinal;
     if (disjoint) {
       kept.push(span);
       continue;
@@ -1731,6 +1741,24 @@ export function applyIndexChange(
       }
     }
   }
+  // How far the skeleton STREAM has contiguously reached once this frame is
+  // folded in.
+  //
+  // An `appended` delta seats its entries at the end and is part of the same
+  // delivery, so a prefix that had caught up to where this append BEGINS
+  // follows `rowCount` rather than being left behind - otherwise the next
+  // stream-completeness question would report a gap the delta itself just
+  // filled. `appendCursor` is where the appends stopped.
+  //
+  // Measured against `appendBase` for the same reason the loss check above is.
+  // On the append republish the snapshot has already carried `window.rowCount`
+  // past this prefix, so an equality against it can never hold again and the
+  // prefix freezes at the pre-append count for the rest of the epoch. The two
+  // agree on every frame the snapshot has NOT run ahead of.
+  const coveredThrough =
+    window.skeletonStreamCoveredThrough === appendBase
+      ? Math.max(appendCursor, input.rowCount)
+      : window.skeletonStreamCoveredThrough;
   const next: TranscriptWindow = {
     ...window,
     skeleton,
@@ -1740,33 +1768,56 @@ export function applyIndexChange(
     // compared against, whether it was adopted under the boundary or earned by
     // being the immediate successor.
     indexRevisionRebuilding: false,
-    // A delta that grew the index past what the client has assembled means the
-    // skeleton is no longer complete, even though it was.
+    // Whether the client holds a COMPLETE index once this frame is folded in,
+    // re-derived from the two conditions {@link applySkeletonChunk} uses - and
+    // deliberately NOT gated on the completeness this window arrived with.
     //
-    // By COVERAGE, not by length - the same distinction `applySkeletonChunk`
-    // draws and for the same reason. The skeleton is sparse, so an append that
-    // seats new entries at `rowCount` can extend the array to exactly the new
-    // length while interior ordinals a dropped frame should have filled stay
-    // holes, and a length test reads that as complete.
+    // That gate was a third rule for the same question, and the append
+    // republish is where it bites: the snapshot lands first at a `rowCount`
+    // whose last ordinals only the delta behind it fills, so it correctly
+    // declares the skeleton short - and a delta that then fills exactly those
+    // ordinals could never say otherwise. Sticky-false completeness is not
+    // inert: `chunkedDeliveryIncomplete()` reads it, so the completion
+    // watchdog reads every healthy append as a stalled skeleton stream and
+    // spends its whole per-epoch restream budget on resnapshots that repair
+    // nothing.
+    //
+    // Both conditions are kept because they catch different losses. The PREFIX
+    // catches a delivery that never arrived - a dropped chunk, or an append
+    // frame the snapshot got ahead of - and is what still keeps a genuinely
+    // short skeleton from reading as complete here. The SCAN catches a hole
+    // from any other cause: the skeleton is sparse, so an append that seats
+    // entries at `rowCount` can extend the array to exactly the new length
+    // while an interior ordinal stays a hole, and a length test reads that as
+    // complete.
     skeletonComplete:
-      window.skeletonComplete && coversEveryOrdinal(skeleton, input.rowCount),
-    // An `appended` delta seats its entries at the end and is part of the same
-    // delivery, so the prefix follows `rowCount` rather than being left behind
-    // - otherwise the next stream-completeness question would report a gap the
-    // delta itself just filled. `appendCursor` is where the appends stopped.
-    skeletonStreamCoveredThrough:
-      window.skeletonStreamCoveredThrough === window.rowCount
-        ? Math.max(appendCursor, input.rowCount)
-        : window.skeletonStreamCoveredThrough,
+      coveredThrough >= input.rowCount &&
+      coversEveryOrdinal(skeleton, input.rowCount),
+    skeletonStreamCoveredThrough: coveredThrough,
     clock: window.clock + 1,
   };
+  // This delta is the first authority to name the ordinals it just appended, so
+  // it owes them the identity resolution a skeleton chunk owes its own - and it
+  // is the LAST authority that will ever reach them, because the skeleton
+  // stream that would otherwise adopt them finished before these rows existed.
+  //
+  // A tail seated positionally holds the empty string at exactly those
+  // ordinals (a host that sends no `tail.rowIds`; see {@link tailRowIdsFor}).
+  // Left unadopted, `transcriptListRows` finds no model named `""`, suppresses
+  // the ordinal, and then drops the real model as one the skeleton has already
+  // placed - so a row this client HOLDS renders nowhere until the next
+  // snapshot re-seats the tail.
+  const reconciled =
+    appendCursor > appendBase
+      ? reconcileSpansWithSkeleton(next, appendBase, appendCursor)
+      : next;
   // Widened to the turn BEFORE the reach is computed: the containing-span seed
   // below is exact only when the rewritten row is hydrated, and a sibling slice
   // holding the same turn's records is the case where it is not. See
   // {@link recordSharingOrdinals}.
   return dropSpansForUpdatedOrdinals(
-    next,
-    recordSharingOrdinals(next, invalidated),
+    reconciled,
+    recordSharingOrdinals(reconciled, invalidated),
   );
 }
 

--- a/clients/gui-app/src/stores/chats/transcript-window.ts
+++ b/clients/gui-app/src/stores/chats/transcript-window.ts
@@ -1646,15 +1646,10 @@ export function applyIndexChange(
   // rather than a gap: applying it again is what the atomic-frame rule already
   // forbids, so it is dropped rather than treated as loss.
   //
-  // This runs BEFORE the append-count check below, and the order is the whole
-  // point rather than a style choice. A duplicate carrying `appended` entries
-  // was already applied here, so this window's `rowCount` already includes
-  // those rows and the frame's own count equals it - which the count check
-  // reads as `0 !== appendedRows`, the exact signature of a LOST frame. Ask
-  // that question of a frame already known to be stale and the most harmless
-  // thing a stream can do becomes a blanked transcript and a full refetch. The
-  // count is a consistency claim ABOUT a frame's changes; it is only meaningful
-  // once the frame is established as one this window has not seen.
+  // This runs BEFORE the append-count check below: the count is a consistency
+  // claim ABOUT a frame's changes, so it is only asked of a frame this window
+  // has not already seen - a duplicate or straggler is dropped on its
+  // revision alone, never re-judged for loss.
   //
   // Both readings compare against a counter this window is assumed to share
   // with the sender, so both are suspended for exactly one frame after a
@@ -1683,26 +1678,45 @@ export function applyIndexChange(
   //
   // The count is the whole detector for that, because `appended` is the only
   // member that moves `rowCount` and it always appends contiguously at the end.
+  //
+  // The baseline is the FRAME's own pre-delta count, never this window's. The
+  // two disagree on every append republish: the host's broadcast emits the
+  // bounded snapshot FIRST - stamped with the post-append `rowCount` but the
+  // subscriber's pre-delta `indexRevision` (see `applyWindowedSnapshot`'s
+  // straggler doc for why that pair is the contract) - and the delta for that
+  // same append lands on a window whose `rowCount` already includes it. Read
+  // against `window.rowCount`, every such delta has the `0 !== appendedRows`
+  // signature of a lost frame, so the whole transcript voids and resnapshots
+  // once per append for the life of the turn. The frame is self-consistent:
+  // its entries occupy exactly `[rowCount - appendedRows, rowCount)`, so a
+  // genuine loss is a BASE the window has not reached - a hole no entry in
+  // this frame fills - and an overlap is just the snapshot having run ahead,
+  // re-seating entries the count already covers (idempotently: the entries are
+  // the host's current truth for those ordinals either way).
   const appendedRows = input.changes.reduce(
     (total, change) =>
       change.type === "appended" ? total + change.entries.length : total,
     0,
   );
-  if (input.rowCount - window.rowCount !== appendedRows) {
+  const appendBase = input.rowCount - appendedRows;
+  if (appendBase > window.rowCount) {
     return voidedTranscriptWindow(window, input);
   }
 
   const skeleton = [...window.skeleton];
   // Appended entries are seated at the ordinals they NAME - which begin at the
-  // PRE-delta `rowCount` - and never at `skeleton.length`. The two are equal
-  // only once the skeleton is complete, and the skeleton is deliberately
-  // sparse while its chunks are still streaming: its length is then "one past
-  // the highest ordinal delivered so far", which is BELOW `rowCount`.
-  // Appending by length in that window seats the new tail rows over ordinals
-  // whose real entries have not arrived yet, so every identity check against
-  // those ordinals rejects a valid range or drops a held span, while the
-  // ordinals the rows actually occupy stay holes forever.
-  let appendCursor = window.rowCount;
+  // frame's own pre-delta `rowCount` (`appendBase`) - and never at
+  // `skeleton.length`. The skeleton is deliberately sparse while its chunks
+  // are still streaming: its length is then "one past the highest ordinal
+  // delivered so far", which is BELOW `rowCount`. Appending by length in that
+  // window seats the new tail rows over ordinals whose real entries have not
+  // arrived yet, so every identity check against those ordinals rejects a
+  // valid range or drops a held span, while the ordinals the rows actually
+  // occupy stay holes forever. `window.rowCount` is wrong for the other
+  // reason: on the snapshot-ran-ahead interleave above it already counts the
+  // rows this delta delivers, and seating from it would shift every entry one
+  // past its real ordinal.
+  let appendCursor = appendBase;
   for (const change of input.changes) {
     if (change.type === "appended") {
       for (const entry of change.entries) {


### PR DESCRIPTION
## What

Launching a new task against a `chat.subscribe@1.8` host showed an **empty transcript** for the whole first turn — only the turn indicator ("Tinkering…") ran. Reported on staging with the first post-merge host/GUI pairing of the windowed line (#1459).

## Root cause

The host's append republish emits, in one synchronous pass: the shared frames, then the bounded **snapshot** — stamped with the **post-append `rowCount`** and the subscriber's **pre-delta `indexRevision`** (the documented pair; see `applyWindowedSnapshot`'s straggler doc) — and then the `indexChanged` delta for that very append.

So the delta always lands on a window whose `rowCount` already includes its rows. The client's lost-frame detector compared the frame's `rowCount` against `window.rowCount`:

```ts
if (input.rowCount - window.rowCount !== appendedRows) return voidedTranscriptWindow(...)
```

For every append republish that reads `0 !== appendedRows` — the exact signature of a lost frame — so the client **voided the entire window (all spans + skeleton) and requested a resnapshot on every append**. Under an active turn the transcript spends its whole life voided: blank chat, spinner running. Verified end-to-end by capturing a real `ChatSessionManager` launch-flow emission (`startInitialTurn` + mid-start 1.8 subscribe) and replaying it through the real store: 3 spurious resnapshots, window repeatedly voided.

There was a second latent defect on the same lines: the append seat cursor used `window.rowCount` as the base, which under the same interleave would seat entries one past their real ordinal.

## Fix

The frame is self-consistent — its appended entries occupy exactly `[rowCount - appendedRows, rowCount)`. `applyIndexChange` now:

- derives the append base from the frame (`input.rowCount - appendedRows`),
- voids only on a genuine hole (`base > window.rowCount` — a frame was lost and nothing in this one fills the gap),
- treats `base <= window.rowCount` as the snapshot having run ahead and re-seats the entries at their true ordinals (idempotent — the entries are the host's current truth either way),
- seats at that base instead of `window.rowCount`.

The revision direction checks are untouched; duplicates and stragglers are still dropped on revision alone.

## Tests

- Unit: the overlap case applies and seats at the frame's own ordinals (fails on the old code with a voided window); the existing lost-frame and streaming-skeleton fixtures still pass unchanged (`base 101 > 100` still voids; `102−2=100` seats identically).
- Store-level: `windowed-append-republish.test.ts` replays the host's real launch-flow emission order (bootstrap → accept → snapshot-ahead → delta, twice) and pins that no resnapshot fires, the window is never invalidated, and both rows render.
- Full `src/stores/chats` suite: 768/768.

🤖 Generated with [Claude Code](https://claude.com/claude-code)