### PR TITLE
fix(gui-app): keep the communication graph centred through a tile resize

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/comm-graph/__tests__/comm-graph-office-canvas.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/comm-graph/__tests__/comm-graph-office-canvas.test.tsx
@@ -37,7 +37,7 @@ import {
   screen,
 } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ReactNode } from "react";
 import { CommGraphOfficeCanvas } from "@/components/epic-canvas/comm-graph/office/comm-graph-office-canvas";
 import {
@@ -129,6 +129,44 @@ function officeElement(
 
 function renderOffice(visibleIds: ReadonlySet<string>) {
   return render(withQueryClient(officeElement(visibleIds, STATIC_OFFICE)));
+}
+
+/**
+ * The same office element as {@link officeElement}, but with the view and its
+ * change callback named explicitly - what the resize tests need to control
+ * whether the runtime starts auto-fitting or already framed.
+ */
+function officeElementWithView(
+  visibleIds: ReadonlySet<string>,
+  options: OfficeRenderOptions,
+  view: CommGraphTileViewState,
+  onViewChange: (next: CommGraphTileViewState) => void,
+) {
+  return (
+    <CommGraphOfficeCanvas
+      epicId="epic-1"
+      tileInstanceId="comm-graph-instance-1"
+      agents={[ORCHESTRATOR, REVIEWER]}
+      agentIds={visibleIds}
+      events={options.events}
+      hosts={[]}
+      initialHistoryCaughtUp={false}
+      playing={false}
+      pulse={options.pulse}
+      pulseKey={options.pulseKey}
+      modeToggle={null}
+      view={view}
+      onViewChange={onViewChange}
+      canOpenAgentForEvent={() => true}
+      canJump={() => false}
+      onJump={vi.fn()}
+      canJumpToSender={() => false}
+      onJumpToSender={vi.fn()}
+      canJumpToCreated={() => false}
+      onJumpToCreated={vi.fn()}
+      onOpenAgent={vi.fn()}
+    />
+  );
 }
 
 function withQueryClient(children: ReactNode) {
@@ -453,5 +491,185 @@ describe("CommGraphOfficeCanvas", () => {
     expect(screen.getByTestId("comm-graph-office-zoom-in")).toBeDefined();
     expect(screen.getByTestId("comm-graph-office-zoom-out")).toBeDefined();
     expect(screen.getByTestId("comm-graph-office-fit")).toBeDefined();
+  });
+});
+
+/**
+ * The global `MockResizeObserver` installed by `test-browser-apis.ts` is a
+ * total no-op - it never invokes its callback. This suite installs a
+ * controllable replacement for its own tests only, restored afterward so the
+ * rest of the file keeps the shared no-op.
+ */
+class ControllableResizeObserver implements ResizeObserver {
+  readonly callback: ResizeObserverCallback;
+
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback;
+    latestControllableResizeObserver = this;
+  }
+
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+
+let latestControllableResizeObserver: ControllableResizeObserver | null = null;
+
+function fireResizeObserverCallback(): void {
+  const observer = latestControllableResizeObserver;
+  if (observer === null) throw new Error("ResizeObserver was not created");
+  // `applyCanvasSize` reads `container.getBoundingClientRect()` itself and
+  // ignores the entry it is handed, so an empty list is enough to invoke it.
+  observer.callback([], observer);
+}
+
+/**
+ * Answers `comm-graph-office-canvas`'s `getBoundingClientRect()` from a
+ * mutable size, and every other element with the zero rect jsdom already
+ * reports by default. Installed on the prototype because the container does
+ * not exist until the component mounts, so it cannot be stubbed by reference
+ * the way an already-rendered element can be.
+ */
+function stubContainerRect(size: { width: number; height: number }): {
+  readonly setSize: (next: { width: number; height: number }) => void;
+  readonly restore: () => void;
+} {
+  let current = size;
+  const originalDescriptor = Object.getOwnPropertyDescriptor(
+    Element.prototype,
+    "getBoundingClientRect",
+  );
+  Element.prototype.getBoundingClientRect = function (this: Element): DOMRect {
+    if (this.getAttribute("data-testid") === "comm-graph-office-canvas") {
+      return DOMRect.fromRect(current);
+    }
+    return DOMRect.fromRect({ width: 0, height: 0 });
+  };
+  return {
+    setSize: (next) => {
+      current = next;
+    },
+    restore: () => {
+      if (originalDescriptor !== undefined) {
+        Object.defineProperty(
+          Element.prototype,
+          "getBoundingClientRect",
+          originalDescriptor,
+        );
+      } else {
+        Reflect.deleteProperty(Element.prototype, "getBoundingClientRect");
+      }
+    },
+  };
+}
+
+/**
+ * The camera keeps the tile's centre fixed across a resize: it shifts by half
+ * the size delta rather than anchoring the top-left corner, which is what a
+ * pane split or a divider drag should look like from inside the tile - but
+ * only once the tile has been framed. A tile still auto-fitting itself is
+ * left for the frame loop instead, so persisting here cannot turn a
+ * never-framed tile into a framed one.
+ */
+describe("resizing the tile container", () => {
+  let originalResizeObserver: typeof ResizeObserver;
+
+  beforeEach(() => {
+    originalResizeObserver = globalThis.ResizeObserver;
+    latestControllableResizeObserver = null;
+    Object.defineProperty(globalThis, "ResizeObserver", {
+      configurable: true,
+      writable: true,
+      value: ControllableResizeObserver,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, "ResizeObserver", {
+      configurable: true,
+      writable: true,
+      value: originalResizeObserver,
+    });
+    vi.useRealTimers();
+  });
+
+  it("shifts the camera by half the size delta once the tile has been framed", () => {
+    vi.useFakeTimers();
+    const rect = stubContainerRect({ width: 400, height: 300 });
+    const onViewChange = vi.fn();
+    // Non-default: `isDefaultCommGraphView` reads false, so the runtime is
+    // created with auto-fit already off, as a tile the user has framed once.
+    const framedView: CommGraphTileViewState = {
+      x: 40,
+      y: 30,
+      zoom: 1,
+      mode: "office",
+    };
+
+    try {
+      render(
+        withQueryClient(
+          officeElementWithView(
+            new Set([ORCHESTRATOR.id, REVIEWER.id]),
+            STATIC_OFFICE,
+            framedView,
+            onViewChange,
+          ),
+        ),
+      );
+
+      rect.setSize({ width: 200, height: 300 });
+      act(() => {
+        fireResizeObserverCallback();
+      });
+      // Past `VIEW_PERSIST_DEBOUNCE_MS` (150ms in the source), which
+      // coalesces the resize into one persisted write.
+      act(() => {
+        vi.advanceTimersByTime(200);
+      });
+
+      expect(onViewChange).toHaveBeenCalledWith({
+        x: -60,
+        y: 30,
+        zoom: 1,
+        mode: "office",
+      });
+    } finally {
+      rect.restore();
+    }
+  });
+
+  it("does not persist a view on resize while a never-framed tile is still auto-fitting", () => {
+    vi.useFakeTimers();
+    const rect = stubContainerRect({ width: 400, height: 300 });
+    const onViewChange = vi.fn();
+
+    try {
+      render(
+        withQueryClient(
+          officeElementWithView(
+            new Set([ORCHESTRATOR.id, REVIEWER.id]),
+            STATIC_OFFICE,
+            OFFICE_VIEW,
+            onViewChange,
+          ),
+        ),
+      );
+
+      rect.setSize({ width: 200, height: 300 });
+      act(() => {
+        fireResizeObserverCallback();
+      });
+      act(() => {
+        vi.advanceTimersByTime(200);
+      });
+
+      // The frame loop's own auto-fit re-frames a never-framed tile; had this
+      // resize persisted a shifted camera it would have turned the tile into
+      // a framed one and cost it that fit on the next open.
+      expect(onViewChange).not.toHaveBeenCalled();
+    } finally {
+      rect.restore();
+    }
   });
 });

--- a/clients/gui-app/src/components/epic-canvas/comm-graph/__tests__/comm-graph-office-canvas.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/comm-graph/__tests__/comm-graph-office-canvas.test.tsx
@@ -501,11 +501,8 @@ describe("CommGraphOfficeCanvas", () => {
  * rest of the file keeps the shared no-op.
  */
 class ControllableResizeObserver implements ResizeObserver {
-  readonly callback: ResizeObserverCallback;
-
   constructor(callback: ResizeObserverCallback) {
-    this.callback = callback;
-    latestControllableResizeObserver = this;
+    latestResizeCallback = callback;
   }
 
   observe(): void {}
@@ -513,14 +510,21 @@ class ControllableResizeObserver implements ResizeObserver {
   disconnect(): void {}
 }
 
-let latestControllableResizeObserver: ControllableResizeObserver | null = null;
+let latestResizeCallback: ResizeObserverCallback | null = null;
+
+/** Handed to the callback as its observer argument; neither renderer reads it. */
+const INERT_RESIZE_OBSERVER: ResizeObserver = {
+  observe(): void {},
+  unobserve(): void {},
+  disconnect(): void {},
+};
 
 function fireResizeObserverCallback(): void {
-  const observer = latestControllableResizeObserver;
-  if (observer === null) throw new Error("ResizeObserver was not created");
+  const callback = latestResizeCallback;
+  if (callback === null) throw new Error("ResizeObserver was not created");
   // `applyCanvasSize` reads `container.getBoundingClientRect()` itself and
   // ignores the entry it is handed, so an empty list is enough to invoke it.
-  observer.callback([], observer);
+  callback([], INERT_RESIZE_OBSERVER);
 }
 
 /**
@@ -576,7 +580,7 @@ describe("resizing the tile container", () => {
 
   beforeEach(() => {
     originalResizeObserver = globalThis.ResizeObserver;
-    latestControllableResizeObserver = null;
+    latestResizeCallback = null;
     Object.defineProperty(globalThis, "ResizeObserver", {
       configurable: true,
       writable: true,

--- a/clients/gui-app/src/components/epic-canvas/comm-graph/__tests__/comm-graph-viewport.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/comm-graph/__tests__/comm-graph-viewport.test.tsx
@@ -411,11 +411,8 @@ describe("CommGraphCanvas viewport", () => {
  * rest of the file keeps the shared no-op.
  */
 class ControllableResizeObserver implements ResizeObserver {
-  readonly callback: ResizeObserverCallback;
-
   constructor(callback: ResizeObserverCallback) {
-    this.callback = callback;
-    latestControllableResizeObserver = this;
+    latestResizeCallback = callback;
   }
 
   observe(): void {}
@@ -423,7 +420,14 @@ class ControllableResizeObserver implements ResizeObserver {
   disconnect(): void {}
 }
 
-let latestControllableResizeObserver: ControllableResizeObserver | null = null;
+let latestResizeCallback: ResizeObserverCallback | null = null;
+
+/** Handed to the callback as its observer argument; neither renderer reads it. */
+const INERT_RESIZE_OBSERVER: ResizeObserver = {
+  observe(): void {},
+  unobserve(): void {},
+  disconnect(): void {},
+};
 
 /** A `ResizeObserverEntry` carrying only the fields the effect reads. */
 function resizeEntry(width: number, height: number): ResizeObserverEntry {
@@ -438,9 +442,9 @@ function resizeEntry(width: number, height: number): ResizeObserverEntry {
 }
 
 function fireResize(width: number, height: number): void {
-  const observer = latestControllableResizeObserver;
-  if (observer === null) throw new Error("ResizeObserver was not created");
-  observer.callback([resizeEntry(width, height)], observer);
+  const callback = latestResizeCallback;
+  if (callback === null) throw new Error("ResizeObserver was not created");
+  callback([resizeEntry(width, height)], INERT_RESIZE_OBSERVER);
 }
 
 describe("CommGraphCanvas viewport resize", () => {
@@ -448,7 +452,7 @@ describe("CommGraphCanvas viewport resize", () => {
 
   beforeEach(() => {
     originalResizeObserver = globalThis.ResizeObserver;
-    latestControllableResizeObserver = null;
+    latestResizeCallback = null;
     Object.defineProperty(globalThis, "ResizeObserver", {
       configurable: true,
       writable: true,

--- a/clients/gui-app/src/components/epic-canvas/comm-graph/__tests__/comm-graph-viewport.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/comm-graph/__tests__/comm-graph-viewport.test.tsx
@@ -30,7 +30,15 @@ import {
   render,
   waitFor,
 } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi, type Mock } from "vitest";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type Mock,
+} from "vitest";
 import type {
   ReactFlowInstance,
   ReactFlowProps,
@@ -141,6 +149,10 @@ type FlowFitView = ReactFlowInstance<
   CommGraphAgentFlowNode,
   CommGraphFlowEdge
 >["fitView"];
+type FlowSetViewport = ReactFlowInstance<
+  CommGraphAgentFlowNode,
+  CommGraphFlowEdge
+>["setViewport"];
 
 function latestFindAdapter(): TileFindAdapter {
   const adapter = registerFindAdapterMock.mock.lastCall?.[0];
@@ -197,13 +209,18 @@ function createFlowInstanceStub(
 function installFlowInstance(viewport: Viewport): {
   readonly setCenter: Mock<FlowSetCenter>;
   readonly fitView: Mock<FlowFitView>;
+  readonly setViewport: Mock<FlowSetViewport>;
 } {
   const setCenter = vi.fn<FlowSetCenter>(() => Promise.resolve(true));
   const instance = createFlowInstanceStub(viewport, setCenter);
   act(() => {
     latestReactFlowProps().onInit?.(instance);
   });
-  return { setCenter, fitView: instance.fitView as Mock<FlowFitView> };
+  return {
+    setCenter,
+    fitView: instance.fitView as Mock<FlowFitView>,
+    setViewport: instance.setViewport as Mock<FlowSetViewport>,
+  };
 }
 
 function setCanvasSize(element: HTMLElement): void {
@@ -384,5 +401,87 @@ describe("CommGraphCanvas viewport", () => {
     await waitFor(() => {
       expect(setCenter).toHaveBeenCalledTimes(1);
     });
+  });
+});
+
+/**
+ * The global `MockResizeObserver` installed by `test-browser-apis.ts` is a
+ * total no-op - it never invokes its callback. This suite installs a
+ * controllable replacement for its own tests only, restored afterward so the
+ * rest of the file keeps the shared no-op.
+ */
+class ControllableResizeObserver implements ResizeObserver {
+  readonly callback: ResizeObserverCallback;
+
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback;
+    latestControllableResizeObserver = this;
+  }
+
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+
+let latestControllableResizeObserver: ControllableResizeObserver | null = null;
+
+/** A `ResizeObserverEntry` carrying only the fields the effect reads. */
+function resizeEntry(width: number, height: number): ResizeObserverEntry {
+  const size: ResizeObserverSize = { inlineSize: width, blockSize: height };
+  return {
+    target: document.createElement("div"),
+    contentRect: DOMRect.fromRect({ width, height }),
+    borderBoxSize: [size],
+    contentBoxSize: [size],
+    devicePixelContentBoxSize: [size],
+  };
+}
+
+function fireResize(width: number, height: number): void {
+  const observer = latestControllableResizeObserver;
+  if (observer === null) throw new Error("ResizeObserver was not created");
+  observer.callback([resizeEntry(width, height)], observer);
+}
+
+describe("CommGraphCanvas viewport resize", () => {
+  let originalResizeObserver: typeof ResizeObserver;
+
+  beforeEach(() => {
+    originalResizeObserver = globalThis.ResizeObserver;
+    latestControllableResizeObserver = null;
+    Object.defineProperty(globalThis, "ResizeObserver", {
+      configurable: true,
+      writable: true,
+      value: ControllableResizeObserver,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, "ResizeObserver", {
+      configurable: true,
+      writable: true,
+      value: originalResizeObserver,
+    });
+  });
+
+  it("keeps the point under the tile's centre under the new centre, and ignores a zero-size entry", () => {
+    const result = renderCanvas(GRAPH_DEFAULT_VIEW, STATIC_CANVAS);
+    const canvasElement = result.getByTestId("comm-graph-canvas");
+    // The effect takes its first measurement from this rect - 600x400 -
+    // before the observer ever fires.
+    setCanvasSize(canvasElement);
+    const { setViewport } = installFlowInstance({ x: 10, y: 20, zoom: 0.8 });
+
+    // Width shrinks by 200, height is unchanged: half the delta shifts x by
+    // -100 and leaves y alone, with zoom untouched.
+    fireResize(400, 400);
+
+    expect(setViewport).toHaveBeenCalledTimes(1);
+    expect(setViewport).toHaveBeenCalledWith({ x: -90, y: 20, zoom: 0.8 });
+
+    // A tile collapsed to nothing (hidden pane) has no centre worth keeping.
+    fireResize(0, 0);
+
+    expect(setViewport).toHaveBeenCalledTimes(1);
   });
 });

--- a/clients/gui-app/src/components/epic-canvas/comm-graph/comm-graph-canvas.tsx
+++ b/clients/gui-app/src/components/epic-canvas/comm-graph/comm-graph-canvas.tsx
@@ -522,6 +522,47 @@ function CommGraphCanvasBody(props: CommGraphCanvasProps) {
     // share a sender: every cursor step gets its own visibility decision.
   }, [findRuntime, flowInstance, nodes, playing, pulse, senderAgentId]);
 
+  // React Flow anchors its viewport at the tile's top-left, so a tile that
+  // shrinks or grows around the graph - a split, a drag of the pane divider -
+  // keeps that corner and lets whatever was in the MIDDLE slide toward an
+  // edge. Shifting by half the size delta keeps the graph point that was
+  // under the centre under the centre. Programmatic, so `onMoveEnd` persists
+  // the shifted viewport without `onMoveStart` reading it as a person taking
+  // the camera.
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (canvas === null || flowInstance === null) return;
+    const first = canvas.getBoundingClientRect();
+    let previous = { width: first.width, height: first.height };
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries.at(-1);
+      if (entry === undefined) return;
+      const next = {
+        width: entry.contentRect.width,
+        height: entry.contentRect.height,
+      };
+      const before = previous;
+      previous = next;
+      // A first measurement, or a tile collapsing to nothing while hidden, has
+      // no centre worth keeping.
+      if (before.width <= 0 || before.height <= 0) return;
+      if (next.width <= 0 || next.height <= 0) return;
+      const dx = (next.width - before.width) / 2;
+      const dy = (next.height - before.height) / 2;
+      if (dx === 0 && dy === 0) return;
+      const viewport = flowInstance.getViewport();
+      void flowInstance.setViewport({
+        x: viewport.x + dx,
+        y: viewport.y + dy,
+        zoom: viewport.zoom,
+      });
+    });
+    observer.observe(canvas);
+    return () => {
+      observer.disconnect();
+    };
+  }, [flowInstance]);
+
   const selectedEdge =
     selectedDetail?.kind === "pair"
       ? (aggregated.find((edge) => edge.id === selectedDetail.edgeId) ?? null)

--- a/clients/gui-app/src/components/epic-canvas/comm-graph/office/comm-graph-office-canvas.tsx
+++ b/clients/gui-app/src/components/epic-canvas/comm-graph/office/comm-graph-office-canvas.tsx
@@ -1682,7 +1682,30 @@ export function CommGraphOfficeCanvas(props: CommGraphOfficeCanvasProps) {
     const rect = container.getBoundingClientRect();
     const dpr = window.devicePixelRatio || 1;
     appliedDprRef.current = dpr;
-    runtime.setViewport({ width: rect.width, height: rect.height });
+    const previous = runtime.getViewport();
+    const next: ScreenSize = { width: rect.width, height: rect.height };
+    // The camera is anchored at the tile's top-left, so a tile that shrinks
+    // or grows around it - a split, a drag of the pane divider - would keep
+    // that corner and let whatever was in the MIDDLE slide toward an edge.
+    // Shifting by half the size delta keeps the floor point that was under
+    // the centre under the centre, which is what a resize should look like
+    // from inside the tile. A first measurement has nothing to keep. A tile
+    // that is still fitting itself is left alone: the frame loop re-fits it
+    // to the new viewport, and persisting a shifted camera here would turn a
+    // never-framed tile into a framed one, costing it that fit on the next
+    // open.
+    if (
+      previous.width > 0 &&
+      previous.height > 0 &&
+      (next.width !== previous.width || next.height !== previous.height) &&
+      !runtime.isAutoFitEnabled()
+    ) {
+      const camera = runtime.getCamera();
+      camera.x += (next.width - previous.width) / 2;
+      camera.y += (next.height - previous.height) / 2;
+      persistView();
+    }
+    runtime.setViewport(next);
     const width = Math.max(1, Math.round(rect.width * dpr));
     const height = Math.max(1, Math.round(rect.height * dpr));
     if (canvas.width === width && canvas.height === height) return;
@@ -1692,7 +1715,7 @@ export function CommGraphOfficeCanvas(props: CommGraphOfficeCanvasProps) {
     // the idle skip assumes is still there. Without this a resize of a still
     // floor leaves the tile blank until something happens to move.
     runtime.invalidateFrame();
-  }, [runtime]);
+  }, [persistView, runtime]);
 
   useEffect(() => {
     const container = containerRef.current;


### PR DESCRIPTION
## Problem

Team report: split the screen with the communication graph tile in view and the graph "does not resize"; the view should re-center on re-tiling and keep the same center across panels and resizes.

Both renderers (office floor and node graph) store the camera as a top-left screen offset plus zoom. A pane split or a divider drag changes the tile's box but not that offset, so the left/top edge stays pinned and whatever was in the middle slides toward an edge. On a horizontal split the right half of the floor simply disappears, which reads as the tile not adapting.

## Fix

One geometric rule for both modes: the point that was under the tile's centre stays under the new centre. On a container size change the camera shifts by half the size delta, zoom untouched.

- **Office** (`comm-graph-office-canvas.tsx`): done in `applyCanvasSize`, the one place the viewport is measured, and only for a tile that has been framed by the user. A never-framed tile is re-fitted by the frame loop (the fit cache already keys on the viewport), and persisting a shifted camera would turn it into a framed tile and cost it that fit on the next open.
- **Node graph** (`comm-graph-canvas.tsx`): a `ResizeObserver` on the flow wrapper moves the React Flow viewport programmatically; the move reaches `onMoveEnd` with a `null` event, so it persists without `onMoveStart` treating it as the person taking the camera.
- Skipped: the first measurement (nothing to keep), a tile collapsing to 0×0 while hidden, and DPR-only changes (same CSS size).

## Tests

- Office: a framed tile resized 400×300 → 200×300 persists `x` shifted by −100 with `y`/zoom unchanged; a never-framed tile persists nothing on resize.
- Graph: a 600×400 → 400×400 entry calls `setViewport` once with `x − 100`, same `y` and zoom; a zero-size entry calls nothing.
- Existing viewport, office canvas and tile suites unchanged and green.