### PR TITLE
fix(gui-app): fence submitted draft deletion

### DIFF
--- a/clients/gui-app/src/lib/drafts/__tests__/draft-coordinator-lifecycle.test.ts
+++ b/clients/gui-app/src/lib/drafts/__tests__/draft-coordinator-lifecycle.test.ts
@@ -2,9 +2,11 @@ import { afterEach, describe, expect, it } from "vitest";
 import type { DraftDocument, DraftWrite } from "@traycer/protocol/host";
 import {
   acquireDraftMirrorSession,
+  applyIncomingDraftDocument,
   bindComposerDraftHost,
   bindInterviewDraftHost,
   collectDraftMirrorDirtyWrites,
+  releaseDraftMirrorSession,
   resetDraftMirrorCoordinatorForTests,
   submitComposerDraft,
   unbindInterviewDraftHost,
@@ -28,19 +30,18 @@ function typed(text: string) {
 interface HostLog {
   readonly upserts: DraftWrite[];
   readonly deletes: string[];
-  /** Resolves the NEXT `drafts.delete`; `null` answers immediately. */
-  holdDelete: (() => void) | null;
+  rows: DraftDocument[];
+  deleteFailures: number;
 }
 
-function mountSession(log: HostLog): void {
-  let listed: DraftDocument[] = [];
-  acquireDraftMirrorSession({
+function mountSession(log: HostLog) {
+  return acquireDraftMirrorSession({
     hostId: HOST_ID,
     client: {
       request: (method: string, params: unknown) => {
         if (method === "drafts.list") {
           return Promise.resolve({
-            drafts: listed,
+            drafts: log.rows,
             tombstones: [],
             snapshotSeq: 0,
             scopeId: null,
@@ -62,13 +63,17 @@ function mountSession(log: HostLog): void {
             },
             revision: 1,
           };
-          listed = [document];
+          log.rows = [document];
           return Promise.resolve({ draft: document });
         }
         if (method === "drafts.delete") {
           const draftId = (params as { draftId: string }).draftId;
           log.deletes.push(draftId);
-          listed = listed.filter((row) => row.draftId !== draftId);
+          if (log.deleteFailures > 0) {
+            log.deleteFailures -= 1;
+            return Promise.reject(new Error("offline"));
+          }
+          log.rows = log.rows.filter((row) => row.draftId !== draftId);
           return Promise.resolve({ deleted: true });
         }
         return Promise.reject(new Error(`unexpected ${String(method)}`));
@@ -81,7 +86,10 @@ function mountSession(log: HostLog): void {
 
 afterEach(() => {
   resetDraftMirrorCoordinatorForTests();
-  useComposerDraftStore.setState({ drafts: {} });
+  useComposerDraftStore.setState({
+    drafts: {},
+    pendingSubmittedDraftDeletes: {},
+  });
   useInterviewDraftStore.setState({ draftsByChat: {} });
 });
 
@@ -120,7 +128,12 @@ describe("interview host binding", () => {
 
 describe("submitComposerDraft", () => {
   it("does not tombstone a draft the user re-created during finalization", async () => {
-    const log: HostLog = { upserts: [], deletes: [], holdDelete: null };
+    const log: HostLog = {
+      upserts: [],
+      deletes: [],
+      rows: [],
+      deleteFailures: 0,
+    };
     mountSession(log);
     bindComposerDraftHost(CHAT_ID, HOST_ID);
 
@@ -152,4 +165,88 @@ describe("submitComposerDraft", () => {
       ),
     ).toEqual([nextDraftId]);
   });
+
+  it("keeps submitted text cleared across an offline delete and bootstrap replay", async () => {
+    const log: HostLog = {
+      upserts: [],
+      deletes: [],
+      rows: [],
+      deleteFailures: 1,
+    };
+    const firstSession = mountSession(log);
+    bindComposerDraftHost(CHAT_ID, HOST_ID);
+    const store = useComposerDraftStore.getState();
+    store.bindTarget(CHAT_ID, EPIC_ID);
+    store.setSnapshot(CHAT_ID, typed("accepted steer"), { from: 1, to: 14 });
+    const draftId = readDraftId();
+    await firstSession.flush([draftId]);
+
+    await submitComposerDraft(CHAT_ID);
+    const epochAfterSubmit = readDraft().resetEpoch;
+    expect(readDraft().content).not.toEqual(typed("accepted steer"));
+    expect(
+      useComposerDraftStore.getState().pendingSubmittedDraftDeletes[draftId],
+    ).toEqual({ hostId: HOST_ID });
+
+    releaseDraftMirrorSession(HOST_ID);
+    mountSession(log);
+    await expect.poll(() => log.rows.length).toBe(0);
+
+    expect(readDraft().content).not.toEqual(typed("accepted steer"));
+    expect(readDraft().resetEpoch).toBe(epochAfterSubmit);
+    expect(
+      useComposerDraftStore.getState().pendingSubmittedDraftDeletes[draftId],
+    ).toBeUndefined();
+  });
+
+  it("suppresses a late subscribe or cloud replay while deletion is fenced", async () => {
+    const store = useComposerDraftStore.getState();
+    store.bindTarget(CHAT_ID, EPIC_ID);
+    store.setSnapshot(CHAT_ID, typed("submitted"), { from: 1, to: 10 });
+    const draftId = readDraftId();
+    store.clearDraft(CHAT_ID);
+    store.fenceAndDetachSubmittedDraft(CHAT_ID, draftId, HOST_ID);
+    const epochAfterSubmit = readDraft().resetEpoch;
+
+    await applyIncomingDraftDocument({
+      draftId,
+      kind: "chat-composer",
+      target: { epicId: EPIC_ID, chatId: CHAT_ID, blockId: null },
+      revision: 3,
+      lastTouchedAt: 1,
+      workspace: null,
+      ownerHostId: HOST_ID,
+      origin: "own",
+      adoption: { state: "adopted", hostId: HOST_ID },
+      publication: {
+        status: "unpublished",
+        lastPublishedAt: null,
+        publishedRevision: null,
+        halted: null,
+      },
+      portable: {
+        content: typed("submitted"),
+        selection: { from: 1, to: 10 },
+        runSettings: null,
+        composerMode: "chat",
+        blobHashes: [],
+        closed: false,
+      },
+    });
+
+    expect(readDraft().content).not.toEqual(typed("submitted"));
+    expect(readDraft().resetEpoch).toBe(epochAfterSubmit);
+  });
 });
+
+function readDraft() {
+  const draft = useComposerDraftStore.getState().drafts[CHAT_ID];
+  if (draft === undefined) throw new Error("missing composer draft");
+  return draft;
+}
+
+function readDraftId(): string {
+  const draftId = readDraft().draftId;
+  if (draftId === null) throw new Error("missing composer draft id");
+  return draftId;
+}

--- a/clients/gui-app/src/lib/drafts/__tests__/draft-mirror-session.test.ts
+++ b/clients/gui-app/src/lib/drafts/__tests__/draft-mirror-session.test.ts
@@ -179,6 +179,8 @@ function createRpc(handlers: {
 function createSink(options: {
   readonly dirty: Set<string>;
   readonly writes: DraftDirtyWrite[];
+  readonly pendingDeletes?: Set<string>;
+  readonly prepareWrite?: DraftMirrorSink["prepareWrite"];
   readonly dropAbsentFromList?: DraftMirrorSink["dropAbsentFromList"];
 }): DraftMirrorSink & {
   readonly upserts: DraftDocument[];
@@ -202,6 +204,11 @@ function createSink(options: {
     scopes,
     synced,
     isDirty: (draftId) => options.dirty.has(draftId),
+    isDeletePending: (draftId) => options.pendingDeletes?.has(draftId) ?? false,
+    pendingDeleteIdsForHost: () => [...(options.pendingDeletes ?? [])],
+    completeDelete: (draftId) => {
+      options.pendingDeletes?.delete(draftId);
+    },
     applyUpsert: (document) => {
       upserts.push(document);
       return Promise.resolve();
@@ -213,7 +220,8 @@ function createSink(options: {
     rememberSynced: (draftId, hostRevision) => {
       synced.push({ draftId, hostRevision });
     },
-    prepareWrite: (_hostId, write) => Promise.resolve(write),
+    prepareWrite:
+      options.prepareWrite ?? ((_hostId, write) => Promise.resolve(write)),
     dropAbsentFromList:
       options.dropAbsentFromList ??
       ((_hostId, _listedIds) => {
@@ -568,8 +576,31 @@ describe("DraftMirrorSession", () => {
       now: () => 0,
     });
     session.start();
-    await session.deleteOnHost("d1");
+    await expect(session.deleteOnHost("d1")).resolves.toBe(true);
     expect(sink.synced).toEqual([]);
+    session.close();
+    await expect(session.deleteOnHost("d1")).resolves.toBe(false);
+  });
+
+  it("treats a missing drafts.delete capability as a completed deletion", async () => {
+    const pendingDeletes = new Set(["d1"]);
+    const session = new DraftMirrorSession({
+      hostId: HOST_ID,
+      rpc: createRpc({
+        list: () => Promise.resolve(listResponse([], 1, [])),
+        upsert: (write) =>
+          Promise.resolve({
+            draft: landingDocument({ draftId: write.draftId, revision: 1 }),
+          }),
+        delete: () => Promise.reject(unsupportedError("drafts.delete")),
+      }),
+      streamClient: createStreamHarness().client,
+      sink: createSink({ dirty: new Set(), writes: [], pendingDeletes }),
+      timing: { debounceMs: 0, maxWaitMs: 0 },
+      now: () => 0,
+    });
+    await expect(session.deleteOnHost("d1")).resolves.toBe(true);
+    expect(pendingDeletes).toEqual(new Set());
   });
 
   it("does not erase a composer draft synced to host A when host B bootstraps", async () => {
@@ -606,6 +637,9 @@ describe("DraftMirrorSession", () => {
     let hostBDropped = false;
     const sink: DraftMirrorSink = {
       isDirty: (draftId) => composerDraftIsDirty(draftId),
+      isDeletePending: () => false,
+      pendingDeleteIdsForHost: () => [],
+      completeDelete: () => undefined,
       applyUpsert: (document) => {
         applyComposerHostDocument(document);
         return Promise.resolve();
@@ -743,6 +777,9 @@ describe("DraftMirrorSession", () => {
     const boundHostByChatId = new Map([["chat-x", HOST_ID]]);
     const sink: DraftMirrorSink = {
       isDirty: (draftId) => composerDraftIsDirty(draftId),
+      isDeletePending: () => false,
+      pendingDeleteIdsForHost: () => [],
+      completeDelete: () => undefined,
       applyUpsert: (document) => {
         applyComposerHostDocument(document);
         return Promise.resolve();
@@ -836,12 +873,106 @@ describe("DraftMirrorSession", () => {
     useComposerDraftStore.setState({ drafts: {} });
   });
 
+  it("orders deletion behind an already-dispatched upsert", async () => {
+    let finishUpsert: () => void = () => {
+      throw new Error("upsert did not start");
+    };
+    const order: string[] = [];
+    const write = landingWrite("ordered", 0);
+    const sink = createSink({
+      dirty: new Set([write.draftId]),
+      writes: [{ write, generation: 1 }],
+    });
+    const session = new DraftMirrorSession({
+      hostId: HOST_ID,
+      rpc: createRpc({
+        list: () => Promise.resolve(listResponse([], 1, [])),
+        upsert: async () => {
+          order.push("upsert-start");
+          await new Promise<void>((resolve) => {
+            finishUpsert = resolve;
+          });
+          order.push("upsert-end");
+          return {
+            draft: landingDocument({ draftId: write.draftId, revision: 1 }),
+          };
+        },
+        delete: () => {
+          order.push("delete");
+          return Promise.resolve({ deleted: true });
+        },
+      }),
+      streamClient: createStreamHarness().client,
+      sink,
+      timing: { debounceMs: 0, maxWaitMs: 0 },
+      now: () => 0,
+    });
+    session.start();
+    await vi.waitFor(() => expect(order).toEqual(["upsert-start"]));
+    const deleting = session.deleteOnHost(write.draftId);
+    await Promise.resolve();
+    expect(order).toEqual(["upsert-start"]);
+    finishUpsert();
+    await deleting;
+    expect(order).toEqual(["upsert-start", "upsert-end", "delete"]);
+    session.close();
+  });
+
+  it("drops a collected write when submission fences it during preparation", async () => {
+    let finishPrepare: () => void = () => {
+      throw new Error("prepare did not start");
+    };
+    let prepareStarted = false;
+    const pendingDeletes = new Set<string>();
+    const write = landingWrite("collected-before-submit", 0);
+    let upsertCount = 0;
+    const sink = createSink({
+      dirty: new Set([write.draftId]),
+      writes: [{ write, generation: 1 }],
+      pendingDeletes,
+      prepareWrite: async (_hostId, prepared) => {
+        prepareStarted = true;
+        await new Promise<void>((resolve) => {
+          finishPrepare = resolve;
+        });
+        return prepared;
+      },
+    });
+    const session = new DraftMirrorSession({
+      hostId: HOST_ID,
+      rpc: createRpc({
+        list: () => Promise.resolve(listResponse([], 1, [])),
+        upsert: () => {
+          upsertCount += 1;
+          return Promise.resolve({
+            draft: landingDocument({ draftId: write.draftId, revision: 1 }),
+          });
+        },
+        delete: () => Promise.resolve({ deleted: true }),
+      }),
+      streamClient: createStreamHarness().client,
+      sink,
+      timing: { debounceMs: 0, maxWaitMs: 0 },
+      now: () => 0,
+    });
+    session.start();
+    await vi.waitFor(() => expect(prepareStarted).toBe(true));
+    pendingDeletes.add(write.draftId);
+    finishPrepare();
+    await vi.waitFor(() => expect(sink.synced).toEqual([]));
+    expect(upsertCount).toBe(0);
+    session.close();
+  });
+
   it("upserts a landing draft created after bootstrap by adopting on the sync path", async () => {
     resetDraftMirrorCoordinatorForTests();
     useLandingDraftStore.setState({ drafts: [], activeDraftId: null });
     bindLandingAdoptionHost(HOST_ID);
     const upserted: string[] = [];
     const sink: DraftMirrorSink = {
+      isDeletePending: () => false,
+      pendingDeleteIdsForHost: () => [],
+      completeDelete: () => undefined,
       isDirty: (draftId) => landingDraftIsDirty(draftId),
       applyUpsert: () => Promise.resolve(),
       applyDelete: () => undefined,

--- a/clients/gui-app/src/lib/drafts/__tests__/draft-stash-sync.test.ts
+++ b/clients/gui-app/src/lib/drafts/__tests__/draft-stash-sync.test.ts
@@ -11,6 +11,7 @@ import { stashDraftWrite } from "@/lib/drafts/draft-write-codec";
 import { installFreshIndexedDb } from "@/lib/composer/__tests__/prompt-stash-fake-idb";
 import { usePromptStashStore } from "@/stores/composer/prompt-stash-store";
 import { fakeDraftStreamClient } from "@/lib/drafts/__tests__/draft-mirror-test-stream";
+import { useComposerDraftStore } from "@/stores/composer/composer-draft-store";
 
 const HOST_ID = "host-stash";
 const EMPTY_DOC = {
@@ -97,6 +98,9 @@ describe("stash host sync", () => {
 
     await deleteStashEntryOnHost(HOST_ID, "stash-1");
     expect(deletes).toEqual(["stash-1", "stash-1"]);
+    expect(
+      useComposerDraftStore.getState().pendingSubmittedDraftDeletes,
+    ).toEqual({});
   });
 
   it("keeps the stash host binding when delete fails so a retry still reaches the row", async () => {

--- a/clients/gui-app/src/lib/drafts/draft-mirror-coordinator.ts
+++ b/clients/gui-app/src/lib/drafts/draft-mirror-coordinator.ts
@@ -38,8 +38,11 @@ import {
   collectComposerDirtyWrites,
   composerDraftIsDirty,
   composerDraftRememberSynced,
+  composerSubmittedDraftDeleteIsPending,
   dropComposerAbsentFromList,
   findComposerChatIdByDraftId,
+  pendingSubmittedDraftDeleteHostId,
+  pendingSubmittedDraftDeleteIdsForHost,
   readComposerDraftSnapshot,
   useComposerDraftStore,
 } from "@/stores/composer/composer-draft-store";
@@ -332,10 +335,20 @@ const sink: DraftMirrorSink = {
       newChatDraftIsDirty(draftId)
     );
   },
+  isDeletePending(draftId) {
+    return composerSubmittedDraftDeleteIsPending(draftId);
+  },
+  pendingDeleteIdsForHost(hostId) {
+    return pendingSubmittedDraftDeleteIdsForHost(hostId);
+  },
+  completeDelete(draftId) {
+    useComposerDraftStore.getState().completeSubmittedDraftDelete(draftId);
+  },
   applyUpsert(document) {
     return applyHostDocument(document);
   },
   applyDelete(draftId) {
+    useComposerDraftStore.getState().completeSubmittedDraftDelete(draftId);
     applyLandingHostDelete(draftId);
     applyComposerHostDelete(draftId);
     applyInterviewHostDelete(draftId);
@@ -374,6 +387,10 @@ const sink: DraftMirrorSink = {
 };
 
 async function applyHostDocument(document: DraftDocument): Promise<void> {
+  if (composerSubmittedDraftDeleteIsPending(document.draftId)) {
+    await retrySubmittedDraftDelete(document.draftId);
+    return;
+  }
   const client = sessionClients.get(document.ownerHostId);
   const hashes = blobHashesOfDocument(document);
   if (client !== undefined && hashes.length > 0) {
@@ -533,6 +550,8 @@ function warnUnboundInterviewTarget(
 }
 
 function hostIdForDraft(draftId: string): string | null {
+  const pendingDeleteHostId = pendingSubmittedDraftDeleteHostId(draftId);
+  if (pendingDeleteHostId !== null) return pendingDeleteHostId;
   const landing = useLandingDraftStore
     .getState()
     .drafts.find((draft) => draft.id === draftId);
@@ -743,20 +762,27 @@ export function draftMirrorSessionCountForTests(): number {
 
 export async function submitComposerDraft(chatId: string): Promise<void> {
   const before = readComposerDraftSnapshot(chatId);
+  const hostId =
+    before.draftId === null ? null : hostIdForDraft(before.draftId);
   const store = useComposerDraftStore.getState();
   store.clearDraft(chatId);
-  if (before.draftId === null) return;
-  // Resolve the session while the id is still on the row - `sessionForDraft`
-  // finds it through the store.
-  const session = sessionForDraft(before.draftId);
+  if (before.draftId === null || hostId === null) return;
   // Then retire the id. `clearDraft` keeps it, so an edit made during the
   // flush/delete round-trip below would be published under the id this
   // function is about to tombstone, and the tombstone would mark that
   // content synced. The next edit mints a fresh id and a fresh host row.
-  store.detachSubmittedDraft(chatId);
-  if (session === null) return;
-  await session.flush([before.draftId]);
-  await session.deleteOnHost(before.draftId);
+  store.fenceAndDetachSubmittedDraft(chatId, before.draftId, hostId);
+  await retrySubmittedDraftDelete(before.draftId);
+}
+
+async function retrySubmittedDraftDelete(draftId: string): Promise<void> {
+  const hostId = pendingSubmittedDraftDeleteHostId(draftId);
+  if (hostId === null) return;
+  const session = sessions.get(hostId)?.session;
+  if (session === undefined) return;
+  if (await session.deleteOnHost(draftId)) {
+    useComposerDraftStore.getState().completeSubmittedDraftDelete(draftId);
+  }
 }
 
 export function collectDraftMirrorDirtyWrites(

--- a/clients/gui-app/src/lib/drafts/draft-mirror-session.ts
+++ b/clients/gui-app/src/lib/drafts/draft-mirror-session.ts
@@ -25,6 +25,9 @@ export interface DraftDirtyWrite {
 
 export interface DraftMirrorSink {
   isDirty(draftId: string): boolean;
+  isDeletePending(draftId: string): boolean;
+  pendingDeleteIdsForHost(hostId: string): readonly string[];
+  completeDelete(draftId: string): void;
   applyUpsert(document: DraftDocument): Promise<void>;
   applyDelete(draftId: string): void;
   collectDirtyWrites(hostId: string): Promise<readonly DraftDirtyWrite[]>;
@@ -112,6 +115,7 @@ export class DraftMirrorSession {
    * restarts its own generation counter (a re-created row) is unaffected.
    */
   private readonly sendChain = new Map<string, PendingSend>();
+  private readonly deleteChain = new Map<string, Promise<boolean>>();
 
   private snapshotSeq = 0;
   private listedScopeId: string | null = null;
@@ -217,9 +221,24 @@ export class DraftMirrorSession {
    * can still find the row.
    */
   async deleteOnHost(draftId: string): Promise<boolean> {
+    const outstanding = this.deleteChain.get(draftId);
+    if (outstanding !== undefined) return outstanding;
+    const deleting = this.runDeleteOnHost(draftId).finally(() => {
+      if (this.deleteChain.get(draftId) === deleting) {
+        this.deleteChain.delete(draftId);
+      }
+    });
+    this.deleteChain.set(draftId, deleting);
+    return deleting;
+  }
+
+  private async runDeleteOnHost(draftId: string): Promise<boolean> {
+    this.clearTimer(draftId);
+    // An upsert may already have passed its send-time fence. Serialize the
+    // tombstone behind it so the host can never observe create-after-delete.
+    await this.sendChain.get(draftId)?.promise;
     if (this.closed) return false;
     if (this.capabilityMissing) return true;
-    this.clearTimer(draftId);
     try {
       const response = await this.rpc.delete(draftId);
       if (!response.deleted) return true;
@@ -295,6 +314,7 @@ export class DraftMirrorSession {
       // Tombstone ids are in `listedIds` so they are not also dropped.
       this.sink.dropAbsentFromList(this.hostId, listedIds);
       if (this.streamSession === null) this.openSubscribe();
+      await this.retryPendingDeletes();
       await this.upsertDirty(null);
     } catch (error: unknown) {
       if (isDraftsCapabilityMissing(error)) {
@@ -475,8 +495,12 @@ export class DraftMirrorSession {
   private async runUpsert(entry: DraftDirtyWrite): Promise<void> {
     if (this.isAbandoned()) return;
     const draftId = entry.write.draftId;
+    if (this.sink.isDeletePending(draftId)) return;
     try {
       const prepared = await this.sink.prepareWrite(this.hostId, entry.write);
+      // Blob preparation is asynchronous. Submission can fence the row while
+      // this write is waiting there, so gate again at actual RPC dispatch.
+      if (this.isAbandoned() || this.sink.isDeletePending(draftId)) return;
       const response = await this.rpc.upsert(prepared);
       this.held.set(response.draft.draftId, {
         kind: "row",
@@ -507,6 +531,14 @@ export class DraftMirrorSession {
       // have a live retry behind it — re-arm with bounded backoff.
       if (this.sink.isDirty(draftId)) {
         this.scheduleRetry(draftId);
+      }
+    }
+  }
+
+  private async retryPendingDeletes(): Promise<void> {
+    for (const draftId of this.sink.pendingDeleteIdsForHost(this.hostId)) {
+      if (await this.deleteOnHost(draftId)) {
+        this.sink.completeDelete(draftId);
       }
     }
   }
@@ -553,6 +585,9 @@ export class DraftMirrorSession {
     this.clearAllTimers();
     this.streamSession?.close();
     this.streamSession = null;
+    for (const draftId of this.sink.pendingDeleteIdsForHost(this.hostId)) {
+      this.sink.completeDelete(draftId);
+    }
   }
 
   /**

--- a/clients/gui-app/src/stores/composer/__tests__/composer-draft-mirror.test.ts
+++ b/clients/gui-app/src/stores/composer/__tests__/composer-draft-mirror.test.ts
@@ -6,6 +6,7 @@ import {
 } from "@/lib/drafts/draft-mirror-coordinator";
 import {
   collectComposerDirtyWrites,
+  applyComposerHostDelete,
   dropComposerAbsentFromList,
   useComposerDraftStore,
 } from "@/stores/composer/composer-draft-store";
@@ -24,12 +25,18 @@ const TYPED = {
 
 describe("composer draft host-mirror bookkeeping", () => {
   beforeEach(() => {
-    useComposerDraftStore.setState({ drafts: {} });
+    useComposerDraftStore.setState({
+      drafts: {},
+      pendingSubmittedDraftDeletes: {},
+    });
     resetDraftMirrorCoordinatorForTests();
   });
 
   afterEach(() => {
-    useComposerDraftStore.setState({ drafts: {} });
+    useComposerDraftStore.setState({
+      drafts: {},
+      pendingSubmittedDraftDeletes: {},
+    });
     resetDraftMirrorCoordinatorForTests();
   });
 
@@ -76,5 +83,22 @@ describe("composer draft host-mirror bookkeeping", () => {
     expect(draft?.content).toEqual(TYPED);
     expect(draft?.resetEpoch).toBe(3);
     expect(draft?.hostRevision).toBe(4);
+  });
+
+  it("clears a stale second-window editor when the host delete frame arrives", () => {
+    useComposerDraftStore.getState().setSnapshot("chat-window-b", TYPED, {
+      from: 1,
+      to: 8,
+    });
+    const before = useComposerDraftStore.getState().drafts["chat-window-b"];
+    if (before?.draftId === null || before?.draftId === undefined) {
+      throw new Error("missing draft id");
+    }
+
+    applyComposerHostDelete(before.draftId);
+
+    const after = useComposerDraftStore.getState().drafts["chat-window-b"];
+    expect(after?.content).toEqual(EMPTY);
+    expect(after?.resetEpoch).toBe(before.resetEpoch + 1);
   });
 });

--- a/clients/gui-app/src/stores/composer/__tests__/composer-draft-store-hydration.test.ts
+++ b/clients/gui-app/src/stores/composer/__tests__/composer-draft-store-hydration.test.ts
@@ -55,7 +55,10 @@ beforeEach(() => {
 });
 afterEach(() => {
   window.localStorage.clear();
-  useComposerDraftStore.setState({ drafts: {} });
+  useComposerDraftStore.setState({
+    drafts: {},
+    pendingSubmittedDraftDeletes: {},
+  });
 });
 
 const EMPTY_DOC: DraftState["content"] = {
@@ -174,6 +177,33 @@ describe("composer draft store hydration", () => {
       origin: null,
       publication: null,
     });
+  });
+
+  it("rehydrates a submitted-draft deletion fence after renderer restart", async () => {
+    useComposerDraftStore
+      .getState()
+      .setSnapshot("chat-fenced", MENTION_DRAFT.content, null);
+    const draftId =
+      useComposerDraftStore.getState().drafts["chat-fenced"]?.draftId;
+    if (draftId === null || draftId === undefined) {
+      throw new Error("draft id was not minted");
+    }
+    useComposerDraftStore
+      .getState()
+      .fenceAndDetachSubmittedDraft("chat-fenced", draftId, "host-a");
+    const persisted = window.localStorage.getItem(STORAGE_KEY);
+    expect(persisted).not.toBeNull();
+
+    useComposerDraftStore.setState({
+      drafts: {},
+      pendingSubmittedDraftDeletes: {},
+    });
+    if (persisted !== null) window.localStorage.setItem(STORAGE_KEY, persisted);
+    await useComposerDraftStore.persist.rehydrate();
+
+    expect(
+      useComposerDraftStore.getState().pendingSubmittedDraftDeletes[draftId],
+    ).toEqual({ hostId: "host-a" });
   });
 });
 

--- a/clients/gui-app/src/stores/composer/composer-draft-store.ts
+++ b/clients/gui-app/src/stores/composer/composer-draft-store.ts
@@ -70,8 +70,15 @@ export interface DraftState {
   readonly publication: DraftPublication | null;
 }
 
+export interface PendingSubmittedDraftDelete {
+  readonly hostId: string;
+}
+
 interface ComposerDraftStore {
   readonly drafts: Partial<Record<string, DraftState>>;
+  readonly pendingSubmittedDraftDeletes: Partial<
+    Record<string, PendingSubmittedDraftDelete>
+  >;
   /**
    * Records a real document mutation - callers must only invoke this from the
    * editor boundary's document-change signal (never a selection-only echo),
@@ -138,7 +145,12 @@ interface ComposerDraftStore {
    * one and a fresh host row. The row is left CLEAN because it is empty and
    * its old id is on its way out; nothing is owed to the host.
    */
-  readonly detachSubmittedDraft: (chatId: string) => void;
+  readonly fenceAndDetachSubmittedDraft: (
+    chatId: string,
+    draftId: string,
+    hostId: string,
+  ) => void;
+  readonly completeSubmittedDraftDelete: (draftId: string) => void;
   readonly bindTarget: (chatId: string, epicId: string) => void;
 }
 const EMPTY_COMPOSER_CONTENT: JsonContent = {
@@ -175,9 +187,9 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
 
-function hasDraftMap(
-  value: unknown,
-): value is { readonly drafts: Record<string, unknown> } {
+function hasDraftMap(value: unknown): value is Record<string, unknown> & {
+  readonly drafts: Record<string, unknown>;
+} {
   return isRecord(value) && isRecord(value.drafts);
 }
 
@@ -195,6 +207,7 @@ export const useComposerDraftStore = create<ComposerDraftStore>()(
   persist(
     (set, get) => ({
       drafts: {},
+      pendingSubmittedDraftDeletes: {},
       setSnapshot: (chatId, content, selection) => {
         const draftId = touchLocalComposerDraft(chatId, {
           content,
@@ -309,11 +322,15 @@ export const useComposerDraftStore = create<ComposerDraftStore>()(
         );
         scheduleLandingImageReconcile();
       },
-      detachSubmittedDraft: (chatId) => {
+      fenceAndDetachSubmittedDraft: (chatId, draftId, hostId) => {
         set((state) => {
           const current = ensureDraft(state.drafts, chatId);
-          if (current.draftId === null) return state;
+          if (current.draftId !== draftId) return state;
           return {
+            pendingSubmittedDraftDeletes: {
+              ...state.pendingSubmittedDraftDeletes,
+              [draftId]: { hostId },
+            },
             drafts: {
               ...state.drafts,
               [chatId]: {
@@ -327,6 +344,18 @@ export const useComposerDraftStore = create<ComposerDraftStore>()(
               },
             },
           };
+        });
+      },
+      completeSubmittedDraftDelete: (draftId) => {
+        set((state) => {
+          if (state.pendingSubmittedDraftDeletes[draftId] === undefined) {
+            return state;
+          }
+          const pendingSubmittedDraftDeletes = {
+            ...state.pendingSubmittedDraftDeletes,
+          };
+          delete pendingSubmittedDraftDeletes[draftId];
+          return { pendingSubmittedDraftDeletes };
         });
       },
       bindTarget: (chatId, epicId) => {
@@ -355,9 +384,7 @@ export const useComposerDraftStore = create<ComposerDraftStore>()(
       // before an `onFinishHydration` subscriber can be registered. Normalize
       // at the merge boundary so legacy revisions are safe on initial import.
       merge: (persistedState, currentState) => {
-        if (!hasDraftMap(persistedState)) {
-          return currentState;
-        }
+        if (!hasDraftMap(persistedState)) return currentState;
         const drafts: Partial<Record<string, DraftState>> = {};
         for (const [taskId, value] of Object.entries(persistedState.drafts)) {
           if (!isRecord(value)) continue;
@@ -387,7 +414,20 @@ export const useComposerDraftStore = create<ComposerDraftStore>()(
             publication: null,
           };
         }
-        return { ...currentState, drafts };
+        const pendingSubmittedDraftDeletes: Partial<
+          Record<string, PendingSubmittedDraftDelete>
+        > = {};
+        if (isRecord(persistedState.pendingSubmittedDraftDeletes)) {
+          for (const [draftId, value] of Object.entries(
+            persistedState.pendingSubmittedDraftDeletes,
+          )) {
+            if (!isRecord(value)) continue;
+            const hostId = normalizedNullableId(value.hostId);
+            if (draftId.length === 0 || hostId === null) continue;
+            pendingSubmittedDraftDeletes[draftId] = { hostId };
+          }
+        }
+        return { ...currentState, drafts, pendingSubmittedDraftDeletes };
       },
     },
   ),
@@ -467,6 +507,34 @@ export function composerDraftIsDirty(draftId: string): boolean {
   const draft = findComposerDraftById(draftId);
   if (draft === null) return false;
   return draft.generation > draft.syncedGeneration;
+}
+
+export function composerSubmittedDraftDeleteIsPending(
+  draftId: string,
+): boolean {
+  return (
+    useComposerDraftStore.getState().pendingSubmittedDraftDeletes[draftId] !==
+    undefined
+  );
+}
+
+export function pendingSubmittedDraftDeleteHostId(
+  draftId: string,
+): string | null {
+  return (
+    useComposerDraftStore.getState().pendingSubmittedDraftDeletes[draftId]
+      ?.hostId ?? null
+  );
+}
+
+export function pendingSubmittedDraftDeleteIdsForHost(
+  hostId: string,
+): readonly string[] {
+  return Object.entries(
+    useComposerDraftStore.getState().pendingSubmittedDraftDeletes,
+  ).flatMap(([draftId, pending]) =>
+    pending?.hostId === hostId ? [draftId] : [],
+  );
 }
 
 export function composerDraftRememberSynced(


### PR DESCRIPTION
## Summary

- persist submitted composer draft deletion intent across renderer and host-session restarts
- suppress fenced draft replay and send-time upserts, while ordering deletion behind any in-flight upsert
- retry deletion on bootstrap and fenced-row sightings without affecting stash deletion

## Regression coverage

Covers delete transport failure/reconnect, in-flight and pre-collected upsert races, late replay, persisted restart recovery, fresh next-draft IDs, delete completion semantics, stash isolation, and second-window convergence.

## Validation

- pre-commit: affected build, compile, lint, and format passed
- focused Vitest: 5 files, 36 tests passed

## Stack

Targets #1586 (`traycer/electric-leopard`) so the staging drafts fix can land on the active cross-device drafts train.