### PR TITLE
fix(gui-app): persist the resource monitor's sort option

### DIFF
--- a/clients/gui-app/src/components/resources/__tests__/resource-monitor-popover.test.tsx
+++ b/clients/gui-app/src/components/resources/__tests__/resource-monitor-popover.test.tsx
@@ -53,6 +53,7 @@ import {
   resourcesRegistry,
   type GlobalResourceProjection,
 } from "@/stores/resources/resources-registry";
+import { useResourceMonitorStore } from "@/stores/resources/resource-monitor-store";
 import { useTitleBarDragStore } from "@/stores/layout/title-bar-drag-store";
 import { queryClient } from "@/lib/query-client";
 import { hostQueryKeys } from "@/lib/query-keys/host-query-keys";
@@ -890,6 +891,9 @@ afterEach(() => {
   globalResourcesUnsupportedMock.unsupported = null;
   resourcesRegistry.disposeAll();
   useTitleBarDragStore.setState({ suppressors: new Set() });
+  // The sort pick is persisted, so it outlives a test that changed it - reset
+  // it the way every other shared store here is reset.
+  useResourceMonitorStore.getState().setSortOption("tab");
   queryClient.clear();
 });
 
@@ -957,6 +961,33 @@ describe("ResourceMonitorPopover", () => {
         .getByRole("menuitemradio", { name: "Tab order" })
         .getAttribute("aria-checked"),
     ).toBe("true");
+  });
+
+  it("keeps the chosen sort option after the popover is closed and reopened", () => {
+    const stub = installStubFactory();
+    renderPopover();
+
+    act(() => {
+      stub.emit().onSnapshot(projection({ owners: [owner({})] }));
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Resources" }));
+    fireEvent.pointerDown(
+      screen.getByRole("button", { name: "Sort resource rows" }),
+      { button: 0, ctrlKey: false, pointerType: "mouse" },
+    );
+    fireEvent.click(screen.getByRole("menuitemradio", { name: "Memory" }));
+
+    // Closing unmounts the panel - the pick has to survive that, not the panel.
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(
+      screen.queryByRole("searchbox", { name: "Search resources" }),
+    ).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Resources" }));
+    expect(
+      screen.getByRole("button", { name: "Sort resource rows" }).textContent,
+    ).toContain("Memory");
   });
 
   it("filters tasks and owners with case-insensitive free text", () => {

--- a/clients/gui-app/src/components/resources/resource-monitor-popover.tsx
+++ b/clients/gui-app/src/components/resources/resource-monitor-popover.tsx
@@ -179,8 +179,12 @@ import {
   type ResourceMemoryMetric,
   type ResourceMemoryUsage,
 } from "@/lib/resources/memory-metric";
+import {
+  isResourceSortOption,
+  useResourceMonitorStore,
+  type ResourceSortOption,
+} from "@/stores/resources/resource-monitor-store";
 
-type ResourceSortOption = "memory" | "cpu" | "name" | "tab";
 type NavigateFn = UseNavigateResult<string>;
 
 const SORT_LABELS: Record<ResourceSortOption, string> = {
@@ -1234,7 +1238,10 @@ function ResourceMonitorPanel(props: {
   readonly sortMenuOpen: boolean;
   readonly onSortMenuOpenChange: (open: boolean) => void;
 }) {
-  const [sortOption, setSortOption] = useState<ResourceSortOption>("tab");
+  // This panel unmounts on every close, so the ordering is held by the store -
+  // see `resource-monitor-store.ts`.
+  const sortOption = useResourceMonitorStore((state) => state.sortOption);
+  const setSortOption = useResourceMonitorStore((state) => state.setSortOption);
   const searchQuery = props.searchQuery;
   const scope = props.scope;
   const sortMenuOpen = props.sortMenuOpen;
@@ -4852,12 +4859,6 @@ function isOwnerNodeRef(ref: EpicCanvasTileRef): ref is EpicNodeRef {
     ref.type === "terminal" ||
     ref.type === "chat" ||
     ref.type === "terminal-agent"
-  );
-}
-
-function isResourceSortOption(value: string): value is ResourceSortOption {
-  return (
-    value === "memory" || value === "cpu" || value === "name" || value === "tab"
   );
 }
 

--- a/clients/gui-app/src/stores/resources/resource-monitor-store.ts
+++ b/clients/gui-app/src/stores/resources/resource-monitor-store.ts
@@ -2,6 +2,16 @@ import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
 import { basePersistOptions, persistKey, STORE_KEYS } from "@/lib/persist";
 
+export type ResourceSortOption = "memory" | "cpu" | "name" | "tab";
+
+export function isResourceSortOption(
+  value: string,
+): value is ResourceSortOption {
+  return (
+    value === "memory" || value === "cpu" || value === "name" || value === "tab"
+  );
+}
+
 interface ResourceMonitorStoreState {
   /**
    * Which host's processes the resource monitor is READING — never which host
@@ -23,6 +33,16 @@ interface ResourceMonitorStoreState {
   readonly scopedHostId: string | null;
   /** `null` returns to following the active host. */
   readonly setScopedHostId: (hostId: string | null) => void;
+  /**
+   * How the panel's rows are ordered. Persisted for the same reason the host
+   * pick is: the popover unmounts on every close, so an ordering held by the
+   * panel would last exactly one viewing and be re-picked on every open.
+   *
+   * Not host-scoped — an ordering is a reading preference about the person, not
+   * a fact about the machine being read.
+   */
+  readonly sortOption: ResourceSortOption;
+  readonly setSortOption: (sortOption: ResourceSortOption) => void;
 }
 
 const RESOURCE_MONITOR_PERSIST_KEY = persistKey(STORE_KEYS.resourceMonitor);
@@ -45,6 +65,25 @@ function persistedScopedHostId(persistedState: unknown): string | null {
   return scopedHostId;
 }
 
+const DEFAULT_SORT_OPTION: ResourceSortOption = "tab";
+
+/**
+ * An unrecognized value falls back to the default ordering rather than being
+ * carried through: the sort key reaches comparators that switch on it
+ * exhaustively, so it has to be one of the four this build knows.
+ */
+function persistedSortOption(persistedState: unknown): ResourceSortOption {
+  if (typeof persistedState !== "object" || persistedState === null) {
+    return DEFAULT_SORT_OPTION;
+  }
+  if (!("sortOption" in persistedState)) return DEFAULT_SORT_OPTION;
+  const sortOption = persistedState.sortOption;
+  if (typeof sortOption !== "string" || !isResourceSortOption(sortOption)) {
+    return DEFAULT_SORT_OPTION;
+  }
+  return sortOption;
+}
+
 export const useResourceMonitorStore = create<ResourceMonitorStoreState>()(
   persist(
     (set, get) => ({
@@ -53,6 +92,11 @@ export const useResourceMonitorStore = create<ResourceMonitorStoreState>()(
         if (get().scopedHostId === scopedHostId) return;
         set({ scopedHostId });
       },
+      sortOption: DEFAULT_SORT_OPTION,
+      setSortOption: (sortOption) => {
+        if (get().sortOption === sortOption) return;
+        set({ sortOption });
+      },
     }),
     {
       ...basePersistOptions(RESOURCE_MONITOR_PERSIST_KEY),
@@ -60,8 +104,12 @@ export const useResourceMonitorStore = create<ResourceMonitorStoreState>()(
       merge: (persistedState, currentState) => ({
         ...currentState,
         scopedHostId: persistedScopedHostId(persistedState),
+        sortOption: persistedSortOption(persistedState),
       }),
-      partialize: (state) => ({ scopedHostId: state.scopedHostId }),
+      partialize: (state) => ({
+        scopedHostId: state.scopedHostId,
+        sortOption: state.sortOption,
+      }),
     },
   ),
 );


### PR DESCRIPTION
## Problem

The Resource Monitor's sort control (Memory / CPU / Name / Tab order) was `useState` inside `ResourceMonitorPanel`. The panel unmounts on every popover close, so the pick survived exactly one viewing — sort by Memory, close, reopen, back to Tab order.

## Change

The sort option moves into the already-persisted `resource-monitor-store`, next to `scopedHostId`, which is persisted for the same reason.

- `ResourceSortOption` and `isResourceSortOption` now live in the store (the popover imports them).
- Not host-scoped: an ordering is a reading preference about the person, not a fact about the machine being read. It is also not reset on sign-out — unlike the host pick, which names an account-owned machine.
- An unrecognized persisted value falls back to `tab`, since the row comparators switch on the key exhaustively.

## Tests

`resource-monitor-popover.test.tsx` gains a close-and-reopen test asserting the chosen sort survives the unmount; it fails against the old `useState` version. `afterEach` resets the store, since the pick now outlives a test by design.