### PR TITLE
fix(gui-app): restore main's typecheck for two transcript fixture files

### DIFF
--- a/clients/gui-app/src/stores/chats/__tests__/transcript-list-rows.test.ts
+++ b/clients/gui-app/src/stores/chats/__tests__/transcript-list-rows.test.ts
@@ -321,6 +321,7 @@ describe("transcriptListRows", () => {
       usage: null,
       reasoningEffort: null,
       serviceTier: null,
+      envCredentialVar: null,
       imageResolutions: [],
     };
     const projectedRowId = assistantRowId(turnId);
@@ -363,6 +364,7 @@ describe("transcriptListRows", () => {
       usage: null,
       reasoningEffort: null,
       serviceTier: null,
+      envCredentialVar: null,
       imageResolutions: [],
     };
     const rows = transcriptListRows({
@@ -582,6 +584,7 @@ describe("transcriptListRows", () => {
       usage: null,
       reasoningEffort: null,
       serviceTier: null,
+      envCredentialVar: null,
       imageResolutions: [],
     };
     const rows = transcriptListRows({
@@ -647,6 +650,7 @@ describe("transcriptListRows", () => {
       usage: null,
       reasoningEffort: null,
       serviceTier: null,
+      envCredentialVar: null,
       imageResolutions: [],
     };
     const rows = transcriptListRows({
@@ -697,6 +701,7 @@ describe("transcriptListRows", () => {
       usage: null,
       reasoningEffort: null,
       serviceTier: null,
+      envCredentialVar: null,
       imageResolutions: [],
     };
     const steeredUser: Extract<Message, { role: "user" }> = {
@@ -750,6 +755,7 @@ describe("transcriptListRows", () => {
       usage: null,
       reasoningEffort: null,
       serviceTier: null,
+      envCredentialVar: null,
       imageResolutions: [],
     };
     const rows = transcriptListRows({

--- a/clients/gui-app/src/stores/chats/__tests__/transcript-window.test.ts
+++ b/clients/gui-app/src/stores/chats/__tests__/transcript-window.test.ts
@@ -85,6 +85,7 @@ function assistantMessage(
     usage: null,
     reasoningEffort: null,
     serviceTier: null,
+    envCredentialVar: null,
     imageResolutions: [],
   };
 }


### PR DESCRIPTION
## main is red

`main`'s own **Tests** run at `176759832` is `completed/failure`. Seven `TS2741: Property 'envCredentialVar' is missing` errors, in two files:

- `clients/gui-app/src/stores/chats/__tests__/transcript-list-rows.test.ts` (6)
- `clients/gui-app/src/stores/chats/__tests__/transcript-window.test.ts` (1)

Every open PR inherits this, because CI type-checks the **merge result** — so a branch that is clean on its own head still goes red, and the errors point at files that branch never touched. That is how this surfaced.

## Two changes that never saw each other

| Change | What it did |
| --- | --- |
| **#1546** `95cfe2a55` — *stabilize windowed transcript hydration* | last touched the two files above |
| **#1550** `176759832` — *disclose the env credential that authenticated a turn* | made `envCredentialVar` a **required** field on an assistant turn, and added it to **five** fixture files in this same directory |

The two files here were not among those five. Each change was green on its own head; the widened type met fixtures that predate it, and the merge is red where neither branch was. Nothing is wrong with either change — they landed close enough together that neither's CI could see the other's fixtures.

## The fix

`envCredentialVar: null` at all seven construction sites, in the same position (after `serviceTier`, before `imageResolutions`) and with the same value #1550 used in its five siblings. Test-only: no product code, no behaviour change, nothing beyond the seven lines.

## Verification

- `bun run --filter @traycer-clients/gui-app compile` — **exit 0** on `main` + this commit (it is exit 1 on `main` alone).
- `src/stores/chats/__tests__` — **838 tests green**.

## One thing worth flagging for whoever tunes the gate

`main`'s **`pre-commit`** run is **green** at this same sha. It checks nx-affected projects, and these files were not in that set — only the full `Tests` run catches the breakage.

So on a red `main`, a green `pre-commit` is not evidence the tree type-checks, and reading the two as interchangeable is how this stayed live. It also nearly sent me the wrong way: I saw `pre-commit: success` first and briefly concluded main was healthy.
