### PR TITLE
fix(gui-app): open modified links externally

### DIFF
--- a/clients/gui-app/src/lib/browser-view/link-routing/__tests__/browser-link-routing.test.ts
+++ b/clients/gui-app/src/lib/browser-view/link-routing/__tests__/browser-link-routing.test.ts
@@ -144,7 +144,7 @@ describe("browser link routing", () => {
         source,
         kind: "markdown",
         url: "https://example.test/markdown-alt",
-        event: { altKey: true },
+        event: { altKey: true, ctrlKey: false, metaKey: false },
         openInApp,
       }),
     ).toBe("in-app");
@@ -154,7 +154,7 @@ describe("browser link routing", () => {
         source,
         kind: "terminal",
         url: "https://example.test/terminal-alt",
-        event: { altKey: true },
+        event: { altKey: true, ctrlKey: false, metaKey: false },
         openInApp,
       }),
     ).toBe("external");
@@ -164,6 +164,30 @@ describe("browser link routing", () => {
       source,
       "https://example.test/markdown-alt",
     );
+  });
+
+  it.each([
+    ["Command", { metaKey: true, ctrlKey: false, altKey: false }],
+    ["Control", { metaKey: false, ctrlKey: true, altKey: false }],
+  ])("opens %s-clicked web links externally", (_modifier, event) => {
+    const source = seedCanvas(SOURCE_TILE);
+    const runnerHost = mockRunnerHost();
+    const openInApp = vi.fn(() => true);
+
+    const result = routeBrowserLink({
+      runnerHost,
+      source,
+      kind: "markdown",
+      url: "https://example.test/docs",
+      event,
+      openInApp,
+    });
+
+    expect(result).toBe("external");
+    expect(runnerHost.openExternalLink).toHaveBeenCalledWith(
+      "https://example.test/docs",
+    );
+    expect(openInApp).not.toHaveBeenCalled();
   });
 
   it("records terminal dev-server origins from URL output only", () => {

--- a/clients/gui-app/src/lib/browser-view/link-routing/browser-link-routing-core.ts
+++ b/clients/gui-app/src/lib/browser-view/link-routing/browser-link-routing-core.ts
@@ -19,6 +19,8 @@ export interface BrowserLinkSource {
 
 export interface BrowserLinkClickEvent {
   readonly altKey: boolean;
+  readonly ctrlKey: boolean;
+  readonly metaKey: boolean;
 }
 
 /**
@@ -66,6 +68,11 @@ export function routeBrowserLink(
   const webUrl = parsed.href;
 
   if (args.source === null) {
+    void args.runnerHost.openExternalLink(webUrl);
+    return "external";
+  }
+
+  if (args.event?.metaKey === true || args.event?.ctrlKey === true) {
     void args.runnerHost.openExternalLink(webUrl);
     return "external";
   }


### PR DESCRIPTION
## Summary

- route Command-clicked and Ctrl-clicked web links to the system browser
- apply the behavior consistently to Markdown and terminal links through the shared browser-link router
- preserve normal-click settings and the existing Alt-click mode override

## Verification

- focused browser-link routing tests pass
- Markdown anchor and terminal link integration tests pass
- pre-commit affected build, compile, lint, and format checks pass
- DCO sign-off present