### PR TITLE
fix(gui): probe a host for a running import before offering selections; lease attached runs

### DIFF
--- a/clients/gui-app/src/components/onboarding/__tests__/onboarding-page.test.tsx
+++ b/clients/gui-app/src/components/onboarding/__tests__/onboarding-page.test.tsx
@@ -195,6 +195,8 @@ vi.mock("@/hooks/session-import/use-session-import-available", () => ({
 const startSessionImportRunMock = vi.hoisted(() => vi.fn());
 vi.mock("@/components/session-import/session-import-run-handle", () => ({
   startSessionImportRun: startSessionImportRunMock,
+  probeSessionImportRun: () => undefined,
+  cancelSessionImportProbe: () => undefined,
 }));
 
 // Off by default: the login-import act needs a browser bridge and saved

--- a/clients/gui-app/src/components/onboarding/__tests__/onboarding-session-import-mount.test.tsx
+++ b/clients/gui-app/src/components/onboarding/__tests__/onboarding-session-import-mount.test.tsx
@@ -107,7 +107,11 @@ describe("startSessionImportRun", () => {
 
   it("forwards the submission to the mounted controller", () => {
     const start = vi.fn();
-    setSessionImportStartHandle({ start });
+    setSessionImportStartHandle({
+      start,
+      probe: () => undefined,
+      cancelProbe: () => undefined,
+    });
     const request = {
       selections: [SELECTION],
       titles: new Map([["claude:native-1", "My Session"]]),
@@ -139,7 +143,11 @@ describe("startSessionImportRun", () => {
 
   it("logs an error and does not call start when no host is bound", () => {
     const start = vi.fn();
-    setSessionImportStartHandle({ start });
+    setSessionImportStartHandle({
+      start,
+      probe: () => undefined,
+      cancelProbe: () => undefined,
+    });
     const consoleError = vi
       .spyOn(console, "error")
       .mockImplementation(() => undefined);

--- a/clients/gui-app/src/components/session-import/__tests__/session-import-run-controller.test.tsx
+++ b/clients/gui-app/src/components/session-import/__tests__/session-import-run-controller.test.tsx
@@ -65,15 +65,29 @@ vi.mock(
 interface StreamBindingHarness {
   client: object | null;
   hostId: string | null;
+  /** The lease the ambient binding hands out; `null` models an unleased one. */
+  retain: (() => () => void) | null;
 }
 
 const streamBinding = vi.hoisted((): StreamBindingHarness => ({
   client: { stream: "test" },
   hostId: "host-a",
+  retain: null,
 }));
 vi.mock("@/lib/host/stream-runtime-context", () => ({
   useWsStreamClient: () => streamBinding.client,
   useStreamHostId: () => streamBinding.hostId,
+  // Rebuilt per read, as the provider republishes a value per client: the
+  // controller keys its once-per-binding probe on the CLIENT, not on this
+  // object's identity.
+  useStreamRuntimeBinding: () =>
+    streamBinding.client === null
+      ? null
+      : {
+          wsStreamClient: streamBinding.client,
+          hostId: streamBinding.hostId,
+          retain: streamBinding.retain,
+        },
 }));
 
 const invalidateQueriesMock = vi.hoisted(() => vi.fn(() => Promise.resolve()));
@@ -161,6 +175,7 @@ function currentRun(): SessionImportRunState {
 beforeEach(() => {
   streamBinding.client = { stream: "test" };
   streamBinding.hostId = "host-a";
+  streamBinding.retain = null;
   runClientHarness.instances = [];
   invalidateQueriesMock.mockClear();
   useSessionImportRunStore.setState({ runs: new Map() });
@@ -438,6 +453,123 @@ describe("<SessionImportRunController />", () => {
     expect(requireInstance(0).close).toHaveBeenCalledTimes(1);
     expect(requireInstance(1).close).not.toHaveBeenCalled();
     expect(requireInstance(1).selections).toEqual([]);
+  });
+
+  it("a surface probe for another host attaches with that binding's lease and releases it when the run ends", () => {
+    render(<SessionImportRunController />);
+    const release = vi.fn();
+    const retain = vi.fn(() => release);
+    const handle = getSessionImportStartHandle();
+    const target = {
+      binding: {
+        wsStreamClient: fakeWsStreamClient(),
+        hostId: "host-b",
+        retain,
+      },
+      hostId: "host-b",
+    };
+    act(() => {
+      handle?.probe(target);
+    });
+    // The ambient probe is instance 0; this is the scoped one.
+    const probe = requireInstance(1);
+    expect(retain).toHaveBeenCalledTimes(1);
+    expect(release).not.toHaveBeenCalled();
+
+    act(() => {
+      probe.callbacks.onStarted({ attached: true, runId: "run-b", total: 2 });
+    });
+    expect(runFor("host-b").status).toBe("running");
+    expect(runFor("host-b").attached).toBe(true);
+    // A second question about a host already being asked or run is a no-op.
+    act(() => {
+      handle?.probe(target);
+    });
+    expect(runClientHarness.instances).toHaveLength(2);
+    expect(retain).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      probe.callbacks.onComplete({
+        runId: "run-b",
+        counts: { imported: 2, skippedAlreadyImported: 0, failed: 0 },
+      });
+    });
+    expect(runFor("host-b").status).toBe("complete");
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancelling withdraws a surface probe still waiting and returns its lease, but never an attached one", () => {
+    render(<SessionImportRunController />);
+    // Settle the controller's own question first: an idle answer closes it
+    // and records the binding as asked, so nothing below re-asks it.
+    act(() => {
+      requireInstance(0).callbacks.onStarted({
+        attached: false,
+        runId: "run-0",
+        total: 0,
+      });
+    });
+    const release = vi.fn();
+    const retain = vi.fn(() => release);
+    const handle = getSessionImportStartHandle();
+    const target = {
+      binding: {
+        wsStreamClient: fakeWsStreamClient(),
+        hostId: "host-b",
+        retain,
+      },
+      hostId: "host-b",
+    };
+    act(() => {
+      handle?.probe(target);
+    });
+    const surfaceProbe = requireInstance(1);
+
+    act(() => {
+      handle?.cancelProbe(target);
+    });
+    expect(surfaceProbe.close).toHaveBeenCalledTimes(1);
+    expect(release).toHaveBeenCalledTimes(1);
+    expect(runFor("host-b").status).toBe("idle");
+    expect(runClientHarness.instances).toHaveLength(2);
+
+    // A probe that attached is the run's subscription and is not withdrawn.
+    act(() => {
+      handle?.probe(target);
+    });
+    const attached = requireInstance(2);
+    act(() => {
+      attached.callbacks.onStarted({
+        attached: true,
+        runId: "run-b",
+        total: 1,
+      });
+    });
+    act(() => {
+      handle?.cancelProbe(target);
+    });
+    expect(attached.close).not.toHaveBeenCalled();
+    expect(runFor("host-b").status).toBe("running");
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it("the ambient probe keeps the ambient binding's lease for a run it attaches to", () => {
+    const release = vi.fn();
+    streamBinding.retain = vi.fn(() => release);
+    render(<SessionImportRunController />);
+    const probe = requireInstance(0);
+    expect(streamBinding.retain).toHaveBeenCalledTimes(1);
+    act(() => {
+      probe.callbacks.onStarted({ attached: true, runId: "run-a", total: 1 });
+    });
+    expect(release).not.toHaveBeenCalled();
+    act(() => {
+      probe.callbacks.onComplete({
+        runId: "run-a",
+        counts: { imported: 1, skippedAlreadyImported: 0, failed: 0 },
+      });
+    });
+    expect(release).toHaveBeenCalledTimes(1);
   });
 
   it("closes the probe on unmount when no answer has arrived yet", () => {

--- a/clients/gui-app/src/components/session-import/__tests__/session-import-wizard.test.tsx
+++ b/clients/gui-app/src/components/session-import/__tests__/session-import-wizard.test.tsx
@@ -114,8 +114,12 @@ vi.mock("@/lib/host/stream-runtime-context", () => ({
   }),
 }));
 
+const probeSessionImportRunMock = vi.hoisted(() => vi.fn());
+const cancelSessionImportProbeMock = vi.hoisted(() => vi.fn());
 vi.mock("@/components/session-import/session-import-run-handle", () => ({
   startSessionImportRun: startSessionImportRunMock,
+  probeSessionImportRun: probeSessionImportRunMock,
+  cancelSessionImportProbe: cancelSessionImportProbeMock,
 }));
 
 vi.mock("@/lib/analytics", () => ({
@@ -991,6 +995,28 @@ describe("<SessionImportWizard />", () => {
 
     expect(screen.getByTestId("session-import-empty")).toBeTruthy();
     expect(screen.queryAllByTestId("session-import-group")).toHaveLength(0);
+  });
+
+  it("asks the host it renders under whether an import is already running when it opens", () => {
+    probeSessionImportRunMock.mockClear();
+    renderWizard(vi.fn());
+    // At least once, and always about the host it renders under. The harness
+    // mints a fresh binding object per render, so the count is not asserted:
+    // the real providers memoise theirs, and the controller dedupes anyway.
+    expect(probeSessionImportRunMock).toHaveBeenCalled();
+    for (const call of probeSessionImportRunMock.mock.calls) {
+      expect(call[0]).toMatchObject({ hostId: "host-a" });
+    }
+  });
+
+  it("withdraws its question when it closes", () => {
+    cancelSessionImportProbeMock.mockClear();
+    const { unmount } = renderWizard(vi.fn());
+    unmount();
+    expect(cancelSessionImportProbeMock).toHaveBeenCalled();
+    expect(cancelSessionImportProbeMock.mock.calls.at(-1)?.[0]).toMatchObject({
+      hostId: "host-a",
+    });
   });
 
   it("offers Import more on the summary, and pressing it retires the run and brings the list back", () => {

--- a/clients/gui-app/src/components/session-import/session-import-run-controller.tsx
+++ b/clients/gui-app/src/components/session-import/session-import-run-controller.tsx
@@ -8,10 +8,7 @@ import {
   type SessionImportRunProgressPayload,
   type SessionImportRunStartedPayload,
 } from "@traycer-clients/shared/host-transport/session-import-run-client";
-import {
-  useStreamHostId,
-  useWsStreamClient,
-} from "@/lib/host/stream-runtime-context";
+import { useStreamRuntimeBinding } from "@/lib/host/stream-runtime-context";
 import { hostQueryKeys, sessionImportQueryKeys } from "@/lib/query-keys";
 import {
   progressEntryFrom,
@@ -62,23 +59,31 @@ function newChatPermissionModeFor(hostId: string): PermissionMode {
  * a run is already going. A window opened while the host is still importing -
  * a reload, a second window - would otherwise show an idle wizard over a live
  * run, and its Import button would attach to that run instead of starting the
- * user's own selection. Only the ambient host is probed: a scoped host is
- * asked about by the surface that opens it, and probing every host the window
- * could reach is a fan-out nothing has asked for.
+ * user's own selection. Only the ambient host is probed on the controller's
+ * own initiative: a scoped host is asked about by the surface that opens a
+ * wizard for it (`probeSessionImportRun`), since probing every host the
+ * window could reach is a fan-out nothing has asked for. Either way the probe
+ * takes the binding's lease, so a run it attaches to outlives the binding.
  */
 export function SessionImportRunController(): null {
   const queryClient = useQueryClient();
-  const ambientStreamClient = useWsStreamClient();
-  // The host the mount-time probe asks. Its name has to come off the same
-  // binding as the client - a host swap between the two reads would invalidate
-  // one machine's queries for a run that happened on another. See
-  // `StreamRuntimeBinding.hostId`.
-  const ambientHostId = useStreamHostId();
+  // The mount-time probe's target: client, host name and lease as ONE value,
+  // so a host swap cannot pair one machine's client with another's name (see
+  // `StreamRuntimeBinding.hostId`) and an attached run keeps the transport
+  // alive past the swap.
+  //
+  // The effect below keys on this OBJECT, which every provider publishes once
+  // per client (`StreamRuntimeBinding`'s contract): a binding re-minted per
+  // render would close a waiting probe and re-ask it on every render.
+  const ambientBinding = useStreamRuntimeBinding();
   const runsRef = useRef<Map<string, HostRun>>(new Map());
-  // The stream client this window has already asked "is a run going?". One
-  // question per binding: a probe that came back empty must not be asked
-  // again on the same connection every time a client closes, while a NEW
-  // binding - the app pointed at another host - has never been asked at all.
+  // The stream client this window has already asked "is a run going?" ON ITS
+  // OWN INITIATIVE. One question per ambient binding: a probe that came back
+  // empty must not be asked again on the same connection every time a client
+  // closes, while a NEW binding - the app pointed at another host - has never
+  // been asked at all. A surface's probe (`probe` below) is deliberately not
+  // recorded here: a wizard re-asks on every open, since another window may
+  // have started a run since, and an empty answer costs the host nothing.
   const probedStreamClientRef = useRef<object | null>(null);
   // Bumped whenever a client closes. Closing only mutates refs, and an effect
   // cannot see a ref change; without this, a run retained across a host swap
@@ -93,9 +98,9 @@ export function SessionImportRunController(): null {
     if (run === undefined) return;
     runsRef.current.delete(hostId);
     run.client.close();
-    // Returns the transport reference this run took at subscribe. A scoped
-    // transport closes here if nothing else is reading it; the ambient one
-    // has no lease to return.
+    // Returns the transport reference this run took at subscribe, so a
+    // transport nothing else is reading closes here. `null` only for a
+    // binding that declared nothing to pin.
     run.release?.();
     noteClientClosed();
   }, []);
@@ -160,6 +165,7 @@ export function SessionImportRunController(): null {
       readonly selections: SessionImportRunRequest["selections"];
       readonly callbacks: SessionImportRunCallbacks;
       readonly waitingProbe: boolean;
+      readonly probeOrigin: ProbeOrigin | null;
     }): SessionImportRunClient => {
       const release = input.target.binding.retain?.() ?? null;
       const client = new SessionImportRunClient({
@@ -172,6 +178,7 @@ export function SessionImportRunController(): null {
         client,
         release,
         waitingProbe: input.waitingProbe,
+        probeOrigin: input.probeOrigin,
       });
       return client;
     },
@@ -201,55 +208,94 @@ export function SessionImportRunController(): null {
         selections: request.selections,
         callbacks: runCallbacks(target.hostId),
         waitingProbe: false,
+        probeOrigin: null,
       });
     },
     [closeRun, openRun, runCallbacks],
   );
 
-  // Subscribing with no selections is the host's "attach to whatever is
-  // running" form: a run in flight replays from the start, and an idle host
-  // answers with an empty run instead. The store is touched only in the first
-  // case - the probe closes on the empty answer before its `complete` frame
-  // could read as "nothing was imported".
-  //
-  // Asked once per stream binding, and not gated on the store: after a host
-  // swap the store may still hold the previous host's finished summary, and a
-  // run in flight on the new host is the fresher fact - `applyStarted` lets a
-  // new run id supersede it. A probe that finds nothing leaves the store as
-  // it was.
-  useEffect(() => {
-    if (ambientStreamClient === null || ambientHostId === null) return;
-    if (runsRef.current.has(ambientHostId)) return;
-    if (probedStreamClientRef.current === ambientStreamClient) return;
-    probedStreamClientRef.current = ambientStreamClient;
-
-    const hostId = ambientHostId;
-    const callbacks = runCallbacks(hostId);
-    let attached = false;
-    const probe = openRun({
-      // The ambient binding never closes under its readers, so there is
-      // nothing to pin: `retain: null` says exactly that.
-      target: {
-        binding: { wsStreamClient: ambientStreamClient, hostId, retain: null },
-        hostId,
-      },
-      selections: [],
-      waitingProbe: true,
-      callbacks: {
-        ...callbacks,
-        onStarted: (payload) => {
-          if (!payload.attached) {
-            closeRun(hostId);
-            return;
-          }
-          attached = true;
-          // It is the run's subscription from here, not a question awaiting an
-          // answer, so `start` must refuse rather than replace it.
-          const run = runsRef.current.get(hostId);
-          if (run !== undefined) run.waitingProbe = false;
-          callbacks.onStarted(payload);
+  // Opens the "attach to whatever is running" subscription for one target.
+  // Subscribing with no selections is the host's form for that: a run in
+  // flight replays from the start, and an idle host answers with an empty run
+  // instead. The store is touched only in the first case - the probe closes
+  // on the empty answer before its `complete` frame could read as "nothing
+  // was imported".
+  const openProbe = useCallback(
+    (input: {
+      readonly target: SessionImportRunTarget;
+      readonly origin: ProbeOrigin;
+    }): SessionImportRunClient => {
+      const { target } = input;
+      const hostId = target.hostId;
+      const callbacks = runCallbacks(hostId);
+      return openRun({
+        target,
+        selections: [],
+        waitingProbe: true,
+        probeOrigin: input.origin,
+        callbacks: {
+          ...callbacks,
+          onStarted: (payload) => {
+            if (!payload.attached) {
+              closeRun(hostId);
+              return;
+            }
+            // It is the run's subscription from here, not a question awaiting
+            // an answer, so `start` must refuse rather than replace it.
+            const run = runsRef.current.get(hostId);
+            if (run !== undefined) run.waitingProbe = false;
+            callbacks.onStarted(payload);
+          },
         },
-      },
+      });
+    },
+    [closeRun, openRun, runCallbacks],
+  );
+
+  // A surface's question about the host it renders under. Nothing to ask
+  // while this window already runs, or is already asking, that host.
+  const probe = useCallback(
+    (target: SessionImportRunTarget): void => {
+      if (runsRef.current.has(target.hostId)) return;
+      openProbe({ target, origin: "surface" });
+    },
+    [openProbe],
+  );
+
+  // The surface's question withdrawn: its wizard closed before the host
+  // answered. Only a SURFACE probe still waiting is closed - one that attached
+  // is the run's subscription now and stays, and the ambient probe is the
+  // controller's own question, cleaned up by its own effect. Without this a
+  // scoped transport pinned by an unanswered probe stayed open for as long as
+  // a wedged host kept the socket alive.
+  const cancelProbe = useCallback(
+    (target: SessionImportRunTarget): void => {
+      const run = runsRef.current.get(target.hostId);
+      if (run === undefined || !run.waitingProbe) return;
+      if (run.probeOrigin !== "surface") return;
+      closeRun(target.hostId);
+    },
+    [closeRun],
+  );
+
+  // The ambient host is asked once per stream binding, and not gated on the
+  // store: after a host swap the store may still hold the previous host's
+  // finished summary, and a run in flight on the new host is the fresher
+  // fact - `applyStarted` lets a new run id supersede it. A probe that finds
+  // nothing leaves the store as it was.
+  useEffect(() => {
+    if (ambientBinding === null || ambientBinding.hostId === null) return;
+    const hostId = ambientBinding.hostId;
+    if (probedStreamClientRef.current === ambientBinding.wsStreamClient) return;
+    // Recorded BEFORE the "already running" check: a host this window is
+    // already running or asking has been asked, as far as this binding is
+    // concerned, and must not be re-asked on the next generation bump.
+    probedStreamClientRef.current = ambientBinding.wsStreamClient;
+    if (runsRef.current.has(hostId)) return;
+
+    const ambientProbe = openProbe({
+      target: { binding: ambientBinding, hostId },
+      origin: "ambient",
     });
     // Copied out of the ref for the cleanup: the map object itself never
     // changes for the life of this controller, so the copy reads the same
@@ -260,7 +306,7 @@ export function SessionImportRunController(): null {
       // asking a connection that is gone; one that attached is the run's
       // subscription now and stays.
       const opened = runs.get(hostId);
-      if (!attached && opened?.client === probe) {
+      if (opened?.client === ambientProbe && opened.waitingProbe) {
         // Closed before the host answered (StrictMode's setup-cleanup-setup
         // replay, or the binding changed underneath it): the question was
         // never answered, so the next run of this effect asks again. Closed
@@ -269,27 +315,20 @@ export function SessionImportRunController(): null {
         // would close and re-ask without end.
         probedStreamClientRef.current = null;
         runs.delete(hostId);
-        probe.close();
+        ambientProbe.close();
         opened.release?.();
       }
     };
-  }, [
-    ambientHostId,
-    ambientStreamClient,
-    clientGeneration,
-    closeRun,
-    openRun,
-    runCallbacks,
-  ]);
+  }, [ambientBinding, clientGeneration, openProbe]);
 
   useEffect(() => {
-    setSessionImportStartHandle({ start });
+    setSessionImportStartHandle({ start, probe, cancelProbe });
     return () => {
       if (getSessionImportStartHandle()?.start === start) {
         setSessionImportStartHandle(null);
       }
     };
-  }, [start]);
+  }, [cancelProbe, probe, start]);
 
   useEffect(
     () => () => {
@@ -301,14 +340,22 @@ export function SessionImportRunController(): null {
   return null;
 }
 
+/** Who asked: the controller at mount (`ambient`) or a wizard (`surface`). */
+type ProbeOrigin = "ambient" | "surface";
+
 interface HostRun {
   readonly client: SessionImportRunClient;
-  /** Returns the transport lease this run took; `null` for the ambient one. */
+  /**
+   * Returns the transport lease this run took; `null` only when the binding
+   * declared nothing to pin.
+   */
   readonly release: (() => void) | null;
   /**
-   * True while this client is the mount-time probe still waiting for the
-   * host's answer, which is what lets `start` tell "a run is going" from "we
-   * are still asking".
+   * True while this client is a probe still waiting for the host's answer,
+   * which is what lets `start` tell "a run is going" from "we are still
+   * asking".
    */
   waitingProbe: boolean;
+  /** Which probe this was, for `cancelProbe`; irrelevant once attached. */
+  readonly probeOrigin: ProbeOrigin | null;
 }

--- a/clients/gui-app/src/components/session-import/session-import-run-handle.ts
+++ b/clients/gui-app/src/components/session-import/session-import-run-handle.ts
@@ -29,6 +29,14 @@ interface SessionImportStartHandle {
     request: SessionImportRunRequest,
     target: SessionImportRunTarget,
   ) => void;
+  /**
+   * Asks the target host whether an import is already running and, if so,
+   * attaches to it so its slice fills in. A no-op for a host this window is
+   * already running or asking.
+   */
+  readonly probe: (target: SessionImportRunTarget) => void;
+  /** Withdraws a surface's still-unanswered probe; see `cancelSessionImportProbe`. */
+  readonly cancelProbe: (target: SessionImportRunTarget) => void;
 }
 
 const ref: { current: SessionImportStartHandle | null } = { current: null };
@@ -72,4 +80,38 @@ export function startSessionImportRun(
     return;
   }
   handle.start(request, { binding, hostId: binding.hostId });
+}
+
+/**
+ * A surface that is about to offer selections for `binding`'s host asks this
+ * first. The app-wide controller only ever probes the window's own host on
+ * its own, so a host that is already importing - started from another window,
+ * or before a reload - looks idle to a wizard opened for it, and a submission
+ * would subscribe with new selections that the host silently folds into the
+ * run in flight. Probing attaches to that run instead, so the wizard shows
+ * its progress and offers nothing. A question rather than a click, so a
+ * missing controller or an unnamed host is simply nothing to ask.
+ */
+export function probeSessionImportRun(
+  binding: StreamRuntimeBinding | null,
+): void {
+  const handle = ref.current;
+  if (handle === null) return;
+  if (binding === null || binding.hostId === null) return;
+  handle.probe({ binding, hostId: binding.hostId });
+}
+
+/**
+ * The surface's question withdrawn, for the wizard's effect cleanup: a probe
+ * still waiting when the wizard closes is closed and its transport lease
+ * returned. One that already attached is the run's subscription and stays; the
+ * wizard's own effect asks again on its next open.
+ */
+export function cancelSessionImportProbe(
+  binding: StreamRuntimeBinding | null,
+): void {
+  const handle = ref.current;
+  if (handle === null) return;
+  if (binding === null || binding.hostId === null) return;
+  handle.cancelProbe({ binding, hostId: binding.hostId });
 }

--- a/clients/gui-app/src/components/session-import/session-import-wizard.tsx
+++ b/clients/gui-app/src/components/session-import/session-import-wizard.tsx
@@ -37,7 +37,11 @@ import {
 } from "@/components/session-import/session-import-group";
 import { SessionImportProgress } from "@/components/session-import/session-import-progress";
 import type { SessionImportScanHandle } from "@/components/session-import/use-session-import-scan";
-import { startSessionImportRun } from "@/components/session-import/session-import-run-handle";
+import {
+  cancelSessionImportProbe,
+  probeSessionImportRun,
+  startSessionImportRun,
+} from "@/components/session-import/session-import-run-handle";
 import { useStreamRuntimeBinding } from "@/lib/host/stream-runtime-context";
 import {
   sessionImportTone,
@@ -115,6 +119,24 @@ export function SessionImportWizard(props: {
       store.reset(hostId);
     }
   }, [hostId]);
+
+  // Then ask that host whether an import is already going. The app-wide
+  // controller only probes the window's own host by itself, so a host picked
+  // in Settings or the tour that is mid-import - from another window, or from
+  // before a reload - would otherwise show an idle list, and a submission
+  // would be folded into the run in flight with its selections dropped.
+  // Attaching instead shows that run's progress. Asked on every open, and
+  // again when the binding changes: another window may have started a run
+  // since the last visit, a reconnect is a new client the question must be
+  // asked of, and an empty answer costs the host nothing. A question still
+  // unanswered when this wizard closes is withdrawn, so its transport lease
+  // does not outlive the surface that took it.
+  useEffect(() => {
+    probeSessionImportRun(streamBinding);
+    return () => {
+      cancelSessionImportProbe(streamBinding);
+    };
+  }, [streamBinding]);
 
   const { state, dispatch } = scan;
   const view = useMemo(() => buildSessionImportView(state), [state]);

--- a/clients/gui-app/src/lib/host/stream-runtime-context.ts
+++ b/clients/gui-app/src/lib/host/stream-runtime-context.ts
@@ -15,6 +15,12 @@ import type { HostStreamRpcRegistry } from "@traycer/protocol/host/registry";
  * bypass this entire provider by mounting the per-Epic / notifications stores
  * with injected stream-client factories.
  */
+/**
+ * Published ONCE per client by every provider (memoised, or held in state):
+ * consumers key effects on the binding's identity - the session-import
+ * controller's mount-time probe among them - so a binding re-minted per
+ * render would tear those down and re-run them every render.
+ */
 export interface StreamRuntimeBinding {
   readonly wsStreamClient: IHostStreamClient<HostStreamRpcRegistry>;
   /**
@@ -42,10 +48,13 @@ export interface StreamRuntimeBinding {
    * The returned release must be called exactly once, when the run's own need
    * for the transport ends.
    *
-   * `null` when the transport never closes under its consumers - the app-wide
-   * binding, which lives for the window. A `null` here is a promise, not an
-   * absence: it says "nothing to pin", so a caller writes `retain?.()` and is
-   * done rather than guessing which kind of binding it holds.
+   * Every binding the app publishes today hands one out, the app-wide one
+   * included: it is rebuilt when the window points at another host, and a run
+   * started or attached on it has to outlive that. `null` is reserved for a
+   * binding that genuinely has nothing to pin - a test harness, or a transport
+   * that never closes under its consumers - and is a promise rather than an
+   * absence: a caller writes `retain?.()` and is done rather than guessing
+   * which kind of binding it holds.
    */
   readonly retain: (() => () => void) | null;
 }


### PR DESCRIPTION
## Summary

Follow-up to #1721 for the two edge cases Codex raised there after merge.

- **A host already importing looked idle to a wizard opened for it.** The app-root controller only probed the window's own host at mount, so a host picked in Settings or the tour that was mid-import (another window, or before a reload) showed the folder list, and a submission subscribed with selections the host folded into the run in flight and silently dropped. The wizard now asks its host on open through `probeSessionImportRun`; the controller attaches to a run in flight so the wizard shows its progress, and withdraws an unanswered question when the wizard closes so a scoped transport lease never outlives its surface.
- **A run attached at mount lost its transport lease.** The mount-time probe rebuilt its binding with `retain: null`, so an active-host switch closed the socket under a run it had attached to. Probes now take the binding's own lease, ambient or scoped, matching started runs.

Also: the `StreamRuntimeBinding` doc no longer claims the app-wide binding has nothing to pin, and states the once-per-client identity contract the controller's effect relies on.

## Related issue

Follow-up to #1721.

## Checklist

- [x] Pre-commit static checks pass (`pre-commit run --all-files` for an explicit full-repo run)
- [ ] Separate CI test checks pass
- [x] Tests added/updated where it makes sense
- [x] Commits are signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#developer-certificate-of-origin-dco)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F2syw8NSoQDc15qdrdE9qa
