### PR TITLE
Add bundled remote GUI development mode

### DIFF
--- a/clients/mobile/__tests__/bundled-build-reload.test.ts
+++ b/clients/mobile/__tests__/bundled-build-reload.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import {
+  BUNDLED_BUILD_META_NAME,
+  bundledBuildIdFromHtml,
+  bundledBuildReloadClient,
+} from "../scripts/bundled-build-reload";
+
+describe("bundled build reload", () => {
+  it("seeds the reload client with the build that produced its HTML", () => {
+    const client = bundledBuildReloadClient("build-one", "/build-revision");
+
+    expect(client).toContain('const activeBuild = "build-one";');
+    expect(client).toContain('fetch("/build-revision"');
+    expect(client).not.toContain("activeBuild === null");
+  });
+
+  it("reads the build ID from the served HTML marker", () => {
+    expect(
+      bundledBuildIdFromHtml(
+        `<meta content="build-two" name="${BUNDLED_BUILD_META_NAME}">`,
+      ),
+    ).toBe("build-two");
+  });
+
+  it("rejects a missing or empty build marker", () => {
+    expect(bundledBuildIdFromHtml("<html></html>")).toBeNull();
+    expect(
+      bundledBuildIdFromHtml(
+        `<meta name="${BUNDLED_BUILD_META_NAME}" content="">`,
+      ),
+    ).toBeNull();
+  });
+});

--- a/clients/mobile/__tests__/bundled-build-reload.test.ts
+++ b/clients/mobile/__tests__/bundled-build-reload.test.ts
@@ -30,6 +30,14 @@ describe("bundled build reload", () => {
     expect(client).not.toContain("activeBuild === null");
   });
 
