### PR TITLE
fix(gui): address the post-merge Codex review of automatic worktree cleanup

### DIFF
--- a/clients/gui-app/src/components/settings/panels/__tests__/worktree-auto-cleanup-section.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/worktree-auto-cleanup-section.test.tsx
@@ -638,6 +638,50 @@ describe("WorktreeAutoCleanupSection", () => {
     });
   });
 
+  it("offers only the presets inside the host's bounds", async () => {
+    const requests: number[] = [];
+    renderSection(
+      clientWithPolicy({
+        get: () =>
+          policyFixture({
+            enabled: true,
+            inactivityDays: 30,
+            bounds: { minDays: 30, maxDays: 60 },
+          }),
+        set: (request) => {
+          requests.push(request.inactivityDays);
+          return policyFixture(request);
+        },
+      }),
+    );
+
+    await openThresholdEditor();
+    // Only the two presets inside [30, 60] are offered - a preset the host
+    // would refuse is not shown as a button at all.
+    screen.getByRole("button", { name: "30 days" });
+    screen.getByRole("button", { name: "60 days" });
+    for (const days of [7, 14, 90]) {
+      expect(screen.queryByRole("button", { name: `${days} days` })).toBeNull();
+    }
+
+    // The custom input validates against the same bounds.
+    const input = screen.getByRole("textbox", {
+      name: "Custom inactivity days",
+    });
+    fireEvent.change(input, { target: { value: "90" } });
+    fireEvent.blur(input);
+    await waitFor(() => {
+      screen.getByText("Choose between 30 and 60 days.");
+    });
+    expect(requests).toEqual([]);
+
+    fireEvent.change(input, { target: { value: "45" } });
+    fireEvent.blur(input);
+    await waitFor(() => {
+      expect(requests).toEqual([45]);
+    });
+  });
+
   it("refuses a custom value outside the host's bounds without sending it", async () => {
     const requests: number[] = [];
     renderSection(

--- a/clients/gui-app/src/components/settings/panels/__tests__/worktree-cleanup-history.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/worktree-cleanup-history.test.tsx
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  act,
   cleanup,
   fireEvent,
   render,
@@ -23,7 +24,9 @@ import {
   hostScopeFixture,
   hostScopeOptionFixture,
 } from "@/components/settings/host-scope/host-scope-fixture";
+import type { HostScope } from "@/components/settings/host-scope/use-host-scope";
 import { useWorktreeCleanupViewStore } from "@/stores/settings/worktree-cleanup-view-store";
+import { isConcealed } from "@/components/settings/host-scope/concealment-test-helpers";
 
 /**
  * The history sub-view's presentation contract: a `skipped` target is neutral,
@@ -120,6 +123,17 @@ function clientWithHistory(
 function renderHistory(client: HostClient<HostRpcRegistry>): {
   readonly onBack: () => void;
 } {
+  return renderHistoryForScope(
+    hostScopeFixture({
+      host: hostScopeOptionFixture({ hostId: "host-a", name: "Host A" }),
+      client,
+    }),
+  );
+}
+
+function renderHistoryForScope(scope: HostScope): {
+  readonly onBack: () => void;
+} {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
@@ -131,13 +145,7 @@ function renderHistory(client: HostClient<HostRpcRegistry>): {
   );
   render(
     <Wrapper>
-      <WorktreeCleanupHistory
-        scope={hostScopeFixture({
-          host: hostScopeOptionFixture({ hostId: "host-a", name: "Host A" }),
-          client,
-        })}
-        onBack={onBack}
-      />
+      <WorktreeCleanupHistory scope={scope} onBack={onBack} />
     </Wrapper>,
   );
   return { onBack };
@@ -357,6 +365,78 @@ describe("WorktreeCleanupHistory", () => {
     );
     cleanup();
     expect(useWorktreeCleanupViewStore.getState().focusedRunId).toBeNull();
+  });
+
+  it("says it is connecting rather than claiming no history while the host is not yet usable", async () => {
+    // With no client the runs query would simply read as disabled - "not
+    // pending, no runs" - which must never surface as "nothing has run" for a
+    // host that is still connecting.
+    renderHistoryForScope(
+      hostScopeFixture({
+        host: hostScopeOptionFixture({ hostId: "host-a", name: "Host A" }),
+        status: "connecting",
+        client: null,
+      }),
+    );
+
+    await waitFor(() => {
+      screen.getByText("Connecting to Host A…");
+    });
+    // The disabled query still resolves as "no runs" underneath, but the
+    // gate must never let that render visibly while the host is connecting.
+    const empty = screen.queryByText(
+      "No automatic cleanup has run on this host yet.",
+    );
+    expect(empty === null || isConcealed(empty)).toBe(true);
+  });
+
+  it("lets a new focused run outrank an earlier manual collapse", async () => {
+    useWorktreeCleanupViewStore.setState({
+      view: "cleanupHistory",
+      focusedRunId: "run-1",
+    });
+    renderHistory(
+      clientWithHistory({
+        listRuns: () => ({
+          runs: [
+            runFixture({ runId: "run-1" }),
+            runFixture({ runId: "run-2" }),
+          ],
+          nextCursor: null,
+        }),
+        getRun: (request) => ({
+          run: runFixture({ runId: request.runId }),
+          targets: [targetFixture({ targetId: "t-1", runId: request.runId })],
+        }),
+      }),
+    );
+
+    function expandedRunIds(): string[] {
+      return screen
+        .getAllByTestId("worktree-cleanup-run")
+        .filter((row) => row.querySelector('[aria-expanded="true"]') !== null)
+        .map((row) => row.getAttribute("data-run-id"))
+        .filter((id): id is string => id !== null);
+    }
+
+    await waitFor(() => {
+      expect(expandedRunIds()).toEqual(["run-1"]);
+    });
+
+    // A manual choice collapses it - and spends the hint that opened it.
+    fireEvent.click(screen.getByRole("button", { expanded: true }));
+    await waitFor(() => {
+      expect(expandedRunIds()).toEqual([]);
+    });
+    expect(useWorktreeCleanupViewStore.getState().focusedRunId).toBeNull();
+
+    // A NEW focus hint outranks that manual choice.
+    act(() => {
+      useWorktreeCleanupViewStore.setState({ focusedRunId: "run-2" });
+    });
+    await waitFor(() => {
+      expect(expandedRunIds()).toEqual(["run-2"]);
+    });
   });
 
   it("says a focused run is gone instead of dead-ending on it", async () => {

--- a/clients/gui-app/src/components/settings/panels/worktree-auto-cleanup-section.tsx
+++ b/clients/gui-app/src/components/settings/panels/worktree-auto-cleanup-section.tsx
@@ -649,7 +649,13 @@ function AutoCleanupThresholdEditor(props: {
           </p>
         </div>
         <div className="flex max-w-full flex-wrap items-center gap-1.5 max-md:w-full">
-          {AUTO_CLEANUP_DAY_PRESETS.map((days) => (
+          {/* Presets commit without the custom input's validation, so a
+              preset the host's bounds exclude is not offered at all rather
+              than being a button that sends a value the host will refuse. */}
+          {AUTO_CLEANUP_DAY_PRESETS.filter(
+            (days) =>
+              days >= policy.bounds.minDays && days <= policy.bounds.maxDays,
+          ).map((days) => (
             <Button
               key={days}
               type="button"

--- a/clients/gui-app/src/components/settings/panels/worktree-cleanup-history.tsx
+++ b/clients/gui-app/src/components/settings/panels/worktree-cleanup-history.tsx
@@ -13,6 +13,10 @@ import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 import { StartTruncatedText } from "@/components/ui/start-truncated-text";
 import type { HostScope } from "@/components/settings/host-scope/use-host-scope";
 import {
+  HostScopeConnecting,
+  HostScopeGate,
+} from "@/components/settings/host-scope/host-scope-gate";
+import {
   useWorktreeAutoCleanupRun,
   useWorktreeAutoCleanupRuns,
 } from "@/hooks/worktree/use-worktree-auto-cleanup";
@@ -59,6 +63,16 @@ export function WorktreeCleanupHistory(props: {
   const [manualExpansion, setManualExpansion] = useState<{
     readonly runId: string | null;
   } | null>(null);
+  // A NEW hint outranks an earlier manual choice: a second notification
+  // clicked while history stays mounted must open the run it names, not keep
+  // whichever row the user last toggled. Adjusted during render (React's
+  // documented way to react to a changing external value) rather than in an
+  // effect, which would paint the stale row first.
+  const [seenFocusedRunId, setSeenFocusedRunId] = useState(focusedRunId);
+  if (focusedRunId !== seenFocusedRunId) {
+    setSeenFocusedRunId(focusedRunId);
+    if (focusedRunId !== null) setManualExpansion(null);
+  }
   const expandedRunId =
     manualExpansion === null ? focusedRunId : manualExpansion.runId;
   // The hint is consumed when this view goes away. Left set, it would silently
@@ -84,16 +98,29 @@ export function WorktreeCleanupHistory(props: {
         </span>
       </div>
       <div className="min-h-0 flex-1 overflow-y-auto">
-        <WorktreeCleanupHistoryBody
-          client={client}
-          runs={runs}
-          expandedRunId={expandedRunId}
-          onToggleRun={(runId) => {
-            setManualExpansion({
-              runId: expandedRunId === runId ? null : runId,
-            });
-          }}
-        />
+        {/* Behind the same gate as the inventory: with no client the runs
+            query is simply disabled, which reads as "not pending, no runs" -
+            and an offline or still-connecting host must never be reported as
+            one on which cleanup has never run. */}
+        <HostScopeGate
+          scope={scope}
+          skeleton={<HostScopeConnecting hostName={scope.hostLabel} />}
+        >
+          <WorktreeCleanupHistoryBody
+            client={client}
+            runs={runs}
+            expandedRunId={expandedRunId}
+            onToggleRun={(runId) => {
+              setManualExpansion({
+                runId: expandedRunId === runId ? null : runId,
+              });
+              // The hint is spent once the user takes over, so clicking the
+              // SAME notification again is a visible change (null → id)
+              // rather than a no-op the manual choice would swallow.
+              clearFocusedRun();
+            }}
+          />
+        </HostScopeGate>
       </div>
     </div>
   );


### PR DESCRIPTION
Follow-ups to #1596 from the Codex review that was posted after it merged (four threads, all still open there).

| Thread | What changed |
| --- | --- |
| [P2 presets bypass host bounds](https://github.com/traycerai/traycer/pull/1596#discussion_r3925484825) | Preset buttons are filtered to `policy.bounds`, so a value the host would refuse is never offered. The custom input already validated against the same bounds. |
| [P2 offline host reads as empty history](https://github.com/traycerai/traycer/pull/1596#discussion_r3925484830) | The history body now sits behind `HostScopeGate` like the inventory (Back header stays outside). With no client the runs query is disabled, which rendered as "No automatic cleanup has run on this host yet." for a connecting or unreachable host. |
| [P2 manual toggle blocks a later notification](https://github.com/traycerai/traycer/pull/1596#discussion_r3925484839) | A newly delivered `focusedRunId` resets the manual expansion (adjust-state-in-render). A manual toggle also clears the hint, so re-clicking the same notification is an observable change again. |
| [P1 draft survives host failover](https://github.com/traycerai/traycer/pull/1596#discussion_r3925484812) | Already fixed by #1703 (`203357cdc`), which keys `AutoCleanupControls` by `hostId`; the editor and its draft remount on a host change. No change here. |

Targets `tgill-release-train` because the automatic-cleanup code has not been promoted to `main` yet. No protocol change; independent of the paired host PR in traycer-internal.

Tests: one per behaviour change in `worktree-auto-cleanup-section.test.tsx` and `worktree-cleanup-history.test.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
