### PR TITLE
fix(gui-app,protocol): offer the terminal sign-in on terminalLogin alone, not oauthArgs

### DIFF
--- a/clients/gui-app/src/components/chat/composer/__tests__/provider-reauth-banner.test.tsx
+++ b/clients/gui-app/src/components/chat/composer/__tests__/provider-reauth-banner.test.tsx
@@ -567,34 +567,40 @@ describe("<ProviderReauthBanner />", () => {
   // (never the headless one) - the same answer `providerSupportsTerminalLogin`
   // and `resolveCreateProfileGate` give, so this surface cannot fall through
   // to the CLI stub for a provider Traycer can open the CLI for.
-  it("offers the terminal button, not the headless one, when terminalLogin is present and oauthArgs is null", () => {
-    render(
-      <ProviderReauthBanner
-        epicId="epic-1"
-        viewTabId="tab-1"
-        providerId="qwen"
-        state={{
-          ...copilotState({
-            oauthArgs: null,
-            token: null,
-            codePaste: null,
-            terminalLogin: {},
-          }),
-          providerId: "qwen",
-        }}
-        reason="provider_unauthenticated"
-        profileId={null}
-        profileLabel={null}
-        onContinueOnAmbient={null}
-      />,
-    );
+  // Both spellings of "no headless command" are covered: this suite's previous
+  // `[]` case asserted the OPPOSITE (neither button), so leaving it out would
+  // drop that boundary from the suite entirely.
+  it.each([{ oauthArgs: null }, { oauthArgs: [] }])(
+    "offers the terminal button, not the headless one, when terminalLogin is present and there is no oauthArgs (%o)",
+    ({ oauthArgs }) => {
+      render(
+        <ProviderReauthBanner
+          epicId="epic-1"
+          viewTabId="tab-1"
+          providerId="qwen"
+          state={{
+            ...copilotState({
+              oauthArgs,
+              token: null,
+              codePaste: null,
+              terminalLogin: {},
+            }),
+            providerId: "qwen",
+          }}
+          reason="provider_unauthenticated"
+          profileId={null}
+          profileLabel={null}
+          onContinueOnAmbient={null}
+        />,
+      );
 
-    expect(screen.queryByRole("button", { name: /Authenticate/ })).toBeNull();
-    expect(
-      screen.queryByRole("button", { name: /Sign in from a terminal/ }),
-    ).not.toBeNull();
-    expect(screen.queryByText(/from its CLI to continue/)).toBeNull();
-  });
+      expect(screen.queryByRole("button", { name: /Authenticate/ })).toBeNull();
+      expect(
+        screen.queryByRole("button", { name: /Sign in from a terminal/ }),
+      ).not.toBeNull();
+      expect(screen.queryByText(/from its CLI to continue/)).toBeNull();
+    },
+  );
 
   // Row 3: unlike browser OAuth (a localhost loopback that only a local host
   // can serve), a device-code terminal login needs no loopback, so it must be

--- a/clients/gui-app/src/components/chat/composer/__tests__/provider-reauth-banner.test.tsx
+++ b/clients/gui-app/src/components/chat/composer/__tests__/provider-reauth-banner.test.tsx
@@ -561,22 +561,27 @@ describe("<ProviderReauthBanner />", () => {
     ).toBeNull();
   });
 
-  // Unified gate: `terminalLogin` present but no real `oauthArgs` (the
-  // command the terminal would run) must read the same way here as it does
-  // in `providerSupportsTerminalLogin` and `resolveCreateProfileGate` - the
-  // banner falls through to the CLI stub, offering neither button.
-  it("offers neither sign-in button when terminalLogin is present but oauthArgs is empty", () => {
+  // A launch-the-CLI provider (Qwen, Droid, OMP, OpenCode) declares
+  // `terminalLogin` with `oauthArgs: null`: there is no headless command, the
+  // host launches the CLI itself. The banner must offer the terminal button
+  // (never the headless one) - the same answer `providerSupportsTerminalLogin`
+  // and `resolveCreateProfileGate` give, so this surface cannot fall through
+  // to the CLI stub for a provider Traycer can open the CLI for.
+  it("offers the terminal button, not the headless one, when terminalLogin is present and oauthArgs is null", () => {
     render(
       <ProviderReauthBanner
         epicId="epic-1"
         viewTabId="tab-1"
-        providerId="copilot"
-        state={copilotState({
-          oauthArgs: [],
-          token: null,
-          codePaste: null,
-          terminalLogin: {},
-        })}
+        providerId="qwen"
+        state={{
+          ...copilotState({
+            oauthArgs: null,
+            token: null,
+            codePaste: null,
+            terminalLogin: {},
+          }),
+          providerId: "qwen",
+        }}
         reason="provider_unauthenticated"
         profileId={null}
         profileLabel={null}
@@ -587,7 +592,8 @@ describe("<ProviderReauthBanner />", () => {
     expect(screen.queryByRole("button", { name: /Authenticate/ })).toBeNull();
     expect(
       screen.queryByRole("button", { name: /Sign in from a terminal/ }),
-    ).toBeNull();
+    ).not.toBeNull();
+    expect(screen.queryByText(/from its CLI to continue/)).toBeNull();
   });
 
   // Row 3: unlike browser OAuth (a localhost loopback that only a local host

--- a/clients/gui-app/src/components/chat/composer/__tests__/provider-reauth-banner.test.tsx
+++ b/clients/gui-app/src/components/chat/composer/__tests__/provider-reauth-banner.test.tsx
@@ -504,6 +504,44 @@ describe("<ProviderReauthBanner />", () => {
     expect(screen.queryByText(/sign-in code/)).toBeNull();
   });
 
+  // The banner resolves its copy through the SAME resolver the picker's setup
+  // CTA uses (`providerTerminalGuidance`), so a launch-the-CLI provider's
+  // in-CLI instruction reaches it. It used to fall back to its own inline copy
+  // of the generic sentences whenever the override table returned null, which
+  // told a Qwen user to read a sign-in code that nothing prints.
+  it("shows the in-CLI instruction, not the generic sign-in-code hint, for a launch-the-CLI provider (qwen)", () => {
+    render(
+      <ProviderReauthBanner
+        epicId="epic-1"
+        viewTabId="tab-1"
+        providerId="qwen"
+        state={{
+          ...copilotState({
+            oauthArgs: null,
+            token: null,
+            codePaste: null,
+            terminalLogin: {},
+          }),
+          providerId: "qwen",
+        }}
+        reason="provider_unauthenticated"
+        profileId={null}
+        profileLabel={null}
+        onContinueOnAmbient={null}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Sign in from a terminal" }),
+    ).toBeDefined();
+    expect(
+      screen.getByText(
+        "Qwen Code opens in that terminal. Type /auth and complete the sign-in there, then use Refresh above.",
+      ),
+    ).toBeDefined();
+    expect(screen.queryByText(/sign-in code/)).toBeNull();
+  });
+
   // Row 2: a provider whose whole `loginCapability` is `null` (Cursor,
   // Traycer, or any CLI with no OAuth session to reconnect) makes the
   // helper's optional chain yield `undefined` for `terminalLogin` -

--- a/clients/gui-app/src/components/chat/composer/provider-reauth-banner.tsx
+++ b/clients/gui-app/src/components/chat/composer/provider-reauth-banner.tsx
@@ -60,7 +60,7 @@ import {
   type ProviderPackPreparing,
 } from "@/components/providers/provider-pack-readiness";
 import { useProviderTerminalLogin } from "@/hooks/providers/use-provider-terminal-login";
-import { providerSetupGuidance } from "@/lib/providers/provider-setup-guidance";
+import { providerTerminalGuidance } from "@/lib/providers/provider-setup-guidance";
 import { useProvidersFocusStore } from "@/stores/settings/providers-focus-store";
 
 function noop(): void {}
@@ -492,7 +492,6 @@ function ReauthBannerInner({
       {terminalRow.kind === "button" ? (
         <TerminalLoginRow
           providerId={providerId}
-          providerLabel={providerLabel}
           epicId={terminalRow.epicId}
           viewTabId={terminalRow.viewTabId}
         />
@@ -532,12 +531,10 @@ function ReauthBannerInner({
  */
 function TerminalLoginRow({
   providerId,
-  providerLabel,
   epicId,
   viewTabId,
 }: {
   readonly providerId: ProviderId;
-  readonly providerLabel: string;
   readonly epicId: string;
   readonly viewTabId: string;
 }) {
@@ -549,11 +546,15 @@ function TerminalLoginRow({
     // host itself reports as replaced.
     launchedFromTile: null,
   });
-  // A provider whose terminal flow is a credential WIZARD rather than a
-  // device-code sign-in (Reasonix's `setup` asks for an API key) gets its own
-  // label and hint: "prints a sign-in code" is false there, and it is the copy
-  // the user reads while deciding what to do next.
-  const guidance = providerSetupGuidance(providerId);
+  // ONE resolver with the picker's setup CTA, never an inline fallback: the
+  // generic sentences are only generic until a provider needs different ones.
+  // A terminal flow that is a credential WIZARD rather than a device-code
+  // sign-in (Reasonix's `setup` asks for an API key) and one that opens the
+  // CLI's own UI (Qwen's `/auth`, Droid's first-run prompt, OMP's
+  // `login <provider>`, OpenCode's picker) each need their own label and hint
+  // - "prints a sign-in code" is false for both, and this is the copy the
+  // user reads while deciding what to do next.
+  const guidance = providerTerminalGuidance(providerId);
   return (
     <div className="flex flex-col gap-1.5">
       <div className="flex flex-wrap items-center gap-2">
@@ -563,16 +564,12 @@ function TerminalLoginRow({
           disabled={terminalLogin.isPending}
           onClick={terminalLogin.start}
         >
-          {guidance === null
-            ? "Sign in from a terminal"
-            : guidance.terminalActionLabel}
+          {guidance.terminalActionLabel}
           {terminalLogin.isPending ? <MutedAgentSpinner /> : null}
         </Button>
       </div>
       <span className="text-ui-xs text-muted-foreground">
-        {guidance === null
-          ? `${providerLabel} prints a sign-in code that only exists in the terminal. Complete the sign-in there, then use Refresh above.`
-          : guidance.terminalHint}
+        {guidance.terminalHint}
       </span>
     </div>
   );

--- a/clients/gui-app/src/components/chat/composer/provider-reauth-banner.tsx
+++ b/clients/gui-app/src/components/chat/composer/provider-reauth-banner.tsx
@@ -255,18 +255,20 @@ function deriveLoginOptions(
       ? loginCapability.token.vars
       : [];
   const oauthArgs = loginCapability !== null ? loginCapability.oauthArgs : null;
-  // Terminal-login providers HAVE real `oauthArgs` - that is the command the
-  // terminal runs - so they pass the check below and must be excluded first,
-  // or the banner offers a headless button the host refuses. No `isLocalHost`
-  // requirement: unlike browser OAuth there is no loopback here, so a device
-  // flow works just as well against a remote host. The `oauthArgs` requirement
-  // lives INSIDE the helper, so this surface and the two gate helpers cannot
-  // answer differently for the same provider.
+  // Terminal login is decided by `terminalLogin` alone, and it excludes the
+  // headless button whatever `oauthArgs` says: Copilot carries real ones (the
+  // host refuses them headlessly), Qwen / Droid / OMP / OpenCode carry `null`
+  // (they have no headless command; the host launches the CLI itself). No
+  // `isLocalHost` requirement: unlike browser OAuth there is no loopback here,
+  // so a device flow works just as well against a remote host. ONE helper for
+  // this surface and the two gate helpers, so they cannot answer differently
+  // for the same provider.
   const canTerminalLogin = providerSupportsTerminalLogin(loginCapability);
-  // A real login needs a non-empty subcommand. `null` = no OAuth; `[]` is also
-  // inert because the host would spawn the bare binary under piped stdio, which
-  // for an interactive-TUI CLI (e.g. droid) opens no browser and hangs the
-  // banner on "Waiting for browser sign-in…".
+  // A real HEADLESS login needs a non-empty subcommand. `null` = no OAuth;
+  // `[]` is also inert because the host would spawn the bare binary under
+  // piped stdio, which for an interactive-TUI CLI (e.g. droid) opens no
+  // browser and hangs the banner on "Waiting for browser sign-in…". (The
+  // terminal row above has no such constraint - a TUI is what it is for.)
   const canOauth =
     !canTerminalLogin &&
     isLocalHost &&

--- a/clients/gui-app/src/components/home/pickers/__tests__/harness-model-picker-create-profile-gate.test.ts
+++ b/clients/gui-app/src/components/home/pickers/__tests__/harness-model-picker-create-profile-gate.test.ts
@@ -58,17 +58,23 @@ describe("resolveCreateProfileGate", () => {
   // A launch-the-CLI provider (Qwen, Droid, OMP, OpenCode) declares
   // `terminalLogin` with `oauthArgs: null`. The terminal reason must still
   // win: the generic one names browser sign-in, which these providers do not
-  // do either.
-  it("uses the terminal reason for a terminal-login provider with no oauthArgs", () => {
-    const gate = resolveCreateProfileGate(true, {
-      oauthArgs: null,
-      token: null,
-      codePaste: null,
-      terminalLogin: {},
-    });
-    expect(gate.disabled).toBe(true);
-    expect(gate.reason).toBe(
-      "This provider is signed in from a terminal, not the browser.",
-    );
-  });
+  // do either. `[]` is covered beside `null` because those are the two
+  // spellings of "no headless command", and the gate that used to fall
+  // through to the generic reason treated them alike - so a regression that
+  // restored it would have to redden both.
+  it.each([{ oauthArgs: null }, { oauthArgs: [] }])(
+    "uses the terminal reason for a terminal-login provider with no oauthArgs (%o)",
+    ({ oauthArgs }) => {
+      const gate = resolveCreateProfileGate(true, {
+        oauthArgs,
+        token: null,
+        codePaste: null,
+        terminalLogin: {},
+      });
+      expect(gate.disabled).toBe(true);
+      expect(gate.reason).toBe(
+        "This provider is signed in from a terminal, not the browser.",
+      );
+    },
+  );
 });

--- a/clients/gui-app/src/components/home/pickers/__tests__/harness-model-picker-create-profile-gate.test.ts
+++ b/clients/gui-app/src/components/home/pickers/__tests__/harness-model-picker-create-profile-gate.test.ts
@@ -55,19 +55,20 @@ describe("resolveCreateProfileGate", () => {
     );
   });
 
-  // Unified gate: terminalLogin present but no real oauthArgs must read the
-  // same as "not a terminal-login provider" here too - the generic reason,
-  // not the terminal-specific one.
-  it("uses the generic reason, not the terminal one, when oauthArgs is empty", () => {
+  // A launch-the-CLI provider (Qwen, Droid, OMP, OpenCode) declares
+  // `terminalLogin` with `oauthArgs: null`. The terminal reason must still
+  // win: the generic one names browser sign-in, which these providers do not
+  // do either.
+  it("uses the terminal reason for a terminal-login provider with no oauthArgs", () => {
     const gate = resolveCreateProfileGate(true, {
-      oauthArgs: [],
+      oauthArgs: null,
       token: null,
       codePaste: null,
       terminalLogin: {},
     });
     expect(gate.disabled).toBe(true);
     expect(gate.reason).toBe(
-      "Add profiles from a local host with browser sign-in available.",
+      "This provider is signed in from a terminal, not the browser.",
     );
   });
 });

--- a/clients/gui-app/src/components/home/pickers/harness-model-picker-create-profile-gate.ts
+++ b/clients/gui-app/src/components/home/pickers/harness-model-picker-create-profile-gate.ts
@@ -66,12 +66,14 @@ export function resolveCreateProfileGate(
   hostIsLocal: boolean,
   loginCapability: ProviderCliState["loginCapability"] | undefined,
 ): { readonly disabled: boolean; readonly reason: string | undefined } {
-  // A terminal-login provider has real `oauthArgs` (they are the command the
-  // terminal runs), so without this it would read as gate-passing here and
-  // offer a "Create new profile" flow the host refuses. Its own reason has to
-  // come first, because the generic copy names browser sign-in - which is
-  // exactly the thing this provider does not do. Ordering is safe against a
-  // null/absent capability because the helper answers false for both.
+  // A terminal-login provider is answered before the `oauthArgs` gate below,
+  // whichever way its `oauthArgs` point. Copilot carries real ones (its
+  // headless command exists, the host just refuses it), so without this it
+  // would read as gate-passing and offer a "Create new profile" flow the host
+  // refuses; Qwen, Droid, OMP and OpenCode carry none, and would fall to the
+  // generic copy - which names browser sign-in, exactly the thing none of
+  // these providers do. Ordering is safe against a null/absent capability
+  // because the helper answers false for both.
   if (providerSupportsTerminalLogin(loginCapability)) {
     return {
       disabled: true,

--- a/clients/gui-app/src/components/providers/__tests__/provider-signin-availability.test.ts
+++ b/clients/gui-app/src/components/providers/__tests__/provider-signin-availability.test.ts
@@ -140,22 +140,25 @@ describe("providerSignInUnavailableHint", () => {
   // `terminalLogin` with `oauthArgs: null` - there is no headless command.
   // The terminal branch must win over the "no browser sign-in, use its own
   // CLI" one: Traycer opens that CLI for the user.
-  it("points at the terminal sign-in flow for a terminal-login provider with no oauthArgs", () => {
-    const hint = providerSignInUnavailableHint(
-      providerState({
-        providerId: "qwen",
-        loginCapability: {
-          oauthArgs: null,
-          token: null,
-          codePaste: null,
-          terminalLogin: {},
-        },
-      }),
-      true,
-    );
-    expect(hint).toContain("Qwen Code is signed in from a terminal");
-    expect(hint).not.toContain("its own CLI");
-  });
+  it.each([{ oauthArgs: null }, { oauthArgs: [] }])(
+    "points at the terminal sign-in flow for a terminal-login provider with no oauthArgs (%o)",
+    ({ oauthArgs }) => {
+      const hint = providerSignInUnavailableHint(
+        providerState({
+          providerId: "qwen",
+          loginCapability: {
+            oauthArgs,
+            token: null,
+            codePaste: null,
+            terminalLogin: {},
+          },
+        }),
+        true,
+      );
+      expect(hint).toContain("Qwen Code is signed in from a terminal");
+      expect(hint).not.toContain("its own CLI");
+    },
+  );
 });
 
 const TERMINAL_LOGIN_CAP: ProviderCliState["loginCapability"] = {

--- a/clients/gui-app/src/components/providers/__tests__/provider-signin-availability.test.ts
+++ b/clients/gui-app/src/components/providers/__tests__/provider-signin-availability.test.ts
@@ -135,6 +135,27 @@ describe("providerSignInUnavailableHint", () => {
     expect(hint).toContain("signed in from a terminal");
     expect(hint).not.toContain("browser sign-in");
   });
+
+  // A launch-the-CLI provider (Qwen, Droid, OMP, OpenCode) declares
+  // `terminalLogin` with `oauthArgs: null` - there is no headless command.
+  // The terminal branch must win over the "no browser sign-in, use its own
+  // CLI" one: Traycer opens that CLI for the user.
+  it("points at the terminal sign-in flow for a terminal-login provider with no oauthArgs", () => {
+    const hint = providerSignInUnavailableHint(
+      providerState({
+        providerId: "qwen",
+        loginCapability: {
+          oauthArgs: null,
+          token: null,
+          codePaste: null,
+          terminalLogin: {},
+        },
+      }),
+      true,
+    );
+    expect(hint).toContain("Qwen Code is signed in from a terminal");
+    expect(hint).not.toContain("its own CLI");
+  });
 });
 
 const TERMINAL_LOGIN_CAP: ProviderCliState["loginCapability"] = {
@@ -174,21 +195,13 @@ describe("providerSupportsTerminalLogin", () => {
     expect(providerSupportsTerminalLogin(undefined)).toBe(false);
   });
 
-  // Unified gate: `oauthArgs` is the command the terminal runs, so a
-  // provider advertising `terminalLogin` with no real command has nothing to
-  // offer. This one check is what keeps the banner, the picker gate, and
-  // this module's own `providerSignInUnavailableHint` from disagreeing about
-  // the same provider (each used to re-check `oauthArgs` separately, in a
-  // different order relative to its own `terminalLogin` branch).
-  it("is false when terminalLogin is present but oauthArgs is empty or null", () => {
-    expect(
-      providerSupportsTerminalLogin({
-        oauthArgs: [],
-        token: null,
-        codePaste: null,
-        terminalLogin: {},
-      }),
-    ).toBe(false);
+  // The command the terminal runs is host-owned, not `oauthArgs` - that is
+  // the HEADLESS command, and the providers whose sign-in lives inside their
+  // own TUI (Qwen, Droid, OMP, OpenCode) ship `terminalLogin` with
+  // `oauthArgs: null` so a client predating the field never offers them a
+  // headless button. This helper once required `oauthArgs` too, which hid
+  // the terminal button for exactly those four.
+  it("is true when terminalLogin is present even though oauthArgs is null or empty", () => {
     expect(
       providerSupportsTerminalLogin({
         oauthArgs: null,
@@ -196,6 +209,14 @@ describe("providerSupportsTerminalLogin", () => {
         codePaste: null,
         terminalLogin: {},
       }),
-    ).toBe(false);
+    ).toBe(true);
+    expect(
+      providerSupportsTerminalLogin({
+        oauthArgs: [],
+        token: null,
+        codePaste: null,
+        terminalLogin: {},
+      }),
+    ).toBe(true);
   });
 });

--- a/clients/gui-app/src/components/providers/provider-signin-availability.ts
+++ b/clients/gui-app/src/components/providers/provider-signin-availability.ts
@@ -17,12 +17,18 @@ import { providerDisplayName } from "@/lib/provider-ordering";
  * cannot drift into offering the headless button for a provider the host will
  * refuse, or the terminal one for a provider it cannot open.
  *
- * It answers CAN, not merely `terminalLogin !== null`, because the command the
- * terminal runs is `oauthArgs` - a provider advertising `terminalLogin` with no
- * command has no terminal sign-in to offer. Folding that in here rather than
- * re-checking it per call site is what makes the consumers agree: they check
- * this in different orders relative to their own `oauthArgs` branches, and with
- * a laxer predicate those orders disagree about the same provider.
+ * It reads `terminalLogin` ALONE. The command the terminal runs is host-owned
+ * (the host's `CliProfile.terminalLaunchArgs`), not `oauthArgs`: `oauthArgs`
+ * is the HEADLESS command, and the providers whose sign-in lives inside their
+ * own TUI (Qwen, Droid, OMP, OpenCode) ship `terminalLogin` with
+ * `oauthArgs: null` precisely so a client that predates this field never
+ * offers them a headless button. Requiring `oauthArgs` here - which this
+ * helper once did, when Copilot and Reasonix were the only terminal-login
+ * providers and both happened to carry one - hid the terminal button for
+ * exactly those four. Every consumer's own `oauthArgs` branch is therefore
+ * ordered AFTER this check, never before it: a terminal-login provider with
+ * `oauthArgs: null` must not fall into a "no browser sign-in, use its CLI"
+ * sentence when Traycer can open that CLI for the user.
  *
  * The `!== null && !== undefined` spelling is load-bearing, not defensive
  * noise, though not for the reason it is tempting to assume. An old host's
@@ -38,9 +44,7 @@ export function providerSupportsTerminalLogin(
   loginCapability: ProviderCliState["loginCapability"] | undefined,
 ): boolean {
   const terminalLogin = loginCapability?.terminalLogin;
-  if (terminalLogin === null || terminalLogin === undefined) return false;
-  const oauthArgs = loginCapability?.oauthArgs ?? null;
-  return oauthArgs !== null && oauthArgs.length > 0;
+  return terminalLogin !== null && terminalLogin !== undefined;
 }
 
 /**
@@ -106,6 +110,16 @@ export function providerSignInUnavailableHint(
   state: ProviderCliState,
   isSelectedHostLocal: boolean,
 ): string | null {
+  if (providerSupportsTerminalLogin(state.loginCapability)) {
+    // A permanent provider property, so it outranks every situational reason
+    // below - and it has to precede the "no browser sign-in" branch too: a
+    // terminal-login provider may ship `oauthArgs: null` (Qwen, Droid, OMP
+    // and OpenCode have no headless command at all), and that branch would
+    // send its user to "its own CLI" when Traycer can open that CLI for them.
+    // It is also FALSE for the host check: a device flow needs no loopback,
+    // so terminal login works on a remote host.
+    return `${providerDisplayName(state.providerId)} is signed in from a terminal. Use the sign-in option in the chat composer.`;
+  }
   const oauthArgs = state.loginCapability?.oauthArgs ?? null;
   if (oauthArgs === null || oauthArgs.length === 0) {
     // A permanent property of the provider, so it outranks the situational
@@ -120,15 +134,6 @@ export function providerSignInUnavailableHint(
       return `${name} does not support browser sign-in.`;
     }
     return `${name} does not support browser sign-in. Authenticate with its own CLI, or set an API key on the Account tab.`;
-  }
-  if (providerSupportsTerminalLogin(state.loginCapability)) {
-    // Also a permanent provider property, and it outranks the host check
-    // below for the same reason - and additionally because it is FALSE there:
-    // a device flow needs no loopback, so terminal login works on a remote
-    // host. Reached only with real `oauthArgs` (both this branch and the one
-    // above require them), so the command exists; it just cannot run
-    // headlessly.
-    return `${providerDisplayName(state.providerId)} is signed in from a terminal. Use the sign-in option in the chat composer.`;
   }
   if (!isSelectedHostLocal) {
     return "Signing in opens a browser on the machine running Traycer, so it is only available on a local host.";

--- a/clients/gui-app/src/lib/providers/__tests__/provider-setup-guidance.test.ts
+++ b/clients/gui-app/src/lib/providers/__tests__/provider-setup-guidance.test.ts
@@ -176,10 +176,13 @@ describe("resolveProviderTerminalSetup", () => {
     expect(setup?.guidance.terminalActionLabel).toBe("Set up in terminal");
   });
 
-  it("preserves reasonix's guidance with canStartTerminal: false when the capability is absent (oauthArgs empty) - the fix for old hosts losing Reasonix's manual instructions", () => {
+  it("preserves reasonix's guidance with canStartTerminal: false when the capability is absent (terminalLogin null) - the fix for old hosts losing Reasonix's manual instructions", () => {
     const setup = resolveProviderTerminalSetup(
       "reasonix",
-      stateWith(capabilityWithTerminalLogin([])),
+      stateWith({
+        ...capabilityWithTerminalLogin(["setup"]),
+        terminalLogin: null,
+      }),
     );
     expect(setup).not.toBeNull();
     expect(setup?.canStartTerminal).toBe(false);
@@ -196,11 +199,77 @@ describe("resolveProviderTerminalSetup", () => {
     expect(setup?.guidance.manualCommand).toBe("reasonix setup");
   });
 
-  it("returns null for copilot when the capability is absent (oauthArgs empty) - no copy-table override to fall back on", () => {
+  it("returns null for copilot when the capability is absent (terminalLogin null) - no copy-table override to fall back on", () => {
     expect(
       resolveProviderTerminalSetup(
         "copilot",
-        stateWith(capabilityWithTerminalLogin([])),
+        stateWith({
+          ...capabilityWithTerminalLogin(["login"]),
+          terminalLogin: null,
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  // The launch-the-CLI providers declare `terminalLogin` with `oauthArgs:
+  // null` (no headless command; the host launches the CLI itself). They get
+  // the terminal action on that capability alone, with the generic guidance
+  // re-worded to name the step inside the CLI - and, like copilot, nothing at
+  // all on a host that declares no capability.
+  it("gives a launch-the-CLI provider (qwen, oauthArgs null) the terminal action with copy naming the in-CLI step", () => {
+    const setup = resolveProviderTerminalSetup(
+      "qwen",
+      stateWith(capabilityWithTerminalLogin(null)),
+    );
+    expect(setup).not.toBeNull();
+    expect(setup?.canStartTerminal).toBe(true);
+    expect(setup?.guidance.terminalActionLabel).toBe("Sign in from a terminal");
+    expect(setup?.guidance.manualCommand).toBeNull();
+    expect(setup?.guidance.summary).toBe(
+      "Qwen Code signs in from inside its own terminal UI.",
+    );
+    expect(setup?.guidance.stepsAfterAction).toEqual([
+      "Type /auth in that terminal, choose a sign-in method and finish in the browser.",
+      "Refresh this list.",
+    ]);
+    expect(setup?.guidance.terminalHint).toContain("Type /auth");
+    expect(setup?.guidance.summary).not.toContain("sign-in code");
+  });
+
+  it("names the in-CLI step for each launch-the-CLI provider and keeps the generic labels", () => {
+    for (const [providerId, step] of [
+      ["droid", "Follow the sign-in prompt Droid shows when it starts."],
+      [
+        "omp",
+        "Type login followed by the provider (for example login anthropic) in that terminal and follow the prompts.",
+      ],
+      [
+        "opencode",
+        "Pick the provider and sign-in method in that terminal and follow the prompts.",
+      ],
+    ] as const) {
+      const guidance = defaultTerminalSignInGuidance(providerId);
+      expect(guidance.stepsAfterAction, providerId).toEqual([
+        step,
+        "Refresh this list.",
+      ]);
+      expect(guidance.terminalActionLabel, providerId).toBe(
+        "Sign in from a terminal",
+      );
+      expect(guidance.summary, providerId).not.toContain("sign-in code");
+      expect(guidance.terminalHint, providerId).not.toContain("sign-in code");
+      expect(guidance.manualCommand, providerId).toBeNull();
+    }
+  });
+
+  it("returns null for a launch-the-CLI provider on a host that declares no capability", () => {
+    expect(
+      resolveProviderTerminalSetup(
+        "droid",
+        stateWith({
+          ...capabilityWithTerminalLogin(null),
+          terminalLogin: null,
+        }),
       ),
     ).toBeNull();
   });
@@ -210,7 +279,10 @@ describe("providerSetupActionPlacement", () => {
   it("returns 'unsupported-host' whenever canStartTerminal is false, regardless of hasSurface", () => {
     const setup = resolveProviderTerminalSetup(
       "reasonix",
-      stateWith(capabilityWithTerminalLogin([])),
+      stateWith({
+        ...capabilityWithTerminalLogin(["setup"]),
+        terminalLogin: null,
+      }),
     );
     expect(setup).not.toBeNull();
     if (setup === null) return;

--- a/clients/gui-app/src/lib/providers/__tests__/provider-setup-guidance.test.ts
+++ b/clients/gui-app/src/lib/providers/__tests__/provider-setup-guidance.test.ts
@@ -216,25 +216,30 @@ describe("resolveProviderTerminalSetup", () => {
   // the terminal action on that capability alone, with the generic guidance
   // re-worded to name the step inside the CLI - and, like copilot, nothing at
   // all on a host that declares no capability.
-  it("gives a launch-the-CLI provider (qwen, oauthArgs null) the terminal action with copy naming the in-CLI step", () => {
-    const setup = resolveProviderTerminalSetup(
-      "qwen",
-      stateWith(capabilityWithTerminalLogin(null)),
-    );
-    expect(setup).not.toBeNull();
-    expect(setup?.canStartTerminal).toBe(true);
-    expect(setup?.guidance.terminalActionLabel).toBe("Sign in from a terminal");
-    expect(setup?.guidance.manualCommand).toBeNull();
-    expect(setup?.guidance.summary).toBe(
-      "Qwen Code signs in from inside its own terminal UI.",
-    );
-    expect(setup?.guidance.stepsAfterAction).toEqual([
-      "Type /auth in that terminal, choose a sign-in method and finish in the browser.",
-      "Refresh this list.",
-    ]);
-    expect(setup?.guidance.terminalHint).toContain("Type /auth");
-    expect(setup?.guidance.summary).not.toContain("sign-in code");
-  });
+  it.each([{ oauthArgs: null }, { oauthArgs: [] }])(
+    "gives a launch-the-CLI provider (qwen, no oauthArgs %o) the terminal action with copy naming the in-CLI step",
+    ({ oauthArgs }) => {
+      const setup = resolveProviderTerminalSetup(
+        "qwen",
+        stateWith(capabilityWithTerminalLogin(oauthArgs)),
+      );
+      expect(setup).not.toBeNull();
+      expect(setup?.canStartTerminal).toBe(true);
+      expect(setup?.guidance.terminalActionLabel).toBe(
+        "Sign in from a terminal",
+      );
+      expect(setup?.guidance.manualCommand).toBeNull();
+      expect(setup?.guidance.summary).toBe(
+        "Qwen Code signs in from inside its own terminal UI.",
+      );
+      expect(setup?.guidance.stepsAfterAction).toEqual([
+        "Type /auth in that terminal, choose a sign-in method and finish in the browser.",
+        "Refresh this list.",
+      ]);
+      expect(setup?.guidance.terminalHint).toContain("Type /auth");
+      expect(setup?.guidance.summary).not.toContain("sign-in code");
+    },
+  );
 
   it("names the in-CLI step for each launch-the-CLI provider and keeps the generic labels", () => {
     for (const [providerId, step] of [

--- a/clients/gui-app/src/lib/providers/provider-setup-guidance.ts
+++ b/clients/gui-app/src/lib/providers/provider-setup-guidance.ts
@@ -21,10 +21,20 @@ import type { ProviderTerminalLoginScopeSupport } from "@/hooks/providers/use-pr
  * (`resolveProviderTerminalSetup`): the host declares it for exactly the
  * providers whose headless login cannot work (Copilot prints its device code
  * where only a terminal shows it; Reasonix's `setup` exits 0 without a
- * credential). WHAT the action says is copy, decided here: a generic sign-in
- * framing by default, overridden per provider where that framing is wrong.
+ * credential; Qwen, Droid, OMP and OpenCode have no login command at all, so
+ * the host launches the CLI itself and the sign-in is a step inside it). WHAT
+ * the action says is copy, decided here: a generic sign-in framing by
+ * default, overridden per provider where that framing is wrong.
  *
- * Reasonix is the override. The generic surfaces describe a sign-in: "Sign in
+ * Two kinds of override. `TERMINAL_SIGN_IN_COPY` re-words the generic
+ * sign-in for the launch-the-CLI providers: the default says the terminal
+ * "prints a sign-in code", but what actually opens is the CLI's own UI, and
+ * a user left in front of a TUI with no instruction is where that flow
+ * stalls - so the first step names the thing to type. It stays the GENERIC
+ * guidance in every other respect (no manual command, the same labels), so
+ * an old host that declares no capability still shows nothing for them.
+ *
+ * Reasonix is the full override. The generic surfaces describe a sign-in: "Sign in
  * from a terminal", "prints a sign-in code". For a provider that owns its own
  * credential store that framing is wrong in a way that costs the user real
  * time - Reasonix's own startup warning names an environment variable
@@ -111,18 +121,69 @@ export function providerSetupGuidance(
 }
 
 /**
+ * The sentences that differ for a provider whose sign-in terminal opens the
+ * CLI itself rather than a login command. Each names the step the user takes
+ * INSIDE that CLI, which is the one thing the generic copy cannot say.
+ */
+interface TerminalSignInCopy {
+  readonly summary: string;
+  /** Replaces the generic "Complete the sign-in in that terminal." step. */
+  readonly firstStep: string;
+  readonly terminalHint: string;
+}
+
+const TERMINAL_SIGN_IN_COPY: {
+  readonly [k in ProviderId]?: TerminalSignInCopy;
+} = {
+  qwen: {
+    summary: "Qwen Code signs in from inside its own terminal UI.",
+    firstStep:
+      "Type /auth in that terminal, choose a sign-in method and finish in the browser.",
+    terminalHint:
+      "Qwen Code opens in that terminal. Type /auth and complete the sign-in there, then use Refresh above.",
+  },
+  droid: {
+    summary: "Droid signs in from inside its own terminal UI.",
+    firstStep: "Follow the sign-in prompt Droid shows when it starts.",
+    terminalHint:
+      "Droid opens in that terminal and prompts you to sign in. Complete it there, then use Refresh above.",
+  },
+  omp: {
+    summary:
+      "Oh My Pi signs in from inside its own terminal UI, one provider account at a time.",
+    firstStep:
+      "Type login followed by the provider (for example login anthropic) in that terminal and follow the prompts.",
+    terminalHint:
+      "Oh My Pi opens in that terminal. Run login <provider> and complete the sign-in there, then use Refresh above.",
+  },
+  opencode: {
+    summary:
+      "OpenCode signs in from a terminal, one provider account at a time.",
+    firstStep:
+      "Pick the provider and sign-in method in that terminal and follow the prompts.",
+    terminalHint:
+      "OpenCode asks for the provider and sign-in method in that terminal. Complete it there, then use Refresh above.",
+  },
+};
+
+/**
  * The generic terminal sign-in copy - the same sentences the composer banner
  * uses for a provider without an override, so the picker and the banner
- * describe one flow the same way.
+ * describe one flow the same way. The launch-the-CLI providers re-word the
+ * three sentences that would otherwise describe a sign-in code nothing prints
+ * (`TERMINAL_SIGN_IN_COPY`) and keep everything else.
  */
 export function defaultTerminalSignInGuidance(
   providerId: ProviderId,
 ): ProviderSetupGuidance {
   const name = PROVIDER_DISPLAY_NAMES[providerId];
+  const copy = TERMINAL_SIGN_IN_COPY[providerId] ?? null;
   return {
-    summary: `${name} signs in from a terminal: it prints a sign-in code that only exists there.`,
+    summary:
+      copy?.summary ??
+      `${name} signs in from a terminal: it prints a sign-in code that only exists there.`,
     stepsAfterAction: [
-      "Complete the sign-in in that terminal.",
+      copy?.firstStep ?? "Complete the sign-in in that terminal.",
       "Refresh this list.",
     ],
     noSurfaceStep:
@@ -130,7 +191,9 @@ export function defaultTerminalSignInGuidance(
     epicOnlyStep: `Open a chat and choose “Sign in from a terminal” from its model picker. This host's version can open the ${name} sign-in from a chat, but not from the start page.`,
     manualCommand: null,
     terminalActionLabel: "Sign in from a terminal",
-    terminalHint: `${name} prints a sign-in code that only exists in the terminal. Complete the sign-in there, then use Refresh above.`,
+    terminalHint:
+      copy?.terminalHint ??
+      `${name} prints a sign-in code that only exists in the terminal. Complete the sign-in there, then use Refresh above.`,
   };
 }
 

--- a/clients/gui-app/src/lib/providers/provider-setup-guidance.ts
+++ b/clients/gui-app/src/lib/providers/provider-setup-guidance.ts
@@ -167,9 +167,9 @@ const TERMINAL_SIGN_IN_COPY: {
 };
 
 /**
- * The generic terminal sign-in copy - the same sentences the composer banner
- * uses for a provider without an override, so the picker and the banner
- * describe one flow the same way. The launch-the-CLI providers re-word the
+ * The generic terminal sign-in copy for a provider with no override. Reached
+ * only through `providerTerminalGuidance`, which is what keeps the picker and
+ * the banner describing one flow the same way. The launch-the-CLI providers re-word the
  * three sentences that would otherwise describe a sign-in code nothing prints
  * (`TERMINAL_SIGN_IN_COPY`) and keep everything else.
  */
@@ -195,6 +195,30 @@ export function defaultTerminalSignInGuidance(
       copy?.terminalHint ??
       `${name} prints a sign-in code that only exists in the terminal. Complete the sign-in there, then use Refresh above.`,
   };
+}
+
+/**
+ * THE copy for a provider's terminal flow: its override if the table has one,
+ * the generic sign-in copy otherwise.
+ *
+ * Every surface that renders a terminal action resolves through this - the
+ * picker's setup CTA (via `resolveProviderTerminalSetup` below) and the
+ * composer banner's `TerminalLoginRow`. The banner used to fall back to its
+ * OWN inline copy of the generic sentences when the override table returned
+ * `null`, which is the same two sentences written twice, and the copy
+ * diverged the moment a provider needed different ones:
+ * `TERMINAL_SIGN_IN_COPY` reached the picker and the banner went on telling a
+ * Qwen user to read a sign-in code that nothing prints. A provider with no
+ * terminal sign-in at all never reaches either surface - the capability gate
+ * (`providerSupportsTerminalLogin`) decides that, not the copy.
+ */
+export function providerTerminalGuidance(
+  providerId: ProviderId,
+): ProviderSetupGuidance {
+  return (
+    providerSetupGuidance(providerId) ??
+    defaultTerminalSignInGuidance(providerId)
+  );
 }
 
 /**
@@ -244,7 +268,7 @@ export function resolveProviderTerminalSetup(
       : { guidance: override, canStartTerminal: false, packPreparing: null };
   }
   return {
-    guidance: override ?? defaultTerminalSignInGuidance(providerId),
+    guidance: providerTerminalGuidance(providerId),
     canStartTerminal: true,
     packPreparing: providerTerminalLoginPackBlock(state),
   };

--- a/protocol/src/host/provider-schemas.ts
+++ b/protocol/src/host/provider-schemas.ts
@@ -989,11 +989,18 @@ export const providerLoginCapabilitySchema = z.object({
    * SDK exposes that code natively, so Traycer never parses it out - the user
    * reads it from the terminal Traycer opened.
    *
-   * Set here, `oauthArgs` stays the command source but the GUI must NOT offer
-   * headless browser OAuth; the host refuses `providers.startLogin` for the
-   * same reason, so a released client that predates this field cannot start a
-   * concurrent broken flow. Shape carries no fields today - existence alone is
-   * the signal - but stays an object for the same reason `codePaste` does.
+   * Set here, the GUI must NOT offer headless browser OAuth, whatever
+   * `oauthArgs` says; the host refuses `providers.startLogin` for the same
+   * reason, so a released client that predates this field cannot start a
+   * concurrent broken flow. The command the terminal runs is host-owned and is
+   * NOT `oauthArgs` - that is the headless command. A provider with no
+   * headless command at all (Qwen, Droid, OMP, OpenCode: the sign-in lives
+   * inside their own TUI, so the host launches the CLI itself) declares this
+   * with `oauthArgs: null`, which is exactly what keeps the headless button
+   * hidden on older clients - so a GUI gate reads this field alone and never
+   * requires `oauthArgs` beside it. Shape carries no fields today - existence
+   * alone is the signal - but stays an object for the same reason `codePaste`
+   * does.
    *
    * `.catch(null)` hardens a present-but-unrecognized value. A genuinely
    * ABSENT key (an old host that predates the field, decoded through the


### PR DESCRIPTION
Client half of traycerai/traycer-internal#5475 (host: launch the CLI in the sign-in terminal for Qwen, Droid, OMP and OpenCode). Follows #1699 / #1708.

## Problem

`providerSupportsTerminalLogin` required a non-empty `oauthArgs` beside `terminalLogin`, from when Copilot and Reasonix were the only terminal-login providers and both happened to carry one. The host now declares `terminalLogin` for four providers that have **no headless login command at all** (Qwen's `qwen auth` is removed and sign-in is `/auth` inside the TUI; Droid has only `droid doctor`; OMP's sign-in is `login <provider>` inside the TUI; OpenCode's `auth login` is an interactive picker). The host launches the CLI itself in the sign-in terminal, and their `oauthArgs` stays `null` because that is what keeps the **headless** button hidden on clients that predate `terminalLogin`. With the old predicate, that same `null` hid the **terminal** button for exactly those four.

## What changes

| File | Change |
| --- | --- |
| `provider-signin-availability.ts` | `providerSupportsTerminalLogin` reads `terminalLogin` alone. `providerSignInUnavailableHint` answers the terminal case **first**, before its "does not support browser sign-in, authenticate with its own CLI" branch, so a terminal-login provider with no headless command is never sent to a CLI Traycer can open for it. |
| `harness-model-picker-create-profile-gate.ts` | Already ordered terminal-first; comment no longer claims terminal-login providers "have real `oauthArgs`". |
| `provider-reauth-banner.tsx` | `deriveLoginOptions` unchanged in logic (terminal excludes headless; headless still needs a real subcommand); comments corrected. |
| `provider-setup-guidance.ts` | The generic terminal copy says the terminal "prints a sign-in code". For the launch-the-CLI providers what opens is the CLI's own UI, so `TERMINAL_SIGN_IN_COPY` re-words the summary, first step and hint to name the step inside it: Qwen "Type /auth …", Droid "Follow the sign-in prompt …", OMP "Type login followed by the provider …", OpenCode "Pick the provider and sign-in method …". Everything else stays generic (no manual command), so an old host that declares no capability still shows nothing for them, exactly like Copilot. |
| `protocol/src/host/provider-schemas.ts` | Doc-only: `terminalLogin`'s comment no longer calls `oauthArgs` the terminal's command source, and says a GUI gate reads this field alone. No schema change. |

Class sweep: every GUI reader of `oauthArgs` next to `terminalLogin` (the predicate, the hint, the profile gate, the banner) plus the protocol comment; `rg` for "real \`oauthArgs\`" / "command the terminal runs" finds no stale claim.

## Compatibility

- **New GUI, old host** (no `terminalLogin` for these four): unchanged, the predicate is false and nothing is offered.
- **New GUI, new host**: the picker CTA, the composer banner row and the Settings hint all offer / point at the terminal sign-in; the headless button stays hidden.
- Copilot and Reasonix are unaffected: they still carry `oauthArgs` and `terminalLogin`.

## Tests

Three cases that pinned the old coupling are flipped (predicate, profile gate, banner) and the null-`oauthArgs` terminal case is added for the predicate, the hint, the profile gate, the banner, and the guidance copy (per-provider steps, generic labels kept, null on a host with no capability). The two guidance tests that spelled "capability absent" as `oauthArgs: []` now spell it as `terminalLogin: null`, which is what absence is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)