### PR TITLE
fix(gui-app): show true chat activity times

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-chat-tree.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-chat-tree.tsx
@@ -154,6 +154,7 @@ import {
   useChatPublicationTargets,
 } from "@/hooks/chats/use-chat-publication-targets";
 import {
+  chatRowLastActiveAt,
   indexOwnCloudChatsByLocalId,
   mergeChatListEntries,
   selectUnfoldedCloudChats,
@@ -836,32 +837,20 @@ export function ChatTreePanelBody(props: ChatTreePanelBodyProps) {
       }),
     [cloudChats.data, localChatIds, publicationTargets.data],
   );
-  // Sharing fold, mutations, and cache keys all address the Epic session
-  // host. The v2 rendered list above stays on the app-wide client — that
-  // hook is shipped and is not this ticket. The redirect map is host-LOCAL
-  // (only the epic's host knows C1→C2), so reading it from the active host
-  // would make "Make private" mutate the wrong lineage after a fork.
-  const sharingCloudChats = useCloudChatList({
-    client: sessionHostClient,
-    taskId: epicId,
-    enabled: epicId.length > 0,
-  });
-  const sharingPublicationTargets = useChatPublicationTargets({
-    client: sessionHostClient,
-    epicId,
-    chatIds: localChatIds,
-    enabled: epicId.length > 0,
-  });
+  // The sharing/activity fold uses the same session-host reads as the rendered
+  // cloud list above. The redirect map is host-local (only the epic's host
+  // knows C1→C2), so one shared pair of observers is both sufficient and the
+  // only identity-safe source for local-row cloud facts.
   const ownCloudChatByLocalId = useMemo(
     () =>
       indexOwnCloudChatsByLocalId({
-        chats: sharingCloudChats.data?.chats ?? EMPTY_CLOUD_CHATS,
+        chats: cloudChats.data?.chats ?? EMPTY_CLOUD_CHATS,
         localChatIds,
         publicationChatIdByChatId: publicationTargetMap(
-          sharingPublicationTargets.data,
+          publicationTargets.data,
         ),
       }),
-    [localChatIds, sharingCloudChats.data, sharingPublicationTargets.data],
+    [cloudChats.data, localChatIds, publicationTargets.data],
   );
   const chatSharingValue = useMemo<SidebarChatSharingValue>(
     () => ({
@@ -1343,6 +1332,22 @@ interface ChatNodeProps {
   onToggleSelection: (id: string) => void;
 }
 
+function localTreeNodeLastActiveAt(input: {
+  readonly isChat: boolean;
+  readonly recordUpdatedAt: number;
+  readonly ownerHostId: string | null;
+  readonly sessionHostId: string | null;
+  readonly cloudChat: CloudChatSummary | null;
+}): number {
+  if (!input.isChat) return input.recordUpdatedAt;
+  return chatRowLastActiveAt({
+    recordUpdatedAt: input.recordUpdatedAt,
+    ownerHostId: input.ownerHostId,
+    sessionHostId: input.sessionHostId,
+    cloudChat: input.cloudChat,
+  });
+}
+
 const ChatNode = memo(function ChatNode(props: ChatNodeProps) {
   const {
     epicId,
@@ -1400,7 +1405,9 @@ const ChatNode = memo(function ChatNode(props: ChatNodeProps) {
   // the archive/menu controls replace on hover. Read from the PROJECTION, not
   // `node.updatedAt` - the tree node is a lagging copy (see the selector's
   // doc), and using it made this row disagree with the hover card.
-  const updatedAt = useEpicNodeUpdatedAt(nodeId);
+  const recordUpdatedAt = useEpicNodeUpdatedAt(nodeId);
+  const sharing = useContext(SidebarChatSharingContext);
+  const cloudChat = sharing.ownCloudChatByLocalId.get(nodeId) ?? null;
   const openableType: OpenableEpicNodeKind | null = isOpenableEpicNodeKind(
     artifactType,
   )
@@ -1449,6 +1456,17 @@ const ChatNode = memo(function ChatNode(props: ChatNodeProps) {
   // is a different machine from the one this tree is showing.
   const ownerHostId = useEpicNodeHostId(nodeId);
   const sessionHostId = useEpicSessionHostId();
+  // Own-host rows read the chat store's real activity timestamp. A row owned
+  // elsewhere is a metadata replica, so its matching cloud publication head
+  // supplies the content clock instead. Terminal agents have no cloud content
+  // plane and keep their record timestamp.
+  const updatedAt = localTreeNodeLastActiveAt({
+    isChat: artifactType === "chat",
+    recordUpdatedAt,
+    ownerHostId,
+    sessionHostId,
+    cloudChat,
+  });
   const openHostId = ownerHostId ?? sessionHostId ?? UNKNOWN_HOST_PLACEHOLDER;
   // The host that SERVES a published copy's read (the owner is unreachable by
   // construction there) - the session's, for the reason above.
@@ -1570,7 +1588,7 @@ const ChatNode = memo(function ChatNode(props: ChatNodeProps) {
       renameInputRef.current?.focus();
       renameInputRef.current?.select();
     }, 0);
-  }, [canMutate, nodeName]);
+  }, [canMutate, nodeName, setIsRenaming, setRenameValue]);
 
   const commitRename = useCallback(() => {
     const trimmed = renameValue.trim();
@@ -1655,6 +1673,7 @@ const ChatNode = memo(function ChatNode(props: ChatNodeProps) {
     renameChat,
     renameTerminalAgent,
     renameValue,
+    setIsRenaming,
     tabId,
   ]);
 
@@ -1668,7 +1687,7 @@ const ChatNode = memo(function ChatNode(props: ChatNodeProps) {
         setIsRenaming(false);
       }
     },
-    [commitRename],
+    [commitRename, setIsRenaming],
   );
 
   const performDelete = () => {

--- a/clients/gui-app/src/lib/chats/__tests__/unified-chat-list.test.ts
+++ b/clients/gui-app/src/lib/chats/__tests__/unified-chat-list.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import type { CloudChatSummary } from "@traycer/protocol/host/epic/cloud-chat";
 import type { SortableNode } from "@/lib/epic-sort";
 import {
+  chatRowLastActiveAt,
+  cloudChatLastActiveAt,
   cloudChatRowKey,
   indexOwnCloudChatsByLocalId,
   localChatRowKey,
@@ -76,6 +78,62 @@ const LOCAL_BACKUP_ROW = cloudChat({
 
 const FORK_REDIRECT = new Map([[WALKTHROUGH, CLONE_ROW]]);
 const NO_REDIRECTS = new Map<string, string>();
+
+describe("cloudChatLastActiveAt", () => {
+  it("uses the published content time instead of a later metadata edit", () => {
+    expect(
+      cloudChatLastActiveAt(
+        cloudChat({
+          chatId: WALKTHROUGH,
+          ownerHostId: LOCAL_HOST,
+          title: "Renamed",
+          publishedAt: 300,
+          metadataUpdatedAt: 900,
+          createdAt: 100,
+        }),
+      ),
+    ).toBe(300);
+  });
+
+  it("falls back to metadata time before the first publication", () => {
+    expect(
+      cloudChatLastActiveAt(
+        cloudChat({
+          chatId: WALKTHROUGH,
+          ownerHostId: LOCAL_HOST,
+          title: "New chat",
+          publishedAt: null,
+          metadataUpdatedAt: 200,
+          createdAt: 100,
+        }),
+      ),
+    ).toBe(200);
+  });
+});
+
+describe("chatRowLastActiveAt", () => {
+  it("keeps the serving host's fresher record activity time", () => {
+    expect(
+      chatRowLastActiveAt({
+        recordUpdatedAt: 900,
+        ownerHostId: LOCAL_HOST,
+        sessionHostId: LOCAL_HOST,
+        cloudChat: LOCAL_BACKUP_ROW,
+      }),
+    ).toBe(900);
+  });
+
+  it("uses publication time for a record replicated from another host", () => {
+    expect(
+      chatRowLastActiveAt({
+        recordUpdatedAt: 900,
+        ownerHostId: OTHER_HOST,
+        sessionHostId: LOCAL_HOST,
+        cloudChat: INCUMBENT_ROW,
+      }),
+    ).toBe(300);
+  });
+});
 
 function node(
   id: string,

--- a/clients/gui-app/src/lib/chats/unified-chat-list.ts
+++ b/clients/gui-app/src/lib/chats/unified-chat-list.ts
@@ -187,6 +187,33 @@ export function cloudRowIsViewersOwn(chat: CloudChatSummary): boolean {
   return chat.isOwnedByViewer;
 }
 
+/** The cloud's content-activity clock for one chat row. */
+export function cloudChatLastActiveAt(chat: CloudChatSummary): number {
+  return chat.publishedAt ?? chat.metadataUpdatedAt;
+}
+
+/**
+ * The best content-activity clock for a row already present in the local tree.
+ *
+ * The serving host's own record comes straight from its chat store and is the
+ * freshest answer. A record replicated from a different owner host carries a
+ * metadata timestamp instead, so its matching cloud head is authoritative.
+ */
+export function chatRowLastActiveAt(input: {
+  readonly recordUpdatedAt: number;
+  readonly ownerHostId: string | null;
+  readonly sessionHostId: string | null;
+  readonly cloudChat: CloudChatSummary | null;
+}): number {
+  const isForeignRecord =
+    input.ownerHostId !== null &&
+    input.sessionHostId !== null &&
+    input.ownerHostId !== input.sessionHostId;
+  return isForeignRecord && input.cloudChat !== null
+    ? cloudChatLastActiveAt(input.cloudChat)
+    : input.recordUpdatedAt;
+}
+
 /**
  * The sort keys a cloud row contributes, in the shape the shared comparator
  * already reads so one ordering rule covers both kinds of row.
@@ -202,7 +229,7 @@ export function cloudChatSortable(chat: CloudChatSummary): SortableNode {
     id: cloudChatRowKey(chat.identity),
     title: chat.title ?? "",
     createdAt: chat.createdAt,
-    updatedAt: chat.publishedAt ?? chat.metadataUpdatedAt,
+    updatedAt: cloudChatLastActiveAt(chat),
   };
 }
 


### PR DESCRIPTION
## Summary

- show each chat row's actual content activity time instead of metadata-edit time
- use the serving host's chat-record clock for local rows and cloud publication time for rows replicated from another host
- reuse the existing session-host cloud observers and cover both clock-selection paths with focused tests

## Related issue

None.

## Testing

- `bun run vitest run --config vitest.config.ts src/lib/chats/__tests__/unified-chat-list.test.ts` (19 passed)
- mandatory affected pre-commit hooks passed (build, compile, lint, format, DCO)

## Checklist

- [x] Pre-commit static checks pass (`pre-commit run --all-files` for an explicit full-repo run)
- [ ] Separate CI test checks pass
- [x] Tests added/updated where it makes sense
- [x] Commits are signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#developer-certificate-of-origin-dco)
