### PR TITLE
fix(scripts): pass the explicit onProgress sink in dev-desktop's registry client

### DIFF
--- a/scripts/dev-desktop.js
+++ b/scripts/dev-desktop.js
@@ -460,8 +460,18 @@ async function resolveCachedHostArchive(release) {
     const { config } = await import(
       path.join(REPO_ROOT, "clients", "traycer-cli", "src", "config.ts")
     );
+    // `createDefaultRegistryClient` takes an explicit `onProgress` sink -
+    // the project style forbids default parameter values, so every caller
+    // passes one. This script has no progress UI to drive and wants the
+    // quiet path, which is spelled `null`: omitting the argument leaves
+    // `onProgress` undefined, and the heartbeat emitter's `=== null` guard
+    // does not catch that, so the first registry heartbeat throws
+    // "onProgress is not a function" and sends every run down the
+    // network-install fallback. Nothing type-checks this file, so only the
+    // explicit argument keeps it honest.
     const client = await registry.createDefaultRegistryClient(
       config.environment,
+      null,
     );
     const { entry, asset } = await client.resolveAsset(
       release ?? "latest",


### PR DESCRIPTION
## Summary

`resolveCachedHostArchive` in `scripts/dev-desktop.js` built its registry client with a single argument:

```js
const client = await registry.createDefaultRegistryClient(config.environment);
```

but `createDefaultRegistryClient` takes two — the environment and an explicit `onProgress` sink. Its own doc comment explains why there is no default:

> This exists as its own export (rather than as default values on `CreateRegistryClientOptions`) because the project style forbids default parameter values [...] every argument must be passed explicitly.

So the omitted argument was simply `undefined`. `emitRegistryHeartbeat` guards with `onProgress === null`, which does not catch `undefined`, so the value flowed past the guard and straight into the call:

```
[dev-desktop] host archive cache unavailable (onProgress is not a function. (In 'onProgress({
    stage: `registry-${resource}-${heartbeat.phase}`,
    ...
  })', 'onProgress' is undefined)); using network install
```

### Why it fired on every single run

`fetchText` emits the `"attempt"` heartbeat unconditionally at the top of its first attempt, before any request goes out:

```js
for (let attempt = 1; attempt <= MAX_NETWORK_ATTEMPTS; attempt += 1) {
  emitHeartbeat(opts.onHeartbeat, "attempt", attempt, MAX_NETWORK_ATTEMPTS);
```

There is no retry or stall needed to reach it, so `resolveAsset`'s manifest fetch threw immediately — on a fresh clone, on a healthy network, every time.

The throw is caught and falls back to a network install, so it was never fatal. That is exactly why it survived: the host archive cache silently never worked, and `make dev-desktop` re-downloaded the host archive on every run instead of reusing the verified one it had already cached.

### Why static checks did not catch it

`lint` and `compile` run through Nx over the workspace packages, and `scripts/` is not one of them — nothing type-checks this file. The three TypeScript call sites (`installer/install.ts`, `installer/download-stage.ts`, `commands/host-available.ts`) all correctly pass both arguments; only the untyped script drifted.

### The fix

Pass `null` explicitly — the spelling for "no progress UI to drive" — with a comment recording why the argument cannot be omitted here.

### Verification

Running the exact import path the script uses, before and after:

```
[before] FAILED -> onProgress is not a function. (In 'onProgress({ stage: `registry-${resource}-${heartbeat.phase}`, ... })', 'onProgress' is undefined)
[after]  OK     -> resolved host 1.2.0
```

The cache now resolves and reuses the archive as intended.

### One note for maintainers

The `onProgress === null` guard in `emitRegistryHeartbeat` is correct against the declared type (`((info: ProgressInfo) => void) | null`), and I left it alone to keep this change focused. It is worth noting, though, that it is the reason a missing argument surfaced as a runtime `TypeError` rather than as nothing at all — and `scripts/` will keep importing this TypeScript from untyped JS. Happy to widen the guard, or to bring `scripts/` under a type-check target, in a separate PR if you'd prefer either.

## Related issue

Related to #1571 — this is the "Also noticed (separate, non-blocking)" item at the end of that report. The main problem in that issue (the host credential never being provisioned, `credentialProvision: { kind: "mint-unavailable" }`) is untouched here and remains open.

## Checklist

- [x] Pre-commit static checks pass — the commit hook ran the affected workspace checks (build, compile, lint, format) and passed. `pre-commit run --all-files` passes as well, with one caveat worth stating rather than hiding behind a tick: the `shellcheck` hook errors on my machine with `shellcheck: command not found`, because the tool is not installed locally. That is an environment gap on my side, not a finding — this PR touches no shell script — but I have not personally seen that hook run green.
- [ ] Separate CI test checks pass — left for CI to confirm on this PR, per `AGENTS.md` ("Tests run in CI (`test.yml`), not in the hook"). This change touches no workspace package
- [ ] Tests added/updated where it makes sense — `scripts/` belongs to no Nx project, so there is no suite this file can be added to. The change was verified by executing the affected code path directly (above). Note that `registry/__tests__/client.test.ts` already covers the `onProgress: null` path that this call site now uses.
- [x] Commits are signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#developer-certificate-of-origin-dco)
