### PR TITLE
fix(gui-app): refresh the provider list from the picker and show Reasonix setup steps instead of a generic signed-out state

### DIFF
--- a/clients/gui-app/src/components/chat/composer/__tests__/provider-reauth-banner.test.tsx
+++ b/clients/gui-app/src/components/chat/composer/__tests__/provider-reauth-banner.test.tsx
@@ -250,6 +250,18 @@ const COPILOT_TERMINAL_CAP: ProviderLoginCapability = {
   terminalLogin: {},
 };
 
+// Reasonix is also a terminal-login provider (its own credential wizard, not
+// a device-code sign-in), but it has setup guidance
+// (`provider-setup-guidance.ts`) - the one live entry today - so
+// `TerminalLoginRow` must swap in the guidance's button label and hint
+// instead of the generic "Sign in from a terminal" copy.
+const REASONIX_CAP: ProviderLoginCapability = {
+  oauthArgs: ["setup"],
+  token: null,
+  codePaste: null,
+  terminalLogin: {},
+};
+
 // The unreachable case this used to model: an old host's payload cannot
 // decode with `terminalLogin` genuinely absent - the v6 -> v7 upgrade bridge
 // (`registry.ts`) fills it to `null` on that exact hop. What DOES leave
@@ -261,6 +273,12 @@ function copilotState(
   loginCapability: ProviderLoginCapability | null,
 ): ProviderCliState {
   return { ...claudeState(loginCapability), providerId: "copilot" };
+}
+
+function reasonixState(
+  loginCapability: ProviderLoginCapability | null,
+): ProviderCliState {
+  return { ...claudeState(loginCapability), providerId: "reasonix" };
 }
 
 function claudeState(
@@ -452,6 +470,38 @@ describe("<ProviderReauthBanner />", () => {
       screen.getByRole("button", { name: /Sign in from a terminal/ }),
     ).toBeDefined();
     expect(screen.queryByRole("button", { name: /Authenticate/ })).toBeNull();
+  });
+
+  // Reasonix is a terminal-login provider with its own setup guidance
+  // (`provider-setup-guidance.ts`): the generic "Sign in from a terminal" /
+  // "prints a sign-in code" copy is wrong for its credential-paste wizard, so
+  // `TerminalLoginRow` swaps in the guidance's own label and hint instead.
+  it("offers 'Set up in terminal' with the API-key hint for a provider with setup guidance (reasonix)", () => {
+    render(
+      <ProviderReauthBanner
+        epicId="epic-1"
+        viewTabId="tab-1"
+        providerId="reasonix"
+        state={reasonixState(REASONIX_CAP)}
+        reason="provider_unauthenticated"
+        profileId={null}
+        profileLabel={null}
+        onContinueOnAmbient={null}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Set up in terminal" }),
+    ).toBeDefined();
+    expect(
+      screen.queryByRole("button", { name: "Sign in from a terminal" }),
+    ).toBeNull();
+    expect(
+      screen.getByText(
+        "Reasonix asks for your provider API key in that terminal. Finish there, then use Refresh above.",
+      ),
+    ).toBeDefined();
+    expect(screen.queryByText(/sign-in code/)).toBeNull();
   });
 
   // Row 2: a provider whose whole `loginCapability` is `null` (Cursor,

--- a/clients/gui-app/src/components/chat/composer/provider-reauth-banner.tsx
+++ b/clients/gui-app/src/components/chat/composer/provider-reauth-banner.tsx
@@ -53,6 +53,7 @@ import { handleSignInLinkCopyError } from "@/components/settings/panels/provider
 import { providerIdToGuiHarnessId } from "@/lib/provider-ordering";
 import { providerSupportsTerminalLogin } from "@/components/providers/provider-signin-availability";
 import { useProviderTerminalLogin } from "@/hooks/providers/use-provider-terminal-login";
+import { providerSetupGuidance } from "@/lib/providers/provider-setup-guidance";
 import { useProvidersFocusStore } from "@/stores/settings/providers-focus-store";
 
 function noop(): void {}
@@ -485,6 +486,11 @@ function TerminalLoginRow({
     // host itself reports as replaced.
     launchedFromTile: null,
   });
