### PR TITLE
fix(gui-app,desktop): build the diff worker pool on first use, and read every JS heap from Diagnostics

### DIFF
--- a/clients/desktop/src/electron-main/app/__tests__/diagnostics-js-heaps.test.ts
+++ b/clients/desktop/src/electron-main/app/__tests__/diagnostics-js-heaps.test.ts
@@ -53,6 +53,8 @@ type MessageListener = (
 interface HeapUsageResult {
   readonly usedSize: number;
   readonly totalSize: number;
+  readonly embedderHeapUsedSize: number | null;
+  readonly backingStorageSize: number | null;
 }
 
 interface FakeWorkerFixture {
@@ -221,13 +223,23 @@ describe("handleMeasureJsHeaps", () => {
         sessionId: "session-epic",
         type: "worker",
         url: "app://renderer/assets/epic-runtime-worker-entry-abc.js",
-        heapUsage: { usedSize: 5_000_000, totalSize: 8_000_000 },
+        heapUsage: {
+          usedSize: 5_000_000,
+          totalSize: 8_000_000,
+          embedderHeapUsedSize: 1_500_000,
+          backingStorageSize: 2_500_000,
+        },
       },
       {
         sessionId: "session-service",
         type: "service_worker",
         url: "app://renderer/service-worker.js",
-        heapUsage: { usedSize: 1, totalSize: 1 },
+        heapUsage: {
+          usedSize: 1,
+          totalSize: 1,
+          embedderHeapUsedSize: null,
+          backingStorageSize: null,
+        },
       },
       {
         sessionId: "session-flaky",
@@ -237,7 +249,12 @@ describe("handleMeasureJsHeaps", () => {
       },
     ];
     const debuggerApi = buildFakeDebugger({
-      pageHeapUsage: { usedSize: 40_000_000, totalSize: 60_000_000 },
+      pageHeapUsage: {
+        usedSize: 40_000_000,
+        totalSize: 60_000_000,
+        embedderHeapUsedSize: 9_000_000,
+        backingStorageSize: 3_000_000,
+      },
       workers,
       isAttachedInitially: false,
       attachThrows: false,
@@ -263,12 +280,16 @@ describe("handleMeasureJsHeaps", () => {
         url: "app://renderer/index.html",
         usedBytes: 40_000_000,
         totalBytes: 60_000_000,
+        embedderBytes: 9_000_000,
+        backingStorageBytes: 3_000_000,
       },
       {
         kind: "worker",
         url: "app://renderer/assets/epic-runtime-worker-entry-abc.js",
         usedBytes: 5_000_000,
         totalBytes: 8_000_000,
+        embedderBytes: 1_500_000,
+        backingStorageBytes: 2_500_000,
       },
     ]);
     // The service-worker target and the worker whose heap read rejected are
@@ -304,9 +325,72 @@ describe("handleMeasureJsHeaps", () => {
     expect(sender.getOSProcessId).toHaveBeenCalled();
   });
 
+  it("carries null for embedder and backing storage when the protocol result omits them, and still returns the row", async () => {
+    // `embedderHeapUsedSize` / `backingStorageSize` are experimental CDP
+    // fields - a build that does not report them (or reports something that
+    // is not a number) must not drop the isolate row, only those two fields.
+    const workers: ReadonlyArray<FakeWorkerFixture> = [
+      {
+        sessionId: "session-worker",
+        type: "worker",
+        url: "app://renderer/assets/worker-DMI2JaPh.js",
+        heapUsage: {
+          usedSize: 2_000_000,
+          totalSize: 3_000_000,
+          embedderHeapUsedSize: null,
+          backingStorageSize: null,
+        },
+      },
+    ];
+    const debuggerApi = buildFakeDebugger({
+      pageHeapUsage: {
+        usedSize: 10_000_000,
+        totalSize: 20_000_000,
+        embedderHeapUsedSize: null,
+        backingStorageSize: null,
+      },
+      workers,
+      isAttachedInitially: false,
+      attachThrows: false,
+    });
+    const { event } = buildFakeEvent({
+      isDestroyed: false,
+      pageUrl: "app://renderer/index.html",
+      pid: 99,
+      debuggerApi,
+    });
+
+    const result = await handleMeasureJsHeaps(event);
+
+    expect(result).not.toBeNull();
+    expect(result?.isolates).toEqual([
+      {
+        kind: "page",
+        url: "app://renderer/index.html",
+        usedBytes: 10_000_000,
+        totalBytes: 20_000_000,
+        embedderBytes: null,
+        backingStorageBytes: null,
+      },
+      {
+        kind: "worker",
+        url: "app://renderer/assets/worker-DMI2JaPh.js",
+        usedBytes: 2_000_000,
+        totalBytes: 3_000_000,
+        embedderBytes: null,
+        backingStorageBytes: null,
+      },
+    ]);
+  });
+
   it("returns null without attaching when a debugger is already attached to this window", async () => {
     const debuggerApi = buildFakeDebugger({
-      pageHeapUsage: { usedSize: 1, totalSize: 1 },
+      pageHeapUsage: {
+        usedSize: 1,
+        totalSize: 1,
+        embedderHeapUsedSize: null,
+        backingStorageSize: null,
+      },
       workers: [],
       isAttachedInitially: true,
       attachThrows: false,
@@ -327,7 +411,12 @@ describe("handleMeasureJsHeaps", () => {
 
   it("returns null and never touches the message listener when attach() throws", async () => {
     const debuggerApi = buildFakeDebugger({
-      pageHeapUsage: { usedSize: 1, totalSize: 1 },
+      pageHeapUsage: {
+        usedSize: 1,
+        totalSize: 1,
+        embedderHeapUsedSize: null,
+        backingStorageSize: null,
+      },
       workers: [],
       isAttachedInitially: false,
       attachThrows: true,
@@ -371,7 +460,12 @@ describe("handleMeasureJsHeaps", () => {
 
   it("returns null when the sender is destroyed, without reading the debugger at all", async () => {
     const debuggerApi = buildFakeDebugger({
-      pageHeapUsage: { usedSize: 1, totalSize: 1 },
+      pageHeapUsage: {
+        usedSize: 1,
+        totalSize: 1,
+        embedderHeapUsedSize: null,
+        backingStorageSize: null,
+      },
       workers: [],
       isAttachedInitially: false,
       attachThrows: false,

--- a/clients/desktop/src/electron-main/app/__tests__/diagnostics-js-heaps.test.ts
+++ b/clients/desktop/src/electron-main/app/__tests__/diagnostics-js-heaps.test.ts
@@ -1,0 +1,392 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type Mock,
+} from "vitest";
+
+vi.mock("electron", () => ({
+  BrowserWindow: { fromWebContents: vi.fn(() => null) },
+  app: {
+    getAppMetrics: vi.fn(
+      (): ReadonlyArray<{
+        readonly pid: number;
+        readonly memory: { readonly workingSetSize: number };
+      }> => [],
+    ),
+  },
+  contentTracing: {
+    startRecording: vi.fn(() => Promise.resolve()),
+    stopRecording: vi.fn(() => Promise.resolve("")),
+  },
+}));
+
+vi.mock("electron-log", () => ({
+  default: {
+    transports: { file: { level: "info" }, console: { level: "info" } },
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock("@sentry/electron/main", () => ({
+  isInitialized: vi.fn((): boolean => false),
+  captureMessage: vi.fn(),
+}));
+
+import type { IpcMainInvokeEvent } from "electron";
+import { app } from "electron";
+import { handleMeasureJsHeaps } from "../diagnostics";
+
+type MessageListener = (
+  event: unknown,
+  method: string,
+  params: unknown,
+  sessionId: string | undefined,
+) => void;
+
+interface HeapUsageResult {
+  readonly usedSize: number;
+  readonly totalSize: number;
+}
+
+interface FakeWorkerFixture {
+  readonly sessionId: string;
+  readonly type: string;
+  readonly url: string;
+  readonly heapUsage: HeapUsageResult | "reject";
+}
+
+interface FakeDebugger {
+  readonly isAttached: Mock<() => boolean>;
+  readonly attach: Mock<(protocolVersion: string) => void>;
+  readonly detach: Mock<() => void>;
+  readonly on: Mock<(event: "message", listener: MessageListener) => void>;
+  readonly removeListener: Mock<
+    (event: "message", listener: MessageListener) => void
+  >;
+  readonly sendCommand: Mock<
+    (
+      method: string,
+      commandParams: Record<string, unknown> | undefined,
+      sessionId: string | undefined,
+    ) => Promise<unknown>
+  >;
+}
+
+interface FakeSender {
+  readonly isDestroyed: Mock<() => boolean>;
+  readonly getURL: Mock<() => string>;
+  readonly getOSProcessId: Mock<() => number>;
+  readonly debugger: FakeDebugger;
+}
+
+interface FakeEvent {
+  readonly sender: FakeSender;
+}
+
+/**
+ * A prototype-less object asserted to the event type, with the one member
+ * `handleMeasureJsHeaps` reads (`sender`, and off it `isDestroyed` / `getURL`
+ * / `getOSProcessId` / `debugger.*`) assigned onto it. `as unknown as` is
+ * lint-forbidden here, and a one-member literal does not overlap the real
+ * event type enough for a direct `as`.
+ */
+function asIpcMainInvokeEvent(fake: FakeEvent): IpcMainInvokeEvent {
+  return Object.assign(Object.create(null) as IpcMainInvokeEvent, fake);
+}
+
+function buildFakeDebugger(options: {
+  readonly pageHeapUsage: HeapUsageResult | "reject";
+  readonly workers: ReadonlyArray<FakeWorkerFixture>;
+  readonly isAttachedInitially: boolean;
+  readonly attachThrows: boolean;
+}): FakeDebugger {
+  let attached = options.isAttachedInitially;
+  let messageListener: MessageListener | null = null;
+  const workersBySessionId = new Map(
+    options.workers.map((worker) => [worker.sessionId, worker]),
+  );
+
+  const isAttached = vi.fn((): boolean => attached);
+  const attach = vi.fn((protocolVersion: string): void => {
+    void protocolVersion;
+    if (options.attachThrows) {
+      throw new Error("attach failed");
+    }
+    attached = true;
+  });
+  const detach = vi.fn((): void => {
+    attached = false;
+  });
+  const on = vi.fn((event: "message", listener: MessageListener): void => {
+    if (event === "message") messageListener = listener;
+  });
+  const removeListener = vi.fn(
+    (event: "message", listener: MessageListener): void => {
+      void event;
+      if (messageListener === listener) messageListener = null;
+    },
+  );
+  const sendCommand = vi.fn(
+    (
+      method: string,
+      commandParams: Record<string, unknown> | undefined,
+      sessionId: string | undefined,
+    ): Promise<unknown> => {
+      if (method === "Runtime.getHeapUsage") {
+        if (sessionId === undefined) {
+          return options.pageHeapUsage === "reject"
+            ? Promise.reject(new Error("page heap read failed"))
+            : Promise.resolve(options.pageHeapUsage);
+        }
+        const worker = workersBySessionId.get(sessionId);
+        if (worker === undefined) {
+          return Promise.reject(new Error(`unknown session ${sessionId}`));
+        }
+        return worker.heapUsage === "reject"
+          ? Promise.reject(new Error("worker heap read failed"))
+          : Promise.resolve(worker.heapUsage);
+      }
+      if (method === "Target.setAutoAttach") {
+        const autoAttach = commandParams?.["autoAttach"];
+        if (autoAttach === true && messageListener !== null) {
+          const listener = messageListener;
+          for (const worker of options.workers) {
+            listener(
+              {},
+              "Target.attachedToTarget",
+              {
+                sessionId: worker.sessionId,
+                targetInfo: { type: worker.type, url: worker.url },
+              },
+              undefined,
+            );
+          }
+        }
+        return Promise.resolve({});
+      }
+      return Promise.resolve({});
+    },
+  );
+
+  return { isAttached, attach, detach, on, removeListener, sendCommand };
+}
+
+function buildFakeEvent(options: {
+  readonly isDestroyed: boolean;
+  readonly pageUrl: string;
+  readonly pid: number;
+  readonly debuggerApi: FakeDebugger;
+}): { readonly event: IpcMainInvokeEvent; readonly sender: FakeSender } {
+  const sender: FakeSender = {
+    isDestroyed: vi.fn((): boolean => options.isDestroyed),
+    getURL: vi.fn((): string => options.pageUrl),
+    getOSProcessId: vi.fn((): number => options.pid),
+    debugger: options.debuggerApi,
+  };
+  return { event: asIpcMainInvokeEvent({ sender }), sender };
+}
+
+function processMetric(
+  pid: number,
+  workingSetKb: number,
+): Electron.ProcessMetric {
+  return {
+    pid,
+    type: "Tab",
+    creationTime: 0,
+    cpu: { percentCPUUsage: 0, idleWakeupsPerSecond: 0 },
+    memory: { workingSetSize: workingSetKb, peakWorkingSetSize: workingSetKb },
+  };
+}
+
+describe("handleMeasureJsHeaps", () => {
+  beforeEach(() => {
+    vi.mocked(app.getAppMetrics).mockReturnValue([]);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the page plus every surviving worker isolate, skips non-worker targets, and converts the working set from KB", async () => {
+    const workers: ReadonlyArray<FakeWorkerFixture> = [
+      {
+        sessionId: "session-epic",
+        type: "worker",
+        url: "app://renderer/assets/epic-runtime-worker-entry-abc.js",
+        heapUsage: { usedSize: 5_000_000, totalSize: 8_000_000 },
+      },
+      {
+        sessionId: "session-service",
+        type: "service_worker",
+        url: "app://renderer/service-worker.js",
+        heapUsage: { usedSize: 1, totalSize: 1 },
+      },
+      {
+        sessionId: "session-flaky",
+        type: "worker",
+        url: "app://renderer/assets/worker-flaky.js",
+        heapUsage: "reject",
+      },
+    ];
+    const debuggerApi = buildFakeDebugger({
+      pageHeapUsage: { usedSize: 40_000_000, totalSize: 60_000_000 },
+      workers,
+      isAttachedInitially: false,
+      attachThrows: false,
+    });
+    const { event, sender } = buildFakeEvent({
+      isDestroyed: false,
+      pageUrl: "app://renderer/index.html",
+      pid: 4242,
+      debuggerApi,
+    });
+    vi.mocked(app.getAppMetrics).mockReturnValue([
+      processMetric(1, 999_999),
+      processMetric(4242, 300_000),
+    ]);
+
+    const result = await handleMeasureJsHeaps(event);
+
+    expect(result).not.toBeNull();
+    expect(result?.workingSetBytes).toBe(300_000 * 1024);
+    expect(result?.isolates).toEqual([
+      {
+        kind: "page",
+        url: "app://renderer/index.html",
+        usedBytes: 40_000_000,
+        totalBytes: 60_000_000,
+      },
+      {
+        kind: "worker",
+        url: "app://renderer/assets/epic-runtime-worker-entry-abc.js",
+        usedBytes: 5_000_000,
+        totalBytes: 8_000_000,
+      },
+    ]);
+    // The service-worker target and the worker whose heap read rejected are
+    // both absent, and their absence did not fail the whole call.
+    expect(
+      result?.isolates.some((isolate) =>
+        isolate.url.includes("service-worker"),
+      ),
+    ).toBe(false);
+    expect(
+      result?.isolates.some((isolate) => isolate.url.includes("worker-flaky")),
+    ).toBe(false);
+
+    expect(debuggerApi.attach).toHaveBeenCalledWith("1.3");
+    expect(debuggerApi.attach).toHaveBeenCalledTimes(1);
+    const autoAttachCalls = debuggerApi.sendCommand.mock.calls.filter(
+      ([method]) => method === "Target.setAutoAttach",
+    );
+    expect(autoAttachCalls).toHaveLength(2);
+    expect(autoAttachCalls[0]?.[1]).toMatchObject({ autoAttach: true });
+    expect(autoAttachCalls[1]?.[1]).toMatchObject({ autoAttach: false });
+    expect(debuggerApi.detach).toHaveBeenCalledTimes(1);
+    expect(debuggerApi.removeListener).toHaveBeenCalledTimes(1);
+    const [, removedListener] = debuggerApi.removeListener.mock.calls[0] ?? [
+      undefined,
+      undefined,
+    ];
+    const [, registeredListener] = debuggerApi.on.mock.calls[0] ?? [
+      undefined,
+      undefined,
+    ];
+    expect(removedListener).toBe(registeredListener);
+    expect(sender.getOSProcessId).toHaveBeenCalled();
+  });
+
+  it("returns null without attaching when a debugger is already attached to this window", async () => {
+    const debuggerApi = buildFakeDebugger({
+      pageHeapUsage: { usedSize: 1, totalSize: 1 },
+      workers: [],
+      isAttachedInitially: true,
+      attachThrows: false,
+    });
+    const { event } = buildFakeEvent({
+      isDestroyed: false,
+      pageUrl: "app://renderer/index.html",
+      pid: 1,
+      debuggerApi,
+    });
+
+    const result = await handleMeasureJsHeaps(event);
+
+    expect(result).toBeNull();
+    expect(debuggerApi.attach).not.toHaveBeenCalled();
+    expect(debuggerApi.detach).not.toHaveBeenCalled();
+  });
+
+  it("returns null and never touches the message listener when attach() throws", async () => {
+    const debuggerApi = buildFakeDebugger({
+      pageHeapUsage: { usedSize: 1, totalSize: 1 },
+      workers: [],
+      isAttachedInitially: false,
+      attachThrows: true,
+    });
+    const { event } = buildFakeEvent({
+      isDestroyed: false,
+      pageUrl: "app://renderer/index.html",
+      pid: 1,
+      debuggerApi,
+    });
+
+    const result = await handleMeasureJsHeaps(event);
+
+    expect(result).toBeNull();
+    expect(debuggerApi.attach).toHaveBeenCalledTimes(1);
+    expect(debuggerApi.on).not.toHaveBeenCalled();
+    expect(debuggerApi.detach).not.toHaveBeenCalled();
+  });
+
+  it("returns null and still detaches when a command rejects mid-measurement", async () => {
+    const debuggerApi = buildFakeDebugger({
+      pageHeapUsage: "reject",
+      workers: [],
+      isAttachedInitially: false,
+      attachThrows: false,
+    });
+    const { event } = buildFakeEvent({
+      isDestroyed: false,
+      pageUrl: "app://renderer/index.html",
+      pid: 1,
+      debuggerApi,
+    });
+
+    const result = await handleMeasureJsHeaps(event);
+
+    expect(result).toBeNull();
+    expect(debuggerApi.attach).toHaveBeenCalledTimes(1);
+    expect(debuggerApi.detach).toHaveBeenCalledTimes(1);
+    expect(debuggerApi.removeListener).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns null when the sender is destroyed, without reading the debugger at all", async () => {
+    const debuggerApi = buildFakeDebugger({
+      pageHeapUsage: { usedSize: 1, totalSize: 1 },
+      workers: [],
+      isAttachedInitially: false,
+      attachThrows: false,
+    });
+    const { event } = buildFakeEvent({
+      isDestroyed: true,
+      pageUrl: "app://renderer/index.html",
+      pid: 1,
+      debuggerApi,
+    });
+
+    const result = await handleMeasureJsHeaps(event);
+
+    expect(result).toBeNull();
+    expect(debuggerApi.isAttached).not.toHaveBeenCalled();
+    expect(debuggerApi.attach).not.toHaveBeenCalled();
+  });
+});

--- a/clients/desktop/src/electron-main/app/__tests__/diagnostics-js-heaps.test.ts
+++ b/clients/desktop/src/electron-main/app/__tests__/diagnostics-js-heaps.test.ts
@@ -53,15 +53,27 @@ type MessageListener = (
 interface HeapUsageResult {
   readonly usedSize: number;
   readonly totalSize: number;
+}
+
+/**
+ * What a build that reports the two experimental fields answers with. A
+ * separate shape rather than optional properties (which this repo's lint
+ * bans), so a fixture can genuinely OMIT the keys - the case
+ * `readHeapUsage` has to survive, and a different one from a key that is
+ * present and null.
+ */
+interface HeapUsageResultWithExternal extends HeapUsageResult {
   readonly embedderHeapUsedSize: number | null;
   readonly backingStorageSize: number | null;
 }
+
+type HeapUsagePayload = HeapUsageResult | HeapUsageResultWithExternal;
 
 interface FakeWorkerFixture {
   readonly sessionId: string;
   readonly type: string;
   readonly url: string;
-  readonly heapUsage: HeapUsageResult | "reject";
+  readonly heapUsage: HeapUsagePayload | "reject" | "pending";
 }
 
 interface FakeDebugger {
@@ -79,6 +91,16 @@ interface FakeDebugger {
       sessionId: string | undefined,
     ) => Promise<unknown>
   >;
+  /**
+   * Settles a worker's `heapUsage: "pending"` read. Separate from
+   * `sendCommand` because the fixture that registers as "pending" does not
+   * know its own answer yet - the test decides it later, after the timeout
+   * has already fired around it.
+   */
+  readonly resolvePendingHeapUsage: (
+    sessionId: string,
+    payload: HeapUsagePayload,
+  ) => void;
 }
 
 interface FakeSender {
@@ -104,7 +126,7 @@ function asIpcMainInvokeEvent(fake: FakeEvent): IpcMainInvokeEvent {
 }
 
 function buildFakeDebugger(options: {
-  readonly pageHeapUsage: HeapUsageResult | "reject";
+  readonly pageHeapUsage: HeapUsagePayload | "reject";
   readonly workers: ReadonlyArray<FakeWorkerFixture>;
   readonly isAttachedInitially: boolean;
   readonly attachThrows: boolean;
@@ -114,6 +136,20 @@ function buildFakeDebugger(options: {
   const workersBySessionId = new Map(
     options.workers.map((worker) => [worker.sessionId, worker]),
   );
+  // One never-resolving-on-its-own promise per "pending" worker, built eagerly
+  // so it exists regardless of call order between the read and the resolve.
+  const pendingHeapUsageResolvers = new Map<
+    string,
+    (payload: HeapUsagePayload) => void
+  >();
+  const pendingHeapUsagePromises = new Map<string, Promise<HeapUsagePayload>>();
+  for (const worker of options.workers) {
+    if (worker.heapUsage !== "pending") continue;
+    const promise = new Promise<HeapUsagePayload>((resolve) => {
+      pendingHeapUsageResolvers.set(worker.sessionId, resolve);
+    });
+    pendingHeapUsagePromises.set(worker.sessionId, promise);
+  }
 
   const isAttached = vi.fn((): boolean => attached);
   const attach = vi.fn((protocolVersion: string): void => {
@@ -151,6 +187,15 @@ function buildFakeDebugger(options: {
         if (worker === undefined) {
           return Promise.reject(new Error(`unknown session ${sessionId}`));
         }
+        if (worker.heapUsage === "pending") {
+          const pending = pendingHeapUsagePromises.get(sessionId);
+          if (pending === undefined) {
+            return Promise.reject(
+              new Error(`no pending heap usage registered for ${sessionId}`),
+            );
+          }
+          return pending;
+        }
         return worker.heapUsage === "reject"
           ? Promise.reject(new Error("worker heap read failed"))
           : Promise.resolve(worker.heapUsage);
@@ -177,7 +222,26 @@ function buildFakeDebugger(options: {
     },
   );
 
-  return { isAttached, attach, detach, on, removeListener, sendCommand };
+  const resolvePendingHeapUsage = (
+    sessionId: string,
+    payload: HeapUsagePayload,
+  ): void => {
+    const resolve = pendingHeapUsageResolvers.get(sessionId);
+    if (resolve === undefined) {
+      throw new Error(`no pending heap usage resolver for ${sessionId}`);
+    }
+    resolve(payload);
+  };
+
+  return {
+    isAttached,
+    attach,
+    detach,
+    on,
+    removeListener,
+    sendCommand,
+    resolvePendingHeapUsage,
+  };
 }
 
 function buildFakeEvent(options: {
@@ -215,6 +279,7 @@ describe("handleMeasureJsHeaps", () => {
 
   afterEach(() => {
     vi.clearAllMocks();
+    vi.useRealTimers();
   });
 
   it("returns the page plus every surviving worker isolate, skips non-worker targets, and converts the working set from KB", async () => {
@@ -325,10 +390,11 @@ describe("handleMeasureJsHeaps", () => {
     expect(sender.getOSProcessId).toHaveBeenCalled();
   });
 
-  it("carries null for embedder and backing storage when the protocol result omits them, and still returns the row", async () => {
+  it("carries null for embedder and backing storage whether the protocol result omits the keys or answers null, and still returns the row", async () => {
     // `embedderHeapUsedSize` / `backingStorageSize` are experimental CDP
-    // fields - a build that does not report them (or reports something that
-    // is not a number) must not drop the isolate row, only those two fields.
+    // fields. The page here is a build that does not send them AT ALL (the
+    // keys are absent), the worker one that sends them as null; neither may
+    // cost the isolate its row, only those two fields.
     const workers: ReadonlyArray<FakeWorkerFixture> = [
       {
         sessionId: "session-worker",
@@ -346,8 +412,6 @@ describe("handleMeasureJsHeaps", () => {
       pageHeapUsage: {
         usedSize: 10_000_000,
         totalSize: 20_000_000,
-        embedderHeapUsedSize: null,
-        backingStorageSize: null,
       },
       workers,
       isAttachedInitially: false,
@@ -482,5 +546,133 @@ describe("handleMeasureJsHeaps", () => {
     expect(result).toBeNull();
     expect(debuggerApi.isAttached).not.toHaveBeenCalled();
     expect(debuggerApi.attach).not.toHaveBeenCalled();
+  });
+
+  it("keeps a timed-out measurement's late cleanup from switching off a later measurement's auto-attach", async () => {
+    // CDP commands cannot be cancelled: a timed-out `measureIsolates` keeps
+    // running behind `withTimeout`. Before the `cancellation` guard, its own
+    // stale cleanup (`Target.setAutoAttach` with `autoAttach:false`) would
+    // fire once its stuck worker read finally settled - this pins that it no
+    // longer does, and that a later, ordinary measurement is unaffected.
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+
+    const workerSessionId = "session-stuck";
+    const workers: ReadonlyArray<FakeWorkerFixture> = [
+      {
+        sessionId: workerSessionId,
+        type: "worker",
+        url: "app://renderer/assets/worker-DMI2JaPh.js",
+        heapUsage: "pending",
+      },
+    ];
+    const debuggerApi = buildFakeDebugger({
+      pageHeapUsage: { usedSize: 1_000_000, totalSize: 2_000_000 },
+      workers,
+      isAttachedInitially: false,
+      attachThrows: false,
+    });
+    const { event } = buildFakeEvent({
+      isDestroyed: false,
+      pageUrl: "app://renderer/index.html",
+      pid: 1,
+      debuggerApi,
+    });
+
+    const resultPromise = handleMeasureJsHeaps(event);
+
+    // `setImmediate` is real (kept out of `toFake` above): production awaits
+    // one between `Target.setAutoAttach: true` and the worker reads, so real
+    // ticks - not fake-clock advancement - are what gets us to the stuck read.
+    const reachedPendingRead = (): boolean =>
+      debuggerApi.sendCommand.mock.calls.some(
+        ([method, , sessionId]) =>
+          method === "Runtime.getHeapUsage" && sessionId === workerSessionId,
+      );
+    for (let tick = 0; tick < 10 && !reachedPendingRead(); tick += 1) {
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+    }
+    expect(reachedPendingRead()).toBe(true);
+
+    // Past the production JS_HEAP_MEASURE_TIMEOUT_MS (10_000ms, not
+    // exported) - `withTimeout` rejects and flips `cancellation.cancelled`
+    // while the worker read above is still outstanding.
+    await vi.advanceTimersByTimeAsync(10_001);
+
+    const result = await resultPromise;
+    expect(result).toBeNull();
+    expect(debuggerApi.detach).toHaveBeenCalledTimes(1);
+
+    // The straggler's read finally answers. Nothing is awaiting its
+    // `measureIsolates` call anymore, but it keeps running behind the
+    // already-settled race - let it reach its own `finally`.
+    debuggerApi.resolvePendingHeapUsage(workerSessionId, {
+      usedSize: 3_000_000,
+      totalSize: 4_000_000,
+    });
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+
+    const autoAttachFalseCalls = debuggerApi.sendCommand.mock.calls.filter(
+      ([method, params]) =>
+        method === "Target.setAutoAttach" && params?.["autoAttach"] === false,
+    );
+    expect(autoAttachFalseCalls).toHaveLength(0);
+
+    vi.useRealTimers();
+
+    // A fresh, ordinary measurement afterward gets the full page + worker
+    // rows and performs its own single autoAttach:false cleanup - the
+    // timed-out run above left nothing behind that spoils it.
+    const freshWorkers: ReadonlyArray<FakeWorkerFixture> = [
+      {
+        sessionId: "session-fresh",
+        type: "worker",
+        url: "app://renderer/assets/worker-DMI2JaPh.js",
+        heapUsage: { usedSize: 6_000_000, totalSize: 7_000_000 },
+      },
+    ];
+    const freshDebuggerApi = buildFakeDebugger({
+      pageHeapUsage: { usedSize: 8_000_000, totalSize: 9_000_000 },
+      workers: freshWorkers,
+      isAttachedInitially: false,
+      attachThrows: false,
+    });
+    const { event: freshEvent } = buildFakeEvent({
+      isDestroyed: false,
+      pageUrl: "app://renderer/index.html",
+      pid: 2,
+      debuggerApi: freshDebuggerApi,
+    });
+
+    const freshResult = await handleMeasureJsHeaps(freshEvent);
+
+    expect(freshResult).not.toBeNull();
+    expect(freshResult?.isolates).toEqual([
+      {
+        kind: "page",
+        url: "app://renderer/index.html",
+        usedBytes: 8_000_000,
+        totalBytes: 9_000_000,
+        embedderBytes: null,
+        backingStorageBytes: null,
+      },
+      {
+        kind: "worker",
+        url: "app://renderer/assets/worker-DMI2JaPh.js",
+        usedBytes: 6_000_000,
+        totalBytes: 7_000_000,
+        embedderBytes: null,
+        backingStorageBytes: null,
+      },
+    ]);
+    const freshAutoAttachFalseCalls =
+      freshDebuggerApi.sendCommand.mock.calls.filter(
+        ([method, params]) =>
+          method === "Target.setAutoAttach" && params?.["autoAttach"] === false,
+      );
+    expect(freshAutoAttachFalseCalls).toHaveLength(1);
   });
 });

--- a/clients/desktop/src/electron-main/app/__tests__/diagnostics-js-heaps.test.ts
+++ b/clients/desktop/src/electron-main/app/__tests__/diagnostics-js-heaps.test.ts
@@ -130,6 +130,12 @@ function buildFakeDebugger(options: {
   readonly workers: ReadonlyArray<FakeWorkerFixture>;
   readonly isAttachedInitially: boolean;
   readonly attachThrows: boolean;
+  /**
+   * Rejects the cleanup `Target.setAutoAttach` call (`autoAttach: false`)
+   * only - the arming call (`autoAttach: true`) always succeeds, matching a
+   * session that goes away only after the reads it enabled already landed.
+   */
+  readonly autoAttachFalseRejects: boolean;
 }): FakeDebugger {
   let attached = options.isAttachedInitially;
   let messageListener: MessageListener | null = null;
@@ -202,6 +208,9 @@ function buildFakeDebugger(options: {
       }
       if (method === "Target.setAutoAttach") {
         const autoAttach = commandParams?.["autoAttach"];
+        if (autoAttach === false && options.autoAttachFalseRejects) {
+          return Promise.reject(new Error("auto-attach cleanup failed"));
+        }
         if (autoAttach === true && messageListener !== null) {
           const listener = messageListener;
           for (const worker of options.workers) {
@@ -323,6 +332,7 @@ describe("handleMeasureJsHeaps", () => {
       workers,
       isAttachedInitially: false,
       attachThrows: false,
+      autoAttachFalseRejects: false,
     });
     const { event, sender } = buildFakeEvent({
       isDestroyed: false,
@@ -416,6 +426,7 @@ describe("handleMeasureJsHeaps", () => {
       workers,
       isAttachedInitially: false,
       attachThrows: false,
+      autoAttachFalseRejects: false,
     });
     const { event } = buildFakeEvent({
       isDestroyed: false,
@@ -458,6 +469,7 @@ describe("handleMeasureJsHeaps", () => {
       workers: [],
       isAttachedInitially: true,
       attachThrows: false,
+      autoAttachFalseRejects: false,
     });
     const { event } = buildFakeEvent({
       isDestroyed: false,
@@ -484,6 +496,7 @@ describe("handleMeasureJsHeaps", () => {
       workers: [],
       isAttachedInitially: false,
       attachThrows: true,
+      autoAttachFalseRejects: false,
     });
     const { event } = buildFakeEvent({
       isDestroyed: false,
@@ -506,6 +519,7 @@ describe("handleMeasureJsHeaps", () => {
       workers: [],
       isAttachedInitially: false,
       attachThrows: false,
+      autoAttachFalseRejects: false,
     });
     const { event } = buildFakeEvent({
       isDestroyed: false,
@@ -533,6 +547,7 @@ describe("handleMeasureJsHeaps", () => {
       workers: [],
       isAttachedInitially: false,
       attachThrows: false,
+      autoAttachFalseRejects: false,
     });
     const { event } = buildFakeEvent({
       isDestroyed: true,
@@ -570,6 +585,7 @@ describe("handleMeasureJsHeaps", () => {
       workers,
       isAttachedInitially: false,
       attachThrows: false,
+      autoAttachFalseRejects: false,
     });
     const { event } = buildFakeEvent({
       isDestroyed: false,
@@ -639,6 +655,7 @@ describe("handleMeasureJsHeaps", () => {
       workers: freshWorkers,
       isAttachedInitially: false,
       attachThrows: false,
+      autoAttachFalseRejects: false,
     });
     const { event: freshEvent } = buildFakeEvent({
       isDestroyed: false,
@@ -674,5 +691,65 @@ describe("handleMeasureJsHeaps", () => {
           method === "Target.setAutoAttach" && params?.["autoAttach"] === false,
       );
     expect(freshAutoAttachFalseCalls).toHaveLength(1);
+  });
+
+  it("still returns the full breakdown, and still detaches, when the cleanup autoAttach:false command rejects", async () => {
+    // CodeRabbit Minor: a `finally` block that throws replaces whatever the
+    // `try` returned. This command can reject for reasons that say nothing
+    // about the rows already read (the page navigated, the session went
+    // away), so the read isolates must survive it rather than turning a
+    // complete breakdown into a failure toast.
+    const workers: ReadonlyArray<FakeWorkerFixture> = [
+      {
+        sessionId: "session-worker",
+        type: "worker",
+        url: "app://renderer/assets/worker-DMI2JaPh.js",
+        heapUsage: { usedSize: 2_000_000, totalSize: 3_000_000 },
+      },
+    ];
+    const debuggerApi = buildFakeDebugger({
+      pageHeapUsage: { usedSize: 10_000_000, totalSize: 20_000_000 },
+      workers,
+      isAttachedInitially: false,
+      attachThrows: false,
+      autoAttachFalseRejects: true,
+    });
+    const { event } = buildFakeEvent({
+      isDestroyed: false,
+      pageUrl: "app://renderer/index.html",
+      pid: 1,
+      debuggerApi,
+    });
+
+    const result = await handleMeasureJsHeaps(event);
+
+    expect(result).not.toBeNull();
+    expect(result?.isolates).toEqual([
+      {
+        kind: "page",
+        url: "app://renderer/index.html",
+        usedBytes: 10_000_000,
+        totalBytes: 20_000_000,
+        embedderBytes: null,
+        backingStorageBytes: null,
+      },
+      {
+        kind: "worker",
+        url: "app://renderer/assets/worker-DMI2JaPh.js",
+        usedBytes: 2_000_000,
+        totalBytes: 3_000_000,
+        embedderBytes: null,
+        backingStorageBytes: null,
+      },
+    ]);
+    expect(debuggerApi.detach).toHaveBeenCalledTimes(1);
+    // The arming call (autoAttach:true) still had to succeed for the worker
+    // row to exist at all - only the cleanup call (autoAttach:false) rejects.
+    const autoAttachCalls = debuggerApi.sendCommand.mock.calls.filter(
+      ([method]) => method === "Target.setAutoAttach",
+    );
+    expect(autoAttachCalls).toHaveLength(2);
+    expect(autoAttachCalls[0]?.[1]).toMatchObject({ autoAttach: true });
+    expect(autoAttachCalls[1]?.[1]).toMatchObject({ autoAttach: false });
   });
 });

--- a/clients/desktop/src/electron-main/app/diagnostics.ts
+++ b/clients/desktop/src/electron-main/app/diagnostics.ts
@@ -82,15 +82,33 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
 
+function readOptionalSize(value: unknown): number | null {
+  return typeof value === "number" ? value : null;
+}
+
+/**
+ * `usedSize` / `totalSize` are the JS heap. `embedderHeapUsedSize` and
+ * `backingStorageSize` are the memory attributed to the isolate that sits
+ * OUTSIDE it - Blink's own objects, and `ArrayBuffer`/WASM backing stores such
+ * as a diff highlighter worker's Oniguruma engine. Both are experimental
+ * protocol fields, so each is carried only when the build answers with it;
+ * dropping them would undercount precisely the workers this readout measures.
+ */
 function readHeapUsage(
   result: unknown,
-): { readonly usedBytes: number; readonly totalBytes: number } | null {
+): Omit<RendererJsHeapIsolate, "kind" | "url"> | null {
   if (!isRecord(result)) return null;
-  const { usedSize, totalSize } = result;
+  const { usedSize, totalSize, embedderHeapUsedSize, backingStorageSize } =
+    result;
   if (typeof usedSize !== "number" || typeof totalSize !== "number") {
     return null;
   }
-  return { usedBytes: usedSize, totalBytes: totalSize };
+  return {
+    usedBytes: usedSize,
+    totalBytes: totalSize,
+    embedderBytes: readOptionalSize(embedderHeapUsedSize),
+    backingStorageBytes: readOptionalSize(backingStorageSize),
+  };
 }
 
 /**
@@ -194,6 +212,14 @@ export async function handleMeasureJsHeaps(
       usedBytes: isolates.reduce((sum, isolate) => sum + isolate.usedBytes, 0),
       totalBytes: isolates.reduce(
         (sum, isolate) => sum + isolate.totalBytes,
+        0,
+      ),
+      embedderBytes: isolates.reduce(
+        (sum, isolate) => sum + (isolate.embedderBytes ?? 0),
+        0,
+      ),
+      backingStorageBytes: isolates.reduce(
+        (sum, isolate) => sum + (isolate.backingStorageBytes ?? 0),
         0,
       ),
     });

--- a/clients/desktop/src/electron-main/app/diagnostics.ts
+++ b/clients/desktop/src/electron-main/app/diagnostics.ts
@@ -8,8 +8,12 @@ import * as SentryElectron from "@sentry/electron/main";
 import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { log } from "./logger";
+import { describeLogError, log } from "./logger";
 import { isSentryEnabled } from "./crash-reporter-state";
+import type {
+  RendererJsHeapBreakdown,
+  RendererJsHeapIsolate,
+} from "../../ipc-contracts/platform-types";
 
 /**
  * Snapshots process-wide and per-process resource usage for support
@@ -50,6 +54,219 @@ export async function handleTakeHeapSnapshot(
     log.error("[diagnostics] heap snapshot failed", { err, filePath });
     return null;
   }
+}
+
+/**
+ * Bounds the whole measurement. Every step is a single round trip to a
+ * renderer that is alive enough to have sent this request, so a wait past this
+ * is a wedged protocol session, not a slow one - and the `finally` below must
+ * get to detach.
+ */
+const JS_HEAP_MEASURE_TIMEOUT_MS = 10_000;
+
+interface AttachedWorkerTarget {
+  readonly sessionId: string;
+  readonly url: string;
+}
+
+interface DebuggerMessageListener {
+  (
+    event: Electron.Event,
+    method: string,
+    params: unknown,
+    sessionId: string | undefined,
+  ): void;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function readHeapUsage(
+  result: unknown,
+): { readonly usedBytes: number; readonly totalBytes: number } | null {
+  if (!isRecord(result)) return null;
+  const { usedSize, totalSize } = result;
+  if (typeof usedSize !== "number" || typeof totalSize !== "number") {
+    return null;
+  }
+  return { usedBytes: usedSize, totalBytes: totalSize };
+}
+
+/**
+ * `Target.attachedToTarget` params. Only dedicated workers are collected: a
+ * service worker or a shared worker belongs to the browser context, not to
+ * this window's process, and would be counted against the wrong renderer.
+ */
+function readAttachedWorkerTarget(
+  params: unknown,
+): AttachedWorkerTarget | null {
+  if (!isRecord(params)) return null;
+  const { sessionId, targetInfo } = params;
+  if (typeof sessionId !== "string" || !isRecord(targetInfo)) return null;
+  if (targetInfo.type !== "worker" || typeof targetInfo.url !== "string") {
+    return null;
+  }
+  return { sessionId, url: targetInfo.url };
+}
+
+function withTimeout<T>(work: Promise<T>, timeoutMs: number): Promise<T> {
+  let timer: NodeJS.Timeout | null = null;
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => {
+      reject(new Error(`js heap measurement timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+  });
+  return Promise.race([work, timeout]).finally(() => {
+    if (timer !== null) clearTimeout(timer);
+  });
+}
+
+/**
+ * Per-isolate JS heap usage for the sender renderer: the page, plus every
+ * dedicated worker it currently runs.
+ *
+ * WHY. A heap snapshot (`handleTakeHeapSnapshot`) walks the main thread's
+ * isolate and nothing else. The renderer also runs one V8 isolate per
+ * dedicated worker - an epic runtime worker per live epic session, a pool of
+ * diff highlighter workers - and none of their memory shows up in that file.
+ * The 2026-09-03 staging investigation had a 1.5 GB renderer whose snapshot
+ * accounted for 190 MB; this readout is what was missing to say where the rest
+ * lived.
+ *
+ * HOW. Chrome DevTools Protocol over `webContents.debugger`, the same channel
+ * the browser tiles use. A page-scoped session cannot list targets
+ * (`Target.getTargets` is browser-scoped), so the workers are reached the way
+ * DevTools reaches them: `Target.setAutoAttach` with `flatten: true`, which
+ * attaches to every existing dedicated worker and announces each one with a
+ * `Target.attachedToTarget` event carrying a session id. `Runtime.getHeapUsage`
+ * on that session id answers for that isolate. Nothing is paused
+ * (`waitForDebuggerOnStart: false`) and nothing is enabled, so the workers
+ * never notice; the whole thing is a handful of round trips.
+ *
+ * Refuses, rather than shares, a debugger someone else has attached: the
+ * auto-attach toggle is session-wide state, and flipping it under a browser
+ * tile's debug session would detach the workers that session was tracking.
+ */
+export async function handleMeasureJsHeaps(
+  event: IpcMainInvokeEvent,
+): Promise<RendererJsHeapBreakdown | null> {
+  const contents = event.sender;
+  if (contents.isDestroyed()) return null;
+  const debuggerApi = contents.debugger;
+  if (debuggerApi.isAttached()) {
+    log.warn(
+      "[diagnostics] js heap measurement skipped: a debugger is already attached to this window",
+    );
+    return null;
+  }
+  const attachedWorkers = new Map<string, AttachedWorkerTarget>();
+  const onMessage: DebuggerMessageListener = (_event, method, params) => {
+    if (method !== "Target.attachedToTarget") return;
+    const target = readAttachedWorkerTarget(params);
+    if (target === null) return;
+    attachedWorkers.set(target.sessionId, target);
+  };
+  try {
+    debuggerApi.attach("1.3");
+  } catch (err) {
+    log.warn("[diagnostics] js heap measurement could not attach", {
+      error: describeLogError(err),
+    });
+    return null;
+  }
+  debuggerApi.on("message", onMessage);
+  try {
+    const isolates = await withTimeout(
+      measureIsolates(debuggerApi, contents.getURL(), attachedWorkers),
+      JS_HEAP_MEASURE_TIMEOUT_MS,
+    );
+    const pid = contents.getOSProcessId();
+    const metric = app.getAppMetrics().find((entry) => entry.pid === pid);
+    const breakdown: RendererJsHeapBreakdown = {
+      capturedAt: Date.now(),
+      workingSetBytes:
+        metric === undefined ? null : metric.memory.workingSetSize * 1024,
+      isolates,
+    };
+    log.info("[diagnostics] js heaps measured", {
+      isolates: isolates.length,
+      usedBytes: isolates.reduce((sum, isolate) => sum + isolate.usedBytes, 0),
+      totalBytes: isolates.reduce(
+        (sum, isolate) => sum + isolate.totalBytes,
+        0,
+      ),
+    });
+    return breakdown;
+  } catch (err) {
+    log.warn("[diagnostics] js heap measurement failed", {
+      error: describeLogError(err),
+    });
+    return null;
+  } finally {
+    debuggerApi.removeListener("message", onMessage);
+    if (debuggerApi.isAttached()) {
+      try {
+        debuggerApi.detach();
+      } catch (err) {
+        log.warn("[diagnostics] js heap measurement detach failed", {
+          error: describeLogError(err),
+        });
+      }
+    }
+  }
+}
+
+async function measureIsolates(
+  debuggerApi: Electron.Debugger,
+  pageUrl: string,
+  attachedWorkers: ReadonlyMap<string, AttachedWorkerTarget>,
+): Promise<ReadonlyArray<RendererJsHeapIsolate>> {
+  const isolates: RendererJsHeapIsolate[] = [];
+  const page = readHeapUsage(
+    await debuggerApi.sendCommand("Runtime.getHeapUsage", {}),
+  );
+  if (page !== null) isolates.push({ kind: "page", url: pageUrl, ...page });
+  await debuggerApi.sendCommand("Target.setAutoAttach", {
+    autoAttach: true,
+    waitForDebuggerOnStart: false,
+    flatten: true,
+  });
+  // The attach announcements for existing workers are delivered before the
+  // command's own response on the same ordered channel; one turn of the event
+  // loop is the belt to that suspender, so a late event is not a missed row.
+  await new Promise<void>((resolve) => {
+    setImmediate(resolve);
+  });
+  try {
+    for (const worker of attachedWorkers.values()) {
+      try {
+        const usage = readHeapUsage(
+          await debuggerApi.sendCommand(
+            "Runtime.getHeapUsage",
+            {},
+            worker.sessionId,
+          ),
+        );
+        if (usage === null) continue;
+        isolates.push({ kind: "worker", url: worker.url, ...usage });
+      } catch (err) {
+        // A worker that exited between the attach and the read. Its row is
+        // simply absent; the others still answer.
+        log.debug("[diagnostics] worker heap read failed", {
+          url: worker.url,
+          error: describeLogError(err),
+        });
+      }
+    }
+  } finally {
+    await debuggerApi.sendCommand("Target.setAutoAttach", {
+      autoAttach: false,
+      waitForDebuggerOnStart: false,
+      flatten: true,
+    });
+  }
+  return isolates;
 }
 
 const MEMORY_SAMPLE_INTERVAL_MS = 5 * 60_000;

--- a/clients/desktop/src/electron-main/app/diagnostics.ts
+++ b/clients/desktop/src/electron-main/app/diagnostics.ts
@@ -128,13 +128,36 @@ function readAttachedWorkerTarget(
   return { sessionId, url: targetInfo.url };
 }
 
-function withTimeout<T>(work: Promise<T>, timeoutMs: number): Promise<T> {
+/**
+ * Set when the measurement has lost its awaiter, so the work still running
+ * behind it stops touching the debugger.
+ *
+ * CDP commands cannot be cancelled - `sendCommand` resolves when the browser
+ * answers, and a timed-out `measureIsolates` keeps going. Left alone it would
+ * reach its own cleanup and send `Target.setAutoAttach: false` after the outer
+ * `finally` detached; the harmful case is not the detached session (that command
+ * simply fails) but a LATER measurement having re-attached by then, whose
+ * auto-attach the straggler would switch off mid-flight, costing it every worker
+ * row and reporting a page-only breakdown as if that were the truth.
+ */
+interface MeasurementCancellation {
+  cancelled: boolean;
+}
+
+function withTimeout<T>(
+  work: Promise<T>,
+  timeoutMs: number,
+  cancellation: MeasurementCancellation,
+): Promise<T> {
   let timer: NodeJS.Timeout | null = null;
   const timeout = new Promise<never>((_resolve, reject) => {
     timer = setTimeout(() => {
+      cancellation.cancelled = true;
       reject(new Error(`js heap measurement timed out after ${timeoutMs}ms`));
     }, timeoutMs);
   });
+  // `Promise.race` keeps a handler on `work`, so a late rejection from the
+  // straggler is absorbed here rather than surfacing as an unhandled rejection.
   return Promise.race([work, timeout]).finally(() => {
     if (timer !== null) clearTimeout(timer);
   });
@@ -194,10 +217,17 @@ export async function handleMeasureJsHeaps(
     return null;
   }
   debuggerApi.on("message", onMessage);
+  const cancellation: MeasurementCancellation = { cancelled: false };
   try {
     const isolates = await withTimeout(
-      measureIsolates(debuggerApi, contents.getURL(), attachedWorkers),
+      measureIsolates(
+        debuggerApi,
+        contents.getURL(),
+        attachedWorkers,
+        cancellation,
+      ),
       JS_HEAP_MEASURE_TIMEOUT_MS,
+      cancellation,
     );
     const pid = contents.getOSProcessId();
     const metric = app.getAppMetrics().find((entry) => entry.pid === pid);
@@ -247,12 +277,16 @@ async function measureIsolates(
   debuggerApi: Electron.Debugger,
   pageUrl: string,
   attachedWorkers: ReadonlyMap<string, AttachedWorkerTarget>,
+  cancellation: MeasurementCancellation,
 ): Promise<ReadonlyArray<RendererJsHeapIsolate>> {
   const isolates: RendererJsHeapIsolate[] = [];
   const page = readHeapUsage(
     await debuggerApi.sendCommand("Runtime.getHeapUsage", {}),
   );
   if (page !== null) isolates.push({ kind: "page", url: pageUrl, ...page });
+  // Every guard below is read in the same synchronous step as the command it
+  // protects, so a cancellation cannot slip between the two.
+  if (cancellation.cancelled) return isolates;
   await debuggerApi.sendCommand("Target.setAutoAttach", {
     autoAttach: true,
     waitForDebuggerOnStart: false,
@@ -266,6 +300,7 @@ async function measureIsolates(
   });
   try {
     for (const worker of attachedWorkers.values()) {
+      if (cancellation.cancelled) break;
       try {
         const usage = readHeapUsage(
           await debuggerApi.sendCommand(
@@ -286,11 +321,17 @@ async function measureIsolates(
       }
     }
   } finally {
-    await debuggerApi.sendCommand("Target.setAutoAttach", {
-      autoAttach: false,
-      waitForDebuggerOnStart: false,
-      flatten: true,
-    });
+    // A cancelled measurement skips its own cleanup: the outer `finally` is
+    // detaching, and auto-attach is session state that dies with the
+    // attachment, so there is nothing left to turn off - only someone else's
+    // attachment to damage.
+    if (!cancellation.cancelled) {
+      await debuggerApi.sendCommand("Target.setAutoAttach", {
+        autoAttach: false,
+        waitForDebuggerOnStart: false,
+        flatten: true,
+      });
+    }
   }
   return isolates;
 }

--- a/clients/desktop/src/electron-main/app/diagnostics.ts
+++ b/clients/desktop/src/electron-main/app/diagnostics.ts
@@ -326,11 +326,23 @@ async function measureIsolates(
     // attachment, so there is nothing left to turn off - only someone else's
     // attachment to damage.
     if (!cancellation.cancelled) {
-      await debuggerApi.sendCommand("Target.setAutoAttach", {
-        autoAttach: false,
-        waitForDebuggerOnStart: false,
-        flatten: true,
-      });
+      try {
+        await debuggerApi.sendCommand("Target.setAutoAttach", {
+          autoAttach: false,
+          waitForDebuggerOnStart: false,
+          flatten: true,
+        });
+      } catch (err) {
+        // A `finally` that throws replaces what the `try` returned, so an
+        // unguarded cleanup would trade a complete breakdown for a failure
+        // toast - and this command rejects for reasons that say nothing about
+        // the rows already read (the page navigated, the session went away).
+        // The outer `finally` detaches either way, which is what actually
+        // undoes the auto-attach.
+        log.debug("[diagnostics] auto-attach cleanup failed", {
+          error: describeLogError(err),
+        });
+      }
     }
   }
   return isolates;

--- a/clients/desktop/src/electron-main/ipc/__tests__/runner-ipc.test.ts
+++ b/clients/desktop/src/electron-main/ipc/__tests__/runner-ipc.test.ts
@@ -703,6 +703,7 @@ describe("RunnerIpcBridge", () => {
           RunnerHostInvoke.windowSetContentProtection,
           RunnerHostInvoke.diagnosticsGetMetrics,
           RunnerHostInvoke.diagnosticsTakeHeapSnapshot,
+          RunnerHostInvoke.diagnosticsMeasureJsHeaps,
           RunnerHostInvoke.diagnosticsTraceStart,
           RunnerHostInvoke.diagnosticsTraceStop,
           RunnerHostInvoke.systemPreferencesAccentColor,

--- a/clients/desktop/src/electron-main/ipc/platform-ipc.ts
+++ b/clients/desktop/src/electron-main/ipc/platform-ipc.ts
@@ -11,6 +11,7 @@ import {
 } from "../app/window-effects";
 import {
   handleGetMetrics,
+  handleMeasureJsHeaps,
   handleTakeHeapSnapshot,
   handleTraceStart,
   handleTraceStop,
@@ -263,6 +264,10 @@ export function registerPlatformIpc(
 
   bridge.handleInvoke(RunnerHostInvoke.diagnosticsTakeHeapSnapshot, (event) => {
     return handleTakeHeapSnapshot(event);
+  });
+
+  bridge.handleInvoke(RunnerHostInvoke.diagnosticsMeasureJsHeaps, (event) => {
+    return handleMeasureJsHeaps(event);
   });
 
   bridge.handleInvoke(RunnerHostInvoke.diagnosticsTraceStart, () => {

--- a/clients/desktop/src/electron-preload/platform-bridge.ts
+++ b/clients/desktop/src/electron-preload/platform-bridge.ts
@@ -16,6 +16,7 @@ import type {
   LogLevelsSnapshot,
   PendingCertificateError,
   ProcessMetricsSnapshot,
+  RendererJsHeapBreakdown,
   TrustedCertificateEntry,
   Vibrancy,
 } from "../ipc-contracts/platform-types";
@@ -30,6 +31,7 @@ export type {
   InstalledFont,
   PendingCertificateError,
   ProcessMetricsSnapshot,
+  RendererJsHeapBreakdown,
   TrustedCertificateEntry,
   Vibrancy,
 } from "../ipc-contracts/platform-types";
@@ -60,6 +62,7 @@ export interface PlatformBridgeSurface {
   diagnostics: {
     getMetrics(): Promise<ProcessMetricsSnapshot>;
     takeHeapSnapshot(): Promise<string | null>;
+    measureJsHeaps(): Promise<RendererJsHeapBreakdown | null>;
     traceStart(): Promise<boolean>;
     traceStop(): Promise<string | null>;
   };
@@ -191,6 +194,10 @@ export function buildPlatformBridge(): PlatformBridgeSurface {
         ipcRenderer.invoke(
           RunnerHostInvoke.diagnosticsTakeHeapSnapshot,
         ) as Promise<string | null>,
+      measureJsHeaps: () =>
+        ipcRenderer.invoke(
+          RunnerHostInvoke.diagnosticsMeasureJsHeaps,
+        ) as Promise<RendererJsHeapBreakdown | null>,
       traceStart: () =>
         ipcRenderer.invoke(
           RunnerHostInvoke.diagnosticsTraceStart,

--- a/clients/desktop/src/ipc-contracts/ipc-channels.ts
+++ b/clients/desktop/src/ipc-contracts/ipc-channels.ts
@@ -190,6 +190,7 @@ export const RunnerHostInvoke = {
   windowSetContentProtection: "runnerHost:window:setContentProtection",
   diagnosticsGetMetrics: "runnerHost:diagnostics:getMetrics",
   diagnosticsTakeHeapSnapshot: "runnerHost:diagnostics:takeHeapSnapshot",
+  diagnosticsMeasureJsHeaps: "runnerHost:diagnostics:measureJsHeaps",
   diagnosticsTraceStart: "runnerHost:diagnostics:trace:start",
   diagnosticsTraceStop: "runnerHost:diagnostics:trace:stop",
   appUpdateGetSnapshot: "runnerHost:appUpdate:getSnapshot",

--- a/clients/desktop/src/ipc-contracts/platform-types.ts
+++ b/clients/desktop/src/ipc-contracts/platform-types.ts
@@ -42,6 +42,19 @@ export interface RendererJsHeapIsolate {
   readonly usedBytes: number;
   /** `Runtime.getHeapUsage` - pages V8 has committed for this isolate. */
   readonly totalBytes: number;
+  /**
+   * `Runtime.getHeapUsage` - memory the embedder (Blink) holds for this
+   * isolate, outside the JS heap the two fields above measure. `null` when the
+   * protocol build does not report it (both fields are experimental).
+   */
+  readonly embedderBytes: number | null;
+  /**
+   * `Runtime.getHeapUsage` - backing stores for `ArrayBuffer`s and WebAssembly
+   * memory. A diff highlighter worker's Oniguruma engine lives here, not in
+   * `usedBytes`, so a row without it undercounts exactly the off-main-thread
+   * memory this readout exists to attribute.
+   */
+  readonly backingStorageBytes: number | null;
 }
 
 /**

--- a/clients/desktop/src/ipc-contracts/platform-types.ts
+++ b/clients/desktop/src/ipc-contracts/platform-types.ts
@@ -29,6 +29,34 @@ export interface ProcessMetricsSnapshot {
   readonly cpuUsage: { readonly user: number; readonly system: number };
 }
 
+/**
+ * One V8 isolate inside the renderer process: the page itself, or one of the
+ * dedicated workers it has spawned. `url` is the isolate's script URL - for a
+ * worker, the chunk it was started from, which is what tells an epic runtime
+ * worker apart from a diff highlighter worker.
+ */
+export interface RendererJsHeapIsolate {
+  readonly kind: "page" | "worker";
+  readonly url: string;
+  /** `Runtime.getHeapUsage` - live objects after the last GC. */
+  readonly usedBytes: number;
+  /** `Runtime.getHeapUsage` - pages V8 has committed for this isolate. */
+  readonly totalBytes: number;
+}
+
+/**
+ * The renderer's JS heaps, one row per isolate. A main-thread heap snapshot
+ * sees the page's isolate only; a renderer that runs a dozen dedicated workers
+ * can hold most of its memory where that snapshot cannot look. This is the
+ * readout that says where.
+ */
+export interface RendererJsHeapBreakdown {
+  readonly capturedAt: number;
+  /** The whole renderer process's working set, or `null` if it has no metric. */
+  readonly workingSetBytes: number | null;
+  readonly isolates: ReadonlyArray<RendererJsHeapIsolate>;
+}
+
 export type Vibrancy =
   | "titlebar"
   | "selection"

--- a/clients/desktop/src/renderer-shell/__tests__/desktop-runner-host.test.ts
+++ b/clients/desktop/src/renderer-shell/__tests__/desktop-runner-host.test.ts
@@ -468,6 +468,7 @@ function buildFakeBridge(
           cpuUsage: { user: 0, system: 0 },
         }),
         takeHeapSnapshot: async () => null,
+        measureJsHeaps: async () => null,
         traceStart: async () => false,
         traceStop: async () => null,
       },

--- a/clients/desktop/src/renderer-shell/desktop-runner-host.ts
+++ b/clients/desktop/src/renderer-shell/desktop-runner-host.ts
@@ -76,6 +76,7 @@ import type {
   InstalledFont,
   PendingCertificateError,
   ProcessMetricsSnapshot,
+  RendererJsHeapBreakdown,
   TrustedCertificateEntry,
   Vibrancy,
 } from "../ipc-contracts/platform-types";
@@ -418,6 +419,7 @@ export interface DesktopPlatformBridge {
   diagnostics: {
     getMetrics(): Promise<ProcessMetricsSnapshot>;
     takeHeapSnapshot(): Promise<string | null>;
+    measureJsHeaps(): Promise<RendererJsHeapBreakdown | null>;
     traceStart(): Promise<boolean>;
     traceStop(): Promise<string | null>;
   };

--- a/clients/gui-app/src/components/__tests__/diff-worker-pool-provider.test.tsx
+++ b/clients/gui-app/src/components/__tests__/diff-worker-pool-provider.test.tsx
@@ -1,43 +1,98 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { cleanup, render, screen } from "@testing-library/react";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type Mock,
+} from "vitest";
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { createContext, useContext, type ReactNode } from "react";
+import type { SetupWorkerPoolProps } from "@pierre/diffs/worker";
+import { useWorkerPool } from "@pierre/diffs/react";
 import { DiffWorkerPoolProvider } from "@/components/diff-worker-pool-provider";
 import { ResolvedThemeContext } from "@/providers/use-resolved-theme";
 import type { ResolvedThemeContextValue } from "@/providers/use-resolved-theme";
+import {
+  __resetDiffWorkerPoolForTests,
+  getDiffWorkerPool,
+  requestDiffWorkerPool,
+} from "@/lib/diff/diff-worker-pool-demand";
 
-const mockSetRenderOptions = vi.fn();
+interface RenderOptionsArg {
+  readonly theme: "pierre-light" | "pierre-dark";
+  readonly useTokenTransformer: boolean;
+}
 
-vi.mock("@pierre/diffs/react", () => ({
-  WorkerPoolContextProvider: ({ children }: { children: React.ReactNode }) => (
-    <div data-testid="worker-pool-provider">{children}</div>
-  ),
-  useWorkerPool: () => ({
-    setRenderOptions: mockSetRenderOptions,
-  }),
+interface FakeWorkerPoolManager {
+  readonly setRenderOptions: Mock<(options: RenderOptionsArg) => Promise<void>>;
+}
+
+function fakeWorkerPoolManager(): FakeWorkerPoolManager {
+  return { setRenderOptions: vi.fn(() => Promise.resolve()) };
+}
+
+const workerPoolMocks = vi.hoisted(() => ({
+  getOrCreateWorkerPoolSingleton:
+    vi.fn<(props: SetupWorkerPoolProps) => FakeWorkerPoolManager>(),
+  terminateWorkerPoolSingleton: vi.fn<() => void>(),
+}));
+
+// A real React context, not a stub of one - every `@pierre/diffs` component
+// reads the pool through this exact context object, so the provider under
+// test and this file's own consumer probe must share the identical instance
+// the library exports.
+vi.mock("@pierre/diffs/react", () => {
+  const context = createContext(undefined);
+  return {
+    WorkerPoolContext: context,
+    useWorkerPool: () => useContext(context),
+  };
+});
+
+vi.mock("@pierre/diffs/worker", () => ({
+  getOrCreateWorkerPoolSingleton:
+    workerPoolMocks.getOrCreateWorkerPoolSingleton,
+  terminateWorkerPoolSingleton: workerPoolMocks.terminateWorkerPoolSingleton,
 }));
 
 vi.mock("@pierre/diffs/worker/worker.js?worker", () => ({
   default: vi.fn(() => ({})),
 }));
 
+function lightTheme(): ResolvedThemeContextValue {
+  return { resolvedTheme: "light", themePreset: "neutral" };
+}
+
+function darkTheme(): ResolvedThemeContextValue {
+  return { resolvedTheme: "dark", themePreset: "neutral" };
+}
+
+function PoolConsumerProbe(): ReactNode {
+  const pool = useWorkerPool();
+  return (
+    <div data-testid="pool-state">
+      {pool === undefined ? "none" : "present"}
+    </div>
+  );
+}
+
 describe("DiffWorkerPoolProvider", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
-    mockSetRenderOptions.mockClear();
+    __resetDiffWorkerPoolForTests();
+    workerPoolMocks.getOrCreateWorkerPoolSingleton.mockReset();
+    workerPoolMocks.terminateWorkerPoolSingleton.mockReset();
   });
 
   afterEach(() => {
     cleanup();
-    vi.resetAllMocks();
+    __resetDiffWorkerPoolForTests();
   });
 
   it("renders children", () => {
-    const themeValue: ResolvedThemeContextValue = {
-      resolvedTheme: "light",
-      themePreset: "neutral",
-    };
-
     render(
-      <ResolvedThemeContext.Provider value={themeValue}>
+      <ResolvedThemeContext.Provider value={lightTheme()}>
         <DiffWorkerPoolProvider>
           <div data-testid="test-child">Child content</div>
         </DiffWorkerPoolProvider>
@@ -48,64 +103,143 @@ describe("DiffWorkerPoolProvider", () => {
     expect(screen.getByText("Child content")).toBeDefined();
   });
 
-  it("mounts WorkerPoolContextProvider", () => {
-    const themeValue: ResolvedThemeContextValue = {
-      resolvedTheme: "light",
-      themePreset: "neutral",
-    };
-
+  it("does not create the pool at mount", () => {
     render(
-      <ResolvedThemeContext.Provider value={themeValue}>
+      <ResolvedThemeContext.Provider value={lightTheme()}>
         <DiffWorkerPoolProvider>
-          <div>Test</div>
+          <PoolConsumerProbe />
         </DiffWorkerPoolProvider>
       </ResolvedThemeContext.Provider>,
     );
 
-    expect(screen.getByTestId("worker-pool-provider")).toBeDefined();
+    expect(
+      workerPoolMocks.getOrCreateWorkerPoolSingleton,
+    ).not.toHaveBeenCalled();
+    expect(screen.getByTestId("pool-state").textContent).toBe("none");
+    expect(getDiffWorkerPool()).toBeUndefined();
   });
 
-  it("calls setRenderOptions with light theme", () => {
-    mockSetRenderOptions.mockClear();
-
-    const themeValue: ResolvedThemeContextValue = {
-      resolvedTheme: "light",
-      themePreset: "neutral",
-    };
+  it("creates the pool on requestDiffWorkerPool() and the consumer then sees it via context", () => {
+    const manager = fakeWorkerPoolManager();
+    workerPoolMocks.getOrCreateWorkerPoolSingleton.mockReturnValue(manager);
 
     render(
-      <ResolvedThemeContext.Provider value={themeValue}>
+      <ResolvedThemeContext.Provider value={lightTheme()}>
         <DiffWorkerPoolProvider>
-          <div>Test</div>
+          <PoolConsumerProbe />
         </DiffWorkerPoolProvider>
       </ResolvedThemeContext.Provider>,
     );
 
-    expect(mockSetRenderOptions).toHaveBeenCalledWith({
+    expect(screen.getByTestId("pool-state").textContent).toBe("none");
+
+    act(() => {
+      requestDiffWorkerPool();
+    });
+
+    expect(screen.getByTestId("pool-state").textContent).toBe("present");
+    expect(
+      workerPoolMocks.getOrCreateWorkerPoolSingleton,
+    ).toHaveBeenCalledTimes(1);
+
+    const [options] =
+      workerPoolMocks.getOrCreateWorkerPoolSingleton.mock.calls[0];
+    expect(options.poolOptions.poolSize).toBeGreaterThanOrEqual(2);
+    expect(options.poolOptions.poolSize).toBeLessThanOrEqual(3);
+    expect(options.highlighterOptions).toEqual({
       theme: "pierre-light",
       useTokenTransformer: true,
     });
   });
 
-  it("calls setRenderOptions with dark theme", () => {
-    mockSetRenderOptions.mockClear();
-
-    const themeValue: ResolvedThemeContextValue = {
-      resolvedTheme: "dark",
-      themePreset: "neutral",
-    };
+  it("does not call setRenderOptions before the pool exists, and calls it with the light theme once requested", () => {
+    const manager = fakeWorkerPoolManager();
+    workerPoolMocks.getOrCreateWorkerPoolSingleton.mockReturnValue(manager);
 
     render(
-      <ResolvedThemeContext.Provider value={themeValue}>
+      <ResolvedThemeContext.Provider value={lightTheme()}>
         <DiffWorkerPoolProvider>
           <div>Test</div>
         </DiffWorkerPoolProvider>
       </ResolvedThemeContext.Provider>,
     );
 
-    expect(mockSetRenderOptions).toHaveBeenCalledWith({
+    expect(manager.setRenderOptions).not.toHaveBeenCalled();
+
+    act(() => {
+      requestDiffWorkerPool();
+    });
+
+    expect(manager.setRenderOptions).toHaveBeenCalledWith({
+      theme: "pierre-light",
+      useTokenTransformer: true,
+    });
+  });
+
+  it("calls setRenderOptions with the dark theme once requested", () => {
+    const manager = fakeWorkerPoolManager();
+    workerPoolMocks.getOrCreateWorkerPoolSingleton.mockReturnValue(manager);
+
+    render(
+      <ResolvedThemeContext.Provider value={darkTheme()}>
+        <DiffWorkerPoolProvider>
+          <div>Test</div>
+        </DiffWorkerPoolProvider>
+      </ResolvedThemeContext.Provider>,
+    );
+
+    act(() => {
+      requestDiffWorkerPool();
+    });
+
+    expect(manager.setRenderOptions).toHaveBeenCalledWith({
       theme: "pierre-dark",
       useTokenTransformer: true,
     });
+  });
+
+  it("honors a request made before the provider mounts", () => {
+    const manager = fakeWorkerPoolManager();
+    workerPoolMocks.getOrCreateWorkerPoolSingleton.mockReturnValue(manager);
+
+    requestDiffWorkerPool();
+    expect(getDiffWorkerPool()).toBeUndefined();
+
+    render(
+      <ResolvedThemeContext.Provider value={lightTheme()}>
+        <DiffWorkerPoolProvider>
+          <PoolConsumerProbe />
+        </DiffWorkerPoolProvider>
+      </ResolvedThemeContext.Provider>,
+    );
+
+    expect(
+      workerPoolMocks.getOrCreateWorkerPoolSingleton,
+    ).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId("pool-state").textContent).toBe("present");
+    expect(getDiffWorkerPool()).toBe(manager);
+  });
+
+  it("terminates the pool on unmount and clears the store", () => {
+    const manager = fakeWorkerPoolManager();
+    workerPoolMocks.getOrCreateWorkerPoolSingleton.mockReturnValue(manager);
+
+    const rendered = render(
+      <ResolvedThemeContext.Provider value={lightTheme()}>
+        <DiffWorkerPoolProvider>
+          <PoolConsumerProbe />
+        </DiffWorkerPoolProvider>
+      </ResolvedThemeContext.Provider>,
+    );
+
+    act(() => {
+      requestDiffWorkerPool();
+    });
+    expect(getDiffWorkerPool()).toBe(manager);
+
+    rendered.unmount();
+
+    expect(workerPoolMocks.terminateWorkerPoolSingleton).toHaveBeenCalled();
+    expect(getDiffWorkerPool()).toBeUndefined();
   });
 });

--- a/clients/gui-app/src/components/diff-worker-pool-provider.tsx
+++ b/clients/gui-app/src/components/diff-worker-pool-provider.tsx
@@ -1,10 +1,37 @@
-import { WorkerPoolContextProvider, useWorkerPool } from "@pierre/diffs/react";
+import type { DiffsThemeNames } from "@pierre/diffs";
+import { WorkerPoolContext } from "@pierre/diffs/react";
+import {
+  getOrCreateWorkerPoolSingleton,
+  terminateWorkerPoolSingleton,
+} from "@pierre/diffs/worker";
 import DiffsWorker from "@pierre/diffs/worker/worker.js?worker";
 import { ResolvedThemeContext } from "@/providers/use-resolved-theme";
-import { use, useEffect, useMemo, type ReactNode } from "react";
+import {
+  getDiffWorkerPool,
+  registerDiffWorkerPoolCreator,
+  subscribeDiffWorkerPool,
+  unregisterDiffWorkerPoolCreator,
+} from "@/lib/diff/diff-worker-pool-demand";
+import {
+  use,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useSyncExternalStore,
+  type ReactNode,
+} from "react";
 
 const MIN_POOL = 2;
-const MAX_POOL = 6;
+/**
+ * Three, down from six. Every pool worker is a full highlighter isolate
+ * (Oniguruma WASM engine, both themes, every grammar it has ever been asked
+ * for), so the pool's size is a memory figure first and a throughput figure
+ * second. Three workers keep a multi-file diff rendering in parallel; six
+ * bought little beyond that on a desktop that rarely has more than a handful
+ * of diffs visible at once, and cost a highlighter isolate each.
+ */
+const MAX_POOL = 3;
 
 function computePoolSize(): number {
   const cores =
@@ -16,28 +43,70 @@ export interface DiffWorkerPoolProviderProps {
   readonly children: ReactNode;
 }
 
+/**
+ * Provides `@pierre/diffs`' worker pool to the tree WITHOUT building it at
+ * mount. The pool is created on the first `requestDiffWorkerPool()` (see
+ * `lib/diff/diff-worker-pool-demand.ts` for why), and this provider is what
+ * knows the recipe: the pool size, the worker factory Vite must see literally,
+ * and the theme the highlighter should start with.
+ *
+ * Renders the library's own context (`WorkerPoolContext`) rather than its
+ * `WorkerPoolContextProvider`, because that provider constructs the pool in a
+ * `useState` initializer - there is no way to hand it a pool later. Every
+ * `@pierre/diffs` React component reads this same context, so they see the
+ * pool the moment it exists.
+ */
 export function DiffWorkerPoolProvider(
   props: DiffWorkerPoolProviderProps,
 ): ReactNode {
   const poolSize = useMemo(() => computePoolSize(), []);
   const themeContext = use(ResolvedThemeContext);
-  const initialTheme =
+  const currentTheme: DiffsThemeNames =
     themeContext?.resolvedTheme === "light" ? "pierre-light" : "pierre-dark";
+  const pool = useSyncExternalStore(
+    subscribeDiffWorkerPool,
+    getDiffWorkerPool,
+    getDiffWorkerPool,
+  );
+
+  // The theme the pool is SEEDED with is whichever is current when it is
+  // built, which can be long after this provider mounted. A ref, so the
+  // creator registered below reads the live value without the theme becoming
+  // a dependency of the registration - re-registering on a theme change would
+  // unregister the live pool. `ThemeSync` keeps the pool current after that.
+  const themeRef = useRef(currentTheme);
+  useLayoutEffect(() => {
+    themeRef.current = currentTheme;
+  }, [currentTheme]);
+
+  // Layout effect, not effect: a diff surface mounted in this same commit
+  // requests the pool from its own effect, and effects run child-first. The
+  // creator has to be registered before that request lands or the request
+  // reads "unavailable" and the surface takes the main-thread path.
+  useLayoutEffect(() => {
+    const creator = () =>
+      getOrCreateWorkerPoolSingleton({
+        poolOptions: {
+          workerFactory: () => new DiffsWorker(),
+          poolSize,
+        },
+        highlighterOptions: {
+          theme: themeRef.current,
+          useTokenTransformer: true,
+        },
+      });
+    registerDiffWorkerPoolCreator(creator);
+    return () => {
+      unregisterDiffWorkerPoolCreator(creator);
+      terminateWorkerPoolSingleton();
+    };
+  }, [poolSize]);
 
   return (
-    <WorkerPoolContextProvider
-      poolOptions={{
-        workerFactory: () => new DiffsWorker(),
-        poolSize,
-      }}
-      highlighterOptions={{
-        theme: initialTheme,
-        useTokenTransformer: true,
-      }}
-    >
+    <WorkerPoolContext.Provider value={pool}>
       <ThemeSync />
       {props.children}
-    </WorkerPoolContextProvider>
+    </WorkerPoolContext.Provider>
   );
 }
 
@@ -46,7 +115,7 @@ function ThemeSync(): ReactNode {
   // bridge tests), the context is null. Skip the sync; production always has
   // ThemeProvider above this.
   const themeContext = use(ResolvedThemeContext);
-  const pool = useWorkerPool();
+  const pool = use(WorkerPoolContext);
   const resolvedTheme = themeContext?.resolvedTheme;
 
   useEffect(() => {

--- a/clients/gui-app/src/components/diff/__tests__/diff-content-primitive-edit-hydration.test.tsx
+++ b/clients/gui-app/src/components/diff/__tests__/diff-content-primitive-edit-hydration.test.tsx
@@ -37,15 +37,55 @@ import {
   type FileDiffMetadata,
 } from "@pierre/diffs";
 import { Editor, type EditorOptions } from "@pierre/diffs/edit";
+import type { WorkerPoolManager } from "@pierre/diffs/worker";
 import type { ReactNode } from "react";
 import { DiffContentPrimitive } from "@/components/diff/diff-content-primitive";
+import { registerDiffWorkerPoolCreator } from "@/lib/diff/diff-worker-pool-demand";
 
 const capturedFileDiffs: FileDiffMetadata[] = [];
+interface CapturedFileRender {
+  readonly file: FileContents;
+  readonly edit: boolean;
+}
+const capturedFileRenders: CapturedFileRender[] = [];
+
+/**
+ * The worker pool `useWorkerPool()` reads from React context. No provider is
+ * ever mounted in this file's render tree, so every existing test's `pool`
+ * has always been `undefined` - this mock keeps that default, and lets the
+ * two new empty-file-editor tests below control it explicitly, the same
+ * store-vs-context seam `use-diff-highlight-ready.test.tsx` drives directly.
+ */
+const poolState = vi.hoisted(() => ({
+  pool: undefined as WorkerPoolManager | undefined,
+}));
+
+interface FakeWorkerPoolManager {
+  readonly setRenderOptions: () => Promise<void>;
+  readonly primeFileHighlightCache: () => Promise<void>;
+  readonly primeDiffHighlightCache: () => Promise<void>;
+}
+
+/**
+ * Same seam as `use-diff-highlight-ready.test.tsx`'s fake: a prototype-less
+ * object asserted to the class type, with the members the gates actually call
+ * assigned onto it (`as unknown as` is lint-forbidden; the real class has
+ * ~90 members, too many to overlap with a direct `as`).
+ */
+function fakeWorkerPoolManager(): WorkerPoolManager {
+  const fake: FakeWorkerPoolManager = {
+    setRenderOptions: () => Promise.resolve(),
+    primeFileHighlightCache: () => Promise.resolve(),
+    primeDiffHighlightCache: () => Promise.resolve(),
+  };
+  return Object.assign(Object.create(null) as WorkerPoolManager, fake);
+}
 
 vi.mock("@pierre/diffs/react", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@pierre/diffs/react")>();
   return {
     ...actual,
+    useWorkerPool: () => poolState.pool,
     FileDiff: (props: {
       readonly fileDiff: FileDiffMetadata;
       readonly edit?: boolean;
@@ -60,6 +100,21 @@ vi.mock("@pierre/diffs/react", async (importOriginal) => {
           data-is-partial={String(props.fileDiff.isPartial)}
           data-type={props.fileDiff.type}
           data-name={props.fileDiff.name}
+        />
+      );
+    },
+    File: (props: {
+      readonly file: FileContents;
+      readonly edit?: boolean;
+      readonly editorOptions?: EditorOptions<undefined>;
+      readonly options?: unknown;
+    }): ReactNode => {
+      capturedFileRenders.push({ file: props.file, edit: props.edit === true });
+      return (
+        <div
+          data-testid="instrumented-file"
+          data-edit={String(props.edit === true)}
+          data-name={props.file.name}
         />
       );
     },
@@ -126,6 +181,15 @@ index 1111111..2222222 100644
  same
 -old
 +new
+`;
+
+// Same empty-untracked-file shape `git-diff-empty-file-edit.test.ts` proves
+// against the raw library: zero hunks, so `isConfirmedEmptyNewFileDiff`
+// matches and `DiffContentPrimitive` renders `<File>` instead of `<FileDiff>`
+// once an edit session is present.
+const EMPTY_NEW_FILE_PATCH = `diff --git a/empty.txt b/empty.txt
+new file mode 100644
+index 000000000..e69de29bb
 `;
 
 const CHANGE_OLD: FileContents = {
@@ -257,10 +321,12 @@ function renderPrimitive(args: {
 describe("<DiffContentPrimitive /> edit hydration (real @pierre/diffs)", () => {
   beforeEach(() => {
     capturedFileDiffs.length = 0;
+    capturedFileRenders.length = 0;
   });
 
   afterEach(() => {
     cleanup();
+    poolState.pool = undefined;
   });
 
   it("pre-hydrates a change diff so the live→pinned parse swap still attaches", async () => {
@@ -593,5 +659,87 @@ index 1111111..2222222 100644
     expect(a).not.toBe(b);
     await assertLibraryAcceptsHydratedDiff(a, null);
     await assertLibraryAcceptsHydratedDiff(b, null);
+  });
+
+  it("renders the plain File editor for a confirmed-empty new file once the pool resolves to unavailable (no provider mounted)", async () => {
+    // No creator is ever registered anywhere in this file, so once this
+    // component's own mount asks for the pool, availability settles to
+    // "unavailable" the same way it does for every other test here -
+    // confirmed explicitly, not assumed, since this is the first test to
+    // exercise the emptyFileEditSession branch at all.
+    const rendered = render(
+      <DiffContentPrimitive
+        patch={EMPTY_NEW_FILE_PATCH}
+        cacheScope="empty-new-file-no-provider"
+        mode="unified"
+        wordWrap={false}
+        backgrounds
+        lineNumbers
+        indicatorStyle="bars"
+        fileHeaders={false}
+        isEmptyFile
+        editSession={{
+          editorOptions: EMPTY_EDITOR_OPTIONS,
+          oldFile: null,
+          newFile: { name: "empty.txt", contents: "" },
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(capturedFileRenders).toHaveLength(1);
+    });
+    expect(
+      rendered.container.querySelector('[data-testid="diff-highlighting"]'),
+    ).toBeNull();
+    expect(capturedFileDiffs).toHaveLength(0);
+    expect(capturedFileRenders[0]?.file.name).toBe("empty.txt");
+    expect(capturedFileRenders[0]?.edit).toBe(true);
+  });
+
+  it("holds the empty-file editor behind the highlight loader until the pool reaches React context, then renders File instead", async () => {
+    // The regression fix 3 closes: before it, `<File>` mounted as soon as
+    // `emptyFileEditSession` was non-null, regardless of `highlightReady` -
+    // before the pool ever reached context - and stayed on the main thread
+    // for that editor's whole lifetime. The gate now precedes the branch.
+    const manager = fakeWorkerPoolManager();
+    registerDiffWorkerPoolCreator(() => manager);
+
+    const props = {
+      patch: EMPTY_NEW_FILE_PATCH,
+      cacheScope: "empty-new-file-pool-context",
+      mode: "unified" as const,
+      wordWrap: false,
+      backgrounds: true,
+      lineNumbers: true,
+      indicatorStyle: "bars" as const,
+      fileHeaders: false,
+      isEmptyFile: true,
+      editSession: {
+        editorOptions: EMPTY_EDITOR_OPTIONS,
+        oldFile: null,
+        newFile: { name: "empty.txt", contents: "" },
+      },
+    };
+    const rendered = render(<DiffContentPrimitive {...props} />);
+
+    await waitFor(() => {
+      expect(
+        rendered.container.querySelector('[data-testid="diff-highlighting"]'),
+      ).not.toBeNull();
+    });
+    expect(capturedFileRenders).toHaveLength(0);
+
+    // The provider re-renders and the pool reaches context.
+    poolState.pool = manager;
+    rendered.rerender(<DiffContentPrimitive {...props} />);
+
+    await waitFor(() => {
+      expect(capturedFileRenders).toHaveLength(1);
+    });
+    expect(
+      rendered.container.querySelector('[data-testid="diff-highlighting"]'),
+    ).toBeNull();
+    expect(capturedFileRenders[0]?.file.name).toBe("empty.txt");
   });
 });

--- a/clients/gui-app/src/components/diff/__tests__/use-diff-highlight-ready.test.tsx
+++ b/clients/gui-app/src/components/diff/__tests__/use-diff-highlight-ready.test.tsx
@@ -294,6 +294,35 @@ describe("useDiffs highlight gates", () => {
     await act(async () => {});
     expect(screen.getByTestId("ready").textContent).toBe("pending");
   });
+
+  it("does not request the pool from a disabled gate", () => {
+    const manager = asWorkerPoolManager(fakeWorkerPoolManager());
+    registerDiffWorkerPoolCreator(() => manager);
+
+    render(
+      <FileReadyProbe
+        file={sampleFile()}
+        theme="pierre-dark"
+        enabled={false}
+      />,
+    );
+
+    expect(getDiffWorkerPool()).toBeUndefined();
+    expect(screen.getByTestId("ready").textContent).toBe("ready");
+  });
+
+  it("does not request the pool for an empty diff list", () => {
+    const manager = asWorkerPoolManager(fakeWorkerPoolManager());
+    registerDiffWorkerPoolCreator(() => manager);
+
+    render(<DiffReadyProbe fileDiffs={[]} theme="pierre-dark" enabled />);
+    render(<EditReadyProbe fileDiffs={[]} theme="pierre-dark" enabled />);
+
+    expect(getDiffWorkerPool()).toBeUndefined();
+    for (const probe of screen.getAllByTestId("ready")) {
+      expect(probe.textContent).toBe("ready");
+    }
+  });
 });
 
 function FileReadyProbe(props: {

--- a/clients/gui-app/src/components/diff/__tests__/use-diff-highlight-ready.test.tsx
+++ b/clients/gui-app/src/components/diff/__tests__/use-diff-highlight-ready.test.tsx
@@ -9,20 +9,27 @@ import {
 } from "vitest";
 import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import type { FileContents, FileDiffMetadata } from "@pierre/diffs";
+import type { WorkerPoolManager } from "@pierre/diffs/worker";
 import {
+  useDiffsDiffEditHighlightReady,
   useDiffsDiffHighlightReady,
   useDiffsFileHighlightReady,
 } from "@/components/diff/use-diff-highlight-ready";
 import { DiffHighlightLoading } from "@/components/diff/diff-highlight-loading";
+import {
+  __resetDiffWorkerPoolForTests,
+  getDiffWorkerPool,
+  registerDiffWorkerPoolCreator,
+} from "@/lib/diff/diff-worker-pool-demand";
+
+interface FakeWorkerPoolManager {
+  setRenderOptions: Mock;
+  primeFileHighlightCache: Mock;
+  primeDiffHighlightCache: Mock;
+}
 
 const poolState = vi.hoisted(() => ({
-  pool: undefined as
-    | undefined
-    | {
-        setRenderOptions: Mock;
-        primeFileHighlightCache: Mock;
-        primeDiffHighlightCache: Mock;
-      },
+  pool: undefined as FakeWorkerPoolManager | undefined,
 }));
 
 vi.mock("@pierre/diffs/react", () => ({
@@ -30,16 +37,39 @@ vi.mock("@pierre/diffs/react", () => ({
   EditProvider: (props: { readonly children: unknown }) => props.children,
 }));
 
+/**
+ * A fake `WorkerPoolManager`. The real class has ~90 members, so a literal
+ * with three of them does not overlap enough for a direct `as`, and
+ * `as unknown as` is lint-forbidden here. The same seam the diagnostics test
+ * support uses instead: a prototype-less object asserted to the class type,
+ * then the three members the gates actually call assigned onto it. Only the
+ * demand store's `manager` field (typed against the real class) ever sees
+ * it; every assertion in this file reads the fake object directly.
+ */
+function fakeWorkerPoolManager(): FakeWorkerPoolManager {
+  return {
+    setRenderOptions: vi.fn(() => Promise.resolve()),
+    primeFileHighlightCache: vi.fn(() => Promise.resolve()),
+    primeDiffHighlightCache: vi.fn(() => Promise.resolve()),
+  };
+}
+
+function asWorkerPoolManager(fake: FakeWorkerPoolManager): WorkerPoolManager {
+  return Object.assign(Object.create(null) as WorkerPoolManager, fake);
+}
+
 describe("useDiffs highlight gates", () => {
   beforeEach(() => {
     poolState.pool = undefined;
+    __resetDiffWorkerPoolForTests();
   });
 
   afterEach(() => {
     cleanup();
+    __resetDiffWorkerPoolForTests();
   });
 
-  it("treats a missing worker pool as ready so main-thread render can proceed", () => {
+  it("releases a surface once it has requested the pool with no provider mounted (availability 'unavailable')", () => {
     render(<FileReadyProbe file={sampleFile()} theme="pierre-dark" enabled />);
     expect(screen.getByTestId("ready").textContent).toBe("ready");
   });
@@ -153,6 +183,117 @@ describe("useDiffs highlight gates", () => {
     render(<DiffHighlightLoading testId="workspace-file-highlighting" />);
     expect(screen.getByTestId("workspace-file-highlighting")).toBeTruthy();
   });
+
+  it("keeps both the file and diff gates closed once a creator is registered but the context has not caught up yet", async () => {
+    const manager = fakeWorkerPoolManager();
+    registerDiffWorkerPoolCreator(() => asWorkerPoolManager(manager));
+    // `poolState.pool` stays undefined on purpose: the store already built the
+    // manager, but the provider that would carry it into context has not
+    // re-rendered in this test, so `useWorkerPool()` still answers undefined.
+
+    render(<FileReadyProbe file={sampleFile()} theme="pierre-dark" enabled />);
+    expect(screen.getByTestId("ready").textContent).toBe("pending");
+    await act(async () => {});
+    expect(screen.getByTestId("ready").textContent).toBe("pending");
+    cleanup();
+
+    render(
+      <DiffReadyProbe
+        fileDiffs={[sampleDiff("a.ts")]}
+        theme="pierre-light"
+        enabled
+      />,
+    );
+    expect(screen.getByTestId("ready").textContent).toBe("pending");
+    await act(async () => {});
+    expect(screen.getByTestId("ready").textContent).toBe("pending");
+  });
+
+  it("requests the pool from the hook's own mount effect, so a registered creator builds it", () => {
+    const manager = asWorkerPoolManager(fakeWorkerPoolManager());
+    registerDiffWorkerPoolCreator(() => manager);
+    expect(getDiffWorkerPool()).toBeUndefined();
+
+    render(<FileReadyProbe file={sampleFile()} theme="pierre-dark" enabled />);
+
+    expect(getDiffWorkerPool()).toBe(manager);
+  });
+
+  it("releases the file gate once the context catches up with the pool the creator built", async () => {
+    const manager = fakeWorkerPoolManager();
+    registerDiffWorkerPoolCreator(() => asWorkerPoolManager(manager));
+
+    const rendered = render(
+      <FileReadyProbe file={sampleFile()} theme="pierre-dark" enabled />,
+    );
+    expect(screen.getByTestId("ready").textContent).toBe("pending");
+
+    poolState.pool = manager;
+    rendered.rerender(
+      <FileReadyProbe file={sampleFile()} theme="pierre-dark" enabled />,
+    );
+
+    await waitFor(() => {
+      expect(manager.primeFileHighlightCache).toHaveBeenCalledWith(
+        sampleFile(),
+      );
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("ready").textContent).toBe("ready");
+    });
+  });
+
+  it("releases the diff gate once the context catches up with the pool the creator built", async () => {
+    const manager = fakeWorkerPoolManager();
+    registerDiffWorkerPoolCreator(() => asWorkerPoolManager(manager));
+    const fileDiffs = [sampleDiff("a.ts")];
+
+    const rendered = render(
+      <DiffReadyProbe fileDiffs={fileDiffs} theme="pierre-light" enabled />,
+    );
+    expect(screen.getByTestId("ready").textContent).toBe("pending");
+
+    poolState.pool = manager;
+    rendered.rerender(
+      <DiffReadyProbe fileDiffs={fileDiffs} theme="pierre-light" enabled />,
+    );
+
+    await waitFor(() => {
+      expect(manager.primeDiffHighlightCache).toHaveBeenCalledWith(
+        fileDiffs[0],
+      );
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("ready").textContent).toBe("ready");
+    });
+  });
+
+  it("releases the edit gate when no creator is registered (availability 'unavailable')", () => {
+    render(
+      <EditReadyProbe
+        fileDiffs={[sampleDiff("a.ts")]}
+        theme="pierre-dark"
+        enabled
+      />,
+    );
+    expect(screen.getByTestId("ready").textContent).toBe("ready");
+  });
+
+  it("keeps the edit gate closed when a creator is registered but no pool is in context yet", async () => {
+    const manager = fakeWorkerPoolManager();
+    registerDiffWorkerPoolCreator(() => asWorkerPoolManager(manager));
+
+    render(
+      <EditReadyProbe
+        fileDiffs={[sampleDiff("a.ts")]}
+        theme="pierre-dark"
+        enabled
+      />,
+    );
+    expect(screen.getByTestId("ready").textContent).toBe("pending");
+    await act(async () => {});
+    expect(screen.getByTestId("ready").textContent).toBe("pending");
+  });
 });
 
 function FileReadyProbe(props: {
@@ -170,6 +311,15 @@ function DiffReadyProbe(props: {
   readonly enabled: boolean;
 }) {
   const ready = useDiffsDiffHighlightReady(props);
+  return <div data-testid="ready">{ready ? "ready" : "pending"}</div>;
+}
+
+function EditReadyProbe(props: {
+  readonly fileDiffs: ReadonlyArray<FileDiffMetadata>;
+  readonly theme: "pierre-dark" | "pierre-light";
+  readonly enabled: boolean;
+}) {
+  const ready = useDiffsDiffEditHighlightReady(props);
   return <div data-testid="ready">{ready ? "ready" : "pending"}</div>;
 }
 

--- a/clients/gui-app/src/components/diff/__tests__/use-diff-highlight-ready.test.tsx
+++ b/clients/gui-app/src/components/diff/__tests__/use-diff-highlight-ready.test.tsx
@@ -295,7 +295,10 @@ describe("useDiffs highlight gates", () => {
     expect(screen.getByTestId("ready").textContent).toBe("pending");
   });
 
-  it("does not request the pool from a disabled gate", () => {
+  it("requests the pool from a disabled gate that has work, but holds release until the pool reaches context", () => {
+    // The file gate's demand signal is `useDiffWorkerPoolAvailability(true)` -
+    // always has work, independent of `enabled` - so a disabled gate still
+    // asks for the pool instead of skipping the request.
     const manager = asWorkerPoolManager(fakeWorkerPoolManager());
     registerDiffWorkerPoolCreator(() => manager);
 
@@ -307,7 +310,49 @@ describe("useDiffs highlight gates", () => {
       />,
     );
 
-    expect(getDiffWorkerPool()).toBeUndefined();
+    expect(getDiffWorkerPool()).toBe(manager);
+    // Only the store built a manager; no pool has reached React context yet,
+    // so the gate holds rather than releasing instantly for being disabled.
+    expect(screen.getByTestId("ready").textContent).toBe("pending");
+  });
+
+  it("holds a disabled gate until the pool reaches context, releases once it does, and never re-closes when enabled later flips true", () => {
+    const manager = fakeWorkerPoolManager();
+    registerDiffWorkerPoolCreator(() => asWorkerPoolManager(manager));
+
+    const rendered = render(
+      <FileReadyProbe
+        file={sampleFile()}
+        theme="pierre-dark"
+        enabled={false}
+      />,
+    );
+    // The store already built the manager (the file gate always has work),
+    // but the provider has not carried it into context yet - the gate holds.
+    expect(screen.getByTestId("ready").textContent).toBe("pending");
+
+    // The provider re-renders and the pool reaches context. Still disabled.
+    poolState.pool = manager;
+    rendered.rerender(
+      <FileReadyProbe
+        file={sampleFile()}
+        theme="pierre-dark"
+        enabled={false}
+      />,
+    );
+
+    // Releases because `!enabled`, not because a cache prime resolved - a
+    // disabled gate never waits on one.
+    expect(screen.getByTestId("ready").textContent).toBe("ready");
+    expect(manager.primeFileHighlightCache).not.toHaveBeenCalled();
+
+    // The regression this pins: an editor that mounted disabled (an edit
+    // session in progress) and is later enabled (the session ends) must stay
+    // released - never close the gate again and replace the mounted editor
+    // with DiffHighlightLoading.
+    rendered.rerender(
+      <FileReadyProbe file={sampleFile()} theme="pierre-dark" enabled />,
+    );
     expect(screen.getByTestId("ready").textContent).toBe("ready");
   });
 

--- a/clients/gui-app/src/components/diff/diff-content-primitive.tsx
+++ b/clients/gui-app/src/components/diff/diff-content-primitive.tsx
@@ -293,6 +293,15 @@ function renderDiffContentBody(args: {
   const diffUnsafeCSS = args.nonEmptyEditorReady
     ? `${DIFF_PANEL_WITH_FIND_UNSAFE_CSS}\n/* traycer-edit-cache-ready */`
     : DIFF_PANEL_WITH_FIND_UNSAFE_CSS;
+  // Ahead of every branch below, including the empty-file editor: the gate is
+  // what holds a `@pierre/diffs` component back until the worker pool is in
+  // context, and a component that mounts without one highlights on the main
+  // thread for the rest of its life (see `use-diff-highlight-ready.ts`). An
+  // empty new file is the one surface where that lifetime is spent growing -
+  // the person is typing into it - so it is the last place to skip the wait.
+  if (!args.highlightReady) {
+    return <DiffHighlightLoading testId="diff-highlighting" />;
+  }
   if (emptyFileEditSession !== null) {
     return (
       <File
@@ -310,9 +319,6 @@ function renderDiffContentBody(args: {
         }}
       />
     );
-  }
-  if (!args.highlightReady) {
-    return <DiffHighlightLoading testId="diff-highlighting" />;
   }
   return args.fileDiffs.map((fileDiff) => (
     <FileDiff

--- a/clients/gui-app/src/components/diff/use-diff-highlight-ready.ts
+++ b/clients/gui-app/src/components/diff/use-diff-highlight-ready.ts
@@ -1,10 +1,43 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useState, useSyncExternalStore } from "react";
 import type {
   DiffsThemeNames,
   FileContents,
   FileDiffMetadata,
 } from "@pierre/diffs";
 import { useWorkerPool } from "@pierre/diffs/react";
+import {
+  getDiffWorkerPoolAvailability,
+  requestDiffWorkerPool,
+  subscribeDiffWorkerPool,
+  type DiffWorkerPoolAvailability,
+} from "@/lib/diff/diff-worker-pool-demand";
+
+/**
+ * Asks for the worker pool and reports where that request stands.
+ *
+ * Every Diffs surface passes through one of the gates below before it mounts a
+ * `@pierre/diffs` component, which makes them the one place a surface can say
+ * "I am about to need a highlighter" early enough for the pool to be created
+ * lazily (see `lib/diff/diff-worker-pool-demand.ts`). The request is made from
+ * an effect rather than during render so that a render which is thrown away
+ * never builds a pool.
+ *
+ * The gates stay closed until the pool is in CONTEXT (`useWorkerPool()`), not
+ * merely in the store: a `@pierre/diffs` component mounted with no pool in
+ * context highlights on the MAIN thread, and keeps doing so for its lifetime -
+ * the pool arriving a render later does not re-route it. Only `"unavailable"`
+ * (no provider mounted at all) releases a surface without one.
+ */
+function useDiffWorkerPoolAvailability(): DiffWorkerPoolAvailability {
+  useEffect(() => {
+    requestDiffWorkerPool();
+  }, []);
+  return useSyncExternalStore(
+    subscribeDiffWorkerPool,
+    getDiffWorkerPoolAvailability,
+    getDiffWorkerPoolAvailability,
+  );
+}
 
 /**
  * Hold only the first paint for highlighting. Once a Diffs surface has been
@@ -15,11 +48,10 @@ function useInitialHighlightReady(props: {
   readonly enabled: boolean;
   readonly hasWork: boolean;
   readonly prepare: (() => Promise<unknown>) | null;
+  readonly poolAvailability: DiffWorkerPoolAvailability;
 }): boolean {
-  const { enabled, hasWork, prepare } = props;
-  const [released, setReleased] = useState(
-    !enabled || !hasWork || prepare === null,
-  );
+  const { enabled, hasWork, prepare, poolAvailability } = props;
+  const [released, setReleased] = useState(false);
 
   useEffect(() => {
     if (!enabled || !hasWork || prepare === null) return;
@@ -39,7 +71,13 @@ function useInitialHighlightReady(props: {
     };
   }, [enabled, hasWork, prepare]);
 
-  return !enabled || !hasWork || prepare === null || released;
+  if (!enabled || !hasWork || released) return true;
+  // No pool in context to prewarm with. "unavailable" means no provider at
+  // all - render on the main thread, as this surface always did outside the
+  // desktop shell. Anything else means the pool exists or is about to, and
+  // the context will carry it on the next render - hold the gate.
+  if (prepare === null) return poolAvailability === "unavailable";
+  return false;
 }
 
 export function useDiffsFileHighlightReady(props: {
@@ -48,6 +86,7 @@ export function useDiffsFileHighlightReady(props: {
   readonly enabled: boolean;
 }): boolean {
   const pool = useWorkerPool();
+  const poolAvailability = useDiffWorkerPoolAvailability();
   const { file, theme } = props;
   const prepareHighlight = useCallback(async (): Promise<void> => {
     // The provider owns render options; theme makes this callback a distinct
@@ -59,6 +98,7 @@ export function useDiffsFileHighlightReady(props: {
     enabled: props.enabled,
     hasWork: true,
     prepare: pool === undefined ? null : prepareHighlight,
+    poolAvailability,
   });
 }
 
@@ -68,6 +108,7 @@ export function useDiffsDiffHighlightReady(props: {
   readonly enabled: boolean;
 }): boolean {
   const pool = useWorkerPool();
+  const poolAvailability = useDiffWorkerPoolAvailability();
   const { fileDiffs, theme } = props;
   const prepareHighlight = useCallback(async (): Promise<void> => {
     if (pool === undefined) return;
@@ -80,6 +121,7 @@ export function useDiffsDiffHighlightReady(props: {
     enabled: props.enabled,
     hasWork: props.fileDiffs.length > 0,
     prepare: pool === undefined ? null : prepareHighlight,
+    poolAvailability,
   });
 }
 
@@ -96,6 +138,7 @@ export function useDiffsDiffEditHighlightReady(props: {
   readonly enabled: boolean;
 }): boolean {
   const pool = useWorkerPool();
+  const poolAvailability = useDiffWorkerPoolAvailability();
   const { enabled, fileDiffs, theme } = props;
   const [preparedTarget, setPreparedTarget] =
     useState<ReadonlyArray<FileDiffMetadata> | null>(null);
@@ -122,10 +165,7 @@ export function useDiffsDiffEditHighlightReady(props: {
     };
   }, [enabled, fileDiffs, pool, theme]);
 
-  return (
-    !enabled ||
-    pool === undefined ||
-    fileDiffs.length === 0 ||
-    preparedTarget === fileDiffs
-  );
+  if (!enabled || fileDiffs.length === 0) return true;
+  if (pool === undefined) return poolAvailability === "unavailable";
+  return preparedTarget === fileDiffs;
 }

--- a/clients/gui-app/src/components/diff/use-diff-highlight-ready.ts
+++ b/clients/gui-app/src/components/diff/use-diff-highlight-ready.ts
@@ -28,10 +28,15 @@ import {
  * the pool arriving a render later does not re-route it. Only `"unavailable"`
  * (no provider mounted at all) releases a surface without one.
  */
-function useDiffWorkerPoolAvailability(): DiffWorkerPoolAvailability {
+function useDiffWorkerPoolAvailability(
+  wanted: boolean,
+): DiffWorkerPoolAvailability {
+  // Only a gate that is enabled and has something to highlight asks: a
+  // disabled gate or an empty diff list would otherwise build the pool for
+  // a surface that will never send it work.
   useEffect(() => {
-    requestDiffWorkerPool();
-  }, []);
+    if (wanted) requestDiffWorkerPool();
+  }, [wanted]);
   return useSyncExternalStore(
     subscribeDiffWorkerPool,
     getDiffWorkerPoolAvailability,
@@ -86,7 +91,7 @@ export function useDiffsFileHighlightReady(props: {
   readonly enabled: boolean;
 }): boolean {
   const pool = useWorkerPool();
-  const poolAvailability = useDiffWorkerPoolAvailability();
+  const poolAvailability = useDiffWorkerPoolAvailability(props.enabled);
   const { file, theme } = props;
   const prepareHighlight = useCallback(async (): Promise<void> => {
     // The provider owns render options; theme makes this callback a distinct
@@ -108,7 +113,9 @@ export function useDiffsDiffHighlightReady(props: {
   readonly enabled: boolean;
 }): boolean {
   const pool = useWorkerPool();
-  const poolAvailability = useDiffWorkerPoolAvailability();
+  const poolAvailability = useDiffWorkerPoolAvailability(
+    props.enabled && props.fileDiffs.length > 0,
+  );
   const { fileDiffs, theme } = props;
   const prepareHighlight = useCallback(async (): Promise<void> => {
     if (pool === undefined) return;
@@ -138,7 +145,9 @@ export function useDiffsDiffEditHighlightReady(props: {
   readonly enabled: boolean;
 }): boolean {
   const pool = useWorkerPool();
-  const poolAvailability = useDiffWorkerPoolAvailability();
+  const poolAvailability = useDiffWorkerPoolAvailability(
+    props.enabled && props.fileDiffs.length > 0,
+  );
   const { enabled, fileDiffs, theme } = props;
   const [preparedTarget, setPreparedTarget] =
     useState<ReadonlyArray<FileDiffMetadata> | null>(null);

--- a/clients/gui-app/src/components/diff/use-diff-highlight-ready.ts
+++ b/clients/gui-app/src/components/diff/use-diff-highlight-ready.ts
@@ -29,14 +29,16 @@ import {
  * (no provider mounted at all) releases a surface without one.
  */
 function useDiffWorkerPoolAvailability(
-  wanted: boolean,
+  hasWork: boolean,
 ): DiffWorkerPoolAvailability {
-  // Only a gate that is enabled and has something to highlight asks: a
-  // disabled gate or an empty diff list would otherwise build the pool for
-  // a surface that will never send it work.
+  // Having work to highlight is the demand signal, NOT being the enabled gate:
+  // a surface that mounts with its read gate disabled (`WorkspaceFileRenderer`
+  // straight into an edit session) still mounts a Diffs component, and one
+  // that mounts pool-less highlights on the main thread for life. An empty
+  // diff list is the only case with genuinely nothing to send a worker.
   useEffect(() => {
-    if (wanted) requestDiffWorkerPool();
-  }, [wanted]);
+    if (hasWork) requestDiffWorkerPool();
+  }, [hasWork]);
   return useSyncExternalStore(
     subscribeDiffWorkerPool,
     getDiffWorkerPoolAvailability,
@@ -56,7 +58,15 @@ function useInitialHighlightReady(props: {
   readonly poolAvailability: DiffWorkerPoolAvailability;
 }): boolean {
   const { enabled, hasWork, prepare, poolAvailability } = props;
-  const [released, setReleased] = useState(false);
+  // A gate that mounts with nothing to wait for is released for the surface's
+  // life. `WorkspaceFileRenderer` mounted mid-edit and `DiffContentPrimitive`
+  // mounted with an edit session both start disabled and enable later; without
+  // this, enabling would close the gate under an already-mounted editor and
+  // replace it with a loader. Deliberately NOT seeded from `prepare === null`
+  // the way it was before the pool became lazy - that is now the ordinary
+  // first-render state, and seeding from it would release every surface before
+  // the pool it is waiting for exists.
+  const [released, setReleased] = useState(!enabled || !hasWork);
 
   useEffect(() => {
     if (!enabled || !hasWork || prepare === null) return;
@@ -76,13 +86,15 @@ function useInitialHighlightReady(props: {
     };
   }, [enabled, hasWork, prepare]);
 
-  if (!enabled || !hasWork || released) return true;
+  if (!hasWork) return true;
   // No pool in context to prewarm with. "unavailable" means no provider at
   // all - render on the main thread, as this surface always did outside the
   // desktop shell. Anything else means the pool exists or is about to, and
-  // the context will carry it on the next render - hold the gate.
+  // the context will carry it on the next render - hold the gate. This holds
+  // for a DISABLED gate too: `enabled` says whether to wait for the cache
+  // prime, never whether the component about to mount needs a worker.
   if (prepare === null) return poolAvailability === "unavailable";
-  return false;
+  return !enabled || released;
 }
 
 export function useDiffsFileHighlightReady(props: {
@@ -91,7 +103,8 @@ export function useDiffsFileHighlightReady(props: {
   readonly enabled: boolean;
 }): boolean {
   const pool = useWorkerPool();
-  const poolAvailability = useDiffWorkerPoolAvailability(props.enabled);
+  // A file surface always has its one file to highlight, editing or not.
+  const poolAvailability = useDiffWorkerPoolAvailability(true);
   const { file, theme } = props;
   const prepareHighlight = useCallback(async (): Promise<void> => {
     // The provider owns render options; theme makes this callback a distinct
@@ -114,7 +127,7 @@ export function useDiffsDiffHighlightReady(props: {
 }): boolean {
   const pool = useWorkerPool();
   const poolAvailability = useDiffWorkerPoolAvailability(
-    props.enabled && props.fileDiffs.length > 0,
+    props.fileDiffs.length > 0,
   );
   const { fileDiffs, theme } = props;
   const prepareHighlight = useCallback(async (): Promise<void> => {
@@ -146,7 +159,7 @@ export function useDiffsDiffEditHighlightReady(props: {
 }): boolean {
   const pool = useWorkerPool();
   const poolAvailability = useDiffWorkerPoolAvailability(
-    props.enabled && props.fileDiffs.length > 0,
+    props.fileDiffs.length > 0,
   );
   const { enabled, fileDiffs, theme } = props;
   const [preparedTarget, setPreparedTarget] =

--- a/clients/gui-app/src/components/settings/panels/__tests__/app-diagnostics-settings-panel.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/app-diagnostics-settings-panel.test.tsx
@@ -429,6 +429,25 @@ describe("<AppDiagnosticsSettingsPanel />", () => {
     expect(path.textContent).toBe("/tmp/heap-1.heapsnapshot");
   });
 
+  it("renders the Measure JS heaps button without a heap-snapshot bridge", async () => {
+    installLogLevelsBridge(defaultSnapshot());
+    installJsHeapBridge(() => Promise.resolve(null));
+    renderPanel(makeHost(makeSupportBridge({})));
+
+    await screen.findByRole("heading", { name: "Memory" });
+    expect(
+      screen.getByRole("button", { name: "Measure JS heaps" }),
+    ).toBeTruthy();
+    expect(
+      screen.queryByRole("button", { name: "Capture heap snapshot" }),
+    ).toBeNull();
+    expect(
+      screen.queryByText(
+        "Memory snapshots are only available on the desktop app.",
+      ),
+    ).toBeNull();
+  });
+
   it("does not render the Measure JS heaps button when the bridge is not installed", async () => {
     installLogLevelsBridge(defaultSnapshot());
     installHeapSnapshotBridge(() => Promise.resolve(null));

--- a/clients/gui-app/src/components/settings/panels/__tests__/app-diagnostics-settings-panel.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/app-diagnostics-settings-panel.test.tsx
@@ -435,7 +435,9 @@ describe("<AppDiagnosticsSettingsPanel />", () => {
     renderPanel(makeHost(makeSupportBridge({})));
 
     await screen.findByRole("heading", { name: "Memory" });
-    expect(screen.queryByTestId("diagnostics-measure-js-heaps")).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Measure JS heaps" }),
+    ).toBeNull();
   });
 
   it("measures JS heaps and renders a labeled breakdown table with a totals footer", async () => {
@@ -471,15 +473,17 @@ describe("<AppDiagnosticsSettingsPanel />", () => {
     installJsHeapBridge(measureJsHeaps);
     renderPanel(makeHost(makeSupportBridge({})));
 
-    const button = await screen.findByTestId("diagnostics-measure-js-heaps");
-    expect(screen.queryByTestId("diagnostics-js-heap-breakdown")).toBeNull();
+    const button = await screen.findByRole("button", {
+      name: "Measure JS heaps",
+    });
+    expect(screen.queryByRole("table")).toBeNull();
     fireEvent.click(button);
 
     await waitFor(() => {
       expect(measureJsHeaps).toHaveBeenCalled();
     });
 
-    const table = await screen.findByTestId("diagnostics-js-heap-breakdown");
+    const table = await screen.findByRole("table");
     expect(within(table).getByText("This window")).toBeTruthy();
     expect(within(table).getByText("Epic runtime worker")).toBeTruthy();
     expect(within(table).getByText("Diff highlighter worker")).toBeTruthy();
@@ -514,7 +518,9 @@ describe("<AppDiagnosticsSettingsPanel />", () => {
     installJsHeapBridge(measureJsHeaps);
     renderPanel(makeHost(makeSupportBridge({})));
 
-    const button = await screen.findByTestId("diagnostics-measure-js-heaps");
+    const button = await screen.findByRole("button", {
+      name: "Measure JS heaps",
+    });
     fireEvent.click(button);
 
     await waitFor(() => {
@@ -522,6 +528,6 @@ describe("<AppDiagnosticsSettingsPanel />", () => {
         "Couldn't measure this window's JS heaps",
       );
     });
-    expect(screen.queryByTestId("diagnostics-js-heap-breakdown")).toBeNull();
+    expect(screen.queryByRole("table")).toBeNull();
   });
 });

--- a/clients/gui-app/src/components/settings/panels/__tests__/app-diagnostics-settings-panel.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/app-diagnostics-settings-panel.test.tsx
@@ -16,6 +16,7 @@ import {
   installCustomLogLevelsBridge,
   installHeapSnapshotBridge,
   installHeldLogLevelsBridge,
+  installJsHeapBridge,
   installLogLevelsBridge,
   makeHost,
   makeSupportBridge,
@@ -28,6 +29,8 @@ import type {
   DesktopSupportLogTarget,
   DesktopSupportSnapshot,
 } from "@/lib/windows/types";
+import type { DesktopJsHeapBreakdown } from "@/lib/resources/desktop-app-resource-usage";
+import { formatMemoryBytes } from "@/lib/resources/format-resource-usage";
 import { RunnerHostProvider } from "@/providers/runner-host-provider";
 import type { IRunnerHost } from "@traycer-clients/shared/platform/runner-host";
 import { toast } from "sonner";
@@ -424,5 +427,101 @@ describe("<AppDiagnosticsSettingsPanel />", () => {
     });
     const path = await screen.findByTestId("diagnostics-heap-snapshot-path");
     expect(path.textContent).toBe("/tmp/heap-1.heapsnapshot");
+  });
+
+  it("does not render the Measure JS heaps button when the bridge is not installed", async () => {
+    installLogLevelsBridge(defaultSnapshot());
+    installHeapSnapshotBridge(() => Promise.resolve(null));
+    renderPanel(makeHost(makeSupportBridge({})));
+
+    await screen.findByRole("heading", { name: "Memory" });
+    expect(screen.queryByTestId("diagnostics-measure-js-heaps")).toBeNull();
+  });
+
+  it("measures JS heaps and renders a labeled breakdown table with a totals footer", async () => {
+    installLogLevelsBridge(defaultSnapshot());
+    installHeapSnapshotBridge(() => Promise.resolve(null));
+    const breakdown: DesktopJsHeapBreakdown = {
+      capturedAt: 1_700_000_000_000,
+      workingSetBytes: 300 * 1024 * 1024,
+      isolates: [
+        {
+          kind: "page",
+          url: "app://renderer/index.html",
+          usedBytes: 40 * 1024 * 1024,
+          totalBytes: 60 * 1024 * 1024,
+        },
+        {
+          kind: "worker",
+          url: "app://renderer/assets/epic-runtime-worker-entry-BKyjY2bC.js",
+          usedBytes: 10 * 1024 * 1024,
+          totalBytes: 15 * 1024 * 1024,
+        },
+        {
+          kind: "worker",
+          url: "app://renderer/assets/worker-DMI2JaPh.js",
+          usedBytes: 5 * 1024 * 1024,
+          totalBytes: 8 * 1024 * 1024,
+        },
+      ],
+    };
+    const measureJsHeaps = vi.fn(() =>
+      Promise.resolve<DesktopJsHeapBreakdown | null>(breakdown),
+    );
+    installJsHeapBridge(measureJsHeaps);
+    renderPanel(makeHost(makeSupportBridge({})));
+
+    const button = await screen.findByTestId("diagnostics-measure-js-heaps");
+    expect(screen.queryByTestId("diagnostics-js-heap-breakdown")).toBeNull();
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(measureJsHeaps).toHaveBeenCalled();
+    });
+
+    const table = await screen.findByTestId("diagnostics-js-heap-breakdown");
+    expect(within(table).getByText("This window")).toBeTruthy();
+    expect(within(table).getByText("Epic runtime worker")).toBeTruthy();
+    expect(within(table).getByText("Diff highlighter worker")).toBeTruthy();
+
+    const usedTotal = breakdown.isolates.reduce(
+      (sum, isolate) => sum + isolate.usedBytes,
+      0,
+    );
+    const committedTotal = breakdown.isolates.reduce(
+      (sum, isolate) => sum + isolate.totalBytes,
+      0,
+    );
+    expect(
+      within(table).getByText(
+        (_content, element) =>
+          element?.textContent ===
+          `3 isolates · process working set ${formatMemoryBytes(300 * 1024 * 1024)}`,
+      ),
+    ).toBeTruthy();
+    expect(within(table).getByText(formatMemoryBytes(usedTotal))).toBeTruthy();
+    expect(
+      within(table).getByText(formatMemoryBytes(committedTotal)),
+    ).toBeTruthy();
+  });
+
+  it("toasts when measuring JS heaps returns null", async () => {
+    installLogLevelsBridge(defaultSnapshot());
+    installHeapSnapshotBridge(() => Promise.resolve(null));
+    const measureJsHeaps = vi.fn(() =>
+      Promise.resolve<DesktopJsHeapBreakdown | null>(null),
+    );
+    installJsHeapBridge(measureJsHeaps);
+    renderPanel(makeHost(makeSupportBridge({})));
+
+    const button = await screen.findByTestId("diagnostics-measure-js-heaps");
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        "Couldn't measure this window's JS heaps",
+      );
+    });
+    expect(screen.queryByTestId("diagnostics-js-heap-breakdown")).toBeNull();
   });
 });

--- a/clients/gui-app/src/components/settings/panels/__tests__/app-diagnostics-settings-panel.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/app-diagnostics-settings-panel.test.tsx
@@ -626,4 +626,54 @@ describe("<AppDiagnosticsSettingsPanel />", () => {
     });
     expect(screen.queryByRole("table")).toBeNull();
   });
+
+  it("serializes the heap snapshot and the JS heap measurement through their shared mutation scope", async () => {
+    installLogLevelsBridge(defaultSnapshot());
+    // Seeded with a callable rather than `null`: the executor runs
+    // synchronously, but TypeScript cannot see that and narrows a
+    // `null`-initialised binding to `null` for the rest of the test.
+    let resolveCapture: (path: string | null) => void = () => undefined;
+    const capturePromise = new Promise<string | null>((resolve) => {
+      resolveCapture = resolve;
+    });
+    const takeHeapSnapshot = vi.fn(() => capturePromise);
+    installHeapSnapshotBridge(takeHeapSnapshot);
+    const measureJsHeaps = vi.fn(() =>
+      Promise.resolve<DesktopJsHeapBreakdown | null>(null),
+    );
+    installJsHeapBridge(measureJsHeaps);
+    renderPanel(makeHost(makeSupportBridge({})));
+
+    const captureButton = await screen.findByTestId(
+      "diagnostics-capture-heap-snapshot",
+    );
+    const measureButton = await screen.findByRole("button", {
+      name: "Measure JS heaps",
+    });
+
+    fireEvent.click(captureButton);
+    await waitFor(() => {
+      expect(takeHeapSnapshot).toHaveBeenCalledTimes(1);
+    });
+
+    // The measure button is its own mutation observer - it is not disabled by
+    // capture being pending, so this click genuinely fires
+    // `measureMutation.mutate()` rather than being a no-op the panel refuses.
+    expect(measureButton.hasAttribute("disabled")).toBe(false);
+    fireEvent.click(measureButton);
+
+    // Let the click's mutate() call and TanStack Query's shared-scope check
+    // settle before asserting the negative: the bridge fn itself must not
+    // have run yet, because it is queued behind the still-pending capture.
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
+    expect(measureJsHeaps).not.toHaveBeenCalled();
+
+    resolveCapture("/tmp/heap-1.heapsnapshot");
+
+    await waitFor(() => {
+      expect(measureJsHeaps).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/clients/gui-app/src/components/settings/panels/__tests__/app-diagnostics-settings-panel.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/app-diagnostics-settings-panel.test.tsx
@@ -471,18 +471,24 @@ describe("<AppDiagnosticsSettingsPanel />", () => {
           url: "app://renderer/index.html",
           usedBytes: 40 * 1024 * 1024,
           totalBytes: 60 * 1024 * 1024,
+          embedderBytes: null,
+          backingStorageBytes: null,
         },
         {
           kind: "worker",
           url: "app://renderer/assets/epic-runtime-worker-entry-BKyjY2bC.js",
           usedBytes: 10 * 1024 * 1024,
           totalBytes: 15 * 1024 * 1024,
+          embedderBytes: null,
+          backingStorageBytes: null,
         },
         {
           kind: "worker",
           url: "app://renderer/assets/worker-DMI2JaPh.js",
           usedBytes: 5 * 1024 * 1024,
           totalBytes: 8 * 1024 * 1024,
+          embedderBytes: null,
+          backingStorageBytes: null,
         },
       ],
     };
@@ -526,6 +532,77 @@ describe("<AppDiagnosticsSettingsPanel />", () => {
     expect(
       within(table).getByText(formatMemoryBytes(committedTotal)),
     ).toBeTruthy();
+  });
+
+  it("renders the Embedder and Backing columns, using — for a null isolate value and a null column total", async () => {
+    installLogLevelsBridge(defaultSnapshot());
+    installHeapSnapshotBridge(() => Promise.resolve(null));
+    const breakdown: DesktopJsHeapBreakdown = {
+      capturedAt: 1_700_000_000_000,
+      workingSetBytes: null,
+      isolates: [
+        {
+          kind: "page",
+          url: "app://renderer/index.html",
+          usedBytes: 40 * 1024 * 1024,
+          totalBytes: 60 * 1024 * 1024,
+          embedderBytes: 5 * 1024 * 1024,
+          backingStorageBytes: null,
+        },
+        {
+          kind: "worker",
+          url: "app://renderer/assets/worker-DMI2JaPh.js",
+          usedBytes: 3 * 1024 * 1024,
+          totalBytes: 4 * 1024 * 1024,
+          embedderBytes: null,
+          backingStorageBytes: null,
+        },
+      ],
+    };
+    const measureJsHeaps = vi.fn(() =>
+      Promise.resolve<DesktopJsHeapBreakdown | null>(breakdown),
+    );
+    installJsHeapBridge(measureJsHeaps);
+    renderPanel(makeHost(makeSupportBridge({})));
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Measure JS heaps" }),
+    );
+    await waitFor(() => {
+      expect(measureJsHeaps).toHaveBeenCalled();
+    });
+
+    const table = await screen.findByRole("table");
+    expect(
+      within(table).getByRole("columnheader", { name: "Live" }),
+    ).toBeTruthy();
+    expect(
+      within(table).getByRole("columnheader", { name: "Committed" }),
+    ).toBeTruthy();
+    expect(
+      within(table).getByRole("columnheader", { name: "Embedder" }),
+    ).toBeTruthy();
+    expect(
+      within(table).getByRole("columnheader", { name: "Backing" }),
+    ).toBeTruthy();
+
+    const [pageRow, workerRow, footerRow] = within(table)
+      .getAllByRole("row")
+      .slice(1);
+    const pageCells = within(pageRow).getAllByRole("cell");
+    const workerCells = within(workerRow).getAllByRole("cell");
+    const footerCells = within(footerRow).getAllByRole("cell");
+
+    // Page row: Embedder carries a real number, Backing is null.
+    expect(pageCells[3].textContent).toBe(formatMemoryBytes(5 * 1024 * 1024));
+    expect(pageCells[4].textContent).toBe("—");
+    // Worker row: both out-of-heap columns are null.
+    expect(workerCells[3].textContent).toBe("—");
+    expect(workerCells[4].textContent).toBe("—");
+    // Footer: Embedder totals the one isolate that reported a number;
+    // Backing stays — because every isolate reported null for it.
+    expect(footerCells[3].textContent).toBe(formatMemoryBytes(5 * 1024 * 1024));
+    expect(footerCells[4].textContent).toBe("—");
   });
 
   it("toasts when measuring JS heaps returns null", async () => {

--- a/clients/gui-app/src/components/settings/panels/__tests__/diagnostics-test-support.ts
+++ b/clients/gui-app/src/components/settings/panels/__tests__/diagnostics-test-support.ts
@@ -13,6 +13,7 @@ import type {
   DesktopSupportLogTailResult,
   DesktopSupportSnapshot,
 } from "@/lib/windows/types";
+import type { DesktopJsHeapBreakdown } from "@/lib/resources/desktop-app-resource-usage";
 
 /**
  * Fixtures shared by the two Diagnostics suites.
@@ -41,7 +42,10 @@ import type {
  * branch under a test that only ever checked the heading.
  */
 interface TestHeapSnapshotBridge {
-  readonly takeHeapSnapshot: () => Promise<string | null>;
+  readonly takeHeapSnapshot: (() => Promise<string | null>) | undefined;
+  readonly measureJsHeaps:
+    | (() => Promise<DesktopJsHeapBreakdown | null>)
+    | undefined;
 }
 
 interface TestRunnerPlatform {
@@ -68,7 +72,33 @@ function mergePlatform(patch: Partial<TestRunnerPlatform>): void {
 export function installHeapSnapshotBridge(
   takeHeapSnapshot: () => Promise<string | null>,
 ): void {
-  mergePlatform({ diagnostics: { takeHeapSnapshot } });
+  const current: TestHeapSnapshotBridge = globalWithRunnerHost.runnerHost
+    ?.platform.diagnostics ?? {
+    takeHeapSnapshot: undefined,
+    measureJsHeaps: undefined,
+  };
+  mergePlatform({
+    diagnostics: { ...current, takeHeapSnapshot },
+  });
+}
+
+/**
+ * The JS-heap-breakdown half of `platform.diagnostics` — merged alongside
+ * `takeHeapSnapshot`, never in place of it, for the same reason the doc
+ * comment above states: replacing the whole `diagnostics` slot would
+ * silently uninstall whichever of the two bridges this call did not name.
+ */
+export function installJsHeapBridge(
+  measureJsHeaps: () => Promise<DesktopJsHeapBreakdown | null>,
+): void {
+  const current: TestHeapSnapshotBridge = globalWithRunnerHost.runnerHost
+    ?.platform.diagnostics ?? {
+    takeHeapSnapshot: undefined,
+    measureJsHeaps: undefined,
+  };
+  mergePlatform({
+    diagnostics: { ...current, measureJsHeaps },
+  });
 }
 
 export function defaultSnapshot(): LogLevelsSnapshot {

--- a/clients/gui-app/src/components/settings/panels/app-diagnostics-settings-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/app-diagnostics-settings-panel.tsx
@@ -145,6 +145,10 @@ const JS_HEAP_MEASURE_MUTATION_SCOPE = "runner-js-heap-measure";
 
 function MemoryDiagnosticsGroup(): ReactNode {
   const bridge = useMemo(() => getDesktopHeapSnapshotBridge(), []);
+  // The two capabilities are gated independently, like every other pair of
+  // desktop bridges on this page: a shell that carries one and not the other
+  // still gets the one it has.
+  const jsHeapAvailable = useMemo(() => getDesktopJsHeapBridge() !== null, []);
   const [snapshotPath, setSnapshotPath] = useState<string | null>(null);
 
   const captureMutation = useMutation({
@@ -171,7 +175,7 @@ function MemoryDiagnosticsGroup(): ReactNode {
     },
   });
 
-  if (bridge === null) {
+  if (bridge === null && !jsHeapAvailable) {
     return (
       <SettingsGroup
         title="Memory"
@@ -193,46 +197,50 @@ function MemoryDiagnosticsGroup(): ReactNode {
       dataTestId={undefined}
       fill={false}
     >
-      <div className="flex flex-wrap items-center justify-between gap-3 px-4 py-2.5">
-        <span className="min-w-0 flex-1 text-ui-xs text-muted-foreground">
-          Captures a heap snapshot of this window for a memory report. The app
-          stops responding while the snapshot is written, and the file can be
-          several gigabytes.
-        </span>
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          className="shrink-0"
-          disabled={captureMutation.isPending}
-          onClick={() => captureMutation.mutate()}
-          data-testid="diagnostics-capture-heap-snapshot"
-        >
-          {captureMutation.isPending ? (
-            <AgentSpinningDots
-              className="text-current"
-              testId={undefined}
-              variant={undefined}
-            />
-          ) : null}
-          Capture heap snapshot
-        </Button>
-      </div>
-      {snapshotPath === null ? null : (
-        <div className="flex items-start gap-2 px-4 pb-3">
-          <pre
-            className="min-w-0 flex-1 overflow-auto rounded-md border border-border/60 bg-muted/30 px-3 py-2 font-mono text-code-xs text-muted-foreground"
-            data-testid="diagnostics-heap-snapshot-path"
-          >
-            {snapshotPath}
-          </pre>
-          <CopyTextButton
-            value={snapshotPath}
-            label="Copy"
-            ariaLabel="Copy heap snapshot path"
-            disabled={false}
-          />
-        </div>
+      {bridge === null ? null : (
+        <>
+          <div className="flex flex-wrap items-center justify-between gap-3 px-4 py-2.5">
+            <span className="min-w-0 flex-1 text-ui-xs text-muted-foreground">
+              Captures a heap snapshot of this window for a memory report. The
+              app stops responding while the snapshot is written, and the file
+              can be several gigabytes.
+            </span>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="shrink-0"
+              disabled={captureMutation.isPending}
+              onClick={() => captureMutation.mutate()}
+              data-testid="diagnostics-capture-heap-snapshot"
+            >
+              {captureMutation.isPending ? (
+                <AgentSpinningDots
+                  className="text-current"
+                  testId={undefined}
+                  variant={undefined}
+                />
+              ) : null}
+              Capture heap snapshot
+            </Button>
+          </div>
+          {snapshotPath === null ? null : (
+            <div className="flex items-start gap-2 px-4 pb-3">
+              <pre
+                className="min-w-0 flex-1 overflow-auto rounded-md border border-border/60 bg-muted/30 px-3 py-2 font-mono text-code-xs text-muted-foreground"
+                data-testid="diagnostics-heap-snapshot-path"
+              >
+                {snapshotPath}
+              </pre>
+              <CopyTextButton
+                value={snapshotPath}
+                label="Copy"
+                ariaLabel="Copy heap snapshot path"
+                disabled={false}
+              />
+            </div>
+          )}
+        </>
       )}
       <JsHeapReadout />
     </SettingsGroup>

--- a/clients/gui-app/src/components/settings/panels/app-diagnostics-settings-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/app-diagnostics-settings-panel.tsx
@@ -133,6 +133,20 @@ function DesktopAppLogEntry(props: {
 }
 
 /**
+ * One serialization scope for BOTH memory diagnostics - see the `scope` note
+ * below for why `scope` and not `mutationKey`.
+ *
+ * They share it because they contend for the same renderer isolate, not merely
+ * for the same button. A heap capture freezes that isolate for as long as the
+ * walk takes (tens of seconds on the long-lived sessions worth capturing),
+ * which is longer than `JS_HEAP_MEASURE_TIMEOUT_MS`; a measurement started
+ * underneath one would have its protocol reads stall behind the freeze and
+ * report a measurement failure for a window that is perfectly measurable a
+ * moment later. Queuing the second action is the honest answer.
+ */
+const MEMORY_DIAGNOSTICS_MUTATION_SCOPE = "runner-memory-diagnostics";
+
+/**
  * On-demand heap capture for memory reports. The renderer freezes while V8
  * walks the heap and the file runs to gigabytes on exactly the long-lived
  * sessions worth capturing, so this is a deliberate button rather than
@@ -140,10 +154,6 @@ function DesktopAppLogEntry(props: {
  * The resulting path is shown for copying rather than revealed in the file
  * manager: no reveal capability is exposed for arbitrary paths.
  */
-/** Serialization scope for the heap capture - see the `scope` note below. */
-const HEAP_SNAPSHOT_MUTATION_SCOPE = "runner-heap-snapshot";
-const JS_HEAP_MEASURE_MUTATION_SCOPE = "runner-js-heap-measure";
-
 function MemoryDiagnosticsGroup(): ReactNode {
   const bridge = useMemo(() => getDesktopHeapSnapshotBridge(), []);
   // The two capabilities are gated independently, like every other pair of
@@ -158,7 +168,7 @@ function MemoryDiagnosticsGroup(): ReactNode {
     // `mutationKey` alone does not. Without it the only thing standing
     // between a double-click and two concurrent multi-gigabyte heap walks
     // is the `disabled` prop, which cannot help a second mounted panel.
-    scope: { id: HEAP_SNAPSHOT_MUTATION_SCOPE },
+    scope: { id: MEMORY_DIAGNOSTICS_MUTATION_SCOPE },
     mutationFn: (): Promise<string | null> =>
       bridge === null ? Promise.resolve(null) : bridge.takeHeapSnapshot(),
     onSuccess: (path) => {
@@ -306,7 +316,7 @@ function JsHeapReadout(): ReactNode {
     // attaches `webContents.debugger`, and a second call while the first holds
     // the attachment is refused in main (`isAttached()`), which would read as
     // a failure toast and clear a readout that was fine.
-    scope: { id: JS_HEAP_MEASURE_MUTATION_SCOPE },
+    scope: { id: MEMORY_DIAGNOSTICS_MUTATION_SCOPE },
     mutationFn: (): Promise<DesktopJsHeapBreakdown | null> =>
       bridge === null ? Promise.resolve(null) : bridge.measureJsHeaps(),
     onSuccess: (result) => {

--- a/clients/gui-app/src/components/settings/panels/app-diagnostics-settings-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/app-diagnostics-settings-panel.tsx
@@ -22,6 +22,7 @@ import {
   getDesktopHeapSnapshotBridge,
   getDesktopJsHeapBridge,
   type DesktopJsHeapBreakdown,
+  type DesktopJsHeapIsolate,
 } from "@/lib/resources/desktop-app-resource-usage";
 import { formatMemoryBytes } from "@/lib/resources/format-resource-usage";
 import { getLogLevelsBridge } from "@/lib/desktop-log-levels";
@@ -247,6 +248,43 @@ function MemoryDiagnosticsGroup(): ReactNode {
   );
 }
 
+interface JsHeapTotals {
+  readonly usedBytes: number;
+  readonly totalBytes: number;
+  readonly embedderBytes: number | null;
+  readonly backingStorageBytes: number | null;
+}
+
+/**
+ * Column totals. The two out-of-heap columns stay `null` until some isolate
+ * reports one, so a build whose protocol omits those experimental fields shows
+ * an empty column rather than a confident zero.
+ */
+function sumJsHeapIsolates(
+  isolates: ReadonlyArray<DesktopJsHeapIsolate>,
+): JsHeapTotals {
+  let usedBytes = 0;
+  let totalBytes = 0;
+  let embedderBytes: number | null = null;
+  let backingStorageBytes: number | null = null;
+  for (const isolate of isolates) {
+    usedBytes += isolate.usedBytes;
+    totalBytes += isolate.totalBytes;
+    if (isolate.embedderBytes !== null) {
+      embedderBytes = (embedderBytes ?? 0) + isolate.embedderBytes;
+    }
+    if (isolate.backingStorageBytes !== null) {
+      backingStorageBytes =
+        (backingStorageBytes ?? 0) + isolate.backingStorageBytes;
+    }
+  }
+  return { usedBytes, totalBytes, embedderBytes, backingStorageBytes };
+}
+
+function formatOptionalMemoryBytes(value: number | null): string {
+  return value === null ? "—" : formatMemoryBytes(value);
+}
+
 /**
  * The per-isolate companion to the heap snapshot. A snapshot walks the page's
  * own V8 isolate and nothing else; the renderer also runs one isolate per
@@ -285,17 +323,7 @@ function JsHeapReadout(): ReactNode {
 
   if (bridge === null) return null;
 
-  const usedTotal =
-    breakdown === null
-      ? 0
-      : breakdown.isolates.reduce((sum, isolate) => sum + isolate.usedBytes, 0);
-  const committedTotal =
-    breakdown === null
-      ? 0
-      : breakdown.isolates.reduce(
-          (sum, isolate) => sum + isolate.totalBytes,
-          0,
-        );
+  const totals = sumJsHeapIsolates(breakdown?.isolates ?? []);
 
   return (
     <>
@@ -303,7 +331,9 @@ function JsHeapReadout(): ReactNode {
         <span className="min-w-0 flex-1 text-ui-xs text-muted-foreground">
           Lists every JS heap in this window: the page and each worker it runs.
           A heap snapshot covers the page only, so this is what accounts for the
-          rest.
+          rest. Embedder and backing sit outside the JS heap — Blink&apos;s own
+          objects, and ArrayBuffer/WebAssembly stores such as a highlighter
+          worker&apos;s regex engine.
         </span>
         <Button
           type="button"
@@ -335,8 +365,14 @@ function JsHeapReadout(): ReactNode {
                 <th scope="col" className="py-1 pr-3 text-right font-normal">
                   Live
                 </th>
-                <th scope="col" className="py-1 text-right font-normal">
+                <th scope="col" className="py-1 pr-3 text-right font-normal">
                   Committed
+                </th>
+                <th scope="col" className="py-1 pr-3 text-right font-normal">
+                  Embedder
+                </th>
+                <th scope="col" className="py-1 text-right font-normal">
+                  Backing
                 </th>
               </tr>
             </thead>
@@ -357,8 +393,14 @@ function JsHeapReadout(): ReactNode {
                   <td className="py-1 pr-3 text-right font-mono tabular-nums">
                     {formatMemoryBytes(isolate.usedBytes)}
                   </td>
-                  <td className="py-1 text-right font-mono tabular-nums">
+                  <td className="py-1 pr-3 text-right font-mono tabular-nums">
                     {formatMemoryBytes(isolate.totalBytes)}
+                  </td>
+                  <td className="py-1 pr-3 text-right font-mono tabular-nums">
+                    {formatOptionalMemoryBytes(isolate.embedderBytes)}
+                  </td>
+                  <td className="py-1 text-right font-mono tabular-nums">
+                    {formatOptionalMemoryBytes(isolate.backingStorageBytes)}
                   </td>
                 </tr>
               ))}
@@ -374,10 +416,16 @@ function JsHeapReadout(): ReactNode {
                     : ` · process working set ${formatMemoryBytes(breakdown.workingSetBytes)}`}
                 </td>
                 <td className="py-1 pr-3 text-right font-mono tabular-nums">
-                  {formatMemoryBytes(usedTotal)}
+                  {formatMemoryBytes(totals.usedBytes)}
+                </td>
+                <td className="py-1 pr-3 text-right font-mono tabular-nums">
+                  {formatMemoryBytes(totals.totalBytes)}
+                </td>
+                <td className="py-1 pr-3 text-right font-mono tabular-nums">
+                  {formatOptionalMemoryBytes(totals.embedderBytes)}
                 </td>
                 <td className="py-1 text-right font-mono tabular-nums">
-                  {formatMemoryBytes(committedTotal)}
+                  {formatOptionalMemoryBytes(totals.backingStorageBytes)}
                 </td>
               </tr>
             </tfoot>

--- a/clients/gui-app/src/components/settings/panels/app-diagnostics-settings-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/app-diagnostics-settings-panel.tsx
@@ -17,7 +17,13 @@ import {
 import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 import { Button } from "@/components/ui/button";
 import { CopyTextButton } from "@/components/copy-text-button";
-import { getDesktopHeapSnapshotBridge } from "@/lib/resources/desktop-app-resource-usage";
+import {
+  describeDesktopJsHeapIsolate,
+  getDesktopHeapSnapshotBridge,
+  getDesktopJsHeapBridge,
+  type DesktopJsHeapBreakdown,
+} from "@/lib/resources/desktop-app-resource-usage";
+import { formatMemoryBytes } from "@/lib/resources/format-resource-usage";
 import { getLogLevelsBridge } from "@/lib/desktop-log-levels";
 import { runnerMutationKeys } from "@/lib/query-keys/runner-mutation-keys";
 import { toastFromRunnerError } from "@/lib/runner-error-toast";
@@ -227,6 +233,143 @@ function MemoryDiagnosticsGroup(): ReactNode {
           />
         </div>
       )}
+      <JsHeapReadout />
     </SettingsGroup>
+  );
+}
+
+/**
+ * The per-isolate companion to the heap snapshot. A snapshot walks the page's
+ * own V8 isolate and nothing else; the renderer also runs one isolate per
+ * dedicated worker (an epic runtime per live epic session, the diff
+ * highlighter pool), and a window whose snapshot explains a fraction of its
+ * footprint is usually carrying the rest there. This readout is cheap - a few
+ * protocol round trips, no freeze - and lists every isolate with what it holds,
+ * so the snapshot can be read against the number it was missing.
+ */
+function JsHeapReadout(): ReactNode {
+  const bridge = useMemo(() => getDesktopJsHeapBridge(), []);
+  const [breakdown, setBreakdown] = useState<DesktopJsHeapBreakdown | null>(
+    null,
+  );
+
+  const measureMutation = useMutation({
+    mutationKey: runnerMutationKeys.measureJsHeaps(),
+    mutationFn: (): Promise<DesktopJsHeapBreakdown | null> =>
+      bridge === null ? Promise.resolve(null) : bridge.measureJsHeaps(),
+    onSuccess: (result) => {
+      setBreakdown(result);
+      if (result === null) {
+        toast.error("Couldn't measure this window's JS heaps");
+      }
+    },
+    onError: (error) => {
+      setBreakdown(null);
+      toastFromRunnerError(error, "Couldn't measure this window's JS heaps");
+    },
+  });
+
+  if (bridge === null) return null;
+
+  const usedTotal =
+    breakdown === null
+      ? 0
+      : breakdown.isolates.reduce((sum, isolate) => sum + isolate.usedBytes, 0);
+  const committedTotal =
+    breakdown === null
+      ? 0
+      : breakdown.isolates.reduce(
+          (sum, isolate) => sum + isolate.totalBytes,
+          0,
+        );
+
+  return (
+    <>
+      <div className="flex flex-wrap items-center justify-between gap-3 border-t border-border/60 px-4 py-2.5">
+        <span className="min-w-0 flex-1 text-ui-xs text-muted-foreground">
+          Lists every JS heap in this window: the page and each worker it runs.
+          A heap snapshot covers the page only, so this is what accounts for the
+          rest.
+        </span>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="shrink-0"
+          disabled={measureMutation.isPending}
+          onClick={() => measureMutation.mutate()}
+          data-testid="diagnostics-measure-js-heaps"
+        >
+          {measureMutation.isPending ? (
+            <AgentSpinningDots
+              className="text-current"
+              testId={undefined}
+              variant={undefined}
+            />
+          ) : null}
+          Measure JS heaps
+        </Button>
+      </div>
+      {breakdown === null ? null : (
+        <div className="px-4 pb-3" data-testid="diagnostics-js-heap-breakdown">
+          <table className="w-full border-collapse text-ui-xs">
+            <thead>
+              <tr className="text-left text-muted-foreground">
+                <th scope="col" className="py-1 pr-3 font-normal">
+                  Isolate
+                </th>
+                <th scope="col" className="py-1 pr-3 text-right font-normal">
+                  Live
+                </th>
+                <th scope="col" className="py-1 text-right font-normal">
+                  Committed
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {breakdown.isolates.map((isolate, index) => (
+                <tr
+                  key={`${isolate.url}:${String(index)}`}
+                  className="border-t border-border/40"
+                >
+                  <td className="py-1 pr-3">
+                    {describeDesktopJsHeapIsolate(isolate)}
+                    {isolate.kind === "worker" ? (
+                      <span className="ml-2 font-mono text-code-xs text-muted-foreground">
+                        {isolate.url.slice(isolate.url.lastIndexOf("/") + 1)}
+                      </span>
+                    ) : null}
+                  </td>
+                  <td className="py-1 pr-3 text-right font-mono tabular-nums">
+                    {formatMemoryBytes(isolate.usedBytes)}
+                  </td>
+                  <td className="py-1 text-right font-mono tabular-nums">
+                    {formatMemoryBytes(isolate.totalBytes)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+            <tfoot>
+              <tr className="border-t border-border/60 text-muted-foreground">
+                <td className="py-1 pr-3">
+                  {breakdown.isolates.length === 1
+                    ? "1 isolate"
+                    : `${String(breakdown.isolates.length)} isolates`}
+                  {breakdown.workingSetBytes === null
+                    ? null
+                    : ` · process working set ${formatMemoryBytes(breakdown.workingSetBytes)}`}
+                </td>
+                <td className="py-1 pr-3 text-right font-mono tabular-nums">
+                  {formatMemoryBytes(usedTotal)}
+                </td>
+                <td className="py-1 text-right font-mono tabular-nums">
+                  {formatMemoryBytes(committedTotal)}
+                </td>
+              </tr>
+            </tfoot>
+          </table>
+        </div>
+      )}
+    </>
   );
 }

--- a/clients/gui-app/src/components/settings/panels/app-diagnostics-settings-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/app-diagnostics-settings-panel.tsx
@@ -141,6 +141,7 @@ function DesktopAppLogEntry(props: {
  */
 /** Serialization scope for the heap capture - see the `scope` note below. */
 const HEAP_SNAPSHOT_MUTATION_SCOPE = "runner-heap-snapshot";
+const JS_HEAP_MEASURE_MUTATION_SCOPE = "runner-js-heap-measure";
 
 function MemoryDiagnosticsGroup(): ReactNode {
   const bridge = useMemo(() => getDesktopHeapSnapshotBridge(), []);
@@ -255,6 +256,11 @@ function JsHeapReadout(): ReactNode {
 
   const measureMutation = useMutation({
     mutationKey: runnerMutationKeys.measureJsHeaps(),
+    // Serialized for the same reason the heap capture is: the measurement
+    // attaches `webContents.debugger`, and a second call while the first holds
+    // the attachment is refused in main (`isAttached()`), which would read as
+    // a failure toast and clear a readout that was fine.
+    scope: { id: JS_HEAP_MEASURE_MUTATION_SCOPE },
     mutationFn: (): Promise<DesktopJsHeapBreakdown | null> =>
       bridge === null ? Promise.resolve(null) : bridge.measureJsHeaps(),
     onSuccess: (result) => {

--- a/clients/gui-app/src/lib/diff/__tests__/diff-worker-pool-demand.test.ts
+++ b/clients/gui-app/src/lib/diff/__tests__/diff-worker-pool-demand.test.ts
@@ -1,0 +1,187 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { WorkerPoolManager } from "@pierre/diffs/worker";
+import {
+  __resetDiffWorkerPoolForTests,
+  getDiffWorkerPool,
+  getDiffWorkerPoolAvailability,
+  registerDiffWorkerPoolCreator,
+  requestDiffWorkerPool,
+  subscribeDiffWorkerPool,
+  unregisterDiffWorkerPoolCreator,
+} from "@/lib/diff/diff-worker-pool-demand";
+
+interface FakeWorkerPoolManager {
+  readonly setRenderOptions: () => Promise<void>;
+  readonly primeFileHighlightCache: () => Promise<void>;
+  readonly primeDiffHighlightCache: () => Promise<void>;
+}
+
+/**
+ * A prototype-less object asserted to the class type, with the three members
+ * a consumer could call assigned onto it (`as unknown as` is lint-forbidden
+ * here, and a three-member literal does not overlap the ~90-member class
+ * enough for a direct `as`). Each fake is its own object identity, which is
+ * all these tests read - none of the three methods is ever called.
+ */
+function fakeManager(id: string): WorkerPoolManager {
+  const fake: FakeWorkerPoolManager & { readonly debugId: string } = {
+    debugId: id,
+    setRenderOptions: () => Promise.resolve(),
+    primeFileHighlightCache: () => Promise.resolve(),
+    primeDiffHighlightCache: () => Promise.resolve(),
+  };
+  return Object.assign(Object.create(null) as WorkerPoolManager, fake);
+}
+
+function fakeCreator(id: string): () => WorkerPoolManager {
+  return () => fakeManager(id);
+}
+
+describe("diff-worker-pool-demand", () => {
+  beforeEach(() => {
+    __resetDiffWorkerPoolForTests();
+  });
+
+  afterEach(() => {
+    __resetDiffWorkerPoolForTests();
+  });
+
+  it("starts pending: no manager, no creator, not requested", () => {
+    expect(getDiffWorkerPool()).toBeUndefined();
+    expect(getDiffWorkerPoolAvailability()).toBe("pending");
+  });
+
+  it("creates the pool exactly once when requested, then registered", () => {
+    const creator = vi.fn(fakeCreator("a"));
+    requestDiffWorkerPool();
+    // No creator registered yet: a request alone cannot create the pool.
+    expect(getDiffWorkerPoolAvailability()).toBe("unavailable");
+    expect(getDiffWorkerPool()).toBeUndefined();
+
+    registerDiffWorkerPoolCreator(creator);
+
+    expect(creator).toHaveBeenCalledTimes(1);
+    expect(getDiffWorkerPoolAvailability()).toBe("ready");
+    expect(getDiffWorkerPool()).toBe(creator.mock.results[0]?.value);
+  });
+
+  it("creates the pool exactly once when registered, then requested", () => {
+    const creator = vi.fn(fakeCreator("b"));
+    registerDiffWorkerPoolCreator(creator);
+    expect(creator).not.toHaveBeenCalled();
+    expect(getDiffWorkerPoolAvailability()).toBe("pending");
+
+    requestDiffWorkerPool();
+
+    expect(creator).toHaveBeenCalledTimes(1);
+    expect(getDiffWorkerPoolAvailability()).toBe("ready");
+    expect(getDiffWorkerPool()).toBe(creator.mock.results[0]?.value);
+  });
+
+  it("never calls the creator a second time for a repeated request or a re-registration", () => {
+    const creator = vi.fn(fakeCreator("c"));
+    registerDiffWorkerPoolCreator(creator);
+    requestDiffWorkerPool();
+    expect(creator).toHaveBeenCalledTimes(1);
+
+    requestDiffWorkerPool();
+    registerDiffWorkerPoolCreator(creator);
+
+    expect(creator).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports 'unavailable' once requested with no creator registered", () => {
+    expect(getDiffWorkerPoolAvailability()).toBe("pending");
+    requestDiffWorkerPool();
+    expect(getDiffWorkerPoolAvailability()).toBe("unavailable");
+    expect(getDiffWorkerPool()).toBeUndefined();
+  });
+
+  it("moves from 'unavailable' to 'ready' once a creator registers after the request", () => {
+    requestDiffWorkerPool();
+    expect(getDiffWorkerPoolAvailability()).toBe("unavailable");
+
+    registerDiffWorkerPoolCreator(fakeCreator("d"));
+
+    expect(getDiffWorkerPoolAvailability()).toBe("ready");
+    expect(getDiffWorkerPool()).toBeDefined();
+  });
+
+  it("moves from 'pending' to 'ready' once the pool is created", () => {
+    registerDiffWorkerPoolCreator(fakeCreator("e"));
+    expect(getDiffWorkerPoolAvailability()).toBe("pending");
+
+    requestDiffWorkerPool();
+
+    expect(getDiffWorkerPoolAvailability()).toBe("ready");
+  });
+
+  it("notifies subscribers on register, request, and unregister", () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeDiffWorkerPool(listener);
+    const creator = fakeCreator("f");
+
+    registerDiffWorkerPoolCreator(creator);
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    requestDiffWorkerPool();
+    // The request both creates the pool (one notify from createIfDue) and
+    // notifies again for the request itself.
+    expect(listener.mock.calls.length).toBeGreaterThanOrEqual(2);
+
+    listener.mockClear();
+    unregisterDiffWorkerPoolCreator(creator);
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+  });
+
+  it("stops notifying a listener once it has unsubscribed", () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeDiffWorkerPool(listener);
+    unsubscribe();
+
+    registerDiffWorkerPoolCreator(fakeCreator("g"));
+    requestDiffWorkerPool();
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("treats unregistering a different creator than the one registered as a no-op", () => {
+    const registered = fakeCreator("h");
+    const other = fakeCreator("not-registered");
+    registerDiffWorkerPoolCreator(registered);
+    requestDiffWorkerPool();
+    const manager = getDiffWorkerPool();
+    expect(manager).toBeDefined();
+
+    unregisterDiffWorkerPoolCreator(other);
+
+    // The real creator (and the manager it built) survive an unregister call
+    // naming a different creator function.
+    expect(getDiffWorkerPool()).toBe(manager);
+    expect(getDiffWorkerPoolAvailability()).toBe("ready");
+  });
+
+  it("clears the manager and creator when the registered creator unregisters", () => {
+    const creator = fakeCreator("i");
+    registerDiffWorkerPoolCreator(creator);
+    requestDiffWorkerPool();
+    expect(getDiffWorkerPool()).toBeDefined();
+
+    unregisterDiffWorkerPoolCreator(creator);
+
+    expect(getDiffWorkerPool()).toBeUndefined();
+    // The request itself is untouched - only the creator/manager are cleared -
+    // so a still-requested surface now reads "unavailable", not "pending".
+    expect(getDiffWorkerPoolAvailability()).toBe("unavailable");
+  });
+
+  it("getDiffWorkerPool() reflects exactly the manager the creator produced", () => {
+    const manager = fakeManager("j");
+    registerDiffWorkerPoolCreator(() => manager);
+    requestDiffWorkerPool();
+
+    expect(getDiffWorkerPool()).toBe(manager);
+  });
+});

--- a/clients/gui-app/src/lib/diff/__tests__/diff-worker-pool-demand.test.ts
+++ b/clients/gui-app/src/lib/diff/__tests__/diff-worker-pool-demand.test.ts
@@ -163,7 +163,7 @@ describe("diff-worker-pool-demand", () => {
     expect(getDiffWorkerPoolAvailability()).toBe("ready");
   });
 
-  it("clears the manager and creator when the registered creator unregisters", () => {
+  it("clears the manager, creator, AND the request when the registered creator unregisters", () => {
     const creator = fakeCreator("i");
     registerDiffWorkerPoolCreator(creator);
     requestDiffWorkerPool();
@@ -172,9 +172,41 @@ describe("diff-worker-pool-demand", () => {
     unregisterDiffWorkerPoolCreator(creator);
 
     expect(getDiffWorkerPool()).toBeUndefined();
-    // The request itself is untouched - only the creator/manager are cleared -
-    // so a still-requested surface now reads "unavailable", not "pending".
-    expect(getDiffWorkerPoolAvailability()).toBe("unavailable");
+    // The request is cleared too, not just the creator/manager: every surface
+    // that could have asked for a pool renders below the provider, so it has
+    // unmounted along with it, and a `requested` left standing would make the
+    // NEXT registration build a pool eagerly during its own mount.
+    expect(getDiffWorkerPoolAvailability()).toBe("pending");
+  });
+
+  it("does not eagerly rebuild a pool for a second app-shell lifetime's registration after unregister", () => {
+    // The regression this pins: a host outage or sign-out unmounts the
+    // provider and remounts it under `HostReadyGate` within one session. The
+    // second lifetime must be exactly as lazy as the first - nothing has
+    // asked for a pool YET in this lifetime, so registering its creator alone
+    // must not build one.
+    const creator1 = vi.fn(fakeCreator("k1"));
+    registerDiffWorkerPoolCreator(creator1);
+    requestDiffWorkerPool();
+    expect(creator1).toHaveBeenCalledTimes(1);
+    expect(getDiffWorkerPool()).toBeDefined();
+
+    unregisterDiffWorkerPoolCreator(creator1);
+
+    // Second lifetime: the provider re-registers with a fresh creator.
+    const creator2 = vi.fn(fakeCreator("k2"));
+    registerDiffWorkerPoolCreator(creator2);
+
+    expect(creator2).not.toHaveBeenCalled();
+    expect(getDiffWorkerPool()).toBeUndefined();
+    expect(getDiffWorkerPoolAvailability()).toBe("pending");
+
+    // Only a fresh request, made in THIS lifetime, re-creates the pool.
+    requestDiffWorkerPool();
+
+    expect(creator2).toHaveBeenCalledTimes(1);
+    expect(getDiffWorkerPool()).toBe(creator2.mock.results[0]?.value);
+    expect(getDiffWorkerPoolAvailability()).toBe("ready");
   });
 
   it("getDiffWorkerPool() reflects exactly the manager the creator produced", () => {

--- a/clients/gui-app/src/lib/diff/diff-worker-pool-demand.ts
+++ b/clients/gui-app/src/lib/diff/diff-worker-pool-demand.ts
@@ -84,11 +84,24 @@ export function registerDiffWorkerPoolCreator(creator: PoolCreator): void {
   notify();
 }
 
-/** Provider unmount. The manager is the provider's to terminate, not ours. */
+/**
+ * Provider unmount. The manager is the provider's to terminate, not ours.
+ *
+ * The demand goes with it. Every surface that can ask for a pool renders BELOW
+ * this provider, so they have all unmounted too and none of their asks is being
+ * discarded - whereas a `requested` left standing would outlive them and make
+ * the next `registerDiffWorkerPoolCreator` build a pool during its own mount.
+ * The shell can be torn down and rebuilt within one session (a host outage or
+ * sign-out unmounts it under `HostReadyGate`), and the second shell has to be
+ * as lazy as the first: eager spawning that only starts on the second lifetime
+ * is exactly the cost this module exists to remove, minus the symptom that
+ * would make anyone look.
+ */
 export function unregisterDiffWorkerPoolCreator(creator: PoolCreator): void {
   if (store.creator !== creator) return;
   store.creator = null;
   store.manager = undefined;
+  store.requested = false;
   notify();
 }
 

--- a/clients/gui-app/src/lib/diff/diff-worker-pool-demand.ts
+++ b/clients/gui-app/src/lib/diff/diff-worker-pool-demand.ts
@@ -1,0 +1,128 @@
+import type { WorkerPoolManager } from "@pierre/diffs/worker";
+
+/**
+ * The lazily-created `@pierre/diffs` worker pool, and the demand signal that
+ * creates it.
+ *
+ * WHY THIS EXISTS. `WorkerPoolManager`'s constructor spawns `poolSize` dedicated
+ * workers and initializes a highlighter (Oniguruma WASM engine + both themes)
+ * in every one of them, synchronously with construction. The provider used to
+ * construct it at app-shell mount, so a fresh window carried six fully
+ * initialized highlighter isolates before it had shown a single diff - the
+ * 2026-09-03 staging launch snapshot found 6 of the renderer's 11 worker
+ * threads sitting in the pool's `workers` array with nothing to render. A
+ * worker isolate is not a JS object the main-thread heap snapshot can see, so
+ * that cost never appeared in the profiles that drove the earlier fixes.
+ *
+ * The pool is now created the first time a diff surface asks for it, through
+ * the highlight-ready gates in `use-diff-highlight-ready.ts`, which are the one
+ * place every Diffs surface already passes through before it mounts a
+ * `@pierre/diffs` component. Creation stays synchronous (the manager itself
+ * queues its own worker initialization), so a surface that asked in an effect
+ * sees the pool on its very next render.
+ *
+ * Module state rather than React state because the pool is a process-wide
+ * singleton on the library side too (`getOrCreateWorkerPoolSingleton`), and
+ * because the demand can arrive from any depth of the tree while the one
+ * provider that knows how to build it sits at the app-shell root.
+ */
+
+/**
+ * Where a surface's request stands. The gates in `use-diff-highlight-ready.ts`
+ * read this next to the pool they get from React context, and the two can
+ * disagree for one render: the store holds the manager the moment it is
+ * created, the context catches up when the provider re-renders. `"ready"` with
+ * no pool in context therefore means "about to arrive - hold", and only
+ * `"unavailable"` releases a surface to the main-thread renderer.
+ */
+export type DiffWorkerPoolAvailability =
+  /** The pool exists. */
+  | "ready"
+  /** Not requested yet, or requested and being created for this render. */
+  | "pending"
+  /**
+   * Requested, and no provider is mounted to build it - a tree outside the
+   * desktop shell. Render on the main thread, as such trees always did.
+   */
+  | "unavailable";
+
+type PoolCreator = () => WorkerPoolManager;
+
+interface DiffWorkerPoolStore {
+  manager: WorkerPoolManager | undefined;
+  creator: PoolCreator | null;
+  requested: boolean;
+}
+
+const store: DiffWorkerPoolStore = {
+  manager: undefined,
+  creator: null,
+  requested: false,
+};
+
+const listeners = new Set<() => void>();
+
+function notify(): void {
+  for (const listener of listeners) listener();
+}
+
+function createIfDue(): void {
+  if (store.manager !== undefined) return;
+  if (!store.requested || store.creator === null) return;
+  store.manager = store.creator();
+  notify();
+}
+
+/**
+ * Called by the provider at mount with the recipe for the pool. Creation
+ * happens here immediately if a surface already asked before the provider
+ * registered (a surface below the provider can mount in the same commit).
+ */
+export function registerDiffWorkerPoolCreator(creator: PoolCreator): void {
+  store.creator = creator;
+  createIfDue();
+  notify();
+}
+
+/** Provider unmount. The manager is the provider's to terminate, not ours. */
+export function unregisterDiffWorkerPoolCreator(creator: PoolCreator): void {
+  if (store.creator !== creator) return;
+  store.creator = null;
+  store.manager = undefined;
+  notify();
+}
+
+/**
+ * A diff surface is about to render. Idempotent; the first call with a
+ * registered creator builds the pool.
+ */
+export function requestDiffWorkerPool(): void {
+  if (store.requested) return;
+  store.requested = true;
+  createIfDue();
+  notify();
+}
+
+export function getDiffWorkerPool(): WorkerPoolManager | undefined {
+  return store.manager;
+}
+
+export function getDiffWorkerPoolAvailability(): DiffWorkerPoolAvailability {
+  if (store.manager !== undefined) return "ready";
+  if (store.requested && store.creator === null) return "unavailable";
+  return "pending";
+}
+
+export function subscribeDiffWorkerPool(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function __resetDiffWorkerPoolForTests(): void {
+  store.manager = undefined;
+  store.creator = null;
+  store.requested = false;
+  listeners.clear();
+}

--- a/clients/gui-app/src/lib/query-keys/runner-mutation-keys.ts
+++ b/clients/gui-app/src/lib/query-keys/runner-mutation-keys.ts
@@ -81,6 +81,9 @@ export const runnerMutationKeys = {
   // heap walk.
   captureHeapSnapshot: () =>
     ["runner.diagnostics.captureHeapSnapshot"] as const,
+  // Per-isolate JS heap readout of this renderer (Diagnostics → Memory): the
+  // page plus every dedicated worker, which a heap snapshot cannot see.
+  measureJsHeaps: () => ["runner.diagnostics.measureJsHeaps"] as const,
   // Force-refresh the registry update probe (bypasses the desktop's 24h
   // on-disk cache). Used by the Settings → Host Updates row's
   // "Check now" / "Retry" buttons so stale cached failures don't survive

--- a/clients/gui-app/src/lib/resources/__tests__/desktop-app-resource-usage.test.ts
+++ b/clients/gui-app/src/lib/resources/__tests__/desktop-app-resource-usage.test.ts
@@ -165,7 +165,14 @@ describe("getDesktopJsHeapBridge", () => {
 
 describe("describeDesktopJsHeapIsolate", () => {
   function isolate(kind: "page" | "worker", url: string): DesktopJsHeapIsolate {
-    return { kind, url, usedBytes: 0, totalBytes: 0 };
+    return {
+      kind,
+      url,
+      usedBytes: 0,
+      totalBytes: 0,
+      embedderBytes: null,
+      backingStorageBytes: null,
+    };
   }
 
   it("labels the page isolate as This window regardless of its URL", () => {

--- a/clients/gui-app/src/lib/resources/__tests__/desktop-app-resource-usage.test.ts
+++ b/clients/gui-app/src/lib/resources/__tests__/desktop-app-resource-usage.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   desktopAppResourceUsageFromMetrics,
+  describeDesktopJsHeapIsolate,
   getDesktopDiagnosticsBridge,
+  getDesktopJsHeapBridge,
+  type DesktopJsHeapIsolate,
   type DesktopProcessMetricsSnapshot,
 } from "@/lib/resources/desktop-app-resource-usage";
 
@@ -132,5 +135,83 @@ describe("desktopAppResourceUsageFromMetrics", () => {
     expect(usage.cpuPercent).toBe(0);
     expect(usage.rssBytes).toBe(0);
     expect(usage.processCount).toBe(1);
+  });
+});
+
+describe("getDesktopJsHeapBridge", () => {
+  it("returns null when runnerHost is missing", () => {
+    expect(getDesktopJsHeapBridge()).toBeNull();
+  });
+
+  it("returns null when measureJsHeaps is absent", () => {
+    setRunnerHost({ platform: { diagnostics: {} } });
+
+    expect(getDesktopJsHeapBridge()).toBeNull();
+  });
+
+  it("returns the bridge when measureJsHeaps is present", () => {
+    const measureJsHeaps = vi.fn(() => Promise.resolve(null));
+    setRunnerHost({
+      platform: {
+        diagnostics: {
+          measureJsHeaps,
+        },
+      },
+    });
+
+    expect(getDesktopJsHeapBridge()).toEqual({ measureJsHeaps });
+  });
+});
+
+describe("describeDesktopJsHeapIsolate", () => {
+  function isolate(kind: "page" | "worker", url: string): DesktopJsHeapIsolate {
+    return { kind, url, usedBytes: 0, totalBytes: 0 };
+  }
+
+  it("labels the page isolate as This window regardless of its URL", () => {
+    expect(
+      describeDesktopJsHeapIsolate(
+        isolate("page", "app://renderer/index.html"),
+      ),
+    ).toBe("This window");
+  });
+
+  it("labels an epic-runtime-worker chunk as Epic runtime worker", () => {
+    expect(
+      describeDesktopJsHeapIsolate(
+        isolate(
+          "worker",
+          "app://renderer/assets/epic-runtime-worker-entry-BKyjY2bC.js",
+        ),
+      ),
+    ).toBe("Epic runtime worker");
+  });
+
+  it("labels a pdf.worker chunk as PDF worker", () => {
+    expect(
+      describeDesktopJsHeapIsolate(
+        isolate("worker", "app://renderer/assets/pdf.worker.min-abc123.mjs"),
+      ),
+    ).toBe("PDF worker");
+  });
+
+  it("labels a bare worker- chunk as Diff highlighter worker", () => {
+    expect(
+      describeDesktopJsHeapIsolate(
+        isolate("worker", "app://renderer/assets/worker-DMI2JaPh.js"),
+      ),
+    ).toBe("Diff highlighter worker");
+  });
+
+  it("falls back to a generic Worker (<file>) label for an unrecognized chunk", () => {
+    expect(
+      describeDesktopJsHeapIsolate(
+        isolate("worker", "app://renderer/assets/mystery-chunk-xyz.js"),
+      ),
+    ).toBe("Worker (mystery-chunk-xyz.js)");
+  });
+
+  it("falls back to bare Worker when the URL has no file part", () => {
+    expect(describeDesktopJsHeapIsolate(isolate("worker", ""))).toBe("Worker");
   });
 });

--- a/clients/gui-app/src/lib/resources/desktop-app-resource-usage.ts
+++ b/clients/gui-app/src/lib/resources/desktop-app-resource-usage.ts
@@ -33,6 +33,28 @@ export interface DesktopHeapSnapshotBridge {
   readonly takeHeapSnapshot: () => Promise<string | null>;
 }
 
+/**
+ * One V8 isolate in this renderer - the page, or a dedicated worker started
+ * from `url`. Mirrors the desktop's `RendererJsHeapIsolate`; the GUI reads it
+ * structurally off the runner host like every other desktop bridge here.
+ */
+export interface DesktopJsHeapIsolate {
+  readonly kind: "page" | "worker";
+  readonly url: string;
+  readonly usedBytes: number;
+  readonly totalBytes: number;
+}
+
+export interface DesktopJsHeapBreakdown {
+  readonly capturedAt: number;
+  readonly workingSetBytes: number | null;
+  readonly isolates: ReadonlyArray<DesktopJsHeapIsolate>;
+}
+
+export interface DesktopJsHeapBridge {
+  readonly measureJsHeaps: () => Promise<DesktopJsHeapBreakdown | null>;
+}
+
 interface RunnerHostWindowShape {
   readonly platform:
     | {
@@ -43,6 +65,9 @@ interface RunnerHostWindowShape {
                 | undefined;
               readonly takeHeapSnapshot:
                 | (() => Promise<string | null>)
+                | undefined;
+              readonly measureJsHeaps:
+                | (() => Promise<DesktopJsHeapBreakdown | null>)
                 | undefined;
             }
           | undefined;
@@ -73,6 +98,36 @@ export function getDesktopHeapSnapshotBridge(): DesktopHeapSnapshotBridge | null
     .runnerHost;
   const takeHeapSnapshot = host?.platform?.diagnostics?.takeHeapSnapshot;
   return takeHeapSnapshot === undefined ? null : { takeHeapSnapshot };
+}
+
+/**
+ * Its own resolver for the same reason as the heap snapshot's: an older shell
+ * can carry the snapshot capability without this one, and the Memory group
+ * offers each button on its own bridge.
+ */
+export function getDesktopJsHeapBridge(): DesktopJsHeapBridge | null {
+  const host = (globalThis as { runnerHost?: RunnerHostWindowShape })
+    .runnerHost;
+  const measureJsHeaps = host?.platform?.diagnostics?.measureJsHeaps;
+  return measureJsHeaps === undefined ? null : { measureJsHeaps };
+}
+
+/**
+ * A human label for an isolate row. The worker's script URL is a hashed Vite
+ * chunk name, so the label reads the chunk's stem, which is stable across
+ * builds: `epic-runtime-worker-entry-<hash>.js` is the per-epic runtime,
+ * `worker-<hash>.js` is `@pierre/diffs`' highlighter (the only worker the app
+ * starts from a bare `worker` chunk), `pdf.worker.min-<hash>.mjs` is pdf.js.
+ */
+export function describeDesktopJsHeapIsolate(
+  isolate: DesktopJsHeapIsolate,
+): string {
+  if (isolate.kind === "page") return "This window";
+  const file = isolate.url.slice(isolate.url.lastIndexOf("/") + 1);
+  if (file.startsWith("epic-runtime-worker")) return "Epic runtime worker";
+  if (file.startsWith("pdf.worker")) return "PDF worker";
+  if (file.startsWith("worker-")) return "Diff highlighter worker";
+  return file === "" ? "Worker" : `Worker (${file})`;
 }
 
 export function desktopAppResourceUsageFromMetrics(

--- a/clients/gui-app/src/lib/resources/desktop-app-resource-usage.ts
+++ b/clients/gui-app/src/lib/resources/desktop-app-resource-usage.ts
@@ -43,6 +43,10 @@ export interface DesktopJsHeapIsolate {
   readonly url: string;
   readonly usedBytes: number;
   readonly totalBytes: number;
+  /** Blink-held memory for this isolate; `null` when the build omits it. */
+  readonly embedderBytes: number | null;
+  /** `ArrayBuffer` / WebAssembly backing stores, outside the JS heap. */
+  readonly backingStorageBytes: number | null;
 }
 
 export interface DesktopJsHeapBreakdown {


### PR DESCRIPTION
## Why

The 2026-09-03 staging launch capture, taken on the build that carries #1694, shows the main-thread heap down from ~500 MB to **192 MB** and the renderer footprint still at **1.5 GB**. `vmmap` puts ~1.0 GB in V8 heap pages, which are summed over **every isolate** in the process, while a heap snapshot walks the page's isolate alone. The process runs **11 dedicated workers**: six `@pierre/diffs` highlighter workers and five epic runtime workers (one per warm epic session, at the cap).

## What

**Lazy diff worker pool** (`gui-app`). `WorkerPoolManager`'s constructor spawns `poolSize` workers and sends each an `initialize` that loads the Oniguruma WASM engine and both themes, and the provider constructed it at app-shell mount - six fully initialized highlighter isolates before a single diff was on screen. The provider now renders the library's own `WorkerPoolContext` with `undefined` and registers a creator; the pool is built the first time a Diffs surface passes through a highlight-ready gate (`lib/diff/diff-worker-pool-demand.ts`). The gates hold a surface until the pool is in React **context**, not merely in the store: a Diffs component mounted with no pool highlights on the main thread for its lifetime, and the store can lead the context by one render. A tree with no provider (outside the desktop shell) releases as before. Pool capped at 3 workers instead of 6.

**"Measure JS heaps" in Settings → Application → Diagnostics → Memory** (`desktop` + `gui-app`). The split of the remaining ~700 MB between the two worker kinds cannot be read from a snapshot (no numeric values) and the packaged app has no debug port. Desktop main attaches `webContents.debugger`, reads `Runtime.getHeapUsage` for the page, `Target.setAutoAttach` (flatten, no pause) to reach every dedicated worker, reads each worker's heap on its session id, then detaches. The GUI lists one row per isolate, labeled by its chunk (This window / Epic runtime worker / Diff highlighter worker / PDF worker), with live and committed bytes and the process working set. Refuses to share a debugger something else has attached (a browser tile's debug session), since auto-attach is session-wide state.

The epic session cap (5) and a warm-session idle TTL are deliberately **left for that readout to decide**.

## Verified

- `compile` green across the OSS graph.
- Seven touched gui-app suites (94 tests) and two desktop suites (25 tests) green.
- Ablation: reverting the gate to its pre-change `prepare === null → ready` shape reddens exactly the four new context-lag tests.

## Follow-up

Next staging build: launch, open the same epics, Diagnostics → Memory → **Measure JS heaps**. Expect no diff highlighter rows until a diff has been shown, at most three after; the epic runtime rows decide the next lever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
