### PR TITLE
fix(desktop): repair Windows, differential, and Linux auto-update failures

### DIFF
--- a/clients/desktop/src/electron-main/app/__tests__/desktop-release-feed.test.ts
+++ b/clients/desktop/src/electron-main/app/__tests__/desktop-release-feed.test.ts
@@ -639,6 +639,10 @@ describe("buildDesktopReleaseFeed", () => {
       updateProvider: ExactReleaseAssetProvider,
       assets: release.assets,
       token: "secret-token",
+      // Carried so `getBlockMapFiles` can resolve the PREVIOUS release's
+      // assets, which `assets` above (this release alone) cannot supply.
+      owner: "traycerai",
+      repo: "private-traycer",
     });
   });
 });
@@ -694,6 +698,8 @@ describe("ExactReleaseAssetProvider", () => {
         updateProvider: ExactReleaseAssetProvider,
         assets,
         token: "secret-token",
+        owner: "traycerai",
+        repo: "private-traycer",
       },
       undefined,
       buildRuntimeOptions(executor),
@@ -764,5 +770,106 @@ describe("ExactReleaseAssetProvider", () => {
     expect(() => provider.resolveFiles(updateInfo)).toThrow(
       /Traycer-1\.6\.0-rc\.3-mac\.zip/,
     );
+  });
+
+  // The differential downloader asks for the blockmap of the release being
+  // installed AND of the one already installed. Artifact names carry no
+  // version, so both blockmaps are called `<installer>.blockmap` - and this
+  // provider is pinned to a single release's assets. Resolving the old one
+  // therefore cannot be a lookup in `assets`; it has to fetch that release.
+  describe("getBlockMapFiles", () => {
+    const newBlockMapUrl =
+      "https://api.github.com/repos/traycerai/private-traycer/releases/assets/1003";
+    const oldBlockMapUrl =
+      "https://api.github.com/repos/traycerai/private-traycer/releases/assets/2003";
+    const blockMapName = "Traycer-1.6.0-rc.3-mac.zip.blockmap";
+
+    function currentReleaseAssets(): DesktopReleaseAsset[] {
+      return [
+        { name: "latest-mac.yml", url: manifestAssetUrl },
+        { name: "Traycer-1.6.0-rc.3-mac.zip", url: installerAssetUrl },
+        { name: blockMapName, url: newBlockMapUrl },
+      ];
+    }
+
+    it("resolves the old blockmap from the previous release and the new one from the pinned assets", async () => {
+      const { executor, provider } = buildProvider(currentReleaseAssets());
+      executor.response = JSON.stringify({
+        assets: [{ name: blockMapName, url: oldBlockMapUrl }],
+      });
+
+      const [oldUrl, newUrl] = await provider.getBlockMapFiles(
+        new URL(installerAssetUrl),
+        "1.5.0",
+        "1.6.0-rc.3",
+      );
+
+      // The two URLs must DIFFER. Returning the new blockmap for both sides is
+      // the failure this override exists to prevent: the downloader would then
+      // "reconstruct" the file already on disk.
+      expect(newUrl.toString()).toBe(newBlockMapUrl);
+      expect(oldUrl.toString()).toBe(oldBlockMapUrl);
+
+      expect(executor.calls).toHaveLength(1);
+      const [options] = executor.calls;
+      expect(options).toMatchObject({
+        hostname: "api.github.com",
+        headers: {
+          accept: "application/vnd.github+json",
+          authorization: "token secret-token",
+        },
+      });
+      // Addressed by TAG, which is the only handle on a release this provider
+      // is not pinned to.
+      expect(String(options.path)).toContain("/releases/tags/desktop-v1.5.0");
+    });
+
+    it("throws when the previous release publishes no matching blockmap", async () => {
+      const { executor, provider } = buildProvider(currentReleaseAssets());
+      executor.response = JSON.stringify({
+        assets: [{ name: "latest-mac.yml", url: manifestAssetUrl }],
+      });
+
+      // Throwing is the correct outcome, not a regression:
+      // `differentialDownloadInstaller` catches it and falls back to a full
+      // download. Silently returning the new blockmap twice would not.
+      await expect(
+        provider.getBlockMapFiles(
+          new URL(installerAssetUrl),
+          "1.5.0",
+          "1.6.0-rc.3",
+        ),
+      ).rejects.toThrow(/1\.5\.0/);
+    });
+
+    it("throws before any network call when this release publishes no blockmap", async () => {
+      const { executor, provider } = buildProvider([
+        { name: "latest-mac.yml", url: manifestAssetUrl },
+        { name: "Traycer-1.6.0-rc.3-mac.zip", url: installerAssetUrl },
+      ]);
+
+      await expect(
+        provider.getBlockMapFiles(
+          new URL(installerAssetUrl),
+          "1.5.0",
+          "1.6.0-rc.3",
+        ),
+      ).rejects.toThrow(/1\.6\.0-rc\.3/);
+      expect(executor.calls).toHaveLength(0);
+    });
+
+    it("throws when the installer URL is not one of the pinned assets", async () => {
+      const { provider } = buildProvider(currentReleaseAssets());
+
+      await expect(
+        provider.getBlockMapFiles(
+          new URL(
+            "https://api.github.com/repos/traycerai/private-traycer/releases/assets/9999",
+          ),
+          "1.5.0",
+          "1.6.0-rc.3",
+        ),
+      ).rejects.toThrow(/9999/);
+    });
   });
 });

--- a/clients/desktop/src/electron-main/app/__tests__/electron-updater-contract.test.ts
+++ b/clients/desktop/src/electron-main/app/__tests__/electron-updater-contract.test.ts
@@ -14,8 +14,12 @@ import { describe, expect, it } from "vitest";
 // provider module: electron-updater ships no `exports` map, so these resolve
 // under both `moduleResolution: bundler` and the esbuild bundle - and the
 // values are the REAL ones, which is the point of a contract test.
-import { parseUpdateInfo } from "electron-updater/out/providers/Provider";
+import {
+  findFile,
+  parseUpdateInfo,
+} from "electron-updater/out/providers/Provider";
 import { DownloadedUpdateHelper } from "electron-updater/out/DownloadedUpdateHelper";
