### PR TITLE
fix(shared): draw a stream's CLOSE seq from the retired counter, not 0

### DIFF
--- a/clients/shared/host-transport/remote/__tests__/remote-session.test.ts
+++ b/clients/shared/host-transport/remote/__tests__/remote-session.test.ts
@@ -7428,3 +7428,102 @@ describe("RemoteSession outbound seq continuity across a stream's CLOSE (host H1
     TEST_BUDGET_MS,
   );
 });
+
+describe("RemoteSession outbound seq continuity across a client-detected inbound failure (host H11 gate)", () => {
+  it(
+    "a stream failed on inbound reassembly sends its CLOSE at the seq after the SUBSCRIBE",
+    async () => {
+      // The fifth retire site, and the one a source-order reading misses:
+      // `failStreamOnInboundError` enqueued the CLOSE ABOVE its delete, but
+      // the seq is drawn when the scheduler pulls - after every synchronous
+      // line of the method - so the CLOSE still left at seq 0. Unlike a
+      // host-sent FATAL, the host has NOT tombstoned this stream (the fault
+      // was detected here), so this CLOSE reaches its seq gate for real.
+      const relay = new FakeRelayHost();
+      relay.streamManifest = buildStreamManifest(
+        cursorStreamRegistry,
+        SERVES_EVERY_INSTALLED_MAJOR,
+      );
+      const warnSpy = vi
+        .spyOn(console, "warn")
+        .mockImplementation(() => undefined);
+      const lease = new MutableBearerLease("valid-token", "user-1");
+      const session = new RemoteSession({
+        ...buildSessionOptions(relay, lease, null),
+        streamRegistry: cursorStreamRegistry,
+      });
+      const faulted = session.subscribe("cursor.subscribe", { cursor: null });
+      let fatalCode: string | null = null;
+      faulted.onStatusChange((_status, reason) => {
+        if (reason?.kind === "fatalError") {
+          fatalCode = reason.details.code;
+        }
+      });
+      // The sibling whose outbound keeps the pump busy. It needs one delivered
+      // server frame to reach `open`, which is what `sendClientFrame` gates on.
+      const sibling = session.subscribe("cursor.subscribe", { cursor: null });
+      sibling.onServerFrame(() => undefined);
+      let siblingOpen = false;
+      sibling.onStatusChange((status) => {
+        if (status === "open") {
+          siblingOpen = true;
+        }
+      });
+      try {
+        await vi.waitFor(
+          () => expect(relay.subscribeStreamIds).toHaveLength(2),
+          WAIT,
+        );
+        const faultedId = relay.subscribeStreamIds[0];
+        const siblingId = relay.subscribeStreamIds[1];
+        await relay.sendStreamFrame(
+          siblingId,
+          { kind: "snapshot", hasBinaryPayload: false },
+          null,
+          QosClass.INTERACTIVE,
+        );
+        await vi.waitFor(() => expect(siblingOpen).toBe(true), WAIT);
+        // A continuation chunk with no start in flight: a per-stream
+        // reassembly fault the client attributes to `faulted`. Sealed ahead
+        // so the two sends below share one synchronous tick.
+        const [, continuation] = buildChunkFrames(faultedId);
+        const sealedFault = await relay.encryptFrame(continuation);
+
+        // The interleaving that made the old code wrong ONLY here: a 3-chunk
+        // client message on the sibling puts the pump mid-`await write` when
+        // the fault lands, so the CLOSE cannot draw its seq synchronously at
+        // enqueue and instead draws it when the pump comes back - after every
+        // line of `failStreamOnInboundError` has run. With an idle pump the
+        // old source order happened to work, which is why a single-stream
+        // version of this test stayed green against the bug.
+        sibling.sendClientFrame(
+          { kind: "snapshot", hasBinaryPayload: true },
+          new Uint8Array(3 * BULK_CHUNK_SIZE_BYTES),
+        );
+        relay.deliverToClient(sealedFault);
+
+        await vi.waitFor(
+          () => expect(relay.closesSent).toContain(faultedId),
+          WAIT,
+        );
+        expect(fatalCode).toBe("STREAM_CHUNK_REASSEMBLY_FAILED");
+        expect(
+          relay.clientFrames
+            .filter((frame) => frame.streamId === faultedId)
+            .map((frame) => ({ type: frame.type, seq: frame.seq })),
+        ).toEqual([
+          { type: MuxFrameType.SUBSCRIBE, seq: 0 },
+          { type: MuxFrameType.CLOSE, seq: 1 },
+        ]);
+        // Stream-local verdict: the sibling is untouched and nobody redialed.
+        expect(siblingOpen).toBe(true);
+        expect(relay.openBearers).toHaveLength(1);
+        expect(relay.errors).toEqual([]);
+      } finally {
+        warnSpy.mockRestore();
+        session.close();
+      }
+    },
+    TEST_BUDGET_MS,
+  );
+});

