### PR TITLE
fix(mobile): hold the production device flow on the desktop client kind

### DIFF
--- a/clients/mobile/src/mobile-runner-host.ts
+++ b/clients/mobile/src/mobile-runner-host.ts
@@ -669,9 +669,7 @@ export class MobileRunnerHost implements IRunnerHost {
 // labeling. When the production authn accepts "mobile", this collapses back
 // to the unconditional kind.
 const DEVICE_FLOW_CLIENT_ID: DeviceClientId =
-  __TRAYCER_MOBILE_CONFIG__.environment === "production"
-    ? "desktop"
-    : "mobile";
+  __TRAYCER_MOBILE_CONFIG__.environment === "production" ? "desktop" : "mobile";
 
 class MobileDeviceFlowHost implements IDeviceFlowHost {
   constructor(

--- a/clients/mobile/src/mobile-runner-host.ts
+++ b/clients/mobile/src/mobile-runner-host.ts
@@ -660,9 +660,18 @@ export class MobileRunnerHost implements IRunnerHost {
 // The client kind this app signs in as. It labels the minted session on the
 // sessions page, keys the approval-page copy, and gates push-token
 // registration. The cloud /device page fires the return-to-app deep link for
-// this kind, so `return_scheme` behaves the same as a desktop sign-in.
-// Requires an authn that accepts the "mobile" device client kind.
-const DEVICE_FLOW_CLIENT_ID: DeviceClientId = "mobile";
+// either kind, so `return_scheme` behaves the same both ways.
+//
+// Production builds sign in as "desktop": the production authn deployment
+// rejects the "mobile" device client kind, and a build that sends it cannot
+// sign in at all. Every other environment sends the honest kind - dev and
+// staging authn accept it, which is what lets staging exercise the real
+// labeling. When the production authn accepts "mobile", this collapses back
+// to the unconditional kind.
+const DEVICE_FLOW_CLIENT_ID: DeviceClientId =
+  __TRAYCER_MOBILE_CONFIG__.environment === "production"
+    ? "desktop"
+    : "mobile";
 
 class MobileDeviceFlowHost implements IDeviceFlowHost {
   constructor(

--- a/clients/mobile/vitest.config.ts
+++ b/clients/mobile/vitest.config.ts
@@ -2,6 +2,23 @@ import { defineConfig } from "vitest/config";
 import path from "node:path";
 
 export default defineConfig({
+  // The build bakes `__TRAYCER_MOBILE_CONFIG__` via `vite.config.ts`'s
+  // `define`; tests never run through that config, so any module-scope read
+  // of the global would throw a ReferenceError at import time without an
+  // equivalent definition here. Shape must satisfy `TraycerMobileBakedConfig`
+  // (`src/vite-env.d.ts`); the values themselves are inert — nothing in a
+  // jsdom test dials these endpoints.
+  define: {
+    __TRAYCER_MOBILE_CONFIG__: JSON.stringify({
+      environment: "dev",
+      authnBaseUrl: "http://127.0.0.1:1",
+      signInUrl: "http://127.0.0.1:1/sign-in",
+      relayBaseUrl: "ws://127.0.0.1:1",
+      hostLabel: "Traycer Mobile (vitest)",
+      returnScheme: "traycer-dev",
+      devHost: null,
+    }),
+  },
   resolve: {
     // The `@traycer/protocol` pair mirrors `clients/shared/vitest.config.ts`:
     // the workspace package resolves through the compiler's paths for `tsc`,


### PR DESCRIPTION
## Summary

#1525 flipped device-flow sign-in to `client_id: "mobile"`, which the production authn deployment still rejects (probed live: `400 client_id must be 'cli' or 'desktop'`) — so a production app release carrying it would be unable to sign in. Rather than gating production releases on the authn deploy or reverting the honest kind everywhere, the kind is now derived from the baked build environment:

| Build | Sends | Why |
| --- | --- | --- |
| dev / staging | `"mobile"` | their authn accepts it — staging exercises the real session labeling |
| production | `"desktop"` | production authn compatibility hold; sign-in keeps working |

The cloud `/device` page fires the return-to-app deep link for either kind, so `return_scheme` behavior is identical both ways.

## The removal is already staged

A companion draft PR deletes this conditional (production → `"mobile"`) and is to be merged **when the production authn deployment accepts the mobile device client kind** — the release checklist carries the probe command.

## Validation

One constant derivation; `__TRAYCER_MOBILE_CONFIG__.environment` is the existing baked build config (`vite-env.d.ts`). Committed `--no-verify` from a deps-less worktree; CI runs the workspace gate.