### PR TITLE
test: kill five CI flake classes at their races (desktop timers, Chrome launcher, cli-binary, darwin log replay)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -286,8 +286,13 @@ jobs:
           restore-keys: |
             nx-${{ runner.os }}-@traycer-clients/desktop-
       - run: bun install --frozen-lockfile
+      # `--outputStyle=stream` for the same reason as the `test` job above:
+      # Nx's default replay is capped, and this job's only failure log to date
+      # cut off mid-replay before Vitest printed the `×` lines - the failing
+      # test was unrecoverable from CI. It replaces `--tui=false` (the two are
+      # mutually exclusive; `stream` is already a non-TUI style).
       - name: Desktop unit tests (darwin-gated blocks included)
-        run: bunx nx run-many --target=test --projects="@traycer-clients/desktop" --tui=false
+        run: bunx nx run-many --target=test --projects="@traycer-clients/desktop" --outputStyle=stream
       - name: Real electron-builder packaging test
         run: bun run test:packaging
         working-directory: clients/desktop

--- a/clients/desktop/src/electron-main/browser-view/__tests__/browser-view-manager.test.ts
+++ b/clients/desktop/src/electron-main/browser-view/__tests__/browser-view-manager.test.ts
@@ -671,6 +671,27 @@ function createHarness(): Harness {
   return createHarnessWithOptions(undefined);
 }
 
