### PR TITLE
fix(gui-app): gate sends on a real rebind draft, not on holders (T14)

### DIFF
--- a/clients/gui-app/src/components/chat/chat-plan-actions-context.ts
+++ b/clients/gui-app/src/components/chat/chat-plan-actions-context.ts
@@ -3,7 +3,11 @@ import { createContext, use } from "react";
 export interface ChatPlanActionsContextValue {
   readonly epicId: string;
   readonly chatId: string;
-  readonly canAct: boolean;
+  // Implement is a SEND (see onImplement), so its enablement is the chat's
+  // send eligibility - access, no stopping turn, no blocking approval - not
+  // bare access. Named for what it gates so a consumer cannot read it as a
+  // permission bit.
+  readonly canSend: boolean;
   readonly pending: boolean;
   // Sends a follow-up user message asking the harness to implement the plan.
   // Plan mode is non-blocking and uniform across harnesses: a plan card never

--- a/clients/gui-app/src/components/chat/segments/__tests__/plan-segment.test.tsx
+++ b/clients/gui-app/src/components/chat/segments/__tests__/plan-segment.test.tsx
@@ -256,7 +256,7 @@ describe("PlanSegment", () => {
           fullContentRef: { kind: "plan_content", hash: "hash-2" },
           contentIdentity: "hash-2",
         }),
-        planActionContext({ canAct: true, pending: false }),
+        planActionContext({ canSend: true, pending: false }),
       ),
     );
 
