### PR TITLE
feat(gui): drop the card-level framing header from interview cards

### DIFF
--- a/clients/gui-app/src/components/chat/__tests__/chat-activity-groups.test.ts
+++ b/clients/gui-app/src/components/chat/__tests__/chat-activity-groups.test.ts
@@ -1561,8 +1561,6 @@ function interviewSegment(
     kind: "interview",
     status: "completed",
     toolName: "question",
-    title: "Question",
-    description: null,
     questions: [
       {
         questionId: null,

--- a/clients/gui-app/src/components/chat/__tests__/chat-find-projection.test.ts
+++ b/clients/gui-app/src/components/chat/__tests__/chat-find-projection.test.ts
@@ -123,8 +123,6 @@ describe("chat find projection", () => {
   it("projects every rendered interview field under the card's owning chain", () => {
     const segment: InterviewSegment = {
       ...interviewSegment("interview-all-fields", "errored"),
-      title: "Deployment title",
-      description: "Rollout description",
       questions: [
         {
           questionId: "q-options",
@@ -209,9 +207,6 @@ describe("chat find projection", () => {
     const model = deriveInterviewReviewModel({
       blockId: segment.id,
       status: segment.status,
-      toolName: segment.toolName,
-      title: segment.title,
-      description: segment.description,
       questions: segment.questions,
       answers: segment.answers,
       draftAnswers: segment.draftAnswers,
@@ -1226,8 +1221,6 @@ function interviewSegment(
     kind: "interview",
     status,
     toolName: "AskUserQuestion",
-    title: null,
-    description: null,
     questions: [
       {
         questionId: "q1",

--- a/clients/gui-app/src/components/chat/__tests__/chat-messages.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/chat-messages.test.tsx
@@ -277,8 +277,6 @@ function makeInterviewFindTranscript(count: number): ChatMessageModel[] {
         kind: "interview",
         status: "completed",
         toolName: "AskUserQuestion",
-        title: null,
-        description: null,
         questions: [
           {
             questionId: "q1",

--- a/clients/gui-app/src/components/chat/__tests__/use-chat-find-controller.test.ts
+++ b/clients/gui-app/src/components/chat/__tests__/use-chat-find-controller.test.ts
@@ -334,8 +334,6 @@ function makeTranscriptWithInterviewDetailNeedle(): ReadonlyArray<ChatMessageMod
         kind: "interview",
         status: "completed",
         toolName: "AskUserQuestion",
-        title: null,
-        description: null,
         questions: [
           {
             questionId: "q1",

--- a/clients/gui-app/src/components/chat/chat-find-projection.ts
+++ b/clients/gui-app/src/components/chat/chat-find-projection.ts
@@ -366,9 +366,6 @@ function interviewSearchUnits(
   const model = deriveInterviewReviewModel({
     blockId: segment.id,
     status: segment.status,
-    toolName: segment.toolName,
-    title: segment.title,
-    description: segment.description,
     questions: segment.questions,
     answers: segment.answers,
     draftAnswers: segment.draftAnswers,

--- a/clients/gui-app/src/components/chat/chat-message-assistant-body.tsx
+++ b/clients/gui-app/src/components/chat/chat-message-assistant-body.tsx
@@ -1018,9 +1018,6 @@ function AssistantSegment({
         <InterviewSegment
           blockId={segment.id}
           status={segment.status}
-          toolName={segment.toolName}
-          title={segment.title}
-          description={segment.description}
           questions={segment.questions}
           answers={segment.answers}
           draftAnswers={segment.draftAnswers}

--- a/clients/gui-app/src/components/chat/segments/__tests__/interview-review-model.test.ts
+++ b/clients/gui-app/src/components/chat/segments/__tests__/interview-review-model.test.ts
@@ -6,7 +6,6 @@ import type {
 import {
   type InterviewReviewInput,
   deriveInterviewReviewModel,
-  displayInterviewFraming,
 } from "@/components/chat/segments/interview-review-model";
 
 function question(
@@ -49,9 +48,6 @@ function reviewInput(
   return {
     blockId: "interview-test-block",
     status: "completed",
-    toolName: "AskUserQuestion",
-    title: null,
-    description: null,
     questions: [],
     answers: [],
     draftAnswers: [],
@@ -68,8 +64,6 @@ describe("deriveInterviewReviewModel", () => {
   it("indexes fields with positional ids that never embed rendered text", () => {
     const model = deriveInterviewReviewModel(
       reviewInput({
-        title: "Deployment plan",
-        description: "Pick a safe rollout.",
         questions: [
           {
             questionId: "q1",
@@ -104,20 +98,6 @@ describe("deriveInterviewReviewModel", () => {
     expect(model.searchableFields.map((field) => field.target)).toEqual([
       {
         fieldKind: "summary",
-        questionIndex: null,
-        optionIndex: null,
-        fallbackIndex: null,
-        valueIndex: null,
-      },
-      {
-        fieldKind: "title",
-        questionIndex: null,
-        optionIndex: null,
-        fallbackIndex: null,
-        valueIndex: null,
-      },
-      {
-        fieldKind: "description",
         questionIndex: null,
         optionIndex: null,
         fallbackIndex: null,
@@ -188,8 +168,6 @@ describe("deriveInterviewReviewModel", () => {
     ).toBe(true);
     expect(model.searchableFields.map((field) => field.text)).toEqual([
       "Answered 1 question",
-      "Deployment plan",
-      "Pick a safe rollout.",
       "Environment",
       "Where should this deploy?",
       "Staging",
@@ -828,51 +806,5 @@ describe("deriveInterviewReviewModel", () => {
         draft: false,
       },
     ]);
-  });
-});
-
-describe("displayInterviewFraming", () => {
-  it("suppresses tool and provider boilerplate while retaining question framing", () => {
-    expect(
-      displayInterviewFraming({
-        toolName: "AskUserQuestion",
-        title: "AskUserQuestion",
-        description: "Codex needs your input",
-      }),
-    ).toEqual({ title: null, description: null });
-
-    expect(
-      displayInterviewFraming({
-        toolName: "AskUserQuestion",
-        title: "Deployment strategy",
-        description: "Choose how the rollout should proceed.",
-      }),
-    ).toEqual({
-      title: "Deployment strategy",
-      description: "Choose how the rollout should proceed.",
-    });
-  });
-
-  it("preserves distinct non-ASCII framing", () => {
-    expect(
-      displayInterviewFraming({
-        toolName: "質問ツール",
-        title: "展開戦略",
-        description: "段階的な公開方法を選択してください。",
-      }),
-    ).toEqual({
-      title: "展開戦略",
-      description: "段階的な公開方法を選択してください。",
-    });
-  });
-
-  it("does not equate framing that normalizes to an empty string", () => {
-    expect(
-      displayInterviewFraming({
-        toolName: "🛠️",
-        title: "🚀",
-        description: null,
-      }),
-    ).toEqual({ title: "🚀", description: null });
   });
 });

--- a/clients/gui-app/src/components/chat/segments/__tests__/interview-segment.test.tsx
+++ b/clients/gui-app/src/components/chat/segments/__tests__/interview-segment.test.tsx
@@ -77,9 +77,6 @@ describe("InterviewSegment", () => {
         <InterviewSegment
           blockId="interview-1"
           status="completed"
-          toolName="AskUserQuestion"
-          title="Need input"
-          description={null}
           questions={[
             {
               questionId: "q1",
@@ -128,9 +125,6 @@ describe("InterviewSegment", () => {
         <InterviewSegment
           blockId="interview-carried"
           status="completed"
-          toolName="AskUserQuestion"
-          title="Need input"
-          description={null}
           questions={[]}
           answers={[]}
           draftAnswers={[]}
@@ -159,9 +153,6 @@ describe("InterviewSegment", () => {
         <InterviewSegment
           blockId="interview-carried-settled"
           status="completed"
-          toolName="AskUserQuestion"
-          title="Need input"
-          description={null}
           questions={[]}
           answers={[]}
           draftAnswers={[]}
@@ -188,9 +179,6 @@ describe("InterviewSegment", () => {
         <InterviewSegment
           blockId="interview-skipped"
           status="errored"
-          toolName="AskUserQuestion"
-          title="Need input"
-          description={null}
           questions={[
             {
               questionId: "q1",
@@ -218,15 +206,12 @@ describe("InterviewSegment", () => {
     expect(onFork).toHaveBeenCalledWith("ab-worktree", "interview-skipped");
   });
 
-  it("expands into a read-only pager with framing, headers, and static options", () => {
+  it("expands into a read-only pager with headers and static options", () => {
     render(
       <InterviewTestProviders>
         <InterviewSegment
           blockId="interview-exact"
           status="completed"
-          toolName="AskUserQuestion"
-          title="Deployment strategy"
-          description="Choose how the rollout should proceed."
           questions={[
             {
               questionId: "q1",
@@ -294,10 +279,6 @@ describe("InterviewSegment", () => {
     fireEvent.click(disclosure);
 
     expect(disclosure.getAttribute("aria-expanded")).toBe("true");
-    expect(screen.getAllByText("Deployment strategy")).toHaveLength(2);
-    expect(
-      screen.getByText("Choose how the rollout should proceed."),
-    ).toBeTruthy();
     expect(screen.getByText("Scope")).toBeTruthy();
     expect(screen.getByText("Which scope?")).toBeTruthy();
     expect(screen.getByText("Selected answer")).toBeTruthy();
@@ -322,9 +303,6 @@ describe("InterviewSegment", () => {
         <InterviewSegment
           blockId="interview-draft"
           status="completed"
-          toolName="AskUserQuestion"
-          title={null}
-          description={null}
           questions={[
             {
               questionId: "q1",
@@ -379,9 +357,6 @@ describe("InterviewSegment", () => {
         <InterviewSegment
           blockId="interview-unlabelled-draft"
           status="completed"
-          toolName="AskUserQuestion"
-          title={null}
-          description={null}
           questions={[]}
           answers={[]}
           draftAnswers={[
@@ -451,9 +426,6 @@ describe("InterviewSegment", () => {
         <InterviewSegment
           blockId="interview-shrink"
           status="completed"
-          toolName="AskUserQuestion"
-          title={null}
-          description={null}
           questions={questions}
           answers={answers}
           draftAnswers={[]}
@@ -495,9 +467,6 @@ describe("InterviewSegment", () => {
         <InterviewSegment
           blockId="interview-force"
           status="completed"
-          toolName="AskUserQuestion"
-          title={null}
-          description={null}
           questions={[
             {
               questionId: "q1",
@@ -559,9 +528,6 @@ describe("InterviewSegment", () => {
         <InterviewSegment
           blockId="interview-force-valid"
           status="completed"
-          toolName="AskUserQuestion"
-          title={null}
-          description={null}
           questions={[
             {
               questionId: "q1",
@@ -621,9 +587,6 @@ describe("InterviewSegment", () => {
         <InterviewSegment
           blockId="interview-force-rapid"
           status="completed"
-          toolName="AskUserQuestion"
-          title={null}
-          description={null}
           questions={[
             {
               questionId: "q1",
@@ -675,9 +638,6 @@ describe("InterviewSegment", () => {
         <InterviewSegment
           blockId="interview-target-page"
           status="completed"
-          toolName="AskUserQuestion"
-          title={null}
-          description={null}
           questions={[
             {
               questionId: "q1",
@@ -755,9 +715,6 @@ describe("InterviewSegment", () => {
         <InterviewSegment
           blockId="interview-manual-page"
           status="completed"
-          toolName="AskUserQuestion"
-          title={null}
-          description={null}
           questions={[
             {
               questionId: "q1",
@@ -808,9 +765,6 @@ describe("InterviewSegment", () => {
         <InterviewSegment
           blockId="interview-details"
           status="completed"
-          toolName="AskUserQuestion"
-          title={null}
-          description={null}
           questions={[
             {
               questionId: "q1",
@@ -867,9 +821,6 @@ describe("InterviewSegment", () => {
           <InterviewSegment
             blockId={blockId}
             status="completed"
-            toolName="AskUserQuestion"
-            title={null}
-            description={null}
             questions={[
               {
                 questionId: "q1",
@@ -930,9 +881,6 @@ describe("InterviewSegment", () => {
         <InterviewSegment
           blockId="interview-delivery"
           status="completed"
-          toolName="AskUserQuestion"
-          title={null}
-          description={null}
           questions={[
             {
               questionId: "q1",
@@ -984,9 +932,6 @@ describe("InterviewSegment", () => {
         <InterviewSegment
           blockId="interview-delivery-retry"
           status="completed"
-          toolName="AskUserQuestion"
-          title={null}
-          description={null}
           questions={[
             {
               questionId: "q1",

--- a/clients/gui-app/src/components/chat/segments/interview-review-model.ts
+++ b/clients/gui-app/src/components/chat/segments/interview-review-model.ts
@@ -13,18 +13,10 @@ export type InterviewReviewFidelity =
   | "no-answer"
   | "draft";
 
-export interface InterviewDisplayFraming {
-  readonly title: string | null;
-  readonly description: string | null;
-}
-
 export interface InterviewReviewInput {
   /** Stable persisted interview block identity; never user-facing text. */
   readonly blockId: string;
   readonly status: "streaming" | "completed" | "errored";
-  readonly toolName: string | null;
-  readonly title: string | null;
-  readonly description: string | null;
   readonly questions: ReadonlyArray<InterviewQuestion>;
   readonly answers: ReadonlyArray<InterviewAnswer>;
   readonly draftAnswers: ReadonlyArray<InterviewAnswer>;
@@ -66,8 +58,6 @@ export interface InterviewReviewDelivery {
  */
 export type InterviewReviewFieldKind =
   | "summary"
-  | "title"
-  | "description"
   | "question-header"
   | "question-text"
   | "option-label"
@@ -97,7 +87,6 @@ export interface InterviewReviewSearchField {
 }
 
 export interface InterviewReviewModel {
-  readonly framing: InterviewDisplayFraming;
   readonly outcome: "answered" | "skipped" | "failed" | "unknown" | "carried";
   readonly summary: string;
   /** Outcome-aware expanded-card progress; rendering must not recalculate it. */
@@ -122,21 +111,6 @@ interface AnswerAssociationResult {
   readonly unassociated: ReadonlyArray<InterviewAnswer>;
 }
 
-// A title is useful only when it identifies the interview as a whole. These
-// are provider/tool labels that historically leaked into the card unchanged.
-// Keep the compatibility table beside the model so live and historical cards
-// use the same suppression decision rather than each growing JSX exceptions.
-const GENERIC_INTERVIEW_FRAMING = new Set([
-  "askuserquestion",
-  "requestuserinput",
-  "question",
-  "input needed",
-  "need input",
-  "needs your input",
-  "codex needs your input",
-  "assistant needs your input",
-]);
-
 function meaningfulText(value: string | null): string | null {
   const trimmed = value?.trim() ?? "";
   return trimmed.length > 0 ? trimmed : null;
@@ -148,50 +122,6 @@ function stableQuestionId(value: string | null): string | null {
 
 function hasMeaningfulAnswerContent(answer: InterviewAnswer): boolean {
   return answer.values.length > 0 || meaningfulText(answer.notes) !== null;
-}
-
-function normalizedFraming(value: string): string {
-  return value
-    .normalize("NFKC")
-    .toLowerCase()
-    .replace(/[^\p{L}\p{M}\p{N}]+/gu, " ")
-    .trim();
-}
-
-function isGenericInterviewFraming(
-  value: string,
-  toolName: string | null,
-): boolean {
-  const normalized = normalizedFraming(value);
-  if (GENERIC_INTERVIEW_FRAMING.has(normalized)) return true;
-  if (toolName === null || normalized.length === 0) return false;
-  const normalizedToolName = normalizedFraming(toolName);
-  return normalizedToolName.length > 0 && normalized === normalizedToolName;
-}
-
-/**
- * Produces only human-facing interview framing. Tool names and known provider
- * boilerplate are treated as absent, leaving question headers as page-level
- * orientation instead of manufacturing a generic card title.
- */
-export function displayInterviewFraming(input: {
-  readonly toolName: string | null;
-  readonly title: string | null;
-  readonly description: string | null;
-}): InterviewDisplayFraming {
-  const title = meaningfulText(input.title);
-  const description = meaningfulText(input.description);
-  return {
-    title:
-      title === null || isGenericInterviewFraming(title, input.toolName)
-        ? null
-        : title,
-    description:
-      description === null ||
-      isGenericInterviewFraming(description, input.toolName)
-        ? null
-        : description,
-  };
 }
 
 function countBy<T>(
@@ -554,7 +484,6 @@ function findUnitId(
 
 function reviewSearchFields(input: {
   readonly blockId: string;
-  readonly framing: InterviewDisplayFraming;
   readonly summary: string;
   readonly pages: ReadonlyArray<InterviewReviewPage>;
   readonly fallbackAnswers: ReadonlyArray<InterviewReviewFallbackAnswer>;
@@ -594,19 +523,6 @@ function reviewSearchFields(input: {
     optionIndex: null,
     valueIndex: null,
   });
-  add(input.framing.title, {
-    fieldKind: "title",
-    questionIndex: null,
-    optionIndex: null,
-    valueIndex: null,
-  });
-  add(input.framing.description, {
-    fieldKind: "description",
-    questionIndex: null,
-    optionIndex: null,
-    valueIndex: null,
-  });
-
   input.pages.forEach((page, questionIndex) => {
     add(page.question.header, {
       fieldKind: "question-header",
@@ -812,7 +728,6 @@ export function deriveInterviewReviewModel(
     input.settlement,
     input.forkedWithoutAnswer,
   );
-  const framing = displayInterviewFraming(input);
   const summary = summaryFor({
     outcome,
     answered: currentAnsweredCount,
@@ -822,7 +737,6 @@ export function deriveInterviewReviewModel(
   });
   const reason = outcome === "answered" ? null : meaningfulText(input.error);
   return {
-    framing,
     outcome,
     summary,
     progress: progressFor({
@@ -839,7 +753,6 @@ export function deriveInterviewReviewModel(
     delivery,
     searchableFields: reviewSearchFields({
       blockId: input.blockId,
-      framing,
       summary,
       pages,
       fallbackAnswers: fallback,

--- a/clients/gui-app/src/components/chat/segments/interview-segment.tsx
+++ b/clients/gui-app/src/components/chat/segments/interview-segment.tsx
@@ -12,9 +12,6 @@ import { ResolvedInterviewCard } from "@/components/chat/segments/resolved-inter
 interface InterviewSegmentProps {
   readonly blockId: string;
   readonly status: "streaming" | "completed" | "errored";
-  readonly toolName: string | null;
-  readonly title: string | null;
-  readonly description: string | null;
   readonly questions: ReadonlyArray<InterviewQuestion>;
   readonly answers: ReadonlyArray<InterviewAnswer>;
   readonly draftAnswers: ReadonlyArray<InterviewAnswer>;
@@ -42,9 +39,6 @@ export function InterviewSegment(props: InterviewSegmentProps) {
       reviewInput={{
         blockId: props.blockId,
         status: props.status,
-        toolName: props.toolName,
-        title: props.title,
-        description: props.description,
         questions: props.questions,
         answers: props.answers,
         draftAnswers: props.draftAnswers,

--- a/clients/gui-app/src/components/chat/segments/interview-visuals.tsx
+++ b/clients/gui-app/src/components/chat/segments/interview-visuals.tsx
@@ -58,35 +58,6 @@ function optionDetails(
   ];
 }
 
-export function InterviewFraming(props: {
-  readonly title: string | null;
-  readonly description: string | null;
-  readonly titleFindUnitId: string | null;
-  readonly descriptionFindUnitId: string | null;
-}) {
-  if (props.title === null && props.description === null) return null;
-  return (
-    <div className="flex min-w-0 flex-col gap-0.5">
-      {props.title === null ? null : (
-        <div
-          data-chat-find-unit={props.titleFindUnitId ?? undefined}
-          className="min-w-0 text-ui font-medium text-foreground"
-        >
-          {props.title}
-        </div>
-      )}
-      {props.description === null ? null : (
-        <p
-          data-chat-find-unit={props.descriptionFindUnitId ?? undefined}
-          className="m-0 min-w-0 text-ui-sm text-muted-foreground"
-        >
-          {props.description}
-        </p>
-      )}
-    </div>
-  );
-}
-
 export function InterviewQuestionHeader(props: {
   readonly header: string | null;
   readonly questionText: string;

--- a/clients/gui-app/src/components/chat/segments/pending-interview/__tests__/pending-interview-card.test.tsx
+++ b/clients/gui-app/src/components/chat/segments/pending-interview/__tests__/pending-interview-card.test.tsx
@@ -408,9 +408,6 @@ function renderCardFor(args: {
       <PendingInterviewCard
         chatId={args.chatId}
         blockId={args.blockId}
-        toolName="AskUserQuestion"
-        title="AskUserQuestion"
-        description="Choose the path to continue."
         questions={args.questions}
         isActive
         isBusy={args.isBusy}
@@ -446,9 +443,6 @@ function cardElement(args: {
     <PendingInterviewCard
       chatId={args.chatId}
       blockId={args.blockId}
-      toolName="AskUserQuestion"
-      title="AskUserQuestion"
-      description="Choose the path to continue."
       questions={args.questions}
       isActive
       isBusy={args.isBusy}
@@ -1919,9 +1913,6 @@ describe("PendingInterviewCard keyboard navigation", () => {
         <PendingInterviewCard
           chatId="chat-1"
           blockId="bg"
-          toolName={null}
-          title={null}
-          description={null}
           questions={[singleSelect("q", "Question?", ["Alpha", "Beta"])]}
           isActive={false}
           isBusy={false}
@@ -1943,9 +1934,6 @@ describe("PendingInterviewCard keyboard navigation", () => {
         <PendingInterviewCard
           chatId="chat-1"
           blockId="fg"
-          toolName={null}
-          title={null}
-          description={null}
           questions={[singleSelect("q", "Question?", ["Alpha", "Beta"])]}
           isActive
           isBusy={false}

--- a/clients/gui-app/src/components/chat/segments/pending-interview/pending-interview-card.tsx
+++ b/clients/gui-app/src/components/chat/segments/pending-interview/pending-interview-card.tsx
@@ -12,20 +12,15 @@ import { PrimaryActionShortcutHint } from "@/components/ui/primary-action-shortc
 import { ShortcutHint } from "@/components/ui/shortcut-hint";
 import { InterviewForkActions } from "@/components/chat/segments/interview-fork-actions";
 import {
-  InterviewFraming,
   InterviewQuestionHeader,
   InterviewQuestionPager,
 } from "@/components/chat/segments/interview-visuals";
-import { displayInterviewFraming } from "@/components/chat/segments/interview-review-model";
 import { QuestionPage } from "./question-page";
 import { QUESTION_TRANSITION, useInterviewCard } from "./use-interview-card";
 
 interface PendingInterviewCardProps {
   chatId: string;
   blockId: string;
-  toolName: string | null;
-  title: string | null;
-  description: string | null;
   questions: ReadonlyArray<InterviewQuestion>;
   // Whether this card's chat tab is the active one in its pane - gates focus
   // for multi-pane layouts (see useInterviewCard).
@@ -67,11 +62,6 @@ interface PendingInterviewCardProps {
 
 export function PendingInterviewCard(props: PendingInterviewCardProps) {
   const shouldReduceMotion = useReducedMotion();
-  const framing = displayInterviewFraming({
-    toolName: props.toolName,
-    title: props.title,
-    description: props.description,
-  });
   const {
     containerRef,
     total,
@@ -111,12 +101,6 @@ export function PendingInterviewCard(props: PendingInterviewCardProps) {
       tabIndex={-1}
       className="flex flex-col gap-3 rounded-md border border-border/70 bg-card/70 p-3 text-ui-sm shadow-sm outline-none"
     >
-      <InterviewFraming
-        title={framing.title}
-        description={framing.description}
-        titleFindUnitId={null}
-        descriptionFindUnitId={null}
-      />
       {question === null ? (
         <InterviewQuestionHeader
           header={null}

--- a/clients/gui-app/src/components/chat/segments/resolved-interview-card.tsx
+++ b/clients/gui-app/src/components/chat/segments/resolved-interview-card.tsx
@@ -23,7 +23,6 @@ import {
   deriveInterviewReviewModel,
 } from "@/components/chat/segments/interview-review-model";
 import {
-  InterviewFraming,
   InterviewDraftStatus,
   InterviewQuestionHeader,
   InterviewQuestionPager,
@@ -138,10 +137,6 @@ export function ResolvedInterviewCard(props: ResolvedInterviewCardProps) {
               <span data-chat-find-unit={summaryFindUnitId ?? undefined}>
                 {model.summary}
               </span>
-              {model.framing.title === null ? null : " · "}
-              {model.framing.title === null ? null : (
-                <span>{model.framing.title}</span>
-              )}
             </span>
             <ChevronRight
               className="size-3.5 shrink-0 text-muted-foreground/65 transition-transform group-data-[state=open]/interview:rotate-90"
@@ -197,22 +192,6 @@ function ResolvedInterviewContent(props: {
       aria-label="Interview review"
       className="mt-1 ml-5 flex min-w-0 flex-col gap-3 rounded-md border border-border/70 bg-card/70 p-3 text-ui-sm shadow-sm"
     >
-      <InterviewFraming
-        title={props.model.framing.title}
-        description={props.model.framing.description}
-        titleFindUnitId={findUnitIdFor(props.model.searchableFields, {
-          fieldKind: "title",
-          questionIndex: null,
-          optionIndex: null,
-          valueIndex: null,
-        })}
-        descriptionFindUnitId={findUnitIdFor(props.model.searchableFields, {
-          fieldKind: "description",
-          questionIndex: null,
-          optionIndex: null,
-          valueIndex: null,
-        })}
-      />
       {props.model.outcome === "carried" ? <CarriedNotice /> : null}
       {page === null ? null : (
         <ReviewPage

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/chat-tile-session-state.test.ts
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/chat-tile-session-state.test.ts
@@ -910,8 +910,6 @@ function interviewMessage(
       kind: "interview",
       status: segment.status,
       toolName: "AskUserQuestion",
-      title: null,
-      description: null,
       questions: [],
       answers: [],
       draftAnswers: [],

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/unanswerable-interview-escape-hatch.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/unanswerable-interview-escape-hatch.test.tsx
@@ -70,9 +70,6 @@ const QUESTION: InterviewQuestion = {
 
 const ANSWERABLE_CARD: PendingInterviewView = {
   blockId: "streaming-block",
-  toolName: "AskUserQuestion",
-  title: null,
-  description: null,
   questions: [QUESTION],
   assistantMessageId: null,
 };

--- a/clients/gui-app/src/components/epic-canvas/renderers/chat-tile-lower-surfaces.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/chat-tile-lower-surfaces.tsx
@@ -572,9 +572,6 @@ function ComposerSurface(props: {
             key={`${model.composer.nodeId}:${model.interview.pending.blockId}`}
             chatId={model.composer.nodeId}
             blockId={model.interview.pending.blockId}
-            toolName={model.interview.pending.toolName}
-            title={model.interview.pending.title}
-            description={model.interview.pending.description}
             questions={model.interview.pending.questions}
             isActive={model.composer.isActive}
             isBusy={model.interview.isBusy}

--- a/clients/gui-app/src/components/epic-canvas/renderers/chat-tile-session-state.ts
+++ b/clients/gui-app/src/components/epic-canvas/renderers/chat-tile-session-state.ts
@@ -740,9 +740,6 @@ export function findPendingInterview(
       if (!isHostPending(segment.id)) continue;
       return {
         blockId: segment.id,
-        toolName: segment.toolName,
-        title: segment.title,
-        description: segment.description,
         questions: segment.questions,
         assistantMessageId: forkableInterviewAssistantMessageId(message),
       };

--- a/clients/gui-app/src/components/epic-canvas/renderers/chat-tile-types.ts
+++ b/clients/gui-app/src/components/epic-canvas/renderers/chat-tile-types.ts
@@ -21,9 +21,6 @@ import type { InterviewQuestion } from "@traycer/protocol/persistence/epic/schem
 
 export interface PendingInterviewView {
   readonly blockId: string;
-  readonly toolName: string | null;
-  readonly title: string | null;
-  readonly description: string | null;
   readonly questions: ReadonlyArray<InterviewQuestion>;
   // Persistent id of the assistant message that owns this pending interview,
   // when it is a stable (non-transient) fork boundary. Drives "fork during

--- a/clients/gui-app/src/stores/chats/rendered-messages.ts
+++ b/clients/gui-app/src/stores/chats/rendered-messages.ts
@@ -4072,8 +4072,9 @@ const BLOCK_HANDLERS: {
     kind: "interview",
     status: block.status,
     toolName: block.toolName,
-    title: block.title,
-    description: block.description,
+    // The block's card-level `title` / `description` are persisted for
+    // history but deliberately not projected: the GUI renders only the
+    // per-question header, so nothing downstream reads them.
     questions: block.questions,
     answers: block.answers,
     draftAnswers: block.draftAnswers,

--- a/clients/gui-app/src/stores/composer/chat-store.ts
+++ b/clients/gui-app/src/stores/composer/chat-store.ts
@@ -474,8 +474,6 @@ export interface InterviewSegment {
   /** Block status: "streaming" while pending, otherwise resolved/errored. */
   status: "streaming" | "completed" | "errored";
   toolName: string | null;
-  title: string | null;
-  description: string | null;
   questions: ReadonlyArray<InterviewQuestion>;
   answers: ReadonlyArray<InterviewAnswer>;
   draftAnswers: ReadonlyArray<InterviewAnswer>;


### PR DESCRIPTION
## What

Interview cards rendered a block-level `title` and `description` above the question pager. This deletes that header.

Both fields are model-authored. The host's `request_user_input` tool advertised them as "optional title / supporting text for the input card", and models filled the description with a preamble summarizing the whole interview:

> My recommendation is a layered model: provider defaults plus per-profile overrides, with explicit bulk propagation. That preserves today's behavior while letting profiles diverge safely.

The card paginates one question at a time, so that sat above **every** page — including page 3 of 3, where it referred to questions already answered and off-screen — while the user still had to select an answer per question. It reads as a shortcut that isn't one. The per-option `(recommended)` suffix already carries the actionable part.

## Changes

- Delete the `InterviewFraming` component, `displayInterviewFraming`, and the `GENERIC_INTERVIEW_FRAMING` boilerplate table. That table existed only to suppress provider labels (`AskUserQuestion`, `Codex needs your input`) that leaked into this header; with the header gone it guards nothing.
- Drop `title` / `description` from the rendered interview segment, `PendingInterviewView`, `InterviewReviewInput`, and the find-index field kinds — chat find no longer indexes text that is never painted.
- Stop appending the title to the collapsed summary row.

## Compatibility

The persisted protocol `interviewBlock` **keeps** both fields, so existing chat history still parses. `rendered-messages` simply does not project them. No migration.

## Verification

- `bun run compile` across the OSS graph (6 projects) — passes
- 10 affected gui-app vitest files, 474 tests — pass

## Coupled PR

Host side, which removes the two fields from the tool schema: traycerai/traycer-internal#5422.

**Land order:** this PR merges first, once the internal PR is green and approved. The internal PR's gitlink is then re-pointed at this PR's squashed `main` SHA and merged. Neither half is useful alone — the host would keep advertising fields the GUI cannot render, or the GUI would drop a header the tool still invites models to fill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)