### PR TITLE
fix(remote-host): reprobe retained sessions after plan denial

### DIFF
--- a/clients/gui-app/src/components/layout/__tests__/desktop-dialog-host.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/desktop-dialog-host.test.tsx
@@ -501,6 +501,7 @@ function createDirtyEpicHandle(
       set({ isDirty: false, unsyncedQueueSize: 0 });
     },
     requestFreshSnapshot: () => undefined,
+    retryTransport: () => undefined,
     retryMigration: () => undefined,
     applyChatRecords: () => undefined,
     peekChatIngestSeq: () => 0,
@@ -544,6 +545,7 @@ function createDirtyEpicHandle(
     dispose: () => undefined,
     detachTransport: () => undefined,
     requestFreshSnapshot: () => undefined,
+    retryTransport: () => undefined,
     isClean: () => !store.getState().isDirty,
     hotArtifactRoomIdsForTests: () => [],
   };

--- a/clients/gui-app/src/components/layout/__tests__/menu-command-listener.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/menu-command-listener.test.tsx
@@ -227,6 +227,7 @@ function buildDirtyHandle(epicId: string): OpenEpicStoreHandle {
     dispose: () => undefined,
     detachTransport: () => undefined,
     requestFreshSnapshot: () => undefined,
+    retryTransport: () => undefined,
     isClean: () => false,
     hotArtifactRoomIdsForTests: () => [],
   };

--- a/clients/gui-app/src/components/layout/__tests__/quit-intercept-bridge.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/quit-intercept-bridge.test.tsx
@@ -110,6 +110,7 @@ function buildHandle(epicId: string, title: string): FakeHandle {
     dispose: () => undefined,
     detachTransport: () => undefined,
     requestFreshSnapshot: () => undefined,
+    retryTransport: () => undefined,
     isClean: () => !state.isDirty,
     hotArtifactRoomIdsForTests: () => [],
     setDirty: (isDirty, queueSize) => {

--- a/clients/gui-app/src/components/layout/__tests__/tab-strip.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/tab-strip.test.tsx
@@ -356,6 +356,7 @@ function buildHeaderEpicHandle(
     dispose: () => undefined,
     detachTransport: () => undefined,
     requestFreshSnapshot: () => undefined,
+    retryTransport: () => undefined,
     isClean: () => true,
     hotArtifactRoomIdsForTests: () => [],
   };

--- a/clients/gui-app/src/components/settings/panels/use-worktree-delete-run.ts
+++ b/clients/gui-app/src/components/settings/panels/use-worktree-delete-run.ts
@@ -827,6 +827,7 @@ function startWorktreeDeleteCommand(
             },
           },
         }),
+      null,
     );
     commandRefs.set(commandId, client);
     // A callback can settle the command DURING the build - in production the
@@ -1057,6 +1058,7 @@ function startQueuedDelete(item: QueuedWorktreeDelete): void {
             },
           },
         }),
+      null,
     );
     clientRefs.set(item.key, client);
   } catch (error) {

--- a/clients/gui-app/src/hooks/managed-command/use-managed-command-output-session.ts
+++ b/clients/gui-app/src/hooks/managed-command/use-managed-command-output-session.ts
@@ -79,6 +79,7 @@ export function useManagedCommandOutputSession(args: {
               close: () => stream.close(),
             };
           },
+          null,
         );
         return {
           loadOlder: (frame) => owned.client.stream.loadOlder(frame),

--- a/clients/gui-app/src/lib/epics/run-worktree-cleanup.ts
+++ b/clients/gui-app/src/lib/epics/run-worktree-cleanup.ts
@@ -309,6 +309,7 @@ function runCleanupCommand(
               },
             },
           }),
+        null,
       );
       adoptClose(holder, owned.close);
     } catch (error) {
@@ -481,6 +482,7 @@ function deleteOneWorktree(input: {
               },
             },
           }),
+        null,
       );
       adoptClose(holder, owned.close);
     } catch (error) {

--- a/clients/gui-app/src/lib/host/__tests__/owned-durable-stream-client.test.ts
+++ b/clients/gui-app/src/lib/host/__tests__/owned-durable-stream-client.test.ts
@@ -117,4 +117,50 @@ describe("openOwnedDurableStreamClient plan-restricted reprobe", () => {
     expect(rebuild).toHaveBeenCalledTimes(1);
     owned.close();
   });
+
+  it("retries an owner rebuild that throws synchronously", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(40_000);
+    const controlled = controllableTransport();
+    const rebuild = vi.fn<() => void>().mockImplementationOnce(() => {
+      throw new Error("wiring failed");
+    });
+    const owned = openOwnedDurableStreamClient(
+      () => controlled.transport,
+      "host-a",
+      () => ({ close: vi.fn() }),
+      rebuild,
+    );
+
+    controlled.emitClosed("plan-restricted:41000");
+    vi.advanceTimersByTime(1_000);
+    expect(rebuild).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(999);
+    expect(rebuild).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(1);
+    expect(rebuild).toHaveBeenCalledTimes(2);
+
+    owned.close();
+  });
+
+  it("bounds repeated synchronous rebuild failures", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(50_000);
+    const controlled = controllableTransport();
+    const rebuild = vi.fn(() => {
+      throw new Error("still unavailable");
+    });
+    const owned = openOwnedDurableStreamClient(
+      () => controlled.transport,
+      "host-a",
+      () => ({ close: vi.fn() }),
+      rebuild,
+    );
+
+    controlled.emitClosed("plan-restricted:51000");
+    vi.advanceTimersByTime(10_000);
+    expect(rebuild).toHaveBeenCalledTimes(3);
+
+    owned.close();
+  });
 });

