### PR TITLE
feat(gui): session import - one Deleted Folders group, per-row folders, and a host picker in the dialog

### DIFF
--- a/clients/gui-app/src/components/layout/bridges/session-import-announcement-controller.tsx
+++ b/clients/gui-app/src/components/layout/bridges/session-import-announcement-controller.tsx
@@ -157,6 +157,9 @@ export function SessionImportAnnouncementController(): ReactNode {
       onClose={() => {
         setDialogOpen(false);
       }}
+      // The toast speaks for the app's active host; the dialog's own picker
+      // is where another machine gets chosen.
+      initialHostId={null}
     />
   );
 }

--- a/clients/gui-app/src/components/onboarding/onboarding-host-picker-model.ts
+++ b/clients/gui-app/src/components/onboarding/onboarding-host-picker-model.ts
@@ -1,4 +1,7 @@
-import { isHostScopeUsable } from "@/components/settings/host-scope/host-scope-status";
+import {
+  scopedHostReadiness,
+  type ScopedHostReadiness,
+} from "@/components/settings/host-scope/scoped-host-readiness";
 import type { HostScope } from "@/components/settings/host-scope/use-host-scope";
 
 // The picker's MODEL, apart from its components: fast refresh only keeps state
@@ -38,25 +41,15 @@ export interface OnboardingHostPicker {
   readonly streamOnPickedHost: boolean;
 }
 
-/** What a stage may show: its live content, a spinner, or a dead end. */
-type OnboardingHostReadiness = "ready" | "connecting" | "unavailable";
-
 /**
- * Gated on there being a PICK, not on the status alone: with no pick the tour
- * reads the host it has always read, and an `unreachable` blip on it is not a
- * reason to replace a working wizard with a notice about a machine the user
- * never chose. The same rule the usage popover applies for the same reason.
- *
- * The transport lag is `connecting`, never `unavailable`: nothing is wrong
- * with the host, the surface has simply not finished moving onto it.
+ * What a stage may show: its live content, a spinner, or a dead end. The rule
+ * is the one every surface with its own host picker applies
+ * (`scopedHostReadiness`); the tour only supplies its picker's three inputs.
  */
 export function onboardingHostReadiness(
   picker: OnboardingHostPicker,
-): OnboardingHostReadiness {
-  if (!picker.hasExplicitPick) return "ready";
-  if (picker.scope.status === "connecting") return "connecting";
-  if (!isHostScopeUsable(picker.scope.status)) return "unavailable";
-  return picker.streamOnPickedHost ? "ready" : "connecting";
+): ScopedHostReadiness {
+  return scopedHostReadiness(picker);
 }
 
 /** Whether the stages may show their live content. */

