### PR TITLE
feat(auth): show the link-login match code on both sides of the approval

### DIFF
--- a/clients/gui-app/src/components/layout/__tests__/link-code-wait-countdown.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/link-code-wait-countdown.test.tsx
@@ -83,9 +83,13 @@ describe("link-login approval countdown", () => {
       "Your code: 47",
     );
     expect(screen.getByRole("status").textContent).toContain("47");
-    expect(
-      screen.getByTestId("link-code-signin-waiting").textContent,
-    ).toContain("Approve it on your computer if the code matches.");
+    // The standing instruction does not depend on the approver showing a
+    // code: an older desktop or CLI asks nothing about it, and "approve only
+    // if it matches" would have the user refuse a prompt that has no code.
+    const waiting = screen.getByTestId("link-code-signin-waiting").textContent;
+    expect(waiting).toContain("Waiting for approval on your computer…");
+    expect(waiting).toContain("If your computer asks, it should show this code.");
+    expect(waiting).not.toContain("only if");
 
     progressHolder.current = {
       nextPollAtMs: START_MS + 3_000,
@@ -106,6 +110,7 @@ describe("link-login approval countdown", () => {
     };
     render(<LinkCodeWaitStatus />);
     expect(screen.queryByTestId("link-code-signin-match-code")).toBeNull();
+    expect(screen.queryByTestId("link-code-signin-match-code-hint")).toBeNull();
     expect(
       screen.getByTestId("link-code-signin-waiting").textContent,
     ).toContain("Waiting for approval on your computer…");

--- a/clients/gui-app/src/components/layout/__tests__/link-code-wait-countdown.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/link-code-wait-countdown.test.tsx
@@ -47,6 +47,7 @@ describe("link-login approval countdown", () => {
     progressHolder.current = {
       nextPollAtMs: START_MS + 3_000,
       phase: "waiting",
+      matchCode: null,
     };
     const view = render(<LinkCodeWaitStatus />);
     expect(statusText()).toBe("Checking again in 3s");
@@ -60,6 +61,7 @@ describe("link-login approval countdown", () => {
     progressHolder.current = {
       nextPollAtMs: START_MS + 800 + 3_000,
       phase: "waiting",
+      matchCode: null,
     };
     view.rerender(<LinkCodeWaitStatus />);
 
@@ -67,10 +69,53 @@ describe("link-login approval countdown", () => {
     expect(statusText()).toBe("Checking again in 3s");
   });
 
+  it("shows the claim's match code large, for the whole wait", () => {
+    // The desktop asks "Does your phone show NN?"; this is the NN. It has
+    // to be there from the first countdown to the finalizing beat — the
+    // human may still be walking over to the desktop.
+    progressHolder.current = {
+      nextPollAtMs: START_MS + 3_000,
+      phase: "waiting",
+      matchCode: "47",
+    };
+    const view = render(<LinkCodeWaitStatus />);
+    expect(screen.getByTestId("link-code-signin-match-code").textContent).toBe(
+      "Your code: 47",
+    );
+    expect(screen.getByRole("status").textContent).toContain("47");
+    expect(
+      screen.getByTestId("link-code-signin-waiting").textContent,
+    ).toContain("Approve it on your computer if the code matches.");
+
+    progressHolder.current = {
+      nextPollAtMs: START_MS + 3_000,
+      phase: "finalizing",
+      matchCode: "47",
+    };
+    view.rerender(<LinkCodeWaitStatus />);
+    expect(screen.getByTestId("link-code-signin-match-code").textContent).toBe(
+      "Your code: 47",
+    );
+  });
+
+  it("shows no code slot at all against a server that sent none", () => {
+    progressHolder.current = {
+      nextPollAtMs: START_MS + 3_000,
+      phase: "waiting",
+      matchCode: null,
+    };
+    render(<LinkCodeWaitStatus />);
+    expect(screen.queryByTestId("link-code-signin-match-code")).toBeNull();
+    expect(
+      screen.getByTestId("link-code-signin-waiting").textContent,
+    ).toContain("Waiting for approval on your computer…");
+  });
+
   it("reads the checking beat once the target has passed", () => {
     progressHolder.current = {
       nextPollAtMs: START_MS + 1_000,
       phase: "waiting",
+      matchCode: null,
     };
     render(<LinkCodeWaitStatus />);
     act(() => {

--- a/clients/gui-app/src/components/layout/__tests__/link-code-wait-countdown.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/link-code-wait-countdown.test.tsx
@@ -88,7 +88,9 @@ describe("link-login approval countdown", () => {
     // if it matches" would have the user refuse a prompt that has no code.
     const waiting = screen.getByTestId("link-code-signin-waiting").textContent;
     expect(waiting).toContain("Waiting for approval on your computer…");
-    expect(waiting).toContain("If your computer asks, it should show this code.");
+    expect(waiting).toContain(
+      "If your computer asks, it should show this code.",
+    );
     expect(waiting).not.toContain("only if");
 
     progressHolder.current = {

--- a/clients/gui-app/src/components/layout/__tests__/sign-in-button.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/sign-in-button.test.tsx
@@ -530,6 +530,90 @@ describe("link-code entry is gated on the mobile-app PRODUCT signal", () => {
     mobile.cleanupClient();
   });
 
+  it("shows the claim's match code through manual entry until the desktop decides", async () => {
+    // Composed, not the leaf: the code travels claim response → AuthService
+    // poll progress → subscription → wait block, and every hop is real here;
+    // only the HTTP boundary is scripted. Settled by a rejection so the
+    // whole wait is observed end to end without the token-application
+    // machinery, which is exercised elsewhere.
+    setMobileApp(true);
+    const tokenPolls = { count: 0 };
+    const scripted = installFetch((url) => {
+      if (url.includes("/link/claim")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              status: "claimed",
+              secret: "S".repeat(43),
+              interval: 1,
+              matchCode: "47",
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        );
+      }
+      if (url.includes("/link/token")) {
+        tokenPolls.count += 1;
+        return Promise.resolve(
+          new Response(
+            JSON.stringify(
+              tokenPolls.count < 2
+                ? { error: "authorization_pending" }
+                : { error: "access_denied" },
+            ),
+            {
+              status: tokenPolls.count < 2 ? 428 : 400,
+              headers: { "Content-Type": "application/json" },
+            },
+          ),
+        );
+      }
+      return Promise.resolve(new Response(null, { status: 401 }));
+    });
+    const mobile = mountSignInButton(buildHost(), "hero");
+    await mobile.waitForAuthService();
+
+    fireEvent.click(screen.getByTestId("link-code-signin-manual"));
+    fireEvent.change(screen.getByTestId("link-code-signin-input"), {
+      target: { value: "abcde-fghjk" },
+    });
+    fireEvent.click(screen.getByTestId("link-code-signin-submit"));
+
+    // The code is up from the first countdown, with the standing instruction
+    // beside it — an older desktop shows no code, so the instruction never
+    // conditions approval on a match.
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("link-code-signin-match-code").textContent,
+      ).toBe("Your code: 47");
+    });
+    const waiting = screen.getByTestId("link-code-signin-waiting").textContent;
+    expect(waiting).toContain("Waiting for approval on your computer…");
+    expect(waiting).toContain("If your computer asks, it should show this code.");
+
+    // Still up across a pending poll (the loop republishes progress every
+    // interval), then gone with the decision — nothing retains it.
+    await waitFor(
+      () => {
+        expect(tokenPolls.count).toBeGreaterThanOrEqual(1);
+      },
+      { timeout: 3_000 },
+    );
+    expect(screen.getByTestId("link-code-signin-match-code")).toBeTruthy();
+    await waitFor(
+      () => {
+        expect(
+          screen.getByTestId("link-code-signin-notice").textContent,
+        ).toContain("rejected on your computer");
+      },
+      { timeout: 4_000 },
+    );
+    expect(screen.queryByTestId("link-code-signin-match-code")).toBeNull();
+    expect(screen.queryByTestId("link-code-signin-waiting")).toBeNull();
+    scripted();
+    mobile.cleanupClient();
+  });
+
   it("mobile hero leads with a primary Scan CTA above a secondary Sign in", async () => {
     setMobileApp(true);
     const mobile = mountSignInButton(buildHost(), "hero");

--- a/clients/gui-app/src/components/layout/__tests__/sign-in-button.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/sign-in-button.test.tsx
@@ -589,7 +589,9 @@ describe("link-code entry is gated on the mobile-app PRODUCT signal", () => {
     });
     const waiting = screen.getByTestId("link-code-signin-waiting").textContent;
     expect(waiting).toContain("Waiting for approval on your computer…");
-    expect(waiting).toContain("If your computer asks, it should show this code.");
+    expect(waiting).toContain(
+      "If your computer asks, it should show this code.",
+    );
 
     // Still up across a pending poll (the loop republishes progress every
     // interval), then gone with the decision — nothing retains it.

--- a/clients/gui-app/src/components/layout/header/sign-in/link-code-wait-status.tsx
+++ b/clients/gui-app/src/components/layout/header/sign-in/link-code-wait-status.tsx
@@ -86,10 +86,21 @@ export function LinkCodeWaitStatus() {
         </p>
       ) : null}
       <p className="text-center text-ui-sm opacity-80">
-        {matchCode !== null
-          ? "Approve it on your computer if the code matches."
-          : "Waiting for approval on your computer…"}
+        Waiting for approval on your computer…
       </p>
+      {matchCode !== null ? (
+        // Conditional on purpose: an approver that predates the code (an
+        // older desktop, or the CLI before it learned to print one) asks
+        // nothing about it, and telling the user to approve "only if the
+        // code matches" would leave them refusing a prompt that never shows
+        // one. The standing line above is the instruction; this is the hint.
+        <p
+          className="text-center text-ui-xs text-muted-foreground"
+          data-testid="link-code-signin-match-code-hint"
+        >
+          If your computer asks, it should show this code.
+        </p>
+      ) : null}
       {progress !== null ? (
         <p
           className="text-center text-ui-xs text-muted-foreground tabular-nums"

--- a/clients/gui-app/src/components/layout/header/sign-in/link-code-wait-status.tsx
+++ b/clients/gui-app/src/components/layout/header/sign-in/link-code-wait-status.tsx
@@ -62,13 +62,33 @@ function WaitStatusLine(props: { readonly progress: LinkLoginProgress }) {
 export function LinkCodeWaitStatus() {
   const auth = useAuthService();
   const progress = useAuthLinkLoginProgress(auth);
+  const matchCode = progress === null ? null : progress.matchCode;
   return (
     <div
       className="flex flex-col items-center gap-0.5"
       data-testid="link-code-signin-waiting"
     >
+      {matchCode !== null ? (
+        // The claim's match code, large: the desktop's prompt asks "Does your
+        // phone show NN?", and this is the NN. It is shown for the whole wait
+        // — the human may still be walking over to the desktop — and it is
+        // an attention proof, not something to type anywhere.
+        <p
+          className="text-center text-ui-sm"
+          data-testid="link-code-signin-match-code"
+          role="status"
+          aria-live="polite"
+        >
+          Your code:{" "}
+          <span className="font-mono text-title-lg tabular-nums">
+            {matchCode}
+          </span>
+        </p>
+      ) : null}
       <p className="text-center text-ui-sm opacity-80">
-        Waiting for approval on your computer…
+        {matchCode !== null
+          ? "Approve it on your computer if the code matches."
+          : "Waiting for approval on your computer…"}
       </p>
       {progress !== null ? (
         <p

--- a/clients/gui-app/src/components/settings/panels/__tests__/link-phone-panel-presentation.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/link-phone-panel-presentation.test.tsx
@@ -194,7 +194,7 @@ describe("LinkPhonePanel presentation", () => {
         address: "192.168.29.87",
         userAgent: "TraycerMobile/1.0 (iPhone)",
         location: "Bengaluru, IN",
-        matchCode: null,
+        matchCode: { kind: "unavailable" },
       },
       deadKind: null,
       code: codeQuery({ data: null, isError: false, error: null }),
@@ -216,7 +216,7 @@ describe("LinkPhonePanel presentation", () => {
       address: "192.168.29.87",
       userAgent: "TraycerMobile/1.0 (iPhone)",
       location: "Bengaluru, IN",
-      matchCode: null,
+      matchCode: { kind: "unavailable" },
     };
     mocks.useLinkLoginWatch.mockReturnValue({
       claim,
@@ -322,7 +322,7 @@ describe("LinkPhonePanel presentation", () => {
         address: null,
         userAgent: null,
         location: null,
-        matchCode: null,
+        matchCode: { kind: "unavailable" },
       },
       deadKind: null,
       code: codeQuery({ data: null, isError: false, error: null }),

--- a/clients/gui-app/src/components/settings/panels/__tests__/link-phone-panel-presentation.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/link-phone-panel-presentation.test.tsx
@@ -194,6 +194,7 @@ describe("LinkPhonePanel presentation", () => {
         address: "192.168.29.87",
         userAgent: "TraycerMobile/1.0 (iPhone)",
         location: "Bengaluru, IN",
+        matchCode: null,
       },
       deadKind: null,
       code: codeQuery({ data: null, isError: false, error: null }),
@@ -215,6 +216,7 @@ describe("LinkPhonePanel presentation", () => {
       address: "192.168.29.87",
       userAgent: "TraycerMobile/1.0 (iPhone)",
       location: "Bengaluru, IN",
+      matchCode: null,
     };
     mocks.useLinkLoginWatch.mockReturnValue({
       claim,
@@ -320,6 +322,7 @@ describe("LinkPhonePanel presentation", () => {
         address: null,
         userAgent: null,
         location: null,
+        matchCode: null,
       },
       deadKind: null,
       code: codeQuery({ data: null, isError: false, error: null }),

--- a/clients/gui-app/src/components/settings/panels/__tests__/link-phone-panel.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/link-phone-panel.test.tsx
@@ -87,11 +87,15 @@ function claimedStatus(claimedAtMs: number, userAgent: string) {
   };
 }
 
-/** The same claim from a server that mints match codes. */
+/**
+ * The same claim from a server that knows about match codes: a string is
+ * the code the phone is showing, `null` is the server saying the phone
+ * presented none.
+ */
 function claimedStatusWithCode(
   claimedAtMs: number,
   userAgent: string,
-  matchCode: string,
+  matchCode: string | null,
 ) {
   const status = claimedStatus(claimedAtMs, userAgent);
   return { ...status, claimant: { ...status.claimant, matchCode } };
@@ -679,6 +683,36 @@ describe("LinkPhonePanel", () => {
       { code: "ABCDE-FGHJK", approve: true },
       expect.anything(),
     );
+  });
+
+  it("warns loudly when the server says the phone presented no code", () => {
+    // `/claim` is unauthenticated and the claimant decides whether a code is
+    // minted, so a leaked-QR holder can withhold it. The server reports that
+    // as an explicit null, and the card must read as a different, worse
+    // state than a normal claim — not as today's prompt with a detail gone.
+    mocks.useAuthLinkLoginCode.mockReturnValue(queryResultWithCode(Date.now()));
+    mocks.useAuthLinkLoginStatus.mockReturnValue(
+      statusResult(claimedStatusWithCode(Date.now(), "iPhone 16 Pro", null)),
+    );
+    render(<LinkPhonePanel />);
+    const warning = screen.getByTestId("link-phone-no-match-code");
+    expect(warning.textContent).toContain(
+      "This phone did not show a sign-in code.",
+    );
+    expect(warning.textContent).toContain("Sign-in request from iPhone 16 Pro.");
+    expect(warning.className).toContain("destructive");
+    expect(screen.queryByTestId("link-phone-match-code")).toBeNull();
+    const card = screen.getByTestId("link-phone-confirm");
+    expect(card.textContent).not.toContain("Approve sign-in from");
+    expect(card.textContent).not.toContain("Does your phone show");
+    // Announced like the other two: the warning is what a screen-reader
+    // user has to hear before the buttons.
+    expect(screen.getByRole("status").textContent).toContain(
+      "did not show a sign-in code",
+    );
+    // Still decidable — a legitimate older phone must get through.
+    expect(screen.getByRole("button", { name: "Approve" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Reject" })).toBeTruthy();
   });
 
   it("falls back to the description prompt when the server sends no match code", () => {

--- a/clients/gui-app/src/components/settings/panels/__tests__/link-phone-panel.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/link-phone-panel.test.tsx
@@ -715,6 +715,51 @@ describe("LinkPhonePanel", () => {
     expect(screen.getByRole("button", { name: "Reject" })).toBeTruthy();
   });
 
+  it("drops the code the moment the status stops carrying it, and with the decision", () => {
+    // The code is read off the CURRENT status, never retained: a status that
+    // stops carrying it (a server that rolled back, or a re-mint watched
+    // onto a code the phone declined on) must lose the code prompt on the
+    // next render, and a decided record — which omits the key — must not
+    // keep a confirm card with a number on it at all.
+    mocks.useAuthLinkLoginCode.mockReturnValue(queryResultWithCode(Date.now()));
+    mocks.useAuthLinkLoginStatus.mockReturnValue(
+      statusResult(claimedStatusWithCode(Date.now(), "iPhone 16 Pro", "47")),
+    );
+    const view = render(<LinkPhonePanel />);
+    expect(screen.getByTestId("link-phone-match-code").textContent).toBe("47");
+
+    mocks.useAuthLinkLoginStatus.mockReturnValue(
+      statusResult(claimedStatus(Date.now(), "iPhone 16 Pro")),
+    );
+    view.rerender(<LinkPhonePanel />);
+    expect(screen.queryByTestId("link-phone-match-code")).toBeNull();
+    expect(screen.getByTestId("link-phone-confirm").textContent).toContain(
+      "Approve sign-in from iPhone 16 Pro?",
+    );
+
+    mocks.useAuthLinkLoginStatus.mockReturnValue(
+      statusResult(claimedStatusWithCode(Date.now(), "iPhone 16 Pro", null)),
+    );
+    view.rerender(<LinkPhonePanel />);
+    expect(screen.getByTestId("link-phone-no-match-code")).toBeTruthy();
+    expect(screen.queryByTestId("link-phone-match-code")).toBeNull();
+
+    mocks.useAuthLinkLoginStatus.mockReturnValue(
+      statusResult(claimedStatusWithCode(Date.now(), "iPhone 16 Pro", "47")),
+    );
+    view.rerender(<LinkPhonePanel />);
+    expect(screen.getByTestId("link-phone-match-code").textContent).toBe("47");
+
+    // Decided elsewhere: the key is gone with the claim. No card, no code.
+    mocks.useAuthLinkLoginStatus.mockReturnValue(
+      statusResult({ status: "denied", claimant: null }),
+    );
+    view.rerender(<LinkPhonePanel />);
+    expect(screen.queryByTestId("link-phone-confirm")).toBeNull();
+    expect(screen.queryByTestId("link-phone-match-code")).toBeNull();
+    expect(screen.getByTestId("link-phone-rejected-elsewhere")).toBeTruthy();
+  });
+
   it("falls back to the description prompt when the server sends no match code", () => {
     // A server that predates the code: today's prompt, unchanged, and no
     // empty code slot on the card.

--- a/clients/gui-app/src/components/settings/panels/__tests__/link-phone-panel.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/link-phone-panel.test.tsx
@@ -702,7 +702,14 @@ describe("LinkPhonePanel", () => {
     expect(warning.textContent).toContain(
       "Sign-in request from iPhone 16 Pro.",
     );
-    expect(warning.className).toContain("destructive");
+    // The BLOCK treatment, not just the text color: a warning that collapsed
+    // to a destructive-tinted subtitle would read as a detail, not a state.
+    // Background, border, icon and heading are what make it loud.
+    expect(warning.className).toContain("bg-destructive/");
+    expect(warning.className).toContain("border-destructive/");
+    expect(warning.className).toContain("text-destructive");
+    expect(warning.querySelector("svg")).not.toBeNull();
+    expect(warning.querySelector("p")?.className).toContain("text-title-");
     expect(screen.queryByTestId("link-phone-match-code")).toBeNull();
     const card = screen.getByTestId("link-phone-confirm");
     expect(card.textContent).not.toContain("Approve sign-in from");

--- a/clients/gui-app/src/components/settings/panels/__tests__/link-phone-panel.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/link-phone-panel.test.tsx
@@ -699,7 +699,9 @@ describe("LinkPhonePanel", () => {
     expect(warning.textContent).toContain(
       "This phone did not show a sign-in code.",
     );
-    expect(warning.textContent).toContain("Sign-in request from iPhone 16 Pro.");
+    expect(warning.textContent).toContain(
+      "Sign-in request from iPhone 16 Pro.",
+    );
     expect(warning.className).toContain("destructive");
     expect(screen.queryByTestId("link-phone-match-code")).toBeNull();
     const card = screen.getByTestId("link-phone-confirm");

--- a/clients/gui-app/src/components/settings/panels/__tests__/link-phone-panel.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/link-phone-panel.test.tsx
@@ -87,6 +87,16 @@ function claimedStatus(claimedAtMs: number, userAgent: string) {
   };
 }
 
+/** The same claim from a server that mints match codes. */
+function claimedStatusWithCode(
+  claimedAtMs: number,
+  userAgent: string,
+  matchCode: string,
+) {
+  const status = claimedStatus(claimedAtMs, userAgent);
+  return { ...status, claimant: { ...status.claimant, matchCode } };
+}
+
 beforeEach(() => {
   vi.useFakeTimers();
   mocks.useAuthLinkLoginStatus.mockReturnValue(statusResult(null));
@@ -637,6 +647,51 @@ describe("LinkPhonePanel", () => {
     render(<LinkPhonePanel />);
     expect(screen.getByTestId("link-phone-confirm").textContent).toContain(
       "Approve sign-in from iPhone 16 Pro?",
+    );
+  });
+
+  it("asks about the match code when the claim carries one, with the device as context", () => {
+    // The question is the code: the phone shows the same two digits, and
+    // agreement between the screens is what the self-reported description
+    // cannot prove. The description stays, demoted to context.
+    mocks.useAuthLinkLoginCode.mockReturnValue(queryResultWithCode(Date.now()));
+    mocks.useAuthLinkLoginStatus.mockReturnValue(
+      statusResult(claimedStatusWithCode(Date.now(), "iPhone 16 Pro", "47")),
+    );
+    const respond = respondIdle();
+    mocks.useRespondLinkLoginMutation.mockReturnValue(respond);
+    render(<LinkPhonePanel />);
+    const card = screen.getByTestId("link-phone-confirm");
+    expect(screen.getByTestId("link-phone-match-code").textContent).toBe("47");
+    expect(card.textContent).toContain("Does your phone show 47?");
+    expect(card.textContent).toContain("Sign-in request from iPhone 16 Pro.");
+    expect(card.textContent).not.toContain("Approve sign-in from");
+    expect(card.textContent).toContain("Approve only if the code matches");
+    // The code is announced with the prompt: a screen-reader user hears the
+    // number they are asked to compare, not only that a prompt appeared.
+    expect(screen.getByRole("status").textContent).toContain("47");
+    // The decision is unchanged by the code: Approve still sends only the
+    // code being decided — the match code is never an input.
+    act(() => {
+      screen.getByTestId("link-phone-approve").click();
+    });
+    expect(respond.mutate).toHaveBeenCalledWith(
+      { code: "ABCDE-FGHJK", approve: true },
+      expect.anything(),
+    );
+  });
+
+  it("falls back to the description prompt when the server sends no match code", () => {
+    // A server that predates the code: today's prompt, unchanged, and no
+    // empty code slot on the card.
+    mocks.useAuthLinkLoginCode.mockReturnValue(queryResultWithCode(Date.now()));
+    mocks.useAuthLinkLoginStatus.mockReturnValue(
+      statusResult(claimedStatus(Date.now(), "iPhone 16 Pro")),
+    );
+    render(<LinkPhonePanel />);
+    expect(screen.queryByTestId("link-phone-match-code")).toBeNull();
+    expect(screen.getByTestId("link-phone-confirm").textContent).not.toContain(
+      "Does your phone show",
     );
   });
 

--- a/clients/gui-app/src/components/settings/panels/__tests__/link-phone-panel.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/link-phone-panel.test.tsx
@@ -673,7 +673,7 @@ describe("LinkPhonePanel", () => {
     // The decision is unchanged by the code: Approve still sends only the
     // code being decided — the match code is never an input.
     act(() => {
-      screen.getByTestId("link-phone-approve").click();
+      screen.getByRole("button", { name: "Approve" }).click();
     });
     expect(respond.mutate).toHaveBeenCalledWith(
       { code: "ABCDE-FGHJK", approve: true },

--- a/clients/gui-app/src/components/settings/panels/link-phone-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/link-phone-panel.tsx
@@ -115,9 +115,7 @@ function ConfirmClaimHeadline(props: { readonly claim: LiveClaim }) {
         data-testid="link-phone-no-match-code"
       >
         <TriangleAlert aria-hidden="true" />
-        <p className="text-title-xs">
-          This phone did not show a sign-in code.
-        </p>
+        <p className="text-title-xs">This phone did not show a sign-in code.</p>
         <p className="text-ui-xs">
           An up-to-date Traycer app always shows one. Approve only if you just
           scanned this code yourself and your phone is waiting without a code;

--- a/clients/gui-app/src/components/settings/panels/link-phone-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/link-phone-panel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, type ReactElement } from "react";
-import { QrCode, Smartphone } from "lucide-react";
+import { QrCode, Smartphone, TriangleAlert } from "lucide-react";
 import type { MintLinkLoginCodeResponse } from "@traycer/protocol/auth/link-login";
 import { claimantDeviceLabel } from "@traycer-clients/shared/auth/link-login";
 import { LinkPhoneQrTile } from "@/components/settings/panels/link-phone-qr-tile";
@@ -82,22 +82,49 @@ function pendingRespondVerdict(
 }
 
 /**
- * The question the approver is actually asked. With a match code, the
- * question is the code: the phone in the user's hand shows the same two
- * digits, and agreement between the two screens proves the prompt belongs to
- * that phone — which the self-reported device description cannot, since the
- * claimant chooses it. The description then drops to secondary context.
+ * The question the approver is actually asked, one of three.
  *
- * Without one (a server that predates the code) the description IS the
- * prompt, exactly as before.
+ * With a match code, the question is the code: the phone in the user's hand
+ * shows the same two digits, and agreement between the two screens proves
+ * the prompt belongs to that phone — which the self-reported device
+ * description cannot, since the claimant chooses it. The description then
+ * drops to secondary context.
+ *
+ * When the server says the phone presented NO code, the card is a warning,
+ * and deliberately the loudest of the three: a legitimate older app looks
+ * exactly like a leaked-QR holder withholding the code to dodge the check,
+ * and the whole point is that this reads differently from a normal claim.
+ *
+ * Without any word on it (a server that predates the code) the description
+ * IS the prompt, exactly as before.
  */
 function ConfirmClaimHeadline(props: { readonly claim: LiveClaim }) {
   const device = claimantDeviceLabel(props.claim.userAgent);
-  if (props.claim.matchCode === null) {
+  const matchCode = props.claim.matchCode;
+  if (matchCode.kind === "unavailable") {
     return (
       <p className="text-ui-sm font-medium text-foreground">
         Approve sign-in from {device}?
       </p>
+    );
+  }
+  if (matchCode.kind === "not-presented") {
+    return (
+      <div
+        className="flex w-full flex-col items-center gap-2 rounded-md border border-destructive/40 bg-destructive/10 px-4 py-3 text-destructive"
+        data-testid="link-phone-no-match-code"
+      >
+        <TriangleAlert aria-hidden="true" />
+        <p className="text-title-xs">
+          This phone did not show a sign-in code.
+        </p>
+        <p className="text-ui-xs">
+          An up-to-date Traycer app always shows one. Approve only if you just
+          scanned this code yourself and your phone is waiting without a code;
+          otherwise reject and update the app.
+        </p>
+        <p className="text-ui-xs">Sign-in request from {device}.</p>
+      </div>
     );
   }
   return (
@@ -111,7 +138,7 @@ function ConfirmClaimHeadline(props: { readonly claim: LiveClaim }) {
           className="font-mono text-title-md tabular-nums"
           data-testid="link-phone-match-code"
         >
-          {props.claim.matchCode}
+          {matchCode.code}
         </span>
         ?
       </p>
@@ -156,11 +183,13 @@ function ConfirmClaimCard(props: {
         >
           {detailLine}
         </p>
-        <p className="text-ui-xs text-muted-foreground">
-          {props.claim.matchCode === null
-            ? "These details are approximate. Approve only if you just scanned this code yourself."
-            : "Approve only if the code matches and you just scanned this code yourself."}
-        </p>
+        {props.claim.matchCode.kind === "not-presented" ? null : (
+          <p className="text-ui-xs text-muted-foreground">
+            {props.claim.matchCode.kind === "shown"
+              ? "Approve only if the code matches and you just scanned this code yourself."
+              : "These details are approximate. Approve only if you just scanned this code yourself."}
+          </p>
+        )}
       </div>
       {props.respondFailed ? (
         <p

--- a/clients/gui-app/src/components/settings/panels/link-phone-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/link-phone-panel.tsx
@@ -81,6 +81,47 @@ function pendingRespondVerdict(
   return variables.approve ? "approve" : "reject";
 }
 
+/**
+ * The question the approver is actually asked. With a match code, the
+ * question is the code: the phone in the user's hand shows the same two
+ * digits, and agreement between the two screens proves the prompt belongs to
+ * that phone — which the self-reported device description cannot, since the
+ * claimant chooses it. The description then drops to secondary context.
+ *
+ * Without one (a server that predates the code) the description IS the
+ * prompt, exactly as before.
+ */
+function ConfirmClaimHeadline(props: { readonly claim: LiveClaim }) {
+  const device = claimantDeviceLabel(props.claim.userAgent);
+  if (props.claim.matchCode === null) {
+    return (
+      <p className="text-ui-sm font-medium text-foreground">
+        Approve sign-in from {device}?
+      </p>
+    );
+  }
+  return (
+    <>
+      <p className="text-ui-sm font-medium text-foreground">
+        Does your phone show{" "}
+        {/* Digits read out as a number ("forty-seven"), which is how a
+            person will say them to themselves while comparing screens;
+            the tabular figures keep "11" and "77" the same width. */}
+        <span
+          className="font-mono text-title-md tabular-nums"
+          data-testid="link-phone-match-code"
+        >
+          {props.claim.matchCode}
+        </span>
+        ?
+      </p>
+      <p className="text-ui-xs text-muted-foreground">
+        Sign-in request from {device}.
+      </p>
+    </>
+  );
+}
+
 function ConfirmClaimCard(props: {
   readonly claim: LiveClaim;
   readonly pendingVerdict: PendingVerdict;
@@ -99,10 +140,16 @@ function ConfirmClaimCard(props: {
       data-testid="link-phone-confirm"
     >
       <QrCode aria-hidden="true" className="text-muted-foreground" />
-      <div className="flex flex-col items-center gap-1 text-center">
-        <p className="text-ui-sm font-medium text-foreground">
-          Approve sign-in from {claimantDeviceLabel(props.claim.userAgent)}?
-        </p>
+      {/* The QR is swapped for this prompt with no user action on this
+          surface, and it is only answerable inside the claim window — a
+          screen-reader user has to hear about it, code included, or the
+          window expires undiscovered. */}
+      <div
+        className="flex flex-col items-center gap-1 text-center"
+        role="status"
+        aria-live="polite"
+      >
+        <ConfirmClaimHeadline claim={props.claim} />
         <p
           className="text-ui-xs text-muted-foreground"
           data-testid="link-phone-claimant"
@@ -110,8 +157,9 @@ function ConfirmClaimCard(props: {
           {detailLine}
         </p>
         <p className="text-ui-xs text-muted-foreground">
-          These details are approximate. Approve only if you just scanned this
-          code yourself.
+          {props.claim.matchCode === null
+            ? "These details are approximate. Approve only if you just scanned this code yourself."
+            : "Approve only if the code matches and you just scanned this code yourself."}
         </p>
       </div>
       {props.respondFailed ? (

--- a/clients/gui-app/src/hooks/auth/use-link-login-watch.ts
+++ b/clients/gui-app/src/hooks/auth/use-link-login-watch.ts
@@ -19,17 +19,37 @@ import {
  * refused while a claim is being decided), so the displayed code is the only
  * code that can ever report a claim — no multi-code bookkeeping exists.
  */
+/**
+ * What the approver can say about the claim's match code. `shown` is the
+ * two digits the phone is displaying. `not-presented` is the server saying
+ * the phone declined to show one — a legitimate older app, or a leaked-QR
+ * holder withholding the flag to dodge the check, which the card cannot
+ * tell apart and so must render as a warning. `unavailable` is a server that
+ * predates the code, where today's description prompt is all there is.
+ */
+export type LiveMatchCode =
+  | { readonly kind: "shown"; readonly code: string }
+  | { readonly kind: "not-presented" }
+  | { readonly kind: "unavailable" };
+
 export interface LiveClaim {
   readonly code: string;
   readonly address: string | null;
   readonly userAgent: string | null;
   readonly location: string | null;
-  /**
-   * The two digits the phone is showing for this claim, or `null` from a
-   * server that predates the match code — the card then falls back to the
-   * description-only prompt.
-   */
-  readonly matchCode: string | null;
+  readonly matchCode: LiveMatchCode;
+}
+
+function liveMatchCodeOf(
+  claimant: NonNullable<LinkLoginStatusResponse["claimant"]>,
+): LiveMatchCode {
+  if (claimant.matchCode === undefined) {
+    return { kind: "unavailable" };
+  }
+  if (claimant.matchCode === null) {
+    return { kind: "not-presented" };
+  }
+  return { kind: "shown", code: claimant.matchCode };
 }
 
 /**
@@ -87,7 +107,7 @@ function claimFromStatus(
     address: claimant.address,
     userAgent: claimant.userAgent,
     location: claimant.location,
-    matchCode: claimant.matchCode ?? null,
+    matchCode: liveMatchCodeOf(claimant),
   };
 }
 

--- a/clients/gui-app/src/hooks/auth/use-link-login-watch.ts
+++ b/clients/gui-app/src/hooks/auth/use-link-login-watch.ts
@@ -24,6 +24,12 @@ export interface LiveClaim {
   readonly address: string | null;
   readonly userAgent: string | null;
   readonly location: string | null;
+  /**
+   * The two digits the phone is showing for this claim, or `null` from a
+   * server that predates the match code — the card then falls back to the
+   * description-only prompt.
+   */
+  readonly matchCode: string | null;
 }
 
 /**
@@ -81,6 +87,7 @@ function claimFromStatus(
     address: claimant.address,
     userAgent: claimant.userAgent,
     location: claimant.location,
+    matchCode: claimant.matchCode ?? null,
   };
 }
 

--- a/clients/gui-app/src/lib/auth/__tests__/auth-service-link-login-progress.test.ts
+++ b/clients/gui-app/src/lib/auth/__tests__/auth-service-link-login-progress.test.ts
@@ -54,11 +54,14 @@ function slowDown(seconds: number): Response {
 
 interface LinkFetchScript {
   tokenResponse: () => Response;
+  /** What the claim response carries as `matchCode`; `null` sends no field. */
+  matchCode: string | null;
 }
 
 function installLinkFetch(): { script: LinkFetchScript; restore: () => void } {
   const script: LinkFetchScript = {
     tokenResponse: () => json({ error: "authorization_pending" }, 428),
+    matchCode: null,
   };
   const originalFetch: unknown = (globalThis as { fetch?: unknown }).fetch;
   Object.defineProperty(globalThis, "fetch", {
@@ -73,6 +76,9 @@ function installLinkFetch(): { script: LinkFetchScript; restore: () => void } {
               status: "claimed",
               secret: "S".repeat(43),
               interval: ADVERTISED_INTERVAL_SECONDS,
+              ...(script.matchCode === null
+                ? {}
+                : { matchCode: script.matchCode }),
             },
             200,
           ),
@@ -221,6 +227,53 @@ describe("link-login poll progress", () => {
     } finally {
       recorder.dispose();
       restore();
+    }
+  });
+
+  it("carries the claim's match code on every emission of the poll, and null when the server sent none", async () => {
+    const service = makeService();
+    const { script, restore } = installLinkFetch();
+    script.matchCode = "47";
+    const recorder = recordProgress(service);
+    try {
+      const linkResult = service.signInWithLinkCode("ABCDE-FGHJK");
+      await vi.advanceTimersByTimeAsync(0);
+      // One pending poll: waiting → checking → waiting, all showing the code
+      // — the phone must keep displaying it until the wait is over.
+      await vi.advanceTimersByTimeAsync(ADVERTISED_INTERVAL_SECONDS * 1_000);
+      const codes = recorder.emissions
+        .filter((entry) => entry.progress !== null)
+        .map((entry) => entry.progress?.matchCode);
+      expect(codes.length).toBeGreaterThanOrEqual(3);
+      expect(new Set(codes)).toEqual(new Set(["47"]));
+
+      script.tokenResponse = () => json({ error: "access_denied" }, 400);
+      await vi.advanceTimersByTimeAsync(ADVERTISED_INTERVAL_SECONDS * 1_000);
+      await linkResult;
+    } finally {
+      recorder.dispose();
+      restore();
+    }
+
+    // An older server: the claim parses as before and the poll runs with
+    // nothing to show.
+    const older = makeService();
+    const olderFetch = installLinkFetch();
+    const olderRecorder = recordProgress(older);
+    try {
+      const linkResult = older.signInWithLinkCode("ABCDE-FGHJK");
+      await vi.advanceTimersByTimeAsync(0);
+      expect(older.getLinkLoginProgress()).toMatchObject({
+        phase: "waiting",
+        matchCode: null,
+      });
+      olderFetch.script.tokenResponse = () =>
+        json({ error: "access_denied" }, 400);
+      await vi.advanceTimersByTimeAsync(ADVERTISED_INTERVAL_SECONDS * 1_000);
+      expect((await linkResult).kind).toBe("denied");
+    } finally {
+      olderRecorder.dispose();
+      olderFetch.restore();
     }
   });
 

--- a/clients/gui-app/src/lib/auth/auth-service.ts
+++ b/clients/gui-app/src/lib/auth/auth-service.ts
@@ -355,6 +355,13 @@ export interface LinkLoginProgress {
    * moment the approval has actually landed.
    */
   readonly phase: "waiting" | "checking" | "finalizing";
+  /**
+   * The claim's match code — the two digits the desktop's prompt is showing
+   * for THIS claim — so the phone can display them for the human to compare.
+   * Constant for the life of the poll; `null` from a server that predates
+   * it, in which case the desktop is showing no code either.
+   */
+  readonly matchCode: string | null;
 }
 
 export type LinkLoginProgressListener = (
@@ -3161,12 +3168,7 @@ export class AuthService {
       }
       return { kind: "network-error" };
     }
-    return this.pollLinkLoginResult(
-      authnBaseUrl,
-      claimed.secret,
-      claimed.pollIntervalSeconds,
-      attempt,
-    );
+    return this.pollLinkLoginResult(authnBaseUrl, claimed, attempt);
   }
 
   /**
@@ -3177,10 +3179,14 @@ export class AuthService {
    */
   private async pollLinkLoginResult(
     authnBaseUrl: string,
-    secret: string,
-    pollIntervalSeconds: number,
+    claim: {
+      readonly secret: string;
+      readonly pollIntervalSeconds: number;
+      readonly matchCode: string | null;
+    },
     attempt: Attempt,
   ): Promise<LinkLoginSignInResult> {
+    const { secret, pollIntervalSeconds, matchCode } = claim;
     const failCurrent = (
       result: LinkLoginSignInResult,
     ): LinkLoginSignInResult => {
@@ -3197,7 +3203,7 @@ export class AuthService {
       // about to wait out — so a directive-stretched wait is counted down at
       // its real length, never at the interval the claim first advertised.
       const nextPollAtMs = Date.now() + intervalMs;
-      this.setLinkLoginProgress({ nextPollAtMs, phase: "waiting" });
+      this.setLinkLoginProgress({ nextPollAtMs, phase: "waiting", matchCode });
       await new Promise((resolve) => setTimeout(resolve, intervalMs));
       if (
         this.isDisposed() ||
@@ -3206,14 +3212,22 @@ export class AuthService {
       ) {
         return { kind: "superseded" };
       }
-      this.setLinkLoginProgress({ nextPollAtMs, phase: "checking" });
+      this.setLinkLoginProgress({
+        nextPollAtMs,
+        phase: "checking",
+        matchCode,
+      });
       const polled = await linkLoginTokenViaHttp(authnBaseUrl, secret);
       if (this.isDisposed() || this.activeAttempt !== attempt) {
         return { kind: "superseded" };
       }
       switch (polled.kind) {
         case "authorized": {
-          this.setLinkLoginProgress({ nextPollAtMs, phase: "finalizing" });
+          this.setLinkLoginProgress({
+            nextPollAtMs,
+            phase: "finalizing",
+            matchCode,
+          });
           // The shared tail re-checks the epoch, consumes the attempt on
           // success, and drops a finalization superseded mid-persist.
           const applied = await this.applyTokenInternal(
@@ -3962,7 +3976,8 @@ export class AuthService {
       (current !== null &&
         next !== null &&
         current.nextPollAtMs === next.nextPollAtMs &&
-        current.phase === next.phase)
+        current.phase === next.phase &&
+        current.matchCode === next.matchCode)
     ) {
       return;
     }

--- a/clients/shared/auth/__tests__/link-login.test.ts
+++ b/clients/shared/auth/__tests__/link-login.test.ts
@@ -292,6 +292,37 @@ describe("match code on the wire", () => {
     if (withoutCode.kind !== "ok") throw new Error("unreachable");
     expect(withoutCode.response.claimant?.matchCode).toBeUndefined();
   });
+
+  it("status keeps an explicit null as its own property — the phone presented no code", async () => {
+    // The strict parser must let the server's explicit null THROUGH, as an
+    // own property distinct from absence: null is what the approver renders
+    // as the loud "no code shown" warning, and a schema that only tolerated
+    // absence would turn it into a parse failure — the warning could never
+    // appear, and the downgrade it exists to expose would read as a network
+    // error instead.
+    installFetch({
+      status: "claimed",
+      claimant: {
+        address: null,
+        userAgent: "iPhone",
+        location: null,
+        claimedAt: 1_760_000_000_000,
+        matchCode: null,
+      },
+    });
+    const declined = await linkLoginStatusViaHttp(
+      AUTHN_BASE_URL,
+      "bearer",
+      NORMALIZED,
+      null,
+    );
+    expect(declined.kind).toBe("ok");
+    if (declined.kind !== "ok") throw new Error("unreachable");
+    const claimant = declined.response.claimant;
+    expect(claimant).not.toBeNull();
+    expect(Object.hasOwn(claimant ?? {}, "matchCode")).toBe(true);
+    expect(claimant?.matchCode).toBeNull();
+  });
 });
 
 /**

--- a/clients/shared/auth/__tests__/link-login.test.ts
+++ b/clients/shared/auth/__tests__/link-login.test.ts
@@ -8,6 +8,8 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   buildLinkLoginQrPayload,
   claimantDeviceLabel,
+  claimLinkLoginCodeViaHttp,
+  linkLoginStatusViaHttp,
   linkLoginTokenViaHttp,
   normalizeLinkLoginCodeInput,
   parseLinkLoginInput,
@@ -157,6 +159,138 @@ describe("token poll: 429 back-off directive", () => {
       kind: "slow-down",
       retryAfterSeconds: null,
     });
+  });
+});
+
+/**
+ * The match code is OPT-IN on the wire: the server sends it only to a request
+ * that declared it understands the field, because these response schemas are
+ * strict and an older client would otherwise fail to parse today's flow. So
+ * this client must (a) always ask, (b) read the code when it comes, and (c)
+ * keep working against a server that predates it and sends nothing.
+ */
+describe("match code on the wire", () => {
+  const AUTHN_BASE_URL = "https://authn.example.test";
+  let originalFetch: typeof globalThis.fetch;
+  let lastBody: unknown = null;
+
+  function installFetch(body: object): void {
+    globalThis.fetch = (async (
+      _input: RequestInfo | URL,
+      init: RequestInit | undefined,
+    ): Promise<Response> => {
+      lastBody =
+        typeof init?.body === "string" ? JSON.parse(init.body) : init?.body;
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as typeof fetch;
+  }
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    lastBody = null;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("claim asks for the code and reads it back", async () => {
+    installFetch({
+      status: "claimed",
+      secret: "S".repeat(43),
+      interval: 5,
+      matchCode: "47",
+    });
+    const result = await claimLinkLoginCodeViaHttp(
+      AUTHN_BASE_URL,
+      NORMALIZED,
+      "iPhone",
+    );
+    expect(lastBody).toEqual({
+      code: NORMALIZED,
+      device: "iPhone",
+      acceptMatchCode: true,
+    });
+    expect(result).toEqual({
+      kind: "claimed",
+      secret: "S".repeat(43),
+      pollIntervalSeconds: 5,
+      matchCode: "47",
+    });
+  });
+
+  it("claim still succeeds against a server that sends no code", async () => {
+    // The pre-match-code response shape, byte for byte: the phone must sign
+    // in exactly as before, with nothing to show.
+    installFetch({ status: "claimed", secret: "S".repeat(43), interval: 5 });
+    const result = await claimLinkLoginCodeViaHttp(
+      AUTHN_BASE_URL,
+      NORMALIZED,
+      null,
+    );
+    expect(lastBody).toEqual({ code: NORMALIZED, acceptMatchCode: true });
+    expect(result).toMatchObject({ kind: "claimed", matchCode: null });
+  });
+
+  it("claim refuses a code that is not two digits", async () => {
+    // A contract drift, not a display nit: the human is asked to COMPARE
+    // this against the desktop, so an unreadable value must not be shown.
+    installFetch({
+      status: "claimed",
+      secret: "S".repeat(43),
+      interval: 5,
+      matchCode: "4",
+    });
+    expect(
+      await claimLinkLoginCodeViaHttp(AUTHN_BASE_URL, NORMALIZED, null),
+    ).toEqual({ kind: "network-error" });
+  });
+
+  it("status asks for the code and reads it back, or its absence", async () => {
+    installFetch({
+      status: "claimed",
+      claimant: {
+        address: null,
+        userAgent: "iPhone",
+        location: null,
+        claimedAt: 1_760_000_000_000,
+        matchCode: "47",
+      },
+    });
+    const withCode = await linkLoginStatusViaHttp(
+      AUTHN_BASE_URL,
+      "bearer",
+      NORMALIZED,
+      null,
+    );
+    expect(lastBody).toEqual({ code: NORMALIZED, acceptMatchCode: true });
+    expect(withCode).toMatchObject({
+      kind: "ok",
+      response: { claimant: { matchCode: "47" } },
+    });
+
+    // An older server: today's exact claimant shape parses unchanged.
+    installFetch({
+      status: "claimed",
+      claimant: {
+        address: null,
+        userAgent: "iPhone",
+        location: null,
+        claimedAt: 1_760_000_000_000,
+      },
+    });
+    const withoutCode = await linkLoginStatusViaHttp(
+      AUTHN_BASE_URL,
+      "bearer",
+      NORMALIZED,
+      null,
+    );
+    expect(withoutCode.kind).toBe("ok");
+    if (withoutCode.kind !== "ok") throw new Error("unreachable");
+    expect(withoutCode.response.claimant?.matchCode).toBeUndefined();
   });
 });
 

--- a/clients/shared/auth/link-login.ts
+++ b/clients/shared/auth/link-login.ts
@@ -72,6 +72,12 @@ export type ClaimLinkLoginCodeFetchResult =
       readonly kind: "claimed";
       readonly secret: string;
       readonly pollIntervalSeconds: number;
+      /**
+       * The claim's match code, for the phone to show while it waits; `null`
+       * from a server that predates it, in which case the desktop's prompt
+       * is showing no code either.
+       */
+      readonly matchCode: string | null;
     }
   | { readonly kind: "invalid-code" }
   | { readonly kind: "rate-limited" }
@@ -321,6 +327,13 @@ export async function mintLinkLoginCodeViaHttp(
 }
 
 /**
+ * Declares that this client understands a `matchCode` in the response. The
+ * response schemas are strict, so the server sends the field only to callers
+ * that ask for it — an older client keeps parsing today's exact shape.
+ */
+const ACCEPT_MATCH_CODE = { acceptMatchCode: true } as const;
+
+/**
  * The phone attaches itself to a scanned/typed code. First scan wins and
  * ONLY that response carries the polling secret; claiming grants nothing
  * else. A 401 means the code is unknown, expired, or already
@@ -340,7 +353,9 @@ export async function claimLinkLoginCodeViaHttp(
     authnBaseUrl,
     "api/v3/auth/link/claim",
     null,
-    deviceHint === null ? { code } : { code, device: deviceHint },
+    deviceHint === null
+      ? { code, ...ACCEPT_MATCH_CODE }
+      : { code, device: deviceHint, ...ACCEPT_MATCH_CODE },
     null,
   );
   if (response === null) {
@@ -362,6 +377,7 @@ export async function claimLinkLoginCodeViaHttp(
         kind: "claimed",
         secret: parsed.secret,
         pollIntervalSeconds: parsed.interval,
+        matchCode: parsed.matchCode ?? null,
       };
 }
 
@@ -434,7 +450,7 @@ export async function linkLoginStatusViaHttp(
     authnBaseUrl,
     "api/v3/auth/link/status",
     bearerToken,
-    { code },
+    { code, ...ACCEPT_MATCH_CODE },
     signal,
   );
   if (response === null) {

--- a/clients/traycer-cli/src/auth/__tests__/link-phone-flow.test.ts
+++ b/clients/traycer-cli/src/auth/__tests__/link-phone-flow.test.ts
@@ -147,6 +147,15 @@ const CLAIMED_WITH_CODE = {
   },
 };
 
+/** The server saying the phone presented no code at all. */
+const CLAIMED_WITHOUT_CODE = {
+  kind: "ok" as const,
+  response: {
+    status: "claimed" as const,
+    claimant: { ...CLAIMED.response.claimant, matchCode: null },
+  },
+};
+
 const UNCLAIMED = {
   kind: "ok" as const,
   response: { status: "unclaimed" as const, claimant: null },
@@ -299,6 +308,33 @@ describe("runLinkPhoneFlow", () => {
     // the description IS the prompt, exactly as before.
     expect(answer.lastPrompt).toContain("Approve sign-in from an iPhone");
     expect(answer.lastPrompt).not.toContain("Does your phone show");
+  });
+
+  it("warns loudly when the server says the phone presented no code", async () => {
+    // A legitimate older app and a leaked-QR holder withholding the code look
+    // identical from here, so this must read as a different, worse state than
+    // an ordinary claim - and still be decidable, so the older app gets
+    // through.
+    statusMock.mockResolvedValue(CLAIMED_WITHOUT_CODE);
+    answer.current = "";
+    const ctx = interactiveCtx();
+
+    const result = await runWithPolls(ctx, 1);
+
+    const output = printed(ctx);
+    expect(output).toContain("WARNING");
+    expect(output).toContain("did not show a sign-in code");
+    expect(output).toContain("otherwise reject and update the app");
+    expect(output).not.toContain("Details are approximate");
+    expect(answer.lastPrompt).toContain("No code shown by the phone");
+    expect(answer.lastPrompt).not.toContain("Does your phone show");
+    expect(respondMock).toHaveBeenCalledWith(
+      expect.any(String),
+      "bearer-1",
+      "ABCDE-FGHJK",
+      false,
+    );
+    expect(result.status).toBe("fulfilled");
   });
 
   it("asks about the match code when the claim carries one, with the device as context", async () => {

--- a/clients/traycer-cli/src/auth/__tests__/link-phone-flow.test.ts
+++ b/clients/traycer-cli/src/auth/__tests__/link-phone-flow.test.ts
@@ -36,7 +36,11 @@ vi.mock("../validate", () => ({ validateStoredCredentials: vi.fn() }));
 // The approval prompt. `answer.current` is what the human "types"; `null` is
 // Ctrl-D — the stream closes and the question is never answered at all, which
 // the double has to be able to express or the deny-on-close path is untestable.
-const answer = vi.hoisted(() => ({ current: "" as string | null }));
+const answer = vi.hoisted(() => ({
+  current: "" as string | null,
+  /** The question the human was last asked, verbatim. */
+  lastPrompt: "",
+}));
 vi.mock("node:readline", () => ({
   createInterface: () => {
     const closeHandlers: (() => void)[] = [];
@@ -51,7 +55,8 @@ vi.mock("node:readline", () => ({
           closeHandlers.push(handler);
         }
       },
-      question: (_prompt: string, callback: (value: string) => void) => {
+      question: (prompt: string, callback: (value: string) => void) => {
+        answer.lastPrompt = prompt;
         const typed = answer.current;
         if (typed === null) {
           // Real readline fires `close` and never invokes the callback.
@@ -133,6 +138,15 @@ const CLAIMED = {
   },
 };
 
+/** The same claim from a server that minted a match code for this phone. */
+const CLAIMED_WITH_CODE = {
+  kind: "ok" as const,
+  response: {
+    status: "claimed" as const,
+    claimant: { ...CLAIMED.response.claimant, matchCode: "47" },
+  },
+};
+
 const UNCLAIMED = {
   kind: "ok" as const,
   response: { status: "unclaimed" as const, claimant: null },
@@ -144,6 +158,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   vi.useFakeTimers();
   answer.current = "";
+  answer.lastPrompt = "";
   originalIsTty = process.stdin.isTTY;
   Object.defineProperty(process.stdin, "isTTY", {
     configurable: true,
@@ -280,6 +295,38 @@ describe("runLinkPhoneFlow", () => {
     expect(output).toContain("203.0.113.7");
     expect(output).toContain("Bengaluru, IN");
     expect(output).toContain("Only approve if you scanned this code yourself");
+    // No code minted (an older server, or a phone that cannot show one):
+    // the description IS the prompt, exactly as before.
+    expect(answer.lastPrompt).toContain("Approve sign-in from an iPhone");
+    expect(answer.lastPrompt).not.toContain("Does your phone show");
+  });
+
+  it("asks about the match code when the claim carries one, with the device as context", async () => {
+    // The phone in the user's hand shows the same two digits; agreement
+    // between the two screens is what the self-reported description cannot
+    // prove. The description stays, demoted to context, and the decision
+    // itself is unchanged - the code is never sent back.
+    statusMock.mockResolvedValue(CLAIMED_WITH_CODE);
+    answer.current = "y";
+    const ctx = interactiveCtx();
+
+    const result = await runWithPolls(ctx, 1);
+
+    const output = printed(ctx);
+    expect(output).toContain("showing the number 47");
+    expect(output).toContain("an iPhone");
+    expect(output).toContain("Only approve if the phone in your hand shows 47");
+    expect(answer.lastPrompt).toContain("Does your phone show 47?");
+    expect(answer.lastPrompt).toContain("an iPhone");
+    expect(respondMock).toHaveBeenCalledWith(
+      expect.any(String),
+      "bearer-1",
+      "ABCDE-FGHJK",
+      true,
+    );
+    expect(result.status === "fulfilled" ? result.value : null).toMatchObject({
+      decision: "approved",
+    });
   });
 
   it("exits with a supersession message when the printed code is gone", async () => {

--- a/clients/traycer-cli/src/auth/link-phone-flow.ts
+++ b/clients/traycer-cli/src/auth/link-phone-flow.ts
@@ -430,27 +430,42 @@ export async function runLinkPhoneFlow(
     claim.claimant.location ?? "location unknown",
   ].join(" · ");
   const device = claimantDeviceLabel(claim.claimant.userAgent);
-  // With a match code the question IS the code: the phone in the user's hand
-  // shows the same two digits, and agreement between the two screens proves
-  // the prompt belongs to that phone — which the self-reported description
-  // cannot, since the claimant chooses it. Without one (an older server, or
-  // a phone that predates the code and so was minted none) the description
-  // is the prompt, exactly as before.
-  const matchCode = claim.claimant.matchCode ?? null;
-  ctx.output.humanRequired(
-    matchCode === null
-      ? `A phone scanned the code.\n` +
-          `  ${detail}\n` +
-          `Details are approximate. Only approve if you scanned this code yourself.`
-      : `A phone scanned the code and is showing the number ${matchCode}.\n` +
-          `  ${device} · ${detail}\n` +
-          `Only approve if the phone in your hand shows ${matchCode} and you scanned this code yourself.`,
-  );
+  // Three prompts. With a match code the question IS the code: the phone in
+  // the user's hand shows the same two digits, and agreement between the two
+  // screens proves the prompt belongs to that phone — which the self-reported
+  // description cannot, since the claimant chooses it. An explicit null is
+  // the server saying the phone presented NO code: a legitimate older app, or
+  // a leaked-QR holder withholding the flag to dodge the check — this
+  // terminal cannot tell, so it warns loudly rather than reading like an
+  // ordinary claim. No word at all (an older server) is today's prompt.
+  const matchCode = claim.claimant.matchCode;
+  if (matchCode === undefined) {
+    ctx.output.humanRequired(
+      `A phone scanned the code.\n` +
+        `  ${detail}\n` +
+        `Details are approximate. Only approve if you scanned this code yourself.`,
+    );
+  } else if (matchCode === null) {
+    ctx.output.humanRequired(
+      `WARNING: a phone scanned the code but did not show a sign-in code.\n` +
+        `  ${device} · ${detail}\n` +
+        `An up-to-date Traycer app always shows one. Only approve if you scanned this code yourself\n` +
+        `and your phone is waiting without a code; otherwise reject and update the app.`,
+    );
+  } else {
+    ctx.output.humanRequired(
+      `A phone scanned the code and is showing the number ${matchCode}.\n` +
+        `  ${device} · ${detail}\n` +
+        `Only approve if the phone in your hand shows ${matchCode} and you scanned this code yourself.`,
+    );
+  }
 
   const approve = await askApproval(
-    matchCode === null
+    matchCode === undefined
       ? `Approve sign-in from ${device} · ${claim.claimant.address ?? "address unknown"}? [y/N] `
-      : `Does your phone show ${matchCode}? Approve sign-in from ${device}? [y/N] `,
+      : matchCode === null
+        ? `No code shown by the phone. Approve sign-in from ${device} anyway? [y/N] `
+        : `Does your phone show ${matchCode}? Approve sign-in from ${device}? [y/N] `,
   );
 
   const responded = await respondLinkLoginViaHttp(

--- a/clients/traycer-cli/src/auth/link-phone-flow.ts
+++ b/clients/traycer-cli/src/auth/link-phone-flow.ts
@@ -429,14 +429,28 @@ export async function runLinkPhoneFlow(
     claim.claimant.address ?? "address unknown",
     claim.claimant.location ?? "location unknown",
   ].join(" · ");
+  const device = claimantDeviceLabel(claim.claimant.userAgent);
+  // With a match code the question IS the code: the phone in the user's hand
+  // shows the same two digits, and agreement between the two screens proves
+  // the prompt belongs to that phone — which the self-reported description
+  // cannot, since the claimant chooses it. Without one (an older server, or
+  // a phone that predates the code and so was minted none) the description
+  // is the prompt, exactly as before.
+  const matchCode = claim.claimant.matchCode ?? null;
   ctx.output.humanRequired(
-    `A phone scanned the code.\n` +
-      `  ${detail}\n` +
-      `Details are approximate. Only approve if you scanned this code yourself.`,
+    matchCode === null
+      ? `A phone scanned the code.\n` +
+          `  ${detail}\n` +
+          `Details are approximate. Only approve if you scanned this code yourself.`
+      : `A phone scanned the code and is showing the number ${matchCode}.\n` +
+          `  ${device} · ${detail}\n` +
+          `Only approve if the phone in your hand shows ${matchCode} and you scanned this code yourself.`,
   );
 
   const approve = await askApproval(
-    `Approve sign-in from ${claimantDeviceLabel(claim.claimant.userAgent)} · ${claim.claimant.address ?? "address unknown"}? [y/N] `,
+    matchCode === null
+      ? `Approve sign-in from ${device} · ${claim.claimant.address ?? "address unknown"}? [y/N] `
+      : `Does your phone show ${matchCode}? Approve sign-in from ${device}? [y/N] `,
   );
 
   const responded = await respondLinkLoginViaHttp(

--- a/protocol/src/auth/link-login.ts
+++ b/protocol/src/auth/link-login.ts
@@ -65,10 +65,13 @@ export type LinkLoginStatusResponse = {
     location: string | null;
     claimedAt: number | null;
     /**
-     * The claim's match code — the two digits the phone is showing — while
-     * the record is `claimed` and the request opted in; `null` once decided.
-     * Absent altogether from a server that predates it, which the desktop
-     * renders as the description-only prompt.
+     * The claim's match code — the two digits the phone is showing. Present
+     * only while the record is `claimed`, only when the PHONE could show a
+     * code (the server mints none for a phone that predates it, so the
+     * desktop is never asked about a number that phone cannot display), and
+     * only when this request opted in. Absent otherwise, and from a server
+     * that predates it; `null` is tolerated for the same fallback. Either
+     * way the desktop renders the description-only prompt.
      */
     matchCode?: string | null;
   } | null;

--- a/protocol/src/auth/link-login.ts
+++ b/protocol/src/auth/link-login.ts
@@ -34,6 +34,15 @@ export type ClaimLinkLoginCodeResponse = {
   secret: string;
   /** Server-directed minimum spacing between result polls, seconds. */
   interval: number;
+  /**
+   * The claim's MATCH CODE: two server-chosen digits the approver's prompt
+   * shows as well, so the human can confirm the prompt on their desktop is
+   * for the phone in their hand. An attention proof, not a credential — it
+   * gates nothing, and the poll below is bound to `secret` alone. Present
+   * only when the request opted in AND the server is new enough to mint one;
+   * a surface without it falls back to the description-only prompt.
+   */
+  matchCode?: string;
 };
 
 export type LinkLoginTokenResponse = {
@@ -55,6 +64,13 @@ export type LinkLoginStatusResponse = {
     userAgent: string | null;
     location: string | null;
     claimedAt: number | null;
+    /**
+     * The claim's match code — the two digits the phone is showing — while
+     * the record is `claimed` and the request opted in; `null` once decided.
+     * Absent altogether from a server that predates it, which the desktop
+     * renders as the description-only prompt.
+     */
+    matchCode?: string | null;
   } | null;
 };
 
@@ -71,12 +87,20 @@ export const mintLinkLoginCodeResponseSchema: z.ZodType<MintLinkLoginCodeRespons
     })
     .strict();
 
+/**
+ * The match code's exact wire shape. Anything else is a contract drift and
+ * fails the parse like any other, rather than putting an unreadable "code"
+ * in front of the human who is asked to compare it.
+ */
+const linkLoginMatchCodeSchema = z.string().regex(/^[0-9]{2}$/);
+
 export const claimLinkLoginCodeResponseSchema: z.ZodType<ClaimLinkLoginCodeResponse> =
   z
     .object({
       status: z.literal("claimed"),
       secret: z.string().min(1),
       interval: z.number().int().positive(),
+      matchCode: linkLoginMatchCodeSchema.optional(),
     })
     .strict();
 
@@ -98,6 +122,7 @@ export const linkLoginStatusResponseSchema: z.ZodType<LinkLoginStatusResponse> =
           userAgent: z.string().nullable(),
           location: z.string().nullable(),
           claimedAt: z.number().nullable(),
+          matchCode: linkLoginMatchCodeSchema.nullable().optional(),
         })
         .strict()
         .nullable(),

--- a/protocol/src/auth/link-login.ts
+++ b/protocol/src/auth/link-login.ts
@@ -65,13 +65,20 @@ export type LinkLoginStatusResponse = {
     location: string | null;
     claimedAt: number | null;
     /**
-     * The claim's match code — the two digits the phone is showing. Present
-     * only while the record is `claimed`, only when the PHONE could show a
-     * code (the server mints none for a phone that predates it, so the
-     * desktop is never asked about a number that phone cannot display), and
-     * only when this request opted in. Absent otherwise, and from a server
-     * that predates it; `null` is tolerated for the same fallback. Either
-     * way the desktop renders the description-only prompt.
+     * The claim's match code, tri-state on purpose:
+     *
+     * - a two-digit string: the phone is showing it; the approver asks
+     *   "Does your phone show NN?".
+     * - `null`: the phone presented NO code. The server mints one only for
+     *   a claimant that declared it can show it (a phone that predates the
+     *   code must not produce a prompt it cannot satisfy) — but `/claim` is
+     *   unauthenticated and that declaration is the claimant's, so a
+     *   leaked-QR holder would simply withhold it. The approver therefore
+     *   renders this as a loud degraded-mode warning, never as the ordinary
+     *   description prompt.
+     * - absent: the record is not `claimed`, this request did not opt in,
+     *   or the server predates the code. The approver renders the
+     *   description-only prompt.
      */
     matchCode?: string | null;
   } | null;


### PR DESCRIPTION
Client half of traycerai/traycer-internal#5489 (authn mints the code; lands first).

## Problem

In the "Link mobile app" QR flow the desktop's Approve/Reject prompt describes the claimant with text the claimant itself reported (device description). Whoever holds the QR chooses that text, so the human's decision rests on attacker-controllable input.

## Design

authn now mints a **match code** at claim: two digits, `"00"`–`"99"`, from the server's CSPRNG, stored on the claim record and returned to the phone (claim response) and to the minting desktop (status view, **while `claimed`**). Neither client can derive it; agreement between the two screens proves the prompt on the desktop belongs to the phone in the user's hand.

**Security posture.** The code is an attention proof, not a secret and not a credential. Two digits are not brute-force relevant because it is never an input to anything: `respond` and `token` are untouched and nothing on the client sends it back. Approval stays a human decision on the desktop. A stale or absent code degrades to today's prompt.

## Change

- `protocol/src/auth/link-login.ts` — `matchCode` on the claim response (optional, strict two-digit) and on the status claimant (**optional and nullable**, tri-state — see below). An unreadable value is a contract drift, not something to put in front of a person asked to compare it.
- `clients/shared/auth/link-login.ts` — claim and status requests carry `acceptMatchCode: true`; the claim result exposes `matchCode: string | null`.
- `clients/gui-app/src/hooks/auth/use-link-login-watch.ts` — `LiveClaim.matchCode: LiveMatchCode` = `shown` / `not-presented` / `unavailable`.
- `clients/gui-app/src/components/settings/panels/link-phone-panel.tsx` — three confirm cards: **shown** → "Does your phone show **47**?" with the device demoted to "Sign-in request from an iPhone."; **not-presented** → a loud destructive-toned warning "This phone did not show a sign-in code. An up-to-date Traycer app always shows one. Approve only if you just scanned this code yourself and your phone is waiting without a code; otherwise reject and update the app."; **unavailable** → today's "Approve sign-in from …?". Location line untouched. All three live in the existing `role="status"` live region.
- `clients/traycer-cli/src/auth/link-phone-flow.ts` — `traycer link-phone` is an approver surface too and already opted in through the shared client; it now prints the same three prompts ("Does your phone show 47? …", a `WARNING:` block for not-presented, today's prompt otherwise).
- `clients/gui-app/src/lib/auth/auth-service.ts` — `LinkLoginProgress.matchCode`, carried on every emission of the poll (constant for the claim).
- `clients/gui-app/src/components/layout/header/sign-in/link-code-wait-status.tsx` — phone shows "Your code: **47**" large for the whole wait. The standing line stays "Waiting for approval on your computer…" in every case, with a conditional hint "If your computer asks, it should show this code." — an older desktop or CLI asks nothing about it, and "approve only if it matches" would have the user refuse a prompt that has no code. Same component serves the scanned and the typed-code paths.

## Mixed-fleet note

All link-login response schemas here are `.strict()`, so an unconditional new server field would have failed every un-updated client's parse (→ `network-error`) the moment authn deployed. The field is therefore **opt-in per request**: this client declares `acceptMatchCode: true` and the server sends the field only then.

The claim-side flag also decides whether a code is **minted**: a phone that cannot show one must not produce a prompt the human cannot satisfy (that would lock out every un-updated phone). But `/claim` is unauthenticated and that flag is the claimant's word, so a leaked-QR holder would simply withhold it — hence the status value is tri-state and the "no code" case is rendered as a **visibly different, degraded-mode warning**, never as today's prompt (codex P1 on traycerai/traycer-internal#5489). Observed prompt per cell:

| | old desktop | new desktop (this PR) |
|---|---|---|
| **old phone** | unchanged: "Approve sign-in from an iPhone?" | status carries `matchCode: null` → loud warning "This phone did not show a sign-in code…" (still decidable, nudges to update) |
| **new phone (this PR)** | phone shows "Your code: 47"; desktop shows today's prompt (never opted in) | both see the same two digits: "Does your phone show 47?" / "Your code: 47" |

Absent key (a server that predates the code, or a decided record) → today's prompt. `respond` / `token` are untouched in every cell.

**Follow-up to retire:** once every shipped mobile build sends `acceptMatchCode` on claim (condition: the oldest supported mobile release includes this PR, so no current app can claim without the flag), the server makes the flag mandatory on `/claim` and the `not-presented` state can no longer be produced by a downgrade — tracked on traycerai/traycer-internal#5489.

## Testing

Narrow suites + `compile` + `format:check` + `oxlint`/`eslint` on `protocol`, `clients/shared`, `clients/gui-app` (CI owns the full gate):

- **shared** — claim/status send the opt-in flag; a code is read back; today's exact response shapes (no field) still parse and yield `matchCode: null`; a one-digit code is refused as drift.
- **panel** — with a code: headline, demoted device line, code inside the `status` live region, Approve still sends only `{ code, approve }`; without one: today's prompt, no empty code slot. Existing presentation/integration suites updated for the new `LiveClaim` field.
- **phone wait** — code shown from the first countdown through `finalizing`; no code slot against an older server.
- **auth-service** — every `waiting`/`checking`/`finalizing` emission of a poll carries the claim's code; an older server's claim parses and polls with `matchCode: null`.

Not verified on a device/simulator in this PR: the rendered size of the code on the phone (`text-title-lg`) and the desktop card (`text-title-md`) — worth a look on the review pass.
