### PR TITLE
fix(ci): allowlist the browser-session key-custody base64 placeholders

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -76,3 +76,12 @@ paths = [
   '''^clients/gui-app/src/components/epic-canvas/pr/__tests__/pr-local-diff-body\.test\.tsx$''',
 ]
 regexes = ['''^YmFkLf(?:8|4)udHh0$''']
+
+[[allowlists]]
+description = "Self-describing base64 placeholders in the browser-session key-custody suite: `d3JhcHBlZEtleQ==` decodes to the ASCII string `wrappedKey` and `cmF3S2V5` to `rawKey`. They are the payloads of `storeKeyWrapRequest` / `storeKeyUnwrapRequest` frames, and the assertions alongside them match on the value verbatim (`user-1:host-1:cmF3S2V5`), which is what a placeholder can do and a credential cannot. The generic-api-key rule matches on base64 shape and entropy only. Third instance of the pattern the two entries above describe: `fetch-depth: 0` makes every PR's scan read the in-flight branch that introduces them (`feat/browser-security-hardening`), so this one fixture fails the gitleaks job on every open PR in the repo and cannot wait for that branch to merge. Scoped to the exact values and the one source path so unrelated findings stay reportable."
+condition = "AND"
+regexTarget = "secret"
+paths = [
+  '''^clients/desktop/src/electron-main/browser-sessions/__tests__/browser-sessions-owner\.test\.ts$''',
+]
+regexes = ['''^(?:d3JhcHBlZEtleQ==|cmF3S2V5)$''']


### PR DESCRIPTION
## Summary

The `gitleaks` job fails on **every PR whose gitleaks job has run since this fixture was pushed today**, on two findings that belong to none of them. Older PRs still display a green gitleaks from a run that predates the fixture; they go red the moment anything re-triggers them.

Sampled runs, all from today:

| Branch | latest gitleaks run | result |
| --- | --- | --- |
| `fix/collab-link-flap` | 13:12Z | `leaks found: 2` |
| `chore/tile-opening-refactor` | 12:55Z | `leaks found: 2` |
| `feat/browser-security-hardening` | 12:59Z | `leaks found: 2` |
| `feat/silent-cli-invocation-migration` | 13:30Z | `leaks found: 2` |

(Read from the job logs, not from `gh pr checks` — that command returns a stale row for a name with more than one run, and reports `pass` for the 13:30Z run above.)

Both findings are the same fixture, on `feat/browser-security-hardening`:

```ts
wrappedKey: "d3JhcHBlZEtleQ==",
```

`d3JhcHBlZEtleQ==` decodes to the ASCII string `wrappedKey`, and its sibling `cmF3S2V5` to `rawKey`. They are the payloads of `storeKeyWrapRequest` / `storeKeyUnwrapRequest` frames in the browser-session key-custody suite, and the assertions beside them match on the value verbatim — `expect(harness.jar.wrapped).toEqual(["user-1:host-1:cmF3S2V5"])` — which is something a placeholder can do and a credential cannot. `generic-api-key` matches them on base64 shape and entropy alone.

## Why this can't wait for that branch to merge

This is the **third** instance of the pattern the two entries directly above it in `.gitleaks.toml` already describe in their own comments. The workflow checks out with `fetch-depth: 0` ("full history so gitleaks can scan every commit") and runs `gitleaks git .`, so every PR's job scans *every branch in the repo*, including unmerged ones. One fixture on one in-flight branch therefore reds the gate for everyone, and it stays red until either that branch merges or the value is allowlisted.

## Relationship to #1667

**#1667 already carries an equivalent entry on its own branch** — same path, same `d3JhcHBlZEtleQ==` value — so this is fixed there and would reach `main` when that branch merges. This PR exists only because that branch is a large feature still in review, and until it lands every other PR's gate stays red. Two consequences worth knowing:

- If #1667 merges first, close this PR — it becomes redundant.
- If this merges first, #1667 will hit a small `.gitleaks.toml` conflict on rebase; the resolution is to drop its own block, since this one is a superset (it also covers the sibling `cmF3S2V5` / `rawKey` in the same fixture pair, which the current rule does not flag but which is the same kind of value).

## Scope

Scoped to the two exact values and the one source path, per the file's own "keep this list tight" rule, so unrelated findings in that file stay reportable.

## Test plan

Run against **gitleaks 8.30.1**, the version the workflow pins, over the same full history the runner sees:

- before (config as on `main`): `leaks found: 2`, both the `wrappedKey` fixture
- after: `no leaks found`, exit code **0**, `1824 commits scanned`

## Follow-up worth considering, deliberately not in this PR

The allowlist treats each instance; the recurrence is structural. Scoping the PR-event scan to the PR's own commit range (`--log-opts` over `base..head`) while leaving the `push: main` scan on full history would keep the "catch a secret that was committed then removed" property on the protected branch and stop one branch's fixture from blocking everyone else. That changes the security posture of the scanner, so it should be a maintainer's call rather than a drive-by.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
