### PR TITLE
fix(gui-app): automatic cleanup schedule copy and history entry point

### DIFF
--- a/clients/gui-app/src/components/settings/panels/__tests__/worktree-auto-cleanup-section.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/worktree-auto-cleanup-section.test.tsx
@@ -224,13 +224,14 @@ describe("WorktreeAutoCleanupSection", () => {
     expect(screen.queryByRole("button", { name: /re-?authorize/i })).toBeNull();
   });
 
-  it("shows the history button only once automatic cleanup is on or has ever run", async () => {
-    // Fresh host, never enabled, never evaluated: a history button would point
-    // at an empty list, and the history is automatic runs only - manual
-    // deletions never appear in it.
+  it("shows the history button only while automatic cleanup is enabled", async () => {
+    // The history is automatic runs only - manual deletions never appear in
+    // it - so with the policy off the button is hidden even when earlier runs
+    // exist. A button beside "Cleanup is off" read as the place manual
+    // deletions should show up.
     const { unmount } = renderSection(
       clientWithPolicy({
-        get: () => policyFixture({}),
+        get: () => policyFixture({ enabled: false, lastEvaluatedAt: 1_000 }),
         set: (r) => policyFixture(r),
       }),
     );
@@ -242,11 +243,9 @@ describe("WorktreeAutoCleanupSection", () => {
     ).toBeNull();
     unmount();
 
-    // Disabled AFTER it ran: the record of what was deleted must stay
-    // reachable - turning the policy off is when someone comes looking.
     renderSection(
       clientWithPolicy({
-        get: () => policyFixture({ enabled: false, lastEvaluatedAt: 1_000 }),
+        get: () => policyFixture({ enabled: true }),
         set: (r) => policyFixture(r),
       }),
     );
@@ -278,6 +277,29 @@ describe("WorktreeAutoCleanupSection", () => {
     expect(schedule.textContent).toMatch(/next check in \d+m/);
     expect(schedule.textContent).not.toContain("next check Just now");
     expect(schedule.textContent).toContain("Last checked");
+  });
+
+  it("renders a sub-minute check as under a minute rather than a seconds count", async () => {
+    // The shared clock ticks once a minute, so a seconds count would sit
+    // frozen past its own deadline. The phrase stays true for the whole tick.
+    renderSection(
+      clientWithPolicy({
+        get: () =>
+          policyFixture({
+            enabled: true,
+            lastEvaluatedAt: Date.now() - 5 * 60_000,
+            nextEvaluationAt: Date.now() + 30_000,
+          }),
+        set: (r) => policyFixture(r),
+      }),
+    );
+
+    await waitFor(() => {
+      screen.getByTestId("worktree-auto-cleanup-schedule");
+    });
+    expect(
+      screen.getByTestId("worktree-auto-cleanup-schedule").textContent,
+    ).toContain("next check in under a minute");
   });
 
   it("renders an overdue check as due now rather than counting down to zero", async () => {

--- a/clients/gui-app/src/components/settings/panels/__tests__/worktree-auto-cleanup-section.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/worktree-auto-cleanup-section.test.tsx
@@ -5,6 +5,7 @@ import {
   render,
   screen,
   waitFor,
+  type RenderResult,
 } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -112,7 +113,9 @@ function clientWithPolicy(
   return spine.createRequester(mockLocalHostEntry);
 }
 
-function renderSection(client: HostClient<HostRpcRegistry> | null): void {
+function renderSection(
+  client: HostClient<HostRpcRegistry> | null,
+): RenderResult {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   });
@@ -121,7 +124,7 @@ function renderSection(client: HostClient<HostRpcRegistry> | null): void {
       <TooltipProvider>{props.children}</TooltipProvider>
     </QueryClientProvider>
   );
-  render(
+  return render(
     <Wrapper>
       <WorktreeAutoCleanupSection
         scope={hostScopeFixture({
@@ -219,6 +222,37 @@ describe("WorktreeAutoCleanupSection", () => {
     ).toContain("Next check: paused");
     // Nothing to press: every pause arm clears without the user acting.
     expect(screen.queryByRole("button", { name: /re-?authorize/i })).toBeNull();
+  });
+
+  it("shows the history button only once automatic cleanup is on or has ever run", async () => {
+    // Fresh host, never enabled, never evaluated: a history button would point
+    // at an empty list, and the history is automatic runs only - manual
+    // deletions never appear in it.
+    const { unmount } = renderSection(
+      clientWithPolicy({
+        get: () => policyFixture({}),
+        set: (r) => policyFixture(r),
+      }),
+    );
+    await waitFor(() => {
+      screen.getByRole("switch", { name: "Automatic cleanup" });
+    });
+    expect(
+      screen.queryByRole("button", { name: /automatic cleanup history/i }),
+    ).toBeNull();
+    unmount();
+
+    // Disabled AFTER it ran: the record of what was deleted must stay
+    // reachable - turning the policy off is when someone comes looking.
+    renderSection(
+      clientWithPolicy({
+        get: () => policyFixture({ enabled: false, lastEvaluatedAt: 1_000 }),
+        set: (r) => policyFixture(r),
+      }),
+    );
+    await waitFor(() => {
+      screen.getByRole("button", { name: /automatic cleanup history/i });
+    });
   });
 
   it("renders an upcoming check as a countdown, never as a past-tense label", async () => {

--- a/clients/gui-app/src/components/settings/panels/__tests__/worktree-auto-cleanup-section.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/worktree-auto-cleanup-section.test.tsx
@@ -302,6 +302,36 @@ describe("WorktreeAutoCleanupSection", () => {
     ).toContain("next check in under a minute");
   });
 
+  it("flips to due now at the deadline without waiting for the next clock tick", async () => {
+    // The shared clock samples once a minute; a deadline landing between two
+    // samples must not leave "in under a minute" on screen past itself.
+    renderSection(
+      clientWithPolicy({
+        get: () =>
+          policyFixture({
+            enabled: true,
+            lastEvaluatedAt: Date.now() - 5 * 60_000,
+            nextEvaluationAt: Date.now() + 700,
+          }),
+        set: (r) => policyFixture(r),
+      }),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("worktree-auto-cleanup-schedule").textContent,
+      ).toContain("next check in under a minute");
+    });
+    await waitFor(
+      () => {
+        expect(
+          screen.getByTestId("worktree-auto-cleanup-schedule").textContent,
+        ).toContain("next check due now");
+      },
+      { timeout: 3_000 },
+    );
+  });
+
   it("renders an overdue check as due now rather than counting down to zero", async () => {
     renderSection(
       clientWithPolicy({

--- a/clients/gui-app/src/components/settings/panels/__tests__/worktree-auto-cleanup-section.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/worktree-auto-cleanup-section.test.tsx
@@ -221,6 +221,52 @@ describe("WorktreeAutoCleanupSection", () => {
     expect(screen.queryByRole("button", { name: /re-?authorize/i })).toBeNull();
   });
 
+  it("renders an upcoming check as a countdown, never as a past-tense label", async () => {
+    renderSection(
+      clientWithPolicy({
+        get: () =>
+          policyFixture({
+            enabled: true,
+            lastEvaluatedAt: Date.now() - 5 * 60_000,
+            nextEvaluationAt: Date.now() + 10 * 60_000,
+          }),
+        set: (r) => policyFixture(r),
+      }),
+    );
+
+    await waitFor(() => {
+      screen.getByTestId("worktree-auto-cleanup-schedule");
+    });
+    const schedule = screen.getByTestId("worktree-auto-cleanup-schedule");
+    // The regression this pins: `useRelativeTimestamp` clamps a negative
+    // delta, so a check ~10m AWAY rendered as "Just now" - a past-tense claim
+    // about an event that has not happened.
+    expect(schedule.textContent).toMatch(/next check in \d+m/);
+    expect(schedule.textContent).not.toContain("next check Just now");
+    expect(schedule.textContent).toContain("Last checked");
+  });
+
+  it("renders an overdue check as due now rather than counting down to zero", async () => {
+    renderSection(
+      clientWithPolicy({
+        get: () =>
+          policyFixture({
+            enabled: true,
+            lastEvaluatedAt: Date.now() - 60 * 60_000,
+            nextEvaluationAt: Date.now() - 60_000,
+          }),
+        set: (r) => policyFixture(r),
+      }),
+    );
+
+    await waitFor(() => {
+      screen.getByTestId("worktree-auto-cleanup-schedule");
+    });
+    expect(
+      screen.getByTestId("worktree-auto-cleanup-schedule").textContent,
+    ).toContain("next check due now");
+  });
+
   it("sends the current revision with a preset threshold change", async () => {
     const requests: Array<{
       readonly inactivityDays: number;

--- a/clients/gui-app/src/components/settings/panels/worktree-auto-cleanup-section.tsx
+++ b/clients/gui-app/src/components/settings/panels/worktree-auto-cleanup-section.tsx
@@ -234,15 +234,12 @@ function AutoCleanupFooter(props: {
           Cleanup is off. Nothing is deleted automatically on this host.
         </span>
       )}
-      {policy !== null &&
-      (policy.enabled || policy.lastEvaluatedAt !== null) ? (
-        // History records AUTOMATIC runs only, so the button earns its spot
-        // when the policy is on or has ever run. Gated on `lastEvaluatedAt`
-        // rather than `enabled` alone: turning cleanup OFF after it deleted
-        // things is exactly when someone comes looking for the record, and
-        // every pass writes a run row, so a non-null last evaluation means
-        // there is history to show. A fresh, never-enabled host shows no
-        // button pointing at an empty list.
+      {policy !== null && policy.enabled ? (
+        // History records AUTOMATIC runs only - manual deletions never appear
+        // in it - so the button belongs to the enabled policy and nowhere
+        // else. With cleanup off, a button here read as the place manual
+        // deletions should show up. The rows themselves persist (retention
+        // is 200 runs / 90 days), so re-enabling brings the record back.
         <Button
           type="button"
           variant="outline"
@@ -302,6 +299,15 @@ function AutoCleanupWhen(props: { readonly at: number }): ReactNode {
 }
 
 /**
+ * A deadline closer than this reads as "under a minute" rather than as a
+ * seconds count. The shared clock ticks once a minute, so "in 28s" would sit
+ * frozen past its own deadline; a phrase that stays true for the whole
+ * minute is honest at that granularity, and a one-second timer for a row
+ * nobody watches would not be.
+ */
+const UNDER_A_MINUTE_MS = 60_000;
+
+/**
  * The FUTURE leaf. `useRelativeTimestamp` is a past-tense formatter whose
  * negative-delta clamp renders any upcoming instant as "Just now" - which is
  * exactly what a freshly enabled policy showed for a check ~30s away. A time
@@ -311,6 +317,7 @@ function AutoCleanupWhen(props: { readonly at: number }): ReactNode {
 function AutoCleanupNextCheck(props: { readonly at: number }): ReactNode {
   const now = useSampledNow();
   if (props.at <= now) return <>due now</>;
+  if (props.at - now < UNDER_A_MINUTE_MS) return <>in under a minute</>;
   return <>in {formatResetCountdown(props.at, now)}</>;
 }
 

--- a/clients/gui-app/src/components/settings/panels/worktree-auto-cleanup-section.tsx
+++ b/clients/gui-app/src/components/settings/panels/worktree-auto-cleanup-section.tsx
@@ -27,7 +27,11 @@ import {
   AUTO_CLEANUP_PAUSED_COPY,
   autoCleanupDaysError,
 } from "@/components/settings/panels/worktree-auto-cleanup-copy";
-import { useRelativeTimestamp } from "@/lib/relative-time";
+import {
+  formatResetCountdown,
+  useRelativeTimestamp,
+  useSampledNow,
+} from "@/lib/relative-time";
 
 /**
  * Settings ▸ Worktrees ▸ Automatic cleanup — the per-HOST opt-in.
@@ -263,7 +267,7 @@ function AutoCleanupSchedule(props: {
         <>Next check: paused</>
       ) : (
         <>
-          next check <AutoCleanupWhen at={policy.nextEvaluationAt} />
+          next check <AutoCleanupNextCheck at={policy.nextEvaluationAt} />
         </>
       )}
     </span>
@@ -274,6 +278,19 @@ function AutoCleanupSchedule(props: {
 function AutoCleanupWhen(props: { readonly at: number }): ReactNode {
   const label = useRelativeTimestamp(props.at);
   return <>{label}</>;
+}
+
+/**
+ * The FUTURE leaf. `useRelativeTimestamp` is a past-tense formatter whose
+ * negative-delta clamp renders any upcoming instant as "Just now" - which is
+ * exactly what a freshly enabled policy showed for a check ~30s away. A time
+ * that has already arrived (the scheduler picks the pass up on its next
+ * cadence tick) reads as due rather than as a countdown of zero.
+ */
+function AutoCleanupNextCheck(props: { readonly at: number }): ReactNode {
+  const now = useSampledNow();
+  if (props.at <= now) return <>due now</>;
+  return <>in {formatResetCountdown(props.at, now)}</>;
 }
 
 /**

--- a/clients/gui-app/src/components/settings/panels/worktree-auto-cleanup-section.tsx
+++ b/clients/gui-app/src/components/settings/panels/worktree-auto-cleanup-section.tsx
@@ -214,14 +214,35 @@ function AutoCleanupControls(props: {
           {AUTO_CLEANUP_PAUSED_COPY[policy.pausedReason]}
         </p>
       ) : null}
-      <div className="flex flex-wrap items-center justify-between gap-2 border-t border-border/40 px-3.5 py-2">
-        {policy !== null && policy.enabled ? (
-          <AutoCleanupSchedule policy={policy} />
-        ) : (
-          <span className="text-ui-xs text-muted-foreground">
-            Cleanup is off. Nothing is deleted automatically on this host.
-          </span>
-        )}
+      <AutoCleanupFooter policy={policy} onOpenHistory={onOpenHistory} />
+    </div>
+  );
+}
+
+/** The schedule line and the history entry point. */
+function AutoCleanupFooter(props: {
+  readonly policy: WorktreeAutoCleanupPolicyState | null;
+  readonly onOpenHistory: () => void;
+}): ReactNode {
+  const { policy, onOpenHistory } = props;
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-2 border-t border-border/40 px-3.5 py-2">
+      {policy !== null && policy.enabled ? (
+        <AutoCleanupSchedule policy={policy} />
+      ) : (
+        <span className="text-ui-xs text-muted-foreground">
+          Cleanup is off. Nothing is deleted automatically on this host.
+        </span>
+      )}
+      {policy !== null &&
+      (policy.enabled || policy.lastEvaluatedAt !== null) ? (
+        // History records AUTOMATIC runs only, so the button earns its spot
+        // when the policy is on or has ever run. Gated on `lastEvaluatedAt`
+        // rather than `enabled` alone: turning cleanup OFF after it deleted
+        // things is exactly when someone comes looking for the record, and
+        // every pass writes a run row, so a non-null last evaluation means
+        // there is history to show. A fresh, never-enabled host shows no
+        // button pointing at an empty list.
         <Button
           type="button"
           variant="outline"
@@ -230,9 +251,9 @@ function AutoCleanupControls(props: {
           onClick={onOpenHistory}
         >
           <History className="size-4" />
-          <span>Cleanup history</span>
+          <span>Automatic cleanup history</span>
         </Button>
-      </div>
+      ) : null}
     </div>
   );
 }

--- a/clients/gui-app/src/components/settings/panels/worktree-auto-cleanup-section.tsx
+++ b/clients/gui-app/src/components/settings/panels/worktree-auto-cleanup-section.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useId, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useId, useState, type ReactNode } from "react";
 import { History, Info } from "lucide-react";
 import type { WorktreeAutoCleanupPolicyState } from "@traycer/protocol/host/worktree-auto-cleanup-schemas";
 import type { HostClient } from "@traycer-clients/shared/host-client/host-client";
@@ -315,7 +315,26 @@ const UNDER_A_MINUTE_MS = 60_000;
  * cadence tick) reads as due rather than as a countdown of zero.
  */
 function AutoCleanupNextCheck(props: { readonly at: number }): ReactNode {
-  const now = useSampledNow();
+  const sampled = useSampledNow();
+  // The deadline-aligned wake. The shared clock samples once a minute, so
+  // without this "in under a minute" would outlive the deadline by up to a
+  // tick. Inside the last minute a one-shot timer fires exactly at `at`;
+  // re-armed on every sample as well as on `at`, because the minute the
+  // deadline enters is only known once a fresh sample says so. `arrivedAt`
+  // needs no reset when `at` moves: a stale value is always below the new
+  // deadline, and `max` with the live sample discards it.
+  const [arrivedAt, setArrivedAt] = useState<number | null>(null);
+  useEffect(() => {
+    const remaining = props.at - Date.now();
+    if (remaining <= 0 || remaining >= UNDER_A_MINUTE_MS) return undefined;
+    const handle = window.setTimeout(() => {
+      setArrivedAt(props.at);
+    }, remaining);
+    return () => {
+      window.clearTimeout(handle);
+    };
+  }, [props.at, sampled]);
+  const now = arrivedAt === null ? sampled : Math.max(sampled, arrivedAt);
   if (props.at <= now) return <>due now</>;
   if (props.at - now < UNDER_A_MINUTE_MS) return <>in under a minute</>;
   return <>in {formatResetCountdown(props.at, now)}</>;

--- a/clients/gui-app/src/components/settings/panels/worktree-cleanup-history.tsx
+++ b/clients/gui-app/src/components/settings/panels/worktree-cleanup-history.tsx
@@ -80,7 +80,7 @@ export function WorktreeCleanupHistory(props: {
           <span>Worktrees</span>
         </Button>
         <span className="min-w-0 truncate text-ui-sm font-medium text-foreground">
-          Cleanup history
+          Automatic cleanup history
         </span>
       </div>
       <div className="min-h-0 flex-1 overflow-y-auto">

--- a/clients/gui-app/src/lib/relative-time.ts
+++ b/clients/gui-app/src/lib/relative-time.ts
@@ -23,7 +23,22 @@ const listeners = new Set<() => void>();
 
 function startIfNeeded(): void {
   if (intervalHandle !== null) return;
+  // A restart after idling re-samples - and a re-sample the subscribers cannot
+  // see is worse than none. The component that woke the clock has ALREADY
+  // rendered against the old `sampledNow`, which is as stale as the idle
+  // period (hours, in a long-open app), and nothing would repaint it for a
+  // full minute: a countdown to a check 30s away read as hours away until the
+  // first tick. Bumping `tick` is what lets `useSyncExternalStore` notice the
+  // fresh sample and re-render every subscriber - a one-time cost paid only
+  // when the clock comes back from idle.
+  const previous = sampledNow;
   sampledNow = Date.now();
+  if (sampledNow !== previous) {
+    tick += 1;
+    for (const listener of listeners) {
+      listener();
+    }
+  }
   intervalHandle = window.setInterval(() => {
     tick += 1;
     sampledNow = Date.now();


### PR DESCRIPTION
## Summary

Follow-ups from live staging testing of automatic worktree cleanup (#1596), all in Settings ▸ Worktrees.

**The next check counted the wrong way.** The schedule row fed `nextEvaluationAt` through `useRelativeTimestamp`, a past-tense formatter whose negative-delta clamp shows any **future** instant as "Just now". The next check now renders through `formatResetCountdown`, the existing future-facing mirror ("in 23h 45m"); a check under a minute away reads "in under a minute" (the shared clock ticks once a minute, so a seconds count would sit frozen past its deadline), and a time that has already arrived reads "due now".

**The shared clock could hand out a stale first sample.** `relative-time.ts` re-sampled `sampledNow` when it restarted from idle but notified nobody, so the component that woke it rendered against a sample as old as the idle period and nothing repainted it for a minute — in a long-open app a check ~30s away could first read as hours away. Restart now bumps the tick and notifies subscribers; every relative-time consumer benefits.

**The history button rendered unconditionally.** The history records automatic runs only — manual deletions never appear in it — yet a host with the policy off showed a "Cleanup history" button beside "Cleanup is off", reading as the place manual deletions should show up. It now shows only while the policy is enabled; the rows persist, so re-enabling brings the record back. The button and the view heading say "Automatic cleanup history".

## Related issue

Follow-up to #1596.

## Checklist

- [x] Pre-commit static checks pass (build · compile · lint · format, nx affected)
- [x] Separate CI test checks pass
- [x] Tests added/updated where it makes sense — countdown, under-a-minute, due-now, hidden-when-disabled, visible-when-enabled (section suite 11/11; clock suite green)
- [x] Commits are signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#developer-certificate-of-origin-dco)
