### PR TITLE
fix(gui-app): keep generated titles in history

### DIFF
--- a/clients/gui-app/src/providers/__tests__/epic-session-provider.test.tsx
+++ b/clients/gui-app/src/providers/__tests__/epic-session-provider.test.tsx
@@ -1505,6 +1505,69 @@ describe("<EpicSessionProvider />", () => {
     });
   });
 
+  it("patches a stale history response inserted after a generated epic title lands", async () => {
+    const queryClient = new QueryClient();
+    const sessionUserId = "alice@example.com";
+    const cloudTasksUserId = "cloud-user-1";
+    useAuthStore.setState({
+      contextMetadata: { userId: cloudTasksUserId, username: sessionUserId },
+    });
+    const queryKey = cloudEpicTasksQueryKey(
+      "host-a",
+      cloudTasksUserId,
+      LIST_CLOUD_TASKS_REQUEST,
+    );
+    const seenHandles: OpenEpicStoreHandle[] = [];
+    __setEpicStreamClientFactoryForTests((_epicId, _callbacks) => ({
+      applyUpdate: () => undefined,
+      awareness: () => undefined,
+      applyArtifactRoomUpdate: () => undefined,
+      artifactRoomAwareness: () => undefined,
+      retryMigration: () => undefined,
+      close: () => undefined,
+    }));
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <EpicSessionProvider
+          epicId="epic-session-test"
+          tabId="epic-session-test"
+        >
+          <HandleProbe
+            onHandle={(handle) => {
+              seenHandles.push(handle);
+            }}
+          />
+        </EpicSessionProvider>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(seenHandles).toHaveLength(1);
+    });
+    expect(
+      queryClient.getQueryData<ListTasksResponse>(queryKey),
+    ).toBeUndefined();
+
+    act(() => {
+      seenHandles[0].store.getState().setEpicTitle("Generated history title");
+    });
+
+    act(() => {
+      queryClient.setQueryData<ListTasksResponse>(queryKey, {
+        tasks: [makeHistoryTask("epic-session-test", "", cloudTasksUserId)],
+        hasMore: false,
+      });
+    });
+
+    await waitFor(() => {
+      expect(
+        queryClient.getQueryData<ListTasksResponse>(queryKey)?.tasks[0]?.epic
+          ?.light?.title,
+      ).toBe("Generated history title");
+    });
+  });
+
   it("claims desktop epic ownership before acquiring a renderer session", async () => {
     const streams: ControlledStream[] = [];
     const calls = {

--- a/clients/gui-app/src/providers/epic-session-provider.tsx
+++ b/clients/gui-app/src/providers/epic-session-provider.tsx
@@ -10,7 +10,11 @@ import {
 } from "react";
 import * as Y from "yjs";
 import { useNavigate } from "@tanstack/react-router";
-import { QueryClientContext, type QueryClient } from "@tanstack/react-query";
+import {
+  QueryClientContext,
+  type QueryCacheNotifyEvent,
+  type QueryClient,
+} from "@tanstack/react-query";
 import {
   createOpenEpicStore,
   type EpicStreamClientFactory,
@@ -933,21 +937,34 @@ function useCloudTaskTitleCacheSync(args: CloudTaskTitleCacheSyncArgs): void {
     if (queryClient === undefined) return;
     if (userId === null) return;
 
-    let lastSyncedTitle: string | null = null;
-    const syncTitle = (): void => {
+    const scope = { hostId: activeHostId, userId };
+    let lastObservedTitle: string | null = null;
+    const currentTitle = (): string | null =>
+      normalizeGeneratedTitle(handle.store.getState().epic.title);
+    const writeThroughTitle = (title: string): void => {
+      updateEpicTitleInCloudTaskCaches(queryClient, scope, epicId, title);
+    };
+    const syncChangedTitle = (): void => {
       const title = normalizeGeneratedTitle(handle.store.getState().epic.title);
-      if (title === null || title === lastSyncedTitle) return;
-      lastSyncedTitle = title;
-      updateEpicTitleInCloudTaskCaches(
-        queryClient,
-        { hostId: activeHostId, userId },
-        epicId,
-        title,
-      );
+      if (title === null || title === lastObservedTitle) return;
+      lastObservedTitle = title;
+      writeThroughTitle(title);
+    };
+    const syncMatchingQueryUpdate = (event: QueryCacheNotifyEvent): void => {
+      if (event.type !== "updated") return;
+      const title = currentTitle();
+      if (title !== null) writeThroughTitle(title);
     };
 
-    syncTitle();
-    return handle.store.subscribe(syncTitle);
+    syncChangedTitle();
+    const unsubscribeStore = handle.store.subscribe(syncChangedTitle);
+    const unsubscribeQueries = queryClient
+      .getQueryCache()
+      .subscribe(syncMatchingQueryUpdate);
+    return () => {
+      unsubscribeStore();
+      unsubscribeQueries();
+    };
   }, [activeHostId, epicId, handle, queryClient, userId]);
 }
 

--- a/clients/gui-app/src/providers/epic-session-provider.tsx
+++ b/clients/gui-app/src/providers/epic-session-provider.tsx
@@ -30,7 +30,11 @@ import { useAuthService } from "@/lib/host";
 import { useEffectiveHostId } from "@/hooks/host/use-effective-host-id";
 import { useSelectionAuthorityAttached } from "@/hooks/host/use-selection-authority-attached";
 import { useReactiveOwnerIdentityKey } from "@/hooks/host/use-reactive-owner-identity-key";
-import { updateEpicTitleInCloudTaskCaches } from "@/lib/cloud-epic-tasks-query/cache";
+import {
+  cloudEpicTasksQueryKeyMatchesScope,
+  epicTaskContextsQueryKeyMatchesScope,
+  updateEpicTitleInCloudTaskCaches,
+} from "@/lib/cloud-epic-tasks-query/cache";
 import {
   claimDesktopEpicOwnership,
   getDesktopEpicOwnershipBridge,
@@ -952,6 +956,14 @@ function useCloudTaskTitleCacheSync(args: CloudTaskTitleCacheSyncArgs): void {
     };
     const syncMatchingQueryUpdate = (event: QueryCacheNotifyEvent): void => {
       if (event.type !== "updated") return;
+      const queryKey: unknown = event.query.queryKey;
+      if (!Array.isArray(queryKey)) return;
+      if (
+        !cloudEpicTasksQueryKeyMatchesScope(queryKey, scope) &&
+        !epicTaskContextsQueryKeyMatchesScope(queryKey, scope)
+      ) {
+        return;
+      }
       const title = currentTitle();
       if (title !== null) writeThroughTitle(title);
     };


### PR DESCRIPTION
## Summary
- subscribe live Epic sessions to matching History task-cache updates
- reapply the current generated title when a late, stale History response creates the cache
- add a regression test for the title-before-cache race

## Verification
- `bun run vitest run --config vitest.config.ts src/providers/__tests__/epic-session-provider.test.tsx` (33 passed)
- React Doctor changed-file scan (no issues)
- pre-commit affected lint, format, compile, and build checks

Replaces #1625, whose source branch carried unrelated release-train ancestry.

Signed-off-by: Tom Gill <tom@traycer.ai>