### PR TITLE
feat(protocol,cli): expose native session bindings

### DIFF
--- a/clients/gui-app/src/lib/host-rpc-policy/host-method-policy-table.ts
+++ b/clients/gui-app/src/lib/host-rpc-policy/host-method-policy-table.ts
@@ -694,6 +694,7 @@ export const HOST_METHOD_POLL_TABLE = {
     poll: null,
   },
   "agent.getTranscript": { ...LATEST_SCHEDULING, poll: null },
+  "agent.getNativeSessionBinding": { ...LATEST_SCHEDULING, poll: null },
   "agent.inbox.read": { ...LATEST_SCHEDULING, poll: null },
   "agent.inbox.ack": {
     mode: "fifo",

--- a/clients/traycer-cli/README.md
+++ b/clients/traycer-cli/README.md
@@ -96,6 +96,14 @@ traycer worktree create --workspace /path/to/repo --branch my-feature
 
 These commands are mainly intended for Traycer-managed automation, but they are regular CLI commands and can be scripted when the host is running and the required IDs are supplied.
 
+`traycer agent binding` prefers the dedicated metadata-only Host RPC. With a
+released Host that predates that RPC, it can recover local TUI bindings from
+the Host's existing authorized agent records and immediately projects them to
+the same five-field response. This compatibility path never subscribes to chat
+state or reads transcript bodies, though the authorized records it projects can
+include launch metadata while they are in CLI memory. GUI bindings require a
+Host with the dedicated RPC and otherwise return `E_HOST_UNSUPPORTED`.
+
 ## Host Security
 
 The npm package ships the CLI bundle only. The Traycer Host is a separate signed binary distributed through GitHub Releases. Before installation, host archives are verified by checksum and minisign signature against the trust root embedded in the CLI.

--- a/clients/traycer-cli/README.md
+++ b/clients/traycer-cli/README.md
@@ -87,6 +87,7 @@ Traycer-launched agent sessions receive environment variables such as `TRAYCER_A
 
 ```sh
 traycer agent list
+traycer agent binding --agent-id <agent-id> --json
 traycer agent inbox
 traycer agent send --to <agent-id> --message "Can you review this change?"
 traycer workspace list

--- a/clients/traycer-cli/src/commands/__tests__/agent-binding.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/agent-binding.test.ts
@@ -81,6 +81,7 @@ function agentList(overrides: Record<string, unknown> | undefined) {
 
 function tuiRecord(overrides: Record<string, unknown> | undefined) {
   return {
+    origin: "registry" as const,
     tuiAgentId: "agent-target",
     ownerUserId: "user-private",
     hostId: "host-local",
@@ -105,6 +106,23 @@ function tuiRecord(overrides: Record<string, unknown> | undefined) {
     revision: 1,
     docResident: false,
     ...(overrides ?? {}),
+  };
+}
+
+function cloudTuiRecord() {
+  return {
+    origin: "cloud" as const,
+    tuiAgentId: "agent-cloud",
+    ownerUserId: "user-private",
+    hostId: "host-remote",
+    harnessId: "codex",
+    parentId: null,
+    title: "Remote agent",
+    isTitleEditedByUser: false,
+    createdAt: 1,
+    updatedAt: 2,
+    archived: false,
+    revision: 1,
   };
 }
 
@@ -308,6 +326,28 @@ describe("agent binding", () => {
       "agent.list",
       "epic.listTuiAgents",
     ]);
+  });
+
+  it("ignores unrelated cloud replicas in the released Host record read", async () => {
+    rpcMock.mockRejectedValueOnce(
+      hostError(
+        "E_HOST_UNSUPPORTED",
+        "This host does not support 'agent.getNativeSessionBinding'.",
+      ),
+    );
+    rpcAtEndpointMock
+      .mockResolvedValueOnce(agentList(undefined))
+      .mockResolvedValueOnce({
+        tuiAgents: [cloudTuiRecord(), tuiRecord(undefined)],
+      });
+
+    const result = await buildCommand()(makeCtx());
+
+    expect(result.data).toMatchObject({
+      agentId: "agent-target",
+      harnessId: "claude",
+      harnessSessionId: "native-session-456",
+    });
   });
 
   it("recovers a pending ambient TUI binding", async () => {

--- a/clients/traycer-cli/src/commands/__tests__/agent-binding.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/agent-binding.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { HostRpcError } from "../../../../shared/host-transport/host-messenger";
-import { callHostRpc } from "../../internal/host-rpc";
+import {
+  callHostRpc,
+  callHostRpcAtEndpoint,
+  resolveEndpoint,
+} from "../../internal/host-rpc";
 import { noopLogger } from "../../logger";
 import { CLI_ERROR_CODES, CliError } from "../../runner/errors";
 import type { CommandContext } from "../../runner/runner";
@@ -24,10 +28,21 @@ vi.mock("../../internal/host-rpc", async () => {
   const actual = await vi.importActual<
     typeof import("../../internal/host-rpc")
   >("../../internal/host-rpc");
-  return { ...actual, callHostRpc: vi.fn() };
+  return {
+    ...actual,
+    callHostRpc: vi.fn(),
+    callHostRpcAtEndpoint: vi.fn(),
+    resolveEndpoint: vi.fn(),
+  };
 });
 
 const rpcMock = vi.mocked(callHostRpc);
+const rpcAtEndpointMock = vi.mocked(callHostRpcAtEndpoint);
+const resolveEndpointMock = vi.mocked(resolveEndpoint);
+const endpoint = {
+  hostId: "host-local",
+  websocketUrl: "ws://127.0.0.1:9000/rpc",
+};
 
 const response = {
   agentId: "agent-target",
@@ -36,6 +51,62 @@ const response = {
   profileSelection: { kind: "ambient" as const },
   harnessSessionId: "session-123",
 };
+
+function agentSummary(overrides: Record<string, unknown> | undefined) {
+  return {
+    id: "agent-target",
+    parentId: "agent-caller",
+    hostId: "host-local",
+    isLocal: true,
+    surface: "tui" as const,
+    harnessId: "claude",
+    isSelf: false,
+    title: "Sensitive title discarded by projection",
+    capabilities: { readTranscript: true, sendMessage: true },
+    active: true,
+    folderPaths: ["/private/workspace"],
+    isWorktree: false,
+    runConfig: null,
+    ...(overrides ?? {}),
+  };
+}
+
+function agentList(overrides: Record<string, unknown> | undefined) {
+  return {
+    caller: { agentId: "agent-caller", canSendMessages: true },
+    scope: "user" as const,
+    agents: [agentSummary(overrides)],
+  };
+}
+
+function tuiRecord(overrides: Record<string, unknown> | undefined) {
+  return {
+    tuiAgentId: "agent-target",
+    ownerUserId: "user-private",
+    hostId: "host-local",
+    harnessId: "claude",
+    harnessSessionId: "native-session-456",
+    parentId: "agent-caller",
+    title: "Sensitive title discarded by projection",
+    isTitleEditedByUser: false,
+    createdAt: 1,
+    updatedAt: 2,
+    archived: false,
+    archivedAt: null,
+    workspaceFolders: ["/private/workspace"],
+    workspaceMode: null,
+    model: "sensitive-model",
+    reasoningEffort: null,
+    agentMode: "regular" as const,
+    profileId: "profile-work",
+    terminalAgentArgs: "--private-arg",
+    terminalShellCommand: null,
+    terminalShellArgs: null,
+    revision: 1,
+    docResident: false,
+    ...(overrides ?? {}),
+  };
+}
 
 function makeCtx(): CommandContext {
   return {
@@ -93,6 +164,10 @@ function hostError(
 
 beforeEach(() => {
   vi.clearAllMocks();
+  rpcMock.mockReset();
+  rpcAtEndpointMock.mockReset();
+  resolveEndpointMock.mockReset();
+  resolveEndpointMock.mockResolvedValue(endpoint);
 });
 
 describe("agent binding", () => {
@@ -101,6 +176,7 @@ describe("agent binding", () => {
 
     await buildCommand()(makeCtx());
 
+    expect(resolveEndpointMock).not.toHaveBeenCalled();
     expect(rpcMock).toHaveBeenCalledTimes(1);
     expect(rpcMock).toHaveBeenCalledWith("agent.getNativeSessionBinding", {
       epicId: "epic-1",
@@ -153,12 +229,13 @@ describe("agent binding", () => {
   });
 
   it("maps an old host to actionable per-call upgrade guidance", async () => {
-    rpcMock.mockRejectedValue(
+    rpcMock.mockRejectedValueOnce(
       hostError(
         "E_HOST_UNSUPPORTED",
         "This host does not support 'agent.getNativeSessionBinding'. Upgrade the host to use this feature.",
       ),
     );
+    rpcAtEndpointMock.mockResolvedValueOnce(agentList({ surface: "gui" }));
 
     const error = await buildCommand()(makeCtx()).catch(
       (caught: unknown) => caught,
@@ -172,7 +249,262 @@ describe("agent binding", () => {
         method: "agent.getNativeSessionBinding",
       },
     });
+    expect(rpcMock).toHaveBeenCalledTimes(1);
+    expect(rpcAtEndpointMock).toHaveBeenCalledTimes(1);
   });
+
+  it("recovers an observed TUI binding from released Host record reads", async () => {
+    rpcMock.mockRejectedValueOnce(
+      hostError(
+        "E_HOST_UNSUPPORTED",
+        "This host does not support 'agent.getNativeSessionBinding'.",
+      ),
+    );
+    rpcAtEndpointMock
+      .mockResolvedValueOnce(agentList(undefined))
+      .mockResolvedValueOnce({ tuiAgents: [tuiRecord(undefined)] });
+
+    const result = await buildCommand()(makeCtx());
+
+    expect(rpcMock).toHaveBeenCalledWith("agent.getNativeSessionBinding", {
+      epicId: "epic-1",
+      senderAgentId: "agent-caller",
+      agentId: "agent-target",
+    });
+    expect(rpcAtEndpointMock).toHaveBeenNthCalledWith(
+      1,
+      "agent.list",
+      {
+        epicId: "epic-1",
+        senderAgentId: "agent-caller",
+        scope: "user",
+      },
+      endpoint,
+    );
+    expect(rpcAtEndpointMock).toHaveBeenNthCalledWith(
+      2,
+      "epic.listTuiAgents",
+      {
+        epicId: "epic-1",
+        hasDocReplica: false,
+      },
+      endpoint,
+    );
+    expect(result.data).toEqual({
+      agentId: "agent-target",
+      surface: "tui",
+      harnessId: "claude",
+      profileSelection: { kind: "profile", profileId: "profile-work" },
+      harnessSessionId: "native-session-456",
+    });
+    expect(result.data).not.toHaveProperty("workspaceFolders");
+    expect(result.data).not.toHaveProperty("terminalAgentArgs");
+    expect(result.data).not.toHaveProperty("title");
+    expect([
+      ...rpcMock.mock.calls.map(([method]) => method),
+      ...rpcAtEndpointMock.mock.calls.map(([method]) => method),
+    ]).toEqual([
+      "agent.getNativeSessionBinding",
+      "agent.list",
+      "epic.listTuiAgents",
+    ]);
+  });
+
+  it("recovers a pending ambient TUI binding", async () => {
+    rpcMock.mockRejectedValueOnce(
+      hostError(
+        "E_HOST_UNSUPPORTED",
+        "This host does not support 'agent.getNativeSessionBinding'.",
+      ),
+    );
+    rpcAtEndpointMock
+      .mockResolvedValueOnce(agentList({ harnessId: "codex" }))
+      .mockResolvedValueOnce({
+        tuiAgents: [
+          tuiRecord({
+            harnessId: "codex",
+            harnessSessionId: null,
+            profileId: null,
+          }),
+        ],
+      });
+
+    const result = await buildCommand()(makeCtx());
+
+    expect(result.data).toMatchObject({
+      harnessId: "codex",
+      profileSelection: { kind: "ambient" },
+      harnessSessionId: null,
+    });
+    expect(result.human).toContain("Native session: not observed yet");
+  });
+
+  it.each([
+    ["missing", { agents: [] }, CLI_ERROR_CODES.AGENT_NOT_FOUND],
+    [
+      "cross-host",
+      agentList({ isLocal: false }),
+      CLI_ERROR_CODES.AGENT_NOT_LOCAL,
+    ],
+  ])(
+    "preserves the non-enumerating %s refusal in the released Host fallback",
+    async (_case, listed, expectedCode) => {
+      rpcMock.mockRejectedValueOnce(
+        hostError(
+          "E_HOST_UNSUPPORTED",
+          "This host does not support 'agent.getNativeSessionBinding'.",
+        ),
+      );
+      rpcAtEndpointMock.mockResolvedValueOnce(
+        "agents" in listed
+          ? {
+              caller: {
+                agentId: "agent-caller",
+                canSendMessages: true,
+              },
+              scope: "user",
+              ...listed,
+            }
+          : listed,
+      );
+
+      const error = await buildCommand()(makeCtx()).catch(
+        (caught: unknown) => caught,
+      );
+
+      expect(error).toBeInstanceOf(CliError);
+      expect(error).toMatchObject({ code: expectedCode });
+      expect(rpcMock).toHaveBeenCalledTimes(1);
+      expect(rpcAtEndpointMock).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it.each([
+    ["record host", undefined, undefined, { hostId: "host-other" }],
+    ["endpoint host", { hostId: "host-other" }, undefined, undefined],
+    ["doc-resident row", undefined, undefined, { docResident: true }],
+    ["harness", undefined, undefined, { harnessId: "codex" }],
+  ])(
+    "rejects inconsistent released Host %s metadata",
+    async (_case, endpointOverrides, targetOverrides, recordOverrides) => {
+      if (endpointOverrides !== undefined) {
+        resolveEndpointMock.mockResolvedValueOnce({
+          ...endpoint,
+          ...endpointOverrides,
+        });
+      }
+      rpcMock.mockRejectedValueOnce(
+        hostError(
+          "E_HOST_UNSUPPORTED",
+          "This host does not support 'agent.getNativeSessionBinding'.",
+        ),
+      );
+      rpcAtEndpointMock
+        .mockResolvedValueOnce(agentList(targetOverrides))
+        .mockResolvedValueOnce({
+          tuiAgents: [tuiRecord(recordOverrides)],
+        });
+
+      const error = await buildCommand()(makeCtx()).catch(
+        (caught: unknown) => caught,
+      );
+
+      expect(error).toBeInstanceOf(CliError);
+      expect(error).toMatchObject({ code: CLI_ERROR_CODES.HOST_INCOMPATIBLE });
+    },
+  );
+
+  it("maps a target deleted between released Host reads to not found", async () => {
+    rpcMock.mockRejectedValueOnce(
+      hostError(
+        "E_HOST_UNSUPPORTED",
+        "This host does not support 'agent.getNativeSessionBinding'.",
+      ),
+    );
+    rpcAtEndpointMock
+      .mockResolvedValueOnce(agentList(undefined))
+      .mockResolvedValueOnce({ tuiAgents: [] })
+      .mockResolvedValueOnce(agentList({ id: "agent-other" }));
+
+    const error = await buildCommand()(makeCtx()).catch(
+      (caught: unknown) => caught,
+    );
+
+    expect(error).toBeInstanceOf(CliError);
+    expect(error).toMatchObject({ code: CLI_ERROR_CODES.AGENT_NOT_FOUND });
+    expect(rpcAtEndpointMock.mock.calls.map(([method]) => method)).toEqual([
+      "agent.list",
+      "epic.listTuiAgents",
+      "agent.list",
+    ]);
+  });
+
+  it.each([
+    [
+      "agent summaries",
+      agentList(undefined),
+      { tuiAgents: [tuiRecord(undefined)] },
+    ],
+    [
+      "TUI records",
+      agentList(undefined),
+      { tuiAgents: [tuiRecord(undefined), tuiRecord({ revision: 2 })] },
+    ],
+  ])("rejects duplicate released Host %s", async (kind, listed, tuiAgents) => {
+    const duplicatedAgentList =
+      kind === "agent summaries"
+        ? {
+            ...listed,
+            agents: [
+              agentSummary(undefined),
+              agentSummary({ title: "duplicate" }),
+            ],
+          }
+        : listed;
+    rpcMock.mockRejectedValueOnce(
+      hostError(
+        "E_HOST_UNSUPPORTED",
+        "This host does not support 'agent.getNativeSessionBinding'.",
+      ),
+    );
+    rpcAtEndpointMock
+      .mockResolvedValueOnce(duplicatedAgentList)
+      .mockResolvedValueOnce(tuiAgents);
+
+    const error = await buildCommand()(makeCtx()).catch(
+      (caught: unknown) => caught,
+    );
+
+    expect(error).toBeInstanceOf(CliError);
+    expect(error).toMatchObject({ code: CLI_ERROR_CODES.HOST_INCOMPATIBLE });
+  });
+
+  it.each([
+    ["empty session", { harnessSessionId: "" }],
+    ["reserved ambient profile", { profileId: "ambient" }],
+  ])(
+    "maps a malformed released Host %s projection to incompatibility",
+    async (_case, recordOverrides) => {
+      rpcMock.mockRejectedValueOnce(
+        hostError(
+          "E_HOST_UNSUPPORTED",
+          "This host does not support 'agent.getNativeSessionBinding'.",
+        ),
+      );
+      rpcAtEndpointMock
+        .mockResolvedValueOnce(agentList(undefined))
+        .mockResolvedValueOnce({
+          tuiAgents: [tuiRecord(recordOverrides)],
+        });
+
+      const error = await buildCommand()(makeCtx()).catch(
+        (caught: unknown) => caught,
+      );
+
+      expect(error).toBeInstanceOf(CliError);
+      expect(error).toMatchObject({ code: CLI_ERROR_CODES.HOST_INCOMPATIBLE });
+    },
+  );
 
   it.each([
     ["E_AGENT_NOT_FOUND", CLI_ERROR_CODES.AGENT_NOT_FOUND],

--- a/clients/traycer-cli/src/commands/__tests__/agent-binding.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/agent-binding.test.ts
@@ -1,0 +1,190 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { HostRpcError } from "../../../../shared/host-transport/host-messenger";
+import { callHostRpc } from "../../internal/host-rpc";
+import { noopLogger } from "../../logger";
+import { CLI_ERROR_CODES, CliError } from "../../runner/errors";
+import type { CommandContext } from "../../runner/runner";
+import { buildAgentBindingCommand } from "../agent-binding";
+
+const loggerMock = vi.hoisted(() => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock("../../logger", () => ({
+  createCliLogger: () => loggerMock,
+  errorFromUnknown: (value: unknown) =>
+    value instanceof Error ? value : new Error(String(value)),
+  noopLogger: loggerMock,
+}));
+
+vi.mock("../../internal/host-rpc", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../internal/host-rpc")
+  >("../../internal/host-rpc");
+  return { ...actual, callHostRpc: vi.fn() };
+});
+
+const rpcMock = vi.mocked(callHostRpc);
+
+const response = {
+  agentId: "agent-target",
+  surface: "gui" as const,
+  harnessId: "claude",
+  profileSelection: { kind: "ambient" as const },
+  harnessSessionId: "session-123",
+};
+
+function makeCtx(): CommandContext {
+  return {
+    runtime: {
+      json: false,
+      quiet: false,
+      noProgress: false,
+      noBootstrap: false,
+      nonInteractive: false,
+      environment: "production",
+      logger: noopLogger,
+    },
+    output: {
+      progress: vi.fn(),
+      human: vi.fn(),
+      humanRequired: vi.fn(),
+      emitResult: vi.fn(),
+      emitError: vi.fn(),
+    },
+    progress: vi.fn(),
+  };
+}
+
+function buildCommand() {
+  return buildAgentBindingCommand({
+    epicId: "epic-1",
+    senderAgentId: "agent-caller",
+    agentId: "agent-target",
+  });
+}
+
+function hostError(
+  code: "E_HOST_UNSUPPORTED" | "E_AGENT_NOT_FOUND" | "E_AGENT_NOT_LOCAL",
+  message: string,
+): HostRpcError {
+  return new HostRpcError({
+    code,
+    message,
+    requestId: "request-1",
+    method: "agent.getNativeSessionBinding",
+    fatalDetails:
+      code === "E_HOST_UNSUPPORTED"
+        ? {
+            code,
+            reason: message,
+            incompatibleMethods: null,
+            upgradeGuidance: {
+              clientShouldUpgrade: false,
+              hostShouldUpgrade: true,
+            },
+          }
+        : null,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("agent binding", () => {
+  it("sends the exact epic, sender, and target ids to the native-binding RPC", async () => {
+    rpcMock.mockResolvedValue(response);
+
+    await buildCommand()(makeCtx());
+
+    expect(rpcMock).toHaveBeenCalledTimes(1);
+    expect(rpcMock).toHaveBeenCalledWith("agent.getNativeSessionBinding", {
+      epicId: "epic-1",
+      senderAgentId: "agent-caller",
+      agentId: "agent-target",
+    });
+  });
+
+  it("returns the canonical DTO and formats an ambient binding", async () => {
+    rpcMock.mockResolvedValue(response);
+
+    const result = await buildCommand()(makeCtx());
+
+    expect(result.data).toEqual(response);
+    expect(result.human).toBe(
+      "Agent: agent-target\nSurface: gui\nHarness: claude\nProfile: ambient\nNative session: session-123",
+    );
+  });
+
+  it("formats a managed profile and a pending native-session observation", async () => {
+    rpcMock.mockResolvedValue({
+      ...response,
+      surface: "tui",
+      harnessId: "codex",
+      profileSelection: { kind: "profile", profileId: "profile-work" },
+      harnessSessionId: null,
+    });
+
+    const result = await buildCommand()(makeCtx());
+
+    expect(result.human).toContain("Surface: tui");
+    expect(result.human).toContain("Profile: profile-work");
+    expect(result.human).toContain("Native session: not observed yet");
+  });
+
+  it("strips fields outside the canonical response projection", async () => {
+    rpcMock.mockResolvedValue({
+      ...response,
+      email: "private@example.com",
+      token: "secret",
+      transcript: "private prompt",
+    } as typeof response);
+
+    const result = await buildCommand()(makeCtx());
+
+    expect(result.data).toEqual(response);
+    expect(result.data).not.toHaveProperty("email");
+    expect(result.data).not.toHaveProperty("token");
+    expect(result.data).not.toHaveProperty("transcript");
+  });
+
+  it("maps an old host to actionable per-call upgrade guidance", async () => {
+    rpcMock.mockRejectedValue(
+      hostError(
+        "E_HOST_UNSUPPORTED",
+        "This host does not support 'agent.getNativeSessionBinding'. Upgrade the host to use this feature.",
+      ),
+    );
+
+    const error = await buildCommand()(makeCtx()).catch(
+      (caught: unknown) => caught,
+    );
+
+    expect(error).toBeInstanceOf(CliError);
+    expect(error).toMatchObject({
+      code: CLI_ERROR_CODES.HOST_UNSUPPORTED,
+      details: {
+        hostShouldUpgrade: true,
+        method: "agent.getNativeSessionBinding",
+      },
+    });
+  });
+
+  it.each([
+    ["E_AGENT_NOT_FOUND", CLI_ERROR_CODES.AGENT_NOT_FOUND],
+    ["E_AGENT_NOT_LOCAL", CLI_ERROR_CODES.AGENT_NOT_LOCAL],
+  ] as const)("preserves the host's %s refusal", async (wireCode, cliCode) => {
+    rpcMock.mockRejectedValue(hostError(wireCode, "Agent is unavailable."));
+
+    const error = await buildCommand()(makeCtx()).catch(
+      (caught: unknown) => caught,
+    );
+
+    expect(error).toBeInstanceOf(CliError);
+    expect(error).toMatchObject({ code: cliCode });
+  });
+});

--- a/clients/traycer-cli/src/commands/__tests__/cli-entrypoint-registration.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/cli-entrypoint-registration.test.ts
@@ -1266,6 +1266,7 @@ describe("traycer CLI entrypoint registration", () => {
       const help = agent.helpInformation();
       expect(help).toContain("list [options]");
       expect(help).toContain("transcript [options]");
+      expect(help).toContain("binding [options]");
       expect(help).not.toContain("create [options]");
       expect(help).not.toContain("selection-guide [options]");
       expect(help).not.toContain("list-harnesses [options]");

--- a/clients/traycer-cli/src/commands/__tests__/readonly-surface-gate.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/readonly-surface-gate.test.ts
@@ -216,6 +216,7 @@ const UNGATED_READS: ReadonlyArray<{
   readonly args: readonly string[];
 }> = [
   { path: ["agent", "list"], args: [] },
+  { path: ["agent", "binding"], args: ["--agent-id", "agent-1"] },
   { path: ["agent", "transcript"], args: ["--agent-id", "agent-1"] },
   { path: ["agent", "inbox"], args: [] },
   { path: ["agent", "role", "list"], args: [] },

--- a/clients/traycer-cli/src/commands/__tests__/rendered-help.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/rendered-help.test.ts
@@ -879,6 +879,16 @@ const EXPECTED_PUBLIC_SURFACE: readonly ExpectedSurfaceEntry[] = [
     args: [],
   },
   {
+    path: "agent binding",
+    options: [
+      { flags: "--agent-id <id>", mandatory: true },
+      { flags: "--json", mandatory: false },
+      { flags: "--no-progress", mandatory: false },
+      { flags: "--quiet", mandatory: false },
+    ],
+    args: [],
+  },
+  {
     path: "agent transcript",
     options: [
       { flags: "--agent-id <id>", mandatory: true },

--- a/clients/traycer-cli/src/commands/agent-binding.ts
+++ b/clients/traycer-cli/src/commands/agent-binding.ts
@@ -1,0 +1,49 @@
+import { formatProfileSelection } from "@traycer/protocol/agent/agent-profile-format";
+import { getAgentNativeSessionBindingResponseSchema } from "@traycer/protocol/host/agent/shared";
+import {
+  callHostRpc,
+  parseCanonicalHostResponse,
+  toAgentCliError,
+} from "../internal/host-rpc";
+import { resolveEpicId, resolveSenderAgentId } from "../internal/agent-context";
+import type { CommandFn } from "../runner/runner";
+
+/**
+ * `traycer agent binding` - read the current provider-native session identity
+ * for one local GUI or TUI agent. The structured response is intentionally
+ * narrow enough for an external recorder to join on `agentId` plus
+ * `harnessSessionId` without receiving provider-account or transcript data.
+ *
+ * A null session id is a successful pending observation, not an error. GUI
+ * agents can later acquire a different current binding after changing harness
+ * or profile, so consumers that need history should retain every non-null pair
+ * they observe rather than overwrite their own join table.
+ */
+export function buildAgentBindingCommand(opts: {
+  readonly epicId: string | null;
+  readonly senderAgentId: string | null;
+  readonly agentId: string;
+}): CommandFn {
+  return async () => {
+    const result = await toAgentCliError(
+      callHostRpc("agent.getNativeSessionBinding", {
+        epicId: resolveEpicId(opts.epicId),
+        senderAgentId: resolveSenderAgentId(opts.senderAgentId),
+        agentId: opts.agentId,
+      }),
+    );
+    const response = parseCanonicalHostResponse(
+      "agent.getNativeSessionBinding",
+      getAgentNativeSessionBindingResponseSchema,
+      result,
+    );
+    const human = [
+      `Agent: ${response.agentId}`,
+      `Surface: ${response.surface}`,
+      `Harness: ${response.harnessId}`,
+      `Profile: ${formatProfileSelection(response.profileSelection)}`,
+      `Native session: ${response.harnessSessionId ?? "not observed yet"}`,
+    ].join("\n");
+    return { data: response, human, exitCode: 0 };
+  };
+}

--- a/clients/traycer-cli/src/commands/agent-binding.ts
+++ b/clients/traycer-cli/src/commands/agent-binding.ts
@@ -1,11 +1,20 @@
 import { formatProfileSelection } from "@traycer/protocol/agent/agent-profile-format";
-import { getAgentNativeSessionBindingResponseSchema } from "@traycer/protocol/host/agent/shared";
+import {
+  getAgentNativeSessionBindingResponseSchema,
+  listAgentsResponseSchema,
+  type GetAgentNativeSessionBindingResponse,
+} from "@traycer/protocol/host/agent/shared";
+import { listTuiAgentsResponseV11Schema } from "@traycer/protocol/host/epic/tui-agent-records";
 import {
   callHostRpc,
+  callHostRpcAtEndpoint,
   parseCanonicalHostResponse,
+  resolveEndpoint,
   toAgentCliError,
 } from "../internal/host-rpc";
+import type { HostTransportEndpoint } from "../../../shared/host-transport/host-messenger";
 import { resolveEpicId, resolveSenderAgentId } from "../internal/agent-context";
+import { CLI_ERROR_CODES, CliError, cliError } from "../runner/errors";
 import type { CommandFn } from "../runner/runner";
 
 /**
@@ -25,18 +34,29 @@ export function buildAgentBindingCommand(opts: {
   readonly agentId: string;
 }): CommandFn {
   return async () => {
-    const result = await toAgentCliError(
-      callHostRpc("agent.getNativeSessionBinding", {
-        epicId: resolveEpicId(opts.epicId),
-        senderAgentId: resolveSenderAgentId(opts.senderAgentId),
+    const epicId = resolveEpicId(opts.epicId);
+    const senderAgentId = resolveSenderAgentId(opts.senderAgentId);
+    const request = { epicId, senderAgentId, agentId: opts.agentId };
+    let response: GetAgentNativeSessionBindingResponse;
+    try {
+      const result = await toAgentCliError(
+        callHostRpc("agent.getNativeSessionBinding", request),
+      );
+      response = parseCanonicalHostResponse(
+        "agent.getNativeSessionBinding",
+        getAgentNativeSessionBindingResponseSchema,
+        result,
+      );
+    } catch (error: unknown) {
+      if (!isNativeBindingUnsupported(error)) throw error;
+      response = await resolveReleasedHostTuiBinding({
+        epicId,
+        senderAgentId,
         agentId: opts.agentId,
-      }),
-    );
-    const response = parseCanonicalHostResponse(
-      "agent.getNativeSessionBinding",
-      getAgentNativeSessionBindingResponseSchema,
-      result,
-    );
+        endpoint: await resolveEndpoint(),
+        unsupportedError: error,
+      });
+    }
     const human = [
       `Agent: ${response.agentId}`,
       `Surface: ${response.surface}`,
@@ -46,4 +66,166 @@ export function buildAgentBindingCommand(opts: {
     ].join("\n");
     return { data: response, human, exitCode: 0 };
   };
+}
+
+/**
+ * Recover a TUI binding from the released Host's existing, authorized record
+ * reads. The fallback never opens `chat.subscribe`: even its windowed v1.8
+ * snapshot carries a hydrated transcript tail, so using it for GUI bindings
+ * would violate this command's metadata-only boundary.
+ *
+ * The two broader responses below can contain titles, workspace folders, and
+ * terminal launch metadata. They live only in this short-lived CLI process and
+ * are immediately projected into the same narrow response schema as the native
+ * RPC. GUI agents keep the original E_HOST_UNSUPPORTED result until the Host
+ * implements the dedicated resolver.
+ */
+async function resolveReleasedHostTuiBinding(input: {
+  readonly epicId: string;
+  readonly senderAgentId: string;
+  readonly agentId: string;
+  readonly endpoint: HostTransportEndpoint;
+  readonly unsupportedError: CliError;
+}): Promise<GetAgentNativeSessionBindingResponse> {
+  const listResult = await toAgentCliError(
+    callHostRpcAtEndpoint(
+      "agent.list",
+      {
+        epicId: input.epicId,
+        senderAgentId: input.senderAgentId,
+        scope: "user",
+      },
+      input.endpoint,
+    ),
+  );
+  const listed = parseCanonicalHostResponse(
+    "agent.list",
+    listAgentsResponseSchema,
+    listResult,
+  );
+  const targets = listed.agents.filter((agent) => agent.id === input.agentId);
+  if (targets.length === 0) throw unavailableAgent();
+  if (targets.length !== 1) {
+    throw incompatibleReleasedHostRecords();
+  }
+  const target = targets[0];
+  if (!target.isLocal) {
+    throw cliError({
+      code: CLI_ERROR_CODES.AGENT_NOT_LOCAL,
+      message:
+        "traycer: Agent is owned by another host; query its binding on that host.",
+      details: null,
+      exitCode: 1,
+    });
+  }
+  if (target.surface !== "tui" || target.harnessId === null) {
+    throw input.unsupportedError;
+  }
+  if (target.hostId !== input.endpoint.hostId) {
+    throw incompatibleReleasedHostRecords();
+  }
+
+  const tuiResult = await toAgentCliError(
+    callHostRpcAtEndpoint(
+      "epic.listTuiAgents",
+      {
+        epicId: input.epicId,
+        hasDocReplica: false,
+      },
+      input.endpoint,
+    ),
+  );
+  const tuiRecords = parseCanonicalHostResponse(
+    "epic.listTuiAgents",
+    listTuiAgentsResponseV11Schema,
+    tuiResult,
+  );
+  const records = tuiRecords.tuiAgents.filter(
+    (candidate) => candidate.tuiAgentId === input.agentId,
+  );
+  const record = records[0];
+  if (records.length === 0) {
+    // The record reads are individually authorized but not atomic. Distinguish
+    // a target deleted between them from a malformed Host registry response.
+    const recheckResult = await toAgentCliError(
+      callHostRpcAtEndpoint(
+        "agent.list",
+        {
+          epicId: input.epicId,
+          senderAgentId: input.senderAgentId,
+          scope: "user",
+        },
+        input.endpoint,
+      ),
+    );
+    const rechecked = parseCanonicalHostResponse(
+      "agent.list",
+      listAgentsResponseSchema,
+      recheckResult,
+    );
+    const remaining = rechecked.agents.filter(
+      (agent) => agent.id === input.agentId,
+    );
+    if (remaining.length === 0) throw unavailableAgent();
+    throw incompatibleReleasedHostRecords();
+  }
+  if (
+    records.length !== 1 ||
+    record === undefined ||
+    record.docResident ||
+    record.hostId !== target.hostId ||
+    record.harnessId !== target.harnessId
+  ) {
+    throw incompatibleReleasedHostRecords();
+  }
+
+  const projected = getAgentNativeSessionBindingResponseSchema.safeParse({
+    agentId: target.id,
+    surface: "tui",
+    harnessId: target.harnessId,
+    profileSelection:
+      record.profileId === null
+        ? { kind: "ambient" }
+        : { kind: "profile", profileId: record.profileId },
+    harnessSessionId: record.harnessSessionId,
+  });
+  if (!projected.success) {
+    throw cliError({
+      code: CLI_ERROR_CODES.HOST_INCOMPATIBLE,
+      message:
+        "traycer: the released host returned a native binding this CLI could not safely project - try 'traycer host restart'.",
+      details: null,
+      exitCode: 1,
+    });
+  }
+  return projected.data;
+}
+
+function unavailableAgent(): CliError {
+  return cliError({
+    code: CLI_ERROR_CODES.AGENT_NOT_FOUND,
+    message:
+      "traycer: Agent is unavailable. Check --agent-id (or $TRAYCER_AGENT_ID).",
+    details: null,
+    exitCode: 1,
+  });
+}
+
+function incompatibleReleasedHostRecords(): CliError {
+  return cliError({
+    code: CLI_ERROR_CODES.HOST_INCOMPATIBLE,
+    message:
+      "traycer: the released host returned inconsistent local agent records - try 'traycer host restart'.",
+    details: null,
+    exitCode: 1,
+  });
+}
+
+/** Match only absence of the new optional method, not an unrelated failure. */
+function isNativeBindingUnsupported(error: unknown): error is CliError {
+  return (
+    error instanceof CliError &&
+    error.code === CLI_ERROR_CODES.HOST_UNSUPPORTED &&
+    error.details?.method === "agent.getNativeSessionBinding"
+  );
 }

--- a/clients/traycer-cli/src/commands/agent-binding.ts
+++ b/clients/traycer-cli/src/commands/agent-binding.ts
@@ -4,7 +4,7 @@ import {
   listAgentsResponseSchema,
   type GetAgentNativeSessionBindingResponse,
 } from "@traycer/protocol/host/agent/shared";
-import { listTuiAgentsResponseV11Schema } from "@traycer/protocol/host/epic/tui-agent-records";
+import { listTuiAgentsResponseV12Schema } from "@traycer/protocol/host/epic/tui-agent-records";
 import {
   callHostRpc,
   callHostRpcAtEndpoint,
@@ -137,7 +137,7 @@ async function resolveReleasedHostTuiBinding(input: {
   );
   const tuiRecords = parseCanonicalHostResponse(
     "epic.listTuiAgents",
-    listTuiAgentsResponseV11Schema,
+    listTuiAgentsResponseV12Schema,
     tuiResult,
   );
   const records = tuiRecords.tuiAgents.filter(
@@ -172,6 +172,7 @@ async function resolveReleasedHostTuiBinding(input: {
   if (
     records.length !== 1 ||
     record === undefined ||
+    record.origin !== "registry" ||
     record.docResident ||
     record.hostId !== target.hostId ||
     record.harnessId !== target.harnessId

--- a/clients/traycer-cli/src/index.ts
+++ b/clients/traycer-cli/src/index.ts
@@ -25,6 +25,7 @@ import { buildCliMarkSourceCommand } from "./commands/cli-mark-source";
 import { buildCliReAnchorCommand } from "./commands/cli-re-anchor";
 import { buildCliUpgradeCommand } from "./commands/cli-upgrade";
 import { buildAgentArchiveCommand } from "./commands/agent-archive";
+import { buildAgentBindingCommand } from "./commands/agent-binding";
 import { buildAgentConfigureCommand } from "./commands/agent-configure";
 import { buildAgentCreateCommand } from "./commands/agent-create";
 import { buildAgentForkCommand } from "./commands/agent-fork";
@@ -2866,6 +2867,24 @@ function registerAgentCommands(
         expectReply: opts.expectReply === true,
         responseId:
           typeof opts.responseId === "string" ? opts.responseId : null,
+      }),
+  );
+
+  withRunner(
+    agent
+      .command("binding")
+      .description(
+        "Print the current provider-native session binding for one local agent",
+      )
+      .requiredOption(
+        "--agent-id <id>",
+        "Full agent id whose native session binding to read",
+      ),
+    (opts) =>
+      buildAgentBindingCommand({
+        epicId: null,
+        senderAgentId: null,
+        agentId: typeof opts.agentId === "string" ? opts.agentId : "",
       }),
   );
 

--- a/protocol/src/host/agent/__tests__/native-session-binding.test.ts
+++ b/protocol/src/host/agent/__tests__/native-session-binding.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from "vitest";
+import {
+  SERVES_EVERY_INSTALLED_MAJOR,
+  splitConnectionManifest,
+} from "@traycer/protocol/framework/index";
+import { agentGetNativeSessionBindingV10 } from "@traycer/protocol/host/agent/contracts";
+import {
+  getAgentNativeSessionBindingRequestSchema,
+  getAgentNativeSessionBindingResponseSchema,
+} from "@traycer/protocol/host/agent/shared";
+import { releasedMethodNames } from "@traycer/protocol/host/__tests__/__fixtures__/released-method-names";
+import { hostRpcRegistry } from "@traycer/protocol/host/registry";
+import { RELEASED_FLOOR_METHOD_NAMES } from "@traycer/protocol/host/released-floor";
+
+const METHOD = "agent.getNativeSessionBinding";
+
+describe("agent.getNativeSessionBinding compatibility", () => {
+  it("registers 1.0 as an optional method with per-call unsupported degradation", () => {
+    expect(agentGetNativeSessionBindingV10.method).toBe(METHOD);
+    expect(agentGetNativeSessionBindingV10.schemaVersion).toEqual({
+      major: 1,
+      minor: 0,
+    });
+    expect(hostRpcRegistry[METHOD].degrade).toEqual({ kind: "unsupported" });
+    expect(hostRpcRegistry[METHOD][1].latestMinor).toBe(0);
+    expect(hostRpcRegistry[METHOD][1].versions[0]?.contract).toBe(
+      agentGetNativeSessionBindingV10,
+    );
+  });
+
+  it("advertises only on the optional manifest and leaves released fixtures frozen", () => {
+    expect(RELEASED_FLOOR_METHOD_NAMES).not.toContain(METHOD);
+    expect(releasedMethodNames).not.toContain(METHOD);
+
+    const split = splitConnectionManifest(
+      hostRpcRegistry,
+      RELEASED_FLOOR_METHOD_NAMES,
+      SERVES_EVERY_INSTALLED_MAJOR,
+    );
+    expect(split.optionalManifest[METHOD]).toEqual({
+      major: 1,
+      minor: 0,
+      supportedMajors: [1],
+    });
+    expect(split.manifest[METHOD]).toBeUndefined();
+  });
+});
+
+describe("agent.getNativeSessionBinding schemas", () => {
+  it("requires non-empty epic, sender, and exact target ids", () => {
+    const request = {
+      epicId: "epic-1",
+      senderAgentId: "agent-caller",
+      agentId: "agent-target",
+    };
+    expect(getAgentNativeSessionBindingRequestSchema.parse(request)).toEqual(
+      request,
+    );
+
+    for (const field of ["epicId", "senderAgentId", "agentId"] as const) {
+      expect(
+        getAgentNativeSessionBindingRequestSchema.safeParse({
+          ...request,
+          [field]: "",
+        }).success,
+      ).toBe(false);
+    }
+    expect(
+      getAgentNativeSessionBindingRequestSchema.safeParse({
+        epicId: "epic-1",
+        agentId: "agent-target",
+      }).success,
+    ).toBe(false);
+  });
+
+  it("accepts an ambient GUI binding whose native session is not observed yet", () => {
+    const response = {
+      agentId: "agent-gui",
+      surface: "gui" as const,
+      harnessId: "claude",
+      profileSelection: { kind: "ambient" as const },
+      harnessSessionId: null,
+    };
+    expect(getAgentNativeSessionBindingResponseSchema.parse(response)).toEqual(
+      response,
+    );
+  });
+
+  it("accepts a managed TUI binding and keeps harness ids open for future providers", () => {
+    const response = {
+      agentId: "agent-tui",
+      surface: "tui" as const,
+      harnessId: "future-provider",
+      profileSelection: {
+        kind: "profile" as const,
+        profileId: "profile-work",
+      },
+      harnessSessionId: "native-session-123",
+    };
+    expect(getAgentNativeSessionBindingResponseSchema.parse(response)).toEqual(
+      response,
+    );
+  });
+
+  it("projects only allowlisted binding fields", () => {
+    const parsed = getAgentNativeSessionBindingResponseSchema.parse({
+      agentId: "agent-tui",
+      surface: "tui",
+      harnessId: "codex",
+      profileSelection: {
+        kind: "profile",
+        profileId: "profile-work",
+        label: "Work account",
+      },
+      harnessSessionId: "thread-123",
+      email: "private@example.com",
+      accountUuid: "account-secret",
+      configPath: "/private/provider/config",
+      authState: "authenticated",
+      token: "secret",
+      transcript: "private prompt",
+      observedAt: "invented-timestamp",
+    });
+
+    expect(parsed).toEqual({
+      agentId: "agent-tui",
+      surface: "tui",
+      harnessId: "codex",
+      profileSelection: {
+        kind: "profile",
+        profileId: "profile-work",
+      },
+      harnessSessionId: "thread-123",
+    });
+  });
+
+  it("rejects empty harness and native session ids", () => {
+    const base = {
+      agentId: "agent-tui",
+      surface: "tui",
+      harnessId: "codex",
+      profileSelection: {
+        kind: "profile",
+        profileId: "profile-work",
+      },
+      harnessSessionId: "thread-123",
+    };
+    expect(
+      getAgentNativeSessionBindingResponseSchema.safeParse({
+        ...base,
+        harnessId: "",
+      }).success,
+    ).toBe(false);
+    expect(
+      getAgentNativeSessionBindingResponseSchema.safeParse({
+        ...base,
+        harnessSessionId: "",
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/protocol/src/host/agent/contracts.ts
+++ b/protocol/src/host/agent/contracts.ts
@@ -20,6 +20,8 @@ import {
   agentSelectionGuideGlobalSetResponseSchema,
   getAgentTranscriptRequestSchema,
   getAgentTranscriptResponseSchema,
+  getAgentNativeSessionBindingRequestSchema,
+  getAgentNativeSessionBindingResponseSchema,
   listHarnessModelsRequestSchemaV10,
   listHarnessModelsRequestSchemaV20,
   listHarnessModelsResponseSchema,
@@ -55,9 +57,10 @@ import {
 // `agent.sendMessage` is the fire-and-forget hand-off path (no streaming -
 // any reply travels back as a separate `agent.sendMessage`);
 // `agent.getTranscript` flattens an agent's conversation into XML-tagged
-// text; and `agent.stop` halts an agent (and optionally its delegated
-// subtree). Schema docs in `agent/shared.ts` are the authority on the field
-// semantics.
+// text; `agent.getNativeSessionBinding` projects the current local
+// provider-session join; and `agent.stop` halts an agent (and optionally its
+// delegated subtree). Schema docs in `agent/shared.ts` are the authority on
+// the field semantics.
 
 export const agentCreateV10 = defineRpcContract({
   method: "agent.create",
@@ -1019,6 +1022,18 @@ export const agentGetTranscriptV10 = defineRpcContract({
   schemaVersion: { major: 1, minor: 0 } as const,
   requestSchema: getAgentTranscriptRequestSchema,
   responseSchema: getAgentTranscriptResponseSchema,
+});
+
+/**
+ * Brand-new v1.0 read method. It stays outside the released method-name floor,
+ * so an old host omits the capability and the caller receives per-call host
+ * upgrade guidance instead of a fatal handshake mismatch.
+ */
+export const agentGetNativeSessionBindingV10 = defineRpcContract({
+  method: "agent.getNativeSessionBinding",
+  schemaVersion: { major: 1, minor: 0 } as const,
+  requestSchema: getAgentNativeSessionBindingRequestSchema,
+  responseSchema: getAgentNativeSessionBindingResponseSchema,
 });
 
 export const agentStopV10 = defineRpcContract({

--- a/protocol/src/host/agent/shared.ts
+++ b/protocol/src/host/agent/shared.ts
@@ -1039,6 +1039,58 @@ export type GetAgentTranscriptResponse = z.infer<
 >;
 
 /**
+ * `agent.getNativeSessionBinding@1.0` - read the provider-native session id
+ * currently bound to one local agent without exposing provider-account or
+ * transcript data.
+ *
+ * The request carries the calling agent explicitly so the host can apply the
+ * same epic, sender, and account authorization used by the rest of the
+ * agent-to-agent surface. `agentId` is an exact Traycer agent id, not a prefix.
+ * The host MUST refuse a caller-owned target bound to another host with
+ * `E_AGENT_NOT_LOCAL`; absent and foreign-account targets both remain
+ * `E_AGENT_NOT_FOUND` so this read cannot become an account-existence oracle.
+ */
+export const getAgentNativeSessionBindingRequestSchema = z.object({
+  epicId: z.string().min(1),
+  senderAgentId: z.string().min(1),
+  agentId: z.string().min(1),
+});
+export type GetAgentNativeSessionBindingRequest = z.infer<
+  typeof getAgentNativeSessionBindingRequestSchema
+>;
+
+/**
+ * A deliberately narrow projection, rather than a persisted chat/TUI record:
+ * account email/UUID, profile label, config or credential paths, environment
+ * overrides, auth state, tokens, workspaces, model settings, and transcript
+ * content must never cross this boundary.
+ *
+ * `harnessId` is intentionally an open non-empty string. It remains the host's
+ * canonical harness id, but consumers only need it as an opaque join key and a
+ * new harness must not force a new RPC major solely to widen an enum.
+ *
+ * `harnessSessionId` normalizes a GUI active-chain `sessionId` and a TUI
+ * record's `harnessSessionId`. `null` means the host has not observed a native
+ * session for the returned configured harness/profile yet. When non-null,
+ * `harnessId` and `profileSelection` describe the session that minted that
+ * exact id, not possibly-newer agent settings. A GUI resolver therefore emits
+ * its active chain only while that chain agrees with the current settings;
+ * otherwise it returns those settings with a null session id. This is the
+ * current binding, not an immutable one-to-one lifetime mapping: GUI agents
+ * can acquire a new native session after a harness/profile change.
+ */
+export const getAgentNativeSessionBindingResponseSchema = z.object({
+  agentId: z.string().min(1),
+  surface: z.enum(["gui", "tui"]),
+  harnessId: z.string().min(1),
+  profileSelection: concreteProfileSelectionSchema,
+  harnessSessionId: z.string().min(1).nullable(),
+});
+export type GetAgentNativeSessionBindingResponse = z.infer<
+  typeof getAgentNativeSessionBindingResponseSchema
+>;
+
+/**
  * `agent.stop@1.0` - halt a running agent and, optionally, the subtree it
  * delegated to. Addresses a single agent by id like the rest of this
  * family; the fan-out is the resolver's job, not the caller's:

--- a/protocol/src/host/registry.ts
+++ b/protocol/src/host/registry.ts
@@ -20,6 +20,7 @@ import {
   agentCreateUpgradeV10ToV20,
   agentCreateUpgradeV20ToV30,
   agentGetTranscriptV10,
+  agentGetNativeSessionBindingV10,
   agentListHarnessModelsDowngradeV2ToV1,
   agentListHarnessModelsV10,
   agentListHarnessModelsV20,
@@ -5436,6 +5437,22 @@ const HOST_RPC_REGISTRY_BASE_DEFINITION = {
       },
       downgradePathsFromLatest: {},
     },
+  },
+  // Public, local-only join from a Traycer agent id to the provider-native
+  // session currently backing it. New optional method: old hosts simply omit
+  // it and callers receive E_HOST_UNSUPPORTED for this call only.
+  "agent.getNativeSessionBinding": {
+    1: {
+      latestMinor: 0,
+      versions: {
+        0: {
+          contract: agentGetNativeSessionBindingV10,
+          upgradeFromPreviousVersion: null,
+        },
+      },
+      downgradePathsFromLatest: {},
+    },
+    degrade: { kind: "unsupported" },
   },
   // Agent role claims. Non-floor, so each declares its missing-peer behavior:
   // an old host simply does not advertise them and the caller gets


### PR DESCRIPTION
## Summary

- Adds the optional `agent.getNativeSessionBinding@1.0` RPC and `traycer agent binding --agent-id <exact-id> --json`.
- Returns only an allowlisted five-field view: agent, surface, harness, effective profile selection, and provider-native session ID (`null` until observed).
- Keeps the released handshake floor. When Host 1.2.0 reports that only this new method is unsupported, the CLI recovers an exact local TUI binding through the Host's existing authorized `agent.list` and `epic.listTuiAgents` reads.
- GUI agents continue to return `E_HOST_UNSUPPORTED` until the dedicated private Host resolver lands; the compatibility path never inspects chat state.
- Omits `observedAt` because the current persistence model has no trustworthy observation timestamp.

Closes #1532.

## Security and semantics

- Authentication still precedes Host discovery on the primary RPC path.
- The fallback resolves one endpoint and pins both reads to it, requires one exact local TUI target, and rejects endpoint/record host disagreement, duplicates, document-resident rows, harness disagreement, and malformed projections.
- Cross-host agents are refused. Missing or deleted targets remain non-enumerating.
- The fallback never calls `chat.subscribe`, `agent transcript`, or private storage APIs. Its authorized source records can contain title, workspace, model, and launch metadata briefly in CLI memory, but only the narrow five-field DTO is returned or rendered.
- Output excludes account email/UUID, profile labels, config paths, environment variables, auth material, tokens, transcript content, model metadata, workspace paths, and launch arguments.
- The result is the current binding and can change for GUI agents; consumers should retain observed `(harnessId, harnessSessionId)` pairs.

## Compatibility

The public protocol remains optional, so older Hosts continue to negotiate normally. A current Host can implement the dedicated RPC directly. Released Host 1.2.0 is immediately useful for local TUI agents through the compatibility projection; no transcript-bearing RPC is used as a fallback.

## Test plan

- `bun run --cwd clients/traycer-cli compile`
- `bun run --cwd clients/traycer-cli lint`
- Focused CLI suites: 61 tests passed.
- `bun run --cwd protocol compile`
- Focused protocol suite: 7 tests passed.
- Full CLI suite: 2,583 passed and 12 skipped; one unrelated existing macOS `/var` versus `/private/var` path-normalization assertion failed.
- `git diff --check`

## Checklist

- [x] CLI and protocol compile/lint checks pass
- [ ] Separate CI checks pass
- [x] Tests added/updated where it makes sense
- [x] Commits are signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#developer-certificate-of-origin-dco)
