### PR TITLE
feat(gui-app): show drafts above task history

### DIFF
--- a/clients/gui-app/src/components/epics/__tests__/epics-list-panel.test.tsx
+++ b/clients/gui-app/src/components/epics/__tests__/epics-list-panel.test.tsx
@@ -1559,39 +1559,45 @@ describe("<EpicsListPanel />", () => {
     expect(document.activeElement).toBe(input);
   });
 
-  it("keeps the epic list when the drafts facet is off", async () => {
+  it("shows retained drafts above the task list without selecting a filter", async () => {
     seedRetainedLandingDraft("abandoned prompt");
     renderPanel("embedded", "/");
 
+    const drafts = await screen.findByTestId("history-drafts-block");
+    const tasks = await screen.findByTestId("epics-list-rows");
+    expect(screen.getByText("abandoned prompt")).not.toBeNull();
     expect(await screen.findByText("Open from landing")).not.toBeNull();
-    expect(screen.queryByTestId("history-drafts-list")).toBeNull();
+    expect(
+      drafts.compareDocumentPosition(tasks) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).not.toBe(0);
   });
 
-  it("exposes start-task drafts in the filter popover and lists retained drafts when selected", async () => {
+  it("does not show a block for an empty start-task composer", async () => {
+    useLandingDraftStore.getState().createDraft(null);
+    renderPanel("embedded", "/");
+
+    expect(await screen.findByText("Open from landing")).not.toBeNull();
+    expect(screen.queryByTestId("history-drafts-block")).toBeNull();
+  });
+
+  it("does not expose drafts as a task filter", async () => {
     seedRetainedLandingDraft("abandoned prompt");
     renderPanel("embedded", "/");
 
     fireEvent.click(await screen.findByRole("button", { name: /filter/i }));
-    fireEvent.click(await screen.findByRole("checkbox", { name: /drafts/i }));
-
-    await waitFor(() => {
-      expect(useHistorySearchStore.getState().search.drafts).toEqual([
-        "landing",
-      ]);
-    });
-    expect(await screen.findByTestId("history-drafts-list")).not.toBeNull();
-    expect(screen.getByText("abandoned prompt")).not.toBeNull();
-    expect(screen.queryByText("Open from landing")).toBeNull();
+    expect(await screen.findByTestId("epics-filter-popover")).not.toBeNull();
+    expect(screen.queryByRole("checkbox", { name: /drafts/i })).toBeNull();
   });
 
   it("opens a retained draft through openLandingDraftFromHistory", async () => {
     const draftId = seedRetainedLandingDraft("abandoned prompt");
-    useHistorySearchStore.setState({
-      search: { ...DEFAULT_HISTORY_SEARCH, drafts: ["landing"] },
-    });
     renderPanel("embedded", "/");
 
-    fireEvent.click(await screen.findByTestId("history-drafts-row-open"));
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "Open draft abandoned prompt",
+      }),
+    );
 
     expect(testState.openLandingDraftFromHistory).toHaveBeenCalledTimes(1);
     expect(testState.openLandingDraftFromHistory.mock.calls[0][1]).toBe(
@@ -1601,9 +1607,6 @@ describe("<EpicsListPanel />", () => {
 
   it("asks for confirmation before deleting a retained draft", async () => {
     const draftId = seedRetainedLandingDraft("abandoned prompt");
-    useHistorySearchStore.setState({
-      search: { ...DEFAULT_HISTORY_SEARCH, drafts: ["landing"] },
-    });
     renderPanel("embedded", "/");
 
     expect(await screen.findByText("abandoned prompt")).not.toBeNull();
@@ -1648,9 +1651,6 @@ describe("<EpicsListPanel />", () => {
   it("warns that an open draft will be deleted on every device", async () => {
     const draftId = seedRetainedLandingDraft("live tab");
     useLandingDraftStore.getState().openDraft(draftId);
-    useHistorySearchStore.setState({
-      search: { ...DEFAULT_HISTORY_SEARCH, drafts: ["landing"] },
-    });
     renderPanel("embedded", "/");
 
     fireEvent.click(await screen.findByTestId("history-drafts-row-delete"));
@@ -1660,63 +1660,25 @@ describe("<EpicsListPanel />", () => {
     expect(screen.getByText(/every device/i)).not.toBeNull();
   });
 
-  it("cycles draft rows with the arrow keys and returns to the query", async () => {
-    const alphaId = seedRetainedLandingDraft("alpha draft");
-    const betaId = seedRetainedLandingDraft("beta draft");
-    // Both seeds land in the same millisecond, and the comparator's tiebreak
-    // for equal `lastTouchedAt` is the uuid - which is random, so the row
-    // order this case is about was a coin flip. Stamp it.
-    const stampedAt = new Map([
-      [alphaId, 1],
-      [betaId, 2],
-    ]);
-    useLandingDraftStore.setState((state) => ({
-      drafts: state.drafts.map((draft) => {
-        const lastTouchedAt = stampedAt.get(draft.id);
-        return lastTouchedAt === undefined
-          ? draft
-          : { ...draft, lastTouchedAt };
-      }),
-    }));
-    useHistorySearchStore.setState({
-      search: { ...DEFAULT_HISTORY_SEARCH, drafts: ["landing"] },
-    });
+  it("caps the draft block and expands it on request", async () => {
+    for (let index = 0; index < 6; index += 1) {
+      seedRetainedLandingDraft(`draft ${index}`);
+    }
 
     renderPanel("page", "/");
-    const input = await screen.findByRole("searchbox", {
-      name: "Search drafts",
-    });
-    // Most-recent first: beta was seeded after alpha.
-    const first = screen.getByRole("button", {
-      name: "Open draft beta draft",
-    });
-    const second = screen.getByRole("button", {
-      name: "Open draft alpha draft",
-    });
-    input.focus();
 
-    fireEvent.keyDown(input, { key: "ArrowDown" });
-    expect(document.activeElement).toBe(first);
-
-    fireEvent.keyDown(first, { key: "ArrowDown" });
-    expect(document.activeElement).toBe(second);
-
-    fireEvent.keyDown(second, { key: "ArrowDown" });
-    expect(document.activeElement).toBe(second);
-
-    fireEvent.keyDown(second, { key: "ArrowUp" });
-    expect(document.activeElement).toBe(first);
-
-    fireEvent.keyDown(first, { key: "ArrowUp" });
-    expect(document.activeElement).toBe(input);
+    expect(await screen.findAllByTestId("history-drafts-row")).toHaveLength(5);
+    fireEvent.click(screen.getByRole("button", { name: "View all 6" }));
+    expect(screen.getAllByTestId("history-drafts-row")).toHaveLength(6);
+    expect(screen.getByRole("button", { name: "Show less" })).not.toBeNull();
   });
 
-  it("hides the drafts facet in the destination picker", async () => {
+  it("hides the drafts block in the destination picker", async () => {
+    seedRetainedLandingDraft("abandoned prompt");
     renderPanel("picker", "/");
 
-    fireEvent.click(await screen.findByRole("button", { name: /filter/i }));
-    expect(await screen.findByTestId("epics-filter-popover")).not.toBeNull();
-    expect(screen.queryByRole("checkbox", { name: /drafts/i })).toBeNull();
+    expect(await screen.findByText("Open from landing")).not.toBeNull();
+    expect(screen.queryByTestId("history-drafts-block")).toBeNull();
   });
 });
 

--- a/clients/gui-app/src/components/epics/__tests__/epics-list-panel.test.tsx
+++ b/clients/gui-app/src/components/epics/__tests__/epics-list-panel.test.tsx
@@ -1572,9 +1572,7 @@ describe("<EpicsListPanel />", () => {
     renderPanel("embedded", "/");
 
     fireEvent.click(await screen.findByRole("button", { name: /filter/i }));
-    fireEvent.click(
-      await screen.findByRole("checkbox", { name: /start-task drafts/i }),
-    );
+    fireEvent.click(await screen.findByRole("checkbox", { name: /drafts/i }));
 
     await waitFor(() => {
       expect(useHistorySearchStore.getState().search.drafts).toEqual([
@@ -1718,9 +1716,7 @@ describe("<EpicsListPanel />", () => {
 
     fireEvent.click(await screen.findByRole("button", { name: /filter/i }));
     expect(await screen.findByTestId("epics-filter-popover")).not.toBeNull();
-    expect(
-      screen.queryByRole("checkbox", { name: /start-task drafts/i }),
-    ).toBeNull();
+    expect(screen.queryByRole("checkbox", { name: /drafts/i })).toBeNull();
   });
 });
 

--- a/clients/gui-app/src/components/epics/epics-filter-popover.tsx
+++ b/clients/gui-app/src/components/epics/epics-filter-popover.tsx
@@ -7,7 +7,6 @@ import {
 } from "@/components/ui/popover";
 import { MatchModeToggle } from "@/components/home/toolbar/match-mode-toggle";
 import type {
-  HistoryDraftScope,
   HistoryMatchMode,
   HistoryOwnershipScope,
   HistoryWorkspaceRef,
@@ -21,13 +20,11 @@ import { useHostDirectoryList } from "@/hooks/host/use-host-directory-list-query
 import { EpicsFilterTrigger } from "@/components/epics/epics-filter-trigger";
 import { StartTruncatedText } from "@/components/ui/start-truncated-text";
 import type { HistoryFacets } from "@/hooks/home/use-history-query";
-import { isHistoryListedLandingDraft } from "@/lib/history-landing-drafts";
 import type {
   HistorySearchPatch,
   HistorySearchState,
 } from "@/lib/history-search";
 import { cn } from "@/lib/utils";
-import { useLandingDraftStore } from "@/stores/home/landing-draft-store";
 
 import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 interface EpicsFilterPopoverProps {
@@ -36,8 +33,6 @@ interface EpicsFilterPopoverProps {
   readonly search: HistorySearchState;
   readonly onSearchChange: (patch: HistorySearchPatch) => void;
   readonly facets: HistoryFacets | undefined;
-  readonly showDraftsFacet: boolean;
-  readonly hostId: string | null;
   /**
    * `false` when the serving host negotiated `epic.listTasks` below @1.3 and
    * would silently discard a host filter. The section still renders any
@@ -60,18 +55,12 @@ const OWNERSHIP_OPTIONS: ReadonlyArray<{
   { value: "shared", label: "Shared" },
 ];
 
-const DRAFT_OPTIONS: ReadonlyArray<{
-  readonly value: HistoryDraftScope;
-  readonly label: string;
-}> = [{ value: "landing", label: "Drafts" }];
-
 function historyFilterActiveCount(search: HistorySearchState): number {
   return (
     search.ownershipScopes.length +
     search.repos.length +
     search.workspaces.length +
-    search.chatHosts.length +
-    search.drafts.length
+    search.chatHosts.length
   );
 }
 
@@ -114,13 +103,6 @@ export function EpicsFilterPopover(props: EpicsFilterPopoverProps): ReactNode {
         className="max-h-[min(var(--radix-popover-content-available-height,70vh),32rem)] w-[min(90vw,24rem)] gap-3 overflow-y-auto"
         data-testid="epics-filter-popover"
       >
-        {props.showDraftsFacet ? (
-          <DraftsFilterSection
-            search={props.search}
-            onSearchChange={props.onSearchChange}
-            hostId={props.hostId}
-          />
-        ) : null}
         <FilterSection label="Ownership" trailing={null}>
           {OWNERSHIP_OPTIONS.map((option) => (
             <FilterOption
@@ -231,35 +213,6 @@ export function EpicsFilterPopover(props: EpicsFilterPopoverProps): ReactNode {
         </FilterSection>
       </PopoverContent>
     </Popover>
-  );
-}
-
-function DraftsFilterSection(props: {
-  readonly search: HistorySearchState;
-  readonly onSearchChange: (patch: HistorySearchPatch) => void;
-  readonly hostId: string | null;
-}): ReactNode {
-  const drafts = useLandingDraftStore((state) => state.drafts);
-  const count = drafts.filter((draft) =>
-    isHistoryListedLandingDraft(draft, props.hostId),
-  ).length;
-  return (
-    <FilterSection label="Drafts" trailing={null}>
-      {DRAFT_OPTIONS.map((option) => (
-        <FilterOption
-          key={option.value}
-          label={option.label}
-          truncateLabelFromStart={false}
-          count={count}
-          checked={props.search.drafts.includes(option.value)}
-          onToggle={() => {
-            props.onSearchChange({
-              drafts: withToggledValue(props.search.drafts, option.value),
-            });
-          }}
-        />
-      ))}
-    </FilterSection>
   );
 }
 

--- a/clients/gui-app/src/components/epics/epics-filter-popover.tsx
+++ b/clients/gui-app/src/components/epics/epics-filter-popover.tsx
@@ -63,7 +63,7 @@ const OWNERSHIP_OPTIONS: ReadonlyArray<{
 const DRAFT_OPTIONS: ReadonlyArray<{
   readonly value: HistoryDraftScope;
   readonly label: string;
-}> = [{ value: "landing", label: "Start-task drafts" }];
+}> = [{ value: "landing", label: "Drafts" }];
 
 function historyFilterActiveCount(search: HistorySearchState): number {
   return (

--- a/clients/gui-app/src/components/epics/epics-list-panel.tsx
+++ b/clients/gui-app/src/components/epics/epics-list-panel.tsx
@@ -114,7 +114,6 @@ import { useRefreshSpinner } from "@/hooks/use-refresh-spinner";
 import { epicDisplayTitle } from "@/lib/display-title";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 import {
-  isHistoryDraftsFacetOn,
   type HistorySearchPatch,
   type HistorySearchState,
 } from "@/lib/history-search";
@@ -257,26 +256,6 @@ function AmbientEpicsListPanel(props: AmbientEpicsListPanelProps): ReactNode {
       autoFocusSearch={props.autoFocusSearch}
     />
   );
-}
-
-/**
- * `allowSelection` only hides the idle "Select" button. The ACTIVE cluster
- * (Select all / Cancel / Sweep / Delete) renders off `selectionMode`, which
- * nothing else clears - so turning the drafts facet on mid-selection left
- * Delete live over epic rows the body had stopped rendering.
- *
- * A render-phase adjustment (React's derived-state pattern) rather than an
- * effect: an effect would commit one frame with that cluster still armed.
- */
-function useSelectionDroppedOnDraftsFacet(
-  showDrafts: boolean,
-  selectionMode: boolean,
-  cancelSelection: () => void,
-): void {
-  const [shown, setShown] = useState(showDrafts);
-  if (shown === showDrafts) return;
-  setShown(showDrafts);
-  if (showDrafts && selectionMode) cancelSelection();
 }
 
 function EpicsListPanelBody(props: EpicsListPanelBodyProps): ReactNode {
@@ -557,12 +536,7 @@ function EpicsListPanelBody(props: EpicsListPanelBodyProps): ReactNode {
     );
   };
 
-  const { showDraftsFacet, showDrafts } = historyDraftsChrome(variant, search);
   const hasActiveFilters = hasActiveHistoryFilters(search);
-  const searchCopy = historySearchFieldCopy(showDrafts);
-  const allowSelection = selectionEnabled ? !showDrafts : false;
-
-  useSelectionDroppedOnDraftsFacet(showDrafts, selectionMode, cancelSelection);
 
   const handleClear = () => {
     clearSearch();
@@ -603,8 +577,8 @@ function EpicsListPanelBody(props: EpicsListPanelBodyProps): ReactNode {
             isFetching={isFetching}
             focusOnMount={props.autoFocusSearch}
             placement="page"
-            placeholder={searchCopy.placeholder}
-            ariaLabel={searchCopy.ariaLabel}
+            placeholder="Search by title, repo, branch, or PR"
+            ariaLabel="Search tasks"
           />
         ) : null}
         <PanelChromeBar
@@ -620,14 +594,13 @@ function EpicsListPanelBody(props: EpicsListPanelBodyProps): ReactNode {
                 isFetching={isFetching}
                 focusOnMount={props.autoFocusSearch}
                 placement="toolbar"
-                placeholder={searchCopy.placeholder}
-                ariaLabel={searchCopy.ariaLabel}
+                placeholder="Search by title, repo, branch, or PR"
+                ariaLabel="Search tasks"
               />
             ) : null
           }
           filters={{ active: hasActiveFilters, onClear: handleClear }}
-          showSelection={allowSelection}
-          showSort={!showDrafts}
+          showSelection={selectionEnabled}
           selection={
             selectionMode
               ? {
@@ -668,45 +641,46 @@ function EpicsListPanelBody(props: EpicsListPanelBodyProps): ReactNode {
           search={search}
           onSearchChange={updateSearch}
           facets={facets}
-          showDraftsFacet={showDraftsFacet}
-          hostId={hostId}
           chatHostFilterSupported={chatHostFilterSupported}
           refresh={{ isFetching, hostId, onRefetch: refetch }}
         />
         <NotificationIndicatorsProvider indicators={notificationIndicators}>
-          <HistoryListBody
-            variant={variant}
-            showDrafts={showDrafts}
-            query={search.query}
-            error={error}
-            isPending={isPending}
-            isFetching={isFetching}
-            hasActiveFilters={hasActiveFilters}
-            chatHostFilterUnsupported={chatHostFilterUnsupported}
-            items={items}
-            onRetry={handleRetry}
-            selectionMode={selectionMode}
-            selectionEnabled={selectionEnabled}
-            selectedIds={selectedIds}
-            onToggleSelection={toggleSelection}
-            onRequestDelete={requestDelete}
-            onRequestSweep={requestSweep}
-            onSetPinned={handleSetPinned}
-            pendingSetPinnedEpicIds={pendingSetPinnedEpicIds}
-            hasNextPage={hasNextPage}
-            isFetchingNextPage={isFetchingNextPage}
-            onLoadMore={fetchNextPage}
-            onSelectEpic={onSelectEpic}
-            onOpenItem={onOpenItem}
-            onOpenInNewWindow={openInNewWindowFlow.requestOpen}
-            openInNewWindowAvailable={openInNewWindowFlow.isAvailable}
-            worktreesByEpicId={worktreesByEpicId}
-            surfaceHostId={hostId}
-            openEpicIds={openEpicIdSet}
-            listRef={listRef}
-            onRowKeyDown={keyboardNav.onRowKeyDown}
-            onRefresh={refreshHistory}
-          />
+          <>
+            {variant === "picker" ? null : (
+              <HistoryDraftsList hostId={hostId} onBeforeOpen={onSelectEpic} />
+            )}
+            <HistoryListBody
+              variant={variant}
+              error={error}
+              isPending={isPending}
+              isFetching={isFetching}
+              hasActiveFilters={hasActiveFilters}
+              chatHostFilterUnsupported={chatHostFilterUnsupported}
+              items={items}
+              onRetry={handleRetry}
+              selectionMode={selectionMode}
+              selectionEnabled={selectionEnabled}
+              selectedIds={selectedIds}
+              onToggleSelection={toggleSelection}
+              onRequestDelete={requestDelete}
+              onRequestSweep={requestSweep}
+              onSetPinned={handleSetPinned}
+              pendingSetPinnedEpicIds={pendingSetPinnedEpicIds}
+              hasNextPage={hasNextPage}
+              isFetchingNextPage={isFetchingNextPage}
+              onLoadMore={fetchNextPage}
+              onSelectEpic={onSelectEpic}
+              onOpenItem={onOpenItem}
+              onOpenInNewWindow={openInNewWindowFlow.requestOpen}
+              openInNewWindowAvailable={openInNewWindowFlow.isAvailable}
+              worktreesByEpicId={worktreesByEpicId}
+              surfaceHostId={hostId}
+              openEpicIds={openEpicIdSet}
+              listRef={listRef}
+              onRowKeyDown={keyboardNav.onRowKeyDown}
+              onRefresh={refreshHistory}
+            />
+          </>
         </NotificationIndicatorsProvider>
       </section>
       <DeleteTasksDialog
@@ -748,33 +722,6 @@ function EpicsListPanelBody(props: EpicsListPanelBodyProps): ReactNode {
   );
 }
 
-function historyDraftsChrome(
-  variant: EpicsListPanelVariant,
-  search: HistorySearchState,
-): {
-  readonly showDraftsFacet: boolean;
-  readonly showDrafts: boolean;
-} {
-  const showDraftsFacet = variant !== "picker";
-  return {
-    showDraftsFacet,
-    showDrafts: showDraftsFacet && isHistoryDraftsFacetOn(search),
-  };
-}
-
-function historySearchFieldCopy(showDrafts: boolean): {
-  readonly placeholder: string;
-  readonly ariaLabel: string;
-} {
-  if (showDrafts) {
-    return { placeholder: "Search drafts", ariaLabel: "Search drafts" };
-  }
-  return {
-    placeholder: "Search by title, repo, branch, or PR",
-    ariaLabel: "Search tasks",
-  };
-}
-
 /**
  * The two chat-host gate answers the panel needs, kept together because they
  * are two faces of one decision: whether to OFFER the filter, and whether the
@@ -803,7 +750,6 @@ function hasActiveHistoryFilters(search: HistorySearchState): boolean {
     search.workspaces.length > 0 ||
     search.chatHosts.length > 0 ||
     search.ownershipScopes.length > 0 ||
-    (Array.isArray(search.drafts) && search.drafts.length > 0) ||
     (search.sortExplicit && search.sort !== DEFAULT_SORT) ||
     search.query.trim().length > 0
   );
@@ -924,7 +870,6 @@ interface PanelChromeBarProps {
   /** False for the read-only `variant="picker"` embed: hides the entry point
    * into bulk select/sweep/delete rather than merely disabling it. */
   readonly showSelection: boolean;
-  readonly showSort: boolean;
   readonly selection: PanelSelectionControls;
   readonly sort: HistorySortOption;
   readonly onSortChange: (next: HistorySortOption) => void;
@@ -933,8 +878,6 @@ interface PanelChromeBarProps {
   readonly search: HistorySearchState;
   readonly onSearchChange: (patch: HistorySearchPatch) => void;
   readonly facets: HistoryFacets | undefined;
-  readonly showDraftsFacet: boolean;
-  readonly hostId: string | null;
   readonly chatHostFilterSupported: boolean;
   readonly refresh: PanelRefreshControls;
 }
@@ -1044,20 +987,13 @@ function PanelChromeBar(props: PanelChromeBarProps): ReactNode {
           // gaps are both gap-1, so the one-line rendering is unchanged.
           <>
             <div className="flex shrink-0 items-center gap-1">
-              {props.showSort ? (
-                <EpicsSortMenu
-                  value={props.sort}
-                  onChange={props.onSortChange}
-                />
-              ) : null}
+              <EpicsSortMenu value={props.sort} onChange={props.onSortChange} />
               <EpicsFilterPopover
                 availableRepos={props.availableRepos}
                 availableWorkspaces={props.availableWorkspaces}
                 search={props.search}
                 onSearchChange={props.onSearchChange}
                 facets={props.facets}
-                showDraftsFacet={props.showDraftsFacet}
-                hostId={props.hostId}
                 chatHostFilterSupported={props.chatHostFilterSupported}
               />
             </div>
@@ -1118,18 +1054,11 @@ function describeDeleteTitle(
 
 interface HistoryListBodyProps extends EpicsListBodyProps {
   readonly variant: EpicsListPanelVariant;
-  /** The drafts facet is on: the body is the drafts list, not the epic list. */
-  readonly showDrafts: boolean;
-  readonly query: string;
   readonly onRefresh: () => Promise<unknown>;
 }
 
 /**
  * Picks the list body the form factor calls for, and owns nothing else.
- *
- * The drafts facet wins first: a start-task draft has no epic, so the drafts
- * list is a sibling view rather than a filtered mode of either epic list, and
- * it is the same list at every width.
  *
  * FORM FACTOR, not product: the phone list is a layout, and a desktop window
  * narrowed past the breakpoint gets it for the same reason it gets the
@@ -1147,19 +1076,6 @@ function HistoryListBody(props: HistoryListBodyProps): ReactNode {
     onSelectEpic: props.onSelectEpic,
     onOpenItem: props.onOpenItem,
   });
-  if (props.showDrafts) {
-    return (
-      <div className="min-h-0 flex-1 overflow-y-auto pb-10">
-        <HistoryDraftsList
-          query={props.query}
-          hostId={props.surfaceHostId}
-          onBeforeOpen={props.onSelectEpic}
-          listRef={props.listRef}
-          onRowKeyDown={props.onRowKeyDown}
-        />
-      </div>
-    );
-  }
   if (isMobileViewport && props.variant !== "picker") {
     return (
       <MobileHistoryList

--- a/clients/gui-app/src/components/epics/history-drafts-list.tsx
+++ b/clients/gui-app/src/components/epics/history-drafts-list.tsx
@@ -1,11 +1,4 @@
-import {
-  memo,
-  useCallback,
-  useMemo,
-  useState,
-  type ReactNode,
-  type RefObject,
-} from "react";
+import { memo, useCallback, useMemo, useState, type ReactNode } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import { formatDistanceToNow } from "date-fns";
 import { LayersPlus, Trash2 } from "lucide-react";
@@ -26,23 +19,22 @@ import {
 import { cn } from "@/lib/utils";
 import { useLandingDraftStore } from "@/stores/home/landing-draft-store";
 
+const DRAFTS_PREVIEW_LIMIT = 5;
+
 export function HistoryDraftsList(props: {
-  readonly query: string;
   readonly hostId: string | null;
   readonly onBeforeOpen: ((draftId: string) => void) | null;
-  readonly listRef: RefObject<HTMLUListElement | null>;
-  readonly onRowKeyDown: (event: React.KeyboardEvent<HTMLElement>) => void;
 }): ReactNode {
-  const { listRef, onRowKeyDown, query, hostId, onBeforeOpen } = props;
+  const { hostId, onBeforeOpen } = props;
   const drafts = useLandingDraftStore((state) => state.drafts);
   const items = useMemo(
     () =>
       listHistoryLandingDrafts({
         drafts,
-        query,
+        query: "",
         currentHostId: hostId,
       }),
-    [drafts, hostId, query],
+    [drafts, hostId],
   );
   const navigate = useNavigate();
   const openDraft = useCallback(
@@ -54,6 +46,7 @@ export function HistoryDraftsList(props: {
   );
   const [pendingDelete, setPendingDelete] =
     useState<HistoryLandingDraft | null>(null);
+  const [expanded, setExpanded] = useState(false);
   const closeDeleteDialog = useCallback(() => {
     setPendingDelete(null);
   }, []);
@@ -63,47 +56,51 @@ export function HistoryDraftsList(props: {
     setPendingDelete(null);
   }, [pendingDelete]);
 
-  if (items.length === 0 && query.trim().length === 0) {
-    return (
-      <div
-        className="flex flex-col items-center justify-center gap-2 py-16 text-center text-ui-sm text-muted-foreground"
-        data-testid="history-drafts-empty"
-      >
-        <p className="font-medium text-foreground">No start-task drafts</p>
-        <p>Closed drafts you have not deleted will show up here.</p>
-      </div>
-    );
-  }
-  if (items.length === 0) {
-    return (
-      <div
-        className="flex flex-col items-center justify-center gap-2 py-16 text-center text-ui-sm text-muted-foreground"
-        data-testid="history-drafts-filtered-empty"
-      >
-        <p className="font-medium text-foreground">
-          No drafts match this search.
-        </p>
-      </div>
-    );
-  }
+  if (items.length === 0) return null;
+
+  const visibleItems = expanded ? items : items.slice(0, DRAFTS_PREVIEW_LIMIT);
+  const canExpand = items.length > DRAFTS_PREVIEW_LIMIT;
 
   return (
     <>
-      <ul
-        ref={listRef}
-        className="flex flex-col gap-2"
-        data-testid="history-drafts-list"
+      <section
+        className="mb-5 border-b border-border/60 pb-5"
+        data-testid="history-drafts-block"
+        aria-labelledby="history-drafts-heading"
       >
-        {items.map((item) => (
-          <HistoryDraftsRow
-            key={item.id}
-            item={item}
-            onOpen={openDraft}
-            onRequestDelete={setPendingDelete}
-            onRowKeyDown={onRowKeyDown}
-          />
-        ))}
-      </ul>
+        <div className="mb-2 flex items-center justify-between gap-3 px-1">
+          <h2
+            id="history-drafts-heading"
+            className="text-ui-sm font-semibold text-foreground"
+          >
+            Drafts
+          </h2>
+          {canExpand ? (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-7 px-2 text-ui-xs text-muted-foreground"
+              aria-expanded={expanded}
+              onClick={() => {
+                setExpanded((current) => !current);
+              }}
+            >
+              {expanded ? "Show less" : `View all ${items.length}`}
+            </Button>
+          ) : null}
+        </div>
+        <ul className="flex flex-col gap-1" data-testid="history-drafts-list">
+          {visibleItems.map((item) => (
+            <HistoryDraftsRow
+              key={item.id}
+              item={item}
+              onOpen={openDraft}
+              onRequestDelete={setPendingDelete}
+            />
+          ))}
+        </ul>
+      </section>
       <HistoryDraftsDeleteDialog
         draft={pendingDelete}
         onOpenChange={(open) => {
@@ -119,7 +116,6 @@ const HistoryDraftsRow = memo(function HistoryDraftsRow(props: {
   readonly item: HistoryLandingDraft;
   readonly onOpen: (draftId: string) => void;
   readonly onRequestDelete: (draft: HistoryLandingDraft) => void;
-  readonly onRowKeyDown: (event: React.KeyboardEvent<HTMLElement>) => void;
 }): ReactNode {
   const { item } = props;
   const updatedLabel = formatDistanceToNow(item.lastTouchedAt, {
@@ -139,14 +135,12 @@ const HistoryDraftsRow = memo(function HistoryDraftsRow(props: {
         <button
           type="button"
           aria-label={`Open draft ${item.title}`}
-          data-history-row-target=""
           className="absolute inset-0 rounded-md outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
           onClick={() => {
             props.onOpen(item.id);
           }}
-          onKeyDown={props.onRowKeyDown}
         />
-        <div className="pointer-events-none relative z-10 flex items-center justify-between gap-3 p-3 pr-28 text-ui-sm">
+        <div className="pointer-events-none relative z-10 flex items-center justify-between gap-3 px-3 py-2 pr-11 text-ui-sm">
           <span className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden">
             <LayersPlus className="size-4 shrink-0 text-muted-foreground" />
             <span className="flex min-w-0 items-center gap-1.5 overflow-hidden">
@@ -173,21 +167,6 @@ const HistoryDraftsRow = memo(function HistoryDraftsRow(props: {
             <span className="shrink-0">edited {updatedLabel}</span>
           </span>
         </div>
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          aria-label={`Open ${item.title}`}
-          data-testid="history-drafts-row-open"
-          className="pointer-events-auto absolute right-11 top-1/2 z-20 -translate-y-1/2 opacity-0 transition-opacity hover:bg-foreground/5 focus-visible:opacity-100 group-hover:opacity-100"
-          onClick={(event) => {
-            event.preventDefault();
-            event.stopPropagation();
-            props.onOpen(item.id);
-          }}
-        >
-          Open
-        </Button>
         <Button
           type="button"
           variant="ghost"

--- a/clients/gui-app/src/components/home/data/home-page.data.ts
+++ b/clients/gui-app/src/components/home/data/home-page.data.ts
@@ -13,7 +13,6 @@ export type HistoryRecencyBucket = "today" | "yesterday" | "earlier";
 export type HistoryItemTaskType = "epic" | "phase";
 export type HistoryMatchMode = "any" | "all";
 export type HistoryOwnershipScope = TaskOwnershipScope;
-export type HistoryDraftScope = "landing";
 export type HistoryWorkspaceRef = TaskWorkspaceIdentifier;
 export type HistorySortOption =
   | "recent"

--- a/clients/gui-app/src/lib/__tests__/history-search.test.ts
+++ b/clients/gui-app/src/lib/__tests__/history-search.test.ts
@@ -3,7 +3,6 @@ import {
   DEFAULT_HISTORY_SEARCH,
   clearHistorySearchParams,
   historySearchToParams,
-  isHistoryDraftsFacetOn,
   normalizePersistedHistorySearch,
   parseHistorySearch,
   patchHistorySearch,
@@ -32,25 +31,12 @@ describe("history search params", () => {
       chatHosts: [],
       chatHostMode: "any",
       ownershipScopes: ["shared"],
-      drafts: [],
       sort: "relevance",
       sortExplicit: false,
     });
   });
 
-  it("round-trips the drafts facet through URL params", () => {
-    const search = parseHistorySearch({ historyDrafts: "landing" });
-
-    expect(search.drafts).toEqual(["landing"]);
-    expect(historySearchToParams(search)).toMatchObject({
-      historyDrafts: ["landing"],
-    });
-    expect(
-      historySearchToParams(parseHistorySearch({})).historyDrafts,
-    ).toBeUndefined();
-  });
-
-  it("fills a missing drafts field from pre-facet persisted search state", () => {
+  it("fills missing fields from older persisted search state", () => {
     expect(
       normalizePersistedHistorySearch({
         query: "api",
@@ -62,7 +48,7 @@ describe("history search params", () => {
         sort: "recent",
         sortExplicit: false,
       }),
-    ).toMatchObject({ query: "api", drafts: [] });
+    ).toMatchObject({ query: "api", chatHosts: [] });
   });
 
   it("preserves an explicit recent sort while a query is active", () => {
@@ -101,13 +87,6 @@ describe("history search params", () => {
         historySort: "relevance",
       }),
     ).toEqual({ focusedAt: 1 });
-  });
-
-  it("treats an empty drafts facet as off", () => {
-    expect(isHistoryDraftsFacetOn(parseHistorySearch({}))).toBe(false);
-    expect(
-      isHistoryDraftsFacetOn(parseHistorySearch({ historyDrafts: "landing" })),
-    ).toBe(true);
   });
 
   it("round-trips chat-host selections through the URL, dropping a default mode", () => {

--- a/clients/gui-app/src/lib/cloud-epic-tasks-query/__tests__/query.test.ts
+++ b/clients/gui-app/src/lib/cloud-epic-tasks-query/__tests__/query.test.ts
@@ -42,18 +42,6 @@ describe("listCloudTasksRequestForHistorySearch", () => {
     });
   });
 
-  it("does not send the drafts facet to the cloud task index", () => {
-    const withoutDrafts = parseHistorySearch({ historyQuery: "api" });
-    const withDrafts = parseHistorySearch({
-      historyQuery: "api",
-      historyDrafts: "landing",
-    });
-
-    expect(listCloudTasksRequestForHistorySearch(withDrafts)).toEqual(
-      listCloudTasksRequestForHistorySearch(withoutDrafts),
-    );
-  });
-
   it("requests central last-viewed sorting", () => {
     const search = parseHistorySearch({ historySort: "last-viewed" });
 

--- a/clients/gui-app/src/lib/history-landing-drafts.ts
+++ b/clients/gui-app/src/lib/history-landing-drafts.ts
@@ -1,5 +1,6 @@
 import type { LandingDraftTab } from "@/stores/home/landing-draft-store";
 import { landingDraftDisplayTitle } from "@/lib/composer/landing-draft-title";
+import { isEmptyLandingDraftContent } from "@/lib/composer/landing-draft-empty";
 
 export interface HistoryLandingDraft {
   readonly id: string;
@@ -22,6 +23,7 @@ export function isHistoryListedLandingDraft(
   draft: LandingDraftTab,
   currentHostId: string | null,
 ): boolean {
+  if (isEmptyLandingDraftContent(draft.content)) return false;
   if (draft.origin === "replica") return false;
   if (draft.ownerHostId !== null && draft.ownerHostId !== currentHostId) {
     return false;

--- a/clients/gui-app/src/lib/history-search.ts
+++ b/clients/gui-app/src/lib/history-search.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
 import type {
-  HistoryDraftScope,
   HistoryMatchMode,
   HistoryOwnershipScope,
   HistorySortOption,
@@ -11,7 +10,6 @@ import { appLogger, describeLogError } from "@/lib/logger";
 
 const historyMatchModeSchema = z.enum(["any", "all"]);
 const historyOwnershipSchema = z.enum(["mine", "shared"]);
-const historyDraftsSchema = z.enum(["landing"]);
 const historySortSchema = z.enum([
   "recent",
   "last-viewed",
@@ -32,9 +30,6 @@ export const historySearchParamsSchema = z.object({
   historyOwnership: z
     .union([historyOwnershipSchema, z.array(historyOwnershipSchema)])
     .optional(),
-  historyDrafts: z
-    .union([historyDraftsSchema, z.array(historyDraftsSchema)])
-    .optional(),
   historySort: historySortSchema.optional(),
 });
 
@@ -53,7 +48,6 @@ export interface HistorySearchState {
   readonly chatHosts: ReadonlyArray<string>;
   readonly chatHostMode: HistoryMatchMode;
   readonly ownershipScopes: ReadonlyArray<HistoryOwnershipScope>;
-  readonly drafts: ReadonlyArray<HistoryDraftScope>;
   readonly sort: HistorySortOption;
   readonly sortExplicit: boolean;
 }
@@ -69,7 +63,6 @@ export type HistorySearchPatch = Partial<
     | "chatHosts"
     | "chatHostMode"
     | "ownershipScopes"
-    | "drafts"
     | "sort"
   >
 > & {
@@ -85,7 +78,6 @@ export const DEFAULT_HISTORY_SEARCH: HistorySearchState = {
   chatHosts: [],
   chatHostMode: "any",
   ownershipScopes: [],
-  drafts: [],
   sort: "recent",
   sortExplicit: false,
 };
@@ -101,7 +93,6 @@ const persistedHistorySearchSchema = z.object({
   chatHosts: z.array(z.string()).optional(),
   chatHostMode: historyMatchModeSchema.optional(),
   ownershipScopes: z.array(historyOwnershipSchema).optional(),
-  drafts: z.array(historyDraftsSchema).optional(),
   sort: historySortSchema.optional(),
   sortExplicit: z.boolean().optional(),
 });
@@ -131,7 +122,6 @@ export function normalizePersistedHistorySearch(
       parsed.data.chatHostMode ?? DEFAULT_HISTORY_SEARCH.chatHostMode,
     ownershipScopes:
       parsed.data.ownershipScopes ?? DEFAULT_HISTORY_SEARCH.ownershipScopes,
-    drafts: normalizeArray(parsed.data.drafts),
     sort: parsed.data.sort ?? DEFAULT_HISTORY_SEARCH.sort,
     sortExplicit:
       parsed.data.sortExplicit ?? DEFAULT_HISTORY_SEARCH.sortExplicit,
@@ -156,7 +146,6 @@ export function parseHistorySearch(
     chatHostMode:
       parsed.data.historyChatHostMode ?? DEFAULT_HISTORY_SEARCH.chatHostMode,
     ownershipScopes: normalizeArray(parsed.data.historyOwnership),
-    drafts: normalizeArray(parsed.data.historyDrafts),
     sort:
       parsed.data.historySort ??
       (query.trim().length > 0 ? "relevance" : DEFAULT_HISTORY_SEARCH.sort),
@@ -181,7 +170,6 @@ export function patchHistorySearch(
     chatHosts: patch.chatHosts ?? current.chatHosts,
     chatHostMode: patch.chatHostMode ?? current.chatHostMode,
     ownershipScopes: patch.ownershipScopes ?? current.ownershipScopes,
-    drafts: patch.drafts ?? current.drafts,
     sort,
     sortExplicit,
   };
@@ -215,7 +203,6 @@ export function historySearchToParams(
         : undefined,
     historyOwnership:
       state.ownershipScopes.length > 0 ? state.ownershipScopes : undefined,
-    historyDrafts: state.drafts.length > 0 ? state.drafts : undefined,
     historySort:
       state.sortExplicit &&
       (state.sort !== DEFAULT_HISTORY_SEARCH.sort || state.query.length > 0)
@@ -330,10 +317,6 @@ function parseWorkspaceParam(value: string): HistoryWorkspaceRef[] {
     });
     return [];
   }
-}
-
-export function isHistoryDraftsFacetOn(search: HistorySearchState): boolean {
-  return Array.isArray(search.drafts) && search.drafts.includes("landing");
 }
 
 function implicitHistorySort(

--- a/clients/gui-app/src/stores/home/__tests__/history-search-store.test.ts
+++ b/clients/gui-app/src/stores/home/__tests__/history-search-store.test.ts
@@ -81,7 +81,6 @@ describe("useHistorySearchStore persisted-state rehydration", () => {
       chatHosts: ["host-a", "host-b"],
       chatHostMode: "all",
       ownershipScopes: ["mine", "shared"],
-      drafts: ["landing"],
       sort: "title-asc",
       sortExplicit: true,
     };


### PR DESCRIPTION
## Summary
- show meaningful cloud-backed drafts in an always-visible block above task history
- cap the preview at five drafts with an explicit View all control
- remove the distinct Drafts filter and its URL/persisted search state
- retain cross-device resume and delete behavior while hiding empty drafts and picker surfaces

## Validation
- pre-commit affected lint, format, compile, and build checks
- focused GUI tests: 4 files, 72 tests