--- a/clients/gui-app/src/components/session-import/__tests__/session-import-dialog.test.tsx
+++ b/clients/gui-app/src/components/session-import/__tests__/session-import-dialog.test.tsx
@@ -1,0 +1,433 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  cleanup,
+  fireEvent,
+  render as renderUi,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import {
+  hostScopeFixture,
+  hostScopeOptionFixture,
+} from "@/components/settings/host-scope/host-scope-fixture";
+import type {
+  HostScope,
+  HostScopeSelection,
+} from "@/components/settings/host-scope/use-host-scope";
+import type { HostScopeStatus } from "@/components/settings/host-scope/host-scope-status";
+import type { HostScopeOption } from "@/components/settings/host-scope/host-scope-model";
+import type { StreamRuntimeBinding } from "@/lib/host/stream-runtime-context";
+import type { IHostStreamClient } from "@traycer-clients/shared/host-transport/host-stream-client";
+import type { HostStreamRpcRegistry } from "@traycer/protocol/host/registry";
+import type { SessionImportScanHandle } from "@/components/session-import/use-session-import-scan";
+import { WithTestQueryClient } from "@/__tests__/with-test-query-client";
+
+/**
+ * The wizard is stubbed exactly as `onboarding-page.test.tsx` and
+ * `session-import-wizard.test.tsx` do it: this suite is about which surface
+ * (wizard vs. notice) the dialog chooses and what it hands `useSessionImportScan`,
+ * not about the wizard's own row/selection behaviour (covered by
+ * `session-import-wizard.test.tsx`).
+ */
+vi.mock("@/components/session-import/session-import-wizard", () => ({
+  SessionImportWizard: (props: { readonly scan: SessionImportScanHandle }) => (
+    <div
+      data-testid="session-import-wizard-stub"
+      data-scan-state={props.scan.state.phase}
+    />
+  ),
+}));
+
+/**
+ * A recording stub rather than a bare mock: the dialog's own gate
+ * (`runIdle && hostReady && scanSupported`) is exactly what this suite has to
+ * prove, and the only way to see it from outside is the `active` argument this
+ * hook was last called with.
+ */
+const scanTrackerMock = vi.hoisted(() => {
+  const calls: boolean[] = [];
+  return {
+    calls,
+    reset(): void {
+      calls.length = 0;
+    },
+  };
+});
+
+vi.mock("@/components/session-import/use-session-import-scan", () => ({
+  useSessionImportScan: (active: boolean) => {
+    scanTrackerMock.calls.push(active);
+    return {
+      state: { kind: "scan-stub" },
+      dispatch: () => undefined,
+    };
+  },
+}));
+
+/** Driven directly, per host, rather than through the stream transport. */
+const scanSupportedMock = vi.hoisted(() => ({ value: true }));
+
+vi.mock("@/hooks/session-import/use-session-import-available", () => ({
+  useSessionImportAvailableFor: () => scanSupportedMock.value,
+}));
+
+vi.mock("@/hooks/auth/use-registered-hosts-query", async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import("@/hooks/auth/use-registered-hosts-query")
+  >()),
+  useRegisteredHostsPollLiveness: () => undefined,
+}));
+
+/**
+ * The scope the dialog sees, over the selection the dialog itself owns — so a
+ * pick made through the real `HostSwitcher` really does re-point the dialog,
+ * the same shape `onboarding-page.test.tsx`'s `tourScope` uses.
+ */
+const hostsMock = vi.hoisted(() => ({
+  hosts: [{ hostId: "host-a", connectable: true }] as ReadonlyArray<{
+    readonly hostId: string;
+    readonly connectable: boolean;
+  }>,
+  activeHostId: "host-a" as string | null,
+}));
+
+/** Overrides the derived status for an explicit pick, for the vanished/unreachable cases. */
+const scopeStatusOverrideMock = vi.hoisted(() => ({
+  value: null as HostScopeStatus | null,
+}));
+
+const hostScopeCallsMock = vi.hoisted(() => ({
+  scopedHostIds: [] as Array<string | null>,
+}));
+
+/** The status the fixture reports for a pick: the same ladder the real scope walks. */
+function scopeStatusFor(
+  explicitPick: boolean,
+  picked: HostScopeOption | null,
+): HostScopeStatus {
+  if (!explicitPick) return "following";
+  if (picked === null) return "vanished";
+  if (scopeStatusOverrideMock.value !== null) {
+    return scopeStatusOverrideMock.value;
+  }
+  return picked.connectable ? "ready" : "unreachable";
+}
+
+/** What the picker strip prints: the host's name, or the id a vanished pick still names. */
+function scopeLabelFor(
+  picked: HostScopeOption | null,
+  scopedHostId: string | null,
+): string {
+  if (picked !== null) return picked.name;
+  return scopedHostId ?? "No host";
+}
+
+function dialogScope(selection: HostScopeSelection): HostScope {
+  hostScopeCallsMock.scopedHostIds.push(selection.scopedHostId);
+  const hosts: HostScopeOption[] = hostsMock.hosts.map((entry) =>
+    hostScopeOptionFixture({
+      hostId: entry.hostId,
+      name: entry.hostId,
+      connectable: entry.connectable,
+    }),
+  );
+  const activeHostId = hostsMock.activeHostId;
+  const explicitPick = selection.scopedHostId !== null;
+  const pickedId = explicitPick ? selection.scopedHostId : activeHostId;
+  const picked = hosts.find((host) => host.hostId === pickedId) ?? null;
+  const status = scopeStatusFor(explicitPick, picked);
+
+  return hostScopeFixture({
+    hosts,
+    host: picked,
+    hostId: picked?.hostId ?? null,
+    hostLabel: scopeLabelFor(picked, selection.scopedHostId),
+    vanishedHostId: status === "vanished" ? selection.scopedHostId : null,
+    activeHostId,
+    activeHost: hosts.find((host) => host.hostId === activeHostId) ?? null,
+    isViewingActive: !explicitPick || picked?.hostId === activeHostId,
+    status,
+    setHostId: selection.setScopedHostId,
+  });
+}
+
+vi.mock(
+  "@/components/settings/host-scope/use-host-scope",
+  async (importOriginal) => ({
+    ...(await importOriginal<
+      typeof import("@/components/settings/host-scope/use-host-scope")
+    >()),
+    useHostScopeFor: (selection: HostScopeSelection) => dialogScope(selection),
+  }),
+);
+
+// The unary half needs no client here: nothing in this suite reads
+// `HostRuntimeContext` beneath the dialog's own re-provider.
+vi.mock("@/components/settings/host-scope/use-scoped-host-binding", () => ({
+  useScopedHostBinding: () => null,
+}));
+
+/**
+ * The stream half is this suite's subject alongside the scan gate: it answers
+ * only once the transport genuinely names the picked host — `null` (still
+ * "connecting", from the picker's point of view) otherwise, reproducing the
+ * commit-after-a-pick gap `scoped-host-readiness.ts` documents.
+ */
+const streamOnHostMock = vi.hoisted(() => ({ hostId: null as string | null }));
+
+const streamBindings = new Map<string, StreamRuntimeBinding>();
+
+function streamBindingFor(hostId: string): StreamRuntimeBinding {
+  const existing = streamBindings.get(hostId);
+  if (existing !== undefined) return existing;
+  const created: StreamRuntimeBinding = {
+    wsStreamClient: fakeWsStreamClient(hostId),
+    hostId,
+    retain: null,
+  };
+  streamBindings.set(hostId, created);
+  return created;
+}
+
+function fakeWsStreamClient(
+  hostId: string,
+): IHostStreamClient<HostStreamRpcRegistry> {
+  return {
+    subscribe: () => {
+      throw new Error("not exercised by this suite");
+    },
+    subscribeWithParamsProvider: () => {
+      throw new Error("not exercised by this suite");
+    },
+    close: () => undefined,
+    isClosed: () => false,
+    isReady: () => true,
+    notifyBearerRotated: () => undefined,
+    reconnectAll: () => undefined,
+    getMethodSupport: () => "unknown",
+    subscribeMethodSupport: () => () => undefined,
+    getMethodSchemaVersion: () => null,
+    subscribeAvailabilityRecovered: () => () => undefined,
+    getClosedReason: () => null,
+    instanceId: `fake-ws-stream-client:${hostId}`,
+    onClosed: () => () => undefined,
+  };
+}
+
+vi.mock("@/components/settings/host-scope/use-scoped-stream-binding", () => ({
+  useScopedStreamBinding: (scope: HostScope) =>
+    scope.hostId !== null && scope.hostId === streamOnHostMock.hostId
+      ? streamBindingFor(scope.hostId)
+      : null,
+}));
+
+// Import after every mock is registered.
+import { SessionImportDialog } from "@/components/session-import/session-import-dialog";
+
+function renderDialog(props: {
+  readonly initialHostId: string | null;
+  readonly onClose: (() => void) | undefined;
+}) {
+  return renderUi(
+    <SessionImportDialog
+      onClose={props.onClose ?? (() => undefined)}
+      initialHostId={props.initialHostId}
+    />,
+    { wrapper: WithTestQueryClient },
+  );
+}
+
+function pickHost(hostId: string): void {
+  fireEvent.click(screen.getByTestId("settings-host-switcher"));
+  fireEvent.click(
+    screen.getByTestId(`settings-host-switcher-option-${hostId}`),
+  );
+}
+
+function lastScanCall(): boolean {
+  const last = scanTrackerMock.calls.at(-1);
+  if (last === undefined) {
+    throw new Error("useSessionImportScan was never called");
+  }
+  return last;
+}
+
+describe("<SessionImportDialog />", () => {
+  beforeEach(() => {
+    hostsMock.hosts = [{ hostId: "host-a", connectable: true }];
+    hostsMock.activeHostId = "host-a";
+    scopeStatusOverrideMock.value = null;
+    streamOnHostMock.hostId = null;
+    scanSupportedMock.value = true;
+    scanTrackerMock.reset();
+    hostScopeCallsMock.scopedHostIds = [];
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders the picker strip and the wizard, and scans immediately, when opened with no pick on a two-host account", () => {
+    hostsMock.hosts = [
+      { hostId: "host-a", connectable: true },
+      { hostId: "host-b", connectable: true },
+    ];
+
+    renderDialog({ initialHostId: null, onClose: undefined });
+
+    expect(screen.getByTestId("session-import-host-picker-row")).not.toBeNull();
+    expect(screen.getByTestId("session-import-wizard-stub")).not.toBeNull();
+    expect(lastScanCall()).toBe(true);
+  });
+
+  it("starts the scope selection on the initialHostId when it names a host other than the active one", () => {
+    hostsMock.hosts = [
+      { hostId: "host-a", connectable: true },
+      { hostId: "host-b", connectable: true },
+    ];
+    hostsMock.activeHostId = "host-a";
+
+    renderDialog({ initialHostId: "host-b", onClose: undefined });
+
+    expect(hostScopeCallsMock.scopedHostIds[0]).toBe("host-b");
+    expect(screen.getByTestId("settings-host-switcher").textContent).toContain(
+      "host-b",
+    );
+  });
+
+  it("withholds the wizard and shows the connecting notice for the new host while the stream still names the previous one", async () => {
+    hostsMock.hosts = [
+      { hostId: "host-a", connectable: true },
+      { hostId: "host-b", connectable: true },
+    ];
+    hostsMock.activeHostId = "host-a";
+    // The ambient/scoped stream never catches up to host-a either, matching a
+    // dialog that opened following the active host with no transport of its own.
+    streamOnHostMock.hostId = null;
+
+    renderDialog({ initialHostId: null, onClose: undefined });
+    expect(screen.getByTestId("session-import-wizard-stub")).not.toBeNull();
+
+    pickHost("host-b");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("host-scope-connecting")).not.toBeNull();
+    });
+    expect(screen.queryByTestId("session-import-wizard-stub")).toBeNull();
+    expect(screen.getByTestId("host-scope-connecting").textContent).toContain(
+      "host-b",
+    );
+    expect(lastScanCall()).toBe(false);
+  });
+
+  it("returns the wizard and resumes the active scan once the stream binding names the picked host", async () => {
+    hostsMock.hosts = [
+      { hostId: "host-a", connectable: true },
+      { hostId: "host-b", connectable: true },
+    ];
+    hostsMock.activeHostId = "host-a";
+    streamOnHostMock.hostId = null;
+
+    const view = renderDialog({ initialHostId: null, onClose: undefined });
+    pickHost("host-b");
+    await waitFor(() => {
+      expect(screen.getByTestId("host-scope-connecting")).not.toBeNull();
+    });
+
+    streamOnHostMock.hostId = "host-b";
+    view.rerender(
+      <SessionImportDialog onClose={() => undefined} initialHostId={null} />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("session-import-wizard-stub")).not.toBeNull();
+    });
+    expect(lastScanCall()).toBe(true);
+  });
+
+  it('shows "Can\'t reach <host>" for a picked host whose scope status is unreachable', async () => {
+    hostsMock.hosts = [
+      { hostId: "host-a", connectable: true },
+      { hostId: "host-b", connectable: false },
+    ];
+    hostsMock.activeHostId = "host-a";
+
+    // Reached the way Settings' Host Overview opens this dialog directly on a
+    // machine, not through the switcher — a non-connectable row is refused
+    // there (see the refusal test below), so `initialHostId` is the only path
+    // onto an explicitly-picked host that is not reachable.
+    renderDialog({ initialHostId: "host-b", onClose: undefined });
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("session-import-host-unavailable").textContent,
+      ).toContain("Can't reach host-b");
+    });
+    expect(screen.queryByTestId("session-import-wizard-stub")).toBeNull();
+  });
+
+  it('shows "<host> is no longer connected" for a picked host whose scope status is vanished', async () => {
+    hostsMock.hosts = [{ hostId: "host-a", connectable: true }];
+    hostsMock.activeHostId = "host-a";
+    scopeStatusOverrideMock.value = "vanished";
+
+    renderDialog({ initialHostId: "host-b", onClose: undefined });
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("session-import-host-unavailable").textContent,
+      ).toContain("host-b is no longer connected");
+    });
+    expect(screen.queryByTestId("session-import-wizard-stub")).toBeNull();
+  });
+
+  it('shows "<host> can\'t import sessions" and stops scanning for a ready host whose client does not support session import', async () => {
+    hostsMock.hosts = [
+      { hostId: "host-a", connectable: true },
+      { hostId: "host-b", connectable: true },
+    ];
+    hostsMock.activeHostId = "host-a";
+    streamOnHostMock.hostId = "host-b";
+    scanSupportedMock.value = false;
+
+    renderDialog({ initialHostId: null, onClose: undefined });
+    pickHost("host-b");
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("session-import-host-unavailable").textContent,
+      ).toContain("host-b can't import sessions");
+    });
+    expect(screen.queryByTestId("session-import-wizard-stub")).toBeNull();
+    expect(lastScanCall()).toBe(false);
+  });
+
+  it("calls onClose when the dialog's own close control is used", () => {
+    const onClose = vi.fn();
+    renderDialog({ initialHostId: null, onClose });
+
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes every non-connectable host to the switcher as refused, disabling its row", () => {
+    hostsMock.hosts = [
+      { hostId: "host-a", connectable: true },
+      { hostId: "host-b", connectable: false },
+    ];
+    hostsMock.activeHostId = "host-a";
+
+    renderDialog({ initialHostId: null, onClose: undefined });
+
+    fireEvent.click(screen.getByTestId("settings-host-switcher"));
+    const refusedRow = screen.getByTestId(
+      "settings-host-switcher-option-host-b",
+    );
+    expect(refusedRow.getAttribute("aria-disabled")).toBe("true");
+    const connectableRow = screen.getByTestId(
+      "settings-host-switcher-option-host-a",
+    );
+    expect(connectableRow.getAttribute("aria-disabled")).not.toBe("true");
+  });
+});

