### PR TITLE
fix(gui-app): keep onboarding row controls readable on dimmed rows

### DIFF
--- a/clients/gui-app/src/components/onboarding/__tests__/onboarding-detected-agents.test.tsx
+++ b/clients/gui-app/src/components/onboarding/__tests__/onboarding-detected-agents.test.tsx
@@ -5,6 +5,7 @@ import {
   fireEvent,
   render,
   screen,
+  within,
   type RenderResult,
 } from "@testing-library/react";
 import { StrictMode } from "react";
@@ -216,7 +217,7 @@ function latestAwaitLoginOptions(): AwaitLoginOptions {
 }
 
 function signInButton(): HTMLElement {
-  return screen.getByRole("button", { name: /sign in to enable/i });
+  return screen.getByRole("button", { name: /sign in & enable/i });
 }
 
 /**
@@ -324,7 +325,7 @@ describe("OnboardingDetectedAgents", () => {
     render(<OnboardingDetectedAgents />);
 
     expect(
-      screen.queryByRole("button", { name: /sign in to enable/i }),
+      screen.queryByRole("button", { name: /sign in & enable/i }),
     ).toBeNull();
     expect(screen.queryByText("Not signed in")).toBeNull();
     expect(
@@ -351,7 +352,7 @@ describe("OnboardingDetectedAgents", () => {
     render(<OnboardingDetectedAgents />);
 
     expect(
-      screen.queryByRole("button", { name: /sign in to enable/i }),
+      screen.queryByRole("button", { name: /sign in & enable/i }),
     ).toBeNull();
     expect(screen.queryByText("Not signed in")).toBeNull();
     expect(screen.getByRole("switch", { name: /^Enable / })).toBeTruthy();
@@ -387,6 +388,30 @@ describe("OnboardingDetectedAgents", () => {
   });
 });
 
+// A disabled row's "Sign in & enable" button and enable switch live in the
+// same trailing area the dim treatment recedes around them, not over them -
+// a row-level opacity would ghost an outline button to near invisibility. The
+// dim belongs to the identity pieces (icon, label, badge) alone.
+describe("OnboardingDetectedAgents row dimming", () => {
+  afterEach(resetFixtures);
+
+  it("dims the install badge but leaves the sign-in button and switch at full opacity, for a disabled+installed row", () => {
+    fixtures.providers = [fixtures.signInProvider];
+    render(<OnboardingDetectedAgents />);
+
+    expect(signInButton().closest(".opacity-60")).toBeNull();
+    expect(
+      screen.getByRole("switch", { name: /^Enable / }).closest(".opacity-60"),
+    ).toBeNull();
+
+    const row = signInButton().closest("li");
+    if (row === null) throw new Error("Expected the row's <li>.");
+    expect(within(row).getByText("Installed").className).toContain(
+      "opacity-60",
+    );
+  });
+});
+
 // Regression coverage for the declined-sign-in path: the GUI rules
 // (`clients/gui-app/AGENTS.md`, "Backend calls -> TanStack Query") forbid
 // ad-hoc `toast.error` in components, so a `providers.startLogin` success with
@@ -399,7 +424,7 @@ describe("SignInToEnableButton declined sign-in", () => {
     fixtures.providers = [fixtures.signInProvider];
     const view = render(<OnboardingDetectedAgents />);
 
-    fireEvent.click(screen.getByRole("button", { name: /sign in to enable/i }));
+    fireEvent.click(screen.getByRole("button", { name: /sign in & enable/i }));
     const [, options] = latestStartLoginCall();
     act(() => {
       fixtures.startLoginPending = false;
@@ -419,7 +444,7 @@ describe("SignInToEnableButton declined sign-in", () => {
     fixtures.providers = [fixtures.signInProvider];
     const view = render(<OnboardingDetectedAgents />);
 
-    fireEvent.click(screen.getByRole("button", { name: /sign in to enable/i }));
+    fireEvent.click(screen.getByRole("button", { name: /sign in & enable/i }));
     const [, options] = latestStartLoginCall();
     act(() => {
       fixtures.startLoginPending = false;
@@ -444,7 +469,7 @@ describe("SignInToEnableButton declined sign-in", () => {
     fixtures.providers = [fixtures.signInProvider];
     render(<OnboardingDetectedAgents />);
 
-    fireEvent.click(screen.getByRole("button", { name: /sign in to enable/i }));
+    fireEvent.click(screen.getByRole("button", { name: /sign in & enable/i }));
     const [, startOptions] = latestStartLoginCall();
     act(() => {
       startOptions.onSuccess({ started: true });
@@ -490,7 +515,7 @@ describe("SignInToEnableButton declined sign-in", () => {
     fixtures.providers = [fixtures.signInProvider];
     const view = render(<OnboardingDetectedAgents />);
 
-    fireEvent.click(screen.getByRole("button", { name: /sign in to enable/i }));
+    fireEvent.click(screen.getByRole("button", { name: /sign in & enable/i }));
     const [, firstOptions] = latestStartLoginCall();
     act(() => {
       fixtures.startLoginPending = false;
@@ -504,7 +529,7 @@ describe("SignInToEnableButton declined sign-in", () => {
     // A fresh `mutate()` resets `isSuccess` synchronously, before the new
     // attempt resolves - the derived `declined` flag must clear at that
     // point, not only once the retry succeeds.
-    fireEvent.click(screen.getByRole("button", { name: /sign in to enable/i }));
+    fireEvent.click(screen.getByRole("button", { name: /sign in & enable/i }));
     act(() => {
       fixtures.startLoginPending = true;
       fixtures.startLoginSuccess = false;
@@ -528,7 +553,7 @@ describe("SignInToEnableButton declined sign-in", () => {
     fixtures.providers = [fixtures.signInProvider];
     const view = render(<OnboardingDetectedAgents />);
 
-    fireEvent.click(screen.getByRole("button", { name: /sign in to enable/i }));
+    fireEvent.click(screen.getByRole("button", { name: /sign in & enable/i }));
     const [, options] = latestStartLoginCall();
     act(() => {
       fixtures.startLoginPending = false;
@@ -545,7 +570,7 @@ describe("SignInToEnableButton declined sign-in", () => {
 
 // The window where `providers.awaitLogin` has settled but the host's ambient
 // auth probe has not. It is not a verdict, and a button whose whole promise is
-// "Sign in to enable" must not silently decline to enable on one.
+// "Sign in & enable" must not silently decline to enable on one.
 describe("SignInToEnableButton unsettled auth verdict", () => {
   afterEach(resetFixtures);
 
@@ -967,7 +992,7 @@ describe("SignInToEnableButton mount survival", () => {
 
     // The precondition TanStack actually requires of us.
     expect(
-      screen.queryByRole("button", { name: /sign in to enable/i }),
+      screen.queryByRole("button", { name: /sign in & enable/i }),
     ).not.toBeNull();
 
     // ...and so the completion still reaches the enable.
@@ -1029,7 +1054,7 @@ describe("SignInToEnableButton already-authenticated with sign-in unavailable", 
 
     expect(screen.getByText("Not signed in")).toBeTruthy();
     expect(
-      screen.queryByRole("button", { name: /sign in to enable/i }),
+      screen.queryByRole("button", { name: /sign in & enable/i }),
     ).toBeNull();
   });
 });

--- a/clients/gui-app/src/components/onboarding/onboarding-detected-agents.tsx
+++ b/clients/gui-app/src/components/onboarding/onboarding-detected-agents.tsx
@@ -130,12 +130,16 @@ function disablingLastEnabledFor(
 function installBadge(
   installDetected: boolean,
   installLabel: string,
+  dimmed: boolean,
 ): ReactNode {
   return (
     <span
       className={cn(
         "font-mono text-overline uppercase tracking-wider",
         installDetected ? "text-[#7fd6a4]" : "text-white/40",
+        // The list deliberately leaves a dimmed row's opacity alone so the
+        // row's controls stay readable, so the badge recedes on its own.
+        dimmed && "opacity-60",
       )}
     >
       {installLabel}
@@ -165,7 +169,7 @@ function accountDescription(state: ProviderCliState | undefined): ReactNode {
 }
 
 /**
- * Whether this row should offer "Sign in to enable": the provider is off, and
+ * Whether this row should offer "Sign in & enable": the provider is off, and
  * its CLI is actually on this machine.
  *
  * The host leaves a provider disabled at first boot when it found no account
@@ -430,7 +434,7 @@ function SignInToEnableButton(props: {
           // host's auth probe still running behind a login that may well have
           // succeeded (see `isAmbientAuthVerdictPending`). Deciding on it would
           // make the button's advertised action silently not happen, which is
-          // the one outcome a screen called "Sign in to enable" cannot have. So
+          // the one outcome a screen called "Sign in & enable" cannot have. So
           // the same bounded re-poll Settings runs applies here, and only a
           // settled - or budget-exhausted - "not authenticated" stops the
           // chain.
@@ -534,7 +538,7 @@ function SignInToEnableButton(props: {
           onSignIn(state.providerId);
         }}
       >
-        Sign in to enable
+        Sign in &amp; enable
         {/* Unchanged label + inline spinner: starting a login spawns the
             provider CLI host-side, so a press with no feedback invites a
             second one. */}
