### PR TITLE
feat(gui): keep a Queue button beside Stop in the phone composer mid-turn

### DIFF
--- a/clients/gui-app/src/components/home/composer/__tests__/composer-send-button.test.tsx
+++ b/clients/gui-app/src/components/home/composer/__tests__/composer-send-button.test.tsx
@@ -1,9 +1,36 @@
-import { cleanup, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ChatActiveTurn } from "@traycer/protocol/host/agent/gui/subscribe";
 
-import { ComposerSendButton } from "../composer-send-button";
+import {
+  ComposerSendButton,
+  type ComposerStopPlacement,
+} from "../composer-send-button";
 
 afterEach(() => cleanup());
+
+interface RenderOptions {
+  readonly stopPlacement: ComposerStopPlacement;
+  readonly activeTurnStatus: ChatActiveTurn["status"] | null;
+  readonly canSubmit: boolean;
+  readonly onSubmit: () => void;
+  readonly onStopTurn: (() => void) | null;
+}
+
+function renderButton(options: RenderOptions) {
+  return render(
+    <ComposerSendButton
+      canSubmit={options.canSubmit}
+      attachmentPending={false}
+      onSubmit={options.onSubmit}
+      activeTurnStatus={options.activeTurnStatus}
+      stopDisabled={false}
+      onStopTurn={options.onStopTurn}
+      disabledHint={null}
+      stopPlacement={options.stopPlacement}
+    />,
+  );
+}
 
 describe("ComposerSendButton attachment preparation", () => {
   it("shows visible pending feedback while attachment work gates submit", () => {
@@ -16,6 +43,7 @@ describe("ComposerSendButton attachment preparation", () => {
         stopDisabled
         onStopTurn={null}
         disabledHint={null}
+        stopPlacement="replace"
       />,
     );
 
@@ -23,5 +51,93 @@ describe("ComposerSendButton attachment preparation", () => {
       screen.getByRole("button", { name: "Send" }).getAttribute("disabled"),
     ).not.toBeNull();
     expect(screen.getByTestId("composer-attachment-pending")).toBeTruthy();
+  });
+});
+
+describe("ComposerSendButton stop placement", () => {
+  it("idle renders Send alone under either placement", () => {
+    renderButton({
+      stopPlacement: "beside",
+      activeTurnStatus: null,
+      canSubmit: true,
+      onSubmit: vi.fn(),
+      onStopTurn: null,
+    });
+    expect(screen.getByRole("button", { name: "Send" })).not.toBeNull();
+    expect(screen.queryByTestId("chat-stop-button")).toBeNull();
+  });
+
+  it("'replace' morphs Send into Stop while a turn runs", () => {
+    renderButton({
+      stopPlacement: "replace",
+      activeTurnStatus: "running",
+      canSubmit: true,
+      onSubmit: vi.fn(),
+      onStopTurn: vi.fn(),
+    });
+    expect(screen.getByRole("button", { name: "Stop" })).not.toBeNull();
+    expect(screen.queryByRole("button", { name: "Send" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Queue" })).toBeNull();
+  });
+
+  it("'beside' keeps a Queue button next to Stop while a turn runs", () => {
+    const onSubmit = vi.fn();
+    const onStopTurn = vi.fn();
+    renderButton({
+      stopPlacement: "beside",
+      activeTurnStatus: "running",
+      canSubmit: true,
+      onSubmit,
+      onStopTurn,
+    });
+
+    const stop = screen.getByRole("button", { name: "Stop" });
+    const queue = screen.getByRole("button", { name: "Queue" });
+    expect(stop.getAttribute("data-testid")).toBe("chat-stop-button");
+    // Stop sits to the left of the queueing Send so an urgent tap never
+    // lands on the primary button.
+    expect(
+      stop.compareDocumentPosition(queue) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).not.toBe(0);
+
+    fireEvent.click(queue);
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onStopTurn).not.toHaveBeenCalled();
+
+    fireEvent.click(stop);
+    expect(onStopTurn).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it("'beside' disables Queue when there is nothing to send", () => {
+    renderButton({
+      stopPlacement: "beside",
+      activeTurnStatus: "running",
+      canSubmit: false,
+      onSubmit: vi.fn(),
+      onStopTurn: vi.fn(),
+    });
+    expect(
+      screen.getByRole("button", { name: "Queue" }).hasAttribute("disabled"),
+    ).toBe(true);
+    expect(
+      screen.getByRole("button", { name: "Stop" }).hasAttribute("disabled"),
+    ).toBe(false);
+  });
+
+  it("'beside' disables both buttons while the turn is stopping", () => {
+    renderButton({
+      stopPlacement: "beside",
+      activeTurnStatus: "stopping",
+      canSubmit: true,
+      onSubmit: vi.fn(),
+      onStopTurn: null,
+    });
+    expect(
+      screen.getByRole("button", { name: "Stopping" }).hasAttribute("disabled"),
+    ).toBe(true);
+    expect(
+      screen.getByRole("button", { name: "Queue" }).hasAttribute("disabled"),
+    ).toBe(true);
   });
 });

--- a/clients/gui-app/src/components/home/composer/composer-send-button.tsx
+++ b/clients/gui-app/src/components/home/composer/composer-send-button.tsx
@@ -1,10 +1,21 @@
 import { ArrowUp, Square } from "lucide-react";
-import { memo, useCallback, type ReactNode } from "react";
+import { memo, type ReactNode } from "react";
 import { Button } from "@/components/ui/button";
 import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 import type { ChatActiveTurn } from "@traycer/protocol/host/agent/gui/subscribe";
 import { cn } from "@/lib/utils";
 import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
+
+/**
+ * Where Stop lives while a turn runs.
+ *
+ * - `"replace"`: this button morphs into Stop. The desktop toolbar's choice -
+ *   Enter still queues there, so Send needs no button of its own mid-turn.
+ * - `"beside"`: Send stays put (tapping it queues) and Stop renders to its
+ *   left. The phone toolbar's choice - Return is a newline on a soft keyboard,
+ *   so this button is the only way to queue.
+ */
+export type ComposerStopPlacement = "replace" | "beside";
 
 interface ComposerSendButtonProps {
   canSubmit: boolean;
@@ -19,7 +30,11 @@ interface ComposerSendButtonProps {
    * leaves the normal "Send" affordance.
    */
   disabledHint: string | null;
+  stopPlacement: ComposerStopPlacement;
 }
+
+const BUTTON_CLASS_NAME =
+  "size-8 rounded-full disabled:bg-foreground/8 disabled:text-muted-foreground aria-disabled:cursor-not-allowed aria-disabled:bg-foreground/8 aria-disabled:text-muted-foreground aria-disabled:hover:bg-foreground/8";
 
 function ComposerSendButtonImpl(props: ComposerSendButtonProps) {
   const {
@@ -30,38 +45,70 @@ function ComposerSendButtonImpl(props: ComposerSendButtonProps) {
     stopDisabled,
     onStopTurn,
     disabledHint,
+    stopPlacement,
   } = props;
-  const stopMode = activeTurnStatus !== null;
-  const disabled = stopMode
-    ? stopDisabled || onStopTurn === null
-    : !canSubmit || disabledHint !== null;
-  const label = composerSendButtonLabel(activeTurnStatus);
+
+  if (activeTurnStatus === null) {
+    return (
+      <SendButton
+        canSubmit={canSubmit}
+        attachmentPending={attachmentPending}
+        onSubmit={onSubmit}
+        disabledHint={disabledHint}
+        queueing={false}
+      />
+    );
+  }
+
+  const stop = (
+    <StopButton
+      activeTurnStatus={activeTurnStatus}
+      disabled={stopDisabled || onStopTurn === null}
+      onStopTurn={onStopTurn}
+    />
+  );
+  if (stopPlacement === "replace") return stop;
+  return (
+    <>
+      {stop}
+      <SendButton
+        // The submit hook refuses sends while stopping; show it rather than
+        // swallow the tap.
+        canSubmit={activeTurnStatus === "stopping" ? false : canSubmit}
+        attachmentPending={attachmentPending}
+        onSubmit={onSubmit}
+        disabledHint={disabledHint}
+        queueing
+      />
+    </>
+  );
+}
+
+export const ComposerSendButton = memo(ComposerSendButtonImpl);
+
+interface SendButtonProps {
+  canSubmit: boolean;
+  attachmentPending: boolean;
+  onSubmit: () => void;
+  disabledHint: string | null;
+  /** True while a turn runs and a press queues rather than sends. */
+  queueing: boolean;
+}
+
+function SendButton(props: SendButtonProps) {
+  const { canSubmit, attachmentPending, onSubmit, disabledHint, queueing } =
+    props;
   // Hint mode (e.g. no workspace) marks the button `aria-disabled` rather than
   // using the `disabled` attribute, so it stays focusable and the styled
   // TooltipWrapper's hint is reachable by hover and keyboard focus (a native
   // `title` is suppressed on a disabled <button>). Other disabled states keep
-  // the real `disabled` attribute and the native Send/Stop title.
-  const hintActive = !stopMode && disabledHint !== null;
-  const buttonTitle = stopMode ? "Stop assistant turn" : "Send";
-  const submitOrStopTurn = useCallback(() => {
-    if (hintActive) return;
-    if (!stopMode) {
-      onSubmit();
-      return;
-    }
-    if (onStopTurn === null) return;
-    onStopTurn();
-  }, [hintActive, onStopTurn, onSubmit, stopMode]);
-  const buttonClassName = cn(
-    "size-8 rounded-full disabled:bg-foreground/8 disabled:text-muted-foreground aria-disabled:cursor-not-allowed aria-disabled:bg-foreground/8 aria-disabled:text-muted-foreground aria-disabled:hover:bg-foreground/8",
-    stopMode
-      ? "bg-foreground/8 text-foreground hover:bg-foreground/10"
-      : "bg-primary text-primary-foreground hover:bg-primary/90",
-  );
+  // the real `disabled` attribute and the native title.
+  const hintActive = disabledHint !== null;
+  const label = queueing ? "Queue" : "Send";
 
   const button = (
     <TooltipWrapper
-      label={hintActive ? undefined : buttonTitle}
+      label={hintActive ? undefined : label}
       side="top"
       sideOffset={undefined}
       align={undefined}
@@ -70,15 +117,17 @@ function ComposerSendButtonImpl(props: ComposerSendButtonProps) {
         <Button
           type="button"
           size="icon"
-          onClick={submitOrStopTurn}
-          disabled={hintActive ? false : disabled}
+          onClick={hintActive ? undefined : onSubmit}
+          disabled={hintActive ? false : !canSubmit}
           aria-disabled={hintActive || undefined}
           aria-label={label}
-          aria-keyshortcuts={stopMode ? undefined : "Meta+Enter Control+Enter"}
-          data-testid={stopMode ? "chat-stop-button" : undefined}
-          className={buttonClassName}
+          aria-keyshortcuts="Meta+Enter Control+Enter"
+          className={cn(
+            BUTTON_CLASS_NAME,
+            "bg-primary text-primary-foreground hover:bg-primary/90",
+          )}
         >
-          {composerSendButtonIcon(attachmentPending, stopMode)}
+          {sendButtonIcon(attachmentPending)}
         </Button>
       </span>
     </TooltipWrapper>
@@ -98,13 +147,44 @@ function ComposerSendButtonImpl(props: ComposerSendButtonProps) {
   );
 }
 
-export const ComposerSendButton = memo(ComposerSendButtonImpl);
+interface StopButtonProps {
+  activeTurnStatus: ChatActiveTurn["status"];
+  disabled: boolean;
+  onStopTurn: (() => void) | null;
+}
 
-function composerSendButtonIcon(
-  attachmentPending: boolean,
-  stopMode: boolean,
-): ReactNode {
-  if (attachmentPending && !stopMode) {
+function StopButton(props: StopButtonProps) {
+  const { activeTurnStatus, disabled, onStopTurn } = props;
+  const label = activeTurnStatus === "stopping" ? "Stopping" : "Stop";
+  return (
+    <TooltipWrapper
+      label="Stop assistant turn"
+      side="top"
+      sideOffset={undefined}
+      align={undefined}
+    >
+      <span className="inline-flex">
+        <Button
+          type="button"
+          size="icon"
+          onClick={onStopTurn ?? undefined}
+          disabled={disabled}
+          aria-label={label}
+          data-testid="chat-stop-button"
+          className={cn(
+            BUTTON_CLASS_NAME,
+            "bg-foreground/8 text-foreground hover:bg-foreground/10",
+          )}
+        >
+          <Square className="size-3.5 fill-current" />
+        </Button>
+      </span>
+    </TooltipWrapper>
+  );
+}
+
+function sendButtonIcon(attachmentPending: boolean): ReactNode {
+  if (attachmentPending) {
     return (
       <AgentSpinningDots
         className="text-current"
@@ -113,14 +193,5 @@ function composerSendButtonIcon(
       />
     );
   }
-  if (stopMode) return <Square className="size-3.5 fill-current" />;
   return <ArrowUp className="size-4" />;
-}
-
-function composerSendButtonLabel(
-  activeTurnStatus: ChatActiveTurn["status"] | null,
-): string {
-  if (activeTurnStatus === null) return "Send";
-  if (activeTurnStatus === "stopping") return "Stopping";
-  return "Stop";
 }

--- a/clients/gui-app/src/components/home/mobile/__tests__/composer-mobile-toolbar.test.tsx
+++ b/clients/gui-app/src/components/home/mobile/__tests__/composer-mobile-toolbar.test.tsx
@@ -2,6 +2,7 @@ import "../../../../../__tests__/test-browser-apis";
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ChatActiveTurn } from "@traycer/protocol/host/agent/gui/subscribe";
 import { ComposerMobileToolbar } from "@/components/home/mobile/composer-mobile-toolbar";
 import { createComposerToolbarStore } from "@/stores/composer/composer-toolbar-store";
 
@@ -30,7 +31,11 @@ function makeStore(modelSlug: string) {
   });
 }
 
-function renderToolbar(modelSlug: string, onSubmit: () => void) {
+function renderToolbar(
+  modelSlug: string,
+  onSubmit: () => void,
+  activeTurnStatus: ChatActiveTurn["status"] | null,
+) {
   return render(
     <ComposerMobileToolbar
       store={makeStore(modelSlug)}
@@ -38,9 +43,9 @@ function renderToolbar(modelSlug: string, onSubmit: () => void) {
       canSubmit
       attachmentPending={false}
       onSubmit={onSubmit}
-      activeTurnStatus={null}
-      stopDisabled
-      onStopTurn={null}
+      activeTurnStatus={activeTurnStatus}
+      stopDisabled={false}
+      onStopTurn={activeTurnStatus === null ? null : vi.fn()}
       composerDisabledHint={null}
       dictation={null}
       dictationPreparing={null}
@@ -53,7 +58,7 @@ function renderToolbar(modelSlug: string, onSubmit: () => void) {
 
 describe("ComposerMobileToolbar", () => {
   it("keeps the desktop arrangement: attach, permission, model, send", () => {
-    renderToolbar("claude-opus-5", vi.fn());
+    renderToolbar("claude-opus-5", vi.fn(), null);
     expect(screen.getByRole("button", { name: "Attach image" })).not.toBeNull();
     expect(screen.getByTestId("mock-model-picker")).not.toBeNull();
     expect(screen.getByRole("button", { name: "Send" })).not.toBeNull();
@@ -62,7 +67,7 @@ describe("ComposerMobileToolbar", () => {
   });
 
   it("renders the permission as an icon, naming it only for assistive tech", () => {
-    renderToolbar("claude-opus-5", vi.fn());
+    renderToolbar("claude-opus-5", vi.fn(), null);
     expect(
       screen.getByRole("button", { name: "Permissions: Supervised" }),
     ).not.toBeNull();
@@ -72,7 +77,7 @@ describe("ComposerMobileToolbar", () => {
   });
 
   it("opens the options sheet from the permission pill", async () => {
-    renderToolbar("claude-opus-5", vi.fn());
+    renderToolbar("claude-opus-5", vi.fn(), null);
     expect(screen.queryByTestId("composer-options-sheet")).toBeNull();
     await userEvent.click(
       screen.getByRole("button", { name: "Permissions: Supervised" }),
@@ -82,7 +87,7 @@ describe("ComposerMobileToolbar", () => {
 
   it("blocks send while the model slug is still empty", () => {
     const onSubmit = vi.fn();
-    renderToolbar("", onSubmit);
+    renderToolbar("", onSubmit, null);
     expect(
       screen.getByRole("button", { name: "Send" }).hasAttribute("disabled"),
     ).toBe(true);
@@ -90,8 +95,18 @@ describe("ComposerMobileToolbar", () => {
 
   it("allows send once the model slug resolves", async () => {
     const onSubmit = vi.fn();
-    renderToolbar("claude-opus-5", onSubmit);
+    renderToolbar("claude-opus-5", onSubmit, null);
     await userEvent.click(screen.getByRole("button", { name: "Send" }));
+    expect(onSubmit).toHaveBeenCalled();
+  });
+
+  it("keeps a Queue button beside Stop while a turn runs", async () => {
+    // Return is a newline on a phone, so without this button there would be
+    // no way to queue a message mid-turn.
+    const onSubmit = vi.fn();
+    renderToolbar("claude-opus-5", onSubmit, "running");
+    expect(screen.getByRole("button", { name: "Stop" })).not.toBeNull();
+    await userEvent.click(screen.getByRole("button", { name: "Queue" }));
     expect(onSubmit).toHaveBeenCalled();
   });
 });

--- a/clients/gui-app/src/components/home/mobile/composer-mobile-toolbar.tsx
+++ b/clients/gui-app/src/components/home/mobile/composer-mobile-toolbar.tsx
@@ -160,6 +160,10 @@ function ComposerMobileToolbarImpl(props: ComposerMobileToolbarProps) {
           stopDisabled={stopDisabled}
           onStopTurn={onStopTurn}
           disabledHint={composerDisabledHint}
+          // Return is a newline on a soft keyboard, so this button is the only
+          // way to queue a message mid-turn: Stop sits beside it, never in
+          // its place.
+          stopPlacement="beside"
         />
       </div>
       <ComposerOptionsSheet

--- a/clients/gui-app/src/components/home/toolbar/composer-toolbar-right.tsx
+++ b/clients/gui-app/src/components/home/toolbar/composer-toolbar-right.tsx
@@ -85,6 +85,8 @@ function ComposerToolbarRightImpl(props: ComposerToolbarRightProps) {
         stopDisabled={stopDisabled}
         onStopTurn={onStopTurn}
         disabledHint={composerDisabledHint}
+        // Enter still queues here, so Send needs no button of its own mid-turn.
+        stopPlacement="replace"
       />
     </div>
   );


### PR DESCRIPTION
## Problem

On a phone there is no way to submit while a turn is running. Return inserts a newline on phone viewports (a soft keyboard has no Shift to chord with), and the single composer button morphs Send into Stop whenever a turn is active. Desktop escapes via Enter, which already queues; the phone has no escape at all.

The queue machinery, the queued-message surface, and its "Steer now" row action all already work on the phone. This was purely a toolbar affordance gap.

## Change

`ComposerSendButton` takes a required `stopPlacement` prop:

- `"replace"`: the unchanged desktop behaviour, Send morphs into Stop. The desktop toolbar passes this.
- `"beside"`: Send stays in place and a muted Stop renders to its left while a turn runs. Mid-turn Send reads "Queue", tapping it queues through the same path the desktop Enter key uses, and it disables while the turn is stopping. The phone toolbar passes this.

Internally the component is split into a small `SendButton` and `StopButton` so both modes share every style, icon, and label. There is no viewport sniffing inside the component; the choice is explicit at the two call sites.

Desktop is unchanged in every state. The phone is unchanged while idle.

## Tests

- `composer-send-button.test.tsx`: idle, replace mid-turn, beside mid-turn (Stop precedes Queue in the DOM, each click reaches only its own handler), empty draft, stopping.
- `composer-mobile-toolbar.test.tsx`: adds the mid-turn Queue-beside-Stop case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)