### PR TITLE
fix(gui-app): copy raw artifact code blocks

### DIFF
--- a/clients/gui-app/__tests__/editor-core/artifact-code-block-node-view.test.tsx
+++ b/clients/gui-app/__tests__/editor-core/artifact-code-block-node-view.test.tsx
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { Editor } from "@tiptap/core";
+import { EditorContent, EditorContext } from "@tiptap/react";
+import * as Y from "yjs";
+import { Awareness } from "y-protocols/awareness";
+import { buildArtifactExtensions, deriveCollabUser } from "@/editor-core";
+
+const writeText = vi.fn();
+
+function mountCodeBlockEditor(code: string): Editor {
+  const ydoc = new Y.Doc();
+  const fragment = ydoc.getXmlFragment("default");
+  const awareness = new Awareness(ydoc);
+  const editor = new Editor({
+    extensions: buildArtifactExtensions({
+      doc: ydoc,
+      fragment,
+      awareness,
+      user: deriveCollabUser({ userName: "Tester", email: null }),
+      onCommentShortcut: null,
+      placeholderText: "Start writing…",
+      titlePlaceholderText: "Untitled",
+    }),
+  });
+  editor.commands.insertContent({
+    type: "codeBlock",
+    attrs: { language: "sh" },
+    content: [{ type: "text", text: code }],
+  });
+  return editor;
+}
+
+beforeEach(() => {
+  writeText.mockReset().mockResolvedValue(undefined);
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    writable: true,
+    value: { writeText },
+  });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ArtifactCodeBlockNodeView", () => {
+  it("copies raw code without markdown fences", async () => {
+    const code = "bun install\nbun run setup";
+    const editor = mountCodeBlockEditor(code);
+    render(
+      <EditorContext.Provider value={{ editor }}>
+        <EditorContent editor={editor} />
+      </EditorContext.Provider>,
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: "Copy code" }));
+
+    expect(writeText).toHaveBeenCalledWith(code);
+    expect(await screen.findByRole("button", { name: "Copied" })).toBeTruthy();
+    editor.destroy();
+  });
+
+  it("keeps the code content editable", async () => {
+    const editor = mountCodeBlockEditor("bun install");
+    const { container } = render(
+      <EditorContext.Provider value={{ editor }}>
+        <EditorContent editor={editor} />
+      </EditorContext.Provider>,
+    );
+
+    const copyButton = await screen.findByRole("button", { name: "Copy code" });
+    const code = container.querySelector("pre code");
+    expect(code).not.toBeNull();
+    expect(code?.textContent).toBe("bun install");
+    expect(code?.getAttribute("contenteditable")).not.toBe("false");
+    expect(copyButton.getAttribute("contenteditable")).toBe("false");
+    editor.destroy();
+  });
+});

--- a/clients/gui-app/__tests__/editor-core/build-artifact-extensions.test.ts
+++ b/clients/gui-app/__tests__/editor-core/build-artifact-extensions.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { Editor } from "@tiptap/core";
+import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
 import * as Y from "yjs";
 import { Awareness } from "y-protocols/awareness";
 import { buildArtifactExtensions, deriveCollabUser } from "@/editor-core";
@@ -23,6 +24,32 @@ function createArtifactEditor(): Editor {
       titlePlaceholderText: "Untitled",
     }),
   });
