### PR TITLE
fix(worktrees): link single-task sweep notifications

### DIFF
--- a/clients/gui-app/src/components/epics/sweep-worktrees-dialog.tsx
+++ b/clients/gui-app/src/components/epics/sweep-worktrees-dialog.tsx
@@ -271,6 +271,7 @@ export function SweepWorktreesDialog(props: SweepWorktreesDialogProps) {
     setInventoryChanged(false);
     startSweepKickoff({
       hostId,
+      epicId: epicIds?.length === 1 ? epicIds[0] : undefined,
       targets,
       mutate: sweepMutation.mutate,
       onClose: () => onOpenChange(false),
@@ -554,6 +555,7 @@ function startSweepPrimary(input: {
 
 function startSweepKickoff(input: {
   readonly hostId: string | null;
+  readonly epicId: string | undefined;
   readonly targets: ReadonlyArray<EpicSweepWorktreeRow>;
   readonly mutate: ReturnType<typeof useEpicSweepWorktrees>["mutate"];
   readonly onClose: () => void;
@@ -563,6 +565,7 @@ function startSweepKickoff(input: {
   input.mutate(
     {
       hostId: input.hostId,
+      epicId: input.epicId,
       worktrees: input.targets.map((row) => ({
         worktreePath: row.entry.worktreePath,
         branch: row.entry.branch,

--- a/clients/gui-app/src/components/settings/panels/use-worktree-delete-run.ts
+++ b/clients/gui-app/src/components/settings/panels/use-worktree-delete-run.ts
@@ -763,6 +763,7 @@ function startWorktreeDeleteCommand(
           wsStreamClient,
           commandId,
           source: "settings",
+          epicId: undefined,
           targets: batchTargets.map((item) => ({
             worktreePath: item.target.worktreePath,
             scripts: item.scripts,

--- a/clients/gui-app/src/hooks/epic/use-epic-batch-delete-mutation.ts
+++ b/clients/gui-app/src/hooks/epic/use-epic-batch-delete-mutation.ts
@@ -172,6 +172,7 @@ export function useEpicBatchDelete(): UseMutationResult<
             hostId,
             paths: eligibleWorktreePaths,
             source: "task_cleanup",
+            epicId: undefined,
             stopOwnersPaths: new Set(),
             expectedHoldersRevisionByPath: new Map(),
           }).then((outcome) => {

--- a/clients/gui-app/src/hooks/epic/use-epic-sweep-worktrees-mutation.ts
+++ b/clients/gui-app/src/hooks/epic/use-epic-sweep-worktrees-mutation.ts
@@ -47,6 +47,8 @@ export interface SweepTargetWorktree {
 export interface SweepWorktreesVariables {
   /** Host on which the dialog's act-time safety proof was computed. */
   readonly hostId: string;
+  /** The one Task that initiated the sweep; absent for bulk Task sweeps. */
+  readonly epicId?: string;
   readonly worktrees: ReadonlyArray<SweepTargetWorktree>;
 }
 
@@ -111,6 +113,7 @@ export function useEpicSweepWorktrees(): UseMutationResult<
         hostId: variables.hostId,
         paths: variables.worktrees.map((target) => target.worktreePath),
         source: "task_sweep",
+        epicId: variables.epicId,
         stopOwnersPaths,
         expectedHoldersRevisionByPath,
       });

--- a/clients/gui-app/src/lib/epics/__tests__/run-worktree-cleanup.test.ts
+++ b/clients/gui-app/src/lib/epics/__tests__/run-worktree-cleanup.test.ts
@@ -20,6 +20,7 @@ const commandMock = vi.hoisted(() => ({
   commands: [] as Array<{
     readonly commandId: string;
     readonly source: string;
+    readonly epicId: string | undefined;
     readonly targets: ReadonlyArray<WorktreeDeleteBatchTarget>;
   }>,
   callbacks: null as WorktreeDeleteBatchStreamCallbacks | null,
@@ -65,12 +66,14 @@ vi.mock(
       constructor(options: {
         readonly commandId: string;
         readonly source: string;
+        readonly epicId: string | undefined;
         readonly targets: ReadonlyArray<WorktreeDeleteBatchTarget>;
         readonly callbacks: WorktreeDeleteBatchStreamCallbacks;
       }) {
         commandMock.commands.push({
           commandId: options.commandId,
           source: options.source,
+          epicId: options.epicId,
           targets: options.targets,
         });
         commandMock.callbacks = options.callbacks;
@@ -226,12 +229,16 @@ describe("runWorktreeCleanup on a current host", () => {
       hostId: "host-1",
       paths: ["/wt/sweep"],
       source: "task_sweep",
+      epicId: "epic-1",
       stopOwnersPaths: new Set(),
       expectedHoldersRevisionByPath: new Map(),
     });
 
     expect(commandMock.commands).toHaveLength(1);
-    expect(commandMock.commands[0]?.source).toBe("task_sweep");
+    expect(commandMock.commands[0]).toMatchObject({
+      source: "task_sweep",
+      epicId: "epic-1",
+    });
     commandCallbacks().onTargetComplete("/wt/sweep", true);
     commandCallbacks().onCommandComplete({
       requestedCount: 1,

--- a/clients/gui-app/src/lib/epics/run-worktree-cleanup.ts
+++ b/clients/gui-app/src/lib/epics/run-worktree-cleanup.ts
@@ -79,6 +79,7 @@ export interface WorktreeCleanupRequest {
   readonly hostId: string;
   readonly paths: ReadonlyArray<string>;
   readonly source: WorktreeDeletionSource;
+  readonly epicId?: string;
   readonly stopOwnersPaths: ReadonlySet<string>;
   readonly expectedHoldersRevisionByPath: ReadonlyMap<string, string>;
 }
@@ -97,12 +98,12 @@ export function runWorktreeCleanup(
     (path) => !request.stopOwnersPaths.has(path),
   );
   if (forcePaths.length === 0) {
-    return runCleanupCommand(
-      openStreamTransport,
-      request.hostId,
-      normalPaths,
-      request.source,
-    );
+    return runCleanupCommand(openStreamTransport, {
+      hostId: request.hostId,
+      paths: normalPaths,
+      source: request.source,
+      epicId: request.epicId,
+    });
   }
   // Force paths first: a HOLDERS_CHANGED refusal must not start the batch
   // delete of the remaining selection.
@@ -116,12 +117,12 @@ export function runWorktreeCleanup(
     if (force.holdersChanged.length > 0 || normalPaths.length === 0) {
       return force;
     }
-    return runCleanupCommand(
-      openStreamTransport,
-      request.hostId,
-      normalPaths,
-      request.source,
-    ).then((normal) => ({
+    return runCleanupCommand(openStreamTransport, {
+      hostId: request.hostId,
+      paths: normalPaths,
+      source: request.source,
+      epicId: request.epicId,
+    }).then((normal) => ({
       removed: [...normal.removed, ...force.removed],
       failed: [...normal.failed, ...force.failed],
       uncertain: [...normal.uncertain, ...force.uncertain],
@@ -143,10 +144,14 @@ export function runWorktreeCleanup(
  */
 function runCleanupCommand(
   openStreamTransport: (hostId: string) => DurableStreamTransport,
-  hostId: string,
-  paths: ReadonlyArray<string>,
-  source: WorktreeDeletionSource,
+  input: {
+    readonly hostId: string;
+    readonly paths: ReadonlyArray<string>;
+    readonly source: WorktreeDeletionSource;
+    readonly epicId: string | undefined;
+  },
 ): Promise<WorktreeCleanupOutcome> {
+  const { hostId, paths, source, epicId } = input;
   return new Promise<WorktreeCleanupOutcome>((resolve) => {
     const removed: string[] = [];
     const failed: string[] = [];
@@ -250,6 +255,7 @@ function runCleanupCommand(
             wsStreamClient,
             commandId: crypto.randomUUID(),
             source,
+            epicId,
             targets: paths.map((worktreePath) => ({
               worktreePath,
               scripts: null,

--- a/clients/gui-app/src/stores/notifications/__tests__/merged-notifications.test.ts
+++ b/clients/gui-app/src/stores/notifications/__tests__/merged-notifications.test.ts
@@ -756,6 +756,36 @@ describe("merged notifications feed", () => {
     });
   });
 
+  it("routes a Task sweep completion back to the Task that initiated it", () => {
+    expect(
+      rowFromHostEntry({
+        id: "worktree.deletion:command-task-sweep",
+        updatedAt: 10,
+        readAt: null,
+        kind: "host.operation.finished",
+        sourceRef: "command-task-sweep",
+        severity: "done",
+        outcome: "completed",
+        epicId: null,
+        chatId: null,
+        payload: {
+          kind: "worktree_deletion",
+          operation: "worktree.deletion",
+          title: "Worktrees deleted",
+          message: "Deleted 2 worktrees.",
+          commandId: "command-task-sweep",
+          source: "task_sweep",
+          epicId: "epic-1",
+          requestedCount: 2,
+          deletedCount: 2,
+          failedCount: 0,
+        },
+      }),
+    ).toMatchObject({
+      payload: { kind: "epic", epicId: "epic-1" },
+    });
+  });
+
   it("renders a newer host's unknown operation payload from its common fields, with no destination", () => {
     const row = rowFromHostEntry({
       id: "testbox.provision:command-2",

--- a/clients/gui-app/src/stores/notifications/merged-notifications.ts
+++ b/clients/gui-app/src/stores/notifications/merged-notifications.ts
@@ -1629,12 +1629,22 @@ function navigationPayloadFromKnown(
     // all - it renders with common-field copy and no deep link, which is the
     // designed degradation rather than a guessed destination.
     case "worktree_deletion":
-      return {
-        kind: "hostSurface",
-        surface: "worktreeSettings",
-        focus: undefined,
-      };
+      return navigationPayloadForWorktreeDeletion(known);
   }
+}
+
+function navigationPayloadForWorktreeDeletion(known: {
+  readonly source: string;
+  readonly epicId?: string;
+}): NotificationPayload {
+  if (known.source === "task_sweep" && known.epicId !== undefined) {
+    return { kind: "epic", epicId: known.epicId };
+  }
+  return {
+    kind: "hostSurface",
+    surface: "worktreeSettings",
+    focus: undefined,
+  };
 }
 
 const HOST_PAGE_LIMIT = 50;

--- a/clients/shared/host-transport/__tests__/worktree-delete-batch-stream-client.test.ts
+++ b/clients/shared/host-transport/__tests__/worktree-delete-batch-stream-client.test.ts
@@ -164,6 +164,27 @@ describe("WorktreeDeleteBatchStreamClient replay safety", () => {
     vi.useRealTimers();
   });
 
+  it("sends a Task sweep's destination only on the start request", () => {
+    const { factory, sockets } = makeFactory();
+    const client = makeClient(factory);
+    const batch = new WorktreeDeleteBatchStreamClient({
+      wsStreamClient: client,
+      commandId: COMMAND_ID,
+      source: "task_sweep",
+      epicId: "epic-1",
+      targets: [{ worktreePath: "/wt/a", scripts: null }],
+      callbacks: NOOP_CALLBACKS,
+    });
+
+    completeHandshake(sockets[0]);
+    expect(subscribeParams(sockets[0])).toMatchObject({
+      mode: "start",
+      source: "task_sweep",
+      epicId: "epic-1",
+    });
+    batch.close();
+  });
+
   it("re-subscribes as observe after a drop, so the transport can never replay the start", () => {
     const { factory, sockets } = makeFactory();
     const client = makeClient(factory);

--- a/clients/shared/host-transport/worktree-delete-batch-stream-client.ts
+++ b/clients/shared/host-transport/worktree-delete-batch-stream-client.ts
@@ -81,6 +81,7 @@ export interface WorktreeDeleteBatchStreamClientOptions {
   /** Client-minted UUID; identifies this command for single-flight reuse. */
   readonly commandId: string;
   readonly source: WorktreeDeletionSource;
+  readonly epicId?: string;
   readonly targets: ReadonlyArray<WorktreeDeleteBatchTarget>;
   readonly callbacks: WorktreeDeleteBatchStreamCallbacks;
 }
@@ -145,6 +146,7 @@ export class WorktreeDeleteBatchStreamClient {
       mode: "start",
       commandId: options.commandId,
       source: options.source,
+      ...(options.epicId === undefined ? {} : { epicId: options.epicId }),
       targets: options.targets.map((target) => ({
         worktreePath: target.worktreePath,
         scripts: target.scripts,

--- a/clients/traycer-cli/src/commands/worktree-delete.ts
+++ b/clients/traycer-cli/src/commands/worktree-delete.ts
@@ -221,6 +221,7 @@ function runDeleteCommand(
       wsStreamClient: client,
       commandId: randomUUID(),
       source: "cli",
+      epicId: undefined,
       targets: [{ worktreePath, scripts: null }],
       callbacks: {
         onTargetStarted: (_worktreePath, hasTeardown) =>

--- a/protocol/src/host/notifications/payloads.ts
+++ b/protocol/src/host/notifications/payloads.ts
@@ -307,6 +307,8 @@ export const hostNotificationWorktreeDeletionPayloadSchema = z
     /** Open string, not the wire enum: a row minted by a newer host with a
      * source this build has never heard of must still render and route. */
     source: idSchema,
+    /** Task that initiated a single-Task sweep. */
+    epicId: idSchema.optional(),
     requestedCount: z.number().int().nonnegative(),
     deletedCount: z.number().int().nonnegative(),
     failedCount: z.number().int().nonnegative(),

--- a/protocol/src/host/worktree-delete-batch-stream.ts
+++ b/protocol/src/host/worktree-delete-batch-stream.ts
@@ -127,6 +127,9 @@ export const worktreeDeleteBatchByPathOpenRequestSchema = z.discriminatedUnion(
       mode: z.literal("start"),
       commandId: commandIdSchema,
       source: worktreeDeletionSourceSchema,
+      /** Task that initiated a single-Task sweep. Absent when there is no
+       * single durable Task destination for the completion notification. */
+      epicId: z.string().min(1).optional(),
       /**
        * Every approved target, in one request. Paths must be unique: the frame
        * tagging keys off `worktreePath`, and a repeated path would make two


### PR DESCRIPTION
## Summary

- carry the originating Task id through the batch worktree deletion command
- route single-Task sweep notifications back to that Task
- retain global notification behavior for Settings, CLI, cleanup, and multi-Task sweeps

## Related issue

None.

## Checklist

- [x] Pre-commit static checks pass (`pre-commit run --all-files` for an explicit full-repo run)
- [x] Separate CI test checks pass
- [x] Tests added/updated where it makes sense
- [x] Commits are signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#developer-certificate-of-origin-dco)