### PR TITLE
fix(gui-app): add fallback reasoning and vision for Kimi K3 models

### DIFF
--- a/clients/gui-app/src/components/home/data/landing-options.ts
+++ b/clients/gui-app/src/components/home/data/landing-options.ts
@@ -274,10 +274,89 @@ function stripProviderPrefix(label: string, providerLabel: string): string {
 
 const NO_REASONING_OPTIONS: ReadonlyArray<ReasoningLevelOption> = [];
 
+/**
+ * Standard reasoning effort levels for Kimi K3 / coding models.
+ *
+ * Used as a client-side fallback for catalog rows (e.g. on `kimi` and `hermes`
+ * harnesses) that shipped no `supportedReasoningEfforts` metadata in the host
+ * response (issue #1236).
+ */
+export const KIMI_K3_DEFAULT_REASONING_OPTIONS: ReadonlyArray<ReasoningLevelOption> =
+  [
+    {
+      id: "off",
+      label: "Off",
+      description: "Standard execution without extended reasoning",
+    },
+    {
+      id: "low",
+      label: "Low",
+      description: "Fast reasoning pass",
+    },
+    {
+      id: "high",
+      label: "High",
+      description: "Deep reasoning pass",
+    },
+    {
+      id: "max",
+      label: "Max",
+      description: "Maximum reasoning effort",
+    },
+  ];
+
+const KIMI_K3_HARNESS_IDS = new Set(["kimi", "hermes", "omp"]);
+
+/**
+ * Checks whether a given model selection matches a known Kimi K3 / Kimi-coding
+ * model identity.
+ *
+ * @param model - The model option or selection descriptor to test.
+ * @returns `true` if the model is a recognized Kimi K3 / coding variant.
+ */
+export function isKimiK3Model(model: {
+  readonly harnessId: string;
+  readonly slug: string;
+  readonly label?: string | null;
+}): boolean {
+  if (!KIMI_K3_HARNESS_IDS.has(model.harnessId)) {
+    return false;
+  }
+  const slugLower = model.slug.toLowerCase();
+  const labelLower = (model.label ?? "").toLowerCase();
+
+  return (
+    slugLower.includes("k3") ||
+    slugLower.includes("kimi-for-coding") ||
+    slugLower.includes("kimi-coding") ||
+    slugLower.includes("kimi-code") ||
+    labelLower.includes("k3") ||
+    labelLower.includes("kimi-for-coding") ||
+    labelLower.includes("kimi-coding")
+  );
+}
+
+/**
+ * Finds the reasoning effort options available for a model.
+ *
+ * If the host catalog provided explicit options, those are returned.
+ * If empty and the model is recognized as a Kimi K3 model, returns the default
+ * K3 reasoning effort options (`off`, `low`, `high`, `max`).
+ *
+ * @param model - The model option to inspect.
+ * @returns An array of supported reasoning level options.
+ */
 export function findReasoningOptionsForModel(
   model: ModelOption | null,
 ): ReadonlyArray<ReasoningLevelOption> {
-  return model?.supportedReasoningEfforts ?? NO_REASONING_OPTIONS;
+  if (model === null) return NO_REASONING_OPTIONS;
+  if (model.supportedReasoningEfforts.length > 0) {
+    return model.supportedReasoningEfforts;
+  }
+  if (isKimiK3Model(model)) {
+    return KIMI_K3_DEFAULT_REASONING_OPTIONS;
+  }
+  return NO_REASONING_OPTIONS;
 }
 
 export function normalizeReasoningForModel(

--- a/clients/gui-app/src/lib/composer/__tests__/chat-run-settings.test.ts
+++ b/clients/gui-app/src/lib/composer/__tests__/chat-run-settings.test.ts
@@ -6,9 +6,23 @@ import {
   permissionFromChatRunSettings,
   selectedModelRejectsImageAttachments,
 } from "@/lib/composer/chat-run-settings";
-import type { ModelOption } from "@/components/home/data/landing-options";
+import {
+  findReasoningOptionsForModel,
+  KIMI_K3_DEFAULT_REASONING_OPTIONS,
+  type ModelOption,
+} from "@/components/home/data/landing-options";
 
-function model(metadata: Record<string, unknown>): ModelOption {
+/**
+ * Helper to construct a test `ModelOption` with metadata and optional property overrides.
+ *
+ * @param metadata - The metadata record for the model option.
+ * @param overrides - Optional field overrides to merge into the default model option shape.
+ * @returns A complete `ModelOption` object for testing.
+ */
+function model(
+  metadata: Record<string, unknown>,
+  overrides: Partial<ModelOption> | undefined = undefined,
+): ModelOption {
   return {
     harnessId: "codex",
     slug: "gpt-test",
@@ -21,6 +35,7 @@ function model(metadata: Record<string, unknown>): ModelOption {
     defaultServiceTier: null,
     supportedServiceTiers: [],
     metadata,
+    ...overrides,
   };
 }
 
@@ -122,7 +137,7 @@ describe("chat run settings", () => {
     ).toBe("full_access");
   });
 
-  it("detects image-capable model metadata", () => {
+  it("detects image-capable model metadata and harness capabilities", () => {
     expect(
       modelSupportsImageAttachments(
         model({ inputModalities: ["text", "image"] }),
@@ -131,7 +146,67 @@ describe("chat run settings", () => {
     expect(modelSupportsImageAttachments(model({ supportsImages: true }))).toBe(
       true,
     );
+
+    // K3 models on kimi, hermes, and omp harnesses support image attachments
+    const kimiK3 = model({}, { harnessId: "kimi", slug: "k3-256k" });
+    const hermesK3 = model(
+      {},
+      { harnessId: "hermes", slug: "kimi-coding:k3-256k" },
+    );
+    const ompK3 = model({}, { harnessId: "omp", slug: "kimi-code/k3-256k" });
+
+    expect(modelSupportsImageAttachments(kimiK3)).toBe(true);
+    expect(modelSupportsImageAttachments(hermesK3)).toBe(true);
+    expect(modelSupportsImageAttachments(ompK3)).toBe(true);
+
+    // Non-K3 model on kimi harness without image metadata stays text-only
+    const kimiTextOnly = model({}, { harnessId: "kimi", slug: "kimi-text-v1" });
+    expect(modelSupportsImageAttachments(kimiTextOnly)).toBe(false);
+
+    // Unrelated generic models are text-only by default
     expect(selectedModelRejectsImageAttachments(model({}))).toBe(true);
     expect(selectedModelRejectsImageAttachments(null)).toBe(false);
+  });
+
+  it("provides fallback reasoning effort options for K3 models with missing metadata", () => {
+    // K3 model on kimi harness with empty reasoning metadata receives fallbacks
+    const kimiK3 = model({}, { harnessId: "kimi", slug: "k3-256k" });
+    expect(findReasoningOptionsForModel(kimiK3)).toEqual(
+      KIMI_K3_DEFAULT_REASONING_OPTIONS,
+    );
+
+    // K3 model on hermes harness receives fallbacks
+    const hermesK3 = model(
+      {},
+      { harnessId: "hermes", slug: "kimi-coding:k3-256k" },
+    );
+    expect(findReasoningOptionsForModel(hermesK3)).toEqual(
+      KIMI_K3_DEFAULT_REASONING_OPTIONS,
+    );
+
+    // Model with explicit reasoning metadata keeps its own options
+    const explicitEffortOption = {
+      id: "low",
+      label: "Low",
+      description: null,
+    };
+    const explicitModel = model(
+      {},
+      {
+        harnessId: "kimi",
+        slug: "k3-256k",
+        supportedReasoningEfforts: [explicitEffortOption],
+      },
+    );
+    expect(findReasoningOptionsForModel(explicitModel)).toEqual([
+      explicitEffortOption,
+    ]);
+
+    // Non-K3 model with empty reasoning metadata returns empty array
+    const nonK3Model = model({}, { harnessId: "codex", slug: "gpt-4o" });
+    expect(findReasoningOptionsForModel(nonK3Model)).toEqual([]);
+
+    // Null model returns empty array
+    expect(findReasoningOptionsForModel(null)).toEqual([]);
   });
 });

--- a/clients/gui-app/src/lib/composer/chat-run-settings.ts
+++ b/clients/gui-app/src/lib/composer/chat-run-settings.ts
@@ -2,6 +2,7 @@ import type { ChatRunSettings } from "@traycer/protocol/host/agent/gui/subscribe
 
 import {
   DEFAULT_PERMISSION,
+  isKimiK3Model,
   isPermissionMode,
 } from "@/components/home/data/landing-options";
 import type {
@@ -87,7 +88,8 @@ export function modelSupportsImageAttachments(model: ModelOption): boolean {
     model.metadata.supportsImages === true ||
     model.metadata.supportsImageAttachments === true ||
     model.metadata.multimodal === true ||
-    model.metadata.vision === true
+    model.metadata.vision === true ||
+    isKimiK3Model(model)
   );
 }
 


### PR DESCRIPTION
Fixes #1236

Traycer's model handlers block features like image uploads or reasoning effort selection if those capabilities aren't advertised in the host's returned catalog metadata. For `k3-256k` on the `kimi` and `hermes` harnesses, this metadata is unexpectedly missing, whereas the same model properly exposes it via the `omp` harness.

This change adds a client-side fallback via `isKimiK3Model` to provide standard `KIMI_K3_DEFAULT_REASONING_OPTIONS` and explicitly treat the model as matching `modelSupportsImageAttachments()`.