### PR TITLE
test(gui-app): make the three train-only red suites pass after the main merges

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/renderers/terminal-quote/__tests__/use-terminal-quote-actions-host-routing.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/terminal-quote/__tests__/use-terminal-quote-actions-host-routing.test.tsx
@@ -75,6 +75,17 @@ vi.mock("@/hooks/host/use-addressable-host-id", () => ({
 vi.mock("@/providers/use-runner-host", () => ({
   useRunnerHost: () => ({ authnBaseUrl: "https://authn.test" }),
 }));
+// `<TabHostProvider>` also mounts the cross-device drafts mirror, whose
+// session reaches `useHostDirectory()` / `useAuthService()` off a real
+// `<HostRuntimeProvider>` this suite deliberately does not stand up. The
+// mount's own escape hatch is a `null` `useHostBinding`, which is not
+// available here: the routing under test resolves a named host through that
+// binding, so it has to be non-null. Stub the mount - it renders `null`
+// either way and carries only drafts effects, which are not this suite's
+// subject.
+vi.mock("@/hooks/drafts/use-tab-draft-mirror", () => ({
+  TabDraftMirrorMount: () => null,
+}));
 
 import { TabHostProvider } from "@/components/epic-canvas/tab-host-provider";
 import { EpicSessionContext } from "@/lib/registries/epic-session-registry";

--- a/clients/gui-app/src/hooks/epic/__tests__/use-epic-node-mutations.react-compiler.test.tsx
+++ b/clients/gui-app/src/hooks/epic/__tests__/use-epic-node-mutations.react-compiler.test.tsx
@@ -1,4 +1,5 @@
 import { act, render } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   afterEach,
   beforeEach,
@@ -59,10 +60,34 @@ function TestHarness(props: { readonly renderKey: number }): ReactElement {
 
 describe("use-epic-node-mutations under React Compiler", () => {
   let handle: OpenedStoreForTest;
+  let queryClient: QueryClient;
   let consoleErrorSpy: MockInstance<typeof console.error>;
+
+  /**
+   * `useEpicDeleteArtifact` invalidates the tombstone list
+   * (`epic.deletedArtifacts.list`) on success, so it holds a `useQueryClient`
+   * - the write itself still rides the write-command queue this pin drives.
+   * The provider is what the hook legitimately needs; nothing here reads the
+   * cache.
+   */
+  function tree(renderKey: number): ReactElement {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <EpicSessionContext.Provider value={handle}>
+          <TestHarness renderKey={renderKey} />
+        </EpicSessionContext.Provider>
+      </QueryClientProvider>
+    );
+  }
 
   beforeEach(() => {
     window.localStorage.clear();
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
     handle = openStoreForTest({
       epicId: "epic-compiler-pin",
       userId: null,
@@ -78,24 +103,13 @@ describe("use-epic-node-mutations under React Compiler", () => {
   afterEach(() => {
     consoleErrorSpy.mockRestore();
     handle.dispose();
+    queryClient.clear();
   });
 
   it("re-renders the same handle across multiple passes with no hook-order error", () => {
-    const { getByTestId, rerender } = render(
-      <EpicSessionContext.Provider value={handle}>
-        <TestHarness renderKey={1} />
-      </EpicSessionContext.Provider>,
-    );
-    rerender(
-      <EpicSessionContext.Provider value={handle}>
-        <TestHarness renderKey={2} />
-      </EpicSessionContext.Provider>,
-    );
-    rerender(
-      <EpicSessionContext.Provider value={handle}>
-        <TestHarness renderKey={3} />
-      </EpicSessionContext.Provider>,
-    );
+    const { getByTestId, rerender } = render(tree(1));
+    rerender(tree(2));
+    rerender(tree(3));
 
     // A store-driven re-render - the same trigger a real pending write
     // command uses - is what surfaces the trap: it re-renders the SAME

--- a/clients/gui-app/src/hooks/host/__tests__/use-tab-host-client.test.tsx
+++ b/clients/gui-app/src/hooks/host/__tests__/use-tab-host-client.test.tsx
@@ -77,6 +77,20 @@ vi.mock("@/hooks/host/use-host-directory-list-query", () => ({
   useHostDirectoryList: () => ({ data: directoryState.data }),
 }));
 
+// `<TabHostProvider>` also mounts the cross-device drafts mirror, whose
+// session reaches `useHostDirectory()` / `useAuthService()` and a
+// `useHostQuery` - all of which want a real `<HostRuntimeProvider>` and a
+// `QueryClientProvider` around a suite that deliberately has neither. Every
+// other tile suite dodges it through the mount's own escape hatch (a `null`
+// `useHostBinding`, which makes it render nothing), but this one CANNOT: its
+// subject, `useHostClientForHostId`, reads that binding to resolve a named
+// host, so the mock above has to hand back a real one. Stub the mount
+// instead - it renders `null` in both branches and carries only effects,
+// none of which this suite is about.
+vi.mock("@/hooks/drafts/use-tab-draft-mirror", () => ({
+  TabDraftMirrorMount: () => null,
+}));
+
 import { useHostClientForHostId } from "@/hooks/host/use-host-client-for-host-id";
 import { useTabHostClient } from "@/hooks/host/use-tab-host-client";
 


### PR DESCRIPTION
## Why

`tgill-release-train` is red on three gui-app suites at its own tip, independent of any open PR (reproduced at 9dc8a538d with no changes). They block every PR against the train, currently #1703.

## Root causes (test harnesses only, no product code changed)

- `use-tab-host-client.test.tsx` and `use-terminal-quote-actions-host-routing.test.tsx`: `<TabHostProvider>` mounts the train-only `TabDraftMirrorMount` (#1586). Its session walks `useHostDirectoryEntryForHostId`, which #1611 rewrote to delegate to the provider-backed `useHostDirectory()`, so it throws without `<HostRuntimeProvider>`. Every other `TabHostProvider` suite escapes via `useHostBinding: () => null`; these two cannot, because their subject reads that binding. Fix: stub `TabDraftMirrorMount` to `null`. It renders nothing on either branch, so no rendered output or assertion changes.
- `use-epic-node-mutations.react-compiler.test.tsx`: the train's `useEpicDeleteArtifact` invalidates the `epic.deletedArtifacts.list` tombstone query via `useQueryClient` (train merge dc6457478); the harness is main's file verbatim and renders bare. Fix: wrap the tree in a `QueryClientProvider`, one client per test.

All three went red in the earlier main merge dc6457478, not in 9dc8a538d.

## Validation

- The three suites: 3 files / 8 tests pass (were 7 failing). The react-compiler suite also passes under `vitest.react-compiler.config.ts`.
- `bun run compile` at the repo root, gui-app `bun run lint`: clean.

## Known gap

With the drafts mount stubbed, neither suite exercises "the drafts mirror mounts under a tab host". That was already true in effect: the mount has thrown in these harnesses since dc6457478. Whether #1586 carries its own mount-level coverage was not checked here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
