### PR TITLE
fix(gui-app): contain epic-session crashes at the hosted-tile seam

### DIFF
--- a/clients/gui-app/src/components/chat/__tests__/chat-progress-icon-no-provider.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/chat-progress-icon-no-provider.test.tsx
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { ChatProgressIcon } from "@/components/chat/chat-progress-icon";
+import { useEpicPermissionRole } from "@/lib/epic-selectors";
+
+/**
+ * Deliberately does NOT mock `@/lib/epic-selectors`: the whole point of the
+ * registered (registry-keyed, non-throwing) selector switch in
+ * `chat-progress-icon.tsx` is that this icon stays renderable with no
+ * `<EpicSessionProvider>` in the tree at all - unlike the sibling
+ * `chat-progress-icon.test.tsx`, which mocks the module to control the
+ * awareness/permission inputs directly.
+ */
+function AmbientPermissionRoleProbe() {
+  useEpicPermissionRole();
+  return null;
+}
+
+afterEach(() => cleanup());
+
+describe("<ChatProgressIcon /> outside an EpicSessionProvider", () => {
+  it("renders the idle chat icon with no running spinner and no read-only lock, using the real (empty) open-epic registry", () => {
+    const { container } = render(
+      <ChatProgressIcon
+        chatId="chat-y"
+        className={undefined}
+        epicId="epic-x"
+        hostId={null}
+        mutedClassName=""
+        testId="icon"
+        defaultIcon={undefined}
+      />,
+    );
+
+    // No running-turn spinner and no background-activity glyph: the
+    // registered activity-tiers selector reads an empty map for an epic this
+    // window never opened, which is the correct "no session, no awareness"
+    // answer - not a throw.
+    expect(screen.queryByTestId("icon-activity-chat-y")).toBeNull();
+    expect(screen.queryByTestId("icon-background-activity-chat-y")).toBeNull();
+    // No read-only lock: the registered permission-role selector reads
+    // `null` (unknown), not "viewer", so the fallback lock never fires.
+    expect(
+      screen.queryByRole("status", { name: "Read-only agent" }),
+    ).toBeNull();
+    expect(container.querySelector(".lucide-message-square-lock")).toBeNull();
+    // The idle default icon (EPIC_NODE_ICONS.chat = lucide MessageSquare)
+    // rendered without throwing.
+    expect(container.querySelector(".lucide-message-square")).not.toBeNull();
+  });
+
+  it("discriminating control: the OLD ambient useEpicPermissionRole() still throws outside a provider, proving the icon's safety comes from the selector switch and not from the hooks becoming lenient", () => {
+    const consoleError = console.error;
+    console.error = () => undefined;
+    try {
+      expect(() => render(<AmbientPermissionRoleProbe />)).toThrow(
+        /must be called inside <EpicSessionProvider>/,
+      );
+    } finally {
+      console.error = consoleError;
+    }
+  });
+});

