### PR TITLE
feat(gui): list Finder alongside the editors as a default open target

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/git-diff/diff-tab-toolbar.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/diff-tab-toolbar.tsx
@@ -69,6 +69,12 @@ interface DiffTabToolbarProps {
   readonly onOpenFile: (() => void) | null;
   readonly openFileDisabled: boolean;
   readonly openFileOpening: boolean;
+  /**
+   * Names the resolved default target, because it is not always an editor -
+   * a Finder default opens the file revealed in Finder, and "Open in editor"
+   * would be describing something else.
+   */
+  readonly openFileLabel: string;
 }
 
 export function DiffTabToolbar(props: DiffTabToolbarProps) {
@@ -249,7 +255,7 @@ export function DiffTabToolbar(props: DiffTabToolbarProps) {
                 ) : (
                   <ExternalLink className="size-4 text-muted-foreground" />
                 )}
-                Open in editor
+                {props.openFileLabel}
               </Button>
             </>
           ) : null}

--- a/clients/gui-app/src/components/epic-canvas/git-diff/diff-tab-toolbar.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/diff-tab-toolbar.tsx
@@ -53,6 +53,24 @@ export type DiffTabToolbarViewPatch =
   | { readonly indicatorStyle: GitDiffIndicatorStyle }
   | { readonly collapsedFilePaths: ReadonlyArray<string> };
 
