### PR TITLE
fix(cli): stop sending an unprovisioned host's owner to `traycer login`

### DIFF
--- a/clients/traycer-cli/src/doctor/__tests__/engine-host-rpc-unauthorized.test.ts
+++ b/clients/traycer-cli/src/doctor/__tests__/engine-host-rpc-unauthorized.test.ts
@@ -1,0 +1,151 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { HostRpcError } from "../../../../shared/host-transport/host-messenger";
+
+// A host `UNAUTHORIZED` covers two failures with OPPOSITE remedies, and this
+// probe used to report only one of them.
+//
+//   - the stored bearer is dead          → signing in again fixes it
+//   - the host holds no credential of
+//     its own and refuses every client   → signing in again fixes NOTHING
+//
+// The second one was reported as "Sign in again", which closes a loop for a
+// user who is already signed in: sign in, still rejected, run doctor, be told
+// to sign in. That is the same trap `HOST_CREDENTIAL_NEEDS_REAUTH` documents
+// on the neighbouring state (a credential that was provisioned and then
+// burned), and it is decided the same way - by the presence of the host's
+// credential file.
+
+// `store/paths` binds its home root from `os.homedir()` at module load.
+const osHome = vi.hoisted(() => ({ current: "" }));
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:os")>();
+  return { ...actual, homedir: () => osHome.current || actual.tmpdir() };
+});
+
+const ORIGINAL_HOME = process.env.HOME;
+const ORIGINAL_USERPROFILE = process.env.USERPROFILE;
+
+let workHome: string;
+
+beforeEach(() => {
+  workHome = mkdtempSync(join(tmpdir(), "traycer-doctor-rpc-unauth-test-"));
+  osHome.current = workHome;
+  process.env.HOME = workHome;
+  process.env.USERPROFILE = workHome;
+  vi.resetModules();
+});
+
+afterEach(() => {
+  if (ORIGINAL_HOME === undefined) {
+    delete process.env.HOME;
+  } else {
+    process.env.HOME = ORIGINAL_HOME;
+  }
+  if (ORIGINAL_USERPROFILE === undefined) {
+    delete process.env.USERPROFILE;
+  } else {
+    process.env.USERPROFILE = ORIGINAL_USERPROFILE;
+  }
+  rmSync(workHome, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+/** The verbatim refusal a host with no delegated credential sends. */
+const NOT_PROVISIONED_MESSAGE =
+  "Host is not provisioned - run `traycer login` on the host machine to authorize it";
+
+function unauthorizedError(message: string): HostRpcError {
+  return new HostRpcError({
+    code: "UNAUTHORIZED",
+    message,
+    requestId: "req-1",
+    method: "host.status",
+    fatalDetails: null,
+  });
+}
+
+/** Writes a host credential file, so the host counts as provisioned. */
+function writeHostCredential(): void {
+  const dir = join(workHome, ".traycer", "host", "auth");
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "credentials.json"), "{}");
+}
+
+async function runIssue(err: HostRpcError) {
+  const { hostRpcUnauthorizedIssue } = await import("../engine");
+  return hostRpcUnauthorizedIssue("ws://127.0.0.1:1234/rpc", err, "production");
+}
+
+describe("hostRpcUnauthorizedIssue", () => {
+  it("names the unprovisioned host and offers no sign-in command", async () => {
+    // No credential file: the host never held one, which is the state where
+    // `traycer login` is the one thing that cannot help.
+    const issue = await runIssue(unauthorizedError(NOT_PROVISIONED_MESSAGE));
+
+    expect(issue.severity).toBe("error");
+    expect(issue.title).toContain("no credential of its own");
+    // The whole point of the correction. Desktop renders "Open in Terminal"
+    // for any non-null `terminalCommand`, so leaving `traycer login` here
+    // would keep offering the button that restarts the loop.
+    expect(issue.fixAction).toBeNull();
+    expect(issue.terminalCommand).toBeNull();
+    // ...which is why the message must carry the repair itself, exactly as
+    // HOST_CREDENTIAL_NEEDS_REAUTH does: with both action fields null this
+    // text is the entire recovery path a reader gets.
+    expect(issue.message).toContain("open the Traycer desktop app");
+    // Says plainly that the user's session is not the fault, because the
+    // reader has usually just signed in and been rejected anyway.
+    expect(issue.message).toContain("signing in again does not change it");
+    expect(issue.details).toMatchObject({
+      hostCredential: "absent",
+      rpcCode: "UNAUTHORIZED",
+    });
+  });
+
+  it("carries the host's own refusal through instead of dropping it", async () => {
+    // The reason was thrown away for the bare status code, which is what left
+    // the report unable to tell the two failures apart - and left a support
+    // bundle with `outcome: UNAUTHORIZED` and nothing else.
+    const issue = await runIssue(unauthorizedError(NOT_PROVISIONED_MESSAGE));
+
+    expect(issue.message).toContain(NOT_PROVISIONED_MESSAGE);
+    expect(issue.details).toMatchObject({
+      hostMessage: NOT_PROVISIONED_MESSAGE,
+    });
+  });
+
+  it("keeps the sign-in reading when the host does hold a credential", async () => {
+    // The other half of the split, pinned so the correction cannot quietly
+    // swallow the case `traycer login` genuinely does repair.
+    writeHostCredential();
+
+    const issue = await runIssue(
+      unauthorizedError("bearer rejected after refresh"),
+    );
+
+    expect(issue.title).toBe("Host rejected the stored credentials");
+    expect(issue.terminalCommand).toBe("traycer login");
+    expect(issue.details).toMatchObject({ hostCredential: "present" });
+  });
+
+  it("reads an unprobeable credential path as 'cannot tell' and keeps the sign-in reading", async () => {
+    // Safe direction: a signed-out user is in the sign-in state, so an
+    // unreadable path must not be reported as "your session is fine".
+    // `hostCredentialPath` resolves under the home root, and pointing the
+    // root at a file makes every path beneath it unstattable.
+    const notADirectory = join(workHome, "not-a-directory");
+    writeFileSync(notADirectory, "");
+    osHome.current = notADirectory;
+    process.env.HOME = notADirectory;
+    process.env.USERPROFILE = notADirectory;
+
+    const issue = await runIssue(unauthorizedError("unreadable"));
+
+    expect(issue.terminalCommand).toBe("traycer login");
+    // Reported as "could not look", never as a provisioning verdict.
+    expect(issue.details).toMatchObject({ hostCredential: "unprobeable" });
+  });
+});

--- a/clients/traycer-cli/src/doctor/engine.ts
+++ b/clients/traycer-cli/src/doctor/engine.ts
@@ -1302,6 +1302,102 @@ function probeWebsocketUrl(url: string): Promise<boolean> {
 // connect" actually lives. Returns null when the round-trip succeeds.
 // Never throws: a probe failure becomes a DoctorIssue, never a doctor
 // crash.
+/**
+ * Splits the host's `UNAUTHORIZED` into the two failures it actually covers,
+ * because they take OPPOSITE remedies and this reported only one of them.
+ *
+ * A dead stored bearer is fixed by signing in again. A host that holds no
+ * delegated credential of its own rejects a perfectly live bearer too - it
+ * answers "Host is not provisioned" to every client - and there signing in
+ * again fixes nothing, because the user is already signed in. Sending them to
+ * `traycer login` closed a loop: sign in, still rejected, run doctor, be told
+ * to sign in.
+ *
+ * That is the same trap `HOST_CREDENTIAL_NEEDS_REAUTH` was written to avoid,
+ * for the same reason, on the neighbouring state - a host whose credential
+ * DIED. It is decided the same way too: the presence of the host's credential
+ * file. The two states are one file apart - never provisioned versus
+ * provisioned and then burned - so the one that had no report deferred to a
+ * remedy the other already documents as useless.
+ *
+ * The file is the signal rather than the rejection text: the host is an
+ * external component, so its wording is not a contract this repo can hold it
+ * to, while the credential path already is one (`hostCredentialPath`). An
+ * unreadable path is treated as "cannot tell" and keeps the sign-in reading,
+ * which is the safe direction - it is the state a signed-out user is in.
+ */
+export async function hostRpcUnauthorizedIssue(
+  websocketUrl: string | null,
+  err: HostRpcError,
+  environment: Environment,
+): Promise<DoctorIssue> {
+  const credential = await probeHostCredentialFile(environment);
+  // `absent` is the only reading that overturns the sign-in verdict. `present`
+  // is a host that HAS a credential and still refused, which is the dead-bearer
+  // shape this always described; `unprobeable` means doctor could not look, and
+  // guessing "never provisioned" there would tell a signed-out user their
+  // session is fine - the one direction that must not be wrong.
+  if (credential !== "absent") {
+    return {
+      code: DOCTOR_ISSUE_CODES.HOST_RPC_UNAUTHORIZED,
+      severity: "error",
+      title: "Host rejected the stored credentials",
+      message:
+        "The host is listening but rejected the authenticated RPC connection (UNAUTHORIZED) even after a bearer refresh. Sign in again.",
+      fixAction: null,
+      terminalCommand: "traycer login",
+      details: {
+        websocketUrl,
+        rpcCode: err.code,
+        hostCredential: credential,
+        // Carried through verbatim: the host states why it refused, and
+        // dropping that for the bare status code is what left this report
+        // unable to tell the two failures apart.
+        hostMessage: err.message,
+      },
+    };
+  }
+  return {
+    code: DOCTOR_ISSUE_CODES.HOST_RPC_UNAUTHORIZED,
+    severity: "error",
+    title: "Host has no credential of its own and is rejecting every client",
+    message:
+      `The host is listening but rejects every authenticated connection (UNAUTHORIZED: ${err.message}). ` +
+      "It holds no delegated credential of its own, and it never had one - so this is not your sign-in: a valid, freshly refreshed bearer is rejected exactly the same way, and signing in again does not change it. " +
+      "A connected owner client provisions that credential silently, so the way out is to open the Traycer desktop app while signed in as this host's owner and let it connect.",
+    // Same reasoning as HOST_CREDENTIAL_NEEDS_REAUTH: no command repairs this,
+    // and Desktop renders "Open in Terminal" for any non-null
+    // `terminalCommand`, so offering one would only restart the loop this
+    // report exists to end. The recovery lives in the message instead.
+    fixAction: null,
+    terminalCommand: null,
+    details: {
+      websocketUrl,
+      rpcCode: err.code,
+      hostCredential: credential,
+      hostMessage: err.message,
+    },
+  };
+}
+
+/**
+ * Whether the host holds a delegated credential of its own. Only ENOENT is
+ * `absent`; every other failure is `unprobeable`, because "we could not look"
+ * and "it is not there" support opposite reports and merging them is how a
+ * permission error would get told to the reader as a provisioning verdict.
+ * Mirrors `probeAuthDirectory`, which draws the same line for the same reason.
+ */
+async function probeHostCredentialFile(
+  environment: Environment,
+): Promise<"present" | "absent" | "unprobeable"> {
+  try {
+    await access(hostCredentialPath(environment));
+    return "present";
+  } catch (err) {
+    return isFileNotFoundError(err) ? "absent" : "unprobeable";
+  }
+}
+
 async function probeHostRpc(
   endpoint: HostTransportEndpoint,
   environment: Environment,
@@ -1328,16 +1424,7 @@ async function probeHostRpc(
   } catch (err) {
     if (err instanceof HostRpcError) {
       if (err.code === "UNAUTHORIZED") {
-        return {
-          code: DOCTOR_ISSUE_CODES.HOST_RPC_UNAUTHORIZED,
-          severity: "error",
-          title: "Host rejected the stored credentials",
-          message:
-            "The host is listening but rejected the authenticated RPC connection (UNAUTHORIZED) even after a bearer refresh. Sign in again.",
-          fixAction: null,
-          terminalCommand: "traycer login",
-          details: { websocketUrl, rpcCode: err.code },
-        };
+        return hostRpcUnauthorizedIssue(websocketUrl, err, environment);
       }
       if (err.code === "INCOMPATIBLE" || err.code === "DOWNGRADE_UNSUPPORTED") {
         return incompatibleRpcIssue(websocketUrl, err, environment);


### PR DESCRIPTION
## Summary

A host `UNAUTHORIZED` covers two failures that take **opposite** remedies, and `probeHostRpc` reported only one of them:

| the host is saying | remedy |
| --- | --- |
| the stored bearer is dead | signing in again fixes it |
| it holds no delegated credential of its own and refuses every client | signing in again fixes **nothing** |

Both landed on:

```
[ERROR] Host rejected the stored credentials
  The host is listening but rejected the authenticated RPC connection
  (UNAUTHORIZED) even after a bearer refresh. Sign in again.
  fix:  traycer login
```

For the second case that closes a loop. The user is already signed in — a live, freshly refreshed bearer is rejected exactly the same way — so they sign in, are still rejected, run doctor, and are told to sign in again. `traycer whoami` validates against the server throughout.

### This trap is already documented in this file

`HOST_CREDENTIAL_NEEDS_REAUTH` was written to avoid exactly this on the **neighbouring** state — a credential that *was* provisioned and then burned. Its comment names the failure mode outright:

> work the host does on your behalf [...] can fail with sign-in-looking errors that signing in again does not fix

and it therefore offers **neither** a fix action nor a terminal command, putting the real recovery in the message:

> NEITHER a fix action NOR a terminal command, and for the same reason: nothing on a command line repairs this.

The two states are one file apart — never provisioned, versus provisioned and then burned — and only the second one had a report of its own. The first fell through to `HOST_RPC_UNAUTHORIZED` and was handed the remedy its neighbour already documents as useless.

### The change

Decide it the way that neighbouring report already does: by the host's credential file.

- **`absent`** → the host never held a credential. New title, no `traycer login`, and the recovery (open the desktop app as the host's owner and let it connect) carried in the message, mirroring `HOST_CREDENTIAL_NEEDS_REAUTH`.
- **`present`** → unchanged. This is the dead-bearer shape the old text always described, and it keeps `traycer login`.
- **`unprobeable`** → keeps the sign-in reading. Only `ENOENT` counts as absent; every other failure means doctor could not look, and rendering that as "your session is fine" to someone who is signed out is the one direction that must not be wrong. Same line `probeAuthDirectory` already draws, for the same reason.

The host's own refusal is also carried through now (`hostMessage`) instead of being dropped for the bare status code — it is the thing that tells the two failures apart, and a support bundle previously recorded `rpcCode: UNAUTHORIZED` and nothing else.

`hostRpcUnauthorizedIssue` is exported for direct testing, following `routeIncompatibleRecovery` in the same file.

### Before / after, on a real host in this state

```
- [ERROR] Host rejected the stored credentials
-   The host is listening but rejected the authenticated RPC connection
-   (UNAUTHORIZED) even after a bearer refresh. Sign in again.
-   fix:  traycer login

+ [ERROR] Host has no credential of its own and is rejecting every client
+   The host is listening but rejects every authenticated connection
+   (UNAUTHORIZED: Host is not provisioned - run `traycer login` on the host
+   machine to authorize it). It holds no delegated credential of its own, and
+   it never had one - so this is not your sign-in: a valid, freshly refreshed
+   bearer is rejected exactly the same way, and signing in again does not
+   change it. A connected owner client provisions that credential silently, so
+   the way out is to open the Traycer desktop app while signed in as this
+   host's owner and let it connect.
```

### A note on scope

This corrects the **report**, not the state it reports. The underlying condition — a host that rejects every client at `state=authenticating` with `Host is not provisioned`, so no client ever reaches the `openAck` that would let it mint the credential — lives in the host itself and is not fixable from this repo. It is described with logs from both sides in the issue below. What this PR fixes is that doctor's answer to that state actively sent the user in a circle.

## Related issue

Related to #1571. That issue's headline problem (the host never becoming provisioned) is untouched here and remains open.

## Checklist

- [x] Pre-commit static checks pass — the commit hook ran the affected workspace checks (build, compile, lint, format) and passed. `pre-commit run --all-files` passes as well, with one caveat worth stating rather than hiding behind a tick: the `shellcheck` hook errors on my machine with `shellcheck: command not found`, because the tool is not installed locally. That is an environment gap on my side, not a finding — this PR touches no shell script — but I have not personally seen that hook run green.
- [ ] Separate CI test checks pass — left for CI to confirm on this PR, per `AGENTS.md`. Locally, the full doctor suite passes: 15 files, 115 tests
- [x] Tests added/updated where it makes sense — new `engine-host-rpc-unauthorized.test.ts` covers all three readings, including that `present` still yields `traycer login`
- [x] Commits are signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#developer-certificate-of-origin-dco)
