### PR TITLE
feat(gui): move saved website sessions into a side sheet

### DIFF
--- a/clients/desktop/src/electron-main/ipc/__tests__/browser-view-clear-site-ipc.test.ts
+++ b/clients/desktop/src/electron-main/ipc/__tests__/browser-view-clear-site-ipc.test.ts
@@ -570,7 +570,7 @@ describe("clear-site IPC jar targeting", () => {
     });
 
     expect(cancelled).toBe(false);
-    expect(fixture.confirmations).toEqual(["Clear this saved login?"]);
+    expect(fixture.confirmations).toEqual(["Remove this website session?"]);
   });
 
   it("reports a confirmed saved-login clear so the settings row can hide", async () => {
@@ -579,7 +579,7 @@ describe("clear-site IPC jar targeting", () => {
     });
 
     expect(confirmed).toBe(true);
-    expect(fixture.confirmations).toEqual(["Clear this saved login?"]);
+    expect(fixture.confirmations).toEqual(["Remove this website session?"]);
   });
 
   it("forgets from the one shared jar when saving is on", async () => {
@@ -639,7 +639,7 @@ describe("clear-site IPC jar targeting", () => {
 
     await invokeHandler("browserViewForgetLogins", undefined);
 
-    expect(fixture.confirmations).toEqual(["Forget browser logins?"]);
+    expect(fixture.confirmations).toEqual(["Remove all website sessions?"]);
     expect(fixture.jarClears).toEqual([]);
     expect(fixture.forgetAllResets).toBe(0);
     expect(fixture.tabRecreations).toBe(0);
@@ -817,9 +817,9 @@ describe("clear-site IPC jar targeting", () => {
 
     await invokeHandler("browserViewClearSite", TILE_KEY);
 
-    expect(fixture.confirmations).toEqual(["Clear this saved login?"]);
+    expect(fixture.confirmations).toEqual(["Remove this website session?"]);
     expect(fixture.confirmationMessages).toEqual([
-      "Sign out of example.com everywhere?",
+      "Remove the saved session for example.com?",
     ]);
     expect(fixture.clears).toEqual([]);
     expect(ledger.revision()).toBe(before);
@@ -834,7 +834,7 @@ describe("clear-site IPC jar targeting", () => {
     await invokeHandler("browserViewClearSite", TILE_KEY);
 
     expect(fixture.confirmationMessages).toEqual([
-      "Sign out of example.com everywhere?",
+      "Remove the saved session for example.com?",
     ]);
     expect(fixture.clears).toEqual([
       { domain: "example.com", partition: fixture.durablePartition },
@@ -859,7 +859,7 @@ describe("clear-site IPC jar targeting", () => {
     await flushMicrotasks();
 
     // The dialog is up - the handler reached the ask...
-    expect(fixture.confirmations).toEqual(["Forget browser logins?"]);
+    expect(fixture.confirmations).toEqual(["Remove all website sessions?"]);
     // ...and nothing moved behind it. The ledger revision is the first
     // irreversible step: it is what tells every host to prune.
     expect(ledger.revision()).toBe(before);

--- a/clients/desktop/src/electron-main/ipc/browser-view-ipc.ts
+++ b/clients/desktop/src/electron-main/ipc/browser-view-ipc.ts
@@ -1320,20 +1320,20 @@ function toBrowserViewWindow(
 }
 
 const FORGET_ALL_LOGINS_CONFIRMATION: MainConfirmation = {
-  title: "Forget browser logins?",
-  message: "Forget all saved browser logins?",
+  title: "Remove all website sessions?",
+  message: "Remove every saved website session?",
   detail:
-    "Every site you are signed in to in Traycer's browser is signed out, here and on every connected machine. This cannot be undone.",
-  confirmLabel: "Forget all",
+    "Open Traycer browser tabs reload signed out, and agent sessions using them may be interrupted. This cannot be undone.",
+  confirmLabel: "Remove all",
 };
 
 function clearSiteConfirmation(domain: string): MainConfirmation {
   return {
-    title: "Clear this saved login?",
-    message: `Sign out of ${domain} everywhere?`,
+    title: "Remove this website session?",
+    message: `Remove the saved session for ${domain}?`,
     detail:
-      "You will be signed out of this site on every machine this account is signed in to. Other sites are untouched.",
-    confirmLabel: "Clear",
+      "Traycer removes its session data from the shared collection. You may be signed out on connected Traycer hosts. Other sites are untouched.",
+    confirmLabel: "Remove",
   };
 }
 

--- a/clients/gui-app/src/components/settings/SETTINGS.md
+++ b/clients/gui-app/src/components/settings/SETTINGS.md
@@ -520,30 +520,30 @@ means the drain UI renders NOTHING - never a zero, which would offer to end
     heading over an empty card. The link-open and agent-tab-surfacing selects
     that used to lead this group live in **Opening behavior** now - see that
     section for the fields and their semantics.
-  - **Saved logins** (`browser-settings-section.tsx`'s second group,
-    `data-testid="settings-saved-logins"`): where website logins in the in-app
-    browser are kept, and the only place they can be turned off, forgotten, or
+  - **Website sessions** (`browser-settings-section.tsx`'s second group,
+    `data-testid="settings-saved-logins"`): where session data from the in-app
+    browser is kept, and the only place it can be turned off, removed, or
     inspected per site. Keychain-refactor spec §7.3; the group renders NOTHING
     without a `browserView` bridge (the web build), because every row is about
     a machine's jar - nor without a host runtime (`useHostBinding()`, the
     non-throwing accessor), since the list is a host's answer and both
-    destructive rows travel to hosts. That gate is on what RENDERS: the rows
+    destructive actions travel to hosts. That gate is on what RENDERS: the rows
     live in their own component so the site-list query, which reaches
     `useHostClient()` and would THROW with no provider, is never mounted
     above it.
     Saving is silent and on by default, Chrome-style - there is no consent
-    step, no status row and nothing to retry - so this group is passive: a
-    toggle, a destructive action, and a list.
-    - **Save website logins on this machine** is the desktop-local pref
+    step and nothing to retry - so this group is passive: a toggle, a compact
+    preview, and an import row.
+    - **Save website sessions on this computer** is the desktop-local pref
       (`useBrowserSaveLogins()`), not a settings-store field and not a host
       value: it is a statement about THIS machine (decision #18), so it neither
       syncs nor follows the scoped host. Off switches new and live `primary`
       tiles onto a throwaway partition (they reload signed out) and leaves the
-      `persist:` jar on disk untouched - that is what Forget is for - so a
+      `persist:` jar on disk untouched - that is what Remove all is for - so a
       confirm stands in front of it and turning it back on returns to the same
       logins. Nothing is copied in either direction.
-    - **Import logins from another browser** (`import-logins-dialog.tsx`) is
-      the row between the toggle and Forget-all. It opens a three-step dialog
+    - **Bring in existing sessions** (`import-logins-dialog.tsx`) is the row
+      after the saved-session preview. It opens a three-step dialog
       over four desktop bridge calls: `listLoginImportSources` (Pick: the
       browsers and profiles found on this machine, plus "Import from a
       file…", whose native picker runs in main so the renderer never names a
@@ -606,22 +606,21 @@ means the drain UI renders NOTHING - never a zero, which would offer to end
         so leaving the tour never resurrects the toast. The toast also holds
         until the system-tab modal API is published, since its action
         navigates through it and would otherwise no-op on a cold launch.
-    - **Forget all browser logins** (destructive confirm) moved here from the
-      tile shield popover, which was ticket 08's temporary home. It calls the
-      bridge's `forgetLogins()` directly and so speaks for EVERY host the user has a live browser stream to; that is
-      what "all" means, and it is why the action is not tile-scoped.
-      It answers whether any stream took the frame, and the confirm closes only
-      then - the same refusal the per-row Clear makes, so a click that reached
-      no host never reads as a completed forget.
-    - **Sites with saved logins** reads `browser.savedLoginSites` from the
-      surface's host (`useBrowserSavedLoginSitesQuery`) - registrable domains
-      and a relative last-seen, never values. The method is optional
+    - **Saved website sessions** reads `browser.savedLoginSites` from the
+      surface's host (`useBrowserSavedLoginSitesQuery`) - registrable domains,
+      never values. Settings shows the count and first three sites in
+      alphabetical order; a non-empty preview opens a right side sheet with
+      search, every site, per-site Remove, and Remove all. A genuinely empty
+      collection has no disclosure, while the sheet stays open after Remove
+      all to offer import as the next step. The method is optional
       (non-floor), so the query is gated on `useHostSupportsMethod` and a host
       that never answered renders no list rather than an empty one. `sealed`
       is NOT "no sites": it says the logins exist but this host cannot open
       them until the desktop that wrapped its key connects, and it renders its
-      own hint. A row whose `contributedByHostId` names a host OTHER than this
-      machine's carries one muted "Includes a sign-in from <host>" line
+      own hint plus Remove all because deleting the jar does not require
+      opening the collection. A preview or sheet row whose
+      `contributedByHostId` names a host OTHER than this machine's carries one
+      muted "Includes a sign-in from <host>" line
       (universal-sign-in decision 9) - weak copy on purpose, because the marker
       behind it is sticky and survives the user signing into that site here.
       The display name resolves through the host directory
@@ -639,14 +638,16 @@ means the drain UI renders NOTHING - never a zero, which would offer to end
       the render guard is `typeof === "string"`, not `!== null`, because the
       same-minor RPC path returns the payload UNPARSED - a host predating the
       field sends no key at all, and the schema's `.default(null)` only runs on
-      the version-gap decode. Per-row **Clear** sends
+      the version-gap decode. Per-row **Remove** sends
       the `clearSite { domain }` frame
       (`browserView.clearSavedLoginSite()`) and refetches; the row is hidden optimistically
       because the host merges asynchronously and the refetch behind the click
       can still read the pre-clear slice. That optimism RELEASES itself: a
       domain is hidden only while the latest response still names it (retired
       from state during render), so signing back into a cleared site shows it
-      again instead of hiding it for the session.
+      again instead of hiding it for the session. **Remove all** calls the
+      bridge's `forgetLogins()` directly and therefore speaks for every host
+      with a live browser stream; main owns both native destructive confirms.
   - **Running agents**: Prevent sleep while running
     (`prevent-sleep-settings-section.tsx`, hidden in the mobile app - see
     "Two different mobile questions"), Show global resources button, Show

--- a/clients/gui-app/src/components/settings/SETTINGS.md
+++ b/clients/gui-app/src/components/settings/SETTINGS.md
@@ -609,7 +609,7 @@ means the drain UI renders NOTHING - never a zero, which would offer to end
     - **Saved website sessions** reads `browser.savedLoginSites` from the
       surface's host (`useBrowserSavedLoginSitesQuery`) - registrable domains,
       never values. Settings shows the count and first three sites in
-      alphabetical order; a non-empty preview opens a right side sheet with
+      alphabetical order; a non-empty preview opens a right-side sheet with
       search, every site, per-site Remove, and Remove all. A genuinely empty
       collection has no disclosure, while the sheet stays open after Remove
       all to offer import as the next step. The method is optional

--- a/clients/gui-app/src/components/settings/__tests__/browser-settings-section-no-host-runtime.test.tsx
+++ b/clients/gui-app/src/components/settings/__tests__/browser-settings-section-no-host-runtime.test.tsx
@@ -32,12 +32,12 @@ describe("<BrowserSettingsSection /> without a host runtime", () => {
     useSettingsStore.setState({ browserDevOrigins: [] });
   });
 
-  it("renders the panel instead of throwing, and leaves the saved-logins group out", () => {
+  it("renders the panel instead of throwing, and leaves the website-session group out", () => {
     useSettingsStore.setState({ browserDevOrigins: ["http://localhost:5173"] });
     render(<BrowserSettingsSection />);
 
     expect(screen.getByText("Detected dev origins")).not.toBeNull();
-    expect(screen.queryByText("Saved logins")).toBeNull();
+    expect(screen.queryByText("Website sessions")).toBeNull();
     expect(screen.queryByRole("switch")).toBeNull();
   });
 });

--- a/clients/gui-app/src/components/settings/__tests__/browser-settings-section.test.tsx
+++ b/clients/gui-app/src/components/settings/__tests__/browser-settings-section.test.tsx
@@ -109,7 +109,7 @@ function controller(
 
 function savedSite(
   domain: string,
-  contributedByHostId: string | null = null,
+  contributedByHostId: string | null,
 ): BrowserSavedLoginSite {
   return { domain, lastSeen: Date.now(), contributedByHostId };
 }
@@ -214,7 +214,7 @@ describe("<BrowserSettingsSection /> website sessions", () => {
     useSettingsStore.setState({ browserDevOrigins: ["http://localhost:5173"] });
     renderSection(controller({ enabled: true }), {
       kind: "sites",
-      sites: [savedSite("example.com")],
+      sites: [savedSite("example.com", null)],
     });
 
     expect(screen.queryByText("Website sessions")).toBeNull();
@@ -226,11 +226,11 @@ describe("<BrowserSettingsSection /> website sessions", () => {
     renderSection(controller({}), {
       kind: "sites",
       sites: [
-        savedSite("zulu.example"),
-        savedSite("beta.example"),
-        savedSite("alpha.example"),
-        savedSite("echo.example"),
-        savedSite("delta.example"),
+        savedSite("zulu.example", null),
+        savedSite("beta.example", null),
+        savedSite("alpha.example", null),
+        savedSite("echo.example", null),
+        savedSite("delta.example", null),
       ],
     });
 
@@ -265,7 +265,10 @@ describe("<BrowserSettingsSection /> website sessions", () => {
   it("searches the side sheet and distinguishes an empty search", () => {
     renderSection(controller({}), {
       kind: "sites",
-      sites: [savedSite("alpha.example"), savedSite("beta.example")],
+      sites: [
+        savedSite("alpha.example", null),
+        savedSite("beta.example", null),
+      ],
     });
     const manager = openManager();
     const search = within(manager).getByLabelText("Search saved sites");
@@ -331,6 +334,9 @@ describe("<BrowserSettingsSection /> website sessions", () => {
     expect(
       within(manager).getByText("Includes a sign-in from Studio Mac"),
     ).not.toBeNull();
+    expect(
+      within(manager).queryByText("Includes a sign-in from This Mac"),
+    ).toBeNull();
     expect(within(manager).queryByText("Includes a sign-in from")).toBeNull();
   });
 
@@ -364,7 +370,7 @@ describe("<BrowserSettingsSection /> website sessions", () => {
   it("removes one site only after main confirms", async () => {
     renderSection(controller({}), {
       kind: "sites",
-      sites: [savedSite("example.com"), savedSite("example.org")],
+      sites: [savedSite("example.com", null), savedSite("example.org", null)],
     });
     const manager = openManager();
 
@@ -385,7 +391,7 @@ describe("<BrowserSettingsSection /> website sessions", () => {
   it("holds an optimistic removal through a stale reply, then releases it", async () => {
     const bothSites: BrowserSavedLoginSitesResponse = {
       kind: "sites",
-      sites: [savedSite("example.com"), savedSite("example.org")],
+      sites: [savedSite("example.com", null), savedSite("example.org", null)],
     };
     saveLogins.current = controller({});
     sites.current = bothSites;
@@ -406,7 +412,7 @@ describe("<BrowserSettingsSection /> website sessions", () => {
 
     sites.current = {
       kind: "sites",
-      sites: [savedSite("example.org")],
+      sites: [savedSite("example.org", null)],
     };
     view.rerender(<BrowserSettingsSection />);
     sites.current = bothSites;
@@ -421,7 +427,7 @@ describe("<BrowserSettingsSection /> website sessions", () => {
       .mockRejectedValueOnce(new Error("the main process went away"));
     renderSection(controller({}), {
       kind: "sites",
-      sites: [savedSite("example.com")],
+      sites: [savedSite("example.com", null)],
     });
     const manager = openManager();
     const remove = () =>
@@ -449,7 +455,7 @@ describe("<BrowserSettingsSection /> website sessions", () => {
     browserViewState.current = bridge;
     renderSection(controller({}), {
       kind: "sites",
-      sites: [savedSite("example.com"), savedSite("example.org")],
+      sites: [savedSite("example.com", null), savedSite("example.org", null)],
     });
     const manager = openManager();
 
@@ -485,7 +491,7 @@ describe("<BrowserSettingsSection /> website sessions", () => {
   it("keeps previews manageable while saving is paused and disables import with a reason", () => {
     renderSection(controller({ enabled: false }), {
       kind: "sites",
-      sites: [savedSite("example.com"), savedSite("example.org")],
+      sites: [savedSite("example.com", null), savedSite("example.org", null)],
     });
 
     expect(screen.getByText("example.com")).not.toBeNull();

--- a/clients/gui-app/src/components/settings/__tests__/browser-settings-section.test.tsx
+++ b/clients/gui-app/src/components/settings/__tests__/browser-settings-section.test.tsx
@@ -6,6 +6,7 @@ import {
   render,
   screen,
   waitFor,
+  within,
 } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { BrowserSettingsSection } from "@/components/settings/browser-settings-section";
@@ -18,91 +19,24 @@ import type {
   BrowserSavedLoginSitesResponse,
 } from "@traycer/protocol/host/browser/contracts";
 
-/**
- * Settings > Browser's saved-logins group. Saving is silent and on by
- * default, Chrome-style, so what is worth pinning here is what the surface
- * still promises: the toggle reflects the machine's answer, turning it off
- * goes behind a destructive confirm, forgetting everything asks first, and
- * the site list carries names and nothing else.
- */
-
 const saveLogins = vi.hoisted((): { current: BrowserSaveLoginsController } => ({
   current: { enabled: true, pending: false, setEnabled: () => undefined },
 }));
-/**
- * A row exactly as a host that PREDATES `contributedByHostId` delivers it: the
- * field is absent, not null. The same-minor RPC path hands the payload back
- * unparsed, so the schema's `.default(null)` never runs on it - which is why
- * the surface has to survive the field being `undefined` at runtime.
- */
-type PreFieldSavedLoginSite = Omit<
-  BrowserSavedLoginSite,
-  "contributedByHostId"
->;
-
-/** What the query hands the section, older hosts included. */
-type SavedLoginSitesAnswer =
-  | Extract<BrowserSavedLoginSitesResponse, { kind: "sealed" }>
-  | {
-      readonly kind: "sites";
-      readonly sites: readonly (
-        | BrowserSavedLoginSite
-        | PreFieldSavedLoginSite
-      )[];
-    };
-
-const sites = vi.hoisted((): { current: SavedLoginSitesAnswer | null } => ({
-  current: null,
-}));
-const refetch = vi.hoisted(() => vi.fn());
-/**
- * The host directory the provenance line (ticket 06) resolves names through.
- * Only the SOURCE is faked here: `useHostDirectoryEntry` and
- * `useReactiveLocalHostId` are the real hooks, so a row renders exactly what
- * the app's own host-naming would give it.
- */
-const hostDirectory = vi.hoisted(
-  (): {
-    localHostId: string | null;
-    /** A host with no entry is one this client cannot currently list. */
-    labels: Record<string, string | undefined>;
-  } => ({
-    localHostId: null,
-    labels: {},
-  }),
+const sites = vi.hoisted(
+  (): { current: BrowserSavedLoginSitesResponse | null } => ({ current: null }),
 );
-/** Whatever a host runtime IS here - the group only asks whether one exists. */
+const queryState = vi.hoisted(() => ({ isLoading: false, isError: false }));
+const refetch = vi.hoisted(() => vi.fn());
 const hostBinding = vi.hoisted((): { current: object | null } => ({
   current: null,
 }));
-/**
- * The bridge itself, not a stand-in for the renderer helper that calls it:
- * both destructive actions are confirmed AND fanned out in main, and what is
- * worth pinning is that the surface asks main and believes main's answer.
- * Booleans, because that is the contract both methods declare.
- */
 const browserView = vi.hoisted(() => ({
   forgetLogins: vi.fn(() => Promise.resolve(true)),
   clearSavedLoginSite: vi.fn((_domain: string) => Promise.resolve(true)),
 }));
-/**
- * What `useRunnerHostOrNull` hands the section: the stub above for most of the
- * suite, and a real `FakeBrowserViewBridge` for the import-row tests that open
- * `<ImportLoginsDialog />`, whose four login-import calls the stub does not
- * answer.
- */
 const browserViewState = vi.hoisted((): { current: object } => ({
   current: {},
 }));
-
-function boundHostRuntime(): object {
-  return {
-    directory: {
-      getLocalHostId: () => hostDirectory.localHostId,
-      onChange: () => ({ dispose: () => undefined }),
-    },
-  };
-}
 
 vi.mock("@/providers/use-runner-host", () => ({
   useRunnerHostOrNull: () => ({ browserView: browserViewState.current }),
@@ -110,22 +44,6 @@ vi.mock("@/providers/use-runner-host", () => ({
 
 vi.mock("@/lib/host", () => ({
   useHostBinding: () => hostBinding.current,
-  useHostDirectory: () => ({
-    findById: (hostId: string) => {
-      const label = hostDirectory.labels[hostId];
-      return label === undefined
-        ? null
-        : {
-            hostId,
-            label,
-            kind: "remote",
-            websocketUrl: null,
-            version: null,
-            transportDialability: "dialable",
-          };
-    },
-    onChange: () => ({ dispose: () => undefined }),
-  }),
 }));
 
 vi.mock("@/lib/browser-view/use-browser-save-logins", () => ({
@@ -134,12 +52,14 @@ vi.mock("@/lib/browser-view/use-browser-save-logins", () => ({
 
 vi.mock("@/hooks/browser/use-browser-saved-login-sites-query", () => ({
   BROWSER_SAVED_LOGIN_SITES_METHOD: "browser.savedLoginSites",
-  useBrowserSavedLoginSitesQuery: () => ({ data: sites.current, refetch }),
+  useBrowserSavedLoginSitesQuery: () => ({
+    data: sites.current,
+    isLoading: queryState.isLoading,
+    isError: queryState.isError,
+    refetch,
+  }),
 }));
 
-// The import dialog's run mutation resolves the surface host to invalidate
-// the saved-sites list on success; the binding stub above has no client to
-// resolve through, and this suite asserts only that the dialog opens.
 vi.mock("@/hooks/host/use-addressable-host-id", () => ({
   useAddressableHostId: () => "host-1",
 }));
@@ -155,21 +75,20 @@ function controller(
   };
 }
 
-/** A row nobody but this desktop contributed - the ordinary case. */
 function savedSite(domain: string): BrowserSavedLoginSite {
   return { domain, lastSeen: Date.now(), contributedByHostId: null };
 }
 
 function renderSection(
   current: BrowserSaveLoginsController,
-  data: SavedLoginSitesAnswer | null,
-): void {
+  data: BrowserSavedLoginSitesResponse | null,
+) {
   saveLogins.current = current;
   sites.current = data;
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
-  render(
+  return render(
     <QueryClientProvider client={client}>
       <BrowserSettingsSection />
     </QueryClientProvider>,
@@ -177,15 +96,22 @@ function renderSection(
 }
 
 function toggle(): HTMLElement {
-  return screen.getByRole("switch", { name: "Save website logins" });
+  return screen.getByRole("switch", {
+    name: "Save website sessions on this computer",
+  });
 }
 
-describe("<BrowserSettingsSection /> saved logins", () => {
+function openManager(): HTMLElement {
+  fireEvent.click(
+    screen.getByRole("button", { name: /^(View all|Manage all)/ }),
+  );
+  return screen.getByRole("dialog", { name: "Saved website sessions" });
+}
+
+describe("<BrowserSettingsSection /> website sessions", () => {
   beforeEach(() => {
     browserViewState.current = browserView;
-    hostBinding.current = boundHostRuntime();
-    hostDirectory.localHostId = null;
-    hostDirectory.labels = {};
+    hostBinding.current = {};
   });
 
   afterEach(() => {
@@ -193,24 +119,28 @@ describe("<BrowserSettingsSection /> saved logins", () => {
     browserView.forgetLogins.mockClear();
     browserView.clearSavedLoginSite.mockClear();
     refetch.mockClear();
+    sites.current = null;
+    queryState.isLoading = false;
+    queryState.isError = false;
     hostBinding.current = {};
+    useBrowserFocusStore.setState({ openImportLogins: false });
     useSettingsStore.setState({ browserDevOrigins: [] });
   });
 
-  it("reflects the machine's decision", () => {
+  it("reflects the computer's saving decision", () => {
     renderSection(controller({ enabled: true }), null);
 
     expect(toggle().getAttribute("data-state")).toBe("checked");
   });
 
-  it("renders nothing until the bridge has answered", () => {
+  it("renders nothing until the browser bridge has answered", () => {
     renderSection(controller({ enabled: null }), null);
 
-    expect(screen.queryByText("Saved logins")).toBeNull();
+    expect(screen.queryByText("Website sessions")).toBeNull();
     expect(screen.queryByRole("switch")).toBeNull();
   });
 
-  it("turns saving on immediately, with no confirm", () => {
+  it("turns saving on immediately", () => {
     const current = controller({ enabled: false });
     renderSection(current, null);
 
@@ -219,20 +149,20 @@ describe("<BrowserSettingsSection /> saved logins", () => {
     expect(current.setEnabled).toHaveBeenCalledExactlyOnceWith(true);
   });
 
-  it("turns saving off only after the destructive confirm", () => {
+  it("turns saving off only after confirmation", () => {
     const current = controller({ enabled: true });
     renderSection(current, null);
 
     fireEvent.click(toggle());
     expect(current.setEnabled).not.toHaveBeenCalled();
-    expect(screen.getByText("Stop saving website logins?")).not.toBeNull();
+    expect(screen.getByText("Stop saving website sessions?")).not.toBeNull();
 
     fireEvent.click(screen.getByTestId("confirm-action"));
 
     expect(current.setEnabled).toHaveBeenCalledExactlyOnceWith(false);
   });
 
-  it("does not turn off when the confirm is cancelled", () => {
+  it("does not turn saving off when confirmation is cancelled", () => {
     const current = controller({ enabled: true });
     renderSection(current, null);
 
@@ -242,312 +172,263 @@ describe("<BrowserSettingsSection /> saved logins", () => {
     expect(current.setEnabled).not.toHaveBeenCalled();
   });
 
-  it("asks the main process directly, with no renderer confirmation of its own", () => {
-    renderSection(controller({}), null);
-
-    fireEvent.click(
-      screen.getByRole("button", { name: "Forget all browser logins…" }),
-    );
-
-    // Main raises a native dialog and is the authority on the answer (browser
-    // security review, root cause C). A second confirmation here would ask
-    // twice and, worse, would read as the gate while the real one is
-    // elsewhere - so the click goes straight through and no dialog opens.
-    expect(browserView.forgetLogins).toHaveBeenCalledTimes(1);
-    expect(screen.queryByTestId("confirm-action")).toBeNull();
-  });
-
-  it("renders nothing at all without a host runtime", () => {
+  it("renders no website-session group without a host runtime", () => {
     hostBinding.current = null;
-    // Seeded so the dev-origins group has a row: it is all that is left of the
-    // Browser group now that link and agent-tab controls live in Settings >
-    // Opening behavior.
     useSettingsStore.setState({ browserDevOrigins: ["http://localhost:5173"] });
     renderSection(controller({ enabled: true }), {
       kind: "sites",
       sites: [savedSite("example.com")],
     });
 
-    // The whole group goes, not just the list: with no host to answer, both
-    // destructive actions would reach nobody.
-    expect(screen.queryByText("Saved logins")).toBeNull();
+    expect(screen.queryByText("Website sessions")).toBeNull();
     expect(screen.queryByRole("switch")).toBeNull();
-    expect(
-      screen.queryByRole("button", { name: "Forget all browser logins…" }),
-    ).toBeNull();
-    // The rest of the Browser section is unaffected.
     expect(screen.getByText("Detected dev origins")).not.toBeNull();
   });
 
-  it("lists site names and last-seen times, and never a value", () => {
+  it("shows three alphabetical previews and discloses the exact remainder", () => {
+    renderSection(controller({}), {
+      kind: "sites",
+      sites: [
+        savedSite("zulu.example"),
+        savedSite("beta.example"),
+        savedSite("alpha.example"),
+        savedSite("echo.example"),
+        savedSite("delta.example"),
+      ],
+    });
+
+    const preview = screen.getByRole("list", {
+      name: "First three saved sites",
+    });
+    expect(
+      within(preview)
+        .getAllByRole("listitem")
+        .map((row) => row.textContent),
+    ).toEqual(["alpha.example", "beta.example", "delta.example"]);
+    expect(screen.queryByText("echo.example")).toBeNull();
+    expect(
+      screen.getByRole("button", { name: "View all 2 more sites" }),
+    ).not.toBeNull();
+    expect(screen.queryByText("Just now")).toBeNull();
+
+    const manager = openManager();
+    expect(
+      within(manager)
+        .getAllByRole("listitem")
+        .map((row) => row.textContent.replace("Remove", "")),
+    ).toEqual([
+      "alpha.example",
+      "beta.example",
+      "delta.example",
+      "echo.example",
+      "zulu.example",
+    ]);
+  });
+
+  it("searches the side sheet and distinguishes an empty search", () => {
+    renderSection(controller({}), {
+      kind: "sites",
+      sites: [savedSite("alpha.example"), savedSite("beta.example")],
+    });
+    const manager = openManager();
+    const search = within(manager).getByLabelText("Search saved sites");
+
+    fireEvent.change(search, { target: { value: "missing" } });
+
+    expect(within(manager).getByText("0 of 2 sites")).not.toBeNull();
+    expect(within(manager).getByText("No matching sites")).not.toBeNull();
+    expect(
+      within(manager).queryByRole("button", { name: "Choose source…" }),
+    ).toBeNull();
+
+    fireEvent.click(
+      within(manager).getByRole("button", { name: "Clear search" }),
+    );
+    expect(within(manager).getByText("2 sites")).not.toBeNull();
+  });
+
+  it("keeps a sealed collection distinct from an empty one", () => {
+    renderSection(controller({}), { kind: "sealed" });
+
+    expect(screen.getByText("Locked")).not.toBeNull();
+    expect(
+      screen.getByText(/Connect this desktop to unlock saved website sessions/),
+    ).not.toBeNull();
+    expect(screen.queryByText("0 sites")).toBeNull();
+  });
+
+  it("shows loading and recoverable failure states", () => {
+    queryState.isLoading = true;
+    const view = renderSection(controller({}), null);
+    expect(screen.getByText("Loading…")).not.toBeNull();
+
+    queryState.isLoading = false;
+    queryState.isError = true;
+    view.rerender(<BrowserSettingsSection />);
+    expect(screen.getByText("Unavailable")).not.toBeNull();
+    expect(screen.getByRole("button", { name: "Try again" })).not.toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows a genuine empty collection without an unnecessary disclosure", () => {
+    renderSection(controller({}), { kind: "sites", sites: [] });
+
+    expect(screen.getByText("0 sites")).not.toBeNull();
+    expect(
+      screen.queryByRole("list", { name: "First three saved sites" }),
+    ).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: /^(View all|Manage all)/ }),
+    ).toBeNull();
+  });
+
+  it("removes one site only after main confirms", async () => {
     renderSection(controller({}), {
       kind: "sites",
       sites: [savedSite("example.com"), savedSite("example.org")],
     });
+    const manager = openManager();
 
-    expect(screen.getByText("example.com")).not.toBeNull();
-    expect(screen.getByText("example.org")).not.toBeNull();
-    expect(screen.getAllByText("Just now")).toHaveLength(2);
-    // A row is a site, a time, and (ticket 06) which machine contributed it.
-    // Nothing on that wire shape can carry a cookie value.
+    fireEvent.click(
+      within(manager).getByRole("button", {
+        name: "Remove saved website session for example.com",
+      }),
+    );
+
+    expect(browserView.clearSavedLoginSite).toHaveBeenCalledWith("example.com");
+    await waitFor(() => {
+      expect(refetch).toHaveBeenCalledTimes(1);
+    });
+    expect(screen.queryByText("example.com")).toBeNull();
+    expect(screen.getAllByText("example.org").length).toBeGreaterThan(0);
   });
 
-  it("says a sealed host is locked, not empty", () => {
-    renderSection(controller({}), { kind: "sealed" });
-
-    // Substring: the sealed line also states the keystore reason (H03), and a
-    // machine whose keystore does not encrypt lands in exactly this state.
-    expect(
-      screen.getByText(/Connect this desktop to unlock saved logins\./),
-    ).not.toBeNull();
-    expect(
-      screen.getByText(/Traycer will not encrypt them here/),
-    ).not.toBeNull();
-    expect(screen.queryByText("No saved logins yet.")).toBeNull();
-  });
-
-  it("says so when the jar is genuinely empty", () => {
-    renderSection(controller({}), { kind: "sites", sites: [] });
-
-    expect(screen.getByText("No saved logins yet.")).not.toBeNull();
-  });
-
-  it("holds the cleared row through the pre-merge window, then releases it", async () => {
-    const bothSites: SavedLoginSitesAnswer = {
+  it("holds an optimistic removal through a stale reply, then releases it", async () => {
+    const bothSites: BrowserSavedLoginSitesResponse = {
       kind: "sites",
       sites: [savedSite("example.com"), savedSite("example.org")],
     };
     saveLogins.current = controller({});
     sites.current = bothSites;
     const view = render(<BrowserSettingsSection />);
+    const manager = openManager();
 
     fireEvent.click(
-      screen.getByRole("button", {
-        name: "Clear saved logins for example.com",
+      within(manager).getByRole("button", {
+        name: "Remove saved website session for example.com",
       }),
     );
     await waitFor(() => {
       expect(screen.queryByText("example.com")).toBeNull();
     });
 
-    // The host merges asynchronously, so the answer behind the click can still
-    // name the site. The row stays hidden - that is what the optimism is for.
     view.rerender(<BrowserSettingsSection />);
     expect(screen.queryByText("example.com")).toBeNull();
 
-    // The merge lands and the host drops it.
     sites.current = {
       kind: "sites",
       sites: [savedSite("example.org")],
     };
     view.rerender(<BrowserSettingsSection />);
-    expect(screen.queryByText("example.com")).toBeNull();
-
-    // The user signs into that site again. The row has to come back: before
-    // this it stayed hidden for the rest of the session.
     sites.current = bothSites;
     view.rerender(<BrowserSettingsSection />);
-    expect(screen.getByText("example.com")).not.toBeNull();
+
+    expect(screen.getAllByText("example.com").length).toBeGreaterThan(0);
   });
 
-  it("sends clearSite for one row, and hides it once main confirms", async () => {
+  it("leaves a site in place when main declines or rejects", async () => {
+    browserView.clearSavedLoginSite
+      .mockResolvedValueOnce(false)
+      .mockRejectedValueOnce(new Error("the main process went away"));
     renderSection(controller({}), {
       kind: "sites",
-      sites: [savedSite("example.com"), savedSite("example.org")],
+      sites: [savedSite("example.com")],
     });
+    const manager = openManager();
+    const remove = () =>
+      within(manager).getByRole("button", {
+        name: "Remove saved website session for example.com",
+      });
 
-    fireEvent.click(
-      screen.getByRole("button", {
-        name: "Clear saved logins for example.com",
-      }),
-    );
-
-    expect(browserView.clearSavedLoginSite).toHaveBeenCalledWith("example.com");
-
+    fireEvent.click(remove());
     await waitFor(() => {
-      expect(refetch).toHaveBeenCalledTimes(1);
+      expect(browserView.clearSavedLoginSite).toHaveBeenCalledTimes(1);
     });
-    // The row goes once main confirms: the host merges asynchronously, so the
-    // refetch behind this click can still read the pre-clear slice.
-    expect(screen.queryByText("example.com")).toBeNull();
-    expect(screen.queryByText("example.org")).not.toBeNull();
-  });
+    expect(remove()).not.toBeNull();
 
-  it("leaves the row in place when main declines the confirmation", async () => {
-    browserView.clearSavedLoginSite.mockResolvedValueOnce(false);
-    renderSection(controller({}), {
-      kind: "sites",
-      sites: [savedSite("example.com"), savedSite("example.org")],
-    });
-
-    fireEvent.click(
-      screen.getByRole("button", {
-        name: "Clear saved logins for example.com",
-      }),
-    );
-
+    fireEvent.click(remove());
     await waitFor(() => {
-      expect(browserView.clearSavedLoginSite).toHaveBeenCalledWith(
-        "example.com",
-      );
+      expect(browserView.clearSavedLoginSite).toHaveBeenCalledTimes(2);
     });
+    expect(remove()).not.toBeNull();
     expect(refetch).not.toHaveBeenCalled();
-    expect(screen.getByText("example.com")).not.toBeNull();
   });
 
-  it("leaves the row in place when the confirmation IPC rejects", async () => {
-    // A rejected invoke is not a confirmation, and a click handler is no place
-    // for it to escape from: main told nobody, so the row must stay.
-    browserView.clearSavedLoginSite.mockRejectedValueOnce(
-      new Error("the main process went away"),
-    );
+  it("keeps the sheet open on remove all and reveals the import next step", async () => {
+    const bridge = new FakeBrowserViewBridge();
+    const forgetLogins = vi.spyOn(bridge, "forgetLogins");
+    browserViewState.current = bridge;
     renderSection(controller({}), {
       kind: "sites",
       sites: [savedSite("example.com"), savedSite("example.org")],
     });
+    const manager = openManager();
 
     fireEvent.click(
-      screen.getByRole("button", {
-        name: "Clear saved logins for example.com",
-      }),
+      within(manager).getByRole("button", { name: "Remove all…" }),
     );
 
+    expect(forgetLogins).toHaveBeenCalledTimes(1);
+    expect(screen.queryByTestId("confirm-action")).toBeNull();
     await waitFor(() => {
-      expect(browserView.clearSavedLoginSite).toHaveBeenCalledWith(
-        "example.com",
-      );
+      expect(
+        within(manager).getByText("No saved website sessions"),
+      ).not.toBeNull();
     });
-    expect(refetch).not.toHaveBeenCalled();
+    expect(
+      within(manager).getByRole("button", { name: "Choose source…" }),
+    ).not.toBeNull();
+    expect(
+      within(manager).getByRole("button", { name: "Done" }),
+    ).not.toBeNull();
+
+    fireEvent.click(
+      within(manager).getByRole("button", { name: "Choose source…" }),
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("import-logins-dialog")).not.toBeNull();
+    });
+    expect(
+      screen.queryByRole("dialog", { name: "Saved website sessions" }),
+    ).toBeNull();
+  });
+
+  it("keeps previews manageable while saving is paused and disables import with a reason", () => {
+    renderSection(controller({ enabled: false }), {
+      kind: "sites",
+      sites: [savedSite("example.com"), savedSite("example.org")],
+    });
+
     expect(screen.getByText("example.com")).not.toBeNull();
-  });
-
-  /**
-   * Provenance (universal-sign-in decision 9). One muted line, and only where
-   * it tells the person something they could not already assume: a login some
-   * OTHER machine of theirs signed into.
-   */
-  describe("attribution", () => {
-    /** Any line the provenance copy could produce. */
-    const ATTRIBUTION_LINE = /^Includes a sign-in from/;
-
-    function contributed(
-      domain: string,
-      hostId: string | null,
-    ): BrowserSavedLoginSite {
-      return { domain, lastSeen: Date.now(), contributedByHostId: hostId };
-    }
-
-    it("names the machine a remote host contributed a sign-in from", () => {
-      hostDirectory.localHostId = "host-here";
-      hostDirectory.labels = { "host-there": "Studio Mac" };
-      renderSection(controller({}), {
-        kind: "sites",
-        sites: [contributed("example.com", "host-there")],
-      });
-
-      expect(
-        screen.getByText("Includes a sign-in from Studio Mac"),
-      ).not.toBeNull();
-    });
-
-    it("says nothing about a login this machine's own host contributed", () => {
-      hostDirectory.localHostId = "host-here";
-      hostDirectory.labels = { "host-here": "This Mac" };
-      renderSection(controller({}), {
-        kind: "sites",
-        sites: [contributed("example.com", "host-here")],
-      });
-
-      // The user signed in here. Naming their own machine on the row would be
-      // noise around the lines that mean "this came from somewhere else".
-      expect(screen.getByText("example.com")).not.toBeNull();
-      expect(screen.queryByText(ATTRIBUTION_LINE)).toBeNull();
-    });
-
-    it("says nothing when the answer attributes nobody", () => {
-      hostDirectory.localHostId = "host-here";
-      renderSection(controller({}), {
-        kind: "sites",
-        sites: [savedSite("example.com")],
-      });
-
-      expect(screen.queryByText(ATTRIBUTION_LINE)).toBeNull();
-    });
-
-    it("says nothing for a field an older host never sent", () => {
-      hostDirectory.localHostId = "host-here";
-      const preField: PreFieldSavedLoginSite = {
-        domain: "example.com",
-        lastSeen: Date.now(),
-      };
-      renderSection(controller({}), { kind: "sites", sites: [preField] });
-
-      // `undefined`, not `null`: the same-minor RPC path returns the host's
-      // payload unparsed, so the schema default never runs. A `!== null` guard
-      // passes it straight through and renders a dangling line naming nobody.
-      expect(screen.getByText("example.com")).not.toBeNull();
-      expect(screen.queryByText(ATTRIBUTION_LINE)).toBeNull();
-    });
-
-    it("attributes every marked row where there is no local machine at all", () => {
-      // Web and mobile shells: `useReactiveLocalHostId` answers null because
-      // there is genuinely no local host here, so nothing a host contributed
-      // is "mine" and every marked row keeps its line.
-      hostDirectory.localHostId = null;
-      hostDirectory.labels = { "host-there": "Studio Mac" };
-      renderSection(controller({}), {
-        kind: "sites",
-        sites: [contributed("example.com", "host-there")],
-      });
-
-      expect(
-        screen.getByText("Includes a sign-in from Studio Mac"),
-      ).not.toBeNull();
-    });
-
-    it("falls back to the canonical id for a host it cannot name", () => {
-      hostDirectory.localHostId = "host-here";
-      renderSection(controller({}), {
-        kind: "sites",
-        sites: [contributed("example.com", "host-there")],
-      });
-
-      // No directory row for it, so there is no display name to resolve. The
-      // id is what the app's own naming falls back to; inventing "another
-      // machine" would claim more than is known.
-      expect(
-        screen.getByText("Includes a sign-in from host-there"),
-      ).not.toBeNull();
-    });
-  });
-
-  it("disables the import row with the correct inline hint when saved logins is off", () => {
-    renderSection(controller({ enabled: false }), null);
-
-    const importButton = screen.getByRole("button", {
-      name: "Import logins…",
-    });
+    expect(
+      screen.getByText(
+        "Saving is paused on this computer. Existing sessions stay available to manage.",
+      ),
+    ).not.toBeNull();
+    const importButton = screen.getByRole("button", { name: "Choose source…" });
     expect(importButton.hasAttribute("disabled")).toBe(true);
     expect(
-      screen.getByText("Turn on Save website logins first."),
+      screen.getByText("Turn on Save website sessions first."),
     ).not.toBeNull();
   });
 
-  it("does not show the off hint, and leaves the import row enabled, when saved logins is on", () => {
-    renderSection(controller({ enabled: true }), null);
-
-    const importButton = screen.getByRole("button", {
-      name: "Import logins…",
-    });
-    expect(importButton.hasAttribute("disabled")).toBe(false);
-    expect(screen.queryByText("Turn on Save website logins first.")).toBeNull();
-  });
-
-  it("opens the import dialog when saved logins is on and a browserView bridge exists", async () => {
+  it("opens the existing import flow from the outcome-led row", async () => {
     browserViewState.current = new FakeBrowserViewBridge();
     renderSection(controller({ enabled: true }), null);
 
-    fireEvent.click(screen.getByRole("button", { name: "Import logins…" }));
+    fireEvent.click(screen.getByRole("button", { name: "Choose source…" }));
 
     await waitFor(() => {
       expect(screen.getByTestId("import-logins-dialog")).not.toBeNull();
@@ -559,12 +440,8 @@ describe("<BrowserSettingsSection /> saved logins", () => {
     ).not.toBeNull();
   });
 
-  describe("the import intent (browser-focus-store)", () => {
-    afterEach(() => {
-      useBrowserFocusStore.setState({ openImportLogins: false });
-    });
-
-    it("an armed intent opens the dialog on mount without a click", async () => {
+  describe("the import intent", () => {
+    it("opens the import flow on mount without a click", async () => {
       browserViewState.current = new FakeBrowserViewBridge();
       useBrowserFocusStore.getState().requestImportLogins();
 
@@ -575,27 +452,23 @@ describe("<BrowserSettingsSection /> saved logins", () => {
       });
     });
 
-    it("closing consumes the intent, so it stays closed on a remount", async () => {
+    it("consumes the intent when the dialog closes", async () => {
       browserViewState.current = new FakeBrowserViewBridge();
       useBrowserFocusStore.getState().requestImportLogins();
-
       renderSection(controller({ enabled: true }), null);
       await waitFor(() => {
         expect(screen.getByTestId("import-logins-dialog")).not.toBeNull();
       });
 
       fireEvent.keyDown(document, { key: "Escape" });
+
       await waitFor(() => {
         expect(screen.queryByTestId("import-logins-dialog")).toBeNull();
       });
       expect(useBrowserFocusStore.getState().openImportLogins).toBe(false);
-
-      cleanup();
-      renderSection(controller({ enabled: true }), null);
-      expect(screen.queryByTestId("import-logins-dialog")).toBeNull();
     });
 
-    it("an intent armed with saving off opens nothing and still consumes it", async () => {
+    it("drops an intent while session saving is off", async () => {
       browserViewState.current = new FakeBrowserViewBridge({
         saveLogins: false,
       });

--- a/clients/gui-app/src/components/settings/__tests__/browser-settings-section.test.tsx
+++ b/clients/gui-app/src/components/settings/__tests__/browser-settings-section.test.tsx
@@ -19,14 +19,34 @@ import type {
   BrowserSavedLoginSitesResponse,
 } from "@traycer/protocol/host/browser/contracts";
 
+type PreFieldSavedLoginSite = Omit<
+  BrowserSavedLoginSite,
+  "contributedByHostId"
+>;
+type SavedLoginSitesAnswer =
+  | Extract<BrowserSavedLoginSitesResponse, { kind: "sealed" }>
+  | {
+      readonly kind: "sites";
+      readonly sites: readonly (
+        | BrowserSavedLoginSite
+        | PreFieldSavedLoginSite
+      )[];
+    };
+
 const saveLogins = vi.hoisted((): { current: BrowserSaveLoginsController } => ({
   current: { enabled: true, pending: false, setEnabled: () => undefined },
 }));
-const sites = vi.hoisted(
-  (): { current: BrowserSavedLoginSitesResponse | null } => ({ current: null }),
-);
+const sites = vi.hoisted((): { current: SavedLoginSitesAnswer | null } => ({
+  current: null,
+}));
 const queryState = vi.hoisted(() => ({ isLoading: false, isError: false }));
 const refetch = vi.hoisted(() => vi.fn());
+const hostDirectory = vi.hoisted(
+  (): {
+    localHostId: string | null;
+    labels: Record<string, string | undefined>;
+  } => ({ localHostId: null, labels: {} }),
+);
 const hostBinding = vi.hoisted((): { current: object | null } => ({
   current: null,
 }));
@@ -60,6 +80,18 @@ vi.mock("@/hooks/browser/use-browser-saved-login-sites-query", () => ({
   }),
 }));
 
+vi.mock("@/hooks/host/use-reactive-local-host-id", () => ({
+  useReactiveLocalHostId: () => hostDirectory.localHostId,
+}));
+
+vi.mock("@/hooks/host/use-host-directory-entry", () => ({
+  useHostDirectoryEntry: (hostId: string | null) => {
+    if (hostId === null) return null;
+    const label = hostDirectory.labels[hostId];
+    return label === undefined ? null : { label };
+  },
+}));
+
 vi.mock("@/hooks/host/use-addressable-host-id", () => ({
   useAddressableHostId: () => "host-1",
 }));
@@ -75,13 +107,16 @@ function controller(
   };
 }
 
-function savedSite(domain: string): BrowserSavedLoginSite {
-  return { domain, lastSeen: Date.now(), contributedByHostId: null };
+function savedSite(
+  domain: string,
+  contributedByHostId: string | null = null,
+): BrowserSavedLoginSite {
+  return { domain, lastSeen: Date.now(), contributedByHostId };
 }
 
 function renderSection(
   current: BrowserSaveLoginsController,
-  data: BrowserSavedLoginSitesResponse | null,
+  data: SavedLoginSitesAnswer | null,
 ) {
   saveLogins.current = current;
   sites.current = data;
@@ -122,6 +157,8 @@ describe("<BrowserSettingsSection /> website sessions", () => {
     sites.current = null;
     queryState.isLoading = false;
     queryState.isError = false;
+    hostDirectory.localHostId = null;
+    hostDirectory.labels = {};
     hostBinding.current = {};
     useBrowserFocusStore.setState({ openImportLogins: false });
     useSettingsStore.setState({ browserDevOrigins: [] });
@@ -247,7 +284,7 @@ describe("<BrowserSettingsSection /> website sessions", () => {
     expect(within(manager).getByText("2 sites")).not.toBeNull();
   });
 
-  it("keeps a sealed collection distinct from an empty one", () => {
+  it("keeps remove-all available when the collection is sealed", async () => {
     renderSection(controller({}), { kind: "sealed" });
 
     expect(screen.getByText("Locked")).not.toBeNull();
@@ -255,6 +292,46 @@ describe("<BrowserSettingsSection /> website sessions", () => {
       screen.getByText(/Connect this desktop to unlock saved website sessions/),
     ).not.toBeNull();
     expect(screen.queryByText("0 sites")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove all…" }));
+    await waitFor(() => {
+      expect(browserView.forgetLogins).toHaveBeenCalledTimes(1);
+      expect(refetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("keeps remote-host attribution in both previews and manager rows", () => {
+    hostDirectory.localHostId = "host-here";
+    hostDirectory.labels = {
+      "host-here": "This Mac",
+      "host-there": "Studio Mac",
+    };
+    const preFieldSite: PreFieldSavedLoginSite = {
+      domain: "legacy.example",
+      lastSeen: Date.now(),
+    };
+    renderSection(controller({}), {
+      kind: "sites",
+      sites: [
+        savedSite("remote.example", "host-there"),
+        savedSite("local.example", "host-here"),
+        preFieldSite,
+      ],
+    });
+
+    const preview = screen.getByRole("list", {
+      name: "First three saved sites",
+    });
+    expect(
+      within(preview).getByText("Includes a sign-in from Studio Mac"),
+    ).not.toBeNull();
+    expect(within(preview).queryByText(/This Mac/)).toBeNull();
+
+    const manager = openManager();
+    expect(
+      within(manager).getByText("Includes a sign-in from Studio Mac"),
+    ).not.toBeNull();
+    expect(within(manager).queryByText("Includes a sign-in from")).toBeNull();
   });
 
   it("shows loading and recoverable failure states", () => {

--- a/clients/gui-app/src/components/settings/browser-settings-section.tsx
+++ b/clients/gui-app/src/components/settings/browser-settings-section.tsx
@@ -30,6 +30,8 @@ import {
   type BrowserSaveLoginsController,
 } from "@/lib/browser-view/use-browser-save-logins";
 import { useBrowserSavedLoginSitesQuery } from "@/hooks/browser/use-browser-saved-login-sites-query";
+import { useHostDirectoryEntry } from "@/hooks/host/use-host-directory-entry";
+import { useReactiveLocalHostId } from "@/hooks/host/use-reactive-local-host-id";
 import { useHostBinding } from "@/lib/host";
 import { useRunnerHostOrNull } from "@/providers/use-runner-host";
 import { appLogger } from "@/lib/logger";
@@ -341,6 +343,20 @@ function SavedWebsiteSessionsRow(props: {
     sites.some((site) => site.domain === domain),
   );
   if (activeCleared.length !== cleared.length) setCleared(activeCleared);
+
+  const removeAll = async (): Promise<boolean> => {
+    const confirmed = await confirmedByMain(
+      props.browserView.forgetLogins(),
+      "[browser] clearing the browser partition failed",
+    );
+    if (!confirmed) return false;
+    setCleared((current) => [
+      ...new Set([...current, ...sites.map((site) => site.domain)]),
+    ]);
+    props.onRefresh();
+    return true;
+  };
+
   if (data === null) {
     if (props.loading) {
       return (
@@ -348,6 +364,7 @@ function SavedWebsiteSessionsRow(props: {
           status="Loading…"
           message={null}
           onRetry={null}
+          onRemoveAll={null}
         />
       );
     }
@@ -357,6 +374,7 @@ function SavedWebsiteSessionsRow(props: {
           status="Unavailable"
           message="Unable to load saved website sessions. Check the host connection and try again."
           onRetry={props.onRefresh}
+          onRemoveAll={null}
         />
       );
     }
@@ -365,6 +383,7 @@ function SavedWebsiteSessionsRow(props: {
         status="Unavailable"
         message="Update the connected Traycer host to view and manage saved website sessions."
         onRetry={null}
+        onRemoveAll={null}
       />
     );
   }
@@ -374,6 +393,7 @@ function SavedWebsiteSessionsRow(props: {
         status="Locked"
         message="Connect this desktop to unlock saved website sessions. If this computer has no system keyring, Traycer cannot encrypt them here, so they stay locked and nothing new is saved."
         onRetry={null}
+        onRemoveAll={removeAll}
       />
     );
   }
@@ -395,19 +415,6 @@ function SavedWebsiteSessionsRow(props: {
     return true;
   };
 
-  const removeAll = async (): Promise<boolean> => {
-    const confirmed = await confirmedByMain(
-      props.browserView.forgetLogins(),
-      "[browser] clearing the browser partition failed",
-    );
-    if (!confirmed) return false;
-    setCleared((current) => [
-      ...new Set([...current, ...sites.map((site) => site.domain)]),
-    ]);
-    props.onRefresh();
-    return true;
-  };
-
   return (
     <SavedWebsiteSessionsManager
       sites={alphabeticalSites}
@@ -424,6 +431,7 @@ function SavedWebsiteSessionsState(props: {
   readonly status: string;
   readonly message: string | null;
   readonly onRetry: (() => void) | null;
+  readonly onRemoveAll: (() => Promise<boolean>) | null;
 }): ReactNode {
   return (
     <div className="border-b border-border/40">
@@ -449,6 +457,19 @@ function SavedWebsiteSessionsState(props: {
               Try again
             </Button>
           )}
+          {props.onRemoveAll === null ? null : (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="text-destructive hover:text-destructive"
+              onClick={() => {
+                void props.onRemoveAll?.();
+              }}
+            >
+              Remove all…
+            </Button>
+          )}
         </div>
       )}
     </div>
@@ -469,6 +490,7 @@ function SavedWebsiteSessionsManager(props: {
   const searchId = useId();
   const searchInputRef = useRef<HTMLInputElement>(null);
   const emptyImportRef = useRef<HTMLButtonElement>(null);
+  const localHostId = useReactiveLocalHostId();
   const preview = props.sites.slice(0, 3);
   const hiddenCount = props.sites.length - preview.length;
   const normalizedQuery = query.trim().toLocaleLowerCase();
@@ -507,12 +529,10 @@ function SavedWebsiteSessionsManager(props: {
                   key={site.domain}
                   className="flex min-w-0 border-b border-border/40 px-5 py-2.5 last:border-b-0"
                 >
-                  <span
-                    className="min-w-0 break-all font-mono text-ui-sm text-foreground"
-                    translate="no"
-                  >
-                    {site.domain}
-                  </span>
+                  <SavedWebsiteSessionDetails
+                    site={site}
+                    localHostId={localHostId}
+                  />
                 </li>
               ))}
             </ul>
@@ -547,7 +567,7 @@ function SavedWebsiteSessionsManager(props: {
             General settings.
           </SheetDescription>
         </SheetHeader>
-        <p className="mx-4 mb-4 rounded-md bg-muted/50 px-3 py-2 text-ui-sm text-muted-foreground">
+        <p className="mx-4 mb-4 rounded-md bg-foreground/8 px-3 py-2 text-ui-sm text-muted-foreground">
           Shared collection · Removing a site may sign you out on connected
           Traycer hosts.
         </p>
@@ -591,12 +611,10 @@ function SavedWebsiteSessionsManager(props: {
                     key={site.domain}
                     className="flex min-w-0 items-center gap-4 border-t border-border/40 px-2 py-2 first:border-t-0"
                   >
-                    <span
-                      className="min-w-0 flex-1 break-all font-mono text-ui-sm text-foreground"
-                      translate="no"
-                    >
-                      {site.domain}
-                    </span>
+                    <SavedWebsiteSessionDetails
+                      site={site}
+                      localHostId={localHostId}
+                    />
                     <Button
                       type="button"
                       variant="ghost"
@@ -704,5 +722,35 @@ function SavedWebsiteSessionsManager(props: {
         </SheetFooter>
       </SheetContent>
     </Sheet>
+  );
+}
+
+function SavedWebsiteSessionDetails(props: {
+  readonly site: BrowserSavedLoginSite;
+  readonly localHostId: string | null;
+}): ReactNode {
+  const contributedByHostId = props.site.contributedByHostId;
+  const remoteHostId =
+    typeof contributedByHostId === "string" &&
+    contributedByHostId !== props.localHostId
+      ? contributedByHostId
+      : null;
+  const entry = useHostDirectoryEntry(remoteHostId);
+  const hostName = entry === null ? remoteHostId : entry.label;
+
+  return (
+    <div className="min-w-0 flex-1">
+      <span
+        className="block min-w-0 break-all font-mono text-ui-sm text-foreground"
+        translate="no"
+      >
+        {props.site.domain}
+      </span>
+      {hostName === null ? null : (
+        <span className="block min-w-0 truncate text-ui-xs text-muted-foreground">
+          Includes a sign-in from {hostName}
+        </span>
+      )}
+    </div>
   );
 }

--- a/clients/gui-app/src/components/settings/browser-settings-section.tsx
+++ b/clients/gui-app/src/components/settings/browser-settings-section.tsx
@@ -1,6 +1,26 @@
-import { useEffect, useState, type ReactNode } from "react";
+import {
+  useEffect,
+  useId,
+  useRef,
+  useState,
+  type ReactNode,
+  type RefObject,
+} from "react";
+import { ArrowRightIcon, SearchIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { ConfirmDestructiveDialog } from "@/components/ui/confirm-destructive-dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
 import { Switch } from "@/components/ui/switch";
 import { ImportLoginsDialog } from "@/components/settings/import-logins-dialog";
 import { SettingsGroup } from "@/components/settings/settings-group";
@@ -10,10 +30,7 @@ import {
   type BrowserSaveLoginsController,
 } from "@/lib/browser-view/use-browser-save-logins";
 import { useBrowserSavedLoginSitesQuery } from "@/hooks/browser/use-browser-saved-login-sites-query";
-import { useHostDirectoryEntry } from "@/hooks/host/use-host-directory-entry";
-import { useReactiveLocalHostId } from "@/hooks/host/use-reactive-local-host-id";
 import { useHostBinding } from "@/lib/host";
-import { formatRelativeTimestamp, useSampledNow } from "@/lib/relative-time";
 import { useRunnerHostOrNull } from "@/providers/use-runner-host";
 import { appLogger } from "@/lib/logger";
 import type { BrowserViewBridge } from "@traycer-clients/shared/platform/browser-view";
@@ -140,33 +157,65 @@ function BrowserSavedLoginsRows(props: {
   readonly saveLogins: BrowserSaveLoginsController;
   readonly enabled: boolean;
 }): ReactNode {
-  // Unconditionally enabled here: this only mounts once the machine has
-  // answered the pref, which is what the gate stood for.
   const sites = useBrowserSavedLoginSitesQuery({ enabled: true });
+  const importTriggerRef = useRef<HTMLButtonElement>(null);
+  const [importOpened, setImportOpened] = useState(false);
+  const requested = useBrowserFocusStore((state) => state.openImportLogins);
+  const consumeImportLogins = useBrowserFocusStore(
+    (state) => state.consumeImportLogins,
+  );
+  const enabled = props.enabled;
+  useEffect(() => {
+    if (requested && !enabled) consumeImportLogins();
+  }, [consumeImportLogins, enabled, requested]);
+  const importOpen = importOpened || (requested && enabled);
+  const setImportOpen = (next: boolean): void => {
+    setImportOpened(next);
+    if (!next && requested) consumeImportLogins();
+  };
+
   return (
-    <SettingsGroup
-      title="Saved logins"
-      tone="default"
-      dataTestId="settings-saved-logins"
-      fill={false}
-    >
-      <SavedLoginsToggleRow
-        saveLogins={props.saveLogins}
-        enabled={props.enabled}
-      />
-      <ImportLoginsRow
-        browserView={props.browserView}
-        enabled={props.enabled}
-      />
-      <ForgetAllLoginsRow browserView={props.browserView} />
-      <SavedLoginSitesRow
-        browserView={props.browserView}
-        data={sites.data ?? null}
-        onCleared={() => {
-          void sites.refetch();
-        }}
-      />
-    </SettingsGroup>
+    <>
+      <SettingsGroup
+        title="Website sessions"
+        tone="default"
+        dataTestId="settings-saved-logins"
+        fill={false}
+      >
+        <SavedLoginsToggleRow
+          saveLogins={props.saveLogins}
+          enabled={props.enabled}
+        />
+        <SavedWebsiteSessionsRow
+          browserView={props.browserView}
+          data={sites.data ?? null}
+          loading={sites.isLoading}
+          failed={sites.isError}
+          enabled={props.enabled}
+          importTriggerRef={importTriggerRef}
+          onImport={() => {
+            setImportOpen(true);
+          }}
+          onRefresh={() => {
+            void sites.refetch();
+          }}
+        />
+        <ImportLoginsRow
+          enabled={props.enabled}
+          triggerRef={importTriggerRef}
+          onOpen={() => {
+            setImportOpen(true);
+          }}
+        />
+      </SettingsGroup>
+      {importOpen ? (
+        <ImportLoginsDialog
+          open={importOpen}
+          onOpenChange={setImportOpen}
+          browserView={props.browserView}
+        />
+      ) : null}
+    </>
   );
 }
 
@@ -184,13 +233,17 @@ function SavedLoginsToggleRow(props: {
   return (
     <>
       <SettingsRow
-        label="Save website logins on this machine"
-        description="Traycer keeps cookies and logins on this machine so agents can reuse the sites you're signed into. Turning this off reloads open browser tabs signed out; the logins already saved stay until you forget them."
+        label="Save website sessions on this computer"
+        description={
+          props.enabled
+            ? "Keep session data from Traycer browser tabs so sites can stay signed in."
+            : "Saving is paused on this computer. Existing sessions stay available to manage."
+        }
         control={
           <Switch
             checked={props.enabled}
             disabled={props.saveLogins.pending}
-            aria-label="Save website logins"
+            aria-label="Save website sessions on this computer"
             onCheckedChange={(next) => {
               if (next) {
                 props.saveLogins.setEnabled(true);
@@ -204,8 +257,8 @@ function SavedLoginsToggleRow(props: {
       <ConfirmDestructiveDialog
         open={confirming}
         onOpenChange={setConfirming}
-        title="Stop saving website logins?"
-        description="Open browser tabs reload signed out and nothing new is saved on this machine. The logins already saved are kept - use Forget all browser logins to delete them."
+        title="Stop saving website sessions?"
+        description="Open browser tabs reload signed out, and this computer stops saving new session data. Existing sessions stay available until you remove them."
         cascadeSummary={null}
         actionLabel="Stop saving"
         isPending={props.saveLogins.pending}
@@ -219,69 +272,30 @@ function SavedLoginsToggleRow(props: {
   );
 }
 
-/**
- * "Import logins from another browser": the way to be signed into the sites
- * the user already uses, without signing into each one again inside Traycer.
- * The dialog owns the three steps; this row only opens it.
- *
- * Disabled with saving off rather than hidden: the import writes the durable
- * jar, which is not the one the tiles are on then, so the row would import
- * into a jar that dies at quit. The hint names the toggle to flip.
- *
- * Opened by the button, or by the one-shot intent the release toast arms
- * before it navigates here (`browser-focus-store`). `open` is DERIVED from
- * the two rather than synced into state - gui-app lint bans a setState in
- * an effect body - and closing consumes the intent, so a later Settings
- * visit does not reopen the dialog. An intent that arrives with saving off
- * is dropped the same way: the row would refuse the import, and an intent
- * kept armed would open the dialog out of nowhere on a later visit.
- */
 function ImportLoginsRow(props: {
-  readonly browserView: BrowserViewBridge;
   readonly enabled: boolean;
+  readonly triggerRef: RefObject<HTMLButtonElement | null>;
+  readonly onOpen: () => void;
 }): ReactNode {
-  const [opened, setOpened] = useState(false);
-  const requested = useBrowserFocusStore((state) => state.openImportLogins);
-  const consumeImportLogins = useBrowserFocusStore(
-    (state) => state.consumeImportLogins,
-  );
-  const enabled = props.enabled;
-  useEffect(() => {
-    if (requested && !enabled) consumeImportLogins();
-  }, [consumeImportLogins, enabled, requested]);
-  const open = opened || (requested && enabled);
-  const setOpen = (next: boolean): void => {
-    setOpened(next);
-    if (!next && requested) consumeImportLogins();
-  };
+  const { enabled, triggerRef, onOpen } = props;
   return (
-    <>
-      <SettingsRow
-        label="Import logins from another browser"
-        description="Bring the sites you're signed into in Chrome, Edge, Brave, Firefox, Safari, or a cookie file into Traycer's browser. Google accounts are left out unless you opt in, because Google binds sign-ins to the device."
-        hint={props.enabled ? null : "Turn on Save website logins first."}
-        control={
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            disabled={!props.enabled}
-            onClick={() => {
-              setOpen(true);
-            }}
-          >
-            Import logins…
-          </Button>
-        }
-      />
-      {open ? (
-        <ImportLoginsDialog
-          open={open}
-          onOpenChange={setOpen}
-          browserView={props.browserView}
-        />
-      ) : null}
-    </>
+    <SettingsRow
+      label="Bring in existing sessions"
+      description="Choose a browser or cookie file, then review the sites before importing."
+      hint={enabled ? null : "Turn on Save website sessions first."}
+      control={
+        <Button
+          ref={triggerRef}
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={!enabled}
+          onClick={onOpen}
+        >
+          Choose source…
+        </Button>
+      }
+    />
   );
 }
 
@@ -303,221 +317,392 @@ async function confirmedByMain(
   });
 }
 
-/**
- * The destructive one, moved here from the tile shield (ticket 08's temporary
- * home). It speaks for this machine AND for every host the user has a live
- * browser stream to, which is what "all" means and why it is not tile-scoped.
- *
- * It always completes, unlike the per-site Clear. This machine's own jar and
- * forget ledger are emptied whether or not a host is listening, and the ledger
- * is what carries the forget to hosts that were not (universal-sign-in decision
- * 6) - so there is no "nothing happened" case left to hold the dialog open for.
- */
-function ForgetAllLoginsRow(props: {
-  readonly browserView: BrowserViewBridge;
-}): ReactNode {
-  return (
-    <SettingsRow
-      label="Forget all browser logins"
-      description="Deletes every saved cookie and login - on this machine and on the host that stores them. Open browser tabs reload signed out and agent sessions using them are suspended."
-      control={
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          className="text-destructive hover:text-destructive"
-          onClick={() => {
-            // No renderer dialog: the main process raises a native one and is
-            // the authority on the answer (browser security review, root cause
-            // C). A second confirmation here would ask twice and, worse, would
-            // read as the gate while the real one lives elsewhere.
-            void confirmedByMain(
-              props.browserView.forgetLogins(),
-              "[browser] clearing the browser partition failed",
-            );
-          }}
-        >
-          Forget all browser logins…
-        </Button>
-      }
-    />
-  );
+const SAVED_WEBSITE_SESSIONS_DESCRIPTION =
+  "Shared with connected Traycer hosts. Removing a site may sign you out there.";
+
+function siteCountLabel(count: number): string {
+  return `${count} ${count === 1 ? "site" : "sites"}`;
 }
 
-/**
- * Which sites the host still holds logins for - names and times only, never a
- * value (spec section 7.3). `sealed` is deliberately not rendered as "none":
- * the logins exist, this host just cannot open them until the desktop that
- * wrapped its key connects.
- *
- * `null` data means the host never answered - it predates the method, or the
- * query has not settled - and the row renders nothing at all rather than
- * claiming an empty jar.
- */
-function SavedLoginSitesRow(props: {
+function SavedWebsiteSessionsRow(props: {
   readonly browserView: BrowserViewBridge;
   readonly data: BrowserSavedLoginSitesResponse | null;
-  readonly onCleared: () => void;
+  readonly loading: boolean;
+  readonly failed: boolean;
+  readonly enabled: boolean;
+  readonly importTriggerRef: RefObject<HTMLButtonElement | null>;
+  readonly onImport: () => void;
+  readonly onRefresh: () => void;
 }): ReactNode {
-  // Optimistic, and only for a frame that actually went out: the host merges
-  // asynchronously, so the refetch right behind a clear can still read the
-  // pre-merge slice and put the row back for a beat.
   const [cleared, setCleared] = useState<readonly string[]>([]);
   const data = props.data;
-  if (data === null) return null;
-  const sites = data.kind === "sealed" ? [] : data.sites;
-  // The optimism releases itself. A domain is hidden only while the LATEST
-  // answer still names it: once the merge lands and the row leaves the
-  // response, it leaves this list too - so signing back into that site while
-  // Settings is open shows it again instead of hiding it for the rest of the
-  // session.
-  //
-  // Retired from state during render (React's documented way to sync state off
-  // a changing external value) rather than in an Effect, because the entry has
-  // to be gone BEFORE a later response can re-introduce that domain - deriving
-  // alone would hide the re-login too.
+  const sites = data?.kind === "sites" ? data.sites : [];
   const activeCleared = cleared.filter((domain) =>
     sites.some((site) => site.domain === domain),
   );
   if (activeCleared.length !== cleared.length) setCleared(activeCleared);
+  if (data === null) {
+    if (props.loading) {
+      return (
+        <SavedWebsiteSessionsState
+          status="Loading…"
+          message={null}
+          onRetry={null}
+        />
+      );
+    }
+    if (props.failed) {
+      return (
+        <SavedWebsiteSessionsState
+          status="Unavailable"
+          message="Unable to load saved website sessions. Check the host connection and try again."
+          onRetry={props.onRefresh}
+        />
+      );
+    }
+    return (
+      <SavedWebsiteSessionsState
+        status="Unavailable"
+        message="Update the connected Traycer host to view and manage saved website sessions."
+        onRetry={null}
+      />
+    );
+  }
+  if (data.kind === "sealed") {
+    return (
+      <SavedWebsiteSessionsState
+        status="Locked"
+        message="Connect this desktop to unlock saved website sessions. If this computer has no system keyring, Traycer cannot encrypt them here, so they stay locked and nothing new is saved."
+        onRetry={null}
+      />
+    );
+  }
+
+  const alphabeticalSites = sites
+    .filter((site) => !activeCleared.includes(site.domain))
+    .sort((first, second) => first.domain.localeCompare(second.domain));
+
+  const removeSite = async (domain: string): Promise<boolean> => {
+    const confirmed = await confirmedByMain(
+      props.browserView.clearSavedLoginSite(domain),
+      "[browser] clearing one saved login failed",
+    );
+    if (!confirmed) return false;
+    setCleared((current) =>
+      current.includes(domain) ? current : [...current, domain],
+    );
+    props.onRefresh();
+    return true;
+  };
+
+  const removeAll = async (): Promise<boolean> => {
+    const confirmed = await confirmedByMain(
+      props.browserView.forgetLogins(),
+      "[browser] clearing the browser partition failed",
+    );
+    if (!confirmed) return false;
+    setCleared((current) => [
+      ...new Set([...current, ...sites.map((site) => site.domain)]),
+    ]);
+    props.onRefresh();
+    return true;
+  };
+
   return (
-    <SettingsRow
-      label="Sites with saved logins"
-      description="Site names only - Traycer never shows the saved values."
-      control={
-        <div className="flex w-full min-w-0 max-w-[min(48vw,26rem)] flex-col gap-1.5 text-ui-sm">
-          {data.kind === "sealed" ? (
-            <p className="text-muted-foreground">
-              Connect this desktop to unlock saved logins. If this machine has
-              no system keyring, Traycer will not encrypt them here, so they
-              stay locked and nothing new is saved.
-            </p>
-          ) : (
-            <SavedLoginSiteList
-              sites={sites.filter(
-                (site) => !activeCleared.includes(site.domain),
-              )}
-              onClear={(domain) => {
-                // Awaited, because main raises a native dialog and a cancelled
-                // one must not hide the row: the answer is the confirmation,
-                // not the request (H10).
-                void confirmedByMain(
-                  props.browserView.clearSavedLoginSite(domain),
-                  "[browser] clearing one saved login failed",
-                ).then((confirmed) => {
-                  if (!confirmed) return;
-                  // The pruned list, not the raw one: a domain the host has
-                  // since dropped never comes back into it.
-                  setCleared([...activeCleared, domain]);
-                  props.onCleared();
-                });
-              }}
-            />
-          )}
-        </div>
-      }
+    <SavedWebsiteSessionsManager
+      sites={alphabeticalSites}
+      enabled={props.enabled}
+      importTriggerRef={props.importTriggerRef}
+      onImport={props.onImport}
+      onRemove={removeSite}
+      onRemoveAll={removeAll}
     />
   );
 }
 
-function SavedLoginSiteList(props: {
-  readonly sites: readonly BrowserSavedLoginSite[];
-  readonly onClear: (domain: string) => void;
+function SavedWebsiteSessionsState(props: {
+  readonly status: string;
+  readonly message: string | null;
+  readonly onRetry: (() => void) | null;
 }): ReactNode {
-  // The shared 60s clock, not `Date.now()`: reading the wall clock during a
-  // render is impure, and the sampled one repaints these labels on its tick.
-  const now = useSampledNow();
-  // THIS machine's host id, read once for the whole list: every row compares
-  // its contributor against the same answer. `useReactiveLocalHostId` rather
-  // than the local directory entry, because the entry goes null while the
-  // local host restarts and a row must not start claiming a remote capture
-  // for the length of that gap.
-  const localHostId = useReactiveLocalHostId();
-  if (props.sites.length === 0) {
-    return <p className="text-muted-foreground">No saved logins yet.</p>;
-  }
   return (
-    <ul className="flex w-full min-w-0 flex-col gap-1">
-      {props.sites.map((site) => (
-        <SavedLoginSiteRow
-          key={site.domain}
-          site={site}
-          localHostId={localHostId}
-          now={now}
-          onClear={props.onClear}
-        />
-      ))}
-    </ul>
+    <div className="border-b border-border/40">
+      <SettingsRow
+        label="Saved website sessions"
+        description={SAVED_WEBSITE_SESSIONS_DESCRIPTION}
+        control={
+          <span className="text-ui-sm text-muted-foreground" role="status">
+            {props.status}
+          </span>
+        }
+      />
+      {props.message === null ? null : (
+        <div className="flex flex-wrap items-center justify-between gap-3 px-5 py-3 text-ui-sm text-muted-foreground">
+          <p className="max-w-[72ch] text-pretty">{props.message}</p>
+          {props.onRetry === null ? null : (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={props.onRetry}
+            >
+              Try again
+            </Button>
+          )}
+        </div>
+      )}
+    </div>
   );
 }
 
-/**
- * One site, plus the provenance line when another machine is what signed in
- * (universal-sign-in decision 9).
- *
- * Its own component because resolving a host's display name is a hook, and a
- * row is where the host id lives. Attribution is deliberately silent for the
- * local machine: a login this desktop's own host captured is one the user made
- * here, and naming their own machine on every row would be noise around the
- * lines that actually say "this came from somewhere else".
- *
- * The copy says "includes a sign-in from", not "captured on", because the
- * marker behind it is STICKY: it records that a headless context on that host
- * once contributed new cookie information for the domain, and it survives the
- * user signing into the same site here afterwards. Anything tighter (a "where
- * this login came from", a "captured at") would be a claim about recency and
- * origin that the store does not make.
- */
-function SavedLoginSiteRow(props: {
-  readonly site: BrowserSavedLoginSite;
-  readonly localHostId: string | null;
-  readonly now: number;
-  readonly onClear: (domain: string) => void;
+function SavedWebsiteSessionsManager(props: {
+  readonly sites: readonly BrowserSavedLoginSite[];
+  readonly enabled: boolean;
+  readonly importTriggerRef: RefObject<HTMLButtonElement | null>;
+  readonly onImport: () => void;
+  readonly onRemove: (domain: string) => Promise<boolean>;
+  readonly onRemoveAll: () => Promise<boolean>;
 }): ReactNode {
-  const contributedByHostId = props.site.contributedByHostId;
-  // `typeof`, not `!== null`, and the difference is load-bearing. The
-  // same-minor RPC path returns the host's payload UNPARSED - the schema's
-  // `.default(null)` only runs when a version gap forces a decode - so against
-  // a host that predates the field this is `undefined` at runtime however the
-  // type reads. A null check would let that through and render a dangling
-  // "Includes a sign-in from " on every row of every older host's list.
-  const remoteHostId =
-    typeof contributedByHostId === "string" &&
-    contributedByHostId !== props.localHostId
-      ? contributedByHostId
-      : null;
-  // The directory is the app's host-naming machinery: its `label` is the
-  // account registry's display name for a remote host and the machine's own
-  // for this one. `null` (a host this client cannot currently list) falls back
-  // to the canonical id rather than inventing a name for it.
-  const entry = useHostDirectoryEntry(remoteHostId);
-  const hostName = entry === null ? remoteHostId : entry.label;
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [status, setStatus] = useState("");
+  const searchId = useId();
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  const emptyImportRef = useRef<HTMLButtonElement>(null);
+  const preview = props.sites.slice(0, 3);
+  const hiddenCount = props.sites.length - preview.length;
+  const normalizedQuery = query.trim().toLocaleLowerCase();
+  const matches = props.sites.filter((site) =>
+    site.domain.toLocaleLowerCase().includes(normalizedQuery),
+  );
+  const disclosureLabel =
+    hiddenCount > 0
+      ? `View all ${hiddenCount} more sites`
+      : `Manage all ${siteCountLabel(props.sites.length)}`;
+
+  const changeOpen = (next: boolean): void => {
+    setOpen(next);
+    if (next) return;
+    setQuery("");
+    setStatus("");
+  };
+
   return (
-    <li className="flex min-w-0 flex-col gap-0.5">
-      <div className="flex min-w-0 items-center gap-2 text-ui-sm">
-        <span className="min-w-0 flex-1 truncate font-mono text-foreground">
-          {props.site.domain}
-        </span>
-        <span className="shrink-0 text-muted-foreground">
-          {formatRelativeTimestamp(props.site.lastSeen, props.now)}
-        </span>
-        <Button
-          type="button"
-          variant="ghost"
-          size="xs"
-          aria-label={`Clear saved logins for ${props.site.domain}`}
-          onClick={() => {
-            props.onClear(props.site.domain);
-          }}
-        >
-          Clear
-        </Button>
+    <Sheet open={open} onOpenChange={changeOpen}>
+      <div className="border-b border-border/40">
+        <SettingsRow
+          label="Saved website sessions"
+          description={SAVED_WEBSITE_SESSIONS_DESCRIPTION}
+          control={
+            <span className="tabular-nums text-ui-sm text-muted-foreground">
+              {siteCountLabel(props.sites.length)}
+            </span>
+          }
+        />
+        {preview.length === 0 ? null : (
+          <>
+            <ul aria-label="First three saved sites">
+              {preview.map((site) => (
+                <li
+                  key={site.domain}
+                  className="flex min-w-0 border-b border-border/40 px-5 py-2.5 last:border-b-0"
+                >
+                  <span
+                    className="min-w-0 break-all font-mono text-ui-sm text-foreground"
+                    translate="no"
+                  >
+                    {site.domain}
+                  </span>
+                </li>
+              ))}
+            </ul>
+            <SheetTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                className="h-auto w-full justify-between rounded-none border-t border-border/40 px-5 py-3 text-start text-muted-foreground"
+              >
+                {disclosureLabel}
+                <ArrowRightIcon aria-hidden="true" />
+              </Button>
+            </SheetTrigger>
+          </>
+        )}
       </div>
-      {hostName === null ? null : (
-        <span className="min-w-0 truncate text-ui-xs text-muted-foreground">
-          Includes a sign-in from {hostName}
-        </span>
-      )}
-    </li>
+      <SheetContent
+        side="right"
+        className="gap-0 overflow-hidden data-[side=right]:w-full data-[side=right]:sm:max-w-xl"
+        onCloseAutoFocus={(event) => {
+          if (props.sites.length > 0) return;
+          const fallback = props.importTriggerRef.current;
+          if (fallback === null || fallback.disabled) return;
+          event.preventDefault();
+          fallback.focus();
+        }}
+      >
+        <SheetHeader className="shrink-0 pe-12">
+          <SheetTitle>Saved website sessions</SheetTitle>
+          <SheetDescription>
+            Search and remove website sessions without losing your place in
+            General settings.
+          </SheetDescription>
+        </SheetHeader>
+        <p className="mx-4 mb-4 rounded-md bg-muted/50 px-3 py-2 text-ui-sm text-muted-foreground">
+          Shared collection · Removing a site may sign you out on connected
+          Traycer hosts.
+        </p>
+        <div className="shrink-0 space-y-2 px-4 pb-4">
+          <Label htmlFor={searchId}>Search saved sites</Label>
+          <div className="relative">
+            <SearchIcon
+              aria-hidden="true"
+              className="pointer-events-none absolute start-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
+            />
+            <Input
+              ref={searchInputRef}
+              id={searchId}
+              name="saved-website-session-search"
+              type="search"
+              autoComplete="off"
+              spellCheck={false}
+              placeholder="example.com"
+              className="ps-8"
+              value={query}
+              onChange={(event) => {
+                setQuery(event.currentTarget.value);
+              }}
+            />
+          </div>
+        </div>
+        <div className="flex min-h-0 flex-1 flex-col border-y border-border/60">
+          <div className="flex shrink-0 items-center justify-between gap-3 px-4 py-2 text-ui-xs text-muted-foreground">
+            <span className="tabular-nums" role="status" aria-live="polite">
+              {normalizedQuery.length > 0
+                ? `${matches.length} of ${siteCountLabel(props.sites.length)}`
+                : siteCountLabel(props.sites.length)}
+            </span>
+            <span>A–Z</span>
+          </div>
+          <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain">
+            {matches.length > 0 ? (
+              <ul aria-label="Saved website sessions" className="px-2 pb-2">
+                {matches.map((site) => (
+                  <li
+                    key={site.domain}
+                    className="flex min-w-0 items-center gap-4 border-t border-border/40 px-2 py-2 first:border-t-0"
+                  >
+                    <span
+                      className="min-w-0 flex-1 break-all font-mono text-ui-sm text-foreground"
+                      translate="no"
+                    >
+                      {site.domain}
+                    </span>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      className="text-muted-foreground hover:text-destructive"
+                      aria-label={`Remove saved website session for ${site.domain}`}
+                      onClick={() => {
+                        void props.onRemove(site.domain).then((removed) => {
+                          if (!removed) return;
+                          setStatus("Website session removed.");
+                          requestAnimationFrame(() => {
+                            searchInputRef.current?.focus();
+                          });
+                        });
+                      }}
+                    >
+                      Remove
+                    </Button>
+                  </li>
+                ))}
+              </ul>
+            ) : null}
+            {matches.length === 0 && props.sites.length === 0 ? (
+              <div className="grid min-h-full place-items-center px-6 py-8 text-center">
+                <div className="max-w-[46ch]">
+                  <h3 className="font-medium text-foreground">
+                    No saved website sessions
+                  </h3>
+                  <p className="mt-1 text-pretty text-ui-sm text-muted-foreground">
+                    {props.enabled
+                      ? "Bring in sessions from another browser, or save new ones as you browse."
+                      : "Turn on Save website sessions to import. Existing sessions will remain available when saving resumes."}
+                  </p>
+                  <Button
+                    ref={emptyImportRef}
+                    type="button"
+                    variant="outline"
+                    className="mt-4"
+                    disabled={!props.enabled}
+                    onClick={() => {
+                      changeOpen(false);
+                      requestAnimationFrame(props.onImport);
+                    }}
+                  >
+                    Choose source…
+                  </Button>
+                </div>
+              </div>
+            ) : null}
+            {matches.length === 0 && props.sites.length > 0 ? (
+              <div className="grid min-h-full place-items-center px-6 py-8 text-center">
+                <div className="max-w-[46ch]">
+                  <h3 className="font-medium text-foreground">
+                    No matching sites
+                  </h3>
+                  <p className="mt-1 text-ui-sm text-muted-foreground">
+                    No sites match your search.
+                  </p>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    className="mt-4"
+                    onClick={() => {
+                      setQuery("");
+                      searchInputRef.current?.focus();
+                    }}
+                  >
+                    Clear search
+                  </Button>
+                </div>
+              </div>
+            ) : null}
+          </div>
+        </div>
+        <SheetFooter className="shrink-0 border-t border-border/60 pb-safe-bottom-gutter sm:flex-row sm:items-center sm:justify-between">
+          <span
+            className="min-h-4 min-w-0 truncate text-ui-xs text-muted-foreground"
+            role="status"
+            aria-live="polite"
+          >
+            {status}
+          </span>
+          <div className="flex w-full items-center justify-between gap-2 sm:w-auto sm:justify-end">
+            <Button
+              type="button"
+              variant="ghost"
+              className="text-destructive hover:text-destructive"
+              disabled={props.sites.length === 0}
+              onClick={() => {
+                void props.onRemoveAll().then((removed) => {
+                  if (!removed) return;
+                  setStatus("All website sessions removed.");
+                  requestAnimationFrame(() => {
+                    emptyImportRef.current?.focus();
+                  });
+                });
+              }}
+            >
+              Remove all…
+            </Button>
+            <SheetClose asChild>
+              <Button type="button">Done</Button>
+            </SheetClose>
+          </div>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
   );
 }


### PR DESCRIPTION
## Summary

- replace the unbounded saved-login list with a three-site preview and count
- move search, per-site removal, remove-all, and empty/import states into a responsive side sheet
- align native destructive confirmations and Settings copy around website sessions

## Verification

- pre-commit affected compile, lint, and format gate
- gui-app focused Vitest: 21 tests passed
- desktop clear-site IPC Vitest: 19 tests passed
- gui-app compile and targeted ESLint/format checks passed before commit