### PR TITLE
fix(protocol): sanitize holder-error revisions and unknown failure codes

### DIFF
--- a/clients/shared/host-transport/__tests__/worktree-delete-stream-client.test.ts
+++ b/clients/shared/host-transport/__tests__/worktree-delete-stream-client.test.ts
@@ -191,4 +191,33 @@ describe("WorktreeDeleteStreamClient", () => {
     expect(onFailed).toHaveBeenCalledWith("Worktree is in use", undefined);
     client.close();
   });
+
+  it("delivers a 1.2 failed frame with an unknown code instead of dropping it", () => {
+    const session = new StubSession();
+    const wsStreamClient = makeWsStreamClient(session);
+    const onFailed = vi.fn();
+    const client = new WorktreeDeleteStreamClient({
+      wsStreamClient,
+      worktreePath: "/wt/a",
+      scripts: null,
+      stopOwners: false,
+      callbacks: {
+        onStarted: () => {},
+        onPhase: () => {},
+        onOutput: () => {},
+        onComplete: () => {},
+        onFailed,
+        onConnectionStatus: () => {},
+      },
+    });
+    session.emitFrame({
+      kind: "failed",
+      reason: "Worktree is in use",
+      code: "SOME_FUTURE_CODE",
+      holders: HOLDERS,
+      hasBinaryPayload: false,
+    });
+    expect(onFailed).toHaveBeenCalledWith("Worktree is in use", HOLDERS);
+    client.close();
+  });
 });

--- a/clients/traycer-cli/src/commands/__tests__/worktree-delete.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/worktree-delete.test.ts
@@ -616,4 +616,29 @@ describe("buildWorktreeDeleteCommand legacy stream v1.1 holders", () => {
       details: null,
     });
   });
+
+  it("settles a v1.2 failed frame whose code is unknown to this client", async () => {
+    const { pending, legacy } = await startLegacyFallback();
+
+    legacy.frameHandler?.({
+      kind: "failed",
+      reason: "worktree is busy",
+      code: "SOME_FUTURE_CODE",
+      holders: [
+        {
+          ownerRef: { epicId: "e1", ownerKind: "chat", ownerId: "c1" },
+          holdKind: "chat-turn",
+          activity: "working",
+          label: "Chat: fix flaky test",
+        },
+      ],
+      hasBinaryPayload: false,
+    });
+
+    await expect(pending).rejects.toMatchObject({
+      code: CLI_ERROR_CODES.UNEXPECTED,
+      exitCode: 1,
+      message: expect.stringContaining("Held by Chat: fix flaky test."),
+    });
+  });
 });

--- a/protocol/src/framework/worktree-busy-holders.ts
+++ b/protocol/src/framework/worktree-busy-holders.ts
@@ -87,13 +87,16 @@ export const holdersRevisionWireFieldSchema = z
 /**
  * `WORKTREE_BUSY` envelope a current client parses when it wants the typed
  * inventory. `holders` omitted = old host; the prose `message` still names
- * the refusal. `holdersRevision` is the digest of that inventory.
+ * the refusal. `holdersRevision` is the digest of that inventory — a
+ * non-digest sanitizes to absent so a GUI that echoes it as
+ * `expectedHoldersRevision` cannot be handed a value the request schema
+ * rejects.
  */
 export const worktreeBusyErrorDetailsSchema = z.object({
   code: z.literal("WORKTREE_BUSY"),
   message: z.string(),
   holders: worktreeBusyHoldersSchema.optional(),
-  holdersRevision: z.string().optional(),
+  holdersRevision: holdersRevisionWireFieldSchema,
 });
 export type WorktreeBusyErrorDetails = z.infer<
   typeof worktreeBusyErrorDetailsSchema
@@ -104,13 +107,16 @@ export type WorktreeBusyErrorDetails = z.infer<
  * `WORKTREE_BUSY` (`message` + optional `holders` + optional
  * `holdersRevision`); a distinguishable `code` so a current GUI can
  * refresh consent instead of treating it as a generic busy. Old clients
