### PR TITLE
fix(cli): bake the Sentry DSN into the npm bundle, and retire a stalled crash-report upload

### DIFF
--- a/clients/traycer-cli/scripts/build-cli-npm.cjs
+++ b/clients/traycer-cli/scripts/build-cli-npm.cjs
@@ -84,6 +84,19 @@ function main() {
         ? workspaceManifest.version
         : "0.0.0-local";
 
+  // Sentry DSN, baked exactly as build-cli-sea.cjs bakes it. `sentry.ts`
+  // reads `process.env.TRAYCER_CLI_SENTRY_DSN` directly (a form esbuild's
+  // define substitutes), and only calls `Sentry.init()` when the value is
+  // non-empty. Without this define the published npm bin kept the runtime
+  // lookup, so no npm install ever initialised Sentry: none of the CLI's
+  // own errors and, from #1673 on, none of the host crashes the supervisor
+  // reports reached it. An unset variable still bakes "", which keeps
+  // local builds telemetry-free.
+  const cliSentryDsn =
+    typeof process.env.TRAYCER_CLI_SENTRY_DSN === "string"
+      ? process.env.TRAYCER_CLI_SENTRY_DSN
+      : "";
+
   // Bundle everything (no externals) so the published artifact resolves
   // nothing at the user's runtime. Node builtins are auto-externalised by
   // `--platform=node`.
@@ -100,6 +113,7 @@ function main() {
     // build-cli-sea.cjs). Double-encoding would inject the quotes into
     // the value and break version resolution.
     `--define:process.env.TRAYCER_CLI_VERSION=${JSON.stringify(cliVersion)}`,
+    `--define:process.env.TRAYCER_CLI_SENTRY_DSN=${JSON.stringify(cliSentryDsn)}`,
   ];
   execFileSync(resolveEsbuildBin(), args, {
     cwd: workspaceRoot,

--- a/clients/traycer-cli/src/host/__tests__/crash-telemetry.test.ts
+++ b/clients/traycer-cli/src/host/__tests__/crash-telemetry.test.ts
@@ -26,6 +26,11 @@ const sentryMocks = vi.hoisted(() => ({
     vi.fn<(extras: Record<string, string | number | boolean>) => void>(),
   setUser: vi.fn<(user: { id: string }) => void>(),
   captureMessage: vi.fn<(message: string, level: string) => void>(),
+  // Defaults to a healthy, already-drained flush so tests that never touch
+  // the transport budget still resolve cleanly.
+  flush: vi.fn<(timeout: number) => Promise<boolean>>(() =>
+    Promise.resolve(true),
+  ),
 }));
 
 vi.mock("@sentry/node", () => ({
@@ -40,6 +45,16 @@ vi.mock("@sentry/node", () => ({
   },
   captureMessage: (message: string, level: string) =>
     sentryMocks.captureMessage(message, level),
+  flush: (timeout: number) => sentryMocks.flush(timeout),
+}));
+
+const sentryTransportMocks = vi.hoisted(() => ({
+  destroySentryTransportRequests: vi.fn<() => number>(() => 0),
+}));
+
+vi.mock("../../sentry-transport", () => ({
+  destroySentryTransportRequests: () =>
+    sentryTransportMocks.destroySentryTransportRequests(),
 }));
 
 const pidMetadataMocks = vi.hoisted(() => ({
@@ -62,6 +77,7 @@ const {
   reportHostCrashToSentry,
   HOST_CRASH_FINGERPRINT_ROOT,
   HOST_CRASH_IDENTITY_TIMEOUT_MS,
+  HOST_CRASH_TRANSPORT_TIMEOUT_MS,
 } = await import("../crash-telemetry");
 
 const { resolveCliVersion } = await import("../../cli-version");
@@ -399,6 +415,12 @@ describe("reportHostCrashToSentry", () => {
     sentryMocks.setExtras.mockReset();
     sentryMocks.setUser.mockReset();
     sentryMocks.captureMessage.mockReset();
+    sentryMocks.flush.mockReset();
+    sentryMocks.flush.mockImplementation(() => Promise.resolve(true));
+    sentryTransportMocks.destroySentryTransportRequests.mockReset();
+    sentryTransportMocks.destroySentryTransportRequests.mockImplementation(
+      () => 0,
+    );
   });
 
   afterEach(() => {
@@ -490,5 +512,98 @@ describe("reportHostCrashToSentry", () => {
     await expect(
       reportHostCrashToSentry(sampleTelemetry({})),
     ).resolves.toBeUndefined();
+  });
+
+  describe("transport budget", () => {
+    it("flushes the transport exactly once with the transport timeout after a successful capture", async () => {
+      pidMetadataMocks.readHostPidMetadata.mockResolvedValue(null);
+
+      await reportHostCrashToSentry(sampleTelemetry({}));
+
+      expect(sentryMocks.flush).toHaveBeenCalledTimes(1);
+      expect(sentryMocks.flush).toHaveBeenCalledWith(
+        HOST_CRASH_TRANSPORT_TIMEOUT_MS,
+      );
+    });
+
+    it("does not destroy the transport when flush resolves true", async () => {
+      pidMetadataMocks.readHostPidMetadata.mockResolvedValue(null);
+      sentryMocks.flush.mockImplementation(() => Promise.resolve(true));
+
+      await reportHostCrashToSentry(sampleTelemetry({}));
+      // Flush the microtask queue so a wrongly-called destroy would have run.
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      expect(
+        sentryTransportMocks.destroySentryTransportRequests,
+      ).not.toHaveBeenCalled();
+    });
+
+    it("destroys the transport once when flush resolves false", async () => {
+      pidMetadataMocks.readHostPidMetadata.mockResolvedValue(null);
+      sentryMocks.flush.mockImplementation(() => Promise.resolve(false));
+
+      await reportHostCrashToSentry(sampleTelemetry({}));
+
+      await vi.waitFor(() => {
+        expect(
+          sentryTransportMocks.destroySentryTransportRequests,
+        ).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it("destroys the transport once when flush rejects, without an unhandled rejection", async () => {
+      pidMetadataMocks.readHostPidMetadata.mockResolvedValue(null);
+      sentryMocks.flush.mockImplementation(() =>
+        Promise.reject(new Error("transport flush failed")),
+      );
+
+      await expect(
+        reportHostCrashToSentry(sampleTelemetry({})),
+      ).resolves.toBeUndefined();
+
+      await vi.waitFor(() => {
+        expect(
+          sentryTransportMocks.destroySentryTransportRequests,
+        ).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it("does not flush or destroy the transport when captureMessage throws", async () => {
+      pidMetadataMocks.readHostPidMetadata.mockResolvedValue(null);
+      sentryMocks.captureMessage.mockImplementation(() => {
+        throw new Error("Sentry transport exploded");
+      });
+
+      await reportHostCrashToSentry(sampleTelemetry({}));
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      expect(sentryMocks.flush).not.toHaveBeenCalled();
+      expect(
+        sentryTransportMocks.destroySentryTransportRequests,
+      ).not.toHaveBeenCalled();
+    });
+
+    it("resolves before the flush settles", async () => {
+      let resolveFlush: (drained: boolean) => void = () => undefined;
+      sentryMocks.flush.mockImplementation(
+        () =>
+          new Promise<boolean>((resolve) => {
+            resolveFlush = resolve;
+          }),
+      );
+      pidMetadataMocks.readHostPidMetadata.mockResolvedValue(null);
+
+      await reportHostCrashToSentry(sampleTelemetry({}));
+
+      // The reporter's own promise already resolved above, while flush is
+      // still pending - so the destroy it could trigger has not run yet.
+      expect(
+        sentryTransportMocks.destroySentryTransportRequests,
+      ).not.toHaveBeenCalled();
+
+      resolveFlush(true);
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    });
   });
 });

--- a/clients/traycer-cli/src/host/crash-telemetry.ts
+++ b/clients/traycer-cli/src/host/crash-telemetry.ts
@@ -6,6 +6,7 @@ import {
 import * as Sentry from "@sentry/node";
 import { resolveCliVersion } from "../cli-version";
 import type { Environment } from "../runner/environment";
+import { destroySentryTransportRequests } from "../sentry-transport";
 import { readHostPidMetadata } from "./pid-metadata";
 
 // Fleet visibility for host crashes.
@@ -95,6 +96,17 @@ export const HOST_CRASH_IDENTITY_TIMEOUT_MS = 1_000;
 // that normally fires; far below the relaunch backoff so a stall costs
 // nothing visible.
 export const HOST_CRASH_REPORT_TIMEOUT_MS = 1_500;
+
+// How long the queued envelope may take to actually leave the machine. The
+// CLI's Sentry transport installs no request timeout (see
+// sentry-transport.ts), and `host start` deliberately bypasses the
+// terminator in runner/exit.ts that would otherwise destroy stalled requests
+// at exit - the supervisor does not exit, it relaunches. So a DSN endpoint
+// that accepts the connection and then goes quiet would leave one live
+// socket per crash for as long as the supervisor lives. This budget is
+// generous enough for a slow but working upload and retires whatever is
+// still open past it.
+export const HOST_CRASH_TRANSPORT_TIMEOUT_MS = 10_000;
 
 /**
  * A stable token for the KIND of death, used to group events into one issue
@@ -224,5 +236,24 @@ export async function reportHostCrashToSentry(
     captureHostCrashEvent(buildHostCrashEvent(telemetry, identity));
   } catch {
     // Intentionally silent: see the module comment.
+    return;
   }
+  retireStalledTransportAfterBudget();
+}
+
+/**
+ * Give the transport {@link HOST_CRASH_TRANSPORT_TIMEOUT_MS} to deliver, then
+ * destroy any request still open. Not awaited by the caller: the supervisor
+ * has already moved on to the relaunch, and this only decides the fate of the
+ * socket. `flush` resolves early when the queue drains, so a healthy upload
+ * costs nothing; only a stalled one reaches the destroy.
+ */
+function retireStalledTransportAfterBudget(): void {
+  void Sentry.flush(HOST_CRASH_TRANSPORT_TIMEOUT_MS)
+    .then((drained) => {
+      if (!drained) destroySentryTransportRequests();
+    })
+    .catch(() => {
+      destroySentryTransportRequests();
+    });
 }


### PR DESCRIPTION
## Why

Follow-up to #1673, which merged before Codex posted its last two findings on it. Both hold.

1. **The published npm CLI never initialised Sentry.** `sentry.ts` reads `process.env.TRAYCER_CLI_SENTRY_DSN` and only calls `Sentry.init()` when it is non-empty. `build-cli-sea.cjs` bakes that variable with an esbuild define; `build-cli-npm.cjs` baked only `TRAYCER_CLI_VERSION`, so the npm bundle kept the runtime lookup and no npm install ever had a DSN. None of the CLI's own errors, and from #1673 on none of the host crashes the supervisor reports, reached Sentry from that distribution. The publish workflow already supplies the secret to that build step.
2. **A stalled upload outlived the report bound.** The reporter resolves when `captureMessage` queues the envelope; the transport itself installs no request timeout (documented in `sentry-transport.ts`), and `host start` deliberately bypasses the terminator in `runner/exit.ts` that destroys stalled requests at exit, because the supervisor does not exit, it relaunches. A DSN endpoint that accepts the connection and then goes quiet would leave one live socket per crash for the life of the supervisor.

## What

- `build-cli-npm.cjs` bakes `process.env.TRAYCER_CLI_SENTRY_DSN` exactly as the SEA build does (empty string when unset, so local builds stay telemetry-free).
- `reportHostCrashToSentry` follows a successful capture with a fire-and-forget `Sentry.flush(10 s)`; when that times out or rejects it calls `destroySentryTransportRequests()`. A healthy upload resolves the flush early and costs nothing; only a stalled one reaches the destroy. Nothing here is awaited by the supervisor.

## Verification

- npm bundle probed locally: built with a probe DSN, the bundle contains the DSN literal and zero remaining `TRAYCER_CLI_SENTRY_DSN` lookups, and `sentry.ts`'s guard reads `dsn = "<probe>"`; rebuilt without the variable it reads `dsn = ""`.
- `src/host/__tests__/crash-telemetry.test.ts`: flush is called once with the budget after a capture; `true` leaves requests alone; `false` and a rejection each destroy them once; a throwing capture calls neither; the reporter's own promise resolves while the flush is still pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
