### PR TITLE
fix(gui-app): stop treating aria-hidden overlays as unpainted occluders

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/__tests__/browser-overlay-coordinator-bridge.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/browser-overlay-coordinator-bridge.test.tsx
@@ -8,6 +8,15 @@ import {
   getBrowserViewSnapshot,
   registerBrowserOverlayTile,
 } from "@/lib/browser-view/tiles/browser-overlay-coordinator";
+import { Dialog, DialogContent } from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { SurfacePresentationBoundary } from "@/components/layout/surface-presentation-boundary";
 import type {
   BrowserViewOverlayOcclusion,
   BrowserViewOverlayOcclusionResult,
@@ -609,6 +618,128 @@ describe("<BrowserOverlayCoordinator />", () => {
     });
 
     overlay.remove();
+  });
+
+  it("keeps a dialog occluded across a real Radix Select's aria-hidden churn", async () => {
+    // The regression: Radix's hideOthers (fired by any Select/Popover/
+    // DropdownMenu opening) sets aria-hidden="true" on every OTHER body
+    // child while it's open - including a settings dialog that is itself a
+    // direct body child via DialogPortal. The old `isElementVisible` treated
+    // aria-hidden as "not painted", so the dialog dropped out of the next
+    // scan's targets and got released while it still visibly covered the
+    // tile. A bare-div overlay stand-in never exercises this: nothing calls
+    // hideOthers on it, so this needs real Radix mount/unmount behavior.
+    const bridge = new FakeBrowserViewBridge();
+    registerTestBrowserOverlayTile({
+      key: BASE_KEY,
+      rect: rect(0, 0, 300, 300),
+    });
+
+    // Controlled `open`, driven by rerender rather than a simulated click:
+    // Radix's own dismissable-layer close (from a real outside click) would
+    // race a second, test-owned click handler toggling the same state,
+    // double-flipping it back open. A controlled prop still mounts/unmounts
+    // the real `SelectContent` - and runs its real `hideOthers` effect - on
+    // each transition, which is the behavior under test.
+    function Harness(props: {
+      readonly selectOpen: boolean;
+    }): React.JSX.Element {
+      return (
+        <SurfacePresentationBoundary visible focused>
+          <Dialog open>
+            <DialogContent>
+              <Select
+                open={props.selectOpen}
+                onOpenChange={() => undefined}
+                value="a"
+                onValueChange={() => undefined}
+              >
+                <SelectTrigger aria-label="Pick">
+                  <SelectValue placeholder="Pick" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="a">A</SelectItem>
+                </SelectContent>
+              </Select>
+            </DialogContent>
+          </Dialog>
+        </SurfacePresentationBoundary>
+      );
+    }
+
+    const runnerHost = Object.assign(
+      new MockRunnerHost({
+        signInUrl: "https://example.com",
+        authnBaseUrl: "https://auth.example.com",
+        localHost: null,
+        hosts: [],
+        workspaceFolderPickerPaths: undefined,
+        hasLocalHost: undefined,
+        traycerCli: undefined,
+      }),
+      { browserView: bridge },
+    );
+    const view = render(
+      <RunnerHostProvider runnerHost={runnerHost}>
+        <BrowserOverlayCoordinatorBridge />
+        <Harness selectOpen={false} />
+      </RunnerHostProvider>,
+    );
+
+    const dialogContent = document.querySelector<HTMLElement>(
+      '[data-slot="dialog-content"]',
+    );
+    if (dialogContent === null) throw new Error("dialog content not mounted");
+    setElementRect(dialogContent, rect(0, 0, 200, 200));
+
+    await waitFor(() => {
+      expect(bridge.occludeCalls).toHaveLength(1);
+    });
+    const dialogOverlayId = bridge.occludeCalls[0].overlayId;
+
+    // Open the Select: real Radix hideOthers churn, not a stubbed attribute.
+    act(() => {
+      view.rerender(
+        <RunnerHostProvider runnerHost={runnerHost}>
+          <BrowserOverlayCoordinatorBridge />
+          <Harness selectOpen />
+        </RunnerHostProvider>,
+      );
+    });
+    await waitFor(() => {
+      expect(dialogContent.getAttribute("aria-hidden")).toBe("true");
+    });
+
+    await act(async () => {
+      window.dispatchEvent(new Event("resize"));
+      await Promise.resolve();
+    });
+    expect(
+      bridge.releaseCalls.some((call) => call.overlayId === dialogOverlayId),
+    ).toBe(false);
+
+    // Close the Select again; the dialog is still open and still covers the
+    // tile, so the scan that follows must not release it either - this is
+    // the scan that catches a release-before-occlude ordering regression too.
+    act(() => {
+      view.rerender(
+        <RunnerHostProvider runnerHost={runnerHost}>
+          <BrowserOverlayCoordinatorBridge />
+          <Harness selectOpen={false} />
+        </RunnerHostProvider>,
+      );
+    });
+    await waitFor(() => {
+      expect(dialogContent.hasAttribute("aria-hidden")).toBe(false);
+    });
+
+    await act(async () => {
+      window.dispatchEvent(new Event("resize"));
+      await Promise.resolve();
+    });
+    expect(
+      bridge.releaseCalls.some((call) => call.overlayId === dialogOverlayId),
+    ).toBe(false);
   });
 });
 