@@ -327,7 +327,7 @@ describe("PlanSegment", () => {
   it("disables preview and modal Implement while an action is pending", () => {
     renderPlanWithContext(
       planSegment({ fullContentRef: null }),
-      planActionContext({ canAct: true, pending: true }),
+      planActionContext({ canSend: true, pending: true }),
     );
 
     const card = screen.getByTestId("plan-segment");
@@ -418,7 +418,7 @@ describe("PlanSegment", () => {
     }));
     render(
       <ChatPlanActionsContext.Provider
-        value={planActionContext({ canAct: true, pending: false })}
+        value={planActionContext({ canSend: true, pending: false })}
       >
         <PlanSegment
           segment={planSegment({
@@ -474,7 +474,7 @@ function renderPublishedPlan() {
           fullContentRef: { kind: "plan_content", hash: "hash-1" },
           contentIdentity: "hash-1",
         }),
-        planActionContext({ canAct: true, pending: false }),
+        planActionContext({ canSend: true, pending: false }),
       )}
     </PublishedChatSourceProvider>,
   );
@@ -483,7 +483,7 @@ function renderPublishedPlan() {
 function renderPlan(segment: PlanSegmentModel) {
   return renderPlanWithContext(
     segment,
-    planActionContext({ canAct: true, pending: false }),
+    planActionContext({ canSend: true, pending: false }),
   );
 }
 
@@ -506,13 +506,13 @@ function planElement(
 }
 
 function planActionContext(input: {
-  readonly canAct: boolean;
+  readonly canSend: boolean;
   readonly pending: boolean;
 }): ChatPlanActionsContextValue {
   return {
     epicId: "epic-1",
     chatId: "chat-1",
-    canAct: input.canAct,
+    canSend: input.canSend,
     pending: input.pending,
     onImplement: implement,
   };

--- a/clients/gui-app/src/components/chat/segments/plan-segment.tsx
+++ b/clients/gui-app/src/components/chat/segments/plan-segment.tsx
@@ -99,7 +99,7 @@ export function PlanSegment(props: PlanSegmentProps) {
   const actionsVisible =
     segment.planStatus === "drafting" || segment.planStatus === "ready";
   const actionsDisabled =
-    planActions === null || !planActions.canAct || planActions.pending;
+    planActions === null || !planActions.canSend || planActions.pending;
   const handleImplement = useCallback(() => {
     planActions?.onImplement();
   }, [planActions]);

--- a/clients/gui-app/src/components/epic-canvas/__tests__/chat-tile.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/chat-tile.test.tsx
@@ -3513,6 +3513,81 @@ describe("<ChatTile />", () => {
     expect(chatHarness.sent[0]?.kind).toBe("send");
   });
 
+  it("gates a next-step click on a staged rebind with the teardown dialog", async () => {
+    stageChatWorktreeDraft("/wt/a");
+    renderChatTile();
+    await waitForChatTileLoaded();
+    act(() => {
+      emitChatSnapshotWithMessages({
+        callbacks: chatHarness.callbacks(),
+        access: "owner",
+        queueItems: [],
+        settings: SESSION_SETTINGS,
+        messages: [hostUserMessage(), nextStepsAssistantMessage()],
+        activeTurn: null,
+        managedCommands: [runningShellOnProject()],
+      });
+    });
+
+    fireEvent.click(getButtonContainingText("/implementation-validation all"));
+
+    expect(await screen.findByTestId("teardown-commit-dialog")).toBeTruthy();
+    expect(chatHarness.sent).toHaveLength(0);
+
+    fireEvent.click(screen.getByTestId("teardown-commit-immediate"));
+
+    await waitFor(() => {
+      expect(chatHarness.sent).toHaveLength(1);
+    });
+    const frame = chatHarness.sent[0];
+    if (frame.kind !== "send") throw new Error("expected send frame");
+    expect(frame.worktreeIntent?.entries[0]).toMatchObject({
+      kind: "import",
+      worktreePath: "/wt/a",
+    });
+  });
+
+  it("sends a next-step click clean when no workspace draft is staged", async () => {
+    renderChatTile();
+    await waitForChatTileLoaded();
+    act(() => {
+      emitChatSnapshotWithMessages({
+        callbacks: chatHarness.callbacks(),
+        access: "owner",
+        queueItems: [],
+        settings: SESSION_SETTINGS,
+        messages: [hostUserMessage(), nextStepsAssistantMessage()],
+        activeTurn: runningActiveTurn(),
+        managedCommands: [runningShellOnProject()],
+      });
+    });
+
+    fireEvent.click(getButtonContainingText("/implementation-validation all"));
+
+    expect(screen.queryByTestId("teardown-commit-dialog")).toBeNull();
+    expect(chatHarness.sent).toHaveLength(1);
+    expect(chatHarness.sent[0]?.kind).toBe("send");
+  });
+
+  it("re-discloses the next send while the draft stays staged after a deferral", async () => {
+    stageChatWorktreeDraft("/wt/a");
+    await loadChatWithDroppedShell();
+
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+    expect(await screen.findByTestId("teardown-commit-dialog")).toBeTruthy();
+
+    fireEvent.click(screen.getByTestId("teardown-commit-cancel"));
+    await waitFor(() => {
+      expect(screen.queryByTestId("teardown-commit-dialog")).toBeNull();
+    });
+    expect(chatHarness.sent).toHaveLength(0);
+
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    expect(await screen.findByTestId("teardown-commit-dialog")).toBeTruthy();
+    expect(chatHarness.sent).toHaveLength(0);
+  });
+
   it("keeps the send confirmation open with a reason when it cannot proceed", async () => {
     stageChatWorktreeDraft("/wt/a");
     await loadChatWithDroppedShell();

--- a/clients/gui-app/src/components/epic-canvas/__tests__/chat-tile.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/chat-tile.test.tsx
@@ -3467,11 +3467,11 @@ describe("<ChatTile />", () => {
   }
 
   function submitComposerWithEnter(): void {
-    const editorDom = document.querySelector('[contenteditable="true"]');
-    if (!(editorDom instanceof HTMLElement)) {
-      throw new Error("expected composer editor");
-    }
-    fireEvent.keyDown(editorDom, { key: "Enter" });
+    // The composer's prompt editor is the only textbox while the inline
+    // message editor is closed; its accessible name is the placeholder,
+    // which varies with narrow/steer-hint state, so the bare role query is
+    // the stable handle.
+    fireEvent.keyDown(screen.getByRole("textbox"), { key: "Enter" });
   }
 
   it("sends clean during a running turn when no workspace draft is staged", async () => {

--- a/clients/gui-app/src/components/epic-canvas/__tests__/chat-tile.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/chat-tile.test.tsx
@@ -117,6 +117,12 @@ vi.mock("@/hooks/host/use-tab-host-client", () => ({
   useTabHostClient: () => MOCK_HOST_CLIENT,
 }));
 
+// The plan card's modal reads the resolved theme; this tree mounts no
+// ThemeProvider. Same stub as plan-segment's own suite.
+vi.mock("@/providers/use-resolved-theme", () => ({
+  useResolvedTheme: () => ({ resolvedTheme: "dark", themePreset: "neutral" }),
+}));
+
 // The tile subscribes to the command catalog itself, because its next-step /
 // compact / implement-plan sends bypass the composer and its picker store. The
 // mocked host client above never resolves a request, so without this the
@@ -706,6 +712,61 @@ function nextStepsAssistantMessage(): Message {
     ],
     timestamp: 2,
     turnId: "turn-next-steps",
+    usage: null,
+    reasoningEffort: null,
+    serviceTier: null,
+    imageResolutions: [],
+  };
+}
+
+function planAssistantMessage(): Message {
+  return {
+    role: "assistant",
+    messageId: "plan-msg",
+    startedAt: 1,
+    sender: {
+      type: "agent",
+      harnessId: "codex",
+      agentId: "codex",
+      displayName: "Codex",
+      reply: { expectsReply: false },
+      inReplyTo: null,
+    },
+    blocks: [
+      {
+        type: "plan",
+        blockId: "plan:block-1",
+        status: "completed",
+        timestamp: 2,
+        planStatus: "ready",
+        planId: "plan-1",
+        harnessId: "codex",
+        source: {
+          harnessId: "codex",
+          sessionId: "session-1",
+          turnId: "turn-plan",
+          kind: "structured",
+        },
+        title: "Renderer plan",
+        summary: "Preview-only plan body",
+        markdownPreview: "## Preview-only plan body",
+        fullContentRef: null,
+        approvalId: null,
+        supersededByPlanId: null,
+        metadata: null,
+        steps: [
+          {
+            id: "step-1",
+            text: "Wire it",
+            status: "pending",
+            activeForm: null,
+          },
+        ],
+        actions: [],
+      },
+    ],
+    timestamp: 2,
+    turnId: "turn-plan",
     usage: null,
     reasoningEffort: null,
     serviceTier: null,
@@ -3630,6 +3691,61 @@ describe("<ChatTile />", () => {
 
     expect(chatHarness.sent).toHaveLength(1);
     expect(chatHarness.sent[0]?.kind).toBe("send");
+  });
+
+  it("holds an implement-plan click to the next-step send rule under a blocking approval", async () => {
+    stageChatWorktreeDraft("/wt/a");
+    renderChatTile();
+    await waitForChatTileLoaded();
+    act(() => {
+      emitChatSnapshotWithMessages({
+        callbacks: chatHarness.callbacks(),
+        access: "owner",
+        queueItems: [],
+        settings: SESSION_SETTINGS,
+        messages: [hostUserMessage(), planAssistantMessage()],
+        activeTurn: runningActiveTurn(),
+        managedCommands: [runningShellOnProject()],
+      });
+      chatHarness.callbacks().onApprovalRequested({
+        kind: "approvalRequested",
+        hasBinaryPayload: false,
+        epicId: EPIC_ID,
+        chatId: CHAT_ARTIFACT.id,
+        approval: approvalState("approval-1", "tool"),
+      });
+    });
+
+    // One send rule at every point: the Implement button disables exactly like
+    // a next-step chip, a click stays refused with or without a staged rebind
+    // (identical to the no-draft immediate path), and nothing is sent.
+    const implementButton = screen.getByRole("button", { name: "Implement" });
+    if (!(implementButton instanceof HTMLButtonElement)) {
+      throw new Error("expected implement button");
+    }
+    expect(implementButton.disabled).toBe(true);
+    fireEvent.click(implementButton);
+    expect(screen.queryByTestId("teardown-commit-dialog")).toBeNull();
+    expect(chatHarness.sent).toHaveLength(0);
+
+    act(() => {
+      chatHarness.callbacks().onApprovalResolved({
+        kind: "approvalResolved",
+        hasBinaryPayload: false,
+        epicId: EPIC_ID,
+        chatId: CHAT_ARTIFACT.id,
+        approvalId: "approval-1",
+        decision: { approved: true },
+        resolvedAt: 3,
+      });
+    });
+
+    // Rule flips back with the approval: the click now reaches the rebind
+    // gate, which discloses the staged rebind instead of sending silently.
+    expect(implementButton.disabled).toBe(false);
+    fireEvent.click(implementButton);
+    expect(await screen.findByTestId("teardown-commit-dialog")).toBeTruthy();
+    expect(chatHarness.sent).toHaveLength(0);
   });
 
   it("re-discloses the next send while the draft stays staged after a deferral", async () => {

--- a/clients/gui-app/src/components/epic-canvas/__tests__/chat-tile.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/chat-tile.test.tsx
@@ -3450,6 +3450,69 @@ describe("<ChatTile />", () => {
     });
   }
 
+  async function loadBusyChatWithShell(): Promise<void> {
+    renderChatTile();
+    await waitForChatTileLoaded();
+    act(() => {
+      emitChatSnapshotWithMessages({
+        callbacks: chatHarness.callbacks(),
+        access: "owner",
+        queueItems: [],
+        settings: SESSION_SETTINGS,
+        messages: [hostUserMessage()],
+        activeTurn: runningActiveTurn(),
+        managedCommands: [runningShellOnProject()],
+      });
+    });
+  }
+
+  function submitComposerWithEnter(): void {
+    const editorDom = document.querySelector('[contenteditable="true"]');
+    if (!(editorDom instanceof HTMLElement)) {
+      throw new Error("expected composer editor");
+    }
+    fireEvent.keyDown(editorDom, { key: "Enter" });
+  }
+
+  it("sends clean during a running turn when no workspace draft is staged", async () => {
+    await loadBusyChatWithShell();
+
+    submitComposerWithEnter();
+
+    expect(screen.queryByTestId("teardown-commit-dialog")).toBeNull();
+    expect(chatHarness.sent).toHaveLength(1);
+    expect(chatHarness.sent[0]?.kind).toBe("send");
+  });
+
+  it("sends clean during a running turn when the staged draft restates the binding", async () => {
+    useWorktreeIntentStagingStore.getState().stageIntent(
+      {
+        surface: "owner",
+        hostId: HOST_ID,
+        epicId: EPIC_ID,
+        ownerKind: "chat",
+        ownerId: CHAT_ARTIFACT.id,
+      },
+      {
+        entries: [
+          {
+            kind: "local",
+            workspacePath: "/Users/test/project",
+            repoIdentifier: null,
+            isPrimary: true,
+          },
+        ],
+      },
+    );
+    await loadBusyChatWithShell();
+
+    submitComposerWithEnter();
+
+    expect(screen.queryByTestId("teardown-commit-dialog")).toBeNull();
+    expect(chatHarness.sent).toHaveLength(1);
+    expect(chatHarness.sent[0]?.kind).toBe("send");
+  });
+
   it("keeps the send confirmation open with a reason when it cannot proceed", async () => {
     stageChatWorktreeDraft("/wt/a");
     await loadChatWithDroppedShell();

--- a/clients/gui-app/src/components/epic-canvas/__tests__/chat-tile.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/chat-tile.test.tsx
@@ -332,7 +332,10 @@ import type {
   WorktreeBinding,
   WorktreeFolderIntent,
 } from "@traycer/protocol/host/worktree-schemas";
-import { useWorktreeIntentStagingStore } from "@/stores/worktree/worktree-intent-staging-store";
+import {
+  readStagedWorktreeIntent,
+  useWorktreeIntentStagingStore,
+} from "@/stores/worktree/worktree-intent-staging-store";
 import {
   getFocusedComposerControls,
   resetFocusedComposerControlsForTests,
@@ -3565,6 +3568,66 @@ describe("<ChatTile />", () => {
     fireEvent.click(getButtonContainingText("/implementation-validation all"));
 
     expect(screen.queryByTestId("teardown-commit-dialog")).toBeNull();
+    expect(chatHarness.sent).toHaveLength(1);
+    expect(chatHarness.sent[0]?.kind).toBe("send");
+  });
+
+  it("refuses a confirmed next-step send when a blocking approval arrived under the dialog", async () => {
+    stageChatWorktreeDraft("/wt/a");
+    renderChatTile();
+    await waitForChatTileLoaded();
+    act(() => {
+      emitChatSnapshotWithMessages({
+        callbacks: chatHarness.callbacks(),
+        access: "owner",
+        queueItems: [],
+        settings: SESSION_SETTINGS,
+        messages: [hostUserMessage(), nextStepsAssistantMessage()],
+        activeTurn: null,
+        managedCommands: [runningShellOnProject()],
+      });
+    });
+
+    fireEvent.click(getButtonContainingText("/implementation-validation all"));
+    expect(await screen.findByTestId("teardown-commit-dialog")).toBeTruthy();
+
+    act(() => {
+      chatHarness.callbacks().onApprovalRequested({
+        kind: "approvalRequested",
+        hasBinaryPayload: false,
+        epicId: EPIC_ID,
+        chatId: CHAT_ARTIFACT.id,
+        approval: approvalState("approval-under-dialog", "tool"),
+      });
+    });
+
+    fireEvent.click(screen.getByTestId("teardown-commit-immediate"));
+
+    expect(chatHarness.sent).toHaveLength(0);
+    expect(screen.getByTestId("teardown-commit-dialog")).toBeTruthy();
+    expect(
+      readStagedWorktreeIntent({
+        surface: "owner",
+        hostId: HOST_ID,
+        epicId: EPIC_ID,
+        ownerKind: "chat",
+        ownerId: CHAT_ARTIFACT.id,
+      }),
+    ).not.toBeNull();
+
+    act(() => {
+      chatHarness.callbacks().onApprovalResolved({
+        kind: "approvalResolved",
+        hasBinaryPayload: false,
+        epicId: EPIC_ID,
+        chatId: CHAT_ARTIFACT.id,
+        approvalId: "approval-under-dialog",
+        decision: { approved: true },
+        resolvedAt: 3,
+      });
+    });
+    fireEvent.click(screen.getByTestId("teardown-commit-immediate"));
+
     expect(chatHarness.sent).toHaveLength(1);
     expect(chatHarness.sent[0]?.kind).toBe("send");
   });

--- a/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
@@ -71,6 +71,7 @@ import type { WorktreeBusyHolder } from "@traycer/protocol/framework/worktree-bu
 import {
   droppedRunDirectoriesFromDraft,
   teardownHolderSetDrifted,
+  worktreeDraftCommitsRebind,
 } from "@/lib/worktree/owner-teardown-snapshot";
 import {
   takeArmedTeardownSubmit,
@@ -2206,6 +2207,19 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
         ownerKind: "chat",
         ownerId: node.id,
       };
+      // The disclosure is consent for the rebind a send would commit. A send
+      // whose draft commits nothing (none staged, or one that restates the
+      // committed binding) has no rebind to consent to — gating it would put
+      // "Send in the new folder?" in front of every steer of a busy agent.
+      if (
+        !worktreeDraftCommitsRebind({
+          binding: state.worktreeBinding,
+          draft: readStagedWorktreeIntent(stagedKey),
+          removedWorkspacePaths: [],
+        })
+      ) {
+        return dispatchUserSend(input);
+      }
       const snapshot = snapshotTeardownHolders(
         droppedRunDirectoriesFromDraft({
           binding: state.worktreeBinding,
@@ -2829,7 +2843,15 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
         const drifted =
           worktreeCommitCaptureIsStale(armed.capture, live) ||
           teardownHolderSetDrifted(disclosedHolders, liveSnapshot.holders);
-        if (drifted && liveSnapshot.holders.length > 0) {
+        // Same bar as arming the dialog: a live draft that commits no rebind
+        // has nothing left to re-consent to, so a drift that CLEARED the
+        // rebind sends rather than re-disclosing holders forever.
+        const liveCommitsRebind = worktreeDraftCommitsRebind({
+          binding: live.binding,
+          draft: live.draft,
+          removedWorkspacePaths: live.removedWorkspacePaths,
+        });
+        if (drifted && liveCommitsRebind && liveSnapshot.holders.length > 0) {
           pendingSubmitRef.current = {
             input: armed.input,
             capture: live,

--- a/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
@@ -1275,14 +1275,25 @@ function teardownSendRefusalReason(
 
 /**
  * A send held by the rebind-consent dialog: the input to re-dispatch on
- * confirm, and the PATH-SPECIFIC dispatch that must run it — a confirmed
+ * confirm, the PATH-SPECIFIC dispatch that must run it — a confirmed
  * compaction still needs its lock and queue promotion, not the composer's
- * title bookkeeping.
+ * title bookkeeping — and the path's LIVE eligibility recheck. The values a
+ * path examined at click time may be a whole open dialog older by the time
+ * the user confirms (a blocking approval can arrive, the turn can start
+ * stopping), so `refusal` reads current state and returns the sentence to
+ * surface instead of dispatching, or `null` when the send is still
+ * eligible. Never a silent no-op: an ineligible confirm states why.
  */
 type GatedChatSend = {
   readonly submit: ChatComposerSubmitInput;
   readonly dispatch: (input: ChatComposerSubmitInput) => boolean;
+  readonly refusal: () => string | null;
 };
+
+// The composer submit's own eligibility (access + sign-in) is re-checked
+// live by the dialog's confirm handler itself, so its slot carries the
+// always-eligible refusal. Module scope for a stable identity.
+const NO_LIVE_SEND_REFUSAL = (): string | null => null;
 
 // eslint-disable-next-line complexity
 function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
@@ -2184,10 +2195,8 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
   // reopens one of two holes: a phantom disclosure on a no-op draft, or a
   // staged rebind committing silently.
   const submitThroughRebindGate = useCallback(
-    (
-      submit: ChatComposerSubmitInput,
-      dispatch: (input: ChatComposerSubmitInput) => boolean,
-    ): boolean => {
+    (send: GatedChatSend): boolean => {
+      const { submit, dispatch } = send;
       const stagedKey: WorktreeStagingKey = {
         surface: "owner",
         hostId: activeHostId,
@@ -2224,7 +2233,7 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
       };
       if (snapshot.holders.length > 0) {
         pendingSubmitRef.current = {
-          input: { submit, dispatch },
+          input: send,
           capture,
           ownerId: node.id,
         };
@@ -2276,7 +2285,11 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
         dispatchUi({ type: "setEditingQueueItemId", editingQueueItemId: null });
         return true;
       }
-      return submitThroughRebindGate(input, dispatchUserSend);
+      return submitThroughRebindGate({
+        submit: input,
+        dispatch: dispatchUserSend,
+        refusal: NO_LIVE_SEND_REFUSAL,
+      });
     },
     [
       activeEditingQueueItemId,
@@ -2295,6 +2308,41 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
       state.pendingApprovals,
       state.pendingFileEditApprovals.length,
     );
+  // `canSendNextStep`, re-derived from LIVE store state for the consent
+  // dialog's deferred dispatch. The render-scope boolean above is what the
+  // click checked, and it can be a whole open dialog stale by confirm time —
+  // reading the stores imperatively is the point, not a shortcut.
+  const nextStepSendRefusal = useCallback((): string | null => {
+    const live = handle.store.getState();
+    if (
+      !chatTileCanAct(
+        live.connectionStatus,
+        live.access?.canAct === true,
+        useAuthStore.getState().profile !== null,
+      )
+    ) {
+      return "You don't have permission to send.";
+    }
+    const liveStopPending = Object.values(live.pendingActions).some(
+      (action) => action.action === "stop",
+    );
+    if (
+      liveStopPending ||
+      resolvedTurnStatus(live, composerTurnStatus(live.runStatus)) ===
+        "stopping"
+    ) {
+      return "The agent is stopping — send again once it settles.";
+    }
+    if (
+      composerHasBlockingApprovals(
+        live.pendingApprovals,
+        live.pendingFileEditApprovals.length,
+      )
+    ) {
+      return "Resolve the pending approval before sending.";
+    }
+    return null;
+  }, [handle.store]);
   const sendNextStep = useCallback(
     (option: TraycerNextStepOption): boolean => {
       if (!canSendNextStep) return false;
@@ -2303,8 +2351,8 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
         plainTextPromptContent(option.prompt),
         slashCatalog,
       );
-      return submitThroughRebindGate(
-        {
+      return submitThroughRebindGate({
+        submit: {
           content,
           contentText: option.prompt,
           attachments: [],
@@ -2312,12 +2360,14 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
           deliveryPolicy: "auto",
           restore: { content, browserAnnotations: [] },
         },
-        dispatchUserSend,
-      );
+        dispatch: dispatchUserSend,
+        refusal: nextStepSendRefusal,
+      });
     },
     [
       canSendNextStep,
       dispatchUserSend,
+      nextStepSendRefusal,
       nextStepSettings,
       profile,
       slashCatalog,
@@ -2412,8 +2462,8 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
         plainTextPromptContent(`/${commandName}`),
         slashCatalog,
       );
-      submitThroughRebindGate(
-        {
+      submitThroughRebindGate({
+        submit: {
           content,
           contentText: `/${commandName}`,
           attachments: [],
@@ -2423,13 +2473,15 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
           deliveryPolicy: "auto",
           restore: { content, browserAnnotations: [] },
         },
-        dispatchCompactSend,
-      );
+        dispatch: dispatchCompactSend,
+        refusal: nextStepSendRefusal,
+      });
     },
     [
       canSendNextStep,
       dispatchCompactSend,
       handle.chatId,
+      nextStepSendRefusal,
       nextStepSettings,
       profile,
       slashCatalog,
@@ -2450,8 +2502,8 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
       plainTextPromptContent("Implement the plan above."),
       slashCatalog,
     );
-    return submitThroughRebindGate(
-      {
+    return submitThroughRebindGate({
+      submit: {
         content,
         contentText: "Implement the plan above.",
         attachments: [],
@@ -2459,11 +2511,13 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
         deliveryPolicy: "auto",
         restore: { content, browserAnnotations: [] },
       },
-      dispatchUserSend,
-    );
+      dispatch: dispatchUserSend,
+      refusal: nextStepSendRefusal,
+    });
   }, [
     canAct,
     dispatchUserSend,
+    nextStepSendRefusal,
     nextStepSettings,
     profile,
     slashCatalog,
@@ -2882,6 +2936,17 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
         }
         if (profile === null) {
           toast("Sign in to send this message.");
+          return;
+        }
+        // The armed path's OWN eligibility, re-read from live state: a
+        // blocking approval or a stopping turn can arrive while the dialog
+        // sits open, and the click-time check cannot see it. Peeked before
+        // taking the armed submit so a refusal keeps the dialog and its
+        // armed send (and the staged draft — consent was for a send that
+        // did not happen), matching the access refusals above.
+        const armedRefusal = pendingSubmitRef.current?.input.refusal() ?? null;
+        if (armedRefusal !== null) {
+          toast(armedRefusal);
           return;
         }
         const armed = takeArmedTeardownSubmit(pendingSubmitRef);

--- a/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
@@ -2495,8 +2495,15 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
     }),
     [canSendNextStep, sendNextStep],
   );
+  // Implement-plan is a submit like any next-step, so it takes the SAME
+  // eligibility rule at every point: the button (`canSend` below), this click
+  // gate, and the consent dialog's deferred confirm (`nextStepSendRefusal`).
+  // A bare `canAct` here once let a click send over a blocking file-edit/tool
+  // approval that the composer and every next-step correctly refuse - and
+  // worse, made the deferred confirm refuse a send the immediate path
+  // allowed: one click, two behaviors.
   const sendImplementPlanMessage = useCallback((): boolean => {
-    if (!canAct) return false;
+    if (!canSendNextStep) return false;
     if (userMessageSenderForProfile(profile) === null) return false;
     const content = buildSubmittedChatJSONContent(
       plainTextPromptContent("Implement the plan above."),
@@ -2515,7 +2522,7 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
       refusal: nextStepSendRefusal,
     });
   }, [
-    canAct,
+    canSendNextStep,
     dispatchUserSend,
     nextStepSendRefusal,
     nextStepSettings,
@@ -2527,13 +2534,13 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
     () => ({
       epicId: currentEpicId,
       chatId: node.id,
-      canAct,
+      canSend: canSendNextStep,
       pending: approvalDecisionPending,
       onImplement: sendImplementPlanMessage,
     }),
     [
       approvalDecisionPending,
-      canAct,
+      canSendNextStep,
       currentEpicId,
       node.id,
       sendImplementPlanMessage,

--- a/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
@@ -1273,6 +1273,17 @@ function teardownSendRefusalReason(
   return undefined;
 }
 
+/**
+ * A send held by the rebind-consent dialog: the input to re-dispatch on
+ * confirm, and the PATH-SPECIFIC dispatch that must run it — a confirmed
+ * compaction still needs its lock and queue promotion, not the composer's
+ * title bookkeeping.
+ */
+type GatedChatSend = {
+  readonly submit: ChatComposerSubmitInput;
+  readonly dispatch: (input: ChatComposerSubmitInput) => boolean;
+};
+
 // eslint-disable-next-line complexity
 function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
   const { handle, node, viewTabId, tileId, isActive, currentEpicId } = props;
@@ -2103,8 +2114,9 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
   const [teardownDialog, setTeardownDialog] = useState<{
     readonly holders: readonly WorktreeBusyHolder[];
   } | null>(null);
-  const pendingSubmitRef =
-    useRef<ArmedTeardownSubmit<ChatComposerSubmitInput> | null>(null);
+  const pendingSubmitRef = useRef<ArmedTeardownSubmit<GatedChatSend> | null>(
+    null,
+  );
   const [teardownOwnerId, setTeardownOwnerId] = useState(node.id);
   if (node.id !== teardownOwnerId) {
     setTeardownOwnerId(node.id);
@@ -2166,6 +2178,70 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
     ],
   );
 
+  // The one rebind-consent gate for every send-shaped path this tile owns —
+  // composer submits, next-step clicks, implement-plan, compaction. A path
+  // that calls `chatActions.sendMessage` without passing through here
+  // reopens one of two holes: a phantom disclosure on a no-op draft, or a
+  // staged rebind committing silently.
+  const submitThroughRebindGate = useCallback(
+    (
+      submit: ChatComposerSubmitInput,
+      dispatch: (input: ChatComposerSubmitInput) => boolean,
+    ): boolean => {
+      const stagedKey: WorktreeStagingKey = {
+        surface: "owner",
+        hostId: activeHostId,
+        epicId: currentEpicId,
+        ownerKind: "chat",
+        ownerId: node.id,
+      };
+      // The disclosure is consent for the rebind a send would commit. A send
+      // whose draft commits nothing (none staged, or one that restates the
+      // committed binding) has no rebind to consent to — gating it would put
+      // "Send in the new folder?" in front of every steer of a busy agent.
+      if (
+        !worktreeDraftCommitsRebind({
+          binding: state.worktreeBinding,
+          draft: readStagedWorktreeIntent(stagedKey),
+          removedWorkspacePaths: [],
+        })
+      ) {
+        return dispatch(submit);
+      }
+      const snapshot = snapshotTeardownHolders(
+        droppedRunDirectoriesFromDraft({
+          binding: state.worktreeBinding,
+          draft: readStagedWorktreeIntent(stagedKey),
+          removedWorkspacePaths: [],
+        }),
+      );
+      const capture: WorktreeCommitCapture = {
+        draft: readStagedWorktreeIntent(stagedKey),
+        revision: stagedWorktreeIntentRevision(stagedKey),
+        binding: state.worktreeBinding,
+        removedWorkspacePaths: [],
+        stopTargets: snapshot.stopTargets,
+      };
+      if (snapshot.holders.length > 0) {
+        pendingSubmitRef.current = {
+          input: { submit, dispatch },
+          capture,
+          ownerId: node.id,
+        };
+        setTeardownDialog({ holders: snapshot.holders });
+        return false;
+      }
+      return dispatch(submit);
+    },
+    [
+      activeHostId,
+      currentEpicId,
+      node.id,
+      snapshotTeardownHolders,
+      state.worktreeBinding,
+    ],
+  );
+
   const submitMessage = useCallback(
     (input: ChatComposerSubmitInput): boolean => {
       if (!canAct) return false;
@@ -2200,63 +2276,16 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
         dispatchUi({ type: "setEditingQueueItemId", editingQueueItemId: null });
         return true;
       }
-      const stagedKey: WorktreeStagingKey = {
-        surface: "owner",
-        hostId: activeHostId,
-        epicId: currentEpicId,
-        ownerKind: "chat",
-        ownerId: node.id,
-      };
-      // The disclosure is consent for the rebind a send would commit. A send
-      // whose draft commits nothing (none staged, or one that restates the
-      // committed binding) has no rebind to consent to — gating it would put
-      // "Send in the new folder?" in front of every steer of a busy agent.
-      if (
-        !worktreeDraftCommitsRebind({
-          binding: state.worktreeBinding,
-          draft: readStagedWorktreeIntent(stagedKey),
-          removedWorkspacePaths: [],
-        })
-      ) {
-        return dispatchUserSend(input);
-      }
-      const snapshot = snapshotTeardownHolders(
-        droppedRunDirectoriesFromDraft({
-          binding: state.worktreeBinding,
-          draft: readStagedWorktreeIntent(stagedKey),
-          removedWorkspacePaths: [],
-        }),
-      );
-      const capture: WorktreeCommitCapture = {
-        draft: readStagedWorktreeIntent(stagedKey),
-        revision: stagedWorktreeIntentRevision(stagedKey),
-        binding: state.worktreeBinding,
-        removedWorkspacePaths: [],
-        stopTargets: snapshot.stopTargets,
-      };
-      if (snapshot.holders.length > 0) {
-        pendingSubmitRef.current = {
-          input,
-          capture,
-          ownerId: node.id,
-        };
-        setTeardownDialog({ holders: snapshot.holders });
-        return false;
-      }
-      return dispatchUserSend(input);
+      return submitThroughRebindGate(input, dispatchUserSend);
     },
     [
       activeEditingQueueItemId,
-      activeHostId,
       canAct,
       chatActions,
-      currentEpicId,
       dispatchUi,
       dispatchUserSend,
-      node.id,
       profile,
-      snapshotTeardownHolders,
-      state.worktreeBinding,
+      submitThroughRebindGate,
     ],
   );
   const canSendNextStep =
@@ -2269,24 +2298,31 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
   const sendNextStep = useCallback(
     (option: TraycerNextStepOption): boolean => {
       if (!canSendNextStep) return false;
-      const sender = userMessageSenderForProfile(profile);
-      if (sender === null) return false;
+      if (userMessageSenderForProfile(profile) === null) return false;
       const content = buildSubmittedChatJSONContent(
         plainTextPromptContent(option.prompt),
         slashCatalog,
       );
-      return (
-        chatActions.sendMessage({
+      return submitThroughRebindGate(
+        {
           content,
-          sender,
-          settings: nextStepSettings,
+          contentText: option.prompt,
           attachments: [],
+          settings: nextStepSettings,
           deliveryPolicy: "auto",
           restore: { content, browserAnnotations: [] },
-        }) !== null
+        },
+        dispatchUserSend,
       );
     },
-    [canSendNextStep, chatActions, nextStepSettings, profile, slashCatalog],
+    [
+      canSendNextStep,
+      dispatchUserSend,
+      nextStepSettings,
+      profile,
+      slashCatalog,
+      submitThroughRebindGate,
+    ],
   );
   // Runs the harness's own compaction from the context-usage chip. Never
   // interrupts: with a turn running (or work already queued) the compact
@@ -2318,18 +2354,18 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
     },
     [],
   );
-  const compactConversation = useCallback(
-    (commandName: string): void => {
-      if (!canSendNextStep) return;
+  // The compaction's own dispatch behind the rebind gate: the lock, the
+  // queue-or-run-now policy, and the promotion belong to the moment the send
+  // actually leaves — a consent dialog may sit between the click and this, so
+  // deciding them at click time would act on stale turn/queue state (and take
+  // the double-click lock for a compaction that never fired).
+  const dispatchCompactSend = useCallback(
+    (input: ChatComposerSubmitInput): boolean => {
       const states = compactStateByChatIdRef.current;
       const existing = states.get(handle.chatId);
-      if (existing?.locked === true) return;
+      if (existing?.locked === true) return false;
       const sender = userMessageSenderForProfile(profile);
-      if (sender === null) return;
-      const content = buildSubmittedChatJSONContent(
-        plainTextPromptContent(`/${commandName}`),
-        slashCatalog,
-      );
+      if (sender === null) return false;
       // A cheap re-entrancy guard against a double-click firing two real
       // compactions: the optimistic-queue dedupe only suppresses the second
       // row's on-screen echo, not the frame that already went to the host.
@@ -2346,29 +2382,58 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
       const { activeTurn, queue } = handle.store.getState();
       const runNow = activeTurn === null && queue.items.length === 0;
       const sent = chatActions.sendMessage({
-        content,
+        content: input.content,
         sender,
-        settings: nextStepSettings,
-        attachments: [],
+        settings: input.settings,
+        attachments: input.attachments,
         deliveryPolicy: runNow ? "auto" : "after_turn",
-        restore: { content, browserAnnotations: [] },
+        restore: input.restore,
       });
-      if (sent === null || runNow) return;
+      if (sent === null) return false;
+      if (runNow) return true;
       state.cancelPromotion?.();
       state.cancelPromotion = promoteQueuedMessageToFront({
         store: handle.store,
         messageId: sent.messageId,
         reorder: chatActions.queueReorder,
       });
+      return true;
+    },
+    [chatActions, handle.chatId, handle.store, profile],
+  );
+  const compactConversation = useCallback(
+    (commandName: string): void => {
+      if (!canSendNextStep) return;
+      if (compactStateByChatIdRef.current.get(handle.chatId)?.locked === true) {
+        return;
+      }
+      if (userMessageSenderForProfile(profile) === null) return;
+      const content = buildSubmittedChatJSONContent(
+        plainTextPromptContent(`/${commandName}`),
+        slashCatalog,
+      );
+      submitThroughRebindGate(
+        {
+          content,
+          contentText: `/${commandName}`,
+          attachments: [],
+          settings: nextStepSettings,
+          // Placeholder only: `dispatchCompactSend` decides queue-or-run-now
+          // from live turn/queue state at actual dispatch.
+          deliveryPolicy: "auto",
+          restore: { content, browserAnnotations: [] },
+        },
+        dispatchCompactSend,
+      );
     },
     [
       canSendNextStep,
-      chatActions,
+      dispatchCompactSend,
       handle.chatId,
-      handle.store,
       nextStepSettings,
       profile,
       slashCatalog,
+      submitThroughRebindGate,
     ],
   );
   const nextStepActions = useMemo(
@@ -2380,23 +2445,30 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
   );
   const sendImplementPlanMessage = useCallback((): boolean => {
     if (!canAct) return false;
-    const sender = userMessageSenderForProfile(profile);
-    if (sender === null) return false;
+    if (userMessageSenderForProfile(profile) === null) return false;
     const content = buildSubmittedChatJSONContent(
       plainTextPromptContent("Implement the plan above."),
       slashCatalog,
     );
-    return (
-      chatActions.sendMessage({
+    return submitThroughRebindGate(
+      {
         content,
-        sender,
-        settings: nextStepSettings,
+        contentText: "Implement the plan above.",
         attachments: [],
+        settings: nextStepSettings,
         deliveryPolicy: "auto",
         restore: { content, browserAnnotations: [] },
-      }) !== null
+      },
+      dispatchUserSend,
     );
-  }, [canAct, chatActions, nextStepSettings, profile, slashCatalog]);
+  }, [
+    canAct,
+    dispatchUserSend,
+    nextStepSettings,
+    profile,
+    slashCatalog,
+    submitThroughRebindGate,
+  ]);
   const planActions = useMemo<ChatPlanActionsContextValue>(
     () => ({
       epicId: currentEpicId,
@@ -2861,7 +2933,7 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
           return;
         }
         setTeardownDialog(null);
-        dispatchUserSend(armed.input);
+        armed.input.dispatch(armed.input.submit);
       },
       onDismiss: () => {
         pendingSubmitRef.current = null;

--- a/clients/gui-app/src/lib/worktree/owner-teardown-snapshot.ts
+++ b/clients/gui-app/src/lib/worktree/owner-teardown-snapshot.ts
@@ -103,6 +103,24 @@ export function runDirectoryOfFolderIntent(
 }
 
 /**
+ * The committed binding's run directory per workspace folder — the shared
+ * "previous" side of both draft predicates below. `worktreeDraftCommitsRebind`
+ * GATES the send disclosure and `droppedRunDirectoriesFromDraft` SCOPES it,
+ * so the two must read the binding identically; building the map here makes
+ * an edit to one an edit to both.
+ */
+function bindingRunDirectoriesByWorkspace(
+  binding: WorktreeBinding | null,
+): ReadonlyMap<string, string> {
+  return new Map(
+    (binding?.entries ?? []).map((entry) => [
+      entry.workspacePath,
+      runDirectoryOfBindingEntry(entry),
+    ]),
+  );
+}
+
+/**
  * Run directories the draft would leave: each staged folder whose next run
  * directory differs from the live binding, plus each pending-removed folder's
  * current run directory. Staged intent is a sparse overlay (changed folders
@@ -114,12 +132,7 @@ export function droppedRunDirectoriesFromDraft(input: {
   readonly draft: WorktreeIntent | null;
   readonly removedWorkspacePaths: readonly string[];
 }): readonly string[] {
-  const previousByWorkspace = new Map(
-    (input.binding?.entries ?? []).map((entry) => [
-      entry.workspacePath,
-      runDirectoryOfBindingEntry(entry),
-    ]),
-  );
+  const previousByWorkspace = bindingRunDirectoriesByWorkspace(input.binding);
   const dropped: string[] = [];
   const seen = new Set<string>();
   const pushDropped = (path: string): void => {
@@ -160,12 +173,7 @@ export function worktreeDraftCommitsRebind(input: {
   readonly draft: WorktreeIntent | null;
   readonly removedWorkspacePaths: readonly string[];
 }): boolean {
-  const previousByWorkspace = new Map(
-    (input.binding?.entries ?? []).map((entry) => [
-      entry.workspacePath,
-      runDirectoryOfBindingEntry(entry),
-    ]),
-  );
+  const previousByWorkspace = bindingRunDirectoriesByWorkspace(input.binding);
   if (
     input.removedWorkspacePaths.some((path) => previousByWorkspace.has(path))
   ) {

--- a/clients/gui-app/src/lib/worktree/owner-teardown-snapshot.ts
+++ b/clients/gui-app/src/lib/worktree/owner-teardown-snapshot.ts
@@ -144,6 +144,42 @@ export function droppedRunDirectoriesFromDraft(input: {
   return dropped;
 }
 
+/**
+ * Whether committing this draft at send would actually change the owner's
+ * binding: a staged folder whose next run directory differs from the bound
+ * one (a staged `worktree` create always does — its run directory does not
+ * exist yet), a staged folder the binding does not carry, or a pending
+ * removal of a bound folder. A draft that merely restates the committed
+ * binding — or no draft at all — commits nothing, so a send with one is not
+ * a rebind gesture and must not be gated on teardown disclosure: the
+ * disclosure exists to confirm "switch folders and stop what runs there",
+ * and with nothing switching there is nothing to confirm.
+ */
+export function worktreeDraftCommitsRebind(input: {
+  readonly binding: WorktreeBinding | null;
+  readonly draft: WorktreeIntent | null;
+  readonly removedWorkspacePaths: readonly string[];
+}): boolean {
+  const previousByWorkspace = new Map(
+    (input.binding?.entries ?? []).map((entry) => [
+      entry.workspacePath,
+      runDirectoryOfBindingEntry(entry),
+    ]),
+  );
+  if (
+    input.removedWorkspacePaths.some((path) => previousByWorkspace.has(path))
+  ) {
+    return true;
+  }
+  if (input.draft === null) return false;
+  return input.draft.entries.some((entry) => {
+    const previous = previousByWorkspace.get(entry.workspacePath);
+    if (previous === undefined) return true;
+    const next = runDirectoryOfFolderIntent(entry);
+    return next === null || next !== previous;
+  });
+}
+
 export function pathContainsDirectory(
   root: string,
   candidate: string,


### PR DESCRIPTION
## What

Fixes the staging incident where **every send/steer/queue to a working agent** opened the "Send in the new folder?" teardown dialog with no worktree change staged — reported by two users, reproduced live, and diagnosed to a single mechanism: the send gate armed on `snapshot.holders.length > 0` alone. Since the snapshot synthesizes a chat-turn holder whenever a turn is active, a running agent was sufficient to gate the composer; the staged draft was never consulted.

Two commits, both directions of the same defect:

- **`worktreeDraftCommitsRebind`** becomes the arming condition: true only for a staged folder whose next run directory differs from the bound one, a folder the binding doesn't carry, or a pending removal of a bound folder. No draft — or a draft that restates the binding — sends clean. Real rebinds disclose exactly as before.
- **`submitThroughRebindGate`** closes the mirror hole: `sendNextStep`, `sendImplementPlanMessage`, and `compactConversation` previously bypassed the gate entirely, so a *real* staged rebind committed with zero disclosure. All four send paths now route through one gated dispatch; the armed dialog carries its path's own dispatch, compaction keeps its double-click lock and decides queue-vs-run from live state at dispatch time while the draft stays capture-pinned; consent is per send (a deferral re-discloses the next send).

Red-first both ways with parent-commit ablation: the phantom (busy chat, no draft ⇒ was gated, now clean, on both composer and next-step paths) and the silent commit (next-step with a staged rebind ⇒ was silent, now discloses, with the intent riding the confirmed frame).

## Tests

132 across 6 suites; adversarially reviewed (Codex ultra), APPROVE with no findings — including both-ways completeness of the arming predicate and lock/token hygiene across all four gated paths. `bun run format`, `bun run lint`, `tsgo -b` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
