### PR TITLE
fix(desktop): disable the dev sandbox as root; drop the removed ozone hint

### DIFF
--- a/clients/desktop/scripts/dev/__tests__/electron-binary.test.ts
+++ b/clients/desktop/scripts/dev/__tests__/electron-binary.test.ts
@@ -13,6 +13,7 @@ const electronBinary = require("../electron-binary.cjs") as {
   }) => string;
   decideDisableChromiumSandbox: (options: {
     platform: NodeJS.Platform;
+    effectiveUid: number;
     apparmorRestrictsUserns: boolean;
     usernsCloneDisabled: boolean;
     sandboxHelperStat: { uid: number; mode: number } | null;
@@ -20,7 +21,6 @@ const electronBinary = require("../electron-binary.cjs") as {
   decideOzonePlatform: (options: {
     platform: NodeJS.Platform;
     ozonePlatformOverride: string | undefined;
-    electronOzoneHint: string | undefined;
     display: string | undefined;
     waylandDisplay: string | undefined;
   }) => string | null;
@@ -55,6 +55,7 @@ describe("dev Electron bundle state", () => {
 describe("decideDisableChromiumSandbox", () => {
   const linuxDefaults = {
     platform: "linux" as const,
+    effectiveUid: 1000,
     apparmorRestrictsUserns: false,
     usernsCloneDisabled: false,
     sandboxHelperStat: null,
@@ -97,6 +98,17 @@ describe("decideDisableChromiumSandbox", () => {
     ).toBe(true);
   });
 
+  it("disables when running as root, which Chromium refuses to sandbox", () => {
+    expect(
+      electronBinary.decideDisableChromiumSandbox({
+        ...linuxDefaults,
+        effectiveUid: 0,
+        // Even the otherwise-ideal case: userns available AND a setuid helper.
+        sandboxHelperStat: { uid: 0, mode: 0o104755 },
+      }),
+    ).toBe(true);
+  });
+
   it("keeps the sandbox when a root-owned setuid helper can take over", () => {
     expect(
       electronBinary.decideDisableChromiumSandbox({
@@ -112,7 +124,6 @@ describe("decideOzonePlatform", () => {
   const bare = {
     platform: "linux" as const,
     ozonePlatformOverride: undefined,
-    electronOzoneHint: undefined,
     display: undefined,
     waylandDisplay: undefined,
   };
@@ -164,15 +175,5 @@ describe("decideOzonePlatform", () => {
         display: ":0",
       }),
     ).toThrow(/TRAYCER_DESKTOP_OZONE_PLATFORM must be one of/);
-  });
-
-  it("defers to a user-set ELECTRON_OZONE_PLATFORM_HINT", () => {
-    expect(
-      electronBinary.decideOzonePlatform({
-        ...bare,
-        electronOzoneHint: "auto",
-        display: ":0",
-      }),
-    ).toBeNull();
   });
 });

--- a/clients/desktop/scripts/dev/dev-main.cjs
+++ b/clients/desktop/scripts/dev/dev-main.cjs
@@ -96,7 +96,6 @@ const electronArgs = [];
 const ozonePlatform = decideOzonePlatform({
   platform: process.platform,
   ozonePlatformOverride: childEnv.TRAYCER_DESKTOP_OZONE_PLATFORM,
-  electronOzoneHint: childEnv.ELECTRON_OZONE_PLATFORM_HINT,
   display: childEnv.DISPLAY,
   waylandDisplay: childEnv.WAYLAND_DISPLAY,
 });

--- a/clients/desktop/scripts/dev/electron-binary.cjs
+++ b/clients/desktop/scripts/dev/electron-binary.cjs
@@ -24,12 +24,19 @@ const { execFileSync } = require("node:child_process");
 // acceptable because the dev shell renders trusted local code.
 function decideDisableChromiumSandbox({
   platform,
+  effectiveUid,
   apparmorRestrictsUserns,
   usernsCloneDisabled,
   sandboxHelperStat,
 }) {
   if (platform !== "linux") {
     return false;
+  }
+  // Chromium refuses to start its browser process as root unless the sandbox
+  // is off, regardless of what the namespace/helper situation looks like -
+  // and root-owned dev containers are exactly where the headless path runs.
+  if (effectiveUid === 0) {
+    return true;
   }
   // With unprivileged userns available the namespace sandbox works and the
   // setuid helper is never consulted.
@@ -65,6 +72,9 @@ function shouldDisableChromiumSandbox(electronBinaryPath) {
   }
   return decideDisableChromiumSandbox({
     platform: process.platform,
+    // `geteuid` is POSIX-only; the platform gate above makes this safe.
+    effectiveUid:
+      typeof process.geteuid === "function" ? process.geteuid() : -1,
     // Ubuntu 24.04+ ships this AppArmor knob defaulted on; processes without
     // a profile granting userns (any node_modules binary) are denied.
     apparmorRestrictsUserns:
@@ -90,8 +100,6 @@ const OZONE_PLATFORMS = ["auto", "headless", "wayland", "x11"];
 //   - an explicit `TRAYCER_DESKTOP_OZONE_PLATFORM` always wins (validated
 //     against the platforms Chromium accepts, so a typo fails here with the
 //     accepted values named rather than deep inside Chromium's startup);
-//   - a user who set Electron's own `ELECTRON_OZONE_PLATFORM_HINT` has
-//     expressed a choice — leave selection to Electron;
 //   - `DISPLAY` present → force `x11`. On real Wayland desktops this is
 //     Xwayland, which universally works; native Wayland stays one env var
 //     away for whoever wants it;
@@ -101,10 +109,14 @@ const OZONE_PLATFORMS = ["auto", "headless", "wayland", "x11"];
 //
 // Returns the `--ozone-platform=<value>` value to force, or null to leave
 // Electron's own selection alone.
+// Deliberately does NOT consult `ELECTRON_OZONE_PLATFORM_HINT`: Electron
+// removed it in 38 (this repo is on 42), so a developer who still exports it
+// gets no platform selection from Electron at all - deferring to it would
+// hand the choice back to `auto` and reinstate the Wayland hang this exists
+// to prevent. `TRAYCER_DESKTOP_OZONE_PLATFORM` is the escape hatch.
 function decideOzonePlatform({
   platform,
   ozonePlatformOverride,
-  electronOzoneHint,
   display,
   waylandDisplay,
 }) {
@@ -128,9 +140,6 @@ function decideOzonePlatform({
       );
     }
     return accepted;
-  }
-  if (typeof electronOzoneHint === "string" && electronOzoneHint.length > 0) {
-    return null;
   }
   if (typeof display === "string" && display.length > 0) {
     return "x11";


### PR DESCRIPTION
## Summary

Two review findings from #1526 that were correct but landed after it merged. Both are in the Linux dev runner only (`clients/desktop/scripts/dev/`).

- **Disable the sandbox when running as root.** Chromium refuses to start its browser process as root unless the sandbox is off, regardless of the namespace/helper situation — and a root-owned dev container or CI image is exactly where the new headless path is meant to run. The previous check could return `false` there and let Electron exit before startup. The effective uid now short-circuits the decision.

- **Stop deferring to `ELECTRON_OZONE_PLATFORM_HINT`.** It was removed in Electron 38 and this repo is on 42, so deferring to it did not hand platform selection to Electron — it handed it back to Chromium's own `auto`, which reinstates the stale-Wayland startup hang #1526 exists to prevent, for exactly the developer who still exports the old variable. `TRAYCER_DESKTOP_OZONE_PLATFORM` remains the escape hatch. (Electron 42's shipped typings no longer mention the variable, consistent with removal.)

## Related issue

Follow-up to #1526.

## Checklist

- [x] Pre-commit static checks pass
- [ ] Separate CI test checks pass <!-- watching -->
- [x] Tests added/updated where it makes sense — 13 unit tests, including a root-euid case and the dropped hint branch
- [x] Commits are signed off per the DCO