--- a/clients/shared/host-transport/remote/__tests__/remote-session.test.ts
+++ b/clients/shared/host-transport/remote/__tests__/remote-session.test.ts
@@ -89,6 +89,7 @@ import {
   BULK_CHUNK_SIZE_BYTES,
   ChunkReassembler,
   encodeMuxMessageBody,
+  nextSeqValue,
   OutboundChunkSource,
   type OutboundMessage,
   type ReassembledMessage,
@@ -265,6 +266,17 @@ interface FakeConnection {
   readonly reassembler: ChunkReassembler;
   readonly seqByStream: Map<number, number>;
   /**
+   * Host-side H11 mirror (`RemoteClientSession.inboundSeqByStream`): the
+   * `seq` due next on each client stream. The production host closes the
+   * whole session with `SESSION_FRAME_SEQUENCE_MISMATCH` when an unchunked
+   * frame skips or repeats one, so the fake fails the same way - into
+   * `errors`, which the suites assert empty. Without it a client that
+   * retired a stream's counter and THEN sent the CLOSE (seq 0 where 1 was
+   * due) passed every test here and killed every real session on the first
+   * unsubscribe.
+   */
+  readonly inboundSeqByStream: Map<number, number>;
+  /**
    * Host-side R-2 mirror (`r2-host-stream-tombstone`), enforced per
    * connection exactly like `RemoteClientSession.terminalStreamIds`: once the
    * fake sends a FATAL for a stream, every later CLIENT frame for that id -
@@ -403,6 +415,7 @@ class FakeRelayHost {
         handshake: null,
         reassembler: new ChunkReassembler(undefined),
         seqByStream: new Map(),
+        inboundSeqByStream: new Map(),
         terminalStreamIds: new Set(),
         queue: Promise.resolve(),
         closed: false,
@@ -520,6 +533,7 @@ class FakeRelayHost {
     // every later client frame for the id, so a client re-open must arrive
     // under a fresh id to be heard.
     connection.terminalStreamIds.add(streamId);
+    connection.inboundSeqByStream.delete(streamId);
     await this.sendMux(connection, {
       type: MuxFrameType.FATAL,
       streamId,
@@ -539,6 +553,7 @@ class FakeRelayHost {
   async sendStreamClose(streamId: number, reason: string): Promise<void> {
     const connection = this.liveConnection();
     connection.terminalStreamIds.add(streamId);
+    connection.inboundSeqByStream.delete(streamId);
     await this.sendMux(connection, {
       type: MuxFrameType.CLOSE,
       streamId,
@@ -634,7 +649,22 @@ class FakeRelayHost {
       });
       return;
     }
+    // H11 mirror, same placement and predicate as the production host's
+    // `feedInbound`: after the tombstone drop, before `accept()`, unchunked
+    // frames only (chunk sequences are ordered by the reassembler itself).
+    const expectedSeq = connection.inboundSeqByStream.get(frame.streamId);
+    if (
+      !frame.chunked &&
+      expectedSeq !== undefined &&
+      frame.seq !== expectedSeq
+    ) {
+      throw new Error(
+        `SESSION_FRAME_SEQUENCE_MISMATCH: frame ${frame.seq} (type ${frame.type}) arrived on stream ${frame.streamId} where ${expectedSeq} was due`,
+      );
+    }
     const message = connection.reassembler.accept(frame);
+    // Advanced only once the reassembler accepted the frame, as on the host.
+    connection.inboundSeqByStream.set(frame.streamId, nextSeqValue(frame.seq));
     if (message === null) {
       return;
     }
@@ -7267,6 +7297,132 @@ describe("RemoteSession clock-skew park re-entrancy", () => {
         expect(recoveryListeners.size).toBe(0);
       } finally {
         live.close();
+      }
+    },
+    TEST_BUDGET_MS,
+  );
+});
+
+/**
+ * The host's H11 gate (`RemoteClientSession.feedInbound`) closes the whole
+ * session when an unchunked frame arrives out of sequence on its stream. A
+ * stream's CLOSE is the last frame the client sends on it, and every path
+ * that retires the stream's `seq` counter must therefore draw the CLOSE's
+ * `seq` from the retired counter, not from a fresh one - a CLOSE at seq 0 on
+ * a stream whose SUBSCRIBE already drew 0 is `SESSION_FRAME_SEQUENCE_MISMATCH`
+ * on the host, which is how every remote session on mobile died on the first
+ * screen change. `FakeRelayHost` enforces the same gate, so each of these
+ * also proves the fake would have caught the regression.
+ */
+describe("RemoteSession outbound seq continuity across a stream's CLOSE (host H11 gate)", () => {
+  function seqsOnStream(
+    relay: FakeRelayHost,
+    streamId: number,
+  ): { type: MuxFrameTypeValue; seq: number }[] {
+    return relay.clientFrames
+      .filter((frame) => frame.streamId === streamId)
+      .map((frame) => ({ type: frame.type, seq: frame.seq }));
+  }
+
+  it(
+    "a caller close sends its CLOSE at the seq after the SUBSCRIBE",
+    async () => {
+      const relay = new FakeRelayHost();
+      relay.streamManifest = buildStreamManifest(
+        cursorStreamRegistry,
+        SERVES_EVERY_INSTALLED_MAJOR,
+      );
+      const lease = new MutableBearerLease("valid-token", "user-1");
+      const session = new RemoteSession({
+        ...buildSessionOptions(relay, lease, null),
+        streamRegistry: cursorStreamRegistry,
+      });
+      const stream = session.subscribe("cursor.subscribe", { cursor: null });
+      try {
+        await vi.waitFor(
+          () => expect(relay.subscribeStreamIds).toHaveLength(1),
+          WAIT,
+        );
+        const streamId = relay.subscribeStreamIds[0];
+        stream.close();
+        // The host HANDLED the CLOSE (it is in `closesSent`, past the seq
+        // gate) - not merely that the client put one on the wire.
+        await vi.waitFor(
+          () => expect(relay.closesSent).toContain(streamId),
+          WAIT,
+        );
+        expect(seqsOnStream(relay, streamId)).toEqual([
+          { type: MuxFrameType.SUBSCRIBE, seq: 0 },
+          { type: MuxFrameType.CLOSE, seq: 1 },
+        ]);
+        expect(relay.errors).toEqual([]);
+      } finally {
+        session.close();
+      }
+    },
+    TEST_BUDGET_MS,
+  );
+
+  it(
+    "a unary that times out sends its CLOSE at the seq after the REQUEST",
+    async () => {
+      const statusContract = defineRpcContract({
+        method: "host.status",
+        schemaVersion: { major: 1, minor: 0 } as const,
+        requestSchema: z.object({}),
+        responseSchema: z.object({ ready: z.boolean() }),
+      });
+      const statusRegistry: VersionedRpcRegistry =
+        defineFloorAwareVersionedRpcRegistry(["host.status"] as const, {
+          "host.status": {
+            1: {
+              latestMinor: 0,
+              versions: {
+                0: {
+                  contract: statusContract,
+                  upgradeFromPreviousVersion: null,
+                },
+              },
+              downgradePathsFromLatest: {},
+            },
+          },
+        });
+      const relay = new FakeRelayHost();
+      relay.floorRpcManifest = { "host.status": { major: 1, minor: 0 } };
+      relay.skipUnaryAutoRespond = true;
+      const lease = new MutableBearerLease("valid-token", "user-1");
+      const session = new RemoteSession({
+        ...buildSessionOptions(relay, lease, null),
+        rpcRegistry: statusRegistry,
+      });
+      try {
+        session.start();
+        await vi.waitFor(() => expect(session.isReady()).toBe(true), WAIT);
+        const pending = session.sendUnary(
+          "host.status",
+          {},
+          null,
+          null,
+          60,
+          false,
+        );
+        await expect(pending).rejects.toBeInstanceOf(HostRpcError);
+        await vi.waitFor(
+          () => expect(relay.unaryRequests).toHaveLength(1),
+          WAIT,
+        );
+        const streamId = relay.unaryRequests[0].streamId;
+        await vi.waitFor(
+          () => expect(relay.closesSent).toContain(streamId),
+          WAIT,
+        );
+        expect(seqsOnStream(relay, streamId)).toEqual([
+          { type: MuxFrameType.REQUEST, seq: 0 },
+          { type: MuxFrameType.CLOSE, seq: 1 },
+        ]);
+        expect(relay.errors).toEqual([]);
+      } finally {
+        session.close();
       }
     },
     TEST_BUDGET_MS,

--- a/clients/shared/host-transport/remote/remote-session.ts
+++ b/clients/shared/host-transport/remote/remote-session.ts
@@ -708,6 +708,14 @@ export class RemoteSession<
 
   private readonly subscriptions = new Map<number, LogicalStream>();
   private readonly pendingUnary = new Map<number, PendingUnary>();
+  /**
+   * Next outbound `seq` per stream. The host gates every unchunked frame on
+   * this progression (`SESSION_FRAME_SEQUENCE_MISMATCH` closes the SESSION,
+   * not the stream), and frames draw their `seq` lazily at scheduler pull -
+   * so a path that ends a stream with a CLOSE must retire the counter
+   * through {@link retireOutboundSeq} and hand the CLOSE the retired
+   * closure. A bare `delete` before the enqueue sends the CLOSE at seq 0.
+   */
   private readonly outboundSeq = new Map<number, number>();
   private readonly restoredStreamIds = new Set<number>();
   /**
@@ -1352,6 +1360,8 @@ export class RemoteSession<
           });
         } catch (cause) {
           this.clearPendingUnary(streamId);
+          // Nothing was enqueued, so nothing follows on this stream.
+          this.retireOutboundSeq(streamId);
           reject(asHostRpcError(cause, requestId, method));
         }
       }
@@ -1627,7 +1637,7 @@ export class RemoteSession<
       this.markStreamTerminal(streamId);
       this.subscriptions.delete(streamId);
       this.restoredStreamIds.delete(streamId);
-      this.outboundSeq.delete(streamId);
+      const nextSeq = this.retireOutboundSeq(streamId);
       // Terminal end: same retry-state cleanup as the FATAL/CLOSE branches.
       this.clearStreamReopen(streamId);
       stream.goFatal({
@@ -1636,13 +1646,17 @@ export class RemoteSession<
         incompatibleMethods: null,
         upgradeGuidance: null,
       });
-      this.enqueueMessage(connection, {
-        type: MuxFrameType.CLOSE,
-        streamId,
-        qos: QosClass.INTERACTIVE,
-        json: { reason: "outbound frame exceeded the message cap" },
-        binary: null,
-      });
+      this.enqueueMessageWithSeq(
+        connection,
+        {
+          type: MuxFrameType.CLOSE,
+          streamId,
+          qos: QosClass.INTERACTIVE,
+          json: { reason: "outbound frame exceeded the message cap" },
+          binary: null,
+        },
+        nextSeq,
+      );
       this.maybeReachReadyBoundary();
     }
   }
@@ -1676,7 +1690,7 @@ export class RemoteSession<
     const connection = this.connection;
     this.subscriptions.delete(streamId);
     this.restoredStreamIds.delete(streamId);
-    this.outboundSeq.delete(streamId);
+    const nextSeq = this.retireOutboundSeq(streamId);
     // A caller close outranks a pending retryable re-open: without this the
     // timer would re-subscribe a stream the consumer has already abandoned.
     this.clearStreamReopen(streamId);
@@ -1691,13 +1705,17 @@ export class RemoteSession<
       // FIFO would park this CLOSE behind a transfer nobody wants anymore
       // (the peer's reassembler accepts a CLOSE mid-sequence as an abort).
       connection.scheduler.dropStreamOutbound(streamId);
-      this.enqueueMessage(connection, {
-        type: MuxFrameType.CLOSE,
-        streamId,
-        qos: QosClass.INTERACTIVE,
-        json: { reason },
-        binary: null,
-      });
+      this.enqueueMessageWithSeq(
+        connection,
+        {
+          type: MuxFrameType.CLOSE,
+          streamId,
+          qos: QosClass.INTERACTIVE,
+          json: { reason },
+          binary: null,
+        },
+        nextSeq,
+      );
     }
     this.maybeReachReadyBoundary();
   }
@@ -2609,18 +2627,22 @@ export class RemoteSession<
     connection.reassembler.forget(streamId);
     this.markStreamTerminal(streamId);
     this.restoredStreamIds.delete(streamId);
-    this.outboundSeq.delete(streamId);
+    const nextSeq = this.retireOutboundSeq(streamId);
     this.subscriptions.delete(streamId);
     // Drop queued outbound first so per-stream FIFO cannot park the CLOSE
     // behind a transfer nobody wants anymore (mirrors `closeStream`).
     connection.scheduler.dropStreamOutbound(streamId);
-    this.enqueueMessage(connection, {
-      type: MuxFrameType.CLOSE,
-      streamId,
-      qos: QosClass.INTERACTIVE,
-      json: { reason: "reassembly-stalled" },
-      binary: null,
-    });
+    this.enqueueMessageWithSeq(
+      connection,
+      {
+        type: MuxFrameType.CLOSE,
+        streamId,
+        qos: QosClass.INTERACTIVE,
+        json: { reason: "reassembly-stalled" },
+        binary: null,
+      },
+      nextSeq,
+    );
     const reopenAttempts = this.streamReopenAttempts.get(streamId);
     this.streamReopenAttempts.delete(streamId);
     const freshStreamId = this.allocateStreamId();
@@ -2765,6 +2787,8 @@ export class RemoteSession<
     }
     const { streamId, entry } = pending;
     this.clearPendingUnary(streamId);
+    // The response ends the exchange; the client sends nothing further here.
+    this.retireOutboundSeq(streamId);
     if (parsed.data.error !== null) {
       entry.reject(
         HostRpcError.fromWireEnvelope(
@@ -3885,12 +3909,47 @@ export class RemoteSession<
     connection: ActiveConnection,
     message: OutboundMessage,
   ): void {
+    this.enqueueMessageWithSeq(connection, message, () =>
+      this.nextSeq(message.streamId),
+    );
+  }
+
+  /**
+   * {@link enqueueMessage} with the `seq` source supplied by the caller - for
+   * the CLOSE that ends a stream whose counter {@link retireOutboundSeq} has
+   * already taken out of {@link outboundSeq}.
+   */
+  private enqueueMessageWithSeq(
+    connection: ActiveConnection,
+    message: OutboundMessage,
+    nextSeq: () => number,
+  ): void {
     const source = new OutboundChunkSource(
       message,
-      () => this.nextSeq(message.streamId),
+      nextSeq,
       connection.bodyCompressionSupported,
     );
     connection.scheduler.enqueue(source);
+  }
+
+  /**
+   * Takes a stream's counter out of {@link outboundSeq} and returns a source
+   * that continues its progression. Frames draw `seq` only when the
+   * scheduler pulls them, so a path that deletes the entry and THEN enqueues
+   * the stream's CLOSE would send that CLOSE at seq 0 - on a stream whose
+   * SUBSCRIBE or REQUEST already drew 0, the host's sequence gate reads that
+   * as a reordered or dropped frame and closes the whole session
+   * (`SESSION_FRAME_SEQUENCE_MISMATCH`). The closure keeps the map bounded
+   * exactly as the delete did, and keeps the CLOSE contiguous.
+   */
+  private retireOutboundSeq(streamId: number): () => number {
+    let next = this.outboundSeq.get(streamId) ?? 0;
+    this.outboundSeq.delete(streamId);
+    return () => {
+      const seq = next;
+      next += 1;
+      return seq;
+    };
   }
 
   private async writeFrame(
@@ -3948,7 +4007,8 @@ export class RemoteSession<
       clearTimeout(entry.timer);
     }
     this.pendingUnary.delete(streamId);
-    this.outboundSeq.delete(streamId);
+    // The stream's `outboundSeq` entry is NOT cleared here: `rejectUnary`
+    // still has a CLOSE to send on it. Each caller retires the counter itself.
   }
 
   private rejectUnary(streamId: number, error: HostRpcError): void {
@@ -3957,6 +4017,7 @@ export class RemoteSession<
       return;
     }
     this.clearPendingUnary(streamId);
+    const nextSeq = this.retireOutboundSeq(streamId);
     // A rejected unary's stream is terminal. Drop any still-queued request
     // upload, clear any partial response accumulator, tombstone the id so a
     // late response chunk (e.g. one landing after the 30s timeout) can't
@@ -3969,13 +4030,17 @@ export class RemoteSession<
     }
     this.markStreamTerminal(streamId);
     if (this.phase === "ready" && connection !== null) {
-      this.enqueueMessage(connection, {
-        type: MuxFrameType.CLOSE,
-        streamId,
-        qos: QosClass.INTERACTIVE,
-        json: { reason: "unary request rejected" },
-        binary: null,
-      });
+      this.enqueueMessageWithSeq(
+        connection,
+        {
+          type: MuxFrameType.CLOSE,
+          streamId,
+          qos: QosClass.INTERACTIVE,
+          json: { reason: "unary request rejected" },
+          binary: null,
+        },
+        nextSeq,
+      );
     }
     entry.reject(error);
   }

--- a/clients/shared/host-transport/remote/remote-session.ts
+++ b/clients/shared/host-transport/remote/remote-session.ts
@@ -2099,21 +2099,29 @@ export class RemoteSession<
       connection.reassembler.forget(frame.streamId);
     }
     this.markStreamTerminal(frame.streamId);
+    // Retired BEFORE the enqueue even though the delete used to sit below
+    // it: the CLOSE draws its seq when the scheduler pulls, which is after
+    // every synchronous line of this method, so a delete anywhere in here
+    // sent it at seq 0.
+    const nextSeq = this.retireOutboundSeq(frame.streamId);
     if (this.phase === "ready" && connection !== null) {
-      this.enqueueMessage(connection, {
-        type: MuxFrameType.CLOSE,
-        streamId: frame.streamId,
-        qos: QosClass.INTERACTIVE,
-        json: { reason: `inbound stream failed: ${details.code}` },
-        binary: null,
-      });
+      this.enqueueMessageWithSeq(
+        connection,
+        {
+          type: MuxFrameType.CLOSE,
+          streamId: frame.streamId,
+          qos: QosClass.INTERACTIVE,
+          json: { reason: `inbound stream failed: ${details.code}` },
+          binary: null,
+        },
+        nextSeq,
+      );
     }
     const stream = this.subscriptions.get(frame.streamId);
     if (stream !== undefined) {
       stream.goFatal(details);
       this.subscriptions.delete(frame.streamId);
       this.restoredStreamIds.delete(frame.streamId);
-      this.outboundSeq.delete(frame.streamId);
       this.stallReopenedStreamIds.delete(frame.streamId);
       this.maybeReachReadyBoundary();
     }


### PR DESCRIPTION
## Problem

Mobile users on a development-built host hit this on the first screen change and stayed stuck across retries:

```
HostTransportFailureError: Remote session for host '…' closed terminally: SESSION_FRAME_SEQUENCE_MISMATCH: Frame 0 arrived on stream 4 where 1 was due; the session cannot tell a reordered frame from a dropped one.
```

The host (internal #5424, H11) now gates every unchunked client frame on its stream's `seq` progression and closes the **session** on a mismatch. Four client paths in `RemoteSession` deleted a stream's outbound `seq` counter *before* enqueueing that stream's CLOSE. The frame's `seq` is drawn lazily when the scheduler pulls it, so every such CLOSE went out as `seq 0` on a stream whose SUBSCRIBE or REQUEST had already drawn 0:

| Path | Trigger |
| --- | --- |
| `closeStream` | any caller unsubscribe |
| `rejectUnary` (via `clearPendingUnary`) | unary timeout / rejection |
| `reopenStalledStream` | reassembly stall re-key |
| `sendStreamFrame` size-cap branch | `STREAM_MESSAGE_TOO_LARGE` |

Only remote-mux sessions cross the gate, which is why desktop (local socket to its own host) did not notice and mobile (always remote) did.

## Fix

- `retireOutboundSeq(streamId)` takes the counter out of the map and returns a closure that continues its progression; the four terminal paths hand that closure to the CLOSE through `enqueueMessageWithSeq`. The map stays bounded exactly as the delete kept it.
- `clearPendingUnary` no longer touches the counter (one caller still has a CLOSE to send); its other two callers retire it themselves.

## Tests

- `FakeRelayHost` now mirrors the host's gate per connection, at the same placement and with the same predicate as `RemoteClientSession.feedInbound`, and fails into `relay.errors`, which the suites assert empty. Without this every test here passed against a client that killed every real session.
- Two new tests pin the caller-close and unary-timeout paths at `[SUBSCRIBE|REQUEST seq 0, CLOSE seq 1]`, waiting on the fake having *handled* the CLOSE (past the gate). Both were red against the old code. The existing stall re-key suites cover the third path through the fake's gate. The size-cap path has no test since it needs a >512 MiB body.

Verified locally in `clients/shared`: `format:check`, `lint`, `compile` clean; `remote-session.test.ts` 125/125.

## Release note

The host gate is unreleased. This must be pinned into `development` before any host release that includes #5424, or every released mobile app and every desktop-to-remote-host session fatals on its first stream close. Internal pin PR to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
