### PR TITLE
fix(gui-app): make the comment poll reachable, and release the transport on a worker fatal

### DIFF
--- a/clients/gui-app/src/components/comments/comment-sidebar.tsx
+++ b/clients/gui-app/src/components/comments/comment-sidebar.tsx
@@ -95,7 +95,7 @@ export function CommentSidebar(props: CommentSidebarProps) {
     epicId,
     artifactType: artifactType,
     artifactId: artifactId,
-    options: { enabled: true },
+    options: { enabled: true, laneDroppedAt },
   });
 
   const resolved = useMemo(

--- a/clients/gui-app/src/components/comments/thread-anchor-hover-popover.tsx
+++ b/clients/gui-app/src/components/comments/thread-anchor-hover-popover.tsx
@@ -126,7 +126,10 @@ export function ThreadAnchorHoverPopover(props: ThreadAnchorHoverPopoverProps) {
     epicId,
     artifactType: artifactType,
     artifactId: artifactId,
-    options: { enabled: false },
+    // `enabled: false` already means this surface never fires traffic, so the
+    // cadence is inert here - passed because the option is required, and
+    // required so no call site can silently omit the lane's liveness.
+    options: { enabled: false, laneDroppedAt },
   });
   const threadsById = useMemo(() => {
     const map = new Map<string, CommentThreadWire>();

--- a/clients/gui-app/src/components/epic-canvas/renderers/collab-tile-body.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/collab-tile-body.tsx
@@ -353,12 +353,15 @@ function CollabTileBodyEditor(props: CollabTileBodyEditorProps) {
     useTabHostId(),
     tabHostClient,
   );
+  // Read BEFORE the query below, which now takes it: the poll has to know
+  // whether the lane is still pushing to decide its cadence.
+  const laneDroppedAt = useEpicLaneCommentThreadsDroppedAt();
   const threadsQuery = useEpicCommentThreadsForClient({
     client: tabHostClient,
     epicId,
     artifactType: commentArtifactKind ?? "spec",
     artifactId: node.id,
-    options: { enabled: commentsSupported },
+    options: { enabled: commentsSupported, laneDroppedAt },
   });
   const clearFlashThread = useCommentThreadsStore((s) => s.clearFlashThread);
   // The state lane's records for this artifact, or `null` where it has said
@@ -368,7 +371,6 @@ function CollabTileBodyEditor(props: CollabTileBodyEditorProps) {
   // whose anchor the decoration layer strips as an orphan, leaving nothing to
   // hover.
   const laneThreads = useEpicLaneCommentThreads(node.id);
-  const laneDroppedAt = useEpicLaneCommentThreadsDroppedAt();
   const commentThreads = useMemo(
     () =>
       resolveArtifactCommentThreads({

--- a/clients/gui-app/src/hooks/comments/__tests__/use-epic-comment-threads-poll-wiring.test.tsx
+++ b/clients/gui-app/src/hooks/comments/__tests__/use-epic-comment-threads-poll-wiring.test.tsx
@@ -1,0 +1,214 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  focusManager,
+  QueryClient,
+  QueryClientProvider,
+  type Query,
+} from "@tanstack/react-query";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { HostClient } from "@traycer-clients/shared/host-client/host-client";
+import { mockLocalHostEntry } from "@traycer-clients/shared/host-client/mock/mock-host-directory";
+import { MockHostMessenger } from "@traycer-clients/shared/host-client/mock/mock-host-messenger";
+import { createRequestContextFixture } from "@traycer-clients/shared/test-fixtures/request-context";
+import { hostRpcRegistry, type HostRpcRegistry } from "@/lib/host";
+import { createHostQueryInvalidator } from "@/lib/host/query-invalidator";
+import { createAppQueryClient } from "@/lib/query-client";
+import { useEpicCommentThreadsForClient } from "@/hooks/comments/use-epic-comment-threads";
+
+const EPIC_ID = "epic-1";
+const ARTIFACT_ID = "artifact-1";
+const METHOD = "epic.listCommentThreads";
+
+/**
+ * The comment poll's WIRE, through the public hook.
+ *
+ * `use-lane-comment-threads.test.ts` pins the two halves separately - that
+ * `commentThreadsShouldPoll` answers correctly, and that the table carries a
+ * cadence for it to opt into. Neither observes the hook actually JOINING them:
+ * delete the `poll:` line from `useEpicCommentThreadsForClient` and every one
+ * of those assertions still passes, because the pure function and the table
+ * entry are both still exactly right. That is the same shape as the bug this
+ * fixes - a mechanism that reads as wired and schedules nothing - so it is
+ * pinned here from the outside, on the query TanStack actually built.
+ */
+describe("useEpicCommentThreadsForClient poll wiring", () => {
+  afterEach(() => {
+    focusManager.setFocused(undefined);
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it("builds no refetch interval while the lane is UP", async () => {
+    const fixture = createCommentThreadsFixture();
+    renderHook(
+      () =>
+        useEpicCommentThreadsForClient({
+          client: fixture.client,
+          epicId: EPIC_ID,
+          artifactType: "spec",
+          artifactId: ARTIFACT_ID,
+          options: { enabled: true, laneDroppedAt: null },
+        }),
+      { wrapper: fixture.Wrapper },
+    );
+
+    await waitFor(() => {
+      expect(fixture.requestCount.value).toBe(1);
+    });
+    expect(refetchIntervalFor(queryForMethod(fixture.queryClient))).toBe(false);
+  });
+
+  it("builds the table's 15s cadence once the lane has DROPPED", async () => {
+    const fixture = createCommentThreadsFixture();
+    renderHook(
+      () =>
+        useEpicCommentThreadsForClient({
+          client: fixture.client,
+          epicId: EPIC_ID,
+          artifactType: "spec",
+          artifactId: ARTIFACT_ID,
+          options: { enabled: true, laneDroppedAt: 1_000 },
+        }),
+      { wrapper: fixture.Wrapper },
+    );
+
+    await waitFor(() => {
+      expect(fixture.requestCount.value).toBe(1);
+    });
+    const query = queryForMethod(fixture.queryClient);
+    // The interval is the TABLE's, never a number this module chose -
+    // `refetchInterval` is `Omit`ted from `useHostQuery`'s surface precisely so
+    // cadence stays in `HOST_METHOD_POLL_TABLE`.
+    expect(refetchIntervalFor(query)).toBe(15_000);
+    // Asserted here rather than taken on trust: a blurred window must stop
+    // polling, with `refetchOnWindowFocus` covering the moment it returns.
+    expect(refetchIntervalInBackgroundFor(query)).toBe(false);
+  });
+
+  it("issues no further request while the lane is up, and does once it drops", async () => {
+    vi.useFakeTimers();
+    focusManager.setFocused(true);
+    const fixture = createCommentThreadsFixture();
+    // Annotated, not inferred: a bare `{ laneDroppedAt: null }` narrows the
+    // prop to `null` and the `rerender` below stops type-checking.
+    const initialProps: { readonly laneDroppedAt: number | null } = {
+      laneDroppedAt: null,
+    };
+    const rendered = renderHook(
+      (props: { readonly laneDroppedAt: number | null }) =>
+        useEpicCommentThreadsForClient({
+          client: fixture.client,
+          epicId: EPIC_ID,
+          artifactType: "spec",
+          artifactId: ARTIFACT_ID,
+          options: { enabled: true, laneDroppedAt: props.laneDroppedAt },
+        }),
+      { wrapper: fixture.Wrapper, initialProps },
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(fixture.requestCount.value).toBe(1);
+
+    // Four cadences' worth of time on a LIVE lane. The count must not move -
+    // this is the arm that would regress into polling every open sidebar.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+    expect(fixture.requestCount.value).toBe(1);
+
+    // The drop is the ONLY thing that changes between the two halves, which is
+    // what makes this a test of the wire rather than of the table.
+    rendered.rerender({ laneDroppedAt: 1_000 });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(15_000);
+    });
+    expect(fixture.requestCount.value).toBe(2);
+  });
+
+  it("stays silent on a DISABLED query even while the lane is down", async () => {
+    vi.useFakeTimers();
+    focusManager.setFocused(true);
+    const fixture = createCommentThreadsFixture();
+    renderHook(
+      () =>
+        useEpicCommentThreadsForClient({
+          client: fixture.client,
+          epicId: EPIC_ID,
+          artifactType: "spec",
+          artifactId: ARTIFACT_ID,
+          // The hover popover's shape: it reads cache and must never put
+          // traffic on the wire. TanStack runs no interval on a disabled
+          // query, and this pins that the poll opt-in did not change it.
+          options: { enabled: false, laneDroppedAt: 1_000 },
+        }),
+      { wrapper: fixture.Wrapper },
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+    expect(fixture.requestCount.value).toBe(0);
+  });
+});
+
+function queryForMethod(queryClient: QueryClient): Query {
+  const query = queryClient
+    .getQueryCache()
+    .getAll()
+    .find((entry) => entry.queryKey.includes(METHOD));
+  if (query === undefined) {
+    throw new Error(`No query cached for ${METHOD}`);
+  }
+  return query;
+}
+
+function refetchIntervalFor(query: Query): unknown {
+  const { options } = query;
+  return "refetchInterval" in options ? options.refetchInterval : undefined;
+}
+
+function refetchIntervalInBackgroundFor(query: Query): unknown {
+  return Reflect.get(query.options, "refetchIntervalInBackground");
+}
+
+function createCommentThreadsFixture(): {
+  readonly client: HostClient<HostRpcRegistry>;
+  readonly queryClient: QueryClient;
+  readonly requestCount: { value: number };
+  readonly Wrapper: (props: { readonly children: ReactNode }) => ReactNode;
+} {
+  const queryClient = createAppQueryClient();
+  const requestCount = { value: 0 };
+  const spine = new HostClient<HostRpcRegistry>({
+    registry: hostRpcRegistry,
+    invalidator: createHostQueryInvalidator(queryClient),
+    findHostById: (hostId) =>
+      hostId === mockLocalHostEntry.hostId ? mockLocalHostEntry : null,
+    messenger: new MockHostMessenger<HostRpcRegistry>({
+      registry: hostRpcRegistry,
+      requestId: () => "req-comment-threads-1",
+      handlers: {
+        "epic.listCommentThreads": () => {
+          requestCount.value += 1;
+          return { threads: [] };
+        },
+      },
+    }),
+  });
+  spine.setRequestContext(
+    createRequestContextFixture({
+      origin: "renderer",
+      bearerToken: "tok-1",
+    }),
+  );
+  const client = spine.createRequester(mockLocalHostEntry);
+  const Wrapper = (props: { readonly children: ReactNode }): ReactNode => (
+    <QueryClientProvider client={queryClient}>
+      {props.children}
+    </QueryClientProvider>
+  );
+  return { client, queryClient, requestCount, Wrapper };
+}

--- a/clients/gui-app/src/hooks/comments/__tests__/use-lane-comment-threads.test.ts
+++ b/clients/gui-app/src/hooks/comments/__tests__/use-lane-comment-threads.test.ts
@@ -4,6 +4,8 @@ import {
   resolveArtifactCommentThreads,
   selectLaneCommentThreads,
 } from "@/hooks/comments/use-lane-comment-threads";
+import { commentThreadsShouldPoll } from "@/hooks/comments/use-epic-comment-threads";
+import { HOST_METHOD_POLL_TABLE } from "@/lib/host-rpc-policy/host-method-policy-table";
 
 const ARTIFACT_ID = "artifact-1";
 
@@ -16,6 +18,45 @@ function threadFixture(threadId: string): CommentThreadWire {
     data: { createdByUserId: "user-1" },
   };
 }
+
+describe("commentThreadsShouldPoll", () => {
+  // THE PREMISE `resolveArtifactCommentThreads` RESTS ON. Its fallback hands
+  // precedence back to the poll only once the poll has answered SINCE the lane
+  // dropped - so if nothing makes the poll answer, that arm is unreachable and
+  // the resolver holds retained rows forever.
+  //
+  // Nothing did. The query configures `staleTime` and `refetchOnWindowFocus`,
+  // and `staleTime` marks data stale without SCHEDULING a request; a
+  // lane-status transition invalidates nothing. On a continuously focused
+  // window with a permanently dead lane, remote additions, deletions and
+  // status changes stayed frozen indefinitely.
+  it("polls while the lane is DOWN", () => {
+    expect(commentThreadsShouldPoll(1_000)).toBe(true);
+  });
+
+  it("does not poll while the lane is UP - the lane is the fresher source by construction", () => {
+    expect(commentThreadsShouldPoll(null)).toBe(false);
+  });
+
+  it("polls at a drop instant of 0, which is a real epoch value and not 'no drop'", () => {
+    // The same `0`-is-not-null trap the resolver's `pollUpdatedAt` documents,
+    // on the other input. A truthiness check here would read epoch as "the
+    // lane is up" and never poll.
+    expect(commentThreadsShouldPoll(0)).toBe(true);
+  });
+
+  it("has a table cadence for the flag to opt into - the flag alone polls nothing", () => {
+    // Both halves are required and they live in different files, so either can
+    // be removed without the other failing to compile. `poll: true` against a
+    // `poll: null` table entry is silently inert - `useHostQuery` only reads
+    // the flag when a policy exists - which is exactly the shape of the bug
+    // being fixed: a mechanism that looks wired and schedules nothing.
+    expect(HOST_METHOD_POLL_TABLE["epic.listCommentThreads"].poll).toEqual({
+      kind: "fixed",
+      intervalMs: 15_000,
+    });
+  });
+});
 
 describe("selectLaneCommentThreads", () => {
   it("returns null for a MISSING key - the lane has said nothing", () => {

--- a/clients/gui-app/src/hooks/comments/use-epic-comment-threads.ts
+++ b/clients/gui-app/src/hooks/comments/use-epic-comment-threads.ts
@@ -26,6 +26,55 @@ export interface UseEpicCommentThreadsOptions {
   /** Disables the query when the comments view is closed for an epic so
    *  the host RPC isn't fired needlessly. */
   readonly enabled: boolean;
+  /**
+   * When the records lane stopped pushing, or `null` while it is up - the same
+   * instant `useEpicLaneCommentThreadsDroppedAt` produces and
+   * `resolveArtifactCommentThreads` orders by.
+   *
+   * Here it decides whether the table's poll cadence applies right now. See
+   * {@link commentThreadsShouldPoll} for why the lane's liveness has to reach
+   * the query at all.
+   */
+  readonly laneDroppedAt: number | null;
+}
+
+/**
+ * Whether the poll should run its table-owned cadence, given the lane's state.
+ *
+ * WHY THE QUERY HAS TO KNOW. `resolveArtifactCommentThreads` hands precedence
+ * back to the poll once it has answered SINCE the lane dropped, and its doc
+ * used to justify having no lane-triggered refetch by saying the query
+ * "already refetches on window focus and after its stale window". The second
+ * half was never true: `staleTime` marks data stale, it does not SCHEDULE a
+ * request - only a mount, a focus, a reconnect or an invalidation fetches, and
+ * a lane-status transition invalidates nothing. So on a continuously focused
+ * window with a permanently dead lane and no local mutation, the poll never
+ * ran again and the resolver waited forever on an event that could not arrive:
+ * remote additions, deletions and status changes stayed frozen behind retained
+ * lane rows. Which is the resurrection bug the ordering rule was added to
+ * prevent, arriving by the other road.
+ *
+ * A cadence rather than an invalidation on the drop EDGE, because the harm is
+ * not confined to the transition: while the lane stays down the poll is the
+ * only source, so it has to keep answering, not answer once.
+ *
+ * A BOOLEAN, not an interval, because the interval is not this module's to
+ * choose: `useHostQuery` reserves `refetchInterval` and owns cadence through
+ * `HOST_METHOD_POLL_TABLE`, where this method's `{ kind: "fixed" }` entry
+ * lives. All a caller may say is whether the table's cadence applies right
+ * now. That seam also sets `refetchIntervalInBackground: false`, which is
+ * wanted here rather than merely tolerated: a blurred window stops polling and
+ * `refetchOnWindowFocus` covers the moment it returns, so the two answer both
+ * halves without either running twice.
+ *
+ * Pure and exported so the policy is pinnable without a QueryClient harness -
+ * the same reason `resolveArtifactCommentThreads` is a pure function beside
+ * its hook.
+ */
+export function commentThreadsShouldPoll(
+  laneDroppedAt: number | null,
+): boolean {
+  return laneDroppedAt !== null;
 }
 
 /**
@@ -63,6 +112,11 @@ export function useEpicCommentThreadsForClient(args: {
       enabled: options.enabled,
       staleTime: 15_000,
       refetchOnWindowFocus: true,
+      // The table's cadence, but only while the lane is down - see
+      // `commentThreadsShouldPoll`. A query with `enabled: false` (the hover
+      // popover, which reads cache and must never fire traffic) is unaffected
+      // either way: TanStack does not run an interval on a disabled query.
+      poll: commentThreadsShouldPoll(options.laneDroppedAt),
     },
   });
 }

--- a/clients/gui-app/src/hooks/comments/use-lane-comment-threads.ts
+++ b/clients/gui-app/src/hooks/comments/use-lane-comment-threads.ts
@@ -221,11 +221,21 @@ export function useEpicLaneCommentThreadsDroppedAt(): number | null {
  * a surface where nothing had changed.
  *
  * So a retained lane keeps precedence until the poll has answered SINCE the
- * drop. There is deliberately no lane-triggered refetch to hurry that along:
- * the rows on screen are the last thing the lane said, which is exactly what
- * retention promises, and the query already refetches on window focus and
- * after its stale window. A permanently dead lane on a never-blurred window is
- * the one case that waits, and it waits showing the newer of the two views.
+ * drop - and the poll has to be able to answer, which is what this rule's
+ * first version got wrong. It justified having no lane-triggered refetch by
+ * saying the query "already refetches on window focus and after its stale
+ * window". The second half was never true: `staleTime` marks data stale, it
+ * does not SCHEDULE a request, and a lane-status transition invalidates
+ * nothing. On a continuously focused window with a permanently dead lane the
+ * poll therefore never ran again, and this rule waited on an event that could
+ * not arrive - freezing remote additions, deletions and status changes behind
+ * retained rows, which is the resurrection above arriving by the other road.
+ *
+ * The lane's liveness now reaches the query, which polls while the lane is
+ * down - see `commentThreadsShouldPoll` in `use-epic-comment-threads.ts`.
+ * Retention is unchanged and still deliberate: the rows on screen remain the
+ * last thing the lane said, and they hold precedence until a poll genuinely
+ * answers later. What changed is that "later" is now bounded.
  *
  * Pure, and shared by every comment surface, so the sidebar, the hover preview
  * and the tile's decoration layer can never disagree about which threads exist

--- a/clients/gui-app/src/lib/host-rpc-policy/host-method-policy-table.ts
+++ b/clients/gui-app/src/lib/host-rpc-policy/host-method-policy-table.ts
@@ -997,7 +997,27 @@ export const HOST_METHOD_POLL_TABLE = {
     joinResponseTimeoutMs: null,
     poll: null,
   },
-  "epic.listCommentThreads": { ...LATEST_SCHEDULING, poll: null },
+  // A FIXED cadence the caller gates, not an always-on one. Comment threads
+  // normally arrive pushed on the records lane, and while that lane is up this
+  // poll must stay quiet - the lane is fresher by construction and a cadence
+  // beside it would be pure waste. But the lane's rows are RETAINED when it
+  // drops, and `resolveArtifactCommentThreads` only hands precedence back once
+  // the poll has answered SINCE that drop - so with no cadence at all, a
+  // permanently dead lane on a focused window froze the surface on retained
+  // rows indefinitely, hiding remote additions, deletions and status changes.
+  // `useEpicCommentThreadsForClient` therefore passes `poll` = "the lane is
+  // down" (`commentThreadsShouldPoll`).
+  //
+  // A condition policy would be the wrong shape: `classify` reads the
+  // RESPONSE, and the lane's liveness is not in it.
+  //
+  // 15s matches that hook's `staleTime`, deliberately - inside the stale
+  // window a read is served from cache anyway, so a tighter interval would
+  // spend requests to learn nothing.
+  "epic.listCommentThreads": {
+    ...LATEST_SCHEDULING,
+    poll: { kind: "fixed", intervalMs: 15 * SECOND_MS },
+  },
   "epic.resolveArtifactByPath": { ...LATEST_SCHEDULING, poll: null },
   "epic.searchArtifacts": { ...LATEST_SCHEDULING, poll: null },
   // The workspace context the decomposed lanes fetch at tab open. A read, so

--- a/clients/gui-app/src/stores/epics/open-epic/runtime/worker/__tests__/spawn-epic-runtime-worker.test.ts
+++ b/clients/gui-app/src/stores/epics/open-epic/runtime/worker/__tests__/spawn-epic-runtime-worker.test.ts
@@ -353,6 +353,54 @@ describe("spawnEpicRuntimeWorker", () => {
     );
   });
 
+  it("releases the transport when the worker fatals, without waiting for a retry", () => {
+    // THE LEAK THE FATAL PATH USED TO LEAVE BEHIND. `surfaceFatal` freed the
+    // accounting books and presented Retry, and stopped there - so `proxy`
+    // kept every real `IStreamSession` the worker had opened. Nothing else
+    // collected them: the provider MARKS the handle dead rather than
+    // disposing it (registry mutation belongs to the acquire effect), and
+    // that pass only runs if the user retries or reopens the epic. A user who
+    // does neither leaves host subscriptions live indefinitely, forwarding
+    // frames toward a bridge nothing reads.
+    //
+    // Cap-eviction cannot stand in for it either: the registry's
+    // `isEvictable` is `handle.isClean()`, which requires
+    // `hostTransportStatus === "open"` - not true of a session whose runtime
+    // just died.
+    const fixture = createFixture(false);
+    const recording = createRecordingStreamClient();
+    const relay = { log: vi.fn(), fatal: vi.fn() };
+    const handle = spawnEpicRuntimeWorker(
+      spawnOptions(
+        { createWorker: () => fixture.worker, projection: SILENT_PROJECTION },
+        { streams: recording.client, relay },
+      ),
+    );
+    openStreams(fixture, 3);
+    expect(recording.closedCount()).toBe(0);
+
+    fixture.pair.worker.post(
+      {
+        frame: "event",
+        event: { kind: "fatal", message: "runtime blew up", stack: null },
+      },
+      [],
+    );
+
+    // Every real session closed, and the thread stopped - no second gesture
+    // from the user required.
+    expect(recording.closedCount()).toBe(3);
+    expect(fixture.terminate).toHaveBeenCalledTimes(1);
+    // The relay still ran, and FIRST: the teardown must not cost the user the
+    // presentation that carries Retry.
+    expect(relay.fatal).toHaveBeenCalledWith("runtime blew up", null);
+    // And the handshake still rejects with the CAUSE. `dispose()` rejects an
+    // unsettled `ready` with its own "disposed before it was ready", so a
+    // teardown ordered before the rejection would replace the reason with the
+    // consequence.
+    return expect(handle.ready).rejects.toThrow("runtime blew up");
+  });
+
   it("closes every real session the worker opened when it disposes", () => {
     // Rule 3: a worker that is terminated mid-life never sends its own closes.
     // A real session left subscribed is a socket carrying frames nothing reads.

--- a/clients/gui-app/src/stores/epics/open-epic/runtime/worker/__tests__/spawn-epic-runtime-worker.test.ts
+++ b/clients/gui-app/src/stores/epics/open-epic/runtime/worker/__tests__/spawn-epic-runtime-worker.test.ts
@@ -241,6 +241,53 @@ describe("spawnEpicRuntimeWorker", () => {
     handle.dispose();
   });
 
+  it("survives a fault delivered while the handle is still constructing", async () => {
+    // THE TEMPORAL DEAD ZONE THE FATAL TEARDOWN OPENED. `surfaceFatal` now
+    // calls `disposeHandle()`, which reads `disposed` and three unsubscribes
+    // declared far BELOW the `onWorkerFault` subscription - subscribed early
+    // on purpose, because a module that fails to evaluate can have faulted
+    // before this handle finishes constructing. An implementation that
+    // answers that by replaying the fault synchronously on subscribe would
+    // hit those bindings in their TDZ, and the `ReferenceError` would come
+    // out of the CONSTRUCTOR - replacing the failed presentation and the
+    // rejected `ready` with a crash, which is strictly worse than the leak
+    // the teardown was added to fix.
+    //
+    // Nothing in `RuntimeWorkerLike` forbids that implementation; the DOM
+    // adapter merely happens not to be one, since `error` arrives as a task.
+    // The bridge's own `fatal` reaches the same place by the other road, from
+    // inside the synchronous `bootstrap` emit.
+    const pair = createFakeBridgePair("sync");
+    const terminate = vi.fn();
+    const worker: RuntimeWorkerLike = {
+      ...createFakeWorkerTarget(pair),
+      terminate,
+      onWorkerFault: (listener) => {
+        listener("the epic runtime worker module failed to load");
+      },
+    };
+    const relay = { log: vi.fn(), fatal: vi.fn() };
+
+    // Construction itself is the first assertion: under the bug this throws.
+    const handle = spawnEpicRuntimeWorker(
+      spawnOptions(
+        { createWorker: () => worker, projection: SILENT_PROJECTION },
+        { relay },
+      ),
+    );
+
+    // The visible half still ran immediately, in the same order as a mid-life
+    // fatal - the deferral moves the TEARDOWN, not the presentation.
+    expect(relay.fatal).toHaveBeenCalledWith(
+      "the epic runtime worker module failed to load",
+      null,
+    );
+    // And the deferred teardown was discharged rather than dropped: a fatal
+    // that only presented would leave the thread running.
+    expect(terminate).toHaveBeenCalledTimes(1);
+    await expect(handle.ready).rejects.toThrow("module failed to load");
+  });
+
   it("disposes idempotently by sending shutdown before terminating", async () => {
     const fixture = createFixture(false);
     const handle = spawnEpicRuntimeWorker(

--- a/clients/gui-app/src/stores/epics/open-epic/runtime/worker/spawn-epic-runtime-worker.ts
+++ b/clients/gui-app/src/stores/epics/open-epic/runtime/worker/spawn-epic-runtime-worker.ts
@@ -396,14 +396,39 @@ export function spawnEpicRuntimeWorker<TProjection>(
     // attached to the process planes. Without this the accountant keeps a
     // dead runtime's cached numbers and dispatches demote requests into a
     // bridge nothing is listening on - a plane that never reclaims and never
-    // explains why. Idempotent, so the `dispose()` that follows a surfaced
-    // fatal is not a second deregistration.
+    // explains why. Idempotent, so the `dispose()` below is not a second
+    // deregistration.
     accounting.dispose();
     options.relay.fatal(message, stack);
     // A fatal before the handshake is the handshake's answer. After it, the
     // promise has already settled and this is a no-op - the relay is what
     // surfaces a mid-life fatal.
+    //
+    // BEFORE the teardown below, and that order is load-bearing: `dispose()`
+    // rejects an unsettled `ready` with its own "disposed before it was
+    // ready", so tearing down first would replace the cause with the
+    // consequence and hand every awaiter the wrong reason.
     failReady?.(new Error(message));
+    // AND RELEASE THE TRANSPORT. Until this, the fatal path freed the books
+    // and presented Retry while `proxy` kept every real `IStreamSession` the
+    // worker had opened - so a user who neither retried nor reopened the epic
+    // left host subscriptions live indefinitely, forwarding frames toward a
+    // bridge nothing reads. Nothing else collected them: the provider marks
+    // the handle dead rather than disposing it (registry mutation belongs to
+    // the acquire effect), and that pass only runs if the user comes back.
+    // Cap-eviction cannot stand in either - `isClean()` requires
+    // `hostTransportStatus === "open"`, which a session whose runtime just
+    // died does not have.
+    //
+    // Through `dispose()` rather than a fatal-only teardown, for the reason
+    // `dispose()` itself gives about `detach()`: a second copy of the
+    // close-then-teardown ordering is what got it wrong the first time. It is
+    // idempotent, it is safe from inside a bridge event (the dispatch
+    // iterates a COPY of the listener set precisely so a listener may
+    // unsubscribe during it), and it touches no registry - this is the
+    // runtime worker handle, one level below the session handle the provider
+    // is talking about.
+    disposeHandle();
   };
 
   // The failure the bridge cannot carry. Subscribed BEFORE the bootstrap is
@@ -601,6 +626,47 @@ export function spawnEpicRuntimeWorker<TProjection>(
     detaching?.dispose();
   }
 
+  // A hoisted declaration rather than a method on the object below, because
+  // `surfaceFatal` calls it and is defined earlier: the fatal path now
+  // releases the transport, not just the books.
+  function disposeHandle(): void {
+    if (disposed) return;
+    disposed = true;
+    // Detach FIRST, and through the same function the detach-only path uses -
+    // one copy of the close-then-teardown ordering, because a second copy is
+    // what got it wrong the first time.
+    detach();
+    // Only then stop routing. Unsubscribing before the detach drops every
+    // report even on a live bridge.
+    unsubscribeEvents();
+    // The transport outlives this worker on the retained-buffer path, so a
+    // manifest listener left behind would emit onto a disposed bridge every
+    // time that connection re-handshakes. BOTH of them: the registry is
+    // module-scoped and process-wide, so a listener leaked there outlives not
+    // just the transport but every session on it.
+    unsubscribeMethodSupport();
+    unsubscribeNegotiatedManifests();
+    // The worker will not get to say `accounting/books registered: false` -
+    // it is about to be terminated - so main releases the holders itself.
+    accounting.dispose();
+    // Ask before killing. `shutdown` lets the worker dispose its own core -
+    // a durable store mid-write, a transport mid-close - whereas
+    // `terminate()` stops it between two machine instructions.
+    bridge.emit({ kind: "shutdown" }, NO_TRANSFER);
+    bridge.dispose();
+    // Nothing waits on the shutdown being observed: a worker that stopped
+    // answering is exactly the case `terminate()` is for, and holding the
+    // window open on it would make disposal depend on the health of the
+    // thing being disposed.
+    worker.terminate();
+    // A never-settled `ready` outlives the handle otherwise, and its awaiter
+    // hangs on a worker that no longer exists. A no-op when a fatal already
+    // rejected it with the real cause.
+    failReady?.(
+      new Error("The epic runtime worker was disposed before it was ready"),
+    );
+  }
+
   return {
     port: bridge,
     ready,
@@ -626,42 +692,7 @@ export function spawnEpicRuntimeWorker<TProjection>(
       bridge.emit({ kind: "runtime/command", command }, NO_TRANSFER);
     },
     detach,
-    dispose(): void {
-      if (disposed) return;
-      disposed = true;
-      // Detach FIRST, and through the same function the detach-only path uses -
-      // one copy of the close-then-teardown ordering, because a second copy is
-      // what got it wrong the first time.
-      detach();
-      // Only then stop routing. Unsubscribing before the detach drops every
-      // report even on a live bridge.
-      unsubscribeEvents();
-      // The transport outlives this worker on the retained-buffer path, so a
-      // manifest listener left behind would emit onto a disposed bridge every
-      // time that connection re-handshakes. BOTH of them: the registry is
-      // module-scoped and process-wide, so a listener leaked there outlives not
-      // just the transport but every session on it.
-      unsubscribeMethodSupport();
-      unsubscribeNegotiatedManifests();
-      // The worker will not get to say `accounting/books registered: false` -
-      // it is about to be terminated - so main releases the holders itself.
-      accounting.dispose();
-      // Ask before killing. `shutdown` lets the worker dispose its own core -
-      // a durable store mid-write, a transport mid-close - whereas
-      // `terminate()` stops it between two machine instructions.
-      bridge.emit({ kind: "shutdown" }, NO_TRANSFER);
-      bridge.dispose();
-      // Nothing waits on the shutdown being observed: a worker that stopped
-      // answering is exactly the case `terminate()` is for, and holding the
-      // window open on it would make disposal depend on the health of the
-      // thing being disposed.
-      worker.terminate();
-      // A never-settled `ready` outlives the handle otherwise, and its awaiter
-      // hangs on a worker that no longer exists.
-      failReady?.(
-        new Error("The epic runtime worker was disposed before it was ready"),
-      );
-    },
+    dispose: disposeHandle,
   };
 }
 

--- a/clients/gui-app/src/stores/epics/open-epic/runtime/worker/spawn-epic-runtime-worker.ts
+++ b/clients/gui-app/src/stores/epics/open-epic/runtime/worker/spawn-epic-runtime-worker.ts
@@ -391,6 +391,36 @@ export function spawnEpicRuntimeWorker<TProjection>(
    * independent, and a second copy would drift on whichever one a later
    * reader thought was the incidental part.
    */
+  /**
+   * Whether construction has reached the point where `disposeHandle` can run.
+   *
+   * A fatal can arrive DURING construction, and `disposeHandle` reads bindings
+   * declared well below this line - `disposed`, and the three unsubscribes -
+   * so calling it early would hit their temporal dead zone and throw a
+   * `ReferenceError` from the constructor, replacing the failed presentation
+   * and the rejected `ready` with a crash. Two ways in, not one:
+   *
+   *  - `worker.onWorkerFault` is subscribed above the bootstrap on purpose,
+   *    because a module that fails to evaluate can have faulted already, and
+   *    nothing in `RuntimeWorkerLike` forbids an implementation that replays
+   *    that fault synchronously on subscribe;
+   *  - the bridge's own `fatal` event, which a synchronous in-process bridge
+   *    can deliver from inside the `bootstrap` emit below.
+   *
+   * Deferring rather than reordering the subscriptions: the fatal's VISIBLE
+   * half - the relay call and the `ready` rejection - still runs immediately
+   * and in the same order, and every subscription that gets created still gets
+   * torn down, which moving the teardown earlier could not promise.
+   *
+   * An OBJECT rather than two `let` booleans, and not as a style choice:
+   * `surfaceFatal` assigns them from inside a closure, which TypeScript's
+   * control-flow analysis does not model, so a plain `let x = false` stays
+   * narrowed to `false` at the discharge site below and
+   * `no-unnecessary-condition` rejects reading it. Property narrowing is
+   * invalidated by the intervening calls, so this reads honestly.
+   */
+  const fatalTeardown = { constructionComplete: false, deferred: false };
+
   const surfaceFatal = (message: string, stack: string | null): void => {
     // The runtime behind the bridge is gone, so its books must not stay
     // attached to the process planes. Without this the accountant keeps a
@@ -428,12 +458,22 @@ export function spawnEpicRuntimeWorker<TProjection>(
     // unsubscribe during it), and it touches no registry - this is the
     // runtime worker handle, one level below the session handle the provider
     // is talking about.
-    disposeHandle();
+    //
+    // Deferred when the fatal beat construction to it - see `fatalTeardown`.
+    // The phase is read, not the clock: a fatal on the very first tick and one
+    // an hour later take the same path.
+    if (fatalTeardown.constructionComplete) {
+      disposeHandle();
+      return;
+    }
+    fatalTeardown.deferred = true;
   };
 
   // The failure the bridge cannot carry. Subscribed BEFORE the bootstrap is
   // emitted below, because a module that fails to evaluate can have already
-  // faulted by the time this handle finishes constructing.
+  // faulted by the time this handle finishes constructing. An implementation
+  // that answers that by replaying the fault synchronously right here is
+  // exactly what `fatalTeardown` above exists to survive.
   worker.onWorkerFault((message) => {
     // No stack: this arrives as a DOM `ErrorEvent`, whose `error` is `null`
     // for a module that never evaluated, and the worker had no chance to
@@ -665,6 +705,15 @@ export function spawnEpicRuntimeWorker<TProjection>(
     failReady?.(
       new Error("The epic runtime worker was disposed before it was ready"),
     );
+  }
+
+  // Everything `disposeHandle` touches now exists, so the deferral above can
+  // be discharged. Before the `return`, deliberately: the caller is handed an
+  // already-disposed handle whose `ready` is already rejected with the real
+  // cause, rather than a live-looking one over a worker that is going away.
+  fatalTeardown.constructionComplete = true;
+  if (fatalTeardown.deferred) {
+    disposeHandle();
   }
 
   return {


### PR DESCRIPTION
Follow-up to #1589, fixing the two P2s Codex posted against its merged head. Both are the same species: a mechanism that reads as wired and schedules nothing.

Each finding was validated against the merged code before anything was changed — one of them turned out to be real with the wrong attribution, noted below.

---

## 1. The comment poll became unreachable once the records lane dropped

`resolveArtifactCommentThreads` retains the lane's rows when it drops, and hands precedence back to the poll only once the poll has answered **since** that drop. Its own doc justified having no lane-triggered refetch like this:

> the query already refetches on window focus and after its stale window

The second half was never true. `staleTime` marks data stale; it does not *schedule* a request — only a mount, focus, reconnect or invalidation fetches, and a lane-status transition invalidates nothing. The query is configured with exactly `staleTime: 15_000` and `refetchOnWindowFocus: true`.

So on a continuously focused window with a permanently dead records lane and no local mutation, the poll never ran again and that fallback arm was **unreachable**. Remote additions, deletions and status changes stayed frozen behind retained rows — the same resurrection the ordering rule was added to prevent, arriving by the other road.

**Fix.** The lane's liveness now reaches the query: `UseEpicCommentThreadsOptions` takes the `laneDroppedAt` its callers already compute, and `commentThreadsShouldPoll` turns it into the poll opt-in.

Through the poll **table**, not `refetchInterval` — my first attempt used the latter and the compiler rejected it, correctly. `refetchInterval` is deliberately `Omit`ted from `useHostQuery`'s surface because cadence is owned by `HOST_METHOD_POLL_TABLE`, so `epic.listCommentThreads` gains a `{ kind: "fixed", intervalMs: 15s }` entry the caller gates. A *condition* policy would be the wrong shape: `classify` reads the response, and the lane's liveness is not in it.

That seam also sets `refetchIntervalInBackground: false`, which is wanted rather than tolerated — a blurred window stops polling and `refetchOnWindowFocus` covers its return, so the two answer both halves without either running twice. The hover popover is `enabled: false` and is unaffected either way.

A cadence rather than an invalidation on the drop *edge*, because the harm is not confined to the transition: while the lane stays down the poll is the only source, so it has to keep answering rather than answer once.

The resolver's doc is corrected rather than left standing — it is where the next reader would go to check this.

## 2. A worker fatal freed the books and leaked the transport

`surfaceFatal` released the accounting books, told the relay and rejected the handshake. It did not dispose `proxy`, so every real `IStreamSession` the worker had opened stayed subscribed.

Nothing else collected them:

- the provider **marks** the handle dead rather than disposing it (registry mutation belongs to the acquire effect), and that pass only runs if the user retries or reopens the epic;
- cap-eviction cannot stand in either — `isEvictable` is `handle.isClean()`, which requires `hostTransportStatus === "open"`, not true of a session whose runtime just died.

A user who neither retried nor reopened left host subscriptions live indefinitely, forwarding frames toward a bridge nothing reads.

**Fix.** The fatal path now tears down, through `dispose()` rather than a fatal-only teardown — the reason `dispose()` itself gives about `detach()`: a second copy of the close-then-teardown ordering is what got it wrong the first time. `dispose` becomes a hoisted declaration so the earlier `surfaceFatal` can reach it. It is safe from inside a bridge event (the dispatch iterates a **copy** of the listener set precisely so a listener may unsubscribe during it) and touches no registry — this is the runtime worker handle, one level below the session handle the provider's comment is about.

Ordered **after** the relay and the rejection, and that is load-bearing: `dispose()` rejects an unsettled `ready` with its own `"disposed before it was ready"`, so tearing down first would replace the cause with the consequence.

**On attribution:** the review tied this to #1589's asynchronous-startup fix. A worker whose module never evaluated has opened no streams, so nothing leaks on that path. The leak is the **mid-life** fatal and predates that change; the new entry point only made the existing gap easier to reach. Fixed regardless — the causal claim is what is being corrected, not the finding.

---

## Pins

| Pin | Ablation | Reddens |
| --- | --- | --- |
| `commentThreadsShouldPoll` down / up / epoch-zero | neuter the flag | those pins only |
| the table entry exists for the flag to opt into | revert entry to `poll: null` | that pin only |
| a fatal closes all 3 sessions + terminates, relay still first, `ready` still rejects with the cause | remove the fatal teardown | that pin only |

The cross-file pin is there because both halves are required and live in different files, so either can be removed without the other failing to compile. `poll: true` against a `poll: null` entry is silently inert — which is the exact shape of the bug being fixed.


---

## Review round 1

Both findings were real. Neither was a point fix.

**CodeRabbit — the poll had no coverage through the public hook.** Verified rather than assumed: replacing the hook's `poll:` argument with a literal `false` left *all 27 existing assertions green*, because the pure function and the table entry are both still exactly right in that state and nothing was looking at the query TanStack built from them. That is the same shape as the bug this PR fixes. `use-epic-comment-threads-poll-wiring.test.tsx` now drives the real hook through a `QueryClientProvider` over a `MockHostMessenger`: lane up builds no interval, lane dropped builds the table's 15s one, four cadences pass on a live lane with no second request and one after the drop produces it, and a disabled query stays silent with the lane down. `poll: false` reddens exactly two of the four.

**Codex (P2) — the fatal teardown opened a temporal dead zone.** `disposeHandle` reads `disposed` and three unsubscribes declared far below the `onWorkerFault` subscription, so a fault delivered *during* construction would throw a `ReferenceError` out of the constructor — strictly worse than the leak the teardown was added to fix. Correctly attributed to this PR: `surfaceFatal`'s prior body only touched `accounting` and `failReady`, both declared above it.

Two things beyond the report. There are **two roads** into it — the bridge's own `fatal` reaches the same place from inside the synchronous `bootstrap` emit — so the fix is keyed on the construction *phase* rather than the caller, and covers both. And the fix takes Codex's second suggestion (defer disposal) rather than its first (reorder the subscriptions), because reordering leaves a worse hole: an early fatal would set `disposed` and then let the manifest subscriptions be created afterwards, leaking them into a process-wide registry. Ablated by restoring the direct call: the new pin alone reddens, with `ReferenceError: Cannot access 'disposed' before initialization`.

Not reachable in production today — the DOM adapter's `error` arrives as a task, and the in-process worker's `onWorkerFault` is a no-op — but nothing in `RuntimeWorkerLike` forbids a synchronous replay, and the subscription's own comment invites one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

