### PR TITLE
fix(gui): drop the browser list from the login-import toast and tour act

### DIFF
--- a/clients/gui-app/src/components/layout/bridges/login-import-announcement-controller.tsx
+++ b/clients/gui-app/src/components/layout/bridges/login-import-announcement-controller.tsx
@@ -112,8 +112,8 @@ export function LoginImportAnnouncementController(): null {
       <ActionToastContent
         toastId={LOGIN_IMPORT_ANNOUNCEMENT_TOAST_ID}
         eyebrow="New in this release"
-        title="Bring your logins with you"
-        description="Import the sites you're signed into in Chrome, Edge, Brave, Firefox, or Safari, so agents work on them as you."
+        title="Your browser logins, in Traycer"
+        description="Import the logins from the browser you already use, so agents work on those sites as you."
         actionLabel="Import logins…"
         onAction={() => {
           useBrowserFocusStore.getState().requestImportLogins();

--- a/clients/gui-app/src/components/onboarding/onboarding-acts.ts
+++ b/clients/gui-app/src/components/onboarding/onboarding-acts.ts
@@ -126,7 +126,7 @@ export const ONBOARDING_ACTS: ReadonlyArray<OnboardingAct> = [
     id: "login-import",
     eyebrowLabel: "YOUR LOGINS",
     title: "Stay signed in\neverywhere",
-    body: "Bring the sites you're signed into in Chrome, Edge, Brave, Firefox, or Safari into Traycer's browser. Agents then work on those sites as you, with nothing to sign into again.",
+    body: "Bring the logins from the browser you already use into Traycer's browser. Agents then work on those sites as you.",
     addon: "login-import",
   },
   AGENT_GUIDE_ACT,


### PR DESCRIPTION
The release toast and the tour's login-import act both named "Chrome, Edge,
Brave, Firefox, or Safari". Safari is only discovered on macOS, and on
Windows Chrome 127+ and Edge keep their cookies under App-Bound Encryption,
which the reader classifies as protected - so on two of three platforms the
copy promised a browser the picker can never offer or open. The picker
already lists what was actually found; the copy now says "the browser you
already use" and leaves the naming to it.

The act's "nothing to sign into again" is gone too: Google accounts are
excluded on purpose, protected and device-bound rows are skipped, and
session cookies expire. The toast's title no longer borrows the "Bring your
… with you" frame that two tour acts already own.

Copy only; no behaviour change.

Follow-up to #1684, from the ticket's open copy question. The Settings row's description still carries the same browser list (with "or a cookie file"); left for a separate decision since it is the row that names the file path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