+import type { ResolvedUpdateFileInfo } from "electron-updater/out/types";
 
 /**
  * Vendored-source contracts at the pinned electron-updater.
@@ -271,5 +275,65 @@ describe("electron-updater 6.8.9 vendored contracts", () => {
     expect(source).toContain("result = (0, js_yaml_1.load)(rawData);");
     expect(source).toContain("return result;");
     expect(source).not.toMatch(/return \{[^}]*version:/u);
+  });
+
+  // `findFile` reads the installer's EXTENSION out of `url.pathname`, twice -
+  // once to filter for the wanted one, once to exclude the unwanted. A feed
+  // whose file URLs carry no filename satisfies neither test, and the fallback
+  // is `files[0]`. This is the whole of the Linux defect: `_DebUpdater` asked
+  // for a `.deb`, got the AppImage that happens to be first in
+  // `latest-linux.yml`, and ran `dpkg -i` on it.
+  //
+  // EXECUTED against the real `findFile`, not text-matched, and asserted in
+  // both directions so the fix is pinned alongside the bug.
+  describe("findFile resolves the installer by pathname extension", () => {
+    // The exact arguments `_DebUpdater.doDownloadUpdate` passes.
+    function pickDeb(
+      files: ResolvedUpdateFileInfo[],
+    ): ResolvedUpdateFileInfo | null | undefined {
+      return findFile(files, "deb", ["AppImage", "rpm", "pacman"]);
+    }
+
+    const LINUX_ARTIFACTS = [
+      "traycer-desktop-linux-x86_64.AppImage",
+      "traycer-desktop-linux-x86_64.deb",
+    ] as const;
+
+    // The manifest half (`info.url`) is identical in both cases; only the
+    // resolved `url` differs, which is exactly the difference the token makes.
+    function filesAt(
+      urlFor: (name: string, index: number) => string,
+    ): ResolvedUpdateFileInfo[] {
+      return LINUX_ARTIFACTS.map((name, index) => ({
+        url: new URL(urlFor(name, index)),
+        info: { url: name, sha512: "abc" },
+      }));
+    }
+
+    it("falls through to files[0] when the URLs are asset-API ids", () => {
+      // The private/authenticated shape: an opaque id, no filename anywhere in
+      // the pathname.
+      const files = filesAt(
+        (_name, index) =>
+          `https://api.github.com/repos/traycerai/traycer/releases/assets/${index + 1}`,
+      );
+
+      const picked = pickDeb(files);
+
+      // Not the `.deb` that was asked for - the AppImage, purely because it is
+      // listed first.
+      expect(picked?.info.url).toBe("traycer-desktop-linux-x86_64.AppImage");
+    });
+
+    it("picks the .deb once the URLs are browser-download URLs", () => {
+      const files = filesAt(
+        (name) =>
+          `https://github.com/traycerai/traycer/releases/download/desktop-v1.2.0/${name}`,
+      );
+
+      const picked = pickDeb(files);
+
+      expect(picked?.info.url).toBe("traycer-desktop-linux-x86_64.deb");
+    });
   });
 });

--- a/clients/desktop/src/electron-main/app/__tests__/updater.test.ts
+++ b/clients/desktop/src/electron-main/app/__tests__/updater.test.ts
@@ -1,3 +1,4 @@
+import { execFile } from "node:child_process";
 import { EventEmitter } from "node:events";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Mock } from "vitest";
@@ -493,6 +494,197 @@ describe("desktop app updater", () => {
     expect(updater.getAppUpdateSnapshot().errorMessage).toBe(
       "Traycer ran into a problem while updating. Please try again in a little while.",
     );
+  });
+
+  // On Windows a completed, sha512-verified download is thrown away whenever
+  // electron-updater's Authenticode check REJECTS - which its PowerShell call
+  // does routinely, because it carries a hardcoded 20s timeout and has to hash
+  // the whole ~138MB installer. The wrapper tolerates that. What it must not
+  // tolerate is the two rejections that are security verdicts rather than
+  // infrastructure failures.
+  describe("tolerateUnrunnableSignatureCheck", () => {
+    const SIGNED_OK = null;
+
+    // REAL `execFile` errors, not hand-built ones. The discriminator is a
+    // property Node stamps onto its own errors, so a fabricated `{ cmd: "…" }`
+    // would assert nothing beyond this test agreeing with the wrapper about
+    // what Node does - the exact shape of vacuous test both would pass.
+    function failingChild(
+      script: string,
+      timeout: number | undefined,
+    ): Promise<Error> {
+      return new Promise((resolve, reject) => {
+        execFile(
+          process.execPath,
+          ["-e", script],
+          timeout === undefined ? {} : { timeout },
+          (err) => {
+            if (err === null) {
+              reject(new Error("expected the child process to fail"));
+              return;
+            }
+            resolve(err);
+          },
+        );
+      });
+    }
+
+    it("proceeds when the verifier subprocess is killed by its timeout", async () => {
+      const { updater } = await loadUpdater(NOT_LINUX_GUIDANCE);
+      const timeoutKill = await failingChild("setTimeout(() => {}, 10000)", 50);
+      // The field fingerprint: killed, no exit code, empty stderr.
+      expect(timeoutKill).toMatchObject({ killed: true, signal: "SIGTERM" });
+
+      const verify = updater.tolerateUnrunnableSignatureCheck(() =>
+        Promise.reject(timeoutKill),
+      );
+
+      await expect(verify(["CN=TRAYCER AI INC."], "C:\\a.exe")).resolves.toBe(
+        SIGNED_OK,
+      );
+    });
+
+    it("proceeds when the verifier subprocess exits non-zero", async () => {
+      const { updater } = await loadUpdater(NOT_LINUX_GUIDANCE);
+      // The fourth field machine: PowerShell ran, failed to load
+      // Microsoft.PowerShell.Security, and exited non-zero in under a second.
+      const nonZeroExit = await failingChild(
+        "console.error('CouldNotAutoloadMatchingModule'); process.exit(1)",
+        undefined,
+      );
+      expect(nonZeroExit).toMatchObject({ killed: false, code: 1 });
+
+      const verify = updater.tolerateUnrunnableSignatureCheck(() =>
+        Promise.reject(nonZeroExit),
+      );
+
+      await expect(verify(["CN=TRAYCER AI INC."], "C:\\a.exe")).resolves.toBe(
+        SIGNED_OK,
+      );
+    });
+
+    it("re-throws a LiteralPath mismatch, which is an anti-substitution verdict", async () => {
+      const { updater } = await loadUpdater(NOT_LINUX_GUIDANCE);
+      // electron-updater mints this one by hand when the file PowerShell
+      // reported on is not the file we are about to install. It carries none of
+      // Node's child-process properties, which is exactly what distinguishes it.
+      const substitution = new Error(
+        "LiteralPath of C:\\other.exe is different than C:\\pending\\temp.exe",
+      );
+
+      const verify = updater.tolerateUnrunnableSignatureCheck(() =>
+        Promise.reject(substitution),
+      );
+
+      await expect(verify(["CN=TRAYCER AI INC."], "C:\\a.exe")).rejects.toBe(
+        substitution,
+      );
+    });
+
+    it("re-throws the unknown-stderr rejection, which upstream fails closed on", async () => {
+      const { updater } = await loadUpdater(NOT_LINUX_GUIDANCE);
+      const unknownStderr = new Error(
+        "Cannot execute Get-AuthenticodeSignature, stderr: ??. Failing signature validation due to unknown stderr.",
+      );
+
+      const verify = updater.tolerateUnrunnableSignatureCheck(() =>
+        Promise.reject(unknownStderr),
+      );
+
+      await expect(verify(["CN=TRAYCER AI INC."], "C:\\a.exe")).rejects.toBe(
+        unknownStderr,
+      );
+    });
+
+    it("passes a publisher mismatch through untouched", async () => {
+      const { updater } = await loadUpdater(NOT_LINUX_GUIDANCE);
+      // A genuine mismatch RESOLVES with a reason string rather than rejecting,
+      // and NsisUpdater fails the update on any non-null result. The wrapper
+      // must not flatten that to null.
+      const mismatch = "publisherNames: CN=TRAYCER AI INC., raw info: {}";
+
+      const verify = updater.tolerateUnrunnableSignatureCheck(() =>
+        Promise.resolve(mismatch),
+      );
+
+      await expect(verify(["CN=TRAYCER AI INC."], "C:\\a.exe")).resolves.toBe(
+        mismatch,
+      );
+    });
+  });
+
+  // `formatUserVisibleUpdateError` is first-match-wins, so bucket ORDER is part
+  // of the behavior and not an implementation detail.
+  describe("update failure classification", () => {
+    const SIGNATURE_MESSAGE =
+      "Traycer couldn't verify this update and did not install it. Please download Traycer again from traycer.ai.";
+    const DOWNLOAD_MESSAGE =
+      "Traycer couldn't download and install the latest update. Please try again in a little while.";
+    const SERVICE_MESSAGE =
+      "Traycer couldn't reach the update service right now. Please try again in a little while.";
+
+    async function messageFor(raw: string): Promise<string | null> {
+      const { autoUpdater, updater } = await loadUpdater(NOT_LINUX_GUIDANCE);
+      autoUpdater.checkForUpdates.mockRejectedValue(new Error(raw));
+      await updater.installAutoUpdater(true, makeDeps(true));
+
+      await updater.checkForUpdatesNow(false, "manual");
+
+      return updater.getAppUpdateSnapshot().errorMessage;
+    }
+
+    it("tells the user an update failed verification rather than failed to download", async () => {
+      // INSTALL_ERROR_HINTS also matches "not signed", so this only reaches the
+      // signature bucket because that bucket is checked first.
+      await expect(
+        messageFor(
+          "New version 1.2.0 is not signed by the application owner: publisherNames: CN=TRAYCER AI INC., raw info: {}",
+        ),
+      ).resolves.toBe(SIGNATURE_MESSAGE);
+    });
+
+    it("classifies a LiteralPath substitution as a verification failure", async () => {
+      await expect(
+        messageFor(
+          "LiteralPath of C:\\other.exe is different than C:\\pending\\temp.exe",
+        ),
+      ).resolves.toBe(SIGNATURE_MESSAGE);
+    });
+
+    it("classifies the unknown-stderr fail-closed as a verification failure", async () => {
+      await expect(
+        messageFor(
+          "Cannot execute Get-AuthenticodeSignature, stderr: ??. Failing signature validation due to unknown stderr.",
+        ),
+      ).resolves.toBe(SIGNATURE_MESSAGE);
+    });
+
+    it("still calls a checksum mismatch a download failure, not a verification one", async () => {
+      // The boundary that keeps the new bucket from swallowing the old one.
+      await expect(
+        messageFor("sha512 checksum mismatch, expected abc got def"),
+      ).resolves.toBe(DOWNLOAD_MESSAGE);
+    });
+
+    it("does not mistake `chcp 65001` for HTTP 500", async () => {
+      // The reason the service hints no longer carry bare digits: "500" is a
+      // substring of "65001", and that code page appears in EVERY Windows
+      // signature-verifier error.
+      await expect(
+        messageFor(
+          'Command failed: set "PSModulePath=" & chcp 65001 >NUL & powershell.exe -Command "Get-AuthenticodeSignature -LiteralPath \'C:\\pending\\temp.exe\'"',
+        ),
+      ).resolves.toBe(DOWNLOAD_MESSAGE);
+    });
+
+    it("still routes a real HTTP status code to the service message", async () => {
+      // Dropping the bare-digit hints must not cost genuine status detection;
+      // this message carries no other service hint, so only the whole-number
+      // match can classify it.
+      await expect(
+        messageFor("unexpected response 503 while fetching the update"),
+      ).resolves.toBe(SERVICE_MESSAGE);
+    });
   });
 
   it("defaults allowPrerelease off so RC builds use the stable feed", async () => {

--- a/clients/desktop/src/electron-main/app/desktop-release-feed.ts
+++ b/clients/desktop/src/electron-main/app/desktop-release-feed.ts
@@ -517,6 +517,22 @@ export interface ExactReleaseFeedConfig {
   ) => ExactReleaseAssetProvider;
   readonly assets: readonly DesktopReleaseAsset[];
   readonly token: string;
+  // Needed to resolve the PREVIOUS release's assets when the differential
+  // downloader asks for its blockmap; the pinned `assets` above describe the
+  // new release alone. See `ExactReleaseAssetProvider.getBlockMapFiles`.
+  readonly owner: string;
+  readonly repo: string;
+}
+
+/**
+ * The tag a desktop release is published under.
+ *
+ * One definition of the convention, so the blockmap lookup below cannot drift
+ * from it. `projectDesktopRelease`'s pattern is the parsing counterpart: this
+ * builds a tag from a version, that recognizes a version in a tag.
+ */
+export function desktopReleaseTag(version: string): string {
+  return `desktop-v${version}`;
 }
 
 // A resolved desktop feed: the generic exact-release provider for public repos,
