### PR TITLE
ci: block telemetry from release train promotion

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -47,6 +47,11 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "24"
+      - name: Require temporary crash telemetry cleanup before main promotion
+        if: matrix.lane == 'static' && github.event_name == 'pull_request'
+        env:
+          PR_HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+        run: node scripts/release-train-promotion-guard.cjs
       - name: Cache Nx
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:

--- a/scripts/__tests__/release-train-promotion-guard.test.mjs
+++ b/scripts/__tests__/release-train-promotion-guard.test.mjs
@@ -1,0 +1,98 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { createRequire } from "node:module";
+import { afterEach, describe, expect, it } from "vitest";
+
+const require = createRequire(import.meta.url);
+const {
+  findTelemetryResidues,
+  isReleaseTrainPromotion,
+  runGuard,
+} = require("../release-train-promotion-guard.cjs");
+
+const temporaryRoots = [];
+
+function fixture(files) {
+  const root = mkdtempSync(join(tmpdir(), "release-train-guard-"));
+  temporaryRoots.push(root);
+  for (const [relativePath, contents] of Object.entries(files)) {
+    const target = join(root, relativePath);
+    mkdirSync(dirname(target), { recursive: true });
+    writeFileSync(target, contents);
+  }
+  return root;
+}
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe("release-train promotion selection", () => {
+  it("only selects a same-repository tgill-release-train promotion to main", () => {
+    expect(
+      isReleaseTrainPromotion({
+        baseRef: "main",
+        headRef: "tgill-release-train",
+        repository: "traycerai/traycer",
+        headRepository: "traycerai/traycer",
+      }),
+    ).toBe(true);
+    expect(
+      isReleaseTrainPromotion({
+        baseRef: "tgill-release-train",
+        headRef: "feature",
+        repository: "traycerai/traycer",
+        headRepository: "traycerai/traycer",
+      }),
+    ).toBe(false);
+    expect(
+      isReleaseTrainPromotion({
+        baseRef: "main",
+        headRef: "tgill-release-train",
+        repository: "traycerai/traycer",
+        headRepository: "fork/traycer",
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("temporary crash telemetry residue detection", () => {
+  it("finds production wiring and telemetry test files", () => {
+    const root = fixture({
+      "clients/gui-app/src/root.tsx": "runner.crashTelemetry.persist(input);",
+      "clients/desktop/src/ipc-contracts/renderer-crash-telemetry.ts":
+        "export const parser = true;",
+      "clients/desktop/src/electron-main/ipc/__tests__/renderer-crash-telemetry-input.test.ts":
+        "test('parser', () => {});",
+    });
+
+    expect(findTelemetryResidues(root)).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("crashTelemetry"),
+        expect.stringContaining("telemetry-only file still exists"),
+      ]),
+    );
+  });
+
+  it("passes a cleaned tree and ignores non-promotion PRs", () => {
+    const root = fixture({
+      "clients/gui-app/src/root.tsx": "export const permanentBoundary = true;",
+    });
+    expect(findTelemetryResidues(root)).toEqual([]);
+    expect(
+      runGuard({
+        environment: {
+          GITHUB_BASE_REF: "tgill-release-train",
+          GITHUB_HEAD_REF: "feature",
+          GITHUB_REPOSITORY: "traycerai/traycer",
+          PR_HEAD_REPOSITORY: "traycerai/traycer",
+        },
+        repositoryRoot: root,
+        force: false,
+      }),
+    ).toEqual({ checked: false, residues: [] });
+  });
+});

--- a/scripts/release-train-promotion-guard.cjs
+++ b/scripts/release-train-promotion-guard.cjs
@@ -1,0 +1,135 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const PROMOTION_BASE = "main";
+const PROMOTION_HEAD = "tgill-release-train";
+
+// These names are deliberately specific to the temporary RootErrorBoundary
+// persistence path. The existing report-issue component stacks and Electron's
+// crash reporter are permanent features and must not trip this guard.
+const FORBIDDEN_MARKERS = [
+  "crashTelemetry",
+  "rendererCrashPersist",
+  "RendererCrashTelemetryInput",
+  "getClientBuildRevision",
+  "VITE_APP_BUILD_REVISION",
+  "renderer-crash-telemetry",
+  "[renderer-crash] RootErrorBoundary captured uncaught error",
+];
+
+const SCANNED_PATHS = [
+  "clients/gui-app/src",
+  "clients/desktop/src",
+  "clients/shared",
+];
+
+const FORBIDDEN_FILES = [
+  "clients/desktop/src/ipc-contracts/renderer-crash-telemetry.ts",
+  "clients/desktop/src/electron-main/ipc/__tests__/renderer-crash-telemetry-input.test.ts",
+];
+
+function isReleaseTrainPromotion(input) {
+  return (
+    input.baseRef === PROMOTION_BASE &&
+    input.headRef === PROMOTION_HEAD &&
+    input.repository.length > 0 &&
+    input.headRepository === input.repository
+  );
+}
+
+function walkFiles(targetPath) {
+  if (!fs.existsSync(targetPath)) return [];
+  const stat = fs.statSync(targetPath);
+  if (stat.isFile()) return [targetPath];
+
+  return fs
+    .readdirSync(targetPath, { withFileTypes: true })
+    .flatMap((entry) => {
+      if (entry.name === "node_modules" || entry.name === ".git") return [];
+      return walkFiles(path.join(targetPath, entry.name));
+    });
+}
+
+function findTelemetryResidues(repositoryRoot) {
+  const residues = [];
+
+  for (const relativePath of FORBIDDEN_FILES) {
+    if (fs.existsSync(path.join(repositoryRoot, relativePath))) {
+      residues.push(`${relativePath}: telemetry-only file still exists`);
+    }
+  }
+
+  for (const relativeRoot of SCANNED_PATHS) {
+    for (const filePath of walkFiles(path.join(repositoryRoot, relativeRoot))) {
+      const contents = fs.readFileSync(filePath, "utf8");
+      for (const marker of FORBIDDEN_MARKERS) {
+        if (contents.includes(marker)) {
+          residues.push(
+            `${path.relative(repositoryRoot, filePath)}: contains ${JSON.stringify(marker)}`,
+          );
+        }
+      }
+    }
+  }
+
+  return [...new Set(residues)].sort();
+}
+
+function runGuard({ environment, repositoryRoot, force }) {
+  const promotion = isReleaseTrainPromotion({
+    baseRef: environment.GITHUB_BASE_REF ?? "",
+    headRef: environment.GITHUB_HEAD_REF ?? "",
+    repository: environment.GITHUB_REPOSITORY ?? "",
+    headRepository: environment.PR_HEAD_REPOSITORY ?? "",
+  });
+
+  if (!force && !promotion) {
+    return { checked: false, residues: [] };
+  }
+
+  return {
+    checked: true,
+    residues: findTelemetryResidues(repositoryRoot),
+  };
+}
+
+function main(argv, environment) {
+  const force = argv.includes("--force");
+  const rootIndex = argv.indexOf("--root");
+  const repositoryRoot =
+    rootIndex === -1 ? process.cwd() : path.resolve(argv[rootIndex + 1]);
+  const result = runGuard({ environment, repositoryRoot, force });
+
+  if (!result.checked) {
+    console.log(
+      `Skipping temporary crash telemetry cleanup guard: this is not ${PROMOTION_HEAD} -> ${PROMOTION_BASE}.`,
+    );
+    return 0;
+  }
+
+  if (result.residues.length === 0) {
+    console.log(
+      "Release-train promotion is free of temporary crash telemetry.",
+    );
+    return 0;
+  }
+
+  console.error(
+    "Release-train promotion blocked: remove the temporary RootErrorBoundary crash telemetry and its tests before merging into main.",
+  );
+  for (const residue of result.residues) console.error(`- ${residue}`);
+  return 1;
+}
+
+module.exports = {
+  findTelemetryResidues,
+  isReleaseTrainPromotion,
+  main,
+  runGuard,
+};
+
+if (require.main === module) {
+  process.exitCode = main(process.argv.slice(2), process.env);
+}


### PR DESCRIPTION
## Summary
- add a promotion-only cleanup guard to the existing required pre-commit status
- block tgill-release-train -> main while temporary RootErrorBoundary crash telemetry or its tests remain
- cover exact promotion selection, fork isolation, residue detection, and the cleaned-tree case

## Verification
- bun run vitest run scripts/__tests__/release-train-promotion-guard.test.mjs
- pre-commit hook passed affected lint, format, compile, and build checks
- forced audit fails on the current train with the complete telemetry residue inventory; ordinary feature-PR mode skips