--- a/clients/gui-app/src/lib/host/__tests__/owned-durable-stream-client.test.ts
+++ b/clients/gui-app/src/lib/host/__tests__/owned-durable-stream-client.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, describe, expect, it, vi, type Mock } from "vitest";
+import type { IStreamSession } from "@traycer-clients/shared/host-transport/i-stream-session";
+import type { IHostStreamClient } from "@traycer-clients/shared/host-transport/host-stream-client";
+import type { HostStreamRpcRegistry } from "@traycer/protocol/host/registry";
+import type { DurableStreamTransport } from "@/lib/host/durable-stream-transport";
+import { openOwnedDurableStreamClient } from "@/lib/host/owned-durable-stream-client";
+
+function fakeStreamSession(): IStreamSession {
+  return {
+    sendClientFrame: () => undefined,
+    onServerFrame: () => undefined,
+    onStatusChange: () => undefined,
+    getNegotiatedSchemaVersion: () => null,
+    requestReconnect: () => undefined,
+    close: () => undefined,
+  };
+}
+
+function controllableTransport(): {
+  readonly transport: DurableStreamTransport;
+  readonly emitClosed: (reason: string) => void;
+  readonly closeTransport: Mock<() => void>;
+} {
+  const closedListeners = new Set<() => void>();
+  let closed = false;
+  let closedReason: string | null = null;
+  const wsStreamClient: IHostStreamClient<HostStreamRpcRegistry> = {
+    subscribe: () => fakeStreamSession(),
+    subscribeWithParamsProvider: () => fakeStreamSession(),
+    close: () => undefined,
+    isClosed: () => closed,
+    getClosedReason: () => closedReason,
+    onClosed: (listener) => {
+      closedListeners.add(listener);
+      return () => closedListeners.delete(listener);
+    },
+    instanceId: "controlled-durable-client",
+    notifyBearerRotated: () => undefined,
+    reconnectAll: () => undefined,
+    isReady: () => !closed,
+    getMethodSupport: () => "unknown",
+    subscribeMethodSupport: () => () => undefined,
+    getMethodSchemaVersion: () => null,
+    subscribeAvailabilityRecovered: () => () => undefined,
+  };
+  const closeTransport = vi.fn();
+  return {
+    transport: { wsStreamClient, close: closeTransport },
+    emitClosed: (reason) => {
+      closed = true;
+      closedReason = reason;
+      for (const listener of [...closedListeners]) listener();
+    },
+    closeTransport,
+  };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("openOwnedDurableStreamClient plan-restricted reprobe", () => {
+  it("asks the owner to rebuild at the session cache deadline", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(10_000);
+    const controlled = controllableTransport();
+    const rebuild = vi.fn();
+    const owned = openOwnedDurableStreamClient(
+      () => controlled.transport,
+      "host-a",
+      () => ({ close: vi.fn() }),
+      rebuild,
+    );
+
+    controlled.emitClosed("plan-restricted:11000");
+    vi.advanceTimersByTime(999);
+    expect(rebuild).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(rebuild).toHaveBeenCalledTimes(1);
+
+    owned.close();
+  });
+
+  it("cancels an armed rebuild when the durable owner is disposed", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(20_000);
+    const controlled = controllableTransport();
+    const rebuild = vi.fn();
+    const owned = openOwnedDurableStreamClient(
+      () => controlled.transport,
+      "host-a",
+      () => ({ close: vi.fn() }),
+      rebuild,
+    );
+
+    controlled.emitClosed("plan-restricted:21000");
+    owned.close();
+    vi.advanceTimersByTime(1_000);
+    expect(rebuild).not.toHaveBeenCalled();
+    expect(controlled.closeTransport).toHaveBeenCalledTimes(1);
+  });
+
+  it("arms the deadline when the negative cache returns an already-closed client", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(30_000);
+    const controlled = controllableTransport();
+    controlled.emitClosed("plan-restricted:31000");
+    const rebuild = vi.fn();
+    const owned = openOwnedDurableStreamClient(
+      () => controlled.transport,
+      "host-a",
+      () => ({ close: vi.fn() }),
+      rebuild,
+    );
+
+    vi.advanceTimersByTime(1_000);
+    expect(rebuild).toHaveBeenCalledTimes(1);
+    owned.close();
+  });
+});

