### PR TITLE
ci: move the Node pin from 24.15.0 to 24.20.0 (libuv RtlGetVersion stack overrun on Windows)

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -46,7 +46,7 @@ jobs:
           bun-version: "1.3.12"
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: "24"
+          node-version: "24.20.0"
       - name: Cache Nx
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:

--- a/.github/workflows/publish-cli-package-managers.yml
+++ b/.github/workflows/publish-cli-package-managers.yml
@@ -184,7 +184,7 @@ jobs:
           no-cache: true
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "24.15.0"
+          node-version: "24.20.0"
       - name: Install workspace dependencies
         run: bun install --frozen-lockfile
       - name: Stamp CLI production deploy target
@@ -250,7 +250,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "24.15.0"
+          node-version: "24.20.0"
       - name: Download CLI descriptors for the formula
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/publish-desktop-cask.yml
+++ b/.github/workflows/publish-desktop-cask.yml
@@ -88,7 +88,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "24.15.0"
+          node-version: "24.20.0"
       - name: Download desktop artifacts from desktop release
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/real-supervisor.yml
+++ b/.github/workflows/real-supervisor.yml
@@ -63,7 +63,7 @@ jobs:
           bun-version: "1.3.12"
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: "24"
+          node-version: "24.20.0"
       - name: Cache bun global install cache
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,7 +107,7 @@ jobs:
           bun-version: "1.3.12"
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: "24"
+          node-version: "24.20.0"
       - name: Cache bun global install cache
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
@@ -231,7 +231,7 @@ jobs:
           bun-version: "1.3.12"
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: "24"
+          node-version: "24.20.0"
       # The standard runner starts immediately. A larger runner queued for
       # more than three minutes, while cache restore on this runner took 3m27
       # plus a 32s install versus 3m51 for the uncached install below.
@@ -266,7 +266,7 @@ jobs:
           bun-version: "1.3.12"
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: "24"
+          node-version: "24.20.0"
       - name: Cache bun global install cache
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:


### PR DESCRIPTION
## Why

Node 24.15.0 vendors libuv 1.51.0, whose Windows TCP connect path (`uv__is_fast_loopback_fail_supported` in `src/win/tcp.c`) calls `RtlGetVersion` on an uninitialized `OSVERSIONINFOW`. `RtlGetVersion` chooses between the 276-byte and the 284-byte structure by reading `dwOSVersionInfoSize`, so stale stack contents of 284 make it write 8 bytes past the buffer into the `/GS` stack cookie of `uv__tcp_connect`. The process then dies with a silent `0xC0000409` fast-fail. Because the helper runs on every `uv_tcp_connect`, a multi-agent workload hits it roughly once an hour.

Two ProcDump minidumps from an affected Windows 11 machine running the packaged host fault at the identical site, symbolized against the official `node.exe` v24.15.0 PDB: `__report_gsfailure` (fast-fail code 2) with `uv__tcp_connect` as the failing frame under `node::TCPWrap::Connect`.

Upstream fix: libuv/libuv#5107 (`aabb7651de`, fixes libuv/libuv#5106, which was Node's own flaky Windows keepalive tests with the same trace). It is in **no libuv release tag through v1.52.1**; Node ships it as a cherry-pick (nodejs/node#62561), first in **v24.16.0**. 24.20.0 is the current Node 24 line.

## What

Every `node-version: "24.15.0"` in this repository's publish workflows becomes `24.20.0`, and the workflows that floated on `node-version: "24"` (test, pre-commit, real-supervisor) are pinned to the same `24.20.0` so CI exercises the exact runtime that ships. Same major, same native ABI. The internal repository moves its release workflows in lockstep: traycerai/traycer-internal PR to follow.

## Verification

- Presence of the fix per Node tag verified through the GitHub contents API on `deps/uv/src/win/tcp.c`: absent in v24.15.0, present in v24.16.0 through v24.20.0.
- Field verification: the reporter keeps ProcDump attached to the new host; zero `0xC0000409` across eight or more hours of the same use closes the case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