+  // A provider whose terminal flow is a credential WIZARD rather than a
+  // device-code sign-in (Reasonix's `setup` asks for an API key) gets its own
+  // label and hint: "prints a sign-in code" is false there, and it is the copy
+  // the user reads while deciding what to do next.
+  const guidance = providerSetupGuidance(providerId);
   return (
     <div className="flex flex-col gap-1.5">
       <div className="flex flex-wrap items-center gap-2">
@@ -494,13 +500,16 @@ function TerminalLoginRow({
           disabled={terminalLogin.isPending}
           onClick={terminalLogin.start}
         >
-          Sign in from a terminal
+          {guidance === null
+            ? "Sign in from a terminal"
+            : guidance.terminalActionLabel}
           {terminalLogin.isPending ? <MutedAgentSpinner /> : null}
         </Button>
       </div>
       <span className="text-ui-xs text-muted-foreground">
-        {providerLabel} prints a sign-in code that only exists in the terminal.
-        Complete the sign-in there, then use Refresh above.
+        {guidance === null
+          ? `${providerLabel} prints a sign-in code that only exists in the terminal. Complete the sign-in there, then use Refresh above.`
+          : guidance.terminalHint}
       </span>
     </div>
   );

--- a/clients/gui-app/src/components/home/pickers/__tests__/harness-model-picker-auth-line.test.tsx
+++ b/clients/gui-app/src/components/home/pickers/__tests__/harness-model-picker-auth-line.test.tsx
@@ -1,0 +1,315 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type {
+  ProviderAuthStatus,
+  ProviderCliState,
+  ProviderId,
+} from "@traycer/protocol/host/provider-schemas";
+import type { GuiHarnessId } from "@traycer/protocol/host/index";
+import { providerSignedOutMessage } from "@traycer/protocol/host/provider-display";
+import { HostRpcError } from "@traycer-clients/shared/host-transport/host-messenger";
+import type { GuiHarnessCatalogEntry } from "@/hooks/harnesses/use-gui-harness-catalog";
+import { PickerProviderAuthLine } from "../harness-model-picker-auth-line";
+
+function noop(): void {}
+
+function baseProviderState(providerId: ProviderId): ProviderCliState {
+  return {
+    providerId,
+    enabled: true,
+    disabledBy: null,
+    selected: { kind: "bundled" },
+    candidates: [],
+    auth: {
+      status: "unauthenticated",
+      badgeText: null,
+      label: null,
+      detail: null,
+    },
+    authPending: false,
+    checkedAt: null,
+    apiKey: { supported: false, configured: false, source: null },
+    terminalAgentArgs: "",
+    envOverrides: [],
+    loginCapability: null,
+    availabilityPending: false,
+    nativeCapabilities: {
+      supportedTabs: ["general", "env", "usage"],
+      mcp: null,
+      plugins: null,
+      skills: null,
+      modelProviders: null,
+    },
+    managedInstallState: null,
+    versionVisibility: null,
+    advisory: null,
+    profiles: [],
+  };
+}
+
+function providerStateWithAuth(
+  providerId: ProviderId,
+  status: ProviderAuthStatus,
+  badgeText: string | null,
+  label: string | null,
+): ProviderCliState {
+  return {
+    ...baseProviderState(providerId),
+    auth: { status, badgeText, label, detail: null },
+  };
+}
+
+function disabledProviderState(providerId: ProviderId): ProviderCliState {
+  return { ...baseProviderState(providerId), enabled: false };
+}
+
+function harnessOption(
+  id: GuiHarnessId,
+  authStatus: ProviderAuthStatus | undefined,
+  modelsError: HostRpcError | null,
+): GuiHarnessCatalogEntry {
+  return {
+    id,
+    label: id,
+    enabled: true,
+    available: true,
+    error: null,
+    modes: ["gui"],
+    requiresApiKey: false,
+    supportedPermissionModes: [
+      "supervised",
+      "auto_accept_edits",
+      "full_access",
+    ],
+    availabilityPending: false,
+    authStatus,
+    models: [],
+    modelsLoading: false,
+    modelsError,
+  };
+}
+
+function catalogErrorFor(
+  method: "agent.gui.listModels",
+  message: string,
+): HostRpcError {
+  return new HostRpcError({
+    code: "RPC_ERROR",
+    message,
+    requestId: "req-1",
+    method,
+    fatalDetails: null,
+  });
+}
+
+describe("<PickerProviderAuthLine />", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders nothing for a null state", () => {
+    const { container } = render(
+      <PickerProviderAuthLine
+        state={null}
+        harness={null}
+        onOpenProviderSettings={noop}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing for a disabled provider", () => {
+    const { container } = render(
+      <PickerProviderAuthLine
+        state={disabledProviderState("reasonix")}
+        harness={null}
+        onOpenProviderSettings={noop}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders the setup-guidance row for a signed-out provider with guidance (reasonix)", () => {
+    const onOpenProviderSettings = vi.fn();
+    render(
+      <PickerProviderAuthLine
+        state={baseProviderState("reasonix")}
+        harness={null}
+        onOpenProviderSettings={onOpenProviderSettings}
+      />,
+    );
+
+    const note = screen.getByRole("note", { name: "Setup required" });
+    expect(note).toBeDefined();
+    expect(screen.getByText("Not authenticated")).toBeDefined();
+    expect(
+      screen.getByText(
+        "Reasonix keeps provider API keys in its own store, not in your shell environment.",
+      ),
+    ).toBeDefined();
+
+    // First ordered-list item names the command in a <code> element.
+    const list = note.querySelector("ol");
+    expect(list).not.toBeNull();
+    const items = list?.querySelectorAll("li") ?? [];
+    expect(items.length).toBe(3);
+    const code = items[0]?.querySelector("code");
+    expect(code?.textContent).toBe("reasonix setup");
+    expect(items[1]?.textContent).toBe(
+      "Paste your provider API key when asked (DeepSeek by default).",
+    );
+    expect(items[2]?.textContent).toBe("Refresh this list.");
+
+    fireEvent.click(screen.getByRole("button", { name: "Open Settings" }));
+    expect(onOpenProviderSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders the bare 'Not authenticated' label for a signed-out provider without guidance", () => {
+    render(
+      <PickerProviderAuthLine
+        state={baseProviderState("claude-code")}
+        harness={null}
+        onOpenProviderSettings={noop}
+      />,
+    );
+
+    expect(screen.getByText("Not authenticated")).toBeDefined();
+    expect(screen.queryByRole("note", { name: "Setup required" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Open Settings" })).toBeNull();
+  });
+
+  it("treats a signed-out harness row (authStatus: unauthenticated) as signed out even when the provider state is authenticated", () => {
+    const onOpenProviderSettings = vi.fn();
+    render(
+      <PickerProviderAuthLine
+        state={providerStateWithAuth(
+          "reasonix",
+          "authenticated",
+          null,
+          "Authenticated",
+        )}
+        harness={harnessOption("reasonix", "unauthenticated", null)}
+        onOpenProviderSettings={onOpenProviderSettings}
+      />,
+    );
+
+    expect(screen.getByText("Not authenticated")).toBeDefined();
+    expect(screen.getByRole("note", { name: "Setup required" })).toBeDefined();
+  });
+
+  it("renders only the compact 'Not authenticated' label (no steps, no button) when the model list already shows the signed-out CTA", () => {
+    const onOpenProviderSettings = vi.fn();
+    render(
+      <PickerProviderAuthLine
+        state={baseProviderState("reasonix")}
+        harness={harnessOption(
+          "reasonix",
+          undefined,
+          catalogErrorFor(
+            "agent.gui.listModels",
+            providerSignedOutMessage("reasonix"),
+          ),
+        )}
+        onOpenProviderSettings={onOpenProviderSettings}
+      />,
+    );
+
+    expect(screen.getByText("Not authenticated")).toBeDefined();
+    expect(screen.queryByRole("note", { name: "Setup required" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Open Settings" })).toBeNull();
+    expect(
+      screen.queryByText(
+        "Reasonix keeps provider API keys in its own store, not in your shell environment.",
+      ),
+    ).toBeNull();
+  });
+
+  it("still renders the full guidance when the model list's error is NOT the signed-out message", () => {
+    render(
+      <PickerProviderAuthLine
+        state={baseProviderState("reasonix")}
+        harness={harnessOption(
+          "reasonix",
+          undefined,
+          catalogErrorFor("agent.gui.listModels", "spawn failed: ENOENT"),
+        )}
+        onOpenProviderSettings={noop}
+      />,
+    );
+
+    expect(screen.getByRole("note", { name: "Setup required" })).toBeDefined();
+    expect(
+      screen.getByText(
+        "Reasonix keeps provider API keys in its own store, not in your shell environment.",
+      ),
+    ).toBeDefined();
+  });
+
+  it("renders the badge/label row for an authenticated provider", () => {
+    render(
+      <PickerProviderAuthLine
+        state={providerStateWithAuth(
+          "claude-code",
+          "authenticated",
+          "GitHub CLI",
+          "Authenticated as octocat",
+        )}
+        harness={null}
+        onOpenProviderSettings={noop}
+      />,
+    );
+
+    expect(screen.getByText("GitHub CLI")).toBeDefined();
+    expect(screen.getByText("Authenticated as octocat")).toBeDefined();
+    expect(screen.queryByText("Not authenticated")).toBeNull();
+  });
+
+  it("renders the badge/label row for a configured provider", () => {
+    render(
+      <PickerProviderAuthLine
+        state={providerStateWithAuth(
+          "cursor",
+          "configured",
+          null,
+          "API key configured",
+        )}
+        harness={null}
+        onOpenProviderSettings={noop}
+      />,
+    );
+
+    expect(screen.getByText("API key configured")).toBeDefined();
+  });
+
+  it("renders nothing for an authenticated provider with no badge or label", () => {
+    const { container } = render(
+      <PickerProviderAuthLine
+        state={providerStateWithAuth(
+          "claude-code",
+          "authenticated",
+          null,
+          null,
+        )}
+        harness={null}
+        onOpenProviderSettings={noop}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing for a non-definitive, non-configured auth status (e.g. unknown)", () => {
+    const { container } = render(
+      <PickerProviderAuthLine
+        state={providerStateWithAuth(
+          "claude-code",
+          "unknown",
+          "some badge",
+          "some label",
+        )}
+        harness={null}
+        onOpenProviderSettings={noop}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/clients/gui-app/src/components/home/pickers/__tests__/harness-model-picker-auth-line.test.tsx
+++ b/clients/gui-app/src/components/home/pickers/__tests__/harness-model-picker-auth-line.test.tsx
@@ -1,5 +1,5 @@
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
 import type {
   ProviderAuthStatus,
   ProviderCliState,
@@ -10,8 +10,6 @@ import { providerSignedOutMessage } from "@traycer/protocol/host/provider-displa
 import { HostRpcError } from "@traycer-clients/shared/host-transport/host-messenger";
 import type { GuiHarnessCatalogEntry } from "@/hooks/harnesses/use-gui-harness-catalog";
 import { PickerProviderAuthLine } from "../harness-model-picker-auth-line";
-
-function noop(): void {}
 
 function baseProviderState(providerId: ProviderId): ProviderCliState {
   return {
@@ -65,13 +63,14 @@ function disabledProviderState(providerId: ProviderId): ProviderCliState {
 
 function harnessOption(
   id: GuiHarnessId,
+  enabled: boolean,
   authStatus: ProviderAuthStatus | undefined,
   modelsError: HostRpcError | null,
 ): GuiHarnessCatalogEntry {
   return {
     id,
     label: id,
-    enabled: true,
+    enabled,
     available: true,
     error: null,
     modes: ["gui"],
@@ -107,40 +106,54 @@ describe("<PickerProviderAuthLine />", () => {
     cleanup();
   });
 
-  it("renders nothing for a null state", () => {
+  it("renders nothing when both state and harness are null (no provider identity to resolve)", () => {
     const { container } = render(
-      <PickerProviderAuthLine
-        state={null}
-        harness={null}
-        onOpenProviderSettings={noop}
-      />,
+      <PickerProviderAuthLine state={null} harness={null} />,
     );
     expect(container.firstChild).toBeNull();
   });
 
-  it("renders nothing for a disabled provider", () => {
+  it("renders nothing for a disabled provider (enabled read off state)", () => {
     const { container } = render(
       <PickerProviderAuthLine
         state={disabledProviderState("reasonix")}
         harness={null}
-        onOpenProviderSettings={noop}
       />,
     );
     expect(container.firstChild).toBeNull();
   });
 
-  it("renders the setup-guidance row for a signed-out provider with guidance (reasonix)", () => {
-    const onOpenProviderSettings = vi.fn();
+  it("renders nothing when state is null and the harness itself is disabled (enabled falls back to harness.enabled)", () => {
+    const { container } = render(
+      <PickerProviderAuthLine
+        state={null}
+        harness={harnessOption("reasonix", false, "unauthenticated", null)}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders the signed-out guidance line when state is null but an enabled harness row reports unauthenticated (provider identity and enabled both resolved from the harness)", () => {
+    render(
+      <PickerProviderAuthLine
+        state={null}
+        harness={harnessOption("reasonix", true, "unauthenticated", null)}
+      />,
+    );
+
+    expect(screen.getByRole("note", { name: "Setup required" })).toBeDefined();
+    expect(screen.getByText("Not authenticated")).toBeDefined();
+  });
+
+  it("renders the setup-guidance row (steps + manual-command sentence, no button) for a signed-out provider with guidance (reasonix)", () => {
     render(
       <PickerProviderAuthLine
         state={baseProviderState("reasonix")}
         harness={null}
-        onOpenProviderSettings={onOpenProviderSettings}
       />,
     );
 
     const note = screen.getByRole("note", { name: "Setup required" });
-    expect(note).toBeDefined();
     expect(screen.getByText("Not authenticated")).toBeDefined();
     expect(
       screen.getByText(
@@ -148,20 +161,24 @@ describe("<PickerProviderAuthLine />", () => {
       ),
     ).toBeDefined();
 
-    // First ordered-list item names the command in a <code> element.
+    // Steps render verbatim - no injected "Run … in a terminal" item.
     const list = note.querySelector("ol");
     expect(list).not.toBeNull();
-    const items = list?.querySelectorAll("li") ?? [];
-    expect(items.length).toBe(3);
-    const code = items[0]?.querySelector("code");
-    expect(code?.textContent).toBe("reasonix setup");
-    expect(items[1]?.textContent).toBe(
+    const items = Array.from(list?.querySelectorAll("li") ?? []);
+    expect(items.map((item) => item.textContent)).toEqual([
+      "From a chat, choose “Set up in terminal” in the banner above the composer. It opens Reasonix's setup wizard on the host this composer runs on.",
       "Paste your provider API key when asked (DeepSeek by default).",
-    );
-    expect(items[2]?.textContent).toBe("Refresh this list.");
+      "Refresh this list.",
+    ]);
 
-    fireEvent.click(screen.getByRole("button", { name: "Open Settings" }));
-    expect(onOpenProviderSettings).toHaveBeenCalledTimes(1);
+    // The manual-command sentence names the command in a <code>.
+    const code = note.querySelector("code");
+    expect(code?.textContent).toBe("reasonix setup");
+    expect(code?.closest("span")?.textContent).toBe(
+      "Installed the CLI yourself? Running reasonix setup in your own terminal on that machine does the same.",
+    );
+
+    expect(screen.queryByRole("button", { name: "Open Settings" })).toBeNull();
   });
 
   it("renders the bare 'Not authenticated' label for a signed-out provider without guidance", () => {
@@ -169,17 +186,14 @@ describe("<PickerProviderAuthLine />", () => {
       <PickerProviderAuthLine
         state={baseProviderState("claude-code")}
         harness={null}
-        onOpenProviderSettings={noop}
       />,
     );
 
     expect(screen.getByText("Not authenticated")).toBeDefined();
     expect(screen.queryByRole("note", { name: "Setup required" })).toBeNull();
-    expect(screen.queryByRole("button", { name: "Open Settings" })).toBeNull();
   });
 
   it("treats a signed-out harness row (authStatus: unauthenticated) as signed out even when the provider state is authenticated", () => {
-    const onOpenProviderSettings = vi.fn();
     render(
       <PickerProviderAuthLine
         state={providerStateWithAuth(
@@ -188,8 +202,7 @@ describe("<PickerProviderAuthLine />", () => {
           null,
           "Authenticated",
         )}
-        harness={harnessOption("reasonix", "unauthenticated", null)}
-        onOpenProviderSettings={onOpenProviderSettings}
+        harness={harnessOption("reasonix", true, "unauthenticated", null)}
       />,
     );
 
@@ -197,26 +210,31 @@ describe("<PickerProviderAuthLine />", () => {
     expect(screen.getByRole("note", { name: "Setup required" })).toBeDefined();
   });
 
-  it("renders only the compact 'Not authenticated' label (no steps, no button) when the model list already shows the signed-out CTA", () => {
-    const onOpenProviderSettings = vi.fn();
+  it("renders only the compact 'Not authenticated' label - never the authenticated badge - when an authenticated state's harness reports the signed-out catalog error", () => {
     render(
       <PickerProviderAuthLine
-        state={baseProviderState("reasonix")}
+        state={providerStateWithAuth(
+          "reasonix",
+          "authenticated",
+          "some badge",
+          "Authenticated",
+        )}
         harness={harnessOption(
           "reasonix",
+          true,
           undefined,
           catalogErrorFor(
             "agent.gui.listModels",
             providerSignedOutMessage("reasonix"),
           ),
         )}
-        onOpenProviderSettings={onOpenProviderSettings}
       />,
     );
 
     expect(screen.getByText("Not authenticated")).toBeDefined();
     expect(screen.queryByRole("note", { name: "Setup required" })).toBeNull();
-    expect(screen.queryByRole("button", { name: "Open Settings" })).toBeNull();
+    expect(screen.queryByText("Authenticated")).toBeNull();
+    expect(screen.queryByText("some badge")).toBeNull();
     expect(
       screen.queryByText(
         "Reasonix keeps provider API keys in its own store, not in your shell environment.",
@@ -230,10 +248,10 @@ describe("<PickerProviderAuthLine />", () => {
         state={baseProviderState("reasonix")}
         harness={harnessOption(
           "reasonix",
+          true,
           undefined,
           catalogErrorFor("agent.gui.listModels", "spawn failed: ENOENT"),
         )}
-        onOpenProviderSettings={noop}
       />,
     );
 
@@ -255,7 +273,6 @@ describe("<PickerProviderAuthLine />", () => {
           "Authenticated as octocat",
         )}
         harness={null}
-        onOpenProviderSettings={noop}
       />,
     );
 
@@ -274,7 +291,6 @@ describe("<PickerProviderAuthLine />", () => {
           "API key configured",
         )}
         harness={null}
-        onOpenProviderSettings={noop}
       />,
     );
 
@@ -291,7 +307,6 @@ describe("<PickerProviderAuthLine />", () => {
           null,
         )}
         harness={null}
-        onOpenProviderSettings={noop}
       />,
     );
     expect(container.firstChild).toBeNull();
@@ -307,7 +322,6 @@ describe("<PickerProviderAuthLine />", () => {
           "some label",
         )}
         harness={null}
-        onOpenProviderSettings={noop}
       />,
     );
     expect(container.firstChild).toBeNull();

--- a/clients/gui-app/src/components/home/pickers/__tests__/harness-model-picker-empty-setup-cta.test.tsx
+++ b/clients/gui-app/src/components/home/pickers/__tests__/harness-model-picker-empty-setup-cta.test.tsx
@@ -1,9 +1,9 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { act, cleanup, render, screen } from "@testing-library/react";
 import { HostRpcError } from "@traycer-clients/shared/host-transport/host-messenger";
 import { providerSignedOutMessage } from "@traycer/protocol/host/provider-display";
 import type { GuiHarnessCatalogEntry } from "@/hooks/harnesses/use-gui-harness-catalog";
-import { useProvidersFocusStore } from "@/stores/settings/providers-focus-store";
+import { useDesktopDialogStore } from "@/stores/dialogs/desktop-dialog-store";
 import { ModelRowsState } from "../harness-model-picker-empty";
 
 // Mirrors the fixture shape in `harness-model-picker-empty-report-issue.test.tsx`
@@ -41,11 +41,18 @@ function catalogErrorFor(message: string): HostRpcError {
 describe("<ModelRowsState /> provider setup CTA (reasonix)", () => {
   afterEach(() => {
     cleanup();
-    useProvidersFocusStore.getState().clearFocusHarnessId();
+    useDesktopDialogStore.setState({
+      activeDialog: null,
+      reportIssueAvailable: false,
+      reportIssueContext: null,
+      reportIssueDraftId: 0,
+    });
   });
 
-  it("renders the setup CTA for a reasonix entry with the signed-out modelsError, with an Open Settings button and no report-issue action", () => {
-    const onOpenProviderSettings = () => undefined;
+  it("renders the setup CTA for a reasonix entry with the signed-out modelsError: steps + manual command, no button, no report-issue action", () => {
+    act(() => {
+      useDesktopDialogStore.setState({ reportIssueAvailable: true });
+    });
     const provider = harnessEntry({
       id: "reasonix",
       label: "Reasonix",
@@ -59,7 +66,7 @@ describe("<ModelRowsState /> provider setup CTA (reasonix)", () => {
         hasQuery: false,
         activeProvider: provider,
         rowsCount: 0,
-        onOpenProviderSettings,
+        onOpenProviderSettings: () => undefined,
       }),
     );
 
@@ -73,17 +80,27 @@ describe("<ModelRowsState /> provider setup CTA (reasonix)", () => {
     expect(code).toBeDefined();
     expect(
       screen.getByText(
+        "From a chat, choose “Set up in terminal” in the banner above the composer. It opens Reasonix's setup wizard on the host this composer runs on.",
+      ),
+    ).toBeDefined();
+    expect(
+      screen.getByText(
         "Paste your provider API key when asked (DeepSeek by default).",
       ),
     ).toBeDefined();
     expect(screen.getByText("Refresh this list.")).toBeDefined();
-    expect(screen.queryByRole("button", { name: "Report issue" })).toBeNull();
 
-    fireEvent.click(screen.getByRole("button", { name: "Open Settings" }));
-    expect(useProvidersFocusStore.getState().focusHarnessId).toBe("reasonix");
+    // No button of any kind - not "Open Settings" (the CTA no longer writes
+    // the focus store or takes a click handler), and not "Report issue"
+    // (reportIssueAvailable is true here, so its absence is the CTA's own
+    // doing, not the feature being globally off).
+    expect(screen.queryByRole("button")).toBeNull();
   });
 
   it("keeps the host reason row and report-issue action for a reasonix entry with a DIFFERENT error message", () => {
+    act(() => {
+      useDesktopDialogStore.setState({ reportIssueAvailable: true });
+    });
     const provider = harnessEntry({
       id: "reasonix",
       label: "Reasonix",
@@ -103,6 +120,7 @@ describe("<ModelRowsState /> provider setup CTA (reasonix)", () => {
 
     expect(screen.queryByText("Set up Reasonix")).toBeNull();
     screen.getByRole("option", { name: "spawn failed: ENOENT" });
+    expect(screen.getByRole("button", { name: "Report issue" })).toBeDefined();
   });
 
   it("keeps the old host reason row for a non-guidance provider (claude) even with the signed-out message", () => {

--- a/clients/gui-app/src/components/home/pickers/__tests__/harness-model-picker-empty-setup-cta.test.tsx
+++ b/clients/gui-app/src/components/home/pickers/__tests__/harness-model-picker-empty-setup-cta.test.tsx
@@ -1,0 +1,131 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { HostRpcError } from "@traycer-clients/shared/host-transport/host-messenger";
+import { providerSignedOutMessage } from "@traycer/protocol/host/provider-display";
+import type { GuiHarnessCatalogEntry } from "@/hooks/harnesses/use-gui-harness-catalog";
+import { useProvidersFocusStore } from "@/stores/settings/providers-focus-store";
+import { ModelRowsState } from "../harness-model-picker-empty";
+
+// Mirrors the fixture shape in `harness-model-picker-empty-report-issue.test.tsx`
+// (kept local rather than imported since that file does not export it).
+function harnessEntry(
+  overrides: Partial<GuiHarnessCatalogEntry>,
+): GuiHarnessCatalogEntry {
+  return {
+    id: "claude",
+    label: "Claude",
+    enabled: true,
+    available: true,
+    error: null,
+    modes: ["gui"],
+    requiresApiKey: false,
+    supportedPermissionModes: ["full_access"],
+    availabilityPending: false,
+    models: [],
+    modelsLoading: false,
+    modelsError: null,
+    ...overrides,
+  };
+}
+
+function catalogErrorFor(message: string): HostRpcError {
+  return new HostRpcError({
+    code: "RPC_ERROR",
+    message,
+    requestId: "req-1",
+    method: "agent.gui.listModels",
+    fatalDetails: null,
+  });
+}
+
+describe("<ModelRowsState /> provider setup CTA (reasonix)", () => {
+  afterEach(() => {
+    cleanup();
+    useProvidersFocusStore.getState().clearFocusHarnessId();
+  });
+
+  it("renders the setup CTA for a reasonix entry with the signed-out modelsError, with an Open Settings button and no report-issue action", () => {
+    const onOpenProviderSettings = () => undefined;
+    const provider = harnessEntry({
+      id: "reasonix",
+      label: "Reasonix",
+      modelsError: catalogErrorFor(providerSignedOutMessage("reasonix")),
+    });
+    render(
+      ModelRowsState({
+        catalogLoading: false,
+        catalogError: false,
+        hostUnavailableLabel: null,
+        hasQuery: false,
+        activeProvider: provider,
+        rowsCount: 0,
+        onOpenProviderSettings,
+      }),
+    );
+
+    expect(screen.getByText("Set up Reasonix")).toBeDefined();
+    expect(
+      screen.getByText(
+        "Reasonix keeps provider API keys in its own store, not in your shell environment.",
+      ),
+    ).toBeDefined();
+    const code = screen.getByText("reasonix setup", { selector: "code" });
+    expect(code).toBeDefined();
+    expect(
+      screen.getByText(
+        "Paste your provider API key when asked (DeepSeek by default).",
+      ),
+    ).toBeDefined();
+    expect(screen.getByText("Refresh this list.")).toBeDefined();
+    expect(screen.queryByRole("button", { name: "Report issue" })).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Open Settings" }));
+    expect(useProvidersFocusStore.getState().focusHarnessId).toBe("reasonix");
+  });
+
+  it("keeps the host reason row and report-issue action for a reasonix entry with a DIFFERENT error message", () => {
+    const provider = harnessEntry({
+      id: "reasonix",
+      label: "Reasonix",
+      modelsError: catalogErrorFor("spawn failed: ENOENT"),
+    });
+    render(
+      ModelRowsState({
+        catalogLoading: false,
+        catalogError: false,
+        hostUnavailableLabel: null,
+        hasQuery: false,
+        activeProvider: provider,
+        rowsCount: 0,
+        onOpenProviderSettings: () => undefined,
+      }),
+    );
+
+    expect(screen.queryByText("Set up Reasonix")).toBeNull();
+    screen.getByRole("option", { name: "spawn failed: ENOENT" });
+  });
+
+  it("keeps the old host reason row for a non-guidance provider (claude) even with the signed-out message", () => {
+    const provider = harnessEntry({
+      id: "claude",
+      label: "Claude",
+      modelsError: catalogErrorFor(providerSignedOutMessage("claude-code")),
+    });
+    render(
+      ModelRowsState({
+        catalogLoading: false,
+        catalogError: false,
+        hostUnavailableLabel: null,
+        hasQuery: false,
+        activeProvider: provider,
+        rowsCount: 0,
+        onOpenProviderSettings: () => undefined,
+      }),
+    );
+
+    expect(screen.queryByText(/^Set up /)).toBeNull();
+    screen.getByRole("option", {
+      name: providerSignedOutMessage("claude-code"),
+    });
+  });
+});

--- a/clients/gui-app/src/components/home/pickers/harness-model-picker-auth-line.tsx
+++ b/clients/gui-app/src/components/home/pickers/harness-model-picker-auth-line.tsx
@@ -1,7 +1,17 @@
 import type { ReactNode } from "react";
 import type { ProviderCliState } from "@traycer/protocol/host/provider-schemas";
 import { Badge } from "@/components/ui/badge";
-import { isProviderAmbientSignedOut } from "@/lib/providers/provider-ambient-auth";
+import { Button } from "@/components/ui/button";
+import type { GuiHarnessCatalogEntry } from "@/hooks/harnesses/use-gui-harness-catalog";
+import {
+  isHarnessRowSignedOut,
+  isProviderAmbientSignedOut,
+} from "@/lib/providers/provider-ambient-auth";
+import {
+  type ProviderSetupGuidance,
+  providerSetupGuidance,
+} from "@/lib/providers/provider-setup-guidance";
+import { isProviderSignedOutCatalogError } from "@/lib/providers/provider-signed-out-catalog-error";
 
 /**
  * The ambient account line for the browsed provider - rendered in the slot the
@@ -20,14 +30,47 @@ import { isProviderAmbientSignedOut } from "@/lib/providers/provider-ambient-aut
  * provider, a probe still settling, or an authenticated account with no
  * badge/label. The signed-out line is the one exception - it pairs with the
  * rail tab's degraded treatment so the gray-out is never unexplained.
+ *
+ * The signed-out verdict is read from the SAME two sources the rail's degraded
+ * treatment reads (`railHarnessDegraded`): the `providers.list` state and the
+ * catalog row's own `authStatus`. OR'd, definitive-only, for the reason spelled
+ * out there - the two are separately timed, and a line that read only one of
+ * them could contradict the dimmed tab beside it.
+ *
+ * For a provider with setup guidance the bare label is replaced by the steps
+ * that actually fix the state, plus a way into Settings. The generic label is
+ * what sent users to export a shell variable that the provider never reads.
+ * The steps live HERE only while the model list below still has rows to show
+ * (the host serves the last good catalog through a sign-out); once the list
+ * itself is in the signed-out error state, `ModelRowsState` renders the full
+ * setup CTA in that space and this line drops back to the compact label, so
+ * the popover never says the same thing twice.
  */
 export function PickerProviderAuthLine(props: {
   readonly state: ProviderCliState | null;
+  /** The catalog entry for the same provider, when the picker has one. */
+  readonly harness: GuiHarnessCatalogEntry | null;
+  readonly onOpenProviderSettings: () => void;
 }): ReactNode {
-  const { state } = props;
+  const { state, harness, onOpenProviderSettings } = props;
   if (state === null || !state.enabled) return null;
-  if (isProviderAmbientSignedOut(state)) {
-    return <AuthLineRow badgeText={null} label="Not authenticated" />;
+  const signedOut =
+    isProviderAmbientSignedOut(state) ||
+    (harness !== null && isHarnessRowSignedOut(harness));
+  if (signedOut) {
+    const guidance = providerSetupGuidance(state.providerId);
+    const listShowsSetup =
+      harness !== null &&
+      isProviderSignedOutCatalogError(state.providerId, harness.modelsError);
+    if (guidance === null || listShowsSetup) {
+      return <AuthLineRow badgeText={null} label="Not authenticated" />;
+    }
+    return (
+      <SetupGuidanceRow
+        guidance={guidance}
+        onOpenProviderSettings={onOpenProviderSettings}
+      />
+    );
   }
   const auth = state.auth;
   if (auth.status !== "authenticated" && auth.status !== "configured") {
@@ -54,6 +97,45 @@ function AuthLineRow(props: {
       {props.label === null ? null : (
         <span className="min-w-0 truncate">{props.label}</span>
       )}
+    </div>
+  );
+}
+
+function SetupGuidanceRow(props: {
+  readonly guidance: ProviderSetupGuidance;
+  readonly onOpenProviderSettings: () => void;
+}): ReactNode {
+  const { guidance, onOpenProviderSettings } = props;
+  return (
+    <div
+      role="note"
+      aria-label="Setup required"
+      className="flex min-w-0 shrink-0 flex-col gap-1.5 border-b px-3 py-2 text-ui-xs text-muted-foreground"
+    >
+      <span className="text-foreground/90">Not authenticated</span>
+      <span>{guidance.summary}</span>
+      <ol className="list-decimal space-y-0.5 pl-4">
+        <li>
+          Run{" "}
+          <code className="rounded-sm bg-foreground/8 px-1 py-px font-mono text-[11px] text-foreground/90">
+            {guidance.command}
+          </code>{" "}
+          in a terminal.
+        </li>
+        {guidance.steps.map((step) => (
+          <li key={step}>{step}</li>
+        ))}
+      </ol>
+      <div>
+        <Button
+          type="button"
+          size="sm"
+          variant="secondary"
+          onClick={onOpenProviderSettings}
+        >
+          Open Settings
+        </Button>
+      </div>
     </div>
   );
 }

--- a/clients/gui-app/src/components/home/pickers/harness-model-picker-auth-line.tsx
+++ b/clients/gui-app/src/components/home/pickers/harness-model-picker-auth-line.tsx
@@ -1,8 +1,11 @@
 import type { ReactNode } from "react";
-import type { ProviderCliState } from "@traycer/protocol/host/provider-schemas";
+import type {
+  ProviderCliState,
+  ProviderId,
+} from "@traycer/protocol/host/provider-schemas";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import type { GuiHarnessCatalogEntry } from "@/hooks/harnesses/use-gui-harness-catalog";
+import { guiHarnessIdToProviderId } from "@/lib/provider-ordering";
 import {
   isHarnessRowSignedOut,
   isProviderAmbientSignedOut,
@@ -31,53 +34,115 @@ import { isProviderSignedOutCatalogError } from "@/lib/providers/provider-signed
  * badge/label. The signed-out line is the one exception - it pairs with the
  * rail tab's degraded treatment so the gray-out is never unexplained.
  *
- * The signed-out verdict is read from the SAME two sources the rail's degraded
- * treatment reads (`railHarnessDegraded`): the `providers.list` state and the
- * catalog row's own `authStatus`. OR'd, definitive-only, for the reason spelled
- * out there - the two are separately timed, and a line that read only one of
- * them could contradict the dimmed tab beside it.
+ * The signed-out verdict is read from THREE sources, OR'd and definitive-only:
+ * the `providers.list` state (the two-signal predicate the rail's degraded
+ * treatment reads), the catalog row's own `authStatus`, and the model list's
+ * signed-out failure. They are separately timed - the list state is held for
+ * fifteen minutes, the row's verdict lapses after thirty seconds, and the
+ * model failure is what the user is looking at right now - so a line that
+ * read only one of them contradicted the dimmed tab beside it or the setup
+ * CTA below it. For the same reason the row alone is enough when the
+ * `providers.list` state has not arrived or has failed: the rail dims from
+ * that row, so this line must be able to explain it from that row.
  *
  * For a provider with setup guidance the bare label is replaced by the steps
- * that actually fix the state, plus a way into Settings. The generic label is
- * what sent users to export a shell variable that the provider never reads.
- * The steps live HERE only while the model list below still has rows to show
- * (the host serves the last good catalog through a sign-out); once the list
- * itself is in the signed-out error state, `ModelRowsState` renders the full
- * setup CTA in that space and this line drops back to the compact label, so
- * the popover never says the same thing twice.
+ * that actually fix the state. The generic label is what sent users to export
+ * a shell variable that the provider never reads. The steps live HERE only
+ * while the model list below still has rows to show (the host serves the last
+ * good catalog through a sign-out); once the list itself is in the signed-out
+ * error state, `ModelRowsState` renders the full setup CTA in that space and
+ * this line drops back to the compact label, so the popover never says the
+ * same thing twice.
  */
 export function PickerProviderAuthLine(props: {
   readonly state: ProviderCliState | null;
   /** The catalog entry for the same provider, when the picker has one. */
   readonly harness: GuiHarnessCatalogEntry | null;
-  readonly onOpenProviderSettings: () => void;
 }): ReactNode {
-  const { state, harness, onOpenProviderSettings } = props;
-  if (state === null || !state.enabled) return null;
-  const signedOut =
-    isProviderAmbientSignedOut(state) ||
-    (harness !== null && isHarnessRowSignedOut(harness));
-  if (signedOut) {
-    const guidance = providerSetupGuidance(state.providerId);
-    const listShowsSetup =
-      harness !== null &&
-      isProviderSignedOutCatalogError(state.providerId, harness.modelsError);
-    if (guidance === null || listShowsSetup) {
+  const verdict = pickerAuthLineVerdict(props.state, props.harness);
+  switch (verdict.kind) {
+    case "hidden":
+      return null;
+    case "signed-out":
       return <AuthLineRow badgeText={null} label="Not authenticated" />;
-    }
-    return (
-      <SetupGuidanceRow
-        guidance={guidance}
-        onOpenProviderSettings={onOpenProviderSettings}
-      />
-    );
+    case "setup":
+      return <SetupGuidanceRow guidance={verdict.guidance} />;
+    case "account":
+      return (
+        <AuthLineRow badgeText={verdict.badgeText} label={verdict.label} />
+      );
   }
+}
+
+type PickerAuthLineVerdict =
+  | { readonly kind: "hidden" }
+  | { readonly kind: "signed-out" }
+  | { readonly kind: "setup"; readonly guidance: ProviderSetupGuidance }
+  | {
+      readonly kind: "account";
+      readonly badgeText: string | null;
+      readonly label: string | null;
+    };
+
+/**
+ * What the line says, decided from both sources. Pure so the rules in the
+ * component doc above are one function rather than a chain of early returns.
+ */
+function pickerAuthLineVerdict(
+  state: ProviderCliState | null,
+  harness: GuiHarnessCatalogEntry | null,
+): PickerAuthLineVerdict {
+  const providerId = resolveProviderId(state, harness);
+  if (providerId === null || !isEnabled(state, harness)) {
+    return { kind: "hidden" };
+  }
+  const catalogSignedOut =
+    harness !== null &&
+    isProviderSignedOutCatalogError(providerId, harness.modelsError);
+  if (catalogSignedOut || isSignedOut(state, harness)) {
+    const guidance = providerSetupGuidance(providerId);
+    // Compact when the model list is showing the setup CTA for the same
+    // verdict, so the popover never says it twice.
+    if (guidance === null || catalogSignedOut) return { kind: "signed-out" };
+    return { kind: "setup", guidance };
+  }
+  if (state === null) return { kind: "hidden" };
   const auth = state.auth;
   if (auth.status !== "authenticated" && auth.status !== "configured") {
-    return null;
+    return { kind: "hidden" };
   }
-  if (auth.badgeText === null && auth.label === null) return null;
-  return <AuthLineRow badgeText={auth.badgeText} label={auth.label} />;
+  if (auth.badgeText === null && auth.label === null) return { kind: "hidden" };
+  return { kind: "account", badgeText: auth.badgeText, label: auth.label };
+}
+
+// The `providers.list` row names the provider directly; a catalog row names
+// it through its harness id. Either is enough to say what this line is about.
+function resolveProviderId(
+  state: ProviderCliState | null,
+  harness: GuiHarnessCatalogEntry | null,
+): ProviderId | null {
+  if (state !== null) return state.providerId;
+  if (harness !== null) return guiHarnessIdToProviderId(harness.id);
+  return null;
+}
+
+function isEnabled(
+  state: ProviderCliState | null,
+  harness: GuiHarnessCatalogEntry | null,
+): boolean {
+  if (state !== null) return state.enabled;
+  return harness !== null && harness.enabled;
+}
+
+// The two separately-timed verdicts the rail's degraded treatment reads.
+function isSignedOut(
+  state: ProviderCliState | null,
+  harness: GuiHarnessCatalogEntry | null,
+): boolean {
+  return (
+    (state !== null && isProviderAmbientSignedOut(state)) ||
+    (harness !== null && isHarnessRowSignedOut(harness))
+  );
 }
 
 function AuthLineRow(props: {
@@ -103,9 +168,8 @@ function AuthLineRow(props: {
 
 function SetupGuidanceRow(props: {
   readonly guidance: ProviderSetupGuidance;
-  readonly onOpenProviderSettings: () => void;
 }): ReactNode {
-  const { guidance, onOpenProviderSettings } = props;
+  const { guidance } = props;
   return (
     <div
       role="note"
@@ -115,27 +179,30 @@ function SetupGuidanceRow(props: {
       <span className="text-foreground/90">Not authenticated</span>
       <span>{guidance.summary}</span>
       <ol className="list-decimal space-y-0.5 pl-4">
-        <li>
-          Run{" "}
-          <code className="rounded-sm bg-foreground/8 px-1 py-px font-mono text-[11px] text-foreground/90">
-            {guidance.command}
-          </code>{" "}
-          in a terminal.
-        </li>
         {guidance.steps.map((step) => (
           <li key={step}>{step}</li>
         ))}
       </ol>
-      <div>
-        <Button
-          type="button"
-          size="sm"
-          variant="secondary"
-          onClick={onOpenProviderSettings}
-        >
-          Open Settings
-        </Button>
-      </div>
+      <ProviderSetupManualCommand command={guidance.manualCommand} />
     </div>
+  );
+}
+
+/**
+ * The self-installed alternative, phrased so nobody reads it as the primary
+ * path: the bundled pack is not on PATH, and on a remote host this shell is
+ * the wrong machine.
+ */
+export function ProviderSetupManualCommand(props: {
+  readonly command: string;
+}): ReactNode {
+  return (
+    <span>
+      Installed the CLI yourself? Running{" "}
+      <code className="rounded-sm bg-foreground/8 px-1 py-px font-mono text-[11px] text-foreground/90">
+        {props.command}
+      </code>{" "}
+      in your own terminal on that machine does the same.
+    </span>
   );
 }

--- a/clients/gui-app/src/components/home/pickers/harness-model-picker-empty.tsx
+++ b/clients/gui-app/src/components/home/pickers/harness-model-picker-empty.tsx
@@ -5,6 +5,7 @@ import { createReportIssueContext } from "@/lib/report-issue-context";
 import type { GuiHarnessCatalogEntry } from "@/hooks/harnesses/use-gui-harness-catalog";
 import { useProvidersFocusStore } from "@/stores/settings/providers-focus-store";
 import { guiHarnessIdToProviderId } from "@/lib/provider-ordering";
+import { ProviderSetupManualCommand } from "@/components/home/pickers/harness-model-picker-auth-line";
 import {
   type ProviderSetupGuidance,
   providerSetupGuidance,
@@ -128,14 +129,7 @@ export function ModelRowsState(props: ModelRowsStateProps): ReactNode | null {
     // report-issue icon beside it invites a bug report for a missing key.
     const setup = providerSetupCta(activeProvider);
     if (setup !== null) {
-      return (
-        <ProviderSetupCta
-          harnessId={activeProvider.id}
-          label={activeProvider.label}
-          guidance={setup}
-          onOpenProviderSettings={onOpenProviderSettings}
-        />
-      );
+      return <ProviderSetupCta label={activeProvider.label} guidance={setup} />;
     }
     // Surface the host's specific reason for API-key providers and packaged SDK
     // failures instead of a generic catch-all. Fall back when the message is
@@ -229,12 +223,13 @@ function providerSetupCta(
 
 // Shown in place of the model list when a provider with its own credential
 // store is signed out. Same shape as the API-key CTA below, but the steps are
-// the provider's terminal flow: Traycer cannot take the key itself.
+// the provider's terminal flow: Traycer cannot take the key itself. No
+// Settings button, deliberately - Settings has no terminal sign-in for such a
+// provider (its own hint sends the user back to the composer), so the button
+// would be a dead end; the steps name the composer banner instead.
 function ProviderSetupCta(props: {
-  readonly harnessId: GuiHarnessCatalogEntry["id"];
   readonly label: string;
   readonly guidance: ProviderSetupGuidance;
-  readonly onOpenProviderSettings: () => void;
 }): ReactNode {
   const { guidance } = props;
   return (
@@ -249,30 +244,13 @@ function ProviderSetupCta(props: {
         {guidance.summary}
       </p>
       <ol className="max-w-[min(90vw,18rem)] list-decimal space-y-0.5 pl-4 text-left text-ui-xs text-muted-foreground">
-        <li>
-          Run{" "}
-          <code className="rounded-sm bg-foreground/8 px-1 py-px font-mono text-[11px] text-foreground/90">
-            {guidance.command}
-          </code>{" "}
-          in a terminal.
-        </li>
         {guidance.steps.map((step) => (
           <li key={step}>{step}</li>
         ))}
       </ol>
-      <Button
-        size="sm"
-        variant="secondary"
-        className="mt-1"
-        onClick={() => {
-          // Land on this provider in Settings → Providers, same as the API-key
-          // CTA, so the Authenticate action there is one click away.
-          useProvidersFocusStore.getState().setFocusHarnessId(props.harnessId);
-          props.onOpenProviderSettings();
-        }}
-      >
-        Open Settings
-      </Button>
+      <p className="max-w-[min(90vw,18rem)] text-left text-ui-xs text-muted-foreground">
+        <ProviderSetupManualCommand command={guidance.manualCommand} />
+      </p>
     </div>
   );
 }

--- a/clients/gui-app/src/components/home/pickers/harness-model-picker-empty.tsx
+++ b/clients/gui-app/src/components/home/pickers/harness-model-picker-empty.tsx
@@ -4,7 +4,13 @@ import { ReportIssueAction } from "@/components/report-issue/report-issue-action
 import { createReportIssueContext } from "@/lib/report-issue-context";
 import type { GuiHarnessCatalogEntry } from "@/hooks/harnesses/use-gui-harness-catalog";
 import { useProvidersFocusStore } from "@/stores/settings/providers-focus-store";
-import { KeyRound } from "lucide-react";
+import { guiHarnessIdToProviderId } from "@/lib/provider-ordering";
+import {
+  type ProviderSetupGuidance,
+  providerSetupGuidance,
+} from "@/lib/providers/provider-setup-guidance";
+import { isProviderSignedOutCatalogError } from "@/lib/providers/provider-signed-out-catalog-error";
+import { KeyRound, SquareTerminal } from "lucide-react";
 import type { ReactNode } from "react";
 
 interface PickerStateRowProps {
@@ -116,6 +122,21 @@ export function ModelRowsState(props: ModelRowsStateProps): ReactNode | null {
   }
 
   if (activeProvider !== null && activeProvider.modelsError !== null) {
+    // A signed-out verdict for a provider with its own setup flow gets the
+    // steps that fix it, in the space the model rows would occupy - the host's
+    // "signed out, reconnect" sentence is true but names no action, and the
+    // report-issue icon beside it invites a bug report for a missing key.
+    const setup = providerSetupCta(activeProvider);
+    if (setup !== null) {
+      return (
+        <ProviderSetupCta
+          harnessId={activeProvider.id}
+          label={activeProvider.label}
+          guidance={setup}
+          onOpenProviderSettings={onOpenProviderSettings}
+        />
+      );
+    }
     // Surface the host's specific reason for API-key providers and packaged SDK
     // failures instead of a generic catch-all. Fall back when the message is
     // empty.
@@ -187,6 +208,72 @@ function unavailableProviderState(
       icon={undefined}
       action={undefined}
     />
+  );
+}
+
+// The setup guidance to show in place of the model list, when the list failed
+// with the host's signed-out verdict AND the provider has a setup flow of its
+// own (Reasonix: a terminal wizard writing the provider's private `.env`).
+// Any other failure keeps the host's own reason below.
+function providerSetupCta(
+  provider: GuiHarnessCatalogEntry,
+): ProviderSetupGuidance | null {
+  const providerId = guiHarnessIdToProviderId(provider.id);
+  if (providerId === null) return null;
+  const guidance = providerSetupGuidance(providerId);
+  if (guidance === null) return null;
+  return isProviderSignedOutCatalogError(providerId, provider.modelsError)
+    ? guidance
+    : null;
+}
+
+// Shown in place of the model list when a provider with its own credential
+// store is signed out. Same shape as the API-key CTA below, but the steps are
+// the provider's terminal flow: Traycer cannot take the key itself.
+function ProviderSetupCta(props: {
+  readonly harnessId: GuiHarnessCatalogEntry["id"];
+  readonly label: string;
+  readonly guidance: ProviderSetupGuidance;
+  readonly onOpenProviderSettings: () => void;
+}): ReactNode {
+  const { guidance } = props;
+  return (
+    <div className="flex flex-col items-center gap-2 px-4 py-6 text-center">
+      <span className="flex size-9 items-center justify-center rounded-full bg-primary/10 text-primary">
+        <SquareTerminal className="size-4" />
+      </span>
+      <span className="text-ui-sm font-medium text-foreground">
+        Set up {props.label}
+      </span>
+      <p className="max-w-[min(90vw,18rem)] text-balance text-ui-xs text-muted-foreground">
+        {guidance.summary}
+      </p>
+      <ol className="max-w-[min(90vw,18rem)] list-decimal space-y-0.5 pl-4 text-left text-ui-xs text-muted-foreground">
+        <li>
+          Run{" "}
+          <code className="rounded-sm bg-foreground/8 px-1 py-px font-mono text-[11px] text-foreground/90">
+            {guidance.command}
+          </code>{" "}
+          in a terminal.
+        </li>
+        {guidance.steps.map((step) => (
+          <li key={step}>{step}</li>
+        ))}
+      </ol>
+      <Button
+        size="sm"
+        variant="secondary"
+        className="mt-1"
+        onClick={() => {
+          // Land on this provider in Settings → Providers, same as the API-key
+          // CTA, so the Authenticate action there is one click away.
+          useProvidersFocusStore.getState().setFocusHarnessId(props.harnessId);
+          props.onOpenProviderSettings();
+        }}
+      >
+        Open Settings
+      </Button>
+    </div>
   );
 }
 

--- a/clients/gui-app/src/components/home/pickers/harness-model-picker-panel.tsx
+++ b/clients/gui-app/src/components/home/pickers/harness-model-picker-panel.tsx
@@ -287,7 +287,6 @@ export function HarnessModelPickerPanel(props: HarnessModelPickerPanelProps) {
             <PickerProviderAuthLine
               state={activeProviderState}
               harness={activeProvider}
-              onOpenProviderSettings={onOpenProviderSettings}
             />
           )}
           <div className="min-h-0 flex-1 overflow-hidden">

--- a/clients/gui-app/src/components/home/pickers/harness-model-picker-panel.tsx
+++ b/clients/gui-app/src/components/home/pickers/harness-model-picker-panel.tsx
@@ -284,7 +284,11 @@ export function HarnessModelPickerPanel(props: HarnessModelPickerPanelProps) {
               />
             </div>
           ) : (
-            <PickerProviderAuthLine state={activeProviderState} />
+            <PickerProviderAuthLine
+              state={activeProviderState}
+              harness={activeProvider}
+              onOpenProviderSettings={onOpenProviderSettings}
+            />
           )}
           <div className="min-h-0 flex-1 overflow-hidden">
             <HarnessModelPickerList

--- a/clients/gui-app/src/hooks/harnesses/__tests__/use-gui-harness-catalog.test.tsx
+++ b/clients/gui-app/src/hooks/harnesses/__tests__/use-gui-harness-catalog.test.tsx
@@ -22,6 +22,8 @@ import type {
   ListGuiAgentCommandsResponse,
   ListGuiAgentModelsResponse,
 } from "@traycer/protocol/host/index";
+import type { ResponseOfMethod } from "@traycer-clients/shared/host-transport/host-messenger";
+import type { ProviderCliState } from "@traycer/protocol/host/provider-schemas";
 import { hostRpcRegistry, type HostRpcRegistry } from "@/lib/host";
 import { createHostQueryInvalidator } from "@/lib/host/query-invalidator";
 import {
@@ -29,7 +31,11 @@ import {
   HARNESS_PENDING_POLL_LANE,
 } from "@/lib/host-rpc-policy/host-method-policy-table";
 import { createAppQueryClient } from "@/lib/query-client";
-import { hostQueryKeys } from "@/lib/query-keys";
+import {
+  hostQueryKeys,
+  providersListQueryKey,
+  providersNativeQueryKeys,
+} from "@/lib/query-keys";
 import { getConditionPollEpisodeCoordinator } from "@/lib/query/condition-poll-episode-coordinator";
 import { useSelectionAuthorityStore } from "@/stores/host/selection-authority-store";
 import {
@@ -838,7 +844,7 @@ describe("…ForClient catalog hooks are scoped to the client argument, not the 
     return spine.createRequester(entry);
   }
 
-  it("useRefreshHarnessCatalogForClient invalidates only the target host's three catalog methods, leaving another host's cache untouched", async () => {
+  it("useRefreshHarnessCatalogForClient invalidates the target host's three catalog methods and its exact classic providers.list key, leaving another host's cache and native-scoped providers.list keys untouched", async () => {
     const queryClient = createAppQueryClient();
     const Wrapper = (props: { readonly children: ReactNode }): ReactNode => (
       <QueryClientProvider client={queryClient}>
@@ -890,6 +896,25 @@ describe("…ForClient catalog hooks are scoped to the client argument, not the 
       expect(hostBCalls).toEqual({ harnesses: 1, models: 1, commands: 1 });
     });
 
+    // Seed the classic `providers.list` cache slot on both hosts, plus a
+    // native-scoped `providers.list` entry on host B - the mock host client
+    // has no `providers.list` handler, so these are written directly into the
+    // query cache rather than fetched.
+    const classicProvidersListResponse: ResponseOfMethod<
+      HostRpcRegistry,
+      "providers.list"
+    > = { providers: [] as ProviderCliState[], native: null };
+    const hostAClassicKey = providersListQueryKey("host-a");
+    const hostBClassicKey = providersListQueryKey("host-b");
+    const hostBNativeMcpKey = providersNativeQueryKeys.mcpList("host-b", {
+      providerId: "claude-code",
+      scope: "global",
+      workspaceRoot: null,
+    });
+    queryClient.setQueryData(hostAClassicKey, classicProvidersListResponse);
+    queryClient.setQueryData(hostBClassicKey, classicProvidersListResponse);
+    queryClient.setQueryData(hostBNativeMcpKey, classicProvidersListResponse);
+
     const { result } = renderHook(
       () => useRefreshHarnessCatalogForClient(clientB),
       { wrapper: Wrapper },
@@ -907,6 +932,23 @@ describe("…ForClient catalog hooks are scoped to the client argument, not the 
     // target through the app-wide default (rather than the `client`
     // argument) would either refresh the wrong host or refresh both.
     expect(hostACalls).toEqual({ harnesses: 1, models: 1, commands: 1 });
+
+    // Host B's exact classic `providers.list` key was invalidated by the
+    // refresh...
+    expect(queryClient.getQueryState(hostBClassicKey)?.isInvalidated).toBe(
+      true,
+    );
+    // ...a native-scoped `providers.list` key on the SAME host was not - the
+    // refresh says nothing about MCP/plugins/skills discovery, only the
+    // classic catalog carrier (`native: null`)...
+    expect(
+      queryClient.getQueryState(hostBNativeMcpKey)?.isInvalidated,
+    ).not.toBe(true);
+    // ...and host A's classic `providers.list` key - a different host,
+    // never passed to the refresh - was left untouched too.
+    expect(queryClient.getQueryState(hostAClassicKey)?.isInvalidated).not.toBe(
+      true,
+    );
   });
 
   it("returns unavailable without retaining invalidation while the target has no RPC endpoint", async () => {

--- a/clients/gui-app/src/hooks/harnesses/__tests__/use-gui-harness-catalog.test.tsx
+++ b/clients/gui-app/src/hooks/harnesses/__tests__/use-gui-harness-catalog.test.tsx
@@ -30,6 +30,7 @@ import type {
   ResponseOfMethod,
 } from "@traycer-clients/shared/host-transport/host-messenger";
 import type { ProviderCliState } from "@traycer/protocol/host/provider-schemas";
+import { DEFAULT_PROVIDER_NATIVE_CAPABILITIES } from "@traycer/protocol/host/provider-native-schemas";
 import { hostRpcRegistry, type HostRpcRegistry } from "@/lib/host";
 import { createHostQueryInvalidator } from "@/lib/host/query-invalidator";
 import {
@@ -814,6 +815,36 @@ describe("…ForClient catalog hooks are scoped to the client argument, not the 
     return { providers: [] as ProviderCliState[], native: null };
   }
 
+  // A provider row carrying a value nothing else in the test produces, so
+  // "the forced response was committed" is an assertion about THIS response
+  // and not about any empty list that happened to land on the key. An empty
+  // `providers` array would have been satisfied by the seeded sentinel, by
+  // the other host's handler, and by a commit of the wrong response alike.
+  function markerProvider(label: string): ProviderCliState {
+    return {
+      providerId: "claude-code",
+      enabled: true,
+      disabledBy: null,
+      nativeCapabilities: DEFAULT_PROVIDER_NATIVE_CAPABILITIES,
+      selected: { kind: "bundled" },
+      candidates: [],
+      auth: {
+        status: "authenticated",
+        badgeText: null,
+        label,
+        detail: null,
+      },
+      authPending: false,
+      checkedAt: null,
+      apiKey: { supported: false, configured: false, source: null },
+      terminalAgentArgs: "",
+      envOverrides: [],
+      loginCapability: null,
+      availabilityPending: false,
+      profiles: [],
+    };
+  }
+
   function buildHostClient(
     queryClient: QueryClient,
     hostId: string,
@@ -883,7 +914,7 @@ describe("…ForClient catalog hooks are scoped to the client argument, not the 
     const hostBProvidersListResponse: ResponseOfMethod<
       HostRpcRegistry,
       "providers.list"
-    > = { providers: [] as ProviderCliState[], native: null };
+    > = { providers: [markerProvider("committed-from-host-b")], native: null };
     const clientA = buildHostClient(
       queryClient,
       "host-a",
@@ -944,11 +975,20 @@ describe("…ForClient catalog hooks are scoped to the client argument, not the 
     });
 
     // Seed host A's classic key and host B's native-scoped key with a
-    // sentinel distinct from host B's forced response, so "untouched" below
-    // means neither invalidated nor overwritten - the commit's exact-key
-    // write is the only thing that should ever move these.
+    // sentinel, so "untouched" below means neither invalidated nor
+    // overwritten - the commit's exact-key write is the only thing that
+    // should ever move these.
+    //
+    // The sentinel's MARKER is what gives those assertions teeth, and it is
+    // load-bearing: while both it and the forced response were `{ providers:
+    // [], native: null }`, a commit that reached the wrong key would have
+    // written a value equal to what was already there, and the assertion
+    // could not fail. Nor would `toBe` have rescued it - `setQueryData`
+    // applies structural sharing, so a structurally-equal write KEEPS the
+    // prior reference and identity holds exactly when equality does.
+    // Distinct contents are the only signal either check can read.
     const sentinel: ResponseOfMethod<HostRpcRegistry, "providers.list"> = {
-      providers: [] as ProviderCliState[],
+      providers: [markerProvider("seeded-sentinel")],
       native: null,
     };
     const hostAClassicKey = providersListQueryKey("host-a");
@@ -997,6 +1037,8 @@ describe("…ForClient catalog hooks are scoped to the client argument, not the 
     // `agent.gui.listHarnesses` back out (it is already in
     // `PROVIDER_INVALIDATIONS`) and only covers `agent.gui.listModels` /
     // `agent.gui.listCommands`, so those land at 2 via that second pass.
+    // That filter is conditional on the commit having run at all - the
+    // failure-path test below is its other half.
     await waitFor(() => {
       expect(hostBCalls).toEqual({ harnesses: 2, models: 2, commands: 2 });
     });
@@ -1007,7 +1049,7 @@ describe("…ForClient catalog hooks are scoped to the client argument, not the 
     expect(hostACalls).toEqual({ harnesses: 1, models: 1, commands: 1 });
   });
 
-  it("still resolves 'refreshed' and still refetches host B's catalog methods when the forced providers.list request throws", async () => {
+  it("still resolves 'refreshed' and refetches ALL THREE of host B's catalog methods - the harness row included - when the forced providers.list request throws", async () => {
     const queryClient = createAppQueryClient();
     const Wrapper = (props: { readonly children: ReactNode }): ReactNode => (
       <QueryClientProvider client={queryClient}>
@@ -1065,12 +1107,14 @@ describe("…ForClient catalog hooks are scoped to the client argument, not the 
     expect(hostBProvidersListCalls).toEqual([
       { forceAuthRefresh: true, native: null },
     ]);
-    // The catalog invalidation still ran despite the failed commit. Only
-    // `agent.gui.listModels` / `agent.gui.listCommands` move here -
-    // `agent.gui.listHarnesses` would have come from the (never-run) commit's
-    // own invalidation, so it stays at its original count.
+    // The catalog invalidation still ran despite the failed commit - and it
+    // covered ALL THREE methods, `agent.gui.listHarnesses` included. On the
+    // success path that one is deducted because the commit already
+    // invalidated it; here the commit never ran, so deducting it would leave
+    // the rail's own row (`enabled` / `available` / `authStatus`) stale
+    // behind a click that reported `refreshed`.
     await waitFor(() => {
-      expect(hostBCalls).toEqual({ harnesses: 1, models: 2, commands: 2 });
+      expect(hostBCalls).toEqual({ harnesses: 2, models: 2, commands: 2 });
     });
   });
 

--- a/clients/gui-app/src/hooks/harnesses/__tests__/use-gui-harness-catalog.test.tsx
+++ b/clients/gui-app/src/hooks/harnesses/__tests__/use-gui-harness-catalog.test.tsx
@@ -14,7 +14,10 @@ import {
   resetHostConnectionRegistryForTest,
 } from "@traycer-clients/shared/host-client/host-connection-registry";
 import { mockLocalHostEntry } from "@traycer-clients/shared/host-client/mock/mock-host-directory";
-import { MockHostMessenger } from "@traycer-clients/shared/host-client/mock/mock-host-messenger";
+import {
+  MockHostMessenger,
+  type MockMethodHandler,
+} from "@traycer-clients/shared/host-client/mock/mock-host-messenger";
 import { createRequestContextFixture } from "@traycer-clients/shared/test-fixtures/request-context";
 import type {
   GuiHarnessId,
@@ -22,7 +25,10 @@ import type {
   ListGuiAgentCommandsResponse,
   ListGuiAgentModelsResponse,
 } from "@traycer/protocol/host/index";
-import type { ResponseOfMethod } from "@traycer-clients/shared/host-transport/host-messenger";
+import type {
+  RequestOfMethod,
+  ResponseOfMethod,
+} from "@traycer-clients/shared/host-transport/host-messenger";
 import type { ProviderCliState } from "@traycer/protocol/host/provider-schemas";
 import { hostRpcRegistry, type HostRpcRegistry } from "@/lib/host";
 import { createHostQueryInvalidator } from "@/lib/host/query-invalidator";
@@ -795,10 +801,24 @@ describe("…ForClient catalog hooks are scoped to the client argument, not the 
     commands: number;
   }
 
+  // Trivial default for callers that never exercise the refresh path (the
+  // two default-host fixtures below): the mock messenger throws for any
+  // method with no registered handler, and `providers.list` is now dispatched
+  // unconditionally by `useRefreshProvidersForClient`'s mutation, so every
+  // `buildHostClient` caller needs SOME handler even when its test never
+  // reads the response.
+  function acceptingProvidersListHandler(): ResponseOfMethod<
+    HostRpcRegistry,
+    "providers.list"
+  > {
+    return { providers: [] as ProviderCliState[], native: null };
+  }
+
   function buildHostClient(
     queryClient: QueryClient,
     hostId: string,
     calls: HostCallCounts,
+    providersList: MockMethodHandler<HostRpcRegistry, "providers.list">,
   ): HostClient<HostRpcRegistry> {
     let requestCounter = 0;
     const entry = {
@@ -832,6 +852,7 @@ describe("…ForClient catalog hooks are scoped to the client argument, not the 
             calls.commands += 1;
             return { harnessId: "opencode", commands: [] };
           },
+          "providers.list": providersList,
         },
       }),
     });
@@ -844,7 +865,7 @@ describe("…ForClient catalog hooks are scoped to the client argument, not the 
     return spine.createRequester(entry);
   }
 
-  it("useRefreshHarnessCatalogForClient invalidates the target host's three catalog methods and its exact classic providers.list key, leaving another host's cache and native-scoped providers.list keys untouched", async () => {
+  it("useRefreshHarnessCatalogForClient forces providers.list for host B only, commits the response under host B's exact classic key, and still refetches host B's three catalog methods", async () => {
     const queryClient = createAppQueryClient();
     const Wrapper = (props: { readonly children: ReactNode }): ReactNode => (
       <QueryClientProvider client={queryClient}>
@@ -853,8 +874,34 @@ describe("…ForClient catalog hooks are scoped to the client argument, not the 
     );
     const hostACalls: HostCallCounts = { harnesses: 0, models: 0, commands: 0 };
     const hostBCalls: HostCallCounts = { harnesses: 0, models: 0, commands: 0 };
-    const clientA = buildHostClient(queryClient, "host-a", hostACalls);
-    const clientB = buildHostClient(queryClient, "host-b", hostBCalls);
+    const hostAProvidersListCalls: Array<
+      RequestOfMethod<HostRpcRegistry, "providers.list">
+    > = [];
+    const hostBProvidersListCalls: Array<
+      RequestOfMethod<HostRpcRegistry, "providers.list">
+    > = [];
+    const hostBProvidersListResponse: ResponseOfMethod<
+      HostRpcRegistry,
+      "providers.list"
+    > = { providers: [] as ProviderCliState[], native: null };
+    const clientA = buildHostClient(
+      queryClient,
+      "host-a",
+      hostACalls,
+      (params) => {
+        hostAProvidersListCalls.push(params);
+        return acceptingProvidersListHandler();
+      },
+    );
+    const clientB = buildHostClient(
+      queryClient,
+      "host-b",
+      hostBCalls,
+      (params) => {
+        hostBProvidersListCalls.push(params);
+        return hostBProvidersListResponse;
+      },
+    );
 
     renderHook(
       () => {
@@ -896,14 +943,14 @@ describe("…ForClient catalog hooks are scoped to the client argument, not the 
       expect(hostBCalls).toEqual({ harnesses: 1, models: 1, commands: 1 });
     });
 
-    // Seed the classic `providers.list` cache slot on both hosts, plus a
-    // native-scoped `providers.list` entry on host B - the mock host client
-    // has no `providers.list` handler, so these are written directly into the
-    // query cache rather than fetched.
-    const classicProvidersListResponse: ResponseOfMethod<
-      HostRpcRegistry,
-      "providers.list"
-    > = { providers: [] as ProviderCliState[], native: null };
+    // Seed host A's classic key and host B's native-scoped key with a
+    // sentinel distinct from host B's forced response, so "untouched" below
+    // means neither invalidated nor overwritten - the commit's exact-key
+    // write is the only thing that should ever move these.
+    const sentinel: ResponseOfMethod<HostRpcRegistry, "providers.list"> = {
+      providers: [] as ProviderCliState[],
+      native: null,
+    };
     const hostAClassicKey = providersListQueryKey("host-a");
     const hostBClassicKey = providersListQueryKey("host-b");
     const hostBNativeMcpKey = providersNativeQueryKeys.mcpList("host-b", {
@@ -911,19 +958,45 @@ describe("…ForClient catalog hooks are scoped to the client argument, not the 
       scope: "global",
       workspaceRoot: null,
     });
-    queryClient.setQueryData(hostAClassicKey, classicProvidersListResponse);
-    queryClient.setQueryData(hostBClassicKey, classicProvidersListResponse);
-    queryClient.setQueryData(hostBNativeMcpKey, classicProvidersListResponse);
+    queryClient.setQueryData(hostAClassicKey, sentinel);
+    queryClient.setQueryData(hostBNativeMcpKey, sentinel);
 
     const { result } = renderHook(
       () => useRefreshHarnessCatalogForClient(clientB),
       { wrapper: Wrapper },
     );
     await act(async () => {
-      await result.current();
+      await expect(result.current()).resolves.toEqual({ kind: "refreshed" });
     });
 
-    // Host B's three catalog methods were re-fetched by the refresh...
+    // Host B received exactly one FORCED providers.list request...
+    expect(hostBProvidersListCalls).toEqual([
+      { forceAuthRefresh: true, native: null },
+    ]);
+    // ...whose response is now committed under host B's exact classic key
+    // (a direct write, not an invalidation - `commitAuthoritativeProvidersList`
+    // sets the cache entry itself so a stale background refetch can never
+    // clobber the fresh probe)...
+    expect(queryClient.getQueryData(hostBClassicKey)).toEqual(
+      hostBProvidersListResponse,
+    );
+    // ...host A - a DIFFERENT client, never passed to the refresh - received
+    // no providers.list call at all, and its classic cache is untouched...
+    expect(hostAProvidersListCalls).toEqual([]);
+    expect(queryClient.getQueryData(hostAClassicKey)).toEqual(sentinel);
+    // ...and a native-scoped `providers.list` key on the SAME host is a
+    // separate cache entry the commit's exact `{ native: null }` key never
+    // reaches.
+    expect(queryClient.getQueryData(hostBNativeMcpKey)).toEqual(sentinel);
+
+    // Host B's three catalog methods were re-fetched. Observed: harnesses
+    // lands at 2 (not 3) - `commitAuthoritativeProvidersList` invalidates
+    // every `PROVIDER_INVALIDATIONS` scope except `providers.list` itself,
+    // which includes `agent.gui.listHarnesses` and refetches it once as an
+    // active query; the refresh's OWN second invalidation pass then filters
+    // `agent.gui.listHarnesses` back out (it is already in
+    // `PROVIDER_INVALIDATIONS`) and only covers `agent.gui.listModels` /
+    // `agent.gui.listCommands`, so those land at 2 via that second pass.
     await waitFor(() => {
       expect(hostBCalls).toEqual({ harnesses: 2, models: 2, commands: 2 });
     });
@@ -932,23 +1005,73 @@ describe("…ForClient catalog hooks are scoped to the client argument, not the 
     // target through the app-wide default (rather than the `client`
     // argument) would either refresh the wrong host or refresh both.
     expect(hostACalls).toEqual({ harnesses: 1, models: 1, commands: 1 });
+  });
 
-    // Host B's exact classic `providers.list` key was invalidated by the
-    // refresh...
-    expect(queryClient.getQueryState(hostBClassicKey)?.isInvalidated).toBe(
-      true,
+  it("still resolves 'refreshed' and still refetches host B's catalog methods when the forced providers.list request throws", async () => {
+    const queryClient = createAppQueryClient();
+    const Wrapper = (props: { readonly children: ReactNode }): ReactNode => (
+      <QueryClientProvider client={queryClient}>
+        {props.children}
+      </QueryClientProvider>
     );
-    // ...a native-scoped `providers.list` key on the SAME host was not - the
-    // refresh says nothing about MCP/plugins/skills discovery, only the
-    // classic catalog carrier (`native: null`)...
-    expect(
-      queryClient.getQueryState(hostBNativeMcpKey)?.isInvalidated,
-    ).not.toBe(true);
-    // ...and host A's classic `providers.list` key - a different host,
-    // never passed to the refresh - was left untouched too.
-    expect(queryClient.getQueryState(hostAClassicKey)?.isInvalidated).not.toBe(
-      true,
+    const hostBCalls: HostCallCounts = { harnesses: 0, models: 0, commands: 0 };
+    const hostBProvidersListCalls: Array<
+      RequestOfMethod<HostRpcRegistry, "providers.list">
+    > = [];
+    const clientB = buildHostClient(
+      queryClient,
+      "host-b",
+      hostBCalls,
+      (params) => {
+        hostBProvidersListCalls.push(params);
+        throw new Error("providers.list unreachable");
+      },
     );
+
+    renderHook(
+      () => {
+        useGuiHarnessesQueryForClient(clientB, {
+          enabled: true,
+          subscribed: true,
+        });
+        useGuiHarnessModelsQueryForClient(clientB, "opencode", null, {
+          enabled: true,
+          subscribed: true,
+        });
+        useGuiHarnessCommandsQuery(clientB, "opencode", [], {
+          enabled: true,
+          subscribed: true,
+        });
+      },
+      { wrapper: Wrapper },
+    );
+
+    await waitFor(() => {
+      expect(hostBCalls).toEqual({ harnesses: 1, models: 1, commands: 1 });
+    });
+
+    const { result } = renderHook(
+      () => useRefreshHarnessCatalogForClient(clientB),
+      { wrapper: Wrapper },
+    );
+    // The forced request failed, but the mutation's own `onError` toasts it
+    // (`toastFromHostError`) and the refresh hook swallows the rejection
+    // (`.catch(() => undefined)`) rather than propagating it - the caller
+    // still gets a definite outcome to drive its spinner off of.
+    await act(async () => {
+      await expect(result.current()).resolves.toEqual({ kind: "refreshed" });
+    });
+
+    expect(hostBProvidersListCalls).toEqual([
+      { forceAuthRefresh: true, native: null },
+    ]);
+    // The catalog invalidation still ran despite the failed commit. Only
+    // `agent.gui.listModels` / `agent.gui.listCommands` move here -
+    // `agent.gui.listHarnesses` would have come from the (never-run) commit's
+    // own invalidation, so it stays at its original count.
+    await waitFor(() => {
+      expect(hostBCalls).toEqual({ harnesses: 1, models: 2, commands: 2 });
+    });
   });
 
   it("returns unavailable without retaining invalidation while the target has no RPC endpoint", async () => {
@@ -1125,6 +1248,7 @@ describe("…ForClient catalog hooks are scoped to the client argument, not the 
         queryClient,
         "default-host",
         defaultHostCalls,
+        acceptingProvidersListHandler,
       ),
     };
     setEffectiveHostId("default-host");
@@ -1165,6 +1289,7 @@ describe("…ForClient catalog hooks are scoped to the client argument, not the 
         queryClient,
         "default-host",
         defaultHostCalls,
+        acceptingProvidersListHandler,
       ),
     };
     setEffectiveHostId("default-host");

--- a/clients/gui-app/src/hooks/harnesses/use-gui-harness-catalog.ts
+++ b/clients/gui-app/src/hooks/harnesses/use-gui-harness-catalog.ts
@@ -2,7 +2,7 @@ import { useQueryClient, type UseQueryResult } from "@tanstack/react-query";
 import { useCallback, useMemo } from "react";
 import type { HostClient } from "@traycer-clients/shared/host-client/host-client";
 import { HostRpcError } from "@traycer-clients/shared/host-transport/host-messenger";
-import { hostQueryKeys } from "@/lib/query-keys";
+import { hostQueryKeys, providersListQueryKey } from "@/lib/query-keys";
 import { useHostBinding, useHostClient } from "@/lib/host";
 import { resolveSubtreeHostClient } from "@/lib/host/binding-host-client";
 import { useEffectiveHostId } from "@/hooks/host/use-effective-host-id";
@@ -522,10 +522,11 @@ const REFRESHABLE_CATALOG_METHODS = [
 
 /**
  * Returns a function that force-refreshes the harness catalog (availability +
- * model lists + commands) for the active host, bypassing the long catalog
- * cache. Wired to the picker's refresh button so users can re-fetch on demand
- * without waiting out the 15-min stale window - e.g. to pick up provider
- * enable/disable changes or an updated models.dev catalog. (It re-queries the
+ * model lists + commands) and the provider list for the active host, bypassing
+ * the long caches. Wired to the picker's refresh button so users can re-fetch
+ * on demand without waiting out the 15-min stale window - e.g. to pick up
+ * provider enable/disable changes, an updated models.dev catalog, or a
+ * credential they just configured in the provider's own store. (It re-queries the
  * existing provider servers; a brand-new shell API key exported after the
  * host started still needs a host restart, since the server's env is fixed
  * at spawn.)
@@ -573,13 +574,26 @@ export function useRefreshHarnessCatalogForClient(
     // `invalidateQueries` resolves once the refetches it triggers on active
     // queries settle, so awaiting all of them lets the caller drive a spinner
     // that reflects real refetch progress (not just fire-and-forget).
-    await Promise.all(
-      REFRESHABLE_CATALOG_METHODS.map((method) =>
+    await Promise.all([
+      ...REFRESHABLE_CATALOG_METHODS.map((method) =>
         queryClient.invalidateQueries({
           queryKey: hostQueryKeys.methodScope(hostId, method),
         }),
       ),
-    );
+      // The picker's auth line and its degraded-tab set read `providers.list`,
+      // which is otherwise held for fifteen minutes. The catalog row's own
+      // `authStatus` cannot stand in for it: the host fills that field from a
+      // thirty-second cache and OMITS it once that expires, so a refresh
+      // pressed a minute after the user fixed their credential re-fetched the
+      // catalog and still rendered the stale signed-out verdict. Exact classic
+      // key, not the method scope - `providers.list` is also the carrier for
+      // the native (MCP/plugins/skills) queries, and a catalog refresh says
+      // nothing about those (same rule as `useRefreshProvidersListOnTurn`).
+      queryClient.invalidateQueries({
+        queryKey: providersListQueryKey(hostId),
+        exact: true,
+      }),
+    ]);
     return { kind: "refreshed" };
   }, [client, queryClient]);
 }

--- a/clients/gui-app/src/hooks/harnesses/use-gui-harness-catalog.ts
+++ b/clients/gui-app/src/hooks/harnesses/use-gui-harness-catalog.ts
@@ -2,7 +2,9 @@ import { useQueryClient, type UseQueryResult } from "@tanstack/react-query";
 import { useCallback, useMemo } from "react";
 import type { HostClient } from "@traycer-clients/shared/host-client/host-client";
 import { HostRpcError } from "@traycer-clients/shared/host-transport/host-messenger";
-import { hostQueryKeys, providersListQueryKey } from "@/lib/query-keys";
+import { hostQueryKeys } from "@/lib/query-keys";
+import { PROVIDER_INVALIDATIONS } from "@/hooks/providers/invalidations";
+import { useRefreshProvidersForClient } from "@/hooks/providers/use-refresh-providers";
 import { useHostBinding, useHostClient } from "@/lib/host";
 import { resolveSubtreeHostClient } from "@/lib/host/binding-host-client";
 import { useEffectiveHostId } from "@/hooks/host/use-effective-host-id";
@@ -556,6 +558,7 @@ export function useRefreshHarnessCatalogForClient(
   client: HostClient<HostRpcRegistry> | null,
 ): () => Promise<HarnessCatalogRefreshOutcome> {
   const queryClient = useQueryClient();
+  const refreshProviders = useRefreshProvidersForClient(client);
   return useCallback(async () => {
     const hostId = client?.getActiveHostId() ?? null;
     if (hostId === null) {
@@ -571,31 +574,34 @@ export function useRefreshHarnessCatalogForClient(
         {},
       ),
     );
+    // The picker's auth line and its degraded-tab set read `providers.list`,
+    // which is otherwise held for fifteen minutes, and the catalog row's own
+    // `authStatus` cannot stand in for it: the host fills that field from a
+    // thirty-second cache and OMITS it once that expires. Nor is invalidating
+    // the list enough - a plain refetch serves the last-known verdict while
+    // the host re-probes in the background - so this is the FORCED refresh
+    // the Settings and banner refresh buttons use, committed under this
+    // host's classic key. Its failure is already toasted by the mutation and
+    // must not withhold the catalog refetch below.
+    await refreshProviders().catch(() => undefined);
     // `invalidateQueries` resolves once the refetches it triggers on active
     // queries settle, so awaiting all of them lets the caller drive a spinner
-    // that reflects real refetch progress (not just fire-and-forget).
-    await Promise.all([
-      ...REFRESHABLE_CATALOG_METHODS.map((method) =>
+    // that reflects real refetch progress (not just fire-and-forget). The
+    // authoritative list commit above already invalidated every
+    // `PROVIDER_INVALIDATIONS` scope (`agent.gui.listHarnesses` among them);
+    // invalidating those again here would restart refetches already in
+    // flight, so only the catalog scopes it does not cover are touched.
+    await Promise.all(
+      REFRESHABLE_CATALOG_METHODS.filter(
+        (method) => !PROVIDER_INVALIDATIONS.includes(method),
+      ).map((method) =>
         queryClient.invalidateQueries({
           queryKey: hostQueryKeys.methodScope(hostId, method),
         }),
       ),
-      // The picker's auth line and its degraded-tab set read `providers.list`,
-      // which is otherwise held for fifteen minutes. The catalog row's own
-      // `authStatus` cannot stand in for it: the host fills that field from a
-      // thirty-second cache and OMITS it once that expires, so a refresh
-      // pressed a minute after the user fixed their credential re-fetched the
-      // catalog and still rendered the stale signed-out verdict. Exact classic
-      // key, not the method scope - `providers.list` is also the carrier for
-      // the native (MCP/plugins/skills) queries, and a catalog refresh says
-      // nothing about those (same rule as `useRefreshProvidersListOnTurn`).
-      queryClient.invalidateQueries({
-        queryKey: providersListQueryKey(hostId),
-        exact: true,
-      }),
-    ]);
+    );
     return { kind: "refreshed" };
-  }, [client, queryClient]);
+  }, [client, queryClient, refreshProviders]);
 }
 
 function guiHarnessCommandsQueryParams(

--- a/clients/gui-app/src/hooks/harnesses/use-gui-harness-catalog.ts
+++ b/clients/gui-app/src/hooks/harnesses/use-gui-harness-catalog.ts
@@ -583,17 +583,30 @@ export function useRefreshHarnessCatalogForClient(
     // the Settings and banner refresh buttons use, committed under this
     // host's classic key. Its failure is already toasted by the mutation and
     // must not withhold the catalog refetch below.
-    await refreshProviders().catch(() => undefined);
+    const providersRefreshed = await refreshProviders().then(
+      () => true,
+      () => false,
+    );
     // `invalidateQueries` resolves once the refetches it triggers on active
     // queries settle, so awaiting all of them lets the caller drive a spinner
-    // that reflects real refetch progress (not just fire-and-forget). The
-    // authoritative list commit above already invalidated every
-    // `PROVIDER_INVALIDATIONS` scope (`agent.gui.listHarnesses` among them);
-    // invalidating those again here would restart refetches already in
-    // flight, so only the catalog scopes it does not cover are touched.
+    // that reflects real refetch progress (not just fire-and-forget).
+    //
+    // The dedupe below is owed entirely to the commit ABOVE HAVING RUN: a
+    // successful `commitAuthoritativeProvidersList` invalidates every
+    // `PROVIDER_INVALIDATIONS` scope (`agent.gui.listHarnesses` among them),
+    // so invalidating those again here would restart refetches already in
+    // flight. A REJECTED forced request never reaches that commit and so
+    // invalidates nothing - and the harness row is where `enabled`,
+    // `available` and `authStatus` come from, the very fields the rail dims
+    // on. Deducting it unconditionally would return `refreshed` from a click
+    // that refetched neither the provider list nor the rail it feeds, over a
+    // provider-probe timeout that left the catalog endpoints perfectly
+    // usable. So the filter applies only on the success path; on failure this
+    // pass covers every refreshable method itself.
     await Promise.all(
       REFRESHABLE_CATALOG_METHODS.filter(
-        (method) => !PROVIDER_INVALIDATIONS.includes(method),
+        (method) =>
+          !providersRefreshed || !PROVIDER_INVALIDATIONS.includes(method),
       ).map((method) =>
         queryClient.invalidateQueries({
           queryKey: hostQueryKeys.methodScope(hostId, method),

--- a/clients/gui-app/src/hooks/providers/use-refresh-providers.ts
+++ b/clients/gui-app/src/hooks/providers/use-refresh-providers.ts
@@ -2,6 +2,7 @@ import type {
   RequestOfMethod,
   ResponseOfMethod,
 } from "@traycer-clients/shared/host-transport/host-messenger";
+import type { HostClient } from "@traycer-clients/shared/host-client/host-client";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
 import { useHostClient, type HostRpcRegistry } from "@/lib/host";
@@ -27,7 +28,25 @@ type RefreshContext = {
  * Resolves once the triggered work settles so the caller can drive a spinner.
  */
 export function useRefreshProviders(): () => Promise<void> {
-  const client = useHostClient();
+  return useRefreshProvidersForClient(useHostClient());
+}
+
+/**
+ * Client-scoped form of {@link useRefreshProviders}: the host is whichever one
+ * `client` addresses, so a composer-bound surface (the model picker's refresh
+ * button) refreshes the host its turns run on rather than the app-wide active
+ * host. `null` is "no host resolved yet" and the returned function is a no-op.
+ *
+ * FORCED, not invalidated, and that is the whole point. A plain `providers.list`
+ * refetch serves the last-known verdict, TTL-stale included, while the host
+ * re-probes in the background (`nonBlockingAuth`), so invalidating the query
+ * after the user fixed a credential out-of-band re-rendered the signed-out
+ * verdict it had just been shown. Only `forceAuthRefresh: true` bypasses the
+ * host's cache and poison and answers with a fresh probe.
+ */
+export function useRefreshProvidersForClient(
+  client: HostClient<HostRpcRegistry> | null,
+): () => Promise<void> {
   const queryClient = useQueryClient();
   const mutation = useHostMutation<
     HostRpcRegistry,
@@ -39,7 +58,7 @@ export function useRefreshProviders(): () => Promise<void> {
     mapVariables: (variables: ProvidersListRequest) => variables,
     options: {
       mutationKey: providersMutationKeys.refresh(),
-      onMutate: () => ({ hostId: client.getActiveHostId() }),
+      onMutate: () => ({ hostId: client?.getActiveHostId() ?? null }),
       onSuccess: async (data: ProvidersListResponse, _variables, ctx) => {
         if (ctx.hostId === null) return;
         // Drops the harness catalogs alongside the list, which is what makes
@@ -67,7 +86,7 @@ export function useRefreshProviders(): () => Promise<void> {
   // refresh control on each provider-fetch tick.
   const { mutateAsync } = mutation;
   return useCallback(async () => {
-    const hostId = client.getActiveHostId();
+    const hostId = client?.getActiveHostId() ?? null;
     if (hostId === null) return;
     getConditionPollEpisodeCoordinator(queryClient).resetQueryByKey(
       hostQueryKeys.method<HostRpcRegistry, "providers.list">(

--- a/clients/gui-app/src/lib/providers/__tests__/provider-setup-guidance.test.ts
+++ b/clients/gui-app/src/lib/providers/__tests__/provider-setup-guidance.test.ts
@@ -2,17 +2,21 @@ import { describe, expect, it } from "vitest";
 import { providerSetupGuidance } from "@/lib/providers/provider-setup-guidance";
 
 describe("providerSetupGuidance", () => {
-  it("returns reasonix's setup guidance with the 'reasonix setup' command", () => {
+  it("returns reasonix's setup guidance with the manual 'reasonix setup' command and three in-app steps", () => {
     const guidance = providerSetupGuidance("reasonix");
     expect(guidance).not.toBeNull();
-    expect(guidance?.command).toBe("reasonix setup");
+    expect(guidance).not.toHaveProperty("command");
+    expect(guidance?.manualCommand).toBe("reasonix setup");
     expect(guidance?.summary).toBe(
       "Reasonix keeps provider API keys in its own store, not in your shell environment.",
     );
     expect(guidance?.steps).toEqual([
+      "From a chat, choose \u201cSet up in terminal\u201d in the banner above the composer. It opens Reasonix's setup wizard on the host this composer runs on.",
       "Paste your provider API key when asked (DeepSeek by default).",
       "Refresh this list.",
     ]);
+    expect(guidance?.steps).toHaveLength(3);
+    expect(guidance?.steps[0]).toContain("Set up in terminal");
     expect(guidance?.terminalActionLabel).toBe("Set up in terminal");
     expect(guidance?.terminalHint).toBe(
       "Reasonix asks for your provider API key in that terminal. Finish there, then use Refresh above.",

--- a/clients/gui-app/src/lib/providers/__tests__/provider-setup-guidance.test.ts
+++ b/clients/gui-app/src/lib/providers/__tests__/provider-setup-guidance.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { providerSetupGuidance } from "@/lib/providers/provider-setup-guidance";
+
+describe("providerSetupGuidance", () => {
+  it("returns reasonix's setup guidance with the 'reasonix setup' command", () => {
+    const guidance = providerSetupGuidance("reasonix");
+    expect(guidance).not.toBeNull();
+    expect(guidance?.command).toBe("reasonix setup");
+    expect(guidance?.summary).toBe(
+      "Reasonix keeps provider API keys in its own store, not in your shell environment.",
+    );
+    expect(guidance?.steps).toEqual([
+      "Paste your provider API key when asked (DeepSeek by default).",
+      "Refresh this list.",
+    ]);
+    expect(guidance?.terminalActionLabel).toBe("Set up in terminal");
+    expect(guidance?.terminalHint).toBe(
+      "Reasonix asks for your provider API key in that terminal. Finish there, then use Refresh above.",
+    );
+  });
+
+  it("returns null for a provider with no guidance entry (cursor)", () => {
+    expect(providerSetupGuidance("cursor")).toBeNull();
+  });
+});

--- a/clients/gui-app/src/lib/providers/__tests__/provider-signed-out-catalog-error.test.ts
+++ b/clients/gui-app/src/lib/providers/__tests__/provider-signed-out-catalog-error.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { providerSignedOutMessage } from "@traycer/protocol/host/provider-display";
+import { isProviderSignedOutCatalogError } from "@/lib/providers/provider-signed-out-catalog-error";
+
+describe("isProviderSignedOutCatalogError", () => {
+  it("is true for the exact signed-out message, including surrounding whitespace", () => {
+    const message = `  ${providerSignedOutMessage("reasonix")}  \n`;
+    expect(isProviderSignedOutCatalogError("reasonix", { message })).toBe(true);
+  });
+
+  it("is false for a different message", () => {
+    expect(
+      isProviderSignedOutCatalogError("reasonix", {
+        message: "spawn failed: ENOENT",
+      }),
+    ).toBe(false);
+  });
+
+  it("is false for a null error", () => {
+    expect(isProviderSignedOutCatalogError("reasonix", null)).toBe(false);
+  });
+
+  it("is false when the message is the signed-out verdict for a DIFFERENT provider", () => {
+    expect(
+      isProviderSignedOutCatalogError("reasonix", {
+        message: providerSignedOutMessage("claude-code"),
+      }),
+    ).toBe(false);
+  });
+});

--- a/clients/gui-app/src/lib/providers/__tests__/provider-signed-out-catalog-error.test.ts
+++ b/clients/gui-app/src/lib/providers/__tests__/provider-signed-out-catalog-error.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { PROVIDER_DISPLAY_NAMES } from "@traycer/protocol/host/provider-schemas";
 import { providerSignedOutMessage } from "@traycer/protocol/host/provider-display";
 import { isProviderSignedOutCatalogError } from "@/lib/providers/provider-signed-out-catalog-error";
 
@@ -24,6 +25,25 @@ describe("isProviderSignedOutCatalogError", () => {
     expect(
       isProviderSignedOutCatalogError("reasonix", {
         message: providerSignedOutMessage("claude-code"),
+      }),
+    ).toBe(false);
+  });
+
+  // Older hosts pin a protocol from before Reasonix got its own signed-out
+  // sentence and still send this generic form for it - the renderer has to
+  // keep recognizing it or those hosts fall back to the report-issue row.
+  it("is true for the legacy generic 'is signed out. Reconnect to continue.' form for reasonix", () => {
+    expect(
+      isProviderSignedOutCatalogError("reasonix", {
+        message: `${PROVIDER_DISPLAY_NAMES.reasonix} is signed out. Reconnect to continue.`,
+      }),
+    ).toBe(true);
+  });
+
+  it("is false for the legacy generic form built for a DIFFERENT provider", () => {
+    expect(
+      isProviderSignedOutCatalogError("reasonix", {
+        message: `${PROVIDER_DISPLAY_NAMES["claude-code"]} is signed out. Reconnect to continue.`,
       }),
     ).toBe(false);
   });

--- a/clients/gui-app/src/lib/providers/provider-setup-guidance.ts
+++ b/clients/gui-app/src/lib/providers/provider-setup-guidance.ts
@@ -1,0 +1,56 @@
+import type { ProviderId } from "@traycer/protocol/host/provider-schemas";
+
+/**
+ * Setup guidance for a provider whose signed-out state is NOT fixed by any of
+ * the generic reconnect affordances (browser OAuth, a pasted token, a Traycer
+ * stored API key).
+ *
+ * The generic surfaces describe a sign-in: "Sign in from a terminal", "prints
+ * a sign-in code". For a provider that owns its own credential store that
+ * framing is wrong in a way that costs the user real time - Reasonix's own
+ * startup warning names an environment variable (`missing env
+ * DEEPSEEK_API_KEY`), so the natural next move is to export it in the shell,
+ * and the shipped CLI ignores the process environment entirely (byte-verified
+ * against 1.35.0: the same key exported into the environment produced an
+ * outbound `x-api-key` of length 0; only `<reasonix-home>/.env` worked).
+ * The only thing that helps is telling the user exactly where the key goes.
+ *
+ * Copy only. Which providers get an entry is a product decision made here,
+ * not derived from `loginCapability`: the capability says HOW the host can
+ * start a login, not what the user has to do inside it.
+ */
+export interface ProviderSetupGuidance {
+  /** One line on why the generic sign-in framing does not apply. */
+  readonly summary: string;
+  /** The command the user runs in a terminal; rendered as code. */
+  readonly command: string;
+  /** What happens after the command, in order. */
+  readonly steps: ReadonlyArray<string>;
+  /** Label for the reauth banner's terminal action. */
+  readonly terminalActionLabel: string;
+  /** Hint under that action. */
+  readonly terminalHint: string;
+}
+
+const PROVIDER_SETUP_GUIDANCE: {
+  readonly [k in ProviderId]?: ProviderSetupGuidance;
+} = {
+  reasonix: {
+    summary:
+      "Reasonix keeps provider API keys in its own store, not in your shell environment.",
+    command: "reasonix setup",
+    steps: [
+      "Paste your provider API key when asked (DeepSeek by default).",
+      "Refresh this list.",
+    ],
+    terminalActionLabel: "Set up in terminal",
+    terminalHint:
+      "Reasonix asks for your provider API key in that terminal. Finish there, then use Refresh above.",
+  },
+};
+
+export function providerSetupGuidance(
+  providerId: ProviderId,
+): ProviderSetupGuidance | null {
+  return PROVIDER_SETUP_GUIDANCE[providerId] ?? null;
+}

--- a/clients/gui-app/src/lib/providers/provider-setup-guidance.ts
+++ b/clients/gui-app/src/lib/providers/provider-setup-guidance.ts
@@ -15,6 +15,14 @@ import type { ProviderId } from "@traycer/protocol/host/provider-schemas";
  * outbound `x-api-key` of length 0; only `<reasonix-home>/.env` worked).
  * The only thing that helps is telling the user exactly where the key goes.
  *
+ * The in-app path is the composer banner's terminal action, which runs the
+ * SELECTED binary's setup command in a terminal on the host the composer runs
+ * on. The steps point there rather than at a bare shell command: the bundled
+ * pack is not on the user's PATH, a custom selection may live elsewhere, and
+ * a remote host has to be configured on that machine, not this one. The
+ * `manualCommand` is the equivalent for someone who installed the CLI
+ * themselves, and is labelled as exactly that.
+ *
  * Copy only. Which providers get an entry is a product decision made here,
  * not derived from `loginCapability`: the capability says HOW the host can
  * start a login, not what the user has to do inside it.
@@ -22,10 +30,14 @@ import type { ProviderId } from "@traycer/protocol/host/provider-schemas";
 export interface ProviderSetupGuidance {
   /** One line on why the generic sign-in framing does not apply. */
   readonly summary: string;
-  /** The command the user runs in a terminal; rendered as code. */
-  readonly command: string;
-  /** What happens after the command, in order. */
+  /** The in-app steps, in order. */
   readonly steps: ReadonlyArray<string>;
+  /**
+   * The command a self-installed CLI runs to do the same thing; rendered as
+   * code, always beside the caveat that it targets whatever binary and home
+   * that shell resolves.
+   */
+  readonly manualCommand: string;
   /** Label for the reauth banner's terminal action. */
   readonly terminalActionLabel: string;
   /** Hint under that action. */
@@ -38,11 +50,12 @@ const PROVIDER_SETUP_GUIDANCE: {
   reasonix: {
     summary:
       "Reasonix keeps provider API keys in its own store, not in your shell environment.",
-    command: "reasonix setup",
     steps: [
+      "From a chat, choose “Set up in terminal” in the banner above the composer. It opens Reasonix's setup wizard on the host this composer runs on.",
       "Paste your provider API key when asked (DeepSeek by default).",
       "Refresh this list.",
     ],
+    manualCommand: "reasonix setup",
     terminalActionLabel: "Set up in terminal",
     terminalHint:
       "Reasonix asks for your provider API key in that terminal. Finish there, then use Refresh above.",

--- a/clients/gui-app/src/lib/providers/provider-signed-out-catalog-error.ts
+++ b/clients/gui-app/src/lib/providers/provider-signed-out-catalog-error.ts
@@ -1,5 +1,21 @@
-import type { ProviderId } from "@traycer/protocol/host/provider-schemas";
+import {
+  PROVIDER_DISPLAY_NAMES,
+  type ProviderId,
+} from "@traycer/protocol/host/provider-schemas";
 import { providerSignedOutMessage } from "@traycer/protocol/host/provider-display";
+
+/**
+ * The sentence every provider's signed-out verdict carried before the
+ * protocol gave Reasonix its own. A signed host is released separately from
+ * this renderer and builds the error from whichever protocol it pins, so a
+ * host from before that change still sends this form for Reasonix, and a
+ * renderer that recognised only the new one would answer such a host with the
+ * generic error row and a report-issue icon - the exact state the setup CTA
+ * exists to replace. Remove once no supported host predates the change.
+ */
+function legacyProviderSignedOutMessage(providerId: ProviderId): string {
+  return `${PROVIDER_DISPLAY_NAMES[providerId]} is signed out. Reconnect to continue.`;
+}
 
 /**
  * Whether a model-list failure is the host's "signed out" verdict for this
@@ -17,8 +33,10 @@ export function isProviderSignedOutCatalogError(
   providerId: ProviderId,
   error: { readonly message: string } | null,
 ): boolean {
+  if (error === null) return false;
+  const message = error.message.trim();
   return (
-    error !== null &&
-    error.message.trim() === providerSignedOutMessage(providerId)
+    message === providerSignedOutMessage(providerId) ||
+    message === legacyProviderSignedOutMessage(providerId)
   );
 }

--- a/clients/gui-app/src/lib/providers/provider-signed-out-catalog-error.ts
+++ b/clients/gui-app/src/lib/providers/provider-signed-out-catalog-error.ts
@@ -1,0 +1,24 @@
+import type { ProviderId } from "@traycer/protocol/host/provider-schemas";
+import { providerSignedOutMessage } from "@traycer/protocol/host/provider-display";
+
+/**
+ * Whether a model-list failure is the host's "signed out" verdict for this
+ * provider, as opposed to a spawn failure, a timeout, or a rejected config.
+ *
+ * The host raises that verdict as `HarnessCatalogAuthError`, which crosses the
+ * wire as a plain error with no code - the MESSAGE is the only discriminator,
+ * and `providerSignedOutMessage` is its single producer on both sides of the
+ * wire (the host builds the error from it, the reauth banner renders it). An
+ * exact match against that same helper is therefore a contract, not a text
+ * heuristic; it just has to be kept in step if the host ever starts sending a
+ * code, at which point this becomes the code check.
+ */
+export function isProviderSignedOutCatalogError(
+  providerId: ProviderId,
+  error: { readonly message: string } | null,
+): boolean {
+  return (
+    error !== null &&
+    error.message.trim() === providerSignedOutMessage(providerId)
+  );
+}

--- a/protocol/src/host/__tests__/provider-display.test.ts
+++ b/protocol/src/host/__tests__/provider-display.test.ts
@@ -13,7 +13,7 @@ describe("providerSignedOutMessage", () => {
     // CLI never reads. The renderer matches this string EXACTLY to recognise
     // the signed-out catalog verdict, so the wording is a contract.
     expect(providerSignedOutMessage("reasonix")).toBe(
-      "Reasonix has no API key configured. Run reasonix setup to continue.",
+      "Reasonix has no usable API key configured. Run reasonix setup to continue.",
     );
   });
 

--- a/protocol/src/host/__tests__/provider-display.test.ts
+++ b/protocol/src/host/__tests__/provider-display.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { providerSignedOutMessage } from "../provider-display";
+import { providerIdSchema } from "../provider-ids";
+import { PROVIDER_DISPLAY_NAMES } from "../provider-schemas";
+
+const PROVIDER_IDS = providerIdSchema.options;
+
+describe("providerSignedOutMessage", () => {
+  it("names the real fix for Reasonix, which has no account to reconnect", () => {
+    // Reasonix reads provider keys from its own `<home>/.env` only; the
+    // generic "reconnect" sentence sent users to export a shell variable the
+    // CLI never reads. The renderer matches this string EXACTLY to recognise
+    // the signed-out catalog verdict, so the wording is a contract.
+    expect(providerSignedOutMessage("reasonix")).toBe(
+      "Reasonix has no API key configured. Run reasonix setup to continue.",
+    );
+  });
+
+  it("keeps the generic reconnect sentence, built from the display name, for every other provider", () => {
+    for (const providerId of PROVIDER_IDS) {
+      if (providerId === "reasonix") continue;
+      expect(providerSignedOutMessage(providerId)).toBe(
+        `${PROVIDER_DISPLAY_NAMES[providerId]} is signed out. Reconnect to continue.`,
+      );
+    }
+  });
+});

--- a/protocol/src/host/provider-display.ts
+++ b/protocol/src/host/provider-display.ts
@@ -18,13 +18,15 @@ import { PROVIDER_DISPLAY_NAMES, type ProviderId } from "./provider-schemas";
  * own `<reasonix-home>/.env` and from nowhere else, and the only way to put
  * one there is its terminal wizard. "Signed out. Reconnect." sent users to
  * export a shell variable the CLI never reads, so its sentence names the real
- * fix. The renderer matches this string exactly to recognise the verdict
- * (`isProviderSignedOutCatalogError`), which is why this function must stay
- * the single producer for every provider.
+ * fix. "Usable", not "missing": the same sentence heads a prompt-time 401 for
+ * a key that is present but rejected or expired, and telling that user no key
+ * is configured hides why a working setup stopped. The renderer matches this
+ * string exactly to recognise the verdict (`isProviderSignedOutCatalogError`),
+ * which is why this function must stay the single producer for every provider.
  */
 export function providerSignedOutMessage(providerId: ProviderId): string {
   if (providerId === "reasonix") {
-    return "Reasonix has no API key configured. Run reasonix setup to continue.";
+    return "Reasonix has no usable API key configured. Run reasonix setup to continue.";
   }
   return `${PROVIDER_DISPLAY_NAMES[providerId]} is signed out. Reconnect to continue.`;
 }

--- a/protocol/src/host/provider-display.ts
+++ b/protocol/src/host/provider-display.ts
@@ -8,10 +8,23 @@ import { PROVIDER_DISPLAY_NAMES, type ProviderId } from "./provider-schemas";
 
 /**
  * Fallback copy for a signed-out provider, shared by the host harnesses (the
- * recoverable `code:"auth"` error event) and the renderer's re-auth banner. The
- * banner renders the real reconnect actions; this only shows in the brief window
- * before it mounts.
+ * recoverable `code:"auth"` error event and the catalog's signed-out verdict)
+ * and the renderer's re-auth banner. The banner renders the real reconnect
+ * actions; this only shows in the brief window before it mounts, and wherever
+ * a surface has no actions to offer (a notification body, the model picker's
+ * error row).
+ *
+ * Reasonix has no account to reconnect: it reads provider API keys from its
+ * own `<reasonix-home>/.env` and from nowhere else, and the only way to put
+ * one there is its terminal wizard. "Signed out. Reconnect." sent users to
+ * export a shell variable the CLI never reads, so its sentence names the real
+ * fix. The renderer matches this string exactly to recognise the verdict
+ * (`isProviderSignedOutCatalogError`), which is why this function must stay
+ * the single producer for every provider.
  */
 export function providerSignedOutMessage(providerId: ProviderId): string {
+  if (providerId === "reasonix") {
+    return "Reasonix has no API key configured. Run reasonix setup to continue.";
+  }
   return `${PROVIDER_DISPLAY_NAMES[providerId]} is signed out. Reconnect to continue.`;
 }


### PR DESCRIPTION
## Summary

Two fixes for a Reasonix user who has configured their key and still sees "Not authenticated" in the model picker, plus the wording those surfaces fall back to.

**The picker's refresh did not reach the verdict it was showing.** The refresh button invalidated only the harness catalog, model list and command list. The picker's auth line and its degraded-tab set read `providers.list`, which the GUI holds for fifteen minutes, and the catalog row's own `authStatus` cannot stand in: the host fills it from a thirty-second cache and omits it once that expires. Invalidating the list is not enough either: a plain refetch serves the last-known verdict while the host re-probes in the background. The refresh now issues the forced `providers.list` request the Settings and banner refresh buttons use, through a new client-scoped `useRefreshProvidersForClient`, commits the response under the host's classic key, and then invalidates only the catalog scopes that commit does not already cover.

**Every signed-out surface described a sign-in Reasonix does not have.** Reasonix reads provider keys from `<reasonix-home>/.env` and nowhere else (byte-verified against the shipped 1.35.0 binary: the same key exported into the process environment produced an outbound `x-api-key` of length 0), and its own startup warning (`missing env DEEPSEEK_API_KEY`) sends people to export a shell variable that does nothing. Three surfaces now carry per-provider setup guidance from one map (`lib/providers/provider-setup-guidance.ts`, Reasonix is the only entry today):

- the picker's auth line, when the model list still has rows (the host serves the last good catalog through a sign-out). Its verdict reads the `providers.list` state, the catalog row's `authStatus` and the model list's signed-out failure, and works from the catalog row alone while the list state is absent;
- the model list's signed-out error state, which replaces the host sentence plus a report-issue icon with a setup CTA. The auth line drops to its compact label when this CTA is showing, so the popover never says it twice;
- the composer reauth banner's terminal row, whose button reads "Set up in terminal" and whose hint stops promising a sign-in code.

The steps point at that banner action, which runs the selected binary's `setup` in a terminal on the composer's host. A bare `reasonix setup` is kept only as the labelled self-install alternative, since the bundled pack is not on PATH and a remote host must be configured on that machine. There is no Settings button: Settings has no terminal sign-in for such a provider.

**The protocol's fallback sentence names the real fix.** `providerSignedOutMessage("reasonix")` now returns "Reasonix has no usable API key configured. Run reasonix setup to continue." instead of "Reasonix is signed out. Reconnect to continue." "Usable" because the same helper heads a prompt-time 401 on a present but rejected key. That sentence heads the composer reauth banner, the host's recoverable auth event, the picker's error row and the agent-stopped notification body. Every other provider keeps the generic form; a protocol test pins both. The renderer recognises the signed-out catalog verdict by exact match against this helper (the error carries no code) and, until no supported host predates this change, also accepts the legacy generic form a host built against the older protocol still sends. The host picks the new wording up on the next submodule pin bump, and its reasonix adapter test already asserts the event message through this helper.

## Related issue

None filed; reported from the staging build during the Reasonix release.

## Checklist

- [x] Pre-commit static checks pass (`pre-commit run --all-files` for an explicit full-repo run)
- [x] Separate CI test checks pass
- [x] Tests added/updated where it makes sense
- [x] Commits are signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#developer-certificate-of-origin-dco)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
