### PR TITLE
fix(gui): compare artifact history to recorded parents

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/artifact-version-history.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/artifact-version-history.test.tsx
@@ -938,6 +938,128 @@ describe("<ArtifactVersionHistoryEntryPoint />", () => {
       screen.getByText("The saved body for this version is missing."),
     ).toBeTruthy();
   });
+
+  it("compares a version against its resolvable parent", () => {
+    const parent = {
+      ...observation("observation-parent", "Parent snapshot"),
+      contentHash: HASH_A,
+    };
+    const child = {
+      ...observation("observation-child", "Child snapshot"),
+      contentHash: HASH_B,
+      parentContentHash: HASH_A,
+    };
+    state.historyEntries = [child, parent];
+    state.blobByObservationId.set("observation-parent", {
+      contentHash: HASH_A,
+      markdown: "parent body",
+    });
+    state.blobByObservationId.set("observation-child", {
+      contentHash: HASH_B,
+      markdown: "child body",
+    });
+
+    openHistory();
+
+    expect(screen.getByText("Compared with parent version")).toBeTruthy();
+    expect(
+      state.queryCalls.some(
+        (call) =>
+          call.method === "epic.artifactVersions.getBlob" &&
+          call.options.enabled &&
+          call.params.observationId === "observation-parent" &&
+          call.cacheKeyIdentity?.[0] === HASH_A,
+      ),
+    ).toBe(true);
+  });
+
+  it("shows an exact Initial version state for a root version and never requests an adjacent comparison", () => {
+    const root = observation("observation-root", "Root snapshot");
+    const other = {
+      ...observation("observation-other", "Other snapshot"),
+      contentHash: HASH_B,
+    };
+    state.historyEntries = [root, other];
+    state.blobByObservationId.set("observation-root", {
+      contentHash: HASH_A,
+      markdown: "root body",
+    });
+    state.blobByObservationId.set("observation-other", {
+      contentHash: HASH_B,
+      markdown: "other body",
+    });
+
+    openHistory();
+
+    expect(screen.getByText("Initial version")).toBeTruthy();
+    expect(screen.queryByText("Parent version unavailable")).toBeNull();
+    const diffContent = screen.getByTestId("diff-content");
+    expect(diffContent.textContent).toContain("root body");
+    expect(diffContent.textContent).not.toContain("other body");
+    expect(
+      state.queryCalls.some(
+        (call) =>
+          call.method === "epic.artifactVersions.getBlob" &&
+          call.params.observationId === "observation-other",
+      ),
+    ).toBe(false);
+    expect(
+      state.queryCalls.some(
+        (call) =>
+          call.method === "epic.artifactVersions.getBlob" &&
+          call.params.observationId === "unselected" &&
+          !call.options.enabled,
+      ),
+    ).toBe(true);
+  });
+
+  it("shows a parent-unavailable state and never falls back to an adjacent entry", () => {
+    const missingParentHash = "c".repeat(64);
+    const orphan = {
+      ...observation("observation-orphan", "Orphan snapshot"),
+      contentHash: HASH_B,
+      parentContentHash: missingParentHash,
+    };
+    const adjacent = {
+      ...observation("observation-adjacent", "Adjacent snapshot"),
+      contentHash: HASH_A,
+    };
+    state.historyEntries = [orphan, adjacent];
+    state.blobByObservationId.set("observation-orphan", {
+      contentHash: HASH_B,
+      markdown: "orphan body",
+    });
+    state.blobByObservationId.set("observation-adjacent", {
+      contentHash: HASH_A,
+      markdown: "adjacent body",
+    });
+
+    openHistory();
+
+    expect(screen.getByText("Parent version unavailable")).toBeTruthy();
+    expect(
+      screen.getByText(
+        "This version's recorded parent is not available in the loaded history.",
+      ),
+    ).toBeTruthy();
+    expect(screen.queryByTestId("diff-content")).toBeNull();
+    expect(
+      state.queryCalls.some(
+        (call) =>
+          call.method === "epic.artifactVersions.getBlob" &&
+          call.options.enabled &&
+          call.params.observationId === "observation-adjacent",
+      ),
+    ).toBe(false);
+    expect(
+      state.queryCalls.some(
+        (call) =>
+          call.method === "epic.artifactVersions.getBlob" &&
+          call.params.observationId === "unselected" &&
+          !call.options.enabled,
+      ),
+    ).toBe(true);
+  });
 });
 
 describe("clampArtifactVersionHistoryPanelWidthPx", () => {

--- a/clients/gui-app/src/components/epic-canvas/renderers/artifact-version-history.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/artifact-version-history.tsx
@@ -268,29 +268,27 @@ function ObservationProvenanceDetail(props: {
   return <p className="px-3 pb-3 text-ui-xs text-muted-foreground">{detail}</p>;
 }
 
+type VersionComparison =
+  | {
+      readonly kind: "parent";
+      readonly entry: ArtifactVersionObservationEntry;
+    }
+  | { readonly kind: "initial" }
+  | { readonly kind: "parent_unavailable" };
+
 function comparisonFor(
   entries: readonly ArtifactVersionObservationEntry[],
   selected: ArtifactVersionObservationEntry | null,
-): {
-  readonly entry: ArtifactVersionObservationEntry;
-  readonly label: string;
-} | null {
+): VersionComparison | null {
   if (selected === null) return null;
-  if (selected.parentContentHash !== null) {
-    const parent = entries.find(
-      (entry) =>
-        entry.available && entry.contentHash === selected.parentContentHash,
-    );
-    if (parent !== undefined)
-      return { entry: parent, label: "Compared with parent version" };
-  }
-  const index = entries.findIndex(
-    (entry) => entry.observationId === selected.observationId,
+  if (selected.parentContentHash === null) return { kind: "initial" };
+  const parent = entries.find(
+    (entry) =>
+      entry.available && entry.contentHash === selected.parentContentHash,
   );
-  const previous = entries.slice(index + 1).find((entry) => entry.available);
-  return previous === undefined
-    ? null
-    : { entry: previous, label: "Compared with previous entry" };
+  return parent === undefined
+    ? { kind: "parent_unavailable" }
+    : { kind: "parent", entry: parent };
 }
 
 function mergeObservationPages(
@@ -476,14 +474,17 @@ function ArtifactVersionHistoryPanel(props: {
     params: {
       epicId: props.epicId,
       artifactId: props.artifactId,
-      observationId: comparison?.entry.observationId ?? "unselected",
+      observationId:
+        comparison?.kind === "parent"
+          ? comparison.entry.observationId
+          : "unselected",
     },
     cacheKeyIdentity:
-      comparison?.entry.contentHash === undefined
+      comparison?.kind !== "parent"
         ? undefined
         : [comparison.entry.contentHash],
     options: {
-      enabled: comparison !== null,
+      enabled: comparison?.kind === "parent",
     },
   });
 
@@ -721,12 +722,16 @@ function ArtifactVersionHistoryPanel(props: {
           <VersionDiffView
             artifactId={props.artifactId}
             selected={selected}
-            comparisonLabel={comparison?.label ?? null}
-            comparisonObservationId={comparison?.entry.observationId ?? null}
+            comparisonKind={comparison?.kind ?? null}
+            comparisonObservationId={
+              comparison?.kind === "parent"
+                ? comparison.entry.observationId
+                : null
+            }
             beforeMarkdown={
-              comparison === null
-                ? null
-                : (comparisonBlob.data?.markdown ?? null)
+              comparison?.kind === "parent"
+                ? (comparisonBlob.data?.markdown ?? null)
+                : null
             }
             afterMarkdown={selectedBlob.data?.markdown ?? null}
             loading={selectedBlob.isLoading || comparisonBlob.isLoading}
@@ -980,7 +985,7 @@ function VersionObservationList(props: {
 function VersionDiffView(props: {
   readonly artifactId: string;
   readonly selected: ArtifactVersionObservationEntry | null;
-  readonly comparisonLabel: string | null;
+  readonly comparisonKind: VersionComparison["kind"] | null;
   readonly comparisonObservationId: string | null;
   readonly beforeMarkdown: string | null;
   readonly afterMarkdown: string | null;
@@ -992,11 +997,12 @@ function VersionDiffView(props: {
   readonly onRestore: () => void;
 }): ReactNode {
   const unchanged =
-    props.comparisonLabel !== null &&
+    props.comparisonKind === "parent" &&
     props.afterMarkdown !== null &&
     props.beforeMarkdown === props.afterMarkdown;
   const patch =
-    props.afterMarkdown === null
+    props.afterMarkdown === null ||
+    props.comparisonKind === "parent_unavailable"
       ? null
       : buildSnapshotUnifiedPatch({
           filePath: `${props.artifactId}.md`,
@@ -1036,7 +1042,7 @@ function VersionDiffView(props: {
             {formatCapturedAt(props.selected.capturedAt)}
           </p>
           <p className="text-ui-xs text-muted-foreground">
-            {props.comparisonLabel ?? "Oldest saved version — shown in full"}
+            {comparisonLabel(props.comparisonKind)}
           </p>
         </div>
         <Button
@@ -1051,6 +1057,7 @@ function VersionDiffView(props: {
       <VersionDiffBody
         loading={props.loading}
         failed={props.failed}
+        parentUnavailable={props.comparisonKind === "parent_unavailable"}
         unchanged={unchanged}
         patch={patch}
         cacheScope={`artifact-version:${props.selected.observationId}:${props.comparisonObservationId ?? "none"}`}
@@ -1060,9 +1067,25 @@ function VersionDiffView(props: {
   );
 }
 
+function comparisonLabel(
+  comparisonKind: VersionComparison["kind"] | null,
+): string {
+  switch (comparisonKind) {
+    case "parent":
+      return "Compared with parent version";
+    case "initial":
+      return "Initial version";
+    case "parent_unavailable":
+      return "Parent version unavailable";
+    case null:
+      return "Version comparison unavailable";
+  }
+}
+
 function VersionDiffBody(props: {
   readonly loading: boolean;
   readonly failed: boolean;
+  readonly parentUnavailable: boolean;
   readonly unchanged: boolean;
   readonly patch: string | null;
   readonly cacheScope: string;
@@ -1086,6 +1109,14 @@ function VersionDiffBody(props: {
           Retry
         </Button>
       </div>
+    );
+  }
+  if (props.parentUnavailable) {
+    return (
+      <p className="p-4 text-muted-foreground">
+        This version&apos;s recorded parent is not available in the loaded
+        history.
+      </p>
     );
   }
   if (props.patch === null) {


### PR DESCRIPTION
## Summary
- compare a selected version only with its recorded parent
- render root captures as **Initial version**
- show an explicit unavailable-parent state rather than an adjacent-version diff

## Verification
- `bun x vitest run --config vitest.config.ts src/components/epic-canvas/renderers/__tests__/artifact-version-history.test.tsx` (28 passed)
- React Doctor on the changed renderer and its test (no issues)

Part of the artifact-history release-train stack; this targets `tgill-release-train`.