- * see an unknown code and keep the 4xx busy-class refusal.
+ * see an unknown code and keep the 4xx busy-class refusal. The HOLDERS_CHANGED
+ * envelope is the echo path: the GUI reads this revision for re-review
+ * and later sends it as `expectedHoldersRevision`, so it uses the same
+ * sanitize-to-absent digest field as the failure-frame wire.
  */
 export const worktreeHoldersChangedErrorDetailsSchema = z.object({
   code: z.literal("WORKTREE_HOLDERS_CHANGED"),
   message: z.string(),
   holders: worktreeBusyHoldersSchema.optional(),
-  holdersRevision: z.string().optional(),
+  holdersRevision: holdersRevisionWireFieldSchema,
 });
 export type WorktreeHoldersChangedErrorDetails = z.infer<
   typeof worktreeHoldersChangedErrorDetailsSchema

--- a/protocol/src/host/__tests__/lifecycle-minors.test.ts
+++ b/protocol/src/host/__tests__/lifecycle-minors.test.ts
@@ -91,14 +91,24 @@ describe("WORKTREE_BUSY typed holders", () => {
     expect(parsed.holdersRevision).toBeUndefined();
   });
 
-  it("accepts holdersRevision on a WORKTREE_BUSY envelope", () => {
+  it("accepts a digest holdersRevision on a WORKTREE_BUSY envelope", () => {
+    const parsed = worktreeBusyErrorDetailsSchema.parse({
+      code: "WORKTREE_BUSY",
+      message: "Worktree is in use by an active agent or terminal.",
+      holders: [holder],
+      holdersRevision: HOLDERS_REVISION_DIGEST,
+    });
+    expect(parsed.holdersRevision).toBe(HOLDERS_REVISION_DIGEST);
+  });
+
+  it("sanitizes a non-digest holdersRevision on a WORKTREE_BUSY envelope to absent", () => {
     const parsed = worktreeBusyErrorDetailsSchema.parse({
       code: "WORKTREE_BUSY",
       message: "Worktree is in use by an active agent or terminal.",
       holders: [holder],
       holdersRevision: "rev-1",
     });
-    expect(parsed.holdersRevision).toBe("rev-1");
+    expect(parsed.holdersRevision).toBeUndefined();
   });
 
   it("keeps holders on the current error envelope", () => {
@@ -360,17 +370,29 @@ describe("worktree.delete@1.2 expectedHoldersRevision", () => {
     expect(parsed).not.toHaveProperty("expectedHoldersRevision");
   });
 
-  it("parses a WORKTREE_HOLDERS_CHANGED envelope with holders and revision", () => {
+  it("parses a WORKTREE_HOLDERS_CHANGED envelope with holders and a digest revision", () => {
     const parsed = worktreeHoldersChangedErrorDetailsSchema.parse({
       code: "WORKTREE_HOLDERS_CHANGED",
       message: "holders changed",
       holders: [{ ...holder, holderId: "chat:chat-1" }],
-      holdersRevision: "rev-abc",
+      holdersRevision: HOLDERS_REVISION_DIGEST,
     });
     expect(parsed.code).toBe("WORKTREE_HOLDERS_CHANGED");
     expect(parsed.holders).toHaveLength(1);
     expect(parsed.holders?.[0]?.holderId).toBe("chat:chat-1");
-    expect(parsed.holdersRevision).toBe("rev-abc");
+    expect(parsed.holdersRevision).toBe(HOLDERS_REVISION_DIGEST);
+  });
+
+  it("sanitizes a non-digest holdersRevision on a WORKTREE_HOLDERS_CHANGED envelope to absent", () => {
+    const parsed = worktreeHoldersChangedErrorDetailsSchema.parse({
+      code: "WORKTREE_HOLDERS_CHANGED",
+      message: "holders changed",
+      holders: [holder],
+      holdersRevision: "rev-1",
+    });
+    expect(parsed.code).toBe("WORKTREE_HOLDERS_CHANGED");
+    expect(parsed.holders).toEqual([holder]);
+    expect(parsed.holdersRevision).toBeUndefined();
   });
 });
 
@@ -523,6 +545,37 @@ describe("worktree.deleteByPath@1.2 expectedHoldersRevision", () => {
     expect(parsed.kind).toBe("failed");
     if (parsed.kind === "failed") {
       expect(parsed.holdersRevision).toBeUndefined();
+    }
+  });
+
+  it("1.2 failed frame sanitizes an unknown code to absent without dropping the terminal frame", () => {
+    const parsed = worktreeDeleteByPathServerFrameSchemaV12.parse({
+      kind: "failed",
+      reason: "holders changed",
+      code: "SOME_FUTURE_CODE",
+      holders: [holder],
+      holdersRevision: HOLDERS_REVISION_DIGEST,
+      hasBinaryPayload: false,
+    });
+    expect(parsed.kind).toBe("failed");
+    if (parsed.kind === "failed") {
+      expect(parsed.code).toBeUndefined();
+      expect(parsed.reason).toBe("holders changed");
+      expect(parsed.holders).toEqual([holder]);
+      expect(parsed.holdersRevision).toBe(HOLDERS_REVISION_DIGEST);
+    }
+  });
+
+  it("1.2 failed frame keeps a known WORKTREE_BUSY code", () => {
+    const parsed = worktreeDeleteByPathServerFrameSchemaV12.parse({
+      kind: "failed",
+      reason: "in use",
+      code: "WORKTREE_BUSY",
+      hasBinaryPayload: false,
+    });
+    expect(parsed.kind).toBe("failed");
+    if (parsed.kind === "failed") {
+      expect(parsed.code).toBe("WORKTREE_BUSY");
     }
   });
 

--- a/protocol/src/host/worktree-delete-stream.ts
+++ b/protocol/src/host/worktree-delete-stream.ts
@@ -206,7 +206,9 @@ export const worktreeDeleteByPathStreamV11 = defineStreamRpcContract({
  * @1.2 failed frames may carry the unary refusal `code` so a current
  * GUI can distinguish `WORKTREE_HOLDERS_CHANGED` from `WORKTREE_BUSY`
  * without parsing `reason`. Absent on a 1.1 host; a 1.1 client schema
- * strips it.
+ * strips it. An unknown `code` (a newer host's future value) sanitizes
+ * to absent so the terminal `failed` frame still parses — dropping the
+ * frame would leave a pending delete unsettled.
  */
 export const worktreeDeleteByPathServerFrameSchemaV12 = z.discriminatedUnion(
   "kind",
@@ -237,7 +239,10 @@ export const worktreeDeleteByPathServerFrameSchemaV12 = z.discriminatedUnion(
       reason: z.string(),
       holders: worktreeBusyHoldersWireFieldSchema,
       holdersRevision: holdersRevisionWireFieldSchema,
-      code: z.enum(["WORKTREE_BUSY", "WORKTREE_HOLDERS_CHANGED"]).optional(),
+      code: z
+        .enum(["WORKTREE_BUSY", "WORKTREE_HOLDERS_CHANGED"])
+        .optional()
+        .catch(undefined),
       hasBinaryPayload: z.literal(false),
     }),
     z.object({


### PR DESCRIPTION
## What

Follow-up to #1517 for two CodeRabbit findings that landed after it merged:

- **Typed holder-error details now sanitize revisions.** `worktreeBusyErrorDetailsSchema` / `worktreeHoldersChangedErrorDetailsSchema` carried `holdersRevision` as a bare optional string, bypassing the digest wire-field sanitizer — and the `WORKTREE_HOLDERS_CHANGED` envelope is exactly the echo path (the GUI reads the fresh revision there and echoes it as `expectedHoldersRevision`). A malformed emission could hand the client a value the request schema rejects. Both now use `holdersRevisionWireFieldSchema` (malformed ⇒ absent).
- **Unknown failure codes no longer reject terminal frames.** A `deleteByPath@1.2` `failed` frame with a future `code` failed parsing outright, so `runLegacyDeleteStream` dropped it and the pending delete never settled. `code` is now `.optional().catch(undefined)` — the terminal frame survives with the code sanitized, per the wire-seam leniency invariant; known codes are unchanged.

Red-first both: `"rev-1"` in either details parses with the revision absent; `code: "SOME_FUTURE_CODE"` parses as a terminal `failed` frame with `code === undefined` and still delivers `onFailed` through the shared stream client.

## Tests

Full protocol suite (213 files, 3815 passed) including the released-surface/stream/floor/frozen-catalog gates; CLI worktree-delete + identity; shared stream client + error boundary; GUI settings panel. All compiles green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
