### PR TITLE
fix(gui-app): keep agent names visible and tappable in A2A card headers

### DIFF
--- a/clients/gui-app/src/components/chat/chat-message-user-body.tsx
+++ b/clients/gui-app/src/components/chat/chat-message-user-body.tsx
@@ -280,9 +280,12 @@ function AgentMessageDisplayView({
       <span aria-hidden className="shrink-0 text-muted-foreground/40">
         ·
       </span>
-      <span className="flex min-w-0 flex-1 items-center gap-1.5 text-ui-sm">
-        <span className="min-w-0 truncate">
-          <span className="text-muted-foreground">from agent </span>
+      {/* flex-wrap lets the badge drop to a second line on narrow (mobile)
+          widths; the name group truncates last, so the sender stays visible
+          and tappable instead of collapsing to "from agent …". */}
+      <span className="flex min-w-0 flex-1 flex-wrap items-center gap-x-1.5 gap-y-1 text-ui-sm">
+        <span className="flex min-w-0 items-center gap-1">
+          <span className="shrink-0 text-muted-foreground">from agent</span>
           <AgentHeaderLink
             name={senderName}
             onOpen={openTarget !== null ? openSenderTab : null}

--- a/clients/gui-app/src/components/chat/segments/agent-header-link.tsx
+++ b/clients/gui-app/src/components/chat/segments/agent-header-link.tsx
@@ -15,7 +15,11 @@ export function AgentHeaderLink(props: {
 }): ReactNode {
   const { name, onOpen } = props;
   if (onOpen === null) {
-    return <span className="font-medium text-foreground/85">{name}</span>;
+    return (
+      <span className="min-w-0 truncate font-medium text-foreground/85">
+        {name}
+      </span>
+    );
   }
   return (
     <span
@@ -31,7 +35,7 @@ export function AgentHeaderLink(props: {
         event.stopPropagation();
         onOpen();
       }}
-      className="rounded font-medium text-primary underline-offset-2 hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+      className="min-w-0 truncate rounded font-medium text-primary underline-offset-2 hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
     >
       {name}
     </span>

--- a/clients/gui-app/src/components/chat/segments/tool-segment.tsx
+++ b/clients/gui-app/src/components/chat/segments/tool-segment.tsx
@@ -697,9 +697,12 @@ function A2ASendToolSegment(
   };
 
   const receiver = (
-    <span className="flex min-w-0 flex-1 items-center gap-1.5 text-ui-sm">
-      <span className="min-w-0 truncate">
-        <span className="text-muted-foreground">to agent </span>
+    // flex-wrap lets the badge drop to a second line on narrow (mobile)
+    // widths; the name group truncates last, so the receiver stays visible
+    // and tappable instead of collapsing to "to agent …".
+    <span className="flex min-w-0 flex-1 flex-wrap items-center gap-x-1.5 gap-y-1 text-ui-sm">
+      <span className="flex min-w-0 items-center gap-1">
+        <span className="shrink-0 text-muted-foreground">to agent</span>
         <AgentHeaderLink
           name={receiverName}
           onOpen={openTarget !== null ? openReceiverTab : null}


### PR DESCRIPTION
## Problem

On phone-width viewports (the mobile app is a thin Capacitor shell around gui-app), the `Sent message · to agent <name>` and `Received message · from agent <name>` card headers truncated the agent name down to nothing. Every other element in the header row is `shrink-0`, so the name span was the only thing allowed to shrink — and it collapsed first, cutting from the end so the static `to agent` label survived while the identifying name disappeared. Since the name is also the tap target for navigating to that agent, navigation was lost too.

## Fix

- The receiver/sender area now uses `flex-wrap`, so the REPLY EXPECTED badge drops to a second line when the row is tight instead of stealing the name's width.
- The short `to agent` / `from agent` label is `shrink-0`; the name group truncates last.
- `AgentHeaderLink` truncates the name itself with an ellipsis as the final fallback, so a long name stays partially visible and tappable instead of vanishing.

Desktop rendering is unchanged — the new rules only take effect when the header runs out of width.

## Verification

- `tool-segment.test.tsx` 20/20 and `chat-message-user-body.test.tsx` 28/28 pass.
- react-doctor on the diff: no issues.
- These are jsdom tests (no real layout), so a visual check at phone width (browser device mode) is recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)