### PR TITLE
test: share the hardened Chrome launcher across the browser regression drivers

### DIFF
--- a/clients/gui-app/scripts/boot-escape-hatch-press-browser.mjs
+++ b/clients/gui-app/scripts/boot-escape-hatch-press-browser.mjs
@@ -16,14 +16,17 @@
 //   bun scripts/boot-escape-hatch-press-browser.mjs
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
-import { constants } from "node:fs";
-import { access, mkdtemp, rm } from "node:fs/promises";
+import { rm } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { createServer as createTcpServer } from "node:net";
-import { tmpdir } from "node:os";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { fileURLToPath } from "node:url";
+import {
+  findChrome,
+  launchChromeWithDevTools,
+  terminateProcessTree,
+} from "./chrome-launcher.mjs";
 
 const projectRoot = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -31,12 +34,10 @@ const projectRoot = path.resolve(
 );
 const fixtureUrlPath = "/src/__tests__/browser/boot-escape-hatch-press.html";
 const BUTTON = '[data-testid="host-boot-open-settings"]';
-const chromePath = await findChrome();
-const profilePath = await mkdtemp(path.join(tmpdir(), "traycer-boot-press-"));
+const chromePath = await findChrome("the boot escape hatch press regression");
 const vitePort = await freePort();
-let devtoolsPort = await freePort();
-while (devtoolsPort === vitePort) devtoolsPort = await freePort();
 let chrome;
+let chromeProfilePath;
 let client;
 let viteProcess;
 
@@ -70,38 +71,21 @@ try {
   });
   await waitForHttp(pageUrl, viteProcess, () => viteError, "Vite");
 
