### PR TITLE
fix(mobile): sign every environment in as the mobile client kind

### DIFF
--- a/clients/mobile/src/mobile-runner-host.ts
+++ b/clients/mobile/src/mobile-runner-host.ts
@@ -674,16 +674,9 @@ export class MobileRunnerHost implements IRunnerHost {
 // The client kind this app signs in as. It labels the minted session on the
 // sessions page, keys the approval-page copy, and gates push-token
 // registration. The cloud /device page fires the return-to-app deep link for
-// either kind, so `return_scheme` behaves the same both ways.
-//
-// Production builds sign in as "desktop": the production authn deployment
-// rejects the "mobile" device client kind, and a build that sends it cannot
-// sign in at all. Every other environment sends the honest kind - dev and
-// staging authn accept it, which is what lets staging exercise the real
-// labeling. When the production authn accepts "mobile", this collapses back
-// to the unconditional kind.
-const DEVICE_FLOW_CLIENT_ID: DeviceClientId =
-  __TRAYCER_MOBILE_CONFIG__.environment === "production" ? "desktop" : "mobile";
+// either kind, so `return_scheme` behaves the same both ways. Every authn
+// deployment accepts it, so every environment sends the honest kind.
+const DEVICE_FLOW_CLIENT_ID: DeviceClientId = "mobile";
 
 class MobileDeviceFlowHost implements IDeviceFlowHost {
   constructor(


### PR DESCRIPTION
## Gate passed

Production authn now accepts the mobile device client kind — probed live today:

- `POST https://authn.traycer.ai/api/v3/auth/device/authorize` with `{"client_id":"mobile","host_label":"probe"}` → **HTTP 200**, device code minted (previously `400 client_id must be 'cli' or 'desktop'`)
- `POST https://authn.traycer.ai/api/v3/user/push-tokens` unauthenticated → **401** (route deployed; previously 404)

## Change

Collapses #1587's production-only `"desktop"` hold back to the unconditional `"mobile"` kind, with the invariant comment rewritten to the now-true state. Rebuilt fresh off `main` (the earlier draft's diff read as empty because its merge-base predated #1587's squash).

## Effect for production users

- sessions page labels phone sign-ins as mobile sessions (they currently read as desktop)
- native push registration binds in production (push-token routes exist now; the earlier hold + missing routes meant no pushes)

## Testing

Single-line constant change plus its comment; the surrounding device-flow tests already assert the `"mobile"` kind in the mobile test suite. CI validates.