### PR TITLE
fix(gui-app): reveal sidebar targets and identify browser hosts

### DIFF
--- a/clients/desktop/src/electron-main/browser-view/__tests__/browser-view-manager.test.ts
+++ b/clients/desktop/src/electron-main/browser-view/__tests__/browser-view-manager.test.ts
@@ -637,6 +637,7 @@ interface Harness {
   readonly views: FakeBrowserView[];
   readonly nativeTabStatuses: BrowserViewNativeTabStatusChange[];
   readonly nativeTabStatusWindowIds: string[];
+  readonly focusedTiles: BrowserViewTileKey[];
   readonly finds: BrowserViewFindChange[];
   readonly downloads: BrowserViewDownloadChange[];
   readonly certificateErrors: BrowserViewCertificateErrorChange[];
@@ -709,6 +710,7 @@ function createHarnessWithOptions(
   const views: FakeBrowserView[] = [];
   const nativeTabStatuses: BrowserViewNativeTabStatusChange[] = [];
   const nativeTabStatusWindowIds: string[] = [];
+  const focusedTiles: BrowserViewTileKey[] = [];
   const finds: BrowserViewFindChange[] = [];
   const downloads: BrowserViewDownloadChange[] = [];
   const certificateErrors: BrowserViewCertificateErrorChange[] = [];
@@ -798,6 +800,9 @@ function createHarnessWithOptions(
         case RunnerHostEvent.browserViewOpenTileRequest:
           record(openTileRequests, payload);
           return true;
+        case RunnerHostEvent.browserViewTileFocused:
+          record(focusedTiles, payload);
+          return true;
         case RunnerHostEvent.browserViewSnapshotInvalidated:
           record(snapshotInvalidations, payload);
           return true;
@@ -833,6 +838,7 @@ function createHarnessWithOptions(
     views,
     nativeTabStatuses,
     nativeTabStatusWindowIds,
+    focusedTiles,
     finds,
     downloads,
     certificateErrors,
@@ -1029,6 +1035,20 @@ describe("BrowserViewManager isolated sessions", () => {
 });
 
 describe("BrowserViewManager native tab lifecycle", () => {
+  it("notifies the owning renderer when an attached native guest receives focus", async () => {
+    const harness = createHarness();
+    const { view } = await attachNativeTab(
+      harness,
+      "window-1",
+      BASE_KEY,
+      "https://example.com/",
+    );
+
+    view.webContents.emit("focus");
+
+    expect(harness.focusedTiles).toEqual([BASE_TILE_KEY]);
+  });
+
   it("provisions CDP before acceptance and starts navigation only after acceptance", async () => {
     const harness = createHarnessWithOptions({
       requireLoadedTargetForPageCommands: true,

--- a/clients/desktop/src/electron-main/browser-view/browser-view-manager.ts
+++ b/clients/desktop/src/electron-main/browser-view/browser-view-manager.ts
@@ -265,6 +265,14 @@ export class BrowserViewManager {
       emitStatus: (entry) => {
         this.emitStatus(entry);
       },
+      emitFocus: (entry) => {
+        if (entry.surface === null) return;
+        this.send(
+          entry.surface.windowId,
+          RunnerHostEvent.browserViewTileFocused,
+          toTileKey(entry.surface),
+        );
+      },
       closeEntry: (entry) => {
         void this.closeEntry(entry);
       },

--- a/clients/desktop/src/electron-main/browser-view/manager/browser-view-entry-factory.ts
+++ b/clients/desktop/src/electron-main/browser-view/manager/browser-view-entry-factory.ts
@@ -49,6 +49,7 @@ interface BrowserViewEntryFactoryOptions {
     reason: string | null,
   ) => void;
   readonly emitStatus: (entry: BrowserViewEntry) => void;
+  readonly emitFocus: (entry: BrowserViewEntry) => void;
   readonly closeEntry: (entry: BrowserViewEntry) => void;
 }
 
@@ -81,6 +82,7 @@ export class BrowserViewEntryFactory {
     reason: string | null,
   ) => void;
   private readonly emitStatus: (entry: BrowserViewEntry) => void;
+  private readonly emitFocus: (entry: BrowserViewEntry) => void;
   private readonly closeEntry: (entry: BrowserViewEntry) => void;
 
   constructor(options: BrowserViewEntryFactoryOptions) {
@@ -96,6 +98,7 @@ export class BrowserViewEntryFactory {
     this.observePrimaryProfileOrigin = options.observePrimaryProfileOrigin;
     this.setStatus = options.setStatus;
     this.emitStatus = options.emitStatus;
+    this.emitFocus = options.emitFocus;
     this.closeEntry = options.closeEntry;
   }
 
@@ -157,6 +160,9 @@ export class BrowserViewEntryFactory {
         },
         "found-in-page": (_event: Event, result: Result): void => {
           this.find.handleFoundInPage(entry, result);
+        },
+        focus: (): void => {
+          this.emitFocus(entry);
         },
         "page-title-updated": (): void => {
           if (entry.internalNavigation) return;

--- a/clients/desktop/src/electron-preload/browser-view-bridge.ts
+++ b/clients/desktop/src/electron-preload/browser-view-bridge.ts
@@ -213,6 +213,11 @@ export function buildBrowserViewBridge(): { browserView: BrowserViewBridge } {
           RunnerHostEvent.browserViewTileCommand,
           handler,
         ),
+      onTileFocused: (handler) =>
+        subscribe<BrowserViewTileKey>(
+          RunnerHostEvent.browserViewTileFocused,
+          handler,
+        ),
       onSnapshotInvalidated: (handler) =>
         subscribe<BrowserViewSnapshotInvalidatedChange>(
           RunnerHostEvent.browserViewSnapshotInvalidated,

--- a/clients/desktop/src/ipc-contracts/ipc-channels.ts
+++ b/clients/desktop/src/ipc-contracts/ipc-channels.ts
@@ -454,6 +454,7 @@ export const RunnerHostEvent = {
   browserViewCertificateError: "runnerHost:event:browserView:certificateError",
   browserViewOpenTileRequest: "runnerHost:event:browserView:openTileRequest",
   browserViewTileCommand: "runnerHost:event:browserView:tileCommand",
+  browserViewTileFocused: "runnerHost:event:browserView:tileFocused",
   browserViewSnapshotInvalidated:
     "runnerHost:event:browserView:snapshotInvalidated",
   // Ticket 04 exit-edge handshake: fired once the un-parked native view's

--- a/clients/desktop/src/renderer-shell/__tests__/desktop-runner-host.test.ts
+++ b/clients/desktop/src/renderer-shell/__tests__/desktop-runner-host.test.ts
@@ -608,6 +608,7 @@ function buildFakeBridge(
       onOpenTileRequest: (_handler) => ({ dispose: () => undefined }),
       onOverlayTileRestored: (_handler) => ({ dispose: () => undefined }),
       onTileCommand: (_handler) => ({ dispose: () => undefined }),
+      onTileFocused: (_handler) => ({ dispose: () => undefined }),
       onSnapshotInvalidated: (_handler) => ({ dispose: () => undefined }),
       onAnnotationEvent: (_handler) => ({ dispose: () => undefined }),
       onAnnotationAttached: (_handler) => ({ dispose: () => undefined }),

--- a/clients/gui-app/src/components/epic-canvas/__tests__/tab-group-view.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/tab-group-view.test.tsx
@@ -60,6 +60,18 @@ import {
 import { buildSyntheticTileSurfaceEnvironment } from "@/components/epic-canvas/surface-host/__tests__/synthetic-tile-surface-fixture";
 import { EpicSessionContext } from "@/lib/registries/epic-session-registry";
 import type { OpenEpicStoreHandle } from "@/stores/epics/open-epic/store";
+import { epicTerminalUiIdentityKey } from "@/lib/terminals/pending-create-identity";
+
+vi.mock("@/hooks/terminal/use-epic-terminal-authority", () => ({
+  useEpicTerminalAuthority: () => ({
+    capability: "legacy",
+    projection: undefined,
+    viewModel: null,
+    canMutate: false,
+    migrationPending: false,
+    rename: { mutate: vi.fn() },
+  }),
+}));
 
 const VIEW_TAB_ID = "view-tab-1";
 
@@ -411,6 +423,16 @@ const CHAT: EpicCanvasTileRef = {
   type: "chat",
   name: "Chat",
   hostId: "host-A",
+};
+
+const TERMINAL: EpicCanvasTileRef = {
+  id: "terminal-1",
+  instanceId: "inst-terminal-1",
+  type: "terminal",
+  name: "Terminal",
+  hostId: "host-A",
+  titleSource: "default",
+  cwd: "/repo",
 };
 
 function specTab(n: number): EpicCanvasTileRef {
@@ -2225,6 +2247,33 @@ describe("<TabGroupView /> Reveal in Sidebar", () => {
     ).toEqual({ nodeId: CHAT.id, nonce: 1 });
     expect(useEpicLeftPanelStore.getState().getActivePanelId(VIEW_TAB_ID)).toBe(
       "chats",
+    );
+  });
+
+  it("targets a host-bound terminal row", () => {
+    const tabs = [SPEC, TERMINAL];
+    seedCanvas(tabs, SPEC.instanceId);
+    render(groupView(tabs, SPEC.instanceId, true));
+
+    fireEvent.contextMenu(
+      screen.getByTestId(`tab-item-${TERMINAL.instanceId}`),
+    );
+    fireEvent.click(
+      screen.getByRole("menuitem", { name: "Reveal in Sidebar" }),
+    );
+
+    expect(
+      useSidebarNodeRevealStore.getState().requestsByViewTabId[VIEW_TAB_ID],
+    ).toEqual({
+      nodeId: epicTerminalUiIdentityKey(
+        "session",
+        TERMINAL.hostId,
+        TERMINAL.id,
+      ),
+      nonce: 1,
+    });
+    expect(useEpicLeftPanelStore.getState().getActivePanelId(VIEW_TAB_ID)).toBe(
+      "terminals",
     );
   });
 });

--- a/clients/gui-app/src/components/epic-canvas/__tests__/tab-group-view.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/tab-group-view.test.tsx
@@ -2132,7 +2132,10 @@ describe("<TabGroupView /> Reveal in Sidebar", () => {
     testState.missingArtifactIds.clear();
     useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
     useFileTreeRevealStore.setState({ requestsByViewTabId: {} }, true);
-    useSidebarNodeRevealStore.setState({ requestsByViewTabId: {} }, true);
+    useSidebarNodeRevealStore.setState(
+      { requestsByViewTabId: {}, visibleByViewTabId: {} },
+      true,
+    );
     useSurfaceHostSelectionStore.getState().resetForTests();
     useEpicLeftPanelStore.setState(
       useEpicLeftPanelStore.getInitialState(),

--- a/clients/gui-app/src/components/epic-canvas/__tests__/tab-group-view.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/tab-group-view.test.tsx
@@ -31,6 +31,10 @@ import {
 import { useFileTreeRevealStore } from "@/stores/file-tree/file-tree-reveal-store";
 import { useSidebarNodeRevealStore } from "@/stores/epics/sidebar-node-reveal-store";
 import { useEpicLeftPanelStore } from "@/stores/epics/left-panel-store";
+import {
+  tabSurfaceKey,
+  useSurfaceHostSelectionStore,
+} from "@/stores/host/surface-host-selection-store";
 import { useTabsStore } from "@/stores/tabs/store";
 import type { TabRef } from "@/stores/tabs/types";
 import { tabCommandCoordinator } from "@/stores/tabs/tab-command-coordinator";
@@ -145,6 +149,10 @@ vi.mock("@dnd-kit/core", () => ({
 // mounts without a HostRuntimeProvider / EpicSessionProvider.
 vi.mock("@/components/epic-canvas/canvas/use-rename-canvas-tab", () => ({
   useRenameCanvasTab: () => () => undefined,
+}));
+
+vi.mock("@/components/epic-canvas/canvas/browser-tab-presentation", () => ({
+  useBrowserTabPresentation: () => null,
 }));
 
 // TabItem resolves the tab's bound-host client for terminal renames; these
@@ -2103,6 +2111,7 @@ describe("<TabGroupView /> Reveal in Sidebar", () => {
     useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
     useFileTreeRevealStore.setState({ requestsByViewTabId: {} }, true);
     useSidebarNodeRevealStore.setState({ requestsByViewTabId: {} }, true);
+    useSurfaceHostSelectionStore.getState().resetForTests();
     useEpicLeftPanelStore.setState(
       useEpicLeftPanelStore.getInitialState(),
       true,
@@ -2117,6 +2126,17 @@ describe("<TabGroupView /> Reveal in Sidebar", () => {
     hostId: "host-A",
     workspacePath: "/repo",
     filePath: "src/lib/a.ts",
+  };
+
+  const BROWSER_TAB: EpicCanvasTileRef = {
+    id: "browser-session:sess-1:browser-tab-1",
+    instanceId: "inst-browser-1",
+    type: "browser-session",
+    name: "Browser",
+    hostId: "host-B",
+    sessionId: "sess-1",
+    tabId: "browser-tab-1",
+    viewportPreset: "responsive",
   };
 
   it("writes a reveal request and switches to the Files panel for a workspace-file tab", () => {
@@ -2147,7 +2167,7 @@ describe("<TabGroupView /> Reveal in Sidebar", () => {
     ).toBe("file-tree");
   });
 
-  it("writes no reveal request for a non-file tab and switches to its own panel", () => {
+  it("writes a reveal request for an artifact tab and switches to its own panel", () => {
     const tabs = [SPEC, WORKSPACE_FILE_TAB];
     seedCanvas(tabs, SPEC.instanceId);
     render(groupView(tabs, SPEC.instanceId, true));
@@ -2158,11 +2178,36 @@ describe("<TabGroupView /> Reveal in Sidebar", () => {
     );
 
     expect(
-      useFileTreeRevealStore.getState().requestsByViewTabId[VIEW_TAB_ID],
-    ).toBeUndefined();
+      useSidebarNodeRevealStore.getState().requestsByViewTabId[VIEW_TAB_ID],
+    ).toEqual({ nodeId: SPEC.id, nonce: 1 });
     expect(
       useEpicLeftPanelStore.getState().activePanelIdByTabId[VIEW_TAB_ID],
     ).toBe("artifacts");
+  });
+
+  it("targets the browser row, panel, and host for an independent browser tab", () => {
+    const tabs = [SPEC, BROWSER_TAB];
+    seedCanvas(tabs, BROWSER_TAB.instanceId);
+    render(groupView(tabs, BROWSER_TAB.instanceId, true));
+
+    fireEvent.contextMenu(
+      screen.getByTestId(`tab-item-${BROWSER_TAB.instanceId}`),
+    );
+    fireEvent.click(
+      screen.getByRole("menuitem", { name: "Reveal in Sidebar" }),
+    );
+
+    expect(
+      useSidebarNodeRevealStore.getState().requestsByViewTabId[VIEW_TAB_ID],
+    ).toEqual({ nodeId: BROWSER_TAB.id, nonce: 1 });
+    expect(useEpicLeftPanelStore.getState().getActivePanelId(VIEW_TAB_ID)).toBe(
+      "browsers",
+    );
+    expect(
+      useSurfaceHostSelectionStore.getState().selections[
+        tabSurfaceKey("browsers", VIEW_TAB_ID)
+      ],
+    ).toBe(BROWSER_TAB.hostId);
   });
 
   it("writes a node reveal request for an agent tab", () => {

--- a/clients/gui-app/src/components/epic-canvas/canvas/tab-group-view.tsx
+++ b/clients/gui-app/src/components/epic-canvas/canvas/tab-group-view.tsx
@@ -33,7 +33,10 @@ import {
   usePaneActivationOwnership,
 } from "@/components/epic-canvas/pane-activation";
 import { cn } from "@/lib/utils";
-import { hasTerminalPendingCreate } from "@/lib/terminals/pending-create-identity";
+import {
+  epicTerminalUiIdentityKey,
+  hasTerminalPendingCreate,
+} from "@/lib/terminals/pending-create-identity";
 import {
   useEpicCanvasStore,
   useIsActivePane,
@@ -102,6 +105,7 @@ import {
 } from "@/stores/epics/left-panel-store";
 import { isEditableRole } from "@/lib/epic-permissions";
 import { useEpicNestedFocusNavigation } from "@/hooks/epic/use-epic-nested-focus-navigation";
+import { prDetailTileId } from "@/lib/pr/pr-detail-tile";
 
 interface TabGroupViewProps {
   readonly epicId: string;
@@ -137,6 +141,33 @@ function panelIdForTabType(
   if (tabType === TILE_KIND_PR_DIFF) return "pull-requests";
   if (tabType === TILE_KIND_BROWSER_SESSION) return "browsers";
   return "artifacts";
+}
+
+function sidebarRevealNodeIdForTab(tab: EpicCanvasTileRef): string | null {
+  if (isTileRefRecordBacked(tab)) return tab.id;
+  switch (tab.type) {
+    case TILE_KIND_BROWSER_SESSION:
+      return tab.id;
+    case "terminal":
+      return epicTerminalUiIdentityKey("session", tab.hostId, tab.id);
+    case TILE_KIND_PUBLISHED_CHAT:
+      return tab.chatId;
+    case TILE_KIND_SNAPSHOT_DIFF:
+      return tab.diff.chatId;
+    case TILE_KIND_PR_DETAIL:
+    case TILE_KIND_PR_DIFF:
+      return prDetailTileId({
+        hostId: tab.hostId,
+        githubHost: tab.githubHost,
+        owner: tab.owner,
+        repo: tab.repo,
+        prNumber: tab.prNumber,
+      });
+    case TILE_KIND_GIT_DIFF:
+      return tab.diff.kind === "file" ? tab.id : null;
+    default:
+      return null;
+  }
 }
 
 /**
@@ -349,11 +380,10 @@ export const TabGroupView = memo(function TabGroupView(
           filePath: tab.filePath,
         });
       }
-      if (
-        tab !== undefined &&
-        (isTileRefRecordBacked(tab) || tab.type === TILE_KIND_BROWSER_SESSION)
-      ) {
-        requestSidebarNodeReveal(tabId, tab.id);
+      const sidebarNodeId =
+        tab === undefined ? null : sidebarRevealNodeIdForTab(tab);
+      if (sidebarNodeId !== null) {
+        requestSidebarNodeReveal(tabId, sidebarNodeId);
       }
       if (tab?.type === TILE_KIND_BROWSER_SESSION) {
         useSurfaceHostSelectionStore

--- a/clients/gui-app/src/components/epic-canvas/canvas/tab-group-view.tsx
+++ b/clients/gui-app/src/components/epic-canvas/canvas/tab-group-view.tsx
@@ -82,12 +82,17 @@ import { reportChatRemoteDeletionState } from "@/components/epic-canvas/surface-
 import { resolveHostedTileOwnership } from "@/components/epic-canvas/surface-host/hosted-tile-resolver";
 import { HOSTED_TILE_RECORD_SELECTOR } from "@/components/epic-canvas/surface-host/hosted-tile-dom";
 import {
+  TILE_KIND_BROWSER_SESSION,
   TILE_KIND_GIT_DIFF,
   TILE_KIND_PUBLISHED_CHAT,
   TILE_KIND_PR_DETAIL,
   TILE_KIND_PR_DIFF,
   TILE_KIND_SNAPSHOT_DIFF,
 } from "@/stores/epics/canvas/tile-kinds";
+import {
+  tabSurfaceKey,
+  useSurfaceHostSelectionStore,
+} from "@/stores/host/surface-host-selection-store";
 
 import { TabStrip } from "@/components/epic-canvas/canvas/tab-strip";
 import { useRenameCanvasTab } from "@/components/epic-canvas/canvas/use-rename-canvas-tab";
@@ -130,6 +135,7 @@ function panelIdForTabType(
   if (tabType === WORKSPACE_FILE_TAB_KIND) return "file-tree";
   if (tabType === TILE_KIND_PR_DETAIL) return "pull-requests";
   if (tabType === TILE_KIND_PR_DIFF) return "pull-requests";
+  if (tabType === TILE_KIND_BROWSER_SESSION) return "browsers";
   return "artifacts";
 }
 
@@ -345,9 +351,14 @@ export const TabGroupView = memo(function TabGroupView(
       }
       if (
         tab !== undefined &&
-        (tab.type === "chat" || tab.type === "terminal-agent")
+        (isTileRefRecordBacked(tab) || tab.type === TILE_KIND_BROWSER_SESSION)
       ) {
         requestSidebarNodeReveal(tabId, tab.id);
+      }
+      if (tab?.type === TILE_KIND_BROWSER_SESSION) {
+        useSurfaceHostSelectionStore
+          .getState()
+          .setSelection(tabSurfaceKey("browsers", tabId), tab.hostId);
       }
       setActivePanelIdAndExpand(tabId, panelIdForTabType(tab?.type));
     },

--- a/clients/gui-app/src/components/epic-canvas/git-diff/__tests__/file-tree-navigation.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/__tests__/file-tree-navigation.test.tsx
@@ -1,13 +1,27 @@
 import type { MouseEvent, ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import type { GitChangedFileV11 } from "@traycer/protocol/host";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 import type { NestedFocusTarget } from "@/lib/epic-nested-focus-route";
+import { makeGitFileDiffTileForFile } from "@/lib/git/git-diff-tile";
+import {
+  requestSidebarNodeReveal,
+  useSidebarNodeRevealStore,
+} from "@/stores/epics/sidebar-node-reveal-store";
 import { FileTree as GitDiffFileTree } from "../file-tree";
 
 const testState = vi.hoisted(() => ({
   treePath: "src/app.ts",
+  activeFilePath: null as string | null,
+  scrollToPath: vi.fn(),
   navigateNested: vi.fn(
     (
       _epicId: string,
@@ -45,8 +59,8 @@ vi.mock("../git-diff-section", () => ({
 }));
 
 vi.mock("../use-git-panel-active-file", () => ({
-  gitPanelActiveFilePathForGroup: () => null,
-  useGitPanelActiveFile: () => null,
+  gitPanelActiveFilePathForGroup: () => testState.activeFilePath,
+  useGitPanelActiveFile: () => testState.activeFilePath,
   useGitPanelRevealSection: () => undefined,
 }));
 
@@ -57,7 +71,8 @@ vi.mock("../use-git-pierre-file-tree-model", () => ({
       getSelectedPaths: () => [],
       getItem: () => null,
       getItemHeight: () => 24,
-      scrollToPath: () => undefined,
+      scrollToPath: testState.scrollToPath,
+      getFileTreeContainer: () => document.createElement("div"),
     },
     paths: files.map((file) => file.path),
     rowDirectoryPaths: ["src"],
@@ -121,6 +136,12 @@ describe("<FileTree /> nested focus navigation", () => {
     cleanup();
     resetCanvas();
     testState.navigateNested.mockClear();
+    testState.activeFilePath = null;
+    testState.scrollToPath.mockClear();
+    useSidebarNodeRevealStore.setState(
+      { requestsByViewTabId: {}, visibleByViewTabId: {} },
+      true,
+    );
   });
 
   it("routes tree-row preview through nested focus navigation", () => {
@@ -147,6 +168,32 @@ describe("<FileTree /> nested focus navigation", () => {
       tabId,
       expect.any(Function),
     );
+  });
+
+  it("scrolls again when revealing the already-active diff row", async () => {
+    const tabId = useEpicCanvasStore.getState().openEpicTab("epic-1", "Epic 1");
+    const file = changedFile();
+    testState.activeFilePath = file.path;
+    renderTree(tabId);
+    testState.scrollToPath.mockClear();
+
+    act(() => {
+      requestSidebarNodeReveal(
+        tabId,
+        makeGitFileDiffTileForFile({
+          hostId: "host-1",
+          runningDir: "/repo",
+          file,
+          repositoryContext: null,
+        }).id,
+      );
+    });
+
+    await waitFor(() => {
+      expect(testState.scrollToPath).toHaveBeenCalledWith(file.path, {
+        offset: "nearest",
+      });
+    });
   });
 
   /**

--- a/clients/gui-app/src/components/epic-canvas/git-diff/file-tree.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/file-tree.tsx
@@ -35,6 +35,11 @@ import { GitFileSectionStack } from "./git-file-section-stack";
 import type { GitFileSectionBodyRenderProps } from "./git-file-section-stack";
 import { useGitPierreFileTreeModel } from "./use-git-pierre-file-tree-model";
 import { onMiddleClick } from "@/lib/dom/on-middle-click";
+import {
+  clearSidebarNodeRevealRequest,
+  useSidebarNodeRevealRequest,
+} from "@/stores/epics/sidebar-node-reveal-store";
+import { flashSidebarElement } from "@/components/epic-canvas/sidebar/epic-sidebar-tree-shared";
 
 export interface FileTreeProps {
   readonly epicId: string;
@@ -211,6 +216,16 @@ function GitTreeSectionBody(props: GitTreeSectionBodyProps): ReactNode {
     },
     [fileByPath, props.hostId, props.repositoryContext, props.runningDir],
   );
+  const revealRequest = useSidebarNodeRevealRequest(props.viewTabId);
+  useEffect(() => {
+    if (activeFilePath === null || revealRequest === null) return;
+    const tile = tileForTreePath(activeFilePath);
+    if (tile?.id !== revealRequest.nodeId) return;
+    const container = model.getFileTreeContainer();
+    if (container === undefined) return;
+    flashSidebarElement(container, revealRequest.nonce);
+    clearSidebarNodeRevealRequest(props.viewTabId, revealRequest.nonce);
+  }, [activeFilePath, model, props.viewTabId, revealRequest, tileForTreePath]);
 
   const openFileFromTreeRow = useCallback(
     (event: MouseEvent<HTMLElement>, gesture: TileOpenGesture) => {

--- a/clients/gui-app/src/components/epic-canvas/git-diff/file-tree.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/file-tree.tsx
@@ -223,6 +223,7 @@ function GitTreeSectionBody(props: GitTreeSectionBodyProps): ReactNode {
     if (tile?.id !== revealRequest.nodeId) return;
     const container = model.getFileTreeContainer();
     if (container === undefined) return;
+    model.scrollToPath(activeFilePath, { offset: "nearest" });
     flashSidebarElement(container, revealRequest.nonce);
     clearSidebarNodeRevealRequest(props.viewTabId, revealRequest.nonce);
   }, [activeFilePath, model, props.viewTabId, revealRequest, tileForTreePath]);

--- a/clients/gui-app/src/components/epic-canvas/pierre-tree-theme.ts
+++ b/clients/gui-app/src/components/epic-canvas/pierre-tree-theme.ts
@@ -66,8 +66,27 @@ export const PIERRE_FILE_TREE_TRUNCATION_TOLERANCE_CSS = `
 }
 `;
 
+export const PIERRE_FILE_TREE_REVEAL_HIGHLIGHT_CSS = `
+:host([data-sidebar-reveal-highlighted="true"]) [data-item-selected="true"] {
+  background: color-mix(in oklab, var(--primary) 15%, transparent) !important;
+  box-shadow: inset 0 0 0 2px color-mix(in oklab, var(--primary) 80%, transparent);
+  animation: sidebar-reveal-pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+}
+
+@keyframes sidebar-reveal-pulse {
+  50% { opacity: 0.5; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :host([data-sidebar-reveal-highlighted="true"]) [data-item-selected="true"] {
+    animation: none;
+  }
+}
+`;
+
 export const GIT_PANEL_PIERRE_FILE_TREE_UNSAFE_CSS = `
 ${PIERRE_FILE_TREE_TRUNCATION_TOLERANCE_CSS}
+${PIERRE_FILE_TREE_REVEAL_HIGHLIGHT_CSS}
 
 [data-item-type="file"] [data-item-section="icon"] {
   opacity: 0.9;

--- a/clients/gui-app/src/components/epic-canvas/pr/__tests__/pr-panel-body.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/pr/__tests__/pr-panel-body.test.tsx
@@ -162,7 +162,10 @@ describe("PrPanelBody card list", () => {
 
   beforeEach(() => {
     resetCanvas();
-    useSidebarNodeRevealStore.setState({ requestsByViewTabId: {} }, true);
+    useSidebarNodeRevealStore.setState(
+      { requestsByViewTabId: {}, visibleByViewTabId: {} },
+      true,
+    );
     nestedFocusBoundaryMock.navigateNested.mockClear();
     queryClient = new QueryClient({
       defaultOptions: { queries: { retry: false } },
@@ -173,7 +176,10 @@ describe("PrPanelBody card list", () => {
   afterEach(() => {
     cleanup();
     resetCanvas();
-    useSidebarNodeRevealStore.setState({ requestsByViewTabId: {} }, true);
+    useSidebarNodeRevealStore.setState(
+      { requestsByViewTabId: {}, visibleByViewTabId: {} },
+      true,
+    );
     queryClient.clear();
   });
 

--- a/clients/gui-app/src/components/epic-canvas/pr/__tests__/pr-panel-body.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/pr/__tests__/pr-panel-body.test.tsx
@@ -21,6 +21,10 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { prDetailTileId } from "@/lib/pr/pr-detail-tile";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 import type { TilePane } from "@/stores/epics/canvas/tile-tree";
+import {
+  requestSidebarNodeReveal,
+  useSidebarNodeRevealStore,
+} from "@/stores/epics/sidebar-node-reveal-store";
 
 vi.mock("@/components/epic-canvas/hooks/use-canvas-host-id", () => ({
   useCanvasHostId: () => "host1",
@@ -47,16 +51,18 @@ vi.mock("@/components/epic-canvas/pr/pr-row", () => {
     },
     prefix: string,
   ) => (
-    <button
-      type="button"
-      key={mockLabel(entry.item)}
-      data-testid={`${prefix}-${mockLabel(entry.item)}`}
-      data-openable={entry.onOpen !== null ? "true" : "false"}
-      data-tile-id={entry.tileId ?? ""}
-      onClick={() => entry.onOpen?.()}
-    >
-      {mockLabel(entry.item)}
-    </button>
+    <div data-sidebar-node-id={entry.tileId ?? undefined}>
+      <button
+        type="button"
+        key={mockLabel(entry.item)}
+        data-testid={`${prefix}-${mockLabel(entry.item)}`}
+        data-openable={entry.onOpen !== null ? "true" : "false"}
+        data-tile-id={entry.tileId ?? ""}
+        onClick={() => entry.onOpen?.()}
+      >
+        {mockLabel(entry.item)}
+      </button>
+    </div>
   );
   return {
     PrRow: (props: {
@@ -156,6 +162,7 @@ describe("PrPanelBody card list", () => {
 
   beforeEach(() => {
     resetCanvas();
+    useSidebarNodeRevealStore.setState({ requestsByViewTabId: {} }, true);
     nestedFocusBoundaryMock.navigateNested.mockClear();
     queryClient = new QueryClient({
       defaultOptions: { queries: { retry: false } },
@@ -166,6 +173,7 @@ describe("PrPanelBody card list", () => {
   afterEach(() => {
     cleanup();
     resetCanvas();
+    useSidebarNodeRevealStore.setState({ requestsByViewTabId: {} }, true);
     queryClient.clear();
   });
 
@@ -192,6 +200,40 @@ describe("PrPanelBody card list", () => {
     expect(
       screen.getByTestId("mock-pr-card-feature/unknown-base"),
     ).toBeTruthy();
+  });
+
+  it("scrolls to and flash-highlights a revealed PR row", async () => {
+    const epicId = "epic-reveal";
+    const tabId = "tab-reveal";
+    const item = buildPrItem({
+      base: { owner: "acme", repo: "widgets", prNumber: 42 },
+      githubHost: "github.com",
+    });
+    const tileId = prDetailTileId({
+      hostId: "host1",
+      githubHost: "github.com",
+      owner: "acme",
+      repo: "widgets",
+      prNumber: 42,
+    });
+    const scrollIntoView = vi
+      .spyOn(Element.prototype, "scrollIntoView")
+      .mockImplementation(() => undefined);
+    requestSidebarNodeReveal(tabId, tileId);
+    renderPanel({ epicId, tabId });
+
+    await emitSnapshot(epicId, [item]);
+
+    const row = screen
+      .getByTestId("mock-pr-card-acme/widgets#42")
+      .closest<HTMLElement>("[data-sidebar-node-id]");
+    await waitFor(() => {
+      expect(scrollIntoView.mock.instances).toContain(row);
+    });
+    expect(row?.dataset.sidebarRevealHighlighted).toBe("true");
+    expect(
+      useSidebarNodeRevealStore.getState().requestsByViewTabId[tabId],
+    ).toBeUndefined();
   });
 
   it("gives an owned-submodule PR its own repo group directly under its superproject's", async () => {

--- a/clients/gui-app/src/components/epic-canvas/pr/pr-panel-body.tsx
+++ b/clients/gui-app/src/components/epic-canvas/pr/pr-panel-body.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useMemo, useState, type ReactNode } from "react";
+import {
+  useCallback,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 import {
   AlertCircle,
   ChevronRight,
@@ -34,6 +41,11 @@ import {
   useMainPanelCollapsed,
 } from "@/stores/epics/left-panel-store";
 import { tileIntent } from "@/lib/canvas/tile-open/intent";
+import {
+  clearSidebarNodeRevealRequest,
+  useSidebarNodeRevealRequest,
+} from "@/stores/epics/sidebar-node-reveal-store";
+import { revealSidebarNode } from "@/components/epic-canvas/sidebar/epic-sidebar-tree-shared";
 
 /**
  * Pull Requests panel body. Subscribes in foreground mode on the canvas host
@@ -174,6 +186,34 @@ function PrPanelBodyContent(props: {
     },
     [epicId, hostId, openTile],
   );
+  const regionRef = useRef<HTMLDivElement>(null);
+  const revealRequest = useSidebarNodeRevealRequest(props.tabId);
+  const revealedRepo =
+    revealRequest === null
+      ? undefined
+      : groups.find((group) =>
+          group.items.some(
+            (item) => buildEntry(item).tileId === revealRequest.nodeId,
+          ),
+        );
+  const revealedRepoLabel =
+    revealedRepo === undefined
+      ? null
+      : formatRepoGroupLabel(revealedRepo.repoIdentifier);
+  useLayoutEffect(() => {
+    if (revealRequest === null || revealedRepoLabel === null) return;
+    if (
+      regionRef.current === null ||
+      !revealSidebarNode(
+        regionRef.current,
+        revealRequest.nodeId,
+        revealRequest.nonce,
+      )
+    ) {
+      return;
+    }
+    clearSidebarNodeRevealRequest(props.tabId, revealRequest.nonce);
+  }, [props.tabId, revealRequest, revealedRepoLabel]);
 
   if (props.isPending && !props.hasCachedData) {
     return (
@@ -209,6 +249,7 @@ function PrPanelBodyContent(props: {
 
   return (
     <div
+      ref={regionRef}
       // Groups are separated by WHITESPACE, not another hairline. With every
       // repo header and every row sharing one continuous ruled stack, a header
       // read as just another row and the eye could not find where one repo's
@@ -242,9 +283,10 @@ function PrPanelBodyContent(props: {
           epicId={props.epicId}
           tabId={props.tabId}
           group={group}
-          collapsed={collapsedRepos.has(
-            formatRepoGroupLabel(group.repoIdentifier),
-          )}
+          collapsed={
+            collapsedRepos.has(formatRepoGroupLabel(group.repoIdentifier)) &&
+            revealedRepoLabel !== formatRepoGroupLabel(group.repoIdentifier)
+          }
           onToggle={toggleRepo}
           buildEntry={buildEntry}
         />

--- a/clients/gui-app/src/components/epic-canvas/pr/pr-row.tsx
+++ b/clients/gui-app/src/components/epic-canvas/pr/pr-row.tsx
@@ -45,6 +45,7 @@ import { useRelativeTimestamp } from "@/lib/relative-time";
 import { useIsActiveTile } from "@/stores/epics/canvas/store";
 import { cn } from "@/lib/utils";
 import { onMiddleClick } from "@/lib/dom/on-middle-click";
+import { SIDEBAR_REVEAL_HIGHLIGHT_CLASS } from "@/components/epic-canvas/sidebar/epic-sidebar-tree-shared";
 
 /**
  * Every badge on row 1 speaks the hover card's dialect: borderless tint,
@@ -192,8 +193,12 @@ export function PrRow(props: {
 
   return (
     <div
-      className="group/pr-row flex min-w-0 flex-col"
+      className={cn(
+        "group/pr-row flex min-w-0 flex-col",
+        SIDEBAR_REVEAL_HIGHLIGHT_CLASS,
+      )}
       data-testid="pr-row"
+      data-sidebar-node-id={props.entry.tileId ?? undefined}
       data-active={isActive ? "true" : "false"}
       data-pr-state={item.state}
       data-pr-identified={identified !== null ? "true" : "false"}

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/agent-browser-tile.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/agent-browser-tile.test.tsx
@@ -14,7 +14,9 @@ import type {
   BrowserViewBoundsUpdate,
   BrowserViewTileCommand,
   BrowserViewTileCommandEvent,
+  BrowserViewTileKey,
 } from "@traycer-clients/shared/platform/browser-view";
+import { registerHostedPaneActivationClaim } from "@/components/epic-canvas/pane-activation";
 
 const state = vi.hoisted(() => ({
   visible: true,
@@ -178,6 +180,25 @@ interface NativeStatusChange {
 }
 
 class TestBridge {
+  private tileFocusedHandler: ((tile: BrowserViewTileKey) => void) | null =
+    null;
+
+  onTileFocused(handler: (tile: BrowserViewTileKey) => void): {
+    dispose: () => void;
+  } {
+    this.tileFocusedHandler = handler;
+    return { dispose: () => (this.tileFocusedHandler = null) };
+  }
+
+  emitTileFocused(): void {
+    this.tileFocusedHandler?.({
+      viewTabId: "view-1",
+      paneId: "pane-1",
+      tileInstanceId: "tile-1",
+      pageSessionId: "browser-session:session-1:tab-1",
+    });
+  }
+
   private statusHandler: ((change: NativeStatusChange) => void) | null = null;
 
   onNativeTabStatusChange(handler: (change: NativeStatusChange) => void): {
@@ -387,6 +408,27 @@ describe("ElectronTabSurface", () => {
 
     expect(screen.getByText("Local servers")).toBeTruthy();
     expect(bindSurface).not.toHaveBeenCalled();
+  });
+
+  it("activates its pane when the native browser guest receives focus", () => {
+    const claim = vi.fn();
+    const unregister = registerHostedPaneActivationClaim(
+      "view-1",
+      "pane-1",
+      claim,
+    );
+    renderTile(createRecordingBinding());
+
+    act(() => {
+      state.bridge?.emitTileFocused();
+    });
+
+    expect(claim).toHaveBeenCalledExactlyOnceWith({
+      defaultPrevented: false,
+      scope: null,
+      target: null,
+    });
+    unregister();
   });
 
   it("detaches the native surface when the tile becomes hidden", async () => {

--- a/clients/gui-app/src/components/epic-canvas/renderers/agent-browser-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/agent-browser-tile.tsx
@@ -51,6 +51,7 @@ import {
   DEFAULT_BROWSER_TILE_URL,
   makeBrowserSessionTileRef,
 } from "@/stores/epics/canvas/tile-schema/browser-tile";
+import { claimHostedPaneActivation } from "@/components/epic-canvas/pane-activation";
 
 interface ElectronTabSurfaceNode {
   readonly id: string;
@@ -276,6 +277,21 @@ export function ElectronTabSurface(props: ElectronTabSurfaceProps) {
       props.viewTabId,
     ],
   );
+
+  useEffect(() => {
+    if (browserView === null) return;
+    const subscription = browserView.onTileFocused((focusedTile) => {
+      if (!isSameBrowserViewTile(focusedTile, tileKey)) return;
+      claimHostedPaneActivation(props.viewTabId, props.paneId, {
+        defaultPrevented: false,
+        scope: null,
+        target: null,
+      });
+    });
+    return () => {
+      subscription.dispose();
+    };
+  }, [browserView, props.paneId, props.viewTabId, tileKey]);
 
   useEffect(() => {
     if (browserView === null) return;

--- a/clients/gui-app/src/components/epic-canvas/renderers/browser-start-page.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/browser-start-page.tsx
@@ -5,6 +5,7 @@ import {
   useHostDirectoryEntryForHostId,
 } from "@/hooks/host/use-host-client-for-host-id";
 import { useHostQuery } from "@/hooks/host/use-host-query";
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 
 interface BrowserStartPageProps {
   readonly epicId: string;
@@ -17,6 +18,7 @@ export function BrowserStartPage(props: BrowserStartPageProps) {
   const headingId = useId();
   const client = useHostClientForHostId(props.hostId);
   const hostEntry = useHostDirectoryEntryForHostId(props.hostId);
+  const hostLabel = hostEntry?.label ?? props.hostId;
   const localServersReachable =
     client !== null && (props.browserRunsOnHost || hostEntry?.kind === "local");
   const query = useHostQuery({
@@ -39,10 +41,26 @@ export function BrowserStartPage(props: BrowserStartPageProps) {
         aria-labelledby={headingId}
         className="mx-auto w-full max-w-3xl px-4 py-6 sm:px-6 sm:py-10"
       >
-        <div className="mb-5 flex items-center gap-2 text-muted-foreground">
+        <div className="mb-5 flex min-w-0 items-center gap-2 text-muted-foreground">
           <RadioTower className="size-5" aria-hidden />
-          <h2 id={headingId} className="text-ui-lg font-medium text-foreground">
-            Local servers
+          <h2
+            id={headingId}
+            className="flex min-w-0 items-baseline gap-2 text-ui-lg font-medium text-foreground"
+          >
+            <span className="shrink-0">Local servers</span>
+            <TooltipWrapper
+              label={hostLabel}
+              side="top"
+              sideOffset={undefined}
+              align={undefined}
+            >
+              <span
+                className="min-w-0 truncate text-ui-sm font-normal text-muted-foreground"
+                aria-label={hostLabel}
+              >
+                on {hostLabel}
+              </span>
+            </TooltipWrapper>
           </h2>
         </div>
         {servers.length > 0 ? (

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-browser-sidebar.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-browser-sidebar.test.tsx
@@ -38,6 +38,10 @@ import { BROWSERS_UNSUPPORTED_MESSAGE } from "@traycer-clients/shared/platform/b
 import { dismissPip } from "@/lib/browser-view/pip/pip-store";
 import { usePanelHeaderSearchStore } from "@/stores/epics/panel-header-search-store";
 import { usePanelHeaderMenuStore } from "@/stores/epics/panel-header-menu-store";
+import {
+  requestSidebarNodeReveal,
+  useSidebarNodeRevealStore,
+} from "@/stores/epics/sidebar-node-reveal-store";
 
 const dndState = vi.hoisted(() => ({
   draggables: [] as Array<{
@@ -308,6 +312,7 @@ describe("BrowsersPanelBody", () => {
       usePanelHeaderMenuStore.getInitialState(),
       true,
     );
+    useSidebarNodeRevealStore.setState({ requestsByViewTabId: {} }, true);
     seedCanvasTab();
     sessionsState.value = {
       hostId: "host-1",
@@ -401,6 +406,27 @@ describe("BrowsersPanelBody", () => {
     ).toContain("cursor-pointer");
     const isoRow = screen.getByTestId("epic-browser-sidebar-row-tab-iso");
     expect(isoRow.innerHTML).toContain("ring-amber-500/80");
+  });
+
+  it("scrolls to and flash-highlights a requested browser row", async () => {
+    const scrollIntoView = vi
+      .spyOn(Element.prototype, "scrollIntoView")
+      .mockImplementation(() => undefined);
+    requestSidebarNodeReveal(
+      "view-tab-1",
+      "browser-session:sess-primary:tab-live",
+    );
+
+    render(wrapper(<BrowsersPanelBody epicId="epic-1" tabId="view-tab-1" />));
+
+    const row = screen.getByTestId("epic-browser-sidebar-row-tab-live");
+    await waitFor(() => {
+      expect(scrollIntoView.mock.instances).toContain(row);
+    });
+    expect(row.dataset.sidebarRevealHighlighted).toBe("true");
+    expect(
+      useSidebarNodeRevealStore.getState().requestsByViewTabId["view-tab-1"],
+    ).toBeUndefined();
   });
 
   it("keeps existing row order stable and appends newly discovered tabs", () => {

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-browser-sidebar.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-browser-sidebar.test.tsx
@@ -312,7 +312,10 @@ describe("BrowsersPanelBody", () => {
       usePanelHeaderMenuStore.getInitialState(),
       true,
     );
-    useSidebarNodeRevealStore.setState({ requestsByViewTabId: {} }, true);
+    useSidebarNodeRevealStore.setState(
+      { requestsByViewTabId: {}, visibleByViewTabId: {} },
+      true,
+    );
     seedCanvasTab();
     sessionsState.value = {
       hostId: "host-1",
@@ -412,6 +415,9 @@ describe("BrowsersPanelBody", () => {
     const scrollIntoView = vi
       .spyOn(Element.prototype, "scrollIntoView")
       .mockImplementation(() => undefined);
+    usePanelHeaderSearchStore
+      .getState()
+      .openSearch("view-tab-1", "browsers", "checkout.example");
     requestSidebarNodeReveal(
       "view-tab-1",
       "browser-session:sess-primary:tab-live",
@@ -424,6 +430,7 @@ describe("BrowsersPanelBody", () => {
       expect(scrollIntoView.mock.instances).toContain(row);
     });
     expect(row.dataset.sidebarRevealHighlighted).toBe("true");
+    expect(screen.getByTestId("epic-browser-sidebar-row-tab-live")).toBe(row);
     expect(
       useSidebarNodeRevealStore.getState().requestsByViewTabId["view-tab-1"],
     ).toBeUndefined();

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-file-tree-source.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-file-tree-source.test.tsx
@@ -201,6 +201,7 @@ const scrollToPathCalls: Array<{
   readonly options: { readonly offset: string };
 }> = [];
 const fileTreeContainer = document.createElement("div");
+let fileTreeContainerAvailable = true;
 const modelListeners = new Set<() => void>();
 // Captured from the real `useFileTree(options)` call the panel makes - the
 // mocked hook below stashes `options.onSelectionChange` here so a test can
@@ -356,7 +357,8 @@ const mockModel = {
   scrollToPath: (path: string, options: { readonly offset: string }) => {
     scrollToPathCalls.push({ path, options });
   },
-  getFileTreeContainer: () => fileTreeContainer,
+  getFileTreeContainer: () =>
+    fileTreeContainerAvailable ? fileTreeContainer : undefined,
 };
 
 vi.mock("@pierre/trees/react", () => ({
@@ -610,6 +612,7 @@ describe("sidebar file tree source selection", () => {
     expandedAtLastReset.clear();
     selectedInModel.clear();
     scrollToPathCalls.length = 0;
+    fileTreeContainerAvailable = true;
     delete fileTreeContainer.dataset.sidebarRevealHighlighted;
     delete fileTreeContainer.dataset.sidebarRevealNonce;
     modelListeners.clear();
@@ -784,6 +787,7 @@ describe("sidebar file tree filter source", () => {
     expandedAtLastReset.clear();
     selectedInModel.clear();
     scrollToPathCalls.length = 0;
+    fileTreeContainerAvailable = true;
     modelListeners.clear();
     capturedOnSelectionChange = null;
     __resetWorkspaceFileListSubscriptionsForTesting();
@@ -1178,6 +1182,7 @@ describe("reveal in sidebar", () => {
     const client = new MockWsStreamClient("unknown");
     renderPanel(client);
 
+    fileTreeContainerAvailable = false;
     act(() => {
       client.sessions[0].emitFrame({
         kind: "listing",
@@ -1247,13 +1252,33 @@ describe("reveal in sidebar", () => {
     await waitFor(() => {
       expect(selectedInModel.has("src/lib/a.ts")).toBe(true);
     });
+    expect(
+      useFileTreeRevealStore.getState().requestsByViewTabId[REVEAL_TAB_ID],
+    ).toBeDefined();
+
+    scrollToPathCalls.length = 0;
+    fileTreeContainerAvailable = true;
+    act(() => {
+      client.sessions[0].emitFrame({
+        kind: "listing",
+        directoryPath: "src/lib/",
+        entries: [
+          { path: "src/lib/a.ts", name: "a.ts", kind: "file", ignored: false },
+        ],
+        truncated: false,
+        hasBinaryPayload: false,
+      });
+    });
+
+    await waitFor(() => {
+      expect(
+        useFileTreeRevealStore.getState().requestsByViewTabId[REVEAL_TAB_ID],
+      ).toBeUndefined();
+    });
     expect(scrollToPathCalls).toEqual([
       { path: "src/lib/a.ts", options: { offset: "nearest" } },
     ]);
     expect(fileTreeContainer.dataset.sidebarRevealHighlighted).toBe("true");
-    expect(
-      useFileTreeRevealStore.getState().requestsByViewTabId[REVEAL_TAB_ID],
-    ).toBeUndefined();
     expect(openPreviewSpy).not.toHaveBeenCalled();
   });
 

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-file-tree-source.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-file-tree-source.test.tsx
@@ -200,6 +200,7 @@ const scrollToPathCalls: Array<{
   readonly path: string;
   readonly options: { readonly offset: string };
 }> = [];
+const fileTreeContainer = document.createElement("div");
 const modelListeners = new Set<() => void>();
 // Captured from the real `useFileTree(options)` call the panel makes - the
 // mocked hook below stashes `options.onSelectionChange` here so a test can
@@ -355,6 +356,7 @@ const mockModel = {
   scrollToPath: (path: string, options: { readonly offset: string }) => {
     scrollToPathCalls.push({ path, options });
   },
+  getFileTreeContainer: () => fileTreeContainer,
 };
 
 vi.mock("@pierre/trees/react", () => ({
@@ -608,6 +610,8 @@ describe("sidebar file tree source selection", () => {
     expandedAtLastReset.clear();
     selectedInModel.clear();
     scrollToPathCalls.length = 0;
+    delete fileTreeContainer.dataset.sidebarRevealHighlighted;
+    delete fileTreeContainer.dataset.sidebarRevealNonce;
     modelListeners.clear();
     capturedOnSelectionChange = null;
     installSearchHost({});
@@ -1246,6 +1250,7 @@ describe("reveal in sidebar", () => {
     expect(scrollToPathCalls).toEqual([
       { path: "src/lib/a.ts", options: { offset: "nearest" } },
     ]);
+    expect(fileTreeContainer.dataset.sidebarRevealHighlighted).toBe("true");
     expect(
       useFileTreeRevealStore.getState().requestsByViewTabId[REVEAL_TAB_ID],
     ).toBeUndefined();

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-selection-mode.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-selection-mode.test.tsx
@@ -1159,6 +1159,27 @@ describe("epic sidebar selection mode", () => {
       });
     });
     expect(scrollIntoView.mock.instances).toContain(row);
+    expect(row.dataset.sidebarRevealHighlighted).toBe("true");
+    expect(
+      useSidebarNodeRevealStore.getState().requestsByViewTabId[TAB_ID],
+    ).toBeUndefined();
+  });
+
+  it("scrolls to and flash-highlights a requested artifact row", async () => {
+    seedArtifactTree();
+    testState.activePanelId = "artifacts";
+    const scrollIntoView = vi
+      .spyOn(Element.prototype, "scrollIntoView")
+      .mockImplementation(() => undefined);
+    requestSidebarNodeReveal(TAB_ID, "ticket-child");
+
+    render(<EpicLeftPanelHost epicId={EPIC_ID} tabId={TAB_ID} side="left" />);
+
+    const row = screen.getByTestId("epic-sidebar-item-ticket-child");
+    await waitFor(() => {
+      expect(scrollIntoView.mock.instances).toContain(row);
+    });
+    expect(row.dataset.sidebarRevealHighlighted).toBe("true");
     expect(
       useSidebarNodeRevealStore.getState().requestsByViewTabId[TAB_ID],
     ).toBeUndefined();

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-selection-mode.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-selection-mode.test.tsx
@@ -22,7 +22,10 @@ import { useNewConversationModalOpenStore } from "@/stores/epics/new-conversatio
 import { useNewConversationModalStore } from "@/stores/epics/new-conversation-modal-store";
 import { useAppDialogStore } from "@/stores/dialogs/app-dialog-store";
 import { useAppLocalNotificationsStore } from "@/stores/notifications/app-local-notifications-store";
-import { usePanelHeaderSearchStore } from "@/stores/epics/panel-header-search-store";
+import {
+  panelHeaderSearchSurfaceKey,
+  usePanelHeaderSearchStore,
+} from "@/stores/epics/panel-header-search-store";
 import {
   ChatTreeSurfaceContext,
   type ChatTreeSurface,
@@ -1139,7 +1142,10 @@ describe("epic sidebar selection mode", () => {
       usePanelHeaderSearchStore.getInitialState(),
       true,
     );
-    useSidebarNodeRevealStore.setState({ requestsByViewTabId: {} }, true);
+    useSidebarNodeRevealStore.setState(
+      { requestsByViewTabId: {}, visibleByViewTabId: {} },
+      true,
+    );
   });
 
   it("scrolls a requested agent row into view and consumes the request", async () => {
@@ -1168,6 +1174,10 @@ describe("epic sidebar selection mode", () => {
   it("scrolls to and flash-highlights a requested artifact row", async () => {
     seedArtifactTree();
     testState.activePanelId = "artifacts";
+    testState.artifactFilterKinds = ["review"];
+    usePanelHeaderSearchStore
+      .getState()
+      .openSearch(TAB_ID, "artifacts", "no match");
     const scrollIntoView = vi
       .spyOn(Element.prototype, "scrollIntoView")
       .mockImplementation(() => undefined);
@@ -1175,14 +1185,51 @@ describe("epic sidebar selection mode", () => {
 
     render(<EpicLeftPanelHost epicId={EPIC_ID} tabId={TAB_ID} side="left" />);
 
-    const row = screen.getByTestId("epic-sidebar-item-ticket-child");
+    const row = screen.getByRole("button", { name: /^Child ticket/ });
     await waitFor(() => {
       expect(scrollIntoView.mock.instances).toContain(row);
     });
     expect(row.dataset.sidebarRevealHighlighted).toBe("true");
+    expect(screen.getByRole("button", { name: /^Child ticket/ })).toBe(row);
+    expect(
+      usePanelHeaderSearchStore.getState().openBySurfaceKey[
+        panelHeaderSearchSurfaceKey(TAB_ID, "artifacts")
+      ],
+    ).toBeUndefined();
     expect(
       useSidebarNodeRevealStore.getState().requestsByViewTabId[TAB_ID],
     ).toBeUndefined();
+  });
+
+  it("flash-highlights an artifact row while it is being renamed", async () => {
+    seedArtifactTree();
+    testState.activePanelId = "artifacts";
+    render(<EpicLeftPanelHost epicId={EPIC_ID} tabId={TAB_ID} side="left" />);
+    fireEvent.click(screen.getByTestId("epic-sidebar-rename-ticket-child"));
+
+    act(() => requestSidebarNodeReveal(TAB_ID, "ticket-child"));
+
+    const row = document.querySelector<HTMLElement>(
+      '[data-sidebar-node-id="ticket-child"]',
+    );
+    await waitFor(() => {
+      expect(row?.dataset.sidebarRevealHighlighted).toBe("true");
+    });
+  });
+
+  it("flash-highlights a chat row while it is being renamed", async () => {
+    seedChatTree();
+    render(<EpicLeftPanelHost epicId={EPIC_ID} tabId={TAB_ID} side="left" />);
+    fireEvent.click(screen.getByTestId("epic-sidebar-rename-chat-child"));
+
+    act(() => requestSidebarNodeReveal(TAB_ID, "chat-child"));
+
+    const row = document.querySelector<HTMLElement>(
+      '[data-sidebar-node-id="chat-child"]',
+    );
+    await waitFor(() => {
+      expect(row?.dataset.sidebarRevealHighlighted).toBe("true");
+    });
   });
 
   it("selects chat rows explicitly and bulk-deletes topmost selected chat roots", async () => {

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/terminal-sidebar-close-tab.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/terminal-sidebar-close-tab.test.tsx
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  act,
   cleanup,
   createEvent,
   fireEvent,
@@ -439,18 +440,27 @@ describe("terminal sidebar Close", () => {
     const scrollIntoView = vi
       .spyOn(Element.prototype, "scrollIntoView")
       .mockImplementation(() => undefined);
-    requestSidebarNodeReveal(
-      TAB_ID,
-      epicTerminalUiIdentityKey("session", "host-1", SESSION_ID),
+    const { getByTestId, findByTestId } = render(
+      wrapper(<TerminalsPanelBody epicId="epic-1" tabId={TAB_ID} />),
     );
+    fireEvent.click(getByTestId(`epic-terminal-sidebar-rename-${SESSION_ID}`));
+    const renameInput = await findByTestId(
+      `epic-terminal-sidebar-rename-input-${SESSION_ID}`,
+    );
+    const row = renameInput.closest<HTMLElement>("[data-sidebar-node-id]");
+    expect(row).not.toBeNull();
 
-    render(wrapper(<TerminalsPanelBody epicId="epic-1" tabId={TAB_ID} />));
+    act(() => {
+      requestSidebarNodeReveal(
+        TAB_ID,
+        epicTerminalUiIdentityKey("session", "host-1", SESSION_ID),
+      );
+    });
 
-    const row = screen.getByTestId(`epic-terminal-sidebar-item-${SESSION_ID}`);
     await waitFor(() => {
       expect(scrollIntoView.mock.instances).toContain(row);
     });
-    expect(row.dataset.sidebarRevealHighlighted).toBe("true");
+    expect(row?.dataset.sidebarRevealHighlighted).toBe("true");
     expect(
       useSidebarNodeRevealStore.getState().requestsByViewTabId[TAB_ID],
     ).toBeUndefined();

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/terminal-sidebar-close-tab.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/terminal-sidebar-close-tab.test.tsx
@@ -405,7 +405,10 @@ describe("terminal sidebar Close", () => {
     durableAuthority.collectionIncludesSession = false;
     terminalSessions.value = [RUNNING_SESSION];
     resetEpicTerminalDurableCreatesForTests();
-    useSidebarNodeRevealStore.setState({ requestsByViewTabId: {} }, true);
+    useSidebarNodeRevealStore.setState(
+      { requestsByViewTabId: {}, visibleByViewTabId: {} },
+      true,
+    );
     seedOpenTerminalTab("legacy");
   });
 
@@ -414,7 +417,10 @@ describe("terminal sidebar Close", () => {
     resetOriginStores();
     useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
     resetEpicTerminalDurableCreatesForTests();
-    useSidebarNodeRevealStore.setState({ requestsByViewTabId: {} }, true);
+    useSidebarNodeRevealStore.setState(
+      { requestsByViewTabId: {}, visibleByViewTabId: {} },
+      true,
+    );
   });
 
   it("highlights the terminal shown in the active canvas pane", () => {

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/terminal-sidebar-close-tab.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/terminal-sidebar-close-tab.test.tsx
@@ -256,6 +256,10 @@ import {
 } from "@/lib/terminals/pending-create-identity";
 import { useProviderLoginTerminalsStore } from "@/stores/providers/provider-login-terminals";
 import { useSetupTerminalsStore } from "@/stores/worktree/setup-terminals";
+import {
+  requestSidebarNodeReveal,
+  useSidebarNodeRevealStore,
+} from "@/stores/epics/sidebar-node-reveal-store";
 
 function createTestQueryClient(): QueryClient {
   return new QueryClient({
@@ -401,6 +405,7 @@ describe("terminal sidebar Close", () => {
     durableAuthority.collectionIncludesSession = false;
     terminalSessions.value = [RUNNING_SESSION];
     resetEpicTerminalDurableCreatesForTests();
+    useSidebarNodeRevealStore.setState({ requestsByViewTabId: {} }, true);
     seedOpenTerminalTab("legacy");
   });
 
@@ -409,6 +414,7 @@ describe("terminal sidebar Close", () => {
     resetOriginStores();
     useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
     resetEpicTerminalDurableCreatesForTests();
+    useSidebarNodeRevealStore.setState({ requestsByViewTabId: {} }, true);
   });
 
   it("highlights the terminal shown in the active canvas pane", () => {
@@ -421,6 +427,27 @@ describe("terminal sidebar Close", () => {
         " ",
       ),
     ).toContain("bg-accent");
+  });
+
+  it("scrolls to and flash-highlights a revealed terminal row", async () => {
+    const scrollIntoView = vi
+      .spyOn(Element.prototype, "scrollIntoView")
+      .mockImplementation(() => undefined);
+    requestSidebarNodeReveal(
+      TAB_ID,
+      epicTerminalUiIdentityKey("session", "host-1", SESSION_ID),
+    );
+
+    render(wrapper(<TerminalsPanelBody epicId="epic-1" tabId={TAB_ID} />));
+
+    const row = screen.getByTestId(`epic-terminal-sidebar-item-${SESSION_ID}`);
+    await waitFor(() => {
+      expect(scrollIntoView.mock.instances).toContain(row);
+    });
+    expect(row.dataset.sidebarRevealHighlighted).toBe("true");
+    expect(
+      useSidebarNodeRevealStore.getState().requestsByViewTabId[TAB_ID],
+    ).toBeUndefined();
   });
 
   it("closes the open canvas tab and kills the session", () => {

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-browser-sidebar-row.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-browser-sidebar-row.tsx
@@ -30,6 +30,7 @@ import { cn } from "@/lib/utils";
 import { makeBrowserSessionTileRef } from "@/stores/epics/canvas/tile-schema/browser-tile";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 import { findPaneById } from "@/stores/epics/canvas/tile-tree";
+import { SIDEBAR_REVEAL_HIGHLIGHT_CLASS } from "@/components/epic-canvas/sidebar/epic-sidebar-tree-shared";
 
 interface BrowserTabRowProps {
   readonly epicId: string;
@@ -151,6 +152,7 @@ export function BrowserTabRow(props: BrowserTabRowProps) {
     <li>
       <div
         data-active={isActive}
+        data-sidebar-node-id={tile.id}
         data-testid={`epic-browser-sidebar-row-${tab.tabId}`}
         className={cn(
           "group/browser-row relative grid h-8 min-w-0 cursor-pointer grid-cols-[minmax(0,1fr)_auto_auto] items-center rounded-md transition-colors duration-100 motion-reduce:transition-none",
@@ -159,6 +161,7 @@ export function BrowserTabRow(props: BrowserTabRowProps) {
             : "text-foreground/75 hover:bg-accent/70 hover:text-accent-foreground",
           isClosing && "opacity-60",
           isDragging && "cursor-grabbing opacity-60",
+          SIDEBAR_REVEAL_HIGHLIGHT_CLASS,
         )}
       >
         <TooltipWrapper

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-browser-sidebar.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-browser-sidebar.tsx
@@ -42,6 +42,7 @@ import { tileIntent } from "@/lib/canvas/tile-open/intent";
 import {
   clearSidebarNodeRevealRequest,
   useSidebarNodeRevealRequest,
+  useVisibleSidebarNodeRevealRequest,
 } from "@/stores/epics/sidebar-node-reveal-store";
 import { revealSidebarNode } from "@/components/epic-canvas/sidebar/epic-sidebar-tree-shared";
 
@@ -84,6 +85,7 @@ function BrowsersPanelBodyLive(props: {
   const sessions = useBrowserSessionsContext();
   const listRef = useRef<HTMLUListElement>(null);
   const revealRequest = useSidebarNodeRevealRequest(props.tabId);
+  const visibleRevealRequest = useVisibleSidebarNodeRevealRequest(props.tabId);
   const searchQuery = usePanelHeaderSearchQuery(props.tabId, BROWSERS_PANEL_ID);
   const chats = useEpicChatRecords();
   const chatById = useMemo(
@@ -94,7 +96,7 @@ function BrowsersPanelBodyLive(props: {
   const { secondaryByKey, duplicateTitles } = useBrowserTabRowLabels(tabs);
   const filteredTabs = useMemo(() => {
     const matches = filterBrowserTabRows(tabs, searchQuery);
-    if (revealRequest === null) return matches;
+    if (visibleRevealRequest === null) return matches;
     const matchKeys = new Set(matches.map((row) => row.key));
     return tabs.filter(
       (row) =>
@@ -102,9 +104,9 @@ function BrowsersPanelBodyLive(props: {
         browserSessionTileId({
           sessionId: row.session.sessionId,
           tabId: row.tab.tabId,
-        }) === revealRequest.nodeId,
+        }) === visibleRevealRequest.nodeId,
     );
-  }, [revealRequest, searchQuery, tabs]);
+  }, [searchQuery, tabs, visibleRevealRequest]);
   const { openTile } = useEpicTileNavigation();
   const { add: addBrowser, isAdding } = useAddBrowserAction(props.tabId, null);
 

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-browser-sidebar.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-browser-sidebar.tsx
@@ -1,5 +1,5 @@
 import { Globe2, Plus, RotateCcw, Search, TriangleAlert } from "lucide-react";
-import { useCallback, useMemo } from "react";
+import { useCallback, useLayoutEffect, useMemo, useRef } from "react";
 import type {
   BrowserSessionInfo,
   BrowserTabDriver,
@@ -32,10 +32,18 @@ import {
   useTabSurfaceKey,
 } from "@/hooks/host/use-surface-host-pin";
 import { useEpicChatRecords } from "@/lib/epic-selectors";
-import { makeBrowserSessionTileRef } from "@/stores/epics/canvas/tile-schema/browser-tile";
+import {
+  browserSessionTileId,
+  makeBrowserSessionTileRef,
+} from "@/stores/epics/canvas/tile-schema/browser-tile";
 import { makeOpenableNodeRef } from "@/stores/epics/canvas/types";
 import { usePanelHeaderSearchQuery } from "@/stores/epics/panel-header-search-store";
 import { tileIntent } from "@/lib/canvas/tile-open/intent";
+import {
+  clearSidebarNodeRevealRequest,
+  useSidebarNodeRevealRequest,
+} from "@/stores/epics/sidebar-node-reveal-store";
+import { revealSidebarNode } from "@/components/epic-canvas/sidebar/epic-sidebar-tree-shared";
 
 /**
  * The browsers panel's header cluster lives in
@@ -74,6 +82,8 @@ function BrowsersPanelBodyLive(props: {
   readonly tabId: string;
 }) {
   const sessions = useBrowserSessionsContext();
+  const listRef = useRef<HTMLUListElement>(null);
+  const revealRequest = useSidebarNodeRevealRequest(props.tabId);
   const searchQuery = usePanelHeaderSearchQuery(props.tabId, BROWSERS_PANEL_ID);
   const chats = useEpicChatRecords();
   const chatById = useMemo(
@@ -82,12 +92,35 @@ function BrowsersPanelBodyLive(props: {
   );
   const tabs = useBrowserSidebarTabRows(sessions.items);
   const { secondaryByKey, duplicateTitles } = useBrowserTabRowLabels(tabs);
-  const filteredTabs = useMemo(
-    () => filterBrowserTabRows(tabs, searchQuery),
-    [searchQuery, tabs],
-  );
+  const filteredTabs = useMemo(() => {
+    const matches = filterBrowserTabRows(tabs, searchQuery);
+    if (revealRequest === null) return matches;
+    const matchKeys = new Set(matches.map((row) => row.key));
+    return tabs.filter(
+      (row) =>
+        matchKeys.has(row.key) ||
+        browserSessionTileId({
+          sessionId: row.session.sessionId,
+          tabId: row.tab.tabId,
+        }) === revealRequest.nodeId,
+    );
+  }, [revealRequest, searchQuery, tabs]);
   const { openTile } = useEpicTileNavigation();
   const { add: addBrowser, isAdding } = useAddBrowserAction(props.tabId, null);
+
+  useLayoutEffect(() => {
+    if (revealRequest === null || listRef.current === null) return;
+    if (
+      !revealSidebarNode(
+        listRef.current,
+        revealRequest.nodeId,
+        revealRequest.nonce,
+      )
+    ) {
+      return;
+    }
+    clearSidebarNodeRevealRequest(props.tabId, revealRequest.nonce);
+  }, [filteredTabs, props.tabId, revealRequest]);
 
   const openTab = useCallback(
     (session: BrowserSessionInfo, tab: BrowserTabInfo) => {
@@ -175,6 +208,7 @@ function BrowsersPanelBodyLive(props: {
       {hasNoResults ? <BrowsersPanelNoResultsState /> : null}
       {hasResults ? (
         <ul
+          ref={listRef}
           aria-label="Browser tabs"
           className="space-y-0.5"
           data-testid="epic-browsers-panel-list"

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-artifact-tree.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-artifact-tree.tsx
@@ -73,6 +73,10 @@ import {
   useIsActiveEpicArtifact,
 } from "@/stores/epics/canvas/store";
 import {
+  clearSidebarNodeRevealRequest,
+  useSidebarNodeRevealRequest,
+} from "@/stores/epics/sidebar-node-reveal-store";
+import {
   isOpenableEpicNodeKind,
   type EpicNodeRef,
   type OpenableEpicNodeKind,
@@ -109,6 +113,7 @@ import {
   startTransition,
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -120,11 +125,13 @@ import {
   EMPTY_PENDING_LIST,
   EMPTY_PRE_ACK_LIST,
   INDENT_PX,
+  SIDEBAR_REVEAL_HIGHLIGHT_CLASS,
   STATUS_DOT_CLASSES,
   STATUS_LABELS,
   computeArtifactNodeAddChildPending,
   computeArtifactNodeStatusDot,
   nodePadRightClass,
+  revealSidebarNode,
   rowAddControlRevealClass,
 } from "./epic-sidebar-tree-shared";
 import { TreeGroupGuide } from "./epic-sidebar-tree-guide";
@@ -522,13 +529,30 @@ export function ArtifactReadLifecycleBridge(props: {
 export function ArtifactTreePanelBody(props: ArtifactTreePanelBodyProps) {
   const { epicId, tabId } = props;
   const panelId: RootCreatePanelId = "artifacts";
+  const treeRegionRef = useRef<HTMLDivElement>(null);
   const sort = useArtifactSort(epicId);
   const comparator = useMemo<NodeComparator | null>(
     () => (isDefaultSort(sort) ? null : makeNodeComparator(sort)),
     [sort],
   );
   const allRootIds = usePanelRootIds(comparator);
-  const visibleIds = useArtifactVisibleIds(epicId);
+  const filteredVisibleIds = useArtifactVisibleIds(epicId);
+  const tree = useEpicTreeIndex();
+  const revealRequest = useSidebarNodeRevealRequest(tabId);
+  const ancestorIdsOfReveal = useAncestorIds(revealRequest?.nodeId ?? null);
+  const visibleIds = useMemo(() => {
+    if (
+      revealRequest === null ||
+      filteredVisibleIds === null ||
+      !Object.hasOwn(tree.nodeById, revealRequest.nodeId)
+    ) {
+      return filteredVisibleIds;
+    }
+    return new Set([
+      ...filteredVisibleIds,
+      ...collectWithAncestors([revealRequest.nodeId], tree.nodeById),
+    ]);
+  }, [filteredVisibleIds, revealRequest, tree]);
   const rootIds = useMemo(
     () => applyVisibleFilter(allRootIds, visibleIds),
     [allRootIds, visibleIds],
@@ -560,8 +584,12 @@ export function ArtifactTreePanelBody(props: ArtifactTreePanelBodyProps) {
 
   const ancestorIdsOfActive = useAncestorIds(activeArtifactId);
   const forcedExpandedIds = useMemo(
-    () => mergeForcedExpanded(ancestorIdsOfActive, visibleIds),
-    [ancestorIdsOfActive, visibleIds],
+    () =>
+      mergeForcedExpanded(
+        mergeForcedExpanded(ancestorIdsOfActive, ancestorIdsOfReveal),
+        visibleIds,
+      ),
+    [ancestorIdsOfActive, ancestorIdsOfReveal, visibleIds],
   );
   const expandedIds = useEpicSidebarEffectiveExpanded(
     tabId,
@@ -584,6 +612,31 @@ export function ArtifactTreePanelBody(props: ArtifactTreePanelBodyProps) {
     },
     [tabId, panelId, expandAction],
   );
+
+  useLayoutEffect(() => {
+    if (revealRequest === null || treeRegionRef.current === null) return;
+    for (const ancestorId of ancestorIdsOfReveal) {
+      expandAction(tabId, panelId, ancestorId);
+    }
+    if (
+      !revealSidebarNode(
+        treeRegionRef.current,
+        revealRequest.nodeId,
+        revealRequest.nonce,
+      )
+    ) {
+      return;
+    }
+    clearSidebarNodeRevealRequest(tabId, revealRequest.nonce);
+  }, [
+    ancestorIdsOfReveal,
+    expandAction,
+    expandedIds,
+    panelId,
+    revealRequest,
+    tabId,
+    tree,
+  ]);
 
   const expansion = useMemo<ExpansionController>(
     () => ({ expandedIds, toggleExpanded, ensureExpanded }),
@@ -701,7 +754,10 @@ export function ArtifactTreePanelBody(props: ArtifactTreePanelBodyProps) {
       <SidebarFilterVisibilityContext.Provider value={visibleIds}>
         <ArtifactPanelSearchShell epicId={epicId} tabId={tabId}>
           <SidebarGroup className="min-h-0 flex-1 px-2 py-1">
-            <SidebarGroupContent className="flex min-h-0 flex-1 flex-col">
+            <SidebarGroupContent
+              ref={treeRegionRef}
+              className="flex min-h-0 flex-1 flex-col"
+            >
               {panelContent}
             </SidebarGroupContent>
           </SidebarGroup>
@@ -1695,6 +1751,7 @@ function ArtifactRowButton(props: ArtifactRowButtonProps) {
     isActive
       ? "bg-accent text-accent-foreground"
       : "text-foreground/75 hover:bg-accent/70 hover:text-accent-foreground",
+    SIDEBAR_REVEAL_HIGHLIGHT_CLASS,
   );
   const selectionInputId = `epic-sidebar-select-input-${nodeId}`;
 
@@ -1704,6 +1761,7 @@ function ArtifactRowButton(props: ArtifactRowButtonProps) {
         htmlFor={selectionInputId}
         ref={dragRef}
         data-testid={`epic-sidebar-item-${nodeId}`}
+        data-sidebar-node-id={nodeId}
         data-artifact-type={artifactType}
         className={rowClassName}
         style={{
@@ -1750,6 +1808,7 @@ function ArtifactRowButton(props: ArtifactRowButtonProps) {
       {...listeners}
       type="button"
       data-testid={`epic-sidebar-item-${nodeId}`}
+      data-sidebar-node-id={nodeId}
       data-artifact-type={artifactType}
       className={rowClassName}
       style={{

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-artifact-tree.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-artifact-tree.tsx
@@ -75,7 +75,9 @@ import {
 import {
   clearSidebarNodeRevealRequest,
   useSidebarNodeRevealRequest,
+  useVisibleSidebarNodeRevealRequest,
 } from "@/stores/epics/sidebar-node-reveal-store";
+import { usePanelHeaderSearchStore } from "@/stores/epics/panel-header-search-store";
 import {
   isOpenableEpicNodeKind,
   type EpicNodeRef,
@@ -539,20 +541,21 @@ export function ArtifactTreePanelBody(props: ArtifactTreePanelBodyProps) {
   const filteredVisibleIds = useArtifactVisibleIds(epicId);
   const tree = useEpicTreeIndex();
   const revealRequest = useSidebarNodeRevealRequest(tabId);
+  const visibleRevealRequest = useVisibleSidebarNodeRevealRequest(tabId);
   const ancestorIdsOfReveal = useAncestorIds(revealRequest?.nodeId ?? null);
   const visibleIds = useMemo(() => {
     if (
-      revealRequest === null ||
+      visibleRevealRequest === null ||
       filteredVisibleIds === null ||
-      !Object.hasOwn(tree.nodeById, revealRequest.nodeId)
+      !Object.hasOwn(tree.nodeById, visibleRevealRequest.nodeId)
     ) {
       return filteredVisibleIds;
     }
     return new Set([
       ...filteredVisibleIds,
-      ...collectWithAncestors([revealRequest.nodeId], tree.nodeById),
+      ...collectWithAncestors([visibleRevealRequest.nodeId], tree.nodeById),
     ]);
-  }, [filteredVisibleIds, revealRequest, tree]);
+  }, [filteredVisibleIds, tree, visibleRevealRequest]);
   const rootIds = useMemo(
     () => applyVisibleFilter(allRootIds, visibleIds),
     [allRootIds, visibleIds],
@@ -598,6 +601,7 @@ export function ArtifactTreePanelBody(props: ArtifactTreePanelBodyProps) {
     forcedExpandedIds,
   );
   const expandAction = useEpicSidebarExpansionStore((s) => s.expand);
+  const closeSearch = usePanelHeaderSearchStore((s) => s.closeSearch);
   const collapseAction = useEpicSidebarExpansionStore((s) => s.collapse);
   const toggleExpanded = useCallback(
     (id: string) => {
@@ -615,6 +619,7 @@ export function ArtifactTreePanelBody(props: ArtifactTreePanelBodyProps) {
 
   useLayoutEffect(() => {
     if (revealRequest === null || treeRegionRef.current === null) return;
+    closeSearch(tabId, panelId);
     for (const ancestorId of ancestorIdsOfReveal) {
       expandAction(tabId, panelId, ancestorId);
     }
@@ -630,6 +635,7 @@ export function ArtifactTreePanelBody(props: ArtifactTreePanelBodyProps) {
     clearSidebarNodeRevealRequest(tabId, revealRequest.nonce);
   }, [
     ancestorIdsOfReveal,
+    closeSearch,
     expandAction,
     expandedIds,
     panelId,
@@ -1612,7 +1618,11 @@ function ArtifactRenameRow(props: ArtifactRenameRowProps) {
   } = props;
   return (
     <div
-      className="flex h-7 min-w-0 flex-1 items-center gap-1.5 rounded-md px-2"
+      data-sidebar-node-id={nodeId}
+      className={cn(
+        "flex h-7 min-w-0 flex-1 items-center gap-1.5 rounded-md px-2",
+        SIDEBAR_REVEAL_HIGHLIGHT_CLASS,
+      )}
       style={{
         paddingLeft: `${depth * INDENT_PX + BASE_PAD_LEFT}px`,
       }}

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-chat-tree.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-chat-tree.tsx
@@ -213,8 +213,10 @@ import {
   EMPTY_PENDING_LIST,
   EMPTY_PRE_ACK_LIST,
   INDENT_PX,
+  SIDEBAR_REVEAL_HIGHLIGHT_CLASS,
   anyMutationPending,
   nodePadRightClass,
+  revealSidebarNode,
   useNodeIconDisplay,
 } from "./epic-sidebar-tree-shared";
 import { TreeGroupGuide } from "./epic-sidebar-tree-guide";
@@ -1006,11 +1008,9 @@ export function ChatTreePanelBody(props: ChatTreePanelBodyProps) {
     for (const ancestorId of ancestorIdsOfReveal) {
       expandAction(tabId, panelId, ancestorId);
     }
-    const row = Array.from(
-      region.querySelectorAll<HTMLElement>("[data-sidebar-node-id]"),
-    ).find((element) => element.dataset.sidebarNodeId === revealRequest.nodeId);
-    if (row === undefined) return;
-    row.scrollIntoView({ block: "nearest", inline: "nearest" });
+    if (!revealSidebarNode(region, revealRequest.nodeId, revealRequest.nonce)) {
+      return;
+    }
     clearSidebarNodeRevealRequest(tabId, revealRequest.nonce);
   }, [
     ancestorIdsOfReveal,
@@ -2855,6 +2855,7 @@ function chatRowClassName(state: {
     state.isActive
       ? "bg-accent text-accent-foreground"
       : "text-foreground/75 hover:bg-accent/70 hover:text-accent-foreground",
+    SIDEBAR_REVEAL_HIGHLIGHT_CLASS,
   );
 }
 

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-chat-tree.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-chat-tree.tsx
@@ -2670,6 +2670,7 @@ function ChatRenameRow(props: ChatRenameRowProps) {
       className={cn(
         "flex min-h-7 min-w-0 flex-1 items-center gap-1.5 rounded-md px-2 py-1",
         props.isArchived && ARCHIVED_ROW_CLASS,
+        SIDEBAR_REVEAL_HIGHLIGHT_CLASS,
       )}
       style={{
         paddingLeft: `${depth * INDENT_PX + BASE_PAD_LEFT}px`,

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-file-tree.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-file-tree.tsx
@@ -58,8 +58,10 @@ import { usePierreCanvasDragBridge } from "@/components/epic-canvas/dnd/use-pier
 import { extractPierreItemPathFromEvent } from "@/components/epic-canvas/pierre-tree-adapter";
 import {
   PIERRE_FILE_TREE_THEME_STYLE,
+  PIERRE_FILE_TREE_REVEAL_HIGHLIGHT_CSS,
   PIERRE_FILE_TREE_TRUNCATION_TOLERANCE_CSS,
 } from "@/components/epic-canvas/pierre-tree-theme";
+import { flashSidebarElement } from "@/components/epic-canvas/sidebar/epic-sidebar-tree-shared";
 import { workspaceFileRefFromTreePath } from "@/components/epic-canvas/workspace-file/workspace-file-ref";
 import { getBasename } from "@/lib/path/cross-platform-path";
 import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
@@ -614,7 +616,7 @@ function FileTreeBodyForResolvedHost(
     // `hide-non-matches`: the filter input below drops every row whose
     // name does not match, keeping only matches and their parents.
     fileTreeSearchMode: "hide-non-matches",
-    unsafeCSS: PIERRE_FILE_TREE_TRUNCATION_TOLERANCE_CSS,
+    unsafeCSS: `${PIERRE_FILE_TREE_TRUNCATION_TOLERANCE_CSS}\n${PIERRE_FILE_TREE_REVEAL_HIGHLIGHT_CSS}`,
     onSelectionChange: (selectedPaths) => {
       const selectedPath = selectedPaths.at(-1);
       if (selectedPath === undefined) return;
@@ -1056,6 +1058,10 @@ function useWorkspaceFileTreeReveal(args: {
       suppressSelectionOpenRef.current = false;
     }
     model.scrollToPath(filePath, { offset: "nearest" });
+    const container = model.getFileTreeContainer();
+    if (container !== undefined) {
+      flashSidebarElement(container, request.nonce);
+    }
     clearFileTreeRevealRequest(viewTabId, request.nonce);
   }, [
     browsing,

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-file-tree.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-file-tree.tsx
@@ -1059,9 +1059,8 @@ function useWorkspaceFileTreeReveal(args: {
     }
     model.scrollToPath(filePath, { offset: "nearest" });
     const container = model.getFileTreeContainer();
-    if (container !== undefined) {
-      flashSidebarElement(container, request.nonce);
-    }
+    if (container === undefined) return;
+    flashSidebarElement(container, request.nonce);
     clearFileTreeRevealRequest(viewTabId, request.nonce);
   }, [
     browsing,

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-tree-shared.ts
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-tree-shared.ts
@@ -10,6 +10,33 @@ import { useSettingsStore } from "@/stores/settings/settings-store";
 export const INDENT_PX = 16;
 export const BASE_PAD_LEFT = 8;
 
+const SIDEBAR_REVEAL_HIGHLIGHT_DURATION_MS = 3_000;
+
+/** Same visual treatment and lifetime as a communication-graph transcript jump. */
+export const SIDEBAR_REVEAL_HIGHLIGHT_CLASS =
+  "data-[sidebar-reveal-highlighted=true]:bg-primary/15 data-[sidebar-reveal-highlighted=true]:ring-2 data-[sidebar-reveal-highlighted=true]:ring-inset data-[sidebar-reveal-highlighted=true]:ring-primary/80 motion-safe:data-[sidebar-reveal-highlighted=true]:animate-pulse";
+
+export function revealSidebarNode(
+  region: HTMLElement,
+  nodeId: string,
+  nonce: number,
+): boolean {
+  const row = Array.from(
+    region.querySelectorAll<HTMLElement>("[data-sidebar-node-id]"),
+  ).find((element) => element.dataset.sidebarNodeId === nodeId);
+  if (row === undefined) return false;
+  const revealNonce = String(nonce);
+  row.scrollIntoView({ block: "nearest", inline: "nearest" });
+  row.dataset.sidebarRevealHighlighted = "true";
+  row.dataset.sidebarRevealNonce = revealNonce;
+  window.setTimeout(() => {
+    if (row.dataset.sidebarRevealNonce !== revealNonce) return;
+    delete row.dataset.sidebarRevealHighlighted;
+    delete row.dataset.sidebarRevealNonce;
+  }, SIDEBAR_REVEAL_HIGHLIGHT_DURATION_MS);
+  return true;
+}
+
 /**
  * Horizontal offset (from a row's own padding-left edge) to the center of its
  * chevron/icon column. Indent guide rails are drawn at the parent depth plus

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-tree-shared.ts
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-tree-shared.ts
@@ -16,6 +16,17 @@ const SIDEBAR_REVEAL_HIGHLIGHT_DURATION_MS = 3_000;
 export const SIDEBAR_REVEAL_HIGHLIGHT_CLASS =
   "data-[sidebar-reveal-highlighted=true]:bg-primary/15 data-[sidebar-reveal-highlighted=true]:ring-2 data-[sidebar-reveal-highlighted=true]:ring-inset data-[sidebar-reveal-highlighted=true]:ring-primary/80 motion-safe:data-[sidebar-reveal-highlighted=true]:animate-pulse";
 
+export function flashSidebarElement(element: HTMLElement, nonce: number): void {
+  const revealNonce = String(nonce);
+  element.dataset.sidebarRevealHighlighted = "true";
+  element.dataset.sidebarRevealNonce = revealNonce;
+  window.setTimeout(() => {
+    if (element.dataset.sidebarRevealNonce !== revealNonce) return;
+    delete element.dataset.sidebarRevealHighlighted;
+    delete element.dataset.sidebarRevealNonce;
+  }, SIDEBAR_REVEAL_HIGHLIGHT_DURATION_MS);
+}
+
 export function revealSidebarNode(
   region: HTMLElement,
   nodeId: string,
@@ -25,15 +36,8 @@ export function revealSidebarNode(
     region.querySelectorAll<HTMLElement>("[data-sidebar-node-id]"),
   ).find((element) => element.dataset.sidebarNodeId === nodeId);
   if (row === undefined) return false;
-  const revealNonce = String(nonce);
   row.scrollIntoView({ block: "nearest", inline: "nearest" });
-  row.dataset.sidebarRevealHighlighted = "true";
-  row.dataset.sidebarRevealNonce = revealNonce;
-  window.setTimeout(() => {
-    if (row.dataset.sidebarRevealNonce !== revealNonce) return;
-    delete row.dataset.sidebarRevealHighlighted;
-    delete row.dataset.sidebarRevealNonce;
-  }, SIDEBAR_REVEAL_HIGHLIGHT_DURATION_MS);
+  flashSidebarElement(row, nonce);
   return true;
 }
 

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-tree-shared.ts
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-tree-shared.ts
@@ -6,11 +6,10 @@
 import type { EpicNodeKind } from "@/lib/artifacts/node-display";
 import { cn } from "@/lib/utils";
 import { useSettingsStore } from "@/stores/settings/settings-store";
+import { SIDEBAR_NODE_REVEAL_VISIBILITY_MS } from "@/stores/epics/sidebar-node-reveal-store";
 
 export const INDENT_PX = 16;
 export const BASE_PAD_LEFT = 8;
-
-const SIDEBAR_REVEAL_HIGHLIGHT_DURATION_MS = 3_000;
 
 /** Same visual treatment and lifetime as a communication-graph transcript jump. */
 export const SIDEBAR_REVEAL_HIGHLIGHT_CLASS =
@@ -24,7 +23,7 @@ export function flashSidebarElement(element: HTMLElement, nonce: number): void {
     if (element.dataset.sidebarRevealNonce !== revealNonce) return;
     delete element.dataset.sidebarRevealHighlighted;
     delete element.dataset.sidebarRevealNonce;
-  }, SIDEBAR_REVEAL_HIGHLIGHT_DURATION_MS);
+  }, SIDEBAR_NODE_REVEAL_VISIBILITY_MS);
 }
 
 export function revealSidebarNode(

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-terminal-sidebar.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-terminal-sidebar.tsx
@@ -18,6 +18,7 @@
 import {
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -84,6 +85,14 @@ import {
 } from "@/components/epic-canvas/sidebar/terminal-list-states";
 import { epicTerminalUiIdentityKey } from "@/lib/terminals/pending-create-identity";
 import { makeListedEpicTerminalRef } from "@/lib/terminals/listed-epic-terminal-ref";
+import {
+  SIDEBAR_REVEAL_HIGHLIGHT_CLASS,
+  revealSidebarNode,
+} from "@/components/epic-canvas/sidebar/epic-sidebar-tree-shared";
+import {
+  clearSidebarNodeRevealRequest,
+  useSidebarNodeRevealRequest,
+} from "@/stores/epics/sidebar-node-reveal-store";
 import type {
   ListedTerminalSidebarSession,
   TerminalSidebarSessionRow,
@@ -191,6 +200,21 @@ interface TerminalSidebarBodyProps {
 
 function TerminalSidebarBody(props: TerminalSidebarBodyProps) {
   const { panel } = props;
+  const listRef = useRef<HTMLUListElement>(null);
+  const revealRequest = useSidebarNodeRevealRequest(props.tabId);
+  useLayoutEffect(() => {
+    if (revealRequest === null || listRef.current === null) return;
+    if (
+      !revealSidebarNode(
+        listRef.current,
+        revealRequest.nodeId,
+        revealRequest.nonce,
+      )
+    ) {
+      return;
+    }
+    clearSidebarNodeRevealRequest(props.tabId, revealRequest.nonce);
+  }, [panel.rows, props.tabId, revealRequest]);
   if (panel.isLoading) {
     return <TerminalsLoadingState testIdPrefix={TERMINALS_TEST_ID_PREFIX} />;
   }
@@ -209,6 +233,7 @@ function TerminalSidebarBody(props: TerminalSidebarBodyProps) {
   }
   return (
     <ul
+      ref={listRef}
       aria-label="Epic terminals"
       className="space-y-0.5"
       data-testid="epic-terminal-sidebar-list"
@@ -416,9 +441,15 @@ function TerminalRow(props: TerminalRowProps) {
                   data-testid={`epic-terminal-sidebar-item-${session.sessionId}`}
                   data-terminal-host-id={hostId}
                   data-terminal-status={runtimeStatus}
+                  data-sidebar-node-id={epicTerminalUiIdentityKey(
+                    "session",
+                    hostId,
+                    session.sessionId,
+                  )}
                   className={cn(
                     "flex h-7 w-full items-center gap-1.5 rounded-md pl-2 pr-8 text-left text-ui-sm transition-colors",
                     "focus-visible:ring-ring focus-visible:outline-none focus-visible:ring-2",
+                    SIDEBAR_REVEAL_HIGHLIGHT_CLASS,
                     isDragging && "cursor-grabbing opacity-60",
                     isActive
                       ? "bg-accent font-medium text-accent-foreground"

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-terminal-sidebar.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-terminal-sidebar.tsx
@@ -412,7 +412,17 @@ function TerminalRow(props: TerminalRowProps) {
     <li>
       <ContextMenu>
         <ContextMenuTrigger asChild disabled={isRenaming}>
-          <div className="group/term-row relative">
+          <div
+            data-sidebar-node-id={epicTerminalUiIdentityKey(
+              "session",
+              hostId,
+              session.sessionId,
+            )}
+            className={cn(
+              "group/term-row relative",
+              SIDEBAR_REVEAL_HIGHLIGHT_CLASS,
+            )}
+          >
             {isRenaming ? (
               <div
                 className={cn(
@@ -441,15 +451,9 @@ function TerminalRow(props: TerminalRowProps) {
                   data-testid={`epic-terminal-sidebar-item-${session.sessionId}`}
                   data-terminal-host-id={hostId}
                   data-terminal-status={runtimeStatus}
-                  data-sidebar-node-id={epicTerminalUiIdentityKey(
-                    "session",
-                    hostId,
-                    session.sessionId,
-                  )}
                   className={cn(
                     "flex h-7 w-full items-center gap-1.5 rounded-md pl-2 pr-8 text-left text-ui-sm transition-colors",
                     "focus-visible:ring-ring focus-visible:outline-none focus-visible:ring-2",
-                    SIDEBAR_REVEAL_HIGHLIGHT_CLASS,
                     isDragging && "cursor-grabbing opacity-60",
                     isActive
                       ? "bg-accent font-medium text-accent-foreground"

--- a/clients/gui-app/src/lib/browser-view/__tests__/fake-browser-view-bridge.ts
+++ b/clients/gui-app/src/lib/browser-view/__tests__/fake-browser-view-bridge.ts
@@ -310,6 +310,12 @@ export class FakeBrowserViewBridge implements BrowserViewBridge {
     };
   }
 
+  onTileFocused(_handler: (tile: BrowserViewTileKey) => void): {
+    dispose: () => void;
+  } {
+    return { dispose: () => undefined };
+  }
+
   onSnapshotInvalidated(
     handler: (change: BrowserViewSnapshotInvalidatedChange) => void,
   ): {

--- a/clients/gui-app/src/stores/epics/__tests__/sidebar-node-reveal-store.test.ts
+++ b/clients/gui-app/src/stores/epics/__tests__/sidebar-node-reveal-store.test.ts
@@ -5,6 +5,7 @@ import {
   SIDEBAR_NODE_REVEAL_VISIBILITY_MS,
   useSidebarNodeRevealStore,
 } from "@/stores/epics/sidebar-node-reveal-store";
+import { flashSidebarElement } from "@/components/epic-canvas/sidebar/epic-sidebar-tree-shared";
 
 beforeEach(() => {
   vi.useFakeTimers();
@@ -19,20 +20,25 @@ afterEach(() => {
 });
 
 it("keeps a served target visible for the flash without an older timer clearing a repeat", () => {
+  const element = document.createElement("div");
   requestSidebarNodeReveal("tab-1", "node-1");
+  flashSidebarElement(element, 1);
   clearSidebarNodeRevealRequest("tab-1", 1);
   vi.advanceTimersByTime(1_000);
 
   requestSidebarNodeReveal("tab-1", "node-1");
-  clearSidebarNodeRevealRequest("tab-1", 1);
+  flashSidebarElement(element, 2);
+  clearSidebarNodeRevealRequest("tab-1", 2);
   vi.advanceTimersByTime(SIDEBAR_NODE_REVEAL_VISIBILITY_MS - 1_000);
 
   expect(
     useSidebarNodeRevealStore.getState().visibleByViewTabId["tab-1"],
-  ).toEqual({ nodeId: "node-1", nonce: 1 });
+  ).toEqual({ nodeId: "node-1", nonce: 2 });
+  expect(element.dataset.sidebarRevealHighlighted).toBe("true");
 
   vi.advanceTimersByTime(1_000);
   expect(
     useSidebarNodeRevealStore.getState().visibleByViewTabId["tab-1"],
   ).toBeUndefined();
+  expect(element.dataset.sidebarRevealHighlighted).toBeUndefined();
 });

--- a/clients/gui-app/src/stores/epics/__tests__/sidebar-node-reveal-store.test.ts
+++ b/clients/gui-app/src/stores/epics/__tests__/sidebar-node-reveal-store.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import {
+  clearSidebarNodeRevealRequest,
+  requestSidebarNodeReveal,
+  SIDEBAR_NODE_REVEAL_VISIBILITY_MS,
+  useSidebarNodeRevealStore,
+} from "@/stores/epics/sidebar-node-reveal-store";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  useSidebarNodeRevealStore.setState(
+    { requestsByViewTabId: {}, visibleByViewTabId: {} },
+    true,
+  );
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+it("keeps a served target visible for the flash without an older timer clearing a repeat", () => {
+  requestSidebarNodeReveal("tab-1", "node-1");
+  clearSidebarNodeRevealRequest("tab-1", 1);
+  vi.advanceTimersByTime(1_000);
+
+  requestSidebarNodeReveal("tab-1", "node-1");
+  clearSidebarNodeRevealRequest("tab-1", 1);
+  vi.advanceTimersByTime(SIDEBAR_NODE_REVEAL_VISIBILITY_MS - 1_000);
+
+  expect(
+    useSidebarNodeRevealStore.getState().visibleByViewTabId["tab-1"],
+  ).toEqual({ nodeId: "node-1", nonce: 1 });
+
+  vi.advanceTimersByTime(1_000);
+  expect(
+    useSidebarNodeRevealStore.getState().visibleByViewTabId["tab-1"],
+  ).toBeUndefined();
+});

--- a/clients/gui-app/src/stores/epics/sidebar-node-reveal-store.ts
+++ b/clients/gui-app/src/stores/epics/sidebar-node-reveal-store.ts
@@ -33,7 +33,9 @@ export function requestSidebarNodeReveal(
   nodeId: string,
 ): void {
   useSidebarNodeRevealStore.setState((state) => {
-    const previous = state.requestsByViewTabId[viewTabId];
+    const previous =
+      state.requestsByViewTabId[viewTabId] ??
+      state.visibleByViewTabId[viewTabId];
     const nonce = previous === undefined ? 1 : previous.nonce + 1;
     return {
       requestsByViewTabId: {

--- a/clients/gui-app/src/stores/epics/sidebar-node-reveal-store.ts
+++ b/clients/gui-app/src/stores/epics/sidebar-node-reveal-store.ts
@@ -16,11 +16,17 @@ interface SidebarNodeRevealState {
   readonly requestsByViewTabId: Readonly<
     Record<string, SidebarNodeRevealRequest | undefined>
   >;
+  readonly visibleByViewTabId: Readonly<
+    Record<string, SidebarNodeRevealRequest | undefined>
+  >;
 }
 
 export const useSidebarNodeRevealStore = create<SidebarNodeRevealState>(() => ({
   requestsByViewTabId: {},
+  visibleByViewTabId: {},
 }));
+
+export const SIDEBAR_NODE_REVEAL_VISIBILITY_MS = 3_000;
 
 export function requestSidebarNodeReveal(
   viewTabId: string,
@@ -42,12 +48,38 @@ export function clearSidebarNodeRevealRequest(
   viewTabId: string,
   nonce: number,
 ): void {
+  const served =
+    useSidebarNodeRevealStore.getState().requestsByViewTabId[viewTabId];
+  if (served === undefined || served.nonce !== nonce) return;
   useSidebarNodeRevealStore.setState((state) => {
-    const current = state.requestsByViewTabId[viewTabId];
-    if (current === undefined || current.nonce !== nonce) return state;
     const { [viewTabId]: _removed, ...rest } = state.requestsByViewTabId;
-    return { requestsByViewTabId: rest };
+    return {
+      requestsByViewTabId: rest,
+      visibleByViewTabId: {
+        ...state.visibleByViewTabId,
+        [viewTabId]: served,
+      },
+    };
   });
+  window.setTimeout(() => {
+    useSidebarNodeRevealStore.setState((state) => {
+      const visible = state.visibleByViewTabId[viewTabId];
+      if (visible !== served) return state;
+      const { [viewTabId]: _removed, ...rest } = state.visibleByViewTabId;
+      return { visibleByViewTabId: rest };
+    });
+  }, SIDEBAR_NODE_REVEAL_VISIBILITY_MS);
+}
+
+export function useVisibleSidebarNodeRevealRequest(
+  viewTabId: string,
+): SidebarNodeRevealRequest | null {
+  return useSidebarNodeRevealStore(
+    (state) =>
+      state.requestsByViewTabId[viewTabId] ??
+      state.visibleByViewTabId[viewTabId] ??
+      null,
+  );
 }
 
 export function useSidebarNodeRevealRequest(

--- a/clients/shared/platform/browser-view.ts
+++ b/clients/shared/platform/browser-view.ts
@@ -841,6 +841,10 @@ export interface BrowserViewBridge {
   onTileCommand(handler: (event: BrowserViewTileCommandEvent) => void): {
     dispose: () => void;
   };
+  /** The native guest received focus, which bypasses the renderer DOM. */
+  onTileFocused(handler: (tile: BrowserViewTileKey) => void): {
+    dispose: () => void;
+  };
   onSnapshotInvalidated(
     handler: (change: BrowserViewSnapshotInvalidatedChange) => void,
   ): {


### PR DESCRIPTION
## Summary

- route independent browser tabs to the browser sidebar and reveal the correct host-bound row
- scroll to and flash-highlight chat, artifact, and browser reveal targets
- identify the host that owns localhost server shortcuts on blank browser pages

## Testing

- [x] targeted GUI tests (222 passed)
- [x] pre-commit workspace checks (lint, format, compile, build)