### PR TITLE
fix(gui-app): settle the post-merge review of the provider sign-in terminal (#1699)

### DIFF
--- a/clients/gui-app/src/components/home/pickers/__tests__/harness-model-picker-auth-line.test.tsx
+++ b/clients/gui-app/src/components/home/pickers/__tests__/harness-model-picker-auth-line.test.tsx
@@ -47,13 +47,6 @@ vi.mock("@/hooks/host/use-host-client-for-host-id", () => ({
   }),
 }));
 
-// The picker passes `runTargetHostId={null}` (follow the app-wide default),
-// which the scope gate resolves through this hook - so it has to name the same
-// host the negotiated manifest below is recorded for.
-vi.mock("@/hooks/host/use-addressable-host-id", () => ({
-  useAddressableHostId: () => HOST_ID,
-}));
-
 function baseProviderState(providerId: ProviderId): ProviderCliState {
   return {
     providerId,
@@ -287,7 +280,7 @@ describe("<PickerProviderAuthLine />", () => {
           kind: "landing",
           resolveLandingPageId: () => "draft-1",
         }}
-        runTargetHostId={null}
+        runTargetHostId={HOST_ID}
         onClosePicker={() => undefined}
       />,
     );
@@ -324,7 +317,7 @@ describe("<PickerProviderAuthLine />", () => {
           kind: "landing",
           resolveLandingPageId: () => "draft-1",
         }}
-        runTargetHostId={null}
+        runTargetHostId={HOST_ID}
         onClosePicker={() => undefined}
       />,
     );
@@ -355,7 +348,7 @@ describe("<PickerProviderAuthLine />", () => {
           kind: "landing",
           resolveLandingPageId: () => "draft-1",
         }}
-        runTargetHostId={null}
+        runTargetHostId={HOST_ID}
         onClosePicker={() => undefined}
       />,
     );
@@ -366,13 +359,50 @@ describe("<PickerProviderAuthLine />", () => {
     expect(
       screen.queryByRole("button", { name: /Set up in terminal/ }),
     ).toBeNull();
-    // And not the "it's on another surface" copy either: there is no surface
-    // on this host that draws it, so the steps must lead with the manual
-    // route rather than pointing at a button nobody can find.
+    // And not the "it's on another surface" copy either: that sentence names
+    // the start page as a place the button exists, which on this host it does
+    // not.
     expect(
       screen.queryByText(
         "Choose \u201CSet up in terminal\u201D from a chat's model picker or the start page's. It opens Reasonix's setup wizard on the host that composer runs on.",
       ),
+    ).toBeNull();
+    // The steps lead with the route this host DOES have - `@1.0` opens the
+    // terminal from a chat natively - rather than "finish in that terminal"
+    // when nothing here opened one.
+    const note = screen.getByRole("note", { name: "Setup required" });
+    const items = Array.from(note.querySelectorAll("ol li"));
+    expect(items.map((item) => item.textContent)).toEqual([
+      "Open a chat and choose \u201CSet up in terminal\u201D from its model picker. This host's version can open Reasonix's setup wizard from a chat, but not from the start page.",
+      "Paste your provider API key when asked (DeepSeek by default).",
+      "Refresh this list.",
+    ]);
+  });
+
+  it("hides the landing action when the composer has no resolved host at all, without reading the app-wide host", () => {
+    recordNegotiatedHostManifest(HOST_ID, {
+      "providers.startTerminalLogin": { major: 2, minor: 0 },
+    });
+
+    renderAuthLine(
+      <PickerProviderAuthLine
+        state={withTerminalLoginCapability(baseProviderState("reasonix"))}
+        harness={null}
+        terminalLoginSurface={{
+          kind: "landing",
+          resolveLandingPageId: () => "draft-1",
+        }}
+        // The \u2205 case: nothing usable to create on. The picker is also drawn
+        // inside Epic tabs, so the gate must not fill this from an app-wide
+        // host authority - it reads as unsupported, the same as an unknown
+        // host.
+        runTargetHostId={null}
+        onClosePicker={() => undefined}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: /Set up in terminal/ }),
     ).toBeNull();
     expect(screen.getByRole("note", { name: "Setup required" })).toBeDefined();
   });
@@ -391,7 +421,7 @@ describe("<PickerProviderAuthLine />", () => {
           kind: "landing",
           resolveLandingPageId: () => "draft-1",
         }}
-        runTargetHostId={null}
+        runTargetHostId={HOST_ID}
         onClosePicker={() => undefined}
       />,
     );