+/**
+ * The toolbar's open-this-file action. One object rather than four parallel
+ * props so "no action" is a single `null` - the label and pending state cannot
+ * outlive the handler, and a caller with no file to open cannot be asked for a
+ * label it would never render.
+ */
+export interface DiffTabToolbarOpenFile {
+  readonly onClick: () => void;
+  /**
+   * Names the resolved default target, because it is not always an editor - a
+   * Finder default reveals the file in Finder, and "Open in editor" would be
+   * describing something else.
+   */
+  readonly label: string;
+  readonly disabled: boolean;
+  readonly pending: boolean;
+}
+
 interface DiffTabToolbarProps {
   readonly view: DiffTabToolbarView;
   readonly onViewPatch: (patch: DiffTabToolbarViewPatch) => void;
@@ -65,19 +83,12 @@ interface DiffTabToolbarProps {
   // `null` hides the refresh control entirely (snapshot diffs are immutable -
   // there is nothing to re-fetch).
   readonly onRefresh: (() => void) | null;
-  // Editor-open action; null hides the row (e.g. bundle tiles with no single file).
-  readonly onOpenFile: (() => void) | null;
-  readonly openFileDisabled: boolean;
-  readonly openFileOpening: boolean;
-  /**
-   * Names the resolved default target, because it is not always an editor -
-   * a Finder default opens the file revealed in Finder, and "Open in editor"
-   * would be describing something else.
-   */
-  readonly openFileLabel: string;
+  // `null` hides the row (e.g. bundle tiles with no single file).
+  readonly openFile: DiffTabToolbarOpenFile | null;
 }
 
 export function DiffTabToolbar(props: DiffTabToolbarProps) {
+  const openFile = props.openFile;
   const view = props.view;
   const isSplit = view.mode === "split";
 
@@ -235,18 +246,18 @@ export function DiffTabToolbar(props: DiffTabToolbarProps) {
               }
             />
           </div>
-          {props.onOpenFile !== null ? (
+          {openFile !== null ? (
             <>
               <Separator className="my-1" />
               <Button
                 type="button"
                 variant="ghost"
                 size="sm"
-                onClick={props.onOpenFile}
-                disabled={props.openFileDisabled}
+                onClick={openFile.onClick}
+                disabled={openFile.disabled}
                 className="h-7 w-full justify-start font-normal text-foreground"
               >
-                {props.openFileOpening ? (
+                {openFile.pending ? (
                   <AgentSpinningDots
                     className="size-4 text-muted-foreground"
                     testId="diff-tab-open-editor-spinner"
@@ -255,7 +266,7 @@ export function DiffTabToolbar(props: DiffTabToolbarProps) {
                 ) : (
                   <ExternalLink className="size-4 text-muted-foreground" />
                 )}
-                {props.openFileLabel}
+                {openFile.label}
               </Button>
             </>
           ) : null}

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/git-bundle-diff-tile-find.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/git-bundle-diff-tile-find.test.tsx
@@ -75,6 +75,14 @@ const state = vi.hoisted(() => ({
 // `use-surface-host-stream-binding.test.tsx`.
 // The hook returns the value to PROVIDE: the ambient binding while following
 // (this suite's), the pin's own once built, null while pending. Following here.
+// These tiles resolve the user's default open target, which asks whether the
+// tile's host is the LOCAL one before it may offer Finder. That read wants the
+// host runtime, which this suite does not mount; `null` is the honest answer
+// here and simply leaves Finder unoffered.
+vi.mock("@/hooks/host/use-host-directory-entry", () => ({
+  useHostDirectoryEntry: () => null,
+}));
+
 vi.mock("@/hooks/host/use-surface-host-stream-binding", async () => {
   const { use } = await import("react");
   const { StreamRuntimeContext } =

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/git-diff-tile-active-gate.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/git-diff-tile-active-gate.test.tsx
@@ -28,6 +28,14 @@ import { __resetSubscriptionsForTesting } from "@/hooks/git/use-git-list-changed
 // `use-surface-host-stream-binding.test.tsx`.
 // The hook returns the value to PROVIDE: the ambient binding while following
 // (this suite's), the pin's own once built, null while pending. Following here.
+// These tiles resolve the user's default open target, which asks whether the
+// tile's host is the LOCAL one before it may offer Finder. That read wants the
+// host runtime, which this suite does not mount; `null` is the honest answer
+// here and simply leaves Finder unoffered.
+vi.mock("@/hooks/host/use-host-directory-entry", () => ({
+  useHostDirectoryEntry: () => null,
+}));
+
 vi.mock("@/hooks/host/use-surface-host-stream-binding", async () => {
   const { use } = await import("react");
   const { StreamRuntimeContext } =

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/git-diff-tile-edit.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/git-diff-tile-edit.test.tsx
@@ -89,6 +89,14 @@ const editorOpenState = vi.hoisted(() => ({ mutate: vi.fn() }));
 // `use-surface-host-stream-binding.test.tsx`.
 // The hook returns the value to PROVIDE: the ambient binding while following
 // (this suite's), the pin's own once built, null while pending. Following here.
+// These tiles resolve the user's default open target, which asks whether the
+// tile's host is the LOCAL one before it may offer Finder. That read wants the
+// host runtime, which this suite does not mount; `null` is the honest answer
+// here and simply leaves Finder unoffered.
+vi.mock("@/hooks/host/use-host-directory-entry", () => ({
+  useHostDirectoryEntry: () => null,
+}));
+
 vi.mock("@/hooks/host/use-surface-host-stream-binding", async () => {
   const { use } = await import("react");
   const { StreamRuntimeContext } =

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/git-diff-tile-host-gate.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/git-diff-tile-host-gate.test.tsx
@@ -50,6 +50,14 @@ const state = vi.hoisted((): GateTestState => ({
 // `use-surface-host-stream-binding.test.tsx`.
 // The hook returns the value to PROVIDE: the ambient binding while following
 // (this suite's), the pin's own once built, null while pending. Following here.
+// These tiles resolve the user's default open target, which asks whether the
+// tile's host is the LOCAL one before it may offer Finder. That read wants the
+// host runtime, which this suite does not mount; `null` is the honest answer
+// here and simply leaves Finder unoffered.
+vi.mock("@/hooks/host/use-host-directory-entry", () => ({
+  useHostDirectoryEntry: () => null,
+}));
+
 vi.mock("@/hooks/host/use-surface-host-stream-binding", async () => {
   const { use } = await import("react");
   const { StreamRuntimeContext } =

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/git-diff-tile-image-routing.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/git-diff-tile-image-routing.test.tsx
@@ -63,6 +63,14 @@ const state = vi.hoisted(() => ({
 // `use-surface-host-stream-binding.test.tsx`.
 // The hook returns the value to PROVIDE: the ambient binding while following
 // (this suite's), the pin's own once built, null while pending. Following here.
+// These tiles resolve the user's default open target, which asks whether the
+// tile's host is the LOCAL one before it may offer Finder. That read wants the
+// host runtime, which this suite does not mount; `null` is the honest answer
+// here and simply leaves Finder unoffered.
+vi.mock("@/hooks/host/use-host-directory-entry", () => ({
+  useHostDirectoryEntry: () => null,
+}));
+
 vi.mock("@/hooks/host/use-surface-host-stream-binding", async () => {
   const { use } = await import("react");
   const { StreamRuntimeContext } =

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/workspace-file-tile-image-mode.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/workspace-file-tile-image-mode.test.tsx
@@ -68,6 +68,14 @@ const state = vi.hoisted(() => ({
   },
 }));
 
+// These tiles resolve the user's default open target, which asks whether the
+// tile's host is the LOCAL one before it may offer Finder. That read wants the
+// host runtime, which this suite does not mount; `null` is the honest answer
+// here and simply leaves Finder unoffered.
+vi.mock("@/hooks/host/use-host-directory-entry", () => ({
+  useHostDirectoryEntry: () => null,
+}));
+
 vi.mock("@/hooks/assets/use-file-asset", () => ({
   useFileAsset: (request: FileAssetRequest) => {
     state.assetRequests.push(request);

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/workspace-file-tile-pdf-routing.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/workspace-file-tile-pdf-routing.test.tsx
@@ -53,6 +53,14 @@ const state = vi.hoisted((): PdfRoutingTestState => ({
   viewerUnavailable: false,
 }));
 
+// These tiles resolve the user's default open target, which asks whether the
+// tile's host is the LOCAL one before it may offer Finder. That read wants the
+// host runtime, which this suite does not mount; `null` is the honest answer
+// here and simply leaves Finder unoffered.
+vi.mock("@/hooks/host/use-host-directory-entry", () => ({
+  useHostDirectoryEntry: () => null,
+}));
+
 vi.mock("@/hooks/assets/use-file-asset", () => ({
   useFileAsset: (request: FileAssetRequest) => {
     state.assetRequests.push(request);

--- a/clients/gui-app/src/components/epic-canvas/renderers/git-diff-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/git-diff-tile.tsx
@@ -59,6 +59,7 @@ import { GitErrorBlock } from "@/components/epic-canvas/git-diff/git-error-block
 import { GitWatcherStatusNotice } from "@/components/epic-canvas/git-diff/git-watcher-status-notice";
 import { useTabHostId } from "@/components/epic-canvas/hooks/use-tab-host-id";
 import { useEffectiveDefaultEditor } from "@/hooks/editor/use-effective-default-editor";
+import { openTargetActionLabel } from "@/lib/editor/editor-menu-catalog";
 import { useHostReachability } from "@/hooks/agent/use-host-reachability";
 import { BoundedTileLoad } from "@/components/epic-canvas/renderers/tile-host-load-state";
 import { useTabHostClient } from "@/hooks/host/use-tab-host-client";
@@ -392,6 +393,7 @@ function GitDiffTileToolbar(props: GitDiffTileToolbarProps): ReactNode {
       onOpenFile={props.onOpenFile !== null ? handleOpenFile : null}
       openFileDisabled={openFileOpening}
       openFileOpening={openFileOpening}
+      openFileLabel={openTargetActionLabel(effectiveEditor)}
     />
   );
 }

--- a/clients/gui-app/src/components/epic-canvas/renderers/git-diff-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/git-diff-tile.tsx
@@ -390,10 +390,16 @@ function GitDiffTileToolbar(props: GitDiffTileToolbarProps): ReactNode {
       collapseAll={collapseAll}
       refreshing={refresh.refreshing}
       onRefresh={refresh.trigger}
-      onOpenFile={props.onOpenFile !== null ? handleOpenFile : null}
-      openFileDisabled={openFileOpening}
-      openFileOpening={openFileOpening}
-      openFileLabel={openTargetActionLabel(effectiveEditor)}
+      openFile={
+        props.onOpenFile !== null
+          ? {
+              onClick: handleOpenFile,
+              label: openTargetActionLabel(effectiveEditor),
+              disabled: openFileOpening,
+              pending: openFileOpening,
+            }
+          : null
+      }
     />
   );
 }

--- a/clients/gui-app/src/components/epic-canvas/renderers/pr-diff-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/pr-diff-tile.tsx
@@ -35,6 +35,7 @@ import {
 import { DiffBundleLoadingSkeleton } from "@/components/epic-canvas/git-diff/diff-bundle-loading-skeleton";
 import { PrLocalDiffBody } from "@/components/epic-canvas/pr/pr-local-diff-body";
 import { PrDetailDeadTileBanner } from "./dead-tile-banner";
+import { OPEN_IN_EDITOR_ACTION_LABEL } from "@/lib/editor/editor-menu-catalog";
 
 interface PrDiffTileProps {
   readonly node: PrDiffTileRef;
@@ -415,6 +416,7 @@ function PrDiffTileLive(props: PrDiffTileProps): ReactNode {
           // endpoints are commits, so there is no single path to hand an
           // editor. The per-file sections keep their own affordances.
           onOpenFile={null}
+          openFileLabel={OPEN_IN_EDITOR_ACTION_LABEL}
           openFileDisabled={false}
           openFileOpening={false}
         />

--- a/clients/gui-app/src/components/epic-canvas/renderers/pr-diff-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/pr-diff-tile.tsx
@@ -35,7 +35,6 @@ import {
 import { DiffBundleLoadingSkeleton } from "@/components/epic-canvas/git-diff/diff-bundle-loading-skeleton";
 import { PrLocalDiffBody } from "@/components/epic-canvas/pr/pr-local-diff-body";
 import { PrDetailDeadTileBanner } from "./dead-tile-banner";
-import { OPEN_IN_EDITOR_ACTION_LABEL } from "@/lib/editor/editor-menu-catalog";
 
 interface PrDiffTileProps {
   readonly node: PrDiffTileRef;
@@ -415,10 +414,7 @@ function PrDiffTileLive(props: PrDiffTileProps): ReactNode {
           // No editor-open row: a PR diff spans many files and the range's
           // endpoints are commits, so there is no single path to hand an
           // editor. The per-file sections keep their own affordances.
-          onOpenFile={null}
-          openFileLabel={OPEN_IN_EDITOR_ACTION_LABEL}
-          openFileDisabled={false}
-          openFileOpening={false}
+          openFile={null}
         />
       }
     >

--- a/clients/gui-app/src/components/epic-canvas/renderers/snapshot-diff-tile-body.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/snapshot-diff-tile-body.tsx
@@ -63,6 +63,7 @@ import {
 } from "@/components/epic-canvas/git-diff/diff-tab-toolbar";
 import { SnapshotDiffSourceUnavailableBanner } from "./dead-tile-banner";
 import { BoundedTileLoad } from "./tile-host-load-state";
+import { OPEN_IN_EDITOR_ACTION_LABEL } from "@/lib/editor/editor-menu-catalog";
 
 const SNAPSHOT_DIFF_LOADING_FIND_MESSAGE =
   "Snapshot diff content is still loading.";
@@ -181,6 +182,7 @@ const SnapshotDiffTileShell = memo(function SnapshotDiffTileShell(
         refreshing={false}
         onRefresh={null}
         onOpenFile={null}
+        openFileLabel={OPEN_IN_EDITOR_ACTION_LABEL}
         openFileDisabled={false}
         openFileOpening={false}
       />

--- a/clients/gui-app/src/components/epic-canvas/renderers/snapshot-diff-tile-body.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/snapshot-diff-tile-body.tsx
@@ -63,7 +63,6 @@ import {
 } from "@/components/epic-canvas/git-diff/diff-tab-toolbar";
 import { SnapshotDiffSourceUnavailableBanner } from "./dead-tile-banner";
 import { BoundedTileLoad } from "./tile-host-load-state";
-import { OPEN_IN_EDITOR_ACTION_LABEL } from "@/lib/editor/editor-menu-catalog";
 
 const SNAPSHOT_DIFF_LOADING_FIND_MESSAGE =
   "Snapshot diff content is still loading.";
@@ -181,10 +180,7 @@ const SnapshotDiffTileShell = memo(function SnapshotDiffTileShell(
         collapseAll={collapseAll}
         refreshing={false}
         onRefresh={null}
-        onOpenFile={null}
-        openFileLabel={OPEN_IN_EDITOR_ACTION_LABEL}
-        openFileDisabled={false}
-        openFileOpening={false}
+        openFile={null}
       />
     ),
     [collapseAll, handleViewPatch, toolbarView],

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/file-tree-row-context-menu.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/file-tree-row-context-menu.test.tsx
@@ -1,19 +1,17 @@
 /**
- * Pins `FileTreeRowContextMenu`'s row recovery, directory/file labeling, and
- * gating:
+ * Pins `FileTreeRowContextMenu`'s row recovery, menu order, and gating:
  *
  * - The row under a right-click is recovered from the event's composed path,
  *   not from a per-row element the tree hands the menu directly - a
  *   right-click that hits no tagged row must not open an empty menu.
- * - A row is a directory by either of two independent tells (a trailing
- *   separator, or absence from the openable-file map); a file row shows
- *   "Reveal in Finder", a directory row "Open in Finder".
+ * - Finder is listed as the last row of the open group, labelled the same for
+ *   a file and a folder: the host picks reveal-vs-open from the path itself.
  * - The absolute path handed to the host strips a directory row's trailing
  *   separator; the copied relative path is the workspace-relative tree path
  *   with the same separator stripped.
- * - The Finder item and the editor items are independently gated (Finder's
- *   own availability probe; the editor items on the host directory entry
- *   being local) while the two Copy items are unconditional.
+ * - Finder and the editors are independently gated (Finder's own availability
+ *   probe; the editors on the host directory entry being local) while the two
+ *   Copy items are unconditional.
  */
 import {
   afterEach,
@@ -135,23 +133,14 @@ vi.mock("sonner", () => ({
   },
 }));
 
-const FILE_NAME_BY_PATH = new Map<string, string>([
-  ["src/index.ts", "index.ts"],
-]);
-
 const FILE_ROW_PATH = "src/index.ts";
-// Directory tell #1: a trailing separator.
+// A directory row, marked by the trailing separator the tree gives folders.
 const DIR_ROW_TRAILING_SLASH_PATH = "src/lib/";
-// Directory tell #2: absent from `fileNameByPath`, no trailing separator.
-const DIR_ROW_ABSENT_PATH = "src/assets";
+const DIR_ROW_PLAIN_PATH = "src/assets";
 
 function renderTree(hostId: string | null) {
   return render(
-    <FileTreeRowContextMenu
-      hostId={hostId}
-      workspacePath="/repo"
-      fileNameByPath={FILE_NAME_BY_PATH}
-    >
+    <FileTreeRowContextMenu hostId={hostId} workspacePath="/repo">
       <div data-testid="tree">
         <div
           data-testid="row-file"
@@ -166,8 +155,8 @@ function renderTree(hostId: string | null) {
           lib
         </div>
         <div
-          data-testid="row-dir-absent"
-          {...{ [PIERRE_ITEM_PATH_ATTR]: DIR_ROW_ABSENT_PATH }}
+          data-testid="row-dir-plain"
+          {...{ [PIERRE_ITEM_PATH_ATTR]: DIR_ROW_PLAIN_PATH }}
         >
           assets
         </div>
@@ -178,11 +167,7 @@ function renderTree(hostId: string | null) {
 
 function renderTreeWithChildren(hostId: string | null, children: ReactElement) {
   return render(
-    <FileTreeRowContextMenu
-      hostId={hostId}
-      workspacePath="/repo"
-      fileNameByPath={FILE_NAME_BY_PATH}
-    >
+    <FileTreeRowContextMenu hostId={hostId} workspacePath="/repo">
       {children}
     </FileTreeRowContextMenu>,
   );
@@ -211,34 +196,38 @@ describe("<FileTreeRowContextMenu />", () => {
     cleanup();
   });
 
-  it("labels the Finder item 'Reveal in Finder' for a file row", () => {
+  it("lists Finder last in the open group, after every editor", () => {
     renderTree("host-1");
 
     fireEvent.contextMenu(screen.getByTestId("row-file"));
 
-    expect(screen.getByTestId("epic-file-tree-row-finder").textContent).toBe(
-      "Reveal in Finder",
-    );
+    const openRowIds = Array.from(
+      screen
+        .getByTestId("epic-file-tree-row-menu")
+        .querySelectorAll("[data-testid^='epic-file-tree-row-open-']"),
+    ).map((node) => node.getAttribute("data-testid"));
+    expect(openRowIds).toEqual([
+      "epic-file-tree-row-open-vscode",
+      "epic-file-tree-row-open-cursor",
+      "epic-file-tree-row-open-windsurf",
+      "epic-file-tree-row-open-zed",
+      "epic-file-tree-row-open-finder",
+    ]);
+    expect(
+      screen.getByTestId("epic-file-tree-row-open-finder").textContent,
+    ).toBe("Finder");
   });
 
-  it("labels the Finder item 'Open in Finder' for a directory row marked by a trailing slash", () => {
+  it("labels Finder identically for a directory row", () => {
+    // The host chooses `open -R` for a file and `open` for a folder, so the
+    // row does not have to say which it is.
     renderTree("host-1");
 
     fireEvent.contextMenu(screen.getByTestId("row-dir-trailing"));
 
-    expect(screen.getByTestId("epic-file-tree-row-finder").textContent).toBe(
-      "Open in Finder",
-    );
-  });
-
-  it("labels the Finder item 'Open in Finder' for a directory row absent from fileNameByPath", () => {
-    renderTree("host-1");
-
-    fireEvent.contextMenu(screen.getByTestId("row-dir-absent"));
-
-    expect(screen.getByTestId("epic-file-tree-row-finder").textContent).toBe(
-      "Open in Finder",
-    );
+    expect(
+      screen.getByTestId("epic-file-tree-row-open-finder").textContent,
+    ).toBe("Finder");
   });
 
   // One select per render: a second launch inside the same menu instance is
@@ -247,7 +236,7 @@ describe("<FileTreeRowContextMenu />", () => {
     renderTree("host-1");
 
     fireEvent.contextMenu(screen.getByTestId("row-file"));
-    fireEvent.click(screen.getByTestId("epic-file-tree-row-finder"));
+    fireEvent.click(screen.getByTestId("epic-file-tree-row-open-finder"));
 
     expect(menuState.mutate).toHaveBeenLastCalledWith({
       editorId: "finder",
@@ -259,7 +248,7 @@ describe("<FileTreeRowContextMenu />", () => {
     renderTree("host-1");
 
     fireEvent.contextMenu(screen.getByTestId("row-dir-trailing"));
-    fireEvent.click(screen.getByTestId("epic-file-tree-row-finder"));
+    fireEvent.click(screen.getByTestId("epic-file-tree-row-open-finder"));
 
     expect(menuState.mutate).toHaveBeenLastCalledWith({
       editorId: "finder",
@@ -300,7 +289,7 @@ describe("<FileTreeRowContextMenu />", () => {
 
     fireEvent.contextMenu(screen.getByTestId("row-file"));
 
-    expect(screen.queryByTestId("epic-file-tree-row-finder")).toBeNull();
+    expect(screen.queryByTestId("epic-file-tree-row-open-finder")).toBeNull();
     screen.getByTestId("epic-file-tree-row-copy-path");
     screen.getByTestId("epic-file-tree-row-copy-relative-path");
   });
@@ -343,8 +332,8 @@ describe("<FileTreeRowContextMenu />", () => {
       // `toContain`, not `toBe`: the spinner glyph shares the item's
       // textContent. A label swapped to "Opening…" still fails this.
       expect(
-        screen.getByTestId("epic-file-tree-row-finder").textContent,
-      ).toContain("Reveal in Finder");
+        screen.getByTestId("epic-file-tree-row-open-finder").textContent,
+      ).toContain("Finder");
     });
 
     it("labels a directory row correctly through the same path", () => {
@@ -357,9 +346,9 @@ describe("<FileTreeRowContextMenu />", () => {
         vi.advanceTimersByTime(700);
       });
 
-      expect(screen.getByTestId("epic-file-tree-row-finder").textContent).toBe(
-        "Open in Finder",
-      );
+      expect(
+        screen.getByTestId("epic-file-tree-row-open-finder").textContent,
+      ).toBe("Finder");
     });
 
     it("opens nothing when the long-press hits no row", () => {
@@ -407,7 +396,7 @@ describe("<FileTreeRowContextMenu />", () => {
       ).not.toBeNull();
       expect(
         screen
-          .getByTestId("epic-file-tree-row-finder")
+          .getByTestId("epic-file-tree-row-open-finder")
           .getAttribute("data-disabled"),
       ).not.toBeNull();
       expect(
@@ -432,15 +421,15 @@ describe("<FileTreeRowContextMenu />", () => {
       // dead item, and the label must not become "Opening…" - the spinner is
       // the only channel that moves.
       screen.getByTestId("epic-file-tree-row-open-vscode-spinner");
-      screen.getByTestId("epic-file-tree-row-finder-spinner");
+      screen.getByTestId("epic-file-tree-row-open-finder-spinner");
       expect(
         screen.getByTestId("epic-file-tree-row-open-vscode").textContent,
       ).toContain("VS Code");
       // `toContain`, not `toBe`: the spinner glyph shares the item's
       // textContent. A label swapped to "Opening…" still fails this.
       expect(
-        screen.getByTestId("epic-file-tree-row-finder").textContent,
-      ).toContain("Reveal in Finder");
+        screen.getByTestId("epic-file-tree-row-open-finder").textContent,
+      ).toContain("Finder");
 
       // The Copy items neither disable nor spin - they touch no host.
       expect(
@@ -457,7 +446,7 @@ describe("<FileTreeRowContextMenu />", () => {
         screen.queryByTestId("epic-file-tree-row-open-vscode-spinner"),
       ).toBeNull();
       expect(
-        screen.queryByTestId("epic-file-tree-row-finder-spinner"),
+        screen.queryByTestId("epic-file-tree-row-open-finder-spinner"),
       ).toBeNull();
     });
 
@@ -466,7 +455,7 @@ describe("<FileTreeRowContextMenu />", () => {
       renderTree("host-1");
 
       fireEvent.contextMenu(screen.getByTestId("row-file"));
-      fireEvent.click(screen.getByTestId("epic-file-tree-row-finder"));
+      fireEvent.click(screen.getByTestId("epic-file-tree-row-open-finder"));
 
       expect(menuState.mutate).not.toHaveBeenCalled();
     });
@@ -478,11 +467,11 @@ describe("<FileTreeRowContextMenu />", () => {
       renderTree("host-1");
 
       fireEvent.contextMenu(screen.getByTestId("row-file"));
-      fireEvent.click(screen.getByTestId("epic-file-tree-row-finder"));
+      fireEvent.click(screen.getByTestId("epic-file-tree-row-open-finder"));
       expect(menuState.mutate).toHaveBeenCalledTimes(1);
 
       fireEvent.contextMenu(screen.getByTestId("row-file"));
-      fireEvent.click(screen.getByTestId("epic-file-tree-row-finder"));
+      fireEvent.click(screen.getByTestId("epic-file-tree-row-open-finder"));
 
       expect(menuState.mutate).toHaveBeenCalledTimes(1);
     });

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/file-tree-row-context-menu.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/file-tree-row-context-menu.test.tsx
@@ -201,21 +201,19 @@ describe("<FileTreeRowContextMenu />", () => {
 
     fireEvent.contextMenu(screen.getByTestId("row-file"));
 
-    const openRowIds = Array.from(
-      screen
-        .getByTestId("epic-file-tree-row-menu")
-        .querySelectorAll("[data-testid^='epic-file-tree-row-open-']"),
-    ).map((node) => node.getAttribute("data-testid"));
-    expect(openRowIds).toEqual([
-      "epic-file-tree-row-open-vscode",
-      "epic-file-tree-row-open-cursor",
-      "epic-file-tree-row-open-windsurf",
-      "epic-file-tree-row-open-zed",
-      "epic-file-tree-row-open-finder",
-    ]);
+    // The whole menu in order: Finder closes the open group, and the two Copy
+    // rows stay below it.
     expect(
-      screen.getByTestId("epic-file-tree-row-open-finder").textContent,
-    ).toBe("Finder");
+      screen.getAllByRole("menuitem").map((item) => item.textContent),
+    ).toEqual([
+      "VS Code",
+      "Cursor",
+      "Windsurf",
+      "Zed",
+      "Finder",
+      "Copy Path",
+      "Copy Relative Path",
+    ]);
   });
 
   it("labels Finder identically for a directory row", () => {
@@ -225,9 +223,7 @@ describe("<FileTreeRowContextMenu />", () => {
 
     fireEvent.contextMenu(screen.getByTestId("row-dir-trailing"));
 
-    expect(
-      screen.getByTestId("epic-file-tree-row-open-finder").textContent,
-    ).toBe("Finder");
+    screen.getByRole("menuitem", { name: "Finder" });
   });
 
   // One select per render: a second launch inside the same menu instance is
@@ -236,7 +232,7 @@ describe("<FileTreeRowContextMenu />", () => {
     renderTree("host-1");
 
     fireEvent.contextMenu(screen.getByTestId("row-file"));
-    fireEvent.click(screen.getByTestId("epic-file-tree-row-open-finder"));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Finder" }));
 
     expect(menuState.mutate).toHaveBeenLastCalledWith({
       editorId: "finder",
@@ -248,7 +244,7 @@ describe("<FileTreeRowContextMenu />", () => {
     renderTree("host-1");
 
     fireEvent.contextMenu(screen.getByTestId("row-dir-trailing"));
-    fireEvent.click(screen.getByTestId("epic-file-tree-row-open-finder"));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Finder" }));
 
     expect(menuState.mutate).toHaveBeenLastCalledWith({
       editorId: "finder",
@@ -260,14 +256,14 @@ describe("<FileTreeRowContextMenu />", () => {
     renderTree("host-1");
 
     fireEvent.contextMenu(screen.getByTestId("row-dir-trailing"));
-    fireEvent.click(screen.getByTestId("epic-file-tree-row-copy-path"));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Copy Path" }));
 
     expect(copyCalls).toEqual(["/repo/src/lib"]);
     expect(toast.success).toHaveBeenLastCalledWith("Copied path");
 
     fireEvent.contextMenu(screen.getByTestId("row-dir-trailing"));
     fireEvent.click(
-      screen.getByTestId("epic-file-tree-row-copy-relative-path"),
+      screen.getByRole("menuitem", { name: "Copy Relative Path" }),
     );
 
     expect(copyCalls).toEqual(["/repo/src/lib", "src/lib"]);
@@ -280,7 +276,7 @@ describe("<FileTreeRowContextMenu />", () => {
     const wasNotPrevented = fireEvent.contextMenu(screen.getByTestId("tree"));
 
     expect(wasNotPrevented).toBe(false);
-    expect(screen.queryByTestId("epic-file-tree-row-menu")).toBeNull();
+    expect(screen.queryByRole("menu")).toBeNull();
   });
 
   it("hides the Finder item when the gate is closed, keeping both Copy items", () => {
@@ -289,9 +285,9 @@ describe("<FileTreeRowContextMenu />", () => {
 
     fireEvent.contextMenu(screen.getByTestId("row-file"));
 
-    expect(screen.queryByTestId("epic-file-tree-row-open-finder")).toBeNull();
-    screen.getByTestId("epic-file-tree-row-copy-path");
-    screen.getByTestId("epic-file-tree-row-copy-relative-path");
+    expect(screen.queryByRole("menuitem", { name: "Finder" })).toBeNull();
+    screen.getByRole("menuitem", { name: "Copy Path" });
+    screen.getByRole("menuitem", { name: "Copy Relative Path" });
   });
 
   it("renders no editor items when the host entry is not local, while both Copy items still render", () => {
@@ -300,10 +296,10 @@ describe("<FileTreeRowContextMenu />", () => {
 
     fireEvent.contextMenu(screen.getByTestId("row-file"));
 
-    expect(screen.queryByTestId("epic-file-tree-row-open-vscode")).toBeNull();
-    expect(screen.queryByTestId("epic-file-tree-row-open-cursor")).toBeNull();
-    screen.getByTestId("epic-file-tree-row-copy-path");
-    screen.getByTestId("epic-file-tree-row-copy-relative-path");
+    expect(screen.queryByRole("menuitem", { name: "VS Code" })).toBeNull();
+    expect(screen.queryByRole("menuitem", { name: "Cursor" })).toBeNull();
+    screen.getByRole("menuitem", { name: "Copy Path" });
+    screen.getByRole("menuitem", { name: "Copy Relative Path" });
   });
 
   // Radix arms a 700ms long-press timer on a touch/pen pointerdown and opens
@@ -331,9 +327,7 @@ describe("<FileTreeRowContextMenu />", () => {
 
       // `toContain`, not `toBe`: the spinner glyph shares the item's
       // textContent. A label swapped to "Opening…" still fails this.
-      expect(
-        screen.getByTestId("epic-file-tree-row-open-finder").textContent,
-      ).toContain("Finder");
+      screen.getByRole("menuitem", { name: "Finder" });
     });
 
     it("labels a directory row correctly through the same path", () => {
@@ -346,9 +340,7 @@ describe("<FileTreeRowContextMenu />", () => {
         vi.advanceTimersByTime(700);
       });
 
-      expect(
-        screen.getByTestId("epic-file-tree-row-open-finder").textContent,
-      ).toBe("Finder");
+      screen.getByRole("menuitem", { name: "Finder" });
     });
 
     it("opens nothing when the long-press hits no row", () => {
@@ -362,7 +354,7 @@ describe("<FileTreeRowContextMenu />", () => {
       });
 
       expect(notPrevented).toBe(false);
-      expect(screen.queryByTestId("epic-file-tree-row-menu")).toBeNull();
+      expect(screen.queryByRole("menu")).toBeNull();
     });
 
     it("ignores a mouse pointerdown, leaving that path to contextMenu", () => {
@@ -375,7 +367,7 @@ describe("<FileTreeRowContextMenu />", () => {
         vi.advanceTimersByTime(700);
       });
 
-      expect(screen.queryByTestId("epic-file-tree-row-menu")).toBeNull();
+      expect(screen.queryByRole("menu")).toBeNull();
     });
   });
 
@@ -391,22 +383,22 @@ describe("<FileTreeRowContextMenu />", () => {
 
       expect(
         screen
-          .getByTestId("epic-file-tree-row-open-vscode")
+          .getByRole("menuitem", { name: "VS Code" })
           .getAttribute("data-disabled"),
       ).not.toBeNull();
       expect(
         screen
-          .getByTestId("epic-file-tree-row-open-finder")
+          .getByRole("menuitem", { name: "Finder" })
           .getAttribute("data-disabled"),
       ).not.toBeNull();
       expect(
         screen
-          .getByTestId("epic-file-tree-row-copy-path")
+          .getByRole("menuitem", { name: "Copy Path" })
           .getAttribute("data-disabled"),
       ).toBeNull();
       expect(
         screen
-          .getByTestId("epic-file-tree-row-copy-relative-path")
+          .getByRole("menuitem", { name: "Copy Relative Path" })
           .getAttribute("data-disabled"),
       ).toBeNull();
     });
@@ -422,14 +414,10 @@ describe("<FileTreeRowContextMenu />", () => {
       // the only channel that moves.
       screen.getByTestId("epic-file-tree-row-open-vscode-spinner");
       screen.getByTestId("epic-file-tree-row-open-finder-spinner");
-      expect(
-        screen.getByTestId("epic-file-tree-row-open-vscode").textContent,
-      ).toContain("VS Code");
+      screen.getByRole("menuitem", { name: "VS Code" });
       // `toContain`, not `toBe`: the spinner glyph shares the item's
       // textContent. A label swapped to "Opening…" still fails this.
-      expect(
-        screen.getByTestId("epic-file-tree-row-open-finder").textContent,
-      ).toContain("Finder");
+      screen.getByRole("menuitem", { name: "Finder" });
 
       // The Copy items neither disable nor spin - they touch no host.
       expect(
@@ -455,7 +443,7 @@ describe("<FileTreeRowContextMenu />", () => {
       renderTree("host-1");
 
       fireEvent.contextMenu(screen.getByTestId("row-file"));
-      fireEvent.click(screen.getByTestId("epic-file-tree-row-open-finder"));
+      fireEvent.click(screen.getByRole("menuitem", { name: "Finder" }));
 
       expect(menuState.mutate).not.toHaveBeenCalled();
     });
@@ -467,11 +455,11 @@ describe("<FileTreeRowContextMenu />", () => {
       renderTree("host-1");
 
       fireEvent.contextMenu(screen.getByTestId("row-file"));
-      fireEvent.click(screen.getByTestId("epic-file-tree-row-open-finder"));
+      fireEvent.click(screen.getByRole("menuitem", { name: "Finder" }));
       expect(menuState.mutate).toHaveBeenCalledTimes(1);
 
       fireEvent.contextMenu(screen.getByTestId("row-file"));
-      fireEvent.click(screen.getByTestId("epic-file-tree-row-open-finder"));
+      fireEvent.click(screen.getByRole("menuitem", { name: "Finder" }));
 
       expect(menuState.mutate).toHaveBeenCalledTimes(1);
     });
@@ -492,6 +480,6 @@ describe("<FileTreeRowContextMenu />", () => {
 
     fireEvent.contextMenu(screen.getByTestId("row-file"));
 
-    screen.getByTestId("epic-file-tree-row-menu");
+    screen.getByRole("menu");
   });
 });

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-file-tree.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-file-tree.tsx
@@ -800,7 +800,6 @@ function FileTreeBodyForResolvedHost(
       <FileTreeRowContextMenu
         hostId={hostId}
         workspacePath={props.workspacePath}
-        fileNameByPath={nameByTreePath}
       >
         <div
           {...bridge.wrapperProps}

--- a/clients/gui-app/src/components/epic-canvas/sidebar/file-tree-row-context-menu.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/file-tree-row-context-menu.tsx
@@ -23,7 +23,7 @@ import {
   type PointerEvent,
   type ReactElement,
 } from "react";
-import { Copy, FolderOpen } from "lucide-react";
+import { Copy } from "lucide-react";
 import { toast } from "sonner";
 import type { OpenPathsTarget } from "@traycer/protocol/host/editor/unary-schemas";
 import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
@@ -39,8 +39,8 @@ import {
   type PierreActivationEvent,
 } from "@/components/epic-canvas/pierre-tree-adapter";
 import {
-  EDITOR_ICONS,
-  resolveEditorState,
+  OPEN_TARGET_ICONS,
+  resolveOpenMenuState,
 } from "@/lib/editor/editor-menu-catalog";
 import { useEditorAvailability } from "@/hooks/editor/use-editor-availability-query";
 import { useEditorOpenFeedback } from "@/hooks/editor/use-editor-open-feedback";
@@ -59,14 +59,11 @@ const COPY_FEEDBACK_RESET_MS = 2000;
 interface FileTreeContextMenuRow {
   /** Workspace-relative tree path; directory rows keep their trailing `/`. */
   readonly treePath: string;
-  readonly isDirectory: boolean;
 }
 
 export interface FileTreeRowContextMenuProps {
   readonly hostId: string | null;
   readonly workspacePath: string;
-  /** Openable file rows; a tree path absent here is a directory row. */
-  readonly fileNameByPath: ReadonlyMap<string, string>;
   /**
    * The tree container, which becomes the menu's trigger. Exactly ONE element:
    * `ContextMenuTrigger asChild` merges its props onto this node through
@@ -85,7 +82,6 @@ function reportCopyFailure(): void {
 }
 
 export function FileTreeRowContextMenu(props: FileTreeRowContextMenuProps) {
-  const { fileNameByPath } = props;
   const [row, setRow] = useState<FileTreeContextMenuRow | null>(null);
 
   const captureRow = useCallback(
@@ -96,15 +92,9 @@ export function FileTreeRowContextMenu(props: FileTreeRowContextMenuProps) {
         setRow(null);
         return;
       }
-      // Two independent tells for a directory: the live listings mark folders
-      // with a trailing separator, and every source omits them from the
-      // openable file map. Either is sufficient.
-      setRow({
-        treePath,
-        isDirectory: treePath.endsWith("/") || !fileNameByPath.has(treePath),
-      });
+      setRow({ treePath });
     },
-    [fileNameByPath],
+    [],
   );
 
   const handleContextMenu = useCallback(
@@ -180,20 +170,21 @@ function FileTreeRowContextMenuContent(
   });
 
   // An editor launches through a URL-scheme handler registered on the host's
-  // own machine, so the editor items are local-host-only for the same reason
-  // the workspace header's are (see `OpenInEditorButton`).
+  // own machine, so the open items are local-host-only for the same reason the
+  // workspace header's are (see `OpenInEditorButton`).
   const hostIsLocal =
     hostEntry !== null &&
     (hostEntry.kind === "local" || hostEntry.kind === "mock");
-  // A context menu has no primary half, so no default editor is consulted -
-  // every editor this host will accept and this machine has installed is
-  // simply listed.
-  const { availableEditors } = resolveEditorState(
-    offerableEditors,
-    availability.data ?? null,
-    null,
-  );
-  const editorEntries = hostIsLocal ? availableEditors : [];
+  // A row menu has no primary half and does not record a default, so no stored
+  // target is consulted - it simply lists what this host and machine can open
+  // the row with, Finder last.
+  const { targets } = resolveOpenMenuState({
+    catalog: offerableEditors,
+    availableEditorIds: availability.data ?? null,
+    finderAvailable,
+    defaultTarget: null,
+  });
+  const openTargets = hostIsLocal ? targets : [];
 
   const absolutePath = resolveAbsolutePath(workspacePath, row.treePath);
   // The tree path already IS the workspace-relative path; a directory row only
@@ -219,29 +210,29 @@ function FileTreeRowContextMenuContent(
 
   return (
     <ContextMenuContent data-testid="epic-file-tree-row-menu">
-      {editorEntries.map((editor) => {
-        const Icon = EDITOR_ICONS[editor.id];
+      {openTargets.map((target) => {
+        const Icon = OPEN_TARGET_ICONS[target.id];
         return (
           <ContextMenuItem
-            key={editor.id}
-            data-testid={`epic-file-tree-row-open-${editor.id}`}
+            key={target.id}
+            data-testid={`epic-file-tree-row-open-${target.id}`}
             disabled={opening}
-            onSelect={() => openPath(editor.id)}
+            onSelect={() => openPath(target.id)}
           >
             {opening ? (
               <AgentSpinningDots
                 className="size-3.5"
-                testId={`epic-file-tree-row-open-${editor.id}-spinner`}
+                testId={`epic-file-tree-row-open-${target.id}-spinner`}
                 variant={undefined}
               />
             ) : (
               <Icon className="size-3.5" aria-hidden />
             )}
-            <span>{editor.label}</span>
+            <span>{target.label}</span>
           </ContextMenuItem>
         );
       })}
-      {editorEntries.length > 0 ? <ContextMenuSeparator /> : null}
+      {openTargets.length > 0 ? <ContextMenuSeparator /> : null}
       <ContextMenuItem
         data-testid="epic-file-tree-row-copy-path"
         onSelect={() => copyAbsolutePath(absolutePath)}
@@ -256,31 +247,6 @@ function FileTreeRowContextMenuContent(
         <Copy className="size-3.5" aria-hidden />
         <span>Copy Relative Path</span>
       </ContextMenuItem>
-      {finderAvailable ? (
-        <>
-          <ContextMenuSeparator />
-          <ContextMenuItem
-            data-testid="epic-file-tree-row-finder"
-            disabled={opening}
-            onSelect={() => openPath("finder")}
-          >
-            {opening ? (
-              <AgentSpinningDots
-                className="size-3.5"
-                testId="epic-file-tree-row-finder-spinner"
-                variant={undefined}
-              />
-            ) : (
-              <FolderOpen className="size-3.5" aria-hidden />
-            )}
-            {/* A folder IS the Finder window; a file is revealed selected
-                inside its parent, which is a different gesture and says so. */}
-            <span>
-              {row.isDirectory ? "Open in Finder" : "Reveal in Finder"}
-            </span>
-          </ContextMenuItem>
-        </>
-      ) : null}
     </ContextMenuContent>
   );
 }

--- a/clients/gui-app/src/components/icons/editor-icons.tsx
+++ b/clients/gui-app/src/components/icons/editor-icons.tsx
@@ -180,6 +180,70 @@ export function VSCodiumIcon({ className, ...props }: EditorIconProps) {
   );
 }
 
+/**
+ * The macOS Finder face: one rounded square split down the middle, the left
+ * half blue and the right half near-white, with the smile crossing both. The
+ * smile is stroked twice under per-half clips because a single colour is
+ * invisible on one side or the other; ids are `useId`-scoped so several
+ * instances cannot collide on them. Kept to flat shapes so the split still
+ * reads at 14px.
+ */
+export function FinderIcon({ className, ...props }: EditorIconProps) {
+  const id = useId();
+  const squareId = `${id}-finder-a`;
+  const leftId = `${id}-finder-b`;
+  const rightId = `${id}-finder-c`;
+  return (
+    <svg {...props} viewBox="0 0 24 24" className={cn(className)}>
+      <defs>
+        <clipPath id={squareId}>
+          <rect x="1" y="1" width="22" height="22" rx="5" />
+        </clipPath>
+        <clipPath id={leftId}>
+          <rect x="1" y="1" width="11" height="22" />
+        </clipPath>
+        <clipPath id={rightId}>
+          <rect x="12" y="1" width="11" height="22" />
+        </clipPath>
+      </defs>
+      <g clipPath={`url(#${squareId})`}>
+        <rect x="1" y="1" width="11" height="22" fill="#2E8BF2" />
+        <rect x="12" y="1" width="11" height="22" fill="#EDF4FE" />
+        <ellipse cx="7.4" cy="9" rx="1.05" ry="1.7" fill="#FFFFFF" />
+        <ellipse cx="16.6" cy="9" rx="1.05" ry="1.7" fill="#31415C" />
+        <g clipPath={`url(#${leftId})`}>
+          <path
+            d="M6 13.7c1.55 2.7 3.65 4.05 6 4.05s4.45-1.35 6-4.05"
+            fill="none"
+            stroke="#FFFFFF"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+          />
+        </g>
+        <g clipPath={`url(#${rightId})`}>
+          <path
+            d="M6 13.7c1.55 2.7 3.65 4.05 6 4.05s4.45-1.35 6-4.05"
+            fill="none"
+            stroke="#31415C"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+          />
+        </g>
+      </g>
+      <rect
+        x="1"
+        y="1"
+        width="22"
+        height="22"
+        rx="5"
+        fill="none"
+        stroke="#31415C"
+        strokeOpacity="0.22"
+      />
+    </svg>
+  );
+}
+
 export function ZedIcon({ className, ...props }: EditorIconProps) {
   return (
     <svg

--- a/clients/gui-app/src/components/worktree/__tests__/open-in-editor-button.test.tsx
+++ b/clients/gui-app/src/components/worktree/__tests__/open-in-editor-button.test.tsx
@@ -261,7 +261,7 @@ describe("<OpenInEditorButton />", () => {
     expect(screen.queryByTestId("workspace-open-in-editor")).toBeNull();
   });
 
-  it("offers Open in Finder and dispatches the finder target when the gate is open", () => {
+  it("offers Finder and dispatches the finder target when the gate is open", () => {
     editorState.finderAvailable = true;
     render(
       <OpenInEditorButton
@@ -316,7 +316,7 @@ describe("<OpenInEditorButton />", () => {
     ).toContain("VS Code");
     expect(
       screen.getByTestId("workspace-open-in-editor-finder").textContent,
-    ).toContain("Open in Finder");
+    ).toContain("Finder");
     // Copy path reaches no host, so it neither disables nor spins.
     expect(
       screen.queryByTestId("workspace-open-in-editor-copy-path-spinner"),
@@ -345,7 +345,7 @@ describe("<OpenInEditorButton />", () => {
     ).toBeNull();
   });
 
-  it("hides Open in Finder when the gate is closed, without hiding the rest of the menu", () => {
+  it("hides Finder when the gate is closed, without hiding the rest of the menu", () => {
     editorState.finderAvailable = false;
     render(
       <OpenInEditorButton
@@ -362,6 +362,89 @@ describe("<OpenInEditorButton />", () => {
     expect(screen.queryByTestId("workspace-open-in-editor-finder")).toBeNull();
     screen.getByTestId("workspace-open-in-editor-vscode");
     screen.getByTestId("workspace-open-in-editor-copy-path");
+  });
+
+  it("lists Finder last in the editor group, after every editor", () => {
+    editorState.finderAvailable = true;
+    render(
+      <OpenInEditorButton
+        openTarget={{ workspacePath: "/repo", hostId: "host-1" }}
+        hostClient={null}
+      />,
+    );
+
+    fireEvent.pointerDown(
+      screen.getByTestId("workspace-open-in-editor-chevron"),
+      { button: 0 },
+    );
+
+    const rowIds = Array.from(
+      screen
+        .getByTestId("workspace-open-in-editor-menu")
+        .querySelectorAll("[data-testid^='workspace-open-in-editor-']"),
+    )
+      .map((node) => node.getAttribute("data-testid"))
+      .filter((id) => id !== "workspace-open-in-editor-copy-path");
+    expect(rowIds.at(-1)).toBe("workspace-open-in-editor-finder");
+    expect(
+      screen.getByTestId("workspace-open-in-editor-finder").textContent,
+    ).toBe("Finder");
+  });
+
+  it("records Finder as the default when it is picked, like any editor row", () => {
+    editorState.finderAvailable = true;
+    render(
+      <OpenInEditorButton
+        openTarget={{ workspacePath: "/repo", hostId: "host-1" }}
+        hostClient={null}
+      />,
+    );
+
+    fireEvent.pointerDown(
+      screen.getByTestId("workspace-open-in-editor-chevron"),
+      { button: 0 },
+    );
+    fireEvent.click(screen.getByTestId("workspace-open-in-editor-finder"));
+
+    expect(useSettingsStore.getState().defaultEditor).toBe("finder");
+  });
+
+  it("opens the workspace in Finder from the primary button once Finder is the default", () => {
+    editorState.finderAvailable = true;
+    useSettingsStore.setState({ defaultEditor: "finder" });
+    render(
+      <OpenInEditorButton
+        openTarget={{ workspacePath: "/repo", hostId: "host-1" }}
+        hostClient={null}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("workspace-open-in-editor-primary"));
+
+    expect(editorState.mutate).toHaveBeenCalledWith({
+      editorId: "finder",
+      paths: ["/repo"],
+    });
+  });
+
+  it("falls the primary button back off a stored Finder default when the gate is closed", () => {
+    // A Mac-only target stored while it was offerable, read on a host that
+    // cannot serve it - the same fallback an unofferable editor id takes.
+    editorState.finderAvailable = false;
+    useSettingsStore.setState({ defaultEditor: "finder" });
+    render(
+      <OpenInEditorButton
+        openTarget={{ workspacePath: "/repo", hostId: "host-1" }}
+        hostClient={null}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("workspace-open-in-editor-primary"));
+
+    expect(editorState.mutate).toHaveBeenCalledWith({
+      editorId: "vscode",
+      paths: ["/repo"],
+    });
   });
 
   it("gates the vscodium menu item on the offer list, not merely on install detection", () => {

--- a/clients/gui-app/src/components/worktree/__tests__/open-in-editor-button.test.tsx
+++ b/clients/gui-app/src/components/worktree/__tests__/open-in-editor-button.test.tsx
@@ -271,11 +271,11 @@ describe("<OpenInEditorButton />", () => {
     );
 
     fireEvent.pointerDown(
-      screen.getByTestId("workspace-open-in-editor-chevron"),
+      screen.getByRole("button", { name: "Choose editor" }),
       { button: 0 },
     );
 
-    fireEvent.click(screen.getByTestId("workspace-open-in-editor-finder"));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Finder" }));
 
     expect(editorState.mutate).toHaveBeenCalledWith({
       editorId: "finder",
@@ -355,13 +355,13 @@ describe("<OpenInEditorButton />", () => {
     );
 
     fireEvent.pointerDown(
-      screen.getByTestId("workspace-open-in-editor-chevron"),
+      screen.getByRole("button", { name: "Choose editor" }),
       { button: 0 },
     );
 
-    expect(screen.queryByTestId("workspace-open-in-editor-finder")).toBeNull();
-    screen.getByTestId("workspace-open-in-editor-vscode");
-    screen.getByTestId("workspace-open-in-editor-copy-path");
+    expect(screen.queryByRole("menuitem", { name: "Finder" })).toBeNull();
+    screen.getByRole("menuitem", { name: "VS Code" });
+    screen.getByRole("menuitem", { name: "Copy path" });
   });
 
   it("lists Finder last in the editor group, after every editor", () => {
@@ -374,21 +374,15 @@ describe("<OpenInEditorButton />", () => {
     );
 
     fireEvent.pointerDown(
-      screen.getByTestId("workspace-open-in-editor-chevron"),
+      screen.getByRole("button", { name: "Choose editor" }),
       { button: 0 },
     );
 
-    const rowIds = Array.from(
-      screen
-        .getByTestId("workspace-open-in-editor-menu")
-        .querySelectorAll("[data-testid^='workspace-open-in-editor-']"),
-    )
-      .map((node) => node.getAttribute("data-testid"))
-      .filter((id) => id !== "workspace-open-in-editor-copy-path");
-    expect(rowIds.at(-1)).toBe("workspace-open-in-editor-finder");
+    // The whole menu in order: Finder closes the open group, and Copy path
+    // stays below it.
     expect(
-      screen.getByTestId("workspace-open-in-editor-finder").textContent,
-    ).toBe("Finder");
+      screen.getAllByRole("menuitem").map((item) => item.textContent),
+    ).toEqual(["VS Code", "Cursor", "Windsurf", "Zed", "Finder", "Copy path"]);
   });
 
   it("records Finder as the default when it is picked, like any editor row", () => {
@@ -401,10 +395,10 @@ describe("<OpenInEditorButton />", () => {
     );
 
     fireEvent.pointerDown(
-      screen.getByTestId("workspace-open-in-editor-chevron"),
+      screen.getByRole("button", { name: "Choose editor" }),
       { button: 0 },
     );
-    fireEvent.click(screen.getByTestId("workspace-open-in-editor-finder"));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Finder" }));
 
     expect(useSettingsStore.getState().defaultEditor).toBe("finder");
   });
@@ -419,7 +413,9 @@ describe("<OpenInEditorButton />", () => {
       />,
     );
 
-    fireEvent.click(screen.getByTestId("workspace-open-in-editor-primary"));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open workspace in editor" }),
+    );
 
     expect(editorState.mutate).toHaveBeenCalledWith({
       editorId: "finder",
@@ -439,7 +435,9 @@ describe("<OpenInEditorButton />", () => {
       />,
     );
 
-    fireEvent.click(screen.getByTestId("workspace-open-in-editor-primary"));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open workspace in editor" }),
+    );
 
     expect(editorState.mutate).toHaveBeenCalledWith({
       editorId: "vscode",
@@ -526,7 +524,9 @@ describe("<OpenInEditorButton />", () => {
       />,
     );
 
-    fireEvent.click(screen.getByTestId("workspace-open-in-editor-primary"));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open workspace in editor" }),
+    );
 
     expect(editorState.mutate).toHaveBeenCalledWith({
       editorId: "vscode",

--- a/clients/gui-app/src/components/worktree/open-in-editor-button.tsx
+++ b/clients/gui-app/src/components/worktree/open-in-editor-button.tsx
@@ -1,7 +1,6 @@
 import type { ReactNode } from "react";
-import { ChevronDown, Code, Copy, FolderOpen } from "lucide-react";
+import { ChevronDown, Code, Copy } from "lucide-react";
 import { toast } from "sonner";
-import type { EditorEntry, EditorId } from "@traycer/protocol/host";
 import type { OpenPathsTarget } from "@traycer/protocol/host/editor/unary-schemas";
 import type { HostClient } from "@traycer-clients/shared/host-client/host-client";
 import type { HostRpcRegistry } from "@traycer/protocol/host/index";
@@ -25,9 +24,11 @@ import { useRunnerHost } from "@/providers/use-runner-host";
 import { useSettingsStore } from "@/stores/settings/settings-store";
 import { reportableErrorToast } from "@/lib/reportable-error-toast";
 import {
-  EDITOR_ICONS,
-  resolveEditorState,
+  OPEN_TARGET_ICONS,
+  resolveOpenMenuState,
+  type DefaultOpenTarget,
   type EditorIconComponent,
+  type OpenTargetEntry,
 } from "@/lib/editor/editor-menu-catalog";
 
 export interface OpenInEditorButtonProps {
@@ -96,16 +97,21 @@ export function OpenInEditorButton(props: OpenInEditorButtonProps) {
   // than flashing an empty list. The primary half opens the user's default
   // editor when available, otherwise the first available one.
   const availableEditorIds = availability.data ?? null;
-  const { availableEditors, noEditorsAvailable, primaryEditorId } =
-    resolveEditorState(offerableEditors, availableEditorIds, defaultEditor);
+  const { targets, noTargetsAvailable, primaryTargetId } = resolveOpenMenuState(
+    {
+      catalog: offerableEditors,
+      availableEditorIds,
+      finderAvailable,
+      defaultTarget: defaultEditor,
+    },
+  );
   const PrimaryIcon: EditorIconComponent | null =
-    primaryEditorId !== null ? EDITOR_ICONS[primaryEditorId] : null;
+    primaryTargetId !== null ? OPEN_TARGET_ICONS[primaryTargetId] : null;
   const PrimaryButtonIcon = PrimaryIcon ?? Code;
   const openingEditor = mutation.isPending || openFeedbackActive;
 
-  // Takes the wire target rather than `EditorId`: `"finder"` shares the whole
-  // pressed-feedback / disable cycle with the editor items and differs only in
-  // the literal on the wire. Choosing a DEFAULT stays editor-only below.
+  // Takes the wire target: Finder shares the whole pressed-feedback / disable
+  // cycle with the editors and differs only in the literal it sends.
   const openInEditor = (editorId: OpenPathsTarget) => {
     if (openingEditor || openTarget === null) return;
     triggerOpenFeedback();
@@ -113,22 +119,20 @@ export function OpenInEditorButton(props: OpenInEditorButtonProps) {
   };
 
   const handleOpenPrimaryEditor = () => {
-    if (primaryEditorId === null) return;
-    openInEditor(primaryEditorId);
+    if (primaryTargetId === null) return;
+    openInEditor(primaryTargetId);
   };
 
-  const handleSelectEditor = (editorId: EditorId) => {
-    setDefaultEditor(editorId);
-    openInEditor(editorId);
+  // Picking a row from this menu also makes it the default, Finder included -
+  // the primary half then opens the workspace there.
+  const handleSelectTarget = (targetId: DefaultOpenTarget) => {
+    setDefaultEditor(targetId);
+    openInEditor(targetId);
   };
 
   const handleCopyPath = () => {
     if (openTarget === null) return;
     copy(openTarget.workspacePath);
-  };
-
-  const handleOpenInFinder = () => {
-    openInEditor("finder");
   };
 
   return (
@@ -140,7 +144,7 @@ export function OpenInEditorButton(props: OpenInEditorButtonProps) {
         type="button"
         variant="ghost"
         size="icon"
-        disabled={openingEditor || noEditorsAvailable || !hostMatches}
+        disabled={openingEditor || noTargetsAvailable || !hostMatches}
         aria-label="Open workspace in editor"
         data-testid="workspace-open-in-editor-primary"
         className="size-7 rounded-r-none"
@@ -171,12 +175,10 @@ export function OpenInEditorButton(props: OpenInEditorButtonProps) {
           data-testid="workspace-open-in-editor-menu"
         >
           <EditorChooserMenuItems
-            availableEditors={availableEditors}
+            targets={targets}
             openingEditor={openingEditor}
-            finderAvailable={finderAvailable}
-            onSelectEditor={handleSelectEditor}
+            onSelectTarget={handleSelectTarget}
             onCopyPath={handleCopyPath}
-            onOpenInFinder={handleOpenInFinder}
           />
         </DropdownMenuContent>
       </DropdownMenu>
@@ -206,44 +208,42 @@ function PrimaryButtonGlyph(props: {
 }
 
 interface EditorChooserMenuItemsProps {
-  readonly availableEditors: ReadonlyArray<EditorEntry>;
+  readonly targets: ReadonlyArray<OpenTargetEntry>;
   readonly openingEditor: boolean;
-  readonly finderAvailable: boolean;
-  readonly onSelectEditor: (editorId: EditorId) => void;
+  readonly onSelectTarget: (targetId: DefaultOpenTarget) => void;
   readonly onCopyPath: () => void;
-  readonly onOpenInFinder: () => void;
 }
 
 // The launching items swap their leading icon for the spinner and keep their
 // label, so a disabled item reads as work in progress. Copy path is untouched:
 // it reaches no host and never disables.
 function EditorChooserMenuItems(props: EditorChooserMenuItemsProps) {
-  const { availableEditors, openingEditor } = props;
+  const { targets, openingEditor } = props;
   return (
     <>
-      {availableEditors.map((editor) => {
-        const Icon = EDITOR_ICONS[editor.id];
+      {targets.map((target) => {
+        const Icon = OPEN_TARGET_ICONS[target.id];
         return (
           <DropdownMenuItem
-            key={editor.id}
-            data-testid={`workspace-open-in-editor-${editor.id}`}
+            key={target.id}
+            data-testid={`workspace-open-in-editor-${target.id}`}
             disabled={openingEditor}
-            onSelect={() => props.onSelectEditor(editor.id)}
+            onSelect={() => props.onSelectTarget(target.id)}
           >
             {openingEditor ? (
               <AgentSpinningDots
                 className="size-3.5"
-                testId={`workspace-open-in-editor-${editor.id}-spinner`}
+                testId={`workspace-open-in-editor-${target.id}-spinner`}
                 variant={undefined}
               />
             ) : (
               <Icon className="size-3.5" aria-hidden />
             )}
-            <span>{editor.label}</span>
+            <span>{target.label}</span>
           </DropdownMenuItem>
         );
       })}
-      {availableEditors.length > 0 ? <DropdownMenuSeparator /> : null}
+      {targets.length > 0 ? <DropdownMenuSeparator /> : null}
       <DropdownMenuItem
         data-testid="workspace-open-in-editor-copy-path"
         onSelect={props.onCopyPath}
@@ -251,24 +251,6 @@ function EditorChooserMenuItems(props: EditorChooserMenuItemsProps) {
         <Copy className="size-3.5" aria-hidden />
         <span>Copy path</span>
       </DropdownMenuItem>
-      {props.finderAvailable ? (
-        <DropdownMenuItem
-          data-testid="workspace-open-in-editor-finder"
-          disabled={openingEditor}
-          onSelect={props.onOpenInFinder}
-        >
-          {openingEditor ? (
-            <AgentSpinningDots
-              className="size-3.5"
-              testId="workspace-open-in-editor-finder-spinner"
-              variant={undefined}
-            />
-          ) : (
-            <FolderOpen className="size-3.5" aria-hidden />
-          )}
-          <span>Open in Finder</span>
-        </DropdownMenuItem>
-      ) : null}
     </>
   );
 }

--- a/clients/gui-app/src/hooks/editor/__tests__/use-effective-default-editor.test.tsx
+++ b/clients/gui-app/src/hooks/editor/__tests__/use-effective-default-editor.test.tsx
@@ -1,38 +1,84 @@
 /**
- * `useEffectiveDefaultEditor` resolves the stored, app-wide default editor
- * against ONE host's offerable set, falling back to the first offerable
- * editor when the stored id cannot be told to that host. This suite drives
- * the REAL hook (and the real `useOfferableEditors` / settings store it
- * composes) and mocks only the host handshake
- * (`useHostMethodSchemaVersion`) - the hook's actual input. The stored
- * default is set through the real Zustand store rather than mocked, so the
- * store's own read/write wiring stays exercised too.
+ * `useEffectiveDefaultEditor` resolves the stored, app-wide default against ONE
+ * host's offerable targets, falling back to the first offerable one when the
+ * stored id cannot be told to that host. Finder obeys the same rule as an
+ * editor: it is a legal default only where its own gate holds.
+ *
+ * This suite drives the REAL hook (and the real `useOfferableEditors` /
+ * `useFinderOpenAvailability` / settings store it composes), mocking only the
+ * hook's inputs - the host handshake, the host directory entry, and the
+ * platform/product signals. The stored default is set through the real Zustand
+ * store rather than mocked, so its read/write wiring stays exercised too.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { renderHook } from "@testing-library/react";
 import type { SchemaVersion } from "@traycer/protocol/framework/index";
+import type { HostDirectoryEntry } from "@traycer-clients/shared/host-client/host-directory";
 import { useSettingsStore } from "@/stores/settings/settings-store";
 
-const state = vi.hoisted((): { version: SchemaVersion | null } => ({
-  version: { major: 1, minor: 1 },
-}));
+const state = vi.hoisted(
+  (): {
+    version: SchemaVersion | null;
+    hostEntry: HostDirectoryEntry | null;
+    isMac: boolean;
+    isMobileApp: boolean;
+  } => ({
+    version: { major: 1, minor: 1 },
+    hostEntry: null,
+    isMac: true,
+    isMobileApp: false,
+  }),
+);
 
 vi.mock("@/hooks/host/use-host-supports-method", () => ({
   useHostMethodSchemaVersion: () => state.version,
 }));
 
+vi.mock("@/hooks/host/use-host-directory-entry", () => ({
+  useHostDirectoryEntry: () => state.hostEntry,
+}));
+
+vi.mock("@/lib/keybindings/platform", () => ({
+  isMac: () => state.isMac,
+}));
+
+vi.mock("@/lib/mobile-app", () => ({
+  isMobileApp: () => state.isMobileApp,
+}));
+
 import { useEffectiveDefaultEditor } from "../use-effective-default-editor";
+
+function hostEntry(kind: HostDirectoryEntry["kind"]): HostDirectoryEntry {
+  return {
+    hostId: "host-A",
+    label: "Host A",
+    kind,
+    websocketUrl: "ws://127.0.0.1:1234",
+    version: "1.1.0",
+    transportDialability: "dialable",
+  };
+}
 
 function resetSettingsStore(): void {
   useSettingsStore.setState({ defaultEditor: "vscode" });
 }
 
+/** Every condition the Finder gate needs, so one flip isolates one cause. */
+function armFinderGate(): void {
+  state.version = { major: 1, minor: 1 };
+  state.hostEntry = hostEntry("local");
+  state.isMac = true;
+  state.isMobileApp = false;
+}
+
 describe("useEffectiveDefaultEditor", () => {
-  beforeEach(resetSettingsStore);
+  beforeEach(() => {
+    armFinderGate();
+    resetSettingsStore();
+  });
   afterEach(resetSettingsStore);
 
   it("returns the stored vscodium default on a 1.1 host", () => {
-    state.version = { major: 1, minor: 1 };
     useSettingsStore.setState({ defaultEditor: "vscodium" });
     const { result } = renderHook(() => useEffectiveDefaultEditor("host-A"));
     expect(result.current).toBe("vscodium");
@@ -40,8 +86,7 @@ describe("useEffectiveDefaultEditor", () => {
 
   it("falls back off a stored vscodium default on a 1.0 host", () => {
     // A 1.0 host's editor.openPaths request schema hard-rejects the
-    // "vscodium" literal at parse - emitting the stored default verbatim
-    // here is exactly the regression this hook exists to prevent.
+    // "vscodium" literal at parse.
     state.version = { major: 1, minor: 0 };
     useSettingsStore.setState({ defaultEditor: "vscodium" });
     const { result } = renderHook(() => useEffectiveDefaultEditor("host-A"));
@@ -64,10 +109,47 @@ describe("useEffectiveDefaultEditor", () => {
     expect(result.current).toBe("cursor");
   });
 
-  it("falls back to vscode when no default editor is stored", () => {
-    state.version = { major: 1, minor: 1 };
+  it("falls back to vscode when no default is stored", () => {
     useSettingsStore.setState({ defaultEditor: null });
     const { result } = renderHook(() => useEffectiveDefaultEditor("host-A"));
     expect(result.current).toBe("vscode");
+  });
+
+  describe("a stored Finder default", () => {
+    it("is effective while the Finder gate holds", () => {
+      useSettingsStore.setState({ defaultEditor: "finder" });
+      const { result } = renderHook(() => useEffectiveDefaultEditor("host-A"));
+      expect(result.current).toBe("finder");
+    });
+
+    // One flip per case, so a dropped condition names itself. Each is a host
+    // the stored preference is simply not legal on.
+    it("falls back on a remote host", () => {
+      state.hostEntry = hostEntry("remote");
+      useSettingsStore.setState({ defaultEditor: "finder" });
+      const { result } = renderHook(() => useEffectiveDefaultEditor("host-A"));
+      expect(result.current).toBe("vscode");
+    });
+
+    it("falls back on a non-Mac client", () => {
+      state.isMac = false;
+      useSettingsStore.setState({ defaultEditor: "finder" });
+      const { result } = renderHook(() => useEffectiveDefaultEditor("host-A"));
+      expect(result.current).toBe("vscode");
+    });
+
+    it("falls back inside the installed mobile app", () => {
+      state.isMobileApp = true;
+      useSettingsStore.setState({ defaultEditor: "finder" });
+      const { result } = renderHook(() => useEffectiveDefaultEditor("host-A"));
+      expect(result.current).toBe("vscode");
+    });
+
+    it("falls back on a 1.0 host", () => {
+      state.version = { major: 1, minor: 0 };
+      useSettingsStore.setState({ defaultEditor: "finder" });
+      const { result } = renderHook(() => useEffectiveDefaultEditor("host-A"));
+      expect(result.current).toBe("vscode");
+    });
   });
 });

--- a/clients/gui-app/src/hooks/editor/__tests__/use-pdf-open-target.test.tsx
+++ b/clients/gui-app/src/hooks/editor/__tests__/use-pdf-open-target.test.tsx
@@ -17,6 +17,14 @@ vi.mock("@/hooks/host/use-host-supports-method", () => ({
   useHostMethodSchemaVersion: () => state.version,
 }));
 
+// The editor branch resolves through the offerable-target catalog, which asks
+// the Finder gate too. Held closed here: this suite is about the "system"
+// routing decision, and an offerable Finder would change what the fallback
+// resolves to without being what any case is checking.
+vi.mock("@/hooks/host/use-host-directory-entry", () => ({
+  useHostDirectoryEntry: () => null,
+}));
+
 import { usePdfOpenExternallyTarget } from "../use-pdf-open-target";
 
 function resetSettingsStore(): void {

--- a/clients/gui-app/src/hooks/editor/use-effective-default-editor.ts
+++ b/clients/gui-app/src/hooks/editor/use-effective-default-editor.ts
@@ -1,22 +1,27 @@
-import type { EditorId } from "@traycer/protocol/host";
-import { useOfferableEditors } from "@/hooks/editor/use-offerable-editors";
-import { resolveEffectiveDefaultEditor } from "@/lib/editor/editor-menu-catalog";
+import { useOfferableOpenTargets } from "@/hooks/editor/use-offerable-open-targets";
+import {
+  resolveEffectiveDefaultEditor,
+  type DefaultOpenTarget,
+} from "@/lib/editor/editor-menu-catalog";
 import { useSettingsStore } from "@/stores/settings/settings-store";
 
 /**
- * The editor id a surface with no menu may send to `hostId`.
+ * The target a surface with no menu may send to `hostId`.
  *
  * `defaultEditor` is one app-wide preference while `editor.openPaths` is
  * host-scoped, so the stored value is a preference and not a legal wire value
- * until a specific host has been asked. Surfaces that open "the user's editor"
- * without offering a choice resolve here rather than reading the store; menu
- * surfaces pass the same catalog to `resolveEditorState` instead.
+ * until a specific host has been asked. That applies to Finder as much as to an
+ * editor: a stored `"finder"` is effective only where the Finder gate holds,
+ * and falls back to the first offerable target on a remote, non-Mac, or too-old
+ * host exactly as an unofferable editor does.
  *
  * `hostId` is the host the request is SENT to - a tile's own bound host, never
  * the app-wide one, since that is the machine whose minor decides the parse.
  */
-export function useEffectiveDefaultEditor(hostId: string | null): EditorId {
+export function useEffectiveDefaultEditor(
+  hostId: string | null,
+): DefaultOpenTarget {
   const defaultEditor = useSettingsStore((s) => s.defaultEditor);
-  const offerableEditors = useOfferableEditors(hostId);
-  return resolveEffectiveDefaultEditor(offerableEditors, defaultEditor);
+  const offerableTargets = useOfferableOpenTargets(hostId);
+  return resolveEffectiveDefaultEditor(offerableTargets, defaultEditor);
 }

--- a/clients/gui-app/src/hooks/editor/use-offerable-open-targets.ts
+++ b/clients/gui-app/src/hooks/editor/use-offerable-open-targets.ts
@@ -1,0 +1,25 @@
+import { useMemo } from "react";
+import { useFinderOpenAvailability } from "@/hooks/editor/use-finder-open-availability";
+import { useOfferableEditors } from "@/hooks/editor/use-offerable-editors";
+import {
+  withFinderTarget,
+  type OpenTargetEntry,
+} from "@/lib/editor/editor-menu-catalog";
+
+/**
+ * Everything `hostId` may be offered as an open target - its offerable editors
+ * plus Finder when that host passes the Finder gate.
+ *
+ * The one place the two catalogs are joined, so a surface cannot list Finder
+ * on a host that would reject it, or resolve a stored Finder default on one.
+ */
+export function useOfferableOpenTargets(
+  hostId: string | null,
+): ReadonlyArray<OpenTargetEntry> {
+  const editors = useOfferableEditors(hostId);
+  const finderAvailable = useFinderOpenAvailability(hostId);
+  return useMemo(
+    () => withFinderTarget(editors, finderAvailable),
+    [editors, finderAvailable],
+  );
+}

--- a/clients/gui-app/src/lib/editor/editor-menu-catalog.ts
+++ b/clients/gui-app/src/lib/editor/editor-menu-catalog.ts
@@ -2,6 +2,7 @@ import type { ComponentType } from "react";
 import type { EditorEntry, EditorId } from "@traycer/protocol/host";
 import {
   CursorIcon,
+  FinderIcon,
   VisualStudioCodeIcon,
   VSCodiumIcon,
   WindsurfIcon,
@@ -11,78 +12,121 @@ import {
 
 export type EditorIconComponent = ComponentType<EditorIconProps>;
 
-/** Keyed by `EditorId`, so a registry entry without an icon fails to compile. */
-export const EDITOR_ICONS: Readonly<Record<EditorId, EditorIconComponent>> = {
+/**
+ * What a surface may open a path WITH, and remember as the user's default.
+ *
+ * Finder sits alongside the editors here and nowhere else: it is not an
+ * `EDITORS` entry (no URL scheme, no install probe) and not `OpenPathsTarget`
+ * either, which also carries `"system"` - a PDF-only routing decision no user
+ * picks. This union is exactly the set a person can choose from a menu.
+ */
+export const FINDER_TARGET = "finder" as const;
+export type DefaultOpenTarget = EditorId | typeof FINDER_TARGET;
+
+/** Keyed by target, so a target without an icon fails to compile. */
+export const OPEN_TARGET_ICONS: Readonly<
+  Record<DefaultOpenTarget, EditorIconComponent>
+> = {
   vscode: VisualStudioCodeIcon,
   cursor: CursorIcon,
   windsurf: WindsurfIcon,
   zed: ZedIcon,
   vscodium: VSCodiumIcon,
+  finder: FinderIcon,
 };
 
+export interface OpenTargetEntry {
+  readonly id: DefaultOpenTarget;
+  readonly label: string;
+}
+
+const FINDER_ENTRY: OpenTargetEntry = { id: FINDER_TARGET, label: "Finder" };
+
 /**
- * The editor a surface with no menu sends - one that simply opens "the user's
- * editor". `catalog` is the target host's offerable set: a stored default that
- * host would reject at parse falls back to the first id it does accept.
+ * How a surface with no menu names the action it performs. Generic for an
+ * editor because the id is not worth spelling out on a one-line button, and
+ * specific for Finder because "Open in editor" would name the wrong app.
+ */
+export const OPEN_IN_EDITOR_ACTION_LABEL = "Open in editor";
+
+export function openTargetActionLabel(target: DefaultOpenTarget): string {
+  return target === FINDER_TARGET
+    ? "Reveal in Finder"
+    : OPEN_IN_EDITOR_ACTION_LABEL;
+}
+
+/** Appends Finder to an editor catalog when that host may be offered it. */
+export function withFinderTarget(
+  editors: ReadonlyArray<EditorEntry>,
+  finderAvailable: boolean,
+): ReadonlyArray<OpenTargetEntry> {
+  const targets: OpenTargetEntry[] = editors.map((editor) => ({
+    id: editor.id,
+    label: editor.label,
+  }));
+  if (finderAvailable) targets.push(FINDER_ENTRY);
+  return targets;
+}
+
+/**
+ * The target a surface with no menu sends - one that simply opens "the user's
+ * choice". `catalog` is what this host may be offered: a stored target missing
+ * from it falls back to the first one that is, which is how a Finder default
+ * behaves on a non-Mac and how an editor default behaves on a host too old for
+ * its id.
  *
  * Deliberately NOT intersected with the installed-editor probe; these surfaces
  * open whatever is stored, installed or not.
  */
 export function resolveEffectiveDefaultEditor(
-  catalog: ReadonlyArray<EditorEntry>,
-  defaultEditor: EditorId | null,
-): EditorId {
+  catalog: ReadonlyArray<OpenTargetEntry>,
+  defaultTarget: DefaultOpenTarget | null,
+): DefaultOpenTarget {
   if (
-    defaultEditor !== null &&
-    catalog.some((editor) => editor.id === defaultEditor)
+    defaultTarget !== null &&
+    catalog.some((target) => target.id === defaultTarget)
   ) {
-    return defaultEditor;
+    return defaultTarget;
   }
   return catalog[0]?.id ?? "vscode";
 }
 
-export interface EditorMenuState {
-  readonly availableEditors: ReadonlyArray<EditorEntry>;
-  readonly noEditorsAvailable: boolean;
-  readonly primaryEditorId: EditorId | null;
+export interface OpenMenuState {
+  /** Menu rows in order: the available editors, then Finder. */
+  readonly targets: ReadonlyArray<OpenTargetEntry>;
+  readonly noTargetsAvailable: boolean;
+  readonly primaryTargetId: DefaultOpenTarget | null;
 }
 
 /**
- * Resolves which editors a menu offers and which one its primary half opens,
- * by intersecting two independent narrowings:
- *
- * - `catalog` is what the HOST will accept (`useOfferableEditors`, keyed on the
- *   negotiated `editor.openPaths` minor);
- * - `availableEditorIds` is what is INSTALLED on this machine (the shell-local
- *   URL-scheme probe), or `null` while that probe is still in flight - shown as
- *   the full catalog rather than flashing an empty list.
- *
- * Lives outside any component so both the workspace header dropdown and the
- * file tree's row context menu resolve one list, not two that drift.
+ * Which rows a menu lists and which one its primary half opens, from three
+ * narrowings: `catalog` is what the HOST accepts, `availableEditorIds` what is
+ * INSTALLED here (`null` while that probe is in flight), and `finderAvailable`
+ * the Finder gate. Finder is exempt from the install probe - it ships with the
+ * OS - so it is appended after the surviving editors.
  */
-export function resolveEditorState(
-  catalog: ReadonlyArray<EditorEntry>,
-  availableEditorIds: ReadonlyArray<EditorId> | null,
-  defaultEditor: EditorId | null,
-): EditorMenuState {
+export function resolveOpenMenuState(args: {
+  readonly catalog: ReadonlyArray<EditorEntry>;
+  readonly availableEditorIds: ReadonlyArray<EditorId> | null;
+  readonly finderAvailable: boolean;
+  readonly defaultTarget: DefaultOpenTarget | null;
+}): OpenMenuState {
+  const { availableEditorIds } = args;
   const availableEditors =
     availableEditorIds === null
-      ? catalog
-      : catalog.filter((editor) => availableEditorIds.includes(editor.id));
-  const noEditorsAvailable =
-    availableEditorIds !== null && availableEditors.length === 0;
-
-  const firstAvailableEditorId: EditorId | null =
-    availableEditors.length > 0 ? availableEditors[0].id : null;
-  let primaryEditorId: EditorId | null = null;
-  if (!noEditorsAvailable) {
-    // Tested against the RESOLVED list, not the raw probe: a default the host
-    // does not accept must not become the primary and fail at parse.
-    primaryEditorId =
-      defaultEditor !== null &&
-      availableEditors.some((editor) => editor.id === defaultEditor)
-        ? defaultEditor
-        : firstAvailableEditorId;
-  }
-  return { availableEditors, noEditorsAvailable, primaryEditorId };
+      ? args.catalog
+      : args.catalog.filter((editor) => availableEditorIds.includes(editor.id));
+  const targets = withFinderTarget(availableEditors, args.finderAvailable);
+  const noTargetsAvailable =
+    availableEditorIds !== null && targets.length === 0;
+  return {
+    targets,
+    noTargetsAvailable,
+    // Resolved against the LISTED rows, so a stored target this host cannot be
+    // offered never becomes the primary and fails at parse.
+    primaryTargetId:
+      targets.length > 0
+        ? resolveEffectiveDefaultEditor(targets, args.defaultTarget)
+        : null,
+  };
 }

--- a/clients/gui-app/src/lib/editor/editor-menu-catalog.ts
+++ b/clients/gui-app/src/lib/editor/editor-menu-catalog.ts
@@ -47,12 +47,8 @@ const FINDER_ENTRY: OpenTargetEntry = { id: FINDER_TARGET, label: "Finder" };
  * editor because the id is not worth spelling out on a one-line button, and
  * specific for Finder because "Open in editor" would name the wrong app.
  */
-export const OPEN_IN_EDITOR_ACTION_LABEL = "Open in editor";
-
 export function openTargetActionLabel(target: DefaultOpenTarget): string {
-  return target === FINDER_TARGET
-    ? "Reveal in Finder"
-    : OPEN_IN_EDITOR_ACTION_LABEL;
+  return target === FINDER_TARGET ? "Reveal in Finder" : "Open in editor";
 }
 
 /** Appends Finder to an editor catalog when that host may be offered it. */

--- a/clients/gui-app/src/stores/settings/settings-store.ts
+++ b/clients/gui-app/src/stores/settings/settings-store.ts
@@ -25,7 +25,6 @@ import {
   type DiffViewerPreferences,
   type DiffViewerPreferencesPatch,
 } from "@/lib/diff/diff-viewer-preferences";
-import { type EditorId } from "@traycer/protocol/host";
 import { worktreeBranchPrefixError } from "@/lib/worktree/worktree-branch-prefix-validation";
 import {
   DEFAULT_NOTIFICATION_CHIME_SOUNDS,
@@ -35,6 +34,7 @@ import {
   type NotificationChimeSound,
   type NotificationChimeSoundsByEvent,
 } from "@/lib/notifications/notification-chime";
+import type { DefaultOpenTarget } from "@/lib/editor/editor-menu-catalog";
 
 export type ThemeMode = "system" | "light" | "dark";
 export type EpicNodeIconColorMode = "byType" | "none";
@@ -161,7 +161,12 @@ export interface SettingsState {
   terminalCursorBlink: boolean;
   artifactIconColorMode: EpicNodeIconColorMode;
   artifactIconColors: EpicNodeIconColors;
-  defaultEditor: EditorId | null;
+  /**
+   * What the open-in-editor surfaces default to. Widened past `EditorId`
+   * because Finder is a first-class choice in those menus; `"system"` is not,
+   * being a PDF routing decision rather than something a user picks.
+   */
+  defaultEditor: DefaultOpenTarget | null;
   /**
    * Voice input (on-device dictation). Opt-in: enabling it surfaces the mic
    * button in the composer and prompts the host to download the STT model.
@@ -242,7 +247,7 @@ export interface SettingsState {
   setArtifactIconColorMode: (mode: EpicNodeIconColorMode) => void;
   setArtifactIconColor: (type: EpicNodeKind, color: string) => void;
   resetArtifactIconColors: () => void;
-  setDefaultEditor: (id: EditorId | null) => void;
+  setDefaultEditor: (id: DefaultOpenTarget | null) => void;
   setVoiceInputEnabled: (value: boolean) => void;
   setVoiceLanguage: (value: string) => void;
   setWorktreeBranchPrefix: (value: string) => void;


### PR DESCRIPTION
## Summary

Follow-up to #1700 from using it: Finder is listed like the editors instead of as a separate "Open in Finder" item, and it can be the default open target.

### Menus

- **Workspace header dropdown**: the trailing "Open in Finder" item is gone. A **Finder** row (with the Finder icon) sits last in the editor group, before Copy path. Selecting it records Finder as the default, exactly as selecting an editor does, and the primary button then shows the Finder icon and opens the workspace in Finder.
- **Files tree right-click**: same Finder row after the editors, then Copy Path / Copy Relative Path. The Reveal/Open wording is dropped — the host already picks `open -R` for a file and `open` for a folder.
- Finder is exempt from the editor install probe (it ships with the OS) and is offered only under the existing gate (local Mac host, not the mobile app, `editor.openPaths >= 1.1`).

### Default open target

- `defaultEditor` widens from `EditorId` to `DefaultOpenTarget = EditorId | "finder"`. Persisted values round-trip unchanged.
- `resolveEffectiveDefaultEditor` resolves through the offerable open targets for the surface's host; a stored Finder default falls back to the first offerable editor wherever the gate does not hold, the same way an unofferable editor id does. The diff tile, file tile and PDF editor branch inherit that.
- The diff-tile toolbar's open button reads **Reveal in Finder** when Finder is the resolved default (it said "Open in editor" unconditionally).
- Analytics still counts editors only (`isEditorId`).

### Refactor

`DiffTabToolbar`'s four flat open-file props (`onOpenFile`, `openFileLabel`, `openFileDisabled`, `openFileOpening`) become one `openFile: DiffTabToolbarOpenFile | null`, so "no button" is `null` rather than a handler-less set of props carrying an unused label. Pure restructure; the rendered output is unchanged and the three call sites are updated.

## Test plan

- Header + tree menu suites: Finder row present only under the gate, positioned after the editors, records the default (header) / does not (tree), pending treatment.
- `use-effective-default-editor`: stored Finder default → Finder on a gated host, first offerable editor otherwise; editors unaffected.
- Settings store: `"finder"` persists and rehydrates.
- Renderers directory (91 files) green after the toolbar refactor; tile suites mount the host-directory boundary as `null`, which is the honest answer for a tile rendered outside the runtime.

```
gui-app compile: exit 0
gui-app renderers: Test Files 91 passed (91)  Tests 895 passed (895)
gui-app editor/menu/store suites: Test Files 9 passed (9)  Tests 144 passed (144)
```
