### PR TITLE
test(gui-app): cover lane-backed epic sessions through the real manifest path

### DIFF
--- a/clients/gui-app/src/providers/__tests__/epic-access-coordinator.test.tsx
+++ b/clients/gui-app/src/providers/__tests__/epic-access-coordinator.test.tsx
@@ -25,7 +25,6 @@ import {
   markEpicCreatedThisSession,
 } from "@/lib/epics/session-created-epics";
 import { __getOpenEpicRegistryForTests } from "@/lib/registries/epic-session-registry";
-import { type EpicStreamClientFactory } from "@/stores/epics/open-epic/store";
 import {
   openStoreForTest,
   type OpenedStoreForTest,
@@ -40,6 +39,12 @@ import { useTabsStore } from "@/stores/tabs/store";
 import { flattenLayoutRefs } from "@/stores/tabs/layout";
 import { tabCommandCoordinator } from "@/stores/tabs/tab-command-coordinator";
 import type { TabRef } from "@/stores/tabs/types";
+import {
+  createEpicSessionFixture,
+  type EpicSessionFixture,
+} from "./epic-session-fixture";
+
+let accessFixture: EpicSessionFixture | null = null;
 
 const { toastInfo } = vi.hoisted(() => ({ toastInfo: vi.fn() }));
 vi.mock("sonner", () => ({ toast: { info: toastInfo } }));
@@ -58,26 +63,17 @@ const TEST_SETTINGS: ChatRunSettings = {
 // HOST clearing, not host scoping itself, so any single consistent id works.
 const TEST_HOST_ID = "host-1";
 
-const fakeFactory: EpicStreamClientFactory = () => ({
-  applyUpdate: () => {},
-  awareness: () => {},
-  applyArtifactRoomUpdate: () => {},
-  artifactRoomAwareness: () => {},
-  retryMigration: () => {},
-  close: () => {},
-});
-
 function registerSession(epicId: string): OpenedStoreForTest {
+  if (accessFixture === null) {
+    throw new Error("expected the access-coordinator fixture");
+  }
   const handle = openStoreForTest({
     epicId: epicId,
     userId: null,
     // The factories go to the COMPOSITION now: the store stopped
     // constructing a runtime, so a `streamClientFactory` has nowhere
     // else to go.
-    factories: {
-      streamClientFactory: fakeFactory,
-      laneSelection: null,
-    },
+    factories: accessFixture.factories,
     writeCommand: null,
   });
   __getOpenEpicRegistryForTests().acquire(epicId, () => handle);
@@ -208,6 +204,7 @@ describe("EpicAccessCoordinator", () => {
     __getOpenEpicRegistryForTests().disposeAll();
     clearSessionCreatedEpics();
     toastInfo.mockClear();
+    accessFixture = createEpicSessionFixture("legacy");
   });
 
   afterEach(() => {
@@ -218,6 +215,8 @@ describe("EpicAccessCoordinator", () => {
     useTabsStore.setState(useTabsStore.getInitialState(), true);
     useComposerRunSettingsStore.getState().resetForTests();
     clearSessionCreatedEpics();
+    accessFixture?.dispose();
+    accessFixture = null;
     vi.restoreAllMocks();
   });
 
@@ -782,7 +781,7 @@ describe("EpicAccessCoordinator", () => {
   it("does not grace a replica that holds unsynced work (isDirty)", async () => {
     markEpicCreatedThisSession("epic-1", "host-x");
     const handle = registerSession("epic-1");
-    // Explicit, not incidental: a freshly built handle from `fakeFactory`
+    // Explicit, not incidental: a freshly built handle from the legacy fixture
     // starts clean, so this is what actually exercises the guard rather than
     // some setup side effect.
     handle.store.setState({ isDirty: true, unsyncedQueueSize: 0 });

--- a/clients/gui-app/src/providers/__tests__/epic-access-coordinator.test.tsx
+++ b/clients/gui-app/src/providers/__tests__/epic-access-coordinator.test.tsx
@@ -25,6 +25,7 @@ import {
   markEpicCreatedThisSession,
 } from "@/lib/epics/session-created-epics";
 import { __getOpenEpicRegistryForTests } from "@/lib/registries/epic-session-registry";
+import { type EpicStreamClientFactory } from "@/stores/epics/open-epic/store";
 import {
   openStoreForTest,
   type OpenedStoreForTest,
@@ -39,12 +40,6 @@ import { useTabsStore } from "@/stores/tabs/store";
 import { flattenLayoutRefs } from "@/stores/tabs/layout";
 import { tabCommandCoordinator } from "@/stores/tabs/tab-command-coordinator";
 import type { TabRef } from "@/stores/tabs/types";
-import {
-  createEpicSessionFixture,
-  type EpicSessionFixture,
-} from "./epic-session-fixture";
-
-let accessFixture: EpicSessionFixture | null = null;
 
 const { toastInfo } = vi.hoisted(() => ({ toastInfo: vi.fn() }));
 vi.mock("sonner", () => ({ toast: { info: toastInfo } }));
@@ -63,17 +58,26 @@ const TEST_SETTINGS: ChatRunSettings = {
 // HOST clearing, not host scoping itself, so any single consistent id works.
 const TEST_HOST_ID = "host-1";
 
+const fakeFactory: EpicStreamClientFactory = () => ({
+  applyUpdate: () => {},
+  awareness: () => {},
+  applyArtifactRoomUpdate: () => {},
+  artifactRoomAwareness: () => {},
+  retryMigration: () => {},
+  close: () => {},
+});
+
 function registerSession(epicId: string): OpenedStoreForTest {
-  if (accessFixture === null) {
-    throw new Error("expected the access-coordinator fixture");
-  }
   const handle = openStoreForTest({
     epicId: epicId,
     userId: null,
     // The factories go to the COMPOSITION now: the store stopped
     // constructing a runtime, so a `streamClientFactory` has nowhere
     // else to go.
-    factories: accessFixture.factories,
+    factories: {
+      streamClientFactory: fakeFactory,
+      laneSelection: null,
+    },
     writeCommand: null,
   });
   __getOpenEpicRegistryForTests().acquire(epicId, () => handle);
@@ -204,7 +208,6 @@ describe("EpicAccessCoordinator", () => {
     __getOpenEpicRegistryForTests().disposeAll();
     clearSessionCreatedEpics();
     toastInfo.mockClear();
-    accessFixture = createEpicSessionFixture("legacy");
   });
 
   afterEach(() => {
@@ -215,8 +218,6 @@ describe("EpicAccessCoordinator", () => {
     useTabsStore.setState(useTabsStore.getInitialState(), true);
     useComposerRunSettingsStore.getState().resetForTests();
     clearSessionCreatedEpics();
-    accessFixture?.dispose();
-    accessFixture = null;
     vi.restoreAllMocks();
   });
 
@@ -781,7 +782,7 @@ describe("EpicAccessCoordinator", () => {
   it("does not grace a replica that holds unsynced work (isDirty)", async () => {
     markEpicCreatedThisSession("epic-1", "host-x");
     const handle = registerSession("epic-1");
-    // Explicit, not incidental: a freshly built handle from the legacy fixture
+    // Explicit, not incidental: a freshly built handle from `fakeFactory`
     // starts clean, so this is what actually exercises the guard rather than
     // some setup side effect.
     handle.store.setState({ isDirty: true, unsyncedQueueSize: 0 });

--- a/clients/gui-app/src/providers/__tests__/epic-session-fixture.ts
+++ b/clients/gui-app/src/providers/__tests__/epic-session-fixture.ts
@@ -1,60 +1,27 @@
 import * as Y from "yjs";
-import type {
-  EarlyMetaEpic,
-  SnapshotMetaEpic,
-} from "@traycer/protocol/host/epic/snapshot-meta";
+import type { SnapshotMetaEpic } from "@traycer/protocol/host/epic/snapshot-meta";
 import type { HostStreamRpcRegistry } from "@traycer/protocol/host/registry";
 import { EPIC_LANE_METHODS } from "@traycer-clients/shared/epic-lanes";
+import type { EpicStateSnapshotFrame } from "@traycer-clients/shared/host-transport/epic-state-stream-client";
+import type { EpicStatusSnapshotFrame } from "@traycer-clients/shared/host-transport/epic-status-stream-client";
+import type { IStreamSession } from "@traycer-clients/shared/host-transport/i-stream-session";
+import {
+  createRecordingStreamClient,
+  type RecordedSession,
+} from "@traycer-clients/shared/replica-runtime/worker/test-support/recording-stream-client";
 import type {
-  EpicStateStreamClientFactory,
-  EpicStatusStreamClientFactory,
-  ArtifactStreamClientFactory,
-} from "@traycer-clients/shared/epic-lanes";
-import type { EpicStreamClientFactory } from "@/stores/epics/open-epic/runtime/legacy-epic-stream-adapter";
-import type { EpicStreamCallbacks } from "@traycer-clients/shared/host-transport/epic-stream-client";
-import type { EpicRuntimeStreamFactories } from "@/stores/epics/open-epic/runtime/worker/epic-runtime-composition";
-import type {
-  EpicLaneSelectionSources,
-  EpicLaneUnaries,
-} from "@/stores/epics/open-epic/runtime/epic-replica-runtime";
-import type { StreamMethodSupport } from "@traycer-clients/shared/host-transport/ws-stream-client";
-import type {
-  EpicStateSnapshotFrame,
-  EpicStateStreamCallbacks,
-} from "@traycer-clients/shared/host-transport/epic-state-stream-client";
-import type {
-  EpicStatusSnapshotFrame,
-  EpicStatusStreamCallbacks,
-} from "@traycer-clients/shared/host-transport/epic-status-stream-client";
-import type { ArtifactStreamCallbacks } from "@traycer-clients/shared/host-transport/artifact-stream-client";
+  ParamsOf,
+  StreamMethodSupport,
+} from "@traycer-clients/shared/host-transport/ws-stream-client";
 import { epicStateSubscribeServerFrameSchemaV10 } from "@traycer/protocol/host/epic/state-subscribe";
 import { epicStatusSubscribeServerFrameSchemaV10 } from "@traycer/protocol/host/epic/status-subscribe";
 import { fakeDurableStreamTransports } from "@/lib/host/test-support/fake-durable-stream-transport";
 
 export type EpicSessionFixtureArm = "legacy" | "lanes";
 
-interface LegacyStream {
-  readonly callbacks: EpicStreamCallbacks;
-  closeCount: number;
-}
-
-interface StateStream {
-  readonly callbacks: EpicStateStreamCallbacks;
-  closeCount: number;
-}
-
-interface StatusStream {
-  readonly callbacks: EpicStatusStreamCallbacks;
-  closeCount: number;
-}
-
-interface ArtifactStream {
-  readonly callbacks: ArtifactStreamCallbacks;
-  closeCount: number;
-}
-
 export interface EpicSessionFixture {
   readonly arm: EpicSessionFixtureArm;
+  /** The host-side source from which both legacy and lane snapshots are built. */
   readonly sourceRoot: Y.Doc;
   readonly manifest: ReadonlyArray<{
     readonly method: keyof HostStreamRpcRegistry & string;
@@ -63,17 +30,15 @@ export interface EpicSessionFixture {
   readonly supportReads: ReadonlyArray<string>;
   readonly transportSupportReads: ReadonlyArray<string>;
   readonly support: (method: string) => StreamMethodSupport;
-  readonly factories: EpicRuntimeStreamFactories;
-  readonly laneSelection: EpicLaneSelectionSources | null;
-  readonly legacyStreams: ReadonlyArray<LegacyStream>;
-  readonly stateStreams: ReadonlyArray<StateStream>;
-  readonly statusStreams: ReadonlyArray<StatusStream>;
-  readonly artifactStreams: ReadonlyArray<ArtifactStream>;
+  readonly legacyStreams: ReadonlyArray<RecordedSession>;
+  readonly stateStreams: ReadonlyArray<RecordedSession>;
+  readonly statusStreams: ReadonlyArray<RecordedSession>;
+  readonly artifactStreams: ReadonlyArray<RecordedSession>;
   readonly opens: {
-    legacy: number;
-    state: number;
-    status: number;
-    artifact: number;
+    readonly legacy: number;
+    readonly state: number;
+    readonly status: number;
+    readonly artifact: number;
   };
   openLegacyStream(index: number): void;
   deliverLegacySnapshot(index: number, roomId: string): void;
@@ -83,16 +48,6 @@ export interface EpicSessionFixture {
 }
 
 const AUTHORITY_EPOCH = "fixture-authority-epoch";
-
-const EARLY_META: EarlyMetaEpic = {
-  epicLight: null,
-  permissionRole: "editor",
-  repos: [],
-  workspaces: [],
-  repoMapping: [],
-  workspaceFolders: [],
-  unresolvedRepos: [],
-};
 
 function legacySnapshotMeta(roomId: string): SnapshotMetaEpic {
   return {
@@ -109,7 +64,19 @@ function legacySnapshotMeta(roomId: string): SnapshotMetaEpic {
   };
 }
 
-function stateSnapshot(): EpicStateSnapshotFrame {
+/**
+ * The host's state-lane boundary, represented in the fixture by the same
+ * JSON-only frame contract the real `EpicLaneSession.snapshotFrame` emits.
+ *
+ * Reading the title from `sourceRoot` makes the source relationship
+ * observable in the provider test. The root's `attachments` map has no field
+ * in this contract, so it cannot cross this boundary with the projected state.
+ */
+function stateSnapshot(sourceRoot: Y.Doc): EpicStateSnapshotFrame {
+  const title: unknown = sourceRoot.getMap("epic").get("title");
+  if (typeof title !== "string") {
+    throw new Error("expected the source root to hold an epic title");
+  }
   const parsed = epicStateSubscribeServerFrameSchemaV10.parse({
     kind: "snapshot",
     hasBinaryPayload: false,
@@ -123,7 +90,7 @@ function stateSnapshot(): EpicStateSnapshotFrame {
     roleClaims: { revision: 1, claims: [] },
     epicMeta: {
       revision: 1,
-      meta: { title: "Fixture Epic", updatedAt: 1 },
+      meta: { title, updatedAt: 1 },
     },
   });
   if (parsed.kind !== "snapshot") {
@@ -150,13 +117,6 @@ function statusSnapshot(): EpicStatusSnapshotFrame {
   return parsed;
 }
 
-function laneUnaries(): EpicLaneUnaries {
-  return {
-    getWorkspaceContext: () => Promise.resolve(EARLY_META),
-    retryMigration: () => Promise.resolve(),
-  };
-}
-
 function buildSupport(arm: EpicSessionFixtureArm): ReadonlyArray<{
   readonly method: keyof HostStreamRpcRegistry & string;
   readonly support: StreamMethodSupport;
@@ -181,100 +141,65 @@ export function createEpicSessionFixture(
   const manifest = buildSupport(arm);
   const supportReads: string[] = [];
   const transportSupportReads: string[] = [];
+  const openedSessions: RecordedSession[] = [];
   const support = (method: string): StreamMethodSupport => {
     supportReads.push(method);
     return (
       manifest.find((entry) => entry.method === method)?.support ?? "unknown"
     );
   };
-  const legacyStreams: LegacyStream[] = [];
-  const stateStreams: StateStream[] = [];
-  const statusStreams: StatusStream[] = [];
-  const artifactStreams: ArtifactStream[] = [];
-  const opens = { legacy: 0, state: 0, status: 0, artifact: 0 };
-  const legacyStreamClientFactory: EpicStreamClientFactory = (
-    _epicId,
-    callbacks,
-  ) => {
-    const stream: LegacyStream = {
-      callbacks,
-      closeCount: 0,
-    };
-    legacyStreams.push(stream);
-    opens.legacy += 1;
-    return {
-      applyUpdate: () => undefined,
-      awareness: () => undefined,
-      applyArtifactRoomUpdate: () => undefined,
-      artifactRoomAwareness: () => undefined,
-      retryMigration: () => undefined,
-      close: () => {
-        stream.closeCount += 1;
-      },
-    };
+  const sessionsFor = (method: string): ReadonlyArray<RecordedSession> =>
+    openedSessions.filter((session) => session.method === method);
+  const opens = {
+    get legacy(): number {
+      return sessionsFor("epic.subscribe").length;
+    },
+    get state(): number {
+      return sessionsFor("epic.state.subscribe").length;
+    },
+    get status(): number {
+      return sessionsFor("epic.status.subscribe").length;
+    },
+    get artifact(): number {
+      return sessionsFor("artifact.subscribe").length;
+    },
   };
-  const stateStreamClientFactory: EpicStateStreamClientFactory = (
-    _epicId,
-    callbacks,
-  ) => {
-    const stream: StateStream = { callbacks, closeCount: 0 };
-    stateStreams.push(stream);
-    opens.state += 1;
-    return {
-      close: () => {
-        stream.closeCount += 1;
-      },
-    };
-  };
-  const statusStreamClientFactory: EpicStatusStreamClientFactory = (
-    _epicId,
-    callbacks,
-  ) => {
-    const stream: StatusStream = { callbacks, closeCount: 0 };
-    statusStreams.push(stream);
-    opens.status += 1;
-    return {
-      close: () => {
-        stream.closeCount += 1;
-      },
-    };
-  };
-  const artifactStreamClientFactory: ArtifactStreamClientFactory = (
-    request,
-  ) => {
-    const stream: ArtifactStream = {
-      callbacks: request.callbacks,
-      closeCount: 0,
-    };
-    artifactStreams.push(stream);
-    opens.artifact += 1;
-    return {
-      applyUpdate: () => undefined,
-      awareness: () => undefined,
-      close: () => {
-        stream.closeCount += 1;
-      },
-    };
-  };
-  const laneSelection: EpicLaneSelectionSources | null =
-    arm === "lanes"
-      ? {
-          support,
-          subscribeSupport: () => () => undefined,
-          stateStreamClientFactory,
-          statusStreamClientFactory,
-          artifactStreamClientFactory,
-          unaries: laneUnaries(),
-        }
-      : null;
-  const factories: EpicRuntimeStreamFactories = {
-    streamClientFactory: legacyStreamClientFactory,
-    laneSelection,
-  };
+
   const durableTransports = fakeDurableStreamTransports();
   const previousOpener = durableTransports.opener;
   const opener = (hostId: string) => {
     const transport = previousOpener(hostId);
+    const recording = createRecordingStreamClient();
+    const capture = (open: () => IStreamSession): IStreamSession => {
+      const previousCount = recording.opened().length;
+      const session = open();
+      const recorded = recording.opened().at(-1);
+      if (
+        recorded === undefined ||
+        recording.opened().length !== previousCount + 1
+      ) {
+        throw new Error("expected one recorded stream session");
+      }
+      openedSessions.push(recorded);
+      return session;
+    };
+    const subscribe = <Method extends keyof HostStreamRpcRegistry & string>(
+      method: Method,
+      params: ParamsOf<HostStreamRpcRegistry, Method>,
+    ): IStreamSession =>
+      capture(() => recording.client.subscribe(method, params));
+    const subscribeWithParamsProvider = <
+      Method extends keyof HostStreamRpcRegistry & string,
+    >(
+      method: Method,
+      paramsProvider: () => ParamsOf<HostStreamRpcRegistry, Method>,
+    ): IStreamSession =>
+      capture(() =>
+        recording.client.subscribeWithParamsProvider(method, paramsProvider),
+      );
+    transport.wsStreamClient.subscribe = subscribe;
+    transport.wsStreamClient.subscribeWithParamsProvider =
+      subscribeWithParamsProvider;
     transport.wsStreamClient.getMethodSupport = (method) => {
       transportSupportReads.push(method);
       return support(method);
@@ -282,6 +207,7 @@ export function createEpicSessionFixture(
     return transport;
   };
   durableTransports.opener = opener;
+
   return {
     arm,
     sourceRoot,
@@ -289,43 +215,53 @@ export function createEpicSessionFixture(
     supportReads,
     transportSupportReads,
     support,
-    factories,
-    laneSelection,
-    legacyStreams,
-    stateStreams,
-    statusStreams,
-    artifactStreams,
+    get legacyStreams() {
+      return sessionsFor("epic.subscribe");
+    },
+    get stateStreams() {
+      return sessionsFor("epic.state.subscribe");
+    },
+    get statusStreams() {
+      return sessionsFor("epic.status.subscribe");
+    },
+    get artifactStreams() {
+      return sessionsFor("artifact.subscribe");
+    },
     opens,
     openLegacyStream: (index) => {
-      const stream = legacyStreams.at(index);
+      const stream = sessionsFor("epic.subscribe").at(index);
       if (stream === undefined) throw new Error("expected a legacy stream");
-      stream.callbacks.onConnectionStatus("open", null);
+      stream.emitStatus("open", null);
     },
     deliverLegacySnapshot: (index, roomId) => {
-      const stream = legacyStreams.at(index);
+      const stream = sessionsFor("epic.subscribe").at(index);
       if (stream === undefined) throw new Error("expected a legacy stream");
-      stream.callbacks.onSnapshot(
-        legacySnapshotMeta(roomId),
+      stream.emitFrame(
+        {
+          kind: "snapshot",
+          hasBinaryPayload: true,
+          meta: legacySnapshotMeta(roomId),
+        },
         Y.encodeStateAsUpdate(sourceRoot),
       );
     },
     openLaneStreams: (index) => {
-      const status = statusStreams.at(index);
-      const state = stateStreams.at(index);
+      const status = sessionsFor("epic.status.subscribe").at(index);
+      const state = sessionsFor("epic.state.subscribe").at(index);
       if (status === undefined || state === undefined) {
         throw new Error("expected state and status streams");
       }
-      status.callbacks.onConnectionStatus("open", null);
-      state.callbacks.onConnectionStatus("open", null);
+      status.emitStatus("open", null);
+      state.emitStatus("open", null);
     },
     deliverLaneSnapshots: (index) => {
-      const status = statusStreams.at(index);
-      const state = stateStreams.at(index);
+      const status = sessionsFor("epic.status.subscribe").at(index);
+      const state = sessionsFor("epic.state.subscribe").at(index);
       if (status === undefined || state === undefined) {
         throw new Error("expected state and status streams");
       }
-      status.callbacks.onSnapshot(statusSnapshot());
-      state.callbacks.onSnapshot(stateSnapshot());
+      status.emitFrame(statusSnapshot(), null);
+      state.emitFrame(stateSnapshot(sourceRoot), null);
     },
     dispose: () => {
       sourceRoot.destroy();

--- a/clients/gui-app/src/providers/__tests__/epic-session-fixture.ts
+++ b/clients/gui-app/src/providers/__tests__/epic-session-fixture.ts
@@ -1,0 +1,337 @@
+import * as Y from "yjs";
+import type {
+  EarlyMetaEpic,
+  SnapshotMetaEpic,
+} from "@traycer/protocol/host/epic/snapshot-meta";
+import type { HostStreamRpcRegistry } from "@traycer/protocol/host/registry";
+import { EPIC_LANE_METHODS } from "@traycer-clients/shared/epic-lanes";
+import type {
+  EpicStateStreamClientFactory,
+  EpicStatusStreamClientFactory,
+  ArtifactStreamClientFactory,
+} from "@traycer-clients/shared/epic-lanes";
+import type { EpicStreamClientFactory } from "@/stores/epics/open-epic/runtime/legacy-epic-stream-adapter";
+import type { EpicStreamCallbacks } from "@traycer-clients/shared/host-transport/epic-stream-client";
+import type { EpicRuntimeStreamFactories } from "@/stores/epics/open-epic/runtime/worker/epic-runtime-composition";
+import type {
+  EpicLaneSelectionSources,
+  EpicLaneUnaries,
+} from "@/stores/epics/open-epic/runtime/epic-replica-runtime";
+import type { StreamMethodSupport } from "@traycer-clients/shared/host-transport/ws-stream-client";
+import type {
+  EpicStateSnapshotFrame,
+  EpicStateStreamCallbacks,
+} from "@traycer-clients/shared/host-transport/epic-state-stream-client";
+import type {
+  EpicStatusSnapshotFrame,
+  EpicStatusStreamCallbacks,
+} from "@traycer-clients/shared/host-transport/epic-status-stream-client";
+import type { ArtifactStreamCallbacks } from "@traycer-clients/shared/host-transport/artifact-stream-client";
+import { epicStateSubscribeServerFrameSchemaV10 } from "@traycer/protocol/host/epic/state-subscribe";
+import { epicStatusSubscribeServerFrameSchemaV10 } from "@traycer/protocol/host/epic/status-subscribe";
+import { fakeDurableStreamTransports } from "@/lib/host/test-support/fake-durable-stream-transport";
+
+export type EpicSessionFixtureArm = "legacy" | "lanes";
+
+interface LegacyStream {
+  readonly callbacks: EpicStreamCallbacks;
+  closeCount: number;
+}
+
+interface StateStream {
+  readonly callbacks: EpicStateStreamCallbacks;
+  closeCount: number;
+}
+
+interface StatusStream {
+  readonly callbacks: EpicStatusStreamCallbacks;
+  closeCount: number;
+}
+
+interface ArtifactStream {
+  readonly callbacks: ArtifactStreamCallbacks;
+  closeCount: number;
+}
+
+export interface EpicSessionFixture {
+  readonly arm: EpicSessionFixtureArm;
+  readonly sourceRoot: Y.Doc;
+  readonly manifest: ReadonlyArray<{
+    readonly method: keyof HostStreamRpcRegistry & string;
+    readonly support: StreamMethodSupport;
+  }>;
+  readonly supportReads: ReadonlyArray<string>;
+  readonly transportSupportReads: ReadonlyArray<string>;
+  readonly support: (method: string) => StreamMethodSupport;
+  readonly factories: EpicRuntimeStreamFactories;
+  readonly laneSelection: EpicLaneSelectionSources | null;
+  readonly legacyStreams: ReadonlyArray<LegacyStream>;
+  readonly stateStreams: ReadonlyArray<StateStream>;
+  readonly statusStreams: ReadonlyArray<StatusStream>;
+  readonly artifactStreams: ReadonlyArray<ArtifactStream>;
+  readonly opens: {
+    legacy: number;
+    state: number;
+    status: number;
+    artifact: number;
+  };
+  openLegacyStream(index: number): void;
+  deliverLegacySnapshot(index: number, roomId: string): void;
+  openLaneStreams(index: number): void;
+  deliverLaneSnapshots(index: number): void;
+  dispose(): void;
+}
+
+const AUTHORITY_EPOCH = "fixture-authority-epoch";
+
+const EARLY_META: EarlyMetaEpic = {
+  epicLight: null,
+  permissionRole: "editor",
+  repos: [],
+  workspaces: [],
+  repoMapping: [],
+  workspaceFolders: [],
+  unresolvedRepos: [],
+};
+
+function legacySnapshotMeta(roomId: string): SnapshotMetaEpic {
+  return {
+    schemaVersion: "2.0.0",
+    roomId,
+    epicLight: null,
+    permissionRole: "editor",
+    repos: [],
+    workspaces: [],
+    repoMapping: [],
+    workspaceFolders: [],
+    unresolvedRepos: [],
+    hostStateVectorBase64: "AA==",
+  };
+}
+
+function stateSnapshot(): EpicStateSnapshotFrame {
+  const parsed = epicStateSubscribeServerFrameSchemaV10.parse({
+    kind: "snapshot",
+    hasBinaryPayload: false,
+    authorityEpoch: AUTHORITY_EPOCH,
+    basis: "cold",
+    position: 1,
+    reconciledWithCloud: true,
+    artifactRecords: [],
+    deletedArtifacts: [],
+    commentThreads: [],
+    roleClaims: { revision: 1, claims: [] },
+    epicMeta: {
+      revision: 1,
+      meta: { title: "Fixture Epic", updatedAt: 1 },
+    },
+  });
+  if (parsed.kind !== "snapshot") {
+    throw new Error(`expected a state snapshot, got ${parsed.kind}`);
+  }
+  return parsed;
+}
+
+function statusSnapshot(): EpicStatusSnapshotFrame {
+  const parsed = epicStatusSubscribeServerFrameSchemaV10.parse({
+    kind: "snapshot",
+    hasBinaryPayload: false,
+    authorityEpoch: AUTHORITY_EPOCH,
+    securityEpoch: 1,
+    permissionRole: "editor",
+    cloudSyncStatus: "connected",
+    dirty: false,
+    migration: null,
+    deletion: { state: "none" },
+  });
+  if (parsed.kind !== "snapshot") {
+    throw new Error(`expected a status snapshot, got ${parsed.kind}`);
+  }
+  return parsed;
+}
+
+function laneUnaries(): EpicLaneUnaries {
+  return {
+    getWorkspaceContext: () => Promise.resolve(EARLY_META),
+    retryMigration: () => Promise.resolve(),
+  };
+}
+
+function buildSupport(arm: EpicSessionFixtureArm): ReadonlyArray<{
+  readonly method: keyof HostStreamRpcRegistry & string;
+  readonly support: StreamMethodSupport;
+}> {
+  const methods: Array<keyof HostStreamRpcRegistry & string> = [
+    "epic.subscribe",
+    ...EPIC_LANE_METHODS,
+  ];
+  const laneSupport: StreamMethodSupport =
+    arm === "lanes" ? "supported" : "unsupported";
+  return methods.map((method) => ({
+    method,
+    support: method === "epic.subscribe" ? "supported" : laneSupport,
+  }));
+}
+
+export function createEpicSessionFixture(
+  arm: EpicSessionFixtureArm,
+): EpicSessionFixture {
+  const sourceRoot = new Y.Doc();
+  sourceRoot.getMap("epic").set("title", "Fixture Epic");
+  const manifest = buildSupport(arm);
+  const supportReads: string[] = [];
+  const transportSupportReads: string[] = [];
+  const support = (method: string): StreamMethodSupport => {
+    supportReads.push(method);
+    return (
+      manifest.find((entry) => entry.method === method)?.support ?? "unknown"
+    );
+  };
+  const legacyStreams: LegacyStream[] = [];
+  const stateStreams: StateStream[] = [];
+  const statusStreams: StatusStream[] = [];
+  const artifactStreams: ArtifactStream[] = [];
+  const opens = { legacy: 0, state: 0, status: 0, artifact: 0 };
+  const legacyStreamClientFactory: EpicStreamClientFactory = (
+    _epicId,
+    callbacks,
+  ) => {
+    const stream: LegacyStream = {
+      callbacks,
+      closeCount: 0,
+    };
+    legacyStreams.push(stream);
+    opens.legacy += 1;
+    return {
+      applyUpdate: () => undefined,
+      awareness: () => undefined,
+      applyArtifactRoomUpdate: () => undefined,
+      artifactRoomAwareness: () => undefined,
+      retryMigration: () => undefined,
+      close: () => {
+        stream.closeCount += 1;
+      },
+    };
+  };
+  const stateStreamClientFactory: EpicStateStreamClientFactory = (
+    _epicId,
+    callbacks,
+  ) => {
+    const stream: StateStream = { callbacks, closeCount: 0 };
+    stateStreams.push(stream);
+    opens.state += 1;
+    return {
+      close: () => {
+        stream.closeCount += 1;
+      },
+    };
+  };
+  const statusStreamClientFactory: EpicStatusStreamClientFactory = (
+    _epicId,
+    callbacks,
+  ) => {
+    const stream: StatusStream = { callbacks, closeCount: 0 };
+    statusStreams.push(stream);
+    opens.status += 1;
+    return {
+      close: () => {
+        stream.closeCount += 1;
+      },
+    };
+  };
+  const artifactStreamClientFactory: ArtifactStreamClientFactory = (
+    request,
+  ) => {
+    const stream: ArtifactStream = {
+      callbacks: request.callbacks,
+      closeCount: 0,
+    };
+    artifactStreams.push(stream);
+    opens.artifact += 1;
+    return {
+      applyUpdate: () => undefined,
+      awareness: () => undefined,
+      close: () => {
+        stream.closeCount += 1;
+      },
+    };
+  };
+  const laneSelection: EpicLaneSelectionSources | null =
+    arm === "lanes"
+      ? {
+          support,
+          subscribeSupport: () => () => undefined,
+          stateStreamClientFactory,
+          statusStreamClientFactory,
+          artifactStreamClientFactory,
+          unaries: laneUnaries(),
+        }
+      : null;
+  const factories: EpicRuntimeStreamFactories = {
+    streamClientFactory: legacyStreamClientFactory,
+    laneSelection,
+  };
+  const durableTransports = fakeDurableStreamTransports();
+  const previousOpener = durableTransports.opener;
+  const opener = (hostId: string) => {
+    const transport = previousOpener(hostId);
+    transport.wsStreamClient.getMethodSupport = (method) => {
+      transportSupportReads.push(method);
+      return support(method);
+    };
+    return transport;
+  };
+  durableTransports.opener = opener;
+  return {
+    arm,
+    sourceRoot,
+    manifest,
+    supportReads,
+    transportSupportReads,
+    support,
+    factories,
+    laneSelection,
+    legacyStreams,
+    stateStreams,
+    statusStreams,
+    artifactStreams,
+    opens,
+    openLegacyStream: (index) => {
+      const stream = legacyStreams.at(index);
+      if (stream === undefined) throw new Error("expected a legacy stream");
+      stream.callbacks.onConnectionStatus("open", null);
+    },
+    deliverLegacySnapshot: (index, roomId) => {
+      const stream = legacyStreams.at(index);
+      if (stream === undefined) throw new Error("expected a legacy stream");
+      stream.callbacks.onSnapshot(
+        legacySnapshotMeta(roomId),
+        Y.encodeStateAsUpdate(sourceRoot),
+      );
+    },
+    openLaneStreams: (index) => {
+      const status = statusStreams.at(index);
+      const state = stateStreams.at(index);
+      if (status === undefined || state === undefined) {
+        throw new Error("expected state and status streams");
+      }
+      status.callbacks.onConnectionStatus("open", null);
+      state.callbacks.onConnectionStatus("open", null);
+    },
+    deliverLaneSnapshots: (index) => {
+      const status = statusStreams.at(index);
+      const state = stateStreams.at(index);
+      if (status === undefined || state === undefined) {
+        throw new Error("expected state and status streams");
+      }
+      status.callbacks.onSnapshot(statusSnapshot());
+      state.callbacks.onSnapshot(stateSnapshot());
+    },
+    dispose: () => {
+      sourceRoot.destroy();
+      if (durableTransports.opener === opener) {
+        durableTransports.opener = previousOpener;
+      }
+    },
+  };
+}

--- a/clients/gui-app/src/providers/__tests__/epic-session-provider.test.tsx
+++ b/clients/gui-app/src/providers/__tests__/epic-session-provider.test.tsx
@@ -229,7 +229,10 @@ import {
   fakeDurableStreamTransports,
   resetFakeDurableStreamTransports,
 } from "@/lib/host/test-support/fake-durable-stream-transport";
-import { createInProcessEpicRuntimeWorker } from "@/stores/epics/open-epic/test-support/in-process-epic-runtime-worker";
+import {
+  createInProcessEpicRuntimeWorker,
+  createProxiedInProcessEpicRuntimeWorker,
+} from "@/stores/epics/open-epic/test-support/in-process-epic-runtime-worker";
 import type { RuntimeWorkerLike } from "@/stores/epics/open-epic/runtime/worker/spawn-epic-runtime-worker";
 import {
   RUNTIME_BRIDGE_PROTOCOL_VERSION,
@@ -237,10 +240,7 @@ import {
 } from "@traycer-clients/shared/replica-runtime/worker/bridge-protocol";
 import type { BridgeMessageEventLike } from "@traycer-clients/shared/replica-runtime/worker/bridge-transports";
 import type { EpicStreamClientFactory } from "@/stores/epics/open-epic/runtime/legacy-epic-stream-adapter";
-import {
-  createEpicSessionFixture,
-  type EpicSessionFixture,
-} from "./epic-session-fixture";
+import { createEpicSessionFixture } from "./epic-session-fixture";
 import {
   ArtifactAttachmentScopeContext,
   type ArtifactAttachmentScopeValue,
@@ -387,10 +387,10 @@ function installStreamFactory(factory: EpicStreamClientFactory): void {
   );
 }
 
-function installFixtureFactory(fixture: EpicSessionFixture): void {
+function installManifestDerivedWorker(): void {
   previousWorkerFactory = getEpicRuntimeWorkerFactoryOverride();
   __setEpicRuntimeWorkerFactoryForTests(() =>
-    createInProcessEpicRuntimeWorker(fixture.factories).createWorker(),
+    createProxiedInProcessEpicRuntimeWorker().createWorker(),
   );
 }
 
@@ -807,10 +807,15 @@ describe("<EpicSessionProvider />", () => {
     reprobeCallbacks.callbacks.length = 0;
   });
 
-  it("builds a manifest and selection for both the legacy and lane arms", () => {
+  it("builds method support for both the legacy and lane fixture arms", () => {
     const legacy = createEpicSessionFixture("legacy");
     const lanes = createEpicSessionFixture("lanes");
     try {
+      // Fixture-construction guard only: no production edit is expected to
+      // redden this assertion. Production manifest -> selection coverage lives
+      // in the public-open pin below, whose worker derives its own factories.
+      expect(legacy.arm).toBe("legacy");
+      expect(lanes.arm).toBe("lanes");
       expect(
         legacy.manifest.find((entry) => entry.method === "epic.subscribe")
           ?.support,
@@ -818,12 +823,10 @@ describe("<EpicSessionProvider />", () => {
       for (const method of EPIC_LANE_METHODS) {
         expect(legacy.support(method)).toBe("unsupported");
       }
-      expect(legacy.laneSelection).toBeNull();
 
       for (const method of EPIC_LANE_METHODS) {
         expect(lanes.support(method)).toBe("supported");
       }
-      expect(lanes.laneSelection).not.toBeNull();
       expect(
         lanes.manifest.filter((entry) => entry.support === "supported"),
       ).toHaveLength(EPIC_LANE_METHODS.length + 1);
@@ -836,7 +839,7 @@ describe("<EpicSessionProvider />", () => {
   it("opens a genuinely lane-backed session through the public provider", async () => {
     const fixture = createEpicSessionFixture("lanes");
     try {
-      installFixtureFactory(fixture);
+      installManifestDerivedWorker();
       const seenHandles: OpenEpicStoreHandle[] = [];
       const view = render(
         <EpicSessionProvider epicId="fixture-epic" tabId="fixture-epic">
@@ -871,7 +874,7 @@ describe("<EpicSessionProvider />", () => {
   it("rebuilds a clean lane session when its attached reprobe fires", async () => {
     const fixture = createEpicSessionFixture("lanes");
     try {
-      installFixtureFactory(fixture);
+      installManifestDerivedWorker();
       const seenHandles: OpenEpicStoreHandle[] = [];
       const view = render(
         <EpicSessionProvider epicId="fixture-epic" tabId="fixture-epic">
@@ -898,8 +901,8 @@ describe("<EpicSessionProvider />", () => {
         });
         await waitFor(() => expect(fixture.opens.state).toBe(2));
         expect(fixture.opens.legacy).toBe(0);
-        expect(fixture.stateStreams[0]?.closeCount).toBe(1);
-        expect(fixture.statusStreams[0]?.closeCount).toBe(1);
+        expect(fixture.stateStreams[0]?.closeCount()).toBe(1);
+        expect(fixture.statusStreams[0]?.closeCount()).toBe(1);
         expect(seenHandles.at(-1)).not.toBe(firstHandle);
         fixture.openLaneStreams(1);
         fixture.deliverLaneSnapshots(1);
@@ -920,8 +923,10 @@ describe("<EpicSessionProvider />", () => {
   it("reads lane attachments from the host unless bytes were pasted locally", async () => {
     const fixture = createEpicSessionFixture("lanes");
     const sourceHash = "c".repeat(64);
+    const sourceTitle = "A2 source root";
     const sourceBytes = Uint8Array.from([1, 2, 3]);
     const pastedBytes = Uint8Array.from([9, 8, 7, 6]);
+    fixture.sourceRoot.getMap("epic").set("title", sourceTitle);
     fixture.sourceRoot
       .getMap<Uint8Array>("attachments")
       .set(sourceHash, sourceBytes);
@@ -955,7 +960,7 @@ describe("<EpicSessionProvider />", () => {
       client: { requestWithSignal },
     };
     try {
-      installFixtureFactory(fixture);
+      installManifestDerivedWorker();
       const seenHandles: OpenEpicStoreHandle[] = [];
       const seenFetchers: ScopedImageBytesFetcher[] = [];
       const view = render(
@@ -978,6 +983,12 @@ describe("<EpicSessionProvider />", () => {
           );
           expect(seenHandles.at(-1)?.store.getState().snapshotLoaded).toBe(
             true,
+          );
+          // Positive boundary control: the projected title came from this
+          // fixture's source root, so the attachment absence below is not a
+          // fresh, unrelated replica that never consumed that source.
+          expect(seenHandles.at(-1)?.store.getState().epic.title).toBe(
+            sourceTitle,
           );
           expect(seenFetchers.length).toBeGreaterThan(0);
         });
@@ -1006,23 +1017,33 @@ describe("<EpicSessionProvider />", () => {
         if (heldPastedBytes === null) {
           throw new Error("expected locally pasted attachment bytes");
         }
+        // Bridge/Yjs reads can return an equivalent Uint8Array with a distinct
+        // realm/prototype; numeric arrays pin the bytes without brittle realm
+        // identity in Vitest's deep-equality matcher.
         expect(Array.from(heldPastedBytes)).toEqual(Array.from(pastedBytes));
 
         const resolved = await fetcher.fetch(
           sourceHash,
           new AbortController().signal,
         );
+        // The fetcher's decoded bytes can cross the same realm boundary.
         expect(Array.from(resolved.bytes)).toEqual([1, 2, 3, 4]);
         expect(resolved.mediaType).toBe("image/png");
-        expect(requests).toHaveLength(1);
-        expect(requests[0]).toMatchObject({
-          method: "epic.fetchArtifactAttachment",
-          params: {
-            epicId: "fixture-epic",
-            artifactId: "fixture-artifact",
-            hash: sourceHash,
+        expect(
+          requests.map((request) => ({
+            method: request.method,
+            params: request.params,
+          })),
+        ).toEqual([
+          {
+            method: "epic.fetchArtifactAttachment",
+            params: {
+              epicId: "fixture-epic",
+              artifactId: "fixture-artifact",
+              hash: sourceHash,
+            },
           },
-        });
+        ]);
       } finally {
         view.unmount();
       }
@@ -1411,7 +1432,7 @@ describe("<EpicSessionProvider />", () => {
   it("addresses a re-point candidate's lane unary to the host it was CONSTRUCTED against, not the still-mounted session's host", async () => {
     const fixture = createEpicSessionFixture("lanes");
     try {
-      installFixtureFactory(fixture);
+      installManifestDerivedWorker();
       const seenHandles: OpenEpicStoreHandle[] = [];
       const view = render(
         <EpicSessionProvider epicId="fixture-epic" tabId="fixture-epic">
@@ -1440,6 +1461,12 @@ describe("<EpicSessionProvider />", () => {
           throw new Error("expected a resolved host-a client");
         }
         hostAClient.request.mockResolvedValue({ context: null });
+        resolveSessionHostClient("host-b");
+        const hostBClient = sessionHostClients.byHostId.get("host-b");
+        if (hostBClient === undefined) {
+          throw new Error("expected a resolved host-b client");
+        }
+        hostBClient.request.mockResolvedValue({ context: null });
 
         act(() => {
           hostState.id = "host-b";
@@ -1459,7 +1486,7 @@ describe("<EpicSessionProvider />", () => {
         // deliberately never delivered, because that is the window the
         // defect lives in: once the replacement commits, the bug is
         // unobservable.
-        expect(fixture.stateStreams[1]?.closeCount).toBe(0);
+        expect(fixture.stateStreams[1]?.closeCount()).toBe(0);
         expect(fixture.opens.legacy).toBe(0);
         expect(__getOpenEpicRegistryForTests().size()).toBe(1);
         if (spawnedRuntimeOptions.laneUnaries.length !== 2) {
@@ -1468,20 +1495,11 @@ describe("<EpicSessionProvider />", () => {
           );
         }
 
-        // The provider resolves BOTH hosts during this window - the mounted
-        // session's ("host-a") and the re-point target's ("host-b") - so the render
-        // path has already created the stub this asserts on. Calling the resolver
-        // here is get-or-create against the same cache the mocked hook reads
-        // (`:96-105`), which hands back that very object rather than a second one;
-        // a fresh stub per call would make the assertion below unreachable. The
-        // call is kept rather than replaced by a bare `get` so the test does not
-        // depend on WHICH render resolved it first.
-        resolveSessionHostClient("host-b");
-        const hostBClient = sessionHostClients.byHostId.get("host-b");
-        if (hostBClient === undefined) {
-          throw new Error("expected a resolved host-b client");
-        }
-        hostBClient.request.mockResolvedValue({ context: null });
+        // Lane installation performs its own workspace-context refresh. Clear
+        // those legitimate initialization calls so the assertions below
+        // describe only the two captured unaries invoked by this test.
+        hostAClient.request.mockClear();
+        hostBClient.request.mockClear();
 
         // THE REDDENING ONE - the candidate's unary must go to B.
         await spawnedRuntimeOptions.laneUnaries[1]({
@@ -1502,10 +1520,16 @@ describe("<EpicSessionProvider />", () => {
         // CONTROL - must be green both before and after the fix. The naive fix
         // ("bind every handle to `targetHostId`") would make the still-mounted A
         // handle's own unary address B too, which this catches.
+        hostAClient.request.mockClear();
+        hostBClient.request.mockClear();
         await spawnedRuntimeOptions.laneUnaries[0]({
           kind: "workspace-context",
         });
         expect(hostAClient.request).toHaveBeenCalledWith(
+          "epic.getWorkspaceContext",
+          { epicId: "fixture-epic" },
+        );
+        expect(hostBClient.request).not.toHaveBeenCalledWith(
           "epic.getWorkspaceContext",
           { epicId: "fixture-epic" },
         );

--- a/clients/gui-app/src/providers/__tests__/epic-session-provider.test.tsx
+++ b/clients/gui-app/src/providers/__tests__/epic-session-provider.test.tsx
@@ -249,8 +249,15 @@ import { useEpicImageFetcher } from "@/lib/attachments/use-attachment-blob-src";
 import { readHeldEpicAttachmentBytes } from "@/lib/epic-replica-reads";
 import type { ScopedImageBytesFetcher } from "@/lib/attachments/image-blob-cache";
 
-/** The jsdom setup file's coreless worker, put back in `afterEach`. */
-let previousWorkerFactory: (() => RuntimeWorkerLike) | null = null;
+/**
+ * The jsdom setup file's coreless worker, captured before this suite can
+ * replace it. A `null` override would fall through to the production Worker
+ * constructor, which jsdom cannot run.
+ */
+const setupWorkerFactory = getEpicRuntimeWorkerFactoryOverride();
+
+/** The worker override present at the start of the current test. */
+let workerFactoryBeforeTest: (() => RuntimeWorkerLike) | null = null;
 
 /**
  * Install this test's stream factory, one seam over.
@@ -293,7 +300,6 @@ interface FatalWorkerRig {
 function installWorkerWithFatalOnFirstSpawn(
   factory: EpicStreamClientFactory,
 ): FatalWorkerRig {
-  previousWorkerFactory = getEpicRuntimeWorkerFactoryOverride();
   let spawns = 0;
   let deliverFatal: (() => void) | null = null;
   __setEpicRuntimeWorkerFactoryForTests(() => {
@@ -368,7 +374,6 @@ function installWorkerWithFatalOnFirstSpawn(
  * bridge exists to report a `fatal` through.
  */
 function installWorkerThatThrowsOnSpawn(): { spawnCount(): number } {
-  previousWorkerFactory = getEpicRuntimeWorkerFactoryOverride();
   let spawns = 0;
   __setEpicRuntimeWorkerFactoryForTests(() => {
     spawns += 1;
@@ -378,7 +383,6 @@ function installWorkerThatThrowsOnSpawn(): { spawnCount(): number } {
 }
 
 function installStreamFactory(factory: EpicStreamClientFactory): void {
-  previousWorkerFactory = getEpicRuntimeWorkerFactoryOverride();
   __setEpicRuntimeWorkerFactoryForTests(() =>
     createInProcessEpicRuntimeWorker({
       streamClientFactory: factory,
@@ -388,7 +392,6 @@ function installStreamFactory(factory: EpicStreamClientFactory): void {
 }
 
 function installManifestDerivedWorker(): void {
-  previousWorkerFactory = getEpicRuntimeWorkerFactoryOverride();
   __setEpicRuntimeWorkerFactoryForTests(() =>
     createProxiedInProcessEpicRuntimeWorker().createWorker(),
   );
@@ -774,6 +777,10 @@ async function readRootEdit(
 
 describe("<EpicSessionProvider />", () => {
   beforeEach(() => {
+    // Capture unconditionally: even a test that installs no worker factory is
+    // followed by an `afterEach`, and restoring an uninitialised sentinel there
+    // would erase the jsdom setup file's coreless worker for the next test.
+    workerFactoryBeforeTest = getEpicRuntimeWorkerFactoryOverride();
     window.localStorage.clear();
     hostState.id = "host-a";
     hostState.attached = true;
@@ -796,8 +803,8 @@ describe("<EpicSessionProvider />", () => {
   afterEach(() => {
     cleanup();
     __getOpenEpicRegistryForTests().disposeAll();
-    // RESTORED, not nulled - see `previousWorkerFactory`.
-    __setEpicRuntimeWorkerFactoryForTests(previousWorkerFactory);
+    // RESTORED, not nulled - see `workerFactoryBeforeTest`.
+    __setEpicRuntimeWorkerFactoryForTests(workerFactoryBeforeTest);
     setDesktopEpicOwnershipBridge(null);
     resetCanvasStore();
     resetAuth("signed-out", null);
@@ -834,6 +841,15 @@ describe("<EpicSessionProvider />", () => {
       lanes.dispose();
       legacy.dispose();
     }
+  });
+
+  it("preserves the setup worker after a fixture-only test installs nothing", () => {
+    // This deliberately follows the fixture-construction guard above. That
+    // test never installs a worker factory, but its `afterEach` still runs. The
+    // setup override must survive; `null` would select the production Worker
+    // constructor and make the next jsdom session crash.
+    expect(setupWorkerFactory).not.toBeNull();
+    expect(getEpicRuntimeWorkerFactoryOverride()).toBe(setupWorkerFactory);
   });
 
   it("opens a genuinely lane-backed session through the public provider", async () => {

--- a/clients/gui-app/src/providers/__tests__/epic-session-provider.test.tsx
+++ b/clients/gui-app/src/providers/__tests__/epic-session-provider.test.tsx
@@ -15,6 +15,7 @@ import type {
   ListTasksResponse,
   TaskLight,
 } from "@traycer/protocol/host/epic/unary-schemas";
+import { EPIC_LANE_METHODS } from "@traycer-clients/shared/epic-lanes";
 import { HostClient } from "@traycer-clients/shared/host-client/host-client";
 import { MockHostMessenger } from "@traycer-clients/shared/host-client/mock/mock-host-messenger";
 import {
@@ -40,6 +41,9 @@ const authServiceStub = vi.hoisted(() => ({
   revalidateCurrentContext: () => Promise.resolve({ kind: "valid" as const }),
 }));
 const navigateMock = vi.hoisted(() => vi.fn());
+const reprobeCallbacks = vi.hoisted((): { callbacks: Array<() => void> } => ({
+  callbacks: [],
+}));
 // Real (non-null) `useHostBinding()` for the R-1 owner-identity rotation test
 // below - every other test in this file relies on the default `null` (no
 // `HostClient` needed to drive `sessionKey`, which is `activeHostId` +
@@ -153,6 +157,24 @@ vi.mock("@tanstack/react-router", () => ({
   useNavigate: () => navigateMock,
 }));
 
+vi.mock("@/lib/host/owned-durable-stream-client", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@/lib/host/owned-durable-stream-client")
+    >();
+  return {
+    ...actual,
+    attachPlanRestrictedReprobe: (
+      wsStreamClient: unknown,
+      onReprobe: (() => void) | null,
+    ) => {
+      void wsStreamClient;
+      if (onReprobe !== null) reprobeCallbacks.callbacks.push(onReprobe);
+      return () => undefined;
+    },
+  };
+});
+
 /**
  * A pass-through spy on `spawnEpicRuntimeWorker`, so a pin can reach the exact
  * `laneUnary` closure the provider hands each worker it spawns. The real spawn
@@ -215,6 +237,17 @@ import {
 } from "@traycer-clients/shared/replica-runtime/worker/bridge-protocol";
 import type { BridgeMessageEventLike } from "@traycer-clients/shared/replica-runtime/worker/bridge-transports";
 import type { EpicStreamClientFactory } from "@/stores/epics/open-epic/runtime/legacy-epic-stream-adapter";
+import {
+  createEpicSessionFixture,
+  type EpicSessionFixture,
+} from "./epic-session-fixture";
+import {
+  ArtifactAttachmentScopeContext,
+  type ArtifactAttachmentScopeValue,
+} from "@/lib/attachments/artifact-attachment-scope-context";
+import { useEpicImageFetcher } from "@/lib/attachments/use-attachment-blob-src";
+import { readHeldEpicAttachmentBytes } from "@/lib/epic-replica-reads";
+import type { ScopedImageBytesFetcher } from "@/lib/attachments/image-blob-cache";
 
 /** The jsdom setup file's coreless worker, put back in `afterEach`. */
 let previousWorkerFactory: (() => RuntimeWorkerLike) | null = null;
@@ -352,6 +385,24 @@ function installStreamFactory(factory: EpicStreamClientFactory): void {
       laneSelection: null,
     }).createWorker(),
   );
+}
+
+function installFixtureFactory(fixture: EpicSessionFixture): void {
+  previousWorkerFactory = getEpicRuntimeWorkerFactoryOverride();
+  __setEpicRuntimeWorkerFactoryForTests(() =>
+    createInProcessEpicRuntimeWorker(fixture.factories).createWorker(),
+  );
+}
+
+function ImageFetcherProbe(props: {
+  onFetcher: (fetcher: ScopedImageBytesFetcher) => void;
+}) {
+  const { onFetcher } = props;
+  const fetcher = useEpicImageFetcher();
+  useEffect(() => {
+    onFetcher(fetcher);
+  }, [fetcher, onFetcher]);
+  return null;
 }
 import { useMaybeOpenEpicHandle } from "@/providers/use-open-epic-handle";
 import { useEpicSessionHostClient } from "@/hooks/epic/use-epic-session-host-client";
@@ -739,6 +790,7 @@ describe("<EpicSessionProvider />", () => {
     clearSessionCreatedEpics();
     resetAuth("signed-in", "alice@example.com");
     spawnedRuntimeOptions.laneUnaries.length = 0;
+    reprobeCallbacks.callbacks.length = 0;
   });
 
   afterEach(() => {
@@ -752,6 +804,231 @@ describe("<EpicSessionProvider />", () => {
     hostBindingRef.value = null;
     resetHostConnectionRegistryForTest();
     clearSessionCreatedEpics();
+    reprobeCallbacks.callbacks.length = 0;
+  });
+
+  it("builds a manifest and selection for both the legacy and lane arms", () => {
+    const legacy = createEpicSessionFixture("legacy");
+    const lanes = createEpicSessionFixture("lanes");
+    try {
+      expect(
+        legacy.manifest.find((entry) => entry.method === "epic.subscribe")
+          ?.support,
+      ).toBe("supported");
+      for (const method of EPIC_LANE_METHODS) {
+        expect(legacy.support(method)).toBe("unsupported");
+      }
+      expect(legacy.laneSelection).toBeNull();
+
+      for (const method of EPIC_LANE_METHODS) {
+        expect(lanes.support(method)).toBe("supported");
+      }
+      expect(lanes.laneSelection).not.toBeNull();
+      expect(
+        lanes.manifest.filter((entry) => entry.support === "supported"),
+      ).toHaveLength(EPIC_LANE_METHODS.length + 1);
+    } finally {
+      lanes.dispose();
+      legacy.dispose();
+    }
+  });
+
+  it("opens a genuinely lane-backed session through the public provider", async () => {
+    const fixture = createEpicSessionFixture("lanes");
+    try {
+      installFixtureFactory(fixture);
+      const seenHandles: OpenEpicStoreHandle[] = [];
+      const view = render(
+        <EpicSessionProvider epicId="fixture-epic" tabId="fixture-epic">
+          <HandleProbe onHandle={(handle) => seenHandles.push(handle)} />
+        </EpicSessionProvider>,
+      );
+      try {
+        await waitFor(() => {
+          expect(fixture.opens.state).toBe(1);
+          expect(fixture.opens.status).toBe(1);
+        });
+        expect(fixture.opens.legacy).toBe(0);
+        for (const method of EPIC_LANE_METHODS) {
+          expect(fixture.transportSupportReads).toContain(method);
+        }
+        fixture.openLaneStreams(0);
+        fixture.deliverLaneSnapshots(0);
+        await waitFor(() => {
+          const handle = seenHandles.at(-1);
+          expect(handle?.store.getState().installedArm).toBe("lanes");
+          expect(handle?.store.getState().snapshotLoaded).toBe(true);
+          expect(handle?.store.getState().hostTransportStatus).toBe("open");
+        });
+      } finally {
+        view.unmount();
+      }
+    } finally {
+      fixture.dispose();
+    }
+  });
+
+  it("rebuilds a clean lane session when its attached reprobe fires", async () => {
+    const fixture = createEpicSessionFixture("lanes");
+    try {
+      installFixtureFactory(fixture);
+      const seenHandles: OpenEpicStoreHandle[] = [];
+      const view = render(
+        <EpicSessionProvider epicId="fixture-epic" tabId="fixture-epic">
+          <HandleProbe onHandle={(handle) => seenHandles.push(handle)} />
+        </EpicSessionProvider>,
+      );
+      try {
+        await waitFor(() => expect(fixture.opens.state).toBe(1));
+        fixture.openLaneStreams(0);
+        fixture.deliverLaneSnapshots(0);
+        await waitFor(() => {
+          expect(seenHandles.at(-1)?.store.getState().snapshotLoaded).toBe(
+            true,
+          );
+        });
+        const firstHandle = seenHandles.at(-1);
+        const fire = reprobeCallbacks.callbacks.at(0);
+        if (firstHandle === undefined || fire === undefined) {
+          throw new Error("expected a loaded lane handle and reprobe callback");
+        }
+        await act(async () => {
+          fire();
+          await Promise.resolve();
+        });
+        await waitFor(() => expect(fixture.opens.state).toBe(2));
+        expect(fixture.opens.legacy).toBe(0);
+        expect(fixture.stateStreams[0]?.closeCount).toBe(1);
+        expect(fixture.statusStreams[0]?.closeCount).toBe(1);
+        expect(seenHandles.at(-1)).not.toBe(firstHandle);
+        fixture.openLaneStreams(1);
+        fixture.deliverLaneSnapshots(1);
+        await waitFor(() => {
+          const replacement = seenHandles.at(-1);
+          expect(replacement).not.toBe(firstHandle);
+          expect(replacement?.store.getState().installedArm).toBe("lanes");
+          expect(replacement?.store.getState().snapshotLoaded).toBe(true);
+        });
+      } finally {
+        view.unmount();
+      }
+    } finally {
+      fixture.dispose();
+    }
+  });
+
+  it("reads lane attachments from the host unless bytes were pasted locally", async () => {
+    const fixture = createEpicSessionFixture("lanes");
+    const sourceHash = "c".repeat(64);
+    const sourceBytes = Uint8Array.from([1, 2, 3]);
+    const pastedBytes = Uint8Array.from([9, 8, 7, 6]);
+    fixture.sourceRoot
+      .getMap<Uint8Array>("attachments")
+      .set(sourceHash, sourceBytes);
+    expect(
+      fixture.sourceRoot.getMap<Uint8Array>("attachments").get(sourceHash),
+    ).toEqual(sourceBytes);
+    const requests: Array<{
+      readonly method: "epic.fetchArtifactAttachment";
+      readonly params: {
+        readonly epicId: string;
+        readonly artifactId: string;
+        readonly hash: string;
+      };
+      readonly signal: AbortSignal | undefined;
+    }> = [];
+    const requestWithSignal: NonNullable<
+      ArtifactAttachmentScopeValue["client"]
+    >["requestWithSignal"] = (method, params, signal) => {
+      requests.push({ method, params, signal });
+      return Promise.resolve({
+        ok: true,
+        bytesBase64: "AQIDBA==",
+        mediaType: "image/png",
+      });
+    };
+    const scope: ArtifactAttachmentScopeValue = {
+      epicId: "fixture-epic",
+      artifactId: "fixture-artifact",
+      hostId: "host-a",
+      hostVersion: "fixture-version",
+      client: { requestWithSignal },
+    };
+    try {
+      installFixtureFactory(fixture);
+      const seenHandles: OpenEpicStoreHandle[] = [];
+      const seenFetchers: ScopedImageBytesFetcher[] = [];
+      const view = render(
+        <EpicSessionProvider epicId="fixture-epic" tabId="fixture-epic">
+          <HandleProbe onHandle={(handle) => seenHandles.push(handle)} />
+          <ArtifactAttachmentScopeContext.Provider value={scope}>
+            <ImageFetcherProbe
+              onFetcher={(fetcher) => seenFetchers.push(fetcher)}
+            />
+          </ArtifactAttachmentScopeContext.Provider>
+        </EpicSessionProvider>,
+      );
+      try {
+        await waitFor(() => expect(fixture.opens.state).toBe(1));
+        fixture.openLaneStreams(0);
+        fixture.deliverLaneSnapshots(0);
+        await waitFor(() => {
+          expect(seenHandles.at(-1)?.store.getState().installedArm).toBe(
+            "lanes",
+          );
+          expect(seenHandles.at(-1)?.store.getState().snapshotLoaded).toBe(
+            true,
+          );
+          expect(seenFetchers.length).toBeGreaterThan(0);
+        });
+        const handle = seenHandles.at(-1);
+        const fetcher = seenFetchers.at(-1);
+        if (handle === undefined || fetcher === undefined) {
+          throw new Error("expected a loaded lane handle and image fetcher");
+        }
+        // The SOURCE root has the bytes, but lane state does not seed that
+        // root map into the worker's local replica.
+        await expect(
+          readHeldEpicAttachmentBytes(handle, sourceHash),
+        ).resolves.toBe(null);
+
+        const donor = new Y.Doc();
+        try {
+          donor.getMap<Uint8Array>("attachments").set(sourceHash, pastedBytes);
+          await handle.applyRootUpdate(Y.encodeStateAsUpdate(donor), true);
+        } finally {
+          donor.destroy();
+        }
+        const heldPastedBytes = await readHeldEpicAttachmentBytes(
+          handle,
+          sourceHash,
+        );
+        if (heldPastedBytes === null) {
+          throw new Error("expected locally pasted attachment bytes");
+        }
+        expect(Array.from(heldPastedBytes)).toEqual(Array.from(pastedBytes));
+
+        const resolved = await fetcher.fetch(
+          sourceHash,
+          new AbortController().signal,
+        );
+        expect(Array.from(resolved.bytes)).toEqual([1, 2, 3, 4]);
+        expect(resolved.mediaType).toBe("image/png");
+        expect(requests).toHaveLength(1);
+        expect(requests[0]).toMatchObject({
+          method: "epic.fetchArtifactAttachment",
+          params: {
+            epicId: "fixture-epic",
+            artifactId: "fixture-artifact",
+            hash: sourceHash,
+          },
+        });
+      } finally {
+        view.unmount();
+      }
+    } finally {
+      fixture.dispose();
+    }
   });
 
   it("shares one resolved host client with every session consumer", async () => {
@@ -1132,53 +1409,12 @@ describe("<EpicSessionProvider />", () => {
   });
 
   it("addresses a re-point candidate's lane unary to the host it was CONSTRUCTED against, not the still-mounted session's host", async () => {
-    const streams: ControlledEpicStream[] = [];
-    const seenHandles: OpenEpicStoreHandle[] = [];
-    installStreamFactory((_epicId, callbacks) => {
-      const stream: ControlledEpicStream = { closeCount: 0, callbacks };
-      streams.push(stream);
-      return {
-        applyUpdate: () => undefined,
-        awareness: () => undefined,
-        applyArtifactRoomUpdate: () => undefined,
-        artifactRoomAwareness: () => undefined,
-        retryMigration: () => undefined,
-        close: () => {
-          stream.closeCount += 1;
-        },
-      };
-    });
-
-    const view = render(
-      <EpicSessionProvider epicId="epic-session-test" tabId="epic-session-test">
-        <HandleProbe
-          onHandle={(handle) => {
-            seenHandles.push(handle);
-          }}
-        />
-      </EpicSessionProvider>,
-    );
-
-    await waitFor(() => {
-      expect(seenHandles).toHaveLength(1);
-    });
-    act(() => {
-      deliverSnapshot(streams[0], "room-a");
-    });
-
-    const hostAClient = sessionHostClients.byHostId.get("host-a");
-    if (hostAClient === undefined) {
-      throw new Error("expected a resolved host-a client");
-    }
-    hostAClient.request.mockResolvedValue({ context: null });
-
-    act(() => {
-      hostState.id = "host-b";
-      view.rerender(
-        <EpicSessionProvider
-          epicId="epic-session-test"
-          tabId="epic-session-test"
-        >
+    const fixture = createEpicSessionFixture("lanes");
+    try {
+      installFixtureFactory(fixture);
+      const seenHandles: OpenEpicStoreHandle[] = [];
+      const view = render(
+        <EpicSessionProvider epicId="fixture-epic" tabId="fixture-epic">
           <HandleProbe
             onHandle={(handle) => {
               seenHandles.push(handle);
@@ -1186,60 +1422,99 @@ describe("<EpicSessionProvider />", () => {
           />
         </EpicSessionProvider>,
       );
-    });
+      try {
+        await waitFor(() => expect(fixture.opens.state).toBe(1));
+        fixture.openLaneStreams(0);
+        fixture.deliverLaneSnapshots(0);
+        await waitFor(() => {
+          expect(seenHandles.at(-1)?.store.getState().installedArm).toBe(
+            "lanes",
+          );
+          expect(seenHandles.at(-1)?.store.getState().snapshotLoaded).toBe(
+            true,
+          );
+        });
 
-    await waitFor(() => {
-      expect(streams).toHaveLength(2);
-    });
-    // The candidate must still be ESTABLISHING - its snapshot is deliberately
-    // never delivered, because that is the window the defect lives in: once
-    // the replacement commits, `session.hostId` becomes B and the bug is
-    // unobservable.
-    expect(streams[1].closeCount).toBe(0);
-    expect(__getOpenEpicRegistryForTests().size()).toBe(1);
-    if (spawnedRuntimeOptions.laneUnaries.length !== 2) {
-      throw new Error(
-        `expected exactly 2 spawned workers (the mounted handle and the re-point candidate), got ${spawnedRuntimeOptions.laneUnaries.length}`,
-      );
+        const hostAClient = sessionHostClients.byHostId.get("host-a");
+        if (hostAClient === undefined) {
+          throw new Error("expected a resolved host-a client");
+        }
+        hostAClient.request.mockResolvedValue({ context: null });
+
+        act(() => {
+          hostState.id = "host-b";
+          view.rerender(
+            <EpicSessionProvider epicId="fixture-epic" tabId="fixture-epic">
+              <HandleProbe
+                onHandle={(handle) => {
+                  seenHandles.push(handle);
+                }}
+              />
+            </EpicSessionProvider>,
+          );
+        });
+
+        await waitFor(() => expect(fixture.opens.state).toBe(2));
+        // The candidate must still be ESTABLISHING - its snapshot is
+        // deliberately never delivered, because that is the window the
+        // defect lives in: once the replacement commits, the bug is
+        // unobservable.
+        expect(fixture.stateStreams[1]?.closeCount).toBe(0);
+        expect(fixture.opens.legacy).toBe(0);
+        expect(__getOpenEpicRegistryForTests().size()).toBe(1);
+        if (spawnedRuntimeOptions.laneUnaries.length !== 2) {
+          throw new Error(
+            `expected exactly 2 spawned workers (the mounted handle and the re-point candidate), got ${spawnedRuntimeOptions.laneUnaries.length}`,
+          );
+        }
+
+        // The provider resolves BOTH hosts during this window - the mounted
+        // session's ("host-a") and the re-point target's ("host-b") - so the render
+        // path has already created the stub this asserts on. Calling the resolver
+        // here is get-or-create against the same cache the mocked hook reads
+        // (`:96-105`), which hands back that very object rather than a second one;
+        // a fresh stub per call would make the assertion below unreachable. The
+        // call is kept rather than replaced by a bare `get` so the test does not
+        // depend on WHICH render resolved it first.
+        resolveSessionHostClient("host-b");
+        const hostBClient = sessionHostClients.byHostId.get("host-b");
+        if (hostBClient === undefined) {
+          throw new Error("expected a resolved host-b client");
+        }
+        hostBClient.request.mockResolvedValue({ context: null });
+
+        // THE REDDENING ONE - the candidate's unary must go to B.
+        await spawnedRuntimeOptions.laneUnaries[1]({
+          kind: "workspace-context",
+        });
+        expect(hostBClient.request).toHaveBeenCalledWith(
+          "epic.getWorkspaceContext",
+          { epicId: "fixture-epic" },
+        );
+        // ...and not to A - today it goes to A instead, since `getCommandRequester`
+        // resolves from `session?.hostId ?? targetHostId`, and `session` is still
+        // A while the candidate is establishing.
+        expect(hostAClient.request).not.toHaveBeenCalledWith(
+          "epic.getWorkspaceContext",
+          { epicId: "fixture-epic" },
+        );
+
+        // CONTROL - must be green both before and after the fix. The naive fix
+        // ("bind every handle to `targetHostId`") would make the still-mounted A
+        // handle's own unary address B too, which this catches.
+        await spawnedRuntimeOptions.laneUnaries[0]({
+          kind: "workspace-context",
+        });
+        expect(hostAClient.request).toHaveBeenCalledWith(
+          "epic.getWorkspaceContext",
+          { epicId: "fixture-epic" },
+        );
+      } finally {
+        view.unmount();
+      }
+    } finally {
+      fixture.dispose();
     }
-
-    // The provider resolves BOTH hosts during this window - the mounted
-    // session's ("host-a") and the re-point target's ("host-b") - so the render
-    // path has already created the stub this asserts on. Calling the resolver
-    // here is get-or-create against the same cache the mocked hook reads
-    // (`:96-105`), which hands back that very object rather than a second one;
-    // a fresh stub per call would make the assertion below unreachable. The
-    // call is kept rather than replaced by a bare `get` so the test does not
-    // depend on WHICH render resolved it first.
-    resolveSessionHostClient("host-b");
-    const hostBClient = sessionHostClients.byHostId.get("host-b");
-    if (hostBClient === undefined) {
-      throw new Error("expected a resolved host-b client");
-    }
-    hostBClient.request.mockResolvedValue({ context: null });
-
-    // THE REDDENING ONE - the candidate's unary must go to B.
-    await spawnedRuntimeOptions.laneUnaries[1]({ kind: "workspace-context" });
-    expect(hostBClient.request).toHaveBeenCalledWith(
-      "epic.getWorkspaceContext",
-      { epicId: "epic-session-test" },
-    );
-    // ...and not to A - today it goes to A instead, since `getCommandRequester`
-    // resolves from `session?.hostId ?? targetHostId`, and `session` is still
-    // A while the candidate is establishing.
-    expect(hostAClient.request).not.toHaveBeenCalledWith(
-      "epic.getWorkspaceContext",
-      { epicId: "epic-session-test" },
-    );
-
-    // CONTROL - must be green both before and after the fix. The naive fix
-    // ("bind every handle to `targetHostId`") would make the still-mounted A
-    // handle's own unary address B too, which this catches.
-    await spawnedRuntimeOptions.laneUnaries[0]({ kind: "workspace-context" });
-    expect(hostAClient.request).toHaveBeenCalledWith(
-      "epic.getWorkspaceContext",
-      { epicId: "epic-session-test" },
-    );
   });
 
   it("uses a plain swap when the replacement reports a different room", async () => {

--- a/clients/gui-app/src/stores/epics/open-epic/test-support/in-process-epic-runtime-worker.ts
+++ b/clients/gui-app/src/stores/epics/open-epic/test-support/in-process-epic-runtime-worker.ts
@@ -15,7 +15,7 @@
  * relocation - the stream-factory override did not, because a factory built on
  * MAIN cannot cross `postMessage` to a runtime that lives in the worker.
  *
- * One helper, three users, no third wiring. The rule
+ * One bridge harness, two explicit composition modes, no second wiring. The rule
  * `open-store-for-test.ts`'s header states - "a second wiring is a second
  * harness to keep honest, and the two would drift in exactly the places that
  * matter" - is why this file exists rather than a copy in the provider suite.
@@ -24,8 +24,14 @@ import { createFakeBridgePair } from "@traycer-clients/shared/replica-runtime/wo
 import type { FakeBridgeDelivery } from "@traycer-clients/shared/replica-runtime/worker/test-support/fake-bridge-pair";
 import { createFakeWorkerTarget } from "@traycer-clients/shared/replica-runtime/worker/test-support/fake-worker-target";
 import type { RuntimeWorkerLike } from "../runtime/worker/spawn-epic-runtime-worker";
-import { startEpicRuntimeWorkerHost } from "../runtime/worker/epic-runtime-worker-host";
-import { installEpicRuntimeCore } from "../runtime/worker/install-epic-runtime-core";
+import {
+  startEpicRuntimeWorkerHost,
+  type EpicRuntimeWorkerHost,
+} from "../runtime/worker/epic-runtime-worker-host";
+import {
+  buildProxiedRuntimeFactories,
+  installEpicRuntimeCore,
+} from "../runtime/worker/install-epic-runtime-core";
 import type { EpicRuntimeStreamFactories } from "../runtime/worker/epic-runtime-composition";
 import type { EpicReplicaRuntime } from "../runtime/epic-replica-runtime";
 
@@ -68,17 +74,36 @@ export interface InProcessEpicRuntimeWorker {
 export function createInProcessEpicRuntimeWorker(
   factories: EpicRuntimeStreamFactories,
 ): InProcessEpicRuntimeWorker {
+  return createInProcessWorker(() => factories);
+}
+
+/**
+ * The same in-process bridge, with the production worker's factory builder.
+ *
+ * Provider tests use this entry point when their claim begins at negotiated
+ * method support: the main-side spawner emits `stream/manifest`,
+ * {@link buildProxiedRuntimeFactories} reads that replicated manifest, and the
+ * runtime selects its arm from the resulting live support source. Supplying a
+ * pre-composed `laneSelection` here would bypass the very bootstrap path those
+ * tests exist to cover.
+ */
+export function createProxiedInProcessEpicRuntimeWorker(): InProcessEpicRuntimeWorker {
+  return createInProcessWorker(buildProxiedRuntimeFactories);
+}
+
+function createInProcessWorker(
+  buildFactories: (host: EpicRuntimeWorkerHost) => EpicRuntimeStreamFactories,
+): InProcessEpicRuntimeWorker {
   // ALWAYS `"sync"` here: composition happens inside the caller's
   // `spawnEpicRuntimeWorker`, over this pipe, so a pair queued from birth
   // cannot construct a runtime at all. A suite that needs queued delivery gets
   // it by flipping AFTER composition - see `setDelivery`.
   const pair = createFakeBridgePair("sync");
-  // The worker side, in this thread: the real host, given the caller's
-  // factories in place of the proxy-built ones. That injection is the seam
-  // `epic-runtime-composition.ts` documents - production passes the
-  // proxy-built factories, a caller supplying its own stream passes those.
+  // The worker side, in this thread: the real host, given either production's
+  // proxy builder or the caller's explicit factories through the one seam
+  // `epic-runtime-composition.ts` documents.
   const host = startEpicRuntimeWorkerHost(pair.worker);
-  const composed = installEpicRuntimeCore(host, () => factories);
+  const composed = installEpicRuntimeCore(host, buildFactories);
   return {
     createWorker: () => ({
       ...createFakeWorkerTarget(pair),


### PR DESCRIPTION
## Summary

Test-only. Closes the coverage debt left by #1589 (register item E1) and lands the client half of the A2 read-path pin from the attachment back-fill work.

**Why:** every world in `providers/__tests__/epic-session-provider.test.tsx` was built with `laneSelection: null`, so the lane arm that production uses had no end-to-end pin through the public provider. That is the same class of blindness that hid the v2 blocker: an arm the suite cannot present because the one fixture every world is built from does not produce it.

**What:**

- `providers/__tests__/epic-session-fixture.ts`: `createEpicSessionFixture(arm: "legacy" | "lanes")`. The fixture supplies arm-derived **method support** and recording socket stand-ins only. It does not construct or inject `laneSelection`, so lanes are reached through the production chain: fake transport `getMethodSupport` → the real spawner's `emitManifest()` → worker `deliverManifest` → production `buildProxiedRuntimeFactories` reading `host.streams.manifest()` → runtime `applySelection`.
- Shared in-process harness: `createProxiedInProcessEpicRuntimeWorker()`, a second composition mode that passes the production proxied factory builder into the real `installEpicRuntimeCore`. Existing explicit-factory users are unchanged.
- Provider pins: public open lands on lanes (`installedArm === "lanes"`, one state and one status open, zero legacy opens); the #1589 clean attached-reprobe rebuild holds on lanes; a re-point candidate constructed on lanes addresses its unary to the constructing host (with a mounted-host negative control).
- A2: the fixture's state-lane frame is derived from a seeded source root; the test positively observes the seeded title arriving through that frame, then asserts the lane session's `readHeldEpicAttachmentBytes` is `null` for bytes present in the same source root; a local `applyRootUpdate` makes distinct bytes readable; the real `useEpicImageFetcher` issues exactly `epic.fetchArtifactAttachment` (projected `{method, params}` compared with `toEqual`).
- The fixture's both-arms test is labelled as a construction guard (no production edit reddens it); production coverage is the public-open pin.

## Evidence

Production ablations, restored after each run: forcing `buildProxiedRuntimeFactories` support to `unknown` reddens the public-open pin at `fixture.opens.state` (0 vs 1); copying the source-root update across the lane bootstrap boundary reddens the A2 null assertion with the seeded bytes. Provider 42/42, access-coordinator 15/15. Cold-reviewed twice before push (the first pass caught that the initial fixture injected the lane verdict; the second pass traced the corrected chain link by link).

E2 (`bytesReclaimed` attribution) is deliberately deferred. Ticket: `epic-sync-overhaul/tickets/coverage-debt-e1-e2` (Traycer epic artifacts).