### PR TITLE
fix(mobile): give the usage export a working download and a share sheet

### DIFF
--- a/clients/desktop/src/renderer-shell/desktop-runner-host.ts
+++ b/clients/desktop/src/renderer-shell/desktop-runner-host.ts
@@ -1164,6 +1164,8 @@ function isEphemeralDropPath(filePath: string): boolean {
 function buildDesktopFileSave(bridge: DesktopFileDropsBridge): IFileSaveHost {
   return {
     saveFile: (request) => bridge.saveFile(request),
+    // The native dialog writes the file the user named.
+    saveRoute: "download" as const,
     openSavedFile: (path) => bridge.openSavedFile(path),
     // The save dialog already writes the file the user named, so there is no
     // second, chooser-free route to offer - and nothing here for a surface to

--- a/clients/desktop/src/renderer-shell/desktop-runner-host.ts
+++ b/clients/desktop/src/renderer-shell/desktop-runner-host.ts
@@ -653,6 +653,9 @@ export class DesktopRunnerHost implements IRunnerHost {
   readonly authnBaseUrl: string;
   readonly relayBaseUrl: string;
   readonly hasLocalHost: boolean = true;
+  // The renderer's own clipboard takes images, and where a MIME type defeats
+  // it the main-process nativeImage bridge picks the write up.
+  readonly canCopyImages: boolean = true;
 
   readonly secureStorage: ISecureStorage;
   readonly tokenStore: ITokenStore;

--- a/clients/desktop/src/renderer-shell/desktop-runner-host.ts
+++ b/clients/desktop/src/renderer-shell/desktop-runner-host.ts
@@ -1162,6 +1162,10 @@ function buildDesktopFileSave(bridge: DesktopFileDropsBridge): IFileSaveHost {
   return {
     saveFile: (request) => bridge.saveFile(request),
     openSavedFile: (path) => bridge.openSavedFile(path),
+    // The save dialog already writes the file the user named, so there is no
+    // second, chooser-free route to offer - and nothing here for a surface to
+    // split into separate "share" and "download" affordances.
+    downloadFile: null,
   };
 }
 

--- a/clients/gui-app/__tests__/create-fake-runner-host.ts
+++ b/clients/gui-app/__tests__/create-fake-runner-host.ts
@@ -58,6 +58,7 @@ export function createFakeRunnerHost(
     authnBaseUrl: "https://auth.example.invalid",
     relayBaseUrl: "wss://relay.example.invalid/attach",
     hasLocalHost: true,
+    canCopyImages: true,
     validateAuthTokenIdentity: () =>
       Promise.resolve({ kind: "rejected" as const }),
     listRegisteredHosts: () =>

--- a/clients/gui-app/__tests__/editor-core/mermaid-node-view.test.tsx
+++ b/clients/gui-app/__tests__/editor-core/mermaid-node-view.test.tsx
@@ -13,13 +13,24 @@ import * as Y from "yjs";
 import { Awareness } from "y-protocols/awareness";
 import { buildArtifactExtensions, deriveCollabUser } from "@/editor-core";
 import { TooltipProvider } from "@/components/ui/tooltip";
-import { saveBlobToDisk, type SavedFile } from "@/lib/files/save-blob-to-disk";
+import {
+  downloadBlobToDevice,
+  saveBlobToDisk,
+  type SavedFile,
+} from "@/lib/files/save-blob-to-disk";
 
 // The download path lives in a shared lib module; mock it on its own.
 vi.mock("@/lib/files/save-blob-to-disk", () => ({
   saveBlobToDisk: vi
     .fn()
     .mockResolvedValue({ name: "mermaid-diagram.png", path: null }),
+  downloadBlobToDevice: vi
+    .fn()
+    .mockResolvedValue({ name: "mermaid-diagram.png", path: null }),
+  // Browser-runtime shape: the shell's own save route IS the download, so
+  // there is no chooser, no Share control, and a Download is always offered.
+  hasSeparateDownloadRoute: () => false,
+  canDownloadToDevice: () => true,
   // Browser-runtime shape: no path comes back, so no "Open file" action.
   canOpenSavedFile: () => false,
   openSavedFile: vi.fn(),
@@ -131,6 +142,11 @@ afterEach(() => {
 });
 
 beforeEach(() => {
+  vi.mocked(downloadBlobToDevice).mockReset();
+  vi.mocked(downloadBlobToDevice).mockResolvedValue({
+    name: "mermaid-diagram.png",
+    path: null,
+  });
   vi.mocked(saveBlobToDisk).mockReset();
   vi.mocked(saveBlobToDisk).mockResolvedValue({
     name: "mermaid-diagram.png",
@@ -228,12 +244,13 @@ describe("MermaidNodeView", () => {
   });
 
   it("ignores overlapping download clicks while the save picker is open", async () => {
-    const saveBlobToDiskMock = vi.mocked(saveBlobToDisk);
+    // Download takes the device route; the share sheet is a separate control.
+    const downloadMock = vi.mocked(downloadBlobToDevice);
     let resolveSave = (_value: SavedFile | null): void => undefined;
     const pendingSave = new Promise<SavedFile | null>((resolve) => {
       resolveSave = resolve;
     });
-    saveBlobToDiskMock.mockReturnValueOnce(pendingSave);
+    downloadMock.mockReturnValueOnce(pendingSave);
 
     const editor = mountMermaidEditor({
       code: "graph TD\n  A --> B",
@@ -253,11 +270,11 @@ describe("MermaidNodeView", () => {
 
     fireEvent.click(download);
     await waitFor(() => {
-      expect(saveBlobToDiskMock).toHaveBeenCalledTimes(1);
+      expect(downloadMock).toHaveBeenCalledTimes(1);
       expect((download as HTMLButtonElement).disabled).toBe(true);
     });
     fireEvent.click(download);
-    expect(saveBlobToDiskMock).toHaveBeenCalledTimes(1);
+    expect(downloadMock).toHaveBeenCalledTimes(1);
     resolveSave({ name: "mermaid-diagram.png", path: null });
     await waitFor(() => {
       expect((download as HTMLButtonElement).disabled).toBe(false);

--- a/clients/gui-app/__tests__/files/save-blob-to-disk.test.ts
+++ b/clients/gui-app/__tests__/files/save-blob-to-disk.test.ts
@@ -3,7 +3,11 @@ import type {
   FileSaveRequest,
   SavedFileLocation,
 } from "@traycer-clients/shared/platform/runner-host";
-import { saveBlobToDisk } from "@/lib/files/save-blob-to-disk";
+import {
+  downloadBlobToDevice,
+  hasSeparateDownloadRoute,
+  saveBlobToDisk,
+} from "@/lib/files/save-blob-to-disk";
 
 const createObjectUrlDescriptor = Object.getOwnPropertyDescriptor(
   URL,
@@ -110,6 +114,7 @@ describe("saveBlobToDisk", () => {
       saveBlobToDisk(blob, "diagram.png", {
         saveFile,
         openSavedFile: () => Promise.resolve(),
+        downloadFile: null,
       }),
     ).resolves.toEqual({
       name: "diagram.png",
@@ -123,5 +128,110 @@ describe("saveBlobToDisk", () => {
     });
     expect(window.showSaveFilePicker).not.toHaveBeenCalled();
     expect(createObjectURL).not.toHaveBeenCalled();
+  });
+});
+
+describe("downloadBlobToDevice", () => {
+  it("takes the shell's chooser-free route when it has one", async () => {
+    // The whole point of the second route: a shell whose `saveFile` reaches a
+    // share sheet must not send a "Download" through it.
+    const saveFile = vi.fn<
+      (request: FileSaveRequest) => Promise<SavedFileLocation | null>
+    >(() => Promise.resolve(null));
+    const downloadFile = vi.fn<
+      (request: FileSaveRequest) => Promise<SavedFileLocation>
+    >(() =>
+      Promise.resolve({
+        name: "usage.png",
+        path: "file:///docs/Traycer/usage.png",
+      }),
+    );
+
+    const blob = new Blob(["png"], { type: "image/png" });
+    await expect(
+      downloadBlobToDevice(blob, "usage.png", {
+        saveFile,
+        openSavedFile: null,
+        downloadFile,
+      }),
+    ).resolves.toEqual({
+      name: "usage.png",
+      path: "file:///docs/Traycer/usage.png",
+    });
+    expect(downloadFile).toHaveBeenCalledWith({
+      name: "usage.png",
+      type: "image/png",
+      bytes: await blob.arrayBuffer(),
+    });
+    expect(saveFile).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the shell's own save route where there is no separate one", async () => {
+    // A desktop save dialog IS the download - routing around it would open a
+    // second, worse one.
+    const saveFile = vi.fn<
+      (request: FileSaveRequest) => Promise<SavedFileLocation | null>
+    >(() => Promise.resolve({ name: "usage.png", path: "/tmp/usage.png" }));
+
+    await expect(
+      downloadBlobToDevice(
+        new Blob(["png"], { type: "image/png" }),
+        "usage.png",
+        { saveFile, openSavedFile: null, downloadFile: null },
+      ),
+    ).resolves.toEqual({ name: "usage.png", path: "/tmp/usage.png" });
+    expect(saveFile).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to the browser save APIs with no shell at all", async () => {
+    const createObjectURL = vi.fn(() => "blob:usage");
+    Object.defineProperty(URL, "createObjectURL", {
+      configurable: true,
+      writable: true,
+      value: createObjectURL,
+    });
+    Object.defineProperty(URL, "revokeObjectURL", {
+      configurable: true,
+      writable: true,
+      value: vi.fn(),
+    });
+
+    await expect(
+      downloadBlobToDevice(
+        new Blob(["png"], { type: "image/png" }),
+        "usage.png",
+        null,
+      ),
+    ).resolves.toEqual({ name: "usage.png", path: null });
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("hasSeparateDownloadRoute", () => {
+  it("is false for no shell and for a shell whose save route is the download", () => {
+    const saveFile = vi.fn<
+      (request: FileSaveRequest) => Promise<SavedFileLocation | null>
+    >(() => Promise.resolve(null));
+    expect(hasSeparateDownloadRoute(null)).toBe(false);
+    expect(
+      hasSeparateDownloadRoute({
+        saveFile,
+        openSavedFile: null,
+        downloadFile: null,
+      }),
+    ).toBe(false);
+  });
+
+  it("is true exactly where the shell owns a chooser-free download", () => {
+    const saveFile = vi.fn<
+      (request: FileSaveRequest) => Promise<SavedFileLocation | null>
+    >(() => Promise.resolve(null));
+    expect(
+      hasSeparateDownloadRoute({
+        saveFile,
+        openSavedFile: null,
+        downloadFile: () => Promise.resolve({ name: "u.png", path: null }),
+      }),
+    ).toBe(true);
   });
 });

--- a/clients/gui-app/__tests__/files/save-blob-to-disk.test.ts
+++ b/clients/gui-app/__tests__/files/save-blob-to-disk.test.ts
@@ -4,6 +4,7 @@ import type {
   SavedFileLocation,
 } from "@traycer-clients/shared/platform/runner-host";
 import {
+  canDownloadToDevice,
   downloadBlobToDevice,
   hasSeparateDownloadRoute,
   saveBlobToDisk,
@@ -115,6 +116,8 @@ describe("saveBlobToDisk", () => {
         saveFile,
         openSavedFile: () => Promise.resolve(),
         downloadFile: null,
+
+        saveRoute: "download",
       }),
     ).resolves.toEqual({
       name: "diagram.png",
@@ -153,6 +156,7 @@ describe("downloadBlobToDevice", () => {
         saveFile,
         openSavedFile: null,
         downloadFile,
+        saveRoute: "share",
       }),
     ).resolves.toEqual({
       name: "usage.png",
@@ -177,7 +181,12 @@ describe("downloadBlobToDevice", () => {
       downloadBlobToDevice(
         new Blob(["png"], { type: "image/png" }),
         "usage.png",
-        { saveFile, openSavedFile: null, downloadFile: null },
+        {
+          saveFile,
+          openSavedFile: null,
+          downloadFile: null,
+          saveRoute: "download",
+        },
       ),
     ).resolves.toEqual({ name: "usage.png", path: "/tmp/usage.png" });
     expect(saveFile).toHaveBeenCalledTimes(1);
@@ -207,6 +216,51 @@ describe("downloadBlobToDevice", () => {
   });
 });
 
+describe("canDownloadToDevice", () => {
+  const shareOnlyShell = () => ({
+    saveFile: vi.fn<
+      (request: FileSaveRequest) => Promise<SavedFileLocation | null>
+    >(() => Promise.resolve(null)),
+    openSavedFile: null,
+    downloadFile: null,
+    saveRoute: "share" as const,
+  });
+
+  it("is false ONLY where the shell has a chooser and no direct write", () => {
+    // Android 10: the shared-storage route does not exist and `saveFile` is the
+    // share sheet. Offering Download there would route it INTO the sheet - the
+    // exact mislabelling this split removes.
+    expect(canDownloadToDevice(shareOnlyShell())).toBe(false);
+  });
+
+  it("is true for a browser, a direct writer, and a shell that saves itself", () => {
+    expect(canDownloadToDevice(null)).toBe(true);
+    expect(
+      canDownloadToDevice({
+        ...shareOnlyShell(),
+        downloadFile: () => Promise.resolve({ name: "u.png", path: null }),
+      }),
+    ).toBe(true);
+    expect(
+      canDownloadToDevice({ ...shareOnlyShell(), saveRoute: "download" }),
+    ).toBe(true);
+  });
+
+  it("refuses to route a download through a chooser rather than doing it quietly", async () => {
+    // Callers gate on the capability, so reaching this is a bug - and it has to
+    // surface as one instead of silently opening the share sheet.
+    const shell = shareOnlyShell();
+    await expect(
+      downloadBlobToDevice(
+        new Blob(["x"], { type: "image/png" }),
+        "u.png",
+        shell,
+      ),
+    ).rejects.toThrow("no download destination");
+    expect(shell.saveFile).not.toHaveBeenCalled();
+  });
+});
+
 describe("hasSeparateDownloadRoute", () => {
   it("is false for no shell and for a shell whose save route is the download", () => {
     const saveFile = vi.fn<
@@ -218,6 +272,7 @@ describe("hasSeparateDownloadRoute", () => {
         saveFile,
         openSavedFile: null,
         downloadFile: null,
+        saveRoute: "download",
       }),
     ).toBe(false);
   });
@@ -231,6 +286,7 @@ describe("hasSeparateDownloadRoute", () => {
         saveFile,
         openSavedFile: null,
         downloadFile: () => Promise.resolve({ name: "u.png", path: null }),
+        saveRoute: "share",
       }),
     ).toBe(true);
   });

--- a/clients/gui-app/src/components/chat/__tests__/expanded-image-dialog.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/expanded-image-dialog.test.tsx
@@ -15,6 +15,15 @@ const saveBlobToDiskMock = vi.hoisted(() =>
     Promise.resolve({ name: "generated.png", path: null }),
   ),
 );
+const downloadBlobToDeviceMock = vi.hoisted(() =>
+  vi.fn<(blob: Blob, suggestedName: string) => Promise<SavedFile | null>>(() =>
+    Promise.resolve({ name: "generated.png", path: null }),
+  ),
+);
+/** Whether the shell under test hands files to an OS chooser. */
+const hasShareRoute = vi.hoisted(() => vi.fn<() => boolean>(() => false));
+/** Whether a Download can be honoured at all on that shell. */
+const canDownload = vi.hoisted(() => vi.fn<() => boolean>(() => true));
 const copyImageMock = vi.hoisted(() =>
   vi.fn<(blob: Blob) => Promise<void>>(() => Promise.resolve()),
 );
@@ -22,6 +31,12 @@ const copyImageMock = vi.hoisted(() =>
 vi.mock("@/lib/files/save-blob-to-disk", () => ({
   saveBlobToDisk: (blob: Blob, suggestedName: string) =>
     saveBlobToDiskMock(blob, suggestedName),
+  downloadBlobToDevice: (blob: Blob, suggestedName: string) =>
+    downloadBlobToDeviceMock(blob, suggestedName),
+  // Browser-runtime shape: the shell's own save route IS the download, so no
+  // chooser and no Share control.
+  hasSeparateDownloadRoute: () => hasShareRoute(),
+  canDownloadToDevice: () => canDownload(),
   canOpenSavedFile: () => false,
   openSavedFile: () => Promise.resolve(),
 }));
@@ -71,6 +86,13 @@ function renderOpenDialog(image: ExpandedImageState): void {
 beforeEach(() => {
   saveBlobToDiskMock.mockReset();
   saveBlobToDiskMock.mockResolvedValue({ name: "generated.png", path: null });
+  downloadBlobToDeviceMock.mockReset();
+  downloadBlobToDeviceMock.mockResolvedValue({
+    name: "generated.png",
+    path: null,
+  });
+  hasShareRoute.mockReturnValue(false);
+  canDownload.mockReturnValue(true);
   copyImageMock.mockReset();
   copyImageMock.mockResolvedValue(undefined);
   vi.stubGlobal(

--- a/clients/gui-app/src/components/chat/expanded-image-dialog.tsx
+++ b/clients/gui-app/src/components/chat/expanded-image-dialog.tsx
@@ -9,7 +9,10 @@ import { imageMutationKeys } from "@/lib/query-keys";
 import { toastFromRunnerError } from "@/lib/runner-error-toast";
 import { useFileSaveHost } from "@/hooks/files/use-file-save-host";
 import { useCanCopyImages } from "@/hooks/images/use-can-copy-images";
-import { hasSeparateDownloadRoute } from "@/lib/files/save-blob-to-disk";
+import {
+  canDownloadToDevice,
+  hasSeparateDownloadRoute,
+} from "@/lib/files/save-blob-to-disk";
 
 import {
   type ImageAction,
@@ -148,6 +151,7 @@ function ExpandedImageActionBar(props: {
       // reach the system clipboard with one.
       canCopy={isClipboardImageMediaType(props.mediaType) && canCopyOnShell}
       canShare={hasSeparateDownloadRoute(fileSave)}
+      canDownload={canDownloadToDevice(fileSave)}
       remote={null}
       onCopy={() => imageAction.mutate("copy")}
       onShare={() => imageAction.mutate("share")}

--- a/clients/gui-app/src/components/chat/expanded-image-dialog.tsx
+++ b/clients/gui-app/src/components/chat/expanded-image-dialog.tsx
@@ -8,6 +8,8 @@ import { useOpenSavedFile } from "@/hooks/files/use-open-saved-file";
 import { imageMutationKeys } from "@/lib/query-keys";
 import { toastFromRunnerError } from "@/lib/runner-error-toast";
 import { useFileSaveHost } from "@/hooks/files/use-file-save-host";
+import { useCanCopyImages } from "@/hooks/images/use-can-copy-images";
+import { hasSeparateDownloadRoute } from "@/lib/files/save-blob-to-disk";
 
 import {
   type ImageAction,
@@ -121,6 +123,7 @@ function ExpandedImageActionBar(props: {
 }): ReactNode {
   const fileSave = useFileSaveHost();
   const openSaved = useOpenSavedFile();
+  const canCopyOnShell = useCanCopyImages();
   const imageAction = useMutation<void, Error, ImageAction>({
     mutationKey: imageMutationKeys.perform(),
     mutationFn: (action) =>
@@ -141,9 +144,13 @@ function ExpandedImageActionBar(props: {
   return (
     <ImageActions
       pendingAction={imageAction.isPending ? imageAction.variables : null}
-      canCopy={isClipboardImageMediaType(props.mediaType)}
+      // The media type must take a clipboard image AND the shell must actually
+      // reach the system clipboard with one.
+      canCopy={isClipboardImageMediaType(props.mediaType) && canCopyOnShell}
+      canShare={hasSeparateDownloadRoute(fileSave)}
       remote={null}
       onCopy={() => imageAction.mutate("copy")}
+      onShare={() => imageAction.mutate("share")}
       onDownload={() => imageAction.mutate("download")}
     />
   );

--- a/clients/gui-app/src/components/chat/segments/__tests__/image-lightbox.test.tsx
+++ b/clients/gui-app/src/components/chat/segments/__tests__/image-lightbox.test.tsx
@@ -37,6 +37,8 @@ const downloadBlobToDeviceMock = vi.hoisted(() =>
 );
 /** Whether the shell under test hands files to an OS chooser. */
 const hasShareRoute = vi.hoisted(() => vi.fn<() => boolean>(() => false));
+/** Whether a Download can be honoured at all on that shell. */
+const canDownload = vi.hoisted(() => vi.fn<() => boolean>(() => true));
 const trustedMarkupSpy = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/files/save-blob-to-disk", () => ({
@@ -48,6 +50,7 @@ vi.mock("@/lib/files/save-blob-to-disk", () => ({
   // download, so there is no chooser and no Share control. A case that wants
   // the share-sheet shape opts into it.
   hasSeparateDownloadRoute: () => hasShareRoute(),
+  canDownloadToDevice: () => canDownload(),
   // Browser-runtime shape: no path comes back, so no "Open file" action.
   canOpenSavedFile: () => false,
   openSavedFile: vi.fn(),
@@ -131,6 +134,7 @@ beforeEach(() => {
     path: null,
   });
   hasShareRoute.mockReturnValue(false);
+  canDownload.mockReturnValue(true);
   copyImageMock.mockReset();
   copyImageMock.mockResolvedValue(undefined);
   trustedMarkupSpy.mockClear();

--- a/clients/gui-app/src/components/chat/segments/__tests__/image-lightbox.test.tsx
+++ b/clients/gui-app/src/components/chat/segments/__tests__/image-lightbox.test.tsx
@@ -27,11 +27,27 @@ const saveBlobToDiskMock = vi.hoisted(() =>
 const copyImageMock = vi.hoisted(() =>
   vi.fn<(blob: Blob) => Promise<void>>(() => Promise.resolve()),
 );
+const downloadBlobToDeviceMock = vi.hoisted(() =>
+  vi.fn<
+    (
+      blob: Blob,
+      suggestedName: string,
+    ) => Promise<{ name: string; path: string | null } | null>
+  >(() => Promise.resolve({ name: "generated.png", path: null })),
+);
+/** Whether the shell under test hands files to an OS chooser. */
+const hasShareRoute = vi.hoisted(() => vi.fn<() => boolean>(() => false));
 const trustedMarkupSpy = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/files/save-blob-to-disk", () => ({
   saveBlobToDisk: (blob: Blob, suggestedName: string) =>
     saveBlobToDiskMock(blob, suggestedName),
+  downloadBlobToDevice: (blob: Blob, suggestedName: string) =>
+    downloadBlobToDeviceMock(blob, suggestedName),
+  // Browser-runtime shape by default: the shell's own save route IS the
+  // download, so there is no chooser and no Share control. A case that wants
+  // the share-sheet shape opts into it.
+  hasSeparateDownloadRoute: () => hasShareRoute(),
   // Browser-runtime shape: no path comes back, so no "Open file" action.
   canOpenSavedFile: () => false,
   openSavedFile: vi.fn(),
@@ -109,6 +125,12 @@ beforeEach(() => {
   });
   saveBlobToDiskMock.mockReset();
   saveBlobToDiskMock.mockResolvedValue({ name: "generated.png", path: null });
+  downloadBlobToDeviceMock.mockReset();
+  downloadBlobToDeviceMock.mockResolvedValue({
+    name: "generated.png",
+    path: null,
+  });
+  hasShareRoute.mockReturnValue(false);
   copyImageMock.mockReset();
   copyImageMock.mockResolvedValue(undefined);
   trustedMarkupSpy.mockClear();
@@ -165,7 +187,7 @@ describe("<ImageLightbox /> actions", () => {
     expect(onMouseDown).not.toHaveBeenCalled();
   });
 
-  it("downloads through saveBlobToDisk with the suggested file name", async () => {
+  it("downloads through downloadBlobToDevice with the suggested file name", async () => {
     renderWithRunner(
       <ImageLightbox
         src="blob:http://localhost/raster"
@@ -181,17 +203,86 @@ describe("<ImageLightbox /> actions", () => {
     fireEvent.click(screen.getByRole("button", { name: "Download image" }));
 
     await waitFor(() => {
-      expect(saveBlobToDiskMock).toHaveBeenCalledTimes(1);
+      expect(downloadBlobToDeviceMock).toHaveBeenCalledTimes(1);
     });
     expect(screen.getByRole("button", { name: "Copy image" })).toBeTruthy();
     expect(vi.mocked(fetch)).toHaveBeenCalledWith(
       "blob:http://localhost/raster",
     );
-    const [blob, name] = saveBlobToDiskMock.mock.calls[0];
+    const [blob, name] = downloadBlobToDeviceMock.mock.calls[0];
     expect(name).toBe("pier.png");
     // jsdom may not share Blob identity across realms; assert blob-shaped.
     expect(blob.size).toBeGreaterThan(0);
     expect(typeof blob.arrayBuffer).toBe("function");
+  });
+
+  it("offers no share control where the shell's save route is the download", () => {
+    renderWithRunner(
+      <ImageLightbox
+        src="blob:http://localhost/raster"
+        alt="a misty pier"
+        mediaType="image/png"
+        suggestedName="pier.png"
+        className={undefined}
+      >
+        <img src="blob:http://localhost/raster" alt="a misty pier" />
+      </ImageLightbox>,
+    );
+
+    expect(screen.queryByRole("button", { name: "Share image" })).toBeNull();
+  });
+
+  it("adds a share control where the shell's save route is an OS chooser", async () => {
+    hasShareRoute.mockReturnValue(true);
+    renderWithRunner(
+      <ImageLightbox
+        src="blob:http://localhost/raster"
+        alt="a misty pier"
+        mediaType="image/png"
+        suggestedName="pier.png"
+        className={undefined}
+      >
+        <img src="blob:http://localhost/raster" alt="a misty pier" />
+      </ImageLightbox>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Share image" }));
+
+    // Share takes the shell's OWN save route - the sheet - while Download
+    // goes past it. Two controls, two routes.
+    await waitFor(() => {
+      expect(saveBlobToDiskMock).toHaveBeenCalledTimes(1);
+    });
+    expect(downloadBlobToDeviceMock).not.toHaveBeenCalled();
+  });
+
+  it("drops copy where the shell cannot reach the image clipboard", () => {
+    // Android's WebView resolves the write having written nothing, so the
+    // control would report a success the clipboard never received.
+    runnerHost = new MockRunnerHost({
+      signInUrl: "https://auth.traycer.test/sign-in",
+      authnBaseUrl: "https://auth.traycer.test",
+      localHost: null,
+      hosts: [],
+      workspaceFolderPickerPaths: undefined,
+      hasLocalHost: undefined,
+      traycerCli: undefined,
+    });
+    Object.defineProperty(runnerHost, "canCopyImages", { value: false });
+    renderWithRunner(
+      <ImageLightbox
+        src="blob:http://localhost/raster"
+        alt="a misty pier"
+        mediaType="image/png"
+        suggestedName="pier.png"
+        className={undefined}
+      >
+        <img src="blob:http://localhost/raster" alt="a misty pier" />
+      </ImageLightbox>,
+    );
+
+    expect(screen.queryByRole("button", { name: "Copy image" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Download image" })).toBeTruthy();
   });
 
   it("copies through copyImageBlobToClipboard (ClipboardItem path lives there)", async () => {

--- a/clients/gui-app/src/components/chat/segments/image-actions.tsx
+++ b/clients/gui-app/src/components/chat/segments/image-actions.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { Copy, Download, ExternalLink } from "lucide-react";
+import { Copy, Download, ExternalLink, Share2 } from "lucide-react";
 
 import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
@@ -14,8 +14,15 @@ export interface ImageRemoteOpen {
 export function ImageActions(props: {
   readonly pendingAction: ImageAction | null;
   readonly canCopy: boolean;
+  /**
+   * Whether this shell hands files to an OS chooser, in which case sharing and
+   * downloading are two different acts and both are offered. Ignored beside a
+   * remote image, whose control is Open-in-browser rather than any save.
+   */
+  readonly canShare: boolean;
   readonly remote: ImageRemoteOpen | null;
   readonly onCopy: () => void;
+  readonly onShare: () => void;
   readonly onDownload: () => void;
 }): ReactNode {
   return (
@@ -27,6 +34,15 @@ export function ImageActions(props: {
           pending={props.pendingAction === "copy"}
           onClick={props.onCopy}
           icon={<Copy className="size-3.5" aria-hidden />}
+        />
+      ) : null}
+      {props.canShare && props.remote === null ? (
+        <ImageActionButton
+          label="Share image"
+          disabled={props.pendingAction !== null}
+          pending={props.pendingAction === "share"}
+          onClick={props.onShare}
+          icon={<Share2 className="size-3.5" aria-hidden />}
         />
       ) : null}
       {props.remote === null ? (

--- a/clients/gui-app/src/components/chat/segments/image-actions.tsx
+++ b/clients/gui-app/src/components/chat/segments/image-actions.tsx
@@ -20,11 +20,44 @@ export function ImageActions(props: {
    * remote image, whose control is Open-in-browser rather than any save.
    */
   readonly canShare: boolean;
+  /**
+   * Whether a Download can be honoured at all. False on a shell that hands
+   * everything to a chooser and owns no direct write (Android 10), where the
+   * control would route back into the share sheet it is meant to be distinct
+   * from.
+   */
+  readonly canDownload: boolean;
   readonly remote: ImageRemoteOpen | null;
   readonly onCopy: () => void;
   readonly onShare: () => void;
   readonly onDownload: () => void;
 }): ReactNode {
+  // The trailing slot: Open-in-browser for a remote image (no save capability
+  // gates it), Download for a local one - and nothing at all where the shell
+  // is chooser-only, since a Download there would route back into the share
+  // sheet it is meant to be distinct from.
+  let saveOrOpen: ReactNode = null;
+  if (props.remote !== null) {
+    saveOrOpen = (
+      <ImageActionButton
+        label="Open in browser"
+        disabled={props.pendingAction !== null || props.remote.pending}
+        pending={props.remote.pending}
+        onClick={props.remote.onOpen}
+        icon={<ExternalLink className="size-3.5" aria-hidden />}
+      />
+    );
+  } else if (props.canDownload) {
+    saveOrOpen = (
+      <ImageActionButton
+        label="Download image"
+        disabled={props.pendingAction !== null}
+        pending={props.pendingAction === "download"}
+        onClick={props.onDownload}
+        icon={<Download className="size-3.5" aria-hidden />}
+      />
+    );
+  }
   return (
     <div className="flex items-center gap-1 rounded-md border border-white/15 bg-black/65 p-1 text-white shadow-sm backdrop-blur-sm @max-[8rem]:gap-0 @max-[8rem]:border-0 @max-[8rem]:p-0">
       {props.canCopy ? (
@@ -45,23 +78,7 @@ export function ImageActions(props: {
           icon={<Share2 className="size-3.5" aria-hidden />}
         />
       ) : null}
-      {props.remote === null ? (
-        <ImageActionButton
-          label="Download image"
-          disabled={props.pendingAction !== null}
-          pending={props.pendingAction === "download"}
-          onClick={props.onDownload}
-          icon={<Download className="size-3.5" aria-hidden />}
-        />
-      ) : (
-        <ImageActionButton
-          label="Open in browser"
-          disabled={props.pendingAction !== null || props.remote.pending}
-          pending={props.remote.pending}
-          onClick={props.remote.onOpen}
-          icon={<ExternalLink className="size-3.5" aria-hidden />}
-        />
-      )}
+      {saveOrOpen}
     </div>
   );
 }

--- a/clients/gui-app/src/components/chat/segments/image-lightbox.tsx
+++ b/clients/gui-app/src/components/chat/segments/image-lightbox.tsx
@@ -14,7 +14,10 @@ import { toastFromRunnerError } from "@/lib/runner-error-toast";
 import { cn } from "@/lib/utils";
 import { useFileSaveHost } from "@/hooks/files/use-file-save-host";
 import { useCanCopyImages } from "@/hooks/images/use-can-copy-images";
-import { hasSeparateDownloadRoute } from "@/lib/files/save-blob-to-disk";
+import {
+  canDownloadToDevice,
+  hasSeparateDownloadRoute,
+} from "@/lib/files/save-blob-to-disk";
 
 import {
   type ImageAction,
@@ -79,6 +82,7 @@ export function ImageLightbox(props: ImageLightboxProps): ReactNode {
       pendingAction={imageAction.isPending ? imageAction.variables : null}
       canCopy={canCopy}
       canShare={canShare}
+      canDownload={canDownloadToDevice(fileSave)}
       remote={
         remoteUrl === null
           ? null

--- a/clients/gui-app/src/components/chat/segments/image-lightbox.tsx
+++ b/clients/gui-app/src/components/chat/segments/image-lightbox.tsx
@@ -13,6 +13,8 @@ import { imageMutationKeys } from "@/lib/query-keys";
 import { toastFromRunnerError } from "@/lib/runner-error-toast";
 import { cn } from "@/lib/utils";
 import { useFileSaveHost } from "@/hooks/files/use-file-save-host";
+import { useCanCopyImages } from "@/hooks/images/use-can-copy-images";
+import { hasSeparateDownloadRoute } from "@/lib/files/save-blob-to-disk";
 
 import {
   type ImageAction,
@@ -46,8 +48,16 @@ export function ImageLightbox(props: ImageLightboxProps): ReactNode {
   const suggestedName =
     props.suggestedName ?? imageFileName(alt, props.src, props.mediaType);
   const remoteUrl = /^https:/i.test(props.src) ? props.src : null;
+  // Three facts, all required: the bytes must be local, the media type must be
+  // one the clipboard takes, and the SHELL must actually reach the system
+  // clipboard with an image - Android's WebView resolves that write having
+  // written nothing.
+  const canCopyOnShell = useCanCopyImages();
   const canCopy =
-    remoteUrl === null && isClipboardImageMediaType(props.mediaType);
+    remoteUrl === null &&
+    isClipboardImageMediaType(props.mediaType) &&
+    canCopyOnShell;
+  const canShare = hasSeparateDownloadRoute(fileSave);
 
   const imageAction = useMutation<void, Error, ImageAction>({
     mutationKey: imageMutationKeys.perform(),
@@ -68,6 +78,7 @@ export function ImageLightbox(props: ImageLightboxProps): ReactNode {
     <ImageActions
       pendingAction={imageAction.isPending ? imageAction.variables : null}
       canCopy={canCopy}
+      canShare={canShare}
       remote={
         remoteUrl === null
           ? null
@@ -77,6 +88,7 @@ export function ImageLightbox(props: ImageLightboxProps): ReactNode {
             }
       }
       onCopy={() => imageAction.mutate("copy")}
+      onShare={() => imageAction.mutate("share")}
       onDownload={() => imageAction.mutate("download")}
     />
   );

--- a/clients/gui-app/src/components/epic-canvas/panels/__tests__/epic-usage-dialog.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/panels/__tests__/epic-usage-dialog.test.tsx
@@ -81,6 +81,13 @@ const mocks = vi.hoisted(() => ({
   saveBlobToDisk: vi.fn(),
   downloadBlobToDevice: vi.fn(),
   hasSeparateDownloadRoute: vi.fn<() => boolean>(),
+  useCanCopyImages: vi.fn<() => boolean>(),
+}));
+
+// The shell capability behind "Copy image". Mocked at the hook rather than by
+// mounting a runner host, so a case states the one fact it varies.
+vi.mock("@/hooks/images/use-can-copy-images", () => ({
+  useCanCopyImages: mocks.useCanCopyImages,
 }));
 
 vi.mock("@/stores/tabs/use-system-tab-modal", () => ({
@@ -117,6 +124,7 @@ beforeEach(() => {
   // The shape of every shell whose own save route IS the download - desktop
   // and a plain browser tab. The share-sheet shape is opted into per case.
   mocks.hasSeparateDownloadRoute.mockReturnValue(false);
+  mocks.useCanCopyImages.mockReturnValue(true);
 });
 
 afterEach(() => {
@@ -128,6 +136,7 @@ afterEach(() => {
   mocks.saveBlobToDisk.mockReset();
   mocks.downloadBlobToDevice.mockReset();
   mocks.hasSeparateDownloadRoute.mockReset();
+  mocks.useCanCopyImages.mockReset();
 });
 
 const ZERO_PROVENANCE_SPLIT: UsageSummaryResponse["summary"]["totals"]["provenanceSplit"] =
@@ -700,20 +709,33 @@ describe("<EpicUsageDialog />", () => {
     expect(mocks.copyImageBlobPromiseToClipboard).not.toHaveBeenCalled();
   });
 
-  it("swaps copy for share on a shell whose save route is an OS chooser", async () => {
+  it("adds share alongside copy on a shell whose save route is an OS chooser", async () => {
     // Same policy as the Settings surface, from the same shared hook: the
     // two usage surfaces cannot drift into different control sets.
     mocks.hasSeparateDownloadRoute.mockReturnValue(true);
     renderDialog(usageSummaryResponse);
     await screen.findByTestId("usage-cost-figure");
 
-    expect(screen.queryByTestId("epic-usage-copy-image")).toBeNull();
+    expect(screen.getByTestId("epic-usage-copy-image").textContent).toContain(
+      "Copy image",
+    );
     expect(screen.getByTestId("epic-usage-share-image").textContent).toContain(
       "Share image",
     );
     expect(
       screen.getByTestId("epic-usage-download-image").textContent,
     ).toContain("Download image");
+  });
+
+  it("drops copy where the shell cannot put an image on the clipboard", async () => {
+    mocks.hasSeparateDownloadRoute.mockReturnValue(true);
+    mocks.useCanCopyImages.mockReturnValue(false);
+    renderDialog(usageSummaryResponse);
+    await screen.findByTestId("usage-cost-figure");
+
+    expect(screen.queryByTestId("epic-usage-copy-image")).toBeNull();
+    expect(screen.getByTestId("epic-usage-share-image")).toBeTruthy();
+    expect(screen.getByTestId("epic-usage-download-image")).toBeTruthy();
   });
 
   it("sends share through the shell's own save route and download past it", async () => {

--- a/clients/gui-app/src/components/epic-canvas/panels/__tests__/epic-usage-dialog.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/panels/__tests__/epic-usage-dialog.test.tsx
@@ -81,6 +81,7 @@ const mocks = vi.hoisted(() => ({
   saveBlobToDisk: vi.fn(),
   downloadBlobToDevice: vi.fn(),
   hasSeparateDownloadRoute: vi.fn<() => boolean>(),
+  canDownloadToDevice: vi.fn<() => boolean>(),
   useCanCopyImages: vi.fn<() => boolean>(),
 }));
 
@@ -116,6 +117,7 @@ vi.mock("@/lib/files/save-blob-to-disk", () => ({
   saveBlobToDisk: mocks.saveBlobToDisk,
   downloadBlobToDevice: mocks.downloadBlobToDevice,
   hasSeparateDownloadRoute: mocks.hasSeparateDownloadRoute,
+  canDownloadToDevice: mocks.canDownloadToDevice,
   canOpenSavedFile: () => false,
   openSavedFile: vi.fn(),
 }));
@@ -124,6 +126,8 @@ beforeEach(() => {
   // The shape of every shell whose own save route IS the download - desktop
   // and a plain browser tab. The share-sheet shape is opted into per case.
   mocks.hasSeparateDownloadRoute.mockReturnValue(false);
+  // Every shell but a chooser-only one can honour a Download.
+  mocks.canDownloadToDevice.mockReturnValue(true);
   mocks.useCanCopyImages.mockReturnValue(true);
 });
 
@@ -136,6 +140,7 @@ afterEach(() => {
   mocks.saveBlobToDisk.mockReset();
   mocks.downloadBlobToDevice.mockReset();
   mocks.hasSeparateDownloadRoute.mockReset();
+  mocks.canDownloadToDevice.mockReset();
   mocks.useCanCopyImages.mockReset();
 });
 

--- a/clients/gui-app/src/components/epic-canvas/panels/__tests__/epic-usage-dialog.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/panels/__tests__/epic-usage-dialog.test.tsx
@@ -8,7 +8,15 @@ import {
 import userEvent from "@testing-library/user-event";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
-import { afterEach, describe, expect, it, vi, type Mock } from "vitest";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type Mock,
+} from "vitest";
 import { HostClient } from "@traycer-clients/shared/host-client/host-client";
 import { mockLocalHostEntry } from "@traycer-clients/shared/host-client/mock/mock-host-directory";
 import { MockHostMessenger } from "@traycer-clients/shared/host-client/mock/mock-host-messenger";
@@ -71,6 +79,8 @@ const mocks = vi.hoisted(() => ({
   copyImageBlobPromiseToClipboard:
     vi.fn<(blobPromise: Promise<Blob>) => Promise<void>>(),
   saveBlobToDisk: vi.fn(),
+  downloadBlobToDevice: vi.fn(),
+  hasSeparateDownloadRoute: vi.fn<() => boolean>(),
 }));
 
 vi.mock("@/stores/tabs/use-system-tab-modal", () => ({
@@ -97,9 +107,17 @@ vi.mock("@/lib/images/copy-image-to-clipboard", () => ({
 
 vi.mock("@/lib/files/save-blob-to-disk", () => ({
   saveBlobToDisk: mocks.saveBlobToDisk,
+  downloadBlobToDevice: mocks.downloadBlobToDevice,
+  hasSeparateDownloadRoute: mocks.hasSeparateDownloadRoute,
   canOpenSavedFile: () => false,
   openSavedFile: vi.fn(),
 }));
+
+beforeEach(() => {
+  // The shape of every shell whose own save route IS the download - desktop
+  // and a plain browser tab. The share-sheet shape is opted into per case.
+  mocks.hasSeparateDownloadRoute.mockReturnValue(false);
+});
 
 afterEach(() => {
   cleanup();
@@ -108,6 +126,8 @@ afterEach(() => {
   mocks.copyImageBlobToClipboard.mockReset();
   mocks.copyImageBlobPromiseToClipboard.mockReset();
   mocks.saveBlobToDisk.mockReset();
+  mocks.downloadBlobToDevice.mockReset();
+  mocks.hasSeparateDownloadRoute.mockReset();
 });
 
 const ZERO_PROVENANCE_SPLIT: UsageSummaryResponse["summary"]["totals"]["provenanceSplit"] =
@@ -653,7 +673,7 @@ describe("<EpicUsageDialog />", () => {
     const user = userEvent.setup();
     const blob = new Blob(["fake-png-bytes"], { type: "image/png" });
     mocks.captureUsageExportImageBlob.mockResolvedValue(blob);
-    mocks.saveBlobToDisk.mockResolvedValue({
+    mocks.downloadBlobToDevice.mockResolvedValue({
       name: "traycer-usage-7d.png",
       path: null,
     });
@@ -664,11 +684,11 @@ describe("<EpicUsageDialog />", () => {
     await user.click(screen.getByTestId("epic-usage-download-image"));
 
     await waitFor(() => {
-      expect(mocks.saveBlobToDisk).toHaveBeenCalledWith(
+      expect(mocks.downloadBlobToDevice).toHaveBeenCalledWith(
         blob,
         "traycer-usage-7d.png",
         // This harness mounts no runner host, so there is no native save
-        // route and the save falls through to the browser APIs.
+        // route and the download falls through to the browser APIs.
         null,
       );
     });
@@ -678,5 +698,47 @@ describe("<EpicUsageDialog />", () => {
       subheading: "Cost and token usage for this task.",
     });
     expect(mocks.copyImageBlobPromiseToClipboard).not.toHaveBeenCalled();
+  });
+
+  it("swaps copy for share on a shell whose save route is an OS chooser", async () => {
+    // Same policy as the Settings surface, from the same shared hook: the
+    // two usage surfaces cannot drift into different control sets.
+    mocks.hasSeparateDownloadRoute.mockReturnValue(true);
+    renderDialog(usageSummaryResponse);
+    await screen.findByTestId("usage-cost-figure");
+
+    expect(screen.queryByTestId("epic-usage-copy-image")).toBeNull();
+    expect(screen.getByTestId("epic-usage-share-image").textContent).toContain(
+      "Share image",
+    );
+    expect(
+      screen.getByTestId("epic-usage-download-image").textContent,
+    ).toContain("Download image");
+  });
+
+  it("sends share through the shell's own save route and download past it", async () => {
+    const user = userEvent.setup();
+    const blob = new Blob(["fake-png-bytes"], { type: "image/png" });
+    mocks.hasSeparateDownloadRoute.mockReturnValue(true);
+    mocks.captureUsageExportImageBlob.mockResolvedValue(blob);
+    mocks.saveBlobToDisk.mockResolvedValue({ name: "shared.png", path: null });
+    mocks.downloadBlobToDevice.mockResolvedValue({
+      name: "traycer-usage-7d.png",
+      path: "file:///docs/Traycer/traycer-usage-7d.png",
+    });
+    renderDialog(usageSummaryResponse);
+    await screen.findByTestId("usage-cost-figure");
+
+    await user.click(screen.getByTestId("epic-usage-share-image"));
+    await waitFor(() => {
+      expect(mocks.saveBlobToDisk).toHaveBeenCalledTimes(1);
+    });
+    expect(mocks.downloadBlobToDevice).not.toHaveBeenCalled();
+
+    await user.click(screen.getByTestId("epic-usage-download-image"));
+    await waitFor(() => {
+      expect(mocks.downloadBlobToDevice).toHaveBeenCalledTimes(1);
+    });
+    expect(mocks.saveBlobToDisk).toHaveBeenCalledTimes(1);
   });
 });

--- a/clients/gui-app/src/components/epic-canvas/panels/epic-usage-dialog.tsx
+++ b/clients/gui-app/src/components/epic-canvas/panels/epic-usage-dialog.tsx
@@ -1,11 +1,9 @@
 import { useMemo, useRef, useState, type ReactNode } from "react";
-import { Copy, Download } from "lucide-react";
 import type { UseQueryResult } from "@tanstack/react-query";
 import type { HostClient } from "@traycer-clients/shared/host-client/host-client";
 import type { HostRpcError } from "@traycer-clients/shared/host-transport/host-messenger";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
-import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 import type { HostRpcRegistry } from "@/lib/host";
 import { useSystemTabModalActions } from "@/stores/tabs/use-system-tab-modal";
 import { useUsageImageExport } from "@/hooks/usage-analytics/use-usage-image-export";
@@ -40,6 +38,7 @@ import { UsageChatBreakdown } from "@/components/usage-analytics/usage-chat-brea
 import { UsageHarnessSplit } from "@/components/usage-analytics/usage-harness-split";
 import { UsageStatTiles } from "@/components/usage-analytics/usage-stat-tiles";
 import { UsageWindowPicker } from "@/components/usage-analytics/usage-window-picker";
+import { UsageExportImageActions } from "@/components/usage-analytics/usage-export-image-actions";
 import {
   UsageDialogFrame,
   USAGE_DIALOG_SHEET_CLASSES,
@@ -113,23 +112,18 @@ export function EpicUsageDialog(props: EpicUsageDialogProps): ReactNode {
   const contentRef = useRef<HTMLDivElement | null>(null);
   const exportReady =
     query.data !== undefined && query.data.summary.totals.factCount > 0;
-  const { mutation, copyImage, downloadImage } = useUsageImageExport({
-    getExportNode: () =>
-      contentRef.current?.querySelector<HTMLElement>(
-        USAGE_EXPORT_REGION_SELECTOR,
-      ) ?? null,
-    fileName: `traycer-usage-${String(windowDays)}d.png`,
-    heading: "Usage",
-    subheading: "Cost and token usage for this task.",
-    errorSource: "Epic usage dialog",
-    analyticsSource: "epic_dialog",
-  });
-  // One export runs at a time, so BOTH buttons go disabled while either is
-  // pending; only the button that started it shows the spinner, which is
-  // what the variables discriminate.
-  const isExporting = mutation.isPending;
-  const isCopying = isExporting && mutation.variables.action === "copy";
-  const isDownloading = isExporting && mutation.variables.action === "download";
+  const { pendingAction, copyImage, shareImage, downloadImage } =
+    useUsageImageExport({
+      getExportNode: () =>
+        contentRef.current?.querySelector<HTMLElement>(
+          USAGE_EXPORT_REGION_SELECTOR,
+        ) ?? null,
+      fileName: `traycer-usage-${String(windowDays)}d.png`,
+      heading: "Usage",
+      subheading: "Cost and token usage for this task.",
+      errorSource: "Epic usage dialog",
+      analyticsSource: "epic_dialog",
+    });
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -163,46 +157,16 @@ export function EpicUsageDialog(props: EpicUsageDialogProps): ReactNode {
                   sheet tier the footer column-reverses, so this group
                   stacks below it, full width like its sibling. */}
               <div className="flex gap-2 max-[28rem]:flex-col sm:mr-auto">
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  className="max-[28rem]:w-full"
-                  data-testid="epic-usage-copy-image"
-                  disabled={!exportReady || isExporting}
-                  onClick={copyImage}
-                >
-                  {isCopying ? (
-                    <AgentSpinningDots
-                      className="size-3"
-                      testId={undefined}
-                      variant={undefined}
-                    />
-                  ) : (
-                    <Copy aria-hidden />
-                  )}
-                  Copy image
-                </Button>
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  className="max-[28rem]:w-full"
-                  data-testid="epic-usage-download-image"
-                  disabled={!exportReady || isExporting}
-                  onClick={downloadImage}
-                >
-                  {isDownloading ? (
-                    <AgentSpinningDots
-                      className="size-3"
-                      testId={undefined}
-                      variant={undefined}
-                    />
-                  ) : (
-                    <Download aria-hidden />
-                  )}
-                  Download image
-                </Button>
+                <UsageExportImageActions
+                  exportReady={exportReady}
+                  pendingAction={pendingAction}
+                  copyImage={copyImage}
+                  shareImage={shareImage}
+                  downloadImage={downloadImage}
+                  testIdPrefix="epic-usage"
+                  variant="labelled"
+                  buttonClassName="max-[28rem]:w-full"
+                />
               </div>
               <Button
                 type="button"

--- a/clients/gui-app/src/components/layout/__tests__/desktop-dialog-host.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/desktop-dialog-host.test.tsx
@@ -307,6 +307,7 @@ function createBaseRunnerHost(): IRunnerHost {
     authnBaseUrl: "https://auth.example.invalid",
     relayBaseUrl: "wss://relay.example.invalid/attach",
     hasLocalHost: true,
+    canCopyImages: true,
     validateAuthTokenIdentity: () =>
       Promise.resolve({ kind: "rejected" as const }),
     listRegisteredHosts: () =>

--- a/clients/gui-app/src/components/layout/dialogs/desktop/__tests__/report-issue-capture-dialog.test.tsx
+++ b/clients/gui-app/src/components/layout/dialogs/desktop/__tests__/report-issue-capture-dialog.test.tsx
@@ -211,6 +211,7 @@ function createBaseRunnerHost(): IRunnerHost {
     authnBaseUrl: "https://auth.example.invalid",
     relayBaseUrl: "wss://relay.example.invalid/attach",
     hasLocalHost: true,
+    canCopyImages: true,
     validateAuthTokenIdentity: () =>
       Promise.resolve({ kind: "rejected" as const }),
     listRegisteredHosts: () =>

--- a/clients/gui-app/src/components/usage-analytics/__tests__/usage-export-image-actions.test.tsx
+++ b/clients/gui-app/src/components/usage-analytics/__tests__/usage-export-image-actions.test.tsx
@@ -1,0 +1,196 @@
+/**
+ * The export controls both usage surfaces render. What is asserted here is the
+ * part that is the same wherever they are mounted: which buttons exist for a
+ * given set of shell capabilities, what they are called, and how one running
+ * export gates all of them.
+ */
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { UsageExportImageActions } from "@/components/usage-analytics/usage-export-image-actions";
+import type { UsageImageExportAction } from "@/hooks/usage-analytics/use-usage-image-export";
+
+afterEach(cleanup);
+
+interface Overrides {
+  readonly exportReady: boolean;
+  readonly pendingAction: UsageImageExportAction | null;
+  readonly copyImage: (() => void) | null;
+  readonly shareImage: (() => void) | null;
+  readonly downloadImage: () => void;
+  readonly variant: "icon" | "labelled";
+}
+
+/** The shell shape where `saveFile` IS the download: desktop, browser tab. */
+function ownDownloadShell(): Pick<Overrides, "copyImage" | "shareImage"> {
+  return { copyImage: () => undefined, shareImage: null };
+}
+
+/** The shell shape where `saveFile` reaches an OS chooser: the mobile app. */
+function shareSheetShell(): Pick<Overrides, "copyImage" | "shareImage"> {
+  return { copyImage: null, shareImage: () => undefined };
+}
+
+function renderActions(overrides: Overrides): void {
+  render(
+    <TooltipProvider>
+      <UsageExportImageActions
+        exportReady={overrides.exportReady}
+        pendingAction={overrides.pendingAction}
+        copyImage={overrides.copyImage}
+        shareImage={overrides.shareImage}
+        downloadImage={overrides.downloadImage}
+        testIdPrefix="usage"
+        variant={overrides.variant}
+        buttonClassName={undefined}
+      />
+    </TooltipProvider>,
+  );
+}
+
+/** Every export button on screen, in render order. */
+function buttonTestIds(): readonly string[] {
+  return screen
+    .getAllByRole("button")
+    .map((button) => button.getAttribute("data-testid") ?? "");
+}
+
+describe("<UsageExportImageActions />", () => {
+  it("renders copy then download where the shell has no share surface", () => {
+    renderActions({
+      exportReady: true,
+      pendingAction: null,
+      ...ownDownloadShell(),
+      downloadImage: () => undefined,
+      variant: "icon",
+    });
+
+    expect(buttonTestIds()).toEqual([
+      "usage-copy-image",
+      "usage-download-image",
+    ]);
+  });
+
+  it("renders share then download where the shell's save route is a chooser", () => {
+    renderActions({
+      exportReady: true,
+      pendingAction: null,
+      ...shareSheetShell(),
+      downloadImage: () => undefined,
+      variant: "icon",
+    });
+
+    expect(buttonTestIds()).toEqual([
+      "usage-share-image",
+      "usage-download-image",
+    ]);
+  });
+
+  it("names an icon-only button for assistive tech", () => {
+    renderActions({
+      exportReady: true,
+      pendingAction: null,
+      ...shareSheetShell(),
+      downloadImage: () => undefined,
+      variant: "icon",
+    });
+
+    // The icon variant carries no visible text at all, so the accessible name
+    // is the ONLY name these buttons have.
+    expect(screen.getByLabelText("Share usage image")).toBeTruthy();
+    expect(screen.getByLabelText("Download usage image")).toBeTruthy();
+  });
+
+  it("labels the buttons in the labelled variant instead", () => {
+    renderActions({
+      exportReady: true,
+      pendingAction: null,
+      ...shareSheetShell(),
+      downloadImage: () => undefined,
+      variant: "labelled",
+    });
+
+    expect(screen.getByTestId("usage-share-image").textContent).toContain(
+      "Share image",
+    );
+    expect(screen.getByTestId("usage-download-image").textContent).toContain(
+      "Download image",
+    );
+  });
+
+  it("disables every control while any export runs", () => {
+    renderActions({
+      exportReady: true,
+      pendingAction: "share",
+      ...shareSheetShell(),
+      downloadImage: () => undefined,
+      variant: "labelled",
+    });
+
+    // A capture is an expensive full-region rasterisation, so a second one
+    // must not start while the first is in flight - whichever control it was.
+    for (const button of screen.getAllByRole("button")) {
+      expect(button instanceof HTMLButtonElement && button.disabled).toBe(true);
+    }
+  });
+
+  it("disables every control until the surface has something truthful to capture", () => {
+    renderActions({
+      exportReady: false,
+      pendingAction: null,
+      ...ownDownloadShell(),
+      downloadImage: () => undefined,
+      variant: "icon",
+    });
+
+    for (const button of screen.getAllByRole("button")) {
+      expect(button instanceof HTMLButtonElement && button.disabled).toBe(true);
+    }
+  });
+
+  it("spins only the control that started the export", () => {
+    renderActions({
+      exportReady: true,
+      pendingAction: "download",
+      ...shareSheetShell(),
+      downloadImage: () => undefined,
+      variant: "labelled",
+    });
+
+    const download = screen.getByTestId("usage-download-image");
+    const share = screen.getByTestId("usage-share-image");
+    // The spinner replaces the glyph, so the pending button loses its icon and
+    // the other one keeps it.
+    expect(download.querySelector("svg")).toBeNull();
+    expect(share.querySelector("svg")).not.toBeNull();
+  });
+
+  it("runs the handler belonging to the control that was pressed", async () => {
+    const user = userEvent.setup();
+    const shareImage = vi.fn();
+    const downloadImage = vi.fn();
+    render(
+      <TooltipProvider>
+        <UsageExportImageActions
+          exportReady
+          pendingAction={null}
+          copyImage={null}
+          shareImage={shareImage}
+          downloadImage={downloadImage}
+          testIdPrefix="usage"
+          variant="labelled"
+          buttonClassName={undefined}
+        />
+      </TooltipProvider>,
+    );
+
+    await user.click(screen.getByTestId("usage-share-image"));
+    expect(shareImage).toHaveBeenCalledTimes(1);
+    expect(downloadImage).not.toHaveBeenCalled();
+
+    await user.click(screen.getByTestId("usage-download-image"));
+    expect(downloadImage).toHaveBeenCalledTimes(1);
+    expect(shareImage).toHaveBeenCalledTimes(1);
+  });
+});

--- a/clients/gui-app/src/components/usage-analytics/__tests__/usage-export-image-actions.test.tsx
+++ b/clients/gui-app/src/components/usage-analytics/__tests__/usage-export-image-actions.test.tsx
@@ -27,8 +27,20 @@ function ownDownloadShell(): Pick<Overrides, "copyImage" | "shareImage"> {
   return { copyImage: () => undefined, shareImage: null };
 }
 
-/** The shell shape where `saveFile` reaches an OS chooser: the mobile app. */
-function shareSheetShell(): Pick<Overrides, "copyImage" | "shareImage"> {
+/**
+ * A shell with an OS chooser AND a working image clipboard - the iOS install.
+ * The two capabilities are independent, so this is the shape that carries all
+ * three controls at once.
+ */
+function shareAndCopyShell(): Pick<Overrides, "copyImage" | "shareImage"> {
+  return { copyImage: () => undefined, shareImage: () => undefined };
+}
+
+/**
+ * A shell with an OS chooser whose WebView cannot reach the image clipboard -
+ * the Android install.
+ */
+function shareOnlyShell(): Pick<Overrides, "copyImage" | "shareImage"> {
   return { copyImage: null, shareImage: () => undefined };
 }
 
@@ -76,7 +88,7 @@ describe("<UsageExportImageActions />", () => {
     renderActions({
       exportReady: true,
       pendingAction: null,
-      ...shareSheetShell(),
+      ...shareOnlyShell(),
       downloadImage: () => undefined,
       variant: "icon",
     });
@@ -87,11 +99,29 @@ describe("<UsageExportImageActions />", () => {
     ]);
   });
 
+  it("renders copy, share then download where the shell can do both", () => {
+    renderActions({
+      exportReady: true,
+      pendingAction: null,
+      ...shareAndCopyShell(),
+      downloadImage: () => undefined,
+      variant: "icon",
+    });
+
+    // Fixed order regardless of which controls exist, so a shell gaining or
+    // losing one never reshuffles the rest under the user's thumb.
+    expect(buttonTestIds()).toEqual([
+      "usage-copy-image",
+      "usage-share-image",
+      "usage-download-image",
+    ]);
+  });
+
   it("names an icon-only button for assistive tech", () => {
     renderActions({
       exportReady: true,
       pendingAction: null,
-      ...shareSheetShell(),
+      ...shareOnlyShell(),
       downloadImage: () => undefined,
       variant: "icon",
     });
@@ -106,7 +136,7 @@ describe("<UsageExportImageActions />", () => {
     renderActions({
       exportReady: true,
       pendingAction: null,
-      ...shareSheetShell(),
+      ...shareOnlyShell(),
       downloadImage: () => undefined,
       variant: "labelled",
     });
@@ -123,7 +153,7 @@ describe("<UsageExportImageActions />", () => {
     renderActions({
       exportReady: true,
       pendingAction: "share",
-      ...shareSheetShell(),
+      ...shareOnlyShell(),
       downloadImage: () => undefined,
       variant: "labelled",
     });
@@ -153,7 +183,7 @@ describe("<UsageExportImageActions />", () => {
     renderActions({
       exportReady: true,
       pendingAction: "download",
-      ...shareSheetShell(),
+      ...shareOnlyShell(),
       downloadImage: () => undefined,
       variant: "labelled",
     });

--- a/clients/gui-app/src/components/usage-analytics/__tests__/usage-summary-panel-image-export.test.tsx
+++ b/clients/gui-app/src/components/usage-analytics/__tests__/usage-summary-panel-image-export.test.tsx
@@ -34,6 +34,13 @@ const mocks = vi.hoisted(() => ({
   saveBlobToDisk: vi.fn(),
   downloadBlobToDevice: vi.fn(),
   hasSeparateDownloadRoute: vi.fn<() => boolean>(),
+  useCanCopyImages: vi.fn<() => boolean>(),
+}));
+
+// The shell capability behind "Copy image". Mocked at the hook rather than by
+// mounting a runner host, so a case states the one fact it varies.
+vi.mock("@/hooks/images/use-can-copy-images", () => ({
+  useCanCopyImages: mocks.useCanCopyImages,
 }));
 
 // html-to-image's `toBlob` rasterises via a canvas that jsdom can't back -
@@ -65,6 +72,7 @@ beforeEach(() => {
   // The shape of every shell whose own save route IS the download - desktop
   // and a plain browser tab. The share-sheet shape is opted into per case.
   mocks.hasSeparateDownloadRoute.mockReturnValue(false);
+  mocks.useCanCopyImages.mockReturnValue(true);
 });
 
 afterEach(() => {
@@ -75,6 +83,7 @@ afterEach(() => {
   mocks.saveBlobToDisk.mockReset();
   mocks.downloadBlobToDevice.mockReset();
   mocks.hasSeparateDownloadRoute.mockReset();
+  mocks.useCanCopyImages.mockReset();
 });
 
 const ZERO_PROVENANCE_SPLIT: UsageSummaryResponse["summary"]["totals"]["provenanceSplit"] =
@@ -368,21 +377,48 @@ describe("<UsageSummaryPanel /> image export", () => {
     expect(screen.getByTestId("usage-copy-image")).toBeTruthy();
   });
 
-  it("swaps copy for share on a shell whose save route is an OS chooser", async () => {
-    // The installed mobile app: its `saveFile` reaches the share sheet, so
-    // share and download are two different acts - and its WebView cannot put
-    // an image on the system clipboard, so a Copy button there would report a
-    // success the clipboard never received.
+  it("adds share alongside copy on a shell whose save route is an OS chooser", async () => {
+    // The iOS install: its `saveFile` reaches the share sheet, so share and
+    // download are two different acts - and WKWebView does honour an image
+    // clipboard write, so Copy stays. All three controls.
     mocks.hasSeparateDownloadRoute.mockReturnValue(true);
     renderPanel(usageSummaryResponse);
     await screen.findByTestId("usage-cost-figure");
     await screen.findByTestId("usage-activity-section");
 
-    expect(screen.queryByTestId("usage-copy-image")).toBeNull();
+    expect(screen.getByTestId("usage-copy-image")).toBeTruthy();
     const shareButton = screen.getByTestId("usage-share-image");
     expect(
       shareButton instanceof HTMLButtonElement && shareButton.disabled,
     ).toBe(false);
+    expect(screen.getByTestId("usage-download-image")).toBeTruthy();
+  });
+
+  it("drops copy where the shell cannot put an image on the clipboard", async () => {
+    // The Android install: the write RESOLVES having written nothing, so a
+    // Copy button would report a success the clipboard never received. Share
+    // and download are unaffected, and the sheet's own Copy action is the
+    // route that works.
+    mocks.hasSeparateDownloadRoute.mockReturnValue(true);
+    mocks.useCanCopyImages.mockReturnValue(false);
+    renderPanel(usageSummaryResponse);
+    await screen.findByTestId("usage-cost-figure");
+    await screen.findByTestId("usage-activity-section");
+
+    expect(screen.queryByTestId("usage-copy-image")).toBeNull();
+    expect(screen.getByTestId("usage-share-image")).toBeTruthy();
+    expect(screen.getByTestId("usage-download-image")).toBeTruthy();
+  });
+
+  it("drops copy on a clipboard-less shell even with no share route", async () => {
+    // The two capabilities are independent: losing Copy must not depend on
+    // having gained Share.
+    mocks.useCanCopyImages.mockReturnValue(false);
+    renderPanel(usageSummaryResponse);
+    await screen.findByTestId("usage-cost-figure");
+
+    expect(screen.queryByTestId("usage-copy-image")).toBeNull();
+    expect(screen.queryByTestId("usage-share-image")).toBeNull();
     expect(screen.getByTestId("usage-download-image")).toBeTruthy();
   });
 

--- a/clients/gui-app/src/components/usage-analytics/__tests__/usage-summary-panel-image-export.test.tsx
+++ b/clients/gui-app/src/components/usage-analytics/__tests__/usage-summary-panel-image-export.test.tsx
@@ -2,7 +2,7 @@ import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { HostClient } from "@traycer-clients/shared/host-client/host-client";
 import { mockLocalHostEntry } from "@traycer-clients/shared/host-client/mock/mock-host-directory";
 import { MockHostMessenger } from "@traycer-clients/shared/host-client/mock/mock-host-messenger";
@@ -32,6 +32,8 @@ const mocks = vi.hoisted(() => ({
   copyImageBlobPromiseToClipboard:
     vi.fn<(blobPromise: Promise<Blob>) => Promise<void>>(),
   saveBlobToDisk: vi.fn(),
+  downloadBlobToDevice: vi.fn(),
+  hasSeparateDownloadRoute: vi.fn<() => boolean>(),
 }));
 
 // html-to-image's `toBlob` rasterises via a canvas that jsdom can't back -
@@ -51,11 +53,19 @@ vi.mock("@/lib/images/copy-image-to-clipboard", () => ({
 
 vi.mock("@/lib/files/save-blob-to-disk", () => ({
   saveBlobToDisk: mocks.saveBlobToDisk,
+  downloadBlobToDevice: mocks.downloadBlobToDevice,
+  hasSeparateDownloadRoute: mocks.hasSeparateDownloadRoute,
   // Browser-runtime shape: the picker never reports a path, so the saved
   // toast has no "Open file" action to offer.
   canOpenSavedFile: () => false,
   openSavedFile: vi.fn(),
 }));
+
+beforeEach(() => {
+  // The shape of every shell whose own save route IS the download - desktop
+  // and a plain browser tab. The share-sheet shape is opted into per case.
+  mocks.hasSeparateDownloadRoute.mockReturnValue(false);
+});
 
 afterEach(() => {
   cleanup();
@@ -63,6 +73,8 @@ afterEach(() => {
   mocks.copyImageBlobToClipboard.mockReset();
   mocks.copyImageBlobPromiseToClipboard.mockReset();
   mocks.saveBlobToDisk.mockReset();
+  mocks.downloadBlobToDevice.mockReset();
+  mocks.hasSeparateDownloadRoute.mockReset();
 });
 
 const ZERO_PROVENANCE_SPLIT: UsageSummaryResponse["summary"]["totals"]["provenanceSplit"] =
@@ -321,7 +333,7 @@ describe("<UsageSummaryPanel /> image export", () => {
     const user = userEvent.setup();
     const blob = new Blob(["fake-png-bytes"], { type: "image/png" });
     mocks.captureUsageExportImageBlob.mockResolvedValue(blob);
-    mocks.saveBlobToDisk.mockResolvedValue({
+    mocks.downloadBlobToDevice.mockResolvedValue({
       name: "traycer-usage-30d.png",
       path: null,
     });
@@ -332,11 +344,11 @@ describe("<UsageSummaryPanel /> image export", () => {
     await user.click(screen.getByTestId("usage-download-image"));
 
     await waitFor(() => {
-      expect(mocks.saveBlobToDisk).toHaveBeenCalledWith(
+      expect(mocks.downloadBlobToDevice).toHaveBeenCalledWith(
         blob,
         expect.stringMatching(/^traycer-usage-30d\.png$/),
         // This harness mounts no runner host, so there is no native save
-        // route and the save falls through to the browser APIs.
+        // route and the download falls through to the browser APIs.
         null,
       );
     });
@@ -346,5 +358,60 @@ describe("<UsageSummaryPanel /> image export", () => {
       subheading: EXPECTED_SUBHEADING,
     });
     expect(mocks.copyImageBlobPromiseToClipboard).not.toHaveBeenCalled();
+  });
+
+  it("offers no share control on a shell whose save route is already the download", async () => {
+    renderPanel(usageSummaryResponse);
+    await screen.findByTestId("usage-cost-figure");
+
+    expect(screen.queryByTestId("usage-share-image")).toBeNull();
+    expect(screen.getByTestId("usage-copy-image")).toBeTruthy();
+  });
+
+  it("swaps copy for share on a shell whose save route is an OS chooser", async () => {
+    // The installed mobile app: its `saveFile` reaches the share sheet, so
+    // share and download are two different acts - and its WebView cannot put
+    // an image on the system clipboard, so a Copy button there would report a
+    // success the clipboard never received.
+    mocks.hasSeparateDownloadRoute.mockReturnValue(true);
+    renderPanel(usageSummaryResponse);
+    await screen.findByTestId("usage-cost-figure");
+    await screen.findByTestId("usage-activity-section");
+
+    expect(screen.queryByTestId("usage-copy-image")).toBeNull();
+    const shareButton = screen.getByTestId("usage-share-image");
+    expect(
+      shareButton instanceof HTMLButtonElement && shareButton.disabled,
+    ).toBe(false);
+    expect(screen.getByTestId("usage-download-image")).toBeTruthy();
+  });
+
+  it("sends share through the shell's own save route and download past it", async () => {
+    const user = userEvent.setup();
+    const blob = new Blob(["fake-png-bytes"], { type: "image/png" });
+    mocks.hasSeparateDownloadRoute.mockReturnValue(true);
+    mocks.captureUsageExportImageBlob.mockResolvedValue(blob);
+    mocks.saveBlobToDisk.mockResolvedValue({ name: "shared.png", path: null });
+    mocks.downloadBlobToDevice.mockResolvedValue({
+      name: "traycer-usage-30d.png",
+      path: "file:///docs/Traycer/traycer-usage-30d.png",
+    });
+    renderPanel(usageSummaryResponse);
+    await screen.findByTestId("usage-cost-figure");
+    await screen.findByTestId("usage-activity-section");
+
+    await user.click(screen.getByTestId("usage-share-image"));
+    await waitFor(() => {
+      expect(mocks.saveBlobToDisk).toHaveBeenCalledTimes(1);
+    });
+    expect(mocks.downloadBlobToDevice).not.toHaveBeenCalled();
+
+    await user.click(screen.getByTestId("usage-download-image"));
+    await waitFor(() => {
+      expect(mocks.downloadBlobToDevice).toHaveBeenCalledTimes(1);
+    });
+    // The share leg did not run again: the two controls are genuinely
+    // separate routes, not one route under two labels.
+    expect(mocks.saveBlobToDisk).toHaveBeenCalledTimes(1);
   });
 });

--- a/clients/gui-app/src/components/usage-analytics/__tests__/usage-summary-panel-image-export.test.tsx
+++ b/clients/gui-app/src/components/usage-analytics/__tests__/usage-summary-panel-image-export.test.tsx
@@ -34,6 +34,7 @@ const mocks = vi.hoisted(() => ({
   saveBlobToDisk: vi.fn(),
   downloadBlobToDevice: vi.fn(),
   hasSeparateDownloadRoute: vi.fn<() => boolean>(),
+  canDownloadToDevice: vi.fn<() => boolean>(),
   useCanCopyImages: vi.fn<() => boolean>(),
 }));
 
@@ -62,6 +63,7 @@ vi.mock("@/lib/files/save-blob-to-disk", () => ({
   saveBlobToDisk: mocks.saveBlobToDisk,
   downloadBlobToDevice: mocks.downloadBlobToDevice,
   hasSeparateDownloadRoute: mocks.hasSeparateDownloadRoute,
+  canDownloadToDevice: mocks.canDownloadToDevice,
   // Browser-runtime shape: the picker never reports a path, so the saved
   // toast has no "Open file" action to offer.
   canOpenSavedFile: () => false,
@@ -72,6 +74,8 @@ beforeEach(() => {
   // The shape of every shell whose own save route IS the download - desktop
   // and a plain browser tab. The share-sheet shape is opted into per case.
   mocks.hasSeparateDownloadRoute.mockReturnValue(false);
+  // Every shell but a chooser-only one can honour a Download.
+  mocks.canDownloadToDevice.mockReturnValue(true);
   mocks.useCanCopyImages.mockReturnValue(true);
 });
 
@@ -83,6 +87,7 @@ afterEach(() => {
   mocks.saveBlobToDisk.mockReset();
   mocks.downloadBlobToDevice.mockReset();
   mocks.hasSeparateDownloadRoute.mockReset();
+  mocks.canDownloadToDevice.mockReset();
   mocks.useCanCopyImages.mockReset();
 });
 

--- a/clients/gui-app/src/components/usage-analytics/usage-export-image-actions.tsx
+++ b/clients/gui-app/src/components/usage-analytics/usage-export-image-actions.tsx
@@ -16,7 +16,8 @@ export interface UsageExportImageActionsProps {
   /** The controls this shell can honour, from `useUsageImageExport`. */
   readonly copyImage: (() => void) | null;
   readonly shareImage: (() => void) | null;
-  readonly downloadImage: () => void;
+  /** `null` where this device has no download destination at all. */
+  readonly downloadImage: (() => void) | null;
   /**
    * Names this surface's buttons in tests - `usage-copy-image`,
    * `epic-usage-download-image`. Each surface keeps the ids it already had.
@@ -76,13 +77,17 @@ export function UsageExportImageActions(
             onClick: props.shareImage,
           },
         ]),
-    {
-      action: "download" as const,
-      label: "Download image",
-      ariaLabel: "Download usage image",
-      icon: Download,
-      onClick: props.downloadImage,
-    },
+    ...(props.downloadImage === null
+      ? []
+      : [
+          {
+            action: "download" as const,
+            label: "Download image",
+            ariaLabel: "Download usage image",
+            icon: Download,
+            onClick: props.downloadImage,
+          },
+        ]),
   ];
 
   return (

--- a/clients/gui-app/src/components/usage-analytics/usage-export-image-actions.tsx
+++ b/clients/gui-app/src/components/usage-analytics/usage-export-image-actions.tsx
@@ -1,0 +1,142 @@
+import { Fragment, type ReactNode } from "react";
+import { Copy, Download, Share2, type LucideIcon } from "lucide-react";
+import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
+import { Button } from "@/components/ui/button";
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
+import type { UsageImageExportAction } from "@/hooks/usage-analytics/use-usage-image-export";
+
+/** How a surface wants the export controls drawn. */
+export type UsageExportImageActionsVariant = "icon" | "labelled";
+
+export interface UsageExportImageActionsProps {
+  /** Whether the surface has enough loaded to capture a truthful image. */
+  readonly exportReady: boolean;
+  /** Which control's export is in flight, from `useUsageImageExport`. */
+  readonly pendingAction: UsageImageExportAction | null;
+  /** The controls this shell can honour, from `useUsageImageExport`. */
+  readonly copyImage: (() => void) | null;
+  readonly shareImage: (() => void) | null;
+  readonly downloadImage: () => void;
+  /**
+   * Names this surface's buttons in tests - `usage-copy-image`,
+   * `epic-usage-download-image`. Each surface keeps the ids it already had.
+   */
+  readonly testIdPrefix: string;
+  readonly variant: UsageExportImageActionsVariant;
+  /** Layout the host footer/header imposes, e.g. full-width on a sheet. */
+  readonly buttonClassName: string | undefined;
+}
+
+interface UsageExportControl {
+  readonly action: UsageImageExportAction;
+  /** Tooltip and button copy, and the stem of the test id. */
+  readonly label: string;
+  /** What a screen reader announces where the button is icon-only. */
+  readonly ariaLabel: string;
+  readonly icon: LucideIcon;
+  readonly onClick: () => void;
+}
+
+/**
+ * The export controls a usage surface renders, in a fixed order, from the
+ * set the shell can actually honour.
+ *
+ * ONE export runs at a time, so EVERY button goes disabled while any is
+ * pending; only the one that started it shows the spinner, which is what the
+ * mutation's variables discriminate. Shared by both usage surfaces so the set
+ * of controls, their copy and their pending behaviour cannot drift apart -
+ * which control exists at all is decided once, in `useUsageImageExport`, off
+ * shell capability rather than per surface.
+ */
+export function UsageExportImageActions(
+  props: UsageExportImageActionsProps,
+): ReactNode {
+  const { exportReady, pendingAction, variant, buttonClassName } = props;
+  const isExporting = pendingAction !== null;
+  const controls: readonly UsageExportControl[] = [
+    ...(props.copyImage === null
+      ? []
+      : [
+          {
+            action: "copy" as const,
+            label: "Copy image",
+            ariaLabel: "Copy usage image",
+            icon: Copy,
+            onClick: props.copyImage,
+          },
+        ]),
+    ...(props.shareImage === null
+      ? []
+      : [
+          {
+            action: "share" as const,
+            label: "Share image",
+            ariaLabel: "Share usage image",
+            icon: Share2,
+            onClick: props.shareImage,
+          },
+        ]),
+    {
+      action: "download" as const,
+      label: "Download image",
+      ariaLabel: "Download usage image",
+      icon: Download,
+      onClick: props.downloadImage,
+    },
+  ];
+
+  return (
+    <>
+      {controls.map((control) => {
+        const Icon = control.icon;
+        const glyph =
+          pendingAction === control.action ? (
+            <AgentSpinningDots
+              className="size-3"
+              testId={undefined}
+              variant={undefined}
+            />
+          ) : (
+            <Icon
+              aria-hidden
+              className={variant === "icon" ? "size-3.5" : undefined}
+            />
+          );
+        const button = (
+          <Button
+            type="button"
+            variant="outline"
+            size={variant === "icon" ? "icon-sm" : "sm"}
+            className={buttonClassName}
+            aria-label={variant === "icon" ? control.ariaLabel : undefined}
+            data-testid={`${props.testIdPrefix}-${control.action}-image`}
+            disabled={!exportReady || isExporting}
+            onClick={control.onClick}
+          >
+            {glyph}
+            {variant === "labelled" ? control.label : null}
+          </Button>
+        );
+        // The labelled variant already says what it does; a tooltip repeating
+        // the label is noise, and on the touch surfaces that variant is drawn
+        // for there is no hover to open one anyway. A keyed Fragment rather
+        // than a wrapper element: the button has to stay a direct child of the
+        // host's flex row, or its width and the row's gap both stop applying.
+        if (variant === "labelled") {
+          return <Fragment key={control.action}>{button}</Fragment>;
+        }
+        return (
+          <TooltipWrapper
+            key={control.action}
+            label={control.label}
+            side="top"
+            sideOffset={undefined}
+            align={undefined}
+          >
+            {button}
+          </TooltipWrapper>
+        );
+      })}
+    </>
+  );
+}

--- a/clients/gui-app/src/components/usage-analytics/usage-summary-panel.tsx
+++ b/clients/gui-app/src/components/usage-analytics/usage-summary-panel.tsx
@@ -1,16 +1,11 @@
 import { useMemo, useRef, useState, type ReactNode } from "react";
-import { Copy, Download } from "lucide-react";
 import type { UseQueryResult } from "@tanstack/react-query";
 import type { HostClient } from "@traycer-clients/shared/host-client/host-client";
 import type { HostRpcError } from "@traycer-clients/shared/host-transport/host-messenger";
 import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
-import { Button } from "@/components/ui/button";
-import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 import type { HostRpcRegistry } from "@/lib/host";
-import {
-  useUsageImageExport,
-  type UsageImageExportMutation,
-} from "@/hooks/usage-analytics/use-usage-image-export";
+import { useUsageImageExport } from "@/hooks/usage-analytics/use-usage-image-export";
+import { UsageExportImageActions } from "@/components/usage-analytics/usage-export-image-actions";
 import { USAGE_EXPORT_REGION_SELECTOR } from "@/lib/usage-analytics/usage-export-image";
 import {
   buildUsageSummaryRequest,
@@ -249,22 +244,23 @@ export function UsageSummaryPanel(props: UsageSummaryPanelProps): ReactNode {
   const exportReady =
     query.data !== undefined &&
     usageActivityLaneSettled(activityQuery, activityFallbackQuery);
-  const { mutation, copyImage, downloadImage } = useUsageImageExport({
-    getExportNode: () =>
-      panelRef.current?.querySelector<HTMLElement>(
-        USAGE_EXPORT_REGION_SELECTOR,
-      ) ?? null,
-    fileName: `traycer-usage-${String(windowDays)}d.png`,
-    heading: "Usage",
-    // The metric belongs in the subheading because its toggle sits OUTSIDE
-    // the capture region: the chart and the activity calendar both obey it,
-    // so a tokens-mode capture is a page of magnitudes with nothing naming
-    // what they measure - a reader would take them for dollars. The date
-    // range alone describes only half the scope of what the image shows.
-    subheading: `${dateRangeLabel} · ${USAGE_METRIC_LABELS[metric]}`,
-    errorSource: "Usage settings",
-    analyticsSource: "settings",
-  });
+  const { pendingAction, copyImage, shareImage, downloadImage } =
+    useUsageImageExport({
+      getExportNode: () =>
+        panelRef.current?.querySelector<HTMLElement>(
+          USAGE_EXPORT_REGION_SELECTOR,
+        ) ?? null,
+      fileName: `traycer-usage-${String(windowDays)}d.png`,
+      heading: "Usage",
+      // The metric belongs in the subheading because its toggle sits OUTSIDE
+      // the capture region: the chart and the activity calendar both obey it,
+      // so a tokens-mode capture is a page of magnitudes with nothing naming
+      // what they measure - a reader would take them for dollars. The date
+      // range alone describes only half the scope of what the image shows.
+      subheading: `${dateRangeLabel} · ${USAGE_METRIC_LABELS[metric]}`,
+      errorSource: "Usage settings",
+      analyticsSource: "settings",
+    });
   return (
     <div ref={panelRef} className="flex w-full max-w-4xl flex-col gap-5">
       <div className="flex flex-wrap items-center justify-between gap-3">
@@ -291,9 +287,13 @@ export function UsageSummaryPanel(props: UsageSummaryPanelProps): ReactNode {
           <UsageMetricToggle metric={metric} onChange={setMetric} />
           <UsageExportImageActions
             exportReady={exportReady}
-            mutation={mutation}
-            onCopyImage={copyImage}
-            onDownloadImage={downloadImage}
+            pendingAction={pendingAction}
+            copyImage={copyImage}
+            shareImage={shareImage}
+            downloadImage={downloadImage}
+            testIdPrefix="usage"
+            variant="icon"
+            buttonClassName={undefined}
           />
         </div>
       </div>
@@ -313,81 +313,6 @@ export function UsageSummaryPanel(props: UsageSummaryPanelProps): ReactNode {
         }
       />
     </div>
-  );
-}
-
-/**
- * The header's Copy image / Download image pair. One export runs at a time,
- * so BOTH buttons go disabled while either is pending; only the button that
- * started it shows the spinner, which is what the mutation's variables
- * discriminate. Extracted from the panel so the pending derivations live
- * beside the buttons they gate.
- */
-function UsageExportImageActions(props: {
-  readonly exportReady: boolean;
-  readonly mutation: UsageImageExportMutation;
-  readonly onCopyImage: () => void;
-  readonly onDownloadImage: () => void;
-}): ReactNode {
-  const { exportReady, mutation } = props;
-  const isExporting = mutation.isPending;
-  const isCopying = isExporting && mutation.variables.action === "copy";
-  const isDownloading = isExporting && mutation.variables.action === "download";
-  return (
-    <>
-      <TooltipWrapper
-        label="Copy image"
-        side="top"
-        sideOffset={undefined}
-        align={undefined}
-      >
-        <Button
-          type="button"
-          variant="outline"
-          size="icon-sm"
-          aria-label="Copy usage image"
-          data-testid="usage-copy-image"
-          disabled={!exportReady || isExporting}
-          onClick={props.onCopyImage}
-        >
-          {isCopying ? (
-            <AgentSpinningDots
-              className="size-3"
-              testId={undefined}
-              variant={undefined}
-            />
-          ) : (
-            <Copy aria-hidden className="size-3.5" />
-          )}
-        </Button>
-      </TooltipWrapper>
-      <TooltipWrapper
-        label="Download image"
-        side="top"
-        sideOffset={undefined}
-        align={undefined}
-      >
-        <Button
-          type="button"
-          variant="outline"
-          size="icon-sm"
-          aria-label="Download usage image"
-          data-testid="usage-download-image"
-          disabled={!exportReady || isExporting}
-          onClick={props.onDownloadImage}
-        >
-          {isDownloading ? (
-            <AgentSpinningDots
-              className="size-3"
-              testId={undefined}
-              variant={undefined}
-            />
-          ) : (
-            <Download aria-hidden className="size-3.5" />
-          )}
-        </Button>
-      </TooltipWrapper>
-    </>
   );
 }
 

--- a/clients/gui-app/src/editor-core/nodes/mermaid/mermaid-block-toolbar.tsx
+++ b/clients/gui-app/src/editor-core/nodes/mermaid/mermaid-block-toolbar.tsx
@@ -1,4 +1,4 @@
-import { Copy, Download, Pencil, X } from "lucide-react";
+import { Copy, Download, Pencil, Share2, X } from "lucide-react";
 import { ToolbarButton } from "../../toolbar/toolbar-button";
 import { BlockFloatingToolbar } from "../shared/block-floating-toolbar";
 
@@ -8,6 +8,11 @@ export interface MermaidBlockToolbarProps {
   readonly onToggleEdit: () => void;
   readonly onCopyCode: () => void;
   readonly onDownloadPng: () => void;
+  /**
+   * Hands the PNG to the OS share sheet, or `null` where the shell owns no
+   * chooser and Download is already the only route out.
+   */
+  readonly onSharePng: (() => void) | null;
   readonly downloadDisabled: boolean;
 }
 
@@ -24,6 +29,7 @@ export function MermaidBlockToolbar(props: MermaidBlockToolbarProps) {
     onToggleEdit,
     onCopyCode,
     onDownloadPng,
+    onSharePng,
     downloadDisabled,
   } = props;
 
@@ -51,6 +57,16 @@ export function MermaidBlockToolbar(props: MermaidBlockToolbarProps) {
         onClick={onCopyCode}
         className="tc-editor-toolbar-button"
       />
+      {onSharePng === null ? null : (
+        <ToolbarButton
+          icon={<Share2 className="size-4" aria-hidden="true" />}
+          label="Share PNG"
+          active={false}
+          disabled={downloadDisabled}
+          onClick={onSharePng}
+          className="tc-editor-toolbar-button"
+        />
+      )}
       <ToolbarButton
         icon={<Download className="size-4" aria-hidden="true" />}
         label="Download PNG"

--- a/clients/gui-app/src/editor-core/nodes/mermaid/mermaid-block-toolbar.tsx
+++ b/clients/gui-app/src/editor-core/nodes/mermaid/mermaid-block-toolbar.tsx
@@ -7,7 +7,8 @@ export interface MermaidBlockToolbarProps {
   readonly editable: boolean;
   readonly onToggleEdit: () => void;
   readonly onCopyCode: () => void;
-  readonly onDownloadPng: () => void;
+  /** `null` where this device has no download destination at all. */
+  readonly onDownloadPng: (() => void) | null;
   /**
    * Hands the PNG to the OS share sheet, or `null` where the shell owns no
    * chooser and Download is already the only route out.
@@ -67,14 +68,16 @@ export function MermaidBlockToolbar(props: MermaidBlockToolbarProps) {
           className="tc-editor-toolbar-button"
         />
       )}
-      <ToolbarButton
-        icon={<Download className="size-4" aria-hidden="true" />}
-        label="Download PNG"
-        active={false}
-        disabled={downloadDisabled}
-        onClick={onDownloadPng}
-        className="tc-editor-toolbar-button"
-      />
+      {onDownloadPng === null ? null : (
+        <ToolbarButton
+          icon={<Download className="size-4" aria-hidden="true" />}
+          label="Download PNG"
+          active={false}
+          disabled={downloadDisabled}
+          onClick={onDownloadPng}
+          className="tc-editor-toolbar-button"
+        />
+      )}
     </BlockFloatingToolbar>
   );
 }

--- a/clients/gui-app/src/editor-core/nodes/mermaid/mermaid-fullscreen-dialog.tsx
+++ b/clients/gui-app/src/editor-core/nodes/mermaid/mermaid-fullscreen-dialog.tsx
@@ -19,7 +19,8 @@ export interface MermaidFullscreenDialogProps {
   readonly code: string;
   readonly title: string;
   readonly onCopyCode: () => void;
-  readonly onDownloadPng: () => void;
+  /** `null` where this device has no download destination at all. */
+  readonly onDownloadPng: (() => void) | null;
   /**
    * Hands the PNG to the OS share sheet, or `null` where the shell owns no
    * chooser and Download is already the only route out.
@@ -92,22 +93,24 @@ export function MermaidFullscreenDialog(props: MermaidFullscreenDialogProps) {
                 </Button>
               </TooltipWrapper>
             )}
-            <TooltipWrapper
-              label="Download PNG"
-              side="top"
-              sideOffset={undefined}
-              align={undefined}
-            >
-              <Button
-                variant="ghost"
-                size="icon-sm"
-                onClick={onDownloadPng}
-                aria-label="Download PNG"
-                disabled={downloadDisabled}
+            {onDownloadPng === null ? null : (
+              <TooltipWrapper
+                label="Download PNG"
+                side="top"
+                sideOffset={undefined}
+                align={undefined}
               >
-                <Download className="size-4" aria-hidden="true" />
-              </Button>
-            </TooltipWrapper>
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  onClick={onDownloadPng}
+                  aria-label="Download PNG"
+                  disabled={downloadDisabled}
+                >
+                  <Download className="size-4" aria-hidden="true" />
+                </Button>
+              </TooltipWrapper>
+            )}
             <TooltipWrapper
               label={
                 <>

--- a/clients/gui-app/src/editor-core/nodes/mermaid/mermaid-fullscreen-dialog.tsx
+++ b/clients/gui-app/src/editor-core/nodes/mermaid/mermaid-fullscreen-dialog.tsx
@@ -1,4 +1,4 @@
-import { Copy, Download, X } from "lucide-react";
+import { Copy, Download, Share2, X } from "lucide-react";
 import {
   Dialog,
   DialogClose,
@@ -20,6 +20,11 @@ export interface MermaidFullscreenDialogProps {
   readonly title: string;
   readonly onCopyCode: () => void;
   readonly onDownloadPng: () => void;
+  /**
+   * Hands the PNG to the OS share sheet, or `null` where the shell owns no
+   * chooser and Download is already the only route out.
+   */
+  readonly onSharePng: (() => void) | null;
   readonly downloadDisabled: boolean;
 }
 
@@ -37,6 +42,7 @@ export function MermaidFullscreenDialog(props: MermaidFullscreenDialogProps) {
     title,
     onCopyCode,
     onDownloadPng,
+    onSharePng,
     downloadDisabled,
   } = props;
   const ariaLabel =
@@ -68,6 +74,24 @@ export function MermaidFullscreenDialog(props: MermaidFullscreenDialogProps) {
                 <Copy className="size-4" aria-hidden="true" />
               </Button>
             </TooltipWrapper>
+            {onSharePng === null ? null : (
+              <TooltipWrapper
+                label="Share PNG"
+                side="top"
+                sideOffset={undefined}
+                align={undefined}
+              >
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  onClick={onSharePng}
+                  aria-label="Share PNG"
+                  disabled={downloadDisabled}
+                >
+                  <Share2 className="size-4" aria-hidden="true" />
+                </Button>
+              </TooltipWrapper>
+            )}
             <TooltipWrapper
               label="Download PNG"
               side="top"

--- a/clients/gui-app/src/editor-core/nodes/mermaid/mermaid-node-view.tsx
+++ b/clients/gui-app/src/editor-core/nodes/mermaid/mermaid-node-view.tsx
@@ -163,10 +163,11 @@ export function MermaidNodeView(props: NodeViewProps) {
     });
   }, [activeCode]);
 
-  const { downloadMermaidPng, isDownloading } = useMermaidPngDownload({
-    svg: render.svg,
-    enabled: render.status === "ready",
-  });
+  const { downloadMermaidPng, shareMermaidPng, isDownloading } =
+    useMermaidPngDownload({
+      svg: render.svg,
+      enabled: render.status === "ready",
+    });
 
   const handleToggleEdit = useCallback(() => {
     setEditing((prev) => {
@@ -211,6 +212,7 @@ export function MermaidNodeView(props: NodeViewProps) {
           onToggleEdit={handleToggleEdit}
           onCopyCode={handleCopy}
           onDownloadPng={downloadMermaidPng}
+          onSharePng={shareMermaidPng}
           downloadDisabled={render.status !== "ready" || isDownloading}
         />
 
@@ -267,6 +269,7 @@ export function MermaidNodeView(props: NodeViewProps) {
           title={ariaLabel}
           onCopyCode={handleCopy}
           onDownloadPng={downloadMermaidPng}
+          onSharePng={shareMermaidPng}
           downloadDisabled={render.status !== "ready" || isDownloading}
         />
 

--- a/clients/gui-app/src/editor-core/nodes/mermaid/use-mermaid-png-download.ts
+++ b/clients/gui-app/src/editor-core/nodes/mermaid/use-mermaid-png-download.ts
@@ -2,7 +2,12 @@ import { useCallback } from "react";
 import { useMutation } from "@tanstack/react-query";
 import { svgToPngBlob } from "@/editor-core/nodes/mermaid/mermaid-service";
 import { readMermaidPalette } from "@/editor-core/nodes/mermaid/mermaid-theme";
-import { saveBlobToDisk, type SavedFile } from "@/lib/files/save-blob-to-disk";
+import {
+  downloadBlobToDevice,
+  hasSeparateDownloadRoute,
+  saveBlobToDisk,
+  type SavedFile,
+} from "@/lib/files/save-blob-to-disk";
 import { toastSavedFile } from "@/lib/files/saved-file-toast";
 import { useOpenSavedFile } from "@/hooks/files/use-open-saved-file";
 import { appLogger } from "@/lib/logger";
@@ -15,13 +20,21 @@ export interface UseMermaidPngDownloadParams {
   readonly enabled: boolean;
 }
 
+/** Which route a run took - see `hasSeparateDownloadRoute`. */
+export type MermaidPngExportAction = "share" | "download";
+
 export interface UseMermaidPngDownloadResult {
   readonly downloadMermaidPng: () => void;
+  /** `null` where the shell owns no OS chooser to hand the PNG to. */
+  readonly shareMermaidPng: (() => void) | null;
   readonly isDownloading: boolean;
+  /** Which control is in flight, so only that one spins. */
+  readonly pendingAction: MermaidPngExportAction | null;
 }
 
 interface MermaidPngDownloadInput {
   readonly svg: string;
+  readonly action: MermaidPngExportAction;
 }
 
 export function useMermaidPngDownload(
@@ -30,7 +43,8 @@ export function useMermaidPngDownload(
   const { svg, enabled } = params;
   const fileSave = useFileSaveHost();
   const openSaved = useOpenSavedFile();
-  const { mutate, isPending } = useMutation<
+  const canShare = hasSeparateDownloadRoute(fileSave);
+  const mutation = useMutation<
     SavedFile | null,
     Error,
     MermaidPngDownloadInput
@@ -42,28 +56,49 @@ export function useMermaidPngDownload(
         svg: input.svg,
         backgroundColor: palette.background,
       });
-      return saveBlobToDisk(blob, "mermaid-diagram.png", fileSave);
+      // `saveBlobToDisk` is the shell's own save route, which on a shell that
+      // also owns a chooser-free download IS the share sheet.
+      return input.action === "share"
+        ? saveBlobToDisk(blob, "mermaid-diagram.png", fileSave)
+        : downloadBlobToDevice(blob, "mermaid-diagram.png", fileSave);
     },
-    onSuccess: (saved) => {
+    onSuccess: (saved, input) => {
       if (saved !== null) {
-        toastSavedFile(saved, openSaved.mutate, fileSave);
+        toastSavedFile(
+          saved,
+          openSaved.mutate,
+          fileSave,
+          input.action === "share" ? "share" : "save",
+        );
       }
     },
-    onError: (err) => {
-      appLogger.errorSummary("[mermaid] download failed", {}, err);
-      reportableErrorToast("Failed to download diagram", undefined, {
-        title: "Could not download diagram",
+    onError: (err, input) => {
+      appLogger.errorSummary(`[mermaid] ${input.action} failed`, {}, err);
+      const verb = input.action === "share" ? "share" : "download";
+      reportableErrorToast(`Failed to ${verb} diagram`, undefined, {
+        title: `Could not ${verb} diagram`,
         message: null,
         code: null,
         source: "Mermaid diagram",
       });
     },
   });
+  const { mutate, isPending } = mutation;
 
   const downloadMermaidPng = useCallback(() => {
     if (!enabled || svg.length === 0) return;
-    mutate({ svg });
+    mutate({ svg, action: "download" });
   }, [enabled, mutate, svg]);
 
-  return { downloadMermaidPng, isDownloading: isPending };
+  const startShare = useCallback(() => {
+    if (!enabled || svg.length === 0) return;
+    mutate({ svg, action: "share" });
+  }, [enabled, mutate, svg]);
+
+  return {
+    downloadMermaidPng,
+    shareMermaidPng: canShare ? startShare : null,
+    isDownloading: isPending,
+    pendingAction: isPending ? mutation.variables.action : null,
+  };
 }

--- a/clients/gui-app/src/editor-core/nodes/mermaid/use-mermaid-png-download.ts
+++ b/clients/gui-app/src/editor-core/nodes/mermaid/use-mermaid-png-download.ts
@@ -3,6 +3,7 @@ import { useMutation } from "@tanstack/react-query";
 import { svgToPngBlob } from "@/editor-core/nodes/mermaid/mermaid-service";
 import { readMermaidPalette } from "@/editor-core/nodes/mermaid/mermaid-theme";
 import {
+  canDownloadToDevice,
   downloadBlobToDevice,
   hasSeparateDownloadRoute,
   saveBlobToDisk,
@@ -24,7 +25,8 @@ export interface UseMermaidPngDownloadParams {
 export type MermaidPngExportAction = "share" | "download";
 
 export interface UseMermaidPngDownloadResult {
-  readonly downloadMermaidPng: () => void;
+  /** `null` where this device has no download destination at all. */
+  readonly downloadMermaidPng: (() => void) | null;
   /** `null` where the shell owns no OS chooser to hand the PNG to. */
   readonly shareMermaidPng: (() => void) | null;
   readonly isDownloading: boolean;
@@ -44,6 +46,7 @@ export function useMermaidPngDownload(
   const fileSave = useFileSaveHost();
   const openSaved = useOpenSavedFile();
   const canShare = hasSeparateDownloadRoute(fileSave);
+  const canDownload = canDownloadToDevice(fileSave);
   const mutation = useMutation<
     SavedFile | null,
     Error,
@@ -96,7 +99,7 @@ export function useMermaidPngDownload(
   }, [enabled, mutate, svg]);
 
   return {
-    downloadMermaidPng,
+    downloadMermaidPng: canDownload ? downloadMermaidPng : null,
     shareMermaidPng: canShare ? startShare : null,
     isDownloading: isPending,
     pendingAction: isPending ? mutation.variables.action : null,

--- a/clients/gui-app/src/hooks/epic/use-epic-export-artifacts-mutation.ts
+++ b/clients/gui-app/src/hooks/epic/use-epic-export-artifacts-mutation.ts
@@ -3,7 +3,11 @@ import {
   createArtifactExport,
   type ArtifactExportFormat,
 } from "@/lib/artifacts/artifact-export";
-import { saveBlobToDisk, type SavedFile } from "@/lib/files/save-blob-to-disk";
+import {
+  hasSeparateDownloadRoute,
+  saveBlobToDisk,
+  type SavedFile,
+} from "@/lib/files/save-blob-to-disk";
 import { toastSavedFile } from "@/lib/files/saved-file-toast";
 import { useOpenSavedFile } from "@/hooks/files/use-open-saved-file";
 import { appLogger } from "@/lib/logger";
@@ -80,7 +84,16 @@ export function useEpicExportArtifacts() {
           format: input.format,
           artifact_count: input.artifacts.length,
         });
-        toastSavedFile(saved, openSaved.mutate, fileSave);
+        // No Share/Download split on this surface, deliberately: its controls
+        // promise an "Export", which a share sheet honours as truthfully as a
+        // save dialog does, so there is no mislabelled control to correct -
+        // only a confirmation that must not claim a save the sheet never made.
+        toastSavedFile(
+          saved,
+          openSaved.mutate,
+          fileSave,
+          hasSeparateDownloadRoute(fileSave) ? "share" : "save",
+        );
       }
     },
     onError: (error, input) => {

--- a/clients/gui-app/src/hooks/images/__tests__/use-can-copy-images.test.tsx
+++ b/clients/gui-app/src/hooks/images/__tests__/use-can-copy-images.test.tsx
@@ -15,7 +15,9 @@ function withHost(host: IRunnerHost | null) {
   return function Wrapper(props: { readonly children: ReactNode }): ReactNode {
     if (host === null) return props.children;
     return (
-      <RunnerHostProvider runnerHost={host}>{props.children}</RunnerHostProvider>
+      <RunnerHostProvider runnerHost={host}>
+        {props.children}
+      </RunnerHostProvider>
     );
   };
 }

--- a/clients/gui-app/src/hooks/images/__tests__/use-can-copy-images.test.tsx
+++ b/clients/gui-app/src/hooks/images/__tests__/use-can-copy-images.test.tsx
@@ -1,0 +1,51 @@
+/**
+ * The image-clipboard capability read. Its DEFAULT is the load-bearing part:
+ * the shell that cannot copy is the one that has to say so, because its
+ * failure mode is a write that resolves having done nothing.
+ */
+import { renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it } from "vitest";
+import type { IRunnerHost } from "@traycer-clients/shared/platform/runner-host";
+import { RunnerHostProvider } from "@/providers/runner-host-provider";
+import { useCanCopyImages } from "@/hooks/images/use-can-copy-images";
+import { createFakeRunnerHost } from "../../../../__tests__/create-fake-runner-host";
+
+function withHost(host: IRunnerHost | null) {
+  return function Wrapper(props: { readonly children: ReactNode }): ReactNode {
+    if (host === null) return props.children;
+    return (
+      <RunnerHostProvider runnerHost={host}>{props.children}</RunnerHostProvider>
+    );
+  };
+}
+
+describe("useCanCopyImages", () => {
+  it("reports the capability a mounted shell declares", () => {
+    const { result } = renderHook(() => useCanCopyImages(), {
+      wrapper: withHost(createFakeRunnerHost({ canCopyImages: false })),
+    });
+
+    expect(result.current).toBe(false);
+  });
+
+  it("passes a declaring shell's `true` straight through", () => {
+    const { result } = renderHook(() => useCanCopyImages(), {
+      wrapper: withHost(createFakeRunnerHost({})),
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  it("assumes the capability with no shell mounted", () => {
+    // A host-less tree is a browser tab or a test harness, both of which
+    // honour the write. Reading absence of a host as absence of the capability
+    // would silently strip Copy from every leaf surface that mounts without
+    // one.
+    const { result } = renderHook(() => useCanCopyImages(), {
+      wrapper: withHost(null),
+    });
+
+    expect(result.current).toBe(true);
+  });
+});

--- a/clients/gui-app/src/hooks/images/use-can-copy-images.ts
+++ b/clients/gui-app/src/hooks/images/use-can-copy-images.ts
@@ -1,0 +1,20 @@
+import { useRunnerHostOrNull } from "@/providers/use-runner-host";
+
+/**
+ * Whether this shell can put an IMAGE on the system clipboard, for the
+ * surfaces that offer a "Copy image" control.
+ *
+ * Defaults to `true` with no provider mounted, and deliberately so: a tree
+ * without a runner host is a browser tab or a test harness, both of which
+ * honour the write. The shell that answers `false` is the one that has to say
+ * so, because its failure mode is a write that RESOLVES having done nothing -
+ * so absence of a host must not be read as absence of the capability, or every
+ * host-less surface would silently lose its Copy button.
+ *
+ * Tolerant of a missing provider for the same reason as `useFileSaveHost`:
+ * copy affordances hang off leaf surfaces that also mount in host-less trees,
+ * and a capability that degrades must not crash the tree around it.
+ */
+export function useCanCopyImages(): boolean {
+  return useRunnerHostOrNull()?.canCopyImages ?? true;
+}

--- a/clients/gui-app/src/hooks/usage-analytics/use-usage-image-export.ts
+++ b/clients/gui-app/src/hooks/usage-analytics/use-usage-image-export.ts
@@ -7,6 +7,7 @@ import {
   type AnalyticsUsageImageExportSource,
 } from "@/lib/analytics";
 import {
+  canDownloadToDevice,
   downloadBlobToDevice,
   hasSeparateDownloadRoute,
   saveBlobToDisk,
@@ -88,7 +89,8 @@ export interface UseUsageImageExportResult {
   readonly copyImage: (() => void) | null;
   /** `null` where the shell owns no OS share surface to hand the image to. */
   readonly shareImage: (() => void) | null;
-  readonly downloadImage: () => void;
+  /** `null` where this device has no download destination at all. */
+  readonly downloadImage: (() => void) | null;
 }
 
 /**
@@ -136,6 +138,7 @@ export function useUsageImageExport(
   const openSaved = useOpenSavedFile();
   const canShare = hasSeparateDownloadRoute(fileSave);
   const canCopy = useCanCopyImages();
+  const canDownload = canDownloadToDevice(fileSave);
   const mutation = useMutation<SavedFile | null, Error, UsageImageExportInput>({
     mutationKey: imageMutationKeys.usageExport(),
     mutationFn: async (input) => {
@@ -242,6 +245,6 @@ export function useUsageImageExport(
     pendingAction: mutation.isPending ? mutation.variables.action : null,
     copyImage: canCopy ? startCopy : null,
     shareImage: canShare ? startShare : null,
-    downloadImage,
+    downloadImage: canDownload ? downloadImage : null,
   };
 }

--- a/clients/gui-app/src/hooks/usage-analytics/use-usage-image-export.ts
+++ b/clients/gui-app/src/hooks/usage-analytics/use-usage-image-export.ts
@@ -174,7 +174,12 @@ export function useUsageImageExport(
           action: input.action,
           source: analyticsSource,
         });
-        toastSavedFile(saved, openSaved.mutate, fileSave);
+        toastSavedFile(
+          saved,
+          openSaved.mutate,
+          fileSave,
+          input.action === "share" ? "share" : "save",
+        );
       }
     },
     onError: (err, input) => {

--- a/clients/gui-app/src/hooks/usage-analytics/use-usage-image-export.ts
+++ b/clients/gui-app/src/hooks/usage-analytics/use-usage-image-export.ts
@@ -20,6 +20,7 @@ import { appLogger } from "@/lib/logger";
 import { imageMutationKeys } from "@/lib/query-keys";
 import { reportableErrorToast } from "@/lib/reportable-error-toast";
 import { useFileSaveHost } from "@/hooks/files/use-file-save-host";
+import { useCanCopyImages } from "@/hooks/images/use-can-copy-images";
 
 export interface UseUsageImageExportParams {
   /**
@@ -81,7 +82,8 @@ export interface UseUsageImageExportResult {
   /**
    * `null` where the shell cannot put an image on the system clipboard, in
    * which case the share sheet is where a user copies one (see
-   * {@link useUsageImageExport}).
+   * {@link useUsageImageExport}). Independent of {@link shareImage}: a shell
+   * can offer both, one, or neither.
    */
   readonly copyImage: (() => void) | null;
   /** `null` where the shell owns no OS share surface to hand the image to. */
@@ -105,11 +107,13 @@ export interface UseUsageImageExportResult {
  *   whose `saveFile` goes through an OS chooser instead - the installed mobile
  *   app, whose sheet hands the file to another app. There, share and download
  *   are genuinely two different acts and both are offered.
- * - Copy is offered everywhere else and NOT there. The installed app's WebView
- *   cannot put an image on the system clipboard: on Android the write resolves
- *   having written nothing, which is worse than no button, since the surface
- *   then reports a success the clipboard never received. The share sheet's own
- *   Copy action is the route that does work, and it is one tap away.
+ * - Copy is offered wherever the shell can actually reach the system clipboard
+ *   with an image (`IRunnerHost.canCopyImages`), which is everywhere except
+ *   Android's WebView. That one resolves the write having written nothing, so
+ *   the button would report a success the clipboard never received - worse
+ *   than no button. The two questions are INDEPENDENT: iOS answers yes to both
+ *   and offers all three controls, and the share sheet's own Copy action is
+ *   the fallback where it answers no.
  *
  * ONE mutation carries every leg, discriminated by its variables: a capture
  * is an expensive full-region rasterisation, so two of them must never be in
@@ -131,6 +135,7 @@ export function useUsageImageExport(
   const fileSave = useFileSaveHost();
   const openSaved = useOpenSavedFile();
   const canShare = hasSeparateDownloadRoute(fileSave);
+  const canCopy = useCanCopyImages();
   const mutation = useMutation<SavedFile | null, Error, UsageImageExportInput>({
     mutationKey: imageMutationKeys.usageExport(),
     mutationFn: async (input) => {
@@ -230,7 +235,7 @@ export function useUsageImageExport(
   return {
     mutation,
     pendingAction: mutation.isPending ? mutation.variables.action : null,
-    copyImage: canShare ? null : startCopy,
+    copyImage: canCopy ? startCopy : null,
     shareImage: canShare ? startShare : null,
     downloadImage,
   };

--- a/clients/gui-app/src/hooks/usage-analytics/use-usage-image-export.ts
+++ b/clients/gui-app/src/hooks/usage-analytics/use-usage-image-export.ts
@@ -6,7 +6,12 @@ import {
   AnalyticsEvent,
   type AnalyticsUsageImageExportSource,
 } from "@/lib/analytics";
-import { saveBlobToDisk, type SavedFile } from "@/lib/files/save-blob-to-disk";
+import {
+  downloadBlobToDevice,
+  hasSeparateDownloadRoute,
+  saveBlobToDisk,
+  type SavedFile,
+} from "@/lib/files/save-blob-to-disk";
 import { toastSavedFile } from "@/lib/files/saved-file-toast";
 import { useOpenSavedFile } from "@/hooks/files/use-open-saved-file";
 import { copyImageBlobPromiseToClipboard } from "@/lib/images/copy-image-to-clipboard";
@@ -40,19 +45,23 @@ export interface UseUsageImageExportParams {
  *
  * The copy leg carries an ALREADY RUNNING promise rather than the node to
  * capture: the clipboard write has to be issued inside the click's user
- * activation, and a `mutationFn` body can run a tick later. The download
- * leg has no such constraint, so it hands over the node and captures inside
- * the mutation.
+ * activation, and a `mutationFn` body can run a tick later. The share and
+ * download legs have no such constraint, so they hand over the node and
+ * capture inside the mutation.
  */
 export type UsageImageExportInput =
   | { readonly action: "copy"; readonly started: Promise<void> }
+  | { readonly action: "share"; readonly node: HTMLElement }
   | { readonly action: "download"; readonly node: HTMLElement };
 
+/** Which export control a run belongs to, for the per-button spinner. */
+export type UsageImageExportAction = UsageImageExportInput["action"];
+
 /**
- * The saved file on a completed download, `null` on a copy (nothing is
- * saved) and on a download the user cancelled out of the save picker.
- * Callers discriminate on the VARIABLES, never on this - both no-file cases
- * are the same `null`.
+ * The saved file on a completed download or share, `null` on a copy (nothing
+ * is saved) and on a run the user cancelled out of the save picker or share
+ * sheet. Callers discriminate on the VARIABLES, never on this - every no-file
+ * case is the same `null`.
  */
 export type UsageImageExportMutation = UseMutationResult<
   SavedFile | null,
@@ -62,19 +71,47 @@ export type UsageImageExportMutation = UseMutationResult<
 
 export interface UseUsageImageExportResult {
   readonly mutation: UsageImageExportMutation;
-  readonly copyImage: () => void;
+  /**
+   * Which control's export is in flight, or `null` when none is. Derived here
+   * rather than at each surface: one export runs at a time, so this is also
+   * "an export is running", and the two facts must not be read differently by
+   * two surfaces.
+   */
+  readonly pendingAction: UsageImageExportAction | null;
+  /**
+   * `null` where the shell cannot put an image on the system clipboard, in
+   * which case the share sheet is where a user copies one (see
+   * {@link useUsageImageExport}).
+   */
+  readonly copyImage: (() => void) | null;
+  /** `null` where the shell owns no OS share surface to hand the image to. */
+  readonly shareImage: (() => void) | null;
   readonly downloadImage: () => void;
 }
 
 /**
- * "Copy image" / "Download image" for a usage dialog: rasterise the
- * dialog's summary region (headline, tiles, trend chart) to a PNG, then
- * hand it to the clipboard or the save-to-disk path. Both legs reuse the
- * app-wide runtime-aware plumbing - `copyImageBlobPromiseToClipboard` falls
- * back to the desktop nativeImage bridge, `saveBlobToDisk` to whichever save
- * route this shell owns - so this hook only owns capture + toasts.
+ * The export controls for a usage surface: rasterise the surface's summary
+ * region (headline, tiles, trend chart) to a PNG, then hand it to the
+ * clipboard, the OS share sheet, or the device's file storage. Every leg
+ * reuses the app-wide runtime-aware plumbing - `copyImageBlobPromiseToClipboard`
+ * falls back to the desktop nativeImage bridge, `saveBlobToDisk` and
+ * `downloadBlobToDevice` to whichever routes this shell owns - so this hook
+ * only owns capture, which controls exist, and the toasts.
  *
- * ONE mutation carries both legs, discriminated by its variables: a capture
+ * WHICH CONTROLS EXIST is decided here, once, off shell capability rather than
+ * per surface, so no usage surface can drift into a different set:
+ *
+ * - A shell with a chooser-free download (`IFileSaveHost.downloadFile`) is one
+ *   whose `saveFile` goes through an OS chooser instead - the installed mobile
+ *   app, whose sheet hands the file to another app. There, share and download
+ *   are genuinely two different acts and both are offered.
+ * - Copy is offered everywhere else and NOT there. The installed app's WebView
+ *   cannot put an image on the system clipboard: on Android the write resolves
+ *   having written nothing, which is worse than no button, since the surface
+ *   then reports a success the clipboard never received. The share sheet's own
+ *   Copy action is the route that does work, and it is one tap away.
+ *
+ * ONE mutation carries every leg, discriminated by its variables: a capture
  * is an expensive full-region rasterisation, so two of them must never be in
  * flight at once. A single pending flag is what lets every export button
  * disable while any export runs.
@@ -93,6 +130,7 @@ export function useUsageImageExport(
 
   const fileSave = useFileSaveHost();
   const openSaved = useOpenSavedFile();
+  const canShare = hasSeparateDownloadRoute(fileSave);
   const mutation = useMutation<SavedFile | null, Error, UsageImageExportInput>({
     mutationKey: imageMutationKeys.usageExport(),
     mutationFn: async (input) => {
@@ -107,7 +145,13 @@ export function useUsageImageExport(
         heading,
         subheading,
       });
-      return saveBlobToDisk(blob, fileName, fileSave);
+      // `saveBlobToDisk` is the shell's own save route, which on a shell that
+      // also owns a direct download is the share sheet - that is exactly what
+      // makes it the SHARE leg here rather than a second download.
+      if (input.action === "share") {
+        return saveBlobToDisk(blob, fileName, fileSave);
+      }
+      return downloadBlobToDevice(blob, fileName, fileSave);
     },
     onSuccess: (saved, input) => {
       if (input.action === "copy") {
@@ -118,10 +162,11 @@ export function useUsageImageExport(
         toast.success("Usage image copied");
         return;
       }
-      // `null` is the user cancelling the picker - a no-op, not a success.
+      // `null` is the user cancelling the picker or the sheet - a no-op, not
+      // a success.
       if (saved !== null) {
         Analytics.getInstance().track(AnalyticsEvent.UsageImageExported, {
-          action: "download",
+          action: input.action,
           source: analyticsSource,
         });
         toastSavedFile(saved, openSaved.mutate, fileSave);
@@ -132,6 +177,16 @@ export function useUsageImageExport(
         appLogger.errorSummary("[usage] image copy failed", {}, err);
         reportableErrorToast("Failed to copy usage image", undefined, {
           title: "Could not copy usage image",
+          message: null,
+          code: null,
+          source: errorSource,
+        });
+        return;
+      }
+      if (input.action === "share") {
+        appLogger.errorSummary("[usage] image share failed", {}, err);
+        reportableErrorToast("Failed to share usage image", undefined, {
+          title: "Could not share usage image",
           message: null,
           code: null,
           source: errorSource,
@@ -149,7 +204,7 @@ export function useUsageImageExport(
   });
 
   const { mutate } = mutation;
-  const copyImage = useCallback(() => {
+  const startCopy = useCallback(() => {
     const node = getExportNode();
     if (node === null) return;
     mutate({
@@ -160,11 +215,23 @@ export function useUsageImageExport(
     });
   }, [getExportNode, heading, subheading, mutate]);
 
+  const startShare = useCallback(() => {
+    const node = getExportNode();
+    if (node === null) return;
+    mutate({ action: "share", node });
+  }, [getExportNode, mutate]);
+
   const downloadImage = useCallback(() => {
     const node = getExportNode();
     if (node === null) return;
     mutate({ action: "download", node });
   }, [getExportNode, mutate]);
 
-  return { mutation, copyImage, downloadImage };
+  return {
+    mutation,
+    pendingAction: mutation.isPending ? mutation.variables.action : null,
+    copyImage: canShare ? null : startCopy,
+    shareImage: canShare ? startShare : null,
+    downloadImage,
+  };
 }

--- a/clients/gui-app/src/lib/analytics.ts
+++ b/clients/gui-app/src/lib/analytics.ts
@@ -746,7 +746,7 @@ export interface AnalyticsEventProperties {
     readonly artifact_count: number;
   };
   readonly [AnalyticsEvent.UsageImageExported]: {
-    readonly action: "copy" | "download";
+    readonly action: "copy" | "download" | "share";
     readonly source: AnalyticsUsageImageExportSource;
   };
   readonly [AnalyticsEvent.CommentCreated]: { readonly has_mention: boolean };

--- a/clients/gui-app/src/lib/analytics.ts
+++ b/clients/gui-app/src/lib/analytics.ts
@@ -1748,7 +1748,7 @@ const EVENT_EXACT_PROPERTY_VALUES = new Map<string, ReadonlySet<string>>([
   ...eventValueEntries(
     [AnalyticsEvent.UsageImageExported],
     "action",
-    new Set(["copy", "download"]),
+    new Set(["copy", "download", "share"]),
   ),
   // Event-scoped so this `source` validates against the export surfaces, not
   // the global gesture-origin `ANALYTICS_SOURCES` fallback.

--- a/clients/gui-app/src/lib/files/__tests__/saved-file-toast.test.ts
+++ b/clients/gui-app/src/lib/files/__tests__/saved-file-toast.test.ts
@@ -46,7 +46,9 @@ function fileSaveHost(
   saveFile: SaveFileMock,
   openSavedFile: ((path: string) => Promise<void>) | null,
 ): IFileSaveHost {
-  return { saveFile, openSavedFile };
+  // No chooser-free download route: these cases are about what a COMPLETED
+  // save can offer afterwards, which is the same question either way.
+  return { saveFile, openSavedFile, downloadFile: null };
 }
 
 function resolvingSaveFile(result: SavedFileLocation | null): SaveFileMock {

--- a/clients/gui-app/src/lib/files/__tests__/saved-file-toast.test.ts
+++ b/clients/gui-app/src/lib/files/__tests__/saved-file-toast.test.ts
@@ -87,7 +87,7 @@ beforeEach(() => {
 describe("toastSavedFile", () => {
   describe("browser runtime (no native save capability)", () => {
     it("shows a plain success toast with no action", () => {
-      toastSavedFile({ name: "a.md", path: null }, vi.fn(), null);
+      toastSavedFile({ name: "a.md", path: null }, vi.fn(), null, "save");
 
       expect(toastSuccess).toHaveBeenCalledWith("Saved a.md");
     });
@@ -101,7 +101,7 @@ describe("toastSavedFile", () => {
       );
 
       const saved = { name: "a.md", path: "/tmp/x/a.md" };
-      toastSavedFile(saved, openSaved, host);
+      toastSavedFile(saved, openSaved, host, "save");
 
       expect(toastSuccess).toHaveBeenCalledTimes(1);
       const [, options] = toastSuccess.mock.calls[0];
@@ -120,21 +120,46 @@ describe("toastSavedFile", () => {
         Promise.resolve(),
       );
 
-      toastSavedFile({ name: "a.md", path: null }, vi.fn(), host);
+      toastSavedFile({ name: "a.md", path: null }, vi.fn(), host, "save");
 
       expect(toastSuccess).toHaveBeenCalledWith("Saved a.md");
     });
   });
 
   describe("phone runtime (a save host that reports no path)", () => {
-    // The share sheet completed, so this IS a save - but nothing came back
-    // that could be re-opened, so offering the action would be a dead button.
+    // Nothing came back that could be re-opened, so offering the action would
+    // be a dead button.
     it("shows a plain toast even though the shell has a native save route", () => {
       const host = fileSaveHost(resolvingSaveFile(null), null);
 
-      toastSavedFile({ name: "a.md", path: null }, vi.fn(), host);
+      toastSavedFile({ name: "a.md", path: null }, vi.fn(), host, "save");
 
       expect(toastSuccess).toHaveBeenCalledWith("Saved a.md");
+    });
+
+    it("says the file was SHARED where the sheet was the route", () => {
+      // The bytes a share sheet is handed live in the app's cache container,
+      // so nothing was saved anywhere the user keeps files. Claiming otherwise
+      // is a plain untruth, and it is the verb the user reads.
+      const host = fileSaveHost(resolvingSaveFile(null), null);
+
+      toastSavedFile({ name: "a.md", path: null }, vi.fn(), host, "share");
+
+      expect(toastSuccess).toHaveBeenCalledWith("Shared a.md");
+    });
+
+    it("still offers no re-open action on a share, path or not", () => {
+      const host = fileSaveHost(resolvingSaveFile(null), null);
+
+      toastSavedFile(
+        { name: "a.md", path: "/tmp/a.md" },
+        vi.fn(),
+        host,
+        "share",
+      );
+
+      const [, options] = toastSuccess.mock.calls[0];
+      expect(isActionToast(options)).toBe(false);
     });
   });
 });

--- a/clients/gui-app/src/lib/files/__tests__/saved-file-toast.test.ts
+++ b/clients/gui-app/src/lib/files/__tests__/saved-file-toast.test.ts
@@ -48,7 +48,7 @@ function fileSaveHost(
 ): IFileSaveHost {
   // No chooser-free download route: these cases are about what a COMPLETED
   // save can offer afterwards, which is the same question either way.
-  return { saveFile, openSavedFile, downloadFile: null };
+  return { saveFile, openSavedFile, downloadFile: null, saveRoute: "share" };
 }
 
 function resolvingSaveFile(result: SavedFileLocation | null): SaveFileMock {

--- a/clients/gui-app/src/lib/files/save-blob-to-disk.ts
+++ b/clients/gui-app/src/lib/files/save-blob-to-disk.ts
@@ -67,6 +67,46 @@ export async function openSavedFile(
 }
 
 /**
+ * Whether this shell keeps "share it" and "download it" apart, i.e. whether
+ * {@link saveBlobToDisk} would reach an OS chooser rather than commit the file
+ * itself. Read off the capability rather than off any notion of which shell is
+ * running: a shell owns a chooser-free download precisely when its `saveFile`
+ * is not one already.
+ */
+export function hasSeparateDownloadRoute(
+  fileSave: IFileSaveHost | null,
+): boolean {
+  return (fileSave?.downloadFile ?? null) !== null;
+}
+
+/**
+ * Persist a Blob the way a "Download" control promises: straight into the
+ * device's storage, with no chooser in between, on the shells that own such a
+ * route. Everywhere else this IS {@link saveBlobToDisk} - a desktop save dialog
+ * and a browser's download both already commit the file - so callers get the
+ * one honest download route for their runtime without asking which runtime it
+ * is.
+ *
+ * `null` only ever comes from the delegated path (a dismissed picker); a direct
+ * write has nothing to dismiss and either lands or throws.
+ */
+export async function downloadBlobToDevice(
+  blob: Blob,
+  suggestedName: string,
+  fileSave: IFileSaveHost | null,
+): Promise<SavedFile | null> {
+  const download = fileSave?.downloadFile ?? null;
+  if (download === null) {
+    return saveBlobToDisk(blob, suggestedName, fileSave);
+  }
+  return download({
+    name: suggestedName,
+    type: blob.type,
+    bytes: await blob.arrayBuffer(),
+  });
+}
+
+/**
  * Derive the picker's accept-type hint from the blob's MIME type and the
  * suggested name's extension. Empty when either is unknown — the helper is
  * generic, so it must not hardcode any one format.

--- a/clients/gui-app/src/lib/files/save-blob-to-disk.ts
+++ b/clients/gui-app/src/lib/files/save-blob-to-disk.ts
@@ -76,7 +76,22 @@ export async function openSavedFile(
 export function hasSeparateDownloadRoute(
   fileSave: IFileSaveHost | null,
 ): boolean {
-  return (fileSave?.downloadFile ?? null) !== null;
+  return fileSave?.saveRoute === "share";
+}
+
+/**
+ * Whether a "Download" control can be honoured at all.
+ *
+ * True with no shell (the browser downloads), true where the shell owns a
+ * chooser-free write, and true where its own `saveFile` IS the download. FALSE
+ * only where the shell hands everything to a chooser and has no direct write -
+ * Android 10, whose shared-storage route does not exist. Offering Download
+ * there would route it into the share sheet, which is the very mislabelling
+ * the split was built to remove.
+ */
+export function canDownloadToDevice(fileSave: IFileSaveHost | null): boolean {
+  if (fileSave === null) return true;
+  return fileSave.downloadFile !== null || fileSave.saveRoute === "download";
 }
 
 /**
@@ -97,6 +112,13 @@ export async function downloadBlobToDevice(
 ): Promise<SavedFile | null> {
   const download = fileSave?.downloadFile ?? null;
   if (download === null) {
+    // Never silently fall through to a chooser: on a shell whose `saveFile` is
+    // a share sheet and which owns no direct write, delegating here is exactly
+    // how a "Download" ends up opening the sheet. Callers gate on
+    // `canDownloadToDevice`, so reaching this is a bug worth surfacing.
+    if (!canDownloadToDevice(fileSave)) {
+      throw new Error("This device has no download destination.");
+    }
     return saveBlobToDisk(blob, suggestedName, fileSave);
   }
   return download({

--- a/clients/gui-app/src/lib/files/saved-file-toast.ts
+++ b/clients/gui-app/src/lib/files/saved-file-toast.ts
@@ -6,20 +6,38 @@ import {
 } from "@/lib/files/save-blob-to-disk";
 
 /**
- * The one success toast for every "save to disk" flow (artifact markdown
- * export, usage image, Mermaid PNG, chat image). Shows `Saved <name>` and,
- * where the runtime can re-open the file (Traycer Desktop, which learns the
- * path from its native dialog), an "Open file" action. The action fires
- * `openSaved` — callers pass `useOpenSavedFile().mutate` so the RunnerHost
- * IPC stays on TanStack Query. Browser and phone runtimes never learn the
- * path, so they get the plain toast.
+ * Which route committed the bytes, because it decides what the user is
+ * truthfully told.
+ *
+ * `"save"` wrote the file itself - a desktop dialog, a browser download, the
+ * phone's direct write into its documents directory. `"share"` handed it to an
+ * OS chooser and another app decided what happened next; on the phone the bytes
+ * the sheet is given live in the app's CACHE container, so nothing was saved
+ * anywhere the user keeps files and claiming otherwise is a plain untruth.
+ */
+export type SavedFileRoute = "save" | "share";
+
+/**
+ * The one success toast for every "commit these bytes" flow (artifact markdown
+ * export, usage image, Mermaid PNG, chat image). Shows `Saved <name>` or
+ * `Shared <name>` per {@link SavedFileRoute} and, where the runtime can re-open
+ * the file (Traycer Desktop, which learns the path from its native dialog), an
+ * "Open file" action. The action fires `openSaved` — callers pass
+ * `useOpenSavedFile().mutate` so the RunnerHost IPC stays on TanStack Query.
+ * Browser and phone runtimes never learn the path, so they get the plain toast.
+ *
+ * The route is PASSED, not derived: a shell that owns a share sheet owns a
+ * direct write too, so `fileSave` alone cannot say which of the two a given
+ * call took.
  */
 export function toastSavedFile(
   saved: SavedFile,
   openSaved: (saved: SavedFile) => void,
   fileSave: IFileSaveHost | null,
+  route: SavedFileRoute,
 ): void {
-  const message = `Saved ${saved.name}`;
+  const message =
+    route === "share" ? `Shared ${saved.name}` : `Saved ${saved.name}`;
   if (!canOpenSavedFile(saved, fileSave)) {
     toast.success(message);
     return;

--- a/clients/gui-app/src/lib/images/perform-image-action.ts
+++ b/clients/gui-app/src/lib/images/perform-image-action.ts
@@ -1,11 +1,20 @@
 import { toast } from "sonner";
 
 import type { IFileSaveHost } from "@traycer-clients/shared/platform/runner-host";
-import { saveBlobToDisk, type SavedFile } from "@/lib/files/save-blob-to-disk";
+import {
+  downloadBlobToDevice,
+  saveBlobToDisk,
+  type SavedFile,
+} from "@/lib/files/save-blob-to-disk";
 import { toastSavedFile } from "@/lib/files/saved-file-toast";
 import { copyImageBlobToClipboard } from "@/lib/images/copy-image-to-clipboard";
 
-export type ImageAction = "copy" | "download";
+/**
+ * Which route a control took. `share` exists only on shells that own an OS
+ * chooser, where handing the bytes to another app and writing them into the
+ * device's own storage are two different acts (see `hasSeparateDownloadRoute`).
+ */
+export type ImageAction = "copy" | "share" | "download";
 
 async function fetchImageBlob(
   src: string,
@@ -37,12 +46,21 @@ export async function performImageAction(params: {
     toast.success("Image copied");
     return;
   }
-  const saved = await saveBlobToDisk(
-    blob,
-    params.suggestedName,
-    params.fileSave,
-  );
-  if (saved !== null) toastSavedFile(saved, params.openSaved, params.fileSave);
+  // `saveBlobToDisk` is the shell's OWN save route, which on a shell that also
+  // owns a chooser-free download is the share sheet - that is what makes it
+  // the share leg rather than a second download.
+  const saved =
+    params.action === "share"
+      ? await saveBlobToDisk(blob, params.suggestedName, params.fileSave)
+      : await downloadBlobToDevice(blob, params.suggestedName, params.fileSave);
+  if (saved !== null) {
+    toastSavedFile(
+      saved,
+      params.openSaved,
+      params.fileSave,
+      params.action === "share" ? "share" : "save",
+    );
+  }
 }
 
 export function imageFileName(

--- a/clients/gui-app/src/markdown/components/mermaid-block.tsx
+++ b/clients/gui-app/src/markdown/components/mermaid-block.tsx
@@ -138,10 +138,11 @@ function MermaidRenderSession(props: {
     });
   }, [sourceCode]);
 
-  const { downloadMermaidPng, isDownloading } = useMermaidPngDownload({
-    svg: render.svg,
-    enabled: render.status === "ready",
-  });
+  const { downloadMermaidPng, shareMermaidPng, isDownloading } =
+    useMermaidPngDownload({
+      svg: render.svg,
+      enabled: render.status === "ready",
+    });
 
   const downloadDisabled = render.status !== "ready" || isDownloading;
   const renderedSvg = useMemo(
@@ -163,6 +164,7 @@ function MermaidRenderSession(props: {
         onToggleEdit={noop}
         onCopyCode={handleCopy}
         onDownloadPng={downloadMermaidPng}
+        onSharePng={shareMermaidPng}
         downloadDisabled={downloadDisabled}
       />
 
@@ -216,6 +218,7 @@ function MermaidRenderSession(props: {
         title={ariaLabel}
         onCopyCode={handleCopy}
         onDownloadPng={downloadMermaidPng}
+        onSharePng={shareMermaidPng}
         downloadDisabled={downloadDisabled}
       />
     </div>

--- a/clients/mobile/__tests__/file-save.test.ts
+++ b/clients/mobile/__tests__/file-save.test.ts
@@ -8,12 +8,13 @@ import { MobileFileSave } from "../src/file-save";
 
 const nativeMocks = vi.hoisted(() => ({
   writeFile: vi.fn(),
+  stat: vi.fn(),
   share: vi.fn(),
 }));
 
 vi.mock("@capacitor/filesystem", () => ({
-  Directory: { Cache: "CACHE" },
-  Filesystem: { writeFile: nativeMocks.writeFile },
+  Directory: { Cache: "CACHE", Documents: "DOCUMENTS" },
+  Filesystem: { writeFile: nativeMocks.writeFile, stat: nativeMocks.stat },
 }));
 
 vi.mock("@capacitor/share", () => ({
@@ -68,11 +69,23 @@ function request(name: string, bytes: Uint8Array) {
   return requestOfType(name, bytes, "image/png");
 }
 
+/** The set of paths a stat should report as already taken. */
+function occupyDocuments(paths: readonly string[]): void {
+  nativeMocks.stat.mockImplementation((options: { path: string }) =>
+    paths.includes(options.path)
+      ? Promise.resolve({ uri: `file:///docs/${options.path}` })
+      : // The plugin REJECTS a stat of a missing file rather than reporting
+        // absence - "not there" only ever arrives as a failure.
+        Promise.reject(new Error("File does not exist")),
+  );
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   nativeMocks.writeFile.mockResolvedValue({
     uri: "file:///cache/traycer-exports/diagram.png",
   });
+  occupyDocuments([]);
   nativeMocks.share.mockResolvedValue({
     activityType: "com.apple.DocumentsApp",
   });
@@ -303,5 +316,121 @@ describe("MobileFileSave", () => {
 
   it("never offers a re-open route, having learned no path to re-open", () => {
     expect(new MobileFileSave().openSavedFile).toBeNull();
+  });
+});
+
+describe("MobileFileSave.downloadFile", () => {
+  it("writes into the documents directory and offers nothing to the user", async () => {
+    nativeMocks.writeFile.mockResolvedValue({
+      uri: "file:///docs/Traycer/traycer-usage-30d.png",
+    });
+
+    const saved = await new MobileFileSave().downloadFile(
+      request("traycer-usage-30d.png", new Uint8Array([1, 2, 3])),
+    );
+
+    expect(writtenFile(0)).toMatchObject({
+      path: "Traycer/traycer-usage-30d.png",
+      directory: "DOCUMENTS",
+      recursive: true,
+    });
+    // The whole difference from `saveFile`: no sheet, so nothing to dismiss
+    // and no second app deciding where the bytes end up.
+    expect(nativeMocks.share).not.toHaveBeenCalled();
+    // The write itself says where it wrote, which the share sheet never does.
+    expect(saved).toEqual({
+      name: "traycer-usage-30d.png",
+      path: "file:///docs/Traycer/traycer-usage-30d.png",
+    });
+  });
+
+  it("hands over the exact bytes it was given", async () => {
+    const bytes = new Uint8Array([0, 1, 127, 128, 200, 255]);
+
+    await new MobileFileSave().downloadFile(request("shot.png", bytes));
+
+    expect(Array.from(writtenBytes())).toEqual(Array.from(bytes));
+  });
+
+  it("numbers a name that is already taken rather than overwriting it", async () => {
+    // Two exports of the same usage window suggest the same name; replacing
+    // the first would lose a file the user believes they still have.
+    occupyDocuments(["Traycer/traycer-usage-30d.png"]);
+
+    const saved = await new MobileFileSave().downloadFile(
+      request("traycer-usage-30d.png", new Uint8Array([1])),
+    );
+
+    expect(writtenFile(0).path).toBe("Traycer/traycer-usage-30d (2).png");
+    // The confirmation names the file the user actually got, not the one that
+    // was asked for.
+    expect(saved.name).toBe("traycer-usage-30d (2).png");
+  });
+
+  it("keeps counting past the first free-looking number", async () => {
+    occupyDocuments([
+      "Traycer/usage.png",
+      "Traycer/usage (2).png",
+      "Traycer/usage (3).png",
+    ]);
+
+    await new MobileFileSave().downloadFile(
+      request("usage.png", new Uint8Array([1])),
+    );
+
+    expect(writtenFile(0).path).toBe("Traycer/usage (4).png");
+  });
+
+  it("still writes something unique when every numbered name is taken", async () => {
+    // The numbering is bounded so a pathological directory cannot turn one
+    // download into an unbounded walk of the filesystem - but the download
+    // must still land, and still not clobber anything.
+    nativeMocks.stat.mockResolvedValue({ uri: "file:///docs/taken" });
+
+    await new MobileFileSave().downloadFile(
+      request("usage.png", new Uint8Array([1])),
+    );
+
+    const path = writtenFile(0).path;
+    expect(path.startsWith("Traycer/usage")).toBe(true);
+    expect(path.endsWith(".png")).toBe(true);
+    expect(path).not.toBe("Traycer/usage.png");
+    expect(path).not.toBe("Traycer/usage (2).png");
+  });
+
+  it("reads an unreadable directory as free rather than as taken", async () => {
+    // A stat that fails for any reason other than absence must not push a
+    // perfectly good download onto a numbered name.
+    nativeMocks.stat.mockRejectedValue(new Error("Directory unreadable"));
+
+    await new MobileFileSave().downloadFile(
+      request("usage.png", new Uint8Array([1])),
+    );
+
+    expect(writtenFile(0).path).toBe("Traycer/usage.png");
+  });
+
+  it("normalises the suggested name the same way the share leg does", async () => {
+    // Same seam, same rules: a separator must not choose a directory, and the
+    // extension comes from the blob's own type when the name carries none.
+    await new MobileFileSave().downloadFile(
+      requestOfType("../../escape/a1b2c3d4", new Uint8Array([1]), "image/png"),
+    );
+
+    expect(writtenFile(0).path).toBe("Traycer/a1b2c3d4.png");
+  });
+
+  it("propagates a failed write so the caller can toast it", async () => {
+    // The API levels that still gate external storage reject the write; a
+    // download that cannot land has to say so rather than resolve.
+    nativeMocks.writeFile.mockRejectedValue(
+      new Error("File permissions denied"),
+    );
+
+    await expect(
+      new MobileFileSave().downloadFile(
+        request("usage.png", new Uint8Array([1])),
+      ),
+    ).rejects.toThrow("File permissions denied");
   });
 });

--- a/clients/mobile/__tests__/file-save.test.ts
+++ b/clients/mobile/__tests__/file-save.test.ts
@@ -76,11 +76,13 @@ function request(name: string, bytes: Uint8Array) {
  */
 const MAX_FILE_NAME_BYTES = 255;
 
-/** Everything already queued has run, microtasks and timers alike. */
-function settle(): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, 0);
-  });
+/**
+ * A rejection shaped like the plugin's own "there is no file there": the code
+ * both native shells reject with, which is the signal absence is read from.
+ */
+function fileNotFoundRejection(): Error {
+  const error = new Error("'stat' failed because file does not exist.");
+  return Object.assign(error, { code: "OS-PLUG-FILE-0008" });
 }
 
 /** The set of paths a stat should report as already taken. */
@@ -90,7 +92,7 @@ function occupyDocuments(paths: readonly string[]): void {
       ? Promise.resolve({ uri: `file:///docs/${options.path}` })
       : // The plugin REJECTS a stat of a missing file rather than reporting
         // absence - "not there" only ever arrives as a failure.
-        Promise.reject(new Error("File does not exist")),
+        Promise.reject(fileNotFoundRejection()),
   );
 }
 
@@ -434,30 +436,39 @@ describe("MobileFileSave.downloadFile", () => {
     );
   });
 
-  it("does not hand the same path to two downloads racing on it", async () => {
-    // A path is only observably taken once its bytes have landed, so two
-    // downloads started close together would both see the same candidate free.
-    let releaseFirstWrite: () => void = () => undefined;
-    nativeMocks.writeFile.mockImplementationOnce(
-      () =>
-        new Promise((resolve) => {
-          releaseFirstWrite = () => {
-            resolve({ uri: "file:///docs/Traycer/usage.png" });
-          };
-        }),
-    );
+  it("does not hand the same path to two downloads started in one tick", async () => {
+    // The hard case: neither has claimed anything yet while both are awaiting
+    // their stat, so the claim set alone closes no window - only serialising
+    // the search does. Separate export surfaces have independent mutations, so
+    // two overlapping downloads are reachable.
     const host = new MobileFileSave();
 
-    const first = host.downloadFile(request("usage.png", new Uint8Array([1])));
-    // Let the first claim its path before the second starts probing.
-    await settle();
-    const second = host.downloadFile(request("usage.png", new Uint8Array([2])));
-    await settle();
-    releaseFirstWrite();
-    await Promise.all([first, second]);
+    await Promise.all([
+      host.downloadFile(request("usage.png", new Uint8Array([1]))),
+      host.downloadFile(request("usage.png", new Uint8Array([2]))),
+    ]);
 
-    expect(writtenFile(0).path).toBe("Traycer/usage.png");
-    expect(writtenFile(1).path).toBe("Traycer/usage (2).png");
+    const paths = [writtenFile(0).path, writtenFile(1).path];
+    expect(new Set(paths).size).toBe(2);
+    expect(paths).toContain("Traycer/usage.png");
+    expect(paths).toContain("Traycer/usage (2).png");
+  });
+
+  it("keeps serving later downloads after a stat throws outright", async () => {
+    // Serialising the search puts every download behind its predecessor, so a
+    // predecessor that blew up must not leave the rest waiting forever.
+    nativeMocks.stat.mockImplementationOnce(() => {
+      throw new Error("bridge unavailable");
+    });
+    const host = new MobileFileSave();
+
+    await expect(
+      host.downloadFile(request("usage.png", new Uint8Array([1]))),
+    ).resolves.toBeTruthy();
+    await expect(
+      host.downloadFile(request("later.png", new Uint8Array([1]))),
+    ).resolves.toBeTruthy();
+    expect(writtenFile(1).path).toBe("Traycer/later.png");
   });
 
   it("frees a claimed path again when its write fails", async () => {
@@ -474,16 +485,29 @@ describe("MobileFileSave.downloadFile", () => {
     expect(writtenFile(1).path).toBe("Traycer/usage.png");
   });
 
-  it("reads an unreadable directory as free rather than as taken", async () => {
-    // A stat that fails for any reason other than absence must not push a
-    // perfectly good download onto a numbered name.
-    nativeMocks.stat.mockRejectedValue(new Error("Directory unreadable"));
-
+  it("takes a confirmed not-found as the name being free", async () => {
+    // The ordinary case, and the one the whole probe rests on: nothing is
+    // there, so the download keeps the name it asked for.
     await new MobileFileSave().downloadFile(
       request("usage.png", new Uint8Array([1])),
     );
 
     expect(writtenFile(0).path).toBe("Traycer/usage.png");
+  });
+
+  it("treats a stat that failed for any other reason as occupied", async () => {
+    // The two mistakes are not equal. Reading an unknown failure as "free"
+    // lets the write replace a file that was there all along - the exact loss
+    // this collision handling exists to prevent - while reading it as "taken"
+    // costs the download nothing but a numbered name.
+    nativeMocks.stat.mockRejectedValue(new Error("I/O error"));
+
+    await new MobileFileSave().downloadFile(
+      request("usage.png", new Uint8Array([1])),
+    );
+
+    expect(writtenFile(0).path).not.toBe("Traycer/usage.png");
+    expect(writtenFile(0).path.startsWith("Traycer/usage")).toBe(true);
   });
 
   it("normalises the suggested name the same way the share leg does", async () => {

--- a/clients/mobile/__tests__/file-save.test.ts
+++ b/clients/mobile/__tests__/file-save.test.ts
@@ -4,12 +4,26 @@
  * and one that resolves successfully having written nothing.
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { MobileFileSave } from "../src/file-save";
+import type {
+  FileSaveRequest,
+  SavedFileLocation,
+} from "@traycer-clients/shared/platform/runner-host";
+import { MobileFileSave, supportsDirectDownload } from "../src/file-save";
 
 const nativeMocks = vi.hoisted(() => ({
   writeFile: vi.fn(),
   stat: vi.fn(),
   share: vi.fn(),
+  getPlatform: vi.fn<() => string>(),
+  getInfo: vi.fn(),
+}));
+
+vi.mock("@capacitor/core", () => ({
+  Capacitor: { getPlatform: nativeMocks.getPlatform },
+}));
+
+vi.mock("@capacitor/device", () => ({
+  Device: { getInfo: nativeMocks.getInfo },
 }));
 
 vi.mock("@capacitor/filesystem", () => ({
@@ -85,6 +99,20 @@ function fileNotFoundRejection(): Error {
   return Object.assign(error, { code: "OS-PLUG-FILE-0008" });
 }
 
+/**
+ * The direct-download route of a shell that HAS the capability, narrowed once
+ * so the cases below read as calls rather than as null checks.
+ */
+function directDownload(): (
+  request: FileSaveRequest,
+) => Promise<SavedFileLocation> {
+  const download = new MobileFileSave(true).downloadFile;
+  if (download === null) {
+    throw new Error("A capable shell must expose a direct download.");
+  }
+  return download;
+}
+
 /** The set of paths a stat should report as already taken. */
 function occupyDocuments(paths: readonly string[]): void {
   nativeMocks.stat.mockImplementation((options: { path: string }) =>
@@ -105,11 +133,93 @@ beforeEach(() => {
   nativeMocks.share.mockResolvedValue({
     activityType: "com.apple.DocumentsApp",
   });
+  nativeMocks.getPlatform.mockReturnValue("ios");
+  nativeMocks.getInfo.mockResolvedValue({ androidSDKVersion: 34 });
+});
+
+describe("supportsDirectDownload", () => {
+  it("answers without asking the OS anywhere but Android", async () => {
+    nativeMocks.getPlatform.mockReturnValue("ios");
+
+    await expect(supportsDirectDownload()).resolves.toBe(true);
+    // iOS writes into its own documents container, which no OS version gates,
+    // so that platform must not pay a plugin round trip on the mount path.
+    expect(nativeMocks.getInfo).not.toHaveBeenCalled();
+  });
+
+  it("withholds the capability on the one Android level with no route", async () => {
+    // API 29 enforces scoped storage without the Documents relaxation that
+    // follows it, so a direct write there could only ever fail.
+    nativeMocks.getPlatform.mockReturnValue("android");
+    nativeMocks.getInfo.mockResolvedValue({ androidSDKVersion: 29 });
+
+    await expect(supportsDirectDownload()).resolves.toBe(false);
+  });
+
+  it("keeps the capability on the Android levels that do have a route", async () => {
+    nativeMocks.getPlatform.mockReturnValue("android");
+    for (const sdk of [26, 28, 30, 33, 36]) {
+      nativeMocks.getInfo.mockResolvedValue({ androidSDKVersion: sdk });
+      await expect(supportsDirectDownload()).resolves.toBe(true);
+    }
+  });
+
+  it("assumes the capability when the probe fails", async () => {
+    // A false negative would hide a working Download from every modern
+    // Android; a false positive costs one API level a loud error beside a
+    // Share that still works. The probe failing is a runtime anomaly and must
+    // not take the common case down with it.
+    nativeMocks.getPlatform.mockReturnValue("android");
+    nativeMocks.getInfo.mockRejectedValue(new Error("plugin unavailable"));
+
+    await expect(supportsDirectDownload()).resolves.toBe(true);
+  });
+
+  it("assumes the capability when the device names no SDK version", async () => {
+    nativeMocks.getPlatform.mockReturnValue("android");
+    nativeMocks.getInfo.mockResolvedValue({});
+
+    await expect(supportsDirectDownload()).resolves.toBe(true);
+  });
+
+  it("gives up on a probe that never settles rather than blocking the mount", async () => {
+    // This runs on the app's mount path: a plugin call that never resolves
+    // would otherwise mean an app that never renders.
+    vi.useFakeTimers();
+    try {
+      nativeMocks.getPlatform.mockReturnValue("android");
+      nativeMocks.getInfo.mockReturnValue(new Promise(() => undefined));
+
+      const settled = supportsDirectDownload();
+      await vi.advanceTimersByTimeAsync(5_000);
+
+      await expect(settled).resolves.toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe("MobileFileSave capability", () => {
+  it("withholds the direct download where the device has no destination", () => {
+    // Absent rather than present-and-broken: a surface reads the capability
+    // and simply does not offer a Download it could only ever fail.
+    expect(new MobileFileSave(false).downloadFile).toBeNull();
+  });
+
+  it("still offers the share sheet without a direct download", async () => {
+    const saved = await new MobileFileSave(false).saveFile(
+      request("diagram.png", new Uint8Array([1])),
+    );
+
+    expect(nativeMocks.share).toHaveBeenCalledTimes(1);
+    expect(saved).toEqual({ name: "diagram.png", path: null });
+  });
 });
 
 describe("MobileFileSave", () => {
   it("stages the bytes in the cache container and offers that file to the share sheet", async () => {
-    const saved = await new MobileFileSave().saveFile(
+    const saved = await new MobileFileSave(true).saveFile(
       request("diagram.png", new Uint8Array([1, 2, 3])),
     );
 
@@ -132,7 +242,7 @@ describe("MobileFileSave", () => {
   it("hands over the exact bytes it was given", async () => {
     const bytes = new Uint8Array([0, 1, 127, 128, 200, 255]);
 
-    await new MobileFileSave().saveFile(request("blob.bin", bytes));
+    await new MobileFileSave(true).saveFile(request("blob.bin", bytes));
 
     expect(Array.from(writtenBytes())).toEqual(Array.from(bytes));
   });
@@ -145,7 +255,7 @@ describe("MobileFileSave", () => {
       bytes[index] = index % 256;
     }
 
-    await new MobileFileSave().saveFile(request("big.bin", bytes));
+    await new MobileFileSave(true).saveFile(request("big.bin", bytes));
 
     const written = writtenBytes();
     expect(written.length).toBe(bytes.length);
@@ -159,7 +269,7 @@ describe("MobileFileSave", () => {
     nativeMocks.share.mockRejectedValue(new Error("Share canceled"));
 
     await expect(
-      new MobileFileSave().saveFile(
+      new MobileFileSave(true).saveFile(
         request("diagram.png", new Uint8Array([1])),
       ),
     ).resolves.toBeNull();
@@ -169,7 +279,7 @@ describe("MobileFileSave", () => {
     nativeMocks.share.mockRejectedValue(new Error("Share API not available"));
 
     await expect(
-      new MobileFileSave().saveFile(
+      new MobileFileSave(true).saveFile(
         request("diagram.png", new Uint8Array([1])),
       ),
     ).rejects.toThrow("Share API not available");
@@ -178,7 +288,7 @@ describe("MobileFileSave", () => {
   it("keeps a composed name inside the export directory", async () => {
     // Suggested names are built from user content (an image's alt text, an
     // epic title), so a separator in one must not choose a directory.
-    await new MobileFileSave().saveFile(
+    await new MobileFileSave(true).saveFile(
       request("../../escape/notes.md", new Uint8Array([1])),
     );
 
@@ -187,7 +297,7 @@ describe("MobileFileSave", () => {
   });
 
   it("falls back to a name rather than writing to the directory itself", async () => {
-    const saved = await new MobileFileSave().saveFile(
+    const saved = await new MobileFileSave(true).saveFile(
       request("   ", new Uint8Array([1])),
     );
 
@@ -199,7 +309,9 @@ describe("MobileFileSave", () => {
   it("falls back for a padded dot, which names the staging directory itself", async () => {
     // Whitespace around the dots hides them from a strip that runs first, and
     // `.../.` is the directory rather than a file in it.
-    await new MobileFileSave().saveFile(request(" . ", new Uint8Array([1])));
+    await new MobileFileSave(true).saveFile(
+      request(" . ", new Uint8Array([1])),
+    );
 
     // The property is that it names a FILE, not the directory or its parent -
     // asserted as such, so the fallback's exact spelling stays free to move.
@@ -209,7 +321,9 @@ describe("MobileFileSave", () => {
   });
 
   it("falls back for a padded double dot, which names the parent", async () => {
-    await new MobileFileSave().saveFile(request(" .. ", new Uint8Array([1])));
+    await new MobileFileSave(true).saveFile(
+      request(" .. ", new Uint8Array([1])),
+    );
 
     expect(stagedBaseName(0)).not.toBe(".");
     expect(stagedBaseName(0)).not.toBe("..");
@@ -221,7 +335,7 @@ describe("MobileFileSave", () => {
     // receiving app finishing its read of the granted URI. Two exports sharing
     // a path would let the second replace bytes the first recipient is still
     // consuming - the same late-read fact that makes deleting unsafe.
-    const host = new MobileFileSave();
+    const host = new MobileFileSave(true);
     await host.saveFile(request("mermaid-diagram.png", new Uint8Array([1])));
     await host.saveFile(request("mermaid-diagram.png", new Uint8Array([2])));
 
@@ -238,7 +352,7 @@ describe("MobileFileSave", () => {
     const title = "経過報告".repeat(30);
     expect(title.length).toBe(120);
 
-    const saved = await new MobileFileSave().saveFile(
+    const saved = await new MobileFileSave(true).saveFile(
       request(`${title}.md`, new Uint8Array([1])),
     );
 
@@ -257,7 +371,7 @@ describe("MobileFileSave", () => {
     // Four bytes each: the same 120-code-point allowance is 480 bytes here.
     const title = "🌊".repeat(120);
 
-    await new MobileFileSave().saveFile(
+    await new MobileFileSave(true).saveFile(
       request(`${title}.png`, new Uint8Array([1])),
     );
 
@@ -268,7 +382,7 @@ describe("MobileFileSave", () => {
   });
 
   it("leaves a name that already fits exactly as it was suggested", async () => {
-    await new MobileFileSave().saveFile(
+    await new MobileFileSave(true).saveFile(
       request("mermaid-diagram.png", new Uint8Array([1])),
     );
 
@@ -281,7 +395,7 @@ describe("MobileFileSave", () => {
     // is handed a file URI and nothing else, so the OS infers the type from
     // the path - extensionless reads as generic data, and "Save Image" is not
     // offered for it.
-    const saved = await new MobileFileSave().saveFile(
+    const saved = await new MobileFileSave(true).saveFile(
       requestOfType("a1b2c3d4", new Uint8Array([1]), "image/png"),
     );
 
@@ -291,7 +405,7 @@ describe("MobileFileSave", () => {
   });
 
   it("leaves a name that already carries an extension alone", async () => {
-    await new MobileFileSave().saveFile(
+    await new MobileFileSave(true).saveFile(
       requestOfType("photo.jpeg", new Uint8Array([1]), "image/png"),
     );
 
@@ -303,7 +417,7 @@ describe("MobileFileSave", () => {
   it("reads past a media type's parameters to reach the extension", async () => {
     // A Blob keeps the full type it was handed, so a response served as
     // `image/svg+xml; charset=utf-8` arrives with the charset attached.
-    await new MobileFileSave().saveFile(
+    await new MobileFileSave(true).saveFile(
       requestOfType(
         "diagram",
         new Uint8Array([1]),
@@ -315,7 +429,7 @@ describe("MobileFileSave", () => {
   });
 
   it("reads a type case-insensitively, as media types are", async () => {
-    await new MobileFileSave().saveFile(
+    await new MobileFileSave(true).saveFile(
       requestOfType("shot", new Uint8Array([1]), "IMAGE/PNG"),
     );
 
@@ -323,7 +437,7 @@ describe("MobileFileSave", () => {
   });
 
   it("invents no extension for a type it cannot name one for", async () => {
-    await new MobileFileSave().saveFile(
+    await new MobileFileSave(true).saveFile(
       requestOfType("payload", new Uint8Array([1]), "application/x-unknown"),
     );
 
@@ -331,7 +445,7 @@ describe("MobileFileSave", () => {
   });
 
   it("never offers a re-open route, having learned no path to re-open", () => {
-    expect(new MobileFileSave().openSavedFile).toBeNull();
+    expect(new MobileFileSave(true).openSavedFile).toBeNull();
   });
 });
 
@@ -341,7 +455,7 @@ describe("MobileFileSave.downloadFile", () => {
       uri: "file:///docs/Traycer/traycer-usage-30d.png",
     });
 
-    const saved = await new MobileFileSave().downloadFile(
+    const saved = await directDownload()(
       request("traycer-usage-30d.png", new Uint8Array([1, 2, 3])),
     );
 
@@ -363,7 +477,7 @@ describe("MobileFileSave.downloadFile", () => {
   it("hands over the exact bytes it was given", async () => {
     const bytes = new Uint8Array([0, 1, 127, 128, 200, 255]);
 
-    await new MobileFileSave().downloadFile(request("shot.png", bytes));
+    await directDownload()(request("shot.png", bytes));
 
     expect(Array.from(writtenBytes())).toEqual(Array.from(bytes));
   });
@@ -373,7 +487,7 @@ describe("MobileFileSave.downloadFile", () => {
     // the first would lose a file the user believes they still have.
     occupyDocuments(["Traycer/traycer-usage-30d.png"]);
 
-    const saved = await new MobileFileSave().downloadFile(
+    const saved = await directDownload()(
       request("traycer-usage-30d.png", new Uint8Array([1])),
     );
 
@@ -390,9 +504,7 @@ describe("MobileFileSave.downloadFile", () => {
       "Traycer/usage (3).png",
     ]);
 
-    await new MobileFileSave().downloadFile(
-      request("usage.png", new Uint8Array([1])),
-    );
+    await directDownload()(request("usage.png", new Uint8Array([1])));
 
     expect(writtenFile(0).path).toBe("Traycer/usage (4).png");
   });
@@ -403,9 +515,7 @@ describe("MobileFileSave.downloadFile", () => {
     // must still land, and still not clobber anything.
     nativeMocks.stat.mockResolvedValue({ uri: "file:///docs/taken" });
 
-    await new MobileFileSave().downloadFile(
-      request("usage.png", new Uint8Array([1])),
-    );
+    await directDownload()(request("usage.png", new Uint8Array([1])));
 
     const path = writtenFile(0).path;
     expect(path.startsWith("Traycer/usage")).toBe(true);
@@ -424,7 +534,7 @@ describe("MobileFileSave.downloadFile", () => {
     expect(new TextEncoder().encode(name).length).toBe(MAX_FILE_NAME_BYTES);
     occupyDocuments([`Traycer/${name}`]);
 
-    await new MobileFileSave().downloadFile(request(name, new Uint8Array([1])));
+    await directDownload()(request(name, new Uint8Array([1])));
 
     const written = writtenFile(0).path;
     const basename = written.split("/").at(-1) ?? "";
@@ -441,11 +551,11 @@ describe("MobileFileSave.downloadFile", () => {
     // their stat, so the claim set alone closes no window - only serialising
     // the search does. Separate export surfaces have independent mutations, so
     // two overlapping downloads are reachable.
-    const host = new MobileFileSave();
+    const host = directDownload();
 
     await Promise.all([
-      host.downloadFile(request("usage.png", new Uint8Array([1]))),
-      host.downloadFile(request("usage.png", new Uint8Array([2]))),
+      host(request("usage.png", new Uint8Array([1]))),
+      host(request("usage.png", new Uint8Array([2]))),
     ]);
 
     const paths = [writtenFile(0).path, writtenFile(1).path];
@@ -460,13 +570,13 @@ describe("MobileFileSave.downloadFile", () => {
     nativeMocks.stat.mockImplementationOnce(() => {
       throw new Error("bridge unavailable");
     });
-    const host = new MobileFileSave();
+    const host = directDownload();
 
     await expect(
-      host.downloadFile(request("usage.png", new Uint8Array([1]))),
+      host(request("usage.png", new Uint8Array([1]))),
     ).resolves.toBeTruthy();
     await expect(
-      host.downloadFile(request("later.png", new Uint8Array([1]))),
+      host(request("later.png", new Uint8Array([1]))),
     ).resolves.toBeTruthy();
     expect(writtenFile(1).path).toBe("Traycer/later.png");
   });
@@ -475,12 +585,12 @@ describe("MobileFileSave.downloadFile", () => {
     // A write that never landed leaves the path genuinely free; holding the
     // claim would push the user's retry onto a numbered name for nothing.
     nativeMocks.writeFile.mockRejectedValueOnce(new Error("Disk full"));
-    const host = new MobileFileSave();
+    const host = directDownload();
 
     await expect(
-      host.downloadFile(request("usage.png", new Uint8Array([1]))),
+      host(request("usage.png", new Uint8Array([1]))),
     ).rejects.toThrow("Disk full");
-    await host.downloadFile(request("usage.png", new Uint8Array([1])));
+    await host(request("usage.png", new Uint8Array([1])));
 
     expect(writtenFile(1).path).toBe("Traycer/usage.png");
   });
@@ -488,9 +598,7 @@ describe("MobileFileSave.downloadFile", () => {
   it("takes a confirmed not-found as the name being free", async () => {
     // The ordinary case, and the one the whole probe rests on: nothing is
     // there, so the download keeps the name it asked for.
-    await new MobileFileSave().downloadFile(
-      request("usage.png", new Uint8Array([1])),
-    );
+    await directDownload()(request("usage.png", new Uint8Array([1])));
 
     expect(writtenFile(0).path).toBe("Traycer/usage.png");
   });
@@ -502,9 +610,7 @@ describe("MobileFileSave.downloadFile", () => {
     // costs the download nothing but a numbered name.
     nativeMocks.stat.mockRejectedValue(new Error("I/O error"));
 
-    await new MobileFileSave().downloadFile(
-      request("usage.png", new Uint8Array([1])),
-    );
+    await directDownload()(request("usage.png", new Uint8Array([1])));
 
     expect(writtenFile(0).path).not.toBe("Traycer/usage.png");
     expect(writtenFile(0).path.startsWith("Traycer/usage")).toBe(true);
@@ -513,7 +619,7 @@ describe("MobileFileSave.downloadFile", () => {
   it("normalises the suggested name the same way the share leg does", async () => {
     // Same seam, same rules: a separator must not choose a directory, and the
     // extension comes from the blob's own type when the name carries none.
-    await new MobileFileSave().downloadFile(
+    await directDownload()(
       requestOfType("../../escape/a1b2c3d4", new Uint8Array([1]), "image/png"),
     );
 
@@ -528,9 +634,7 @@ describe("MobileFileSave.downloadFile", () => {
     );
 
     await expect(
-      new MobileFileSave().downloadFile(
-        request("usage.png", new Uint8Array([1])),
-      ),
+      directDownload()(request("usage.png", new Uint8Array([1]))),
     ).rejects.toThrow("File permissions denied");
   });
 });

--- a/clients/mobile/__tests__/file-save.test.ts
+++ b/clients/mobile/__tests__/file-save.test.ts
@@ -69,6 +69,20 @@ function request(name: string, bytes: Uint8Array) {
   return requestOfType(name, bytes, "image/png");
 }
 
+/**
+ * The byte bound a single path component may occupy, as `file-save.ts`
+ * enforces it. Restated here rather than exported, so a test that pushes a
+ * name to the limit is pinned to the platform's rule and not to the module's.
+ */
+const MAX_FILE_NAME_BYTES = 255;
+
+/** Everything already queued has run, microtasks and timers alike. */
+function settle(): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
+}
+
 /** The set of paths a stat should report as already taken. */
 function occupyDocuments(paths: readonly string[]): void {
   nativeMocks.stat.mockImplementation((options: { path: string }) =>
@@ -396,6 +410,68 @@ describe("MobileFileSave.downloadFile", () => {
     expect(path.endsWith(".png")).toBe(true);
     expect(path).not.toBe("Traycer/usage.png");
     expect(path).not.toBe("Traycer/usage (2).png");
+  });
+
+  it("keeps the collision suffix on a name already at the byte limit", async () => {
+    // The insert is the ONLY thing making an occupied name free. Composing
+    // first and bounding after truncates from the end and eats it, so every
+    // numbered candidate would come back as the occupied name and the write
+    // would replace the download it was meant to sit beside.
+    const stem = "a".repeat(MAX_FILE_NAME_BYTES - ".png".length);
+    const name = `${stem}.png`;
+    expect(new TextEncoder().encode(name).length).toBe(MAX_FILE_NAME_BYTES);
+    occupyDocuments([`Traycer/${name}`]);
+
+    await new MobileFileSave().downloadFile(request(name, new Uint8Array([1])));
+
+    const written = writtenFile(0).path;
+    const basename = written.split("/").at(-1) ?? "";
+    expect(written).not.toBe(`Traycer/${name}`);
+    expect(basename).toContain(" (2)");
+    expect(basename.endsWith(".png")).toBe(true);
+    expect(new TextEncoder().encode(basename).length).toBeLessThanOrEqual(
+      MAX_FILE_NAME_BYTES,
+    );
+  });
+
+  it("does not hand the same path to two downloads racing on it", async () => {
+    // A path is only observably taken once its bytes have landed, so two
+    // downloads started close together would both see the same candidate free.
+    let releaseFirstWrite: () => void = () => undefined;
+    nativeMocks.writeFile.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          releaseFirstWrite = () => {
+            resolve({ uri: "file:///docs/Traycer/usage.png" });
+          };
+        }),
+    );
+    const host = new MobileFileSave();
+
+    const first = host.downloadFile(request("usage.png", new Uint8Array([1])));
+    // Let the first claim its path before the second starts probing.
+    await settle();
+    const second = host.downloadFile(request("usage.png", new Uint8Array([2])));
+    await settle();
+    releaseFirstWrite();
+    await Promise.all([first, second]);
+
+    expect(writtenFile(0).path).toBe("Traycer/usage.png");
+    expect(writtenFile(1).path).toBe("Traycer/usage (2).png");
+  });
+
+  it("frees a claimed path again when its write fails", async () => {
+    // A write that never landed leaves the path genuinely free; holding the
+    // claim would push the user's retry onto a numbered name for nothing.
+    nativeMocks.writeFile.mockRejectedValueOnce(new Error("Disk full"));
+    const host = new MobileFileSave();
+
+    await expect(
+      host.downloadFile(request("usage.png", new Uint8Array([1]))),
+    ).rejects.toThrow("Disk full");
+    await host.downloadFile(request("usage.png", new Uint8Array([1])));
+
+    expect(writtenFile(1).path).toBe("Traycer/usage.png");
   });
 
   it("reads an unreadable directory as free rather than as taken", async () => {

--- a/clients/mobile/__tests__/mobile-runner-host.test.ts
+++ b/clients/mobile/__tests__/mobile-runner-host.test.ts
@@ -256,6 +256,9 @@ function runner(returnScheme: string | null): MobileRunnerHost {
     // The native save leg has its own suite (`file-save.test.ts`); `null` is
     // the dev-web answer, and keeps the plugin pair out of these tests.
     fileSave: null,
+    // Dev-web flavoured, matching `fileSave` above: a browser tab honours an
+    // image clipboard write.
+    canCopyImages: true,
   });
 }
 
@@ -324,6 +327,7 @@ function phoneRunner(input: {
     deviceDescriber: null,
     linkLoginDeepLinks: null,
     fileSave: null,
+    canCopyImages: true,
   });
 }
 

--- a/clients/mobile/android/app/src/main/AndroidManifest.xml
+++ b/clients/mobile/android/app/src/main/AndroidManifest.xml
@@ -77,4 +77,28 @@
         to "granted".
     -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+
+    <!--
+        A direct download (IFileSaveHost.downloadFile) writes into the SHARED
+        Documents folder, which is external storage. Same rule as the line
+        above: the Filesystem plugin declares the matching @Permission alias
+        but contributes no <uses-permission> of its own, so without this the
+        write is refused on the API levels that still gate it and the plugin
+        reports "file permissions denied" without ever prompting.
+
+        maxSdkVersion 28 is where the gate ends, not a guess: it is what the
+        plugin's own check encodes - granted outright from API 33, and from
+        API 30 for a directory-rooted path, because an app may write files it
+        creates under Documents with no permission at all. Declaring it past
+        28 asks for something the platform no longer honours.
+
+        API 29 is the one level with no route: scoped storage is enforced there
+        and the Documents relaxation is not yet in place, so a direct download
+        fails loudly. The share sheet still works, and buying that one level
+        back would mean requestLegacyExternalStorage - opting the whole app out
+        of scoped storage - which is not a trade worth making for it.
+    -->
+    <uses-permission
+        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="28" />
 </manifest>

--- a/clients/mobile/ios/App/App/Info.plist
+++ b/clients/mobile/ios/App/App/Info.plist
@@ -37,10 +37,24 @@
 	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<!-- The iOS half of a direct download (IFileSaveHost.downloadFile), which
+	     writes into the app's own Documents container. iOS has no shared
+	     downloads folder an app may write to unaided, so these two keys are
+	     what turn that container into a real destination: together they put
+	     "Traycer" under On My iPhone in the Files app, where the written PNG
+	     can be opened, moved and shared like any other file. Without them the
+	     write still succeeds and the user can never reach it, which would make
+	     the Download control a lie on this platform. Both are required - the
+	     first surfaces the folder, the second lets other apps open its files
+	     in place rather than only copy them out. -->
+	<key>LSSupportsOpeningDocumentsInPlace</key>
+	<true/>
 	<key>NSCameraUsageDescription</key>
 	<string>Traycer uses the camera to scan the sign-in QR code shown on your desktop.</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>
 	<string>Traycer saves exported images to your photo library when you choose Save Image.</string>
+	<key>UIFileSharingEnabled</key>
+	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/clients/mobile/src/file-save.ts
+++ b/clients/mobile/src/file-save.ts
@@ -224,19 +224,40 @@ function withNameInsert(name: string, insert: string): string {
 }
 
 /**
- * Whether something already occupies `path` in the documents directory. The
- * plugin REJECTS a stat of a missing file rather than reporting absence, so a
- * rejection is the "no" - and any other failure (an unreadable directory)
- * reads as "no" too, which is the safe answer: the caller only uses this to
- * pick a free name, and guessing "taken" would push a perfectly good download
- * onto a numbered name for no reason.
+ * The plugin's own code for "there is no file there", identical on both native
+ * shells (`FilesystemErrors.doesNotExist` / `FilesystemError.fileNotFound`).
+ * It arrives on the JS error because the plugin rejects with a code beside its
+ * message.
+ */
+const FILE_NOT_FOUND_CODE = "OS-PLUG-FILE-0008";
+
+function isFileNotFound(error: unknown): boolean {
+  if (!(typeof error === "object" && error !== null)) return false;
+  const code: unknown = Reflect.get(error, "code");
+  if (code === FILE_NOT_FOUND_CODE) return true;
+  // Both shells spell absence the same way in prose. Read as a fallback only,
+  // for a rejection that reaches here without the plugin's code on it.
+  const message: unknown = Reflect.get(error, "message");
+  return typeof message === "string" && message.includes("does not exist");
+}
+
+/**
+ * Whether something already occupies `path` in the documents directory.
+ *
+ * The plugin REJECTS a stat of a missing file rather than reporting absence,
+ * so only a CONFIRMED not-found answers "free". Every other failure - a
+ * transient I/O error, an unreadable directory, a denied permission - answers
+ * "taken", because the two mistakes are not equal: guessing "taken" costs a
+ * download a numbered name, while guessing "free" lets the write replace a
+ * file that was there all along, which is the exact loss this collision
+ * handling exists to prevent.
  */
 async function fileExists(path: string): Promise<boolean> {
   try {
     await Filesystem.stat({ path, directory: Directory.Documents });
     return true;
-  } catch {
-    return false;
+  } catch (error) {
+    return !isFileNotFound(error);
   }
 }
 
@@ -252,6 +273,32 @@ async function fileExists(path: string): Promise<boolean> {
 const claimedDownloadPaths = new Set<string>();
 
 /**
+ * Serialises {@link claimDownloadPath}, so a search and the claim that ends it
+ * are one indivisible step.
+ *
+ * The search AWAITS a stat per candidate. Without this, two downloads of the
+ * same name started in one tick would both begin probing before either had
+ * claimed anything, both would see the candidate free, and both would claim
+ * and write it - the set alone closes no window, because nothing is in it yet
+ * while the stats are in flight. Running the searches one after another is
+ * what makes a claim visible to the next.
+ */
+let downloadClaimQueue: Promise<unknown> = Promise.resolve();
+
+function claimDownloadPath(name: string): Promise<string> {
+  // Settled either way: a rejected predecessor must not wedge the queue.
+  const next = downloadClaimQueue.then(
+    () => searchForFreeDownloadPath(name),
+    () => searchForFreeDownloadPath(name),
+  );
+  downloadClaimQueue = next.then(
+    () => undefined,
+    () => undefined,
+  );
+  return next;
+}
+
+/**
  * Whether `path` is spoken for, by a file already on disk or by a download
  * still writing one.
  */
@@ -262,6 +309,8 @@ async function downloadPathIsTaken(path: string): Promise<boolean> {
 /**
  * Claim the first free path for `name` in the download directory. The caller
  * MUST release it with {@link releaseDownloadPath} once the write settles.
+ * Only ever entered through {@link claimDownloadPath}, which is what makes the
+ * check and the claim atomic.
  *
  * A download must not silently replace an earlier one - two exports of the
  * same usage window suggest the same name, and overwriting the first would
@@ -270,7 +319,7 @@ async function downloadPathIsTaken(path: string): Promise<boolean> {
  * {@link MAX_NUMBERED_DOWNLOAD_ATTEMPTS} the launch stamp takes over, which is
  * unique by construction and so always terminates.
  */
-async function claimDownloadPath(name: string): Promise<string> {
+async function searchForFreeDownloadPath(name: string): Promise<string> {
   const claim = (path: string): string => {
     claimedDownloadPaths.add(path);
     return path;

--- a/clients/mobile/src/file-save.ts
+++ b/clients/mobile/src/file-save.ts
@@ -1,3 +1,5 @@
+import { Capacitor } from "@capacitor/core";
+import { Device } from "@capacitor/device";
 import { Directory, Filesystem } from "@capacitor/filesystem";
 import { Share } from "@capacitor/share";
 import type {
@@ -341,6 +343,61 @@ function releaseDownloadPath(path: string): void {
 }
 
 /**
+ * The one Android level with no route into the shared Documents folder.
+ *
+ * From API 30 an app may write files it creates there with no permission at
+ * all, and up to API 28 `WRITE_EXTERNAL_STORAGE` is declared and grantable. API
+ * 29 sits between: scoped storage is enforced, and the Documents relaxation
+ * that follows it is not yet in place. Buying it back would mean
+ * `requestLegacyExternalStorage`, i.e. opting the whole app out of scoped
+ * storage for one shrinking OS version - so the honest answer is to not offer
+ * a direct download there at all, and leave the share sheet as the route.
+ */
+const ANDROID_SCOPED_STORAGE_GAP_SDK = 29;
+
+/**
+ * How long the OS is given to name its own version before the probe gives up.
+ *
+ * This runs on the app's mount path, so a plugin call that never settles would
+ * mean an app that never renders. A capability this small must not be able to
+ * do that; the timeout bounds it, and its expiry is answered the same way any
+ * other unknown is (see {@link supportsDirectDownload}).
+ */
+const DEVICE_PROBE_TIMEOUT_MS = 2_000;
+
+/**
+ * Whether this device can honour {@link MobileFileSave.downloadFile}.
+ *
+ * Answered WITHOUT a plugin call anywhere but Android - iOS writes into its own
+ * documents container, which no OS version gates - so only one platform pays
+ * the await at all.
+ *
+ * An unknown answer resolves to `true`, deliberately. The two mistakes are not
+ * equal here: a false negative hides a working Download from every device on
+ * every modern Android, while a false positive costs one API level a loud error
+ * toast beside a Share button that still works. A probe that fails or hangs is
+ * a runtime anomaly, and it must not take the common case down with it.
+ */
+export async function supportsDirectDownload(): Promise<boolean> {
+  if (Capacitor.getPlatform() !== "android") return true;
+  try {
+    const info = await Promise.race([
+      Device.getInfo(),
+      new Promise<null>((resolve) => {
+        setTimeout(() => {
+          resolve(null);
+        }, DEVICE_PROBE_TIMEOUT_MS);
+      }),
+    ]);
+    if (info === null) return true;
+    // Absent on a device that reports no SDK version - unknown, so `true`.
+    return info.androidSDKVersion !== ANDROID_SCOPED_STORAGE_GAP_SDK;
+  } catch {
+    return true;
+  }
+}
+
+/**
  * The plugin rejects a dismissed sheet rather than resolving it, and the
  * rejection carries prose rather than a code. Matching the wording is a guess,
  * but the alternative - reporting every rejection as a failure - tells a user
@@ -424,7 +481,26 @@ export class MobileFileSave implements IFileSaveHost {
    * re-open it - the path is the honest record of the location, not a route
    * back to it.
    */
-  async downloadFile(request: FileSaveRequest): Promise<SavedFileLocation> {
+  readonly downloadFile:
+    | ((request: FileSaveRequest) => Promise<SavedFileLocation>)
+    | null;
+
+  /**
+   * @param directDownloads whether this device has a documents destination
+   *   this shell may write to - {@link supportsDirectDownload} answers it.
+   *   `false` makes {@link downloadFile} `null`, which is what stops a surface
+   *   offering a Download it could only ever fail: the capability is absent
+   *   rather than present-and-broken, and Share is unaffected.
+   */
+  constructor(directDownloads: boolean) {
+    this.downloadFile = directDownloads
+      ? (request) => this.writeDownload(request)
+      : null;
+  }
+
+  private async writeDownload(
+    request: FileSaveRequest,
+  ): Promise<SavedFileLocation> {
     const name = toFileName(request.name, request.type);
     const path = await claimDownloadPath(name);
     try {

--- a/clients/mobile/src/file-save.ts
+++ b/clients/mobile/src/file-save.ts
@@ -197,14 +197,30 @@ function toFileName(suggested: string, mediaType: string): string {
 }
 
 /**
- * A name with `insert` placed between its stem and its extension, re-bounded
- * afterwards - the insert is what makes an otherwise-taken name free, and a
- * name only has to fit once it is final.
+ * A name with `insert` placed between its stem and its extension, within the
+ * same byte bound as any other component.
+ *
+ * The STEM gives way, never the insert. Composing first and bounding after
+ * would truncate from the end and eat the insert itself, so a name already at
+ * the limit would come back unchanged - and since the insert is the only thing
+ * making an occupied name free, every numbered candidate and the stamped
+ * fallback would resolve to that same occupied path and the write would
+ * overwrite the download it was meant to sit beside. An extension that cannot
+ * fit alongside the insert is dropped for the same reason: uniqueness is what
+ * is load-bearing here.
  */
 function withNameInsert(name: string, insert: string): string {
   const dot = name.lastIndexOf(".");
-  if (dot <= 0) return boundFileNameBytes(`${name}${insert}`);
-  return boundFileNameBytes(`${name.slice(0, dot)}${insert}${name.slice(dot)}`);
+  const stem = dot > 0 ? name.slice(0, dot) : name;
+  const insertBytes = utf8Length(insert);
+  const extension = dot > 0 ? name.slice(dot) : "";
+  const keptExtension =
+    insertBytes + utf8Length(extension) <= MAX_FILE_NAME_BYTES ? extension : "";
+  const budget = Math.max(
+    0,
+    MAX_FILE_NAME_BYTES - insertBytes - utf8Length(keptExtension),
+  );
+  return `${truncateToBytes(stem, budget)}${insert}${keptExtension}`;
 }
 
 /**
@@ -225,7 +241,27 @@ async function fileExists(path: string): Promise<boolean> {
 }
 
 /**
- * The first free path for `name` in the download directory.
+ * Paths handed out by {@link freeDownloadPath} whose write has not finished.
+ *
+ * A path is only OBSERVABLY taken once its bytes have landed, so two downloads
+ * started close together would both see the same candidate free and race for
+ * it - one replacing the other's file. Claiming the path for the length of the
+ * write closes that window; it is an in-process set because a phone runs one
+ * copy of this shell, which is the only concurrency there is to arbitrate.
+ */
+const claimedDownloadPaths = new Set<string>();
+
+/**
+ * Whether `path` is spoken for, by a file already on disk or by a download
+ * still writing one.
+ */
+async function downloadPathIsTaken(path: string): Promise<boolean> {
+  return claimedDownloadPaths.has(path) || (await fileExists(path));
+}
+
+/**
+ * Claim the first free path for `name` in the download directory. The caller
+ * MUST release it with {@link releaseDownloadPath} once the write settles.
  *
  * A download must not silently replace an earlier one - two exports of the
  * same usage window suggest the same name, and overwriting the first would
@@ -234,15 +270,25 @@ async function fileExists(path: string): Promise<boolean> {
  * {@link MAX_NUMBERED_DOWNLOAD_ATTEMPTS} the launch stamp takes over, which is
  * unique by construction and so always terminates.
  */
-async function freeDownloadPath(name: string): Promise<string> {
+async function claimDownloadPath(name: string): Promise<string> {
+  const claim = (path: string): string => {
+    claimedDownloadPaths.add(path);
+    return path;
+  };
   const candidate = `${DOWNLOAD_DIRECTORY}/${name}`;
-  if (!(await fileExists(candidate))) return candidate;
+  if (!(await downloadPathIsTaken(candidate))) return claim(candidate);
   for (let n = 2; n <= MAX_NUMBERED_DOWNLOAD_ATTEMPTS; n++) {
     const numbered = `${DOWNLOAD_DIRECTORY}/${withNameInsert(name, ` (${String(n)})`)}`;
-    if (!(await fileExists(numbered))) return numbered;
+    if (!(await downloadPathIsTaken(numbered))) return claim(numbered);
   }
   stagedRequests += 1;
-  return `${DOWNLOAD_DIRECTORY}/${withNameInsert(name, `-${stagingStamp}-${String(stagedRequests)}`)}`;
+  return claim(
+    `${DOWNLOAD_DIRECTORY}/${withNameInsert(name, `-${stagingStamp}-${String(stagedRequests)}`)}`,
+  );
+}
+
+function releaseDownloadPath(path: string): void {
+  claimedDownloadPaths.delete(path);
 }
 
 /**
@@ -331,15 +377,21 @@ export class MobileFileSave implements IFileSaveHost {
    */
   async downloadFile(request: FileSaveRequest): Promise<SavedFileLocation> {
     const name = toFileName(request.name, request.type);
-    const path = await freeDownloadPath(name);
-    const written = await Filesystem.writeFile({
-      path,
-      data: toBase64(request.bytes),
-      directory: Directory.Documents,
-      recursive: true,
-    });
-    // The name the user ends up with is the one that was free, which a
-    // collision may have numbered - the confirmation has to say that one.
-    return { name: path.split("/").at(-1) ?? name, path: written.uri };
+    const path = await claimDownloadPath(name);
+    try {
+      const written = await Filesystem.writeFile({
+        path,
+        data: toBase64(request.bytes),
+        directory: Directory.Documents,
+        recursive: true,
+      });
+      // The name the user ends up with is the one that was free, which a
+      // collision may have numbered - the confirmation has to say that one.
+      return { name: path.split("/").at(-1) ?? name, path: written.uri };
+    } finally {
+      // Released on failure too: a write that never landed leaves the path
+      // genuinely free, and holding it would push the retry onto a number.
+      releaseDownloadPath(path);
+    }
   }
 }

--- a/clients/mobile/src/file-save.ts
+++ b/clients/mobile/src/file-save.ts
@@ -185,8 +185,19 @@ function baseMediaType(mediaType: string): string {
  * one would otherwise choose a directory - and an empty result would write to
  * the export directory itself.
  */
+/**
+ * Characters Android's shared storage rejects in a file name. The volumes
+ * behind Documents are FAT-derived, so a name that is perfectly legal on the
+ * machine it came from - an image's alt text, an epic title - makes the write
+ * fail outright rather than land under a mangled name.
+ */
+const INVALID_FILE_NAME_CHARACTERS = /[:*?"<>|\u0000-\u001f]/g;
+
 function toFileName(suggested: string, mediaType: string): string {
-  const leaf = suggested.split(/[\\/]/).at(-1) ?? "";
+  const leaf = (suggested.split(/[\\/]/).at(-1) ?? "").replace(
+    INVALID_FILE_NAME_CHARACTERS,
+    "-",
+  );
   // Trimmed BEFORE the leading dots are stripped, or surrounding whitespace
   // hides them from the strip: `" . "` would survive as `"."` and `" .. "` as
   // `".."`, naming the staging directory itself or its parent rather than a
@@ -443,6 +454,13 @@ export class MobileFileSave implements IFileSaveHost {
    * application, whether or not it knows where the file is.
    */
   readonly openSavedFile = null;
+
+  /**
+   * The share sheet is what `saveFile` reaches, on every platform and every OS
+   * version - unlike { downloadFile}, which one Android level cannot
+   * honour at all.
+   */
+  readonly saveRoute = "share" as const;
 
   async saveFile(request: FileSaveRequest): Promise<SavedFileLocation | null> {
     const name = toFileName(request.name, request.type);

--- a/clients/mobile/src/file-save.ts
+++ b/clients/mobile/src/file-save.ts
@@ -14,6 +14,21 @@ import type {
 const EXPORT_DIRECTORY = "traycer-exports";
 
 /**
+ * Where a DIRECT download lands, inside the platform's documents directory: a
+ * folder of the app's own so a phone's Documents root does not accumulate
+ * loose Traycer files among everything else that writes there.
+ */
+const DOWNLOAD_DIRECTORY = "Traycer";
+
+/**
+ * How many numbered variants of a taken name are tried before falling back to
+ * the launch stamp. Two downloads of the same usage window in one session is
+ * the case worth handling; a user with twenty is better served by a name that
+ * is merely unique than by twenty more round trips to the filesystem.
+ */
+const MAX_NUMBERED_DOWNLOAD_ATTEMPTS = 20;
+
+/**
  * Each request stages into its OWN directory under that root, keeping the
  * user-facing basename intact.
  *
@@ -182,6 +197,55 @@ function toFileName(suggested: string, mediaType: string): string {
 }
 
 /**
+ * A name with `insert` placed between its stem and its extension, re-bounded
+ * afterwards - the insert is what makes an otherwise-taken name free, and a
+ * name only has to fit once it is final.
+ */
+function withNameInsert(name: string, insert: string): string {
+  const dot = name.lastIndexOf(".");
+  if (dot <= 0) return boundFileNameBytes(`${name}${insert}`);
+  return boundFileNameBytes(`${name.slice(0, dot)}${insert}${name.slice(dot)}`);
+}
+
+/**
+ * Whether something already occupies `path` in the documents directory. The
+ * plugin REJECTS a stat of a missing file rather than reporting absence, so a
+ * rejection is the "no" - and any other failure (an unreadable directory)
+ * reads as "no" too, which is the safe answer: the caller only uses this to
+ * pick a free name, and guessing "taken" would push a perfectly good download
+ * onto a numbered name for no reason.
+ */
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await Filesystem.stat({ path, directory: Directory.Documents });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * The first free path for `name` in the download directory.
+ *
+ * A download must not silently replace an earlier one - two exports of the
+ * same usage window suggest the same name, and overwriting the first would
+ * lose a file the user believes they still have. Numbered variants mirror what
+ * a desktop browser does with the same collision; past
+ * {@link MAX_NUMBERED_DOWNLOAD_ATTEMPTS} the launch stamp takes over, which is
+ * unique by construction and so always terminates.
+ */
+async function freeDownloadPath(name: string): Promise<string> {
+  const candidate = `${DOWNLOAD_DIRECTORY}/${name}`;
+  if (!(await fileExists(candidate))) return candidate;
+  for (let n = 2; n <= MAX_NUMBERED_DOWNLOAD_ATTEMPTS; n++) {
+    const numbered = `${DOWNLOAD_DIRECTORY}/${withNameInsert(name, ` (${String(n)})`)}`;
+    if (!(await fileExists(numbered))) return numbered;
+  }
+  stagedRequests += 1;
+  return `${DOWNLOAD_DIRECTORY}/${withNameInsert(name, `-${stagingStamp}-${String(stagedRequests)}`)}`;
+}
+
+/**
  * The plugin rejects a dismissed sheet rather than resolving it, and the
  * rejection carries prose rather than a code. Matching the wording is a guess,
  * but the alternative - reporting every rejection as a failure - tells a user
@@ -198,13 +262,21 @@ function isShareDismissal(error: unknown): boolean {
  * A WKWebView honours none of the browser save routes - there is no File
  * System Access API, and `<a download>` navigates instead of saving - so
  * every export on this shell was a silent no-op until the bytes took a native
- * path. That path is two plugins: the file is written into the app's cache
- * container, then offered to the OS share sheet, which is where a phone user
- * chooses "Save to Files", a photo library, or another app entirely.
+ * path. This shell owns TWO such paths, and the difference between them is
+ * the whole reason `IFileSaveHost` names them separately:
  *
- * The consequence for the contract is `path: null`. The sheet reports which
- * ACTIVITY the user picked, never where that activity put the bytes, so this
- * shell cannot re-open what it saved and `openSavedFile` is `null`.
+ * - {@link MobileFileSave.saveFile} stages the file in the app's cache
+ *   container and offers it to the OS share sheet, where a phone user chooses
+ *   "Save to Files", a photo library, or another app entirely. Where the bytes
+ *   end up is that app's decision.
+ * - {@link MobileFileSave.downloadFile} writes them into the platform's
+ *   documents directory and stops. Nothing is offered and nothing is chosen.
+ *
+ * The sheet reports which ACTIVITY the user picked, never where that activity
+ * put the bytes, so `saveFile` reports `path: null`; the direct write knows
+ * exactly where it wrote and says so. `openSavedFile` is `null` either way -
+ * this shell carries no plugin that hands a file to the OS default app, so
+ * knowing the path is not the same as having a route back to it.
  *
  * The staged copy is deliberately left in place, and each request gets its own
  * directory (see {@link stagingPath}). The sheet resolves when it is dismissed,
@@ -215,8 +287,8 @@ function isShareDismissal(error: unknown): boolean {
  */
 export class MobileFileSave implements IFileSaveHost {
   /**
-   * `null`: no activity in the sheet reports a destination back, so there is
-   * never a path to re-open.
+   * `null`: this shell has no route that opens a file with the OS default
+   * application, whether or not it knows where the file is.
    */
   readonly openSavedFile = null;
 
@@ -237,5 +309,37 @@ export class MobileFileSave implements IFileSaveHost {
       throw error;
     }
     return { name, path: null };
+  }
+
+  /**
+   * The phone's chooser-free download: the bytes are written into the
+   * platform's documents directory and nothing else happens - no sheet, no
+   * second app, and no decision left to the user after the tap.
+   *
+   * What "documents" means is the platform's answer, not this file's. On
+   * Android it is the shared Documents folder, which every file manager lists
+   * and other apps can read; on iOS it is the app's own documents container,
+   * which the Files app shows under "On My iPhone → Traycer" because the two
+   * `Info.plist` sharing keys are set. Neither needs a plugin this shell does
+   * not already carry, and both put a real, persistent file somewhere the user
+   * can go and find it - which is the whole of what a download promises.
+   *
+   * Unlike {@link saveFile} this reports a path: the write itself says where
+   * the bytes went. `openSavedFile` is still `null`, so nothing offers to
+   * re-open it - the path is the honest record of the location, not a route
+   * back to it.
+   */
+  async downloadFile(request: FileSaveRequest): Promise<SavedFileLocation> {
+    const name = toFileName(request.name, request.type);
+    const path = await freeDownloadPath(name);
+    const written = await Filesystem.writeFile({
+      path,
+      data: toBase64(request.bytes),
+      directory: Directory.Documents,
+      recursive: true,
+    });
+    // The name the user ends up with is the one that was free, which a
+    // collision may have numbered - the confirmation has to say that one.
+    return { name: path.split("/").at(-1) ?? name, path: written.uri };
   }
 }

--- a/clients/mobile/src/mobile-runner-host.ts
+++ b/clients/mobile/src/mobile-runner-host.ts
@@ -180,6 +180,14 @@ export interface MobileRunnerHostOptions {
    * Access API and `<a download>`, which is exactly what gui-app falls back to.
    */
   readonly fileSave: IFileSaveHost | null;
+  /**
+   * Whether this install's WebView actually puts an image on the system
+   * clipboard - see `IRunnerHost.canCopyImages`. Decided by the entry point
+   * rather than here, for the same reason as the members above: which platform
+   * this shell runs on is the entry's business, and nothing downstream of it
+   * may branch on the answer.
+   */
+  readonly canCopyImages: boolean;
 }
 
 const STEP_UP_EXPIRY_SKEW_MS = 5_000;
@@ -226,6 +234,7 @@ export class MobileRunnerHost implements IRunnerHost {
     readNativeClipboardFilePaths: async (): Promise<readonly string[]> => [],
   };
   readonly fileSave: IFileSaveHost | null;
+  readonly canCopyImages: boolean;
   readonly zoom = null;
   readonly service = null;
   readonly traycerCli = null;
@@ -286,6 +295,7 @@ export class MobileRunnerHost implements IRunnerHost {
     this.deviceDescriber = options.deviceDescriber;
     this.linkLoginDeepLinks = options.linkLoginDeepLinks;
     this.fileSave = options.fileSave;
+    this.canCopyImages = options.canCopyImages;
     this.notifications = buildNotifications(options.pushRegistration);
     this.pushPermission = buildPushPermission(
       options.pushRegistration,

--- a/clients/mobile/src/web/main.tsx
+++ b/clients/mobile/src/web/main.tsx
@@ -25,7 +25,7 @@ import {
 import "./index.css";
 import { MobileRunnerHost } from "../mobile-runner-host";
 import { MobileDeviceDescriber } from "../device-describer";
-import { MobileFileSave } from "../file-save";
+import { MobileFileSave, supportsDirectDownload } from "../file-save";
 import { MobileLinkCodeScanner } from "../link-code-scanner";
 import { MobileLinkLoginDeepLinks } from "../link-login-deep-links";
 import {
@@ -190,6 +190,33 @@ function bootstrap(): void {
     ? new MobileLinkLoginDeepLinks(App)
     : null;
   linkLoginDeepLinks?.start();
+  // Everything above stays SYNCHRONOUS, and the deep-link read above stays
+  // first: a QR scanned by the system camera makes the launch URL readable
+  // exactly once, so nothing may await before it. Only the remainder - which
+  // needs a capability the OS has to be asked for - moves behind an await.
+  // `void`, because a bootstrap failure has nowhere to be reported to.
+  void mount({ pushRegistration, linkLoginDeepLinks });
+}
+
+/**
+ * The rest of bootstrap, after the one thing the OS must be asked.
+ *
+ * `supportsDirectDownload()` is a plugin call, so the host cannot be built in
+ * the same tick as the synchronous setup above. The ordering that matters is
+ * unchanged: `pushRegistration.start` still runs after the host exists and
+ * still before the first render, so a cold-start notification tap is captured
+ * before the GUI mounts. What moved is that BOTH now happen one microtask
+ * later than they used to, and on Android after a bounded device probe.
+ */
+async function mount(input: {
+  readonly pushRegistration: MobilePushRegistration | null;
+  readonly linkLoginDeepLinks: MobileLinkLoginDeepLinks | null;
+}): Promise<void> {
+  const { pushRegistration, linkLoginDeepLinks } = input;
+  // Asked once, before the host exists, because `IFileSaveHost.downloadFile`
+  // is read synchronously at render time - a capability that resolved later
+  // would leave a Download control on screen that the shell cannot honour.
+  const directDownloads = await supportsDirectDownload();
   const host = new MobileRunnerHost({
     signInUrl: config.signInUrl,
     authnBaseUrl: config.authnBaseUrl,
@@ -231,7 +258,9 @@ function bootstrap(): void {
     // phone user saves through, and neither plugin has a web implementation
     // worth preferring over the browser save APIs gui-app already falls back
     // to in a tab.
-    fileSave: Capacitor.isNativePlatform() ? new MobileFileSave() : null,
+    fileSave: Capacitor.isNativePlatform()
+      ? new MobileFileSave(directDownloads)
+      : null,
     // The one place this difference is allowed to be named. WKWebView honours
     // an image clipboard write; Android's WebView RESOLVES it having written
     // nothing, because Chromium reaches the Android clipboard for an image

--- a/clients/mobile/src/web/main.tsx
+++ b/clients/mobile/src/web/main.tsx
@@ -232,6 +232,15 @@ function bootstrap(): void {
     // worth preferring over the browser save APIs gui-app already falls back
     // to in a tab.
     fileSave: Capacitor.isNativePlatform() ? new MobileFileSave() : null,
+    // The one place this difference is allowed to be named. WKWebView honours
+    // an image clipboard write; Android's WebView RESOLVES it having written
+    // nothing, because Chromium reaches the Android clipboard for an image
+    // through an embedder-supplied image file provider and that embedder
+    // installs none. Nothing rejects, so gui-app cannot learn this by trying -
+    // it reads the capability instead, and simply does not offer a Copy that
+    // would report a success the clipboard never received. The dev web entry
+    // is a real browser tab, where the write works.
+    canCopyImages: Capacitor.getPlatform() !== "android",
   });
   // After the host exists: registration follows the token store (sign-in,
   // app start while signed in, sign-out) and the host's resume edge (a

--- a/clients/shared/host-client/mock/mock-runner-host.ts
+++ b/clients/shared/host-client/mock/mock-runner-host.ts
@@ -160,6 +160,9 @@ export class MockRunnerHost implements IRunnerHost {
   // instead), so this never needs to vary per test the way `authnBaseUrl` does.
   readonly relayBaseUrl: string = "wss://relay.test.invalid/attach";
   readonly hasLocalHost: boolean;
+  // Browser-tab flavoured, like `fileSave` below: a tab's own clipboard takes
+  // images, so image-copy affordances render by default in tests.
+  readonly canCopyImages: boolean = true;
   readonly openedExternalLinks: string[] = [];
   readonly notificationsSent: Array<{
     readonly title: string;

--- a/clients/shared/platform/runner-host.ts
+++ b/clients/shared/platform/runner-host.ts
@@ -751,6 +751,18 @@ export interface IFileSaveHost {
   readonly downloadFile:
     | ((request: FileSaveRequest) => Promise<SavedFileLocation>)
     | null;
+  /**
+   * What {@link saveFile} DOES, from the user's point of view: `"download"`
+   * where it commits the file itself (a desktop save dialog), `"share"` where
+   * it hands the bytes to an OS chooser and another app decides.
+   *
+   * Independent of {@link downloadFile}, and it has to be: a shell can own a
+   * chooser and NO direct download (Android 10, where the shared-storage write
+   * has no route). Reading "is this a chooser?" off the presence of a direct
+   * download would answer `false` there and put a Download label on the share
+   * sheet - the exact defect this contract exists to prevent.
+   */
+  readonly saveRoute: "download" | "share";
 }
 
 /**

--- a/clients/shared/platform/runner-host.ts
+++ b/clients/shared/platform/runner-host.ts
@@ -717,6 +717,22 @@ export interface IFileSaveHost {
    * also every case where `saveFile` reports `path: null`.
    */
   readonly openSavedFile: ((path: string) => Promise<void>) | null;
+  /**
+   * Writes the bytes straight into the device's own file storage, with no
+   * chooser, sheet or dialog in between - what a phone user means by
+   * "download". Resolves with where the file landed, or rejects; there is no
+   * dismissal to report, because nothing was offered to dismiss.
+   *
+   * `null` on every shell whose {@link saveFile} ALREADY commits the file
+   * itself - a desktop save dialog names the file it writes, so a second
+   * direct route would be the same act under a second name. Non-null exactly
+   * where `saveFile` hands the bytes to an OS chooser and another app decides
+   * where they land, which is what makes "share" and "download" two different
+   * things worth offering separately there.
+   */
+  readonly downloadFile:
+    | ((request: FileSaveRequest) => Promise<SavedFileLocation>)
+    | null;
 }
 
 /**

--- a/clients/shared/platform/runner-host.ts
+++ b/clients/shared/platform/runner-host.ts
@@ -424,6 +424,24 @@ export interface IRunnerHost {
   readonly hasLocalHost: boolean;
 
   /**
+   * Whether an image written through the web clipboard API on this shell
+   * actually reaches the system clipboard.
+   *
+   * `true` everywhere the write is honoured - desktop, a browser tab, and
+   * WKWebView, which is what the promise-valued `ClipboardItem` path exists
+   * for. `false` on Android's WebView, where the write RESOLVES having written
+   * nothing: Chromium reaches the Android clipboard for an image through an
+   * embedder-supplied clipboard image file provider, and that embedder installs
+   * none. Nothing rejects, so a surface cannot learn this by trying.
+   *
+   * A capability rather than a platform identity: what a surface needs to know
+   * is whether offering "Copy image" would report a success the clipboard never
+   * received, and shells answer that for themselves. Callers that copy TEXT are
+   * unaffected and must not consult this.
+   */
+  readonly canCopyImages: boolean;
+
+  /**
    * Subscribes to local-host snapshot changes. The handler fires
    * synchronously on subscribe with the current snapshot (or `null`), then
    * again whenever the snapshot transitions. Mobile shells emit a single


### PR DESCRIPTION
Fixes share / copy / download across the mobile app, on both platforms.

## Problem

On the installed mobile app the export controls lie, and they lie the same way
everywhere because they share one save seam.

**Copy silently does nothing on Android.** The app issues
`navigator.clipboard.write(new ClipboardItem({ "image/png": … }))` inside the
click's user activation — the correct call, honoured on desktop, in a browser
tab, and in WKWebView. Android's WebView is the one runtime that *resolves* it
having written nothing: Chromium reaches the Android clipboard for an image
through an embedder-supplied clipboard image file provider, and the WebView
embedder installs none. Nothing rejects, so the app toasts a success the
clipboard never received.

**Download opens the share sheet.** `saveBlobToDisk` routes through
`IRunnerHost.fileSave`, whose mobile implementation (#1538) stages the bytes in
the app's cache container and hands them to `Share.share()`. A share sheet,
correctly built and wrongly labelled.

**And the confirmation compounded it** — every share-sheet export toasted
`Saved <name>`, for bytes that only ever reached a cache container.

## The rule this PR applies

> A control that says **Download** must not open a chooser. A control that says
> **Export** is truthful either way. And the confirmation names the route that
> actually ran.

That rule, not a blanket "add Share everywhere", decides each surface below.

## Capabilities, not platform branches

No `isMobileApp()` or platform check enters the shared GUI — per
`clients/mobile/AGENTS.md` platform differences live in the shell, and per
`lib/mobile-app.ts` "can this shell physically do X?" is a capability question.
Two independent facts were added:

- **`IFileSaveHost.downloadFile`** — write into the device's own storage, no
  chooser. `null` wherever `saveFile` already commits the file itself (a desktop
  dialog names the file it writes); non-null exactly where `saveFile` reaches an
  OS chooser. That is what makes share and download two different acts.
- **`IRunnerHost.canCopyImages`** — whether an image written through the web
  clipboard API actually reaches the system clipboard. `false` only on Android's
  WebView. A surface cannot learn this by trying, because the write resolves.

They are independent, which is the whole shape:

| Shell | Usage / Mermaid / image lightbox |
| --- | --- |
| Desktop, browser tab | Copy · Download (unchanged) |
| iOS install | Copy · Share · Download |
| Android install | Share · Download |
| Android API 29 | Share only (see below) |

## Surfaces

- **Usage analytics** — Settings → Usage and the epic usage dialog, both through
  the shared `useUsageImageExport` + new `<UsageExportImageActions>`; each keeps
  its existing test ids.
- **Chat image lightbox** — both mounts. `performImageAction` gains a `share`
  route; Copy is additionally gated on `canCopyImages`.
- **Mermaid PNG** — block toolbar and fullscreen dialog: "Share PNG" beside
  "Download PNG".
- **Artifact export — deliberately NOT split.** Its menu reads "Export as
  Markdown" / "Export as PDF", and a share sheet honours an *export* as
  truthfully as a save dialog does, so there is no mislabelled control to fix;
  doubling every format entry would add noise to solve a problem that surface
  does not have. What it did have was the dishonest toast, which the app-wide
  verb fix covers.
- **Toast** — `toastSavedFile` takes an explicit `SavedFileRoute`; the share
  path says `Shared <name>`. Passed rather than derived, because a shell with a
  sheet usually has a direct write too, so `fileSave` alone cannot say which
  route a given call took.

## Android API 29

`MobileFileSave` takes the capability in its constructor, so `downloadFile` is
`null` on API 29 and no surface offers a Download that could only ever fail.
From API 30 an app may write files it creates under Documents with no permission
at all, and up to API 28 `WRITE_EXTERNAL_STORAGE` is declared (`maxSdkVersion`
28 — the plugin declares the alias but contributes no `<uses-permission>`, the
same trap as `POST_NOTIFICATIONS`) and the plugin requests it on demand. API 29
alone has neither, and buying it back would mean `requestLegacyExternalStorage`,
i.e. opting the whole app out of scoped storage for one shrinking OS version.

**Entry-point ordering — the one thing to review closely.** `supportsDirectDownload()`
is a plugin call, so the host can no longer be built in the same tick as the
synchronous setup. What did *not* change: everything before it stays
synchronous, including `linkLoginDeepLinks.start()`, which must stay first
because a QR-launched app can read its launch URL exactly once; and the relative
order of host → `pushRegistration.start` → first render is untouched, so a
cold-start notification tap is still captured before the GUI mounts. What *did*
change: those three now happen one microtask later than before, plus a bounded
probe on Android. iOS and web pay no plugin call at all. The probe is capped at
2s and **every** failure path resolves *capable* — a false negative would hide a
working Download from every modern Android, while a false positive costs one API
level a loud error beside a Share that still works.

## Copy on Android: why it is hidden rather than fixed

`@capacitor/clipboard` was evaluated and **rejected on evidence**. Its
`write({ image })` is honoured only on iOS (`UIPasteboard.general.image`); on
Android `ClipboardPlugin.java` routes the image through the same text-only
`ClipData.newPlainText(...)` as strings and URLs. Adding it would put a
multi-megabyte `data:image/png;base64,…` **string** on the clipboard — the user
would paste a wall of base64 instead of nothing, which is worse — and it buys
iOS nothing WKWebView does not already do. Anything better needs a custom native
plugin (PNG → FileProvider → content URI on the ClipData). The share sheet's own
Copy action is the working route on Android.

### iOS Files visibility

`UIFileSharingEnabled` + `LSSupportsOpeningDocumentsInPlace`. iOS has no shared
downloads folder an app may write to unaided, so the honest answer is the
Files-app document flow: these put "Traycer" under **On My iPhone**, where the
written file is real and reachable. Without them the write succeeds and the user
can never find it.

## Testing

- `clients/mobile` — full suite, **134 pass**. `supportsDirectDownload` cases:
  iOS never probes, API 29 withholds, 26/28/30/33/36 keep, probe failure and
  absent SDK version both assume capable, and a never-settling probe gives up
  under fake timers rather than blocking mount. Download cases cover the direct
  write, byte fidelity, collision numbering (including a name already at the
  255-byte limit), same-tick concurrent downloads landing on distinct paths,
  not-found-vs-other-stat-failure, and claim release on a failed write.
- `clients/gui-app` — capability read incl. its host-less default; export
  control sets per shell shape on both usage surfaces; lightbox share/download
  routing and Copy dropping on a clipboard-less shell; the `Shared`/`Saved`
  verb; route selection in `save-blob-to-disk`.
- `compile` clean for gui-app, mobile and desktop; oxlint and oxfmt clean.

**Untested legs, stated plainly:** no simulator or device run — nothing here has
been observed on a phone. Specifically unverified: the reordered mobile entry
(the microtask delay above), that the Android write lands in shared Documents on
a real device and that API 29 behaves as the capability assumes, that the iOS
plist keys surface the folder in Files, that iOS Copy behaves as WebKit's
promise-valued `ClipboardItem` path implies, and the Android clipboard diagnosis
itself — reasoned from Chromium's embedder-supplied image file provider and from
reading `@capacitor/clipboard`'s native sources, not from an instrumented run.
On an iOS phone the epic usage dialog footer now stacks four full-width buttons;
it should fit the fixed-height frame, but no one has looked at it.

Desktop and browser behaviour is unchanged throughout: `downloadFile` is `null`
and `canCopyImages` is `true` there, so every control renders and routes exactly
as before.
