### PR TITLE
fix(gui-app): copy shared Yjs updates before transfer, attribute durable-transport closes, back off plan-denied rebuilds

### DIFF
--- a/clients/gui-app/src/lib/host/__tests__/plan-restricted-session-rebuild-backoff.test.ts
+++ b/clients/gui-app/src/lib/host/__tests__/plan-restricted-session-rebuild-backoff.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createPlanRestrictedSessionRebuildBackoff,
+  PLAN_RESTRICTED_SESSION_REBUILD_INITIAL_BACKOFF_MS,
+  PLAN_RESTRICTED_SESSION_REBUILD_MAX_BACKOFF_MS,
+} from "../plan-restricted-session-rebuild-backoff";
+
+describe("createPlanRestrictedSessionRebuildBackoff", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("runs immediately, then follows the 1m/2m/4m ladder and caps at 15m", () => {
+    vi.useFakeTimers();
+    const rebuild = vi.fn();
+    const backoff = createPlanRestrictedSessionRebuildBackoff();
+
+    backoff.request(rebuild);
+    expect(rebuild).toHaveBeenCalledTimes(1);
+
+    const delays = [
+      PLAN_RESTRICTED_SESSION_REBUILD_INITIAL_BACKOFF_MS,
+      PLAN_RESTRICTED_SESSION_REBUILD_INITIAL_BACKOFF_MS * 2,
+      PLAN_RESTRICTED_SESSION_REBUILD_INITIAL_BACKOFF_MS * 4,
+      PLAN_RESTRICTED_SESSION_REBUILD_INITIAL_BACKOFF_MS * 8,
+      PLAN_RESTRICTED_SESSION_REBUILD_MAX_BACKOFF_MS,
+      PLAN_RESTRICTED_SESSION_REBUILD_MAX_BACKOFF_MS,
+    ];
+    for (const [index, delay] of delays.entries()) {
+      backoff.request(rebuild);
+      expect(rebuild).toHaveBeenCalledTimes(index + 1);
+      vi.advanceTimersByTime(delay - 1);
+      expect(rebuild).toHaveBeenCalledTimes(index + 1);
+      vi.advanceTimersByTime(1);
+      expect(rebuild).toHaveBeenCalledTimes(index + 2);
+    }
+  });
+
+  it("coalesces a pending request, and markHealthy resets and cancels its ladder", () => {
+    vi.useFakeTimers();
+    const rebuild = vi.fn();
+    const backoff = createPlanRestrictedSessionRebuildBackoff();
+
+    backoff.request(rebuild);
+    backoff.request(rebuild);
+    backoff.request(rebuild);
+    expect(rebuild).toHaveBeenCalledTimes(1);
+
+    backoff.markHealthy();
+    vi.advanceTimersByTime(PLAN_RESTRICTED_SESSION_REBUILD_MAX_BACKOFF_MS);
+    expect(rebuild).toHaveBeenCalledTimes(1);
+
+    backoff.request(rebuild);
+    expect(rebuild).toHaveBeenCalledTimes(2);
+  });
+
+  it("cancel cancels a pending request and resets the next request to immediate", () => {
+    vi.useFakeTimers();
+    const rebuild = vi.fn();
+    const backoff = createPlanRestrictedSessionRebuildBackoff();
+
+    backoff.request(rebuild);
+    backoff.request(rebuild);
+    backoff.request(rebuild);
+    backoff.cancel();
+    vi.advanceTimersByTime(PLAN_RESTRICTED_SESSION_REBUILD_MAX_BACKOFF_MS);
+    expect(rebuild).toHaveBeenCalledTimes(1);
+
+    backoff.request(rebuild);
+    expect(rebuild).toHaveBeenCalledTimes(2);
+  });
+});