@@ -639,12 +643,13 @@ export function OnboardingDetectedAgents() {
       enabledProviderCount,
     );
     const name = providerDisplayName(providerId);
+    const dimmed = state !== undefined && !enabled;
     return {
       providerId,
       active: false,
-      dimmed: state !== undefined && !enabled,
+      dimmed,
       enabled: state?.enabled ?? null,
-      badge: installBadge(installDetected, installLabel),
+      badge: installBadge(installDetected, installLabel, dimmed),
       description: accountDescription(state),
       trailing:
         state === undefined ? null : (

--- a/clients/gui-app/src/components/providers/provider-list.tsx
+++ b/clients/gui-app/src/components/providers/provider-list.tsx
@@ -66,16 +66,14 @@ function ProviderListItem(props: {
   return (
     <li className={liClassName(variant)}>
       {onSelect === null ? (
-        <div className={rowClassName(variant, row.active, row.dimmed)}>
-          {rowContent}
-        </div>
+        <div className={rowClassName(variant, row.active)}>{rowContent}</div>
       ) : (
         <button
           type="button"
           aria-label={providerDisplayName(row.providerId)}
           data-active={row.active}
           onClick={() => onSelect(row.providerId)}
-          className={rowClassName(variant, row.active, row.dimmed)}
+          className={rowClassName(variant, row.active)}
         >
           {rowContent}
         </button>
@@ -104,11 +102,7 @@ function innerClassName(): string {
   return "flex w-full min-w-0 items-center gap-2.5";
 }
 
-function rowClassName(
-  variant: ProviderListVariant,
-  active: boolean,
-  dimmed: boolean,
-): string {
+function rowClassName(variant: ProviderListVariant, active: boolean): string {
   if (variant === "settings") {
     return cn(
       "flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-left text-ui-sm transition-colors",
@@ -123,12 +117,22 @@ function rowClassName(
       active ? "bg-accent text-accent-foreground" : "text-foreground/80",
     );
   }
-  return cn("min-w-0", dimmed && "opacity-60");
+  // No row-level dim: a dimmed onboarding row still carries its live controls
+  // ("Sign in & enable", the enable switch) in `trailing`, and a wrapper
+  // opacity would dim those with it - stacked on the outline button's
+  // translucent dark fill it left the row's one call to action near
+  // invisible. The dimmed treatment lives on the identity pieces instead
+  // (icon, label, badge - each already keyed on `dimmed`), which recede
+  // without taking the controls down with them.
+  return "min-w-0";
 }
 
 function iconClassName(variant: ProviderListVariant, dimmed: boolean): string {
   if (variant === "onboarding") {
-    return cn("size-4", dimmed ? "text-white/35" : "text-white/85");
+    // Opacity as well as text color: brand icons that paint their own colors
+    // ignore `currentColor`, so without the opacity a disabled row's logo
+    // renders at full vibrance next to its dimmed label.
+    return cn("size-4", dimmed ? "text-white/35 opacity-60" : "text-white/85");
   }
   if (variant === "diorama") return "size-3.5 shrink-0";
   return "";

--- a/clients/gui-app/src/lib/providers/provider-ambient-auth.ts
+++ b/clients/gui-app/src/lib/providers/provider-ambient-auth.ts
@@ -131,7 +131,7 @@ export function isDefinitiveProviderAuthStatus(
  *
  * Both surfaces that turn an `awaitLogin` completion into a decision read this
  * one predicate - Settings' login flow (which drives its own state machine off
- * it) and onboarding's "Sign in to enable" button (which decides whether to
+ * it) and onboarding's "Sign in & enable" button (which decides whether to
  * write the enablement). A second copy of the rule would be a silent
  * divergence in exactly the case neither surface can reproduce on demand.
  */
@@ -150,7 +150,7 @@ export function isAmbientAuthVerdictPending(
  * the unsettled case.
  *
  * Beside the predicate rather than in either flow because BOTH flows spend it
- * - Settings' login state machine and onboarding's "Sign in to enable" button
+ * - Settings' login state machine and onboarding's "Sign in & enable" button
  * - and two budgets would mean the same sign-in gets a different amount of
  * patience depending on which screen the user is standing on.
  */
@@ -170,7 +170,7 @@ export const AMBIENT_AUTH_PENDING_REPOLL_DELAY_MS = 2_000;
  * (returns false) so a half-converged reconnect never phantom-clears while the
  * account is still signed out.
  *
- * Onboarding's "Sign in to enable" spends this on an `awaitLogin` completion
+ * Onboarding's "Sign in & enable" spends this on an `awaitLogin` completion
  * for the same reason, and gets both halves of that rule: an ambient row that
  * lands first no longer burns the re-poll budget waiting for the summary, and
  * a stale top-level `authenticated` can no longer enable a provider whose


### PR DESCRIPTION
## What

A disabled provider row on the onboarding providers act dimmed itself with a wrapper `opacity-60` — taking the trailing controls down with it. The outline sign-in button's translucent dark fill (`bg-input/30`), stacked under the row opacity on the dark cinematic art, rendered the row's one call to action near invisible; a shared pending-disable stacked a further `disabled:opacity-50` on top of that.

Since every row carrying the sign-in affordance is by definition disabled, the CTA was *always* ghosted.

## Fix

- **`provider-list.tsx`** — drop the row-level `opacity-60` for the onboarding variant. Dim lives on the identity pieces: label via text color (as before), icon via opacity **and** text color (multicolor brand SVGs ignore `currentColor`, so text-color dimming alone left them at full vibrance).
- **`onboarding-detected-agents.tsx`** — the INSTALLED / Not found badge dims itself (`opacity-60`) instead of riding the row wrapper.
- Controls ("Sign in & enable" button, enable switch, the "Not signed in" hint) render at full contrast.

## Copy

Renamed the button "Sign in to enable" → **"Sign in & enable"**: the switch beside it enables without signing in (sticky intent, by design), so the old label read as a requirement the adjacent control disproves. The button performs both actions; the label now names both.

## Tests

New regression test asserts a disabled+installed row's sign-in button and switch have no `opacity-60` ancestor while its install badge carries it. Existing label queries updated. 27/27 green in `onboarding-detected-agents.test.tsx`; react-doctor clean.

## Verified

Live on a dev desktop (`make dev-desktop`): disabled Kiro / Kilo Code / Kimi rows show a full-contrast button beside dimmed identity; Amp / Qwen Code (terminal-login-only) correctly keep the plain "Not signed in" hint.