--- a/clients/gui-app/src/components/home/pickers/__tests__/harness-model-picker-auth-line.test.tsx
+++ b/clients/gui-app/src/components/home/pickers/__tests__/harness-model-picker-auth-line.test.tsx
@@ -404,7 +404,16 @@ describe("<PickerProviderAuthLine />", () => {
     expect(
       screen.queryByRole("button", { name: /Set up in terminal/ }),
     ).toBeNull();
-    expect(screen.getByRole("note", { name: "Setup required" })).toBeDefined();
+    const note = screen.getByRole("note", { name: "Setup required" });
+    // And no claim about the machine either: "this host's version can open
+    // the setup wizard from a chat" is only true of a RECORDED pre-scope
+    // manifest, and there is no host here to have recorded one. The
+    // claim-free copy leads with the manual route.
+    const items = Array.from(note.querySelectorAll("ol li"));
+    expect(items.map((item) => item.textContent)).toEqual([
+      "Paste your provider API key when asked (DeepSeek by default).",
+      "Refresh this list.",
+    ]);
   });
 
   it("shows the pack's preparing state instead of the button while the provider cannot spawn", () => {

--- a/clients/gui-app/src/components/home/pickers/__tests__/harness-model-picker-auth-line.test.tsx
+++ b/clients/gui-app/src/components/home/pickers/__tests__/harness-model-picker-auth-line.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, render, screen, within } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ReactNode } from "react";
@@ -371,7 +371,7 @@ describe("<PickerProviderAuthLine />", () => {
     // terminal from a chat natively - rather than "finish in that terminal"
     // when nothing here opened one.
     const note = screen.getByRole("note", { name: "Setup required" });
-    const items = Array.from(note.querySelectorAll("ol li"));
+    const items = within(note).getAllByRole("listitem");
     expect(items.map((item) => item.textContent)).toEqual([
       "Open a chat and choose \u201CSet up in terminal\u201D from its model picker. This host's version can open Reasonix's setup wizard from a chat, but not from the start page.",
       "Paste your provider API key when asked (DeepSeek by default).",
@@ -409,7 +409,7 @@ describe("<PickerProviderAuthLine />", () => {
     // the setup wizard from a chat" is only true of a RECORDED pre-scope
     // manifest, and there is no host here to have recorded one. The
     // claim-free copy leads with the manual route.
-    const items = Array.from(note.querySelectorAll("ol li"));
+    const items = within(note).getAllByRole("listitem");
     expect(items.map((item) => item.textContent)).toEqual([
       "Paste your provider API key when asked (DeepSeek by default).",
       "Refresh this list.",

--- a/clients/gui-app/src/components/home/pickers/__tests__/harness-model-picker-empty-setup-cta.test.tsx
+++ b/clients/gui-app/src/components/home/pickers/__tests__/harness-model-picker-empty-setup-cta.test.tsx
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ProviderTerminalLoginScopeSupport } from "@/hooks/providers/use-provider-terminal-login-scope-support";
 import {
   act,
   cleanup,
@@ -19,15 +20,21 @@ import { ModelRowsState } from "../harness-model-picker-empty";
 const mocks = vi.hoisted(() => ({
   start: vi.fn(),
   // The host's negotiated `providers.startTerminalLogin` major, which decides
-  // whether the LANDING action can be sent at all. `true` here is the modern
-  // host; the gate's own rules live in
+  // whether the LANDING action can be sent at all. `"supported"` here is the
+  // modern host; the gate's own rules live in
   // `use-provider-terminal-login-scope-support.test.tsx`.
-  scopeSupported: { current: true },
+  scopeSupported: {
+    current: "supported",
+  },
 }));
 
 vi.mock("@/hooks/providers/use-provider-terminal-login-scope-support", () => ({
   useProviderTerminalLoginScopeSupported: () => mocks.scopeSupported.current,
 }));
+
+function setScopeSupport(value: ProviderTerminalLoginScopeSupport): void {
+  mocks.scopeSupported.current = value;
+}
 
 vi.mock("@/hooks/providers/use-landing-provider-terminal-login", () => ({
   useLandingProviderStartTerminalLogin: () => ({
@@ -123,7 +130,7 @@ describe("<ModelRowsState /> provider setup CTA (reasonix)", () => {
       reportIssueDraftId: 0,
     });
     mocks.start.mockClear();
-    mocks.scopeSupported.current = true;
+    setScopeSupport("supported");
   });
 
   it("renders the setup CTA for a reasonix entry with the signed-out modelsError: steps + manual command, no button, no report-issue action", () => {
@@ -457,7 +464,7 @@ describe("<ModelRowsState /> provider setup CTA (reasonix)", () => {
   });
 
   it("hides the copilot CTA on a host that cannot carry the landing scope, leaving no always-failing button", () => {
-    mocks.scopeSupported.current = false;
+    setScopeSupport("unsupported");
     const provider = harnessEntry({
       id: "copilot",
       label: "Copilot",

--- a/clients/gui-app/src/components/home/pickers/harness-model-picker-auth-line.tsx
+++ b/clients/gui-app/src/components/home/pickers/harness-model-picker-auth-line.tsx
@@ -201,7 +201,7 @@ function SetupGuidanceRow(props: {
 }): ReactNode {
   const { setup, terminalLoginSurface } = props;
   const { guidance } = setup;
-  const scopeSupported = useProviderTerminalLoginScopeSupported(
+  const scopeSupport = useProviderTerminalLoginScopeSupported(
     terminalLoginSurface,
     props.runTargetHostId,
   );
@@ -211,7 +211,7 @@ function SetupGuidanceRow(props: {
   const placement = providerSetupActionPlacement(
     setup,
     terminalLoginSurface !== null,
-    scopeSupported,
+    scopeSupport,
   );
   const surface = placement === "here" ? terminalLoginSurface : null;
   const preparingLabel = providerSetupPreparingLabel(setup, props.providerId);

--- a/clients/gui-app/src/components/home/pickers/harness-model-picker-empty.tsx
+++ b/clients/gui-app/src/components/home/pickers/harness-model-picker-empty.tsx
@@ -278,7 +278,7 @@ function ProviderSetupCta(props: {
 }): ReactNode {
   const { setup, terminalLoginSurface } = props;
   const { guidance } = setup;
-  const scopeSupported = useProviderTerminalLoginScopeSupported(
+  const scopeSupport = useProviderTerminalLoginScopeSupported(
     terminalLoginSurface,
     props.runTargetHostId,
   );
@@ -287,7 +287,7 @@ function ProviderSetupCta(props: {
   const placement = providerSetupActionPlacement(
     setup,
     terminalLoginSurface !== null,
-    scopeSupported,
+    scopeSupport,
   );
   const preparingLabel = providerSetupPreparingLabel(setup, props.providerId);
   return (

--- a/clients/gui-app/src/components/home/terminal-panel/__tests__/landing-terminal-lifecycle.test.ts
+++ b/clients/gui-app/src/components/home/terminal-panel/__tests__/landing-terminal-lifecycle.test.ts
@@ -1081,6 +1081,45 @@ describe("adoptListedProviderLoginSessions", () => {
     ]);
   });
 
+  it("adopts only the NEWEST exited sign-in per provider when none is running - rapid retries leave several in the grace listing", () => {
+    const adopted = adoptListedProviderLoginSessions({
+      tabs: [],
+      activeHostId: HOST_A,
+      sessions: [
+        {
+          ...session({ sessionId: "signin-old", status: "exited" }),
+          createdAt: 1,
+        },
+        {
+          ...session({ sessionId: "signin-newest", status: "exited" }),
+          createdAt: 3,
+        },
+        {
+          ...session({ sessionId: "signin-mid", status: "exited" }),
+          createdAt: 2,
+        },
+        // Another provider's exited sign-in is its own newest.
+        {
+          ...session({ sessionId: "copilot-old", status: "exited" }),
+          createdAt: 1,
+        },
+      ],
+      excludedSessionKeys: new Set(),
+      mintInstanceId: () => "adopted",
+      providerLoginProviderFor: (sessionId) => {
+        if (sessionId.startsWith("signin-")) return "reasonix";
+        if (sessionId.startsWith("copilot-")) return "copilot";
+        return null;
+      },
+    });
+    // One "Start again" surface per provider, never a stale duplicate whose
+    // restart would retire only itself.
+    expect(adopted.map((entry) => entry.sessionId).sort()).toEqual([
+      "copilot-old",
+      "signin-newest",
+    ]);
+  });
+
   it("does not let another host's tab for the same session id stand in", () => {
     const adopted = adoptListedProviderLoginSessions({
       tabs: [

--- a/clients/gui-app/src/components/home/terminal-panel/__tests__/landing-terminal-lifecycle.test.ts
+++ b/clients/gui-app/src/components/home/terminal-panel/__tests__/landing-terminal-lifecycle.test.ts
@@ -1157,8 +1157,13 @@ describe("retiredProviderLoginPredecessors", () => {
     origin: "provider-login",
     originProviderId: input.providerId,
   });
+  const providerLoginProviderFor = (sessionId: string) => {
+    if (sessionId.startsWith("signin-")) return "reasonix" as const;
+    if (sessionId.startsWith("copilot-")) return "copilot" as const;
+    return null;
+  };
 
-  it("retires this host's exited sign-in tab for a provider whose successor is being adopted", () => {
+  it("retires this host's exited sign-in tab for a provider the listing shows a running successor for", () => {
     // Another window pressed "Start again": the host killed the predecessor
     // this window still shows as an ended tab, and lists the successor.
     const retired = retiredProviderLoginPredecessors({
@@ -1168,7 +1173,7 @@ describe("retiredProviderLoginPredecessors", () => {
           sessionId: "signin-old",
           providerId: "reasonix",
         }),
-        // Another provider's ended tab is untouched.
+        // Another provider's ended tab is untouched: nothing newer listed.
         signInTab({
           instanceId: "copilot-ended",
           sessionId: "copilot-old",
@@ -1181,52 +1186,94 @@ describe("retiredProviderLoginPredecessors", () => {
       sessions: [
         session({ sessionId: "signin-old", status: "exited" }),
         session({ sessionId: "signin-new", status: "running" }),
+        session({ sessionId: "copilot-old", status: "exited" }),
       ],
-      adopted: [
+      providerLoginProviderFor,
+    });
+    expect(retired).toEqual(["old-signin"]);
+  });
+
+  it("retires the predecessor even when the successor is ALREADY a tab here - adopted as ordinary before its record arrived, classified since", () => {
+    const retired = retiredProviderLoginPredecessors({
+      tabs: [
+        signInTab({
+          instanceId: "old-signin",
+          sessionId: "signin-old",
+          providerId: "reasonix",
+        }),
         signInTab({
           instanceId: "new-signin",
           sessionId: "signin-new",
           providerId: "reasonix",
         }),
       ],
+      activeHostId: HOST_A,
+      sessions: [
+        session({ sessionId: "signin-old", status: "exited" }),
+        session({ sessionId: "signin-new", status: "running" }),
+      ],
+      providerLoginProviderFor,
     });
+    // Nothing is adopted in this pass (both sessions are tabbed), and the
+    // predecessor still has to go.
     expect(retired).toEqual(["old-signin"]);
   });
 
-  it("does not retire a predecessor whose session is still running, nor anything when nothing was adopted", () => {
-    const tabs = [
-      signInTab({
-        instanceId: "live-signin",
-        sessionId: "signin-live",
-        providerId: "reasonix",
-      }),
-    ];
-    const sessions = [
-      session({ sessionId: "signin-live", status: "running" }),
-      session({ sessionId: "signin-new", status: "running" }),
-    ];
-    expect(
-      retiredProviderLoginPredecessors({
-        tabs,
-        activeHostId: HOST_A,
-        sessions,
-        adopted: [
-          signInTab({
-            instanceId: "new-signin",
-            sessionId: "signin-new",
-            providerId: "reasonix",
-          }),
-        ],
-      }),
-    ).toEqual([]);
-    expect(
-      retiredProviderLoginPredecessors({
-        tabs,
-        activeHostId: HOST_A,
-        sessions: [session({ sessionId: "signin-live", status: "exited" })],
-        adopted: [],
-      }),
-    ).toEqual([]);
+  it("retires an older exited tab when a newer exited sign-in is listed, and keeps the tab that IS the newest", () => {
+    const retired = retiredProviderLoginPredecessors({
+      tabs: [
+        signInTab({
+          instanceId: "older",
+          sessionId: "signin-older",
+          providerId: "reasonix",
+        }),
+        signInTab({
+          instanceId: "newest",
+          sessionId: "signin-newest",
+          providerId: "reasonix",
+        }),
+      ],
+      activeHostId: HOST_A,
+      sessions: [
+        {
+          ...session({ sessionId: "signin-older", status: "exited" }),
+          createdAt: 1,
+        },
+        {
+          ...session({ sessionId: "signin-newest", status: "exited" }),
+          createdAt: 2,
+        },
+      ],
+      providerLoginProviderFor,
+    });
+    expect(retired).toEqual(["older"]);
+  });
+
+  it("never retires a tab whose own session is still running, nor one whose provider has nothing newer listed", () => {
+    const retired = retiredProviderLoginPredecessors({
+      tabs: [
+        signInTab({
+          instanceId: "live-signin",
+          sessionId: "signin-live",
+          providerId: "reasonix",
+        }),
+        // Aged out of the grace listing entirely, and nothing newer listed
+        // for its provider: the ended tab stays, it is still the restart
+        // surface.
+        signInTab({
+          instanceId: "copilot-absent",
+          sessionId: "copilot-gone",
+          providerId: "copilot",
+        }),
+      ],
+      activeHostId: HOST_A,
+      sessions: [
+        session({ sessionId: "signin-live", status: "running" }),
+        session({ sessionId: "signin-new", status: "running" }),
+      ],
+      providerLoginProviderFor,
+    });
+    expect(retired).toEqual([]);
   });
 
   it("the legacy arm drops the retired predecessor while adopting its successor", () => {
@@ -1246,13 +1293,53 @@ describe("retiredProviderLoginPredecessors", () => {
       ],
       excludedSessionKeys: new Set(),
       mintInstanceId: () => "new-signin",
-      providerLoginProviderFor: (sessionId) =>
-        sessionId.startsWith("signin-") ? "reasonix" : null,
+      providerLoginProviderFor,
     });
     expect(result.tabs.map((entry) => entry.instanceId)).toEqual([
       "new-signin",
     ]);
     expect(result.activeInstanceId).toBe("new-signin");
+  });
+
+  it("a tombstoned newest retry still outranks the older exited retries: closing it promotes none of them", () => {
+    // The user closed the newest exited sign-in here; its kill is in flight
+    // and the host still lists it. The older retries beside it in the grace
+    // listing must not become fresh "Start again" tabs.
+    const sessions = [
+      {
+        ...session({ sessionId: "signin-older", status: "exited" }),
+        createdAt: 1,
+      },
+      {
+        ...session({ sessionId: "signin-newest", status: "exited" }),
+        createdAt: 2,
+      },
+    ];
+    const excludedSessionKeys = new Set([
+      terminalSessionKey(HOST_A, "signin-newest"),
+    ]);
+    expect(
+      adoptListedProviderLoginSessions({
+        tabs: [],
+        activeHostId: HOST_A,
+        sessions,
+        excludedSessionKeys,
+        mintInstanceId: () => "never",
+        providerLoginProviderFor,
+      }),
+    ).toEqual([]);
+    // Same through the legacy arm, which filters tombstoned sessions out of
+    // its own matching but must not hide them from this rule.
+    const result = reconcileLandingTerminalTabs({
+      tabs: [],
+      activeInstanceId: null,
+      activeHostId: HOST_A,
+      sessions,
+      excludedSessionKeys,
+      mintInstanceId: () => "never",
+      providerLoginProviderFor,
+    });
+    expect(result.adoptedTabs).toEqual([]);
   });
 });
 

--- a/clients/gui-app/src/components/home/terminal-panel/__tests__/landing-terminal-lifecycle.test.ts
+++ b/clients/gui-app/src/components/home/terminal-panel/__tests__/landing-terminal-lifecycle.test.ts
@@ -16,6 +16,7 @@ import {
   adoptListedProviderLoginSessions,
   reconcileLandingTerminalTabs,
   resolveLandingTerminalSyncedTitle,
+  retiredProviderLoginPredecessors,
   resolveLandingTerminalTitleCwd,
 } from "@/components/home/terminal-panel/landing-terminal-reconciliation";
 import { resolveLandingTerminalAvailability } from "@/components/home/terminal-panel/landing-terminal-availability";
@@ -1139,6 +1140,119 @@ describe("adoptListedProviderLoginSessions", () => {
     expect(adopted.map((entry) => entry.instanceId)).toEqual([
       "adopted-signin-instance",
     ]);
+  });
+});
+
+describe("retiredProviderLoginPredecessors", () => {
+  const signInTab = (input: {
+    readonly instanceId: string;
+    readonly sessionId: string;
+    readonly providerId: "reasonix" | "copilot";
+  }): LandingTerminalTabRef => ({
+    ...tab({
+      instanceId: input.instanceId,
+      sessionId: input.sessionId,
+      hostId: HOST_A,
+    }),
+    origin: "provider-login",
+    originProviderId: input.providerId,
+  });
+
+  it("retires this host's exited sign-in tab for a provider whose successor is being adopted", () => {
+    // Another window pressed "Start again": the host killed the predecessor
+    // this window still shows as an ended tab, and lists the successor.
+    const retired = retiredProviderLoginPredecessors({
+      tabs: [
+        signInTab({
+          instanceId: "old-signin",
+          sessionId: "signin-old",
+          providerId: "reasonix",
+        }),
+        // Another provider's ended tab is untouched.
+        signInTab({
+          instanceId: "copilot-ended",
+          sessionId: "copilot-old",
+          providerId: "copilot",
+        }),
+        // An ordinary tab is never a predecessor.
+        tab({ instanceId: "plain", sessionId: "plain-1", hostId: HOST_A }),
+      ],
+      activeHostId: HOST_A,
+      sessions: [
+        session({ sessionId: "signin-old", status: "exited" }),
+        session({ sessionId: "signin-new", status: "running" }),
+      ],
+      adopted: [
+        signInTab({
+          instanceId: "new-signin",
+          sessionId: "signin-new",
+          providerId: "reasonix",
+        }),
+      ],
+    });
+    expect(retired).toEqual(["old-signin"]);
+  });
+
+  it("does not retire a predecessor whose session is still running, nor anything when nothing was adopted", () => {
+    const tabs = [
+      signInTab({
+        instanceId: "live-signin",
+        sessionId: "signin-live",
+        providerId: "reasonix",
+      }),
+    ];
+    const sessions = [
+      session({ sessionId: "signin-live", status: "running" }),
+      session({ sessionId: "signin-new", status: "running" }),
+    ];
+    expect(
+      retiredProviderLoginPredecessors({
+        tabs,
+        activeHostId: HOST_A,
+        sessions,
+        adopted: [
+          signInTab({
+            instanceId: "new-signin",
+            sessionId: "signin-new",
+            providerId: "reasonix",
+          }),
+        ],
+      }),
+    ).toEqual([]);
+    expect(
+      retiredProviderLoginPredecessors({
+        tabs,
+        activeHostId: HOST_A,
+        sessions: [session({ sessionId: "signin-live", status: "exited" })],
+        adopted: [],
+      }),
+    ).toEqual([]);
+  });
+
+  it("the legacy arm drops the retired predecessor while adopting its successor", () => {
+    const result = reconcileLandingTerminalTabs({
+      tabs: [
+        signInTab({
+          instanceId: "old-signin",
+          sessionId: "signin-old",
+          providerId: "reasonix",
+        }),
+      ],
+      activeInstanceId: "old-signin",
+      activeHostId: HOST_A,
+      sessions: [
+        session({ sessionId: "signin-old", status: "exited" }),
+        session({ sessionId: "signin-new", status: "running" }),
+      ],
+      excludedSessionKeys: new Set(),
+      mintInstanceId: () => "new-signin",
+      providerLoginProviderFor: (sessionId) =>
+        sessionId.startsWith("signin-") ? "reasonix" : null,
+    });
+    expect(result.tabs.map((entry) => entry.instanceId)).toEqual([
+      "new-signin",
+    ]);
+    expect(result.activeInstanceId).toBe("new-signin");
   });
 });
 

--- a/clients/gui-app/src/components/home/terminal-panel/__tests__/landing-terminal-lifecycle.test.ts
+++ b/clients/gui-app/src/components/home/terminal-panel/__tests__/landing-terminal-lifecycle.test.ts
@@ -13,6 +13,7 @@ import {
 } from "@/stores/home/landing-terminal-store";
 import {
   reconcileHostAuthoritativeLandingTerminalTabs,
+  adoptListedProviderLoginSessions,
   reconcileLandingTerminalTabs,
   resolveLandingTerminalSyncedTitle,
   resolveLandingTerminalTitleCwd,
@@ -945,6 +946,173 @@ describe("landing terminal lifecycle", () => {
     });
 
     expect(result.tabs).toEqual([{ ...defaultTab, name: "vim" }]);
+  });
+});
+
+describe("adoptListedProviderLoginSessions", () => {
+  const providerLoginProviderFor = (sessionId: string) =>
+    sessionId === "signin-session" ? ("reasonix" as const) : null;
+
+  it("adopts a registry-claimed running session that has no tab, in the sign-in shape", () => {
+    const adopted = adoptListedProviderLoginSessions({
+      tabs: [],
+      activeHostId: HOST_A,
+      sessions: [
+        session({ sessionId: "signin-session", status: "running" }),
+        session({ sessionId: "ordinary-session", status: "running" }),
+      ],
+      excludedSessionKeys: new Set(),
+      mintInstanceId: () => "adopted-signin-instance",
+      providerLoginProviderFor,
+    });
+
+    // The ordinary session is left alone: on a capable host the plain
+    // projection is the authority over it, and adopting it from the list
+    // would race that arm with a second, unacknowledged tab.
+    expect(adopted).toEqual([
+      {
+        instanceId: "adopted-signin-instance",
+        sessionId: "signin-session",
+        hostId: HOST_A,
+        cwd: "/workspace/project",
+        name: "Reasonix sign-in",
+        titleSource: "manual",
+        origin: "provider-login",
+        originProviderId: "reasonix",
+      },
+    ]);
+  });
+
+  it("adopts nothing for a session that already has a tab on this host, whatever that tab's shape", () => {
+    const adopted = adoptListedProviderLoginSessions({
+      tabs: [
+        tab({
+          instanceId: "existing",
+          sessionId: "signin-session",
+          hostId: HOST_A,
+        }),
+      ],
+      activeHostId: HOST_A,
+      sessions: [session({ sessionId: "signin-session", status: "running" })],
+      excludedSessionKeys: new Set(),
+      mintInstanceId: () => "never",
+      providerLoginProviderFor,
+    });
+
+    // Reclassifying that tab is the reconciliation pass's job
+    // (`classifyLandingTab`); this only fills an ABSENCE.
+    expect(adopted).toEqual([]);
+  });
+
+  it("adopts nothing for a tombstoned session or one that is not running", () => {
+    const tombstoned = adoptListedProviderLoginSessions({
+      tabs: [],
+      activeHostId: HOST_A,
+      sessions: [session({ sessionId: "signin-session", status: "running" })],
+      // Closed here; the kill is still in flight, so the host still lists it.
+      excludedSessionKeys: new Set([
+        terminalSessionKey(HOST_A, "signin-session"),
+      ]),
+      mintInstanceId: () => "never",
+      providerLoginProviderFor,
+    });
+    expect(tombstoned).toEqual([]);
+
+    const exited = adoptListedProviderLoginSessions({
+      tabs: [],
+      activeHostId: HOST_A,
+      sessions: [session({ sessionId: "signin-session", status: "exited" })],
+      excludedSessionKeys: new Set(),
+      mintInstanceId: () => "never",
+      providerLoginProviderFor,
+    });
+    expect(exited).toEqual([]);
+  });
+
+  it("does not let another host's tab for the same session id stand in", () => {
+    const adopted = adoptListedProviderLoginSessions({
+      tabs: [
+        tab({
+          instanceId: "other-host",
+          sessionId: "signin-session",
+          hostId: HOST_B,
+        }),
+      ],
+      activeHostId: HOST_A,
+      sessions: [session({ sessionId: "signin-session", status: "running" })],
+      excludedSessionKeys: new Set(),
+      mintInstanceId: () => "adopted-signin-instance",
+      providerLoginProviderFor,
+    });
+
+    expect(adopted.map((entry) => entry.instanceId)).toEqual([
+      "adopted-signin-instance",
+    ]);
+  });
+});
+
+describe("revealPanel", () => {
+  beforeEach(() => {
+    useLandingTerminalStore.getState().resetForTests();
+  });
+
+  it("opens the named pages and records the reveal; clearPanelReveal retires it", () => {
+    const store = useLandingTerminalStore.getState();
+    store.setPanelOpen("page-a", false);
+    store.setPanelOpen("page-b", false);
+
+    store.revealPanel({
+      landingPageIds: ["page-a", "page-b"],
+      everyPage: false,
+      instanceId: "sign-in-instance",
+    });
+
+    const state = useLandingTerminalStore.getState();
+    expect(landingTerminalLayoutFor(state, "page-a").panelOpen).toBe(true);
+    expect(landingTerminalLayoutFor(state, "page-b").panelOpen).toBe(true);
+    // A page it did not name keeps its own layout.
+    expect(state.fallbackLayout?.panelOpen ?? false).toBe(false);
+    expect(state.panelReveal).toBe("sign-in-instance");
+
+    state.clearPanelReveal();
+    expect(useLandingTerminalStore.getState().panelReveal).toBeNull();
+  });
+
+  it("with everyPage opens the named pages AND every other - each keyed layout and the fallback - and still records the reveal", () => {
+    const store = useLandingTerminalStore.getState();
+    store.setPanelOpen("page-closed", false);
+
+    store.revealPanel({
+      landingPageIds: ["page-initiating"],
+      everyPage: true,
+      instanceId: "sign-in-instance",
+    });
+
+    const state = useLandingTerminalStore.getState();
+    expect(landingTerminalLayoutFor(state, "page-closed").panelOpen).toBe(true);
+    expect(landingTerminalLayoutFor(state, "page-never-seen").panelOpen).toBe(
+      true,
+    );
+    // The initiating page still records a layout of its own.
+    expect(state.layoutsByLandingPageId["page-initiating"]?.panelOpen).toBe(
+      true,
+    );
+    expect(state.panelReveal).toBe("sign-in-instance");
+  });
+
+  it("does not persist the reveal", async () => {
+    useLandingTerminalStore.getState().revealPanel({
+      landingPageIds: [],
+      everyPage: true,
+      instanceId: "sign-in-instance",
+    });
+    await useLandingTerminalStore.persist.rehydrate();
+    const persisted = JSON.parse(
+      window.localStorage.getItem(
+        useLandingTerminalStore.persist.getOptions().name ?? "",
+      ) ?? "{}",
+    ) as { state?: Record<string, unknown> };
+    expect(persisted.state).not.toHaveProperty("panelReveal");
   });
 });
 

--- a/clients/gui-app/src/components/home/terminal-panel/__tests__/landing-terminal-lifecycle.test.ts
+++ b/clients/gui-app/src/components/home/terminal-panel/__tests__/landing-terminal-lifecycle.test.ts
@@ -516,6 +516,30 @@ describe("landing terminal lifecycle", () => {
     expect(result.adoptedTabs[0]?.name).not.toBe("project · New Terminal");
   });
 
+  it("adopts an unmatched EXITED session as a sign-in tab when the registry claims it, but never as an ordinary tab", () => {
+    const result = reconcileLandingTerminalTabs({
+      tabs: [],
+      activeInstanceId: null,
+      activeHostId: HOST_A,
+      sessions: [
+        session({ sessionId: "signin-session", status: "exited" }),
+        session({ sessionId: "plain-session", status: "exited" }),
+      ],
+      excludedSessionKeys: new Set(),
+      mintInstanceId: () => "adopted-ended-instance",
+      providerLoginProviderFor: (sessionId) =>
+        sessionId === "signin-session" ? "reasonix" : null,
+    });
+
+    // The same rule the matched arm applies (a sign-in tab survives its
+    // session's exit): the registry-claimed session becomes the ended-state
+    // tab with its restart, the plain one stays dead and unadopted.
+    expect(result.adoptedTabs.map((tab) => tab.sessionId)).toEqual([
+      "signin-session",
+    ]);
+    expect(result.adoptedTabs[0]?.origin).toBe("provider-login");
+  });
+
   it("adopts the same unmatched running session as an ordinary tab when providerLoginProviderFor returns null", () => {
     const result = reconcileLandingTerminalTabs({
       tabs: [],
@@ -1004,7 +1028,7 @@ describe("adoptListedProviderLoginSessions", () => {
     expect(adopted).toEqual([]);
   });
 
-  it("adopts nothing for a tombstoned session or one that is not running", () => {
+  it("adopts nothing for a tombstoned session", () => {
     const tombstoned = adoptListedProviderLoginSessions({
       tabs: [],
       activeHostId: HOST_A,
@@ -1017,16 +1041,44 @@ describe("adoptListedProviderLoginSessions", () => {
       providerLoginProviderFor,
     });
     expect(tombstoned).toEqual([]);
+  });
 
-    const exited = adoptListedProviderLoginSessions({
+  it("adopts an EXITED registry-claimed session - the ended-state tab is the 'Start again' surface", () => {
+    // A short-lived sign-in can end before this window learns what it was;
+    // the host still lists it through its exit grace window. Running-only
+    // adoption would leave this window without the restart surface for good.
+    const adopted = adoptListedProviderLoginSessions({
       tabs: [],
       activeHostId: HOST_A,
       sessions: [session({ sessionId: "signin-session", status: "exited" })],
       excludedSessionKeys: new Set(),
-      mintInstanceId: () => "never",
+      mintInstanceId: () => "adopted-ended-instance",
       providerLoginProviderFor,
     });
-    expect(exited).toEqual([]);
+    expect(adopted.map((entry) => entry.instanceId)).toEqual([
+      "adopted-ended-instance",
+    ]);
+    expect(adopted[0]?.origin).toBe("provider-login");
+  });
+
+  it("does not adopt an exited sign-in whose provider has a RUNNING sign-in on the host - the predecessor a restart killed", () => {
+    const adopted = adoptListedProviderLoginSessions({
+      tabs: [],
+      activeHostId: HOST_A,
+      sessions: [
+        session({ sessionId: "signin-session", status: "exited" }),
+        session({ sessionId: "signin-session-2", status: "running" }),
+      ],
+      excludedSessionKeys: new Set(),
+      mintInstanceId: () => "adopted-live-instance",
+      providerLoginProviderFor: (sessionId) =>
+        sessionId.startsWith("signin-session") ? "reasonix" : null,
+    });
+    // The window that pressed "Start again" retired the dead tab; this one
+    // must not raise it beside the live successor.
+    expect(adopted.map((entry) => entry.sessionId)).toEqual([
+      "signin-session-2",
+    ]);
   });
 
   it("does not let another host's tab for the same session id stand in", () => {

--- a/clients/gui-app/src/components/home/terminal-panel/__tests__/landing-terminal-lifecycle.test.ts
+++ b/clients/gui-app/src/components/home/terminal-panel/__tests__/landing-terminal-lifecycle.test.ts
@@ -517,7 +517,7 @@ describe("landing terminal lifecycle", () => {
     expect(result.adoptedTabs[0]?.name).not.toBe("project · New Terminal");
   });
 
-  it("adopts an unmatched EXITED session as a sign-in tab when the registry claims it, but never as an ordinary tab", () => {
+  it("adopts no unmatched EXITED session, registry-claimed or not", () => {
     const result = reconcileLandingTerminalTabs({
       tabs: [],
       activeInstanceId: null,
@@ -527,18 +527,11 @@ describe("landing terminal lifecycle", () => {
         session({ sessionId: "plain-session", status: "exited" }),
       ],
       excludedSessionKeys: new Set(),
-      mintInstanceId: () => "adopted-ended-instance",
+      mintInstanceId: () => "never",
       providerLoginProviderFor: (sessionId) =>
         sessionId === "signin-session" ? "reasonix" : null,
     });
-
-    // The same rule the matched arm applies (a sign-in tab survives its
-    // session's exit): the registry-claimed session becomes the ended-state
-    // tab with its restart, the plain one stays dead and unadopted.
-    expect(result.adoptedTabs.map((tab) => tab.sessionId)).toEqual([
-      "signin-session",
-    ]);
-    expect(result.adoptedTabs[0]?.origin).toBe("provider-login");
+    expect(result.adoptedTabs).toEqual([]);
   });
 
   it("adopts the same unmatched running session as an ordinary tab when providerLoginProviderFor returns null", () => {
@@ -1044,22 +1037,21 @@ describe("adoptListedProviderLoginSessions", () => {
     expect(tombstoned).toEqual([]);
   });
 
-  it("adopts an EXITED registry-claimed session - the ended-state tab is the 'Start again' surface", () => {
-    // A short-lived sign-in can end before this window learns what it was;
-    // the host still lists it through its exit grace window. Running-only
-    // adoption would leave this window without the restart surface for good.
+  it("never adopts an EXITED session, even a registry-claimed one - an ended tab belongs to the window that had it", () => {
+    // The host lists an exited sign-in through a grace window and evicts it
+    // on `terminal.kill`, so which exited retry is "the one" changes with
+    // every close; every rule built on that resurrected some retry. The
+    // window that opened the sign-in keeps its ended tab through the exit
+    // (the matched arm); any other window starts fresh from the picker.
     const adopted = adoptListedProviderLoginSessions({
       tabs: [],
       activeHostId: HOST_A,
       sessions: [session({ sessionId: "signin-session", status: "exited" })],
       excludedSessionKeys: new Set(),
-      mintInstanceId: () => "adopted-ended-instance",
+      mintInstanceId: () => "never",
       providerLoginProviderFor,
     });
-    expect(adopted.map((entry) => entry.instanceId)).toEqual([
-      "adopted-ended-instance",
-    ]);
-    expect(adopted[0]?.origin).toBe("provider-login");
+    expect(adopted).toEqual([]);
   });
 
   it("does not adopt an exited sign-in whose provider has a RUNNING sign-in on the host - the predecessor a restart killed", () => {
@@ -1079,45 +1071,6 @@ describe("adoptListedProviderLoginSessions", () => {
     // must not raise it beside the live successor.
     expect(adopted.map((entry) => entry.sessionId)).toEqual([
       "signin-session-2",
-    ]);
-  });
-
-  it("adopts only the NEWEST exited sign-in per provider when none is running - rapid retries leave several in the grace listing", () => {
-    const adopted = adoptListedProviderLoginSessions({
-      tabs: [],
-      activeHostId: HOST_A,
-      sessions: [
-        {
-          ...session({ sessionId: "signin-old", status: "exited" }),
-          createdAt: 1,
-        },
-        {
-          ...session({ sessionId: "signin-newest", status: "exited" }),
-          createdAt: 3,
-        },
-        {
-          ...session({ sessionId: "signin-mid", status: "exited" }),
-          createdAt: 2,
-        },
-        // Another provider's exited sign-in is its own newest.
-        {
-          ...session({ sessionId: "copilot-old", status: "exited" }),
-          createdAt: 1,
-        },
-      ],
-      excludedSessionKeys: new Set(),
-      mintInstanceId: () => "adopted",
-      providerLoginProviderFor: (sessionId) => {
-        if (sessionId.startsWith("signin-")) return "reasonix";
-        if (sessionId.startsWith("copilot-")) return "copilot";
-        return null;
-      },
-    });
-    // One "Start again" surface per provider, never a stale duplicate whose
-    // restart would retire only itself.
-    expect(adopted.map((entry) => entry.sessionId).sort()).toEqual([
-      "copilot-old",
-      "signin-newest",
     ]);
   });
 
@@ -1219,17 +1172,12 @@ describe("retiredProviderLoginPredecessors", () => {
     expect(retired).toEqual(["old-signin"]);
   });
 
-  it("retires an older exited tab when a newer exited sign-in is listed, and keeps the tab that IS the newest", () => {
+  it("keeps every ended tab while nothing for its provider runs - a newer EXITED sign-in supersedes nothing", () => {
     const retired = retiredProviderLoginPredecessors({
       tabs: [
         signInTab({
           instanceId: "older",
           sessionId: "signin-older",
-          providerId: "reasonix",
-        }),
-        signInTab({
-          instanceId: "newest",
-          sessionId: "signin-newest",
           providerId: "reasonix",
         }),
       ],
@@ -1246,7 +1194,7 @@ describe("retiredProviderLoginPredecessors", () => {
       ],
       providerLoginProviderFor,
     });
-    expect(retired).toEqual(["older"]);
+    expect(retired).toEqual([]);
   });
 
   it("never retires a tab whose own session is still running, nor one whose provider has nothing newer listed", () => {
@@ -1301,45 +1249,38 @@ describe("retiredProviderLoginPredecessors", () => {
     expect(result.activeInstanceId).toBe("new-signin");
   });
 
-  it("a tombstoned newest retry still outranks the older exited retries: closing it promotes none of them", () => {
-    // The user closed the newest exited sign-in here; its kill is in flight
-    // and the host still lists it. The older retries beside it in the grace
-    // listing must not become fresh "Start again" tabs.
+  it("a tombstoned RUNNING successor still retires its predecessor, and retiring the last tab collapses the panel", () => {
+    // The user closed the running successor here; its kill is in flight and
+    // the host still lists it running. The exited predecessor stays retired
+    // (it is not coming back), nothing is adopted (the successor is
+    // tombstoned), and the pass ends with no tabs - which must collapse the
+    // panel, or the settlement's empty-panel path spawns a plain shell right
+    // after the user closed the sign-in.
     const sessions = [
-      {
-        ...session({ sessionId: "signin-older", status: "exited" }),
-        createdAt: 1,
-      },
-      {
-        ...session({ sessionId: "signin-newest", status: "exited" }),
-        createdAt: 2,
-      },
+      session({ sessionId: "signin-old", status: "exited" }),
+      session({ sessionId: "signin-new", status: "running" }),
     ];
     const excludedSessionKeys = new Set([
-      terminalSessionKey(HOST_A, "signin-newest"),
+      terminalSessionKey(HOST_A, "signin-new"),
     ]);
-    expect(
-      adoptListedProviderLoginSessions({
-        tabs: [],
-        activeHostId: HOST_A,
-        sessions,
-        excludedSessionKeys,
-        mintInstanceId: () => "never",
-        providerLoginProviderFor,
-      }),
-    ).toEqual([]);
-    // Same through the legacy arm, which filters tombstoned sessions out of
-    // its own matching but must not hide them from this rule.
     const result = reconcileLandingTerminalTabs({
-      tabs: [],
-      activeInstanceId: null,
+      tabs: [
+        signInTab({
+          instanceId: "old-signin",
+          sessionId: "signin-old",
+          providerId: "reasonix",
+        }),
+      ],
+      activeInstanceId: "old-signin",
       activeHostId: HOST_A,
       sessions,
       excludedSessionKeys,
       mintInstanceId: () => "never",
       providerLoginProviderFor,
     });
+    expect(result.tabs).toEqual([]);
     expect(result.adoptedTabs).toEqual([]);
+    expect(result.collapseWhenEmpty).toBe(true);
   });
 });
 

--- a/clients/gui-app/src/components/home/terminal-panel/__tests__/landing-terminal-panel.test.tsx
+++ b/clients/gui-app/src/components/home/terminal-panel/__tests__/landing-terminal-panel.test.tsx
@@ -16,6 +16,11 @@ import {
   type LandingTerminalTabRef,
 } from "@/stores/home/landing-terminal-store";
 import {
+  recordProviderLoginTerminal,
+  useProviderLoginTerminalsStore,
+} from "@/stores/providers/provider-login-terminals";
+import { openLandingSignInTerminal } from "@/lib/terminals/landing-sign-in-terminal";
+import {
   landingTerminalRightActionsKey,
   useMobileHeaderStore,
 } from "@/stores/layout/mobile-header-store";
@@ -637,6 +642,10 @@ describe("<LandingTerminalPanel />", () => {
     resetTerminalFocusRegistryForTests();
     resetPrimaryFocusCoordinatorForTests();
     useLandingTerminalStore.getState().resetForTests();
+    useProviderLoginTerminalsStore.setState({
+      providerBySessionKey: {},
+      recentKeys: [],
+    });
     setSystemTabModalApi(null);
     useTabsStore.setState(INITIAL_TABS_LAYOUT);
   });
@@ -1427,6 +1436,114 @@ describe("<LandingTerminalPanel />", () => {
     // The capable arm's shared mutation never sees a provider-login close -
     // it has no plain-terminal row to require, and would reject.
     expect(mocks.plainCloseAsync).not.toHaveBeenCalled();
+  });
+
+  it("reveals a host-created sign-in tab into a CLOSED panel without settling the open as a gesture", async () => {
+    mocks.activeHostId = "host-a";
+    mocks.clientActiveHostId = "host-a";
+    mocks.primaryWorkspacePath = "/workspace/project";
+    mocks.probeData = emptyList("/Users/dev");
+    mocks.freshProbeData = mocks.probeData;
+    mocks.plainAuthorityStatus = "capable";
+    mocks.plainCanMutate = true;
+    // A fresh projection, or the capable pass waits instead of settling and
+    // the gesture below would never be acted on either way.
+    mocks.plainCollection = freshPlainCollection([]);
+    // Panel closed when the host answers `providers.startTerminalLogin`. The
+    // mount pass runs closed and fetches too; let it fetch and settle first so
+    // the count below is the TRANSITION's own pass, not the mount's.
+    render(panelUi());
+    await waitFor(() => {
+      expect(mocks.queryClient.fetchQuery).toHaveBeenCalled();
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    const fetchesBeforeOpen = mocks.queryClient.fetchQuery.mock.calls.length;
+
+    act(() => {
+      openLandingSignInTerminal({
+        landingPageId: TEST_LANDING_PAGE_ID,
+        hostId: "host-a",
+        providerId: "reasonix",
+        sessionId: "term-sign-in",
+        replacedSessionId: null,
+        launchedFromSessionId: null,
+      });
+    });
+    expect(
+      landingTerminalLayoutFor(
+        useLandingTerminalStore.getState(),
+        TEST_LANDING_PAGE_ID,
+      ).panelOpen,
+    ).toBe(true);
+
+    // The closed-to-open transition used to be read as the user's opening
+    // gesture, which settles by re-targeting the launch cwd. The sign-in
+    // tab's display-only `"~"` matches none, so settlement spawned a plain
+    // shell and activated it - over the tab that carries the sign-in code.
+    // The transition re-keys reconciliation; wait for its fresh list, then
+    // let the settlement run, so "nothing spawned" is an ordering claim.
+    await waitFor(() => {
+      expect(mocks.queryClient.fetchQuery.mock.calls.length).toBeGreaterThan(
+        fetchesBeforeOpen,
+      );
+    });
+    // Settlement is several awaits past the fetch (stale checks, the capable
+    // pass); drain them all before claiming nothing spawned.
+    await act(async () => {
+      for (let tick = 0; tick < 10; tick += 1) await Promise.resolve();
+    });
+
+    const state = useLandingTerminalStore.getState();
+    expect(state.tabs).toHaveLength(1);
+    expect(state.tabs[0]?.origin).toBe("provider-login");
+    expect(state.activeInstanceId).toBe(state.tabs[0]?.instanceId);
+    expect(mocks.plainCreateAsync).not.toHaveBeenCalled();
+    // Consumed by that one transition, so the next open is a real gesture.
+    expect(state.panelReveal).toBeNull();
+  });
+
+  it("adopts a sign-in session another window started, from terminal.list, on a capable host whose projection cannot carry it", async () => {
+    mocks.activeHostId = "host-a";
+    mocks.clientActiveHostId = "host-a";
+    mocks.primaryWorkspacePath = "/workspace/project";
+    // Listed by the host - it is a live manager-owned session - but absent
+    // from the plain projection, which only ever holds plain-registry rows.
+    mocks.probeData = listWith(
+      [runningSession("term-peer-sign-in")],
+      "/Users/dev",
+    );
+    mocks.freshProbeData = mocks.probeData;
+    mocks.plainAuthorityStatus = "capable";
+    mocks.plainCanMutate = true;
+    mocks.plainCollection = freshPlainCollection([]);
+    // The peer window's record, arrived through the shared registry.
+    recordProviderLoginTerminal({
+      hostId: "host-a",
+      sessionId: "term-peer-sign-in",
+      providerId: "reasonix",
+    });
+    useLandingTerminalStore.getState().setPanelOpen(TEST_LANDING_PAGE_ID, true);
+    render(panelUi());
+
+    await waitFor(() => {
+      expect(useLandingTerminalStore.getState().tabs).toHaveLength(1);
+    });
+    const tab = useLandingTerminalStore.getState().tabs[0];
+    expect(tab).toMatchObject({
+      sessionId: "term-peer-sign-in",
+      hostId: "host-a",
+      name: "Reasonix sign-in",
+      titleSource: "manual",
+      origin: "provider-login",
+      originProviderId: "reasonix",
+    });
+    // Adopted as the host's session, never created or imported under its id:
+    // the durable bootstrap would `terminal.plain.create` a bare shell, and
+    // an import would hand the plain registry a session it never spawned.
+    expect(mocks.plainCreateAsync).not.toHaveBeenCalled();
+    expect(mocks.plainImportAsync).not.toHaveBeenCalled();
   });
 
   it("leaves the tombstone to the owner when its close merely joins one", async () => {

--- a/clients/gui-app/src/components/home/terminal-panel/__tests__/landing-terminal-panel.test.tsx
+++ b/clients/gui-app/src/components/home/terminal-panel/__tests__/landing-terminal-panel.test.tsx
@@ -1546,6 +1546,39 @@ describe("<LandingTerminalPanel />", () => {
     expect(mocks.plainImportAsync).not.toHaveBeenCalled();
   });
 
+  it("adopts a listed sign-in even while the capable host's plain stream is read-only - the list that answered is all it needs", async () => {
+    mocks.activeHostId = "host-a";
+    mocks.clientActiveHostId = "host-a";
+    mocks.primaryWorkspacePath = "/workspace/project";
+    mocks.probeData = listWith(
+      [runningSession("term-peer-sign-in")],
+      "/Users/dev",
+    );
+    mocks.freshProbeData = mocks.probeData;
+    mocks.plainAuthorityStatus = "capable";
+    // A reconnecting list stream: the capable pass waits for mutability and
+    // returns without settling. A sign-in is short-lived; one that exits
+    // during that wait could never be adopted afterwards (running sessions
+    // only), and its restart surface with it.
+    mocks.plainCanMutate = false;
+    mocks.plainCollection = freshPlainCollection([]);
+    recordProviderLoginTerminal({
+      hostId: "host-a",
+      sessionId: "term-peer-sign-in",
+      providerId: "reasonix",
+    });
+    useLandingTerminalStore.getState().setPanelOpen(TEST_LANDING_PAGE_ID, true);
+    render(panelUi());
+
+    await waitFor(() => {
+      expect(useLandingTerminalStore.getState().tabs).toHaveLength(1);
+    });
+    expect(useLandingTerminalStore.getState().tabs[0]).toMatchObject({
+      sessionId: "term-peer-sign-in",
+      origin: "provider-login",
+    });
+  });
+
   it("leaves the tombstone to the owner when its close merely joins one", async () => {
     // The close coordinator keys by the terminal's LIFETIME, not by RPC, so
     // this close can join an in-flight `terminal.kill` the recovery bridge

--- a/clients/gui-app/src/components/home/terminal-panel/__tests__/landing-terminal-panel.test.tsx
+++ b/clients/gui-app/src/components/home/terminal-panel/__tests__/landing-terminal-panel.test.tsx
@@ -1530,6 +1530,9 @@ describe("<LandingTerminalPanel />", () => {
     await waitFor(() => {
       expect(useLandingTerminalStore.getState().tabs).toHaveLength(1);
     });
+    // Through the rendered panel too: the adopted tab is reachable, not only
+    // stored.
+    await screen.findByRole("tab", { name: /Reasonix sign-in/ });
     const tab = useLandingTerminalStore.getState().tabs[0];
     expect(tab).toMatchObject({
       sessionId: "term-peer-sign-in",
@@ -1573,6 +1576,7 @@ describe("<LandingTerminalPanel />", () => {
     await waitFor(() => {
       expect(useLandingTerminalStore.getState().tabs).toHaveLength(1);
     });
+    await screen.findByRole("tab", { name: /Reasonix sign-in/ });
     expect(useLandingTerminalStore.getState().tabs[0]).toMatchObject({
       sessionId: "term-peer-sign-in",
       origin: "provider-login",

--- a/clients/gui-app/src/components/home/terminal-panel/landing-terminal-panel.tsx
+++ b/clients/gui-app/src/components/home/terminal-panel/landing-terminal-panel.tsx
@@ -674,16 +674,29 @@ export function LandingTerminalPanel(): ReactNode {
   useEffect(() => {
     const previous = previousPanelLayoutRef.current;
     previousPanelLayoutRef.current = { landingPageId, panelOpen };
+    const store = useLandingTerminalStore.getState();
     if (previous.landingPageId !== landingPageId) {
       clearPendingTerminalFocus(null);
+      // A reveal written for the page just left has had its transition there
+      // or never will; left standing it would suppress this page's next real
+      // gesture.
+      store.clearPanelReveal();
       return;
     }
     const wasOpen = previous.panelOpen;
     if (wasOpen === panelOpen) return;
     if (panelOpen) {
-      if (!pending) capture();
-      const openActiveInstanceId =
-        useLandingTerminalStore.getState().activeInstanceId;
+      const openActiveInstanceId = store.activeInstanceId;
+      // An open made to SHOW the active tab is not an opening gesture. Settling
+      // it as one re-targets the launch cwd, which a host-created sign-in tab
+      // (display-only `"~"`) never matches - so it would spawn a bare shell
+      // over the tab the open was for. Consumed here whatever it named, so a
+      // reveal cannot outlive the one transition it describes.
+      const revealed =
+        store.panelReveal !== null &&
+        store.panelReveal === openActiveInstanceId;
+      store.clearPanelReveal();
+      if (!pending && !revealed) capture();
       if (
         openActiveInstanceId !== null &&
         directoryRequestRef.current === null
@@ -694,7 +707,10 @@ export function LandingTerminalPanel(): ReactNode {
     }
     // Every collapse path converges on this store transition: the chord, the
     // header button, closing the last tab, close-all, and a shell exiting.
-    // All of them should hand the keyboard back to the composer.
+    // All of them should hand the keyboard back to the composer. A reveal that
+    // found the panel already open never saw a transition; it retires here so
+    // the NEXT open - a real gesture - is settled as one.
+    store.clearPanelReveal();
     clearPendingTerminalFocus(null);
     focusActiveComposer();
   }, [capture, landingPageId, panelOpen, pending]);

--- a/clients/gui-app/src/components/home/terminal-panel/landing-terminal-reconciliation.ts
+++ b/clients/gui-app/src/components/home/terminal-panel/landing-terminal-reconciliation.ts
@@ -294,20 +294,36 @@ export function adoptListedProviderLoginSessions(
         terminalSessionKey(input.activeHostId, session.sessionId),
       ),
   );
-  const providersWithRunningSignIn = new Set(
-    listed.flatMap((session) => {
-      if (session.status !== "running") return [];
-      const providerId = input.providerLoginProviderFor(session.sessionId);
-      return providerId === null ? [] : [providerId];
-    }),
-  );
+  // Per provider: is a sign-in running, and which exited one is newest.
+  // Rapid retries can leave several exited sign-ins for one provider in the
+  // grace listing; only the newest is the one a "Start again" should stand
+  // for, the rest are the predecessors those retries killed.
+  const providersWithRunningSignIn = new Set<ProviderId>();
+  const newestExitedSessionIdByProvider = new Map<
+    ProviderId,
+    Pick<CanonicalTerminalSessionInfo, "sessionId" | "createdAt">
+  >();
+  for (const session of listed) {
+    const providerId = input.providerLoginProviderFor(session.sessionId);
+    if (providerId === null) continue;
+    if (session.status === "running") {
+      providersWithRunningSignIn.add(providerId);
+      continue;
+    }
+    const newest = newestExitedSessionIdByProvider.get(providerId);
+    if (newest === undefined || session.createdAt > newest.createdAt) {
+      newestExitedSessionIdByProvider.set(providerId, session);
+    }
+  }
   return listed.flatMap((session) => {
     if (tabbedSessionIds.has(session.sessionId)) return [];
     const providerId = input.providerLoginProviderFor(session.sessionId);
     if (providerId === null) return [];
     if (
       session.status !== "running" &&
-      providersWithRunningSignIn.has(providerId)
+      (providersWithRunningSignIn.has(providerId) ||
+        newestExitedSessionIdByProvider.get(providerId)?.sessionId !==
+          session.sessionId)
     ) {
       return [];
     }

--- a/clients/gui-app/src/components/home/terminal-panel/landing-terminal-reconciliation.ts
+++ b/clients/gui-app/src/components/home/terminal-panel/landing-terminal-reconciliation.ts
@@ -198,7 +198,18 @@ export function reconcileLandingTerminalTabs(
     return [tab];
   });
   const adoptedTabs = [...signInTabs, ...ordinaryTabs];
-  const nextTabs = [...tabs, ...adoptedTabs];
+  const retired = new Set(
+    retiredProviderLoginPredecessors({
+      tabs,
+      activeHostId: input.activeHostId,
+      sessions,
+      adopted: signInTabs,
+    }),
+  );
+  const nextTabs = [
+    ...tabs.filter((tab) => !retired.has(tab.instanceId)),
+    ...adoptedTabs,
+  ];
   const activeInstanceId = resolveActiveInstanceId(
     input.activeInstanceId,
     nextTabs,
@@ -336,6 +347,51 @@ export function adoptListedProviderLoginSessions(
       }),
     ];
   });
+}
+
+/**
+ * The sign-in tabs an adoption SUPERSEDES: this host's existing tabs for the
+ * same provider as an adopted session, whose own session is no longer
+ * running. Returned as instance ids for the caller to drop alongside the
+ * adoption, in both arms.
+ *
+ * A restart kills its predecessor, and only the window that pressed it
+ * retires that tab (`openLandingSignInTerminal`). Every other window that had
+ * adopted the predecessor - the ended-state tab is kept on purpose - would
+ * otherwise adopt the successor beside it and hold two "Start again" tabs
+ * for one provider, the stale one restarting only itself. A predecessor
+ * whose session is still running is NOT retired: that is two live sign-ins,
+ * which is the host's to resolve, not this window's to hide.
+ */
+export function retiredProviderLoginPredecessors(input: {
+  readonly tabs: ReadonlyArray<LandingTerminalTabRef>;
+  readonly activeHostId: string;
+  readonly sessions: LandingTerminalReconciliationInput["sessions"];
+  readonly adopted: ReadonlyArray<LandingTerminalTabRef>;
+}): ReadonlyArray<string> {
+  if (input.adopted.length === 0) return [];
+  const runningSessionIds = new Set(
+    input.sessions
+      .filter((session) => session.status === "running")
+      .map((session) => session.sessionId),
+  );
+  const adoptedSessionIds = new Set(input.adopted.map((tab) => tab.sessionId));
+  const adoptedProviders = new Set(
+    input.adopted.flatMap((tab) =>
+      tab.originProviderId === undefined ? [] : [tab.originProviderId],
+    ),
+  );
+  return input.tabs
+    .filter(
+      (tab) =>
+        tab.hostId === input.activeHostId &&
+        isProviderLoginLandingTab(tab) &&
+        tab.originProviderId !== undefined &&
+        adoptedProviders.has(tab.originProviderId) &&
+        !adoptedSessionIds.has(tab.sessionId) &&
+        !runningSessionIds.has(tab.sessionId),
+    )
+    .map((tab) => tab.instanceId);
 }
 
 /**

--- a/clients/gui-app/src/components/home/terminal-panel/landing-terminal-reconciliation.ts
+++ b/clients/gui-app/src/components/home/terminal-panel/landing-terminal-reconciliation.ts
@@ -172,23 +172,20 @@ export function reconcileLandingTerminalTabs(
     return [name === classified.name ? classified : { ...classified, name }];
   });
 
-  const adoptedTabs = sessions.flatMap((session) => {
+  // Sign-ins first, through the one adoption rule both arms share (it also
+  // takes an exited session, which an ordinary adoption never does), then
+  // ordinary running sessions the registry does not claim.
+  const signInTabs = adoptListedProviderLoginSessions({
+    ...input,
+    tabs: survivingTabs,
+  });
+  const ordinaryTabs = sessions.flatMap((session) => {
     if (
       session.status !== "running" ||
-      matchedSessionIds.has(session.sessionId)
+      matchedSessionIds.has(session.sessionId) ||
+      input.providerLoginProviderFor(session.sessionId) !== null
     ) {
       return [];
-    }
-    const originProviderId = input.providerLoginProviderFor(session.sessionId);
-    if (originProviderId !== null) {
-      return [
-        providerLoginLandingTab({
-          instanceId: input.mintInstanceId(),
-          hostId: input.activeHostId,
-          session,
-          providerId: originProviderId,
-        }),
-      ];
     }
     const tab: LandingTerminalTabRef = {
       instanceId: input.mintInstanceId(),
@@ -200,6 +197,7 @@ export function reconcileLandingTerminalTabs(
     };
     return [tab];
   });
+  const adoptedTabs = [...signInTabs, ...ordinaryTabs];
   const nextTabs = [...tabs, ...adoptedTabs];
   const activeInstanceId = resolveActiveInstanceId(
     input.activeInstanceId,
@@ -261,6 +259,16 @@ function providerLoginLandingTab(input: {
  * A tombstoned session (closed here, kill still in flight) is excluded for the
  * same reason the legacy arm excludes it: adopting it back would resurrect a
  * tab the user just closed.
+ *
+ * An EXITED sign-in is adopted too, unlike an ordinary session. A sign-in tab
+ * keeps its ended state on purpose - that is the "Start again" surface - and
+ * a short-lived sign-in can end before this window learns what it was, while
+ * the host still lists it through its exit grace window; adopting running
+ * sessions only would leave this window without that surface for good. The
+ * one exited sign-in NOT adopted is one the same provider has a running
+ * successor for on this host: a restart kills its predecessor, and the
+ * window that pressed it retires that tab, so this window should not raise
+ * the dead one beside the live one.
  */
 export function adoptListedProviderLoginSessions(
   input: Pick<
@@ -278,20 +286,31 @@ export function adoptListedProviderLoginSessions(
       .filter((tab) => tab.hostId === input.activeHostId)
       .map((tab) => tab.sessionId),
   );
-  return input.sessions.flatMap((session) => {
-    if (
-      session.scope.kind !== "independent" ||
-      session.sessionKind !== "terminal" ||
-      session.status !== "running" ||
-      tabbedSessionIds.has(session.sessionId) ||
-      input.excludedSessionKeys.has(
+  const listed = input.sessions.filter(
+    (session) =>
+      session.scope.kind === "independent" &&
+      session.sessionKind === "terminal" &&
+      !input.excludedSessionKeys.has(
         terminalSessionKey(input.activeHostId, session.sessionId),
-      )
+      ),
+  );
+  const providersWithRunningSignIn = new Set(
+    listed.flatMap((session) => {
+      if (session.status !== "running") return [];
+      const providerId = input.providerLoginProviderFor(session.sessionId);
+      return providerId === null ? [] : [providerId];
+    }),
+  );
+  return listed.flatMap((session) => {
+    if (tabbedSessionIds.has(session.sessionId)) return [];
+    const providerId = input.providerLoginProviderFor(session.sessionId);
+    if (providerId === null) return [];
+    if (
+      session.status !== "running" &&
+      providersWithRunningSignIn.has(providerId)
     ) {
       return [];
     }
-    const providerId = input.providerLoginProviderFor(session.sessionId);
-    if (providerId === null) return [];
     return [
       providerLoginLandingTab({
         instanceId: input.mintInstanceId(),

--- a/clients/gui-app/src/components/home/terminal-panel/landing-terminal-reconciliation.ts
+++ b/clients/gui-app/src/components/home/terminal-panel/landing-terminal-reconciliation.ts
@@ -202,8 +202,8 @@ export function reconcileLandingTerminalTabs(
     retiredProviderLoginPredecessors({
       tabs,
       activeHostId: input.activeHostId,
-      sessions,
-      adopted: signInTabs,
+      sessions: input.sessions,
+      providerLoginProviderFor: input.providerLoginProviderFor,
     }),
   );
   const nextTabs = [
@@ -254,32 +254,108 @@ function providerLoginLandingTab(input: {
 }
 
 /**
- * The CAPABLE host's adoption of sign-in sessions, from `terminal.list`.
+ * What the registry-claimed sessions the host lists say about each provider:
+ * which are running, and which exited one is newest. Computed over EVERY
+ * listed claimed session, tombstoned ones included - a tombstone means "raise
+ * no tab for this session", not "this session did not happen". The newest
+ * retry the user just closed still outranks the older retries beside it in
+ * the exit-grace listing; dropping it from the summary would promote one of
+ * them into a fresh "Start again" tab the moment the close landed.
+ */
+interface ProviderLoginListing {
+  readonly runningSessionIds: ReadonlySet<string>;
+  readonly newestExited: Pick<
+    CanonicalTerminalSessionInfo,
+    "sessionId" | "createdAt"
+  > | null;
+}
+
+function listedProviderLoginSessions(
+  sessions: LandingTerminalReconciliationInput["sessions"],
+): LandingTerminalReconciliationInput["sessions"] {
+  return sessions.filter(
+    (session) =>
+      session.scope.kind === "independent" &&
+      session.sessionKind === "terminal",
+  );
+}
+
+function summarizeProviderLoginListing(
+  sessions: LandingTerminalReconciliationInput["sessions"],
+  providerLoginProviderFor: (sessionId: string) => ProviderId | null,
+): ReadonlyMap<ProviderId, ProviderLoginListing> {
+  const summary = new Map<
+    ProviderId,
+    {
+      runningSessionIds: Set<string>;
+      newestExited: ProviderLoginListing["newestExited"];
+    }
+  >();
+  for (const session of sessions) {
+    const providerId = providerLoginProviderFor(session.sessionId);
+    if (providerId === null) continue;
+    const entry = summary.get(providerId) ?? {
+      runningSessionIds: new Set<string>(),
+      newestExited: null,
+    };
+    if (session.status === "running") {
+      entry.runningSessionIds.add(session.sessionId);
+    } else if (
+      entry.newestExited === null ||
+      session.createdAt > entry.newestExited.createdAt
+    ) {
+      entry.newestExited = session;
+    }
+    summary.set(providerId, entry);
+  }
+  return summary;
+}
+
+/**
+ * Whether a sign-in session (or the tab standing for it) is one this window
+ * should show for its provider: every running one, else the newest exited
+ * one. Rapid retries can leave several exited sign-ins for one provider in
+ * the grace listing; only the newest is the one a "Start again" should stand
+ * for, the rest are the predecessors those retries killed. An absent session
+ * (aged out of the grace window, or gone with a host restart) is outranked by
+ * anything listed - it is by construction older.
+ */
+function providerLoginSessionIsCurrent(
+  listing: ProviderLoginListing | undefined,
+  sessionId: string,
+): boolean {
+  if (listing === undefined) return true;
+  if (listing.runningSessionIds.has(sessionId)) return true;
+  if (listing.runningSessionIds.size > 0) return false;
+  return listing.newestExited === null
+    ? true
+    : listing.newestExited.sessionId === sessionId;
+}
+
+/**
+ * The sign-in sessions the host lists that this window should hold a tab for
+ * and does not, as sign-in tabs. Shared by both arms.
  *
  * The capable arm reconciles against the plain-terminal projection, and a
  * host-created sign-in session is never in it: the host made it for
  * `providers.startTerminalLogin`, through the session manager, so the plain
- * registry has no row for it. The legacy arm adopts such a session from
- * `terminal.list` (above); without this the capable arm could classify a tab
- * that already existed but never CREATE one - so a sign-in started in another
- * window, whose record arrived through the shared registry, had no tab on a
- * capable host and its code stayed invisible there.
+ * registry has no row for it. Without this the capable arm could classify a
+ * tab that already existed but never CREATE one - so a sign-in started in
+ * another window, whose record arrived through the shared registry, had no
+ * tab on a capable host and its code stayed invisible there.
  *
  * Sign-in sessions ONLY - a session the registry does not claim is left to the
  * projection, which is the capable host's authority over ordinary terminals.
- * A tombstoned session (closed here, kill still in flight) is excluded for the
- * same reason the legacy arm excludes it: adopting it back would resurrect a
- * tab the user just closed.
+ * A tombstoned session (closed here, kill still in flight) is never adopted:
+ * that would resurrect a tab the user just closed. It still counts in the
+ * per-provider listing above, so closing the newest retry does not promote an
+ * older one.
  *
  * An EXITED sign-in is adopted too, unlike an ordinary session. A sign-in tab
  * keeps its ended state on purpose - that is the "Start again" surface - and
  * a short-lived sign-in can end before this window learns what it was, while
  * the host still lists it through its exit grace window; adopting running
- * sessions only would leave this window without that surface for good. The
- * one exited sign-in NOT adopted is one the same provider has a running
- * successor for on this host: a restart kills its predecessor, and the
- * window that pressed it retires that tab, so this window should not raise
- * the dead one beside the live one.
+ * sessions only would leave this window without that surface for good.
  */
 export function adoptListedProviderLoginSessions(
   input: Pick<
@@ -297,44 +373,24 @@ export function adoptListedProviderLoginSessions(
       .filter((tab) => tab.hostId === input.activeHostId)
       .map((tab) => tab.sessionId),
   );
-  const listed = input.sessions.filter(
-    (session) =>
-      session.scope.kind === "independent" &&
-      session.sessionKind === "terminal" &&
-      !input.excludedSessionKeys.has(
-        terminalSessionKey(input.activeHostId, session.sessionId),
-      ),
+  const listed = listedProviderLoginSessions(input.sessions);
+  const listing = summarizeProviderLoginListing(
+    listed,
+    input.providerLoginProviderFor,
   );
-  // Per provider: is a sign-in running, and which exited one is newest.
-  // Rapid retries can leave several exited sign-ins for one provider in the
-  // grace listing; only the newest is the one a "Start again" should stand
-  // for, the rest are the predecessors those retries killed.
-  const providersWithRunningSignIn = new Set<ProviderId>();
-  const newestExitedSessionIdByProvider = new Map<
-    ProviderId,
-    Pick<CanonicalTerminalSessionInfo, "sessionId" | "createdAt">
-  >();
-  for (const session of listed) {
-    const providerId = input.providerLoginProviderFor(session.sessionId);
-    if (providerId === null) continue;
-    if (session.status === "running") {
-      providersWithRunningSignIn.add(providerId);
-      continue;
-    }
-    const newest = newestExitedSessionIdByProvider.get(providerId);
-    if (newest === undefined || session.createdAt > newest.createdAt) {
-      newestExitedSessionIdByProvider.set(providerId, session);
-    }
-  }
   return listed.flatMap((session) => {
-    if (tabbedSessionIds.has(session.sessionId)) return [];
+    if (
+      tabbedSessionIds.has(session.sessionId) ||
+      input.excludedSessionKeys.has(
+        terminalSessionKey(input.activeHostId, session.sessionId),
+      )
+    ) {
+      return [];
+    }
     const providerId = input.providerLoginProviderFor(session.sessionId);
     if (providerId === null) return [];
     if (
-      session.status !== "running" &&
-      (providersWithRunningSignIn.has(providerId) ||
-        newestExitedSessionIdByProvider.get(providerId)?.sessionId !==
-          session.sessionId)
+      !providerLoginSessionIsCurrent(listing.get(providerId), session.sessionId)
     ) {
       return [];
     }
@@ -350,47 +406,49 @@ export function adoptListedProviderLoginSessions(
 }
 
 /**
- * The sign-in tabs an adoption SUPERSEDES: this host's existing tabs for the
- * same provider as an adopted session, whose own session is no longer
- * running. Returned as instance ids for the caller to drop alongside the
- * adoption, in both arms.
+ * The sign-in tabs the host's listing has SUPERSEDED: this host's tabs whose
+ * session is no longer the one to show for its provider (a running sign-in
+ * exists, or a newer exited one does). Returned as instance ids for the
+ * caller to drop in the same pass that adopts, in both arms.
  *
  * A restart kills its predecessor, and only the window that pressed it
- * retires that tab (`openLandingSignInTerminal`). Every other window that had
- * adopted the predecessor - the ended-state tab is kept on purpose - would
- * otherwise adopt the successor beside it and hold two "Start again" tabs
- * for one provider, the stale one restarting only itself. A predecessor
- * whose session is still running is NOT retired: that is two live sign-ins,
- * which is the host's to resolve, not this window's to hide.
+ * retires that tab (`openLandingSignInTerminal`). Every other window that
+ * shows the predecessor - adopted, or reclassified once its provenance
+ * arrived - would otherwise hold it beside the successor and have two
+ * "Start again" tabs for one provider, the stale one restarting only itself.
+ * Judged from the listing rather than from what THIS pass adopted: the
+ * successor may already be a tab here, adopted as an ordinary terminal
+ * before its record arrived and classified since, in which case nothing is
+ * adopted and the predecessor still has to go. A tab whose own session is
+ * still running is never retired: two live sign-ins are the host's to
+ * resolve, not this window's to hide.
  */
 export function retiredProviderLoginPredecessors(input: {
   readonly tabs: ReadonlyArray<LandingTerminalTabRef>;
   readonly activeHostId: string;
   readonly sessions: LandingTerminalReconciliationInput["sessions"];
-  readonly adopted: ReadonlyArray<LandingTerminalTabRef>;
+  readonly providerLoginProviderFor: (sessionId: string) => ProviderId | null;
 }): ReadonlyArray<string> {
-  if (input.adopted.length === 0) return [];
-  const runningSessionIds = new Set(
-    input.sessions
-      .filter((session) => session.status === "running")
-      .map((session) => session.sessionId),
-  );
-  const adoptedSessionIds = new Set(input.adopted.map((tab) => tab.sessionId));
-  const adoptedProviders = new Set(
-    input.adopted.flatMap((tab) =>
-      tab.originProviderId === undefined ? [] : [tab.originProviderId],
-    ),
+  const listing = summarizeProviderLoginListing(
+    listedProviderLoginSessions(input.sessions),
+    input.providerLoginProviderFor,
   );
   return input.tabs
-    .filter(
-      (tab) =>
-        tab.hostId === input.activeHostId &&
-        isProviderLoginLandingTab(tab) &&
-        tab.originProviderId !== undefined &&
-        adoptedProviders.has(tab.originProviderId) &&
-        !adoptedSessionIds.has(tab.sessionId) &&
-        !runningSessionIds.has(tab.sessionId),
-    )
+    .filter((tab) => {
+      if (
+        tab.hostId !== input.activeHostId ||
+        !isProviderLoginLandingTab(tab)
+      ) {
+        return false;
+      }
+      const providerId =
+        tab.originProviderId ?? input.providerLoginProviderFor(tab.sessionId);
+      if (providerId === null) return false;
+      return !providerLoginSessionIsCurrent(
+        listing.get(providerId),
+        tab.sessionId,
+      );
+    })
     .map((tab) => tab.instanceId);
 }
 

--- a/clients/gui-app/src/components/home/terminal-panel/landing-terminal-reconciliation.ts
+++ b/clients/gui-app/src/components/home/terminal-panel/landing-terminal-reconciliation.ts
@@ -172,8 +172,7 @@ export function reconcileLandingTerminalTabs(
     return [name === classified.name ? classified : { ...classified, name }];
   });
 
-  // Sign-ins first, through the one adoption rule both arms share (it also
-  // takes an exited session, which an ordinary adoption never does), then
+  // Sign-ins first, through the one adoption rule both arms share, then
   // ordinary running sessions the registry does not claim.
   const signInTabs = adoptListedProviderLoginSessions({
     ...input,
@@ -210,6 +209,7 @@ export function reconcileLandingTerminalTabs(
     ...tabs.filter((tab) => !retired.has(tab.instanceId)),
     ...adoptedTabs,
   ];
+  const retiredAny = retired.size > 0;
   const activeInstanceId = resolveActiveInstanceId(
     input.activeInstanceId,
     nextTabs,
@@ -223,6 +223,7 @@ export function reconcileLandingTerminalTabs(
     collapseWhenEmpty:
       nextTabs.length === 0 &&
       (exitedInstanceIds.length > 0 ||
+        retiredAny ||
         survivingTabs.length !== input.tabs.length),
   };
 }
@@ -255,19 +256,23 @@ function providerLoginLandingTab(input: {
 
 /**
  * What the registry-claimed sessions the host lists say about each provider:
- * which are running, and which exited one is newest. Computed over EVERY
- * listed claimed session, tombstoned ones included - a tombstone means "raise
- * no tab for this session", not "this session did not happen". The newest
- * retry the user just closed still outranks the older retries beside it in
- * the exit-grace listing; dropping it from the summary would promote one of
- * them into a fresh "Start again" tab the moment the close landed.
+ * which of them are RUNNING. Computed over every listed claimed session,
+ * tombstoned ones included - a tombstone means "raise no tab for this
+ * session", not "this session did not happen", and a running successor the
+ * user just closed still supersedes its predecessor until the kill lands.
+ *
+ * Exited sessions carry no weight here, deliberately. The host lists an
+ * exited sign-in through a grace window and evicts it on `terminal.kill`, so
+ * the set of exited sessions is a moving, partial record of retries: which
+ * of them is "the one to show" changes with every close, and every rule
+ * built on it (newest wins, tombstoned newest still wins, ...) left a case
+ * where a close resurrected an older retry. An ended sign-in tab exists for
+ * the window that HAD the tab - it keeps it through the exit (matched arm) -
+ * and any other window starts a sign-in from the picker, so nothing is lost
+ * by never adopting one.
  */
 interface ProviderLoginListing {
   readonly runningSessionIds: ReadonlySet<string>;
-  readonly newestExited: Pick<
-    CanonicalTerminalSessionInfo,
-    "sessionId" | "createdAt"
-  > | null;
 }
 
 function listedProviderLoginSessions(
@@ -284,57 +289,41 @@ function summarizeProviderLoginListing(
   sessions: LandingTerminalReconciliationInput["sessions"],
   providerLoginProviderFor: (sessionId: string) => ProviderId | null,
 ): ReadonlyMap<ProviderId, ProviderLoginListing> {
-  const summary = new Map<
-    ProviderId,
-    {
-      runningSessionIds: Set<string>;
-      newestExited: ProviderLoginListing["newestExited"];
-    }
-  >();
+  const summary = new Map<ProviderId, { runningSessionIds: Set<string> }>();
   for (const session of sessions) {
+    if (session.status !== "running") continue;
     const providerId = providerLoginProviderFor(session.sessionId);
     if (providerId === null) continue;
     const entry = summary.get(providerId) ?? {
       runningSessionIds: new Set<string>(),
-      newestExited: null,
     };
-    if (session.status === "running") {
-      entry.runningSessionIds.add(session.sessionId);
-    } else if (
-      entry.newestExited === null ||
-      session.createdAt > entry.newestExited.createdAt
-    ) {
-      entry.newestExited = session;
-    }
+    entry.runningSessionIds.add(session.sessionId);
     summary.set(providerId, entry);
   }
   return summary;
 }
 
 /**
- * Whether a sign-in session (or the tab standing for it) is one this window
- * should show for its provider: every running one, else the newest exited
- * one. Rapid retries can leave several exited sign-ins for one provider in
- * the grace listing; only the newest is the one a "Start again" should stand
- * for, the rest are the predecessors those retries killed. An absent session
- * (aged out of the grace window, or gone with a host restart) is outranked by
- * anything listed - it is by construction older.
+ * Whether the tab standing for a sign-in session is one this window should
+ * keep showing for its provider: yes while its session runs, and yes while
+ * nothing for that provider runs (an ended tab is the "Start again" surface);
+ * no once the provider has a running session that is not this one - a
+ * restart killed this predecessor.
  */
 function providerLoginSessionIsCurrent(
   listing: ProviderLoginListing | undefined,
   sessionId: string,
 ): boolean {
   if (listing === undefined) return true;
-  if (listing.runningSessionIds.has(sessionId)) return true;
-  if (listing.runningSessionIds.size > 0) return false;
-  return listing.newestExited === null
-    ? true
-    : listing.newestExited.sessionId === sessionId;
+  return (
+    listing.runningSessionIds.has(sessionId) ||
+    listing.runningSessionIds.size === 0
+  );
 }
 
 /**
- * The sign-in sessions the host lists that this window should hold a tab for
- * and does not, as sign-in tabs. Shared by both arms.
+ * The RUNNING sign-in sessions the host lists that this window has no tab
+ * for, as sign-in tabs. Shared by both arms.
  *
  * The capable arm reconciles against the plain-terminal projection, and a
  * host-created sign-in session is never in it: the host made it for
@@ -348,14 +337,9 @@ function providerLoginSessionIsCurrent(
  * projection, which is the capable host's authority over ordinary terminals.
  * A tombstoned session (closed here, kill still in flight) is never adopted:
  * that would resurrect a tab the user just closed. It still counts in the
- * per-provider listing above, so closing the newest retry does not promote an
- * older one.
- *
- * An EXITED sign-in is adopted too, unlike an ordinary session. A sign-in tab
- * keeps its ended state on purpose - that is the "Start again" surface - and
- * a short-lived sign-in can end before this window learns what it was, while
- * the host still lists it through its exit grace window; adopting running
- * sessions only would leave this window without that surface for good.
+ * per-provider listing above while it runs, so its predecessor stays retired
+ * until the kill lands. Exited sessions are not adopted at all - see
+ * `ProviderLoginListing` for why.
  */
 export function adoptListedProviderLoginSessions(
   input: Pick<
@@ -380,6 +364,7 @@ export function adoptListedProviderLoginSessions(
   );
   return listed.flatMap((session) => {
     if (
+      session.status !== "running" ||
       tabbedSessionIds.has(session.sessionId) ||
       input.excludedSessionKeys.has(
         terminalSessionKey(input.activeHostId, session.sessionId),
@@ -407,9 +392,11 @@ export function adoptListedProviderLoginSessions(
 
 /**
  * The sign-in tabs the host's listing has SUPERSEDED: this host's tabs whose
- * session is no longer the one to show for its provider (a running sign-in
- * exists, or a newer exited one does). Returned as instance ids for the
- * caller to drop in the same pass that adopts, in both arms.
+ * session is not running while another sign-in for the same provider is.
+ * Returned as instance ids for the caller to drop in the same pass that
+ * adopts, in both arms - and to count as removals, so a pass that retires
+ * the last tab collapses the panel instead of leaving an empty one open for
+ * the auto-spawn to fill with a plain shell the user never asked for.
  *
  * A restart kills its predecessor, and only the window that pressed it
  * retires that tab (`openLandingSignInTerminal`). Every other window that

--- a/clients/gui-app/src/components/home/terminal-panel/landing-terminal-reconciliation.ts
+++ b/clients/gui-app/src/components/home/terminal-panel/landing-terminal-reconciliation.ts
@@ -181,22 +181,14 @@ export function reconcileLandingTerminalTabs(
     }
     const originProviderId = input.providerLoginProviderFor(session.sessionId);
     if (originProviderId !== null) {
-      // Same ref shape the opening path writes, so every reader downstream -
-      // the adopt-only tile, the legacy-import exclusion, the close and rename
-      // paths - classifies a session discovered here exactly as one this
-      // window opened. Manual title for the same reason: the host names it
-      // "<Provider> sign-in" and reconciliation must not retitle it from cwd.
-      const signInTab: LandingTerminalTabRef = {
-        instanceId: input.mintInstanceId(),
-        sessionId: session.sessionId,
-        hostId: input.activeHostId,
-        cwd: session.cwd,
-        name: `${PROVIDER_DISPLAY_NAMES[originProviderId]} sign-in`,
-        titleSource: "manual",
-        origin: "provider-login",
-        originProviderId,
-      };
-      return [signInTab];
+      return [
+        providerLoginLandingTab({
+          instanceId: input.mintInstanceId(),
+          hostId: input.activeHostId,
+          session,
+          providerId: originProviderId,
+        }),
+      ];
     }
     const tab: LandingTerminalTabRef = {
       instanceId: input.mintInstanceId(),
@@ -224,6 +216,91 @@ export function reconcileLandingTerminalTabs(
       (exitedInstanceIds.length > 0 ||
         survivingTabs.length !== input.tabs.length),
   };
+}
+
+/**
+ * The ref for a listed sign-in session this window did not open. Same shape
+ * the opening path writes, so every reader downstream - the adopt-only tile,
+ * the legacy-import exclusion, the close and rename paths - classifies a
+ * session discovered here exactly as one this window opened. Manual title for
+ * the same reason: the host names it "<Provider> sign-in" and reconciliation
+ * must not retitle it from cwd.
+ */
+function providerLoginLandingTab(input: {
+  readonly instanceId: string;
+  readonly hostId: string;
+  readonly session: Pick<CanonicalTerminalSessionInfo, "sessionId" | "cwd">;
+  readonly providerId: ProviderId;
+}): LandingTerminalTabRef {
+  return {
+    instanceId: input.instanceId,
+    sessionId: input.session.sessionId,
+    hostId: input.hostId,
+    cwd: input.session.cwd,
+    name: `${PROVIDER_DISPLAY_NAMES[input.providerId]} sign-in`,
+    titleSource: "manual",
+    origin: "provider-login",
+    originProviderId: input.providerId,
+  };
+}
+
+/**
+ * The CAPABLE host's adoption of sign-in sessions, from `terminal.list`.
+ *
+ * The capable arm reconciles against the plain-terminal projection, and a
+ * host-created sign-in session is never in it: the host made it for
+ * `providers.startTerminalLogin`, through the session manager, so the plain
+ * registry has no row for it. The legacy arm adopts such a session from
+ * `terminal.list` (above); without this the capable arm could classify a tab
+ * that already existed but never CREATE one - so a sign-in started in another
+ * window, whose record arrived through the shared registry, had no tab on a
+ * capable host and its code stayed invisible there.
+ *
+ * Sign-in sessions ONLY - a session the registry does not claim is left to the
+ * projection, which is the capable host's authority over ordinary terminals.
+ * A tombstoned session (closed here, kill still in flight) is excluded for the
+ * same reason the legacy arm excludes it: adopting it back would resurrect a
+ * tab the user just closed.
+ */
+export function adoptListedProviderLoginSessions(
+  input: Pick<
+    LandingTerminalReconciliationInput,
+    | "tabs"
+    | "activeHostId"
+    | "sessions"
+    | "excludedSessionKeys"
+    | "mintInstanceId"
+    | "providerLoginProviderFor"
+  >,
+): ReadonlyArray<LandingTerminalTabRef> {
+  const tabbedSessionIds = new Set(
+    input.tabs
+      .filter((tab) => tab.hostId === input.activeHostId)
+      .map((tab) => tab.sessionId),
+  );
+  return input.sessions.flatMap((session) => {
+    if (
+      session.scope.kind !== "independent" ||
+      session.sessionKind !== "terminal" ||
+      session.status !== "running" ||
+      tabbedSessionIds.has(session.sessionId) ||
+      input.excludedSessionKeys.has(
+        terminalSessionKey(input.activeHostId, session.sessionId),
+      )
+    ) {
+      return [];
+    }
+    const providerId = input.providerLoginProviderFor(session.sessionId);
+    if (providerId === null) return [];
+    return [
+      providerLoginLandingTab({
+        instanceId: input.mintInstanceId(),
+        hostId: input.activeHostId,
+        session,
+        providerId,
+      }),
+    ];
+  });
 }
 
 /**

--- a/clients/gui-app/src/components/home/terminal-panel/use-landing-terminal-reconciliation.ts
+++ b/clients/gui-app/src/components/home/terminal-panel/use-landing-terminal-reconciliation.ts
@@ -287,6 +287,22 @@ export function useLandingTerminalReconciliation(
       const initial = useLandingTerminalStore.getState();
 
       if (plainAuthority.authority.capability.status === "capable") {
+        // From `terminal.list`, which the capable pass below never reads: a
+        // host-created sign-in session has no plain-terminal row, so the
+        // projection cannot adopt it, and a sign-in started in another window
+        // - whose record reached this one through the shared registry - would
+        // otherwise have no tab here. FIRST, ahead of the plain authority's
+        // own gates: the list that just answered is all this needs, and a
+        // sign-in is short-lived - one that exits while the stream is
+        // read-only or non-fresh could never be adopted afterwards (running
+        // sessions only), and its restart surface with it. Only for the
+        // selected host: the bound host fleet reconciles other hosts from
+        // their projections alone and fetches no list for them.
+        adoptListedSignInSessions({
+          activeHostId,
+          landingPageId,
+          sessions: freshSessions,
+        });
         // A read-only authority is a reconnecting list stream, not a failed
         // fetch. `onError` clears the picker's selected target and reports
         // "The terminal directory could not be opened.", which is simply
@@ -335,18 +351,6 @@ export function useLandingTerminalReconciliation(
           releaseLatch();
           return;
         }
-        // From `terminal.list`, which the capable pass above never reads: a
-        // host-created sign-in session has no plain-terminal row, so the
-        // projection cannot adopt it, and a sign-in started in another window
-        // - whose record reached this one through the shared registry - would
-        // otherwise have no tab here. Only for the selected host: the bound
-        // host fleet reconciles other hosts from their projections alone and
-        // fetches no list for them.
-        adoptListedSignInSessions({
-          activeHostId,
-          landingPageId,
-          sessions: freshSessions,
-        });
         onReconciled(hostContext);
         onSettled(generation, hostContext);
         return;

--- a/clients/gui-app/src/components/home/terminal-panel/use-landing-terminal-reconciliation.ts
+++ b/clients/gui-app/src/components/home/terminal-panel/use-landing-terminal-reconciliation.ts
@@ -41,6 +41,7 @@ import {
   adoptListedProviderLoginSessions,
   reconcileHostAuthoritativeLandingTerminalTabs,
   reconcileLandingTerminalTabs,
+  retiredProviderLoginPredecessors,
   type LandingTerminalReconciliationInput,
 } from "./landing-terminal-reconciliation";
 import type { LandingTerminalAvailability } from "./landing-terminal-availability";
@@ -457,9 +458,19 @@ function adoptListedSignInSessions(args: {
       providerLoginTerminalProviderId(activeHostId, sessionId),
   });
   if (adopted.length === 0) return;
+  // The predecessors these adoptions supersede - a restart another window
+  // pressed killed them, and only that window retired its tab.
+  const retired = new Set(
+    retiredProviderLoginPredecessors({
+      tabs: current.tabs,
+      activeHostId,
+      sessions: args.sessions,
+      adopted,
+    }),
+  );
   current.applyReconciliation(
     args.landingPageId,
-    [...current.tabs, ...adopted],
+    [...current.tabs.filter((tab) => !retired.has(tab.instanceId)), ...adopted],
     current.activeInstanceId,
     false,
   );

--- a/clients/gui-app/src/components/home/terminal-panel/use-landing-terminal-reconciliation.ts
+++ b/clients/gui-app/src/components/home/terminal-panel/use-landing-terminal-reconciliation.ts
@@ -457,17 +457,19 @@ function adoptListedSignInSessions(args: {
     providerLoginProviderFor: (sessionId) =>
       providerLoginTerminalProviderId(activeHostId, sessionId),
   });
-  if (adopted.length === 0) return;
-  // The predecessors these adoptions supersede - a restart another window
-  // pressed killed them, and only that window retired its tab.
+  // The predecessors the listing supersedes - a restart another window
+  // pressed killed them, and only that window retired its tab. Independent of
+  // what this pass adopted: the successor may already be a tab here.
   const retired = new Set(
     retiredProviderLoginPredecessors({
       tabs: current.tabs,
       activeHostId,
       sessions: args.sessions,
-      adopted,
+      providerLoginProviderFor: (sessionId) =>
+        providerLoginTerminalProviderId(activeHostId, sessionId),
     }),
   );
+  if (adopted.length === 0 && retired.size === 0) return;
   current.applyReconciliation(
     args.landingPageId,
     [...current.tabs.filter((tab) => !retired.has(tab.instanceId)), ...adopted],

--- a/clients/gui-app/src/components/home/terminal-panel/use-landing-terminal-reconciliation.ts
+++ b/clients/gui-app/src/components/home/terminal-panel/use-landing-terminal-reconciliation.ts
@@ -474,7 +474,9 @@ function adoptListedSignInSessions(args: {
     args.landingPageId,
     [...current.tabs.filter((tab) => !retired.has(tab.instanceId)), ...adopted],
     current.activeInstanceId,
-    false,
+    // Retirement is a removal: a pass that retires the last tab must collapse
+    // the panel, or the settlement's empty-panel path spawns a plain shell.
+    retired.size > 0,
   );
 }
 

--- a/clients/gui-app/src/components/home/terminal-panel/use-landing-terminal-reconciliation.ts
+++ b/clients/gui-app/src/components/home/terminal-panel/use-landing-terminal-reconciliation.ts
@@ -38,8 +38,10 @@ import {
   type LandingTerminalPendingKill,
 } from "@/stores/home/landing-terminal-store";
 import {
+  adoptListedProviderLoginSessions,
   reconcileHostAuthoritativeLandingTerminalTabs,
   reconcileLandingTerminalTabs,
+  type LandingTerminalReconciliationInput,
 } from "./landing-terminal-reconciliation";
 import type { LandingTerminalAvailability } from "./landing-terminal-availability";
 import type { LandingTerminalAuthorityEntry } from "./landing-terminal-authority-fleet";
@@ -333,6 +335,18 @@ export function useLandingTerminalReconciliation(
           releaseLatch();
           return;
         }
+        // From `terminal.list`, which the capable pass above never reads: a
+        // host-created sign-in session has no plain-terminal row, so the
+        // projection cannot adopt it, and a sign-in started in another window
+        // - whose record reached this one through the shared registry - would
+        // otherwise have no tab here. Only for the selected host: the bound
+        // host fleet reconciles other hosts from their projections alone and
+        // fetches no list for them.
+        adoptListedSignInSessions({
+          activeHostId,
+          landingPageId,
+          sessions: freshSessions,
+        });
         onReconciled(hostContext);
         onSettled(generation, hostContext);
         return;
@@ -409,6 +423,42 @@ export function useLandingTerminalReconciliation(
     provenanceRevision,
     queryClient,
   ]);
+}
+
+/**
+ * Adds a tab for every registry-claimed sign-in session the host lists that
+ * has none, keeping the current selection. See
+ * `adoptListedProviderLoginSessions` for why the capable arm needs this.
+ */
+function adoptListedSignInSessions(args: {
+  readonly activeHostId: string;
+  readonly landingPageId: string;
+  readonly sessions: LandingTerminalReconciliationInput["sessions"];
+}): void {
+  const { activeHostId } = args;
+  const current = useLandingTerminalStore.getState();
+  const adopted = adoptListedProviderLoginSessions({
+    tabs: current.tabs,
+    activeHostId,
+    sessions: args.sessions,
+    excludedSessionKeys: new Set(
+      current.pendingKills
+        .filter((pending) => pending.hostId === activeHostId)
+        .map((pending) =>
+          terminalSessionKey(pending.hostId, pending.sessionId),
+        ),
+    ),
+    mintInstanceId: () => `landing-terminal-${uuidv4()}`,
+    providerLoginProviderFor: (sessionId) =>
+      providerLoginTerminalProviderId(activeHostId, sessionId),
+  });
+  if (adopted.length === 0) return;
+  current.applyReconciliation(
+    args.landingPageId,
+    [...current.tabs, ...adopted],
+    current.activeInstanceId,
+    false,
+  );
 }
 
 /**

--- a/clients/gui-app/src/hooks/providers/__tests__/use-provider-terminal-login-scope-support.test.tsx
+++ b/clients/gui-app/src/hooks/providers/__tests__/use-provider-terminal-login-scope-support.test.tsx
@@ -6,10 +6,17 @@ import {
   resetNegotiatedManifests,
 } from "@traycer-clients/shared/host-transport/negotiated-manifest-registry";
 
-const mocks = vi.hoisted(() => ({ addressableHostId: { current: "host-1" } }));
-
+// The pickers that render this gate are drawn inside Epic TABS as well as on
+// the start page, and a tab resolves host identity through its lifetime
+// binding only. Any read of the app-wide host authority from this hook is a
+// violation, whichever surface then ignores the answer - so the module is
+// mocked to THROW, and every case below runs through it.
 vi.mock("@/hooks/host/use-addressable-host-id", () => ({
-  useAddressableHostId: () => mocks.addressableHostId.current,
+  useAddressableHostId: (): string => {
+    throw new Error(
+      "useProviderTerminalLoginScopeSupported must not read the addressable host",
+    );
+  },
 }));
 
 import {
@@ -45,7 +52,6 @@ function scopeSupported(
 describe("useProviderTerminalLoginScopeSupported", () => {
   beforeEach(() => {
     resetNegotiatedManifests();
-    mocks.addressableHostId.current = HOST_ID;
   });
 
   afterEach(() => {
@@ -71,6 +77,11 @@ describe("useProviderTerminalLoginScopeSupported", () => {
     expect(scopeSupported(EPIC_SURFACE, HOST_ID)).toBe(true);
   });
 
+  it("is true for the EPIC surface with no manifest recorded at all - the epic path never consults the registry", () => {
+    expect(scopeSupported(EPIC_SURFACE, HOST_ID)).toBe(true);
+    expect(scopeSupported(EPIC_SURFACE, null)).toBe(true);
+  });
+
   it("is true for the landing surface once the host negotiates the scoped major", () => {
     recordNegotiatedHostManifest(HOST_ID, manifestWithMajor(2));
 
@@ -85,21 +96,22 @@ describe("useProviderTerminalLoginScopeSupported", () => {
     expect(scopeSupported(null, HOST_ID)).toBe(true);
   });
 
-  it("resolves a null run target through the addressable host, not as an unknown host", () => {
+  it("reads a null landing run target as unsupported rather than filling it from the app-wide host", () => {
     recordNegotiatedHostManifest(HOST_ID, manifestWithMajor(2));
 
-    // `null` means "follow the app-wide default", which is the picker's COMMON
-    // case. Reading it as an unknown host would hide the action there.
-    expect(scopeSupported(LANDING_SURFACE, null)).toBe(true);
+    // The landing composer resolves its placement host itself and hands it
+    // down; `null` reaches the picker only in the ∅ case, where there is
+    // nothing usable to create on and submit refuses too. Resolving it here
+    // through the app-wide authority would be exactly the read a tab-bound
+    // picker must never make.
+    expect(scopeSupported(LANDING_SURFACE, null)).toBe(false);
   });
 
-  it("follows the addressable host's answer, not the last host recorded", () => {
+  it("answers for the host it was given, not the last host recorded", () => {
     recordNegotiatedHostManifest(HOST_ID, manifestWithMajor(2));
     recordNegotiatedHostManifest("host-2", manifestWithMajor(1));
-    mocks.addressableHostId.current = "host-2";
 
-    expect(scopeSupported(LANDING_SURFACE, null)).toBe(false);
-    // An explicit run target still outranks the app-wide default.
+    expect(scopeSupported(LANDING_SURFACE, "host-2")).toBe(false);
     expect(scopeSupported(LANDING_SURFACE, HOST_ID)).toBe(true);
   });
 });

--- a/clients/gui-app/src/hooks/providers/__tests__/use-provider-terminal-login-scope-support.test.tsx
+++ b/clients/gui-app/src/hooks/providers/__tests__/use-provider-terminal-login-scope-support.test.tsx
@@ -22,6 +22,7 @@ vi.mock("@/hooks/host/use-addressable-host-id", () => ({
 import {
   START_TERMINAL_LOGIN_METHOD,
   useProviderTerminalLoginScopeSupported,
+  type ProviderTerminalLoginScopeSupport,
 } from "@/hooks/providers/use-provider-terminal-login-scope-support";
 import type { ProviderTerminalLoginSurface } from "@/lib/providers/provider-terminal-login-surface";
 
@@ -40,10 +41,10 @@ function manifestWithMajor(major: number): ConnectionManifest {
   return { [START_TERMINAL_LOGIN_METHOD]: { major, minor: 0 } };
 }
 
-function scopeSupported(
+function scopeSupport(
   surface: ProviderTerminalLoginSurface | null,
   hostId: string | null,
-): boolean {
+): ProviderTerminalLoginScopeSupport {
   return renderHook(() =>
     useProviderTerminalLoginScopeSupported(surface, hostId),
   ).result.current;
@@ -58,60 +59,63 @@ describe("useProviderTerminalLoginScopeSupported", () => {
     resetNegotiatedManifests();
   });
 
-  it("is false for the landing surface on a host that negotiated the pre-scope major", () => {
+  it("is 'unsupported' for the landing surface on a host that negotiated the pre-scope major", () => {
     // `@1.0` has no `scope` field, so the client's downgrade refuses the
     // independent scope outright - the button could only ever fail, and for a
     // provider on the generic guidance there is no manual command to fall
-    // back to.
+    // back to. A POSITIVE answer: the copy built on it claims this host can
+    // open the sign-in from a chat, which a recorded `@1.0` proves.
     recordNegotiatedHostManifest(HOST_ID, manifestWithMajor(1));
 
-    expect(scopeSupported(LANDING_SURFACE, HOST_ID)).toBe(false);
+    expect(scopeSupport(LANDING_SURFACE, HOST_ID)).toBe("unsupported");
   });
 
-  it("is true for the EPIC surface on that same pre-scope host", () => {
+  it("is 'supported' for the EPIC surface on that same pre-scope host", () => {
     recordNegotiatedHostManifest(HOST_ID, manifestWithMajor(1));
 
     // `@1.0` represents an epic scope natively, so the epic action is
     // unaffected - the same provider on the same host answers differently per
     // surface, which is the whole reason this is not a provider-row fact.
-    expect(scopeSupported(EPIC_SURFACE, HOST_ID)).toBe(true);
+    expect(scopeSupport(EPIC_SURFACE, HOST_ID)).toBe("supported");
   });
 
-  it("is true for the EPIC surface with no manifest recorded at all - the epic path never consults the registry", () => {
-    expect(scopeSupported(EPIC_SURFACE, HOST_ID)).toBe(true);
-    expect(scopeSupported(EPIC_SURFACE, null)).toBe(true);
+  it("is 'supported' for the EPIC surface with no manifest recorded at all - the epic path never consults the registry", () => {
+    expect(scopeSupport(EPIC_SURFACE, HOST_ID)).toBe("supported");
+    expect(scopeSupport(EPIC_SURFACE, null)).toBe("supported");
   });
 
-  it("is true for the landing surface once the host negotiates the scoped major", () => {
+  it("is 'supported' for the landing surface once the host negotiates the scoped major", () => {
     recordNegotiatedHostManifest(HOST_ID, manifestWithMajor(2));
 
-    expect(scopeSupported(LANDING_SURFACE, HOST_ID)).toBe(true);
+    expect(scopeSupport(LANDING_SURFACE, HOST_ID)).toBe("supported");
   });
 
-  it("fails closed for the landing surface while the host's manifest is unknown", () => {
-    expect(scopeSupported(LANDING_SURFACE, HOST_ID)).toBe(false);
+  it("is 'unknown', not 'unsupported', for the landing surface while the host's manifest is unrecorded", () => {
+    // Fails closed (no button), but does NOT say the host negotiated the
+    // pre-scope major - nothing has been proven about it yet.
+    expect(scopeSupport(LANDING_SURFACE, HOST_ID)).toBe("unknown");
   });
 
-  it("is vacuously true with no surface, so a fork dialog still says where the button lives", () => {
-    expect(scopeSupported(null, HOST_ID)).toBe(true);
+  it("is vacuously 'supported' with no surface, so a fork dialog still says where the button lives", () => {
+    expect(scopeSupport(null, HOST_ID)).toBe("supported");
   });
 
-  it("reads a null landing run target as unsupported rather than filling it from the app-wide host", () => {
+  it("reads a null landing run target as 'unknown' rather than filling it from the app-wide host", () => {
     recordNegotiatedHostManifest(HOST_ID, manifestWithMajor(2));
 
     // The landing composer resolves its placement host itself and hands it
     // down; `null` reaches the picker only in the ∅ case, where there is
     // nothing usable to create on and submit refuses too. Resolving it here
     // through the app-wide authority would be exactly the read a tab-bound
-    // picker must never make.
-    expect(scopeSupported(LANDING_SURFACE, null)).toBe(false);
+    // picker must never make - and there is no machine to make a claim about.
+    expect(scopeSupport(LANDING_SURFACE, null)).toBe("unknown");
   });
 
   it("answers for the host it was given, not the last host recorded", () => {
     recordNegotiatedHostManifest(HOST_ID, manifestWithMajor(2));
     recordNegotiatedHostManifest("host-2", manifestWithMajor(1));
 
-    expect(scopeSupported(LANDING_SURFACE, "host-2")).toBe(false);
-    expect(scopeSupported(LANDING_SURFACE, HOST_ID)).toBe(true);
+    expect(scopeSupport(LANDING_SURFACE, "host-2")).toBe("unsupported");
+    expect(scopeSupport(LANDING_SURFACE, HOST_ID)).toBe("supported");
   });
 });

--- a/clients/gui-app/src/hooks/providers/use-provider-terminal-login-scope-support.ts
+++ b/clients/gui-app/src/hooks/providers/use-provider-terminal-login-scope-support.ts
@@ -1,4 +1,3 @@
-import { useAddressableHostId } from "@/hooks/host/use-addressable-host-id";
 import { useHostMethodSchemaVersion } from "@/hooks/host/use-host-supports-method";
 import type { ProviderTerminalLoginSurface } from "@/lib/providers/provider-terminal-login-surface";
 
@@ -35,20 +34,23 @@ const SCOPED_START_TERMINAL_LOGIN_MAJOR = 2;
  * action after `providers.list` answered on that same host, and that handshake
  * is what populates the registry.
  *
- * `hostId` is the picker's run target, where `null` follows the app-wide
- * default exactly as `useHostClientForHostId(null)` does - so it resolves
- * through `useAddressableHostId()`, the id that client addresses. Reading the
- * raw `null` as "unknown host" would hide the action on the default-host path,
- * which is the common one.
+ * The registry is consulted for the LANDING surface only, and only through
+ * the `hostId` the caller resolved. The pickers that render this are drawn
+ * inside Epic tabs as well as on the start page, and a tab resolves host
+ * identity through its lifetime binding and nothing else - so this hook must
+ * not reach for an app-wide host authority (`useAddressableHostId`) to fill a
+ * `null`, not even on a path the epic surface then ignores: the subscription
+ * itself is the violation. On the landing surface `hostId` is the composer's
+ * resolved placement host, which is `null` only in the ∅ case - nothing
+ * usable to create on, where submit refuses too - so a `null` there reads as
+ * unsupported for the same reason an unknown host does.
  */
 export function useProviderTerminalLoginScopeSupported(
   surface: ProviderTerminalLoginSurface | null,
   hostId: string | null,
 ): boolean {
-  const addressableHostId = useAddressableHostId();
-  const resolvedHostId = hostId ?? addressableHostId;
   const version = useHostMethodSchemaVersion(
-    resolvedHostId,
+    surface?.kind === "landing" ? hostId : null,
     START_TERMINAL_LOGIN_METHOD,
   );
   if (surface === null || surface.kind === "epic") return true;

--- a/clients/gui-app/src/hooks/providers/use-provider-terminal-login-scope-support.ts
+++ b/clients/gui-app/src/hooks/providers/use-provider-terminal-login-scope-support.ts
@@ -14,6 +14,22 @@ export const START_TERMINAL_LOGIN_METHOD = "providers.startTerminalLogin";
 const SCOPED_START_TERMINAL_LOGIN_MAJOR = 2;
 
 /**
+ * Whether a host can be sent the scope a surface needs - three-valued, because
+ * the copy that follows makes a POSITIVE claim on `"unsupported"` ("this
+ * host's version can open the sign-in from a chat, but not from the start
+ * page") and that claim is only true of a host that negotiated the pre-scope
+ * major. An unrecorded manifest, or no host at all, proves nothing and must
+ * not be described as if it did.
+ */
+export type ProviderTerminalLoginScopeSupport =
+  | "supported"
+  /** The host negotiated the pre-scope major: the epic action works, the
+   *  landing action cannot. */
+  | "unsupported"
+  /** No host to ask, or its manifest is not recorded yet. */
+  | "unknown";
+
+/**
  * Whether `hostId` can be sent the scope `surface` needs.
  *
  * The provider row's `terminalLogin` capability answers "does this PROVIDER
@@ -29,10 +45,10 @@ const SCOPED_START_TERMINAL_LOGIN_MAJOR = 2;
  * `null` surface is vacuously supported: there is no surface making a claim.
  *
  * **Fails closed**, like every other negotiated-manifest gate: an unrecorded
- * host reads `null` from the registry and the landing action stays hidden. The
- * unknown state is not sticky here in practice - the picker only renders this
- * action after `providers.list` answered on that same host, and that handshake
- * is what populates the registry.
+ * host reads `"unknown"` and the landing action stays hidden. The unknown
+ * state is not sticky here in practice - the picker only renders this action
+ * after `providers.list` answered on that same host, and that handshake is
+ * what populates the registry.
  *
  * The registry is consulted for the LANDING surface only, and only through
  * the `hostId` the caller resolved. The pickers that render this are drawn
@@ -42,17 +58,20 @@ const SCOPED_START_TERMINAL_LOGIN_MAJOR = 2;
  * `null`, not even on a path the epic surface then ignores: the subscription
  * itself is the violation. On the landing surface `hostId` is the composer's
  * resolved placement host, which is `null` only in the ∅ case - nothing
- * usable to create on, where submit refuses too - so a `null` there reads as
- * unsupported for the same reason an unknown host does.
+ * usable to create on, where submit refuses too - so a `null` there is
+ * `"unknown"`: no button, and no claim about a machine there is not.
  */
 export function useProviderTerminalLoginScopeSupported(
   surface: ProviderTerminalLoginSurface | null,
   hostId: string | null,
-): boolean {
+): ProviderTerminalLoginScopeSupport {
   const version = useHostMethodSchemaVersion(
     surface?.kind === "landing" ? hostId : null,
     START_TERMINAL_LOGIN_METHOD,
   );
-  if (surface === null || surface.kind === "epic") return true;
-  return version !== null && version.major >= SCOPED_START_TERMINAL_LOGIN_MAJOR;
+  if (surface === null || surface.kind === "epic") return "supported";
+  if (version === null) return "unknown";
+  return version.major >= SCOPED_START_TERMINAL_LOGIN_MAJOR
+    ? "supported"
+    : "unsupported";
 }

--- a/clients/gui-app/src/lib/providers/__tests__/provider-setup-guidance.test.ts
+++ b/clients/gui-app/src/lib/providers/__tests__/provider-setup-guidance.test.ts
@@ -4,6 +4,7 @@ import type {
   ProviderLoginCapability,
 } from "@traycer/protocol/host/provider-schemas";
 import {
+  defaultTerminalSignInGuidance,
   providerSetupActionPlacement,
   providerSetupGuidance,
   providerSetupPreparingLabel,
@@ -121,6 +122,28 @@ describe("providerSetupSteps", () => {
     expect(steps).toEqual(guidance.stepsAfterAction);
     expect(steps).not.toContain(guidance.noSurfaceStep);
   });
+
+  it("leads with the epic-only step for 'unsupported-scope' - the post-action steps alone would say to finish in a terminal nothing here opened", () => {
+    const guidance = providerSetupGuidance("reasonix");
+    expect(guidance).not.toBeNull();
+    if (guidance === null) return;
+    const steps = providerSetupSteps(guidance, "unsupported-scope");
+    expect(steps).toEqual([
+      guidance.epicOnlyStep,
+      ...guidance.stepsAfterAction,
+    ]);
+    // Not the no-surface sentence: that one names the start page as a place
+    // the button exists, which on this host it does not.
+    expect(steps).not.toContain(guidance.noSurfaceStep);
+  });
+
+  it("gives the generic guidance an epic-only step too, so a provider with no manual command (copilot) still has a route", () => {
+    const guidance = defaultTerminalSignInGuidance("copilot");
+    expect(guidance.manualCommand).toBeNull();
+    expect(providerSetupSteps(guidance, "unsupported-scope")[0]).toBe(
+      "Open a chat and choose “Sign in from a terminal” from its model picker. This host's version can open the Copilot sign-in from a chat, but not from the start page.",
+    );
+  });
 });
 
 describe("resolveProviderTerminalSetup", () => {
@@ -210,7 +233,7 @@ describe("providerSetupActionPlacement", () => {
     expect(providerSetupActionPlacement(setup, true, true)).toBe("here");
   });
 
-  it("returns 'unsupported-host' when the host cannot carry this surface's scope, even with a surface and the capability", () => {
+  it("returns 'unsupported-scope' when the host cannot carry this surface's scope, even with a surface and the capability", () => {
     const setup = resolveProviderTerminalSetup(
       "reasonix",
       stateWith(capabilityWithTerminalLogin(["setup"])),
@@ -219,9 +242,11 @@ describe("providerSetupActionPlacement", () => {
     if (setup === null) return;
     // The provider row says yes and the surface exists; only the host's
     // negotiated `providers.startTerminalLogin` major says no. Reporting
-    // 'here' would lead the steps with a button that can only ever fail.
+    // 'here' would lead the steps with a button that can only ever fail, and
+    // 'unsupported-host' would lead with nothing - but this host DOES draw
+    // the button, in an Epic, and the steps have to say so.
     expect(providerSetupActionPlacement(setup, true, false)).toBe(
-      "unsupported-host",
+      "unsupported-scope",
     );
   });
 
@@ -273,7 +298,7 @@ describe("providerSetupActionPlacement", () => {
     expect(providerSetupActionPlacement(setup, true, true)).toBe("here");
   });
 
-  it("permanent reasons outrank the transient one: an unsupported scope on a preparing pack is 'unsupported-host'", () => {
+  it("permanent reasons outrank the transient one: an unsupported scope on a preparing pack is 'unsupported-scope'", () => {
     const setup = resolveProviderTerminalSetup(
       "reasonix",
       providerState(capabilityWithTerminalLogin(["setup"]), {
@@ -284,7 +309,7 @@ describe("providerSetupActionPlacement", () => {
     expect(setup).not.toBeNull();
     if (setup === null) return;
     expect(providerSetupActionPlacement(setup, true, false)).toBe(
-      "unsupported-host",
+      "unsupported-scope",
     );
   });
 

--- a/clients/gui-app/src/lib/providers/__tests__/provider-setup-guidance.test.ts
+++ b/clients/gui-app/src/lib/providers/__tests__/provider-setup-guidance.test.ts
@@ -215,10 +215,10 @@ describe("providerSetupActionPlacement", () => {
     expect(setup).not.toBeNull();
     if (setup === null) return;
     expect(setup.canStartTerminal).toBe(false);
-    expect(providerSetupActionPlacement(setup, true, true)).toBe(
+    expect(providerSetupActionPlacement(setup, true, "supported")).toBe(
       "unsupported-host",
     );
-    expect(providerSetupActionPlacement(setup, false, true)).toBe(
+    expect(providerSetupActionPlacement(setup, false, "supported")).toBe(
       "unsupported-host",
     );
   });
@@ -230,7 +230,7 @@ describe("providerSetupActionPlacement", () => {
     );
     expect(setup).not.toBeNull();
     if (setup === null) return;
-    expect(providerSetupActionPlacement(setup, true, true)).toBe("here");
+    expect(providerSetupActionPlacement(setup, true, "supported")).toBe("here");
   });
 
   it("returns 'unsupported-scope' when the host cannot carry this surface's scope, even with a surface and the capability", () => {
@@ -245,8 +245,27 @@ describe("providerSetupActionPlacement", () => {
     // 'here' would lead the steps with a button that can only ever fail, and
     // 'unsupported-host' would lead with nothing - but this host DOES draw
     // the button, in an Epic, and the steps have to say so.
-    expect(providerSetupActionPlacement(setup, true, false)).toBe(
+    expect(providerSetupActionPlacement(setup, true, "unsupported")).toBe(
       "unsupported-scope",
+    );
+  });
+
+  it("returns 'unsupported-host', not 'unsupported-scope', while the host's scope support is unknown", () => {
+    const setup = resolveProviderTerminalSetup(
+      "reasonix",
+      stateWith(capabilityWithTerminalLogin(["setup"])),
+    );
+    expect(setup).not.toBeNull();
+    if (setup === null) return;
+    // No manifest recorded, or no host at all: the button stays hidden, but
+    // the epic-only sentence claims this host negotiated the pre-scope major,
+    // which nothing has proven. The claim-free copy leads with the manual
+    // route instead.
+    expect(providerSetupActionPlacement(setup, true, "unknown")).toBe(
+      "unsupported-host",
+    );
+    expect(providerSetupActionPlacement(setup, false, "unknown")).toBe(
+      "unsupported-host",
     );
   });
 
@@ -262,9 +281,13 @@ describe("providerSetupActionPlacement", () => {
     if (setup === null) return;
     expect(setup.canStartTerminal).toBe(true);
     expect(setup.packPreparing).not.toBeNull();
-    expect(providerSetupActionPlacement(setup, true, true)).toBe("preparing");
+    expect(providerSetupActionPlacement(setup, true, "supported")).toBe(
+      "preparing",
+    );
     // A transient wait never becomes "the button is on another surface".
-    expect(providerSetupActionPlacement(setup, false, true)).toBe("preparing");
+    expect(providerSetupActionPlacement(setup, false, "supported")).toBe(
+      "preparing",
+    );
     // The wait reads as the same sentence every other gated surface shows.
     expect(providerSetupPreparingLabel(setup, "reasonix")).toBe(
       "Preparing Reasonix… 30%",
@@ -295,7 +318,7 @@ describe("providerSetupActionPlacement", () => {
     if (setup === null) return;
     expect(setup.packPreparing).toBeNull();
     expect(providerSetupPreparingLabel(setup, "reasonix")).toBeNull();
-    expect(providerSetupActionPlacement(setup, true, true)).toBe("here");
+    expect(providerSetupActionPlacement(setup, true, "supported")).toBe("here");
   });
 
   it("permanent reasons outrank the transient one: an unsupported scope on a preparing pack is 'unsupported-scope'", () => {
@@ -308,7 +331,7 @@ describe("providerSetupActionPlacement", () => {
     );
     expect(setup).not.toBeNull();
     if (setup === null) return;
-    expect(providerSetupActionPlacement(setup, true, false)).toBe(
+    expect(providerSetupActionPlacement(setup, true, "unsupported")).toBe(
       "unsupported-scope",
     );
   });
@@ -320,7 +343,7 @@ describe("providerSetupActionPlacement", () => {
     );
     expect(setup).not.toBeNull();
     if (setup === null) return;
-    expect(providerSetupActionPlacement(setup, false, true)).toBe(
+    expect(providerSetupActionPlacement(setup, false, "supported")).toBe(
       "other-surface",
     );
   });

--- a/clients/gui-app/src/lib/providers/provider-setup-guidance.ts
+++ b/clients/gui-app/src/lib/providers/provider-setup-guidance.ts
@@ -60,6 +60,13 @@ export interface ProviderSetupGuidance {
    */
   readonly noSurfaceStep: string;
   /**
+   * The first step on a start page whose host can open the terminal only
+   * from an Epic (it negotiated the pre-scope `providers.startTerminalLogin`
+   * major), naming that route. Distinct from `noSurfaceStep`, which also
+   * names the start page - the one surface this host cannot open it from.
+   */
+  readonly epicOnlyStep: string;
+  /**
    * The command a self-installed CLI runs to do the same thing; rendered as
    * code, always beside the caveat that it targets whatever binary and home
    * that shell resolves. `null` when the renderer has nothing truthful to
@@ -85,6 +92,8 @@ const PROVIDER_SETUP_GUIDANCE: {
     ],
     noSurfaceStep:
       "Choose “Set up in terminal” from a chat's model picker or the start page's. It opens Reasonix's setup wizard on the host that composer runs on.",
+    epicOnlyStep:
+      "Open a chat and choose “Set up in terminal” from its model picker. This host's version can open Reasonix's setup wizard from a chat, but not from the start page.",
     manualCommand: "reasonix setup",
     terminalActionLabel: "Set up in terminal",
     terminalHint:
@@ -117,6 +126,7 @@ export function defaultTerminalSignInGuidance(
     ],
     noSurfaceStep:
       "Choose “Sign in from a terminal” from a chat's model picker or the start page's. It opens the sign-in on the host that composer runs on.",
+    epicOnlyStep: `Open a chat and choose “Sign in from a terminal” from its model picker. This host's version can open the ${name} sign-in from a chat, but not from the start page.`,
     manualCommand: null,
     terminalActionLabel: "Sign in from a terminal",
     terminalHint: `${name} prints a sign-in code that only exists in the terminal. Complete the sign-in there, then use Refresh above.`,
@@ -204,6 +214,15 @@ export type ProviderSetupActionPlacement =
   /** No button anywhere on this host - the manual command is the route. */
   | "unsupported-host"
   /**
+   * A button on this host, but only in an Epic: the host negotiated the
+   * pre-scope `providers.startTerminalLogin` major, which cannot carry the
+   * scope the start page needs. The steps lead with that route - the
+   * post-action steps alone would tell the user to finish in a terminal
+   * nothing here can open, and the generic guidance has no manual command to
+   * fall back on.
+   */
+  | "unsupported-scope"
+  /**
    * A button here in principle, but the provider's pack cannot spawn yet. The
    * preparing label stands where the button would; the steps read as they do
    * for `here`, because that is what they will be once it lands.
@@ -221,7 +240,7 @@ export type ProviderSetupActionPlacement =
  * `providers.startTerminalLogin` can carry the scope that surface needs. On the
  * release just before the scope bump it cannot, and only for the landing
  * surface - so the same provider on the same host is `here` in an Epic and
- * `unsupported-host` on the start page. See
+ * `unsupported-scope` on the start page. See
  * `useProviderTerminalLoginScopeSupported`.
  */
 export function providerSetupActionPlacement(
@@ -231,7 +250,8 @@ export function providerSetupActionPlacement(
 ): ProviderSetupActionPlacement {
   // Permanent reasons first: a pack that will finish downloading does not
   // change a host that can never carry this scope.
-  if (!setup.canStartTerminal || !scopeSupported) return "unsupported-host";
+  if (!setup.canStartTerminal) return "unsupported-host";
+  if (!scopeSupported) return "unsupported-scope";
   if (setup.packPreparing !== null) return "preparing";
   return hasSurface ? "here" : "other-surface";
 }
@@ -249,6 +269,9 @@ export function providerSetupSteps(
 ): ReadonlyArray<string> {
   if (placement === "other-surface") {
     return [guidance.noSurfaceStep, ...guidance.stepsAfterAction];
+  }
+  if (placement === "unsupported-scope") {
+    return [guidance.epicOnlyStep, ...guidance.stepsAfterAction];
   }
   return guidance.stepsAfterAction;
 }

--- a/clients/gui-app/src/lib/providers/provider-setup-guidance.ts
+++ b/clients/gui-app/src/lib/providers/provider-setup-guidance.ts
@@ -11,6 +11,7 @@ import {
   providerPackPreparingLabel,
   type ProviderPackPreparing,
 } from "@/components/providers/provider-pack-readiness";
+import type { ProviderTerminalLoginScopeSupport } from "@/hooks/providers/use-provider-terminal-login-scope-support";
 
 /**
  * What the picker says and does for a provider whose sign-in has to happen in
@@ -211,7 +212,11 @@ export type ProviderSetupActionPlacement =
   | "here"
   /** A button, but on another surface (a fork dialog's picker). */
   | "other-surface"
-  /** No button anywhere on this host - the manual command is the route. */
+  /**
+   * No button this copy can vouch for: the host declares no terminal
+   * sign-in, or there is no host to ask / its manifest is not recorded yet.
+   * The manual command is the route; no claim is made about the machine.
+   */
   | "unsupported-host"
   /**
    * A button on this host, but only in an Epic: the host negotiated the
@@ -234,7 +239,7 @@ export type ProviderSetupActionPlacement =
  * so the auth line and the model list cannot classify the same state
  * differently - the reason they were wrong about old hosts in the first place.
  *
- * `scopeSupported` is the third because the first two cannot see it: the
+ * `scopeSupport` is the third because the first two cannot see it: the
  * provider row says this provider HAS a terminal sign-in, and the surface says
  * where a button would go, but neither knows whether this host's negotiated
  * `providers.startTerminalLogin` can carry the scope that surface needs. On the
@@ -246,12 +251,16 @@ export type ProviderSetupActionPlacement =
 export function providerSetupActionPlacement(
   setup: ProviderTerminalSetup,
   hasSurface: boolean,
-  scopeSupported: boolean,
+  scopeSupport: ProviderTerminalLoginScopeSupport,
 ): ProviderSetupActionPlacement {
   // Permanent reasons first: a pack that will finish downloading does not
   // change a host that can never carry this scope.
   if (!setup.canStartTerminal) return "unsupported-host";
-  if (!scopeSupported) return "unsupported-scope";
+  // `unsupported-scope` leads the steps with "this host's version can open
+  // the sign-in from a chat" - a claim only a RECORDED pre-scope manifest
+  // proves. An unknown manifest, or no host at all, gets the claim-free copy.
+  if (scopeSupport === "unknown") return "unsupported-host";
+  if (scopeSupport === "unsupported") return "unsupported-scope";
   if (setup.packPreparing !== null) return "preparing";
   return hasSurface ? "here" : "other-surface";
 }

--- a/clients/gui-app/src/lib/terminals/landing-sign-in-terminal.ts
+++ b/clients/gui-app/src/lib/terminals/landing-sign-in-terminal.ts
@@ -75,6 +75,15 @@ export function openLandingSignInTerminal(args: {
     origin: "provider-login",
     originProviderId: providerId,
   });
+  // `addTab` activated the tab to show - the new one, or the existing tab for
+  // the same session on a retry.
+  const activeInstanceId = useLandingTerminalStore.getState().activeInstanceId;
+  if (activeInstanceId === null) return;
+  // Opened as a REVEAL of that tab, never as an opening gesture: the panel
+  // settles a gesture by re-targeting the launch cwd, and this tab's
+  // display-only `"~"` matches none, so a gesture-open would spawn a bare
+  // shell and put it in front of the sign-in code.
+  //
   // The page this started from, plus every start page with a mounted panel
   // slot. They differ when focus moved while the host was answering: there is
   // ONE panel per window, portaled into whichever page `LandingTerminalHost`
@@ -88,19 +97,20 @@ export function openLandingSignInTerminal(args: {
   // (an epic tab), and that retained id lives in the host's React state, which
   // nothing outside it can read. Every id it can return is in this set, so
   // opening all of them covers the hosted one without guessing which it is.
-  const anchoredPageIds = landingPaneAnchorDraftIds();
-  for (const pageId of new Set([landingPageId, ...anchoredPageIds])) {
-    store.setPanelOpen(pageId, true);
-  }
-  // No pane mounted at all, so none of the ids above names a surface the user
+  //
+  // No pane mounted at all means none of those ids names a surface the user
   // can see this on right now - and `landingPageId` may not even name a live
   // start page: a draft bound at press time can be submitted or discarded
   // while the host is still answering, which is a window a picker press opens
-  // by construction. The page-less open covers whichever start page mounts
+  // by construction. The page-less reveal covers whichever start page mounts
   // next - one that already recorded a closed layout included - so the
   // terminal carrying the sign-in code is never left behind a panel with no
   // way to ask for it.
-  if (anchoredPageIds.length === 0) store.openPanelForEveryPage();
-  const activeInstanceId = useLandingTerminalStore.getState().activeInstanceId;
-  if (activeInstanceId !== null) focusTerminalInstance(activeInstanceId);
+  const anchoredPageIds = landingPaneAnchorDraftIds();
+  store.revealPanel({
+    landingPageIds: [...new Set([landingPageId, ...anchoredPageIds])],
+    everyPage: anchoredPageIds.length === 0,
+    instanceId: activeInstanceId,
+  });
+  focusTerminalInstance(activeInstanceId);
 }

--- a/clients/gui-app/src/stores/home/landing-terminal-store.ts
+++ b/clients/gui-app/src/stores/home/landing-terminal-store.ts
@@ -141,27 +141,51 @@ export interface LandingTerminalStoreState {
    */
   readonly fallbackLayout: LandingTerminalLayout | null;
   readonly pendingKills: ReadonlyArray<LandingTerminalPendingKill>;
+  /**
+   * The tab a programmatic panel open was made to SHOW, or `null`. Not
+   * persisted: it describes one open transition in this window.
+   *
+   * The panel reads a closed-to-open transition as the user's opening gesture
+   * and settles it by re-targeting the launch cwd - reuse a terminal already
+   * running there, else spawn one and focus it. An open made to reveal a tab
+   * that already exists (a host-created sign-in terminal, whose display-only
+   * `"~"` cwd matches no launch cwd) is not that gesture: settling it would
+   * spawn a bare shell and put it in front of the tab the open was for. The
+   * panel consumes this on its next open transition to tell the two apart.
+   */
+  readonly panelReveal: string | null;
   readonly setPanelOpen: (landingPageId: string, open: boolean) => void;
   /**
-   * Opens the panel on EVERY start page - each page that has recorded a layout
-   * of its own, and through the fallback every page that has not. The
-   * page-less form of {@link setPanelOpen}, for a caller with a tab to show and
-   * no live page to show it on.
+   * Opens the panel to SHOW `instanceId` on each of `landingPageIds`, and
+   * with `everyPage` on EVERY start page as well: each page that has recorded
+   * a layout of its own, and through the fallback every page that has not.
+   * Records `panelReveal` so the panel does not settle the open as a gesture.
    *
-   * The one caller is the sign-in open: a start page can be discarded while
-   * `providers.startTerminalLogin` is in flight, and if no other pane is
-   * mounted there is no id left to key an open by. Whichever start page mounts
-   * NEXT then shows the panel, which is where the tab (tabs are shared across
-   * pages) already is. Both halves are needed: `landingTerminalLayoutFor`
-   * gives a page's own layout precedence over the fallback, so a page that
-   * once closed its panel would ignore a fallback-only write and hide the
-   * terminal behind the very layout it recorded.
+   * The one caller is the sign-in open. `everyPage` is for a start page
+   * discarded while `providers.startTerminalLogin` was in flight with no
+   * other pane mounted, so no id names a surface the user can see this on.
+   * Whichever start page mounts NEXT then shows the panel, which is where the
+   * tab (tabs are shared across pages) already is. Both halves of that form
+   * are needed: `landingTerminalLayoutFor` gives a page's own layout
+   * precedence over the fallback, so a page that once closed its panel would
+   * ignore a fallback-only write and hide the terminal behind the very layout
+   * it recorded.
    *
    * Bounded by the same rule that retires layouts generally:
    * `collapseLayoutsForEmptyTerminalSet` closes every one of them once the
    * last tab is gone, so this cannot outlive the terminal it was written for.
    */
-  readonly openPanelForEveryPage: () => void;
+  readonly revealPanel: (reveal: {
+    readonly landingPageIds: ReadonlyArray<string>;
+    readonly everyPage: boolean;
+    readonly instanceId: string;
+  }) => void;
+  /**
+   * Retires `panelReveal`. The panel calls it on every open or collapse
+   * transition and on a page switch, so a reveal that never saw its
+   * transition (the panel was already open) cannot suppress a later gesture.
+   */
+  readonly clearPanelReveal: () => void;
   readonly setPanelWidthFraction: (
     landingPageId: string,
     fraction: number,
@@ -315,6 +339,7 @@ export const useLandingTerminalStore = create<LandingTerminalStoreState>()(
   persist(
     (set, get) => ({
       ...initialLandingTerminalState(),
+      panelReveal: null,
       setPanelOpen: (landingPageId, panelOpen) =>
         set((state) =>
           updateLandingTerminalLayout(state, landingPageId, {
@@ -322,29 +347,19 @@ export const useLandingTerminalStore = create<LandingTerminalStoreState>()(
             panelOpen,
           }),
         ),
-      openPanelForEveryPage: () =>
+      revealPanel: ({ landingPageIds, everyPage, instanceId }) =>
         set((state) => {
-          const layoutsByLandingPageId: Partial<
-            Record<string, LandingTerminalLayout>
-          > = {};
-          for (const [landingPageId, layout] of Object.entries(
-            state.layoutsByLandingPageId,
-          )) {
-            if (layout !== undefined) {
-              layoutsByLandingPageId[landingPageId] = {
-                ...layout,
-                panelOpen: true,
-              };
-            }
-          }
+          const opened = everyPage ? openEveryPageLayout(state) : {};
           return {
-            layoutsByLandingPageId,
-            fallbackLayout: {
-              ...(state.fallbackLayout ?? DEFAULT_LANDING_TERMINAL_LAYOUT),
-              panelOpen: true,
-            },
+            ...opened,
+            ...openPageLayouts({ ...state, ...opened }, landingPageIds),
+            panelReveal: instanceId,
           };
         }),
+      clearPanelReveal: () =>
+        set((state) =>
+          state.panelReveal === null ? state : { panelReveal: null },
+        ),
       setPanelWidthFraction: (landingPageId, panelWidthFraction) =>
         set((state) =>
           updateLandingTerminalLayout(state, landingPageId, {
@@ -531,7 +546,8 @@ export const useLandingTerminalStore = create<LandingTerminalStoreState>()(
               : {}),
           };
         }),
-      resetForTests: () => set(initialLandingTerminalState()),
+      resetForTests: () =>
+        set({ ...initialLandingTerminalState(), panelReveal: null }),
     }),
     {
       ...basePersistOptions(landingTerminalsKey(null)),
@@ -550,6 +566,53 @@ export const useLandingTerminalStore = create<LandingTerminalStoreState>()(
     },
   ),
 );
+
+function openPageLayouts(
+  state: Pick<
+    LandingTerminalStoreState,
+    "layoutsByLandingPageId" | "fallbackLayout"
+  >,
+  landingPageIds: ReadonlyArray<string>,
+): Pick<LandingTerminalStoreState, "layoutsByLandingPageId"> {
+  let next = state;
+  for (const landingPageId of landingPageIds) {
+    next = {
+      ...next,
+      ...updateLandingTerminalLayout(next, landingPageId, {
+        ...landingTerminalLayoutFor(next, landingPageId),
+        panelOpen: true,
+      }),
+    };
+  }
+  return { layoutsByLandingPageId: next.layoutsByLandingPageId };
+}
+
+function openEveryPageLayout(
+  state: Pick<
+    LandingTerminalStoreState,
+    "layoutsByLandingPageId" | "fallbackLayout"
+  >,
+): Pick<
+  LandingTerminalStoreState,
+  "layoutsByLandingPageId" | "fallbackLayout"
+> {
+  const layoutsByLandingPageId: Partial<Record<string, LandingTerminalLayout>> =
+    {};
+  for (const [landingPageId, layout] of Object.entries(
+    state.layoutsByLandingPageId,
+  )) {
+    if (layout !== undefined) {
+      layoutsByLandingPageId[landingPageId] = { ...layout, panelOpen: true };
+    }
+  }
+  return {
+    layoutsByLandingPageId,
+    fallbackLayout: {
+      ...(state.fallbackLayout ?? DEFAULT_LANDING_TERMINAL_LAYOUT),
+      panelOpen: true,
+    },
+  };
+}
 
 function updateLandingTerminalLayout(
   state: Pick<LandingTerminalStoreState, "layoutsByLandingPageId">,

--- a/clients/gui-app/src/stores/providers/__tests__/provider-login-terminals.test.ts
+++ b/clients/gui-app/src/stores/providers/__tests__/provider-login-terminals.test.ts
@@ -146,6 +146,53 @@ describe("useProviderLoginTerminalsStore", () => {
     expect(useProviderLoginTerminalsStore.getState().revision).toBe(2);
   });
 
+  it("writes nothing back, and does not bump `revision`, for a peer payload that adds no record - the same set in the peer's order", () => {
+    recordProviderLoginTerminal({
+      hostId: HOST_A,
+      sessionId: "session-a",
+      providerId: "reasonix",
+    });
+    recordProviderLoginTerminal({
+      hostId: HOST_B,
+      sessionId: "session-b",
+      providerId: "copilot",
+    });
+    const before = useProviderLoginTerminalsStore.getState();
+    const onDisk = window.localStorage.getItem(PERSIST_KEY);
+    expect(before.recentKeys).toEqual([
+      `${HOST_B}:session-b`,
+      `${HOST_A}:session-a`,
+    ]);
+
+    // The peer holds the identical two records with ITS own record first.
+    // Merging keeps this window's order, so the result equals what is already
+    // here - and a `setState` on it would go through persist, write the whole
+    // payload, and fire the peer's `storage` event in turn: the peer would
+    // merge, keep ITS order, write, and fire ours. Two windows would trade
+    // orders forever, bumping `revision` and re-running reconciliation on
+    // every hop.
+    window.dispatchEvent(
+      new StorageEvent("storage", {
+        key: PERSIST_KEY,
+        newValue: JSON.stringify({
+          state: {
+            providerBySessionKey: {
+              [`${HOST_A}:session-a`]: "reasonix",
+              [`${HOST_B}:session-b`]: "copilot",
+            },
+            recentKeys: [`${HOST_A}:session-a`, `${HOST_B}:session-b`],
+          },
+          version: CURRENT_PERSIST_VERSION,
+        }),
+      }),
+    );
+
+    const after = useProviderLoginTerminalsStore.getState();
+    expect(after).toBe(before);
+    expect(after.revision).toBe(before.revision);
+    expect(window.localStorage.getItem(PERSIST_KEY)).toBe(onDisk);
+  });
+
   it("does not persist `revision`, and hydration does not reset it", async () => {
     recordProviderLoginTerminal({
       hostId: HOST_A,

--- a/clients/gui-app/src/stores/providers/__tests__/provider-login-terminals.test.ts
+++ b/clients/gui-app/src/stores/providers/__tests__/provider-login-terminals.test.ts
@@ -193,6 +193,71 @@ describe("useProviderLoginTerminalsStore", () => {
     expect(window.localStorage.getItem(PERSIST_KEY)).toBe(onDisk);
   });
 
+  it("republishes the union, without bumping `revision`, when a peer writes a strict SUBSET of it", () => {
+    recordProviderLoginTerminal({
+      hostId: HOST_A,
+      sessionId: "session-a",
+      providerId: "reasonix",
+    });
+    recordProviderLoginTerminal({
+      hostId: HOST_B,
+      sessionId: "session-b",
+      providerId: "copilot",
+    });
+    const before = useProviderLoginTerminalsStore.getState();
+
+    // A stale concurrent write: the peer wrote from a memory that predates
+    // this window's second record. Nothing to learn here - but left on disk,
+    // that subset is what a window opened LATER hydrates, and it would
+    // recreate the omitted live session as a bare shell.
+    const stale = persistedPayload({ [`${HOST_A}:session-a`]: "reasonix" });
+    window.localStorage.setItem(PERSIST_KEY, stale);
+    window.dispatchEvent(
+      new StorageEvent("storage", { key: PERSIST_KEY, newValue: stale }),
+    );
+
+    const after = useProviderLoginTerminalsStore.getState();
+    expect(after.revision).toBe(before.revision);
+    expect(after.providerBySessionKey).toEqual(before.providerBySessionKey);
+    const republished = JSON.parse(
+      window.localStorage.getItem(PERSIST_KEY) ?? "{}",
+    ) as { state: { providerBySessionKey: Record<string, string> } };
+    expect(republished.state.providerBySessionKey).toEqual({
+      [`${HOST_A}:session-a`]: "reasonix",
+      [`${HOST_B}:session-b`]: "copilot",
+    });
+  });
+
+  it("does not republish at the bound when the peer's set is one this window cannot absorb - the loop by another name", () => {
+    // 32 records here, 32 different ones from the peer: the merge keeps this
+    // window's own and evicts every one of the peer's, so "the peer lacks
+    // records" is true of BOTH windows forever. Republishing on "differs"
+    // would trade the two sets until one window closed.
+    for (let index = 0; index < 32; index += 1) {
+      recordProviderLoginTerminal({
+        hostId: HOST_A,
+        sessionId: `session-${index}`,
+        providerId: "reasonix",
+      });
+    }
+    const before = useProviderLoginTerminalsStore.getState();
+    const onDisk = window.localStorage.getItem(PERSIST_KEY);
+    const peerRecords: Record<string, string> = {};
+    for (let index = 0; index < 32; index += 1) {
+      peerRecords[`${HOST_B}:peer-${index}`] = "copilot";
+    }
+
+    window.dispatchEvent(
+      new StorageEvent("storage", {
+        key: PERSIST_KEY,
+        newValue: persistedPayload(peerRecords),
+      }),
+    );
+
+    expect(useProviderLoginTerminalsStore.getState()).toBe(before);
+    expect(window.localStorage.getItem(PERSIST_KEY)).toBe(onDisk);
+  });
+
   it("does not persist `revision`, and hydration does not reset it", async () => {
     recordProviderLoginTerminal({
       hostId: HOST_A,

--- a/clients/gui-app/src/stores/providers/provider-login-terminals.ts
+++ b/clients/gui-app/src/stores/providers/provider-login-terminals.ts
@@ -154,16 +154,36 @@ function sameRecords(
   a: SharedProviderLoginRecords,
   b: SharedProviderLoginRecords,
 ): boolean {
-  if (a.recentKeys.length !== b.recentKeys.length) return false;
-  if (a.recentKeys.some((entry, index) => entry !== b.recentKeys[index])) {
-    return false;
-  }
+  return (
+    a.recentKeys.length === b.recentKeys.length &&
+    a.recentKeys.every((entry, index) => entry === b.recentKeys[index]) &&
+    sameRecordSet(a, b)
+  );
+}
+
+/** Same keys mapped to the same providers, in any order. */
+function sameRecordSet(
+  a: SharedProviderLoginRecords,
+  b: SharedProviderLoginRecords,
+): boolean {
   const aEntries = Object.entries(a.providerBySessionKey);
-  if (aEntries.length !== Object.keys(b.providerBySessionKey).length) {
-    return false;
-  }
-  return aEntries.every(
-    ([entry, value]) => b.providerBySessionKey[entry] === value,
+  return (
+    aEntries.length === Object.keys(b.providerBySessionKey).length &&
+    aEntries.every(([entry, value]) => b.providerBySessionKey[entry] === value)
+  );
+}
+
+/** Every record of `subset` is in `superset`, which has more. */
+function strictRecordSubset(
+  subset: SharedProviderLoginRecords,
+  superset: SharedProviderLoginRecords,
+): boolean {
+  const subsetEntries = Object.entries(subset.providerBySessionKey);
+  return (
+    subsetEntries.length < Object.keys(superset.providerBySessionKey).length &&
+    subsetEntries.every(
+      ([entry, value]) => superset.providerBySessionKey[entry] === value,
+    )
   );
 }
 
@@ -292,21 +312,42 @@ if (typeof window !== "undefined") {
     // A `removeItem` arrives with `newValue: null` and merges as "nothing
     // new", for the same reason a `clear()` is ignored above.
     const current = useProviderLoginTerminalsStore.getState();
-    const merged = mergeRecords(current, parsePersistedPayload(event.newValue));
-    // A merge that adds nothing writes nothing. `setState` goes through
-    // persist, which writes the WHOLE payload back to storage, and that write
-    // is a `storage` event in the peer. Two windows holding the same set in
-    // different orders (each put its own record first) would otherwise trade
-    // it forever: A's write fires B's event, B's merge keeps B's order and
-    // writes it, which fires A's event, and so on - every hop bumping
-    // `revision` and re-running each reconciliation keyed on it. The peer's
-    // ORDER is not something this window needs: the union is what the
-    // classifier reads, and the bound evicts by this window's own recency.
-    if (sameRecords(current, merged)) return;
-    useProviderLoginTerminalsStore.setState({
-      ...merged,
-      revision: current.revision + 1,
-    });
+    const peer = parsePersistedPayload(event.newValue);
+    const merged = mergeRecords(current, peer);
+    // `setState` goes through persist, which writes the WHOLE payload back to
+    // storage, and that write is a `storage` event in the peer - so every
+    // write here must be one the peer cannot answer with another. Two windows
+    // holding the same set in different orders (each put its own record
+    // first) would otherwise trade it forever: A's write fires B's event, B's
+    // merge keeps B's order and writes it, which fires A's event, and so on -
+    // every hop bumping `revision` and re-running each reconciliation keyed
+    // on it. The peer's ORDER is not something this window needs: the union
+    // is what the classifier reads, and the bound evicts by this window's own
+    // recency.
+    //
+    // So: learn what the peer has (and write the union), or, when there is
+    // nothing to learn but the peer wrote a strict SUBSET of it, republish
+    // the union without changing anything here. A subset on disk is a stale
+    // concurrent write, and a window opened later hydrates from disk - it
+    // would lack the omitted records and recreate their live sessions as
+    // bare shells. Strict subset rather than "differs": at the bound two
+    // windows can hold sets neither can absorb without evicting, and each
+    // republishing its own would be the same loop by another name. A learn
+    // strictly grows this window's set (bounded), and a republish is
+    // answered only by a learn or by silence, so the exchange terminates.
+    if (!sameRecords(current, merged)) {
+      useProviderLoginTerminalsStore.setState({
+        ...merged,
+        revision: current.revision + 1,
+      });
+      return;
+    }
+    if (sameRecordSet(peer, merged) || !strictRecordSubset(peer, merged)) {
+      return;
+    }
+    // Persist writes on every `setState`, changed or not; `revision` stays,
+    // because nothing this window classifies against has changed.
+    useProviderLoginTerminalsStore.setState({});
   });
 }
 

--- a/clients/gui-app/src/stores/providers/provider-login-terminals.ts
+++ b/clients/gui-app/src/stores/providers/provider-login-terminals.ts
@@ -149,6 +149,24 @@ function mergeRecords(
   return { providerBySessionKey, recentKeys };
 }
 
+/** Same keys in the same order, mapped to the same providers. */
+function sameRecords(
+  a: SharedProviderLoginRecords,
+  b: SharedProviderLoginRecords,
+): boolean {
+  if (a.recentKeys.length !== b.recentKeys.length) return false;
+  if (a.recentKeys.some((entry, index) => entry !== b.recentKeys[index])) {
+    return false;
+  }
+  const aEntries = Object.entries(a.providerBySessionKey);
+  if (aEntries.length !== Object.keys(b.providerBySessionKey).length) {
+    return false;
+  }
+  return aEntries.every(
+    ([entry, value]) => b.providerBySessionKey[entry] === value,
+  );
+}
+
 function parsePersistedPayload(raw: string | null): SharedProviderLoginRecords {
   if (raw === null) return NO_SHARED_RECORDS;
   try {
@@ -273,10 +291,22 @@ if (typeof window !== "undefined") {
     //
     // A `removeItem` arrives with `newValue: null` and merges as "nothing
     // new", for the same reason a `clear()` is ignored above.
-    useProviderLoginTerminalsStore.setState((state) => ({
-      ...mergeRecords(state, parsePersistedPayload(event.newValue)),
-      revision: state.revision + 1,
-    }));
+    const current = useProviderLoginTerminalsStore.getState();
+    const merged = mergeRecords(current, parsePersistedPayload(event.newValue));
+    // A merge that adds nothing writes nothing. `setState` goes through
+    // persist, which writes the WHOLE payload back to storage, and that write
+    // is a `storage` event in the peer. Two windows holding the same set in
+    // different orders (each put its own record first) would otherwise trade
+    // it forever: A's write fires B's event, B's merge keeps B's order and
+    // writes it, which fires A's event, and so on - every hop bumping
+    // `revision` and re-running each reconciliation keyed on it. The peer's
+    // ORDER is not something this window needs: the union is what the
+    // classifier reads, and the bound evicts by this window's own recency.
+    if (sameRecords(current, merged)) return;
+    useProviderLoginTerminalsStore.setState({
+      ...merged,
+      revision: current.revision + 1,
+    });
   });
 }
 


### PR DESCRIPTION
Follow-up to #1699, addressing the five Codex findings posted after it merged. Triaged as one round; each fix below links its thread.

## Fixes

| Thread | Finding | Fix |
| --- | --- | --- |
| [Prevent panel-open reconciliation from replacing sign-in focus](https://github.com/traycerai/traycer/pull/1699#discussion_r3930012503) | Opening a closed panel to show the sign-in tab was read as the user's opening gesture; settlement re-targeted the launch cwd, which the tab's display-only `~` never matches, and spawned a plain shell over the sign-in code. | `useLandingTerminalStore.revealPanel` records the open as a reveal (`panelReveal`, not persisted); the panel's open-transition effect consumes it instead of calling `capture()`. Cleared on collapse and page switch so it can never suppress a later real gesture. |
| [Adopt listed sign-ins during capable reconciliation](https://github.com/traycerai/traycer/pull/1699#discussion_r3930012490) | The capable arm reconciles against the plain projection, which never carries a manager-owned sign-in session, so a sign-in started in another window had no tab on a capable host. | `adoptListedProviderLoginSessions` adopts registry-claimed, running, un-tombstoned `terminal.list` sessions for the selected host after the capable pass. Sign-in sessions only; ordinary sessions stay the projection's. The bound-host fleet fetches no list and is unchanged (documented at the call site). |
| [Stop storage-event merges from rewriting storage](https://github.com/traycerai/traycer/pull/1699#discussion_r3930012499) | Every peer `storage` event went through `setState`, which persist writes back, firing the peer's event; two windows holding the same set in different orders traded orders forever. | The listener merges first and returns without `setState` when the merge adds nothing (`sameRecords`), so nothing is written and `revision` does not move. Converges in at most one exchange once both windows hold the union. |
| [Avoid reading the addressable host from tab pickers](https://github.com/traycerai/traycer/pull/1699#discussion_r3930012495) | `useProviderTerminalLoginScopeSupported` called `useAddressableHostId()` unconditionally, subscribing Epic-tab pickers to the app-wide host authority. | The hook reads the registry only for the landing surface and only through the `hostId` the caller resolved (the landing composer's placement host); `null` there is the ∅ case and reads as unsupported. The hook's test now mocks `useAddressableHostId` to throw. |
| [Keep actionable guidance for unsupported landing scopes](https://github.com/traycerai/traycer/pull/1699#discussion_r3930012494) | On a `providers.startTerminalLogin@1.0` host the landing picker hid the button but the steps still said "complete the sign-in in that terminal", with no manual command for the generic guidance. | New `unsupported-scope` placement (distinct from `unsupported-host`, which still means no button anywhere) leads the steps with a new per-guidance `epicOnlyStep` naming the chat-picker route that `@1.0` does support. |

## Validation

- New tests: reveal into a closed panel (fails under ablation with a second, spawned tab), capable-host adoption from `terminal.list` (fails under ablation), storage no-op guard (fails under ablation), pure adoption helper cases, `revealPanel` store cases, scope-gate without the ambient read, `unsupported-scope` steps and placement, auth-line copy on a pre-scope host and on a null run target.
- `bun run compile` and `bun run lint` green in `clients/gui-app`; the ten touched suites pass (262 tests).

Internal pin PR to follow once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