+  it("waits for each build check before scheduling the next one", () => {
+    const client = bundledBuildReloadClient("build-one", "/build-revision");
+
+    expect(client).toContain("await checkForBuild();");
+    expect(client).toContain("setTimeout(() => void pollForBuild(), 750);");
+    expect(client).not.toContain("setInterval(");
+  });
+
   it("reads the build ID from the served HTML marker", () => {
     expect(
       bundledBuildIdFromHtml(

--- a/clients/mobile/__tests__/bundled-build-reload.test.ts
+++ b/clients/mobile/__tests__/bundled-build-reload.test.ts
@@ -3,9 +3,25 @@ import {
   BUNDLED_BUILD_META_NAME,
   bundledBuildIdFromHtml,
   bundledBuildReloadClient,
+  resolveBundledDevelopment,
 } from "../scripts/bundled-build-reload";
 
 describe("bundled build reload", () => {
+  it("allows bundled mode only for development builds", () => {
+    expect(resolveBundledDevelopment("dev", undefined)).toBe(false);
+    expect(resolveBundledDevelopment("dev", "vite")).toBe(false);
+    expect(resolveBundledDevelopment("dev", "bundled")).toBe(true);
+    expect(() => resolveBundledDevelopment("staging", "bundled")).toThrow(
+      "requires TRAYCER_MOBILE_ENV=dev",
+    );
+    expect(() => resolveBundledDevelopment("production", "bundled")).toThrow(
+      "requires TRAYCER_MOBILE_ENV=dev",
+    );
+    expect(() => resolveBundledDevelopment("dev", "invalid")).toThrow(
+      "must be vite or bundled",
+    );
+  });
+
   it("seeds the reload client with the build that produced its HTML", () => {
     const client = bundledBuildReloadClient("build-one", "/build-revision");
 

--- a/clients/mobile/__tests__/bundled-build-reload.test.ts
+++ b/clients/mobile/__tests__/bundled-build-reload.test.ts
@@ -38,6 +38,16 @@ describe("bundled build reload", () => {
     expect(client).not.toContain("setInterval(");
   });
 
+  it("bounds a stalled build check before polling again", () => {
+    const client = bundledBuildReloadClient("build-one", "/build-revision");
+
+    expect(client).toContain("const controller = new AbortController();");
+    expect(client).toContain("signal: controller.signal");
+    expect(client).toContain("controller.abort()");
+    expect(client).toContain("clearTimeout(timeout);");
+    expect(client).toContain("Bundled build check failed; retrying");
+  });
+
   it("reads the build ID from the served HTML marker", () => {
     expect(
       bundledBuildIdFromHtml(

--- a/clients/mobile/package.json
+++ b/clients/mobile/package.json
@@ -9,6 +9,7 @@
     "build:web": "vite build --config vite.config.ts",
     "build:web:staging": "TRAYCER_MOBILE_ENV=staging vite build --config vite.config.ts",
     "dev:web": "vite --config vite.config.ts",
+    "dev:web:bundled": "bun scripts/dev-web-bundled.ts",
     "dev:ios": "bun scripts/dev-ios.ts",
     "dev:ios:device": "bun scripts/dev-ios-device.ts",
     "sync:ios": "bun run build:web && bun x cap sync ios",

--- a/clients/mobile/scripts/bundled-build-reload.ts
+++ b/clients/mobile/scripts/bundled-build-reload.ts
@@ -1,0 +1,43 @@
+export const BUNDLED_BUILD_META_NAME = "traycer-bundled-build";
+
+function htmlAttribute(tag: string, name: string): string | null {
+  const expression = new RegExp(
+    `\\b${name}\\s*=\\s*(?:"([^"]*)"|'([^']*)')`,
+    "i",
+  );
+  const match = expression.exec(tag);
+  return match?.[1] ?? match?.[2] ?? null;
+}
+
+export function bundledBuildIdFromHtml(html: string): string | null {
+  for (const tag of html.match(/<meta\b[^>]*>/gi) ?? []) {
+    if (htmlAttribute(tag, "name") !== BUNDLED_BUILD_META_NAME) continue;
+    const buildId = htmlAttribute(tag, "content");
+    return buildId === null || buildId.length === 0 ? null : buildId;
+  }
+  return null;
+}
+
+export function bundledBuildReloadClient(
+  buildId: string,
+  buildPath: string,
+): string {
+  return `
+(() => {
+  const activeBuild = ${JSON.stringify(buildId)};
+  const checkForBuild = async () => {
+    try {
+      const response = await fetch(${JSON.stringify(buildPath)}, {
+        cache: "no-store",
+      });
+      if (!response.ok) return;
+      const nextBuild = await response.text();
+      if (nextBuild !== activeBuild) location.reload();
+    } catch {
+      // A build can replace dist/web between polls. Retry on the next tick.
+    }
+  };
+  void checkForBuild();
+  setInterval(() => void checkForBuild(), 750);
+})();`;
+}

--- a/clients/mobile/scripts/bundled-build-reload.ts
+++ b/clients/mobile/scripts/bundled-build-reload.ts
@@ -44,15 +44,20 @@ export function bundledBuildReloadClient(
 (() => {
   const activeBuild = ${JSON.stringify(buildId)};
   const checkForBuild = async () => {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 10_000);
     try {
       const response = await fetch(${JSON.stringify(buildPath)}, {
         cache: "no-store",
+        signal: controller.signal,
       });
       if (!response.ok) return;
       const nextBuild = await response.text();
       if (nextBuild !== activeBuild) location.reload();
-    } catch {
-      // A build can replace dist/web between polls. Retry on the next tick.
+    } catch (error) {
+      console.warn("Bundled build check failed; retrying", error);
+    } finally {
+      clearTimeout(timeout);
     }
   };
   const pollForBuild = async () => {

--- a/clients/mobile/scripts/bundled-build-reload.ts
+++ b/clients/mobile/scripts/bundled-build-reload.ts
@@ -55,7 +55,10 @@ export function bundledBuildReloadClient(
       // A build can replace dist/web between polls. Retry on the next tick.
     }
   };
-  void checkForBuild();
-  setInterval(() => void checkForBuild(), 750);
+  const pollForBuild = async () => {
+    await checkForBuild();
+    setTimeout(() => void pollForBuild(), 750);
+  };
+  void pollForBuild();
 })();`;
 }

--- a/clients/mobile/scripts/bundled-build-reload.ts
+++ b/clients/mobile/scripts/bundled-build-reload.ts
@@ -1,5 +1,23 @@
 export const BUNDLED_BUILD_META_NAME = "traycer-bundled-build";
 
+export function resolveBundledDevelopment(
+  environment: "dev" | "staging" | "production",
+  rawMode: string | undefined,
+): boolean {
+  if (rawMode === undefined || rawMode === "vite") return false;
+  if (rawMode !== "bundled") {
+    throw new Error(
+      `TRAYCER_GUI_MODE must be vite or bundled (got "${rawMode}")`,
+    );
+  }
+  if (environment !== "dev") {
+    throw new Error(
+      `TRAYCER_GUI_MODE=bundled requires TRAYCER_MOBILE_ENV=dev (got "${environment}")`,
+    );
+  }
+  return true;
+}
+
 function htmlAttribute(tag: string, name: string): string | null {
   const expression = new RegExp(
     `\\b${name}\\s*=\\s*(?:"([^"]*)"|'([^']*)')`,

--- a/clients/mobile/scripts/dev-web-bundled.ts
+++ b/clients/mobile/scripts/dev-web-bundled.ts
@@ -1,0 +1,53 @@
+/**
+ * Tunnel-friendly GUI development server.
+ *
+ * Vite's normal dev server preserves each source module, which gives excellent
+ * HMR on a local machine but turns a cold page load into hundreds of serial
+ * requests over an SSH tunnel. This lane watches a non-minified build, serves
+ * it through Vite preview, and lets the injected build poller reload the page
+ * after a successful rebuild.
+ */
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { build, preview } from "vite";
+
+const mobileRoot = resolve(fileURLToPath(new URL("..", import.meta.url)));
+const configFile = resolve(mobileRoot, "vite.config.ts");
+
+process.env.TRAYCER_GUI_MODE = "bundled";
+
+const buildResult = await build({
+  configFile,
+  build: { watch: {} },
+});
+if (Array.isArray(buildResult) || !("on" in buildResult)) {
+  throw new Error("Vite did not start the bundled build watcher");
+}
+
+const watcher = buildResult;
+console.log("[gui-app] waiting for the initial bundled build");
+await new Promise<void>((resolveInitialBuild) => {
+  let buildFailed = false;
+  watcher.on("event", (event) => {
+    if (event.code === "START") buildFailed = false;
+    if (event.code === "ERROR") buildFailed = true;
+    if (event.code === "END" && !buildFailed) resolveInitialBuild();
+  });
+});
+
+const server = await preview({ configFile });
+console.log("[gui-app] bundled build ready; watching for changes");
+server.printUrls();
+
+let closing = false;
+async function close(): Promise<void> {
+  if (closing) return;
+  closing = true;
+  await Promise.all([watcher.close(), server.close()]);
+}
+
+for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"] as const) {
+  process.once(signal, () => {
+    void close().then(() => process.exit(0));
+  });
+}

--- a/clients/mobile/vite.config.ts
+++ b/clients/mobile/vite.config.ts
@@ -1,11 +1,16 @@
-import { readFileSync } from "node:fs";
+import { readFileSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 import babel from "@rolldown/plugin-babel";
 import tailwindcss from "@tailwindcss/vite";
 import { tanstackRouter } from "@tanstack/router-plugin/vite";
 import react, { reactCompilerPreset } from "@vitejs/plugin-react";
-import { defineConfig, type Plugin, type UserConfig } from "vite";
+import {
+  defineConfig,
+  type Connect,
+  type Plugin,
+  type UserConfig,
+} from "vite";
 import { sanitizeDevDesktopSlot } from "../shared/platform/dev-desktop-slot";
 import { devRelayBaseUrlFromEnv } from "../shared/platform/dev-backend-urls";
 
@@ -19,6 +24,8 @@ import { devRelayBaseUrlFromEnv } from "../shared/platform/dev-backend-urls";
 // against a local `make dev-desktop` host. The shipped mobile client reaches
 // remote hosts through real host discovery and must not depend on this.
 const DEV_HOST_PATH = "/__traycer/dev-host";
+const BUNDLED_BUILD_PATH = "/__traycer/bundled-build";
+const GUI_MODE_ENV = "TRAYCER_GUI_MODE";
 /** Mirrors the desktop's baked value (`clients/desktop/src/config.ts`). */
 const RELAY_BASE_URL = "wss://relay.traycer.ai/attach";
 
@@ -72,6 +79,13 @@ function resolveMobileEnvironment(): MobileEnvironment {
   throw new Error(
     `TRAYCER_MOBILE_ENV must be dev, staging or production (got "${raw}")`,
   );
+}
+
+function isBundledDevelopment(): boolean {
+  const raw = process.env[GUI_MODE_ENV];
+  if (raw === undefined || raw === "vite") return false;
+  if (raw === "bundled") return true;
+  throw new Error(`${GUI_MODE_ENV} must be vite or bundled (got "${raw}")`);
 }
 
 function shippedConfig(
@@ -175,22 +189,82 @@ function isMissingFile(error: unknown): boolean {
   return error instanceof Error && "code" in error && error.code === "ENOENT";
 }
 
+function devHostMiddleware(slot: string): Connect.SimpleHandleFunction {
+  return (_request, response) => {
+    const pidPath = devHostPidPath(slot);
+    let host: DevHostPid;
+    try {
+      host = parseDevHostPid(readFileSync(pidPath, "utf8"), pidPath);
+    } catch {
+      response.statusCode = 503;
+      response.end();
+      return;
+    }
+    response.setHeader("Content-Type", "application/json");
+    response.end(JSON.stringify(host));
+  };
+}
+
 function devHostEndpoint(slot: string): Plugin {
+  const middleware = devHostMiddleware(slot);
   return {
     name: "traycer-dev-host-endpoint",
     configureServer(server) {
-      server.middlewares.use(DEV_HOST_PATH, (_request, response) => {
-        const pidPath = devHostPidPath(slot);
-        let host: DevHostPid;
+      server.middlewares.use(DEV_HOST_PATH, middleware);
+    },
+    configurePreviewServer(server) {
+      server.middlewares.use(DEV_HOST_PATH, middleware);
+    },
+  };
+}
+
+function bundledBuildReload(): Plugin {
+  const indexPath = resolve(mobileRoot, "dist", "web", "index.html");
+  const reloadClient = `
+(() => {
+  let activeBuild = null;
+  const checkForBuild = async () => {
+    try {
+      const response = await fetch(${JSON.stringify(BUNDLED_BUILD_PATH)}, {
+        cache: "no-store",
+      });
+      if (!response.ok) return;
+      const nextBuild = await response.text();
+      if (activeBuild === null) {
+        activeBuild = nextBuild;
+      } else if (nextBuild !== activeBuild) {
+        location.reload();
+      }
+    } catch {
+      // A build can replace dist/web between polls. Retry on the next tick.
+    }
+  };
+  void checkForBuild();
+  setInterval(() => void checkForBuild(), 750);
+})();`;
+  return {
+    name: "traycer-bundled-build-reload",
+    transformIndexHtml() {
+      return [
+        {
+          tag: "script",
+          children: reloadClient,
+          injectTo: "head",
+        },
+      ];
+    },
+    configurePreviewServer(server) {
+      server.middlewares.use(BUNDLED_BUILD_PATH, (_request, response) => {
         try {
-          host = parseDevHostPid(readFileSync(pidPath, "utf8"), pidPath);
+          const stat = statSync(indexPath);
+          response.statusCode = 200;
+          response.setHeader("Cache-Control", "no-store");
+          response.setHeader("Content-Type", "text/plain; charset=utf-8");
+          response.end(`${stat.mtimeMs}:${stat.size}`);
         } catch {
           response.statusCode = 503;
           response.end();
-          return;
         }
-        response.setHeader("Content-Type", "application/json");
-        response.end(JSON.stringify(host));
       });
     },
   };
@@ -250,6 +324,7 @@ async function guiAppDevConfig(): Promise<TraycerMobileBakedConfig> {
 
 export default defineConfig(async (): Promise<UserConfig> => {
   const environment = resolveMobileEnvironment();
+  const bundledDevelopment = isBundledDevelopment();
   const config =
     environment === "dev"
       ? await guiAppDevConfig()
@@ -261,6 +336,7 @@ export default defineConfig(async (): Promise<UserConfig> => {
   // phone on the same LAN can load the bundle; everything else stays on
   // loopback.
   let server: UserConfig["server"];
+  let preview: UserConfig["preview"];
   if (environment === "dev") {
     const portRaw = requiredEnv("PORT");
     const port = Number.parseInt(portRaw, 10);
@@ -272,20 +348,24 @@ export default defineConfig(async (): Promise<UserConfig> => {
       typeof hostRaw === "string" && hostRaw.trim().length > 0
         ? hostRaw.trim()
         : "127.0.0.1";
-    server = {
-      host,
-      port,
-      strictPort: true,
-      // Pre-transform the app from its entry at server start instead of on
-      // the first browser request: the entry pulls in effectively all of
-      // gui-app through the react-compiler babel pass, which otherwise
-      // makes the first page load of a fresh stack take tens of seconds.
-      // Warmup shares the normal transform cache and module graph, so HMR,
-      // invalidation, and every later request behave exactly as before —
-      // nothing observes the request-triggered laziness, it only moves the
-      // same work earlier.
-      warmup: { clientFiles: ["./main.tsx"] },
-    };
+    if (bundledDevelopment) {
+      preview = { host, port, strictPort: true };
+    } else {
+      server = {
+        host,
+        port,
+        strictPort: true,
+        // Pre-transform the app from its entry at server start instead of on
+        // the first browser request: the entry pulls in effectively all of
+        // gui-app through the react-compiler babel pass, which otherwise
+        // makes the first page load of a fresh stack take tens of seconds.
+        // Warmup shares the normal transform cache and module graph, so HMR,
+        // invalidation, and every later request behave exactly as before —
+        // nothing observes the request-triggered laziness, it only moves the
+        // same work earlier.
+        warmup: { clientFiles: ["./main.tsx"] },
+      };
+    }
   }
 
   return {
@@ -297,6 +377,7 @@ export default defineConfig(async (): Promise<UserConfig> => {
       ...(config.devHost === null
         ? []
         : [devHostEndpoint(config.devHost.host.label)]),
+      ...(bundledDevelopment ? [bundledBuildReload()] : []),
       tanstackRouter({
         enableRouteGeneration: false,
         target: "react",
@@ -327,8 +408,13 @@ export default defineConfig(async (): Promise<UserConfig> => {
       target: "es2022",
       emptyOutDir: true,
       outDir: resolve(mobileRoot, "dist", "web"),
-      sourcemap: false,
+      // The tunnel-friendly development bundle favors rebuild speed and
+      // debuggability. Ordinary release builds retain Vite's minification and
+      // the existing no-sourcemap output.
+      minify: bundledDevelopment ? false : undefined,
+      sourcemap: bundledDevelopment,
     },
     server,
+    preview,
   };
 });

--- a/clients/mobile/vite.config.ts
+++ b/clients/mobile/vite.config.ts
@@ -5,12 +5,7 @@ import babel from "@rolldown/plugin-babel";
 import tailwindcss from "@tailwindcss/vite";
 import { tanstackRouter } from "@tanstack/router-plugin/vite";
 import react, { reactCompilerPreset } from "@vitejs/plugin-react";
-import {
-  defineConfig,
-  type Connect,
-  type Plugin,
-  type UserConfig,
-} from "vite";
+import { defineConfig, type Connect, type Plugin, type UserConfig } from "vite";
 import { sanitizeDevDesktopSlot } from "../shared/platform/dev-desktop-slot";
 import { devRelayBaseUrlFromEnv } from "../shared/platform/dev-backend-urls";
 

--- a/clients/mobile/vite.config.ts
+++ b/clients/mobile/vite.config.ts
@@ -13,6 +13,7 @@ import {
   BUNDLED_BUILD_META_NAME,
   bundledBuildIdFromHtml,
   bundledBuildReloadClient,
+  resolveBundledDevelopment,
 } from "./scripts/bundled-build-reload";
 
 // Dev-server endpoint that re-reads the host's pid.json on every request. The
@@ -80,13 +81,6 @@ function resolveMobileEnvironment(): MobileEnvironment {
   throw new Error(
     `TRAYCER_MOBILE_ENV must be dev, staging or production (got "${raw}")`,
   );
-}
-
-function isBundledDevelopment(): boolean {
-  const raw = process.env[GUI_MODE_ENV];
-  if (raw === undefined || raw === "vite") return false;
-  if (raw === "bundled") return true;
-  throw new Error(`${GUI_MODE_ENV} must be vite or bundled (got "${raw}")`);
 }
 
 function shippedConfig(
@@ -319,7 +313,10 @@ async function guiAppDevConfig(): Promise<TraycerMobileBakedConfig> {
 
 export default defineConfig(async (): Promise<UserConfig> => {
   const environment = resolveMobileEnvironment();
-  const bundledDevelopment = isBundledDevelopment();
+  const bundledDevelopment = resolveBundledDevelopment(
+    environment,
+    process.env[GUI_MODE_ENV],
+  );
   const config =
     environment === "dev"
       ? await guiAppDevConfig()

--- a/clients/mobile/vite.config.ts
+++ b/clients/mobile/vite.config.ts
@@ -1,4 +1,5 @@
-import { readFileSync, statSync } from "node:fs";
+import { randomUUID } from "node:crypto";
+import { readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 import babel from "@rolldown/plugin-babel";
@@ -8,6 +9,11 @@ import react, { reactCompilerPreset } from "@vitejs/plugin-react";
 import { defineConfig, type Connect, type Plugin, type UserConfig } from "vite";
 import { sanitizeDevDesktopSlot } from "../shared/platform/dev-desktop-slot";
 import { devRelayBaseUrlFromEnv } from "../shared/platform/dev-backend-urls";
+import {
+  BUNDLED_BUILD_META_NAME,
+  bundledBuildIdFromHtml,
+  bundledBuildReloadClient,
+} from "./scripts/bundled-build-reload";
 
 // Dev-server endpoint that re-reads the host's pid.json on every request. The
 // baked define config only captures the host port as of Vite startup; the dev
@@ -213,56 +219,50 @@ function devHostEndpoint(slot: string): Plugin {
   };
 }
 
-function bundledBuildReload(): Plugin {
+function bundledBuildReload(): readonly Plugin[] {
   const indexPath = resolve(mobileRoot, "dist", "web", "index.html");
-  const reloadClient = `
-(() => {
-  let activeBuild = null;
-  const checkForBuild = async () => {
-    try {
-      const response = await fetch(${JSON.stringify(BUNDLED_BUILD_PATH)}, {
-        cache: "no-store",
-      });
-      if (!response.ok) return;
-      const nextBuild = await response.text();
-      if (activeBuild === null) {
-        activeBuild = nextBuild;
-      } else if (nextBuild !== activeBuild) {
-        location.reload();
-      }
-    } catch {
-      // A build can replace dist/web between polls. Retry on the next tick.
-    }
-  };
-  void checkForBuild();
-  setInterval(() => void checkForBuild(), 750);
-})();`;
-  return {
-    name: "traycer-bundled-build-reload",
-    transformIndexHtml() {
-      return [
-        {
-          tag: "script",
-          children: reloadClient,
-          injectTo: "head",
-        },
-      ];
+  return [
+    {
+      name: "traycer-bundled-build-marker",
+      apply: "build",
+      transformIndexHtml() {
+        const buildId = randomUUID();
+        return [
+          {
+            tag: "meta",
+            attrs: { name: BUNDLED_BUILD_META_NAME, content: buildId },
+            injectTo: "head",
+          },
+          {
+            tag: "script",
+            children: bundledBuildReloadClient(buildId, BUNDLED_BUILD_PATH),
+            injectTo: "head",
+          },
+        ];
+      },
     },
-    configurePreviewServer(server) {
-      server.middlewares.use(BUNDLED_BUILD_PATH, (_request, response) => {
-        try {
-          const stat = statSync(indexPath);
-          response.statusCode = 200;
-          response.setHeader("Cache-Control", "no-store");
-          response.setHeader("Content-Type", "text/plain; charset=utf-8");
-          response.end(`${stat.mtimeMs}:${stat.size}`);
-        } catch {
-          response.statusCode = 503;
-          response.end();
-        }
-      });
+    {
+      name: "traycer-bundled-build-endpoint",
+      apply: "serve",
+      configurePreviewServer(server) {
+        server.middlewares.use(BUNDLED_BUILD_PATH, (_request, response) => {
+          try {
+            const buildId = bundledBuildIdFromHtml(
+              readFileSync(indexPath, "utf8"),
+            );
+            if (buildId === null) throw new Error("Missing bundled build ID");
+            response.statusCode = 200;
+            response.setHeader("Cache-Control", "no-store");
+            response.setHeader("Content-Type", "text/plain; charset=utf-8");
+            response.end(buildId);
+          } catch {
+            response.statusCode = 503;
+            response.end();
+          }
+        });
+      },
     },
-  };
+  ];
 }
 
 async function guiAppDevConfig(): Promise<TraycerMobileBakedConfig> {
@@ -372,7 +372,7 @@ export default defineConfig(async (): Promise<UserConfig> => {
       ...(config.devHost === null
         ? []
         : [devHostEndpoint(config.devHost.host.label)]),
-      ...(bundledDevelopment ? [bundledBuildReload()] : []),
+      ...(bundledDevelopment ? bundledBuildReload() : []),
       tanstackRouter({
         enableRouteGeneration: false,
         target: "react",


### PR DESCRIPTION
## Summary

- add a tunnel-friendly bundled watch mode for the shared GUI web shell
- serve the build through Vite preview with the live dev-host endpoint
- reload connected browsers after successful rebuilds while keeping the existing Vite mode as the default

## Related issue

No linked issue.

## Checklist

- [x] Focused static and browser checks pass
- [x] Separate GUI smoke checks pass
- [x] Tests added/updated where it makes sense
- [x] Commits are signed off