### PR TITLE
feat(gui-app): offer automatic cleanup from a Sweep that found proven-safe worktrees

### DIFF
--- a/clients/gui-app/src/components/epics/__tests__/sweep-worktrees-dialog-auto-cleanup-discovery.test.tsx
+++ b/clients/gui-app/src/components/epics/__tests__/sweep-worktrees-dialog-auto-cleanup-discovery.test.tsx
@@ -1,0 +1,326 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  type RenderResult,
+} from "@testing-library/react";
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { WorktreeHostEntryV14 } from "@traycer/protocol/host/index";
+import type { WorktreeAutoCleanupPolicyState } from "@traycer/protocol/host/worktree-auto-cleanup-schemas";
+import { HostClient } from "@traycer-clients/shared/host-client/host-client";
+import { mockLocalHostEntry } from "@traycer-clients/shared/host-client/mock/mock-host-directory";
+import { MockHostMessenger } from "@traycer-clients/shared/host-client/mock/mock-host-messenger";
+import { createRequestContextFixture } from "@traycer-clients/shared/test-fixtures/request-context";
+import { hostRpcRegistry, type HostRpcRegistry } from "@/lib/host";
+
+/**
+ * The Sweep dialog's passive discovery line for automatic cleanup.
+ *
+ * The policy RPC runs for real against a `MockHostMessenger`, so "is the read
+ * still in flight" and "did it come back enabled" go through the actual query
+ * path. Only the two facts the dialog cannot synthesize are stubbed: the
+ * candidate census, and whether this host advertised the capability at all.
+ */
+const testState = vi.hoisted(() => ({
+  rows: [] as ReadonlyArray<unknown>,
+  supported: true as boolean | null,
+  navigate: vi.fn(),
+}));
+
+vi.mock("@tanstack/react-router", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@tanstack/react-router")>()),
+  useNavigate: () => testState.navigate,
+}));
+
+vi.mock("@/hooks/host/use-host-supports-method", () => ({
+  useHostMethodSupport: () => testState.supported,
+  useHostSupportsMethod: () => testState.supported === true,
+  useHostMethodSchemaVersion: () => null,
+}));
+
+vi.mock("@/hooks/epic/use-epic-sweep-worktree-candidates-query", () => ({
+  useEpicSweepWorktreeCandidatesForClient: () => ({
+    hostId: "host-1",
+    rows: testState.rows,
+    isPending: false,
+    isError: false,
+    checkedAt: Date.now(),
+    canRefresh: true,
+    refresh: () => Promise.resolve(testState.rows),
+    prove: () => Promise.resolve(testState.rows),
+  }),
+}));
+
+vi.mock("@/hooks/epic/use-epic-sweep-worktrees-mutation", () => ({
+  useEpicSweepWorktrees: () => ({ isPending: false, mutate: vi.fn() }),
+  useSweepingWorktreePaths: () => new Set<string>(),
+}));
+
+vi.mock("@/components/worktree/worktree-pr-metadata", () => ({
+  WorktreePrPills: () => null,
+}));
+
+vi.mock("@/lib/worktree/teardown-agent-names", () => ({
+  useTeardownAgentNames: () => new Map<string, string>(),
+}));
+
+vi.mock("@/components/settings/panels/use-worktree-task-titles", () => ({
+  useWorktreeTaskTitles: () => new Map<string, string>(),
+}));
+
+import { SweepWorktreesDialog } from "@/components/epics/sweep-worktrees-dialog";
+import { __resetTabNavigationControllerForTesting } from "@/lib/tab-navigation";
+import {
+  __resetTabSyncCoordinatorForTesting,
+  installTabSyncCoordinator,
+} from "@/lib/tab-sync/tab-sync-coordinator";
+import { useTabsStore } from "@/stores/tabs/store";
+import { useSettingsHostScopeStore } from "@/stores/settings/settings-host-scope-store";
+import { useWorktreeCleanupViewStore } from "@/stores/settings/worktree-cleanup-view-store";
+
+const DISCOVERY = "sweep-worktrees-auto-cleanup-discovery";
+
+function worktreeEntry(): WorktreeHostEntryV14 {
+  return {
+    worktreePath: "/tmp/traycer-discovery",
+    branch: "traycer/discovery",
+    repoLabel: "traycerai/traycer",
+    repoIdentifier: { owner: "traycerai", repo: "traycer" },
+    inUse: false,
+    uncommittedCount: 0,
+    gitRemovable: true,
+    scripts: null,
+    owners: [],
+    lastActivityAt: null,
+    branchStatus: null,
+    createdAt: null,
+    prState: null,
+    prNumber: null,
+    prUrl: null,
+    mergedHeadShaMatches: false,
+    submodules: [],
+    atBaseCommit: true,
+    resolvedAt: Date.now(),
+  };
+}
+
+function sweepRow(defaultChecked: boolean): unknown {
+  return {
+    entry: worktreeEntry(),
+    tier: defaultChecked ? "at-base-commit" : "review",
+    defaultChecked,
+    disabled: false,
+    note: defaultChecked ? null : "not-landed",
+    holders: [],
+    holdersStatus: "none",
+  };
+}
+
+function policyFixture(
+  overrides: Partial<WorktreeAutoCleanupPolicyState>,
+): WorktreeAutoCleanupPolicyState {
+  return {
+    enabled: false,
+    inactivityDays: 30,
+    revision: 0,
+    updatedAt: null,
+    updatedByUserId: null,
+    lastEvaluatedAt: null,
+    nextEvaluationAt: null,
+    pausedReason: null,
+    bounds: { minDays: 1, maxDays: 365 },
+    ...overrides,
+  };
+}
+
+function clientWithPolicy(
+  get: () =>
+    | WorktreeAutoCleanupPolicyState
+    | Promise<WorktreeAutoCleanupPolicyState>,
+): HostClient<HostRpcRegistry> {
+  const spine = new HostClient<HostRpcRegistry>({
+    registry: hostRpcRegistry,
+    invalidator: { invalidateHostScope: () => undefined },
+    findHostById: (hostId) =>
+      hostId === mockLocalHostEntry.hostId ? mockLocalHostEntry : null,
+    messenger: new MockHostMessenger<HostRpcRegistry>({
+      registry: hostRpcRegistry,
+      requestId: () => `req-${Math.random().toString(36).slice(2)}`,
+      handlers: { "worktree.getAutoCleanupPolicy": () => get() },
+    }),
+  });
+  spine.setRequestContext(
+    createRequestContextFixture({ origin: "renderer", bearerToken: "tok-1" }),
+  );
+  return spine.createRequester(mockLocalHostEntry);
+}
+
+function renderDialog(input: {
+  readonly client: HostClient<HostRpcRegistry> | null;
+  readonly onOpenChange: (open: boolean) => void;
+}): RenderResult {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const Wrapper = (props: { readonly children: ReactNode }): ReactNode => (
+    <QueryClientProvider client={queryClient}>
+      {props.children}
+    </QueryClientProvider>
+  );
+  return render(
+    <SweepWorktreesDialog
+      epicIds={["epic-1"]}
+      hostClient={input.client}
+      hostChoice={null}
+      fleetPending={false}
+      taskTitle="Discovery sweep"
+      onOpenChange={input.onOpenChange}
+    />,
+    { wrapper: Wrapper },
+  );
+}
+
+/** The census is on screen, so anything conditional on it has had its turn. */
+async function censusRendered(): Promise<void> {
+  await screen.findByText("traycer/discovery");
+}
+
+describe("SweepWorktreesDialog automatic-cleanup discovery", () => {
+  beforeEach(async () => {
+    testState.rows = [sweepRow(true)];
+    testState.supported = true;
+    testState.navigate = vi.fn();
+    __resetTabNavigationControllerForTesting();
+    __resetTabSyncCoordinatorForTesting();
+    installTabSyncCoordinator({ readyPromise: Promise.resolve() });
+    await Promise.resolve();
+    await Promise.resolve();
+    useTabsStore.getState().closeSystemTab("settings");
+    useSettingsHostScopeStore.setState({ scopedHostId: null });
+    useWorktreeCleanupViewStore.setState({
+      view: "settings",
+      focusedRunId: null,
+      autoCleanupFocusRequested: false,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("offers automatic cleanup beside a proven-safe row while the policy is off", async () => {
+    renderDialog({
+      client: clientWithPolicy(() => policyFixture({})),
+      onOpenChange: () => undefined,
+    });
+
+    const line = await screen.findByTestId(DISCOVERY);
+    // The sentence describes the POLICY. It must not claim the row on screen
+    // is due for automatic removal - Sweep's census never proved inactivity.
+    expect(line.textContent).toBe(
+      "Proven-safe worktrees can be removed automatically. Set up automatic cleanup",
+    );
+    const link = screen.getByRole("button", {
+      name: "Set up automatic cleanup",
+    });
+    // A real button, not an anchor: this is an in-app destination, and an href
+    // would route through link egress rather than tab navigation.
+    expect(link.tagName).toBe("BUTTON");
+    expect(link.getAttribute("href")).toBeNull();
+  });
+
+  it("retires the line once automatic cleanup is enabled on that host", async () => {
+    renderDialog({
+      client: clientWithPolicy(() => policyFixture({ enabled: true })),
+      onOpenChange: () => undefined,
+    });
+
+    await censusRendered();
+    // Policy state IS the frequency cap - there is no dismissal to persist.
+    await waitFor(() => {
+      expect(screen.queryByTestId(DISCOVERY)).toBeNull();
+    });
+    expect(screen.queryByTestId(DISCOVERY)).toBeNull();
+  });
+
+  it("says nothing on a host that never advertised the capability", async () => {
+    testState.supported = false;
+    let reads = 0;
+    renderDialog({
+      client: clientWithPolicy(() => {
+        reads += 1;
+        return policyFixture({});
+      }),
+      onOpenChange: () => undefined,
+    });
+
+    await censusRendered();
+    expect(screen.queryByTestId(DISCOVERY)).toBeNull();
+    // The capability question is asked BEFORE the read is mounted, so a host
+    // that negotiated the method away is never asked for a policy.
+    expect(reads).toBe(0);
+  });
+
+  it("stays silent while the policy read is still in flight", async () => {
+    renderDialog({
+      client: clientWithPolicy(
+        () => new Promise<WorktreeAutoCleanupPolicyState>(() => undefined),
+      ),
+      onOpenChange: () => undefined,
+    });
+
+    await censusRendered();
+    // Nothing about the sweep waits on this read, and the read never claims an
+    // answer it does not have: an unsettled policy renders nothing.
+    expect(screen.queryByTestId(DISCOVERY)).toBeNull();
+    expect(
+      screen.getByRole<HTMLButtonElement>("button", {
+        name: "Remove 1 worktree",
+      }).disabled,
+    ).toBe(false);
+  });
+
+  it("says nothing when the census proved no worktree safe to delete", async () => {
+    testState.rows = [sweepRow(false)];
+    renderDialog({
+      client: clientWithPolicy(() => policyFixture({})),
+      onOpenChange: () => undefined,
+    });
+
+    await censusRendered();
+    // Without a visibly safe example the offer has nothing to stand beside.
+    expect(screen.queryByTestId(DISCOVERY)).toBeNull();
+  });
+
+  it("closes the dialog and opens Settings ▸ Worktrees on the latched host", async () => {
+    const onOpenChange = vi.fn();
+    renderDialog({
+      client: clientWithPolicy(() => policyFixture({})),
+      onOpenChange,
+    });
+
+    await screen.findByTestId(DISCOVERY);
+    fireEvent.click(
+      screen.getByRole("button", { name: "Set up automatic cleanup" }),
+    );
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(testState.navigate).toHaveBeenCalledWith(
+      expect.objectContaining({ to: "/settings/worktrees" }),
+    );
+    // The policy is per HOST, so the destination is only well defined once
+    // Settings is administering the machine this sweep was pointed at.
+    expect(useSettingsHostScopeStore.getState().scopedHostId).toBe("host-1");
+    // The inventory, never the cleanup history - and the card asks to be
+    // brought into view once the panel mounts it.
+    expect(useWorktreeCleanupViewStore.getState()).toMatchObject({
+      view: "settings",
+      focusedRunId: null,
+      autoCleanupFocusRequested: true,
+    });
+  });
+});

--- a/clients/gui-app/src/components/epics/__tests__/sweep-worktrees-dialog-auto-cleanup-discovery.test.tsx
+++ b/clients/gui-app/src/components/epics/__tests__/sweep-worktrees-dialog-auto-cleanup-discovery.test.tsx
@@ -28,12 +28,20 @@ import { hostRpcRegistry, type HostRpcRegistry } from "@/lib/host";
 const testState = vi.hoisted(() => ({
   rows: [] as ReadonlyArray<unknown>,
   supported: true as boolean | null,
-  navigate: vi.fn(),
+  // The HOOK is counted, not only its result: the point of the structure is
+  // that a router-less dialog never reaches `useNavigate` at all.
+  useNavigateCalls: 0,
+  navigations: [] as Array<unknown>,
 }));
 
 vi.mock("@tanstack/react-router", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@tanstack/react-router")>()),
-  useNavigate: () => testState.navigate,
+  useNavigate: () => {
+    testState.useNavigateCalls += 1;
+    return (options: unknown): void => {
+      testState.navigations.push(options);
+    };
+  },
 }));
 
 vi.mock("@/hooks/host/use-host-supports-method", () => ({
@@ -193,7 +201,8 @@ describe("SweepWorktreesDialog automatic-cleanup discovery", () => {
   beforeEach(async () => {
     testState.rows = [sweepRow(true)];
     testState.supported = true;
-    testState.navigate = vi.fn();
+    testState.useNavigateCalls = 0;
+    testState.navigations = [];
     __resetTabNavigationControllerForTesting();
     __resetTabSyncCoordinatorForTesting();
     installTabSyncCoordinator({ readyPromise: Promise.resolve() });
@@ -204,7 +213,7 @@ describe("SweepWorktreesDialog automatic-cleanup discovery", () => {
     useWorktreeCleanupViewStore.setState({
       view: "settings",
       focusedRunId: null,
-      autoCleanupFocusRequested: false,
+      autoCleanupFocusHostId: null,
     });
   });
 
@@ -245,6 +254,7 @@ describe("SweepWorktreesDialog automatic-cleanup discovery", () => {
       expect(screen.queryByTestId(DISCOVERY)).toBeNull();
     });
     expect(screen.queryByTestId(DISCOVERY)).toBeNull();
+    expect(testState.useNavigateCalls).toBe(0);
   });
 
   it("says nothing on a host that never advertised the capability", async () => {
@@ -309,18 +319,36 @@ describe("SweepWorktreesDialog automatic-cleanup discovery", () => {
     );
 
     expect(onOpenChange).toHaveBeenCalledWith(false);
-    expect(testState.navigate).toHaveBeenCalledWith(
+    expect(testState.navigations).toContainEqual(
       expect.objectContaining({ to: "/settings/worktrees" }),
     );
     // The policy is per HOST, so the destination is only well defined once
     // Settings is administering the machine this sweep was pointed at.
     expect(useSettingsHostScopeStore.getState().scopedHostId).toBe("host-1");
     // The inventory, never the cleanup history - and the card asks to be
-    // brought into view once the panel mounts it.
+    // brought into view once the panel mounts it, NAMING the host it is about
+    // so another host's card cannot pick the request up later.
     expect(useWorktreeCleanupViewStore.getState()).toMatchObject({
       view: "settings",
       focusedRunId: null,
-      autoCleanupFocusRequested: true,
+      autoCleanupFocusHostId: "host-1",
     });
+  });
+
+  it("never touches the router unless the line itself renders", async () => {
+    // A Sweep dialog rendered without a `RouterProvider` is the normal case in
+    // these suites. `useNavigate` only warns outside one, so the guarantee has
+    // to be structural: the hook lives in the line, and the line only exists
+    // once the capability is proven and the policy came back off.
+    testState.supported = false;
+
+    renderDialog({
+      client: clientWithPolicy(() => policyFixture({})),
+      onOpenChange: () => undefined,
+    });
+
+    await censusRendered();
+    expect(screen.queryByTestId(DISCOVERY)).toBeNull();
+    expect(testState.useNavigateCalls).toBe(0);
   });
 });

--- a/clients/gui-app/src/components/epics/sweep-worktrees-dialog.tsx
+++ b/clients/gui-app/src/components/epics/sweep-worktrees-dialog.tsx
@@ -1076,7 +1076,13 @@ function SweepAutoCleanupDiscoveryPolicy(props: {
   readonly client: HostClient<HostRpcRegistry>;
   readonly onCloseDialog: () => void;
 }): ReactNode {
-  const policy = useWorktreeAutoCleanupPolicy(props.client, true).data ?? null;
+  const query = useWorktreeAutoCleanupPolicy(props.client, true);
+  // A failed read renders nothing even when a stale cached policy is still
+  // attached to it: TanStack keeps `data` through a failed background refetch,
+  // and an offer to set up cleanup must not stand on a policy the host cannot
+  // currently confirm.
+  if (query.isError) return null;
+  const policy = query.data ?? null;
   if (policy === null || policy.enabled) return null;
   return (
     <SweepAutoCleanupDiscoveryLine

--- a/clients/gui-app/src/components/epics/sweep-worktrees-dialog.tsx
+++ b/clients/gui-app/src/components/epics/sweep-worktrees-dialog.tsx
@@ -364,7 +364,6 @@ export function SweepWorktreesDialog(props: SweepWorktreesDialogProps) {
       },
     });
   };
-  const navigate = useNavigate();
   const handlePrimary = (hostName: string | null): void => {
     startSweepPrimary({
       sessionKey: selectionKey,
@@ -445,10 +444,7 @@ export function SweepWorktreesDialog(props: SweepWorktreesDialogProps) {
         // row set, read from the rows rather than from the live selection, so
         // unchecking one does not retract a statement about the POLICY.
         hasProvenSafeRow={rows.some((row) => row.defaultChecked)}
-        onSetUpAutoCleanup={() => {
-          onOpenChange(false);
-          openWorktreeAutoCleanupSettings(navigate, hostId);
-        }}
+        onCloseDialog={() => onOpenChange(false)}
         checkedAt={checkedAt}
         refreshing={refresh.refreshing}
         canRefresh={canRefresh}
@@ -896,7 +892,7 @@ function SweepWorktreesChoose(props: {
   readonly hostClient: HostClient<HostRpcRegistry> | null;
   /** The proof settled with at least one row proven safe to delete. */
   readonly hasProvenSafeRow: boolean;
-  readonly onSetUpAutoCleanup: () => void;
+  readonly onCloseDialog: () => void;
   readonly checkedAt: number | null;
   readonly refreshing: boolean;
   readonly canRefresh: boolean;
@@ -994,7 +990,7 @@ function SweepWorktreesChoose(props: {
             <SweepAutoCleanupDiscovery
               hostId={props.hostId}
               hostClient={props.hostClient}
-              onSetUpAutoCleanup={props.onSetUpAutoCleanup}
+              onCloseDialog={props.onCloseDialog}
             />
           ) : null}
         </section>
@@ -1043,7 +1039,7 @@ function SweepWorktreesChoose(props: {
 function SweepAutoCleanupDiscovery(props: {
   readonly hostId: string | null;
   readonly hostClient: HostClient<HostRpcRegistry> | null;
-  readonly onSetUpAutoCleanup: () => void;
+  readonly onCloseDialog: () => void;
 }): ReactNode {
   const supported = useHostMethodSupport(
     props.hostId,
@@ -1052,17 +1048,52 @@ function SweepAutoCleanupDiscovery(props: {
   // `null` is "no handshake yet", and it stays hidden exactly like `false`:
   // hiding an affordance under an unknown strands nothing, and the line is
   // education rather than a control anyone is waiting for.
-  if (supported !== true || props.hostClient === null) return null;
+  //
+  // `supported === true` also settles the host id - the support registry
+  // answers `null` for a null host - which is why the policy read below can
+  // take a plain `string`.
+  if (supported !== true || props.hostId === null) return null;
+  if (props.hostClient === null) return null;
   return (
-    <SweepAutoCleanupDiscoveryLine
+    <SweepAutoCleanupDiscoveryPolicy
+      hostId={props.hostId}
       client={props.hostClient}
-      onSetUpAutoCleanup={props.onSetUpAutoCleanup}
+      onCloseDialog={props.onCloseDialog}
     />
   );
 }
 
 /**
- * The line itself, mounted only once the capability is proven present.
+ * The policy read, mounted only once the capability is proven present.
+ *
+ * Kept apart from the line it gates so the line - and the router hook it
+ * needs - exists only when there is something to render. A read that is
+ * loading or failed answers `null` here and nothing paints, which is also why
+ * no part of the sweep ever waits on it.
+ */
+function SweepAutoCleanupDiscoveryPolicy(props: {
+  readonly hostId: string;
+  readonly client: HostClient<HostRpcRegistry>;
+  readonly onCloseDialog: () => void;
+}): ReactNode {
+  const policy = useWorktreeAutoCleanupPolicy(props.client, true).data ?? null;
+  if (policy === null || policy.enabled) return null;
+  return (
+    <SweepAutoCleanupDiscoveryLine
+      hostId={props.hostId}
+      onCloseDialog={props.onCloseDialog}
+    />
+  );
+}
+
+/**
+ * The line itself, mounted only when the offer actually stands.
+ *
+ * It owns the deep link, and therefore `useNavigate`, rather than taking a
+ * pre-built handler from the dialog: a Sweep dialog rendered outside a router
+ * (every direct-render suite) must not depend on TanStack warning and carrying
+ * on. Reaching the router is now a consequence of this line rendering, which
+ * only happens where a router exists.
  *
  * The copy describes the POLICY, never these rows: manual Sweep's green rows
  * are examples of what stays proven safe, not a promise that automatic cleanup
@@ -1072,11 +1103,10 @@ function SweepAutoCleanupDiscovery(props: {
  * honest frequency cap.
  */
 function SweepAutoCleanupDiscoveryLine(props: {
-  readonly client: HostClient<HostRpcRegistry>;
-  readonly onSetUpAutoCleanup: () => void;
+  readonly hostId: string;
+  readonly onCloseDialog: () => void;
 }): ReactNode {
-  const policy = useWorktreeAutoCleanupPolicy(props.client, true).data ?? null;
-  if (policy === null || policy.enabled) return null;
+  const navigate = useNavigate();
   return (
     <p
       className="mt-2 text-ui-xs text-muted-foreground wrap-anywhere"
@@ -1088,7 +1118,10 @@ function SweepAutoCleanupDiscoveryLine(props: {
         variant="link"
         size="xs"
         className="h-auto p-0 align-baseline"
-        onClick={props.onSetUpAutoCleanup}
+        onClick={() => {
+          props.onCloseDialog();
+          openWorktreeAutoCleanupSettings(navigate, props.hostId);
+        }}
       >
         Set up automatic cleanup
       </Button>

--- a/clients/gui-app/src/components/epics/sweep-worktrees-dialog.tsx
+++ b/clients/gui-app/src/components/epics/sweep-worktrees-dialog.tsx
@@ -1077,11 +1077,12 @@ function SweepAutoCleanupDiscoveryPolicy(props: {
   readonly onCloseDialog: () => void;
 }): ReactNode {
   const query = useWorktreeAutoCleanupPolicy(props.client, true);
-  // A failed read renders nothing even when a stale cached policy is still
-  // attached to it: TanStack keeps `data` through a failed background refetch,
-  // and an offer to set up cleanup must not stand on a policy the host cannot
-  // currently confirm.
-  if (query.isError) return null;
+  // A read in flight or in error renders nothing even when a stale cached
+  // policy is still attached to it: TanStack keeps `data` through a background
+  // refetch and through its failure, and an offer to set up cleanup must not
+  // stand on a policy the host has not confirmed just now - another device may
+  // have enabled it since the cached read.
+  if (query.isError || query.isFetching) return null;
   const policy = query.data ?? null;
   if (policy === null || policy.enabled) return null;
   return (

--- a/clients/gui-app/src/components/epics/sweep-worktrees-dialog.tsx
+++ b/clients/gui-app/src/components/epics/sweep-worktrees-dialog.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useId, useRef, useState, type ReactNode } from "react";
+import { useNavigate } from "@tanstack/react-router";
 import { AlertTriangle, Paintbrush } from "lucide-react";
 import { toast } from "sonner";
 import type { HostClient } from "@traycer-clients/shared/host-client/host-client";
@@ -44,6 +45,9 @@ import {
   type SweepWorktreesResult,
 } from "@/hooks/epic/use-epic-sweep-worktrees-mutation";
 import { useRefreshSpinner } from "@/hooks/use-refresh-spinner";
+import { useHostMethodSupport } from "@/hooks/host/use-host-supports-method";
+import { useWorktreeAutoCleanupPolicy } from "@/hooks/worktree/use-worktree-auto-cleanup";
+import { openWorktreeAutoCleanupSettings } from "@/lib/worktree/open-auto-cleanup-settings";
 import { useWorktreeTaskTitles } from "@/components/settings/panels/use-worktree-task-titles";
 import { useBareKeyClaimer } from "@/lib/keybindings/use-bare-key-claimer";
 import { isEditableEventTarget } from "@/lib/keybindings/editable-target";
@@ -360,6 +364,7 @@ export function SweepWorktreesDialog(props: SweepWorktreesDialogProps) {
       },
     });
   };
+  const navigate = useNavigate();
   const handlePrimary = (hostName: string | null): void => {
     startSweepPrimary({
       sessionKey: selectionKey,
@@ -434,6 +439,16 @@ export function SweepWorktreesDialog(props: SweepWorktreesDialogProps) {
         bulkSelectedCount={bulkSelectedCount}
         allBulkSelected={allBulkSelected}
         selectedCount={checkedRows.length}
+        hostClient={props.hostClient}
+        // The offer stands beside a concrete, visibly safe example - never on
+        // a census that proved nothing. `defaultChecked` is the proven-safe
+        // row set, read from the rows rather than from the live selection, so
+        // unchecking one does not retract a statement about the POLICY.
+        hasProvenSafeRow={rows.some((row) => row.defaultChecked)}
+        onSetUpAutoCleanup={() => {
+          onOpenChange(false);
+          openWorktreeAutoCleanupSettings(navigate, hostId);
+        }}
         checkedAt={checkedAt}
         refreshing={refresh.refreshing}
         canRefresh={canRefresh}
@@ -877,6 +892,11 @@ function SweepWorktreesChoose(props: {
   readonly bulkSelectedCount: number;
   readonly allBulkSelected: boolean;
   readonly selectedCount: number;
+  /** The latched host's client, for the automatic-cleanup policy read. */
+  readonly hostClient: HostClient<HostRpcRegistry> | null;
+  /** The proof settled with at least one row proven safe to delete. */
+  readonly hasProvenSafeRow: boolean;
+  readonly onSetUpAutoCleanup: () => void;
   readonly checkedAt: number | null;
   readonly refreshing: boolean;
   readonly canRefresh: boolean;
@@ -967,6 +987,16 @@ function SweepWorktreesChoose(props: {
             canRefresh={props.canRefresh}
             onRefresh={props.onRefresh}
           />
+          {/* Passive education, so it sits below the census and its refresh
+              footer and OUTSIDE the destructive action row - it must never
+              read as part of what Remove is about to do. */}
+          {props.proofReady && !props.isPending && props.hasProvenSafeRow ? (
+            <SweepAutoCleanupDiscovery
+              hostId={props.hostId}
+              hostClient={props.hostClient}
+              onSetUpAutoCleanup={props.onSetUpAutoCleanup}
+            />
+          ) : null}
         </section>
       </TooltipProvider>
       <div className="grid min-w-0 shrink-0 grid-cols-2 gap-2 border-t border-border/60 bg-foreground/3 px-5 py-3 sm:flex sm:justify-end">
@@ -995,6 +1025,74 @@ function SweepWorktreesChoose(props: {
         </Button>
       </div>
     </>
+  );
+}
+
+/**
+ * One quiet line offering the policy that would have removed these rows
+ * unattended - shown only to someone who is looking at proven-safe worktrees
+ * on a host that CAN run automatic cleanup and currently does not.
+ *
+ * The capability question is asked HERE, before any host read is mounted, for
+ * the same reason `WorktreeAutoCleanupSection` asks it above its own gate: a
+ * host that negotiated the method away has no policy to read, and a dialog
+ * whose whole job is a destructive confirmation must not acquire a query it
+ * would then have to wait on. Nothing here can delay or block the sweep - a
+ * policy read that is loading, failed, or unsupported renders nothing at all.
+ */
+function SweepAutoCleanupDiscovery(props: {
+  readonly hostId: string | null;
+  readonly hostClient: HostClient<HostRpcRegistry> | null;
+  readonly onSetUpAutoCleanup: () => void;
+}): ReactNode {
+  const supported = useHostMethodSupport(
+    props.hostId,
+    "worktree.getAutoCleanupPolicy",
+  );
+  // `null` is "no handshake yet", and it stays hidden exactly like `false`:
+  // hiding an affordance under an unknown strands nothing, and the line is
+  // education rather than a control anyone is waiting for.
+  if (supported !== true || props.hostClient === null) return null;
+  return (
+    <SweepAutoCleanupDiscoveryLine
+      client={props.hostClient}
+      onSetUpAutoCleanup={props.onSetUpAutoCleanup}
+    />
+  );
+}
+
+/**
+ * The line itself, mounted only once the capability is proven present.
+ *
+ * The copy describes the POLICY, never these rows: manual Sweep's green rows
+ * are examples of what stays proven safe, not a promise that automatic cleanup
+ * is about to take them (it applies its own inactivity threshold and re-proves
+ * at execution time). Enabling the policy is what retires the line - there is
+ * no dismissal and nothing persisted, because policy state is already the
+ * honest frequency cap.
+ */
+function SweepAutoCleanupDiscoveryLine(props: {
+  readonly client: HostClient<HostRpcRegistry>;
+  readonly onSetUpAutoCleanup: () => void;
+}): ReactNode {
+  const policy = useWorktreeAutoCleanupPolicy(props.client, true).data ?? null;
+  if (policy === null || policy.enabled) return null;
+  return (
+    <p
+      className="mt-2 text-ui-xs text-muted-foreground wrap-anywhere"
+      data-testid="sweep-worktrees-auto-cleanup-discovery"
+    >
+      Proven-safe worktrees can be removed automatically.{" "}
+      <Button
+        type="button"
+        variant="link"
+        size="xs"
+        className="h-auto p-0 align-baseline"
+        onClick={props.onSetUpAutoCleanup}
+      >
+        Set up automatic cleanup
+      </Button>
+    </p>
   );
 }
 

--- a/clients/gui-app/src/components/settings/SETTINGS.md
+++ b/clients/gui-app/src/components/settings/SETTINGS.md
@@ -2129,6 +2129,27 @@ aria-live="polite"` carrying the equivalent text for
       validated against the host's own `bounds` (`autoCleanupDaysError`), never
       a constant here — a host that moves its bounds needs no client release,
       and the control can never offer a value the host is about to refuse.
+    - **Arriving from a Sweep.** The per-Task **Sweep worktrees** dialog
+      (`components/epics/sweep-worktrees-dialog.tsx`) shows one muted line in
+      its Choose state — "Proven-safe worktrees can be removed automatically."
+      plus a link-styled **Set up automatic cleanup** button — only while the
+      census settled with at least one `defaultChecked` row AND that dialog's
+      latched host both advertises `worktree.getAutoCleanupPolicy` and reads
+      back `enabled: false`. A loading, failed, unsupported or enabled policy
+      renders nothing, and the capability is checked BEFORE the read is
+      mounted, so nothing about the sweep ever waits on it. Enabling the policy
+      is the whole frequency cap: no dismissal, nothing persisted. The link
+      goes through `lib/worktree/open-auto-cleanup-settings.ts`, which reuses
+      the notification router's three seams in the same order —
+      `carryViewedHostIntoSettingsScope` (the policy is per host),
+      `selectWorktreeCleanupView("settings", null)` (the inventory, never
+      history), and then `ensureSettingsTab` — plus a third hint of its own,
+      `requestAutoCleanupFocus`. That flag is one-shot exactly like
+      `focusedRunId`: `AutoCleanupControls` consumes it in an effect
+      (`scrollIntoView` + `focus()` on the summary row, which carries
+      `tabIndex={-1}` so it is programmatically focusable without joining the
+      tab order) and clears it, and `openHistory` drops it because a card-focus
+      request is stale the moment the panel leaves the inventory.
     - **Paused** states render the reason in plain English
       (`AUTO_CLEANUP_PAUSED_COPY`, a `Record` over the closed wire enum so a new
       arm fails to compile rather than rendering as silence) and offer NO repair

--- a/clients/gui-app/src/components/settings/SETTINGS.md
+++ b/clients/gui-app/src/components/settings/SETTINGS.md
@@ -2144,12 +2144,22 @@ aria-live="polite"` carrying the equivalent text for
       `carryViewedHostIntoSettingsScope` (the policy is per host),
       `selectWorktreeCleanupView("settings", null)` (the inventory, never
       history), and then `ensureSettingsTab` — plus a third hint of its own,
-      `requestAutoCleanupFocus`. That flag is one-shot exactly like
-      `focusedRunId`: `AutoCleanupControls` consumes it in an effect
-      (`scrollIntoView` + `focus()` on the summary row, which carries
-      `tabIndex={-1}` so it is programmatically focusable without joining the
-      tab order) and clears it, and `openHistory` drops it because a card-focus
-      request is stale the moment the panel leaves the inventory.
+      `requestAutoCleanupFocus(hostId)`. That request is one-shot exactly like
+      `focusedRunId`, and it NAMES ITS HOST (`autoCleanupFocusHostId`, not a
+      bare boolean): the policy is per host and the card administers exactly
+      one, so a request whose host never mounts a card — offline, too old, or
+      Settings never opened — must not be spent on whichever host is scoped
+      next. The summary row consumes it in an effect only while
+      `scope.hostId` matches, then clears it (`scrollIntoView` + `focus()` on
+      that row, which carries `tabIndex={-1}` so it is programmatically
+      focusable without joining the tab order in front of the switch).
+      `openHistory` drops it because a card-focus request is stale the moment
+      the panel leaves the inventory, and a caller with no host to name asks
+      for no focus at all.
+      The line's own `useNavigate` lives in the innermost component, which
+      mounts only once the capability is proven AND the policy came back off —
+      so a Sweep dialog rendered without a `RouterProvider` never reaches the
+      router hook, rather than relying on TanStack warning and carrying on.
     - **Paused** states render the reason in plain English
       (`AUTO_CLEANUP_PAUSED_COPY`, a `Record` over the closed wire enum so a new
       arm fails to compile rather than rendering as silence) and offer NO repair

--- a/clients/gui-app/src/components/settings/panels/__tests__/worktree-auto-cleanup-section.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/worktree-auto-cleanup-section.test.tsx
@@ -1,4 +1,12 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type MockInstance,
+} from "vitest";
 import {
   cleanup,
   fireEvent,
@@ -78,6 +86,15 @@ async function openThresholdEditor(): Promise<void> {
   await waitFor(() => {
     screen.getByRole("textbox", { name: "Custom inactivity days" });
   });
+}
+
+/**
+ * Which nodes were scrolled to. The jsdom setup installs a no-op
+ * `scrollIntoView` on the prototype; spying on it records the receiver in
+ * `mock.contexts`, which is the only thing these tests need from it.
+ */
+function spyOnScrollIntoView(): MockInstance<() => void> {
+  return vi.spyOn(Element.prototype, "scrollIntoView");
 }
 
 function policyFixture(
@@ -167,12 +184,13 @@ beforeEach(() => {
   useWorktreeCleanupViewStore.setState({
     view: "settings",
     focusedRunId: null,
-    autoCleanupFocusRequested: false,
+    autoCleanupFocusHostId: null,
   });
 });
 
 afterEach(() => {
   cleanup();
+  vi.restoreAllMocks();
 });
 
 describe("WorktreeAutoCleanupSection", () => {
@@ -335,40 +353,64 @@ describe("WorktreeAutoCleanupSection", () => {
     ).toBeNull();
   });
 
-  it("brings itself into view for a deep link, then drops the request", async () => {
-    // The Sweep dialog's discovery line leaves this one-shot flag behind. The
-    // card is what the link promised, so it scrolls into view AND takes the
-    // caret - and clears the flag, or a later visit to Settings would re-scroll
-    // to a card nobody asked about that time.
-    const scrolled: Array<HTMLElement> = [];
-    const proto = Element.prototype as unknown as {
-      scrollIntoView: () => void;
-    };
-    const original = proto.scrollIntoView;
-    proto.scrollIntoView = function scrollIntoViewSpy(this: HTMLElement) {
-      scrolled.push(this);
-    };
-    useWorktreeCleanupViewStore.getState().requestAutoCleanupFocus();
+  it("brings itself into view for a deep link naming its host, then drops the request", async () => {
+    // The Sweep dialog's discovery line leaves this one-shot request behind.
+    // The card is what the link promised, so it scrolls into view AND takes
+    // the caret - and clears the request, or a later visit to Settings would
+    // re-scroll to a card nobody asked about that time.
+    const scrolls = spyOnScrollIntoView();
+    useWorktreeCleanupViewStore.getState().requestAutoCleanupFocus("host-a");
 
-    try {
-      renderSection(
-        clientWithPolicy({
-          get: () => policyFixture({}),
-          set: (r) => policyFixture(r),
-        }),
-      );
+    renderSection(
+      clientWithPolicy({
+        get: () => policyFixture({}),
+        set: (r) => policyFixture(r),
+      }),
+    );
 
-      const row = screen.getByTestId("worktree-auto-cleanup-summary-row");
-      await waitFor(() => {
-        expect(scrolled).toContain(row);
-      });
-      expect(document.activeElement).toBe(row);
-      expect(
-        useWorktreeCleanupViewStore.getState().autoCleanupFocusRequested,
-      ).toBe(false);
-    } finally {
-      proto.scrollIntoView = original;
-    }
+    const row = screen.getByTestId("worktree-auto-cleanup-summary-row");
+    await waitFor(() => {
+      expect(scrolls.mock.contexts).toContain(row);
+    });
+    expect(document.activeElement).toBe(row);
+    expect(
+      useWorktreeCleanupViewStore.getState().autoCleanupFocusHostId,
+    ).toBeNull();
+  });
+
+  it("leaves another host's focus request alone until that host is scoped", async () => {
+    // The request outlives its destination whenever the named host never
+    // mounts a card - offline, too old, or Settings simply never opened. An
+    // unscoped flag would then be spent on whichever host came next, scrolling
+    // to a machine nobody asked about.
+    const scrolls = spyOnScrollIntoView();
+    useWorktreeCleanupViewStore.getState().requestAutoCleanupFocus("host-b");
+    const client = clientWithPolicy({
+      get: () => policyFixture({}),
+      set: (r) => policyFixture(r),
+    });
+
+    const { rerender } = renderSection(client);
+
+    await loadedCleanupToggle();
+    expect(scrolls.mock.contexts).toEqual([]);
+    expect(document.activeElement).not.toBe(
+      screen.getByTestId("worktree-auto-cleanup-summary-row"),
+    );
+    // Untouched, so it is still there for the host it was actually about.
+    expect(useWorktreeCleanupViewStore.getState().autoCleanupFocusHostId).toBe(
+      "host-b",
+    );
+
+    rerender(sectionForHost(client, HOST_B));
+
+    const row = screen.getByTestId("worktree-auto-cleanup-summary-row");
+    await waitFor(() => {
+      expect(scrolls.mock.contexts).toContain(row);
+    });
+    expect(
+      useWorktreeCleanupViewStore.getState().autoCleanupFocusHostId,
+    ).toBeNull();
   });
 
   it("says the host is too old rather than offering a client-side fallback", () => {

--- a/clients/gui-app/src/components/settings/panels/__tests__/worktree-auto-cleanup-section.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/worktree-auto-cleanup-section.test.tsx
@@ -47,6 +47,7 @@ import {
   hostScopeFixture,
   hostScopeOptionFixture,
 } from "@/components/settings/host-scope/host-scope-fixture";
+import { useWorktreeCleanupViewStore } from "@/stores/settings/worktree-cleanup-view-store";
 
 /**
  * The toggle renders immediately but stays DISABLED until the policy read
@@ -163,6 +164,11 @@ function renderSection(
 beforeEach(() => {
   state.reachability = { status: "reachable", hostLabel: "Host A" };
   state.supported = true;
+  useWorktreeCleanupViewStore.setState({
+    view: "settings",
+    focusedRunId: null,
+    autoCleanupFocusRequested: false,
+  });
 });
 
 afterEach(() => {
@@ -327,6 +333,42 @@ describe("WorktreeAutoCleanupSection", () => {
     expect(
       screen.queryByRole("textbox", { name: "Custom inactivity days" }),
     ).toBeNull();
+  });
+
+  it("brings itself into view for a deep link, then drops the request", async () => {
+    // The Sweep dialog's discovery line leaves this one-shot flag behind. The
+    // card is what the link promised, so it scrolls into view AND takes the
+    // caret - and clears the flag, or a later visit to Settings would re-scroll
+    // to a card nobody asked about that time.
+    const scrolled: Array<HTMLElement> = [];
+    const proto = Element.prototype as unknown as {
+      scrollIntoView: () => void;
+    };
+    const original = proto.scrollIntoView;
+    proto.scrollIntoView = function scrollIntoViewSpy(this: HTMLElement) {
+      scrolled.push(this);
+    };
+    useWorktreeCleanupViewStore.getState().requestAutoCleanupFocus();
+
+    try {
+      renderSection(
+        clientWithPolicy({
+          get: () => policyFixture({}),
+          set: (r) => policyFixture(r),
+        }),
+      );
+
+      const row = screen.getByTestId("worktree-auto-cleanup-summary-row");
+      await waitFor(() => {
+        expect(scrolled).toContain(row);
+      });
+      expect(document.activeElement).toBe(row);
+      expect(
+        useWorktreeCleanupViewStore.getState().autoCleanupFocusRequested,
+      ).toBe(false);
+    } finally {
+      proto.scrollIntoView = original;
+    }
   });
 
   it("says the host is too old rather than offering a client-side fallback", () => {

--- a/clients/gui-app/src/components/settings/panels/worktree-auto-cleanup-section.tsx
+++ b/clients/gui-app/src/components/settings/panels/worktree-auto-cleanup-section.tsx
@@ -1,4 +1,12 @@
-import { useCallback, useEffect, useId, useState, type ReactNode } from "react";
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+  type ReactNode,
+  type RefObject,
+} from "react";
 import { ChevronRight, History, Info } from "lucide-react";
 import type { WorktreeAutoCleanupPolicyState } from "@traycer/protocol/host/worktree-auto-cleanup-schemas";
 import type { HostClient } from "@traycer-clients/shared/host-client/host-client";
@@ -41,6 +49,7 @@ import {
   useRelativeTimestamp,
   useSampledNow,
 } from "@/lib/relative-time";
+import { useWorktreeCleanupViewStore } from "@/stores/settings/worktree-cleanup-view-store";
 
 /**
  * Settings ▸ Worktrees ▸ Automatic cleanup — the per-HOST opt-in.
@@ -242,6 +251,34 @@ function AutoCleanupControls(props: {
 }
 
 /**
+ * Consumes the one-shot "show me this card" request another surface left in
+ * `worktree-cleanup-view-store` (the Sweep dialog's discovery line).
+ *
+ * Lives BELOW the section's gate, so the request survives a host that is still
+ * handshaking: nothing consumes it until a real card is mounted to scroll to.
+ * Cleared the moment it is acted on, so a later visit to Settings does not
+ * re-scroll to a card nobody asked about this time.
+ */
+function useAutoCleanupFocusRequest(
+  containerRef: RefObject<HTMLDivElement | null>,
+): void {
+  const requested = useWorktreeCleanupViewStore(
+    (state) => state.autoCleanupFocusRequested,
+  );
+  useEffect(() => {
+    if (!requested) return;
+    const node = containerRef.current;
+    if (node === null) return;
+    node.scrollIntoView({ block: "center" });
+    // The card is scrolled to AND given the caret, so a keyboard arrival lands
+    // on the control the link promised rather than at the top of the panel.
+    // `preventScroll` because the line above already placed it.
+    node.focus({ preventScroll: true });
+    useWorktreeCleanupViewStore.getState().clearAutoCleanupFocus();
+  }, [containerRef, requested]);
+}
+
+/**
  * Line one: what the policy currently does, the disclosure, and the switch.
  *
  * The disclosure trigger is its OWN button rather than the whole row, because
@@ -258,10 +295,21 @@ function AutoCleanupSummaryRow(props: {
 }): ReactNode {
   const { policy, density, busy, expanded, onSetEnabled } = props;
   const enabled = policy !== null && policy.enabled;
+  // The row owns its own node rather than taking one down from the card: a ref
+  // threaded through props is read during THIS component's render, which is
+  // exactly what `react-hooks/refs` forbids.
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  useAutoCleanupFocusRequest(containerRef);
   return (
     <div
+      // Programmatically focusable only: a deep link from another surface hands
+      // this row the caret, but it never joins the tab order in front of the
+      // switch it introduces.
+      ref={containerRef}
+      tabIndex={-1}
+      data-testid="worktree-auto-cleanup-summary-row"
       className={cn(
-        "flex flex-wrap items-center",
+        "flex flex-wrap items-center outline-none",
         SUMMARY_PADDING[density],
         SETTINGS_ROW_STACK.container,
       )}

--- a/clients/gui-app/src/components/settings/panels/worktree-auto-cleanup-section.tsx
+++ b/clients/gui-app/src/components/settings/panels/worktree-auto-cleanup-section.tsx
@@ -325,7 +325,10 @@ function AutoCleanupSummaryRow(props: {
       tabIndex={-1}
       data-testid="worktree-auto-cleanup-summary-row"
       className={cn(
-        "flex flex-wrap items-center outline-none",
+        // The deep link's programmatic focus must still be SEEN: no default
+        // outline (it would box the whole row on a mouse click inside it),
+        // but the same ring every control here shows to a keyboard user.
+        "flex flex-wrap items-center rounded-md outline-none focus-visible:ring-3 focus-visible:ring-ring/50",
         SUMMARY_PADDING[density],
         SETTINGS_ROW_STACK.container,
       )}

--- a/clients/gui-app/src/components/settings/panels/worktree-auto-cleanup-section.tsx
+++ b/clients/gui-app/src/components/settings/panels/worktree-auto-cleanup-section.tsx
@@ -86,6 +86,10 @@ export function WorktreeAutoCleanupSection(props: {
   if (gate !== "ready") {
     return <AutoCleanupNotice gate={gate} hostLabel={scope.hostLabel} />;
   }
+  // Unreachable: `resolveAutoCleanupGate` answers "absent" without a host, so
+  // "ready" already proves this. Restated for the type system rather than
+  // asserted, so the two can never disagree silently.
+  if (hostId === null) return null;
   // Keyed by host: switching the sidebar straight from one usable host to
   // another keeps this position in the tree, and the disclosure state inside
   // the controls is per host, not per panel visit. Remounting is what makes
@@ -93,6 +97,7 @@ export function WorktreeAutoCleanupSection(props: {
   return (
     <AutoCleanupControls
       key={hostId}
+      hostId={hostId}
       client={scope.client}
       hostLabel={scope.hostLabel}
       onOpenHistory={onOpenHistory}
@@ -161,6 +166,8 @@ const DISCLOSURE_PADDING: Record<SettingsDensity, string> = {
  * the card is consulted for — so those stay on screen and the rest folds away.
  */
 function AutoCleanupControls(props: {
+  /** The host this card administers. Non-null: `gate === "ready"` proves it. */
+  readonly hostId: string;
   readonly client: HostClient<HostRpcRegistry> | null;
   readonly hostLabel: string;
   readonly onOpenHistory: () => void;
@@ -187,6 +194,7 @@ function AutoCleanupControls(props: {
     >
       <Collapsible open={expanded} onOpenChange={setConfiguring}>
         <AutoCleanupSummaryRow
+          hostId={props.hostId}
           policy={policy}
           density={density}
           busy={setPolicy.isPending}
@@ -258,13 +266,20 @@ function AutoCleanupControls(props: {
  * handshaking: nothing consumes it until a real card is mounted to scroll to.
  * Cleared the moment it is acted on, so a later visit to Settings does not
  * re-scroll to a card nobody asked about this time.
+ *
+ * Matched by HOST, and left alone otherwise. A request whose host never
+ * mounted a card - offline, too old, or Settings never opened - outlives its
+ * own destination, and an unmatched request that this card consumed anyway
+ * would scroll to a machine nobody asked about.
  */
 function useAutoCleanupFocusRequest(
+  hostId: string,
   containerRef: RefObject<HTMLDivElement | null>,
 ): void {
-  const requested = useWorktreeCleanupViewStore(
-    (state) => state.autoCleanupFocusRequested,
+  const requestedHostId = useWorktreeCleanupViewStore(
+    (state) => state.autoCleanupFocusHostId,
   );
+  const requested = requestedHostId === hostId;
   useEffect(() => {
     if (!requested) return;
     const node = containerRef.current;
@@ -287,6 +302,7 @@ function useAutoCleanupFocusRequest(
  * a single tab stop unreachable.
  */
 function AutoCleanupSummaryRow(props: {
+  readonly hostId: string;
   readonly policy: WorktreeAutoCleanupPolicyState | null;
   readonly density: SettingsDensity;
   readonly busy: boolean;
@@ -299,7 +315,7 @@ function AutoCleanupSummaryRow(props: {
   // threaded through props is read during THIS component's render, which is
   // exactly what `react-hooks/refs` forbids.
   const containerRef = useRef<HTMLDivElement | null>(null);
-  useAutoCleanupFocusRequest(containerRef);
+  useAutoCleanupFocusRequest(props.hostId, containerRef);
   return (
     <div
       // Programmatically focusable only: a deep link from another surface hands

--- a/clients/gui-app/src/lib/worktree/open-auto-cleanup-settings.ts
+++ b/clients/gui-app/src/lib/worktree/open-auto-cleanup-settings.ts
@@ -22,7 +22,9 @@ import { carryViewedHostIntoSettingsScope } from "@/components/settings/host-sco
  *
  * `hostId` is the CALLING surface's latched host. `null` leaves Settings
  * administering whatever host it already was, which is the honest answer when
- * the caller has no machine of its own to name.
+ * the caller has no machine of its own to name - and it asks for no card
+ * focus either, because a request that cannot name its host is a request the
+ * card cannot check before acting on.
  */
 export function openWorktreeAutoCleanupSettings(
   navigate: UseNavigateResult<string>,
@@ -30,7 +32,9 @@ export function openWorktreeAutoCleanupSettings(
 ): void {
   carryViewedHostIntoSettingsScope(hostId);
   selectWorktreeCleanupView("settings", null);
-  useWorktreeCleanupViewStore.getState().requestAutoCleanupFocus();
+  if (hostId !== null) {
+    useWorktreeCleanupViewStore.getState().requestAutoCleanupFocus(hostId);
+  }
   navigateToTabIntent(
     navigate,
     ensureSettingsTab({ subSection: "worktrees", resetToGeneral: false }),

--- a/clients/gui-app/src/lib/worktree/open-auto-cleanup-settings.ts
+++ b/clients/gui-app/src/lib/worktree/open-auto-cleanup-settings.ts
@@ -1,0 +1,39 @@
+import type { UseNavigateResult } from "@tanstack/react-router";
+import { ensureSettingsTab } from "@/lib/commands/actions/open-system-tab";
+import { navigateToTabIntent } from "@/lib/tab-navigation";
+import {
+  selectWorktreeCleanupView,
+  useWorktreeCleanupViewStore,
+} from "@/stores/settings/worktree-cleanup-view-store";
+import { carryViewedHostIntoSettingsScope } from "@/components/settings/host-scope/carry-viewed-host-into-settings";
+
+/**
+ * "Take me to automatic cleanup for THIS host" — the deep link a surface uses
+ * when it has just shown someone proven-safe worktrees and wants to offer the
+ * policy that removes them unattended.
+ *
+ * Assembled from the same three seams `routeHostSurfaceNotification` uses, in
+ * the same order and for the same reasons: the host scope and the sub-view are
+ * applied BEFORE navigating, so the panel reads them on its first render rather
+ * than flashing the wrong host or the cleanup history. The difference is the
+ * third hint - a notification names a run, this names the card - and it is a
+ * hint in exactly the same sense: a host that is offline or too old renders no
+ * card at all, and the destination still has to be the worktrees panel.
+ *
+ * `hostId` is the CALLING surface's latched host. `null` leaves Settings
+ * administering whatever host it already was, which is the honest answer when
+ * the caller has no machine of its own to name.
+ */
+export function openWorktreeAutoCleanupSettings(
+  navigate: UseNavigateResult<string>,
+  hostId: string | null,
+): void {
+  carryViewedHostIntoSettingsScope(hostId);
+  selectWorktreeCleanupView("settings", null);
+  useWorktreeCleanupViewStore.getState().requestAutoCleanupFocus();
+  navigateToTabIntent(
+    navigate,
+    ensureSettingsTab({ subSection: "worktrees", resetToGeneral: false }),
+    undefined,
+  );
+}

--- a/clients/gui-app/src/stores/settings/worktree-cleanup-view-store.ts
+++ b/clients/gui-app/src/stores/settings/worktree-cleanup-view-store.ts
@@ -27,14 +27,19 @@ interface WorktreeCleanupViewState {
   /**
    * A ONE-SHOT request to bring the Automatic cleanup card itself into view,
    * left by a surface elsewhere that sent the user here to set cleanup up
-   * (the Sweep dialog's discovery line).
+   * (the Sweep dialog's discovery line). `null` is "nobody asked".
    *
-   * A boolean rather than an id, because the card is a singleton within the
-   * inventory view — there is nothing to name. Like `focusedRunId` it is a
-   * HINT: the card may be absent (an offline or too-old host), and nothing
+   * Names the HOST it was asked for, not merely that it was asked. The policy
+   * is per host and the card administers exactly one, so a request the card
+   * never consumed — the host was offline, too old, or the panel was never
+   * opened — must not be picked up by whichever host is scoped next. A bare
+   * boolean did precisely that: it outlived its own destination and then
+   * scrolled to a different machine's card.
+   *
+   * Like `focusedRunId` it is a HINT: the card may be absent, and nothing
    * about the destination depends on it being consumed.
    */
-  readonly autoCleanupFocusRequested: boolean;
+  readonly autoCleanupFocusHostId: string | null;
   readonly openHistory: (focusedRunId: string | null) => void;
   readonly closeHistory: () => void;
   /**
@@ -42,7 +47,7 @@ interface WorktreeCleanupViewState {
    * later does not silently re-expand a run the user already closed.
    */
   readonly clearFocusedRun: () => void;
-  readonly requestAutoCleanupFocus: () => void;
+  readonly requestAutoCleanupFocus: (hostId: string) => void;
   /** Same one-shot discipline as `clearFocusedRun`, for the same reason. */
   readonly clearAutoCleanupFocus: () => void;
 }
@@ -51,7 +56,7 @@ export const useWorktreeCleanupViewStore = create<WorktreeCleanupViewState>(
   (set) => ({
     view: "settings",
     focusedRunId: null,
-    autoCleanupFocusRequested: false,
+    autoCleanupFocusHostId: null,
     // History is the OTHER sub-view, so a card-focus request that has not been
     // consumed yet is stale the moment the panel leaves the inventory - it
     // would otherwise fire on whatever return to the card came next.
@@ -59,12 +64,13 @@ export const useWorktreeCleanupViewStore = create<WorktreeCleanupViewState>(
       set({
         view: "cleanupHistory",
         focusedRunId,
-        autoCleanupFocusRequested: false,
+        autoCleanupFocusHostId: null,
       }),
     closeHistory: () => set({ view: "settings", focusedRunId: null }),
     clearFocusedRun: () => set({ focusedRunId: null }),
-    requestAutoCleanupFocus: () => set({ autoCleanupFocusRequested: true }),
-    clearAutoCleanupFocus: () => set({ autoCleanupFocusRequested: false }),
+    requestAutoCleanupFocus: (hostId) =>
+      set({ autoCleanupFocusHostId: hostId }),
+    clearAutoCleanupFocus: () => set({ autoCleanupFocusHostId: null }),
   }),
 );
 

--- a/clients/gui-app/src/stores/settings/worktree-cleanup-view-store.ts
+++ b/clients/gui-app/src/stores/settings/worktree-cleanup-view-store.ts
@@ -24,6 +24,17 @@ interface WorktreeCleanupViewState {
   readonly view: WorktreeCleanupView;
   /** The run to scroll to and expand once history mounts. */
   readonly focusedRunId: string | null;
+  /**
+   * A ONE-SHOT request to bring the Automatic cleanup card itself into view,
+   * left by a surface elsewhere that sent the user here to set cleanup up
+   * (the Sweep dialog's discovery line).
+   *
+   * A boolean rather than an id, because the card is a singleton within the
+   * inventory view — there is nothing to name. Like `focusedRunId` it is a
+   * HINT: the card may be absent (an offline or too-old host), and nothing
+   * about the destination depends on it being consumed.
+   */
+  readonly autoCleanupFocusRequested: boolean;
   readonly openHistory: (focusedRunId: string | null) => void;
   readonly closeHistory: () => void;
   /**
@@ -31,16 +42,29 @@ interface WorktreeCleanupViewState {
    * later does not silently re-expand a run the user already closed.
    */
   readonly clearFocusedRun: () => void;
+  readonly requestAutoCleanupFocus: () => void;
+  /** Same one-shot discipline as `clearFocusedRun`, for the same reason. */
+  readonly clearAutoCleanupFocus: () => void;
 }
 
 export const useWorktreeCleanupViewStore = create<WorktreeCleanupViewState>(
   (set) => ({
     view: "settings",
     focusedRunId: null,
+    autoCleanupFocusRequested: false,
+    // History is the OTHER sub-view, so a card-focus request that has not been
+    // consumed yet is stale the moment the panel leaves the inventory - it
+    // would otherwise fire on whatever return to the card came next.
     openHistory: (focusedRunId) =>
-      set({ view: "cleanupHistory", focusedRunId }),
+      set({
+        view: "cleanupHistory",
+        focusedRunId,
+        autoCleanupFocusRequested: false,
+      }),
     closeHistory: () => set({ view: "settings", focusedRunId: null }),
     clearFocusedRun: () => set({ focusedRunId: null }),
+    requestAutoCleanupFocus: () => set({ autoCleanupFocusRequested: true }),
+    clearAutoCleanupFocus: () => set({ autoCleanupFocusRequested: false }),
   }),
 );
 


### PR DESCRIPTION
## Why

Automatic worktree cleanup (#1596) is default-off and lives in Settings ▸ Worktrees. The one moment a user is already looking at proven-safe worktrees is the per-Task **Sweep worktrees** dialog, so that is where the feature introduces itself. Design record: epic artifact `automatic-worktree-cleanup/sweep-dialog-discovery`.

## What

One passive line in the dialog's Choose state, below the census and its refresh footer and outside the destructive footer:

> Proven-safe worktrees can be removed automatically. **Set up automatic cleanup**

Shown only when all hold: the proof has settled with at least one proven-safe row (`defaultChecked`), the latched host supports `worktree.getAutoCleanupPolicy`, and the policy read returned `enabled: false`. Loading, errored, unsupported, or enabled renders nothing; the capability is checked before any policy read is mounted, so the sweep is never delayed. No task-count gate: the same line appears for a multi-selection from the Tasks list. No dismiss state, nothing persisted; enabling the policy is what retires it.

The link closes the dialog and opens Settings ▸ Worktrees with the host scope pinned to the dialog's host, the inventory view selected (not history), and the Automatic cleanup card scrolled into view and focused. The route is one shared helper, `openWorktreeAutoCleanupSettings`, built from the same three seams notification routing uses, plus a one-shot focus request in the existing cleanup view store that the card consumes and clears.

Untouched: `SweepWorktreesReview`, the teardown dialogs, `DeleteTasksDialog`.

## Tests

New `sweep-worktrees-dialog-auto-cleanup-discovery.test.tsx` (6): shown with safe row + disabled policy; hidden when enabled, unsupported (policy RPC never called), pending, or no safe rows; link closes the dialog, pins the host scope, selects the inventory view, sets the focus request, navigates to the Settings tab. `worktree-auto-cleanup-section.test.tsx` +1: the card consumes and clears the focus request. Other sweep suites and the Settings panel suites still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
