### PR TITLE
feat(gui): announce session import with a release toast for existing installs

### DIFF
--- a/clients/gui-app/src/components/layout/bridges/__tests__/session-import-announcement-controller.test.tsx
+++ b/clients/gui-app/src/components/layout/bridges/__tests__/session-import-announcement-controller.test.tsx
@@ -1,0 +1,357 @@
+import type { ReactElement } from "react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import type { ExternalToast } from "sonner";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SessionImportAnnouncementController } from "@/components/layout/bridges/session-import-announcement-controller";
+import {
+  HostReadinessControllerContext,
+  type DefaultHostReadinessPresentation,
+  type HostReadinessController,
+  type SurfaceReadiness,
+} from "@/components/layout/host-readiness-controller-context";
+import { useAuthStore } from "@/stores/auth/auth-store";
+import { useOnboardingStore } from "@/stores/onboarding/onboarding-store";
+import { useOnboardingTourOpenStore } from "@/stores/onboarding/onboarding-tour-open-store";
+import { useFeatureAnnouncementsStore } from "@/stores/settings/feature-announcements-store";
+import { persistKey, STORE_KEYS } from "@/lib/persist";
+
+// Typed to the two sonner calls the controller makes, so `mock.lastCall`
+// destructures to a real tuple and not `any`.
+const toastMock = vi.hoisted(() => {
+  const toast =
+    vi.fn<(message: ReactElement, options: ExternalToast) => string | number>();
+  return Object.assign(toast, {
+    dismiss: vi.fn<(id: string | number) => string | number>(),
+  });
+});
+vi.mock("sonner", () => ({ toast: toastMock }));
+
+const sessionImportAvailableMock = vi.hoisted(() => ({ value: true }));
+vi.mock("@/hooks/session-import/use-session-import-available", () => ({
+  useSessionImportAvailable: () => sessionImportAvailableMock.value,
+}));
+
+// The controller only asks whether a stream client is live; the dialog it
+// opens is stubbed below, so nothing else in the tree reads the transport.
+const streamLiveMock = vi.hoisted(() => ({ value: true }));
+vi.mock("@/lib/host/stream-runtime-context", () => ({
+  useWsStreamClient: () => (streamLiveMock.value ? {} : null),
+}));
+
+vi.mock("@/components/session-import/session-import-dialog", () => ({
+  SessionImportDialog: (props: { readonly onClose: () => void }) => (
+    <div data-testid="session-import-dialog">
+      <button type="button" onClick={props.onClose}>
+        Close
+      </button>
+    </div>
+  ),
+}));
+
+const READINESS_STUB_PRESENTATION: DefaultHostReadinessPresentation = {
+  targetKind: "unknown",
+  localBootIntent: false,
+  localHostState: "unknown",
+  stage: "loading",
+  progress: null,
+  lastProgress: null,
+  provisioningError: null,
+  provisioning: false,
+  removed: false,
+  hostBusy: false,
+  canManageHost: false,
+  retryProvisioning: () => undefined,
+  forceProvisioning: () => undefined,
+  reinstall: () => undefined,
+  configureShell: () => undefined,
+  refreshDirectory: () => undefined,
+  openSettings: () => undefined,
+  compatibility: {
+    status: "compatible",
+    degraded: false,
+    unreachable: false,
+    hostStatus: null,
+  },
+};
+
+const READY_READINESS: SurfaceReadiness = { kind: "ready" };
+const LOADING_HOST_READINESS: SurfaceReadiness = { kind: "loading-host" };
+
+function readinessController(
+  readiness: SurfaceReadiness,
+): HostReadinessController {
+  return {
+    readinessFor: () => readiness,
+    defaultHostPresentation: READINESS_STUB_PRESENTATION,
+    // Post-latch: the app has been ready at least once this window, so a
+    // narrator-owned kind (loading-host) suppresses the toast behind its
+    // dead-pointer-events overlay rather than blocking the app from mounting.
+    hasBeenDefaultHostReady: true,
+  };
+}
+
+function renderWithReadiness(
+  ui: ReactElement,
+  readiness: SurfaceReadiness,
+): { readonly rerenderReadiness: (next: SurfaceReadiness) => void } {
+  function tree(forReadiness: SurfaceReadiness): ReactElement {
+    return (
+      <HostReadinessControllerContext.Provider
+        value={readinessController(forReadiness)}
+      >
+        {ui}
+      </HostReadinessControllerContext.Provider>
+    );
+  }
+  const view = render(tree(readiness));
+  return {
+    rerenderReadiness: (next) => {
+      view.rerender(tree(next));
+    },
+  };
+}
+
+function resetStores(): void {
+  useAuthStore.setState({ status: "signed-in" });
+  useOnboardingStore.setState({ completedAt: Date.now(), step: 0 });
+  useOnboardingTourOpenStore.getState().setOpen(false);
+  useFeatureAnnouncementsStore.setState({ consumed: {} });
+  window.localStorage.clear();
+}
+
+function lastToastContent(): ReactElement {
+  const [messageNode] = toastMock.mock.lastCall ?? [];
+  if (messageNode === undefined) {
+    throw new Error("expected the announcement toast content");
+  }
+  return messageNode;
+}
+
+describe("<SessionImportAnnouncementController />", () => {
+  beforeEach(() => {
+    sessionImportAvailableMock.value = true;
+    streamLiveMock.value = true;
+    toastMock.mockClear();
+    toastMock.dismiss.mockClear();
+    resetStores();
+  });
+
+  afterEach(() => {
+    cleanup();
+    resetStores();
+  });
+
+  it("shows once and consumes, so a second mount shows nothing", () => {
+    const { unmount } = render(<SessionImportAnnouncementController />);
+
+    expect(toastMock).toHaveBeenCalledTimes(1);
+    expect(
+      useFeatureAnnouncementsStore.getState().consumed["session-import"],
+    ).toBeDefined();
+
+    unmount();
+    toastMock.mockClear();
+    render(<SessionImportAnnouncementController />);
+
+    expect(toastMock).not.toHaveBeenCalled();
+  });
+
+  it("does not show when the host cannot import sessions", () => {
+    sessionImportAvailableMock.value = false;
+    render(<SessionImportAnnouncementController />);
+
+    expect(toastMock).not.toHaveBeenCalled();
+  });
+
+  it("does not show before onboarding is complete", () => {
+    useOnboardingStore.setState({ completedAt: null, step: 0 });
+    render(<SessionImportAnnouncementController />);
+
+    expect(toastMock).not.toHaveBeenCalled();
+  });
+
+  it("shows for a user who finished onboarding before the feature existed", () => {
+    // The whole point of the toast: an older install has a completion
+    // stamp and no `session-import` record, since the id did not exist.
+    useOnboardingStore.setState({ completedAt: 1, step: 0 });
+    render(<SessionImportAnnouncementController />);
+
+    expect(toastMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not show once the wizard has been met on another surface", () => {
+    useFeatureAnnouncementsStore.getState().consume("session-import");
+    render(<SessionImportAnnouncementController />);
+
+    expect(toastMock).not.toHaveBeenCalled();
+  });
+
+  it("holds while the tour is open, then shows when it closes", () => {
+    useOnboardingTourOpenStore.getState().setOpen(true);
+    render(<SessionImportAnnouncementController />);
+
+    expect(toastMock).not.toHaveBeenCalled();
+
+    act(() => {
+      useOnboardingTourOpenStore.getState().setOpen(false);
+    });
+
+    expect(toastMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not show when signed out", () => {
+    useAuthStore.setState({ status: "signed-out" });
+    render(<SessionImportAnnouncementController />);
+
+    expect(toastMock).not.toHaveBeenCalled();
+  });
+
+  it("holds behind the window narrator, then shows on release", async () => {
+    const harness = renderWithReadiness(
+      <SessionImportAnnouncementController />,
+      LOADING_HOST_READINESS,
+    );
+
+    expect(toastMock).not.toHaveBeenCalled();
+
+    harness.rerenderReadiness(READY_READINESS);
+
+    await waitFor(() => {
+      expect(toastMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("holds while no stream client is live, then shows once one is, without claiming early", () => {
+    streamLiveMock.value = false;
+    const { rerender } = render(<SessionImportAnnouncementController />);
+
+    expect(toastMock).not.toHaveBeenCalled();
+    expect(
+      useFeatureAnnouncementsStore.getState().consumed["session-import"],
+    ).toBeUndefined();
+
+    streamLiveMock.value = true;
+    rerender(<SessionImportAnnouncementController />);
+
+    expect(toastMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("the primary action opens the import dialog in place and dismisses the toast", () => {
+    render(<SessionImportAnnouncementController />);
+    expect(toastMock).toHaveBeenCalledTimes(1);
+    expect(screen.queryByTestId("session-import-dialog")).toBeNull();
+
+    // The toast body renders outside the controller's tree (sonner owns
+    // it), so it is mounted beside the controller here; its button reaches
+    // the controller through the closure it was created with.
+    render(<>{lastToastContent()}</>);
+    fireEvent.click(screen.getByRole("button", { name: "Import work…" }));
+
+    expect(toastMock.dismiss).toHaveBeenCalledWith(
+      "traycer-session-import-announcement",
+    );
+    expect(screen.queryByTestId("session-import-dialog")).not.toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+    expect(screen.queryByTestId("session-import-dialog")).toBeNull();
+  });
+
+  it("does not show when another window already claimed the announcement", () => {
+    // Written straight into localStorage, as another renderer's own
+    // claim()/consume() would have - never through THIS window's store.
+    window.localStorage.setItem(
+      persistKey(STORE_KEYS.featureAnnouncements),
+      JSON.stringify({
+        state: { consumed: { "session-import": 123 } },
+        version: 1,
+      }),
+    );
+    expect(useFeatureAnnouncementsStore.getState().consumed).toEqual({});
+
+    render(<SessionImportAnnouncementController />);
+
+    expect(toastMock).not.toHaveBeenCalled();
+    expect(
+      useFeatureAnnouncementsStore.getState().consumed["session-import"],
+    ).toBe(123);
+  });
+
+  it("Later dismisses and the announcement stays consumed", () => {
+    render(<SessionImportAnnouncementController />);
+    const { unmount } = render(<>{lastToastContent()}</>);
+
+    fireEvent.click(screen.getByRole("button", { name: "Later" }));
+    expect(toastMock.dismiss).toHaveBeenCalledWith(
+      "traycer-session-import-announcement",
+    );
+    unmount();
+
+    toastMock.mockClear();
+    render(<SessionImportAnnouncementController />);
+    expect(toastMock).not.toHaveBeenCalled();
+  });
+
+  it("dismisses the toast once the tour opens after it showed", () => {
+    render(<SessionImportAnnouncementController />);
+    expect(toastMock).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      useOnboardingTourOpenStore.getState().setOpen(true);
+    });
+
+    expect(toastMock.dismiss).toHaveBeenCalledWith(
+      "traycer-session-import-announcement",
+    );
+  });
+
+  it("dismisses the toast once availability flips to false after it showed", () => {
+    const { rerender } = render(<SessionImportAnnouncementController />);
+    expect(toastMock).toHaveBeenCalledTimes(1);
+
+    sessionImportAvailableMock.value = false;
+    rerender(<SessionImportAnnouncementController />);
+
+    expect(toastMock.dismiss).toHaveBeenCalledWith(
+      "traycer-session-import-announcement",
+    );
+  });
+
+  it("does NOT dismiss the toast when only a transient gate closes over it", () => {
+    const harness = renderWithReadiness(
+      <SessionImportAnnouncementController />,
+      READY_READINESS,
+    );
+    expect(toastMock).toHaveBeenCalledTimes(1);
+
+    // The narrator and a stream drop are transient - a toast under a dialog
+    // is inert rather than wrong, and a reconnect brings the host back. They
+    // must not take the toast down the way sign-out and the tour do, since
+    // the claim is permanent.
+    harness.rerenderReadiness(LOADING_HOST_READINESS);
+    streamLiveMock.value = false;
+    harness.rerenderReadiness(LOADING_HOST_READINESS);
+
+    expect(toastMock.dismiss).not.toHaveBeenCalled();
+  });
+
+  it("does not dismiss on the tour opening when THIS controller never showed the toast", () => {
+    useFeatureAnnouncementsStore.setState({
+      consumed: { "session-import": Date.now() },
+    });
+    render(<SessionImportAnnouncementController />);
+    expect(toastMock).not.toHaveBeenCalled();
+
+    act(() => {
+      useOnboardingTourOpenStore.getState().setOpen(true);
+    });
+
+    expect(toastMock.dismiss).not.toHaveBeenCalled();
+  });
+});

--- a/clients/gui-app/src/components/layout/bridges/session-import-announcement-controller.tsx
+++ b/clients/gui-app/src/components/layout/bridges/session-import-announcement-controller.tsx
@@ -1,0 +1,149 @@
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import { toast } from "sonner";
+import { ActionToastContent } from "@/components/layout/bridges/action-toast-content";
+import {
+  gateBlocksApp,
+  useHostReadinessController,
+  useSurfaceReadiness,
+  windowNarratorOwns,
+} from "@/components/layout/host-readiness-controller-context";
+import { SessionImportDialog } from "@/components/session-import/session-import-dialog";
+import { useSessionImportAvailable } from "@/hooks/session-import/use-session-import-available";
+import { useWsStreamClient } from "@/lib/host/stream-runtime-context";
+import { useAuthStore } from "@/stores/auth/auth-store";
+import { useOnboardingStore } from "@/stores/onboarding/onboarding-store";
+import { useOnboardingTourOpenStore } from "@/stores/onboarding/onboarding-tour-open-store";
+import {
+  isFeatureAnnouncementConsumed,
+  useFeatureAnnouncementsStore,
+} from "@/stores/settings/feature-announcements-store";
+
+const SESSION_IMPORT_ANNOUNCEMENT_TOAST_ID =
+  "traycer-session-import-announcement";
+
+/**
+ * Tells a user who already finished onboarding that this release can import
+ * the work they started in other coding agents - once, ever, per install.
+ *
+ * The same shape as `LoginImportAnnouncementController`, with two
+ * differences. The action opens the import wizard RIGHT HERE, as a dialog
+ * under the app-wide stream binding (the active host, the one the home
+ * screen's terminal lands on), rather than navigating to Settings through a
+ * one-shot intent - the wizard is self-contained and needs no row to land
+ * on. And the tour never consumes the id on its own finish: only mounting
+ * the wizard does (`SessionImportWizard`), so a user who skipped the tour
+ * before its import act still gets this toast, which is the point of it.
+ *
+ * The toast shows on the first launch where ALL of these hold, and showing
+ * it claims the `session-import` announcement (`feature-announcements-store`)
+ * so it never shows again, in this window or another:
+ *
+ * - the bound host can import sessions (`useSessionImportAvailable`; a host
+ *   that predates the feature hides the row, so a toast leading to nothing
+ *   would be worse than none);
+ * - the user is signed in and has COMPLETED onboarding - a fresh user meets
+ *   the feature as the tour's last act instead, which consumes the same id;
+ * - the tour is not on screen (a replay from Settings), for the reason the
+ *   session-import progress toast holds: a toast over the stage is noise;
+ * - the window narrator does not own the frame with the app gated behind
+ *   its dialog, where a toast renders dead (`pointer-events: none`) and
+ *   could never be dismissed - the same predicate the app-update toast
+ *   reads. Held, not dropped: the effect re-runs when the narrator releases;
+ * - the app-wide stream client is live, so the dialog the action opens has a
+ *   host to scan. Held, never a reason to dismiss: a reconnect is transient,
+ *   and the claim is permanent.
+ *
+ * "Later" just dismisses - the announcement is consumed either way. A gate
+ * that closes while the toast is up - the host losing the capability,
+ * sign-out, the tour opening - dismisses it, since it is permanent
+ * otherwise; see the effect.
+ */
+export function SessionImportAnnouncementController(): ReactNode {
+  const available = useSessionImportAvailable();
+  const streamLive = useWsStreamClient() !== null;
+  const signedIn = useAuthStore((state) => state.status === "signed-in");
+  const onboardingComplete = useOnboardingStore(
+    (state) => state.completedAt !== null,
+  );
+  const tourOpen = useOnboardingTourOpenStore((state) => state.open);
+  const consumed = useFeatureAnnouncementsStore((state) =>
+    isFeatureAnnouncementConsumed(state.consumed, "session-import"),
+  );
+  const claim = useFeatureAnnouncementsStore((state) => state.claim);
+  const readiness = useSurfaceReadiness("default-host", null);
+  const { hasBeenDefaultHostReady } = useHostReadinessController();
+  const narrated =
+    windowNarratorOwns(readiness) &&
+    !gateBlocksApp({
+      readiness,
+      hasBeenReady: hasBeenDefaultHostReady,
+      signedIn,
+      bypassed: false,
+    });
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  // Whether THIS controller put the toast up. `consumed` cannot stand in
+  // for it: the claim flips it the moment the toast shows, and another
+  // window's claim flips it with no toast here at all.
+  const shownRef = useRef(false);
+
+  useEffect(() => {
+    // The toast is permanent, so a gate that closes after it is up takes it
+    // down: the host losing the capability (a swap to an older host), a
+    // sign-out, or the tour opening (a replay from Settings, which shows the
+    // same feature as an act, and a toast over the stage is noise). Not the
+    // narrator or a stream drop: both are transient, and a toast under a
+    // dialog is inert rather than wrong. Gone is gone: the id is claimed, so
+    // nothing re-shows it.
+    if (shownRef.current && (!available || !signedIn || tourOpen)) {
+      shownRef.current = false;
+      toast.dismiss(SESSION_IMPORT_ANNOUNCEMENT_TOAST_ID);
+      return;
+    }
+    if (consumed || !available || !signedIn || !onboardingComplete) return;
+    if (tourOpen || narrated || !streamLive) return;
+    // A claim, not a consume: `consumed` above is this window's copy, and a
+    // second window restored alongside this one holds its own. The claim
+    // re-reads the install's record, so of two windows that both get here
+    // exactly one shows the toast.
+    if (!claim("session-import")) return;
+    shownRef.current = true;
+    toast(
+      <ActionToastContent
+        toastId={SESSION_IMPORT_ANNOUNCEMENT_TOAST_ID}
+        eyebrow="New in this release"
+        title="Bring your work with you"
+        description="Import work you started in other coding agents and keep going within Traycer."
+        actionLabel="Import work…"
+        onAction={() => {
+          setDialogOpen(true);
+        }}
+        onLater={null}
+      />,
+      {
+        id: SESSION_IMPORT_ANNOUNCEMENT_TOAST_ID,
+        description: null,
+        duration: Infinity,
+        cancel: null,
+      },
+    );
+  }, [
+    available,
+    claim,
+    consumed,
+    narrated,
+    onboardingComplete,
+    signedIn,
+    streamLive,
+    tourOpen,
+  ]);
+
+  if (!dialogOpen) return null;
+  return (
+    <SessionImportDialog
+      onClose={() => {
+        setDialogOpen(false);
+      }}
+    />
+  );
+}

--- a/clients/gui-app/src/components/onboarding/onboarding-page.tsx
+++ b/clients/gui-app/src/components/onboarding/onboarding-page.tsx
@@ -1107,7 +1107,9 @@ export function OnboardingPage(props: { readonly replay: boolean }) {
         // no act; an act the list held can be dropped again before it is
         // reached; and on a shell with no bridge the toast never shows, so
         // consuming costs nothing. Before `complete()`, which is what makes
-        // the toast eligible.
+        // the toast eligible. `session-import` is deliberately NOT consumed
+        // here: its toast exists to reach the user who never saw the import
+        // act, and the wizard consumes the id itself on mount.
         consumeAnnouncement("login-import");
         complete();
         if (replay) {

--- a/clients/gui-app/src/components/session-import/session-import-wizard.tsx
+++ b/clients/gui-app/src/components/session-import/session-import-wizard.tsx
@@ -44,6 +44,7 @@ import {
   type SessionImportSurface,
 } from "@/components/session-import/session-import-tone";
 import { useSessionImportRunStore } from "@/stores/session-import/session-import-run-store";
+import { useFeatureAnnouncementsStore } from "@/stores/settings/feature-announcements-store";
 
 export interface SessionImportSecondaryAction {
   readonly label: string;
@@ -75,6 +76,19 @@ export function SessionImportWizard(props: {
   const tone = sessionImportTone(surface);
   const runStatus = useSessionImportRunStore((state) => state.status);
   const runIdle = runStatus === "idle";
+  // Meeting the wizard on any surface - the tour act, the Settings dialog,
+  // the release toast's own dialog - is the announcement: the id is consumed
+  // on mount so the toast never follows for a user who has already opened
+  // the feature, whether or not they imported anything. Only reaching the
+  // wizard counts; skipping the tour before its act does not, so a skipper
+  // still gets the toast (unlike `login-import`, which the tour's finish
+  // consumes unconditionally).
+  const consumeAnnouncement = useFeatureAnnouncementsStore(
+    (state) => state.consume,
+  );
+  useEffect(() => {
+    consumeAnnouncement("session-import");
+  }, [consumeAnnouncement]);
 
   // Opening the wizard retires a FINISHED run's summary, so a second visit
   // scans afresh instead of re-reading last time's result. Mount-only on

--- a/clients/gui-app/src/stores/settings/feature-announcements-store.ts
+++ b/clients/gui-app/src/stores/settings/feature-announcements-store.ts
@@ -17,10 +17,11 @@ import { basePersistOptions, persistKey, STORE_KEYS } from "@/lib/persist";
  * The timestamp is when the id was consumed, kept for support reports rather
  * than read by any surface.
  */
-export type FeatureAnnouncementId = "login-import";
+export type FeatureAnnouncementId = "login-import" | "session-import";
 
 const FEATURE_ANNOUNCEMENT_IDS: ReadonlyArray<FeatureAnnouncementId> = [
   "login-import",
+  "session-import",
 ];
 
 type ConsumedAnnouncements = Readonly<

--- a/clients/gui-app/src/traycer-app.tsx
+++ b/clients/gui-app/src/traycer-app.tsx
@@ -2,6 +2,7 @@ import { ChatUsageDialog } from "@/components/chat/chat-usage-dialog";
 import { PersistentBrowserGuestHost } from "@/components/epic-canvas/browser-guest/persistent-browser-guest-host";
 import { AppUpdateToastController } from "@/components/layout/bridges/app-update-toast-controller";
 import { LoginImportAnnouncementController } from "@/components/layout/bridges/login-import-announcement-controller";
+import { SessionImportAnnouncementController } from "@/components/layout/bridges/session-import-announcement-controller";
 import { DesktopZoomController } from "@/components/layout/bridges/desktop-zoom-controller";
 import { HostControllerStatusListener } from "@/components/layout/bridges/host-controller-status-listener";
 import { LinkLoginDeepLinkBridge } from "@/components/layout/bridges/link-login-deep-link-bridge";
@@ -331,6 +332,7 @@ function TraycerAppRuntimeSurface(props: TraycerAppRuntimeSurfaceProps) {
       <HostControllerStatusListener />
       <AppUpdateToastController />
       <LoginImportAnnouncementController />
+      <SessionImportAnnouncementController />
       <LinkLoginDeepLinkBridge />
       <WorktreeDeleteProgressToastBridge />
       <SessionImportProgressToastBridge />


### PR DESCRIPTION
## Why

Session import (bring Claude Code / Codex / OpenCode work into Traycer as tasks) is surfaced as the last act of the onboarding tour and as a Settings row. A user who finished onboarding before that act existed never learns the feature is there. This adds a once-per-install release toast for exactly that user, on the pattern the login-import announcement (#1684) established.

## What

- `SessionImportAnnouncementController`, mounted beside the login-import one. Eyebrow "New in this release", title "Bring your work with you", description "Import work you started in other coding agents and keep going within Traycer.", buttons "Import work…" / "Later".
- `"session-import"` joins `FeatureAnnouncementId` in the persisted feature-announcements store; the toast claims it across windows the same way login-import does.
- `SessionImportWizard` consumes the id on mount, so the tour act, the Settings dialog and the toast's own dialog all count as "the user has met the feature".

## Two deliberate differences from login-import

- **The action opens the wizard in place**, as `SessionImportDialog` rendered under the app-wide stream binding (the active host), instead of arming a one-shot intent and navigating to Settings. The wizard is self-contained and needs no row to land on.
- **Tour Skip does not consume the id.** Only mounting the wizard does. A user who skips the tour before its last act still gets the toast on the next launch, which is the point of the toast. Login-import consumes on tour finish unconditionally; that stays as is.

Gates: host supports `sessionImport.scan`, signed in, onboarding completed, tour not open, window narrator not owning the frame, app-wide stream client live. The last two are hold gates only; a stream drop or a narrator dialog never dismisses the toast, since the claim is permanent. Loss of the capability, sign-out and the tour opening do dismiss it.

## Tests

New `session-import-announcement-controller.test.tsx` (16 cases) cloned from the login-import suite: old-install case, skip path, cross-window claim, hold vs dismiss gates, in-place dialog open/close. Wizard, entry-point, onboarding-mount, login-import and announcement-store suites still pass. gui-app compile, oxlint, eslint and oxfmt clean.
