### PR TITLE
feat(browser): import logins from Aside and Helium; group the picker by browser

### DIFF
--- a/clients/desktop/src/electron-main/browser-view/storage/login-import/__tests__/secret-providers.test.ts
+++ b/clients/desktop/src/electron-main/browser-view/storage/login-import/__tests__/secret-providers.test.ts
@@ -102,6 +102,28 @@ describe("readMacosKeychainPassphrase", () => {
       "Brave",
     ]);
   });
+
+  it("asks for Helium's 'Storage Key' item, which breaks the Safe Storage naming", async () => {
+    const { run, calls } = fakeRunner({
+      kind: "exited",
+      exitCode: 0,
+      stdout: "helium-secret\n",
+    });
+
+    await readMacosKeychainPassphrase("helium", run);
+
+    expect(calls).toHaveLength(1);
+    const call = calls[0];
+    if (call === undefined) throw new Error("expected one call");
+    expect(call.args).toEqual([
+      "find-generic-password",
+      "-w",
+      "-s",
+      "Helium Storage Key",
+      "-a",
+      "Helium",
+    ]);
+  });
 });
 
 describe("readLinuxSecretServicePassphrase", () => {
@@ -158,6 +180,8 @@ describe("readLinuxSecretServicePassphrase", () => {
       arc: "chromium",
       vivaldi: "chrome",
       opera: "chromium",
+      aside: "chromium",
+      helium: "chromium",
     };
 
     for (const [browser, application] of Object.entries(

--- a/clients/desktop/src/electron-main/browser-view/storage/login-import/__tests__/sources.test.ts
+++ b/clients/desktop/src/electron-main/browser-view/storage/login-import/__tests__/sources.test.ts
@@ -131,15 +131,43 @@ describe("discoverLoginImportSources: chromium", () => {
   });
 
   it("does not look for Aside or Helium on Windows or Linux", async () => {
+    // Each platform gets a Chrome jar at its real root, so a run that finds
+    // Chrome and not the candidates below proves discovery walked the tree
+    // and skipped them, rather than finding nothing at all. The candidate
+    // roots are where a Chromium fork conventionally lands on each OS.
+    const local = join(root, "AppData", "Local");
+    const config = join(root, ".config");
+    const candidates: Record<"win32" | "linux", readonly string[]> = {
+      win32: [
+        join(local, "Google", "Chrome", "User Data"),
+        join(local, "Aside", "User Data"),
+        join(local, "Aside"),
+        join(local, "net.imput.helium", "User Data"),
+        join(local, "imput", "Helium", "User Data"),
+      ],
+      linux: [
+        join(config, "google-chrome"),
+        join(config, "Aside"),
+        join(config, "aside"),
+        join(config, "net.imput.helium"),
+        join(config, "helium"),
+      ],
+    };
     for (const platform of ["win32", "linux"] as const) {
+      for (const userDataDir of candidates[platform]) {
+        await writeFileAt(join(userDataDir, "Default", "Cookies"), "c", T1);
+      }
+
       const sources = await discoverLoginImportSources(
         environment({ platform }),
       );
+
+      expect(sources.some((source) => source.browser === "chrome")).toBe(true);
       expect(
-        sources.some(
+        sources.filter(
           (source) => source.browser === "aside" || source.browser === "helium",
         ),
-      ).toBe(false);
+      ).toEqual([]);
     }
   });
 

--- a/clients/desktop/src/electron-main/browser-view/storage/login-import/__tests__/sources.test.ts
+++ b/clients/desktop/src/electron-main/browser-view/storage/login-import/__tests__/sources.test.ts
@@ -103,6 +103,46 @@ describe("discoverLoginImportSources: chromium", () => {
     }
   });
 
+  it("finds Aside and Helium under their macOS Application Support roots", async () => {
+    const support = join(root, "Library", "Application Support");
+    await writeFileAt(join(support, "Aside", "Default", "Cookies"), "a", T1);
+    await writeFileAt(
+      join(support, "net.imput.helium", "Default", "Cookies"),
+      "h",
+      T2,
+    );
+
+    const sources = await discoverLoginImportSources(environment({}));
+    const aside = sources.find((source) => source.browser === "aside");
+    const helium = sources.find((source) => source.browser === "helium");
+
+    expect(aside?.location).toEqual({
+      kind: "chromium",
+      browser: "aside",
+      cookiesPath: join(support, "Aside", "Default", "Cookies"),
+      localStatePath: join(support, "Aside", "Local State"),
+    });
+    expect(helium?.location).toEqual({
+      kind: "chromium",
+      browser: "helium",
+      cookiesPath: join(support, "net.imput.helium", "Default", "Cookies"),
+      localStatePath: join(support, "net.imput.helium", "Local State"),
+    });
+  });
+
+  it("does not look for Aside or Helium on Windows or Linux", async () => {
+    for (const platform of ["win32", "linux"] as const) {
+      const sources = await discoverLoginImportSources(
+        environment({ platform }),
+      );
+      expect(
+        sources.some(
+          (source) => source.browser === "aside" || source.browser === "helium",
+        ),
+      ).toBe(false);
+    }
+  });
+
   it("finds Opera's profileless root-level cookie database as 'Default'", async () => {
     const operaRoot = join(
       root,

--- a/clients/desktop/src/electron-main/browser-view/storage/login-import/secret-providers/keychain-macos.ts
+++ b/clients/desktop/src/electron-main/browser-view/storage/login-import/secret-providers/keychain-macos.ts
@@ -32,6 +32,9 @@ const KEYCHAIN_ITEMS: Readonly<
   arc: { service: "Arc Safe Storage", account: "Arc" },
   vivaldi: { service: "Vivaldi Safe Storage", account: "Vivaldi" },
   opera: { service: "Opera Safe Storage", account: "Opera" },
+  aside: { service: "Aside Safe Storage", account: "Aside" },
+  // Helium names its item "Helium Storage Key", not "<Browser> Safe Storage".
+  helium: { service: "Helium Storage Key", account: "Helium" },
 };
 
 export async function readMacosKeychainPassphrase(

--- a/clients/desktop/src/electron-main/browser-view/storage/login-import/secret-providers/secret-service-linux.ts
+++ b/clients/desktop/src/electron-main/browser-view/storage/login-import/secret-providers/secret-service-linux.ts
@@ -26,6 +26,9 @@ const SECRET_SERVICE_APPLICATION: Readonly<
   arc: "chromium",
   vivaldi: "chrome",
   opera: "chromium",
+  // Neither has a Linux root in discovery; the entries only close the record.
+  aside: "chromium",
+  helium: "chromium",
 };
 
 export async function readLinuxSecretServicePassphrase(

--- a/clients/desktop/src/electron-main/browser-view/storage/login-import/sources.ts
+++ b/clients/desktop/src/electron-main/browser-view/storage/login-import/sources.ts
@@ -80,6 +80,8 @@ const BROWSER_ORDER: readonly LoginImportBrowser[] = [
   "arc",
   "vivaldi",
   "opera",
+  "aside",
+  "helium",
   "chromium",
   "firefox",
   "safari",
@@ -141,6 +143,10 @@ function chromiumRoots(
       root("arc", join(support, "Arc", "User Data")),
       root("vivaldi", join(support, "Vivaldi")),
       profilelessRoot("opera", join(support, "com.operasoftware.Opera")),
+      // Aside and Helium ship macOS builds only as far as this list has
+      // verified; their Windows and Linux roots are not listed below.
+      root("aside", join(support, "Aside")),
+      root("helium", join(support, "net.imput.helium")),
     ];
   }
   if (environment.platform === "win32") {

--- a/clients/gui-app/src/components/settings/__tests__/import-logins-dialog.test.tsx
+++ b/clients/gui-app/src/components/settings/__tests__/import-logins-dialog.test.tsx
@@ -6,6 +6,7 @@ import {
   render,
   screen,
   waitFor,
+  within,
 } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ImportLoginsDialog } from "@/components/settings/import-logins-dialog";
@@ -175,6 +176,45 @@ describe("<ImportLoginsDialog /> pick step", () => {
     expect(
       screen.getByRole("button", { name: /Import from a file…/ }),
     ).not.toBeNull();
+  });
+
+  it("groups profiles under one heading per browser, most recently used browser first", async () => {
+    const bridge = new TestBridge();
+    const hour = 60 * 60 * 1000;
+    bridge.sources = [
+      source({
+        id: "safari",
+        browser: "safari",
+        profileLabel: "Safari",
+        lastUsedAt: Date.now() - hour,
+      }),
+      source({
+        id: "chrome-work",
+        browser: "chrome",
+        profileLabel: "Work",
+        lastUsedAt: Date.now() - 2 * hour,
+      }),
+      source({
+        id: "chrome-default",
+        browser: "chrome",
+        profileLabel: "Default",
+        lastUsedAt: Date.now() - 3 * hour,
+      }),
+    ];
+    renderDialog(bridge);
+
+    const headings = await screen.findAllByRole("heading", { level: 3 });
+    expect(headings.map((heading) => heading.textContent)).toEqual([
+      "Safari",
+      "Google Chrome",
+    ]);
+    const chrome = screen.getByRole("region", { name: "Google Chrome" });
+    expect(
+      within(chrome)
+        .getAllByRole("button")
+        .map((button) => button.textContent),
+    ).toEqual(["Work2h ago", "Default3h ago"]);
+    expect(screen.getAllByText("Google Chrome")).toHaveLength(1);
   });
 
   it("picking the same file twice lists it once", async () => {

--- a/clients/gui-app/src/components/settings/__tests__/import-logins-dialog.test.tsx
+++ b/clients/gui-app/src/components/settings/__tests__/import-logins-dialog.test.tsx
@@ -214,6 +214,13 @@ describe("<ImportLoginsDialog /> pick step", () => {
         .getAllByRole("button")
         .map((button) => button.textContent),
     ).toEqual(["Work2h ago", "Default3h ago"]);
+    // The heading carries the browser visually; each row still names it for
+    // assistive tech, so a reader never hears a bare "Default".
+    expect(
+      within(chrome)
+        .getAllByRole("button")
+        .map((button) => button.getAttribute("aria-label")),
+    ).toEqual(["Google Chrome · Work", "Google Chrome · Default"]);
     expect(
       screen.getAllByRole("heading", { level: 3, name: "Google Chrome" }),
     ).toHaveLength(1);

--- a/clients/gui-app/src/components/settings/__tests__/import-logins-dialog.test.tsx
+++ b/clients/gui-app/src/components/settings/__tests__/import-logins-dialog.test.tsx
@@ -214,6 +214,11 @@ describe("<ImportLoginsDialog /> pick step", () => {
         .getAllByRole("button")
         .map((button) => button.textContent),
     ).toEqual(["Work2h ago", "Default3h ago"]);
+    expect(
+      screen.getAllByRole("heading", { level: 3, name: "Google Chrome" }),
+    ).toHaveLength(1);
+    // And the heading is the only place the browser name is rendered: the
+    // rows under it carry the profile alone.
     expect(screen.getAllByText("Google Chrome")).toHaveLength(1);
   });
 

--- a/clients/gui-app/src/components/settings/import-logins-flow.tsx
+++ b/clients/gui-app/src/components/settings/import-logins-flow.tsx
@@ -219,30 +219,41 @@ function PickStep(props: {
             cookie file instead.
           </p>
         ) : null}
-        {listed.map((source) => (
-          <button
-            key={source.id}
-            type="button"
-            className="flex w-full min-w-0 items-center justify-between gap-3 rounded-md px-3 py-2 text-left hover:bg-foreground/8 focus-visible:bg-foreground/8 focus-visible:outline-none"
-            onClick={() => {
-              props.onPick(source);
-            }}
+        {groupSourcesByBrowser(listed).map((group) => (
+          <section
+            key={group.browser}
+            aria-labelledby={`login-import-browser-${group.browser}`}
+            className="flex flex-col gap-0.5 not-first:mt-2"
           >
-            <span className="min-w-0 flex-1 truncate">
-              <span className="font-medium text-foreground">
-                {BROWSER_LABELS[source.browser]}
-              </span>
-              <span className="text-muted-foreground"> · </span>
-              <span className="text-muted-foreground">
-                {source.profileLabel}
-              </span>
-            </span>
-            {source.lastUsedAt !== null ? (
-              <span className="shrink-0 text-ui-xs text-muted-foreground">
-                {formatRelativeTimestamp(source.lastUsedAt, now)}
-              </span>
-            ) : null}
-          </button>
+            <h3
+              id={`login-import-browser-${group.browser}`}
+              className="mb-0.5 px-3 font-semibold text-ui-xs tracking-wide text-muted-foreground/70 uppercase"
+            >
+              {BROWSER_LABELS[group.browser]}
+            </h3>
+            {group.sources.map((source) => (
+              <button
+                key={source.id}
+                type="button"
+                // The heading carries the browser visually; the row's own
+                // name keeps it so a screen reader does not hear "Default".
+                aria-label={`${BROWSER_LABELS[group.browser]} · ${source.profileLabel}`}
+                className="flex w-full min-w-0 items-center justify-between gap-3 rounded-md px-3 py-2 text-left hover:bg-foreground/8 focus-visible:bg-foreground/8 focus-visible:outline-none"
+                onClick={() => {
+                  props.onPick(source);
+                }}
+              >
+                <span className="min-w-0 flex-1 truncate text-foreground">
+                  {source.profileLabel}
+                </span>
+                {source.lastUsedAt !== null ? (
+                  <span className="shrink-0 text-ui-xs text-muted-foreground">
+                    {formatRelativeTimestamp(source.lastUsedAt, now)}
+                  </span>
+                ) : null}
+              </button>
+            ))}
+          </section>
         ))}
       </div>
       <Frame.Footer>
@@ -273,6 +284,31 @@ function PickStep(props: {
       </Frame.Footer>
     </>
   );
+}
+
+interface LoginImportSourceGroup {
+  readonly browser: LoginImportBrowser;
+  readonly sources: readonly LoginImportSource[];
+}
+
+/**
+ * One section per browser, in the order the browsers first appear in the
+ * (most-recently-used-first) list: the browser whose profile was used last
+ * heads the list, and its profiles keep their own recency order under it.
+ */
+function groupSourcesByBrowser(
+  sources: readonly LoginImportSource[],
+): readonly LoginImportSourceGroup[] {
+  const groups = new Map<LoginImportBrowser, LoginImportSource[]>();
+  for (const source of sources) {
+    const group = groups.get(source.browser);
+    if (group === undefined) groups.set(source.browser, [source]);
+    else group.push(source);
+  }
+  return [...groups].map(([browser, grouped]) => ({
+    browser,
+    sources: grouped,
+  }));
 }
 
 function ChooseStep(props: {

--- a/clients/shared/platform/browser-view.ts
+++ b/clients/shared/platform/browser-view.ts
@@ -246,6 +246,8 @@ export type LoginImportBrowser =
   | "arc"
   | "vivaldi"
   | "opera"
+  | "aside"
+  | "helium"
   | "firefox"
   | "safari"
   | "file";
@@ -261,6 +263,8 @@ export const LOGIN_IMPORT_BROWSER_LABELS: Readonly<
   arc: "Arc",
   vivaldi: "Vivaldi",
   opera: "Opera",
+  aside: "Aside",
+  helium: "Helium",
   firefox: "Firefox",
   safari: "Safari",
   file: "Cookie file",


### PR DESCRIPTION
## Summary

Two more Chromium-family sources for **Settings ▸ Browser ▸ Import logins from another browser**, and a grouped picker.

**New sources (macOS)**

| Browser | User Data root | Keychain item |
| --- | --- | --- |
| Aside | `~/Library/Application Support/Aside` | `Aside Safe Storage` / `Aside` |
| Helium | `~/Library/Application Support/net.imput.helium` | `Helium Storage Key` / `Helium` |

Both are stock Chromium layouts (`Local State` → `info_cache`, `Default/Cookies`, `v10` rows), so no new reader: each is a root in `chromiumRoots()` plus a keychain entry. Helium is the one that breaks the `<Browser> Safe Storage` naming, which is why its entry carries a comment.

Neither is discovered on Windows or Linux. Only the macOS install has been verified, so those roots are left out rather than guessed; the Linux secret-service map gains entries only to keep the `Record<ChromiumImportBrowser, …>` closed.

**Picker**

The source list now shows one heading per browser with its profiles under it, instead of repeating `Google Chrome ·` on every row. Sections keep the most-recently-used order (the browser whose profile was used last heads the list; profiles keep their own recency under it). Each row keeps `<Browser> · <Profile>` as its accessible name, so the heading is not the only place a screen reader hears the browser.

Client-only. No protocol change, no new dependencies.

## Verification

- `sources.test.ts`: both roots discovered on darwin; neither on win32/linux.
- `secret-providers.test.ts`: Helium's `Storage Key` lookup.
- `import-logins-dialog.test.tsx`: one heading per browser, MRU section order, rows grouped, browser label rendered once.
- Discovery run against a real home directory listed Aside (`Work`) and Helium (`You`) alongside Chrome, Brave and Safari.