@@ -543,7 +559,7 @@ export function buildDesktopReleaseFeed(
       url: `https://github.com/${owner}/${repo}/releases/download/${encodeURIComponent(release.tag)}/`,
     };
   }
-  return privateExactReleaseFeed(release.assets, token);
+  return privateExactReleaseFeed(release.assets, token, owner, repo);
 }
 
 // The URL + headers used to fetch a candidate's channel manifest during
@@ -582,12 +598,16 @@ export function resolveDesktopManifestRequest(
 function privateExactReleaseFeed(
   assets: readonly DesktopReleaseAsset[],
   token: string,
+  owner: string,
+  repo: string,
 ): ExactReleaseFeedConfig {
   return {
     provider: "custom",
     updateProvider: ExactReleaseAssetProvider,
     assets,
     token,
+    owner,
+    repo,
   };
 }
 
@@ -601,6 +621,8 @@ function privateExactReleaseFeed(
 export class ExactReleaseAssetProvider extends Provider<UpdateInfo> {
   private readonly assets: readonly DesktopReleaseAsset[];
   private readonly token: string;
+  private readonly owner: string;
+  private readonly repo: string;
 
   constructor(
     options: ExactReleaseFeedConfig,
@@ -610,6 +632,8 @@ export class ExactReleaseAssetProvider extends Provider<UpdateInfo> {
     super(runtimeOptions);
     this.assets = options.assets;
     this.token = options.token;
+    this.owner = options.owner;
+    this.repo = options.repo;
   }
 
   // GitHub's asset API 302-redirects to a signed object-store URL; mirror
@@ -648,6 +672,23 @@ export class ExactReleaseAssetProvider extends Provider<UpdateInfo> {
     return this.assetHeaders("application/octet-stream");
   }
 
+  /**
+   * The URLs this provider resolves are `api.github.com/.../releases/assets/<id>`
+   * - an opaque id, with NO filename and NO extension in the pathname. That is
+   * GitHub's only authenticated download path, so it is not negotiable here, but
+   * two pieces of electron-updater read a filename out of that pathname and
+   * quietly get nothing:
+   *
+   *   - `Provider.getBlockMapFiles` - overridden below.
+   *   - `findFile(files, extension, not)`, which each platform updater uses to
+   *     pick its installer. Its extension filter matches nothing AND its
+   *     exclusion list excludes nothing, so it falls through to `files[0]`.
+   *     `_DebUpdater` asking for `deb` therefore receives whatever is first in
+   *     the channel manifest, and `dpkg -i` is handed an AppImage.
+   *
+   * So this provider must never be pointed at a platform that publishes more
+   * than one installer format in one channel manifest.
+   */
   resolveFiles(updateInfo: UpdateInfo): ResolvedUpdateFileInfo[] {
     return getFileList(updateInfo).map((file) => {
       const name = posix.basename(file.url).replace(/ /g, "-");
@@ -659,6 +700,86 @@ export class ExactReleaseAssetProvider extends Provider<UpdateInfo> {
       }
       return { url: new URL(asset.url), info: file };
     });
+  }
+
+  /**
+   * Blockmap URLs for the differential downloader, resolved by ASSET NAME.
+   *
+   * The base implementation suffixes `baseUrl.pathname` with `.blockmap` and
+   * derives the old one by substituting the version *inside that pathname*.
+   * Both halves are inert against an asset-API URL: there is no filename to
+   * suffix and no version to substitute, so the base returns two identical,
+   * malformed URLs and the delta download dies parsing a JSON error body as
+   * gzip (`incorrect header check`).
+   *
+   * Resolving by name needs TWO asset sets, not one. This provider is pinned to
+   * a single release, and `artifactName` carries no version
+   * (`traycer-desktop-windows-${arch}.${ext}`), so the previous release's
+   * blockmap has exactly the SAME name as the new one. Looking the name up in
+   * the pinned set would hand back the new blockmap for both sides, and the
+   * downloader would then "reconstruct" a file it already has - wasting the
+   * round trip and failing its digest. So the old release's assets are fetched
+   * by tag, which is what `GitLabProvider` does for this same reason.
+   *
+   * Throwing when either side is missing is the intended outcome rather than a
+   * failure to avoid: `differentialDownloadInstaller` wraps this whole call and
+   * falls back to a full download.
+   */
+  async getBlockMapFiles(
+    baseUrl: URL,
+    oldVersion: string,
+    newVersion: string,
+  ): Promise<URL[]> {
+    const blockMapName = `${this.assetNameForUrl(baseUrl)}.blockmap`;
+    const newBlockMap = this.assets.find((it) => it.name === blockMapName);
+    if (newBlockMap === undefined) {
+      throw new Error(
+        `Blockmap "${blockMapName}" is not published on the ${newVersion} release`,
+      );
+    }
+    const previous = await this.fetchReleaseAssets(
+      desktopReleaseTag(oldVersion),
+    );
+    const oldBlockMap = previous.find((it) => it.name === blockMapName);
+    if (oldBlockMap === undefined) {
+      throw new Error(
+        `Blockmap "${blockMapName}" is not published on the ${oldVersion} release`,
+      );
+    }
+    return [new URL(oldBlockMap.url), new URL(newBlockMap.url)];
+  }
+
+  // An asset-API URL carries only an opaque id, so the pinned asset set is the
+  // one place it can be mapped back to a filename. Both sides are normalized
+  // through `URL` so the comparison can't fail on incidental spelling.
+  private assetNameForUrl(url: URL): string {
+    const asset = this.assets.find((it) => new URL(it.url).href === url.href);
+    if (asset === undefined) {
+      throw new Error(
+        `Update file "${url.href}" is not among the desktop release assets`,
+      );
+    }
+    return asset.name;
+  }
+
+  private async fetchReleaseAssets(
+    tag: string,
+  ): Promise<DesktopReleaseAsset[]> {
+    const url = new URL(
+      `https://api.github.com/repos/${this.owner}/${this.repo}/releases/tags/${encodeURIComponent(tag)}`,
+    );
+    const raw = await this.httpRequest(
+      url,
+      this.assetHeaders("application/vnd.github+json"),
+    );
+    if (raw === null) {
+      throw new Error(`Release "${tag}" returned no body`);
+    }
+    const parsed: unknown = JSON.parse(raw);
+    if (!isRecord(parsed)) {
+      throw new Error(`Release "${tag}" returned a malformed response`);
+    }
+    return readReleaseAssets(parsed.assets);
   }
 
   private assetHeaders(accept: string): OutgoingHttpHeaders {

--- a/clients/desktop/src/electron-main/app/updater.ts
+++ b/clients/desktop/src/electron-main/app/updater.ts
@@ -1,5 +1,8 @@
 import { app } from "electron";
 import { autoUpdater } from "electron-updater";
+// Type-only: erased at compile time, so it is unaffected by the unit suite's
+// `electron-updater` package-root mock (which exports `autoUpdater` alone).
+import type { VerifyUpdateCodeSignature } from "electron-updater";
 import { execFileSync } from "node:child_process";
 import { access } from "node:fs/promises";
 import { release as osRelease } from "node:os";
@@ -127,6 +130,12 @@ const UPDATE_ERROR_SERVICE_MESSAGE =
   "Traycer couldn't reach the update service right now. Please try again in a little while.";
 const UPDATE_ERROR_DOWNLOAD_MESSAGE =
   "Traycer couldn't download and install the latest update. Please try again in a little while.";
+// The download itself succeeded and its checksum matched; what failed is the
+// authenticity check on the downloaded installer. "Try again" is the wrong
+// advice - a retry re-downloads bytes that were never the problem - and the
+// artifact to distrust is the UPDATE, not the copy already installed.
+const UPDATE_ERROR_SIGNATURE_MESSAGE =
+  "Traycer couldn't verify this update and did not install it. Please download Traycer again from traycer.ai.";
 const UPDATE_ERROR_GENERIC_MESSAGE =
   "Traycer ran into a problem while updating. Please try again in a little while.";
 // Linux deb/rpm only: a live install attempt hit an escalation failure
@@ -298,6 +307,83 @@ export async function installAutoUpdater(
   }
 }
 
+/**
+ * Windows only: an update whose signature check could not RUN must not be
+ * thrown away, but one that genuinely FAILED still must be.
+ *
+ * `NsisUpdater.verifySignature` settles five different ways, and only one of
+ * the rejecting ones means "the verifier itself broke":
+ *
+ * | branch                                          | settles                | meaning                |
+ * | ----------------------------------------------- | ---------------------- | ---------------------- |
+ * | publisher mismatch, or `Status !== 0`           | `resolve(<reason>)`    | genuine mismatch       |
+ * | Windows 6.x, or the `ConvertTo-Json` probe threw | `resolve(null)`        | can't run - upstream already proceeds |
+ * | `execFile` failed and the probe passed          | `reject(execFile err)` | can't run - **ours**   |
+ * | `LiteralPath` !== the file we downloaded        | `reject(new Error)`    | ANTI-SUBSTITUTION check |
+ * | exit 0 but stderr non-empty                     | `reject(new Error)`    | upstream's deliberate fail-closed |
+ *
+ * So a blanket `catch` would also swallow the verify-one-file/install-another
+ * check and upstream's fail-closed branch - downgrading two security controls
+ * to a log line. Only the third row is ours to tolerate.
+ *
+ * The discriminator is structural, never textual: Node stamps `cmd` onto every
+ * error `execFile` raises - a timeout kill and a non-zero exit alike, which are
+ * exactly the two modes seen in the field - while the two rejections
+ * electron-updater mints by hand carry no such property. Matching on message
+ * text instead would quietly stop working the next time upstream rewords one.
+ */
+export function tolerateUnrunnableSignatureCheck(
+  base: VerifyUpdateCodeSignature,
+): VerifyUpdateCodeSignature {
+  return async (publisherNames, filePath) => {
+    try {
+      return await base(publisherNames, filePath);
+    } catch (err) {
+      if (!isChildProcessFailure(err)) {
+        throw err;
+      }
+      log.warn(
+        "[updater] code-signature verification could not run; installing the downloaded update anyway",
+        err,
+      );
+      return null;
+    }
+  };
+}
+
+function isChildProcessFailure(error: unknown): boolean {
+  return (
+    error instanceof Error && typeof Reflect.get(error, "cmd") === "string"
+  );
+}
+
+// The `verifyUpdateCodeSignature` accessor exists only on `NsisUpdater`. We
+// feature-detect rather than `instanceof NsisUpdater`, because importing that
+// class as a VALUE would resolve to the unit suite's `electron-updater`
+// package-root mock (which exports `autoUpdater` alone) and make every test
+// throw on `instanceof undefined`.
+interface CodeSignatureVerifyingUpdater {
+  verifyUpdateCodeSignature: VerifyUpdateCodeSignature;
+}
+
+function hasCodeSignatureVerifier(
+  candidate: object,
+): candidate is CodeSignatureVerifyingUpdater {
+  return (
+    typeof Reflect.get(candidate, "verifyUpdateCodeSignature") === "function"
+  );
+}
+
+function installWindowsSignatureTolerance(): void {
+  if (process.platform !== "win32" || !hasCodeSignatureVerifier(autoUpdater)) {
+    return;
+  }
+  const nsisUpdater: CodeSignatureVerifyingUpdater = autoUpdater;
+  nsisUpdater.verifyUpdateCodeSignature = tolerateUnrunnableSignatureCheck(
+    nsisUpdater.verifyUpdateCodeSignature,
+  );
+}
+
 // Applies the persisted channel, configures the update feed, and attaches every
 // electron-updater event listener. Extracted so `installAutoUpdater` can wrap it
 // in a single initialization boundary that always settles the readiness barrier
@@ -331,6 +417,10 @@ async function configureAutoUpdater(deps: AppUpdaterDeps): Promise<void> {
   // update" click, where a failure is guaranteed to surface visibly (see
   // `handleUpdaterError`'s `installingUpdate` branch).
   autoUpdater.autoInstallOnAppQuit = linuxPackageType === null;
+  // Windows: keep a completed, sha512-verified download from being discarded
+  // when the Authenticode check can't execute (its PowerShell call carries a
+  // hardcoded 20s timeout that a full ~138MB installer hash routinely exceeds).
+  installWindowsSignatureTolerance();
   // electron-updater auto-enables prereleases when the running build is an RC,
   // and then selects the newest prerelease it can see - across release lines,
   // and across the `host-v*` / `cli-v*` tags this repository also publishes.
@@ -609,6 +699,18 @@ export async function checkForUpdatesNow(
     // THE MODE decides whether the namespaced selector runs, not the flag it
     // derived: `allowPrerelease` is now an effect of the mode, and reading the
     // effect back to re-decide the cause is how the two drift.
+    //
+    // Stable deliberately does NOT run discovery, and is safe without it only
+    // because of an invariant that lives in the release workflows rather than
+    // here: electron-updater's stable path resolves this repository's
+    // `/releases/latest`, and although the repo also publishes `host-v*` and
+    // `cli-v*` stable tags, both are created with `--latest=false`
+    // (`release-host.yml`: "host version releases must never become the
+    // latest"; same in `release-cli.yml`), while only a stable desktop publish
+    // passes `--latest`. So `/releases/latest` can only ever be a `desktop-v*`
+    // stable release. If that ever changes, a host-only release becomes the
+    // latest, its `latest.yml` does not exist, and EVERY stable check starts
+    // failing - at which point stable needs the selector too.
     if (modeAllowsPrerelease(activeChannelMode)) {
       const feed = await resolveDesktopReleaseFeed(activeChannelMode);
       // Discovery is async: if the channel changed while it ran, reject this
@@ -1475,6 +1577,23 @@ function invalidPrivateConfig(): boolean {
   );
 }
 
+/**
+ * The stable feed: electron-updater's own GitHub provider, which resolves the
+ * repository's `/releases/latest`.
+ *
+ * That is only correct because of an invariant enforced OUTSIDE this file. The
+ * repository publishes `host-v*` and `cli-v*` releases beside `desktop-v*`, and
+ * GitHub would by default hand `/releases/latest` to whichever of them is the
+ * newest non-prerelease - a host-only release such as `host-v1.1.11` (which has
+ * no `desktop-v1.1.11` counterpart) would then win it, and every stable check
+ * would fail on its absent `latest.yml`. It cannot, because both other release
+ * workflows publish with `--latest=false` ("host version releases must never
+ * become the latest") while only a stable desktop publish passes `--latest`.
+ *
+ * If that ever changes, stable must move to `resolveDesktopReleaseFeed` like
+ * the prerelease modes already have - the namespaced selector is the only
+ * in-process defence.
+ */
 function configureStableGitHubUpdateFeed(): void {
   const coordinate = resolveUpdateRepo();
   const token = PRIVATE_UPDATE_TOKEN.trim();
@@ -2023,13 +2142,22 @@ function formatUserVisibleUpdateError(rawMessage: string): string {
   ) {
     return UPDATE_BLOCKED_LOCATION_REASON;
   }
+  // BEFORE install, and deliberately the most specific set: every phrase below
+  // also contains `signature` or `not signed`, both of which INSTALL matches -
+  // so the reverse order would make this bucket unreachable.
+  if (includesAny(message, SIGNATURE_ERROR_HINTS)) {
+    return UPDATE_ERROR_SIGNATURE_MESSAGE;
+  }
   if (includesAny(message, CONNECTIVITY_ERROR_HINTS)) {
     return UPDATE_ERROR_OFFLINE_MESSAGE;
   }
   if (includesAny(message, INSTALL_ERROR_HINTS)) {
     return UPDATE_ERROR_DOWNLOAD_MESSAGE;
   }
-  if (includesAny(message, SERVICE_ERROR_HINTS)) {
+  if (
+    includesAny(message, SERVICE_ERROR_HINTS) ||
+    includesHttpStatusCode(message)
+  ) {
     return UPDATE_ERROR_SERVICE_MESSAGE;
   }
   return UPDATE_ERROR_GENERIC_MESSAGE;
@@ -2037,6 +2165,17 @@ function formatUserVisibleUpdateError(rawMessage: string): string {
 
 function includesAny(message: string, hints: readonly string[]): boolean {
   return hints.some((hint) => message.includes(hint));
+}
+
+// A bare `"500"` hint is an unanchored substring match, so it also fires inside
+// `chcp 65001` - which appears in every Windows signature-verifier error - and
+// `"404"` fires inside any longer id ending in those digits. Word boundaries
+// pin each code to a standalone number: `\b500\b` does NOT match `65001`,
+// because the digits either side of it are word characters.
+const SERVICE_HTTP_STATUS_PATTERN = /\b(?:401|403|404|500|502|503|504)\b/;
+
+function includesHttpStatusCode(message: string): boolean {
+  return SERVICE_HTTP_STATUS_PATTERN.test(message);
 }
 
 // macOS Squirrel.Mac refuses to apply an update when the running app sits on a
@@ -2079,6 +2218,26 @@ const CONNECTIVITY_ERROR_HINTS: readonly string[] = [
   "offline",
 ];
 
+// The downloaded installer is not authentic, or its authenticity could not be
+// established for a reason that is NOT an infrastructure failure. Exactly three
+// texts reach here, all Windows, and none of them mentions a checksum - so a
+// `sha512` mismatch still lands in the install bucket where it belongs:
+//   1. `New version X is not signed by the application owner: …`
+//      (`ERR_UPDATER_INVALID_SIGNATURE`) - the publisher genuinely mismatched.
+//   2. `LiteralPath of A is different than B` - upstream's verify-one-file /
+//      install-another check; rethrown by `tolerateUnrunnableSignatureCheck`.
+//   3. `… Failing signature validation due to unknown stderr.` - upstream's
+//      deliberate fail-closed branch; likewise rethrown.
+// Each hint must match the MINTED message and not the command echo that every
+// `Command failed:` error carries. `"literalpath"` alone would match the echoed
+// `-LiteralPath '<file>'` present in every verifier invocation, and so would
+// classify an ordinary timeout as a tampered installer.
+const SIGNATURE_ERROR_HINTS: readonly string[] = [
+  "is not signed by the application owner",
+  "literalpath of ",
+  "failing signature validation",
+];
+
 // The update was located but couldn't be downloaded, verified, or applied:
 // checksum/signature mismatch, full disk, or filesystem permission errors.
 const INSTALL_ERROR_HINTS: readonly string[] = [
@@ -2099,17 +2258,13 @@ const INSTALL_ERROR_HINTS: readonly string[] = [
 // The update feed/service was reachable but returned an error response, or a
 // raw HTTP error body leaked through (GitHub `releases.atom` 404, status codes,
 // missing channel manifests). All of these are transient/server-side.
+// Numeric status codes are NOT listed here as bare strings - see
+// `includesHttpStatusCode`, which matches them as whole numbers instead.
 const SERVICE_ERROR_HINTS: readonly string[] = [
   "releases.atom",
   "status code",
   "statuscode",
-  "404",
-  "403",
-  "401",
-  "500",
-  "502",
-  "503",
-  "504",
+  "failed with http",
   "httperror",
   "not found",
   "forbidden",

--- a/clients/gui-app/src/lib/__tests__/query-client.test.ts
+++ b/clients/gui-app/src/lib/__tests__/query-client.test.ts
@@ -1,5 +1,6 @@
 import { MutationObserver, onlineManager } from "@tanstack/react-query";
-import { afterEach, describe, expect, it } from "vitest";
+import { HostRpcError } from "@traycer-clients/shared/host-transport/host-messenger";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createAppQueryClient } from "@/lib/query-client";
 
 // Regression coverage for the wake-from-sleep freeze: Chromium can report
@@ -42,5 +43,97 @@ describe("createAppQueryClient while the browser reports offline", () => {
     // the click but nothing will ever run until connectivity is re-reported.
     expect(observer.getCurrentResult().isPaused).toBe(false);
     await expect(mutation).resolves.toBe("sent");
+  });
+});
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+/**
+ * Runs a failing query through the real client and returns the `error` object
+ * the app-wide `onError` actually emitted, parsed back out of the structured
+ * console line. No mocking of the logger: what this asserts is exactly the text
+ * a support log would carry.
+ */
+async function loggedErrorFieldsForQueryFailure(
+  failure: Error,
+): Promise<Record<string, unknown>> {
+  const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+  try {
+    const client = createAppQueryClient();
+    await client
+      .fetchQuery({
+        // `failure` belongs in the key because `queryFn` closes over it. The
+        // name is carried too: keys hash through `JSON.stringify`, an `Error`
+        // serializes to `{}`, and without it both cases would collide on one
+        // cache entry.
+        queryKey: ["failure-logging", failure.name, failure],
+        queryFn: () => Promise.reject(failure),
+        retry: false,
+      })
+      .catch(() => undefined);
+    const line = warn.mock.calls
+      .map((call) => String(call[0]))
+      .find((text) => text.includes("[query] request failed"));
+    if (line === undefined) {
+      throw new Error("the query failure was never logged");
+    }
+    const parsed: unknown = JSON.parse(line.slice(line.indexOf("{")));
+    if (!isRecord(parsed) || !isRecord(parsed.fields)) {
+      throw new Error("the logged line carried no fields");
+    }
+    const described = parsed.fields.error;
+    if (!isRecord(described)) {
+      throw new Error("the logged fields carried no error");
+    }
+    return described;
+  } finally {
+    warn.mockRestore();
+  }
+}
+
+// This callback fires BEFORE a hook's own `onError`, so what it records is what
+// a support log actually carries - and it cannot be undone downstream.
+//
+// A `HostRpcError` must be logged in FULL: summarizing it reduced every report
+// to `{ name: "HostRpcError", messageLength: 198, stack: null }`, which is why
+// traycerai/traycer#1556 could not be diagnosed from its own logs.
+//
+// Everything else must stay SUMMARIZED. Six hooks feeding this cache
+// deliberately call `appLogger.errorSummary` in their own `onError` because
+// their messages quote the user - `use-epic-export-artifacts-mutation` throws
+// `"<artifact.title>" is still loading.`. A global full log defeats all six,
+// and it does so silently, which is how it shipped the first time.
+describe("createAppQueryClient failure logging", () => {
+  it("summarizes a non-host error whose message quotes the user", async () => {
+    const described = await loggedErrorFieldsForQueryFailure(
+      new Error("“Q3 revenue teardown” is still loading."),
+    );
+    expect(described.message).toBeUndefined();
+    expect(described.stack).toBeNull();
+    expect(described.messageLength).toBe(
+      "“Q3 revenue teardown” is still loading.".length,
+    );
+    expect(JSON.stringify(described)).not.toContain("Q3 revenue teardown");
+  });
+
+  it("records a HostRpcError in full, with its structured attribution", async () => {
+    const described = await loggedErrorFieldsForQueryFailure(
+      new HostRpcError({
+        code: "RPC_ERROR",
+        message: "worktree.create failed: branch already checked out",
+        requestId: "req-8821",
+        method: "worktree.create",
+        fatalDetails: null,
+      }),
+    );
+    expect(described.message).toBe(
+      "worktree.create failed: branch already checked out",
+    );
+    expect(described.messageLength).toBeUndefined();
+    expect(described.code).toBe("RPC_ERROR");
+    expect(described.method).toBe("worktree.create");
+    expect(described.requestId).toBe("req-8821");
   });
 });

--- a/clients/gui-app/src/lib/query-client.ts
+++ b/clients/gui-app/src/lib/query-client.ts
@@ -4,10 +4,14 @@ import {
   QueryClient,
   type QueryKey,
 } from "@tanstack/react-query";
-import { RetryableTransportError } from "@traycer-clients/shared/host-transport/host-messenger";
+import {
+  HostRpcError,
+  RetryableTransportError,
+} from "@traycer-clients/shared/host-transport/host-messenger";
 import {
   appLogger,
-  describeLogErrorSummary,
+  describeLogError,
+  type AppLogFields,
   type AppLogValue,
 } from "@/lib/logger";
 import { installConditionPollEpisodeCoordinator } from "@/lib/query/condition-poll-episode-coordinator";
@@ -38,7 +42,7 @@ export function createAppQueryClient(): QueryClient {
           failureCount: query.state.fetchFailureCount,
           fetchStatus: query.state.fetchStatus,
           status: query.state.status,
-          error: describeLogErrorSummary(error),
+          error: describeRequestError(error),
         });
       },
     }),
@@ -48,7 +52,7 @@ export function createAppQueryClient(): QueryClient {
           mutationKey: summarizeQueryKey(mutation.options.mutationKey ?? []),
           failureCount: mutation.state.failureCount,
           status: mutation.state.status,
-          error: describeLogErrorSummary(error),
+          error: describeRequestError(error),
         });
       },
     }),
@@ -89,6 +93,55 @@ export function createAppQueryClient(): QueryClient {
 }
 
 export const queryClient = createAppQueryClient();
+
+/**
+ * The app-wide catch-all for failed host RPCs, so this is the ONE log line most
+ * support reports carry about a failure.
+ *
+ * It used to record `describeLogErrorSummary`, which keeps the error's name and
+ * replaces its text with `messageLength` - a number. That reduced every report
+ * to `{ name: "HostRpcError", messageLength: 198, stack: null }`, which
+ * identifies nothing: two unrelated failures with equal-length messages are
+ * indistinguishable, and no failure can be diagnosed at all.
+ *
+ * Privacy, stated precisely. `redactLogText` (inside `describeLogError`) is a
+ * CREDENTIAL scrubber - Authorization/Bearer/Cookie/digest/AWS4/userinfo and
+ * sensitive query params, then a 1000-char truncation. It does NOT remove
+ * filesystem paths, submitted URLs, or other request-derived text, and a host
+ * RPC message can interpolate any of those. Do not cite it as though it made
+ * arbitrary text safe. What justifies the full message here is the destination
+ * and the existing convention, not the scrubber:
+ *
+ * - it lands in a LOCAL log file (`console.warn` -> the desktop shell's
+ *   `console-message` handler -> `traycer-desktop.log`); there is no telemetry
+ *   sink on this path;
+ * - the support bundle that log feeds already tails the HOST's own log
+ *   (`diagnostics.logs.tail`), which carries absolute paths by construction, so
+ *   summarizing here removes nothing from what a report actually ships;
+ * - full message + stack is already this renderer's default - `appLogger.error`
+ *   and every nested `Error` go through `describeLogError` unconditionally.
+ *
+ * A new sink for these logs (telemetry, auto-upload) invalidates the first two
+ * and this call site must be revisited with it.
+ *
+ * `describeLogErrorSummary` remains correct where the message can quote the
+ * USER - see `interview-draft-store`, whose `JSON.parse` failures echo a
+ * fragment of the person's own draft. Do not sweep that call site.
+ */
+function describeRequestError(error: unknown): AppLogFields {
+  const described = describeLogError(error);
+  if (!(error instanceof HostRpcError)) {
+    return described;
+  }
+  // Structured attribution the message text does not carry, and which was
+  // previously dropped entirely.
+  return {
+    ...described,
+    code: error.code,
+    method: error.method,
+    requestId: error.requestId,
+  };
+}
 
 function summarizeQueryKey(queryKey: QueryKey): AppLogValue {
   return queryKey.slice(0, 4).map((part) => {

--- a/clients/gui-app/src/lib/query-client.ts
+++ b/clients/gui-app/src/lib/query-client.ts
@@ -11,6 +11,7 @@ import {
 import {
   appLogger,
   describeLogError,
+  describeLogErrorSummary,
   type AppLogFields,
   type AppLogValue,
 } from "@/lib/logger";
@@ -98,45 +99,46 @@ export const queryClient = createAppQueryClient();
  * The app-wide catch-all for failed host RPCs, so this is the ONE log line most
  * support reports carry about a failure.
  *
- * It used to record `describeLogErrorSummary`, which keeps the error's name and
- * replaces its text with `messageLength` - a number. That reduced every report
- * to `{ name: "HostRpcError", messageLength: 198, stack: null }`, which
+ * It used to record `describeLogErrorSummary` for EVERY error, which keeps the
+ * name and replaces the text with `messageLength` - a number. That reduced every
+ * report to `{ name: "HostRpcError", messageLength: 198, stack: null }`, which
  * identifies nothing: two unrelated failures with equal-length messages are
  * indistinguishable, and no failure can be diagnosed at all.
  *
- * Privacy, stated precisely. `redactLogText` (inside `describeLogError`) is a
- * CREDENTIAL scrubber - Authorization/Bearer/Cookie/digest/AWS4/userinfo and
- * sensitive query params, then a 1000-char truncation. It does NOT remove
- * filesystem paths, submitted URLs, or other request-derived text, and a host
- * RPC message can interpolate any of those. Do not cite it as though it made
- * arbitrary text safe. What justifies the full message here is the destination
- * and the existing convention, not the scrubber:
+ * The split is by error TYPE, because the two kinds have different AUTHORS:
  *
- * - it lands in a LOCAL log file (`console.warn` -> the desktop shell's
- *   `console-message` handler -> `traycer-desktop.log`); there is no telemetry
- *   sink on this path;
- * - the support bundle that log feeds already tails the HOST's own log
- *   (`diagnostics.logs.tail`), which carries absolute paths by construction, so
- *   summarizing here removes nothing from what a report actually ships;
- * - full message + stack is already this renderer's default - `appLogger.error`
- *   and every nested `Error` go through `describeLogError` unconditionally.
+ * - `HostRpcError` is host-authored diagnostic text and the thing support
+ *   reports actually need. Logged in full, plus the structured `code` /
+ *   `method` / `requestId` the message does not carry and which were dropped
+ *   entirely.
+ * - Everything else reaching these callbacks is app-authored and can quote the
+ *   USER. `use-epic-export-artifacts-mutation` throws
+ *   `"<artifact.title>" is still loading.`, and SIX hooks feeding this cache
+ *   deliberately call `appLogger.errorSummary` in their own `onError`
+ *   (export-artifacts, send-queued-invites, open-saved-file, mermaid-png-
+ *   download, usage-image-export, git-file-diffs-batched). A global full log
+ *   fires BEFORE theirs and would defeat every one of those decisions, so this
+ *   branch keeps the summary.
  *
- * A new sink for these logs (telemetry, auto-upload) invalidates the first two
- * and this call site must be revisited with it.
- *
- * `describeLogErrorSummary` remains correct where the message can quote the
- * USER - see `interview-draft-store`, whose `JSON.parse` failures echo a
- * fragment of the person's own draft. Do not sweep that call site.
+ * On the host branch specifically: `redactLogText` (inside `describeLogError`)
+ * is a CREDENTIAL scrubber - it removes no filesystem path, URL, or other
+ * request-derived text, so do not cite it as though it made arbitrary text
+ * safe. What justifies the full message is the destination: it lands in a LOCAL
+ * log file (`console.warn` -> the desktop shell's `console-message` handler ->
+ * `traycer-desktop.log`) with no telemetry sink, and the support bundle that
+ * log feeds already tails the HOST's own log verbatim (`diagnostics.logs.tail`),
+ * which carries absolute paths by construction. A new sink for these logs
+ * (telemetry, auto-upload) invalidates that, and this call site must be
+ * revisited with it.
  */
 function describeRequestError(error: unknown): AppLogFields {
-  const described = describeLogError(error);
   if (!(error instanceof HostRpcError)) {
-    return described;
+    return describeLogErrorSummary(error);
   }
   // Structured attribution the message text does not carry, and which was
   // previously dropped entirely.
   return {
-    ...described,
+    ...describeLogError(error),
     code: error.code,
     method: error.method,
     requestId: error.requestId,


### PR DESCRIPTION
Fixes the four auto-update defects found while investigating #1556, and the Windows one filed as #1557.

Three of the four share a single root cause.

## 1. Windows updates failed after a successful download (#1557)

electron-updater's `verifySignature` shells out to PowerShell with a hardcoded 20s `execFile` timeout. On four field machines that call could not run — three carry the timeout fingerprint (≈20s + probe), one a module-load error — and the rejection propagates out of `downloadUpdate()`, discarding a completed, sha512-verified download. The user sees "Couldn't update Traycer" and no update ever applies.

`tolerateUnrunnableSignatureCheck` wraps the verifier: a check that could not **run** is downgraded to a warning, a genuine **mismatch** still fails the update.

The two are told apart **structurally**, which is the load-bearing detail. Upstream settles five ways, and a blanket catch — or a message-text match — would invert two of them:

| Branch | Settles | Meaning |
|---|---|---|
| publisher mismatch / `Status != 0` | `resolve(string)` | genuine mismatch |
| old Win6 / `ConvertTo-Json` probe fails | `resolve(null)` | can't run (upstream already fails open) |
| `execFile` error, probe passes | `reject(err)` | **can't run — the case to tolerate** |
| `LiteralPath` != temp update file | `reject(new Error(...))` | **anti-substitution check** |
| `error == null && stderr` | `reject(new Error(...))` | **deliberate fail-closed** |

Node stamps `cmd` on every `execFile` failure; the two security rejections are hand-minted `Error`s carrying none. So the gate is `typeof err.cmd === "string"`, and the tests pin all three directions — tolerate `cmd`-bearing, rethrow `LiteralPath`, rethrow unknown-stderr — using real spawned child processes rather than synthesized error objects.

## 2 & 3. Dead differential downloads (Windows + macOS) and wrong Linux artifact

Both trace to the update feed resolving assets to `api.github.com/.../releases/assets/<id>` — a pathname carrying no filename and no extension. electron-updater reads a filename out of that pathname twice and gets nothing both times:

- `Provider.getBlockMapFiles` appends `.blockmap` → not an endpoint → JSON → `Cannot parse blockmap ... incorrect header check`. Every delta falls back to a full ~138MB transfer.
- `Provider.findFile` matches installers by extension, so the `.deb` filter matches nothing **and** the `["AppImage","rpm","pacman"]` exclusion excludes nothing — falling through to `files[0]`, handing `dpkg -i` an AppImage it can never install.

That URL shape appears only when the feed is authenticated, which the release workflow did unconditionally. **The token itself is removed in the internal repo** (that change ships alongside this one); this PR makes the private-repo escape hatch correct rather than dormant-broken:

- `ExactReleaseAssetProvider.getBlockMapFiles` resolves blockmaps as **named release assets**, fetching the previous release **by tag** — necessary because `artifactName` carries no version, so old and new blockmaps share a filename and a name lookup against one release's asset list can only ever return the new one. Missing on either side throws, which `differentialDownloadInstaller` catches into a full download.
- `resolveFiles` gains a comment recording that asset-API URLs defeat extension matching.

A contract test now pins the `findFile` behaviour whose absence let defect 3 ship.

## 4. The renderer destroyed the one diagnostic string

The app-wide query/mutation catch-all logged `describeLogErrorSummary` — `{ name: "HostRpcError", messageLength: 198, stack: null }`. Two unrelated failures with equal-length messages are indistinguishable and nothing is diagnosable; this is why #1556 could not be read from its own logs. Now logs the full described error plus `HostRpcError`'s structured `code` / `method` / `requestId`, which were dropped entirely.

The comment states the privacy position precisely: `redactLogText` is a **credential** scrubber and removes no paths or URLs, so it is explicitly *not* the justification. What justifies it is the destination (a local log file; no telemetry sink), that the support bundle already tails the host's own log verbatim, and that full errors are already this renderer's default (`appLogger.error` at 32 sites). `interview-draft-store` deliberately keeps the summary — its `JSON.parse` failures quote the user's own draft.

## Also

- A signature failure is reported as its own thing rather than as a download failure, which sent users to retry a download that had succeeded.
- The numeric HTTP hints gained a word boundary: `includesAny` is unanchored, and `"65001".includes("500")` is true — so `chcp 65001` in any Windows verifier error matched the service bucket. Latent only because INSTALL was checked first.

## Verification

201 desktop + 24 gui-app tests pass; compile green across 6 projects.

**Not verified:** change 1 end-to-end on real Windows hardware with a slow or blocked `Get-AuthenticodeSignature`. That needs a physical box; the unit tests cover the discriminator but not the integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