--- a/clients/gui-app/src/components/session-import/__tests__/session-import-model.test.ts
+++ b/clients/gui-app/src/components/session-import/__tests__/session-import-model.test.ts
@@ -18,9 +18,11 @@ import {
   sessionImportFailureDetailVaries,
   sessionImportNotImportedLine,
   sessionImportGroupKey,
+  sessionImportGroupViewKey,
   sessionImportScanWindowLabel,
   sessionImportSelectionKey,
   sessionImportWizardReducer,
+  SESSION_IMPORT_DELETED_FOLDERS_GROUP_KEY,
   SESSION_IMPORT_INITIAL_STATE,
   SESSION_IMPORT_SCAN_WINDOW_OPTIONS,
   type SessionImportOutcomeEntry,
@@ -882,9 +884,31 @@ describe("buildSessionImportView - group ordering", () => {
       { kind: "scanGroupArrived", group: busyRepo },
     ]);
 
-    expect(buildSessionImportView(state).groups.map((one) => one.path)).toEqual(
-      ["/repo/busy", "/repo/quiet", "/home/loose", "/gone"],
-    );
+    // The missing folder no longer keeps its own path in the header - every
+    // missing_folder group folds into the one "Deleted Folders" group, so the
+    // last tier is identified by its groupKey, not the source folder's path.
+    expect(
+      buildSessionImportView(state).groups.map((one) => one.groupKey),
+    ).toEqual([
+      sessionImportGroupKey(folderLocation("/repo/busy")),
+      sessionImportGroupKey(folderLocation("/repo/quiet")),
+      sessionImportGroupKey(folderLocation("/home/loose")),
+      SESSION_IMPORT_DELETED_FOLDERS_GROUP_KEY,
+    ]);
+  });
+
+  it("carries the source group's own path as folderPath on a normal folder row", () => {
+    const state = applyActions([
+      {
+        kind: "scanGroupArrived",
+        group: group(folderLocation("/repo/a"), [
+          candidate({ nativeSessionId: "s1" }),
+        ]),
+      },
+    ]);
+
+    const view = buildSessionImportView(state);
+    expect(view.groups[0]?.rows[0]?.folderPath).toBe("/repo/a");
   });
 
   it("breaks a count tie by the group's most recent session", () => {
@@ -903,6 +927,210 @@ describe("buildSessionImportView - group ordering", () => {
     expect(buildSessionImportView(state).groups.map((one) => one.path)).toEqual(
       ["/home/fresh", "/home/stale"],
     );
+  });
+});
+
+describe("sessionImportGroupViewKey", () => {
+  it("maps every missing_folder location to the shared Deleted Folders key, and leaves any other location at its own scan group key", () => {
+    expect(
+      sessionImportGroupViewKey({ kind: "missing_folder", path: "/gone-a" }),
+    ).toBe(SESSION_IMPORT_DELETED_FOLDERS_GROUP_KEY);
+    expect(
+      sessionImportGroupViewKey({ kind: "missing_folder", path: "/gone-b" }),
+    ).toBe(SESSION_IMPORT_DELETED_FOLDERS_GROUP_KEY);
+    const folder = folderLocation("/repo/a");
+    expect(sessionImportGroupViewKey(folder)).toBe(
+      sessionImportGroupKey(folder),
+    );
+  });
+});
+
+describe("buildSessionImportView - Deleted Folders group", () => {
+  const missingLocationA: SessionImportGroupLocation = {
+    kind: "missing_folder",
+    path: "/gone-a",
+  };
+  const missingLocationB: SessionImportGroupLocation = {
+    kind: "missing_folder",
+    path: "/gone-b",
+  };
+
+  it("folds two missing-folder groups into one Deleted Folders view group, rows newest-first, each carrying its own folderPath", () => {
+    const older = candidate({ nativeSessionId: "a1", updatedAt: 100 });
+    const newer = candidate({ nativeSessionId: "b1", updatedAt: 900 });
+    const groupA = group(missingLocationA, [older]);
+    const groupB = group(missingLocationB, [newer]);
+
+    const state = applyActions([
+      { kind: "scanGroupArrived", group: groupA },
+      { kind: "scanGroupArrived", group: groupB },
+    ]);
+    const view = buildSessionImportView(state);
+
+    expect(view.groups).toHaveLength(1);
+    const deletedGroup = view.groups[0];
+    expect(deletedGroup.groupKey).toBe(
+      SESSION_IMPORT_DELETED_FOLDERS_GROUP_KEY,
+    );
+    expect(deletedGroup.name).toBe("Deleted Folders");
+    expect(deletedGroup.path).toBe("2 folders no longer on this machine");
+    expect(deletedGroup.missingFolder).toBe(true);
+    // Two rows across two folders, summed - not a per-folder count.
+    expect(deletedGroup.totalCount).toBe(2);
+    // Newest first, regardless of arrival order.
+    expect(deletedGroup.rows.map((row) => row.selectionKey)).toEqual([
+      sessionImportSelectionKey("claude", "b1"),
+      sessionImportSelectionKey("claude", "a1"),
+    ]);
+    expect(deletedGroup.rows[0].folderPath).toBe("/gone-b");
+    expect(deletedGroup.rows[1].folderPath).toBe("/gone-a");
+  });
+
+  it("keeps a missing folder's own scan identity on arrival, so two of them are both retained rather than deduped into one", () => {
+    const groupA = group(missingLocationA, [
+      candidate({ nativeSessionId: "s1" }),
+    ]);
+    const groupB = group(missingLocationB, [
+      candidate({ nativeSessionId: "s2" }),
+    ]);
+
+    const state = applyActions([
+      { kind: "scanGroupArrived", group: groupA },
+      { kind: "scanGroupArrived", group: groupB },
+    ]);
+
+    expect(state.groups).toHaveLength(2);
+  });
+
+  it("groupSelectionSet on the Deleted Folders key unticks/re-ticks importable rows across BOTH folders", () => {
+    const groupA = group(missingLocationA, [
+      candidate({ nativeSessionId: "s1" }),
+    ]);
+    const groupB = group(missingLocationB, [
+      candidate({ nativeSessionId: "s2" }),
+    ]);
+
+    let state = applyActions([
+      { kind: "scanGroupArrived", group: groupA },
+      { kind: "scanGroupArrived", group: groupB },
+    ]);
+    expect(buildSessionImportView(state).groups[0]?.selectionState).toBe("all");
+
+    state = sessionImportWizardReducer(state, {
+      kind: "groupSelectionSet",
+      groupKey: SESSION_IMPORT_DELETED_FOLDERS_GROUP_KEY,
+      selected: false,
+    });
+    expect(buildSessionImportView(state).groups[0]?.selectionState).toBe(
+      "none",
+    );
+    expect(state.selected.has(sessionImportSelectionKey("claude", "s1"))).toBe(
+      false,
+    );
+    expect(state.selected.has(sessionImportSelectionKey("claude", "s2"))).toBe(
+      false,
+    );
+
+    state = sessionImportWizardReducer(state, {
+      kind: "groupSelectionSet",
+      groupKey: SESSION_IMPORT_DELETED_FOLDERS_GROUP_KEY,
+      selected: true,
+    });
+    expect(buildSessionImportView(state).groups[0]?.selectionState).toBe("all");
+  });
+
+  it("searching by one missing folder's path shows only its rows, while the header counts still span both folders", () => {
+    const groupA = group(missingLocationA, [
+      candidate({ nativeSessionId: "s1" }),
+    ]);
+    const groupB = group(missingLocationB, [
+      candidate({ nativeSessionId: "s2" }),
+    ]);
+
+    const state = applyActions([
+      { kind: "scanGroupArrived", group: groupA },
+      { kind: "scanGroupArrived", group: groupB },
+      { kind: "queryChanged", query: "gone-a" },
+    ]);
+    const view = buildSessionImportView(state);
+
+    expect(view.groups).toHaveLength(1);
+    expect(view.groups[0]?.rows.map((row) => row.selectionKey)).toEqual([
+      sessionImportSelectionKey("claude", "s1"),
+    ]);
+    // The header still counts everything in scope, search or not.
+    expect(view.groups[0]?.totalCount).toBe(2);
+    expect(view.groups[0]?.selectableCount).toBe(2);
+  });
+
+  it("does not pre-select a missing folder arriving after the Deleted Folders header was cleared, but does pre-select one arriving after it was re-ticked", () => {
+    const groupA = group(missingLocationA, [
+      candidate({ nativeSessionId: "s1" }),
+    ]);
+
+    let state = applyActions([
+      { kind: "scanGroupArrived", group: groupA },
+      {
+        kind: "groupSelectionSet",
+        groupKey: SESSION_IMPORT_DELETED_FOLDERS_GROUP_KEY,
+        selected: false,
+      },
+    ]);
+    expect(state.deletedFoldersCleared).toBe(true);
+
+    const groupB = group(missingLocationB, [
+      candidate({ nativeSessionId: "s2" }),
+    ]);
+    state = sessionImportWizardReducer(state, {
+      kind: "scanGroupArrived",
+      group: groupB,
+    });
+    expect(state.selected.has(sessionImportSelectionKey("claude", "s2"))).toBe(
+      false,
+    );
+
+    // Re-ticking the header lifts the clear, so the NEXT missing folder that
+    // arrives is pre-selected again.
+    state = sessionImportWizardReducer(state, {
+      kind: "groupSelectionSet",
+      groupKey: SESSION_IMPORT_DELETED_FOLDERS_GROUP_KEY,
+      selected: true,
+    });
+    expect(state.deletedFoldersCleared).toBe(false);
+
+    const groupC = group({ kind: "missing_folder", path: "/gone-c" }, [
+      candidate({ nativeSessionId: "s3" }),
+    ]);
+    state = sessionImportWizardReducer(state, {
+      kind: "scanGroupArrived",
+      group: groupC,
+    });
+    expect(state.selected.has(sessionImportSelectionKey("claude", "s3"))).toBe(
+      true,
+    );
+  });
+
+  it("keeps deletedFoldersCleared across a reconnect restart, but resets it on a fresh one", () => {
+    const groupA = group(missingLocationA, [
+      candidate({ nativeSessionId: "s1" }),
+    ]);
+
+    let state = applyActions([
+      { kind: "scanGroupArrived", group: groupA },
+      {
+        kind: "groupSelectionSet",
+        groupKey: SESSION_IMPORT_DELETED_FOLDERS_GROUP_KEY,
+        selected: false,
+      },
+      { kind: "scanRestarted", reason: "reconnect" },
+    ]);
+    expect(state.deletedFoldersCleared).toBe(true);
+
+    state = sessionImportWizardReducer(state, {
+      kind: "scanRestarted",
+      reason: "fresh",
+    });
+    expect(state.deletedFoldersCleared).toBe(false);
   });
 });
 