+}
+
+interface CodeBlockRange {
+  readonly contentFrom: number;
+  readonly contentTo: number;
+  readonly nodeFrom: number;
+  readonly nodeTo: number;
+}
+
+function findCodeBlockRange(doc: ProseMirrorNode): CodeBlockRange {
+  const ranges: CodeBlockRange[] = [];
+  doc.descendants((node, pos) => {
+    if (node.type.name !== "codeBlock") return true;
+    ranges.push({
+      contentFrom: pos + 1,
+      contentTo: pos + 1 + node.content.size,
+      nodeFrom: pos,
+      nodeTo: pos + node.nodeSize,
+    });
+    return false;
+  });
+  const range = ranges.at(0);
+  if (range === undefined) {
+    throw new Error("Expected a code block in the document");
+  }
+  return range;
 }
 
 describe("buildArtifactExtensions", () => {
@@ -178,6 +205,53 @@ describe("buildArtifactExtensions", () => {
     );
 
     expect(text).toBe(command);
+    editor.destroy();
+  });
+
+  it.each([
+    {
+      container: "blockquote",
+      markdown: ["> ```sh", "> bun run compile", "> ```", ""].join("\n"),
+    },
+    {
+      container: "list item",
+      markdown: ["- ```sh", "  bun run compile", "  ```", ""].join("\n"),
+    },
+  ])(
+    "copies code nested in a $container without markdown markers",
+    ({ markdown }) => {
+      const editor = createArtifactEditor();
+      editor.commands.setContent(markdown, {
+        contentType: "markdown",
+        parseOptions: { preserveWhitespace: false },
+      });
+
+      const { doc } = editor.state;
+      const { contentFrom, contentTo } = findCodeBlockRange(doc);
+      const { text } = editor.view.serializeForClipboard(
+        doc.slice(contentFrom, contentTo),
+      );
+
+      expect(text).toBe("bun run compile");
+      editor.destroy();
+    },
+  );
+
+  it("keeps markdown fences when a whole nested code block is copied", () => {
+    const editor = createArtifactEditor();
+    editor.commands.setContent(
+      ["> ```sh", "> bun run compile", "> ```", ""].join("\n"),
+      { contentType: "markdown", parseOptions: { preserveWhitespace: false } },
+    );
+
+    const { doc } = editor.state;
+    const { nodeFrom, nodeTo } = findCodeBlockRange(doc);
+    const { text } = editor.view.serializeForClipboard(
+      doc.slice(nodeFrom, nodeTo),
+    );
+
+    expect(text).toContain("```sh");
+    expect(text).toContain("bun run compile");
     editor.destroy();
   });
 

--- a/clients/gui-app/__tests__/editor-core/build-artifact-extensions.test.ts
+++ b/clients/gui-app/__tests__/editor-core/build-artifact-extensions.test.ts
@@ -165,6 +165,39 @@ describe("buildArtifactExtensions", () => {
     editor.destroy();
   });
 
+  it("copies a text selection inside a code block without markdown fences", () => {
+    const editor = createArtifactEditor();
+    const command = "bun run compile";
+    editor.commands.setContent(["```sh", command, "```", ""].join("\n"), {
+      contentType: "markdown",
+    });
+
+    const { doc } = editor.state;
+    const { text } = editor.view.serializeForClipboard(
+      doc.slice(1, command.length + 1),
+    );
+
+    expect(text).toBe(command);
+    editor.destroy();
+  });
+
+  it("keeps markdown fences when a whole code block is copied", () => {
+    const editor = createArtifactEditor();
+    const command = "bun run compile";
+    editor.commands.setContent(["```sh", command, "```", ""].join("\n"), {
+      contentType: "markdown",
+    });
+
+    const { doc } = editor.state;
+    const { text } = editor.view.serializeForClipboard(
+      doc.slice(0, doc.content.size),
+    );
+
+    expect(text).toContain("```sh");
+    expect(text).toContain(command);
+    editor.destroy();
+  });
+
   it("pairs the artifact-room doc fragment with artifactRoom awareness - Collaboration binds to the artifact-room doc and CollaborationCaret binds to the same artifactRoom awareness", () => {
     // Per ticket 4a598302-…/Fix: GUI artifact-room-doc awareness and reconnect-safe
     // body edits - when the body fragment lives in a artifact-room doc, the

--- a/clients/gui-app/src/editor-core/artifact-document-bundle.ts
+++ b/clients/gui-app/src/editor-core/artifact-document-bundle.ts
@@ -15,7 +15,6 @@ import {
   TableHeader,
   TableCell,
 } from "@tiptap/extension-table";
-import CodeBlockLowlight from "@tiptap/extension-code-block-lowlight";
 import { yXmlFragmentToProseMirrorRootNode } from "@tiptap/y-tiptap";
 import { createLowlight, common } from "lowlight";
 import type * as Y from "yjs";
@@ -23,6 +22,7 @@ import { MermaidNode } from "./nodes/mermaid/mermaid-node";
 import { WireframeNode } from "./nodes/wireframe/wireframe-node";
 import { ThreadAnchor } from "./extensions/thread-anchor";
 import { ArtifactImageNode } from "./nodes/image/artifact-image-node";
+import { ArtifactCodeBlock } from "./nodes/code-block/artifact-code-block";
 
 const lowlight = createLowlight(common);
 
@@ -74,7 +74,7 @@ const extensions: AnyExtension[] = [
   TableCell,
   MermaidNode,
   WireframeNode,
-  CodeBlockLowlight.configure({ lowlight }),
+  ArtifactCodeBlock.configure({ lowlight }),
   // Inline mark anchoring artifact comment threads. It belongs in the shared
   // document schema so editor and export serialization cannot drift.
   ThreadAnchor,

--- a/clients/gui-app/src/editor-core/extensions/markdown-clipboard-extension.ts
+++ b/clients/gui-app/src/editor-core/extensions/markdown-clipboard-extension.ts
@@ -26,6 +26,14 @@ export const MarkdownClipboard = Extension.create({
         key: new PluginKey("markdownClipboard"),
         props: {
           clipboardTextSerializer: (slice) => {
+            const onlyChild = slice.content.firstChild;
+            if (
+              slice.content.childCount === 1 &&
+              onlyChild?.type.name === "codeBlock" &&
+              (slice.openStart > 0 || slice.openEnd > 0)
+            ) {
+              return onlyChild.textContent;
+            }
             const doc = sliceToDocJson(slice);
             if (doc === null) {
               return slice.content.textBetween(0, slice.content.size, "\n");

--- a/clients/gui-app/src/editor-core/extensions/markdown-clipboard-extension.ts
+++ b/clients/gui-app/src/editor-core/extensions/markdown-clipboard-extension.ts
@@ -1,4 +1,5 @@
 import { Extension } from "@tiptap/core";
+import type { Fragment, Slice } from "@tiptap/pm/model";
 import { Plugin, PluginKey } from "@tiptap/pm/state";
 
 import { sliceToDocJson } from "@/lib/editor/prosemirror-json";
@@ -26,14 +27,8 @@ export const MarkdownClipboard = Extension.create({
         key: new PluginKey("markdownClipboard"),
         props: {
           clipboardTextSerializer: (slice) => {
-            const onlyChild = slice.content.firstChild;
-            if (
-              slice.content.childCount === 1 &&
-              onlyChild?.type.name === "codeBlock" &&
-              (slice.openStart > 0 || slice.openEnd > 0)
-            ) {
-              return onlyChild.textContent;
-            }
+            const codeText = selectedCodeText(slice);
+            if (codeText !== null) return codeText;
             const doc = sliceToDocJson(slice);
             if (doc === null) {
               return slice.content.textBetween(0, slice.content.size, "\n");
@@ -45,3 +40,19 @@ export const MarkdownClipboard = Extension.create({
     ];
   },
 });
+
+function selectedCodeText(slice: Slice): string | null {
+  let content: Fragment = slice.content;
+  let depth = 0;
+  while (content.childCount === 1) {
+    const onlyChild = content.firstChild;
+    if (onlyChild === null) return null;
+    if (onlyChild.type.name === "codeBlock") {
+      const codeBlockIsOpen = depth < slice.openStart && depth < slice.openEnd;
+      return codeBlockIsOpen ? onlyChild.textContent : null;
+    }
+    content = onlyChild.content;
+    depth += 1;
+  }
+  return null;
+}

--- a/clients/gui-app/src/editor-core/nodes/code-block/artifact-code-block-node-view.tsx
+++ b/clients/gui-app/src/editor-core/nodes/code-block/artifact-code-block-node-view.tsx
@@ -1,0 +1,51 @@
+import { Check, Copy } from "lucide-react";
+import { useCallback, type MouseEvent, type ReactNode } from "react";
+import {
+  NodeViewContent,
+  NodeViewWrapper,
+  type NodeViewProps,
+} from "@tiptap/react";
+import { useClipboardCopy } from "@/hooks/ui/use-clipboard-copy";
+import { cn } from "@/lib/utils";
+
+export function ArtifactCodeBlockNodeView(props: NodeViewProps): ReactNode {
+  const code = props.node.textContent;
+  const { copied, copy } = useClipboardCopy({
+    resetMs: 2000,
+    onSuccess: null,
+    onError: null,
+  });
+  const handleCopy = useCallback(() => copy(code), [copy, code]);
+  const preserveEditorSelection = useCallback(
+    (event: MouseEvent<HTMLButtonElement>): void => event.preventDefault(),
+    [],
+  );
+
+  return (
+    <NodeViewWrapper className="group/artifact-code relative">
+      <button
+        type="button"
+        contentEditable={false}
+        onMouseDown={preserveEditorSelection}
+        onClick={handleCopy}
+        aria-label={copied ? "Copied" : "Copy code"}
+        className={cn(
+          "absolute top-1.5 right-1.5 z-10 inline-flex size-7 items-center justify-center rounded-md",
+          "border border-border bg-popover text-muted-foreground shadow-sm transition-all",
+          "opacity-0 group-hover/artifact-code:opacity-100 focus-visible:opacity-100 pointer-coarse:opacity-100",
+          "hover:bg-accent hover:text-foreground",
+          "focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none",
+        )}
+      >
+        {copied ? (
+          <Check className="size-3.5" aria-hidden />
+        ) : (
+          <Copy className="size-3.5" aria-hidden />
+        )}
+      </button>
+      <pre>
+        <NodeViewContent<"code"> as="code" />
+      </pre>
+    </NodeViewWrapper>
+  );
+}

--- a/clients/gui-app/src/editor-core/nodes/code-block/artifact-code-block.ts
+++ b/clients/gui-app/src/editor-core/nodes/code-block/artifact-code-block.ts
@@ -1,0 +1,9 @@
+import CodeBlockLowlight from "@tiptap/extension-code-block-lowlight";
+import { ReactNodeViewRenderer } from "@tiptap/react";
+import { ArtifactCodeBlockNodeView } from "./artifact-code-block-node-view";
+
+export const ArtifactCodeBlock = CodeBlockLowlight.extend({
+  addNodeView() {
+    return ReactNodeViewRenderer(ArtifactCodeBlockNodeView);
+  },
+});


### PR DESCRIPTION
## Summary

- copy selected text inside artifact code blocks without Markdown fences
- add a hover/focus copy button to ordinary artifact code blocks
- preserve whole-block Markdown serialization, editing, and syntax highlighting

## Related issue

None.

## Checklist

- [x] Pre-commit static checks pass
- [ ] Separate CI test checks pass
- [x] Tests added/updated where it makes sense
- [x] Commits are signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#developer-certificate-of-origin-dco)

Focused validation: 13 tests passed across the artifact code-block node view and artifact extension suites. React Doctor reported no issues.