### PR TITLE
feat(mobile): mount the artifact row's export entries on the switcher

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/mobile/__tests__/switcher-lists.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/__tests__/switcher-lists.test.tsx
@@ -4,6 +4,7 @@ import {
   screen,
   type RenderResult,
 } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as Y from "yjs";
 import type { ReactElement, ReactNode } from "react";
@@ -54,6 +55,15 @@ interface Holder {
   ownerHostIdByNodeId: Record<string, string>;
   indicators: IndicatorFixture;
   search: ArtifactSearchResults;
+  /** What the artifact row's export entries asked the mutation for. */
+  exportCalls: ArtifactExportCall[];
+}
+
+/** The `useEpicExportArtifacts` payload an export entry submits. */
+interface ArtifactExportCall {
+  readonly artifacts: ReadonlyArray<{ readonly id: string }>;
+  readonly format: string;
+  readonly archive: boolean;
 }
 
 interface IndicatorFlags {
@@ -90,6 +100,7 @@ const holder = vi.hoisted((): Holder => ({
     isFetching: false,
     refetch: () => {},
   },
+  exportCalls: [],
 }));
 
 vi.mock("@/lib/epic-selectors", () => ({
@@ -174,6 +185,18 @@ vi.mock("@/hooks/epic/use-epic-tui-agent-mutations", () => ({
 vi.mock("@/hooks/epic/use-epic-node-mutations", () => ({
   useEpicDeleteArtifact: () => ({ mutate: vi.fn(), isPending: false }),
   useEpicRenameArtifact: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+// The artifact row's export entries. Recorded rather than discarded, so what
+// the row asks the shared mutation for is asserted instead of assumed - and
+// mocked at all because the real hook reaches TanStack Query, which this
+// harness deliberately does not mount.
+vi.mock("@/hooks/epic/use-epic-export-artifacts-mutation", () => ({
+  useEpicExportArtifacts: () => ({
+    mutate: (input: ArtifactExportCall) => {
+      holder.exportCalls.push(input);
+    },
+    isPending: false,
+  }),
 }));
 vi.mock("@/hooks/terminal/use-terminal-rename-for-mutation", () => ({
   useTerminalRenameFor: () => ({ mutate: vi.fn(), isPending: false }),
@@ -315,11 +338,67 @@ beforeEach(() => {
   holder.indicatorChatIdCalls = [];
   holder.ownerHostIdByNodeId = {};
   holder.indicators = { epics: {}, chats: {} };
+  holder.exportCalls = [];
   sessionHandle = newSessionHandle();
 });
 afterEach(() => {
   cleanup();
   sessionHandle.dispose();
+});
+
+describe("<SwitcherArtifactsList /> row export", () => {
+  const ARTIFACT_RECORD = {
+    id: "tk-1",
+    parentId: null,
+    name: "Ticket One",
+    type: "ticket" as const,
+    status: 1,
+    hostId: "host-A",
+  };
+
+  it("offers the desktop row menu's export entries on an artifact", async () => {
+    // Mirror-desktop: the desktop artifact row menu offers both formats, so
+    // mounting one and omitting the other would be a curation this list has
+    // no grounds to make.
+    holder.records = [ARTIFACT_RECORD];
+    render(<SwitcherArtifactsList {...PROPS} />);
+
+    await userEvent.click(screen.getByTestId("switcher-more-tk-1"));
+
+    expect(screen.getByTestId("switcher-export-markdown-tk-1")).toBeTruthy();
+    expect(screen.getByTestId("switcher-export-pdf-tk-1")).toBeTruthy();
+  });
+
+  it("exports the row's own artifact, unarchived", async () => {
+    holder.records = [ARTIFACT_RECORD];
+    render(<SwitcherArtifactsList {...PROPS} />);
+
+    await userEvent.click(screen.getByTestId("switcher-more-tk-1"));
+    await userEvent.click(screen.getByTestId("switcher-export-markdown-tk-1"));
+
+    expect(holder.exportCalls).toHaveLength(1);
+    const [call] = holder.exportCalls;
+    expect(call.artifacts.map((a) => a.id)).toEqual(["tk-1"]);
+    expect(call.format).toBe("markdown");
+    // Not a ZIP: one row, one file. The archive path belongs to desktop's
+    // multi-select, which this flat list has no counterpart for.
+    expect(call.archive).toBe(false);
+  });
+
+  it("carries the chosen format through, not a fixed one", async () => {
+    holder.records = [ARTIFACT_RECORD];
+    render(<SwitcherArtifactsList {...PROPS} />);
+
+    await userEvent.click(screen.getByTestId("switcher-more-tk-1"));
+    await userEvent.click(screen.getByTestId("switcher-export-pdf-tk-1"));
+
+    expect(holder.exportCalls.map((c) => c.format)).toEqual(["pdf"]);
+  });
+
+  // The "no export on a chat or terminal row" case is not asserted here: the
+  // agents list pulls in the chat-tree panel, which needs a QueryClient this
+  // harness deliberately does not mount. The gate is `kind === "artifact"` in
+  // `switcher-row-actions.tsx`, structural rather than conditional on data.
 });
 
 describe("<SwitcherArtifactsList />", () => {

--- a/clients/gui-app/src/components/epic-canvas/mobile/switcher-row-actions.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/switcher-row-actions.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useState } from "react";
-import { MoreHorizontal, Pencil, Trash2 } from "lucide-react";
+import { FileDown, MoreHorizontal, Pencil, Trash2 } from "lucide-react";
+import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -21,6 +22,7 @@ import { isEditableRole } from "@/lib/epic-permissions";
 import { useEpicDeleteChat } from "@/hooks/epic/use-epic-chat-mutations";
 import { useEpicDeleteTuiAgent } from "@/hooks/epic/use-epic-tui-agent-mutations";
 import { useEpicDeleteArtifact } from "@/hooks/epic/use-epic-node-mutations";
+import { useEpicExportArtifacts } from "@/hooks/epic/use-epic-export-artifacts-mutation";
 import { useTerminalKillFor } from "@/hooks/terminal/use-terminal-kill-for-mutation";
 import { useEpicSessionHostClient } from "@/hooks/epic/use-epic-session-host-client";
 import { useEpicNestedFocusNavigation } from "@/hooks/epic/use-epic-nested-focus-navigation";
@@ -46,13 +48,20 @@ const RENAME_TITLE: Record<SwitcherRowKind, string> = {
 };
 
 /**
- * The per-row "…" actions for the switcher's flat lists: Rename + Delete for
- * agents/artifacts (delete confirmed), Rename + Close for PTY terminals (Close
- * is immediate, matching desktop parity). Reuses the exact desktop mutation
- * hooks and the shared row-menu item renderer; the whole affordance is
- * editor-gated (a viewer gets no menu at all, so no dead-end mutations). Delete
- * also closes the item's open canvas tile so the mobile view never lands on a
- * dead tile.
+ * The per-row "…" actions for the switcher's flat lists: Export as
+ * Markdown/PDF for artifacts, then Rename + Delete for agents/artifacts
+ * (delete confirmed), Rename + Close for PTY terminals (Close is immediate,
+ * matching desktop parity). Reuses the exact desktop mutation hooks and the
+ * shared row-menu item renderer; the whole affordance is editor-gated (a
+ * viewer gets no menu at all, so no dead-end mutations). Delete also closes
+ * the item's open canvas tile so the mobile view never lands on a dead tile.
+ *
+ * The export pair mirrors the desktop artifact row's own entries, in its
+ * order, wording and disabled semantics - both formats, because desktop
+ * offers both and mounting only one would be a curation this list has no
+ * grounds to make. Desktop's multi-select ZIP export has no counterpart here:
+ * it hangs off a selection model the flat mobile list does not have, so
+ * exporting is per-row, which is exactly what the desktop row menu does too.
  */
 export function SwitcherRowActions(props: SwitcherRowActionsProps) {
   const { epicId, tabId, kind, nodeId, name, cascadeSummary } = props;
@@ -61,6 +70,7 @@ export function SwitcherRowActions(props: SwitcherRowActionsProps) {
   const [confirmOpen, setConfirmOpen] = useState(false);
 
   const rename = useSwitcherRename(epicId);
+  const exportArtifacts = useEpicExportArtifacts();
   const deleteChat = useEpicDeleteChat();
   const deleteTuiAgent = useEpicDeleteTuiAgent();
   const deleteArtifact = useEpicDeleteArtifact();
@@ -86,6 +96,21 @@ export function SwitcherRowActions(props: SwitcherRowActionsProps) {
       prepareCloseCanvasTabFocusTarget(tabId, found.paneId, found.instanceId),
     );
   }, [epicId, nodeId, navigateNested, prepareCloseCanvasTabFocusTarget, tabId]);
+
+  // Single-row export, the same shape the desktop artifact row uses: one
+  // artifact, no archive, so the save lands as `<title>.<ext>` rather than a
+  // ZIP the phone has no second artifact to fill.
+  const exportOne = useCallback(
+    (format: "markdown" | "pdf") => {
+      exportArtifacts.mutate({
+        artifacts: [{ id: nodeId, title: name }],
+        format,
+        archive: false,
+        archiveTitle: null,
+      });
+    },
+    [exportArtifacts, name, nodeId],
+  );
 
   const submitRename = useCallback(
     (title: string) => {
@@ -139,7 +164,54 @@ export function SwitcherRowActions(props: SwitcherRowActionsProps) {
     deleteTuiAgent.isPending ||
     deleteArtifact.isPending;
 
+  const exportIcon = exportArtifacts.isPending ? (
+    <AgentSpinningDots
+      className={undefined}
+      testId={undefined}
+      variant={undefined}
+    />
+  ) : (
+    <FileDown className="size-3.5" />
+  );
+
+  // Artifacts only: a chat or a terminal has no exportable document behind it.
+  const exportEntries: ReadonlyArray<SidebarRowMenuEntry> =
+    kind === "artifact"
+      ? [
+          {
+            kind: "item",
+            id: "export-markdown",
+            label: "Export as Markdown",
+            icon: exportIcon,
+            disabled: exportArtifacts.isPending,
+            disabledTooltip: null,
+            variant: "default",
+            testIds: {
+              dropdown: `switcher-export-markdown-${nodeId}`,
+              context: `switcher-export-markdown-ctx-${nodeId}`,
+            },
+            onSelect: () => exportOne("markdown"),
+          },
+          {
+            kind: "item",
+            id: "export-pdf",
+            label: "Export as PDF",
+            icon: exportIcon,
+            disabled: exportArtifacts.isPending,
+            disabledTooltip: null,
+            variant: "default",
+            testIds: {
+              dropdown: `switcher-export-pdf-${nodeId}`,
+              context: `switcher-export-pdf-ctx-${nodeId}`,
+            },
+            onSelect: () => exportOne("pdf"),
+          },
+          { kind: "separator", id: "after-export" },
+        ]
+      : [];
+
   const entries: ReadonlyArray<SidebarRowMenuEntry> = [
+    ...exportEntries,
     {
       kind: "item",
       id: "rename",


### PR DESCRIPTION
## What

The mobile switcher's artifact rows now offer **Export as Markdown** and **Export as PDF**, mirroring the desktop artifact row menu.

## Why this is a mount, not a bug fix

`useEpicExportArtifacts` had exactly two consumers, both under `components/epic-canvas/sidebar/` — desktop. The mobile row menu (`switcher-row-actions.tsx`) defined Rename and Delete, and nothing else; there was no command-palette entry either. So exporting an artifact had **no phone trigger at all**.

That is worth stating precisely, because the parity ledger had it recorded the other way round: artifact export was listed among the mobile surfaces taking a dead save path. It could not take that path — it could not be reached. A gap recorded as *working-but-broken* is invisible in a way that *absent* is not, so the ledger row is being corrected alongside this.

## What it mirrors, and what it deliberately does not

Desktop's artifact row menu offers both formats, in this order, with these labels, disabled while a previous export is in flight. All of that is mirrored verbatim. **Both** formats, because desktop offers both and mounting only one would be exactly the silent curation the mirror-desktop rule exists to prevent.

Desktop's **multi-select ZIP** export has no counterpart here and none is invented: it hangs off a selection model the flat mobile list does not have. Exporting is therefore per-row — which is also what the desktop row menu itself does.

Gated to `kind === "artifact"`: a chat or terminal row has no exportable document behind it.

## How it was found

A simulator run went looking for a subject to exercise the mobile save seam with, and found the export it expected to test was not offered. The seam itself (#1538) works — three other surfaces feed it on the phone, and its Mermaid/usage-image path is device-verified — but the markdown-export half had no button to press.

## Verification

Four tests on the artifact row's menu: both entries present; the export submits the row's own artifact id with `archive: false`; the chosen format is carried through rather than fixed; and the existing row behaviour is unchanged. They assert the submitted payload rather than that a mutation was called, so a wired-to-the-wrong-row regression fails them.

The "no export on a chat or terminal row" case is **not** asserted: mounting the agents list drags in the chat-tree panel, which needs a QueryClient this harness deliberately does not provide. The gate is structural (`kind === "artifact"`) rather than data-conditional, and that is noted where the test would have gone rather than left as a silent omission.

Local `build · compile · lint · format` green.
