### PR TITLE
fix(gui-app): re-measure hosted tile geometry when a split reverses

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/tile-surface-geometry-coordinator.test.ts
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/__tests__/tile-surface-geometry-coordinator.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   registerTileSurfaceGeometryHost,
   registerTileSurfaceGeometrySlot,
+  remeasureTileSurfaceGeometry,
   resetTileSurfaceGeometryCoordinatorForTesting,
   type TileSurfaceRect,
 } from "@/components/epic-canvas/surface-host/tile-surface-geometry-coordinator";
@@ -175,6 +176,47 @@ describe("host-root movement invalidates every registered slot", () => {
     expect(rectsA).toEqual([{ left: 100, top: 100, width: 50, height: 50 }]);
     expect(rectsB).toEqual([{ left: 300, top: 300, width: 50, height: 50 }]);
     expect(hostRectRead).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("explicit remeasure (position-only move)", () => {
+  it("re-applies every registered slot's rect on an explicit remeasure when only its position changed and no RO callback fired", () => {
+    const host = document.createElement("div");
+    stubRect(host, { left: 0, top: 0, width: 1000, height: 600 });
+    registerTileSurfaceGeometryHost(host);
+
+    const slotA = document.createElement("div");
+    stubRect(slotA, { left: 0, top: 0, width: 500, height: 600 });
+    const rectsA: TileSurfaceRect[] = [];
+    registerTileSurfaceGeometrySlot("chat-a", slotA, (rect) =>
+      rectsA.push(rect),
+    );
+
+    const slotB = document.createElement("div");
+    stubRect(slotB, { left: 500, top: 0, width: 500, height: 600 });
+    const rectsB: TileSurfaceRect[] = [];
+    registerTileSurfaceGeometrySlot("chat-b", slotB, (rect) =>
+      rectsB.push(rect),
+    );
+
+    rectsA.length = 0;
+    rectsB.length = 0;
+
+    // Position-only move: ONLY `left` changes, width/height stay identical -
+    // exactly the "Reverse views" swap condition (`swapSplitSides`) that a
+    // ResizeObserver cannot see, since it only fires on a SIZE change.
+    stubRect(slotA, { left: 500, top: 0, width: 500, height: 600 });
+    stubRect(slotB, { left: 0, top: 0, width: 500, height: 600 });
+
+    // No RO callback is triggered here - proves the RO path alone cannot see
+    // a position-only move: nothing has been delivered yet.
+    expect(rectsA).toEqual([]);
+    expect(rectsB).toEqual([]);
+
+    remeasureTileSurfaceGeometry();
+
+    expect(rectsA).toEqual([{ left: 500, top: 0, width: 500, height: 600 }]);
+    expect(rectsB).toEqual([{ left: 0, top: 0, width: 500, height: 600 }]);
   });
 });
 

--- a/clients/gui-app/src/components/epic-canvas/surface-host/tile-surface-geometry-coordinator.ts
+++ b/clients/gui-app/src/components/epic-canvas/surface-host/tile-surface-geometry-coordinator.ts
@@ -99,6 +99,21 @@ function applyAllRegisteredRects(): void {
 }
 
 /**
+ * Re-reads every registered slot's rect right now, outside any observer
+ * callback. The shared `ResizeObserver` only fires on a SIZE change, so a
+ * layout change that moves a slot without resizing it - "Reverse views" on
+ * a top-level split, which swaps the two panes' `left` offsets while each
+ * keeps its own width - never reaches `applyAllRegisteredRects` on its own,
+ * and every hosted body stays painted at its pre-move rect while the pane
+ * chrome around it (tab strip, sidebar) has already moved. The layout that
+ * performs such a move calls this after commit, from a layout effect, so the
+ * rects it reads are the post-move ones.
+ */
+export function remeasureTileSurfaceGeometry(): void {
+  applyAllRegisteredRects();
+}
+
+/**
  * Registers the plane's own root element as the coordinate origin every
  * slot rect is reported relative to. Exactly one host element is expected
  * live at a time; a later register replaces the origin outright (the

--- a/clients/gui-app/src/components/layout/__tests__/top-level-tab-host.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/top-level-tab-host.test.tsx
@@ -1010,3 +1010,158 @@ describe("TopLevelTabHost hosted-plane wiring (design-review F3: real pointerdow
     expect(activatedTab.id).toBe(EPIC_B.id);
   });
 });
+
+/**
+ * "Reverse views" on a top-level split (`swapSplitSides`) exchanges the two
+ * sides' `left` offsets while each side keeps its own width - at ratio 0.5
+ * literally, and at any other ratio because `1 - leftRatio` on the other side
+ * is the width it already had. A hosted chat body is positioned by rects the
+ * geometry coordinator reads inside a ResizeObserver callback, and a
+ * ResizeObserver reports SIZE changes only, so nothing about the swap reached
+ * the coordinator: both hosted bodies stayed painted at their pre-swap rects
+ * while the tab strips and sidebars around them had already crossed over,
+ * overlapping the other side's sidebar. This pins the remeasure
+ * `TopLevelTabHost` now performs on every placement change. The
+ * `ControllableResizeObserver` installed above never fires unless triggered,
+ * and this test deliberately never triggers it - that IS the real-world
+ * condition for a position-only move.
+ */
+describe("TopLevelTabHost re-measures hosted geometry on a position-only placement change (Reverse views)", () => {
+  const CHAT_A = "reverse-views-chat-a";
+  const CHAT_B = "reverse-views-chat-b";
+  const PANE_ID = "p1";
+
+  beforeEach(() => {
+    window.localStorage.clear();
+    useTabsStore.setState(useTabsStore.getInitialState(), true);
+    useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
+    useLandingDraftStore.setState(useLandingDraftStore.getInitialState(), true);
+    tabCommandCoordinator.resetReconciliationForTesting();
+    resetTileSurfaceMembershipForTesting();
+    resetTileSurfaceEnvironmentRegistryForTesting();
+    stableTileSurfaceHostTestState.enabled = true;
+  });
+
+  afterEach(() => {
+    cleanup();
+    stableTileSurfaceHostTestState.enabled = false;
+    useTabsStore.setState(useTabsStore.getInitialState(), true);
+    useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
+    useLandingDraftStore.setState(useLandingDraftStore.getInitialState(), true);
+    tabCommandCoordinator.resetReconciliationForTesting();
+    resetTileSurfaceMembershipForTesting();
+    resetTileSurfaceEnvironmentRegistryForTesting();
+  });
+
+  function stubAnchorRect(
+    anchor: HTMLDivElement,
+    rect: { readonly left: number; readonly width: number },
+  ): void {
+    anchor.getBoundingClientRect = () => ({
+      left: rect.left,
+      top: 0,
+      width: rect.width,
+      height: 600,
+      right: rect.left + rect.width,
+      bottom: 600,
+      x: rect.left,
+      y: 0,
+      toJSON: () => ({}),
+    });
+  }
+
+  function seedChatCanvas(epic: TabRef, instanceId: string): void {
+    useEpicCanvasStore.setState((state) => ({
+      ...state,
+      canvasByTabId: {
+        ...state.canvasByTabId,
+        [epic.id]: {
+          root: pane(PANE_ID, [instanceId]),
+          activePaneId: PANE_ID,
+          tilesByInstanceId: {
+            [instanceId]: {
+              id: instanceId,
+              instanceId,
+              type: "chat" as const,
+              name: `Chat ${instanceId}`,
+              hostId: TEST_HOST_ID,
+            },
+          },
+          sizesByGroupId: {},
+        },
+      },
+    }));
+  }
+
+  async function hostedRecord(instanceId: string): Promise<HTMLElement> {
+    return waitFor(() => {
+      const element = document.querySelector(
+        `[${HOSTED_TILE_INSTANCE_ID_ATTRIBUTE}="${instanceId}"]`,
+      );
+      if (!(element instanceof HTMLElement)) {
+        throw new Error(`hosted record ${instanceId} not yet published`);
+      }
+      return element;
+    });
+  }
+
+  it("moves both hosted bodies to their swapped slots when the sides exchange offsets but keep their widths, with no ResizeObserver callback", async () => {
+    seedSources([EPIC_A, EPIC_B]);
+    seedChatCanvas(EPIC_A, CHAT_A);
+    seedChatCanvas(EPIC_B, CHAT_B);
+    setSplit(EPIC_A, EPIC_B, "left");
+
+    render(<TopLevelTabHost />);
+
+    // The two slots as the DOM lays them out before the swap: A fills the
+    // left half, B the right half, equal widths.
+    const anchorA = document.createElement("div");
+    const anchorB = document.createElement("div");
+    stubAnchorRect(anchorA, { left: 0, width: 500 });
+    stubAnchorRect(anchorB, { left: 500, width: 500 });
+
+    act(() => {
+      for (const [epic, instanceId, anchor] of [
+        [EPIC_A, CHAT_A, anchorA],
+        [EPIC_B, CHAT_B, anchorB],
+      ] as const) {
+        const base = buildSyntheticTileSurfaceEnvironment(instanceId, {
+          placement: {
+            epicId: epic.id,
+            viewTabId: epic.id,
+            paneId: PANE_ID,
+            hostId: TEST_HOST_ID,
+          },
+        });
+        publishTileSurfaceEnvironment({
+          ...base,
+          identity: { ...base.identity, epicId: epic.id },
+          services: { ...base.services, geometryAnchorElement: anchor },
+        });
+      }
+    });
+
+    const recordA = await hostedRecord(CHAT_A);
+    const recordB = await hostedRecord(CHAT_B);
+    expect(recordA.style.transform).toBe("translate(0px, 0px)");
+    expect(recordB.style.transform).toBe("translate(500px, 0px)");
+    expect(recordA.style.width).toBe("500px");
+    expect(recordB.style.width).toBe("500px");
+
+    // Reverse views: the DOM slots exchange `left` and keep their widths...
+    stubAnchorRect(anchorA, { left: 500, width: 500 });
+    stubAnchorRect(anchorB, { left: 0, width: 500 });
+    // ...and the strip commits the swapped split at the same 0.5 ratio -
+    // exactly what `swapSplitSides` produces for this item.
+    act(() => setSplit(EPIC_B, EPIC_A, "right"));
+
+    // Both records are the SAME elements (no remount), now at swapped rects.
+    expect(screen.getByTestId(`stable-tile-surface-record-${CHAT_A}`)).toBe(
+      recordA,
+    );
+    expect(recordA.style.transform).toBe("translate(500px, 0px)");
+    expect(recordB.style.transform).toBe("translate(0px, 0px)");
+    expect(recordA.style.width).toBe("500px");
+    expect(recordB.style.width).toBe("500px");
+  });
+});

--- a/clients/gui-app/src/components/layout/top-level-tab-host.tsx
+++ b/clients/gui-app/src/components/layout/top-level-tab-host.tsx
@@ -1,6 +1,7 @@
 import {
   Suspense,
   useCallback,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -59,6 +60,7 @@ import {
 import { StableTileSurfaceHost } from "@/components/epic-canvas/surface-host/stable-tile-surface-host";
 import { STABLE_TILE_SURFACE_HOST_ENABLED } from "@/components/epic-canvas/surface-host/stable-tile-surface-host-switch";
 import { renderHostedChatSurfaceBody } from "@/components/epic-canvas/surface-host/hosted-chat-surface-body";
+import { remeasureTileSurfaceGeometry } from "@/components/epic-canvas/surface-host/tile-surface-geometry-coordinator";
 import {
   activateHostedTopLevelSurface,
   refIsFocused,
@@ -135,6 +137,23 @@ export function TopLevelTabHost() {
       },
     ];
   });
+  // Hosted chat bodies (`StableTileSurfaceHost`) are positioned by rects the
+  // geometry coordinator reads inside a ResizeObserver callback, and a
+  // ResizeObserver reports SIZE changes only. A placement change here can move
+  // a surface without resizing it - "Reverse views" swaps the two sides'
+  // `left` offsets while each side keeps its width (`1 - leftRatio` on the
+  // other side is the same width it already had) - so without this the two
+  // hosted bodies stay painted at their pre-swap rects while the tab strips
+  // and sidebars around them have already crossed over. Layout effect, not
+  // effect: the surface styles above are applied in this same commit and the
+  // re-read has to see them before paint. Parent layout effects run after the
+  // children's, so every record's own registration already exists by now.
+  const placementSignature = mounts
+    .map((mount) => surfacePlacementKey(mount.tab, mount.placement))
+    .join("\u001f");
+  useLayoutEffect(() => {
+    remeasureTileSurfaceGeometry();
+  }, [placementSignature]);
 
   return (
     <div
@@ -502,6 +521,21 @@ function splitSidePlacement(
     left: leftWidth,
     width: `${(1 - item.leftRatio) * 100}%`,
   };
+}
+
+function surfacePlacementKey(
+  tab: HeaderTab,
+  placement: SurfacePlacement,
+): string {
+  switch (placement.kind) {
+    case "hidden":
+    case "single":
+      return `${tabRefKey(tab)}:${placement.kind}`;
+    case "left":
+      return `${tabRefKey(tab)}:left:${placement.width}`;
+    case "right":
+      return `${tabRefKey(tab)}:right:${placement.left}:${placement.width}`;
+  }
 }
 
 function surfaceClassName(placement: SurfacePlacement): string {


### PR DESCRIPTION
## The bug

In a split tab layout with a left panel open on one side, **Reverse views** left the chat body and the epic sidebar overlapping — the chat content drew straight across the Agents/Artifacts panel that had just moved under it.

## Why

Hosted chat bodies do not paint inside their pane. They render in the fixed `StableTileSurfaceHost` plane, positioned at a rect that `tile-surface-geometry-coordinator` reads inside **one shared `ResizeObserver` callback** — and a `ResizeObserver` reports **size** changes only.

`swapSplitSides` exchanges the two sides' `left` offsets while each side keeps its own width — literally at ratio 0.5, and at any other ratio too, because `1 - leftRatio` on the other side is the width that side already had. So the swap produced no size change anywhere, no RO callback fired, and both hosted bodies stayed painted at their **pre-swap** rects while the tab strips and sidebars around them had already crossed over.

This is not specific to having a left panel open. The panel just makes the misplacement obvious, because the stale body has something visible to cover.

## The fix

- `tile-surface-geometry-coordinator.ts` exports `remeasureTileSurfaceGeometry()` — the same all-registered-slots pass the RO callback already runs, callable from outside the observer path.
- `TopLevelTabHost` calls it from a `useLayoutEffect` keyed on a signature of every mounted surface's placement (kind, `left`, `width`).

Layout effect rather than effect: the surface styles are applied in that same commit and the re-read has to see them before paint. Parent layout effects run after their children's, so every record's own slot registration already exists by then.

## Tests

| Level | Pin |
| --- | --- |
| Coordinator unit | A position-only move (only `left` changes, widths identical) with **no** RO callback fired: nothing is delivered until `remeasureTileSurfaceGeometry()` runs, which then reports both new host-relative rects. |
| `TopLevelTabHost` integration | Renders the real host with two hosted records in a split, exchanges only their offsets, swaps the split at an unchanged ratio, and asserts both records land on their new rects — same elements, no remount. The suite's `ControllableResizeObserver` is never triggered, which is exactly the real-world condition. |

**Ablation:** commenting out the `remeasureTileSurfaceGeometry()` call fails the integration pin on the post-swap transform — `expected 'translate(0px, 0px)' to be 'translate(500px, 0px)'`.

## Verification

`bun run vitest run` on both suites (38 passed), `bun run compile`, `oxfmt --check` and `eslint` clean on the four touched files, all on top of current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