--- a/clients/gui-app/src/lib/host/owned-durable-stream-client.ts
+++ b/clients/gui-app/src/lib/host/owned-durable-stream-client.ts
@@ -4,6 +4,9 @@ import type { DurableStreamTransport } from "@/lib/host/durable-stream-transport
 import { planRestrictedReprobeAtFromClosedReason } from "@traycer-clients/shared/host-transport/remote/config";
 import { appLogger } from "@/lib/logger";
 
+const REPROBE_RETRY_DELAY_MS = 1_000;
+const MAX_REPROBE_REBUILD_ATTEMPTS = 3;
+
 /**
  * Owns a durable transport for the lifetime of one typed stream client — the
  * single place the "open transport → build typed client → compose close →
@@ -23,25 +26,39 @@ export function openOwnedDurableStreamClient<TClient extends { close(): void }>(
   try {
     const client = build(transport.wsStreamClient);
     let reprobeTimer: number | null = null;
+    let reprobeAttempts = 0;
+    const runPlanRestrictedReprobe = (): void => {
+      reprobeTimer = null;
+      reprobeAttempts += 1;
+      try {
+        onPlanRestrictedReprobe?.();
+      } catch (cause) {
+        appLogger.error(
+          "[stream] durable plan-restricted reprobe failed",
+          {},
+          cause,
+        );
+        // A rebuild can fail after it has closed this owned client. Keep the
+        // recovery trigger in this closure alive for a bounded number of
+        // backed-off attempts; the retained owner callback is disposal-aware
+        // and becomes a no-op once its store is gone.
+        if (reprobeAttempts < MAX_REPROBE_REBUILD_ATTEMPTS) {
+          reprobeTimer = window.setTimeout(
+            runPlanRestrictedReprobe,
+            REPROBE_RETRY_DELAY_MS * reprobeAttempts,
+          );
+        }
+      }
+    };
     const schedulePlanRestrictedReprobe = (): void => {
       const reprobeAt = planRestrictedReprobeAtFromClosedReason(
         transport.wsStreamClient.getClosedReason(),
       );
       if (reprobeAt === null || onPlanRestrictedReprobe === null) return;
       if (reprobeTimer !== null) window.clearTimeout(reprobeTimer);
+      reprobeAttempts = 0;
       reprobeTimer = window.setTimeout(
-        () => {
-          reprobeTimer = null;
-          try {
-            onPlanRestrictedReprobe();
-          } catch (cause) {
-            appLogger.error(
-              "[stream] durable plan-restricted reprobe failed",
-              {},
-              cause,
-            );
-          }
-        },
+        runPlanRestrictedReprobe,
         Math.max(0, reprobeAt - Date.now()),
       );
     };

--- a/clients/gui-app/src/lib/host/owned-durable-stream-client.ts
+++ b/clients/gui-app/src/lib/host/owned-durable-stream-client.ts
@@ -1,28 +1,71 @@
 import type { IHostStreamClient } from "@traycer-clients/shared/host-transport/host-stream-client";
 import type { HostStreamRpcRegistry } from "@traycer/protocol/host/registry";
 import type { DurableStreamTransport } from "@/lib/host/durable-stream-transport";
+import { planRestrictedReprobeAtFromClosedReason } from "@traycer-clients/shared/host-transport/remote/config";
 import { appLogger } from "@/lib/logger";
 
 /**
  * Owns a durable transport for the lifetime of one typed stream client — the
  * single place the "open transport → build typed client → compose close →
  * close-on-throw" lifetime lives, shared by the epic / chat / terminal session
- * stores. `close()` tears down BOTH the typed client and its transport (socket
- * + wake wiring); a synchronous throw in `build` closes the half-built transport
- * so it never leaks.
+ * stores. It also translates a terminal plan-denial deadline into an OWNER
+ * rebuild: reconnecting the closed client itself cannot acquire the cache's
+ * controlled fresh session. `close()` tears down the client, timer and
+ * transport; a synchronous build/wiring throw closes every completed layer.
  */
 export function openOwnedDurableStreamClient<TClient extends { close(): void }>(
   openTransport: (hostId: string) => DurableStreamTransport,
   hostId: string,
   build: (wsStreamClient: IHostStreamClient<HostStreamRpcRegistry>) => TClient,
+  onPlanRestrictedReprobe: (() => void) | null,
 ): { readonly client: TClient; readonly close: () => void } {
   const transport = openTransport(hostId);
   try {
     const client = build(transport.wsStreamClient);
+    let reprobeTimer: number | null = null;
+    const schedulePlanRestrictedReprobe = (): void => {
+      const reprobeAt = planRestrictedReprobeAtFromClosedReason(
+        transport.wsStreamClient.getClosedReason(),
+      );
+      if (reprobeAt === null || onPlanRestrictedReprobe === null) return;
+      if (reprobeTimer !== null) window.clearTimeout(reprobeTimer);
+      reprobeTimer = window.setTimeout(
+        () => {
+          reprobeTimer = null;
+          try {
+            onPlanRestrictedReprobe();
+          } catch (cause) {
+            appLogger.error(
+              "[stream] durable plan-restricted reprobe failed",
+              {},
+              cause,
+            );
+          }
+        },
+        Math.max(0, reprobeAt - Date.now()),
+      );
+    };
+    let unsubscribeClosed: () => void;
+    try {
+      unsubscribeClosed = transport.wsStreamClient.onClosed(
+        schedulePlanRestrictedReprobe,
+      );
+      // RemoteSession.onClosed deliberately does not retro-fire. A negative-
+      // cache adoption can therefore hand this owner an already-closed client;
+      // inspect it after subscribing so neither close ordering loses the timer.
+      if (transport.wsStreamClient.isClosed()) {
+        schedulePlanRestrictedReprobe();
+      }
+    } catch (cause) {
+      client.close();
+      throw cause;
+    }
     appLogger.debug("[stream] owned durable client opened", { hostId });
     return {
       client,
       close: () => {
+        unsubscribeClosed();
+        if (reprobeTimer !== null) window.clearTimeout(reprobeTimer);
         client.close();
         transport.close();
       },

--- a/clients/gui-app/src/lib/registries/chat-session-registry.ts
+++ b/clients/gui-app/src/lib/registries/chat-session-registry.ts
@@ -172,6 +172,7 @@ export function useChatSessionHandle(
     // tile unmount), the socket stays alive across close -> warm -> reopen, so a
     // revived session is never handed a dead transport. `retry()` re-invokes
     // this factory, rebuilding the transport with live deps.
+    let acquiredHandle: ChatSessionStoreHandle | null = null;
     const factory: ChatStreamClientFactory = (
       factoryEpicId,
       factoryChatId,
@@ -198,6 +199,7 @@ export function useChatSessionHandle(
             chatId: factoryChatId,
             callbacks,
           }),
+        () => acquiredHandle?.store.getState().retry(),
       );
       return {
         sendAction: (frame) => result.client.sendAction(frame),
@@ -241,6 +243,7 @@ export function useChatSessionHandle(
           onProviderAuthError,
         }),
     );
+    acquiredHandle = next;
     handleHostIds.set(next, hostId);
     setHandle(next);
 

--- a/clients/gui-app/src/lib/registries/terminal-session-registry.ts
+++ b/clients/gui-app/src/lib/registries/terminal-session-registry.ts
@@ -190,6 +190,7 @@ export function useTerminalSessionHandle(
       }
     }
 
+    let acquiredHandle: TerminalSessionStoreHandle | null = null;
     const factory: TerminalStreamClientFactory = (streamArgs) => {
       if (streamClientFactoryOverride !== null) {
         return streamClientFactoryOverride(streamArgs);
@@ -212,6 +213,7 @@ export function useTerminalSessionHandle(
             viewer: streamArgs.viewer,
             callbacks: streamArgs.callbacks,
           }),
+        () => acquiredHandle?.store.getState().retryTransport(),
       );
       return {
         sendAction: (frame) => result.client.sendAction(frame),
@@ -235,6 +237,7 @@ export function useTerminalSessionHandle(
       },
       args.hostId,
     );
+    acquiredHandle = next;
     handleHostIds.set(next, args.hostId);
     handleOwnerIdentityKeys.set(next, ownerIdentityKey);
     setHandle(next);

--- a/clients/gui-app/src/lib/worktree/__tests__/teardown-agent-names.test.tsx
+++ b/clients/gui-app/src/lib/worktree/__tests__/teardown-agent-names.test.tsx
@@ -59,6 +59,7 @@ function seedOpenEpicWithChatTitle(title: string): {
     dispose: () => undefined,
     detachTransport: () => undefined,
     requestFreshSnapshot: () => undefined,
+    retryTransport: () => undefined,
     isClean: () => true,
     hotArtifactRoomIdsForTests: () => [],
   };

--- a/clients/gui-app/src/providers/__tests__/auth-lifecycle-bridge.test.tsx
+++ b/clients/gui-app/src/providers/__tests__/auth-lifecycle-bridge.test.tsx
@@ -40,6 +40,7 @@ function fakeOpenEpicHandle(id: string): OpenEpicStoreHandle & {
     },
     detachTransport: () => undefined,
     requestFreshSnapshot: () => undefined,
+    retryTransport: () => undefined,
     isClean: () => true,
     hotArtifactRoomIdsForTests: () => [],
     disposeCount: 0,

--- a/clients/gui-app/src/providers/epic-session-provider.tsx
+++ b/clients/gui-app/src/providers/epic-session-provider.tsx
@@ -496,6 +496,7 @@ export function EpicSessionProvider(
     // handed a dead transport; the durable transport's live endpoint + wake
     // re-dial heal a host restart under a stable `hostId` on their own. Tests
     // drive the stream through the override seam and never open a real socket.
+    let reprobeHandle: OpenEpicStoreHandle | null = null;
     const streamClientFactory: EpicStreamClientFactory = (
       factoryEpicId,
       callbacks,
@@ -520,6 +521,7 @@ export function EpicSessionProvider(
             callbacks,
             seedOfferProvider,
           }),
+        () => reprobeHandle?.requestFreshSnapshot(),
       );
       return {
         applyUpdate: (updateBytes) => result.client.applyUpdate(updateBytes),
@@ -543,6 +545,7 @@ export function EpicSessionProvider(
         userId: sessionUserId,
         onAuthError: handleSessionAuthError,
       });
+      reprobeHandle = created;
       // Construction-honest stamp, written exactly once: `streamClientFactory`
       // above captures this run's `targetHostId` into the transport it opens,
       // so the stamp IS the handle's transport binding. Nothing re-stamps a

--- a/clients/gui-app/src/providers/epic-session-provider.tsx
+++ b/clients/gui-app/src/providers/epic-session-provider.tsx
@@ -521,7 +521,7 @@ export function EpicSessionProvider(
             callbacks,
             seedOfferProvider,
           }),
