### PR TITLE
fix(gui): place Stop beside Send on phone viewports in every composer

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/__tests__/chat-tile.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/chat-tile.test.tsx
@@ -136,7 +136,7 @@ vi.mock("@/providers/use-resolved-theme", () => ({
 
 // The composer's send button places Stop beside Send on a phone-width
 // viewport; jsdom is desktop-width, so the phone case flips this explicitly.
-const viewport = { mobile: false };
+const viewport = vi.hoisted(() => ({ mobile: false }));
 vi.mock("@/hooks/ui/use-mobile-viewport", async (importActual) => ({
   ...(await importActual<typeof import("@/hooks/ui/use-mobile-viewport")>()),
   useIsMobileViewport: () => viewport.mobile,
@@ -1529,7 +1529,7 @@ describe("<ChatTile />", () => {
       });
     });
 
-    expect(screen.getByTestId("chat-stop-button")).not.toBeNull();
+    expect(screen.getByRole("button", { name: "Stop" })).not.toBeNull();
     fireEvent.click(screen.getByRole("button", { name: "Queue" }));
 
     expect(chatHarness.sent).toHaveLength(1);

--- a/clients/gui-app/src/components/epic-canvas/__tests__/chat-tile.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/chat-tile.test.tsx
@@ -134,6 +134,14 @@ vi.mock("@/providers/use-resolved-theme", () => ({
   useResolvedTheme: () => ({ resolvedTheme: "dark", themePreset: "neutral" }),
 }));
 
+// The composer's send button places Stop beside Send on a phone-width
+// viewport; jsdom is desktop-width, so the phone case flips this explicitly.
+const viewport = { mobile: false };
+vi.mock("@/hooks/ui/use-mobile-viewport", async (importActual) => ({
+  ...(await importActual<typeof import("@/hooks/ui/use-mobile-viewport")>()),
+  useIsMobileViewport: () => viewport.mobile,
+}));
+
 // The tile subscribes to the command catalog itself, because its next-step /
 // compact / implement-plan sends bypass the composer and its picker store. The
 // mocked host client above never resolves a request, so without this the
@@ -1250,6 +1258,7 @@ describe("<ChatTile />", () => {
 
   afterEach(() => {
     cleanup();
+    viewport.mobile = false;
     restoreLegendListTestClock();
     vi.restoreAllMocks();
     resetFocusedComposerControlsForTests();
@@ -1486,6 +1495,47 @@ describe("<ChatTile />", () => {
     const frame = chatHarness.sent[0];
     if (frame.kind !== "stop") throw new Error("expected stop frame");
     expect(frame.turnId).toBe("turn-1");
+  });
+
+  it("on a phone keeps a Queue button beside Stop and queues through it", async () => {
+    // Return is a newline on a phone-width viewport, so this button is the
+    // only way to queue a message while a turn runs.
+    viewport.mobile = true;
+    renderChatTile();
+
+    await waitForChatTileLoaded();
+
+    act(() => {
+      chatHarness.callbacks().onTurnStateChanged({
+        kind: "turnStateChanged",
+        hasBinaryPayload: false,
+        epicId: EPIC_ID,
+        chatId: CHAT_ARTIFACT.id,
+        runStatus: "running",
+        activeTurn: {
+          agentMode: "regular",
+          sameTurnSteeringSupported: false,
+          turnId: "turn-1",
+          status: "running",
+          harnessId: "claude",
+          model: "haiku",
+          profileId: null,
+          userMessageId: "message-1",
+          startedAt: 2,
+          updatedAt: 2,
+          reasoningEffort: null,
+          serviceTier: null,
+        },
+      });
+    });
+
+    expect(screen.getByTestId("chat-stop-button")).not.toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Queue" }));
+
+    expect(chatHarness.sent).toHaveLength(1);
+    const frame = chatHarness.sent[0];
+    if (frame.kind !== "send") throw new Error("expected send frame");
+    expect(frame.deliveryPolicy).toBe("auto");
   });
 
   it("sends delete-message-suffix after inline confirmation", async () => {

--- a/clients/gui-app/src/components/home/composer/__tests__/composer-send-button.test.tsx
+++ b/clients/gui-app/src/components/home/composer/__tests__/composer-send-button.test.tsx
@@ -2,15 +2,19 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ChatActiveTurn } from "@traycer/protocol/host/agent/gui/subscribe";
 
-import {
-  ComposerSendButton,
-  type ComposerStopPlacement,
-} from "../composer-send-button";
+import { ComposerSendButton } from "../composer-send-button";
 
-afterEach(() => cleanup());
+const viewport = { mobile: false };
+vi.mock("@/hooks/ui/use-mobile-viewport", () => ({
+  useIsMobileViewport: () => viewport.mobile,
+}));
+
+afterEach(() => {
+  cleanup();
+  viewport.mobile = false;
+});
 
 interface RenderOptions {
-  readonly stopPlacement: ComposerStopPlacement;
   readonly activeTurnStatus: ChatActiveTurn["status"] | null;
   readonly canSubmit: boolean;
   readonly onSubmit: () => void;
@@ -27,7 +31,6 @@ function renderButton(options: RenderOptions) {
       stopDisabled={false}
       onStopTurn={options.onStopTurn}
       disabledHint={null}
-      stopPlacement={options.stopPlacement}
     />,
   );
 }
@@ -43,7 +46,6 @@ describe("ComposerSendButton attachment preparation", () => {
         stopDisabled
         onStopTurn={null}
         disabledHint={null}
-        stopPlacement="replace"
       />,
     );
 
@@ -54,10 +56,10 @@ describe("ComposerSendButton attachment preparation", () => {
   });
 });
 
-describe("ComposerSendButton stop placement", () => {
-  it("idle renders Send alone under either placement", () => {
+describe("ComposerSendButton mid-turn", () => {
+  it("idle renders Send alone on any viewport", () => {
+    viewport.mobile = true;
     renderButton({
-      stopPlacement: "beside",
       activeTurnStatus: null,
       canSubmit: true,
       onSubmit: vi.fn(),
@@ -67,9 +69,8 @@ describe("ComposerSendButton stop placement", () => {
     expect(screen.queryByTestId("chat-stop-button")).toBeNull();
   });
 
-  it("'replace' morphs Send into Stop while a turn runs", () => {
+  it("desktop morphs Send into Stop while a turn runs", () => {
     renderButton({
-      stopPlacement: "replace",
       activeTurnStatus: "running",
       canSubmit: true,
       onSubmit: vi.fn(),
@@ -80,11 +81,13 @@ describe("ComposerSendButton stop placement", () => {
     expect(screen.queryByRole("button", { name: "Queue" })).toBeNull();
   });
 
-  it("'beside' keeps a Queue button next to Stop while a turn runs", () => {
+  it("phone keeps a Queue button beside Stop while a turn runs", () => {
+    // Return is a newline on a phone, so without this button there would be
+    // no way to queue a message mid-turn.
+    viewport.mobile = true;
     const onSubmit = vi.fn();
     const onStopTurn = vi.fn();
     renderButton({
-      stopPlacement: "beside",
       activeTurnStatus: "running",
       canSubmit: true,
       onSubmit,
@@ -109,9 +112,9 @@ describe("ComposerSendButton stop placement", () => {
     expect(onSubmit).toHaveBeenCalledTimes(1);
   });
 
-  it("'beside' disables Queue when there is nothing to send", () => {
+  it("phone disables Queue when there is nothing to send", () => {
+    viewport.mobile = true;
     renderButton({
-      stopPlacement: "beside",
       activeTurnStatus: "running",
       canSubmit: false,
       onSubmit: vi.fn(),
@@ -125,9 +128,9 @@ describe("ComposerSendButton stop placement", () => {
     ).toBe(false);
   });
 
-  it("'beside' disables both buttons while the turn is stopping", () => {
+  it("phone disables both buttons while the turn is stopping", () => {
+    viewport.mobile = true;
     renderButton({
-      stopPlacement: "beside",
       activeTurnStatus: "stopping",
       canSubmit: true,
       onSubmit: vi.fn(),

--- a/clients/gui-app/src/components/home/composer/__tests__/composer-send-button.test.tsx
+++ b/clients/gui-app/src/components/home/composer/__tests__/composer-send-button.test.tsx
@@ -4,7 +4,7 @@ import type { ChatActiveTurn } from "@traycer/protocol/host/agent/gui/subscribe"
 
 import { ComposerSendButton } from "../composer-send-button";
 
-const viewport = { mobile: false };
+const viewport = vi.hoisted(() => ({ mobile: false }));
 vi.mock("@/hooks/ui/use-mobile-viewport", () => ({
   useIsMobileViewport: () => viewport.mobile,
 }));

--- a/clients/gui-app/src/components/home/composer/composer-send-button.tsx
+++ b/clients/gui-app/src/components/home/composer/composer-send-button.tsx
@@ -3,19 +3,9 @@ import { memo, type ReactNode } from "react";
 import { Button } from "@/components/ui/button";
 import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 import type { ChatActiveTurn } from "@traycer/protocol/host/agent/gui/subscribe";
+import { useIsMobileViewport } from "@/hooks/ui/use-mobile-viewport";
 import { cn } from "@/lib/utils";
 import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
-
-/**
- * Where Stop lives while a turn runs.
- *
- * - `"replace"`: this button morphs into Stop. The desktop toolbar's choice -
- *   Enter still queues there, so Send needs no button of its own mid-turn.
- * - `"beside"`: Send stays put (tapping it queues) and Stop renders to its
- *   left. The phone toolbar's choice - Return is a newline on a soft keyboard,
- *   so this button is the only way to queue.
- */
-export type ComposerStopPlacement = "replace" | "beside";
 
 interface ComposerSendButtonProps {
   canSubmit: boolean;
@@ -30,7 +20,6 @@ interface ComposerSendButtonProps {
    * leaves the normal "Send" affordance.
    */
   disabledHint: string | null;
-  stopPlacement: ComposerStopPlacement;
 }
 
 const BUTTON_CLASS_NAME =
@@ -45,8 +34,12 @@ function ComposerSendButtonImpl(props: ComposerSendButtonProps) {
     stopDisabled,
     onStopTurn,
     disabledHint,
-    stopPlacement,
   } = props;
+  // On a phone-width viewport Return inserts a newline (`chat-list-keymap`),
+  // so this button is the only way to queue a message mid-turn: Stop renders
+  // beside Send there instead of replacing it. Same VIEWPORT signal as the
+  // keymap, so the two can never disagree.
+  const stopBesideSend = useIsMobileViewport();
 
   if (activeTurnStatus === null) {
     return (
@@ -67,7 +60,7 @@ function ComposerSendButtonImpl(props: ComposerSendButtonProps) {
       onStopTurn={onStopTurn}
     />
   );
-  if (stopPlacement === "replace") return stop;
+  if (!stopBesideSend) return stop;
   return (
     <>
       {stop}

--- a/clients/gui-app/src/components/home/mobile/__tests__/composer-mobile-toolbar.test.tsx
+++ b/clients/gui-app/src/components/home/mobile/__tests__/composer-mobile-toolbar.test.tsx
@@ -2,7 +2,6 @@ import "../../../../../__tests__/test-browser-apis";
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { ChatActiveTurn } from "@traycer/protocol/host/agent/gui/subscribe";
 import { ComposerMobileToolbar } from "@/components/home/mobile/composer-mobile-toolbar";
 import { createComposerToolbarStore } from "@/stores/composer/composer-toolbar-store";
 
@@ -31,11 +30,7 @@ function makeStore(modelSlug: string) {
   });
 }
 
-function renderToolbar(
-  modelSlug: string,
-  onSubmit: () => void,
-  activeTurnStatus: ChatActiveTurn["status"] | null,
-) {
+function renderToolbar(modelSlug: string, onSubmit: () => void) {
   return render(
     <ComposerMobileToolbar
       store={makeStore(modelSlug)}
@@ -43,9 +38,9 @@ function renderToolbar(
       canSubmit
       attachmentPending={false}
       onSubmit={onSubmit}
-      activeTurnStatus={activeTurnStatus}
-      stopDisabled={false}
-      onStopTurn={activeTurnStatus === null ? null : vi.fn()}
+      activeTurnStatus={null}
+      stopDisabled
+      onStopTurn={null}
       composerDisabledHint={null}
       dictation={null}
       dictationPreparing={null}
@@ -58,7 +53,7 @@ function renderToolbar(
 
 describe("ComposerMobileToolbar", () => {
   it("keeps the desktop arrangement: attach, permission, model, send", () => {
-    renderToolbar("claude-opus-5", vi.fn(), null);
+    renderToolbar("claude-opus-5", vi.fn());
     expect(screen.getByRole("button", { name: "Attach image" })).not.toBeNull();
     expect(screen.getByTestId("mock-model-picker")).not.toBeNull();
     expect(screen.getByRole("button", { name: "Send" })).not.toBeNull();
@@ -67,7 +62,7 @@ describe("ComposerMobileToolbar", () => {
   });
 
   it("renders the permission as an icon, naming it only for assistive tech", () => {
-    renderToolbar("claude-opus-5", vi.fn(), null);
+    renderToolbar("claude-opus-5", vi.fn());
     expect(
       screen.getByRole("button", { name: "Permissions: Supervised" }),
     ).not.toBeNull();
@@ -77,7 +72,7 @@ describe("ComposerMobileToolbar", () => {
   });
 
   it("opens the options sheet from the permission pill", async () => {
-    renderToolbar("claude-opus-5", vi.fn(), null);
+    renderToolbar("claude-opus-5", vi.fn());
     expect(screen.queryByTestId("composer-options-sheet")).toBeNull();
     await userEvent.click(
       screen.getByRole("button", { name: "Permissions: Supervised" }),
@@ -87,7 +82,7 @@ describe("ComposerMobileToolbar", () => {
 
   it("blocks send while the model slug is still empty", () => {
     const onSubmit = vi.fn();
-    renderToolbar("", onSubmit, null);
+    renderToolbar("", onSubmit);
     expect(
       screen.getByRole("button", { name: "Send" }).hasAttribute("disabled"),
     ).toBe(true);
@@ -95,18 +90,8 @@ describe("ComposerMobileToolbar", () => {
 
   it("allows send once the model slug resolves", async () => {
     const onSubmit = vi.fn();
-    renderToolbar("claude-opus-5", onSubmit, null);
+    renderToolbar("claude-opus-5", onSubmit);
     await userEvent.click(screen.getByRole("button", { name: "Send" }));
-    expect(onSubmit).toHaveBeenCalled();
-  });
-
-  it("keeps a Queue button beside Stop while a turn runs", async () => {
-    // Return is a newline on a phone, so without this button there would be
-    // no way to queue a message mid-turn.
-    const onSubmit = vi.fn();
-    renderToolbar("claude-opus-5", onSubmit, "running");
-    expect(screen.getByRole("button", { name: "Stop" })).not.toBeNull();
-    await userEvent.click(screen.getByRole("button", { name: "Queue" }));
     expect(onSubmit).toHaveBeenCalled();
   });
 });

--- a/clients/gui-app/src/components/home/mobile/composer-mobile-toolbar.tsx
+++ b/clients/gui-app/src/components/home/mobile/composer-mobile-toolbar.tsx
@@ -160,10 +160,6 @@ function ComposerMobileToolbarImpl(props: ComposerMobileToolbarProps) {
           stopDisabled={stopDisabled}
           onStopTurn={onStopTurn}
           disabledHint={composerDisabledHint}
-          // Return is a newline on a soft keyboard, so this button is the only
-          // way to queue a message mid-turn: Stop sits beside it, never in
-          // its place.
-          stopPlacement="beside"
         />
       </div>
       <ComposerOptionsSheet

--- a/clients/gui-app/src/components/home/toolbar/composer-toolbar-right.tsx
+++ b/clients/gui-app/src/components/home/toolbar/composer-toolbar-right.tsx
@@ -85,8 +85,6 @@ function ComposerToolbarRightImpl(props: ComposerToolbarRightProps) {
         stopDisabled={stopDisabled}
         onStopTurn={onStopTurn}
         disabledHint={composerDisabledHint}
-        // Enter still queues here, so Send needs no button of its own mid-turn.
-        stopPlacement="replace"
       />
     </div>
   );


### PR DESCRIPTION
## Problem

#1685 added a `stopPlacement` prop to the composer send button and set `"beside"` only in the landing composer's mobile toolbar. A turn never runs in the landing composer. The conversation screen renders the desktop toolbar at every width, so on a phone it still replaced Send with Stop and there was still no way to queue a message mid-turn.

## Change

- Drop the `stopPlacement` prop. The button reads `useIsMobileViewport()` itself, the same viewport signal `chat-list-keymap` uses to make Return a newline, so Stop sits beside Send exactly where the keyboard cannot queue. Every composer surface gets this without any threading.
- `composer-toolbar-right.tsx`, `composer-mobile-toolbar.tsx`, and the mobile toolbar test return to their pre-#1685 shape.
- Net product-code change against main: one import and one hook call in, the prop type and toolbar wiring out.

Desktop is unchanged in every state. Phones are unchanged while idle.

## Tests

- `chat-tile.test.tsx`: new integrated case at the conversation-screen level. Phone viewport, running turn, both Stop and Queue rendered, tapping Queue sends a frame with `deliveryPolicy: "auto"`.
- `composer-send-button.test.tsx`: same five states as before, now switched by the viewport mock instead of a prop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)