### PR TITLE
test: restore Codex round-7 coverage flagged after #1688 merged

### DIFF
--- a/clients/desktop/src/electron-main/app/__tests__/updater.test.ts
+++ b/clients/desktop/src/electron-main/app/__tests__/updater.test.ts
@@ -1491,6 +1491,40 @@ describe("RC release discovery and channel safety", () => {
       url: "https://github.com/traycerai/traycer/releases/download/desktop-v1.6.0-rc.1/",
     });
   });
+
+  it("falls back to an older release when the newest release's manifest version disagrees with its tag (finding 4)", async () => {
+    const { autoUpdater, updater } = await loadUpdater(NOT_LINUX_GUIDANCE);
+    vi.stubGlobal(
+      "fetch",
+      fetchRouter(
+        [
+          macReleaseFixture("desktop-v1.8.0-rc.1", true),
+          macReleaseFixture("desktop-v1.7.0-rc.1", true),
+        ],
+        {
+          // Publishing error: the manifest names a different version than
+          // the release tag it was fetched from.
+          "desktop-v1.8.0-rc.1": manifestYamlForTag(
+            "desktop-v1.8.0-rc.2",
+            macZipAssetName("desktop-v1.8.0-rc.1"),
+          ),
+          "desktop-v1.7.0-rc.1": manifestYamlForTag(
+            "desktop-v1.7.0-rc.1",
+            macZipAssetName("desktop-v1.7.0-rc.1"),
+          ),
+        },
+      ),
+    );
+    await updater.installAutoUpdater(true, makeDeps(true));
+
+    await updater.setAllowPrereleaseUpdates(true);
+    await updater.checkForUpdatesNow(false, "manual");
+
+    expect(autoUpdater.setFeedURL).toHaveBeenLastCalledWith({
+      provider: "generic",
+      url: "https://github.com/traycerai/traycer/releases/download/desktop-v1.7.0-rc.1/",
+    });
+  });
   it("never selects a tag with a leading-zero identifier, falling back to a strict-SemVer release", async () => {
     const { autoUpdater, updater } = await loadUpdater(NOT_LINUX_GUIDANCE);
     vi.stubGlobal(

--- a/clients/desktop/src/electron-main/browser-view/__tests__/browser-view-manager.test.ts
+++ b/clients/desktop/src/electron-main/browser-view/__tests__/browser-view-manager.test.ts
@@ -2329,6 +2329,33 @@ describe("BrowserViewManager host window renderer reset (fix round 2)", () => {
     ).toBe(true);
     expect(view.visible).toBe(true);
   });
+
+  it("does not re-show a stale entry that was never reattached", async () => {
+    const harness = createHarness();
+    const { view } = await makeVisible(harness, BASE_KEY);
+
+    const hostWebContents = harness.windows.get("window-1")?.webContents;
+    if (hostWebContents === undefined) throw new Error("expected host window");
+    hostWebContents.emit(
+      "did-start-navigation",
+      {},
+      "http://localhost:31873/",
+      false,
+      true,
+      1,
+      1,
+    );
+    expect(view.visible).toBe(false);
+
+    // A recompute unrelated to this exact tile (e.g. another tile's bounds
+    // update triggering window reconciliation) must not accidentally
+    // re-show a stale-generation entry that the new renderer never claimed.
+    harness.manager.updateBounds("window-1", {
+      ...BASE_KEY,
+      bounds: { x: 5, y: 5, width: 300, height: 200 },
+    });
+    expect(view.visible).toBe(false);
+  });
 });
 
 describe("BrowserViewManager overlay occlusion broadcast routing (fix round 3)", () => {

--- a/clients/desktop/src/electron-main/host/__tests__/host-controller.test.ts
+++ b/clients/desktop/src/electron-main/host/__tests__/host-controller.test.ts
@@ -5026,6 +5026,50 @@ describe("applyPendingLoginItemRevisionIfIdle", () => {
     );
   });
 
+  it("awaitMutationLaneIdle waits for a standalone (non-FIFO) revision-refresh cycle", async () => {
+    vi.mocked(hostManagesHostLoginItem).mockResolvedValue(true);
+    const controller = newController("production");
+    writeInstallRecord("production", {
+      version: "1.7.0",
+      runtimeVersion: "1.7.0",
+    });
+    writePidMetadata("production", { version: "1.7.0", pid: process.pid });
+    vi.mocked(hasUnappliedPendingLoginItemRevision).mockResolvedValue(true);
+    const registerGate = deferred<"enabled">();
+    let registerCalled = false;
+    vi.mocked(registerHostLoginItem).mockImplementation(async () => {
+      registerCalled = true;
+      return registerGate.promise;
+    });
+    vi.mocked(streamBundledTraycerCliJson).mockResolvedValue({
+      data: {
+        action: "noop",
+        running: true,
+        version: "1.7.0",
+        runtimeVersion: "1.7.0",
+      },
+    });
+
+    const refreshPromise =
+      controller.applyPendingLoginItemRevisionIfIdle("outside-lane");
+    // Real fs reads precede the disruptive step (readRunningRuntimeVersion,
+    // probeHostBusyVerdict, the lock acquisition, readRunningHostIdentity,
+    // readDesktopHostInstallRecord) - poll rather than a fixed microtask
+    // flush so this doesn't race those.
+    await vi.waitFor(() => {
+      if (!registerCalled) throw new Error("register not reached yet");
+    });
+
+    // Mid-cycle, never having gone through `enqueueMutation` - the drain
+    // must still see it as busy rather than idle.
+    expect(await controller.awaitMutationLaneIdle(20)).toBe(false);
+
+    registerGate.resolve("enabled");
+    await refreshPromise;
+
+    expect(await controller.awaitMutationLaneIdle(20)).toBe(true);
+  });
+
   it("P4: quit drain sees the pending-revision intent during its reachability precheck", async () => {
     vi.mocked(hostManagesHostLoginItem).mockResolvedValue(true);
     const reachabilityGate = deferred<boolean>();
@@ -5674,6 +5718,55 @@ describe("Class B no-op liveness", () => {
     vi.mocked(runBundledTraycerCliJson).mockResolvedValue(
       availableSnapshotFixture("1.7.0", ["1.7.0"]),
     );
+
+    await expect(
+      controller.applyStaged("manual", false),
+    ).resolves.toMatchObject({
+      kind: "installed-not-converged",
+    });
+  });
+
+  it("does not trust a CLI no-op apply to imply activation without a live endpoint", async () => {
+    const controller = newControllerWithReachability(
+      "production",
+      async () => false,
+    );
+    writeInstallRecord("production", {
+      version: "1.7.0",
+      runtimeVersion: "1.7.0",
+    });
+    writeStagedRecord("production", "1.8.0", "1.8.0");
+    vi.mocked(runBundledTraycerCliJson).mockResolvedValue(
+      availableSnapshotFixture("1.8.0", ["1.8.0"]),
+    );
+    vi.mocked(streamBundledTraycerCliJson).mockResolvedValue({
+      data: { outcome: "no-op", installedVersion: "1.7.0" },
+    });
+
+    await expect(
+      controller.applyStaged("manual", false),
+    ).resolves.toMatchObject({
+      kind: "installed-not-converged",
+    });
+  });
+
+  it("does not trust a packaged-mac no-op apply to imply activation without a live endpoint", async () => {
+    vi.mocked(hostManagesHostLoginItem).mockResolvedValue(true);
+    const controller = newControllerWithReachability(
+      "production",
+      async () => false,
+    );
+    writeInstallRecord("production", {
+      version: "1.7.0",
+      runtimeVersion: "1.7.0",
+    });
+    writeStagedRecord("production", "1.8.0", "1.8.0");
+    vi.mocked(runBundledTraycerCliJson).mockResolvedValue(
+      availableSnapshotFixture("1.8.0", ["1.8.0"]),
+    );
+    vi.mocked(streamBundledTraycerCliJson).mockResolvedValue({
+      data: { outcome: "no-op", installedVersion: "1.7.0" },
+    });
 
     await expect(
       controller.applyStaged("manual", false),

--- a/clients/desktop/src/electron-main/ipc/__tests__/host-management-maintenance.test.ts
+++ b/clients/desktop/src/electron-main/ipc/__tests__/host-management-maintenance.test.ts
@@ -1987,6 +1987,40 @@ describe("maintenance identity + doctorRepairIfIdle IPC", () => {
     });
   });
 
+  it("queued restart hands the controller a user-repair intent", async () => {
+    // The third sibling. A restart queues exactly like converge/register, so
+    // a pre-enqueue check alone proves nothing about the host a zero-argument
+    // respawn would eventually force-restart — the identity question has to
+    // ride the intent to the head of the lane.
+    writeEnrollment(LIVE_HOST_ID);
+    const invoke = RunnerHostInvoke;
+    const bridge = makeBridge();
+    const handler = await registerHandler(
+      bridge,
+      invoke.traycerDoctorRepairQueued,
+    );
+    const respawn = vi.fn((_intent: LocalHostMutationIntent) =>
+      Promise.resolve({ kind: "ok" as const, value: { activated: true } }),
+    );
+    bridge.options.hostController.respawn = respawn;
+
+    await expect(
+      handler(null, { repair: "restart", expectedHostId: LIVE_HOST_ID }),
+    ).resolves.toEqual({ kind: "applied" });
+    expect(respawn).toHaveBeenCalledTimes(1);
+
+    const [intent] = respawn.mock.calls[0] ?? [];
+    if (intent?.kind !== "user-repair") {
+      throw new Error("expected a user-repair intent");
+    }
+    await expect(intent.guard()).resolves.toEqual({ kind: "proceed" });
+    writeEnrollment("some-other-host");
+    await expect(intent.guard()).resolves.toEqual({
+      kind: "abandon",
+      message: expect.stringContaining("host changed"),
+    });
+  });
+
   it("the watched restart passes a user-repair intent and reports a late refusal as declined", async () => {
     // `traycerHostRestartIfIdle` is admitted only against an empty lane, but
     // admission-to-execution still crosses a microtask boundary, so the

--- a/clients/desktop/src/electron-main/startup/__tests__/host-launch-converge.test.ts
+++ b/clients/desktop/src/electron-main/startup/__tests__/host-launch-converge.test.ts
@@ -434,6 +434,15 @@ describe("runLaunchHostConvergeReconcile (fixup B1 + B2)", () => {
   // had nobody left to re-register it and the machine stayed unreachable until
   // the next launch.
   it.each([
+    ["a failed apply", { kind: "failed" as const, message: "apply failed" }],
+    [
+      "a stage that no longer matches",
+      { kind: "stage-fingerprint-mismatch" as const, message: "mismatch" },
+    ],
+    [
+      "bytes that committed without converging",
+      { kind: "installed-not-converged" as const, message: "not converged" },
+    ],
     // Codex P1: `deferred` is NOT always contention. A registry outage leaves
     // the stage un-eligibility-checked and resolves this same arm while
     // holding no lock at all - skipping recovery there left an installed

--- a/clients/shared/host-transport/__tests__/ws-stream-client.test.ts
+++ b/clients/shared/host-transport/__tests__/ws-stream-client.test.ts
@@ -5262,6 +5262,67 @@ describe("WsStreamClient clock-skew park", () => {
     session.close();
   });
 
+  it("keeps today's behaviour at the pre-dial gate when the tracker says the clock is fine", async () => {
+    const { factory } = makeFactory();
+    const revalidator = makeRevalidator("rotated");
+    const clock = makeClockSignal("ok");
+    const client = makeClockClient({
+      factory,
+      auth: revalidator.auth,
+      clock: clock.signal,
+      bearer: () => expiredJwt(),
+    });
+    const session = client.subscribe("epic.subscribe", { epicId: "e1" });
+
+    await pollUntil(
+      "the pre-dial gate to revalidate",
+      () => revalidator.calls.count > 0,
+    );
+    expect(clock.recoverySubscribers()).toBe(0);
+
+    session.close();
+  });
+
+  it("still reaches the terminal bound for a HOST CONFIG MISMATCH, which looks identical on the wire", async () => {
+    // The whole reason parking keys on the tracker's verdict and not on the
+    // rejection shape: "authn validates it, the host rejects it" is also what a
+    // misconfigured host produces, and retrying that forever helps nobody.
+    const { factory, sockets } = makeFactory();
+    const revalidator = makeRevalidator("rotated");
+    const clock = makeClockSignal("ok");
+    const client = makeClockClient({
+      factory,
+      auth: revalidator.auth,
+      clock: clock.signal,
+      bearer: () => "plain-bearer",
+    });
+    const statuses: StreamConnectionStatus[] = [];
+    const closeReasons: Array<StreamCloseReason | null> = [];
+    const session = client.subscribe("epic.subscribe", { epicId: "e1" });
+    session.onStatusChange((status, reason) => {
+      statuses.push(status);
+      closeReasons.push(reason);
+    });
+
+    // Each cycle drives ITS OWN dial. Reaching for the most recent socket
+    // behind a fixed wait re-drives the previous one when the redial has not
+    // landed yet, which silently turns three cycles into fewer.
+    for (let cycle = 0; cycle < 3; cycle += 1) {
+      const socket = await nthSocket(sockets, cycle);
+      socket.fireOpen();
+      socket.fireText(UNAUTHORIZED_FATAL);
+    }
+    await pollUntil("the no-progress bound to close the session", () =>
+      statuses.includes("closed"),
+    );
+
+    expect(statuses).toContain("closed");
+    const fatalClose = closeReasons.find((r) => r?.kind === "fatalError");
+    expect(fatalClose?.kind).toBe("fatalError");
+
+    session.close();
+  });
+
   it("does NOT park on a clock running BEHIND, and still walks the no-progress bound to terminal", async () => {
     // The mirror of the incident, and the failure this feature would otherwise
     // have reintroduced in the opposite direction. A SLOW clock makes a bearer

--- a/clients/shared/host-transport/remote/__tests__/remote-session.test.ts
+++ b/clients/shared/host-transport/remote/__tests__/remote-session.test.ts
@@ -7171,6 +7171,11 @@ describe("RemoteSession clock-skew park", () => {
       try {
         session.start();
         await vi.waitFor(() => expect(session.isClosed()).toBe(true), WAIT);
+        // The bound is what this case is about, so pin that it was actually
+        // walked. Without this, an implementation that closed on the first
+        // rejection - never retrying at all - would satisfy `isClosed()` and
+        // read as "reached the terminal bound".
+        expect(relay.openBearers).toHaveLength(3);
         expect(clock.recoverySubscribers()).toBe(0);
       } finally {
         session.close();

--- a/clients/shared/host-transport/remote/__tests__/remote-session.test.ts
+++ b/clients/shared/host-transport/remote/__tests__/remote-session.test.ts
@@ -7157,6 +7157,27 @@ describe("RemoteSession clock-skew park", () => {
     },
     TEST_BUDGET_MS,
   );
+
+  it(
+    "still reaches the terminal bound for a host config mismatch, which looks identical on the wire",
+    async () => {
+      // The reason the park keys on the tracker's verdict and never on the
+      // rejection shape: a misconfigured host produces the very same
+      // no-progress streak, and retrying that forever helps nobody.
+      const relay = new FakeRelayHost();
+      const lease = new MutableBearerLease("mismatched-token", "user-1");
+      const clock = makeClockSignal("ok");
+      const session = buildNoProgressSession(relay, lease, clock.signal);
+      try {
+        session.start();
+        await vi.waitFor(() => expect(session.isClosed()).toBe(true), WAIT);
+        expect(clock.recoverySubscribers()).toBe(0);
+      } finally {
+        session.close();
+      }
+    },
+    TEST_BUDGET_MS,
+  );
   it(
     "does NOT park on a clock running BEHIND, and still reaches the terminal bound",
     async () => {

--- a/clients/traycer-cli/src/commands/__tests__/host-start.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/host-start.test.ts
@@ -1384,6 +1384,48 @@ describe("runHostStart - signal/exit propagation", () => {
     expect(String(crashed?.fields.stderrTail)).toContain("partial fatal text");
   });
 
+  it("writes the marker within the stderr-end deadline when the stream never ends", async () => {
+    // A grandchild holding the inherited stderr fd can delay close forever;
+    // the wait is bounded so the supervisor cannot hang on exit.
+    const exec = "/opt/traycer/host/install/traycer-host";
+    const { child, recorded, deps } = makeRunStubs(sampleRecord(exec), null);
+    const stderr = new PassThrough();
+    Object.assign(child, { stderr });
+    const originalSpawn = deps.spawn;
+    if (originalSpawn === undefined) {
+      throw new Error("test spawn dependency missing");
+    }
+
+    const started = Date.now();
+    await runUntilExit(
+      () =>
+        runHostStart(
+          { environment: "production", cwd: null },
+          {
+            ...deps,
+            spawn: (command, args, options) => {
+              const spawned = originalSpawn(command, args, options);
+              setImmediate(() => {
+                stderr.write(Buffer.from("partial\n"));
+                // Never end/close — only exit.
+                child.emit("exit", 7, null);
+              });
+              return spawned;
+            },
+          },
+        ),
+      recorded,
+    );
+    const elapsed = Date.now() - started;
+
+    expect(recorded.exited).toBe(7);
+    const crashed = recorded.markers.find((m) => m.phase === "crashed");
+    expect(crashed).toBeDefined();
+    // Bound: wait is STDERR_END_WAIT_TIMEOUT_MS, not forever.
+    expect(elapsed).toBeLessThan(STDERR_END_WAIT_TIMEOUT_MS + 1_500);
+    expect(elapsed).toBeGreaterThanOrEqual(STDERR_END_WAIT_TIMEOUT_MS - 200);
+  }, 10_000);
+
   it("does not hold the relaunch decision on a reportHostCrash that never resolves", async () => {
     // The reporter is dispatched WITHOUT awaiting it: the relaunch decision
     // and its backoff must start the moment the marker is written, not after
@@ -2359,6 +2401,35 @@ describe("runHostStart - crash relaunch loop", () => {
     // Still a deliberate stop: no relaunch, and no nonzero exit asking the
     // service manager to start a replacement.
     expect(recorded.spawnCalls).toHaveLength(1);
+    expect(recorded.exited).toBe(0);
+  });
+
+  it("relaunches a host the OOM killer took, which no diagnostic whitelist names", async () => {
+    // Recoverability and diagnosability are different questions, and deciding
+    // one with the other's answer is the bug this pins. `describeFatalSignal`
+    // lists native-crash signals so a support log can explain them; SIGKILL is
+    // deliberately absent because there is nothing to explain. Keying "should
+    // we relaunch" off that list made the single most likely signal death on
+    // Linux - the OOM killer - the one death that was never recovered.
+    //
+    // The real question is only whether the death was ASKED FOR, and this
+    // supervisor asks with SIGTERM/SIGINT/SIGHUP.
+    const { recorded, deps } = makeRunStubs(sampleRecord(exec), null);
+    const scripted = withScriptedAttempts(deps, [
+      { code: null, signal: "SIGKILL" },
+      { code: 0, signal: null },
+    ]);
+
+    await runUntilExit(
+      () =>
+        runHostStart(
+          { environment: "production", cwd: null },
+          { ...scripted.deps, maxRelaunches: 5 },
+        ),
+      recorded,
+    );
+
+    expect(recorded.spawnCalls).toHaveLength(2);
     expect(recorded.exited).toBe(0);
   });
 

--- a/clients/traycer-cli/src/service/platforms/__tests__/macos.test.ts
+++ b/clients/traycer-cli/src/service/platforms/__tests__/macos.test.ts
@@ -334,6 +334,55 @@ printf '%s\\n' "$@" > ${JSON.stringify(args)}
       await rm(work, { recursive: true, force: true });
     }
   });
+
+  it("launcher file: starts both an N-1 CLI without --service-label and a current CLI with it, preserving leading invocation args", async () => {
+    const work = mkdtempSync(join(tmpdir(), "traycer-host-start-launcher-"));
+    const launcher = join(work, "traycer-host-start");
+    const oldCli = join(work, "old-cli.sh");
+    const newCli = join(work, "new-cli.sh");
+    const oldArgs = join(work, "old-args.txt");
+    const newArgs = join(work, "new-args.txt");
+    try {
+      await writeFile(
+        launcher,
+        buildHostStartLauncherScript("ai.traycer.host.compat"),
+        "utf8",
+      );
+      await chmod(launcher, 0o755);
+      await writeFile(
+        oldCli,
+        `#!/bin/sh
+if [ "$1" = "host" ] && [ "$2" = "capabilities" ]; then
+  echo "error: unknown command 'capabilities'" >&2
+  exit 1
+fi
+printf '%s\\n' "$@" > ${JSON.stringify(oldArgs)}
+`,
+        "utf8",
+      );
+      await writeFile(
+        newCli,
+        `#!/bin/sh
+if [ "$1" = "--entry=cli-entry.js" ] && [ "$2" = "host" ] && [ "$3" = "adoption-nonce" ]; then printf '%s\\n' '11111111-1111-4111-8111-111111111111'; exit 0; fi
+if [ "$1" = "--entry=cli-entry.js" ] && [ "$2" = "host" ] && [ "$3" = "capabilities" ] && [ "$4" = "--has" ] && { [ "$5" = "service-label" ] || [ "$5" = "host-start-adoption-v2" ]; }; then exit 0; fi
+printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
+`,
+        "utf8",
+      );
+      await chmod(oldCli, 0o700);
+      await chmod(newCli, 0o700);
+
+      await execFileAsync(launcher, [oldCli]);
+      await execFileAsync(launcher, [newCli, "--entry=cli-entry.js"]);
+
+      expect(await readFile(oldArgs, "utf8")).toBe("host\nstart\n");
+      expect(await readFile(newArgs, "utf8")).toBe(
+        "--entry=cli-entry.js\nhost\nstart\n--service-label\nai.traycer.host.compat\n--adoption-nonce\n11111111-1111-4111-8111-111111111111\n",
+      );
+    } finally {
+      await rm(work, { recursive: true, force: true });
+    }
+  });
   // Field observation 2026-07-28 (sfltool dumpbtm): with `/bin/sh` as
   // ProgramArguments[0], BTM recorded `Name: sh, Parent Identifier:
   // Unknown Developer` for every CLI-registered install, and

--- a/clients/traycer-cli/src/service/platforms/__tests__/macos.test.ts
+++ b/clients/traycer-cli/src/service/platforms/__tests__/macos.test.ts
@@ -335,54 +335,59 @@ printf '%s\\n' "$@" > ${JSON.stringify(args)}
     }
   });
 
-  it("launcher file: starts both an N-1 CLI without --service-label and a current CLI with it, preserving leading invocation args", async () => {
-    const work = mkdtempSync(join(tmpdir(), "traycer-host-start-launcher-"));
-    const launcher = join(work, "traycer-host-start");
-    const oldCli = join(work, "old-cli.sh");
-    const newCli = join(work, "new-cli.sh");
-    const oldArgs = join(work, "old-args.txt");
-    const newArgs = join(work, "new-args.txt");
-    try {
-      await writeFile(
-        launcher,
-        buildHostStartLauncherScript("ai.traycer.host.compat"),
-        "utf8",
-      );
-      await chmod(launcher, 0o755);
-      await writeFile(
-        oldCli,
-        `#!/bin/sh
+  // Runs the emitted launcher through its own `#!/bin/sh` shebang rather than
+  // naming an interpreter, which Windows does not honour.
+  it.skipIf(process.platform === "win32")(
+    "launcher file: starts both an N-1 CLI without --service-label and a current CLI with it, preserving leading invocation args",
+    async () => {
+      const work = mkdtempSync(join(tmpdir(), "traycer-host-start-launcher-"));
+      const launcher = join(work, "traycer-host-start");
+      const oldCli = join(work, "old-cli.sh");
+      const newCli = join(work, "new-cli.sh");
+      const oldArgs = join(work, "old-args.txt");
+      const newArgs = join(work, "new-args.txt");
+      try {
+        await writeFile(
+          launcher,
+          buildHostStartLauncherScript("ai.traycer.host.compat"),
+          "utf8",
+        );
+        await chmod(launcher, 0o755);
+        await writeFile(
+          oldCli,
+          `#!/bin/sh
 if [ "$1" = "host" ] && [ "$2" = "capabilities" ]; then
   echo "error: unknown command 'capabilities'" >&2
   exit 1
 fi
 printf '%s\\n' "$@" > ${JSON.stringify(oldArgs)}
 `,
-        "utf8",
-      );
-      await writeFile(
-        newCli,
-        `#!/bin/sh
+          "utf8",
+        );
+        await writeFile(
+          newCli,
+          `#!/bin/sh
 if [ "$1" = "--entry=cli-entry.js" ] && [ "$2" = "host" ] && [ "$3" = "adoption-nonce" ]; then printf '%s\\n' '11111111-1111-4111-8111-111111111111'; exit 0; fi
 if [ "$1" = "--entry=cli-entry.js" ] && [ "$2" = "host" ] && [ "$3" = "capabilities" ] && [ "$4" = "--has" ] && { [ "$5" = "service-label" ] || [ "$5" = "host-start-adoption-v2" ]; }; then exit 0; fi
 printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
 `,
-        "utf8",
-      );
-      await chmod(oldCli, 0o700);
-      await chmod(newCli, 0o700);
+          "utf8",
+        );
+        await chmod(oldCli, 0o700);
+        await chmod(newCli, 0o700);
 
-      await execFileAsync(launcher, [oldCli]);
-      await execFileAsync(launcher, [newCli, "--entry=cli-entry.js"]);
+        await execFileAsync(launcher, [oldCli]);
+        await execFileAsync(launcher, [newCli, "--entry=cli-entry.js"]);
 
-      expect(await readFile(oldArgs, "utf8")).toBe("host\nstart\n");
-      expect(await readFile(newArgs, "utf8")).toBe(
-        "--entry=cli-entry.js\nhost\nstart\n--service-label\nai.traycer.host.compat\n--adoption-nonce\n11111111-1111-4111-8111-111111111111\n",
-      );
-    } finally {
-      await rm(work, { recursive: true, force: true });
-    }
-  });
+        expect(await readFile(oldArgs, "utf8")).toBe("host\nstart\n");
+        expect(await readFile(newArgs, "utf8")).toBe(
+          "--entry=cli-entry.js\nhost\nstart\n--service-label\nai.traycer.host.compat\n--adoption-nonce\n11111111-1111-4111-8111-111111111111\n",
+        );
+      } finally {
+        await rm(work, { recursive: true, force: true });
+      }
+    },
+  );
   // Field observation 2026-07-28 (sfltool dumpbtm): with `/bin/sh` as
   // ProgramArguments[0], BTM recorded `Name: sh, Parent Identifier:
   // Unknown Developer` for every CLI-registered install, and

--- a/clients/traycer-cli/src/store/__tests__/well-known-cli.test.ts
+++ b/clients/traycer-cli/src/store/__tests__/well-known-cli.test.ts
@@ -1995,6 +1995,31 @@ it("packaged, no manifest, slot reports an OLDER version: still re-stages", asyn
   expect(result?.staged).toBe("staged");
   expect(readFileSync(wellKnownPath, "utf8")).toBe(runningBytes);
 });
+
+it("packaged, no manifest, slot version probe fails: stages (seniority unprovable)", async () => {
+  seaState.current = true;
+  const { refreshWellKnownSlotIfStale, wellKnownCliBinaryPath } =
+    await import("../well-known-cli");
+  const wellKnownPath = wellKnownCliBinaryPath(ENVIRONMENT);
+  mkdirSync(dirname(wellKnownPath), { recursive: true });
+  writeFileSync(wellKnownPath, "a slot binary that cannot answer --version");
+  const running = join(workHome, "running-binary");
+  const runningBytes = "the running binary's bytes";
+  writeFileSync(running, runningBytes);
+  const base = Date.now();
+  utimesSync(wellKnownPath, new Date(base), new Date(base));
+  utimesSync(running, new Date(base - 120_000), new Date(base - 120_000));
+  // No `slotProbeControl.versionForPath` entry for `wellKnownPath` - the
+  // mock's default rejects, exactly like spawning this suite's plain-text
+  // fixture would in production.
+
+  const result = await withExecPath(running, () =>
+    refreshWellKnownSlotIfStale(ENVIRONMENT),
+  );
+
+  expect(result?.staged).toBe("staged");
+  expect(readFileSync(wellKnownPath, "utf8")).toBe(runningBytes);
+});
 // Answering `--version` proves a program RUNS, not that it may hold the
 // slot. `isInterpreterDistribution` already refuses to nominate an npm
 // install for exactly one reason - the slot is spawned by the host daemon

--- a/protocol/src/host/agent/gui/__tests__/interview-settlement.test.ts
+++ b/protocol/src/host/agent/gui/__tests__/interview-settlement.test.ts
@@ -1574,6 +1574,21 @@ describe("delivery monotonicity", () => {
       source: "gui",
     });
   });
+
+  it("clears delivery when a winning settlement carries null", () => {
+    // Same adopt-on-win rule, null included. The new settlement has no
+    // outbox item; inheriting the old projection would attribute a stale
+    // delivery to a fresh answer. Contrast "never lets a null delivery
+    // clear an existing projection" above, which is a same-id replay
+    // (MERGE, silence is not a retraction).
+    const stored = makeDeliveryProjection("delivery-1", "delivered", false, 0);
+    const result = applyInterviewSettlement(runtimeAuthoritativeBlock(stored), {
+      ...guiAnswered(20),
+      delivery: null,
+    });
+    expect(result.changed).toBe(true);
+    expect(result.patch.delivery).toBeNull();
+  });
 });
 
 describe("draft/outcome relation", () => {


### PR DESCRIPTION
Follow-up to #1688. Codex posted its final review **89 seconds after that PR
merged**, so its 13 findings never had a chance to gate it. This restores the
coverage they name.

Every finding was validated against merged `main` before anything was
restored — for each one I checked what actually survives the slim and whether
the surviving arm can be satisfied by the regression Codex describes. **All 13
held.** The recurring shape is the same one the earlier rounds on #1688 had:
*the deleted case was one arm of a guard, and the surviving arm alone is
satisfiable by a wrong implementation.*

| # | File | Restored | Why the survivor is not enough |
| --- | --- | --- | --- |
| 1 | `host-launch-converge` | 3 table rows | `recoverAfterFailedApply` was cut to its `deferred` row; `failed`, `stage-fingerprint-mismatch` and `installed-not-converged` are separate resolved outcomes on the same recovery path |
| 2 | `browser-view-manager` | stale-generation tile | survivor only proves an explicitly reattached tile becomes visible, never the bounds-reconciliation race |
| 3 | `ws-stream-client` | `ok`-clock pre-dial + terminal controls | every surviving control supplies a skewed verdict |
| 4 | `remote-session` | `ok`-clock terminal control | same: parking all but `skewed-behind` would stay green |
| 5 | `updater` | manifest-version/tag mismatch | survivor only rejects syntactically broken YAML |
| 6 | `host-start` | bounded `stderrEnded` wait | survivor settles the stream immediately |
| 7 | `host-start` | SIGKILL relaunch | survivor uses `SIGABRT`, already on the diagnostic whitelist |
| 8 | `well-known-cli` | failed slot-version probe | both surviving seniority cases get a valid `--version` |
| 9 | `interview-settlement` | winning settlement with `delivery: null` | survivor replaces one non-null projection with another |
| 10 | `host-controller` | quit drain through the revision swap | survivor stops at the reachability precheck |
| 11 | `host-controller` | two `no-op` apply liveness controls | survivor never exercises a `no-op` apply outcome |
| 12 | `host-management-maintenance` | identity fencing on queued `restart` | survivor covers the `converge-ready` arm only |
| 13 | `macos` | execution of the emitted launcher file | survivor executes the compatibility script the launcher wraps, not the launcher |

Findings 3 and 4 are the same defect in two transports, so 13 findings are 12
distinct issues.

## Validation

Ran every touched suite locally:

| Package | Result |
| --- | --- |
| `@traycer/protocol` | 66 passed |
| `@traycer-clients/shared` | 232 passed |
| `@traycer-clients/traycer-cli` | 256 passed, 1 skipped |
| `@traycer-clients/desktop` | 471 passed |

The diff is **439 insertions and zero deletions** across 11 files. Each restore
was audited to land in its original `describe` — restoring a test is not the
inverse of deleting it, since deletion also removes scaffolding and
re-insertion has to re-establish scope. A separate check confirms no existing
cell was displaced or lost.