--- a/clients/gui-app/src/components/epic-canvas/browser-overlay-coordinator-bridge.tsx
+++ b/clients/gui-app/src/components/epic-canvas/browser-overlay-coordinator-bridge.tsx
@@ -113,10 +113,13 @@ function BrowserOverlayCoordinator(props: {
         targets.map((target) => [target.overlayId, target]),
       );
 
-      activeSignaturesByOverlayId.forEach((_signature, overlayId) => {
-        if (!nextTargetsByOverlayId.has(overlayId)) releaseOverlay(overlayId);
-      });
-
+      // Occlude before release: main-process release is synchronous while
+      // occlude is async, so releasing first can un-park a tile that another
+      // overlay in this same scan still covers for the duration of that
+      // overlay's occludeForOverlay round trip. A tile must stay parked
+      // across an ownership handoff between overlays, never revealed in
+      // between - so occlusion for the still-active overlays goes out before
+      // any release for the ones that dropped out.
       targets.forEach((target) => {
         if (
           activeSignaturesByOverlayId.get(target.overlayId) === target.signature
@@ -164,6 +167,10 @@ function BrowserOverlayCoordinator(props: {
             ignoreError(error);
           });
       });
+
+      activeSignaturesByOverlayId.forEach((_signature, overlayId) => {
+        if (!nextTargetsByOverlayId.has(overlayId)) releaseOverlay(overlayId);
+      });
     };
 
     const unsubscribeLayout = subscribeBrowserOverlayLayout(scheduleScan);
@@ -176,7 +183,6 @@ function BrowserOverlayCoordinator(props: {
       childList: true,
       attributes: true,
       attributeFilter: [
-        "aria-hidden",
         "class",
         "data-browser-overlay",
         "data-browser-overlay-ignore",

--- a/clients/gui-app/src/lib/browser-view/tiles/browser-overlay-coordinator.ts
+++ b/clients/gui-app/src/lib/browser-view/tiles/browser-overlay-coordinator.ts
@@ -260,7 +260,6 @@ function readOverlayKind(element: HTMLElement): string {
 
 function isElementVisible(element: HTMLElement): boolean {
   if (element.hidden) return false;
-  if (element.getAttribute("aria-hidden") === "true") return false;
   if (element.getAttribute("data-state") === "closed") return false;
   const style = window.getComputedStyle(element);
   if (style.display === "none" || style.visibility === "hidden") return false;


### PR DESCRIPTION
## Summary

Fixes two related bugs in the browser-tile occlusion coordinator that let a native `WebContentsView` briefly paint above a still-open Radix dialog.

- `isElementVisible` treated `aria-hidden="true"` as "not painted" and dropped an element as an occluder on that basis. Radix's `hideOthers` marks every sibling of an open overlay `aria-hidden` - including an ancestor dialog that is still fully visible and still covering a native browser tile beneath it. That is an assistive-tech signal, not a paint signal, so the coordinator was disqualifying a real occluder.
- `runScan` ran the release loop before the occlude loop. When a nested overlay (e.g. a `Select` inside a `Dialog`) closes, its release and the dialog's continued occlusion should be reconciled release-after-occlude so the tile stays parked across the ownership handoff; running release first let the tile surface for a few frames before the still-open dialog's occlusion applied.

Causal chain proven by the new regression test: open a real Radix `Dialog`, open a `Select` inside it, close the `Select` - `hideOthers` toggles `aria-hidden` on the dialog during the churn, the coordinator's `aria-hidden` check made it stop treating the dialog as an occluder, and the release-before-occlude ordering let the native view repaint above the still-open dialog. The test is red against the pre-fix code and green after.

## Fix

- Delete the `aria-hidden` check from `isElementVisible` (every remaining predicate is a real paint signal).
- Reorder `runScan` to occlude before release, with an invariant comment explaining why.

## Test plan

- [x] New test in `browser-overlay-coordinator-bridge.test.tsx` drives a real Radix `Dialog` + `Select` (no mocked primitives) to exercise the actual `hideOthers` churn; verified red against the unfixed code, green after.
- [x] `pre-commit` workspace checks (lint, compile, build) passed locally on this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)