-  chrome = spawn(
+  const launched = await launchChromeWithDevTools(
     chromePath,
-    [
-      "--headless=new",
-      "--disable-background-networking",
-      "--disable-component-update",
-      "--disable-default-apps",
-      "--disable-extensions",
-      "--disable-features=Translate",
-      "--disable-sync",
-      "--no-default-browser-check",
-      "--no-first-run",
-      "--no-sandbox",
-      `--remote-debugging-port=${devtoolsPort}`,
-      `--user-data-dir=${profilePath}`,
-      "about:blank",
-    ],
-    { stdio: ["ignore", "ignore", "pipe"] },
+    "traycer-boot-press-",
   );
-  let chromeError = "";
-  chrome.stderr.setEncoding("utf8");
-  chrome.stderr.on("data", (chunk) => {
-    chromeError += chunk;
-  });
+  chrome = launched.chrome;
+  chromeProfilePath = launched.profilePath;
+  const devtoolsUrl = launched.devtoolsHttpUrl;
   await waitForHttp(
-    `http://127.0.0.1:${devtoolsPort}/json/version`,
+    new URL("/json/version", devtoolsUrl).href,
     chrome,
-    () => chromeError,
+    launched.readError,
     "Chrome DevTools",
   );
   const targetResponse = await fetch(
-    `http://127.0.0.1:${devtoolsPort}/json/new?about:blank`,
+    new URL("/json/new?about:blank", devtoolsUrl),
     { method: "PUT" },
   );
   if (!targetResponse.ok) {
@@ -195,13 +179,20 @@ try {
   process.exitCode = 1;
 } finally {
   client?.close();
-  chrome?.kill("SIGKILL");
-  viteProcess?.kill("SIGKILL");
-  await delay(300);
-  try {
-    await rm(profilePath, { recursive: true, force: true });
-  } catch {
-    // A leftover temp profile is not a test result.
+  // `terminateProcessTree` replaces the old `chrome.kill("SIGKILL")` plus a
+  // 300ms sleep: it takes down the whole process GROUP and verifies it is
+  // gone, so the profile below is removed from under a browser that is
+  // provably finished writing rather than one that has probably stopped.
+  if (chrome !== undefined) {
+    await terminateProcessTree(chrome);
+  }
+  viteProcess?.kill("SIGTERM");
+  if (chromeProfilePath !== undefined) {
+    await rm(chromeProfilePath, {
+      recursive: true,
+      force: true,
+      maxRetries: 3,
+    });
   }
 }
 
@@ -263,24 +254,6 @@ async function rectCentre(client, selector) {
 
 function settle(client) {
   return evaluate(client, `new Promise((r) => setTimeout(r, 250))`);
-}
-
-async function findChrome() {
-  const candidates = [
-    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
-    "/Applications/Chromium.app/Contents/MacOS/Chromium",
-    "/usr/bin/google-chrome",
-    "/usr/bin/chromium",
-  ];
-  for (const candidate of candidates) {
-    try {
-      await access(candidate, constants.X_OK);
-      return candidate;
-    } catch {
-      continue;
-    }
-  }
-  throw new Error("No Chrome/Chromium binary found");
 }
 
 function freePort() {

--- a/clients/gui-app/scripts/chrome-launcher.mjs
+++ b/clients/gui-app/scripts/chrome-launcher.mjs
@@ -1,0 +1,202 @@
+// The one headless-Chrome launcher every browser regression in `scripts/` uses.
+//
+// Each of those drivers used to carry its own copy of "find Chrome, spawn it,
+// wait for DevTools", and the copies drifted: only one of them honoured
+// `CHROME_BIN`, only one retried a cold start, and the rest killed the browser
+// PID alone and left its renderers and crashpad handlers behind. The hardening
+// below was written for `diff-edit-browser-regression.mjs` (OSS #1552) after a
+// CI runner had to reap exactly that orphan pile; it lives here so a fix lands
+// once instead of four times.
+//
+// Consumers own everything downstream of the DevTools endpoint (CDP client,
+// fixtures, assertions) - this module owns only the process.
+import { spawn } from "node:child_process";
+import { constants } from "node:fs";
+import { access, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+
+/**
+ * Resolves a Chrome/Chromium executable, preferring `CHROME_BIN`.
+ *
+ * `purpose` names the caller in the failure message, which is the only thing
+ * that differs between drivers.
+ */
+export async function findChrome(purpose) {
+  const candidates = [
+    process.env.CHROME_BIN,
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    "/Applications/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing",
+    "/Applications/Chromium.app/Contents/MacOS/Chromium",
+    "/usr/bin/google-chrome",
+    "/usr/bin/google-chrome-stable",
+    "/usr/bin/chromium",
+    "/usr/bin/chromium-browser",
+  ].filter((candidate) => candidate !== undefined);
+  for (const candidate of candidates) {
+    try {
+      await access(candidate, constants.X_OK);
+      return candidate;
+    } catch {
+      // Try the next platform-standard location.
+    }
+  }
+  throw new Error(
+    `Chrome is required for ${purpose}. Set CHROME_BIN to its executable.`,
+  );
+}
+
+/**
+ * Launches headless Chrome and waits for its DevTools endpoint, retrying the
+ * whole spawn on timeout.
+ *
+ * A cold CI runner has been observed to take Chrome past the 30s DevTools
+ * deadline outright (its FIRST stderr line arrived 21s after spawn), and a
+ * single flat deadline makes that a hard failure. A retry only helps when it
+ * starts clean, so each attempt gets a fresh profile directory, and a
+ * timed-out attempt's whole process GROUP is terminated and verified gone
+ * (see `terminateProcessTree`) and its profile removed before the next
+ * spawn - otherwise the retry inherits a locked profile plus the previous
+ * attempt's crashpad children, which is exactly the orphan pile the runner
+ * had to reap. `detached: true` is what makes that possible: it puts Chrome
+ * at the head of its own process group, so renderers and crashpad handlers
+ * are addressable together as one negative-PGID signal instead of only the
+ * browser PID.
+ *
+ * The debugging port is `0` and the real endpoint is read back off Chrome's
+ * stderr: a port picked in advance is only free until Chrome gets round to
+ * binding it, and on a retry it is still held by the attempt that just died.
+ *
+ * `profilePrefix` is the `mkdtemp` prefix for this driver's profile
+ * directories, so a stray temp dir names the driver that leaked it.
+ */
+export async function launchChromeWithDevTools(chromePath, profilePrefix) {
+  const chromeEnv = { ...process.env };
+  delete chromeEnv.DBUS_SESSION_BUS_ADDRESS;
+  const attempts = 3;
+  let lastError = new Error("Chrome launch was not attempted");
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    const profilePath = await mkdtemp(path.join(tmpdir(), profilePrefix));
+    const chrome = spawn(
+      chromePath,
+      [
+        "--headless=new",
+        "--disable-background-networking",
+        "--disable-component-update",
+        "--disable-default-apps",
+        "--disable-extensions",
+        "--disable-features=Translate",
+        "--disable-sync",
+        "--no-default-browser-check",
+        "--no-first-run",
+        "--no-sandbox",
+        "--remote-debugging-port=0",
+        `--user-data-dir=${profilePath}`,
+        "about:blank",
+      ],
+      { env: chromeEnv, stdio: ["ignore", "ignore", "pipe"], detached: true },
+    );
+    let chromeError = "";
+    chrome.stderr.setEncoding("utf8");
+    chrome.stderr.on("data", (chunk) => {
+      chromeError += chunk;
+    });
+    // A spawn failure (ENOENT/EACCES) surfaces as an "error" event, not an
+    // exit; without a listener Node throws it as an uncaught event before
+    // the retry catch can clean up the attempt's profile.
+    let spawnFailure = null;
+    chrome.on("error", (error) => {
+      spawnFailure = error instanceof Error ? error : new Error(String(error));
+    });
+    try {
+      const devtoolsWebSocketUrl = await waitForDevToolsUrl(
+        chrome,
+        () => chromeError,
+        () => spawnFailure,
+      );
+      const devtoolsHttpUrl = new URL(devtoolsWebSocketUrl);
+      devtoolsHttpUrl.protocol = "http:";
+      devtoolsHttpUrl.pathname = "";
+      devtoolsHttpUrl.search = "";
+      devtoolsHttpUrl.hash = "";
+      return {
+        chrome,
+        profilePath,
+        devtoolsWebSocketUrl,
+        devtoolsHttpUrl,
+        readError: () => chromeError,
+      };
+    } catch (error) {
+      lastError = error instanceof Error ? error : new Error(String(error));
+      console.error(
+        `Chrome launch attempt ${attempt}/${attempts} failed: ${lastError.message}`,
+      );
+      await terminateProcessTree(chrome);
+      await rm(profilePath, { recursive: true, force: true, maxRetries: 3 });
+    }
+  }
+  throw lastError;
+}
+
+/**
+ * Terminates a detached child's whole process TREE, with a bounded wait.
+ *
+ * The child is spawned `detached`, so it leads its own process group and its
+ * descendants (Chrome's renderers and crashpad handlers, which survive a
+ * plain parent kill - the CI runner had to reap exactly that pile) are all
+ * addressable as one negative-PGID signal. SIGTERM first (Chrome ignores it
+ * during early startup), a 2s grace, then SIGKILL to the group, then a
+ * BOUNDED verification that no group member remains. A tree that somehow
+ * survives SIGKILL fails loudly rather than letting a retry - or the final
+ * cleanup - proceed over a half-dead tree.
+ */
+export async function terminateProcessTree(child) {
+  const groupId = child.pid;
+  if (groupId === undefined) return;
+  const signalGroup = (signal) => {
+    try {
+      process.kill(-groupId, signal);
+      return true;
+    } catch {
+      // ESRCH: every member of the group is already gone.
+      return false;
+    }
+  };
+  if (!signalGroup("SIGTERM")) return;
+  const termDeadline = Date.now() + 2_000;
+  while (signalGroup(0) && Date.now() < termDeadline) {
+    await delay(50);
+  }
+  if (!signalGroup("SIGKILL")) return;
+  const killDeadline = Date.now() + 2_000;
+  while (signalGroup(0) && Date.now() < killDeadline) {
+    await delay(50);
+  }
+  if (signalGroup(0)) {
+    throw new Error(
+      `Chrome process group ${groupId} survived SIGKILL; refusing to continue over a half-dead tree`,
+    );
+  }
+}
+
+async function waitForDevToolsUrl(process, readError, readSpawnFailure) {
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    const spawnFailure = readSpawnFailure();
+    if (spawnFailure !== null) {
+      throw new Error(`Chrome failed to spawn: ${spawnFailure.message}`);
+    }
+    if (process.exitCode !== null) {
+      throw new Error(
+        `Chrome exited before DevTools was ready:\n${readError()}`,
+      );
+    }
+    const match = readError().match(
+      /DevTools listening on (ws:\/\/[^\s]+\/devtools\/browser\/[^\s]+)/,
+    );
+    if (match !== null) return match[1];
+    await delay(50);
+  }
+  throw new Error(`Timed out waiting for Chrome DevTools:\n${readError()}`);
+}

--- a/clients/gui-app/scripts/chrome-launcher.mjs
+++ b/clients/gui-app/scripts/chrome-launcher.mjs
@@ -184,14 +184,17 @@ export async function terminateProcessTree(child) {
   }
 }
 
-async function waitForDevToolsUrl(process, readError, readSpawnFailure) {
+async function waitForDevToolsUrl(child, readError, readSpawnFailure) {
   const deadline = Date.now() + 30_000;
   while (Date.now() < deadline) {
     const spawnFailure = readSpawnFailure();
     if (spawnFailure !== null) {
       throw new Error(`Chrome failed to spawn: ${spawnFailure.message}`);
     }
-    if (process.exitCode !== null) {
+    // A signal-terminated Chrome (an OOM-killed cold start is the CI case)
+    // leaves exitCode null and sets signalCode; without checking both, the
+    // wait would burn its whole deadline on a corpse instead of retrying.
+    if (child.exitCode !== null || child.signalCode !== null) {
       throw new Error(
         `Chrome exited before DevTools was ready:\n${readError()}`,
       );

--- a/clients/gui-app/scripts/chrome-launcher.mjs
+++ b/clients/gui-app/scripts/chrome-launcher.mjs
@@ -1,12 +1,16 @@
-// The one headless-Chrome launcher every browser regression in `scripts/` uses.
+// The shared headless-Chrome launcher for the browser regression drivers:
+// all four CI-gated scripts (see `run-tests.ts`) plus `toast-over-modal-
+// hittest.mjs`. The two manual instruments (`window-host-modal-alignment-
+// browser.mjs`, `host-boot-family-gallery-browser.mjs`) still carry their own
+// standalone launchers.
 //
-// Each of those drivers used to carry its own copy of "find Chrome, spawn it,
-// wait for DevTools", and the copies drifted: only one of them honoured
-// `CHROME_BIN`, only one retried a cold start, and the rest killed the browser
-// PID alone and left its renderers and crashpad handlers behind. The hardening
-// below was written for `diff-edit-browser-regression.mjs` (OSS #1552) after a
-// CI runner had to reap exactly that orphan pile; it lives here so a fix lands
-// once instead of four times.
+// Each driver used to carry its own copy of "find Chrome, spawn it, wait for
+// DevTools", and the copies drifted: only one of them honoured `CHROME_BIN`,
+// only one retried a cold start, and the rest killed the browser PID alone
+// and left its renderers and crashpad handlers behind. The hardening below
+// was written for `diff-edit-browser-regression.mjs` (OSS #1552) after a CI
+// runner had to reap exactly that orphan pile; it lives here so a fix lands
+// once instead of five times.
 //
 // Consumers own everything downstream of the DevTools endpoint (CDP client,
 // fixtures, assertions) - this module owns only the process.

--- a/clients/gui-app/scripts/destructive-dialog-focus-browser.mjs
+++ b/clients/gui-app/scripts/destructive-dialog-focus-browser.mjs
@@ -11,26 +11,27 @@
 // RUN_DIFF_EDIT_BROWSER_REGRESSION, which CI sets for this package.
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
-import { constants } from "node:fs";
-import { access, mkdtemp, rm } from "node:fs/promises";
+import { rm } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { createServer as createTcpServer } from "node:net";
-import { tmpdir } from "node:os";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { fileURLToPath } from "node:url";
+import {
+  findChrome,
+  launchChromeWithDevTools,
+  terminateProcessTree,
+} from "./chrome-launcher.mjs";
 
 const projectRoot = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   "..",
 );
 const fixtureUrlPath = "/src/__tests__/browser/destructive-dialog-focus.html";
-const chromePath = await findChrome();
-const profilePath = await mkdtemp(path.join(tmpdir(), "traycer-dialog-focus-"));
+const chromePath = await findChrome("the destructive-dialog focus regression");
 const vitePort = await freePort();
-let devtoolsPort = await freePort();
-while (devtoolsPort === vitePort) devtoolsPort = await freePort();
 let chrome;
+let chromeProfilePath;
 let client;
 let viteProcess;
 
@@ -64,38 +65,21 @@ try {
   });
   await waitForHttp(pageUrl, viteProcess, () => viteError, "Vite");
 
-  chrome = spawn(
+  const launched = await launchChromeWithDevTools(
     chromePath,
-    [
-      "--headless=new",
-      "--disable-background-networking",
-      "--disable-component-update",
-      "--disable-default-apps",
-      "--disable-extensions",
-      "--disable-features=Translate",
-      "--disable-sync",
-      "--no-default-browser-check",
-      "--no-first-run",
-      "--no-sandbox",
-      `--remote-debugging-port=${devtoolsPort}`,
-      `--user-data-dir=${profilePath}`,
-      "about:blank",
-    ],
-    { stdio: ["ignore", "ignore", "pipe"] },
+    "traycer-dialog-focus-",
   );
-  let chromeError = "";
-  chrome.stderr.setEncoding("utf8");
-  chrome.stderr.on("data", (chunk) => {
-    chromeError += chunk;
-  });
+  chrome = launched.chrome;
+  chromeProfilePath = launched.profilePath;
+  const devtoolsUrl = launched.devtoolsHttpUrl;
   await waitForHttp(
-    `http://127.0.0.1:${devtoolsPort}/json/version`,
+    new URL("/json/version", devtoolsUrl).href,
     chrome,
-    () => chromeError,
+    launched.readError,
     "Chrome DevTools",
   );
   const targetResponse = await fetch(
-    `http://127.0.0.1:${devtoolsPort}/json/new?${encodeURIComponent(pageUrl)}`,
+    new URL(`/json/new?${encodeURIComponent(pageUrl)}`, devtoolsUrl),
     { method: "PUT" },
   );
   if (!targetResponse.ok) {
@@ -151,36 +135,25 @@ try {
   process.exitCode = 1;
 } finally {
   client?.close();
-  chrome?.kill("SIGKILL");
-  viteProcess?.kill("SIGKILL");
-  await delay(300);
-  try {
-    await rm(profilePath, { recursive: true, force: true });
-  } catch {
-    // leftover temp profile is not a result
+  // `terminateProcessTree` replaces the old `chrome.kill("SIGKILL")` plus a
+  // 300ms sleep: it takes down the whole process GROUP and verifies it is
+  // gone, so the profile below is removed from under a browser that is
+  // provably finished writing rather than one that has probably stopped.
+  if (chrome !== undefined) {
+    await terminateProcessTree(chrome);
+  }
+  viteProcess?.kill("SIGTERM");
+  if (chromeProfilePath !== undefined) {
+    await rm(chromeProfilePath, {
+      recursive: true,
+      force: true,
+      maxRetries: 3,
+    });
   }
 }
 
 function settle(client) {
   return evaluate(client, `new Promise((r) => setTimeout(r, 250))`);
-}
-
-async function findChrome() {
-  const candidates = [
-    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
-    "/Applications/Chromium.app/Contents/MacOS/Chromium",
-    "/usr/bin/google-chrome",
-    "/usr/bin/chromium",
-  ];
-  for (const candidate of candidates) {
-    try {
-      await access(candidate, constants.X_OK);
-      return candidate;
-    } catch {
-      continue;
-    }
-  }
-  throw new Error("No Chrome/Chromium binary found");
 }
 
 function freePort() {

--- a/clients/gui-app/scripts/diff-edit-browser-regression.mjs
+++ b/clients/gui-app/scripts/diff-edit-browser-regression.mjs
@@ -1,20 +1,23 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
-import { constants } from "node:fs";
-import { access, mkdtemp, rm } from "node:fs/promises";
+import { rm } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { createServer as createTcpServer } from "node:net";
-import { tmpdir } from "node:os";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { fileURLToPath } from "node:url";
+import {
+  findChrome,
+  launchChromeWithDevTools,
+  terminateProcessTree,
+} from "./chrome-launcher.mjs";
 
 const projectRoot = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   "..",
 );
 const fixtureUrlPath = "/src/__tests__/browser/diff-edit-focus.html";
-const chromePath = await findChrome();
+const chromePath = await findChrome("the diff edit browser regression");
 const vitePort = await freePort();
 let chrome;
 let chromeProfilePath;
@@ -52,18 +55,14 @@ try {
   });
   await waitForHttp(pageUrl, viteProcess, () => viteError, "Vite");
 
-  const chromeEnv = { ...process.env };
-  delete chromeEnv.DBUS_SESSION_BUS_ADDRESS;
-  const launched = await launchChromeWithDevTools(chromePath, chromeEnv);
+  const launched = await launchChromeWithDevTools(
+    chromePath,
+    "traycer-diff-edit-",
+  );
   chrome = launched.chrome;
   chromeProfilePath = launched.profilePath;
   const readChromeError = launched.readError;
-  const devtoolsWebSocketUrl = launched.devtoolsWebSocketUrl;
-  const devtoolsUrl = new URL(devtoolsWebSocketUrl);
-  devtoolsUrl.protocol = "http:";
-  devtoolsUrl.pathname = "";
-  devtoolsUrl.search = "";
-  devtoolsUrl.hash = "";
+  const devtoolsUrl = launched.devtoolsHttpUrl;
   await waitForHttp(
     new URL("/json/version", devtoolsUrl).href,
     chrome,
@@ -429,29 +428,6 @@ try {
   }
 }
 
-async function findChrome() {
-  const candidates = [
-    process.env.CHROME_BIN,
-    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
-    "/Applications/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing",
-    "/usr/bin/google-chrome",
-    "/usr/bin/google-chrome-stable",
-    "/usr/bin/chromium",
-    "/usr/bin/chromium-browser",
-  ].filter((candidate) => candidate !== undefined);
-  for (const candidate of candidates) {
-    try {
-      await access(candidate, constants.X_OK);
-      return candidate;
-    } catch {
-      // Try the next platform-standard location.
-    }
-  }
-  throw new Error(
-    "Chrome is required for the diff edit browser regression. Set CHROME_BIN to its executable.",
-  );
-}
-
 async function freePort() {
   return await new Promise((resolve, reject) => {
     const server = createTcpServer();
@@ -484,147 +460,6 @@ async function waitForHttp(url, process, readError, label) {
     await delay(50);
   }
   throw new Error(`Timed out waiting for ${label}:\n${readError()}`);
-}
-
-async function waitForDevToolsUrl(process, readError, readSpawnFailure) {
-  const deadline = Date.now() + 30_000;
-  while (Date.now() < deadline) {
-    const spawnFailure = readSpawnFailure();
-    if (spawnFailure !== null) {
-      throw new Error(`Chrome failed to spawn: ${spawnFailure.message}`);
-    }
-    if (process.exitCode !== null) {
-      throw new Error(
-        `Chrome exited before DevTools was ready:\n${readError()}`,
-      );
-    }
-    const match = readError().match(
-      /DevTools listening on (ws:\/\/[^\s]+\/devtools\/browser\/[^\s]+)/,
-    );
-    if (match !== null) return match[1];
-    await delay(50);
-  }
-  throw new Error(`Timed out waiting for Chrome DevTools:\n${readError()}`);
-}
-
-/**
- * Launches headless Chrome and waits for its DevTools endpoint, retrying the
- * whole spawn on timeout.
- *
- * A cold CI runner has been observed to take Chrome past the 30s DevTools
- * deadline outright (its FIRST stderr line arrived 21s after spawn), and a
- * single flat deadline makes that a hard failure. A retry only helps when it
- * starts clean, so each attempt gets a fresh profile directory, and a
- * timed-out attempt's whole process GROUP is terminated and verified gone
- * (see `terminateProcessTree`) and its profile removed before the next
- * spawn - otherwise the retry inherits a locked profile plus the previous
- * attempt's crashpad children, which is exactly the orphan pile the runner
- * had to reap. `detached: true` is what makes that possible: it puts Chrome
- * at the head of its own process group, so renderers and crashpad handlers
- * are addressable together as one negative-PGID signal instead of only the
- * browser PID.
- */
-async function launchChromeWithDevTools(chromePath, chromeEnv) {
-  const attempts = 3;
-  let lastError = new Error("Chrome launch was not attempted");
-  for (let attempt = 1; attempt <= attempts; attempt += 1) {
-    const profilePath = await mkdtemp(
-      path.join(tmpdir(), "traycer-diff-edit-"),
-    );
-    const chrome = spawn(
-      chromePath,
-      [
-        "--headless=new",
-        "--disable-background-networking",
-        "--disable-component-update",
-        "--disable-default-apps",
-        "--disable-extensions",
-        "--disable-features=Translate",
-        "--disable-sync",
-        "--no-default-browser-check",
-        "--no-first-run",
-        "--no-sandbox",
-        "--remote-debugging-port=0",
-        `--user-data-dir=${profilePath}`,
-        "about:blank",
-      ],
-      { env: chromeEnv, stdio: ["ignore", "ignore", "pipe"], detached: true },
-    );
-    let chromeError = "";
-    chrome.stderr.setEncoding("utf8");
-    chrome.stderr.on("data", (chunk) => {
-      chromeError += chunk;
-    });
-    // A spawn failure (ENOENT/EACCES) surfaces as an "error" event, not an
-    // exit; without a listener Node throws it as an uncaught event before
-    // the retry catch can clean up the attempt's profile.
-    let spawnFailure = null;
-    chrome.on("error", (error) => {
-      spawnFailure = error instanceof Error ? error : new Error(String(error));
-    });
-    try {
-      const devtoolsWebSocketUrl = await waitForDevToolsUrl(
-        chrome,
-        () => chromeError,
-        () => spawnFailure,
-      );
-      return {
-        chrome,
-        profilePath,
-        devtoolsWebSocketUrl,
-        readError: () => chromeError,
-      };
-    } catch (error) {
-      lastError = error instanceof Error ? error : new Error(String(error));
-      console.error(
-        `Chrome launch attempt ${attempt}/${attempts} failed: ${lastError.message}`,
-      );
-      await terminateProcessTree(chrome);
-      await rm(profilePath, { recursive: true, force: true, maxRetries: 3 });
-    }
-  }
-  throw lastError;
-}
-
-/**
- * Terminates a detached child's whole process TREE, with a bounded wait.
- *
- * The child is spawned `detached`, so it leads its own process group and its
- * descendants (Chrome's renderers and crashpad handlers, which survive a
- * plain parent kill - the CI runner had to reap exactly that pile) are all
- * addressable as one negative-PGID signal. SIGTERM first (Chrome ignores it
- * during early startup), a 2s grace, then SIGKILL to the group, then a
- * BOUNDED verification that no group member remains. A tree that somehow
- * survives SIGKILL fails loudly rather than letting a retry - or the final
- * cleanup - proceed over a half-dead tree.
- */
-async function terminateProcessTree(child) {
-  const groupId = child.pid;
-  if (groupId === undefined) return;
-  const signalGroup = (signal) => {
-    try {
-      process.kill(-groupId, signal);
-      return true;
-    } catch {
-      // ESRCH: every member of the group is already gone.
-      return false;
-    }
-  };
-  if (!signalGroup("SIGTERM")) return;
-  const termDeadline = Date.now() + 2_000;
-  while (signalGroup(0) && Date.now() < termDeadline) {
-    await delay(50);
-  }
-  if (!signalGroup("SIGKILL")) return;
-  const killDeadline = Date.now() + 2_000;
-  while (signalGroup(0) && Date.now() < killDeadline) {
-    await delay(50);
-  }
-  if (signalGroup(0)) {
-    throw new Error(
-      `Chrome process group ${groupId} survived SIGKILL; refusing to continue over a half-dead tree`,
-    );
-  }
 }
 
 async function connectCdp(url) {

--- a/clients/gui-app/scripts/quit-intercept-cancel-browser.mjs
+++ b/clients/gui-app/scripts/quit-intercept-cancel-browser.mjs
@@ -11,26 +11,27 @@
 // RUN_DIFF_EDIT_BROWSER_REGRESSION, which CI sets for this package.
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
-import { constants } from "node:fs";
-import { access, mkdtemp, rm } from "node:fs/promises";
+import { rm } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { createServer as createTcpServer } from "node:net";
-import { tmpdir } from "node:os";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { fileURLToPath } from "node:url";
+import {
+  findChrome,
+  launchChromeWithDevTools,
+  terminateProcessTree,
+} from "./chrome-launcher.mjs";
 
 const projectRoot = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   "..",
 );
 const fixtureUrlPath = "/src/__tests__/browser/quit-intercept-cancel.html";
-const chromePath = await findChrome();
-const profilePath = await mkdtemp(path.join(tmpdir(), "traycer-quit-cancel-"));
+const chromePath = await findChrome("the quit-intercept Cancel regression");
 const vitePort = await freePort();
-let devtoolsPort = await freePort();
-while (devtoolsPort === vitePort) devtoolsPort = await freePort();
 let chrome;
+let chromeProfilePath;
 let client;
 let viteProcess;
 
@@ -64,38 +65,21 @@ try {
   });
   await waitForHttp(pageUrl, viteProcess, () => viteError, "Vite");
 
-  chrome = spawn(
+  const launched = await launchChromeWithDevTools(
     chromePath,
-    [
-      "--headless=new",
-      "--disable-background-networking",
-      "--disable-component-update",
-      "--disable-default-apps",
-      "--disable-extensions",
-      "--disable-features=Translate",
-      "--disable-sync",
-      "--no-default-browser-check",
-      "--no-first-run",
-      "--no-sandbox",
-      `--remote-debugging-port=${devtoolsPort}`,
-      `--user-data-dir=${profilePath}`,
-      "about:blank",
-    ],
-    { stdio: ["ignore", "ignore", "pipe"] },
+    "traycer-quit-cancel-",
   );
-  let chromeError = "";
-  chrome.stderr.setEncoding("utf8");
-  chrome.stderr.on("data", (chunk) => {
-    chromeError += chunk;
-  });
+  chrome = launched.chrome;
+  chromeProfilePath = launched.profilePath;
+  const devtoolsUrl = launched.devtoolsHttpUrl;
   await waitForHttp(
-    `http://127.0.0.1:${devtoolsPort}/json/version`,
+    new URL("/json/version", devtoolsUrl).href,
     chrome,
-    () => chromeError,
+    launched.readError,
     "Chrome DevTools",
   );
   const targetResponse = await fetch(
-    `http://127.0.0.1:${devtoolsPort}/json/new?${encodeURIComponent(pageUrl)}`,
+    new URL(`/json/new?${encodeURIComponent(pageUrl)}`, devtoolsUrl),
     { method: "PUT" },
   );
   if (!targetResponse.ok) {
@@ -243,13 +227,20 @@ try {
   process.exitCode = 1;
 } finally {
   client?.close();
-  chrome?.kill("SIGKILL");
-  viteProcess?.kill("SIGKILL");
-  await delay(300);
-  try {
-    await rm(profilePath, { recursive: true, force: true });
-  } catch {
-    // A leftover temp profile is not a test result.
+  // `terminateProcessTree` replaces the old `chrome.kill("SIGKILL")` plus a
+  // 300ms sleep: it takes down the whole process GROUP and verifies it is
+  // gone, so the profile below is removed from under a browser that is
+  // provably finished writing rather than one that has probably stopped.
+  if (chrome !== undefined) {
+    await terminateProcessTree(chrome);
+  }
+  viteProcess?.kill("SIGTERM");
+  if (chromeProfilePath !== undefined) {
+    await rm(chromeProfilePath, {
+      recursive: true,
+      force: true,
+      maxRetries: 3,
+    });
   }
 }
 
@@ -295,24 +286,6 @@ async function rectCentre(client, selector) {
 
 function settle(client) {
   return evaluate(client, `new Promise((r) => setTimeout(r, 250))`);
-}
-
-async function findChrome() {
-  const candidates = [
-    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
-    "/Applications/Chromium.app/Contents/MacOS/Chromium",
-    "/usr/bin/google-chrome",
-    "/usr/bin/chromium",
-  ];
-  for (const candidate of candidates) {
-    try {
-      await access(candidate, constants.X_OK);
-      return candidate;
-    } catch {
-      continue;
-    }
-  }
-  throw new Error("No Chrome/Chromium binary found");
 }
 
 function freePort() {

--- a/clients/gui-app/scripts/toast-over-modal-hittest.mjs
+++ b/clients/gui-app/scripts/toast-over-modal-hittest.mjs
@@ -5,26 +5,27 @@
 // Structure copied from `diff-edit-browser-regression.mjs` (vite + headless
 // Chrome over CDP).
 import { spawn } from "node:child_process";
-import { constants } from "node:fs";
-import { access, mkdtemp, rm } from "node:fs/promises";
+import { rm } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { createServer as createTcpServer } from "node:net";
-import { tmpdir } from "node:os";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { fileURLToPath } from "node:url";
+import {
+  findChrome,
+  launchChromeWithDevTools,
+  terminateProcessTree,
+} from "./chrome-launcher.mjs";
 
 const projectRoot = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   "..",
 );
 const fixtureUrlPath = "/src/__tests__/browser/toast-over-modal.html";
-const chromePath = await findChrome();
-const profilePath = await mkdtemp(path.join(tmpdir(), "traycer-hittest-"));
+const chromePath = await findChrome("the toast-over-modal hit test");
 const vitePort = await freePort();
-let devtoolsPort = await freePort();
-while (devtoolsPort === vitePort) devtoolsPort = await freePort();
 let chrome;
+let chromeProfilePath;
 let client;
 let viteProcess;
 
@@ -58,38 +59,21 @@ try {
   });
   await waitForHttp(pageUrl, viteProcess, () => viteError, "Vite");
 
-  chrome = spawn(
+  const launched = await launchChromeWithDevTools(
     chromePath,
-    [
-      "--headless=new",
-      "--disable-background-networking",
-      "--disable-component-update",
-      "--disable-default-apps",
-      "--disable-extensions",
-      "--disable-features=Translate",
-      "--disable-sync",
-      "--no-default-browser-check",
-      "--no-first-run",
-      "--no-sandbox",
-      `--remote-debugging-port=${devtoolsPort}`,
-      `--user-data-dir=${profilePath}`,
-      "about:blank",
-    ],
-    { stdio: ["ignore", "ignore", "pipe"] },
+    "traycer-hittest-",
   );
-  let chromeError = "";
-  chrome.stderr.setEncoding("utf8");
-  chrome.stderr.on("data", (chunk) => {
-    chromeError += chunk;
-  });
+  chrome = launched.chrome;
+  chromeProfilePath = launched.profilePath;
+  const devtoolsUrl = launched.devtoolsHttpUrl;
   await waitForHttp(
-    `http://127.0.0.1:${devtoolsPort}/json/version`,
+    new URL("/json/version", devtoolsUrl).href,
     chrome,
-    () => chromeError,
+    launched.readError,
     "Chrome DevTools",
   );
   const targetResponse = await fetch(
-    `http://127.0.0.1:${devtoolsPort}/json/new?${encodeURIComponent(pageUrl)}`,
+    new URL(`/json/new?${encodeURIComponent(pageUrl)}`, devtoolsUrl),
     { method: "PUT" },
   );
   if (!targetResponse.ok) {
@@ -246,32 +230,22 @@ try {
   process.exitCode = 1;
 } finally {
   client?.close();
-  chrome?.kill("SIGKILL");
-  viteProcess?.kill("SIGKILL");
-  await delay(300);
-  try {
-    await rm(profilePath, { recursive: true, force: true });
-  } catch {
-    // A leftover temp profile is not a measurement result.
+  // `terminateProcessTree` replaces the old `chrome.kill("SIGKILL")` plus a
+  // 300ms sleep: it takes down the whole process GROUP and verifies it is
+  // gone, so the profile below is removed from under a browser that is
+  // provably finished writing rather than one that has probably stopped -
+  // which is what the `rm` up here used to need its own `catch` for.
+  if (chrome !== undefined) {
+    await terminateProcessTree(chrome);
   }
-}
-
-async function findChrome() {
-  const candidates = [
-    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
-    "/Applications/Chromium.app/Contents/MacOS/Chromium",
-    "/usr/bin/google-chrome",
-    "/usr/bin/chromium",
-  ];
-  for (const candidate of candidates) {
-    try {
-      await access(candidate, constants.X_OK);
-      return candidate;
-    } catch {
-      continue;
-    }
+  viteProcess?.kill("SIGTERM");
+  if (chromeProfilePath !== undefined) {
+    await rm(chromeProfilePath, {
+      recursive: true,
+      force: true,
+      maxRetries: 3,
+    });
   }
-  throw new Error("No Chrome/Chromium binary found");
 }
 
 function freePort() {


### PR DESCRIPTION
Follow-up to #1552, which hardened the Chrome launcher in `diff-edit-browser-regression.mjs` alone. The sibling drivers in the same CI gate kept the old flat-30s single-attempt pattern (pre-allocated debugging port, PID-only kill) and would flake the same way.

- New `clients/gui-app/scripts/chrome-launcher.mjs` shared by all four CI-gated drivers (`run-tests.ts`) plus `toast-over-modal-hittest.mjs`: 3 attempts, fresh `mkdtemp` profile per attempt, `detached: true` process-group ownership, TERM → 2s → group-KILL → bounded verified-gone teardown that throws on survival, spawn-`error` surfacing threaded into the DevTools wait.
- Port 0 + stderr parse replaces the pre-allocated `--remote-debugging-port` — load-bearing for retries, since a pre-picked port is still held by the attempt that just died. Drivers derive `/json/version` / `/json/new` from the returned DevTools URL.
- `findChrome` unified as a strict union (every driver keeps its candidates, all honor `CHROME_BIN`); the `DBUS_SESSION_BUS_ADDRESS` strip now applies everywhere.
- Placed flat in `scripts/` deliberately: `**/lib/` is gitignored repo-wide, so a `scripts/lib/` module would be silently untracked.
- Not ported (manual instruments, not gated): `window-host-modal-alignment-browser.mjs`, `host-boot-family-gallery-browser.mjs`.

Verification: all five drivers pass end-to-end; forced spawn failure (`CHROME_BIN=<dir>`) on all five exits gracefully through 3 named attempts with zero surviving processes and zero leftover profile dirs. Cold-reviewed (approve; one doc-scope finding fixed in the head commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