--- a/clients/gui-app/src/components/chat/__tests__/chat-progress-icon.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/chat-progress-icon.test.tsx
@@ -54,8 +54,8 @@ const mockSessionState = vi.hoisted<{
 }));
 
 vi.mock("@/lib/epic-selectors", () => ({
-  useEpicAgentActivityTiers: () => mockSessionState.activityTiers,
-  useEpicPermissionRole: () => mockSessionState.epicPermissionRole,
+  useRegisteredEpicAgentActivityTiers: () => mockSessionState.activityTiers,
+  useRegisteredEpicPermissionRole: () => mockSessionState.epicPermissionRole,
 }));
 
 vi.mock("@/lib/registries/chat-session-registry", () => ({

--- a/clients/gui-app/src/components/chat/chat-progress-icon.tsx
+++ b/clients/gui-app/src/components/chat/chat-progress-icon.tsx
@@ -4,8 +4,8 @@ import { MessageSquareLock } from "lucide-react";
 import { NotificationIndicatorIcon } from "@/components/notifications/notification-indicator-icon";
 import { useSurfaceNotificationIndicatorState } from "@/components/notifications/notification-indicator-context";
 import {
-  useEpicAgentActivityTiers,
-  useEpicPermissionRole,
+  useRegisteredEpicAgentActivityTiers,
+  useRegisteredEpicPermissionRole,
 } from "@/lib/epic-selectors";
 import { useExistingChatSessionHandle } from "@/lib/registries/chat-session-registry";
 import { chatActivityIndicator } from "@/components/epic-canvas/renderers/chat-tile-session-state";
@@ -53,9 +53,22 @@ export function ChatProgressIcon(props: ChatProgressIconProps) {
   // rollup already reads, so a background-only chat now presents the same way
   // whether you look at its own row or at the collapsed parent standing in
   // for it. A host that has not classified its agents still reports `"turn"`.
+  //
+  // Both reads go through the REGISTERED (keyed, non-throwing) selectors, not
+  // the ambient `useEpicAgentActivityTiers()` / `useEpicPermissionRole()`: this
+  // icon already carries its `epicId`, and it is a presentational leaf that
+  // must stay renderable wherever a chat node is drawn - the same rule the
+  // sibling `TuiAgentLiveTabIcon` follows. With the ambient hooks it was the
+  // least-defended node icon: any render outside an `<EpicSessionProvider>`
+  // (or under one whose handle is momentarily `null`) threw from here and
+  // blanked the window via the root boundary. Outside a session both degrade
+  // - no activity, `null` role - which is the same neutral idle the icon
+  // already shows for an unknown permission.
   const awarenessRunning: IndicatorRunningKind =
-    useEpicAgentActivityTiers().get(props.chatId) ?? false;
-  const fallbackReadOnly = useEpicPermissionRole() === "viewer";
+    useRegisteredEpicAgentActivityTiers(props.epicId).get(props.chatId) ??
+    false;
+  const fallbackReadOnly =
+    useRegisteredEpicPermissionRole(props.epicId) === "viewer";
   const handle = useExistingChatSessionHandle(
     props.epicId,
     props.chatId,

--- a/clients/gui-app/src/components/epic-canvas/__tests__/tab-group-view.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/tab-group-view.test.tsx
@@ -187,8 +187,11 @@ vi.mock("@/lib/epic-selectors", () => ({
   useRegisteredEpicNodeArchived: () => false,
   // Chat tab strip icons (ChatProgressIcon) need activity tiers when a chat
   // tile is the active tab - not exercised by the older spec/terminal-only
-  // fixtures in this file.
+  // fixtures in this file. The icon reads the REGISTERED (keyed,
+  // non-throwing) selectors, so both forms are answered here.
   useEpicAgentActivityTiers: () => new Map<string, false>(),
+  useRegisteredEpicAgentActivityTiers: () => new Map<string, false>(),
+  useRegisteredEpicPermissionRole: () => "owner",
 }));
 
 vi.mock("@/lib/registries/chat-session-registry", () => ({

--- a/clients/gui-app/src/components/epic-canvas/mobile/__tests__/switcher-agent-icon.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/__tests__/switcher-agent-icon.test.tsx
@@ -38,9 +38,17 @@ vi.mock("@/lib/epic-selectors", () => ({
     state.tier === null
       ? new Map<string, AgentActivityTier>()
       : new Map<string, AgentActivityTier>([["n1", state.tier]]),
+  // ChatProgressIcon reads the REGISTERED (registry-keyed, non-throwing)
+  // selectors rather than the ambient ones, so a whole-module mock has to
+  // answer those too - same data, addressed by epic id instead of by context.
+  useRegisteredEpicAgentActivityTiers: () =>
+    state.tier === null
+      ? new Map<string, AgentActivityTier>()
+      : new Map<string, AgentActivityTier>([["n1", state.tier]]),
   useEpicChatHarnessId: () => state.gui,
   useMaybeEpicTuiAgentHarnessId: () => state.tui,
   useEpicPermissionRole: () => state.role,
+  useRegisteredEpicPermissionRole: () => state.role,
   useEpicNodeHostId: () => state.ownerHostId,
 }));
 

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-selection-mode.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-selection-mode.test.tsx
@@ -822,6 +822,15 @@ vi.mock("@/lib/epic-selectors", () => ({
         testState.activityTierById.get(id) ?? "turn",
       ]),
     ),
+  // ChatProgressIcon reads the REGISTERED (keyed, non-throwing) selector for
+  // the same data, so a whole-module mock has to answer that form too.
+  useRegisteredEpicAgentActivityTiers: () =>
+    new Map(
+      [...testState.activeAgentIds].map((id) => [
+        id,
+        testState.activityTierById.get(id) ?? "turn",
+      ]),
+    ),
   useEpicArtifact: (artifactId: string | null) => {
     if (artifactId === null) return null;
     const node = testState.tree.nodeById[artifactId];
@@ -861,6 +870,7 @@ vi.mock("@/lib/epic-selectors", () => ({
   // effect's dependency never changes and it never seeds in these tests.
   useEpicNodeWorkspaceFolders: () => EMPTY_WORKSPACE_FOLDERS,
   useEpicPermissionRole: () => testState.permissionRole,
+  useRegisteredEpicPermissionRole: () => testState.permissionRole,
   useEpicSnapshotMeta: () => ({ epicLight: { title: "Test epic" } }),
   useEpicTreeIndex: () => testState.tree,
   useEpicTreeNode: (nodeId: string) => testState.tree.nodeById[nodeId] ?? null,

--- a/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/hosted-tile-body-boundary.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/hosted-tile-body-boundary.test.tsx
@@ -1,0 +1,303 @@
+import { useState, type ReactNode } from "react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { HostedTileBodyBoundary } from "@/components/epic-canvas/surface-host/hosted-tile-body-boundary";
+import type {
+  ReportIssueErrorCapture,
+  ReportIssueErrorCaptureInput,
+} from "@/lib/report-issue-error-capture";
+import type { appLogger } from "@/lib/logger";
+import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import type { EpicCanvasState, EpicNodeRef } from "@/stores/epics/canvas/types";
+import { useTabsStore } from "@/stores/tabs/store";
+import type { TabRef } from "@/stores/tabs/types";
+import { TEST_HOST_ID } from "@/stores/epics/canvas/__tests__/canvas-test-fixtures";
+import { resetTileSurfaceMembershipForTesting } from "@/components/epic-canvas/surface-host/tile-surface-membership";
+import {
+  publishTileSurfaceEnvironment,
+  resetTileSurfaceEnvironmentRegistryForTesting,
+  type ReadyTileSurfaceEnvironment,
+} from "@/components/epic-canvas/surface-host/tile-surface-environment-registry";
+import { resetTileSurfaceGeometryCoordinatorForTesting } from "@/components/epic-canvas/surface-host/tile-surface-geometry-coordinator";
+import { StableTileSurfaceHost } from "@/components/epic-canvas/surface-host/stable-tile-surface-host";
+import { buildSyntheticTileSurfaceEnvironment } from "@/components/epic-canvas/surface-host/__tests__/synthetic-tile-surface-fixture";
+
+// Typed with the real signature so `mock.calls` carries the input shape the
+// assertions below read (an untyped `vi.fn(() => ...)` types its calls as `[]`).
+const captureReportIssueError = vi.hoisted(() =>
+  vi.fn((input: ReportIssueErrorCaptureInput): ReportIssueErrorCapture => ({
+    cause: {
+      type: "Error",
+      message: "boom",
+      stack: null,
+      componentStack: input.componentStack,
+      errorCode: null,
+      sourceAction: input.sourceAction,
+      timestamp: 1,
+    },
+    correlationId: "correlation-1",
+    fingerprint: "fp:v1:test",
+    stackFamily: null,
+  })),
+);
+const errorSummary = vi.hoisted(() => vi.fn<typeof appLogger.errorSummary>());
+
+vi.mock("@/lib/report-issue-error-capture", () => ({
+  captureReportIssueError,
+}));
+
+vi.mock("@/lib/logger", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/logger")>()),
+  appLogger: { errorSummary, info: vi.fn(), warn: vi.fn() },
+}));
+
+afterEach(() => {
+  cleanup();
+  captureReportIssueError.mockClear();
+  errorSummary.mockClear();
+});
+
+function Boom(props: { readonly shouldThrow: boolean }): ReactNode {
+  if (props.shouldThrow) throw new Error("boom");
+  return <div data-testid="boom-child">ok</div>;
+}
+
+function RetryHarness(): ReactNode {
+  const [shouldThrow, setShouldThrow] = useState(true);
+  return (
+    <div>
+      <button
+        type="button"
+        data-testid="stop-throwing"
+        onClick={() => setShouldThrow(false)}
+      >
+        stop throwing
+      </button>
+      <HostedTileBodyBoundary instanceId="chat-1" resetKey="env-1">
+        <Boom shouldThrow={shouldThrow} />
+      </HostedTileBodyBoundary>
+    </div>
+  );
+}
+
+function ResetKeyHarness(): ReactNode {
+  const [resetKey, setResetKey] = useState("env-1");
+  const [renderTick, setRenderTick] = useState(0);
+  const [shouldThrow, setShouldThrow] = useState(true);
+  return (
+    <div>
+      <span data-testid="render-tick">{renderTick}</span>
+      <button
+        type="button"
+        data-testid="rerender-same-key"
+        onClick={() => setRenderTick((tick) => tick + 1)}
+      >
+        rerender same key
+      </button>
+      <button
+        type="button"
+        data-testid="change-reset-key"
+        onClick={() => {
+          setShouldThrow(false);
+          setResetKey("env-2");
+        }}
+      >
+        change reset key
+      </button>
+      <HostedTileBodyBoundary instanceId="chat-1" resetKey={resetKey}>
+        <Boom shouldThrow={shouldThrow} />
+      </HostedTileBodyBoundary>
+    </div>
+  );
+}
+
+describe("<HostedTileBodyBoundary />", () => {
+  it("shows the fallback panel, captures the error, and leaves siblings outside the boundary untouched", () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    render(
+      <div>
+        <div data-testid="sibling">sibling content</div>
+        <HostedTileBodyBoundary instanceId="chat-1" resetKey="env-1">
+          <Boom shouldThrow />
+        </HostedTileBodyBoundary>
+      </div>,
+    );
+
+    const alert = screen.getByRole("alert");
+    expect(alert.getAttribute("data-testid")).toBe(
+      "hosted-tile-body-error-chat-1",
+    );
+    expect(
+      screen.getByText("This agent's view stopped rendering."),
+    ).not.toBeNull();
+    expect(screen.getByTestId("sibling").textContent).toBe("sibling content");
+
+    expect(captureReportIssueError).toHaveBeenCalledTimes(1);
+    const [captureCall] = captureReportIssueError.mock.calls[0];
+    expect(captureCall.sourceAction).toBe("Agent tile");
+    expect(captureCall.componentStack).not.toBeNull();
+
+    expect(errorSummary).toHaveBeenCalledTimes(1);
+    const [, summaryDetails] = errorSummary.mock.calls[0];
+    expect(summaryDetails).toMatchObject({ instanceId: "chat-1" });
+
+    consoleError.mockRestore();
+  });
+
+  it("clicking Retry re-renders the child once it has stopped throwing", () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    render(<RetryHarness />);
+    expect(screen.getByRole("alert")).not.toBeNull();
+
+    fireEvent.click(screen.getByTestId("stop-throwing"));
+    expect(screen.getByRole("alert")).not.toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(screen.getByTestId("boom-child")).not.toBeNull();
+
+    consoleError.mockRestore();
+  });
+
+  it("clears the fallback automatically when resetKey identity changes, but not on an unrelated re-render carrying the same key", () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    render(<ResetKeyHarness />);
+    expect(screen.getByRole("alert")).not.toBeNull();
+
+    fireEvent.click(screen.getByTestId("rerender-same-key"));
+    expect(screen.getByTestId("render-tick").textContent).toBe("1");
+    expect(screen.getByRole("alert")).not.toBeNull();
+
+    fireEvent.click(screen.getByTestId("change-reset-key"));
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(screen.getByTestId("boom-child")).not.toBeNull();
+
+    consoleError.mockRestore();
+  });
+});
+
+function chatRef(instanceId: string): EpicNodeRef {
+  return {
+    id: instanceId,
+    instanceId,
+    type: "chat",
+    name: `Chat ${instanceId}`,
+    hostId: TEST_HOST_ID,
+  };
+}
+
+function canvasWithChats(
+  paneId: string,
+  instanceIds: ReadonlyArray<string>,
+): EpicCanvasState {
+  return {
+    // NOT the shared `pane()` fixture: it only seeds `activationHistory`
+    // with the FIRST tab id, but retention (`retained-pane-chats.ts`) reads
+    // membership off `activationHistory`, capped at
+    // `RETAINED_PANE_CHAT_CAP` (2). Both chats here must be retained, so
+    // both must be recorded as recently-active.
+    root: {
+      kind: "pane",
+      id: paneId,
+      tabInstanceIds: instanceIds,
+      activeTabId: instanceIds[0] ?? null,
+      previewTabId: null,
+      activationHistory: [...instanceIds],
+    },
+    activePaneId: paneId,
+    tilesByInstanceId: Object.fromEntries(
+      instanceIds.map((id) => [id, chatRef(id)]),
+    ),
+    sizesByGroupId: {},
+  };
+}
+
+function seedSingleTabStrip(
+  refs: ReadonlyArray<TabRef>,
+  activeRef: TabRef,
+): void {
+  useTabsStore.setState((state) => ({
+    ...state,
+    items: refs.map((ref) => ({
+      kind: "tab" as const,
+      id: `tab:${ref.kind}:${ref.id}`,
+      ref,
+    })),
+    activeItemId: `tab:${activeRef.kind}:${activeRef.id}`,
+    stripOrder: refs,
+  }));
+}
+
+function resetSurfaceHostState(): void {
+  useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
+  useTabsStore.setState(useTabsStore.getInitialState(), true);
+  resetTileSurfaceMembershipForTesting();
+  resetTileSurfaceEnvironmentRegistryForTesting();
+  resetTileSurfaceGeometryCoordinatorForTesting();
+}
+
+function ThrowingRecordBody(): ReactNode {
+  throw new Error("tile body crashed");
+}
+
+describe("StableTileSurfaceHost + HostedTileBodyBoundary integration", () => {
+  afterEach(() => {
+    cleanup();
+    resetSurfaceHostState();
+  });
+
+  it("one record's crashing body shows only that record's fallback while a sibling record keeps rendering", () => {
+    resetSurfaceHostState();
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    useEpicCanvasStore.setState({
+      tabsById: {
+        "tab-1": { tabId: "tab-1", epicId: "epic-1", name: "Epic 1" },
+      },
+      canvasByTabId: { "tab-1": canvasWithChats("p1", ["chat-1", "chat-2"]) },
+      openTabOrder: ["tab-1"],
+      activeTabId: "tab-1",
+    });
+    seedSingleTabStrip([{ kind: "epic", id: "tab-1" }], {
+      kind: "epic",
+      id: "tab-1",
+    });
+    publishTileSurfaceEnvironment(
+      buildSyntheticTileSurfaceEnvironment("chat-1", {}),
+    );
+    publishTileSurfaceEnvironment(
+      buildSyntheticTileSurfaceEnvironment("chat-2", {}),
+    );
+
+    function renderRecordBody(
+      environment: ReadyTileSurfaceEnvironment,
+    ): ReactNode {
+      if (environment.identity.instanceId === "chat-1") {
+        return <ThrowingRecordBody />;
+      }
+      return (
+        <div data-testid={`ok-body-${environment.identity.instanceId}`}>ok</div>
+      );
+    }
+
+    render(<StableTileSurfaceHost renderRecordBody={renderRecordBody} />);
+
+    expect(screen.getByTestId("hosted-tile-body-error-chat-1")).not.toBeNull();
+    expect(screen.getByTestId("ok-body-chat-2").textContent).toBe("ok");
+    expect(screen.queryByTestId("ok-body-chat-1")).toBeNull();
+
+    consoleError.mockRestore();
+  });
+});

--- a/clients/gui-app/src/components/epic-canvas/surface-host/hosted-tile-body-boundary.tsx
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/hosted-tile-body-boundary.tsx
@@ -1,0 +1,139 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+import { Button } from "@/components/ui/button";
+import { ReportIssueAction } from "@/components/report-issue/report-issue-action";
+import { appLogger } from "@/lib/logger";
+import { createReportIssueDraftContext } from "@/lib/report-issue-draft-context";
+import {
+  captureReportIssueError,
+  type ReportIssueErrorCapture,
+} from "@/lib/report-issue-error-capture";
+
+interface HostedTileBodyBoundaryProps {
+  /** The hosted record this body belongs to - for the log line and test ids. */
+  readonly instanceId: string;
+  /**
+   * Any value whose identity change means "the body was re-pointed" (the
+   * host passes the slot's anchor element, which changes on transfer): a
+   * crash that belonged to the previous placement is cleared and the body
+   * retried, so moving or re-hosting a tile is itself a recovery, not
+   * something the user has to follow with a Retry click. Keep it to a value
+   * that changes on re-pointing ONLY - a key that churns on ordinary
+   * re-renders would retry (and re-capture) a deterministic crash on every
+   * one of them.
+   */
+  readonly resetKey: unknown;
+  readonly children: ReactNode;
+}
+
+interface HostedTileBodyBoundaryState {
+  readonly error: Error | null;
+  readonly capture: ReportIssueErrorCapture | null;
+}
+
+const CLEARED: HostedTileBodyBoundaryState = { error: null, capture: null };
+
+/**
+ * The error boundary at the hosted-tile body seam (`StableTileSurfaceHost`
+ * record → `renderBody`). Every retained chat tile renders under this plane,
+ * and without a boundary here the nearest one above is the ROOT boundary: a
+ * single icon or composer throwing took the whole window to "Something went
+ * wrong" (observed 2026-08-30, `useOpenEpicHandle must be called inside
+ * <EpicSessionProvider>` thrown from a leaf under one tile). The record's DOM
+ * container, its geometry, and every other tile stay up; only this body is
+ * replaced by a recoverable panel.
+ *
+ * Deliberately NOT a silent `null` fallback like `StatusRowChromeBoundary`: a
+ * chat body is the surface's content, and its absence would read as a loading
+ * hang. The user sees what happened and can retry in place.
+ */
+export class HostedTileBodyBoundary extends Component<
+  HostedTileBodyBoundaryProps,
+  HostedTileBodyBoundaryState
+> {
+  constructor(props: HostedTileBodyBoundaryProps) {
+    super(props);
+    this.state = CLEARED;
+  }
+
+  static getDerivedStateFromError(error: Error): HostedTileBodyBoundaryState {
+    return { error, capture: null };
+  }
+
+  override componentDidCatch(error: Error, info: ErrorInfo): void {
+    // Captured at catch time, once per error (mints the correlation id and
+    // reports to Sentry) - never in render, which re-runs.
+    const capture = captureReportIssueError({
+      error,
+      componentStack: info.componentStack ?? null,
+      errorCode: null,
+      sourceAction: "Agent tile",
+    });
+    this.setState({ capture });
+    // The component stack is the one fact the renderer console capture drops
+    // (it prints React's `%s` args but does not persist them), so it is
+    // logged explicitly here.
+    appLogger.errorSummary(
+      "[hosted-tile] tile body crashed",
+      {
+        instanceId: this.props.instanceId,
+        componentStack: capture.cause.componentStack,
+      },
+      error,
+    );
+  }
+
+  override componentDidUpdate(prev: HostedTileBodyBoundaryProps): void {
+    if (this.state.error !== null && prev.resetKey !== this.props.resetKey) {
+      this.setState(CLEARED);
+    }
+  }
+
+  private readonly retry = (): void => {
+    this.setState(CLEARED);
+  };
+
+  override render(): ReactNode {
+    const { error, capture } = this.state;
+    if (error === null) {
+      return this.props.children;
+    }
+    return (
+      <div
+        role="alert"
+        data-testid={`hosted-tile-body-error-${this.props.instanceId}`}
+        className="flex h-full w-full flex-col items-center justify-center gap-3 bg-background p-6 text-center"
+      >
+        <div className="text-ui font-medium text-foreground">
+          This agent's view stopped rendering.
+        </div>
+        <div className="max-w-md text-ui-sm text-muted-foreground">
+          The rest of the window is unaffected. Retry to rebuild this view; if
+          it keeps happening, report it so we can see the cause.
+        </div>
+        <div className="flex items-center gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={this.retry}
+          >
+            Retry
+          </Button>
+          <ReportIssueAction
+            context={createReportIssueDraftContext({
+              title: "Agent tile stopped rendering",
+              // Real error text goes ONLY into `capture.cause`, never here -
+              // this is the public GitHub-issue prefill.
+              message: null,
+              code: null,
+              source: "Agent tile",
+              capture,
+            })}
+            presentation="icon"
+            className={undefined}
+          />
+        </div>
+      </div>
+    );
+  }
+}

--- a/clients/gui-app/src/components/epic-canvas/surface-host/stable-tile-surface-host.tsx
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/stable-tile-surface-host.tsx
@@ -50,6 +50,7 @@ import {
   type ReactNode,
 } from "react";
 import { cn } from "@/lib/utils";
+import { HostedTileBodyBoundary } from "@/components/epic-canvas/surface-host/hosted-tile-body-boundary";
 import { runPresentationLossBlur } from "@/components/epic-tabs/pane-visibility-context";
 import {
   getTileSurfaceMembership,
@@ -231,7 +232,20 @@ function TileSurfaceRecord(props: {
         : {})}
     >
       {environment !== null && canMountBody ? (
-        <Suspense fallback={null}>{props.renderBody(environment)}</Suspense>
+        // The boundary sits OUTSIDE Suspense so a throw from a lazily loaded
+        // body module is caught here too. Its reset key is the slot's anchor
+        // element - the one field that changes exactly when the record is
+        // re-hosted in a different slot (transfer) - and deliberately NOT the
+        // environment object: the slot republishes a fresh environment on
+        // every presentation change (tab select, pane focus), which would turn
+        // a deterministic crash into a fresh throw and Sentry capture per
+        // focus toggle. Same-slot recovery is the user's Retry.
+        <HostedTileBodyBoundary
+          instanceId={instanceId}
+          resetKey={environment.services.geometryAnchorElement}
+        >
+          <Suspense fallback={null}>{props.renderBody(environment)}</Suspense>
+        </HostedTileBodyBoundary>
       ) : null}
     </div>
   );

--- a/clients/gui-app/src/lib/registries/__tests__/epic-session-context-hmr-stability.test.ts
+++ b/clients/gui-app/src/lib/registries/__tests__/epic-session-context-hmr-stability.test.ts
@@ -1,0 +1,148 @@
+import { createElement, useContext, type ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import type { Context } from "react";
+import type { OpenEpicStoreHandle } from "@/stores/epics/open-epic/store";
+import type { EpicSessionPresentation } from "@/lib/registries/epic-session-registry";
+import type { HostClient } from "@traycer-clients/shared/host-client/host-client";
+import type { HostRpcRegistry } from "@traycer/protocol/host/index";
+
+/**
+ * Mirrors `src/providers/__tests__/host-runtime-provider-context.test.ts`:
+ * the pattern for proving a `globalThis`-pinned context survives Fast
+ * Refresh module re-imports. `epic-session-registry.ts` pins THREE contexts
+ * (`EpicSessionContext`, `EpicSessionPresentationContext`,
+ * `EpicSessionHostClientContext`) via one `createStableDevContext` helper, so
+ * each global is exercised the same way.
+ */
+interface EpicSessionDevGlobals {
+  __TRAYCER_EPIC_SESSION_CONTEXT__:
+    | Context<OpenEpicStoreHandle | null>
+    | undefined;
+  __TRAYCER_EPIC_SESSION_PRESENTATION_CONTEXT__:
+    | Context<EpicSessionPresentation | null>
+    | undefined;
+  __TRAYCER_EPIC_SESSION_HOST_CLIENT_CONTEXT__:
+    | Context<HostClient<HostRpcRegistry> | null>
+    | undefined;
+}
+
+const HANDLE_KEY = "__TRAYCER_EPIC_SESSION_CONTEXT__";
+const PRESENTATION_KEY = "__TRAYCER_EPIC_SESSION_PRESENTATION_CONTEXT__";
+const HOST_CLIENT_KEY = "__TRAYCER_EPIC_SESSION_HOST_CLIENT_CONTEXT__";
+
+// Typed as the dev-globals record alone (not the `typeof globalThis`
+// intersection) so the keyed write in `restoreGlobal` type-checks against the
+// one property it is generic over - the same shape the source module uses.
+const devGlobals: EpicSessionDevGlobals = globalThis as typeof globalThis &
+  EpicSessionDevGlobals;
+
+const initialHandleContext = devGlobals[HANDLE_KEY];
+const initialPresentationContext = devGlobals[PRESENTATION_KEY];
+const initialHostClientContext = devGlobals[HOST_CLIENT_KEY];
+
+function restoreGlobal<K extends keyof EpicSessionDevGlobals>(
+  key: K,
+  value: EpicSessionDevGlobals[K],
+): void {
+  if (value === undefined) {
+    Reflect.deleteProperty(devGlobals, key);
+    return;
+  }
+  devGlobals[key] = value;
+}
+
+function deleteAllPinnedGlobals(): void {
+  Reflect.deleteProperty(devGlobals, HANDLE_KEY);
+  Reflect.deleteProperty(devGlobals, PRESENTATION_KEY);
+  Reflect.deleteProperty(devGlobals, HOST_CLIENT_KEY);
+}
+
+afterEach(() => {
+  cleanup();
+  vi.resetModules();
+  restoreGlobal(HANDLE_KEY, initialHandleContext);
+  restoreGlobal(PRESENTATION_KEY, initialPresentationContext);
+  restoreGlobal(HOST_CLIENT_KEY, initialHostClientContext);
+});
+
+describe("epic-session-registry HMR-stable contexts", () => {
+  it("retains all three epic-session contexts across Fast Refresh module generations", async () => {
+    vi.resetModules();
+    deleteAllPinnedGlobals();
+
+    const gen1 = await import("@/lib/registries/epic-session-registry");
+
+    // The globals must now be populated - proof the module actually pinned
+    // them, not merely that two generations happen to agree.
+    expect(devGlobals[HANDLE_KEY]).toBeDefined();
+    expect(devGlobals[PRESENTATION_KEY]).toBeDefined();
+    expect(devGlobals[HOST_CLIENT_KEY]).toBeDefined();
+
+    vi.resetModules();
+    const gen2 = await import("@/lib/registries/epic-session-registry");
+
+    expect(gen2.EpicSessionContext).toBe(gen1.EpicSessionContext);
+    expect(gen2.EpicSessionPresentationContext).toBe(
+      gen1.EpicSessionPresentationContext,
+    );
+    expect(gen2.EpicSessionHostClientContext).toBe(
+      gen1.EpicSessionHostClientContext,
+    );
+  });
+
+  it("negative control: without the pinned globals surviving between imports, two generations get DIFFERENT context objects", async () => {
+    // Proves the `toBe` assertions above are discriminating, not vacuous
+    // (e.g. because module caching alone would make this pass regardless of
+    // whether pinning works): deleting the global right before each import
+    // forces a fresh `createContext()` call every time.
+    vi.resetModules();
+    deleteAllPinnedGlobals();
+    const gen1 = await import("@/lib/registries/epic-session-registry");
+
+    vi.resetModules();
+    deleteAllPinnedGlobals();
+    const gen2 = await import("@/lib/registries/epic-session-registry");
+
+    expect(gen2.EpicSessionContext).not.toBe(gen1.EpicSessionContext);
+    expect(gen2.EpicSessionPresentationContext).not.toBe(
+      gen1.EpicSessionPresentationContext,
+    );
+    expect(gen2.EpicSessionHostClientContext).not.toBe(
+      gen1.EpicSessionHostClientContext,
+    );
+  });
+
+  it("a provider mounted from generation 1 is readable by a consumer resolved from generation 2", async () => {
+    vi.resetModules();
+    deleteAllPinnedGlobals();
+    const gen1 = await import("@/lib/registries/epic-session-registry");
+
+    vi.resetModules();
+    const gen2 = await import("@/lib/registries/epic-session-registry");
+
+    // Object identity only matters for the `use()`/`useContext()` lookup;
+    // any object shaped like the handle works here (mirrors the exemplar's
+    // `Object.create(null) as HostRuntimeBinding<...>` binding fake).
+    const fakeHandle = Object.create(null) as OpenEpicStoreHandle;
+
+    function Consumer(): ReactNode {
+      const value = useContext(gen2.EpicSessionContext);
+      return createElement(
+        "div",
+        { "data-testid": "consumer-value" },
+        value === fakeHandle ? "match" : "no-match",
+      );
+    }
+
+    render(
+      createElement(
+        gen1.EpicSessionContext.Provider,
+        { value: fakeHandle },
+        createElement(Consumer),
+      ),
+    );
+
+    expect(screen.getByTestId("consumer-value").textContent).toBe("match");
+  });
+});

--- a/clients/gui-app/src/lib/registries/epic-session-registry.ts
+++ b/clients/gui-app/src/lib/registries/epic-session-registry.ts
@@ -1,4 +1,4 @@
-import { createContext } from "react";
+import { createContext, type Context } from "react";
 import {
   DEFAULT_MAX_LIVE_EPICS,
   OpenEpicSessionRegistry,
@@ -14,8 +14,9 @@ import type { HostClient } from "@traycer-clients/shared/host-client/host-client
 import type { HostRpcRegistry } from "@traycer/protocol/host/index";
 import { releaseDesktopEpicOwnershipForEpic } from "@/lib/windows/desktop-epic-ownership";
 
-export const EpicSessionContext = createContext<OpenEpicStoreHandle | null>(
-  null,
+export const EpicSessionContext = createStableDevContext(
+  "__TRAYCER_EPIC_SESSION_CONTEXT__",
+  () => createContext<OpenEpicStoreHandle | null>(null),
 );
 
 type EpicSessionPresentationState =
@@ -46,16 +47,72 @@ export type EpicSessionPresentation = EpicSessionPresentationState & {
  * complete snapshot; consumers use this presentation state to show a bounded
  * recovery result instead of treating a missing effective host as silence.
  */
-export const EpicSessionPresentationContext =
-  createContext<EpicSessionPresentation | null>(null);
+export const EpicSessionPresentationContext = createStableDevContext(
+  "__TRAYCER_EPIC_SESSION_PRESENTATION_CONTEXT__",
+  () => createContext<EpicSessionPresentation | null>(null),
+);
+
+/**
+ * The three epic-session contexts are pinned on `globalThis` in Vite's hot
+ * runtime, exactly as `HostCompatibilityContext` and the host runtime state are
+ * (`lib/host/compatibility-state.ts`, `lib/host/runtime.ts`): Fast Refresh can
+ * keep a provider from one module generation mounted while a refreshed
+ * consumer reads hooks from the next, and a context object created per
+ * generation makes those two sides address DIFFERENT contexts - the consumer
+ * reads the default `null` and the throwing `useOpenEpicHandle()` blanks the
+ * window with "must be called inside <EpicSessionProvider>" (observed during a
+ * dev-slot live pass, 2026-08-30). Reusing one object per page removes the only
+ * way two epic-session contexts can coexist. A production build has no
+ * `import.meta.hot` and gets ordinary page-local contexts; a real reload resets
+ * `globalThis`. Vitest's `import.meta.hot` stub exercises the same
+ * module-reimport path.
+ *
+ * All three are pinned, not just the handle context: the provider writes them
+ * as one tuple (`epic-session-provider.tsx`), and a split on any one of them
+ * leaves a consumer reading a stale presentation or host client.
+ */
+interface EpicSessionDevGlobals {
+  __TRAYCER_EPIC_SESSION_CONTEXT__:
+    | Context<OpenEpicStoreHandle | null>
+    | undefined;
+  __TRAYCER_EPIC_SESSION_PRESENTATION_CONTEXT__:
+    | Context<EpicSessionPresentation | null>
+    | undefined;
+  __TRAYCER_EPIC_SESSION_HOST_CLIENT_CONTEXT__:
+    | Context<HostClient<HostRpcRegistry> | null>
+    | undefined;
+}
+
+function createStableDevContext<K extends keyof EpicSessionDevGlobals>(
+  key: K,
+  create: () => NonNullable<EpicSessionDevGlobals[K]>,
+): NonNullable<EpicSessionDevGlobals[K]> {
+  if (import.meta.hot === undefined) {
+    return create();
+  }
+  // Typed as the dev-globals record alone (not the `typeof globalThis`
+  // intersection) so the keyed write below type-checks against the one
+  // property this function is generic over.
+  const devGlobals: EpicSessionDevGlobals = globalThis as typeof globalThis &
+    EpicSessionDevGlobals;
+  const existing = devGlobals[key];
+  if (existing !== undefined) {
+    return existing;
+  }
+  const context = create();
+  devGlobals[key] = context;
+  return context;
+}
 
 /**
  * The RPC client resolved for the same host that owns `EpicSessionContext`.
  * Session-level provisioning prevents sidebar rows from independently mounting
  * host-directory subscriptions just to address the same Epic host.
  */
-export const EpicSessionHostClientContext =
-  createContext<HostClient<HostRpcRegistry> | null>(null);
+export const EpicSessionHostClientContext = createStableDevContext(
+  "__TRAYCER_EPIC_SESSION_HOST_CLIENT_CONTEXT__",
+  () => createContext<HostClient<HostRpcRegistry> | null>(null),
+);
 
 export const handleHostIds = new WeakMap<OpenEpicStoreHandle, string | null>();
 // The R-1 rotation rationale that used to live here now lives at the acquire


### PR DESCRIPTION
## Why

A dev-slot pass hit `useOpenEpicHandle must be called inside <EpicSessionProvider>` thrown from a leaf under one chat tile, and the root boundary turned that into a blank window.

The mechanism was never reproduced — an audit found no user-reachable path, and two independent reviews refuted the first two candidate explanations. **None of these three changes claims to explain the crash.** They remove the ways a crash of that shape can take the whole window down, and the one way two epic-session contexts could coexist.

## What

**1. Pin the epic-session contexts under Vite's hot runtime** (`lib/registries/epic-session-registry.ts`)

`EpicSessionContext`, `EpicSessionPresentationContext` and `EpicSessionHostClientContext` are now created through `createStableDevContext`, the same shape as `createStableHostCompatibilityContext` (`lib/host/compatibility-state.ts`) and `createStableHostRuntimeState` (`lib/host/runtime.ts`): when `import.meta.hot` is defined the context object is parked on a `__TRAYCER_EPIC_SESSION_*__` global and reused by later module generations. Fast Refresh can otherwise leave a mounted provider and a refreshed consumer addressing different context objects, at which point the consumer reads the default `null` and the throwing hook fires.

All three are pinned, not just the handle — the provider writes them as one tuple. Production has no `import.meta.hot` and gets ordinary page-local contexts.

**2. Error boundary at the hosted-tile body seam** (new `components/epic-canvas/surface-host/hosted-tile-body-boundary.tsx`)

Every retained chat tile renders under `StableTileSurfaceHost`, and the nearest boundary above it was the ROOT boundary — so one icon throwing blanked the window. `HostedTileBodyBoundary` now wraps each record's `renderBody`, outside `Suspense` so a throw from a lazily loaded body module is caught too. The crashing tile shows a small in-place panel with **Retry** and **Report issue**; the record's container, its geometry, and every other tile stay up.

Deliberately not a silent `null` fallback like `StatusRowChromeBoundary`: a chat body is the surface's content, and its absence would read as a loading hang.

The reset key is the slot's `geometryAnchorElement`, not the environment object. The slot republishes a fresh environment on every presentation change (tab select, pane focus), so keying on that would re-throw and re-capture a deterministic crash on every focus toggle. The anchor changes exactly when the record is re-hosted in a different slot, which is the intended "transfer is itself a recovery" semantics; same-slot recovery is the user's Retry.

**3. `ChatProgressIcon` on the registered selectors** (`components/chat/chat-progress-icon.tsx`)

Reads `useRegisteredEpicAgentActivityTiers(epicId)` / `useRegisteredEpicPermissionRole(epicId)` instead of the ambient throwing hooks, mirroring `TuiAgentLiveTabIcon`. This icon already carries its `epicId` and is a presentational leaf drawn wherever a chat node appears — with the ambient hooks it was the least-defended node icon. Outside a session both degrade (no activity, `null` role) to the neutral idle it already shows for an unknown permission.

## Tests

Three new files, 9 tests, each with a control that proves the assertion discriminates:

- `lib/registries/__tests__/epic-session-context-hmr-stability.test.ts` — `vi.resetModules()` + double import keeps all three contexts identical; a **negative control** deletes the globals between imports and shows the objects then differ (so the `toBe` is not vacuous); a gen-1 `Provider` is read through a gen-2 `useContext`.
- `components/epic-canvas/surface-host/__tests__/hosted-tile-body-boundary.test.tsx` — fallback panel, `captureReportIssueError` / `appLogger.errorSummary` called once with the component stack, siblings untouched; Retry; `resetKey` identity change clears while an unrelated same-key re-render does not; and an integration case through real `StableTileSurfaceHost` with two chat records where only the crashing one shows its fallback and the sibling keeps rendering.
- `components/chat/__tests__/chat-progress-icon-no-provider.test.tsx` — the icon renders outside any `EpicSessionProvider` with the real selectors; a control asserts the old ambient `useEpicPermissionRole()` still throws there.

## Verification

Run from `clients/gui-app` on this branch (rebased onto `tgill-release-train`):

| Check | Result |
| --- | --- |
| `bun run compile` | exit 0 |
| `oxlint -c oxlint.config.ts --deny-warnings` (8 touched files) | clean |
| `eslint --max-warnings 0` (8 touched files) | clean |
| `oxfmt --check` (8 touched files) | clean |
| `vitest run` — 3 new + `chat-progress-icon`, `stable-tile-surface-host`, `host-runtime-provider-context` | 6 files, 39/39 pass |
| `react-doctor` (changed scope + directory scans for the new files) | no findings in new or changed code |

## Notes

- Based on `tgill-release-train`, not `main` — targeted at the release train.
- Not in scope: finding the actual mechanism of the original crash.