+/**
+ * Every manager this file creates, so cleanup does not depend on any single
+ * test reaching its own last line.
+ *
+ * A live PiP capture re-arms a real 200ms timer forever
+ * (`BrowserPipCapture.captureFrame`); one left running outlives its test,
+ * and once a LATER test installs fake timers the chain migrates into the
+ * fake queue and spins `runAllTimersAsync` into vitest's 10000-timer abort.
+ * An assertion failure between `startPipCapture` and an in-test stop would
+ * resurrect exactly that leak - one failed test manufacturing a second,
+ * flaky one - so the stop lives in an `afterEach` that covers every
+ * PiP-starting path, current and future. `pip.stop()` is idempotent, so
+ * stopping managers that never captured is a no-op.
+ */
+const createdManagers: BrowserViewManager[] = [];
+
+afterEach(() => {
+  for (const manager of createdManagers) manager.pip.stop();
+  createdManagers.length = 0;
+});
+
 function createHarnessWithOptions(
   harnessOptions: HarnessOptions | undefined,
 ): Harness {
@@ -798,8 +819,10 @@ function createHarnessWithOptions(
       harnessOptions?.boundsStreamLogIntervalMs ?? 1000,
     hostPlatform: harnessOptions?.hostPlatform ?? "darwin",
   };
+  const manager = new BrowserViewManager(options);
+  createdManagers.push(manager);
   return {
-    manager: new BrowserViewManager(options),
+    manager,
     windows,
     views,
     nativeTabStatuses,
@@ -1844,12 +1867,6 @@ describe("BrowserViewManager native tab lifecycle", () => {
       { x: -300, y: -200, width: 300, height: 200 },
     ]);
     expect(view.visible).toBe(true);
-
-    // The capture loop re-arms a real 200ms timer forever; left running it
-    // outlives this test and, once a later test installs fake timers, hops
-    // into the fake queue and spins `runAllTimersAsync` into the 10000-timer
-    // abort. Stop it before handing the worker to the next test.
-    harness.manager.pip.stop();
   });
 
   it("holds and releases the compositor lease for an unbound PiP tab", async () => {

--- a/clients/desktop/src/electron-main/browser-view/__tests__/browser-view-manager.test.ts
+++ b/clients/desktop/src/electron-main/browser-view/__tests__/browser-view-manager.test.ts
@@ -1844,6 +1844,12 @@ describe("BrowserViewManager native tab lifecycle", () => {
       { x: -300, y: -200, width: 300, height: 200 },
     ]);
     expect(view.visible).toBe(true);
+
+    // The capture loop re-arms a real 200ms timer forever; left running it
+    // outlives this test and, once a later test installs fake timers, hops
+    // into the fake queue and spins `runAllTimersAsync` into the 10000-timer
+    // abort. Stop it before handing the worker to the next test.
+    harness.manager.pip.stop();
   });
 
   it("holds and releases the compositor lease for an unbound PiP tab", async () => {

--- a/clients/desktop/src/electron-main/ipc/__tests__/selection-authority-ipc.test.ts
+++ b/clients/desktop/src/electron-main/ipc/__tests__/selection-authority-ipc.test.ts
@@ -628,6 +628,45 @@ async function lastMessageOn(
   return found;
 }
 
+/**
+ * Waits until `window` has seen the fleet-membership fan-out naming `hostId`.
+ *
+ * Fleet membership is published by an async seed pipeline (`void
+ * fleet.refresh()` at install: a real fs identity read, then the registry
+ * fetch, then the engine publish). Every write the engine directory-validates
+ * misbehaves when it runs before that pipeline lands - `activate` refuses
+ * with `unknown-host`, and dial evidence is silently DROPPED for hosts
+ * outside the fleet - and gating on the fixed `flushIo()` sleep lost exactly
+ * that race in CI (`unknown-host` from a fleet that did not hold the host
+ * yet). Wait for the observable fact instead: a `selectionLeasesChanged`
+ * fan-out carrying the host.
+ */
+async function awaitFleetMembership(
+  window: CapturingWindow,
+  hostId: string,
+): Promise<void> {
+  await vi.waitFor(() => {
+    const arrived = window.sentMessages.some((message) => {
+      if (message.channel !== RunnerHostEvent.selectionLeasesChanged) {
+        return false;
+      }
+      const payload = message.payload;
+      if (typeof payload !== "object" || payload === null) return false;
+      const change = (payload as { change: unknown }).change;
+      return (
+        Array.isArray(change) &&
+        change.some(
+          (entry) =>
+            typeof entry === "object" &&
+            entry !== null &&
+            (entry as { hostId: unknown }).hostId === hostId,
+        )
+      );
+    });
+    expect(arrived).toBe(true);
+  });
+}
+
 function attachHandler(): InvokeHandler {
   const handler = ipcMainState.handlers.get(
     SelectionAuthorityChannels.invoke.attach,
@@ -949,7 +988,8 @@ describe("selection authority IPC binding", () => {
       registry.add("window-a", 101, windowA);
       registry.add("window-b", 202, windowB);
       bridge.install();
-      await flushIo();
+      await awaitFleetMembership(windowA, "shared-host");
+      await awaitFleetMembership(windowB, "shared-host");
 
       const attach = attachHandler();
       const seqA = invokeSyncWithSender(RunnerHostSync.selectionAttachSeq, 101);
@@ -1140,7 +1180,11 @@ describe("selection authority IPC binding", () => {
     registry.add("window-a", 101, windowA);
     registry.add("window-b", 202, windowB);
     bridge.install();
-    await flushIo();
+    // Dial evidence for a host outside the fleet is DROPPED by the engine,
+    // so the refusal counting below silently no-ops when it outruns the
+    // async membership seed - wait for the fan-out fact, not a clock.
+    await awaitFleetMembership(windowA, "close-host");
+    await awaitFleetMembership(windowB, "close-host");
 
     const attach = attachHandler();
     const seqA = invokeSyncWithSender(RunnerHostSync.selectionAttachSeq, 101);
@@ -1271,7 +1315,11 @@ describe("selection authority IPC binding", () => {
       registry.add("window-a", 101, windowA);
       registry.add("window-b", 202, windowB);
       bridge.install();
-      await flushIo();
+      // Dial evidence for a host outside the fleet is DROPPED by the engine,
+      // so the refusal counting below silently no-ops when it outruns the
+      // async membership seed - wait for the fan-out fact, not a clock.
+      await awaitFleetMembership(windowA, "crash-host");
+      await awaitFleetMembership(windowB, "crash-host");
 
       const attach = attachHandler();
       const seqA = invokeSyncWithSender(RunnerHostSync.selectionAttachSeq, 101);
@@ -1396,7 +1444,11 @@ describe("selection authority IPC binding", () => {
       registry.add("window-a", 101, windowA);
       registry.add("window-b", 202, windowB);
       bridge.install();
-      await flushIo();
+      // Dial evidence for a host outside the fleet is DROPPED by the engine,
+      // so the refusal counting below silently no-ops when it outruns the
+      // async membership seed - wait for the fan-out fact, not a clock.
+      await awaitFleetMembership(windowA, "detach-host");
+      await awaitFleetMembership(windowB, "detach-host");
 
       const attach = attachHandler();
       const seqA = invokeSyncWithSender(RunnerHostSync.selectionAttachSeq, 101);
@@ -1561,7 +1613,11 @@ describe("selection authority IPC binding", () => {
       const windowA = buildWindow();
       registry.add("window-a", 101, windowA);
       bridge.install();
-      await flushIo();
+      // The one-shot rejection below is meant for the EXPLICIT refresh; a
+      // clock gate here let a slow seed refresh land late and swallow it,
+      // handing the explicit refresh the resolved value instead. Wait for
+      // the seed's fetch to have actually happened before arming it.
+      await settledSeedFetchCount();
 
       fetchRegisteredHostsMock.mockRejectedValueOnce(
         new Error("registry blip"),

--- a/clients/gui-app/scripts/diff-edit-browser-regression.mjs
+++ b/clients/gui-app/scripts/diff-edit-browser-regression.mjs
@@ -511,11 +511,14 @@ async function waitForDevToolsUrl(process, readError) {
  * deadline outright (its FIRST stderr line arrived 21s after spawn), and a
  * single flat deadline makes that a hard failure. A retry only helps when it
  * starts clean, so each attempt gets a fresh profile directory, and a
- * timed-out attempt is fully killed (SIGTERM, then SIGKILL after a grace
- * period, awaited to the exit event) and its profile removed before the next
+ * timed-out attempt's whole process GROUP is terminated and verified gone
+ * (see `terminateProcessTree`) and its profile removed before the next
  * spawn - otherwise the retry inherits a locked profile plus the previous
  * attempt's crashpad children, which is exactly the orphan pile the runner
- * had to reap.
+ * had to reap. `detached: true` is what makes that possible: it puts Chrome
+ * at the head of its own process group, so renderers and crashpad handlers
+ * are addressable together as one negative-PGID signal instead of only the
+ * browser PID.
  */
 async function launchChromeWithDevTools(chromePath, chromeEnv) {
   const attempts = 3;
@@ -541,7 +544,7 @@ async function launchChromeWithDevTools(chromePath, chromeEnv) {
         `--user-data-dir=${profilePath}`,
         "about:blank",
       ],
-      { env: chromeEnv, stdio: ["ignore", "ignore", "pipe"] },
+      { env: chromeEnv, stdio: ["ignore", "ignore", "pipe"], detached: true },
     );
     let chromeError = "";
     chrome.stderr.setEncoding("utf8");
@@ -572,21 +575,43 @@ async function launchChromeWithDevTools(chromePath, chromeEnv) {
 }
 
 /**
- * Ends a spawned process for real: SIGTERM, a 2s grace period, then SIGKILL,
- * resolving only once the `exit` event has fired. Chrome ignores SIGTERM
- * during early startup, and a fire-and-forget kill left it (and its crashpad
- * handlers) alive for the CI runner to reap as orphans.
+ * Terminates a detached child's whole process TREE, with a bounded wait.
+ *
+ * The child is spawned `detached`, so it leads its own process group and its
+ * descendants (Chrome's renderers and crashpad handlers, which survive a
+ * plain parent kill - the CI runner had to reap exactly that pile) are all
+ * addressable as one negative-PGID signal. SIGTERM first (Chrome ignores it
+ * during early startup), a 2s grace, then SIGKILL to the group, then a
+ * BOUNDED verification that no group member remains. A tree that somehow
+ * survives SIGKILL fails loudly rather than letting a retry - or the final
+ * cleanup - proceed over a half-dead tree.
  */
 async function terminateProcessTree(child) {
-  if (child.exitCode !== null || child.signalCode !== null) return;
-  const exited = new Promise((resolve) => {
-    child.once("exit", () => resolve(true));
-  });
-  child.kill("SIGTERM");
-  const terminated = await Promise.race([exited, delay(2_000, false)]);
-  if (terminated === false) {
-    child.kill("SIGKILL");
-    await exited;
+  const groupId = child.pid;
+  if (groupId === undefined) return;
+  const signalGroup = (signal) => {
+    try {
+      process.kill(-groupId, signal);
+      return true;
+    } catch {
+      // ESRCH: every member of the group is already gone.
+      return false;
+    }
+  };
+  if (!signalGroup("SIGTERM")) return;
+  const termDeadline = Date.now() + 2_000;
+  while (signalGroup(0) && Date.now() < termDeadline) {
+    await delay(50);
+  }
+  if (!signalGroup("SIGKILL")) return;
+  const killDeadline = Date.now() + 2_000;
+  while (signalGroup(0) && Date.now() < killDeadline) {
+    await delay(50);
+  }
+  if (signalGroup(0)) {
+    throw new Error(
+      `Chrome process group ${groupId} survived SIGKILL; refusing to continue over a half-dead tree`,
+    );
   }
 }
 

--- a/clients/gui-app/scripts/diff-edit-browser-regression.mjs
+++ b/clients/gui-app/scripts/diff-edit-browser-regression.mjs
@@ -15,9 +15,9 @@ const projectRoot = path.resolve(
 );
 const fixtureUrlPath = "/src/__tests__/browser/diff-edit-focus.html";
 const chromePath = await findChrome();
-const profilePath = await mkdtemp(path.join(tmpdir(), "traycer-diff-edit-"));
 const vitePort = await freePort();
 let chrome;
+let chromeProfilePath;
 let client;
 let viteProcess;
 
@@ -54,35 +54,11 @@ try {
 
   const chromeEnv = { ...process.env };
   delete chromeEnv.DBUS_SESSION_BUS_ADDRESS;
-  chrome = spawn(
-    chromePath,
-    [
-      "--headless=new",
-      "--disable-background-networking",
-      "--disable-component-update",
-      "--disable-default-apps",
-      "--disable-extensions",
-      "--disable-features=Translate",
-      "--disable-sync",
-      "--no-default-browser-check",
-      "--no-first-run",
-      "--no-sandbox",
-      "--remote-debugging-port=0",
-      `--user-data-dir=${profilePath}`,
-      "about:blank",
-    ],
-    { env: chromeEnv, stdio: ["ignore", "ignore", "pipe"] },
-  );
-  let chromeError = "";
-  chrome.stderr.setEncoding("utf8");
-  chrome.stderr.on("data", (chunk) => {
-    chromeError += chunk;
-  });
-
-  const devtoolsWebSocketUrl = await waitForDevToolsUrl(
-    chrome,
-    () => chromeError,
-  );
+  const launched = await launchChromeWithDevTools(chromePath, chromeEnv);
+  chrome = launched.chrome;
+  chromeProfilePath = launched.profilePath;
+  const readChromeError = launched.readError;
+  const devtoolsWebSocketUrl = launched.devtoolsWebSocketUrl;
   const devtoolsUrl = new URL(devtoolsWebSocketUrl);
   devtoolsUrl.protocol = "http:";
   devtoolsUrl.pathname = "";
@@ -91,7 +67,7 @@ try {
   await waitForHttp(
     new URL("/json/version", devtoolsUrl).href,
     chrome,
-    () => chromeError,
+    readChromeError,
     "Chrome DevTools",
   );
   const targetResponse = await fetch(
@@ -440,9 +416,17 @@ try {
   console.log("diff edit browser regression passed");
 } finally {
   client?.close();
-  chrome?.kill("SIGTERM");
+  if (chrome !== undefined) {
+    await terminateProcessTree(chrome);
+  }
   viteProcess?.kill("SIGTERM");
-  await rm(profilePath, { recursive: true, force: true, maxRetries: 3 });
+  if (chromeProfilePath !== undefined) {
+    await rm(chromeProfilePath, {
+      recursive: true,
+      force: true,
+      maxRetries: 3,
+    });
+  }
 }
 
 async function findChrome() {
@@ -517,6 +501,93 @@ async function waitForDevToolsUrl(process, readError) {
     await delay(50);
   }
   throw new Error(`Timed out waiting for Chrome DevTools:\n${readError()}`);
+}
+
+/**
+ * Launches headless Chrome and waits for its DevTools endpoint, retrying the
+ * whole spawn on timeout.
+ *
+ * A cold CI runner has been observed to take Chrome past the 30s DevTools
+ * deadline outright (its FIRST stderr line arrived 21s after spawn), and a
+ * single flat deadline makes that a hard failure. A retry only helps when it
+ * starts clean, so each attempt gets a fresh profile directory, and a
+ * timed-out attempt is fully killed (SIGTERM, then SIGKILL after a grace
+ * period, awaited to the exit event) and its profile removed before the next
+ * spawn - otherwise the retry inherits a locked profile plus the previous
+ * attempt's crashpad children, which is exactly the orphan pile the runner
+ * had to reap.
+ */
+async function launchChromeWithDevTools(chromePath, chromeEnv) {
+  const attempts = 3;
+  let lastError = new Error("Chrome launch was not attempted");
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    const profilePath = await mkdtemp(
+      path.join(tmpdir(), "traycer-diff-edit-"),
+    );
+    const chrome = spawn(
+      chromePath,
+      [
+        "--headless=new",
+        "--disable-background-networking",
+        "--disable-component-update",
+        "--disable-default-apps",
+        "--disable-extensions",
+        "--disable-features=Translate",
+        "--disable-sync",
+        "--no-default-browser-check",
+        "--no-first-run",
+        "--no-sandbox",
+        "--remote-debugging-port=0",
+        `--user-data-dir=${profilePath}`,
+        "about:blank",
+      ],
+      { env: chromeEnv, stdio: ["ignore", "ignore", "pipe"] },
+    );
+    let chromeError = "";
+    chrome.stderr.setEncoding("utf8");
+    chrome.stderr.on("data", (chunk) => {
+      chromeError += chunk;
+    });
+    try {
+      const devtoolsWebSocketUrl = await waitForDevToolsUrl(
+        chrome,
+        () => chromeError,
+      );
+      return {
+        chrome,
+        profilePath,
+        devtoolsWebSocketUrl,
+        readError: () => chromeError,
+      };
+    } catch (error) {
+      lastError = error instanceof Error ? error : new Error(String(error));
+      console.error(
+        `Chrome launch attempt ${attempt}/${attempts} failed: ${lastError.message}`,
+      );
+      await terminateProcessTree(chrome);
+      await rm(profilePath, { recursive: true, force: true, maxRetries: 3 });
+    }
+  }
+  throw lastError;
+}
+
+/**
+ * Ends a spawned process for real: SIGTERM, a 2s grace period, then SIGKILL,
+ * resolving only once the `exit` event has fired. Chrome ignores SIGTERM
+ * during early startup, and a fire-and-forget kill left it (and its crashpad
+ * handlers) alive for the CI runner to reap as orphans.
+ */
+async function terminateProcessTree(child) {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  const exited = new Promise((resolve) => {
+    child.once("exit", () => resolve(true));
+  });
+  child.kill("SIGTERM");
+  const terminated = await Promise.race([exited, delay(2_000, false)]);
+  if (terminated === false) {
+    child.kill("SIGKILL");
+    await exited;
+  }
 }
 
 async function connectCdp(url) {

--- a/clients/gui-app/scripts/diff-edit-browser-regression.mjs
+++ b/clients/gui-app/scripts/diff-edit-browser-regression.mjs
@@ -486,9 +486,13 @@ async function waitForHttp(url, process, readError, label) {
   throw new Error(`Timed out waiting for ${label}:\n${readError()}`);
 }
 
-async function waitForDevToolsUrl(process, readError) {
+async function waitForDevToolsUrl(process, readError, readSpawnFailure) {
   const deadline = Date.now() + 30_000;
   while (Date.now() < deadline) {
+    const spawnFailure = readSpawnFailure();
+    if (spawnFailure !== null) {
+      throw new Error(`Chrome failed to spawn: ${spawnFailure.message}`);
+    }
     if (process.exitCode !== null) {
       throw new Error(
         `Chrome exited before DevTools was ready:\n${readError()}`,
@@ -551,10 +555,18 @@ async function launchChromeWithDevTools(chromePath, chromeEnv) {
     chrome.stderr.on("data", (chunk) => {
       chromeError += chunk;
     });
+    // A spawn failure (ENOENT/EACCES) surfaces as an "error" event, not an
+    // exit; without a listener Node throws it as an uncaught event before
+    // the retry catch can clean up the attempt's profile.
+    let spawnFailure = null;
+    chrome.on("error", (error) => {
+      spawnFailure = error instanceof Error ? error : new Error(String(error));
+    });
     try {
       const devtoolsWebSocketUrl = await waitForDevToolsUrl(
         chrome,
         () => chromeError,
+        () => spawnFailure,
       );
       return {
         chrome,

--- a/clients/traycer-cli/src/service/__tests__/cli-binary.test.ts
+++ b/clients/traycer-cli/src/service/__tests__/cli-binary.test.ts
@@ -1042,7 +1042,9 @@ describe("resolveServiceCliInvocation", () => {
     // exactly as the refresh test below does, which also upgrades the
     // size-only comparison to full byte equality.
     const fakeExecPath = join(workHome, "fake-packaged-binary");
-    const packagedBytes = "packaged binary bytes";
+    // Raw non-UTF-8 bytes: a text fixture round-trips through a utf8 decode
+    // and would miss corruption that only shows on binary content.
+    const packagedBytes = Buffer.from([0x00, 0xff, 0x80, 0x7f, 0x01, 0xfe]);
     writeFileSync(fakeExecPath, packagedBytes);
     const originalExecPath = process.execPath;
     Object.defineProperty(process, "execPath", {
@@ -1065,7 +1067,7 @@ describe("resolveServiceCliInvocation", () => {
       const slotStat = await lstat(wellKnownPath);
       expect(slotStat.isSymbolicLink()).toBe(false);
       expect(slotStat.isFile()).toBe(true);
-      expect(readFileSync(wellKnownPath, "utf8")).toBe(packagedBytes);
+      expect(readFileSync(wellKnownPath)).toEqual(packagedBytes);
     } finally {
       Object.defineProperty(process, "execPath", {
         value: originalExecPath,

--- a/clients/traycer-cli/src/service/__tests__/cli-binary.test.ts
+++ b/clients/traycer-cli/src/service/__tests__/cli-binary.test.ts
@@ -8,7 +8,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import type { PathLike } from "node:fs";
-import { lstat, stat } from "node:fs/promises";
+import { lstat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { delimiter, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -1034,25 +1034,44 @@ describe("resolveServiceCliInvocation", () => {
   // `allowSelfInvocation`.
   it("stages a copy of process.execPath at the well-known slot and returns empty args when packaged, even with allowSelfInvocation false", async () => {
     seaState.current = true;
-    const { wellKnownCliBinaryPath } =
-      await import("../../store/well-known-cli");
-    const wellKnownPath = wellKnownCliBinaryPath(ENVIRONMENT);
-    const { resolveServiceCliInvocation } = await import("../cli-binary");
-
-    const result = await resolveServiceCliInvocation({
-      environment: ENVIRONMENT,
-      override: null,
-      allowSelfInvocation: false,
+    // Staging copies `process.execPath`'s BYTES, and under vitest that used
+    // to be the real ~100MB Node binary: on a loaded CI runner pushing it
+    // through the copy+rename staging pipeline blew the 5s test timeout.
+    // The contract is "a copy of whatever execPath names lands in the
+    // slot", not "100MB copies in 5s" - point execPath at a small stand-in,
+    // exactly as the refresh test below does, which also upgrades the
+    // size-only comparison to full byte equality.
+    const fakeExecPath = join(workHome, "fake-packaged-binary");
+    const packagedBytes = "packaged binary bytes";
+    writeFileSync(fakeExecPath, packagedBytes);
+    const originalExecPath = process.execPath;
+    Object.defineProperty(process, "execPath", {
+      value: fakeExecPath,
+      configurable: true,
     });
+    try {
+      const { wellKnownCliBinaryPath } =
+        await import("../../store/well-known-cli");
+      const wellKnownPath = wellKnownCliBinaryPath(ENVIRONMENT);
+      const { resolveServiceCliInvocation } = await import("../cli-binary");
 
-    expect(result).toEqual({ command: wellKnownPath, args: [] });
-    const slotStat = await lstat(wellKnownPath);
-    expect(slotStat.isSymbolicLink()).toBe(false);
-    expect(slotStat.isFile()).toBe(true);
-    // process.execPath is the ~100MB running binary - compare sizes rather
-    // than reading and diffing the whole file.
-    const execStat = await stat(process.execPath);
-    expect(slotStat.size).toBe(execStat.size);
+      const result = await resolveServiceCliInvocation({
+        environment: ENVIRONMENT,
+        override: null,
+        allowSelfInvocation: false,
+      });
+
+      expect(result).toEqual({ command: wellKnownPath, args: [] });
+      const slotStat = await lstat(wellKnownPath);
+      expect(slotStat.isSymbolicLink()).toBe(false);
+      expect(slotStat.isFile()).toBe(true);
+      expect(readFileSync(wellKnownPath, "utf8")).toBe(packagedBytes);
+    } finally {
+      Object.defineProperty(process, "execPath", {
+        value: originalExecPath,
+        configurable: true,
+      });
+    }
   });
 
   // winget's portable installer replaces process.execPath's bytes in place


### PR DESCRIPTION
Five recurring CI flakes, each diagnosed to a named race and fixed by removing the timing assumption — no timeouts widened, no tests skipped. Cold-reviewed (2 rounds, independent ablations of both deterministic repros).

## Fixes

1. **desktop `selection-authority-ipc`** — fleet membership is seeded by a fire-and-forget refresh, and tests gated on a fixed 10ms sleep; when the seed loses the race the engine correctly refuses with `unknown-host` (CI's exact diff). Now gated on the observable fact: a `selectionLeasesChanged` fan-out naming the host (`awaitFleetMembership`, bounded, missed-event-safe). Four sibling tests with the same silent race (outside-fleet refusal evidence is dropped, turning their assertions into no-ops) hardened with the same helper. Repro: delaying the mocked registry fetch 15ms past the old sleep produced the CI failure deterministically; green under the same instrumentation after.

2. **desktop `browser-view-manager` "attach ack times out"** — a *previous* test started a PiP capture and never stopped it; the orphaned 200ms self-rescheduling chain migrates into the fake-timer queue when a later test calls `vi.useFakeTimers()`, aborting with "Aborting after running 10000 timers" (CI's exact stack). Fixed structurally: the harness records every manager it builds and a file-level `afterEach` stops all captures (idempotent), so no test's failure can manufacture another test's flake. Repro: holding the fake-timer window open 250ms reproduced the abort deterministically; ablation of the afterEach reproduces it, restoring it clears it.

3. **gui-app `diff-edit-browser-regression.mjs`** — one flat 30s deadline vs a 21s+ Chrome cold start on a contended runner, and a fire-and-forget SIGTERM that left crashpad orphans (visible in the runner's reaper log). Chrome now spawns `detached: true` (owns its process group); teardown signals the negative PGID (TERM → 2s → KILL-to-group) with a bounded no-survivor verification that throws rather than letting a retry proceed over a half-dead tree; up to 3 attempts, fresh profile each, failed attempts fully torn down. Forced-failure check: peak 10 tree processes during attempt 1 → 0 survivors and 0 profile dirs after retry + exit. (The three sibling browser scripts share the old launch pattern; follow-up candidate.)

4. **darwin desktop job** — the actual failing test was unrecoverable: `--tui=false` makes Nx buffer and cap the replay, truncating before Vitest's failure lines (all three log artifacts identically cut). Ported the ubuntu job's documented `--outputStyle=stream` fix so the next occurrence names its test.

5. **protocol CLI `cli-binary` staging test** — staged the real `process.execPath` (~110MB under CI) through the copy+rename pipeline inside a 5s test timeout (CI recorded 5005ms). Now stages a small stand-in via the same `Object.defineProperty` pattern the sibling test uses; the size-only assertion upgrades to full byte equality (catches wrong slot, symlink-instead-of-copy, truncation, same-size corruption). Runs in ~30ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