--- a/clients/gui-app/src/components/session-import/__tests__/session-import-wizard.test.tsx
+++ b/clients/gui-app/src/components/session-import/__tests__/session-import-wizard.test.tsx
@@ -421,7 +421,56 @@ describe("<SessionImportWizard />", () => {
     expect(screen.getByTestId("session-import-submit").textContent).toBe(
       "Import 3 sessions",
     );
-    expect(screen.getByTestId("session-import-missing-folder")).toBeTruthy();
+    // The "Folder not found" pill is gone: a missing folder now renders under
+    // the shared "Deleted Folders" header instead of its own per-folder pill.
+    expect(screen.getByText("Deleted Folders")).toBeTruthy();
+  });
+
+  it("folds two missing-folder groups into one Deleted Folders group, showing each row's own folder and toggling all of them together", () => {
+    renderWizard(vi.fn());
+    const callbacks = requireCallbacks();
+
+    act(() => {
+      callbacks.onGroup(
+        missingFolderGroup({
+          path: "/repo/gone-a",
+          sessions: [
+            importableCandidate("claude", "s1", "Session from gone-a"),
+          ],
+        }),
+      );
+    });
+    act(() => {
+      callbacks.onGroup(
+        missingFolderGroup({
+          path: "/repo/gone-b",
+          sessions: [importableCandidate("codex", "s2", "Session from gone-b")],
+        }),
+      );
+    });
+
+    // Both missing folders fold into ONE rendered group.
+    expect(screen.getAllByTestId("session-import-group")).toHaveLength(1);
+    expect(screen.getByText("Deleted Folders")).toBeTruthy();
+
+    fireEvent.click(screen.getByTestId("session-import-group-toggle"));
+    const folderLabels = screen
+      .getAllByTestId("session-import-row-folder")
+      .map((element) => element.textContent);
+    expect(folderLabels).toEqual(
+      expect.arrayContaining(["/repo/gone-a", "/repo/gone-b"]),
+    );
+
+    // The group's own checkbox governs every row across both folders.
+    fireEvent.click(screen.getByTestId("session-import-group-select"));
+    for (const row of screen.getAllByTestId("session-import-row")) {
+      expect(row.getAttribute("aria-checked")).not.toBe("true");
+    }
+
+    fireEvent.click(screen.getByTestId("session-import-group-select"));
+    for (const row of screen.getAllByTestId("session-import-row")) {
+      expect(row.getAttribute("aria-checked")).toBe("true");
+    }
   });
 
   it("marks the unreadable row disabled and unticked, the importable one ticked", () => {

--- a/clients/gui-app/src/components/session-import/session-import-dialog.tsx
+++ b/clients/gui-app/src/components/session-import/session-import-dialog.tsx
@@ -1,3 +1,4 @@
+import { use, useMemo, useState, type ReactNode } from "react";
 import {
   Dialog,
   DialogContent,
@@ -5,26 +6,120 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { HostSwitcher } from "@/components/settings/host-scope/host-switcher";
+import { HostScopeConnecting } from "@/components/settings/host-scope/host-scope-gate";
+import { scopedHostReadiness } from "@/components/settings/host-scope/scoped-host-readiness";
+import {
+  useHostScopeFor,
+  type HostScope,
+} from "@/components/settings/host-scope/use-host-scope";
+import { useScopedHostBinding } from "@/components/settings/host-scope/use-scoped-host-binding";
+import { useScopedStreamBinding } from "@/components/settings/host-scope/use-scoped-stream-binding";
 import { SessionImportWizard } from "@/components/session-import/session-import-wizard";
 import { useSessionImportScan } from "@/components/session-import/use-session-import-scan";
-import { useStreamHostId } from "@/lib/host/stream-runtime-context";
+import { useSessionImportAvailableFor } from "@/hooks/session-import/use-session-import-available";
+import { useRegisteredHostsPollLiveness } from "@/hooks/auth/use-registered-hosts-query";
+import { HostRuntimeContext, useHostBinding } from "@/lib/host";
+import {
+  StreamRuntimeContext,
+  useStreamRuntimeBinding,
+} from "@/lib/host/stream-runtime-context";
 import { useSessionImportRun } from "@/stores/session-import/session-import-run-store";
 
 /**
- * The wizard as a Settings dialog. Closing it does not stop an import that has
- * already started (spec §5) - the run belongs to the app-wide controller, and
- * this dialog is only a window onto it.
+ * The wizard as a dialog, with its own host picker. Closing it does not stop
+ * an import that has already started (spec §5) - the run belongs to the
+ * app-wide controller, and this dialog is only a window onto it.
+ *
+ * The sessions listed and the run started here belong to ONE machine, and
+ * that machine is the one thing about this dialog a person may want to
+ * change - the same picker the resources popover and the onboarding tour
+ * head their card with. The pick lives in this dialog's own state: it is a
+ * choice about this import, and must not leak into Settings' scope or outlive
+ * the dialog.
+ *
+ * Both runtimes are re-provided, and both are needed: the scan and every run
+ * started from the wizard ride the STREAM (`StreamRuntimeContext`), while the
+ * wizard's unary lookups go through `HostRuntimeContext`. Swapping only one is
+ * how a surface reads host B's sessions over host A's transport. They wrap
+ * the body UNCONDITIONALLY (the pattern `ResourceMonitorPopover` documents):
+ * mounting them only once a pick resolves would change the element type at
+ * this position and remount the wizard - and drop the rows the user had
+ * ticked - the instant a host was chosen.
+ *
+ * Safe to re-provide here because the dialog contains no composer and
+ * therefore no microphone path (see `useScopedHostBinding`).
  */
-export function SessionImportDialog(props: { readonly onClose: () => void }) {
-  const { onClose } = props;
-  // The scan lives as long as the dialog is open and pauses while a run owns
-  // the screen; the wizard retires a finished run on mount, which is what
-  // brings the scan back for a second visit.
-  // The run on the host this dialog renders under, which is the one its
-  // wizard submits to.
-  const streamHostId = useStreamHostId();
+export function SessionImportDialog(props: {
+  readonly onClose: () => void;
+  /**
+   * The host the dialog opens on, when the surface that opened it names one:
+   * Settings' Host Overview passes the host its page is scoped to, so the
+   * picker agrees with the page behind it. `null` follows the app's active
+   * host, which is what the announcement toast has to offer.
+   */
+  readonly initialHostId: string | null;
+}) {
+  const [scopedHostId, setScopedHostId] = useState<string | null>(
+    props.initialHostId,
+  );
+  const scope = useHostScopeFor({ scopedHostId, setScopedHostId });
+  const scopedBinding = useScopedHostBinding(scope);
+  const ambientBinding = useHostBinding();
+  const scopedStreamBinding = useScopedStreamBinding(scope);
+  const ambientStreamBinding = use(StreamRuntimeContext);
+  return (
+    <HostRuntimeContext.Provider value={scopedBinding ?? ambientBinding}>
+      <StreamRuntimeContext.Provider
+        value={scopedStreamBinding ?? ambientStreamBinding}
+      >
+        <SessionImportDialogBody
+          scope={scope}
+          hasExplicitPick={scopedHostId !== null}
+          onClose={props.onClose}
+        />
+      </StreamRuntimeContext.Provider>
+    </HostRuntimeContext.Provider>
+  );
+}
+
+/**
+ * Everything beneath the re-providers, so that every hook here reads the
+ * PICKED host's transports rather than the ambient ones.
+ */
+function SessionImportDialogBody(props: {
+  readonly scope: HostScope;
+  readonly hasExplicitPick: boolean;
+  readonly onClose: () => void;
+}): ReactNode {
+  const { scope, hasExplicitPick, onClose } = props;
+  // Read INSIDE the providers, so it is the transport the wizard actually
+  // uses. `useScopedStreamBinding` fills its binding in an effect, so the
+  // scope can say `ready` for host B while this still names host A - the
+  // wizard must not scan, list or submit through that gap.
+  const streamBinding = useStreamRuntimeBinding();
+  const streamHostId = streamBinding?.hostId ?? null;
+  const readiness = scopedHostReadiness({
+    scope,
+    hasExplicitPick,
+    streamOnPickedHost:
+      streamBinding !== null && streamBinding.hostId === scope.hostId,
+  });
+  const hostReady = readiness === "ready";
+  // Asked of the client the scan and the import would actually RUN on: a host
+  // that predates session import negotiates the methods away, and without
+  // this the dialog would offer a wizard the picked machine cannot serve.
+  // `null` client answers "supported"; the readiness gate withholds the
+  // wizard in that case anyway.
+  const scanSupported = useSessionImportAvailableFor(
+    streamBinding?.wsStreamClient ?? null,
+  );
+  // The scan lives as long as the dialog is open, pauses while a run owns the
+  // screen (the wizard retires a finished run on mount, which is what brings
+  // the scan back for a second visit), and never runs through the pick gap
+  // above - a scan through it would list the wrong machine's sessions.
   const runIdle = useSessionImportRun(streamHostId).status === "idle";
-  const scan = useSessionImportScan(runIdle);
+  const scan = useSessionImportScan(runIdle && hostReady && scanSupported);
   return (
     <Dialog
       open
@@ -43,21 +138,138 @@ export function SessionImportDialog(props: { readonly onClose: () => void }) {
             into Traycer as tasks.
           </DialogDescription>
         </DialogHeader>
-        {/* Bled to the dialog's edges so the wizard's pinned header and footer
-            rules run the full width and the footer sits flush in the corner -
-            the dialog's chrome, not a panel floating inside its padding. */}
+        {/* Bled to the dialog's edges so the picker strip, the wizard's pinned
+            header and the footer rules run the full width and the footer sits
+            flush in the corner - the dialog's chrome, not a panel floating
+            inside its padding. */}
         <div className="-mx-4 -mb-4 flex min-h-0 flex-1 flex-col">
-          <SessionImportWizard
-            surface="dialog"
-            scan={scan}
-            // Submit means go: the dialog gets out of the way and the app-wide
-            // progress toast takes over. Reopening while the run is live shows
-            // the inline progress view - this closes a surface, never a run.
-            onImportStarted={onClose}
-            secondaryAction={{ label: "Close", onSelect: onClose }}
-          />
+          <SessionImportHostPickerRow scope={scope} />
+          {hostReady && scanSupported ? (
+            <SessionImportWizard
+              surface="dialog"
+              scan={scan}
+              // Submit means go: the dialog gets out of the way and the
+              // app-wide progress toast takes over. Reopening while the run is
+              // live shows the inline progress view - this closes a surface,
+              // never a run.
+              onImportStarted={onClose}
+              secondaryAction={{ label: "Close", onSelect: onClose }}
+            />
+          ) : (
+            <SessionImportHostNotice
+              scope={scope}
+              connecting={readiness === "connecting"}
+              refusal={
+                hostReady ? `${scope.hostLabel} can't import sessions` : null
+              }
+            />
+          )}
         </div>
       </DialogContent>
     </Dialog>
+  );
+}
+
+/**
+ * The strip that names the machine, the way the resources popover heads its
+ * card: full-bleed on purpose, so the picker's list can drop from it at
+ * exactly the dialog's width.
+ */
+function SessionImportHostPickerRow(props: {
+  readonly scope: HostScope;
+}): ReactNode {
+  const { scope } = props;
+  // Every host the import cannot reach, with the word its row would carry if
+  // the status column were silent. The row's own status word ("offline",
+  // "stopped") speaks first when it has one; this only makes the row inert.
+  // A refusal rather than the `pin` intent, which would gate the same rows:
+  // `pin` also drops the ACTIVE tag and the "currently viewing" mark, and this
+  // dialog has exactly the distinction those carry - following this window's
+  // host, or looking at another one - the same way the usage popover does.
+  const refusalByHostId = useMemo(
+    (): ReadonlyMap<string, string> =>
+      new Map(
+        scope.hosts
+          .filter((host) => !host.connectable)
+          .map((host) => [host.hostId, "unreachable"]),
+      ),
+    [scope.hosts],
+  );
+  // The host rows are served by a NON-polling observer; the Settings sidebar
+  // is normally what opts a window into the liveness poll. Opened from the
+  // announcement toast this dialog is the only host-list surface on screen,
+  // so it carries the same opt-in for as long as it is up.
+  useRegisteredHostsPollLiveness();
+  return (
+    // Ruled on BOTH edges: the popover's strip sits at the top of its card, but
+    // this one sits under the dialog's own title and description, so without
+    // the top rule the host name reads as a third line of the header instead
+    // of the strip that heads the list.
+    <div
+      className="flex shrink-0 items-center border-y"
+      data-testid="session-import-host-picker-row"
+    >
+      <HostSwitcher
+        hosts={scope.hosts}
+        selected={scope.host}
+        activeHostId={scope.activeHostId}
+        onSelect={scope.setHostId}
+        refusalByHostId={refusalByHostId}
+        inertExceptHostId={null}
+        // No trailing "Manage hosts" row: managing hosts is Settings' job, and
+        // this dialog may already be open on top of it. It only picks among
+        // the machines that exist.
+        action={null}
+        surface="panel-header"
+        intent="view"
+        disabled={false}
+        isLoading={scope.isLoading}
+        listsFailed={scope.listsFailed}
+        onRetryLists={scope.retryLists}
+        updateViewForHost={null}
+      />
+    </div>
+  );
+}
+
+/**
+ * Why the dialog is showing nothing rather than showing another machine's
+ * work under the name in the strip above it.
+ */
+function SessionImportHostNotice(props: {
+  readonly scope: HostScope;
+  readonly connecting: boolean;
+  /**
+   * A refusal only this dialog can state - "this host is too old to scan" -
+   * or `null` for the scope's own states. Set only once the host is otherwise
+   * usable, since a host with no client has negotiated nothing to refuse with.
+   */
+  readonly refusal: string | null;
+}): ReactNode {
+  const { scope, connecting, refusal } = props;
+  return (
+    <div className="flex min-h-0 flex-1 items-center justify-center p-6">
+      {connecting ? (
+        <HostScopeConnecting hostName={scope.hostLabel} />
+      ) : (
+        <div
+          role="status"
+          data-testid="session-import-host-unavailable"
+          className="flex max-w-[40ch] flex-col items-center gap-2 text-center"
+        >
+          <p className="text-ui-sm font-medium text-foreground">
+            {refusal ??
+              (scope.status === "vanished"
+                ? `${scope.hostLabel} is no longer connected`
+                : `Can't reach ${scope.hostLabel}`)}
+          </p>
+          <p className="text-ui-sm text-muted-foreground">
+            {refusal === null
+              ? "Pick another machine above to carry on."
+              : "Update it, or pick another machine above."}
+          </p>
+        </div>
+      )}
+    </div>
   );
 }

--- a/clients/gui-app/src/components/session-import/session-import-group.tsx
+++ b/clients/gui-app/src/components/session-import/session-import-group.tsx
@@ -1,4 +1,4 @@
-import { Check, ChevronRight, FolderX, Minus } from "lucide-react";
+import { Check, ChevronRight, Minus } from "lucide-react";
 import { HarnessIcon } from "@/components/home/pickers/harness-icon";
 import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 import { cn } from "@/lib/utils";
@@ -9,9 +9,6 @@ import type {
   SessionImportRowView,
 } from "@/components/session-import/session-import-model";
 import type { SessionImportTone } from "@/components/session-import/session-import-tone";
-
-const MISSING_FOLDER_HINT =
-  "This folder no longer exists - this work imports without a workspace.";
 
 /**
  * Checkbox visual with no interactive element of its own: the row around it is
@@ -82,9 +79,14 @@ function groupCountLabel(group: SessionImportGroupView): string {
 function SessionRow(props: {
   readonly row: SessionImportRowView;
   readonly tone: SessionImportTone;
+  /**
+   * Whether to show the folder the session ran in under its title. Only the
+   * Deleted Folders group does: everywhere else the header names the folder.
+   */
+  readonly showFolder: boolean;
   readonly onToggle: (selectionKey: string) => void;
 }) {
-  const { row, tone, onToggle } = props;
+  const { row, tone, showFolder, onToggle } = props;
   const { candidate } = row;
 
   return (
@@ -103,7 +105,12 @@ function SessionRow(props: {
         // unavailable could never open - which is the only explanation the
         // user gets.
         aria-disabled={!row.selectable}
-        aria-label={row.title}
+        // Inside Deleted Folders the header names no folder, so the folder
+        // has to be part of the name: two "Fix the build" rows from different
+        // gone checkouts are otherwise indistinguishable to a screen reader.
+        aria-label={
+          showFolder ? `${row.title} in ${row.folderPath}` : row.title
+        }
         data-testid="session-import-row"
         data-selectable={row.selectable}
         onClick={() => {
@@ -127,8 +134,18 @@ function SessionRow(props: {
           harnessId={candidate.harness}
           className={cn("size-3.5", tone.muted)}
         />
-        <span className={cn("min-w-0 flex-1 truncate text-ui-sm", tone.strong)}>
-          {row.title}
+        <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+          <span className={cn("min-w-0 truncate text-ui-sm", tone.strong)}>
+            {row.title}
+          </span>
+          {showFolder ? (
+            <span
+              data-testid="session-import-row-folder"
+              className={cn("min-w-0 truncate text-ui-xs", tone.faint)}
+            >
+              {row.folderPath}
+            </span>
+          ) : null}
         </span>
         {row.unavailableLabel !== null ? (
           <span className={cn("shrink-0 text-ui-xs", tone.faint)}>
@@ -227,25 +244,6 @@ export function SessionImportGroupItem(props: {
               >
                 {group.name}
               </span>
-              {group.missingFolder ? (
-                <TooltipWrapper
-                  label={MISSING_FOLDER_HINT}
-                  side="top"
-                  sideOffset={undefined}
-                  align={undefined}
-                >
-                  <span
-                    data-testid="session-import-missing-folder"
-                    className={cn(
-                      "inline-flex shrink-0 items-center gap-1 rounded px-1.5 py-0.5 text-ui-xs",
-                      tone.warningSurface,
-                    )}
-                  >
-                    <FolderX aria-hidden className="size-3" />
-                    Folder not found
-                  </span>
-                </TooltipWrapper>
-              ) : null}
             </span>
             <span className={cn("min-w-0 truncate text-ui-xs", tone.faint)}>
               {group.path}
@@ -271,6 +269,7 @@ export function SessionImportGroupItem(props: {
               key={row.selectionKey}
               row={row}
               tone={tone}
+              showFolder={group.missingFolder}
               onToggle={onToggleSession}
             />
           ))}

--- a/clients/gui-app/src/components/session-import/session-import-model.ts
+++ b/clients/gui-app/src/components/session-import/session-import-model.ts
@@ -37,10 +37,49 @@ export function sessionImportSelectionKey(
   return `${harness}:${nativeSessionId}`;
 }
 
+/**
+ * A scan group's identity: one per location, which is how the scan streams
+ * them and how arrival dedupes a re-delivered group.
+ */
 export function sessionImportGroupKey(
   location: SessionImportGroupLocation,
 ): string {
   return `${location.kind}:${location.path}`;
+}
+
+/**
+ * Every folder that no longer exists on disk renders as ONE group, under this
+ * key. The scan still reports them one location per folder - the wire shape
+ * is per folder, and so is an older host - so the merge is the projection's:
+ * a person deciding about "work whose folder is gone" decides once, not once
+ * per deleted checkout, and the folder each row ran in stays on the row.
+ */
+export const SESSION_IMPORT_DELETED_FOLDERS_GROUP_KEY = "deleted-folders";
+export const SESSION_IMPORT_DELETED_FOLDERS_NAME = "Deleted Folders";
+
+/**
+ * The key a RENDERED group answers to - what the header's checkbox and expand
+ * toggle dispatch, and what {@link groupsForViewKey} resolves back to scan
+ * groups. Distinct from {@link sessionImportGroupKey}: a missing folder keeps
+ * its own scan identity (so two of them are not deduped into one on arrival)
+ * while sharing one rendered group.
+ */
+export function sessionImportGroupViewKey(
+  location: SessionImportGroupLocation,
+): string {
+  if (location.kind === "missing_folder") {
+    return SESSION_IMPORT_DELETED_FOLDERS_GROUP_KEY;
+  }
+  return sessionImportGroupKey(location);
+}
+
+function groupsForViewKey(
+  state: SessionImportWizardState,
+  groupKey: string,
+): ReadonlyArray<SessionImportGroup> {
+  return state.groups.filter(
+    (candidate) => sessionImportGroupViewKey(candidate.location) === groupKey,
+  );
 }
 
 export type SessionImportScanPhase = "scanning" | "complete" | "failed";
@@ -86,6 +125,14 @@ export interface SessionImportWizardState {
   readonly scanErrorDetail: string | null;
   readonly selected: ReadonlySet<string>;
   readonly expandedGroups: ReadonlySet<string>;
+  /**
+   * Whether the user cleared the Deleted Folders header. Every missing folder
+   * renders under that one header, so a missing folder that arrives AFTER the
+   * clear (a reconnected scan delivering one the first pass never reached)
+   * must not arrive ticked: it would re-tick a header the user just cleared.
+   * Re-ticking the header, or a fresh scan, lifts it.
+   */
+  readonly deletedFoldersCleared: boolean;
   readonly query: string;
   /**
    * Providers the user has switched OUT of the import. This is scope, not a
@@ -112,6 +159,7 @@ export const SESSION_IMPORT_INITIAL_STATE: SessionImportWizardState = {
   scanErrorDetail: null,
   selected: new Set(),
   expandedGroups: new Set(),
+  deletedFoldersCleared: false,
   query: "",
   disabledHarnesses: new Set(),
   scanWindow: SESSION_IMPORT_DEFAULT_SCAN_WINDOW,
@@ -258,11 +306,18 @@ function applyScanFrame(
       if (sessions.length === 0) return state;
       const group = { ...action.group, sessions };
       // Everything importable arrives pre-selected, missing folders included
-      // (spec §5): those still import, just without a workspace. A provider the
-      // user has switched out of the import is the one exception - its rows are
-      // not on screen, so ticking them would import work the user cannot see.
+      // (spec §5): those still import, just without a workspace. Two
+      // exceptions: a provider the user has switched out of the import - its
+      // rows are not on screen, so ticking them would import work the user
+      // cannot see - and a missing folder landing under a Deleted Folders
+      // header the user has already cleared, which shares that header's
+      // decision rather than reopening it.
+      const preselect =
+        group.location.kind !== "missing_folder" ||
+        !state.deletedFoldersCleared;
       const selected = new Set(state.selected);
       for (const candidate of group.sessions) {
+        if (!preselect) break;
         if (!isImportable(candidate)) continue;
         if (state.disabledHarnesses.has(candidate.harness)) continue;
         selected.add(
@@ -356,22 +411,28 @@ function applyGroupSelectionSet(
   groupKey: string,
   select: boolean,
 ): SessionImportWizardState {
-  const group = state.groups.find(
-    (candidate) => sessionImportGroupKey(candidate.location) === groupKey,
-  );
-  if (group === undefined) return state;
+  // A rendered group may stand for several scan groups (every missing folder
+  // shares one), and its checkbox governs all of them.
+  const groups = groupsForViewKey(state, groupKey);
+  if (groups.length === 0) return state;
   const selected = new Set(state.selected);
-  for (const candidate of group.sessions) {
-    if (!isImportable(candidate)) continue;
-    if (state.disabledHarnesses.has(candidate.harness)) continue;
-    const key = sessionImportSelectionKey(
-      candidate.harness,
-      candidate.nativeSessionId,
-    );
-    if (select) selected.add(key);
-    else selected.delete(key);
+  for (const group of groups) {
+    for (const candidate of group.sessions) {
+      if (!isImportable(candidate)) continue;
+      if (state.disabledHarnesses.has(candidate.harness)) continue;
+      const key = sessionImportSelectionKey(
+        candidate.harness,
+        candidate.nativeSessionId,
+      );
+      if (select) selected.add(key);
+      else selected.delete(key);
+    }
   }
-  return { ...state, selected };
+  const deletedFoldersCleared =
+    groupKey === SESSION_IMPORT_DELETED_FOLDERS_GROUP_KEY
+      ? !select
+      : state.deletedFoldersCleared;
+  return { ...state, selected, deletedFoldersCleared };
 }
 
 /**
@@ -412,6 +473,12 @@ export interface SessionImportRowView {
   readonly selectionKey: string;
   readonly candidate: SessionImportCandidate;
   readonly title: string;
+  /**
+   * The folder this session ran in, as the scan spelled it. Every row carries
+   * it; the list shows it only inside the Deleted Folders group, where the
+   * header no longer names one folder.
+   */
+  readonly folderPath: string;
   readonly selected: boolean;
   readonly selectable: boolean;
   /** Short reason a row is not selectable, e.g. "Unreadable". */
@@ -582,6 +649,7 @@ function failureCause(reason: SessionImportFailureReason): string {
 
 function rowView(
   candidate: SessionImportCandidate,
+  folderPath: string,
   selected: ReadonlySet<string>,
 ): SessionImportRowView {
   const selectionKey = sessionImportSelectionKey(
@@ -598,6 +666,7 @@ function rowView(
       selectionKey,
       candidate,
       title,
+      folderPath,
       selected: false,
       selectable: false,
       unavailableLabel: "Unreadable",
@@ -608,6 +677,7 @@ function rowView(
     selectionKey,
     candidate,
     title,
+    folderPath,
     selected: selected.has(selectionKey),
     selectable: true,
     unavailableLabel: null,
@@ -694,6 +764,18 @@ export function buildSessionImportView(
   let selectableSessions = 0;
   let matchedSessions = 0;
   let visibleSelectedCount = 0;
+  // Every missing folder lands here instead of in `sortable`, and becomes one
+  // rendered group after the walk. Its counts span every missing folder in
+  // scope, searched or not - the same rule as a folder header - while its
+  // rows are only the searched slice.
+  const deletedRows: SessionImportRowView[] = [];
+  const deleted = {
+    folders: 0,
+    inScope: 0,
+    selectable: 0,
+    selected: 0,
+    latest: 0,
+  };
 
   for (const group of state.groups) {
     const path = group.location.path;
@@ -709,10 +791,9 @@ export function buildSessionImportView(
       matchesQuery(candidate, path, needle),
     );
     matchedSessions += matching.length;
-    if (matching.length === 0) continue;
 
     const rows = matching.map((candidate) =>
-      rowView(candidate, state.selected),
+      rowView(candidate, path, state.selected),
     );
     for (const row of rows) {
       if (!row.selectable) continue;
@@ -725,26 +806,66 @@ export function buildSessionImportView(
         sessionImportSelectionKey(candidate.harness, candidate.nativeSessionId),
       ),
     ).length;
+    const latest = Math.max(
+      0,
+      ...inScope.map((candidate) => candidate.updatedAt),
+    );
 
-    const missingFolder = group.location.kind === "missing_folder";
+    if (group.location.kind === "missing_folder") {
+      if (inScope.length > 0) deleted.folders += 1;
+      deletedRows.push(...rows);
+      deleted.inScope += inScope.length;
+      deleted.selectable += selectable.length;
+      deleted.selected += selectedCount;
+      deleted.latest = Math.max(deleted.latest, latest);
+      continue;
+    }
+    if (matching.length === 0) continue;
+
+    const groupKey = sessionImportGroupViewKey(group.location);
     sortable.push({
       view: {
-        groupKey: sessionImportGroupKey(group.location),
+        groupKey,
         name: folderDisplayName(path),
         path,
-        missingFolder,
-        expanded: state.expandedGroups.has(
-          sessionImportGroupKey(group.location),
-        ),
+        missingFolder: false,
+        expanded: state.expandedGroups.has(groupKey),
         rows,
         totalCount: inScope.length,
         selectableCount: selectable.length,
         selectedCount,
         selectionState: selectionStateFor(selectable.length, selectedCount),
       },
-      tier: groupSortTier(missingFolder, group.gitBacked),
+      tier: groupSortTier(false, group.gitBacked),
       count: inScope.length,
-      latest: Math.max(0, ...inScope.map((candidate) => candidate.updatedAt)),
+      latest,
+    });
+  }
+
+  if (deletedRows.length > 0) {
+    // Rows from several folders interleave, so the group keeps the list's
+    // own order - newest first - rather than the arrival order of folders.
+    const rows = [...deletedRows].sort(
+      (left, right) => right.candidate.updatedAt - left.candidate.updatedAt,
+    );
+    sortable.push({
+      view: {
+        groupKey: SESSION_IMPORT_DELETED_FOLDERS_GROUP_KEY,
+        name: SESSION_IMPORT_DELETED_FOLDERS_NAME,
+        path: deletedFoldersSubtitle(deleted.folders),
+        missingFolder: true,
+        expanded: state.expandedGroups.has(
+          SESSION_IMPORT_DELETED_FOLDERS_GROUP_KEY,
+        ),
+        rows,
+        totalCount: deleted.inScope,
+        selectableCount: deleted.selectable,
+        selectedCount: deleted.selected,
+        selectionState: selectionStateFor(deleted.selectable, deleted.selected),
+      },
+      tier: groupSortTier(true, false),
+      count: deleted.inScope,
+      latest: deleted.latest,
     });
   }
 
@@ -771,10 +892,19 @@ export function buildSessionImportView(
   };
 }
 
-/** Repos sort above loose folders, which sort above missing ones. */
+/** Repos sort above loose folders, which sort above the deleted ones. */
 function groupSortTier(missingFolder: boolean, gitBacked: boolean): number {
   if (missingFolder) return 2;
   return gitBacked ? 0 : 1;
+}
+
+/**
+ * The Deleted Folders header's second line, where a folder group shows its
+ * path: how many folders the rows below came from.
+ */
+function deletedFoldersSubtitle(folders: number): string {
+  const noun = folders === 1 ? "folder" : "folders";
+  return `${folders.toLocaleString()} ${noun} no longer on this machine`;
 }
 
 export interface SessionImportFailureEntryView {

--- a/clients/gui-app/src/components/settings/host-scope/scoped-host-readiness.ts
+++ b/clients/gui-app/src/components/settings/host-scope/scoped-host-readiness.ts
@@ -1,0 +1,43 @@
+import { isHostScopeUsable } from "@/components/settings/host-scope/host-scope-status";
+import type { HostScope } from "@/components/settings/host-scope/use-host-scope";
+
+/**
+ * What a surface that re-provides a picked host's transports may show: its
+ * live content, a spinner, or a dead end.
+ */
+export type ScopedHostReadiness = "ready" | "connecting" | "unavailable";
+
+/**
+ * The gate every stream-backed surface with its own host picker applies before
+ * rendering live content - the onboarding tour's two host-dependent acts and
+ * the session-import dialog share it, because each re-derivation of these
+ * three rules has eventually got one of them wrong.
+ *
+ * Gated on there being a PICK, not on the status alone: with no pick the
+ * surface reads the host it has always read, and an `unreachable` blip on it
+ * is not a reason to replace a working wizard with a notice about a machine
+ * the user never chose. The same rule the usage popover applies for the same
+ * reason.
+ *
+ * `streamOnPickedHost` is a second question from `scope.status`, and the
+ * surface is wrong without it: `useScopedStreamBinding` fills its binding in
+ * an EFFECT, so for at least the commit after a pick - and for as long as that
+ * transport is null or closed - the subtree is still on the ambient stream
+ * while the scope has already resolved to the new host. A scan, a wizard and
+ * the run it starts all ride that transport, so rendering through the gap
+ * would list host A's sessions, and import them, under host B's name. That
+ * lag is `connecting`, never `unavailable`: nothing is wrong with the host,
+ * the surface has simply not finished moving onto it.
+ */
+export function scopedHostReadiness(input: {
+  readonly scope: HostScope;
+  /** The user named a host, rather than following the one the surface opened on. */
+  readonly hasExplicitPick: boolean;
+  /** The stream transport beneath the surface is dialing the host the picker names. */
+  readonly streamOnPickedHost: boolean;
+}): ScopedHostReadiness {
+  if (!input.hasExplicitPick) return "ready";
+  if (input.scope.status === "connecting") return "connecting";
+  if (!isHostScopeUsable(input.scope.status)) return "unavailable";
+  return input.streamOnPickedHost ? "ready" : "connecting";
+}

--- a/clients/gui-app/src/components/settings/host-scope/use-scoped-host-binding.ts
+++ b/clients/gui-app/src/components/settings/host-scope/use-scoped-host-binding.ts
@@ -33,6 +33,11 @@ import type { HostScope } from "@/components/settings/host-scope/use-host-scope"
  * contexts for that reason, and it is safe for the positional reason below:
  * the tour has no composer, and so no path to the microphone.
  *
+ * The session-import DIALOG (`session-import-dialog.tsx`) is the ninth, for
+ * the same reason as the tour's import act: it carries its own host picker,
+ * and the scan it shows and the run it starts belong to the machine that
+ * picker names. It also re-provides BOTH contexts, and contains no composer.
+ *
  * ⚠ A RE-PROVIDER MUST NOT WRAP A SURFACE CONTAINING THE MIC PATH.
  * `useDictationAvailability` reads `useHostClient()` and is app-wide BY DESIGN
  * (see its own doc and `AGENTS.md`): `speech.dictate` streams live microphone
@@ -52,16 +57,19 @@ import type { HostScope } from "@/components/settings/host-scope/use-host-scope"
  * was the only stream re-provider, and the epic sidebar's file tree, the git
  * diff panel, the HOST OVERVIEW (`host-settings-panel.tsx`, whose
  * `StreamRuntimeContext.Provider` carries `useScopedStreamBinding`) and the
- * onboarding TOUR are now four more. The Overview joined the list for its
- * Data & migration group: both rows move ONE machine's local data over a
- * stream, so the stream has to be the named host's. The tour joined it for
- * the same reason one act down — the session scan and the run it starts are
- * that machine's. Both are safe for the same positional reason as the other
- * three — they contain no composer, and so no path to the microphone.
+ * onboarding TOUR are now four more, and the session-import DIALOG a fifth.
+ * The Overview joined the list for its Data & migration group: both rows
+ * move ONE machine's local data over a stream, so the stream has to be the
+ * named host's. The tour joined it for the same reason one act down — the
+ * session scan and the run it starts are that machine's — and the dialog
+ * for exactly that scan and run. All are safe for the same positional reason
+ * as the other three — they contain no composer, and so no path to the
+ * microphone.
  *
- * Two consumers of a re-provided stream now also CHECK it before acting,
+ * Three consumers of a re-provided stream now also CHECK it before acting,
  * because this hook's binding lands in an effect: `host-import-migration-
- * section.tsx` withholds its rows and the tour withholds its stages until
+ * section.tsx` withholds its rows, and the tour its stages and the dialog its
+ * wizard (both through `scopedHostReadiness`), until
  * `useStreamRuntimeBinding()` names the host the surface does. A re-provider
  * whose subtree starts work on one machine's data owes that check — the
  * commit after a pick is still on the ambient transport.

--- a/clients/gui-app/src/components/settings/panels/host-import-migration-section.tsx
+++ b/clients/gui-app/src/components/settings/panels/host-import-migration-section.tsx
@@ -135,10 +135,13 @@ function SessionImportRow(props: {
           </Button>
         }
       />
-      {/* Rendered inline, so the wizard inside it inherits this page's
-          re-provided contexts and submits to the host the row named. */}
+      {/* Opens on the host this row named, so the dialog's own picker agrees
+          with the page behind it; the pick can still be changed there. */}
       {importOpen ? (
-        <SessionImportDialog onClose={() => setImportOpen(false)} />
+        <SessionImportDialog
+          onClose={() => setImportOpen(false)}
+          initialHostId={props.hostId}
+        />
       ) : null}
     </>
   );

--- a/protocol/src/host/session-import/candidate.ts
+++ b/protocol/src/host/session-import/candidate.ts
@@ -141,12 +141,16 @@ export type SessionImportCandidate = z.infer<
  *
  * `missing_folder` is a first-class location rather than a flag, because the
  * wizard treats it as one: those sessions still import, just without a
- * workspace, and the group carries the warning marker. The path is kept
- * either way - it is the only human-readable name that group has.
+ * workspace. The scan reports one such location per folder; the wizard folds
+ * every one of them into a single "Deleted Folders" group and shows each
+ * row's own path, which is why the path is kept - it is the only
+ * human-readable name that work has left.
  *
  * `workspaceId` is null for a folder Traycer does not know yet; the import
  * decides whether to adopt it as a workspace, so the wizard does not have to
- * expose that mapping.
+ * expose that mapping. A current host adopts every folder it binds through the
+ * same registration "add folder" uses, so it no longer looks the folder up and
+ * always reports null; the field stays for older hosts, which still fill it.
  */
 export const sessionImportGroupLocationSchema = z.discriminatedUnion("kind", [
   z.object({


### PR DESCRIPTION
## Summary

Session import wizard: one "Deleted Folders" group, per-row folder paths, and a host picker in the dialog.

**Deleted folders.** The wizard folds every `missing_folder` location the scan reports into one rendered "Deleted Folders" group. The scan's per-folder locations stay on the wire and drive arrival dedupe (`sessionImportGroupKey`); the rendered key, expand state and header checkbox use `sessionImportGroupViewKey`, which is `deleted-folders` for every missing folder. Each row carries its own `folderPath`; inside that group the row shows it and includes it in the checkbox's accessible name, so two identically titled sessions from different gone checkouts stay distinguishable. The "Folder not found" pill is gone, since the header now says what the group is. A header the user cleared stays cleared for a missing folder that arrives later (a reconnected scan) instead of re-ticking it.

**Host picker.** The dialog carries its own host picker strip (the resources popover's `HostSwitcher`) and re-provides both runtime contexts for the picked host, exactly as the onboarding tour does, gated by `scopedHostReadiness`, which the tour's picker model now delegates to. Settings' Host Overview opens it on the page's host; the announcement toast on the active one.

**Protocol.** No shape changes. `candidate.ts` only updates its doc comment for `workspaceId` (a current host always reports null) and the merged missing folders.

Pairs with the host change in traycer-internal, which places each session by its transcript's git root instead of a worktree-binding lookup and hides Traycer's own OpenCode sessions by their system prompt; the internal PR pins this branch.

## Related issue

None.

## Checklist

- [x] Pre-commit static checks pass (`pre-commit run --all-files` for an explicit full-repo run)
- [ ] Separate CI test checks pass
- [x] Tests added/updated where it makes sense
- [x] Commits are signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#developer-certificate-of-origin-dco)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
