### PR TITLE
fix(gui-app): make chime previews immediate

### DIFF
--- a/clients/gui-app/src/components/settings/panels/__tests__/app-notifications-settings-panel.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/app-notifications-settings-panel.test.tsx
@@ -22,14 +22,23 @@ import { useSettingsStore } from "@/stores/settings/settings-store";
 import { DEFAULT_NOTIFICATION_CHIME_SOUNDS } from "@/lib/notifications/notification-chime";
 
 const navigateToSettingsSectionMock = vi.hoisted(() => vi.fn());
+const playNotificationChimeSoundMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/settings-navigation", () => ({
   navigateToSettingsSection: navigateToSettingsSectionMock,
 }));
 
+vi.mock("@/lib/notifications/notification-chime", async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import("@/lib/notifications/notification-chime")
+  >()),
+  playNotificationChimeSound: playNotificationChimeSoundMock,
+}));
+
 afterEach(() => {
   cleanup();
   navigateToSettingsSectionMock.mockClear();
+  playNotificationChimeSoundMock.mockClear();
   useSettingsStore.setState({
     notificationChimeSounds: DEFAULT_NOTIFICATION_CHIME_SOUNDS,
   });
@@ -62,6 +71,45 @@ describe("<AppNotificationsSettingsPanel />", () => {
       screen.queryByText("Warm, calm, and deliberately subtle."),
     ).toBeNull();
     expect(screen.queryByTestId("notifications-severity-policy")).toBeNull();
+  });
+
+  it("previews a selected chime before persisting the setting", () => {
+    const persistSelection = vi.fn();
+    useSettingsStore.setState({
+      setNotificationChimeSoundForEvent: persistSelection,
+    });
+    renderPanel({ pushPermission: null, systemSettings: null });
+
+    fireEvent.keyDown(screen.getByRole("combobox", { name: "Failure sound" }), {
+      key: "ArrowDown",
+    });
+    const classicOption = screen.getByRole("option", { name: "Classic" });
+    fireEvent.focus(classicOption);
+    fireEvent.keyDown(classicOption, { key: "Enter" });
+
+    expect(playNotificationChimeSoundMock).toHaveBeenCalledWith("classic");
+    expect(persistSelection).toHaveBeenCalledWith("failure", "classic");
+    expect(
+      playNotificationChimeSoundMock.mock.invocationCallOrder[0],
+    ).toBeLessThan(persistSelection.mock.invocationCallOrder[0]);
+  });
+
+  it("previews the currently selected chime when it is clicked again", () => {
+    const persistSelection = vi.fn();
+    useSettingsStore.setState({
+      setNotificationChimeSoundForEvent: persistSelection,
+    });
+    renderPanel({ pushPermission: null, systemSettings: null });
+
+    fireEvent.keyDown(screen.getByRole("combobox", { name: "Failure sound" }), {
+      key: "ArrowDown",
+    });
+    const selectedOption = screen.getByRole("option", { name: "Rift" });
+    fireEvent.pointerDown(selectedOption, { pointerType: "mouse" });
+    fireEvent.pointerUp(selectedOption, { pointerType: "mouse" });
+
+    expect(playNotificationChimeSoundMock).toHaveBeenCalledWith("rift");
+    expect(persistSelection).not.toHaveBeenCalled();
   });
 
   it("owns this phone's OS push permission", async () => {

--- a/clients/gui-app/src/components/settings/panels/__tests__/app-notifications-settings-panel.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/app-notifications-settings-panel.test.tsx
@@ -19,7 +19,6 @@ import { createFakeRunnerHost } from "../../../../../__tests__/create-fake-runne
 import { AppNotificationsSettingsPanel } from "@/components/settings/panels/app-notifications-settings-panel";
 import { RunnerHostProvider } from "@/providers/runner-host-provider";
 import { useSettingsStore } from "@/stores/settings/settings-store";
-import { DEFAULT_NOTIFICATION_CHIME_SOUNDS } from "@/lib/notifications/notification-chime";
 
 const navigateToSettingsSectionMock = vi.hoisted(() => vi.fn());
 const playNotificationChimeSoundMock = vi.hoisted(() => vi.fn());
@@ -39,9 +38,7 @@ afterEach(() => {
   cleanup();
   navigateToSettingsSectionMock.mockClear();
   playNotificationChimeSoundMock.mockClear();
-  useSettingsStore.setState({
-    notificationChimeSounds: DEFAULT_NOTIFICATION_CHIME_SOUNDS,
-  });
+  useSettingsStore.setState(useSettingsStore.getInitialState(), true);
 });
 
 describe("<AppNotificationsSettingsPanel />", () => {
@@ -110,6 +107,24 @@ describe("<AppNotificationsSettingsPanel />", () => {
 
     expect(playNotificationChimeSoundMock).toHaveBeenCalledWith("rift");
     expect(persistSelection).not.toHaveBeenCalled();
+  });
+
+  it("previews a chime activated by a synthesized click", () => {
+    const persistSelection = vi.fn();
+    useSettingsStore.setState({
+      setNotificationChimeSoundForEvent: persistSelection,
+    });
+    renderPanel({ pushPermission: null, systemSettings: null });
+
+    fireEvent.keyDown(screen.getByRole("combobox", { name: "Failure sound" }), {
+      key: "ArrowDown",
+    });
+    fireEvent.click(screen.getByRole("option", { name: "Classic" }), {
+      detail: 0,
+    });
+
+    expect(playNotificationChimeSoundMock).toHaveBeenCalledWith("classic");
+    expect(persistSelection).toHaveBeenCalledWith("failure", "classic");
   });
 
   it("owns this phone's OS push permission", async () => {

--- a/clients/gui-app/src/components/settings/panels/notification-chime-settings-section.tsx
+++ b/clients/gui-app/src/components/settings/panels/notification-chime-settings-section.tsx
@@ -132,6 +132,13 @@ function ChimeOption(props: { readonly sound: NotificationChimeSound }) {
     <SelectItem
       value={props.sound}
       onPointerUp={preview}
+      onClick={(event) => {
+        // Pointer activations already preview on pointer-up, before Radix
+        // persists and closes the menu. A zero-detail click is synthesized
+        // (for example by a screen reader or HTMLElement.click()) and has no
+        // pointer event to provide that preview.
+        if (event.detail === 0) preview();
+      }}
       onKeyDown={(event) => {
         if (event.key === "Enter" || event.key === " ") preview();
       }}

--- a/clients/gui-app/src/components/settings/panels/notification-chime-settings-section.tsx
+++ b/clients/gui-app/src/components/settings/panels/notification-chime-settings-section.tsx
@@ -96,7 +96,6 @@ function NotificationChimeSelect(props: {
       onValueChange={(next) => {
         if (!isNotificationChimeSound(next)) return;
         props.setSoundForEvent(props.eventType, next);
-        playNotificationChimeSound(next);
       }}
     >
       <SelectTrigger
@@ -127,8 +126,16 @@ function NotificationChimeSelect(props: {
 }
 
 function ChimeOption(props: { readonly sound: NotificationChimeSound }) {
+  const preview = (): void => playNotificationChimeSound(props.sound);
+
   return (
-    <SelectItem value={props.sound}>
+    <SelectItem
+      value={props.sound}
+      onPointerUp={preview}
+      onKeyDown={(event) => {
+        if (event.key === "Enter" || event.key === " ") preview();
+      }}
+    >
       {NOTIFICATION_CHIME_LABELS[props.sound]}
     </SelectItem>
   );

--- a/clients/gui-app/src/lib/notifications/__tests__/notification-chime.test.ts
+++ b/clients/gui-app/src/lib/notifications/__tests__/notification-chime.test.ts
@@ -4,6 +4,7 @@ import {
   disposeNotificationChimeAudio,
   notificationChimeEventTypeForSeverities,
   playNotificationChimeSound,
+  prepareNotificationChimeAudio,
 } from "@/lib/notifications/notification-chime";
 
 const oscillators: Array<{
@@ -59,6 +60,16 @@ afterEach(() => {
 });
 
 describe("playNotificationChimeSound", () => {
+  it("primes the audio renderer before the first audible chime", () => {
+    vi.stubGlobal("AudioContext", FakeAudioContext);
+
+    prepareNotificationChimeAudio();
+
+    expect(oscillators).toHaveLength(1);
+    expect(oscillators[0].start).toHaveBeenCalledWith(2);
+    expect(oscillators[0].stop).toHaveBeenCalledWith(2.02);
+  });
+
   it("does not create an audio context when chimes are disabled", () => {
     const AudioContext = vi.fn(FakeAudioContext);
     vi.stubGlobal("AudioContext", AudioContext);
@@ -104,6 +115,27 @@ describe("playNotificationChimeSound", () => {
       oscillators[0].frequency.exponentialRampToValueAtTime.mock.calls[0];
     expect(frequencyRamp[0]).toBe(880);
     expect(frequencyRamp[1]).toBeCloseTo(2.095);
+  });
+
+  it("plays Rift as a restrained descending failure cue", () => {
+    vi.stubGlobal("AudioContext", FakeAudioContext);
+
+    playNotificationChimeSound("rift");
+
+    expect(oscillators).toHaveLength(3);
+    expect(oscillators[0].frequency.setValueAtTime).toHaveBeenCalledWith(
+      659.25,
+      2.005,
+    );
+    expect(oscillators[1].frequency.setValueAtTime).toHaveBeenCalledWith(
+      622.25,
+      2.105,
+    );
+    expect(oscillators[2].frequency.setValueAtTime).toHaveBeenCalledWith(
+      440,
+      2.205,
+    );
+    expect(oscillators[2].stop.mock.calls[0][0]).toBeCloseTo(2.415);
   });
 
   it("reuses one interactive audio context across chimes", () => {
@@ -168,7 +200,7 @@ describe("notificationChimeEventTypeForSeverities", () => {
   it("uses distinct semantic defaults for each notification lane", () => {
     expect(DEFAULT_NOTIFICATION_CHIME_SOUNDS).toEqual({
       needs_action: "orbit",
-      failure: "beacon",
+      failure: "rift",
       done: "prism",
       info: "ember",
     });

--- a/clients/gui-app/src/lib/notifications/notification-chime.ts
+++ b/clients/gui-app/src/lib/notifications/notification-chime.ts
@@ -4,6 +4,7 @@ export const CORE_NOTIFICATION_CHIME_SOUNDS = [
   "ripple",
   "ember",
   "orbit",
+  "rift",
 ] as const;
 
 export const PLAYFUL_NOTIFICATION_CHIME_SOUNDS = [
@@ -33,6 +34,7 @@ export const NOTIFICATION_CHIME_LABELS: Readonly<
   ripple: "Ripple",
   ember: "Ember",
   orbit: "Orbit",
+  rift: "Rift",
   coin: "Coin",
   bloop: "Bloop",
   cuckoo: "Cuckoo",
@@ -49,6 +51,7 @@ export const NOTIFICATION_CHIME_DESCRIPTIONS: Readonly<
   ripple: "A playful water-drop glide with a quiet echo.",
   ember: "Warm, calm, and deliberately subtle.",
   orbit: "An attentive two-note call with gentle width.",
+  rift: "A restrained descending warning with a soft low resolve.",
   coin: "A tiny retro reward jingle.",
   bloop: "A comedic cartoon bubble bounce.",
   cuckoo: "A woody, two-note clock call.",
@@ -74,7 +77,7 @@ export type NotificationChimeSoundsByEvent = Readonly<
 export const DEFAULT_NOTIFICATION_CHIME_SOUNDS: NotificationChimeSoundsByEvent =
   {
     needs_action: "orbit",
-    failure: "beacon",
+    failure: "rift",
     done: "prism",
     info: "ember",
   };
@@ -233,6 +236,44 @@ const CHIME_VOICES: Readonly<
       gain: 0.35,
       startFrequency: 661,
       type: "sine",
+    },
+  ],
+  rift: [
+    {
+      attack: 0.005,
+      delay: 0,
+      duration: 0.16,
+      endFrequency: 659.25,
+      frequencyRampDuration: 0.16,
+      gain: 0.62,
+      startFrequency: 659.25,
+      type: "triangle",
+      decayStart: 0.005,
+      decayTimeConstant: 0.06,
+    },
+    {
+      attack: 0.005,
+      delay: 0.1,
+      duration: 0.2,
+      endFrequency: 622.25,
+      frequencyRampDuration: 0.2,
+      gain: 0.7,
+      startFrequency: 622.25,
+      type: "triangle",
+      decayStart: 0.005,
+      decayTimeConstant: 0.075,
+    },
+    {
+      attack: 0.008,
+      delay: 0.2,
+      duration: 0.19,
+      endFrequency: 440,
+      frequencyRampDuration: 0.19,
+      gain: 0.3,
+      startFrequency: 440,
+      type: "sine",
+      decayStart: 0.008,
+      decayTimeConstant: 0.08,
     },
   ],
   coin: [
@@ -441,6 +482,7 @@ const CHIME_VOICES: Readonly<
 };
 
 let notificationAudioContext: AudioContext | null = null;
+let primedAudioContext: AudioContext | null = null;
 
 function getNotificationAudioContext(): AudioContext | null {
   if (typeof window === "undefined") return null;
@@ -456,11 +498,33 @@ function getNotificationAudioContext(): AudioContext | null {
   return notificationAudioContext;
 }
 
+function primeNotificationAudioRenderer(context: AudioContext): void {
+  if (context.state !== "running" || primedAudioContext === context) return;
+
+  const startsAt = context.currentTime;
+  const oscillator = context.createOscillator();
+  const gain = context.createGain();
+  gain.gain.setValueAtTime(0, startsAt);
+  oscillator.connect(gain);
+  gain.connect(context.destination);
+  oscillator.start(startsAt);
+  oscillator.stop(startsAt + 0.02);
+  oscillator.onended = () => gain.disconnect();
+  primedAudioContext = context;
+}
+
 export function prepareNotificationChimeAudio(): void {
   try {
     const context = getNotificationAudioContext();
-    if (context?.state !== "suspended") return;
-    void context.resume().catch(() => undefined);
+    if (context === null) return;
+    if (context.state === "suspended") {
+      void context
+        .resume()
+        .then(() => primeNotificationAudioRenderer(context))
+        .catch(() => undefined);
+      return;
+    }
+    primeNotificationAudioRenderer(context);
   } catch {
     // Audio setup can be rejected by autoplay or device restrictions.
   }
@@ -490,6 +554,7 @@ export function installNotificationChimeAudioWarmup(): () => void {
 export function disposeNotificationChimeAudio(): void {
   const context = notificationAudioContext;
   notificationAudioContext = null;
+  primedAudioContext = null;
   if (context === null || context.state === "closed") return;
   void context.close().catch(() => undefined);
 }


### PR DESCRIPTION
## Summary
- add a restrained Rift failure chime and use it as the failure default
- prime the interactive audio renderer and start previews before settings persistence
- replay a chime when the currently selected option is activated again

## Verification
- `bun run vitest run src/lib/notifications/__tests__/notification-chime.test.ts src/stores/settings/__tests__/settings-store.test.ts src/components/settings/panels/__tests__/app-notifications-settings-panel.test.tsx` (82 passed)
- React Doctor: no issues
- pre-commit affected lint, format, compile, and build checks passed