--- a/clients/gui-app/src/lib/host/__tests__/plan-restricted-session-rebuild-backoff.test.ts
+++ b/clients/gui-app/src/lib/host/__tests__/plan-restricted-session-rebuild-backoff.test.ts
@@ -77,7 +77,9 @@ describe("createPlanRestrictedSessionRebuildBackoff", () => {
 
     backoff.request(newOwner, newRebuild);
     expect(vi.getTimerCount()).toBe(1);
-    vi.advanceTimersByTime(PLAN_RESTRICTED_SESSION_REBUILD_INITIAL_BACKOFF_MS - 1);
+    vi.advanceTimersByTime(
+      PLAN_RESTRICTED_SESSION_REBUILD_INITIAL_BACKOFF_MS - 1,
+    );
     expect(newRebuild).not.toHaveBeenCalled();
 
     vi.advanceTimersByTime(1);
@@ -102,7 +104,9 @@ describe("createPlanRestrictedSessionRebuildBackoff", () => {
     backoff.request(thirdOwner, thirdRebuild);
 
     expect(vi.getTimerCount()).toBe(1);
-    vi.advanceTimersByTime(PLAN_RESTRICTED_SESSION_REBUILD_INITIAL_BACKOFF_MS - 1);
+    vi.advanceTimersByTime(
+      PLAN_RESTRICTED_SESSION_REBUILD_INITIAL_BACKOFF_MS - 1,
+    );
     expect(secondRebuild).not.toHaveBeenCalled();
     expect(thirdRebuild).not.toHaveBeenCalled();
 
@@ -112,7 +116,9 @@ describe("createPlanRestrictedSessionRebuildBackoff", () => {
     expect(thirdRebuild).toHaveBeenCalledTimes(1);
 
     backoff.request(fourthOwner, fourthRebuild);
-    vi.advanceTimersByTime(PLAN_RESTRICTED_SESSION_REBUILD_INITIAL_BACKOFF_MS * 2 - 1);
+    vi.advanceTimersByTime(
+      PLAN_RESTRICTED_SESSION_REBUILD_INITIAL_BACKOFF_MS * 2 - 1,
+    );
     expect(fourthRebuild).not.toHaveBeenCalled();
     vi.advanceTimersByTime(1);
     expect(fourthRebuild).toHaveBeenCalledTimes(1);

--- a/clients/gui-app/src/lib/host/__tests__/plan-restricted-session-rebuild-backoff.test.ts
+++ b/clients/gui-app/src/lib/host/__tests__/plan-restricted-session-rebuild-backoff.test.ts
@@ -10,12 +10,15 @@ describe("createPlanRestrictedSessionRebuildBackoff", () => {
     vi.useRealTimers();
   });
 
-  it("runs immediately, then follows the 1m/2m/4m ladder and caps at 15m", () => {
+  it("runs immediately, then follows the 1m/2m/4m/8m ladder and caps at 15m", () => {
     vi.useFakeTimers();
     const rebuild = vi.fn();
     const backoff = createPlanRestrictedSessionRebuildBackoff();
+    function newOwner(): object {
+      return {};
+    }
 
-    backoff.request(rebuild);
+    backoff.request(newOwner(), rebuild);
     expect(rebuild).toHaveBeenCalledTimes(1);
 
     const delays = [
@@ -27,7 +30,7 @@ describe("createPlanRestrictedSessionRebuildBackoff", () => {
       PLAN_RESTRICTED_SESSION_REBUILD_MAX_BACKOFF_MS,
     ];
     for (const [index, delay] of delays.entries()) {
-      backoff.request(rebuild);
+      backoff.request(newOwner(), rebuild);
       expect(rebuild).toHaveBeenCalledTimes(index + 1);
       vi.advanceTimersByTime(delay - 1);
       expect(rebuild).toHaveBeenCalledTimes(index + 1);
@@ -36,37 +39,101 @@ describe("createPlanRestrictedSessionRebuildBackoff", () => {
     }
   });
 
-  it("coalesces a pending request, and markHealthy resets and cancels its ladder", () => {
+  it("markHealthy cancels a pending request and resets its ladder", () => {
     vi.useFakeTimers();
     const rebuild = vi.fn();
     const backoff = createPlanRestrictedSessionRebuildBackoff();
+    const immediateOwner = {};
+    const pendingOwner = {};
+    const resetOwner = {};
 
-    backoff.request(rebuild);
-    backoff.request(rebuild);
-    backoff.request(rebuild);
+    backoff.request(immediateOwner, rebuild);
+    backoff.request(pendingOwner, rebuild);
     expect(rebuild).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(1);
 
     backoff.markHealthy();
     vi.advanceTimersByTime(PLAN_RESTRICTED_SESSION_REBUILD_MAX_BACKOFF_MS);
     expect(rebuild).toHaveBeenCalledTimes(1);
 
-    backoff.request(rebuild);
+    backoff.request(resetOwner, rebuild);
     expect(rebuild).toHaveBeenCalledTimes(2);
+  });
+
+  it("ignores a duplicate old owner and gives the delayed callback to a newer owner", () => {
+    vi.useFakeTimers();
+    const oldRebuild = vi.fn();
+    const newRebuild = vi.fn();
+    const oldOwner = {};
+    const newOwner = {};
+    const backoff = createPlanRestrictedSessionRebuildBackoff();
+
+    backoff.request(oldOwner, oldRebuild);
+    expect(oldRebuild).toHaveBeenCalledTimes(1);
+
+    backoff.request(oldOwner, oldRebuild);
+    expect(oldRebuild).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
+
+    backoff.request(newOwner, newRebuild);
+    expect(vi.getTimerCount()).toBe(1);
+    vi.advanceTimersByTime(PLAN_RESTRICTED_SESSION_REBUILD_INITIAL_BACKOFF_MS - 1);
+    expect(newRebuild).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(newRebuild).toHaveBeenCalledTimes(1);
+    expect(oldRebuild).toHaveBeenCalledTimes(1);
+  });
+
+  it("replaces a pending callback without advancing or duplicating the ladder", () => {
+    vi.useFakeTimers();
+    const firstRebuild = vi.fn();
+    const secondRebuild = vi.fn();
+    const thirdRebuild = vi.fn();
+    const fourthRebuild = vi.fn();
+    const firstOwner = {};
+    const secondOwner = {};
+    const thirdOwner = {};
+    const fourthOwner = {};
+    const backoff = createPlanRestrictedSessionRebuildBackoff();
+
+    backoff.request(firstOwner, firstRebuild);
+    backoff.request(secondOwner, secondRebuild);
+    backoff.request(thirdOwner, thirdRebuild);
+
+    expect(vi.getTimerCount()).toBe(1);
+    vi.advanceTimersByTime(PLAN_RESTRICTED_SESSION_REBUILD_INITIAL_BACKOFF_MS - 1);
+    expect(secondRebuild).not.toHaveBeenCalled();
+    expect(thirdRebuild).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(firstRebuild).toHaveBeenCalledTimes(1);
+    expect(secondRebuild).not.toHaveBeenCalled();
+    expect(thirdRebuild).toHaveBeenCalledTimes(1);
+
+    backoff.request(fourthOwner, fourthRebuild);
+    vi.advanceTimersByTime(PLAN_RESTRICTED_SESSION_REBUILD_INITIAL_BACKOFF_MS * 2 - 1);
+    expect(fourthRebuild).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(fourthRebuild).toHaveBeenCalledTimes(1);
   });
 
   it("cancel cancels a pending request and resets the next request to immediate", () => {
     vi.useFakeTimers();
     const rebuild = vi.fn();
     const backoff = createPlanRestrictedSessionRebuildBackoff();
+    const immediateOwner = {};
+    const pendingOwner = {};
+    const resetOwner = {};
 
-    backoff.request(rebuild);
-    backoff.request(rebuild);
-    backoff.request(rebuild);
+    backoff.request(immediateOwner, rebuild);
+    backoff.request(pendingOwner, rebuild);
+    expect(vi.getTimerCount()).toBe(1);
     backoff.cancel();
     vi.advanceTimersByTime(PLAN_RESTRICTED_SESSION_REBUILD_MAX_BACKOFF_MS);
     expect(rebuild).toHaveBeenCalledTimes(1);
 
-    backoff.request(rebuild);
+    backoff.request(resetOwner, rebuild);
     expect(rebuild).toHaveBeenCalledTimes(2);
   });
 });

--- a/clients/gui-app/src/lib/host/durable-stream-transport.ts
+++ b/clients/gui-app/src/lib/host/durable-stream-transport.ts
@@ -22,6 +22,21 @@ export interface DurableStreamTransport {
   readonly close: () => void;
 }
 
+/** A durable session transport whose owner can attribute its final close. */
+export interface AttributableDurableStreamTransport
+  extends DurableStreamTransport {
+  /**
+   * Same teardown, with a caller-authored diagnostic reason.
+   *
+   * Kept on the transport rather than achieved by closing `wsStreamClient`
+   * directly: wake, endpoint-change and availability wiring must be disposed
+   * BEFORE the socket closes, or a close notification can race live reconnect
+   * wiring. `close()` is the historical default for owners with no narrower
+   * attribution.
+   */
+  readonly closeWithReason: (reason: string) => void;
+}
+
 /**
  * Builds a LONG-LIVED host stream transport for a SESSION STORE to own across
  * its warm lifetime (not a React tile). This is the ONE place "durable stream =
@@ -85,7 +100,7 @@ export function openDurableStreamTransport(params: {
    * see {@link NamedHostRecoveryTarget}.
    */
   readonly notifyRecoveredForNamedHost: () => void;
-}): DurableStreamTransport {
+}): AttributableDurableStreamTransport {
   const wsStreamClient = buildHostStreamClient({
     target: params.target,
     endpoint: params.endpoint,
@@ -145,14 +160,18 @@ export function openDurableStreamTransport(params: {
     wsStreamClient.close("durable-transport-wiring-failed");
     throw cause;
   }
-  return {
-    wsStreamClient,
+  const closeWithReason = (reason: string): void => {
     // Dispose wake + endpoint-change wiring BEFORE the socket, so neither can
     // fire `reconnectAll` on a socket that is being torn down.
+    disposers.forEach((dispose) => dispose());
+    wsStreamClient.close(reason);
+  };
+  return {
+    wsStreamClient,
     close: () => {
-      disposers.forEach((dispose) => dispose());
-      wsStreamClient.close("durable-transport-closed");
+      closeWithReason("durable-transport-closed");
     },
+    closeWithReason,
   };
 }
 

--- a/clients/gui-app/src/lib/host/durable-stream-transport.ts
+++ b/clients/gui-app/src/lib/host/durable-stream-transport.ts
@@ -23,8 +23,7 @@ export interface DurableStreamTransport {
 }
 
 /** A durable session transport whose owner can attribute its final close. */
-export interface AttributableDurableStreamTransport
-  extends DurableStreamTransport {
+export interface AttributableDurableStreamTransport extends DurableStreamTransport {
   /**
    * Same teardown, with a caller-authored diagnostic reason.
    *

--- a/clients/gui-app/src/lib/host/plan-restricted-session-rebuild-backoff.ts
+++ b/clients/gui-app/src/lib/host/plan-restricted-session-rebuild-backoff.ts
@@ -3,13 +3,22 @@
  * reprobe deadline. The transport cache already waits before it permits a new
  * remote session; this ladder prevents a host that keeps denying the plan from
  * rebuilding the whole Epic session at every cache deadline forever.
+ *
+ * Requests are owned by the handle that observed the denial. One handle may
+ * claim at most one ladder attempt, including the synchronous first attempt.
+ * When a replacement handle is denied while a delayed attempt is pending, its
+ * callback takes over that timer; a retired handle must never strand the live
+ * one by keeping the only scheduled callback.
  */
 export const PLAN_RESTRICTED_SESSION_REBUILD_INITIAL_BACKOFF_MS = 60_000;
 export const PLAN_RESTRICTED_SESSION_REBUILD_MAX_BACKOFF_MS = 15 * 60_000;
 
 export interface PlanRestrictedSessionRebuildBackoff {
-  /** Runs the first rebuild immediately, then delays repeated denied rebuilds. */
-  readonly request: (rebuild: () => void) => void;
+  /**
+   * Runs the first owner's rebuild immediately, then delays distinct
+   * replacement owners. `owner` must remain stable for that handle's lifetime.
+   */
+  readonly request: (owner: object, rebuild: () => void) => void;
   /** A loaded session on an open transport proves the denial loop ended. */
   readonly markHealthy: () => void;
   /** Ends any pending delay when the owning provider/host target goes away. */
@@ -25,30 +34,47 @@ function delayForAttempt(attempt: number): number {
 }
 
 export function createPlanRestrictedSessionRebuildBackoff(): PlanRestrictedSessionRebuildBackoff {
-  let completedRequests = 0;
+  let claimedAttempts = 0;
+  let attemptedOwners = new WeakSet<object>();
   let pendingTimer: number | null = null;
+  let pendingRebuild: (() => void) | null = null;
 
   const clear = (): void => {
     if (pendingTimer !== null) window.clearTimeout(pendingTimer);
     pendingTimer = null;
-    completedRequests = 0;
+    pendingRebuild = null;
+    claimedAttempts = 0;
+    attemptedOwners = new WeakSet<object>();
   };
 
   return {
-    request: (rebuild) => {
-      // One plan-denied handle contributes one deadline. Coalesce defensively
-      // so duplicate close notifications cannot advance the ladder or create
-      // two owner rebuilds.
-      if (pendingTimer !== null) return;
-      const delayMs = delayForAttempt(completedRequests);
-      completedRequests += 1;
+    request: (owner, rebuild) => {
+      // Remember the owner even when attempt zero runs synchronously. Without
+      // this, a duplicate close notification from that retired handle can arm
+      // attempt one with a callback that will be inert by the time it fires.
+      if (attemptedOwners.has(owner)) return;
+      attemptedOwners.add(owner);
+
+      if (pendingTimer !== null) {
+        // A replacement handle reached its own denial before the current rung
+        // fired. Keep the rung/deadline, but hand ownership to the live handle
+        // instead of dropping its request behind a retired callback.
+        pendingRebuild = rebuild;
+        return;
+      }
+
+      const delayMs = delayForAttempt(claimedAttempts);
+      claimedAttempts += 1;
       if (delayMs === 0) {
         rebuild();
         return;
       }
+      pendingRebuild = rebuild;
       pendingTimer = window.setTimeout(() => {
         pendingTimer = null;
-        rebuild();
+        const rebuildForLatestOwner = pendingRebuild;
+        pendingRebuild = null;
+        rebuildForLatestOwner?.();
       }, delayMs);
     },
     markHealthy: clear,

--- a/clients/gui-app/src/lib/host/plan-restricted-session-rebuild-backoff.ts
+++ b/clients/gui-app/src/lib/host/plan-restricted-session-rebuild-backoff.ts
@@ -1,0 +1,57 @@
+/**
+ * Extra OWNER-level delay after a plan-restricted transport reaches its own
+ * reprobe deadline. The transport cache already waits before it permits a new
+ * remote session; this ladder prevents a host that keeps denying the plan from
+ * rebuilding the whole Epic session at every cache deadline forever.
+ */
+export const PLAN_RESTRICTED_SESSION_REBUILD_INITIAL_BACKOFF_MS = 60_000;
+export const PLAN_RESTRICTED_SESSION_REBUILD_MAX_BACKOFF_MS = 15 * 60_000;
+
+export interface PlanRestrictedSessionRebuildBackoff {
+  /** Runs the first rebuild immediately, then delays repeated denied rebuilds. */
+  readonly request: (rebuild: () => void) => void;
+  /** A loaded session on an open transport proves the denial loop ended. */
+  readonly markHealthy: () => void;
+  /** Ends any pending delay when the owning provider/host target goes away. */
+  readonly cancel: () => void;
+}
+
+function delayForAttempt(attempt: number): number {
+  if (attempt === 0) return 0;
+  return Math.min(
+    PLAN_RESTRICTED_SESSION_REBUILD_INITIAL_BACKOFF_MS * 2 ** (attempt - 1),
+    PLAN_RESTRICTED_SESSION_REBUILD_MAX_BACKOFF_MS,
+  );
+}
+
+export function createPlanRestrictedSessionRebuildBackoff(): PlanRestrictedSessionRebuildBackoff {
+  let completedRequests = 0;
+  let pendingTimer: number | null = null;
+
+  const clear = (): void => {
+    if (pendingTimer !== null) window.clearTimeout(pendingTimer);
+    pendingTimer = null;
+    completedRequests = 0;
+  };
+
+  return {
+    request: (rebuild) => {
+      // One plan-denied handle contributes one deadline. Coalesce defensively
+      // so duplicate close notifications cannot advance the ladder or create
+      // two owner rebuilds.
+      if (pendingTimer !== null) return;
+      const delayMs = delayForAttempt(completedRequests);
+      completedRequests += 1;
+      if (delayMs === 0) {
+        rebuild();
+        return;
+      }
+      pendingTimer = window.setTimeout(() => {
+        pendingTimer = null;
+        rebuild();
+      }, delayMs);
+    },
+    markHealthy: clear,
+    cancel: clear,
+  };
+}

--- a/clients/gui-app/src/lib/host/test-support/fake-durable-stream-transport.ts
+++ b/clients/gui-app/src/lib/host/test-support/fake-durable-stream-transport.ts
@@ -27,12 +27,13 @@
 import type { IHostStreamClient } from "@traycer-clients/shared/host-transport/host-stream-client";
 import type { IStreamSession } from "@traycer-clients/shared/host-transport/i-stream-session";
 import type { HostStreamRpcRegistry } from "@traycer/protocol/host/registry";
-import type { DurableStreamTransport } from "@/lib/host/durable-stream-transport";
+import type { AttributableDurableStreamTransport } from "@/lib/host/durable-stream-transport";
 
 /** One transport this opener minted, and what has happened to it since. */
 export interface FakeTransportRecord {
   readonly hostId: string;
   closeCount: number;
+  readonly closeReasons: string[];
   readonly wsStreamClient: IHostStreamClient<HostStreamRpcRegistry>;
 }
 
@@ -56,7 +57,7 @@ export interface FakeDurableStreamTransports {
    * `resetFakeDurableStreamTransports` puts the default back, so a churned
    * opener cannot leak into the next test in the file.
    */
-  opener: (hostId: string) => DurableStreamTransport;
+  opener: (hostId: string) => AttributableDurableStreamTransport;
 }
 
 function fakeStreamSession(): IStreamSession {
@@ -72,13 +73,16 @@ function fakeStreamSession(): IStreamSession {
 
 function createWsStreamClient(
   instanceIndex: number,
+  closeReasons: string[],
 ): IHostStreamClient<HostStreamRpcRegistry> {
   let closed = false;
   return {
     subscribe: () => fakeStreamSession(),
     subscribeWithParamsProvider: () => fakeStreamSession(),
-    close: () => {
+    close: (reason) => {
+      if (closed) return;
       closed = true;
+      closeReasons.push(reason);
     },
     isClosed: () => closed,
     isReady: () => true,
@@ -101,15 +105,28 @@ function createWsStreamClient(
 
 const records: FakeTransportRecord[] = [];
 
-const defaultOpener = (hostId: string): DurableStreamTransport => {
-  const wsStreamClient = createWsStreamClient(records.length);
-  const record: FakeTransportRecord = { hostId, closeCount: 0, wsStreamClient };
+const defaultOpener = (
+  hostId: string,
+): AttributableDurableStreamTransport => {
+  const closeReasons: string[] = [];
+  const wsStreamClient = createWsStreamClient(records.length, closeReasons);
+  const record: FakeTransportRecord = {
+    hostId,
+    closeCount: 0,
+    closeReasons,
+    wsStreamClient,
+  };
   records.push(record);
+  const closeWithReason = (reason: string): void => {
+    record.closeCount += 1;
+    wsStreamClient.close(reason);
+  };
   return {
     wsStreamClient,
     close: () => {
-      record.closeCount += 1;
+      closeWithReason("durable-transport-closed");
     },
+    closeWithReason,
   };
 };
 

--- a/clients/gui-app/src/lib/host/test-support/fake-durable-stream-transport.ts
+++ b/clients/gui-app/src/lib/host/test-support/fake-durable-stream-transport.ts
@@ -76,17 +76,19 @@ function createWsStreamClient(
   closeReasons: string[],
 ): IHostStreamClient<HostStreamRpcRegistry> {
   let closed = false;
+  let closedReason: string | null = null;
   return {
     subscribe: () => fakeStreamSession(),
     subscribeWithParamsProvider: () => fakeStreamSession(),
     close: (reason) => {
       if (closed) return;
       closed = true;
+      closedReason = reason;
       closeReasons.push(reason);
     },
     isClosed: () => closed,
     isReady: () => true,
-    getClosedReason: () => null,
+    getClosedReason: () => closedReason,
     notifyBearerRotated: () => undefined,
     reconnectAll: () => undefined,
     // "unsupported" on every lane method pins the adapter-selection verdict to

--- a/clients/gui-app/src/lib/host/test-support/fake-durable-stream-transport.ts
+++ b/clients/gui-app/src/lib/host/test-support/fake-durable-stream-transport.ts
@@ -107,9 +107,7 @@ function createWsStreamClient(
 
 const records: FakeTransportRecord[] = [];
 
-const defaultOpener = (
-  hostId: string,
-): AttributableDurableStreamTransport => {
+const defaultOpener = (hostId: string): AttributableDurableStreamTransport => {
   const closeReasons: string[] = [];
   const wsStreamClient = createWsStreamClient(records.length, closeReasons);
   const record: FakeTransportRecord = {

--- a/clients/gui-app/src/lib/host/use-durable-stream-transport.ts
+++ b/clients/gui-app/src/lib/host/use-durable-stream-transport.ts
@@ -4,7 +4,7 @@ import { useRunnerHost } from "@/providers/use-runner-host";
 import { useStreamAuthRevalidator } from "@/lib/host/stream-auth-revalidator";
 import {
   openDurableStreamTransport,
-  type DurableStreamTransport,
+  type AttributableDurableStreamTransport,
 } from "@/lib/host/durable-stream-transport";
 import { dialableHostEndpoint } from "@/lib/host/transport-key";
 
@@ -22,7 +22,7 @@ import { dialableHostEndpoint } from "@/lib/host/transport-key";
  */
 export function useDurableStreamTransportFactory(): (
   hostId: string,
-) => DurableStreamTransport {
+) => AttributableDurableStreamTransport {
   const directory = useHostDirectory();
   const globalClient = useHostClient();
   const runnerHost = useRunnerHost();

--- a/clients/gui-app/src/lib/registries/epic-session-registry.ts
+++ b/clients/gui-app/src/lib/registries/epic-session-registry.ts
@@ -15,9 +15,12 @@ import {
 // module imports THAT one, so a map declared here could not be read there
 // without a cycle. The provider's import path is unchanged.
 export {
+  attributeEpicSessionTransportClose,
   isEpicSessionHandleDead,
   trackEpicSessionHandleLiveness,
+  trackEpicSessionTransportCloseAttribution,
 } from "@/stores/epics/open-epic/session-registry";
+export type { EpicSessionTransportCloseTrigger } from "@/stores/epics/open-epic/session-registry";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 import type { OpenEpicStoreHandle } from "@/stores/epics/open-epic/store";
 import type { HostClient } from "@traycer-clients/shared/host-client/host-client";

--- a/clients/gui-app/src/providers/__tests__/epic-session-transport-ownership.test.tsx
+++ b/clients/gui-app/src/providers/__tests__/epic-session-transport-ownership.test.tsx
@@ -321,6 +321,9 @@ describe("<EpicSessionProvider /> transport ownership", () => {
     });
     expect(record.closeCount).toBe(1);
     expect(record.closeReasons).toEqual(["durable-transport-closed:tab-close"]);
+    expect(record.wsStreamClient.getClosedReason()).toBe(
+      "durable-transport-closed:tab-close",
+    );
 
     // Idempotent on its own: a second dispose (e.g. a duplicate teardown path)
     // must not double-close the socket.

--- a/clients/gui-app/src/providers/__tests__/epic-session-transport-ownership.test.tsx
+++ b/clients/gui-app/src/providers/__tests__/epic-session-transport-ownership.test.tsx
@@ -216,6 +216,7 @@ async function mountSession(
   tabId: string,
 ): Promise<{
   handle: OpenEpicStoreHandle;
+  unmount: () => void;
   /**
    * Every handle this mount has presented, in order - a GETTER because the
    * interesting ones arrive after this function returns. One caller: the
@@ -224,13 +225,21 @@ async function mountSession(
   handles: () => ReadonlyArray<OpenEpicStoreHandle>;
 }> {
   const seenHandles: OpenEpicStoreHandle[] = [];
-  render(sessionBody(epicId, tabId, (handle) => seenHandles.push(handle)));
+  const rendered = render(
+    sessionBody(epicId, tabId, (handle) => seenHandles.push(handle)),
+  );
   await waitFor(() => {
     expect(seenHandles).toHaveLength(1);
   });
   const handle = seenHandles.at(0);
   if (handle === undefined) throw new Error("expected a handle");
-  return { handle, handles: () => seenHandles };
+  return {
+    handle,
+    handles: () => seenHandles,
+    unmount: () => {
+      rendered.unmount();
+    },
+  };
 }
 
 describe("<EpicSessionProvider /> transport ownership", () => {
@@ -311,6 +320,7 @@ describe("<EpicSessionProvider /> transport ownership", () => {
       handle.dispose();
     });
     expect(record.closeCount).toBe(1);
+    expect(record.closeReasons).toEqual(["durable-transport-closed:tab-close"]);
 
     // Idempotent on its own: a second dispose (e.g. a duplicate teardown path)
     // must not double-close the socket.
@@ -318,6 +328,33 @@ describe("<EpicSessionProvider /> transport ownership", () => {
       handle.dispose();
     });
     expect(record.closeCount).toBe(1);
+  });
+
+  it("attributes MRU prune teardown to prune", async () => {
+    // Unmount each provider so its clean session becomes WARM rather than
+    // remaining mounted (mounted entries are not prune candidates). The sixth
+    // acquisition exceeds the five-entry cap and prunes the oldest transport.
+    const leaveWarm = async (epicId: string): Promise<void> => {
+      const mounted = await mountSession(epicId, epicId);
+      act(() => {
+        mounted.handle.store.setState({
+          snapshotLoaded: true,
+          isDirty: false,
+          hostTransportStatus: "open",
+        });
+      });
+      mounted.unmount();
+    };
+    await leaveWarm("epic-prune-1");
+    await leaveWarm("epic-prune-2");
+    await leaveWarm("epic-prune-3");
+    await leaveWarm("epic-prune-4");
+    await leaveWarm("epic-prune-5");
+    await mountSession("epic-prune-6", "epic-prune-6");
+
+    const oldest = transportRegistry.records.at(0);
+    if (oldest === undefined) throw new Error("expected oldest transport");
+    expect(oldest.closeReasons).toEqual(["durable-transport-closed:prune"]);
   });
 
   it("attaches a plan-restricted reprobe to THIS session's client, and detaches it with the transport", async () => {
@@ -390,6 +427,9 @@ describe("<EpicSessionProvider /> transport ownership", () => {
       expect(transportRegistry.records.length).toBeGreaterThan(1);
     });
     expect(first.closeCount).toBe(1);
+    expect(first.closeReasons).toEqual([
+      "durable-transport-closed:retry-rebuild",
+    ]);
     expect(handles().length).toBeGreaterThan(1);
   });
 
@@ -406,6 +446,45 @@ describe("<EpicSessionProvider /> transport ownership", () => {
       handle.detachTransport();
     });
     expect(record.closeCount).toBe(1);
+    expect(record.closeReasons).toEqual(["durable-transport-closed:repoint"]);
+  });
+
+  it("attributes a host re-point candidate teardown to repoint", async () => {
+    const seenHandles: OpenEpicStoreHandle[] = [];
+    const rendered = render(
+      sessionBody("epic-repoint-reason", "epic-repoint-reason", (handle) => {
+        seenHandles.push(handle);
+      }),
+    );
+    await waitFor(() => {
+      expect(seenHandles).toHaveLength(1);
+    });
+
+    hostState.id = "host-b";
+    act(() => {
+      rendered.rerender(
+        sessionBody("epic-repoint-reason", "epic-repoint-reason", (handle) => {
+          seenHandles.push(handle);
+        }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(transportRegistry.records.length).toBeGreaterThan(1);
+    });
+    const candidate = transportRegistry.records.at(1);
+    if (candidate === undefined) throw new Error("expected repoint candidate");
+
+    // The candidate is discarded once the already-mounted handle wins the
+    // re-point effect is cleaned up; its transport close must retain the
+    // product trigger even though the provider is unmounted before a snapshot
+    // can commit the replacement.
+    rendered.unmount();
+    await waitFor(() => {
+      expect(candidate.closeReasons).toEqual([
+        "durable-transport-closed:repoint",
+      ]);
+    });
   });
 
   it("dispose() and detachTransport() close the transport only ONCE, in either order", async () => {

--- a/clients/gui-app/src/providers/epic-session-provider.tsx
+++ b/clients/gui-app/src/providers/epic-session-provider.tsx
@@ -33,6 +33,7 @@ import { appLogger } from "@/lib/logger";
 import {
   createOpenEpicStore,
   isProjectionPatch,
+  type OpenEpicState,
   type OpenEpicStoreHandle,
 } from "@/stores/epics/open-epic/store";
 import type { HostClient } from "@traycer-clients/shared/host-client/host-client";
@@ -57,6 +58,7 @@ import {
   EpicSessionContext,
   EpicSessionHostClientContext,
   EpicSessionPresentationContext,
+  attributeEpicSessionTransportClose,
   getEpicSessionHandleHostId,
   getOpenEpicRegistry,
   handleHostClients,
@@ -64,12 +66,15 @@ import {
   isEpicSessionHandleDead,
   releaseOpenEpicSessionIfUnused,
   trackEpicSessionHandleLiveness,
+  trackEpicSessionTransportCloseAttribution,
+  type EpicSessionTransportCloseTrigger,
 } from "@/lib/registries/epic-session-registry";
 import { useHostClientForHostId } from "@/hooks/host/use-host-client-for-host-id";
 import { shouldMergeEpicRoomSwap } from "@/lib/epics/epic-room-swap";
 import { armCarriesRootWrites } from "@/stores/epics/open-epic/runtime/epic-adapter-selection";
 import { ESTABLISHING_DEADLINE_MS } from "@/lib/host/bounded-load-budgets";
 import { attachPlanRestrictedReprobe } from "@/lib/host/owned-durable-stream-client";
+import { createPlanRestrictedSessionRebuildBackoff } from "@/lib/host/plan-restricted-session-rebuild-backoff";
 import { openEpicKey } from "@/lib/persist";
 import { adoptLegacyPersistedKey } from "@/lib/persist/zustand-persist-lifecycle";
 import { useImportedUnseenStore } from "@/stores/session-import/imported-unseen-store";
@@ -374,6 +379,23 @@ export function EpicSessionProvider(
     originalHostId: null,
   });
   const targetHostId = requestedHostId ?? effectiveHostId;
+  // Survives handle replacement so a host that repeatedly denies the plan
+  // cannot reset its owner-level backoff simply by causing the owner to build
+  // the next handle. A host/user move is a different session and resets it.
+  const planRestrictedSessionRebuildBackoff = useMemo(
+    () => createPlanRestrictedSessionRebuildBackoff(),
+    [epicId],
+  );
+  useEffect(() => {
+    return () => {
+      planRestrictedSessionRebuildBackoff.cancel();
+    };
+  }, [
+    ownershipClaimed,
+    planRestrictedSessionRebuildBackoff,
+    sessionUserId,
+    targetHostId,
+  ]);
   const resolvedSessionHostClient = useHostClientForHostId(
     session?.hostId ?? targetHostId,
   );
@@ -461,6 +483,10 @@ export function EpicSessionProvider(
   }, []);
 
   const retryRepoint = useCallback((): void => {
+    // A user-authored Retry supersedes an automatic backed-off retry. Without
+    // cancelling it, the old timer would rebuild the freshly retried session
+    // later with no new failure.
+    planRestrictedSessionRebuildBackoff.cancel();
     // Reaching Retry means the seeded open FAILED at the one job the seed
     // has, so give it up here too. Without this the seed survives a create
     // host that died while `effectiveHostId` never moved - the derivation
@@ -474,17 +500,18 @@ export function EpicSessionProvider(
       setRequestedHostId(null);
     }
     setRetryGeneration((generation) => generation + 1);
-  }, []);
+  }, [planRestrictedSessionRebuildBackoff]);
   const openOnOriginalHost = useCallback((): void => {
     const originalHostId = originalHostIdRef.current;
     if (originalHostId === null) return;
+    planRestrictedSessionRebuildBackoff.cancel();
     // An explicit request replaces the seed and stops being one: the user
     // named this host, so a later derivation move must not silently take it
     // back the way it takes back the create-host seed.
     seededCreateHostRef.current = false;
     setRequestedHostId(originalHostId);
     setRetryGeneration((generation) => generation + 1);
-  }, []);
+  }, [planRestrictedSessionRebuildBackoff]);
 
   // The create-host seed answers ONE question - which host can serve this epic
   // while its cloud record is still being written - and that question is
@@ -618,6 +645,9 @@ export function EpicSessionProvider(
       const transport = openTransport(targetHostId);
       const wsStreamClient = transport.wsStreamClient;
       let transportClosed = false;
+      let pendingTransportCloseTrigger: EpicSessionTransportCloseTrigger | null =
+        null;
+      let detachSessionHealthy: (() => void) | null = null;
       // Filled once the handle exists, because the recovery IS the handle's
       // `retryTransport`. Held in a slot rather than passed in because the
       // subscription has to be live before then: the negative-cache adoption
@@ -626,15 +656,25 @@ export function EpicSessionProvider(
       // lost if this attached afterwards.
       let reprobeHandle: OpenEpicStoreHandle | null = null;
       const detachReprobe = attachPlanRestrictedReprobe(wsStreamClient, () => {
-        reprobeHandle?.retryTransport();
+        planRestrictedSessionRebuildBackoff.request(() => {
+          reprobeHandle?.retryTransport();
+        });
       });
-      const closeSessionTransport = (): void => {
+      const closeSessionTransport = (
+        fallbackTrigger: EpicSessionTransportCloseTrigger,
+      ): void => {
         if (transportClosed) return;
         transportClosed = true;
         // Before `transport.close()`, so the timer cannot outlive the socket
         // it exists to rebuild.
         detachReprobe();
-        transport.close();
+        detachSessionHealthy?.();
+        detachSessionHealthy = null;
+        // The transport owns ordering: it tears down wake/endpoint wiring
+        // before closing the socket with this attributed reason. Keeping the
+        // `durable-transport-closed` prefix preserves existing log searches.
+        const trigger = pendingTransportCloseTrigger ?? fallbackTrigger;
+        transport.closeWithReason(`durable-transport-closed:${trigger}`);
       };
       // EVERY construction between opening the transport and returning a
       // handle that owns its close. A synchronous throw anywhere in here -
@@ -921,6 +961,17 @@ export function EpicSessionProvider(
           revalidatedForUnauthorized = true;
           handleSessionAuthError();
         });
+        const noteSessionHealth = (state: OpenEpicState): void => {
+          if (!state.snapshotLoaded || state.hostTransportStatus !== "open") {
+            return;
+          }
+          // Only a loaded replica on an open transport proves that a previous
+          // plan denial ended. A construction or a transient `connecting`
+          // projection must not reset the ladder.
+          planRestrictedSessionRebuildBackoff.markHealthy();
+        };
+        detachSessionHealthy = created.store.subscribe(noteSessionHealth);
+        noteSessionHealth(created.store.getState());
 
         // Construction-honest stamp, written exactly once: `streamClientFactory`
         // above captures this run's `targetHostId` into the transport it opens,
@@ -938,11 +989,11 @@ export function EpicSessionProvider(
           ...created,
           dispose: () => {
             created.dispose();
-            closeSessionTransport();
+            closeSessionTransport("tab-close");
           },
           detachTransport: () => {
             created.detachTransport();
-            closeSessionTransport();
+            closeSessionTransport("repoint");
           },
         };
         // Stamped on the handle that ESCAPES, not on the inner store object:
@@ -961,11 +1012,19 @@ export function EpicSessionProvider(
         // before this line is already recorded on the handle the moment it
         // exists.
         trackEpicSessionHandleLiveness(handle, liveness);
+        trackEpicSessionTransportCloseAttribution(handle, (trigger) => {
+          // The call site with the most specific product intent runs before
+          // the registry's generic disposal mapping. First-wins preserves it
+          // through the later onBeforeDispose callback.
+          if (pendingTransportCloseTrigger === null) {
+            pendingTransportCloseTrigger = trigger;
+          }
+        });
         return handle;
       } catch (error: unknown) {
         // Idempotent, and the handle's own paths are too, so a later
         // `dispose` on a handle that never escaped cannot double-close.
-        closeSessionTransport();
+        closeSessionTransport("construction-failed");
         throw error;
       }
     };
@@ -1030,23 +1089,20 @@ export function EpicSessionProvider(
       // would delete host A's unsynced work because host B rotated.
       if (current !== null) {
         const discarding = current.handle.userId !== sessionUserId;
-        registry.release(
-          epicId,
-          discarding ? "discard" : "keep",
-          // A ROTATION is not a user change: the same person is still at the
-          // keyboard, nothing was shown to them, and the live handle can hold
-          // unsynced edits. Retaining it under the identity it was built for -
-          // the OLD owner key, which is the room those edits belong to - is
-          // what keeps the re-enrollment from destroying work the user was
-          // never asked about. A user change takes `null`: no prior identity's
-          // document may survive it, exactly as `disposeAll` does at sign-out.
-          discarding
-            ? null
-            : {
-                hostStamp: current.hostId,
-                ownerIdentityKey: current.ownerIdentityKey,
-              },
-        );
+        if (discarding) {
+          registry.releaseForSignOut(epicId, "discard", null);
+        } else {
+          registry.releaseForRetryRebuild(epicId, "keep", {
+            // A ROTATION is not a user change: the same person is still at the
+            // keyboard, nothing was shown to them, and the live handle can hold
+            // unsynced edits. Retaining it under the identity it was built for -
+            // the OLD owner key, which is the room those edits belong to - is
+            // what keeps the re-enrollment from destroying work the user was
+            // never asked about.
+            hostStamp: current.hostId,
+            ownerIdentityKey: current.ownerIdentityKey,
+          });
+        }
       }
       // GUARDED, because `createHandle` runs synchronously inside this call and
       // the very first thing it does is construct a Worker. That throws outright
@@ -1150,6 +1206,10 @@ export function EpicSessionProvider(
     // establishes. The successor is deliberately outside the registry until a
     // complete snapshot makes an atomic replacement possible.
     const nextHandle = createHandle();
+    const disposeRepointCandidate = (): void => {
+      attributeEpicSessionTransportClose(nextHandle, "repoint");
+      nextHandle.dispose();
+    };
     presentSession({
       kind: "establishing",
       targetHostId,
@@ -1159,7 +1219,7 @@ export function EpicSessionProvider(
     const disposePending = (): void => {
       if (settled) return;
       settled = true;
-      nextHandle.dispose();
+      disposeRepointCandidate();
     };
     // ONE Epic can be mounted in TWO tabs of the same window (a duplicated
     // tab: `mostRecentTabIdByEpicId`, `duplicateEpicTab`), and every provider
@@ -1178,7 +1238,7 @@ export function EpicSessionProvider(
     // releases one.
     const adoptWinner = (winner: OpenEpicStoreHandle): void => {
       settled = true;
-      nextHandle.dispose();
+      disposeRepointCandidate();
       // Same question the replacement path asks of its own candidate, asked
       // here of a SIBLING's. The winner arrives from `registry.peek`, which -
       // unlike `acquireMounted` - does not retire a dead entry, so adopting it
@@ -1352,7 +1412,7 @@ export function EpicSessionProvider(
         // fully-built candidate - its worker, its stream transport, its socket
         // and its accounting registrations alive for the life of the tab, with
         // nothing left holding a reference that could ever end them.
-        nextHandle.dispose();
+        disposeRepointCandidate();
         return;
       }
       // A SECOND liveness question, and not the one `lifecycle.cancelled`
@@ -1372,7 +1432,7 @@ export function EpicSessionProvider(
       // Disposed and presented as `failed`, which is what every other
       // non-adoptable exit in this function already does.
       if (isEpicSessionHandleDead(nextHandle)) {
-        nextHandle.dispose();
+        disposeRepointCandidate();
         presentSession({
           kind: "failed",
           targetHostId: hostId,
@@ -1413,7 +1473,7 @@ export function EpicSessionProvider(
           adoptWinner(winner);
           return;
         }
-        nextHandle.dispose();
+        disposeRepointCandidate();
         presentSession({
           kind: "failed",
           targetHostId: hostId,
@@ -1478,6 +1538,7 @@ export function EpicSessionProvider(
     ownerIdentityKey,
     ownerIdentityKeyHostId,
     ownershipClaimed,
+    planRestrictedSessionRebuildBackoff,
     presentSession,
     sessionUserId,
     targetHostId,

--- a/clients/gui-app/src/providers/epic-session-provider.tsx
+++ b/clients/gui-app/src/providers/epic-session-provider.tsx
@@ -379,18 +379,19 @@ export function EpicSessionProvider(
     originalHostId: null,
   });
   const targetHostId = requestedHostId ?? effectiveHostId;
-  // Survives handle replacement so a host that repeatedly denies the plan
-  // cannot reset its owner-level backoff simply by causing the owner to build
-  // the next handle. A host/user move is a different session and resets it.
-  const planRestrictedSessionRebuildBackoff = useMemo(
-    () => createPlanRestrictedSessionRebuildBackoff(),
-    [epicId],
+  // One controller per mounted provider, so handle replacement cannot reset
+  // its owner-level backoff when a host repeatedly denies the plan. The reset
+  // effect below cancels it when this provider is reused for a different Epic
+  // or its host/user/ownership scope changes.
+  const [planRestrictedSessionRebuildBackoff] = useState(
+    createPlanRestrictedSessionRebuildBackoff,
   );
   useEffect(() => {
     return () => {
       planRestrictedSessionRebuildBackoff.cancel();
     };
   }, [
+    epicId,
     ownershipClaimed,
     planRestrictedSessionRebuildBackoff,
     sessionUserId,

--- a/clients/gui-app/src/providers/epic-session-provider.tsx
+++ b/clients/gui-app/src/providers/epic-session-provider.tsx
@@ -656,8 +656,13 @@ export function EpicSessionProvider(
       // lost if this attached afterwards.
       let reprobeHandle: OpenEpicStoreHandle | null = null;
       const detachReprobe = attachPlanRestrictedReprobe(wsStreamClient, () => {
-        planRestrictedSessionRebuildBackoff.request(() => {
-          reprobeHandle?.retryTransport();
+        const deniedHandle = reprobeHandle;
+        if (deniedHandle === null) return;
+        planRestrictedSessionRebuildBackoff.request(deniedHandle, () => {
+          // Capture this exact owner. If its replacement is denied before a
+          // delayed rung fires, the backoff replaces this callback with the
+          // newer handle's rather than calling through a mutable slot.
+          deniedHandle.retryTransport();
         });
       });
       const closeSessionTransport = (

--- a/clients/gui-app/src/stores/epics/open-epic/__tests__/local-body-update-refusal-logging.test.ts
+++ b/clients/gui-app/src/stores/epics/open-epic/__tests__/local-body-update-refusal-logging.test.ts
@@ -3,15 +3,15 @@
  * `createMainThreadBodyDocStore({ onLocalDocUpdate: ... })`).
  *
  * That callback fires on every LOCAL Yjs edit to a resident artifact body and
- * posts it as `void runtime.port.call("body/update", ...).catch(...)`. The
- * verdict is deliberately discarded - a refused body update is not a failed
- * user action - but a `.catch` on a `void`ed chain that RETHROWS mints a new,
- * unhandled rejection instead of reaching a logger: nobody awaits the outer
- * chain, so the rethrow has no catcher. It fires once per keystroke, so one
- * broken worker handler used to produce one unhandled rejection per edit for
- * as long as the person kept typing. The fix logs via `appLogger.error`
- * instead of rethrowing, and leaves the `BridgeDisposedError` early-return
- * (teardown, not a fault) unchanged.
+ * posts it as `void runtime.port.call("body/update", ...)`. A rejected answer
+ * is not a failed user action, but it is observable state: the main-thread doc
+ * is still the only proven holder and must keep `isDirty` latched until that
+ * doc retires. The test also keeps the original unhandled-rejection pin: a
+ * `.catch` on a `void`ed chain that RETHROWS mints a new rejection nobody
+ * awaits. It fires once per keystroke, so one broken worker handler used to
+ * produce one unhandled rejection per edit for as long as the person kept
+ * typing. The fix logs via `appLogger.error` instead of rethrowing, and leaves
+ * the `BridgeDisposedError` early-return (teardown, not a fault) unchanged.
  *
  * Reached through the REAL `createOpenEpicStore`, over a REAL
  * `createMainBridgeEndpoint`/`createFakeBridgePair` pair - not a hand-typed
@@ -87,11 +87,12 @@ async function drainRejections(): Promise<void> {
 /**
  * A hand-written worker side over the fake pair: answers `body/materialize`
  * immediately (granted, empty doc), and hands `body/update` calls to the test
- * so it can choose per-call how the worker answers - the two arms this file
- * pins.
+ * so it can choose per-call how the worker answers - the dropped, rejected,
+ * and bridge-disposed arms this file pins.
  */
 function createWorkerSide(pair: FakeBridgePair): {
   readonly pendingBodyUpdateCallIds: number[];
+  respondBodyUpdateDropped(reason: string): void;
   respondBodyUpdateError(name: string, message: string): void;
   unsubscribe(): void;
 } {
@@ -131,6 +132,20 @@ function createWorkerSide(pair: FakeBridgePair): {
   });
   return {
     pendingBodyUpdateCallIds,
+    respondBodyUpdateDropped(reason): void {
+      const callId = pendingBodyUpdateCallIds.shift();
+      if (callId === undefined) {
+        throw new Error("no outstanding body/update call to answer");
+      }
+      pair.worker.post(
+        {
+          frame: "result",
+          callId,
+          result: { outcome: { kind: "dropped", reason } },
+        },
+        [],
+      );
+    },
     respondBodyUpdateError(name, message): void {
       const callId = pendingBodyUpdateCallIds.shift();
       if (callId === undefined) {
@@ -198,9 +213,9 @@ describe("the local body/update refusal's .catch (open-epic store.ts)", () => {
         throw new Error("artifact body did not become resident");
       }
 
-      // ── Arm 1: a genuine worker-side fault ─────────────────────────────
+      // ── Arm 1: a worker-side dropped answer ────────────────────────────
       typeInto(fragment, "typed");
-      worker.respondBodyUpdateError("Error", "worker handler blew up");
+      worker.respondBodyUpdateDropped("worker holds no replica");
       await drainRejections();
 
       expect(errorSpy).toHaveBeenCalledTimes(1);
@@ -209,10 +224,38 @@ describe("the local body/update refusal's .catch (open-epic store.ts)", () => {
         { docKey: ARTIFACT_ID },
         expect.any(Error),
       );
+      typeInto(fragment, "fault");
+      worker.respondBodyUpdateError("Error", "worker handler blew up");
+      await drainRejections();
+
+      // ── Arm 2: a rejected worker-side answer ───────────────────────────
+      expect(errorSpy).toHaveBeenCalledTimes(2);
+      expect(errorSpy).toHaveBeenCalledWith(
+        "[open-epic] body update refused by the runtime worker",
+        { docKey: ARTIFACT_ID },
+        expect.any(Error),
+      );
+      // The edit remains visible in main's live doc, but the refusal is now
+      // observable as a recovery obligation rather than only as a log.
+      expect(handle.store.getState().isDirty).toBe(true);
+
+      // A later worker projection cannot erase the main-only refusal while the
+      // doc still exists. This is the class pin: projected `false` is only the
+      // worker's verdict, not proof that main's bytes crossed the bridge.
+      handle.projection.apply(
+        {
+          artifactRooms: {
+            stateByArtifactId: { [ARTIFACT_ID]: "ready" },
+          },
+          isDirty: false,
+        },
+        2,
+      );
+      expect(handle.store.getState().isDirty).toBe(true);
 
       errorSpy.mockClear();
 
-      // ── Arm 2 (CONTROL): the bridge disposed underneath the call ───────
+      // ── Arm 3 (CONTROL): the bridge disposed underneath the call ───────
       // Teardown, not a failure - the edit is already in main's live doc, so
       // this must NOT log. Without this half, an unconditional "always log"
       // would pass arm 1 and read identically to the fix.
@@ -232,6 +275,12 @@ describe("the local body/update refusal's .catch (open-epic store.ts)", () => {
       // `void`ed chain mints a fresh, unhandled rejection instead of
       // reaching the logger this test just pinned).
       expect(capture.seen).toEqual([]);
+
+      // Retirement is the proof-based clearing point. `handle.dispose()` drops
+      // the main body docs and invokes the sink's `onDocRetired`; because the
+      // worker verdict above was false, the latch can now restore false.
+      handle.dispose();
+      expect(handle.store.getState().isDirty).toBe(false);
     } finally {
       capture.stop();
       errorSpy.mockRestore();

--- a/clients/gui-app/src/stores/epics/open-epic/__tests__/local-body-update-refusal-logging.test.ts
+++ b/clients/gui-app/src/stores/epics/open-epic/__tests__/local-body-update-refusal-logging.test.ts
@@ -1,17 +1,18 @@
 /**
- * The `.catch` on `onLocalDocUpdate`'s `body/update` call (`store.ts`,
- * `createMainThreadBodyDocStore({ onLocalDocUpdate: ... })`).
+ * The refusal settlement on `onLocalDocUpdate`'s `body/update` call
+ * (`store.ts`, `createMainThreadBodyDocStore({ onLocalDocUpdate: ... })`).
  *
  * That callback fires on every LOCAL Yjs edit to a resident artifact body and
- * posts it as `void runtime.port.call("body/update", ...)`. A rejected answer
- * is not a failed user action, but it is observable state: the main-thread doc
- * is still the only proven holder and must keep `isDirty` latched until that
- * doc retires. The test also keeps the original unhandled-rejection pin: a
- * `.catch` on a `void`ed chain that RETHROWS mints a new rejection nobody
- * awaits. It fires once per keystroke, so one broken worker handler used to
- * produce one unhandled rejection per edit for as long as the person kept
- * typing. The fix logs via `appLogger.error` instead of rethrowing, and leaves
- * the `BridgeDisposedError` early-return (teardown, not a fault) unchanged.
+ * posts it as `void runtime.port.call("body/update", ...)`. A dropped answer or
+ * rejected call is not a failed user action, but it is observable state: the
+ * main-thread doc is still the only proven holder and must keep `isDirty`
+ * latched until that doc retires. The test also keeps the original
+ * unhandled-rejection pin: rethrowing from a `.catch` on a `void`ed chain mints
+ * a new rejection nobody awaits. It fires once per keystroke, so one broken
+ * worker handler used to produce one unhandled rejection per edit for as long
+ * as the person kept typing. The fix logs via `appLogger.error` instead of
+ * rethrowing, and leaves the `BridgeDisposedError` early-return (teardown, not
+ * a fault) unchanged.
  *
  * Reached through the REAL `createOpenEpicStore`, over a REAL
  * `createMainBridgeEndpoint`/`createFakeBridgePair` pair - not a hand-typed
@@ -141,7 +142,10 @@ function createWorkerSide(pair: FakeBridgePair): {
         {
           frame: "result",
           callId,
-          result: { outcome: { kind: "dropped", reason } },
+          result: {
+            outcome: "ok",
+            value: { outcome: { kind: "dropped", reason } },
+          },
         },
         [],
       );
@@ -171,7 +175,7 @@ function typeInto(fragment: Y.XmlFragment, text: string): void {
   fragment.insert(0, [paragraph]);
 }
 
-describe("the local body/update refusal's .catch (open-epic store.ts)", () => {
+describe("local body/update refusal settlement (open-epic store.ts)", () => {
   it("logs a non-disposal refusal once and never as an unhandled rejection; a disposed-bridge refusal is silent and also never unhandled", async () => {
     const capture = captureUnhandledRejections();
     const errorSpy = vi.spyOn(appLogger, "error").mockImplementation(() => {});
@@ -288,4 +292,117 @@ describe("the local body/update refusal's .catch (open-epic store.ts)", () => {
       handle.dispose();
     }
   });
+
+  it.each(["dropped", "error"] as const)(
+    "does not let a delayed %s refusal dirty a replacement resident body",
+    async (settlement) => {
+      const pair = createFakeBridgePair("sync");
+      const worker = createWorkerSide(pair);
+      const main = createMainBridgeEndpoint(
+        pair.main,
+        stubMainCallHandlers({}),
+      );
+      const binding: EpicRuntimeBinding = {
+        port: main,
+        command: () => {},
+        awarenessOut: () => {},
+        currentUser: () => {},
+        detach: () => {},
+        dispose: () => {},
+      };
+      const handle = createOpenEpicStore({
+        epicId: `${EPIC_ID}-lineage-${settlement}`,
+        userId: null,
+        onRetryTransport: () => {},
+        runtime: binding,
+        accounting: createProcessBackedAccountingPort({
+          hostId: "test-host",
+          epicId: `${EPIC_ID}-lineage-${settlement}`,
+          environment: createRendererRuntimeEnvironment(),
+        }),
+      });
+
+      let revision = 1;
+      const replaceResident = async (
+        previousDoc: Y.Doc,
+      ): Promise<{
+        readonly fragment: Y.XmlFragment;
+        readonly doc: Y.Doc;
+      }> => {
+        handle.projection.apply(
+          {
+            artifactRooms: {
+              stateByArtifactId: { [ARTIFACT_ID]: "unavailable" },
+            },
+          },
+          ++revision,
+        );
+        expect(handle.hotArtifactRoomIdsForTests()).toEqual([]);
+
+        handle.projection.apply(
+          {
+            artifactRooms: {
+              stateByArtifactId: { [ARTIFACT_ID]: "ready" },
+            },
+          },
+          ++revision,
+        );
+        const lease = handle.store
+          .getState()
+          .acquireResidentArtifactBodyLease(ARTIFACT_ID, "linger");
+        await lease.resident;
+
+        const replacement = handle.store
+          .getState()
+          .getArtifactFragment(ARTIFACT_ID);
+        if (replacement === null) {
+          throw new Error("replacement artifact body did not become resident");
+        }
+        const replacementDoc = replacement.doc;
+        if (replacementDoc === null) {
+          throw new Error("replacement artifact body did not expose its doc");
+        }
+        expect(replacementDoc).not.toBe(previousDoc);
+        expect(handle.hotArtifactRoomIdsForTests()).toEqual([ARTIFACT_ID]);
+        return { fragment: replacement, doc: replacementDoc };
+      };
+
+      try {
+        handle.projection.apply({ installedArm: "lanes" }, revision);
+        const initialLease = handle.store
+          .getState()
+          .acquireResidentArtifactBodyLease(ARTIFACT_ID, "linger");
+        await initialLease.resident;
+        const initialFragment = handle.store
+          .getState()
+          .getArtifactFragment(ARTIFACT_ID);
+        if (initialFragment === null || initialFragment.doc === null) {
+          throw new Error("initial artifact body did not become resident");
+        }
+
+        typeInto(initialFragment, `${settlement} predecessor`);
+        expect(worker.pendingBodyUpdateCallIds).toHaveLength(1);
+        const replacement = await replaceResident(initialFragment.doc);
+        expect(handle.store.getState().isDirty).toBe(false);
+        expect(worker.pendingBodyUpdateCallIds).toHaveLength(1);
+
+        if (settlement === "dropped") {
+          worker.respondBodyUpdateDropped("predecessor retired");
+        } else {
+          worker.respondBodyUpdateError("Error", "late worker failure");
+        }
+        await drainRejections();
+
+        // The distinct replacement was resident before settlement, so this is
+        // not a vacuous "nothing remained to dirty" assertion. Ablation:
+        // without the dispatched-generation fence, each parameterized case
+        // independently latches the replacement's same docKey dirty.
+        expect(replacement.fragment.doc).toBe(replacement.doc);
+        expect(handle.store.getState().isDirty).toBe(false);
+      } finally {
+        worker.unsubscribe();
+        handle.dispose();
+      }
+    },
+  );
 });

--- a/clients/gui-app/src/stores/epics/open-epic/runtime/__tests__/artifact-room-tier.test.ts
+++ b/clients/gui-app/src/stores/epics/open-epic/runtime/__tests__/artifact-room-tier.test.ts
@@ -1526,4 +1526,64 @@ describe("hot-growth accounting survives a transport that TRANSFERS the update",
     expect(charges).toHaveLength(1);
     expect(charges[0]).toBeGreaterThan(0);
   });
+
+  it("copies before transfer so a later Yjs observer can still read the shared update", () => {
+    let transferred = false;
+    let transferredUpdate: Uint8Array | null = null;
+    let laterObserverUpdate: Uint8Array | null = null;
+    const tier = createArtifactRoomTier({
+      environment: createFakeEnvironment(),
+      session: createFakeSession(),
+      send: (request) => {
+        if (request.kind === "room-update") {
+          transferredUpdate = request.update;
+          const buffer = request.update.buffer;
+          if (
+            buffer instanceof ArrayBuffer &&
+            request.update.byteOffset === 0 &&
+            request.update.byteLength === buffer.byteLength
+          ) {
+            structuredClone(request.update, { transfer: [buffer] });
+            transferred = true;
+          }
+        }
+        return { kind: "sent" };
+      },
+      onDivergenceChanged: () => undefined,
+      isDisposed: () => false,
+      budget: null,
+    });
+    trackTierDisposal(tier);
+
+    const { bytes, hostStateVectorBase64 } = makeSnapshotBytes("hello");
+    tier.applySnapshot({
+      artifactRoomId: "room-two-holders",
+      snapshotBytes: bytes,
+      hostStateVectorBase64,
+      seed: "full",
+      docGuid: null,
+    });
+    tier.acquireSync("room-two-holders");
+    const entry = requireHotEntry(tier, "room-two-holders");
+
+    // This observer is attached AFTER the tier's outbound observer. It sees
+    // the same Yjs-owned update, not a second synthetic callback invocation.
+    entry.doc.on("update", (update) => {
+      expect(transferred).toBe(true);
+      laterObserverUpdate = update;
+      const readableUpdate = update.slice();
+      const replay = new Y.Doc();
+      Y.applyUpdate(replay, readableUpdate);
+      expect(replay.getMap("body").get("local-edit")).toBe("1");
+      replay.destroy();
+    });
+    entry.doc.getMap("body").set("local-edit", "1");
+
+    expect(transferredUpdate).not.toBeNull();
+    expect(laterObserverUpdate).not.toBeNull();
+    // Compare identity as a boolean. Passing the detached outbound view into a
+    // matcher makes Vitest's failure-message formatter iterate its bytes,
+    // which throws before the identity result can be reported.
+    expect(Object.is(laterObserverUpdate, transferredUpdate)).toBe(false);
+  });
 });

--- a/clients/gui-app/src/stores/epics/open-epic/runtime/artifact-room-tier.ts
+++ b/clients/gui-app/src/stores/epics/open-epic/runtime/artifact-room-tier.ts
@@ -1016,20 +1016,32 @@ export function createArtifactRoomTier(
       // was wrong even where the copy path happens to preserve it.
       const updateBytes = update.byteLength;
       if (session.canSendBodyWrites()) {
-        const outcome = send({ kind: "room-update", artifactRoomId, update });
+        // COPIED, because Yjs owns this update and hands the SAME array to
+        // every observer. A resident worker-backed body has two: this outbound
+        // tier observer and the body return leg that mirrors the edit into
+        // main's live doc. The stream proxy transfers full-span arrays in
+        // place, so sending `update` itself detaches it before the return-leg
+        // observer can even copy it (`Uint8Array.prototype.slice` then throws
+        // on the detached buffer). Each transferring consumer therefore takes
+        // its own copy at the point where non-ownership is known.
+        const outboundUpdate = update.slice();
+        const outcome = send({
+          kind: "room-update",
+          artifactRoomId,
+          update: outboundUpdate,
+        });
         if (outcome.kind === "sent") {
           noteHotGrowth(artifactRoomId, updateBytes);
           return;
         }
         // The session may write and this BODY still could not. Fall through to
-        // the queue rather than treating the refusal as delivery - the bytes
-        // are a user's edit and nothing else is holding them.
+        // the queue rather than treating the refusal as delivery. Main's body
+        // return leg is another holder, but it is not proof that this tier's
+        // host propagation obligation was accepted.
         //
-        // Safe to retain the same view: every refusal returns before the
-        // payload reaches the transport (`lane-terminal`, `no-transport`,
-        // `no-body-lane-for-artifact`, `body-not-seeded` all short-circuit),
-        // so a refused update was never handed to a transfer and cannot have
-        // been detached.
+        // Safe to retain the ORIGINAL view regardless of how far the refused
+        // send got: only `outboundUpdate` was handed to the transferring
+        // consumer above. The Yjs-owned `update` was never transferable input.
       }
       // Queue while reconnecting/closed, or while a raw-open stream is still
       // waiting on its fresh root snapshot/permission role. Snapshots collapse

--- a/clients/gui-app/src/stores/epics/open-epic/runtime/worker/__tests__/epic-runtime-core-ports.test.ts
+++ b/clients/gui-app/src/stores/epics/open-epic/runtime/worker/__tests__/epic-runtime-core-ports.test.ts
@@ -683,11 +683,10 @@ describe("bodies.materialize — forward-only vs not-held", () => {
  *
  * Yjs delivers ONE freshly-encoded array to every `update` listener. On the
  * `@1` arm two listen: the tier's outbound observer, which turns it into an
- * `artifactRoomApplyUpdate` frame, and the body return leg. The return leg's
- * bytes are eventually handed to `takeBytesForTransfer`, which transfers a
- * full-span standalone buffer IN PLACE - so passing the shared array straight
- * through detaches the one the tier's frame is still holding, and that frame
- * decodes as `Unexpected end of array` wherever it is finally read.
+ * `artifactRoomApplyUpdate` frame, and the body return leg. Both downstream
+ * legs can eventually transfer a full-span standalone buffer IN PLACE, so
+ * both copy before that handoff. Passing the shared array through from either
+ * observer would detach it before every later observer can make its own copy.
  *
  * Pinned as IDENTITY rather than as a decode failure downstream: the property
  * is "we are not the owner, so we copy", and identity is what states it. A

--- a/clients/gui-app/src/stores/epics/open-epic/runtime/worker/__tests__/main-thread-body-docs.test.ts
+++ b/clients/gui-app/src/stores/epics/open-epic/runtime/worker/__tests__/main-thread-body-docs.test.ts
@@ -46,6 +46,7 @@ function snapshotWith(text: string): { update: Uint8Array; guid: string } {
  */
 const NOOP_SINKS: MainThreadBodyDocSinks = {
   onResidencyChange: () => {},
+  onDocRetired: () => {},
   onLocalDocUpdate: () => {},
   onLocalAwareness: () => {},
 };

--- a/clients/gui-app/src/stores/epics/open-epic/runtime/worker/epic-runtime-core-ports.ts
+++ b/clients/gui-app/src/stores/epics/open-epic/runtime/worker/epic-runtime-core-ports.ts
@@ -281,13 +281,12 @@ export function buildEpicRuntimeCorePorts(
       //
       // Yjs delivers ONE freshly-encoded array to every `update` listener, and
       // on the `@1` arm two listen: the tier's outbound observer, which turns
-      // it into an `artifactRoomApplyUpdate` frame, and this one. The return
-      // leg hands its array to `takeBytesForTransfer`, which transfers a
-      // full-span standalone buffer IN PLACE - a judgement about GEOMETRY that
-      // is a proxy for ownership, and correct only when the caller owns the
-      // bytes. Transferring this one detaches the array the tier's frame is
-      // still holding, and that frame decodes as `Unexpected end of array`
-      // wherever it is finally read.
+      // it into an `artifactRoomApplyUpdate` frame, and this one. BOTH
+      // downstream legs can transfer full-span arrays in place, so both copy:
+      // the tier before its stream send, and this return leg before its worker
+      // post. Neither may rely on observer order; transferring the shared Yjs
+      // array in either observer detaches it before every later observer can
+      // even make its own copy.
       //
       // The copy belongs HERE and not inside `takeBytesForTransfer`: this is
       // the point where non-ownership is known, and teaching the helper to

--- a/clients/gui-app/src/stores/epics/open-epic/runtime/worker/epic-runtime-worker-host.ts
+++ b/clients/gui-app/src/stores/epics/open-epic/runtime/worker/epic-runtime-worker-host.ts
@@ -416,10 +416,11 @@ export function startEpicRuntimeWorkerHost(
       if (core === null) {
         // No core: the body lane this update was destined for does not exist
         // here. `dropped` rather than `queued` because nothing in this worker
-        // is holding it - the main thread's live doc is, and the edit reaches
-        // the host on the next materialize/demote cycle. The reason names the
-        // state so a caller can tell a teardown drop from a lane refusing a
-        // doc it should have had.
+        // is holding it. The main thread's live doc remains the only proven
+        // holder and latches that fact into its visible dirty state until a
+        // full demote or authoritative replacement retires the doc. The reason
+        // names the state so a caller can tell a teardown drop from a lane
+        // refusing a doc it should have had.
         return {
           value: {
             outcome: {

--- a/clients/gui-app/src/stores/epics/open-epic/runtime/worker/main-thread-body-docs.ts
+++ b/clients/gui-app/src/stores/epics/open-epic/runtime/worker/main-thread-body-docs.ts
@@ -61,6 +61,14 @@ const MAIN_BODY_REMOTE_ORIGIN = Symbol("open-epic/main-body-remote");
  */
 export interface MainThreadBodyDocSinks {
   readonly onResidencyChange: () => void;
+  /**
+   * A resident doc was retired or replaced.
+   *
+   * Separate from `onResidencyChange`: replacing one doc under the same key
+   * does not change the resident set, but it does retire every main-only edit
+   * that belonged to the previous lineage.
+   */
+  readonly onDocRetired: (docKey: string) => void;
   /** A local edit to a resident body: `body/update`. */
   readonly onLocalDocUpdate: (docKey: string, update: Uint8Array) => void;
   /**
@@ -257,20 +265,23 @@ export function createMainThreadBodyDocStore(
         ) {
           destroy(held);
           bodies.delete(input.docKey);
+          sinks.onDocRetired(input.docKey);
         } else if (held.docGuid === input.docGuid) {
           // Origin-stamped: this is the worker's copy of the body arriving,
           // not something the editor typed. See MAIN_BODY_REMOTE_ORIGIN.
           Y.applyUpdate(held.doc, input.update, MAIN_BODY_REMOTE_ORIGIN);
           held.hostStateVector = input.hostStateVector;
           return;
+        } else {
+          // DIFFERENT lineage. Replace, never splice - see this module's
+          // header. The old doc is destroyed rather than left for the GC
+          // because its awareness holds a listener on it and because any
+          // editor still bound to it must fail loudly rather than keep editing
+          // a document nothing will ever demote.
+          destroy(held);
+          bodies.delete(input.docKey);
+          sinks.onDocRetired(input.docKey);
         }
-        // DIFFERENT lineage. Replace, never splice - see this module's header.
-        // The old doc is destroyed rather than left for the GC because its
-        // awareness holds a listener on it and because any editor still bound
-        // to it must fail loudly rather than keep editing a document nothing
-        // will ever demote.
-        destroy(held);
-        bodies.delete(input.docKey);
       }
       const doc = new Y.Doc();
       const tracked = track(input.docKey, doc, new Awareness(doc));
@@ -316,6 +327,7 @@ export function createMainThreadBodyDocStore(
       if (held === undefined) return;
       bodies.delete(docKey);
       destroy(held);
+      sinks.onDocRetired(docKey);
       sinks.onResidencyChange();
     },
 
@@ -338,11 +350,14 @@ export function createMainThreadBodyDocStore(
     },
 
     dropAll(): void {
-      const held = [...bodies.values()];
+      const held = [...bodies.entries()];
       // Cleared BEFORE destroying, so a destroy handler that reads this store
       // sees the post-teardown state rather than a half-emptied map.
       bodies.clear();
-      for (const body of held) destroy(body);
+      for (const [docKey, body] of held) {
+        destroy(body);
+        sinks.onDocRetired(docKey);
+      }
       if (held.length > 0) sinks.onResidencyChange();
     },
   };

--- a/clients/gui-app/src/stores/epics/open-epic/session-registry.ts
+++ b/clients/gui-app/src/stores/epics/open-epic/session-registry.ts
@@ -639,10 +639,7 @@ export class OpenEpicSessionRegistry {
     // NO retention, stated rather than defaulted - see above for why the dirty
     // test would answer "the only copy" about a document nothing can read.
     entry.session.pendingRetention = null;
-    attributeEpicSessionTransportClose(
-      entry.session.handle,
-      "retry-rebuild",
-    );
+    attributeEpicSessionTransportClose(entry.session.handle, "retry-rebuild");
     this.sessions.discard(epicId, "released");
   }
 

--- a/clients/gui-app/src/stores/epics/open-epic/session-registry.ts
+++ b/clients/gui-app/src/stores/epics/open-epic/session-registry.ts
@@ -5,6 +5,7 @@ import type {
 import {
   createSessionRegistry,
   type SessionRegistry,
+  type SessionDisposeCause,
 } from "@traycer-clients/shared/replica-runtime";
 import { createRendererRuntimeEnvironment } from "@/stores/epics/open-epic/runtime/runtime-environment";
 import { appLogger } from "@/lib/logger";
@@ -80,6 +81,61 @@ const handleWorkerLiveness = new WeakMap<
   OpenEpicStoreHandle,
   { dead: boolean }
 >();
+
+/**
+ * Why the Epic SESSION owner deliberately ended its durable transport.
+ *
+ * This is deliberately narrower than the shared registry's disposal causes:
+ * staging needs the product-level churn source (prune, tab close, rebuild or
+ * re-point), not the registry mechanism that happened to carry it.
+ */
+export type EpicSessionTransportCloseTrigger =
+  | "prune"
+  | "tab-close"
+  | "retry-rebuild"
+  | "repoint"
+  | "sign-out"
+  | "construction-failed";
+
+const handleTransportCloseAttribution = new WeakMap<
+  OpenEpicStoreHandle,
+  (trigger: EpicSessionTransportCloseTrigger) => void
+>();
+
+/** Binds a provider-owned transport to the registry that decides its fate. */
+export function trackEpicSessionTransportCloseAttribution(
+  handle: OpenEpicStoreHandle,
+  attribute: (trigger: EpicSessionTransportCloseTrigger) => void,
+): void {
+  handleTransportCloseAttribution.set(handle, attribute);
+}
+
+/** Records the next close trigger without widening the store-handle API. */
+export function attributeEpicSessionTransportClose(
+  handle: OpenEpicStoreHandle,
+  trigger: EpicSessionTransportCloseTrigger,
+): void {
+  handleTransportCloseAttribution.get(handle)?.(trigger);
+}
+
+function transportCloseTriggerForCause(
+  cause: SessionDisposeCause,
+): EpicSessionTransportCloseTrigger {
+  switch (cause) {
+    case "idle-expired":
+    case "warm-overflow":
+      return "prune";
+    case "released":
+      return "tab-close";
+    case "scope-mismatch":
+    case "unusable":
+      return "retry-rebuild";
+    case "replaced":
+      return "repoint";
+    case "dispose-all":
+      return "sign-out";
+  }
+}
 
 /** Binds a handle to the liveness cell its own fatal relay writes. */
 export function trackEpicSessionHandleLiveness(
@@ -427,6 +483,17 @@ export class OpenEpicSessionRegistry {
         // Never evict a session holding unsynced edits or unflushed writes.
         isEvictable: (session) => session.handle.isClean(),
         onBeforeDispose: (session, cause) => {
+          // Attribute BEFORE either teardown arm. A dirty outgoing handle is
+          // retained by calling detachTransport below rather than by the
+          // registry's dispose callback, but both routes end the same durable
+          // session transport and must carry the same cause. Provider-side
+          // attribution is first-wins, so a more specific retry override
+          // recorded immediately before a generic `released` discard survives
+          // this fallback mapping.
+          attributeEpicSessionTransportClose(
+            session.handle,
+            transportCloseTriggerForCause(cause),
+          );
           // Same teardown for every route out of the registry, retention
           // included: the entry's subscriptions close over it and call
           // `prune()`/`emit()`, and it is no longer registered for either to be
@@ -572,6 +639,10 @@ export class OpenEpicSessionRegistry {
     // NO retention, stated rather than defaulted - see above for why the dirty
     // test would answer "the only copy" about a document nothing can read.
     entry.session.pendingRetention = null;
+    attributeEpicSessionTransportClose(
+      entry.session.handle,
+      "retry-rebuild",
+    );
     this.sessions.discard(epicId, "released");
   }
 
@@ -942,6 +1013,48 @@ export class OpenEpicSessionRegistry {
     retainedBuffers: "discard" | "keep",
     dirtyLiveHandle: RetainedHandleIdentity | null,
   ): void {
+    this.releaseWithTransportTrigger(
+      epicId,
+      retainedBuffers,
+      dirtyLiveHandle,
+      "tab-close",
+    );
+  }
+
+  /** Rebuilds the session without mislabelling the teardown as a tab close. */
+  releaseForRetryRebuild(
+    epicId: string,
+    retainedBuffers: "discard" | "keep",
+    dirtyLiveHandle: RetainedHandleIdentity | null,
+  ): void {
+    this.releaseWithTransportTrigger(
+      epicId,
+      retainedBuffers,
+      dirtyLiveHandle,
+      "retry-rebuild",
+    );
+  }
+
+  /** Applies the auth boundary while preserving its close attribution. */
+  releaseForSignOut(
+    epicId: string,
+    retainedBuffers: "discard" | "keep",
+    dirtyLiveHandle: RetainedHandleIdentity | null,
+  ): void {
+    this.releaseWithTransportTrigger(
+      epicId,
+      retainedBuffers,
+      dirtyLiveHandle,
+      "sign-out",
+    );
+  }
+
+  private releaseWithTransportTrigger(
+    epicId: string,
+    retainedBuffers: "discard" | "keep",
+    dirtyLiveHandle: RetainedHandleIdentity | null,
+    trigger: EpicSessionTransportCloseTrigger,
+  ): void {
     this.sessions.transact(() => {
       if (retainedBuffers === "discard") {
         // Ordered before the early return: a retention must not outlive the tab
@@ -953,6 +1066,10 @@ export class OpenEpicSessionRegistry {
         this.sessions.notify();
         return;
       }
+      // Must precede `discard`: `onBeforeDispose` sees only the shared
+      // `released` cause. The provider stores the first attribution, so its
+      // generic tab-close fallback cannot overwrite this call-site verdict.
+      attributeEpicSessionTransportClose(entry.session.handle, trigger);
       const retainsLiveEdits =
         retainedBuffers === "keep" &&
         dirtyLiveHandle !== null &&

--- a/clients/gui-app/src/stores/epics/open-epic/store.ts
+++ b/clients/gui-app/src/stores/epics/open-epic/store.ts
@@ -1049,24 +1049,45 @@ export function createOpenEpicStore(
    * The worker's own dirty verdict, before main-only body refusals are folded
    * into it.
    *
-   * A rejected/dropped `body/update` leaves the live main-thread doc as the
-   * only proven holder of that edit. The worker cannot publish dirtiness for
-   * bytes it never accepted, so main latches the doc key below and ORs that
-   * fact into every later projection until the doc is retired after a full
-   * demote/replacement. Keeping the worker verdict separately is what lets
-   * that retirement restore the honest projected value instead of guessing
-   * that the rest of the replica is clean.
+   * A rejected/dropped `body/update` for the still-resident lineage leaves the
+   * live main-thread doc as the only proven holder of that edit. The worker
+   * cannot publish dirtiness for bytes it never accepted, so main latches the
+   * doc key below and ORs that fact into every later projection until the doc
+   * is retired after a full demote/replacement. Keeping the worker verdict
+   * separately is what lets that retirement restore the honest projected
+   * value instead of guessing that the rest of the replica is clean.
    */
   let workerReplicaIsDirty = false;
   const refusedBodyUpdateDocKeys = new Set<string>();
+  /**
+   * Current main-doc lineage per key. Replacement and retirement reuse the
+   * docKey, so an async refusal must prove it still belongs to the resident
+   * lineage before it can latch that key dirty. Retirement deletes the token:
+   * this bounds the map to live lineages and guarantees a same-key replacement
+   * mints an identity no predecessor callback can match.
+   */
+  const bodyDocGenerationByDocKey = new Map<string, symbol>();
 
-  function markBodyUpdateRefused(docKey: string): void {
+  function bodyDocGenerationForDispatch(docKey: string): symbol {
+    const currentGeneration = bodyDocGenerationByDocKey.get(docKey);
+    if (currentGeneration !== undefined) return currentGeneration;
+    const nextGeneration = Symbol();
+    bodyDocGenerationByDocKey.set(docKey, nextGeneration);
+    return nextGeneration;
+  }
+
+  function markBodyUpdateRefused(
+    docKey: string,
+    dispatchedGeneration: symbol,
+  ): void {
+    if (bodyDocGenerationByDocKey.get(docKey) !== dispatchedGeneration) return;
     if (refusedBodyUpdateDocKeys.has(docKey)) return;
     refusedBodyUpdateDocKeys.add(docKey);
     storeApi?.setState({ isDirty: true });
   }
 
-  function retireRefusedBodyUpdate(docKey: string): void {
+  function retireBodyDoc(docKey: string): void {
+    bodyDocGenerationByDocKey.delete(docKey);
     if (!refusedBodyUpdateDocKeys.delete(docKey)) return;
     if (refusedBodyUpdateDocKeys.size > 0) return;
     storeApi?.setState({ isDirty: workerReplicaIsDirty });
@@ -1575,7 +1596,7 @@ export function createOpenEpicStore(
       // by the worker's demote, or after an authoritative replacement/drop.
       // Either way main is no longer the sole holder of the refused edit, so
       // this doc-local latch has reached its proof-based clearing point.
-      retireRefusedBodyUpdate(docKey);
+      retireBodyDoc(docKey);
     },
     onLocalDocUpdate: (docKey, update) => {
       // A lane-level transport refusal does NOT reach this caller as loss.
@@ -1586,16 +1607,18 @@ export function createOpenEpicStore(
       //
       // `dropped` is different: the worker held no replica, so main's live doc
       // is the only proven holder. A non-teardown handler rejection is the
-      // same ownership fact with no parsed outcome. Both latch this doc into
-      // `isDirty` until its full state crosses on demote or an authoritative
-      // replacement retires it. The edit remains visually successful; state
-      // and the log make the recovery obligation observable without turning
-      // typing into a rejected user action.
+      // same ownership fact with no parsed outcome. While the dispatch still
+      // belongs to this resident doc lineage, both latch it into `isDirty`
+      // until its full state crosses on demote or an authoritative replacement
+      // retires it. The edit remains visually successful; state and the log
+      // make the recovery obligation observable without turning typing into a
+      // rejected user action.
+      const dispatchedGeneration = bodyDocGenerationForDispatch(docKey);
       void runtime.port
         .call("body/update", { docKey, update }, NO_TRANSFER)
         .then((answer) => {
           if (answer.outcome.kind !== "dropped") return;
-          markBodyUpdateRefused(docKey);
+          markBodyUpdateRefused(docKey, dispatchedGeneration);
           appLogger.error(
             "[open-epic] body update refused by the runtime worker",
             { docKey },
@@ -1608,7 +1631,7 @@ export function createOpenEpicStore(
           // real fault is still reported rather than being swallowed as "the
           // session closed".
           if (cause instanceof BridgeDisposedError) return;
-          markBodyUpdateRefused(docKey);
+          markBodyUpdateRefused(docKey, dispatchedGeneration);
           // LOGGED, not rethrown. Rethrowing from inside a `.catch` returns a
           // freshly rejected promise, and this chain is `void`ed - so the
           // rethrow did not reach the console the comment above promised, it

--- a/clients/gui-app/src/stores/epics/open-epic/store.ts
+++ b/clients/gui-app/src/stores/epics/open-epic/store.ts
@@ -1046,6 +1046,32 @@ export function createOpenEpicStore(
 
   let storeApi: StoreApi<OpenEpicState> | null = null;
   /**
+   * The worker's own dirty verdict, before main-only body refusals are folded
+   * into it.
+   *
+   * A rejected/dropped `body/update` leaves the live main-thread doc as the
+   * only proven holder of that edit. The worker cannot publish dirtiness for
+   * bytes it never accepted, so main latches the doc key below and ORs that
+   * fact into every later projection until the doc is retired after a full
+   * demote/replacement. Keeping the worker verdict separately is what lets
+   * that retirement restore the honest projected value instead of guessing
+   * that the rest of the replica is clean.
+   */
+  let workerReplicaIsDirty = false;
+  const refusedBodyUpdateDocKeys = new Set<string>();
+
+  function markBodyUpdateRefused(docKey: string): void {
+    if (refusedBodyUpdateDocKeys.has(docKey)) return;
+    refusedBodyUpdateDocKeys.add(docKey);
+    storeApi?.setState({ isDirty: true });
+  }
+
+  function retireRefusedBodyUpdate(docKey: string): void {
+    if (!refusedBodyUpdateDocKeys.delete(docKey)) return;
+    if (refusedBodyUpdateDocKeys.size > 0) return;
+    storeApi?.setState({ isDirty: workerReplicaIsDirty });
+  }
+  /**
    * Ids for pending attachment WAITS, unique per store.
    *
    * The worker keys its pending waits on this, and `attachment/cancel` names
@@ -1365,7 +1391,14 @@ export function createOpenEpicStore(
         "[open-epic] projection applied before the store attached",
       );
     }
-    const { bindingEpoch, ...projected } = patch;
+    const { bindingEpoch, ...workerProjected } = patch;
+    let projected = workerProjected;
+    if (projected.isDirty !== undefined) {
+      workerReplicaIsDirty = projected.isDirty;
+      if (refusedBodyUpdateDocKeys.size > 0) {
+        projected = { ...projected, isDirty: true };
+      }
+    }
     // ── Re-stabilise nested identity, at the grain the projector owns it ──
     //
     // The worker's projector re-allocates ONLY what changed - a rename mints a
@@ -1537,20 +1570,45 @@ export function createOpenEpicStore(
         bodyResidencyVersion: state.bodyResidencyVersion + 1,
       }));
     },
+    onDocRetired: (docKey) => {
+      // A lane body retires only after its full main-side state was accepted
+      // by the worker's demote, or after an authoritative replacement/drop.
+      // Either way main is no longer the sole holder of the refused edit, so
+      // this doc-local latch has reached its proof-based clearing point.
+      retireRefusedBodyUpdate(docKey);
+    },
     onLocalDocUpdate: (docKey, update) => {
-      // The lane's verdict is deliberately DISCARDED here. A refused body
-      // update is not a failed user action: the edit is already in main's
-      // live doc, and the bytes reach the host on the next materialize or
-      // demote cycle regardless. Surfacing it would put an error in front of
-      // someone whose typing worked.
+      // A lane-level transport refusal does NOT reach this caller as loss.
+      // The worker first applies the update to its tier; that tier marks the
+      // room dirty and either sends or queues the bytes, then answers `sent`
+      // because it accepted ownership. That is the lane-arm proof the old
+      // "next cycle regardless" comment was missing.
+      //
+      // `dropped` is different: the worker held no replica, so main's live doc
+      // is the only proven holder. A non-teardown handler rejection is the
+      // same ownership fact with no parsed outcome. Both latch this doc into
+      // `isDirty` until its full state crosses on demote or an authoritative
+      // replacement retires it. The edit remains visually successful; state
+      // and the log make the recovery obligation observable without turning
+      // typing into a rejected user action.
       void runtime.port
         .call("body/update", { docKey, update }, NO_TRANSFER)
+        .then((answer) => {
+          if (answer.outcome.kind !== "dropped") return;
+          markBodyUpdateRefused(docKey);
+          appLogger.error(
+            "[open-epic] body update refused by the runtime worker",
+            { docKey },
+            new Error(answer.outcome.reason),
+          );
+        })
         .catch((cause: unknown) => {
           // Teardown, not a failure: the session is going away and this edit
           // is already in main's live doc. Narrowed on the error type so a
           // real fault is still reported rather than being swallowed as "the
           // session closed".
           if (cause instanceof BridgeDisposedError) return;
+          markBodyUpdateRefused(docKey);
           // LOGGED, not rethrown. Rethrowing from inside a `.catch` returns a
           // freshly rejected promise, and this chain is `void`ed - so the
           // rethrow did not reach the console the comment above promised, it


### PR DESCRIPTION
## Why

Two staging signatures from the lane-arm field run:

- `body update refused by the runtime worker — Cannot perform %TypedArray%.prototype.slice on a detached ArrayBuffer`: a Yjs update array is handed to two observers on the artifact-room tier; the outbound observer transfers its buffer to the stream proxy synchronously, and the body-return observer then slices the detached array.
- `WsStreamClient closed (reason=durable-transport-closed)` repeatedly: that reason is only ever emitted by the provider's own session teardown, so the log could not say which path (registry prune, tab close, re-point, retry rebuild) tore the session down, and a host that keeps answering plan-denied rebuilt a whole session at every transport cache deadline with no backoff.

## What

**G3 — transfer ownership.** Enumerated all 11 production callers of `takeBytesForTransfer` and the holders of each buffer at transfer time. The one uncovered two-holder case was the tier's outbound body-update observer; it now copies before the stream send (the return leg already copied). Attachment-map legs already copy; every other leg transfers a freshly encoded buffer. A refused `body/update` is now observable as state, not only a log line: a worker `dropped` answer or a non-teardown bridge rejection latches the docKey into a main-side set that forces visible `isDirty` until the doc is retired, so a later worker `isDirty:false` projection cannot hide a main-only edit. Lane-arm transport refusals need no latch: the worker tier has already applied, dirtied and queued the update before answering `sent`.

**G6 — teardown attribution and backoff.** The close reason keeps its prefix and gains the trigger: `durable-transport-closed:prune|tab-close|retry-rebuild|repoint|sign-out|construction-failed`, recorded first-wins through a handle-scoped sink with the registry cause as fallback. Session rebuilds after repeated plan-denied answers now back off per provider: immediate, then 1m/2m/4m/8m, capped at 15m; one attempt per denied handle, a replacement handle takes over a pending rung without advancing the ladder; reset on a healthy snapshot, user retry, target/user/ownership change, and unmount.

## Verification

- `bun run --cwd traycer/clients/gui-app vitest run` on the touched suites: artifact-room-tier (real second Yjs observer over a transferred buffer), local-body-update-refusal-logging (dropped and rejected answers, latch survives a later worker false, retirement restores it), epic-session-transport-ownership (exact reasons for tab-close, prune, retry-rebuild, repoint), plan-restricted-session-rebuild-backoff (ladder, cap, same-owner no-op, replacement handoff, reset), epic-runtime-core-ports, main-thread-body-docs.
- `bun run --cwd traycer compile` green across the OSS projects.
- Ablations: removing the tier copy reproduces the detached-buffer failure; removing the latch lets a worker-false projection clear `isDirty`; removing attribution fails the exact-reason pins; making duplicate requests advance the ladder or forgetting attempt-zero ownership fails the backoff pins.
- Cold-reviewed in two passes before opening.

Internal gitlink bump follows the merge.