-        () => reprobeHandle?.requestFreshSnapshot(),
+        () => reprobeHandle?.retryTransport(),
       );
       return {
         applyUpdate: (updateBytes) => result.client.applyUpdate(updateBytes),

--- a/clients/gui-app/src/stores/epics/open-epic/__tests__/session-registry.test.ts
+++ b/clients/gui-app/src/stores/epics/open-epic/__tests__/session-registry.test.ts
@@ -74,6 +74,7 @@ function buildTestHandle(id: string, clean: boolean): TestHandle {
       return base.store;
     },
     requestFreshSnapshot: () => base.requestFreshSnapshot(),
+    retryTransport: () => base.retryTransport(),
     dispose: testDispose,
     detachTransport: () => base.detachTransport(),
     isClean: () => isCleanOverride,

--- a/clients/gui-app/src/stores/epics/open-epic/__tests__/store.test.ts
+++ b/clients/gui-app/src/stores/epics/open-epic/__tests__/store.test.ts
@@ -382,6 +382,35 @@ describe("createOpenEpicStore", () => {
     opened.dispose();
   });
 
+  it("retries only the transport without discarding offline Epic edits", () => {
+    const { factory, handle, handles } = fakeFactory();
+    const opened = createOpenEpicStore({
+      epicId: "epic-a",
+      streamClientFactory: factory,
+      userId: null,
+      onAuthError: null,
+    });
+    handle().callbacks.onSnapshot(
+      buildMeta("editor", new Y.Doc()),
+      emptySnapshot(),
+    );
+    handle().callbacks.onConnectionStatus("reconnecting", null);
+    opened.doc.getMap("epic").set("title", "Buffered title");
+    const docBeforeRetry = opened.doc;
+
+    expect(opened.store.getState().unsyncedQueueSize).toBe(1);
+    opened.retryTransport();
+
+    expect(handles()).toHaveLength(2);
+    expect(handles()[0].closeCount).toBe(1);
+    expect(opened.doc).toBe(docBeforeRetry);
+    expect(opened.doc.getMap("epic").get("title")).toBe("Buffered title");
+    expect(opened.store.getState().unsyncedQueueSize).toBe(1);
+    expect(opened.store.getState().isDirty).toBe(true);
+
+    opened.dispose();
+  });
+
   it("collapses a long offline queue on flush without losing edits or under-reporting its size", () => {
     const { factory, handle } = fakeFactory();
     const opened = createOpenEpicStore({

--- a/clients/gui-app/src/stores/epics/open-epic/__tests__/store.test.ts
+++ b/clients/gui-app/src/stores/epics/open-epic/__tests__/store.test.ts
@@ -411,6 +411,47 @@ describe("createOpenEpicStore", () => {
     opened.dispose();
   });
 
+  it("restores the prior Epic recovery state when reprobe construction throws", () => {
+    const streams = fakeFactory();
+    let attempts = 0;
+    const opened = createOpenEpicStore({
+      epicId: "epic-a",
+      streamClientFactory: (epicId, callbacks, seedOfferProvider) => {
+        attempts += 1;
+        if (attempts > 1) throw new Error("subscription wiring failed");
+        return streams.factory(epicId, callbacks, seedOfferProvider);
+      },
+      userId: null,
+      onAuthError: null,
+    });
+    streams
+      .handle()
+      .callbacks.onSnapshot(buildMeta("editor", new Y.Doc()), emptySnapshot());
+    streams.handle().callbacks.onConnectionStatus("closed", {
+      kind: "fatalError",
+      details: {
+        code: "PLAN_RESTRICTED",
+        reason: "remote access unavailable",
+        incompatibleMethods: null,
+        upgradeGuidance: null,
+      },
+    });
+    opened.doc.getMap("epic").set("title", "Buffered title");
+    const prior = opened.store.getState();
+
+    expect(() => opened.retryTransport()).toThrow("subscription wiring failed");
+    expect(opened.store.getState()).toMatchObject({
+      connectionStatus: prior.connectionStatus,
+      hostTransportStatus: prior.hostTransportStatus,
+      snapshotFetchError: prior.snapshotFetchError,
+      unsyncedQueueSize: 1,
+      isDirty: true,
+    });
+    expect(opened.doc.getMap("epic").get("title")).toBe("Buffered title");
+
+    opened.dispose();
+  });
+
   it("collapses a long offline queue on flush without losing edits or under-reporting its size", () => {
     const { factory, handle } = fakeFactory();
     const opened = createOpenEpicStore({

--- a/clients/gui-app/src/stores/epics/open-epic/store.ts
+++ b/clients/gui-app/src/stores/epics/open-epic/store.ts
@@ -4035,6 +4035,8 @@ export function createOpenEpicStore(
 
           retryTransport: () => {
             if (disposed || transportDetached) return;
+            const prior = get();
+            const priorHasFreshRootSnapshot = hasFreshRootSnapshotForOpenCycle;
             transportStatus = "connecting";
             currentStatus = deriveConnectionStatus(
               transportStatus,
@@ -4048,7 +4050,26 @@ export function createOpenEpicStore(
               snapshotFetchError: null,
               ...cycleDurabilityState,
             });
-            openStreamClient();
+            try {
+              openStreamClient();
+            } catch (cause) {
+              transportStatus = prior.hostTransportStatus;
+              cloudSyncStatus = prior.cloudSyncStatus;
+              hasFreshCloudSyncStatus = prior.hasFreshCloudSyncStatus;
+              hasConnectedOnce = prior.hasConnectedOnce;
+              currentStatus = prior.connectionStatus;
+              hasFreshRootSnapshotForOpenCycle = priorHasFreshRootSnapshot;
+              set({
+                ...connectionStateSlice(),
+                snapshotFetchError: prior.snapshotFetchError,
+                artifactRoomDirtyByArtifactRoomId:
+                  prior.artifactRoomDirtyByArtifactRoomId,
+                rootDirty: prior.rootDirty,
+                hasDirtySnapshotForOpenCycle:
+                  prior.hasDirtySnapshotForOpenCycle,
+              });
+              throw cause;
+            }
           },
 
           retryMigration: () => {

--- a/clients/gui-app/src/stores/epics/open-epic/store.ts
+++ b/clients/gui-app/src/stores/epics/open-epic/store.ts
@@ -512,6 +512,8 @@ export interface OpenEpicState {
    * Y.Doc replica without dropping the owning registry/session entry.
    */
   requestFreshSnapshot: () => void;
+  /** Reopens only the transport, preserving the replica and buffered edits. */
+  retryTransport: () => void;
   /**
    * Sends a `retryMigration` client frame so the host re-runs an
    * interrupted major migration without dropping the `epic.subscribe`
@@ -870,6 +872,7 @@ export interface OpenEpicStoreHandle {
    */
   readonly detachTransport: () => void;
   readonly requestFreshSnapshot: () => void;
+  readonly retryTransport: () => void;
   /**
    * True when this renderer has a loaded, locally clean snapshot and can
    * still reach the host. Cloud acknowledgement is intentionally not part of
@@ -4030,6 +4033,24 @@ export function createOpenEpicStore(
             requestFreshSnapshotImpl?.();
           },
 
+          retryTransport: () => {
+            if (disposed || transportDetached) return;
+            transportStatus = "connecting";
+            currentStatus = deriveConnectionStatus(
+              transportStatus,
+              cloudSyncStatus,
+              hasConnectedOnce,
+            );
+            const cycleDurabilityState = resetDurabilityProofForOpenCycle();
+            closeStreamClient();
+            set({
+              ...connectionStateSlice(),
+              snapshotFetchError: null,
+              ...cycleDurabilityState,
+            });
+            openStreamClient();
+          },
+
           retryMigration: () => {
             if (disposed) return;
             // Nothing to retry until at least one migration has surfaced on
@@ -4659,6 +4680,9 @@ export function createOpenEpicStore(
     hotArtifactRoomIdsForTests: () => Array.from(artifactRoomReplicas.keys()),
     requestFreshSnapshot: () => {
       store.getState().requestFreshSnapshot();
+    },
+    retryTransport: () => {
+      store.getState().retryTransport();
     },
     isClean: () => {
       const state = store.getState();

--- a/clients/gui-app/src/stores/terminals/__tests__/terminal-session-store.test.ts
+++ b/clients/gui-app/src/stores/terminals/__tests__/terminal-session-store.test.ts
@@ -274,6 +274,35 @@ describe("createTerminalSessionStore", () => {
     });
   });
 
+  it("rebuilds a lost retained transport when its owner requests a reprobe", () => {
+    const callbacks: TerminalStreamCallbacks[] = [];
+    const close = vi.fn();
+    const handle = createTerminalSessionStore({
+      scope: { kind: "epic", epicId: "epic-1" },
+      sessionId: "terminal-1",
+      cols: 80,
+      rows: 24,
+      reattachMode: "fresh",
+      kind: "terminal",
+      streamClientFactory: (streamArgs) => {
+        callbacks.push(streamArgs.callbacks);
+        return { sendAction: () => undefined, close };
+      },
+    });
+
+    callbacks[0]?.onConnectionStatus("closed", null);
+    expect(handle.store.getState().status).toBe("lost");
+    handle.store.getState().retryTransport();
+
+    expect(callbacks).toHaveLength(2);
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(handle.store.getState()).toMatchObject({
+      connectionStatus: "connecting",
+      status: "creating",
+    });
+    handle.dispose();
+  });
+
   it("marks the session 'reaped' (definitive) on a TERMINAL_NOT_FOUND fatal, not the recoverable 'lost'", () => {
     const harness = createHarness();
     harness.callbacks().onConnectionStatus("open", null);

--- a/clients/gui-app/src/stores/terminals/__tests__/terminal-session-store.test.ts
+++ b/clients/gui-app/src/stores/terminals/__tests__/terminal-session-store.test.ts
@@ -303,6 +303,39 @@ describe("createTerminalSessionStore", () => {
     handle.dispose();
   });
 
+  it("restores a recoverable lost state when reprobe construction throws", () => {
+    const callbacks: TerminalStreamCallbacks[] = [];
+    const close = vi.fn();
+    let attempts = 0;
+    const handle = createTerminalSessionStore({
+      scope: { kind: "epic", epicId: "epic-1" },
+      sessionId: "terminal-1",
+      cols: 80,
+      rows: 24,
+      reattachMode: "fresh",
+      kind: "terminal",
+      streamClientFactory: (streamArgs) => {
+        attempts += 1;
+        if (attempts > 1) throw new Error("subscription wiring failed");
+        callbacks.push(streamArgs.callbacks);
+        return { sendAction: () => undefined, close };
+      },
+    });
+
+    callbacks[0]?.onConnectionStatus("closed", null);
+    expect(() => handle.store.getState().retryTransport()).toThrow(
+      "subscription wiring failed",
+    );
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(handle.store.getState()).toMatchObject({
+      connectionStatus: "closed",
+      status: "lost",
+      snapshotLoaded: false,
+    });
+
+    handle.dispose();
+  });
+
   it("marks the session 'reaped' (definitive) on a TERMINAL_NOT_FOUND fatal, not the recoverable 'lost'", () => {
     const harness = createHarness();
     harness.callbacks().onConnectionStatus("open", null);

--- a/clients/gui-app/src/stores/terminals/terminal-session-store.ts
+++ b/clients/gui-app/src/stores/terminals/terminal-session-store.ts
@@ -189,6 +189,8 @@ export interface TerminalSessionState {
    * stream — the PTY is no longer addressable.
    */
   setViewer: (viewer: TerminalSubscribeViewer) => void;
+  /** Rebuilds the owned transport while preserving this retained PTY handle. */
+  retryTransport: () => void;
   /** Closes the underlying stream client (does NOT call `terminal.kill`). */
   dispose: () => void;
 }
@@ -939,6 +941,19 @@ export function createTerminalSessionStore(
         return clientActionId;
       },
       setViewer,
+      retryTransport: () => {
+        if (disposed) return;
+        const state = get();
+        if (state.status === "exited" || state.status === "reaped") return;
+        resetAckAccounting();
+        streamGeneration += 1;
+        closeStreamClient();
+        set({
+          connectionStatus: "connecting",
+          status: state.snapshotLoaded ? "running" : "creating",
+        });
+        attachStream(state.requestedCols, state.requestedRows);
+      },
       dispose: () => {
         if (disposed) return;
         disposed = true;

--- a/clients/gui-app/src/stores/terminals/terminal-session-store.ts
+++ b/clients/gui-app/src/stores/terminals/terminal-session-store.ts
@@ -952,7 +952,20 @@ export function createTerminalSessionStore(
           connectionStatus: "connecting",
           status: state.snapshotLoaded ? "running" : "creating",
         });
-        attachStream(state.requestedCols, state.requestedRows);
+        try {
+          attachStream(state.requestedCols, state.requestedRows);
+        } catch (cause) {
+          // Construction can fail after the old client has been closed. Leave
+          // the retained handle in the same recoverable terminal state as an
+          // ordinary transport close, so registry replacement and explicit
+          // retry remain available after the bounded automatic attempts end.
+          set({
+            connectionStatus: "closed",
+            status: "lost",
+            snapshotLoaded: state.snapshotLoaded,
+          });
+          throw cause;
+        }
       },
       dispose: () => {
         if (disposed) return;

--- a/clients/shared/host-selection/__tests__/selection-authority-engine.test.ts
+++ b/clients/shared/host-selection/__tests__/selection-authority-engine.test.ts
@@ -919,6 +919,47 @@ describe("SelectionAuthorityEngineImpl - death aggregation", () => {
 
     authority.dispose();
   });
+
+  it("refreshes the reprobe deadline when a new physical session is denied", () => {
+    const clock = createFakeAuthorityClock(0);
+    const authority = createTestAuthority({
+      initialFleet: {
+        identityGeneration: 0,
+        localHostId: null,
+        hosts: [fleetHost("H", "remote")],
+      },
+      initialIdentityKey: "acct-1",
+      clock,
+    });
+    const { engine } = authority;
+    const seq = engine.allocateAttachSeq("A");
+    const attachment = engine.attach("A", attachRequest(seq, []));
+    if (!attachment.ok) throw new Error("expected attach to succeed");
+
+    engine.ingestEvidence(
+      "A",
+      attachment.incarnationId,
+      dialRefusal("H", "first-identity", "plan-restricted", 0),
+    );
+    clock.advance(PLAN_RESTRICTED_REPROBE_MS / 2);
+    engine.ingestEvidence(
+      "A",
+      attachment.incarnationId,
+      dialRefusal("H", "new-physical-identity", "plan-restricted", 1),
+    );
+
+    // The first deadline has elapsed, but the latest authenticated refusal
+    // owns a complete window of its own.
+    clock.advance(PLAN_RESTRICTED_REPROBE_MS / 2);
+    expect(findLease(engine.snapshot().leases, "H")?.dead).toEqual({
+      reason: "plan-restricted",
+    });
+
+    clock.advance(PLAN_RESTRICTED_REPROBE_MS / 2);
+    expect(findLease(engine.snapshot().leases, "H")?.status).toBe("connecting");
+
+    authority.dispose();
+  });
 });
 
 describe("SelectionAuthorityEngineImpl - session pairing", () => {

--- a/clients/shared/host-selection/selection-authority-engine.ts
+++ b/clients/shared/host-selection/selection-authority-engine.ts
@@ -1504,12 +1504,11 @@ export class SelectionAuthorityEngineImpl implements SelectionAuthorityEngine {
     ) {
       evidence.planRestrictedRefusalObserved = true;
       evidence.refusalStreak = 0;
-      if (
-        evidence.planRestrictedUntil === null ||
-        evidence.planRestrictedUntil <= now
-      ) {
-        evidence.planRestrictedUntil = now + PLAN_RESTRICTED_REPROBE_MS;
-      }
+      // Every non-duplicate refusal is fresh authenticated evidence from the
+      // physical session that just failed. Replace the prior deadline even
+      // while it is active so authority, negative cache and owner rebuild all
+      // describe the latest denial rather than an older identity's window.
+      evidence.planRestrictedUntil = now + PLAN_RESTRICTED_REPROBE_MS;
     }
     if (this.hasLiveSession(hostId)) {
       // Recorded for diagnostics, never accumulated: a live session anywhere


### PR DESCRIPTION
## Summary

- refresh selection-authority suppression from every fresh authenticated plan denial
- schedule retained chat, terminal, and epic owners to rebuild at the negative-cache reprobe deadline
- handle already-closed negative-cache adoption and cancel owner timers on disposal
- keep short-lived destructive streams explicitly outside automatic replay

## Validation

- `@traycer-clients/shared` selection-authority focused suite: 126 passed
- configured GUI focused runs for durable ownership and terminal recovery: 39 + 10 + 1 passed
- pre-commit affected lint, format, compile, and build checks passed

Follow-up to #1639 for post-merge review findings.