### PR TITLE
fix(gui-app): remove typed worktree sweep confirmation

### DIFF
--- a/clients/gui-app/src/components/epics/__tests__/sweep-worktrees-dialog-force-delete.test.tsx
+++ b/clients/gui-app/src/components/epics/__tests__/sweep-worktrees-dialog-force-delete.test.tsx
@@ -416,7 +416,7 @@ describe("SweepWorktreesDialog ergonomics", () => {
     await waitFor(() => {
       expect(screen.getByText("Review this sweep")).toBeTruthy();
     });
-    expect(screen.queryByTestId("sweep-typed-confirm")).toBeNull();
+    expect(screen.queryByRole("textbox")).toBeNull();
     expect(
       screen.getByRole("button", { name: "Stop work & sweep" }),
     ).toBeTruthy();
@@ -449,10 +449,12 @@ describe("SweepWorktreesDialog ergonomics", () => {
       screen.getByRole("button", { name: "Review consequences" }),
     );
     await waitFor(() => {
-      expect(screen.getByText("Review this sweep")).toBeTruthy();
+      expect(
+        screen.getByRole("heading", { name: "Review this sweep" }),
+      ).toBeTruthy();
     });
     const confirm = screen.getByRole("button", { name: "Sweep anyway" });
-    expect(screen.queryByTestId("sweep-typed-confirm")).toBeNull();
+    expect(screen.queryByRole("textbox")).toBeNull();
     expect(confirm.hasAttribute("disabled")).toBe(false);
   });
 
@@ -710,7 +712,9 @@ describe("SweepWorktreesDialog ergonomics", () => {
       screen.getByRole("button", { name: "Review consequences" }),
     );
     await waitFor(() => {
-      expect(screen.getByText("Review this sweep")).toBeTruthy();
+      expect(
+        screen.getByRole("heading", { name: "Review this sweep" }),
+      ).toBeTruthy();
     });
     const individualStops =
       screen.getByTestId("sweep-review-stops").textContent;
@@ -1214,7 +1218,7 @@ describe("SweepWorktreesDialog ergonomics", () => {
       expect(screen.getByText("Review this sweep")).toBeTruthy();
     });
     fireEvent.keyDown(window, { key: "a" });
-    expect(screen.queryByTestId("sweep-typed-confirm")).toBeNull();
+    expect(screen.queryByRole("textbox")).toBeNull();
   });
 
   it("names full shell commands in the review receipt", async () => {

--- a/clients/gui-app/src/components/epics/__tests__/sweep-worktrees-dialog-force-delete.test.tsx
+++ b/clients/gui-app/src/components/epics/__tests__/sweep-worktrees-dialog-force-delete.test.tsx
@@ -306,9 +306,6 @@ describe("SweepWorktreesDialog ergonomics", () => {
     await waitFor(() => {
       expect(screen.getByText("Review this sweep")).toBeTruthy();
     });
-    fireEvent.change(screen.getByTestId("sweep-typed-confirm"), {
-      target: { value: "sweep" },
-    });
     testState.sweepingPaths = new Set(["/wt/review"]);
     fireEvent.click(screen.getByRole("button", { name: "Sweep anyway" }));
     expect(onOpenChange).toHaveBeenCalledWith(false);
@@ -389,7 +386,7 @@ describe("SweepWorktreesDialog ergonomics", () => {
     ).toBe(false);
   });
 
-  it("opens review for in-use, unproven, and shared selections; typing only for unproven", async () => {
+  it("opens review for elevated selections without requiring typed confirmation", async () => {
     testState.rows = [
       {
         entry: worktreeEntry({
@@ -425,7 +422,7 @@ describe("SweepWorktreesDialog ergonomics", () => {
     ).toBeTruthy();
   });
 
-  it("requires typing sweep only when an unproven row is selected", async () => {
+  it("allows click confirmation when an unproven row is selected", async () => {
     testState.rows = [
       {
         entry: worktreeEntry({
@@ -452,13 +449,10 @@ describe("SweepWorktreesDialog ergonomics", () => {
       screen.getByRole("button", { name: "Review consequences" }),
     );
     await waitFor(() => {
-      expect(screen.getByTestId("sweep-typed-confirm")).toBeTruthy();
+      expect(screen.getByText("Review this sweep")).toBeTruthy();
     });
     const confirm = screen.getByRole("button", { name: "Sweep anyway" });
-    expect(confirm.hasAttribute("disabled")).toBe(true);
-    fireEvent.change(screen.getByTestId("sweep-typed-confirm"), {
-      target: { value: "sweep" },
-    });
+    expect(screen.queryByTestId("sweep-typed-confirm")).toBeNull();
     expect(confirm.hasAttribute("disabled")).toBe(false);
   });
 
@@ -1217,15 +1211,10 @@ describe("SweepWorktreesDialog ergonomics", () => {
       screen.getByRole("button", { name: "Review consequences" }),
     );
     await waitFor(() => {
-      expect(screen.getByTestId("sweep-typed-confirm")).toBeTruthy();
+      expect(screen.getByText("Review this sweep")).toBeTruthy();
     });
     fireEvent.keyDown(window, { key: "a" });
-    fireEvent.change(screen.getByTestId("sweep-typed-confirm"), {
-      target: { value: "a" },
-    });
-    expect(
-      screen.getByTestId<HTMLInputElement>("sweep-typed-confirm").value,
-    ).toBe("a");
+    expect(screen.queryByTestId("sweep-typed-confirm")).toBeNull();
   });
 
   it("names full shell commands in the review receipt", async () => {

--- a/clients/gui-app/src/components/epics/sweep-worktrees-dialog.tsx
+++ b/clients/gui-app/src/components/epics/sweep-worktrees-dialog.tsx
@@ -151,7 +151,6 @@ export function SweepWorktreesDialog(props: SweepWorktreesDialogProps) {
   const [step, setStep] = useState<"choose" | "review">("choose");
   const [reviewSnapshot, setReviewSnapshot] =
     useState<SweepReviewSnapshot | null>(null);
-  const [typedSweep, setTypedSweep] = useState("");
   const [inventoryChanged, setInventoryChanged] = useState(false);
   const [sessionOutcomes, setSessionOutcomes] = useState<
     ReadonlyMap<string, SweepSessionOutcome>
@@ -201,7 +200,6 @@ export function SweepWorktreesDialog(props: SweepWorktreesDialogProps) {
     setPreviousInUseByPath,
     setStep,
     setReviewSnapshot,
-    setTypedSweep,
     setInventoryChanged,
     setSessionOutcomes,
   });
@@ -270,7 +268,6 @@ export function SweepWorktreesDialog(props: SweepWorktreesDialogProps) {
     // state. Park the session on Choose before closing so reopening shows the
     // live rows, rather than a spent confirmation receipt.
     setStep("choose");
-    setTypedSweep("");
     setInventoryChanged(false);
     startSweepKickoff({
       hostId,
@@ -285,7 +282,6 @@ export function SweepWorktreesDialog(props: SweepWorktreesDialogProps) {
           return;
         }
         setInventoryChanged(true);
-        setTypedSweep("");
         setCheckOverrides((current) =>
           uncheckNonResubmittableOverrides(current, result),
         );
@@ -314,7 +310,6 @@ export function SweepWorktreesDialog(props: SweepWorktreesDialogProps) {
       sessionOutcomes,
       setSessionOutcomes,
       setReviewSnapshot,
-      setTypedSweep,
       setInventoryChanged,
       setStep,
     });
@@ -333,14 +328,11 @@ export function SweepWorktreesDialog(props: SweepWorktreesDialogProps) {
             selectedEpicIds={selectedEpicIds}
             agentNames={agentNames}
             taskTitles={taskTitles}
-            typedValue={typedSweep}
             inventoryChanged={inventoryChanged}
             activeSweepCount={activeSweepCount}
-            onTypedValueChange={setTypedSweep}
             onBack={() => {
               setStep("choose");
               setReviewSnapshot(null);
-              setTypedSweep("");
               setInventoryChanged(false);
             }}
             onCancel={() => onOpenChange(false)}
@@ -435,7 +427,6 @@ function applySelectionRetarget(input: {
   readonly setPreviousInUseByPath: (next: ReadonlyMap<string, boolean>) => void;
   readonly setStep: (step: "choose" | "review") => void;
   readonly setReviewSnapshot: (next: SweepReviewSnapshot | null) => void;
-  readonly setTypedSweep: (value: string) => void;
   readonly setInventoryChanged: (value: boolean) => void;
   readonly setSessionOutcomes: (
     next: ReadonlyMap<string, SweepSessionOutcome>,
@@ -447,7 +438,6 @@ function applySelectionRetarget(input: {
   input.setPreviousInUseByPath(new Map());
   input.setStep("choose");
   input.setReviewSnapshot(null);
-  input.setTypedSweep("");
   input.setInventoryChanged(false);
   input.setSessionOutcomes(new Map());
 }
@@ -493,7 +483,6 @@ function startSweepPrimary(input: {
     next: ReadonlyMap<string, SweepSessionOutcome>,
   ) => void;
   readonly setReviewSnapshot: (next: SweepReviewSnapshot | null) => void;
-  readonly setTypedSweep: (value: string) => void;
   readonly setInventoryChanged: (value: boolean) => void;
   readonly setStep: (step: "choose" | "review") => void;
 }): void {
@@ -552,7 +541,6 @@ function startSweepPrimary(input: {
           bannersFromSessionOutcomes(nextOutcomes),
         ),
       );
-      input.setTypedSweep("");
       input.setInventoryChanged(false);
       input.setStep("review");
     })

--- a/clients/gui-app/src/components/epics/sweep-worktrees-review.tsx
+++ b/clients/gui-app/src/components/epics/sweep-worktrees-review.tsx
@@ -1,8 +1,7 @@
-import { useId, type ReactNode } from "react";
+import type { ReactNode } from "react";
 import { AlertTriangle } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { DialogDescription, DialogTitle } from "@/components/ui/dialog";
-import { Input } from "@/components/ui/input";
 import {
   formatStopHeading,
   formatTeardownActors,
@@ -24,17 +23,12 @@ export function SweepWorktreesReview(props: {
   readonly selectedEpicIds: ReadonlySet<string>;
   readonly agentNames: ReadonlyMap<string, string>;
   readonly taskTitles: ReadonlyMap<string, string>;
-  readonly typedValue: string;
   readonly inventoryChanged: boolean;
   readonly activeSweepCount: number;
-  readonly onTypedValueChange: (value: string) => void;
   readonly onBack: () => void;
   readonly onCancel: () => void;
   readonly onConfirm: () => void;
 }): ReactNode {
-  const needsTypedGate = props.snapshot.unproven.length > 0;
-  const typedOk = !needsTypedGate || props.typedValue === "sweep";
-  const typedConfirmId = useId();
   const stopActors = formatTeardownActors(
     props.snapshot.disclosedHolders,
     props.agentNames,
@@ -186,25 +180,6 @@ export function SweepWorktreesReview(props: {
           <p className="text-ui-sm font-medium">{removal.worktrees}</p>
           <p className="text-ui-xs text-muted-foreground">{removal.branches}</p>
         </div>
-        {needsTypedGate ? (
-          <div className="space-y-1.5">
-            <label htmlFor={typedConfirmId} className="text-ui-xs font-medium">
-              Type <code className="font-mono">sweep</code> to confirm possible
-              loss of unmerged work
-            </label>
-            <Input
-              id={typedConfirmId}
-              value={props.typedValue}
-              onChange={(event) =>
-                props.onTypedValueChange(event.currentTarget.value)
-              }
-              placeholder="sweep"
-              autoComplete="off"
-              spellCheck={false}
-              data-testid="sweep-typed-confirm"
-            />
-          </div>
-        ) : null}
       </section>
       <div className="flex min-w-0 shrink-0 items-center justify-between gap-2 border-t border-border/60 bg-foreground/3 px-5 py-3">
         <Button
@@ -230,7 +205,6 @@ export function SweepWorktreesReview(props: {
             type="button"
             variant="destructive"
             size="sm"
-            disabled={!typedOk}
             onClick={props.onConfirm}
             data-testid="sweep-worktrees-confirm"
           >


### PR DESCRIPTION
## Summary

- remove the extra requirement to type `sweep` before deleting worktrees with unmerged work
- retain the consequence review and destructive click confirmation
- update regression coverage for the click-only confirmation flow

## Related issue

None.

## Checklist

- [x] Pre-commit static checks pass
- [x] Separate focused test checks pass (36/36)
- [x] Tests added/updated where it makes sense
- [x] Commits are signed off per DCO
