### PR TITLE
fix(mobile,gui-app): make Android's back button and back gesture navigate the app

### DIFF
--- a/clients/desktop/src/renderer-shell/desktop-runner-host.ts
+++ b/clients/desktop/src/renderer-shell/desktop-runner-host.ts
@@ -694,6 +694,9 @@ export class DesktopRunnerHost implements IRunnerHost {
   // No OS push on the desktop: notifications here are native `show` calls, not
   // an APNs/FCM permission the user can revoke from a settings app.
   readonly pushPermission: null = null;
+  // No OS back request on the desktop: back is the header arrows, the mouse
+  // buttons and the keybinding, all of which the GUI owns itself.
+  readonly systemBack: null = null;
   readonly hostControllerStatus: DesktopHostControllerStatusBridge;
   readonly selectionAuthority: SelectionAuthorityClient;
   private readonly refreshSelectionFleet: () => Promise<void>;

--- a/clients/gui-app/__tests__/create-fake-runner-host.ts
+++ b/clients/gui-app/__tests__/create-fake-runner-host.ts
@@ -160,6 +160,9 @@ export function createFakeRunnerHost(
     // Desktop-shaped by default; a phone-shaped test passes its own
     // `pushPermission` double through `overrides`.
     pushPermission: null,
+    // Likewise: a shell that raises an OS back request passes its own
+    // `systemBack` double through `overrides`.
+    systemBack: null,
   };
   return { ...base, ...overrides };
 }

--- a/clients/gui-app/src/components/layout/__tests__/desktop-dialog-host.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/desktop-dialog-host.test.tsx
@@ -393,6 +393,7 @@ function createBaseRunnerHost(): IRunnerHost {
     hostTray: null,
     zoom: null,
     pushPermission: null,
+    systemBack: null,
   };
 }
 

--- a/clients/gui-app/src/components/layout/app-shell.tsx
+++ b/clients/gui-app/src/components/layout/app-shell.tsx
@@ -13,6 +13,7 @@ import { useDragToDismissKeyboard } from "@/components/layout/shell/use-drag-to-
 import { SessionConnectivityStrip } from "@/components/layout/session-connectivity-strip";
 import { ClockSkewBanner } from "@/components/layout/clock-skew-banner";
 import { useMobileHistorySwipes } from "@/components/layout/shell/use-mobile-history-swipes";
+import { useSystemBack } from "@/components/layout/shell/use-system-back";
 import { TopLevelTabHost } from "@/components/layout/top-level-tab-host";
 import { TopLevelSurfaceActivationProvider } from "@/components/layout/top-level-surface-activation-provider";
 import { HostScopeReady } from "@/components/layout/host-readiness-controller";
@@ -57,6 +58,11 @@ export function AppShell(props: AppShellProps) {
   // mobile-app product flag, so desktop attaches nothing and keeps its arrows.
   // Renders nothing until a swipe is actually in flight.
   const historySwipeTransition = useMobileHistorySwipes();
+  // The OS back request, where the shell raises one (Android's key and system
+  // gesture, which never reach the swipe above as a touch). Walks the same
+  // history through the same `goBack`. Self-gated on the shell capability, so
+  // every other shell attaches nothing.
+  useSystemBack();
 
   return (
     <PrimaryFocusCoordinatorProvider>

--- a/clients/gui-app/src/components/layout/dialogs/desktop/__tests__/report-issue-capture-dialog.test.tsx
+++ b/clients/gui-app/src/components/layout/dialogs/desktop/__tests__/report-issue-capture-dialog.test.tsx
@@ -295,6 +295,7 @@ function createBaseRunnerHost(): IRunnerHost {
     hostTray: null,
     zoom: null,
     pushPermission: null,
+    systemBack: null,
   };
 }
 

--- a/clients/gui-app/src/components/layout/shell/__tests__/use-system-back.test.tsx
+++ b/clients/gui-app/src/components/layout/shell/__tests__/use-system-back.test.tsx
@@ -79,6 +79,23 @@ afterEach(() => {
 });
 
 describe("useSystemBack", () => {
+  // The shell mounts under every route-level test, and not all of them stand
+  // up a runner host. No host is the same answer as a host with no capability:
+  // nothing to attach to, nothing attached.
+  it("attaches nothing when mounted outside a runner host provider", () => {
+    const router = makeRouter(createMemoryHistory({ initialEntries: ["/"] }));
+
+    expect(() =>
+      renderHook(() => useSystemBack(), {
+        wrapper: ({ children }) => (
+          <RouterContextProvider router={router}>
+            {children}
+          </RouterContextProvider>
+        ),
+      }),
+    ).not.toThrow();
+  });
+
   it("steps the app's history back on an OS back press", () => {
     const history = createMemoryHistory({ initialEntries: ["/", "/epics"] });
     const backSpy = vi.spyOn(history, "back");

--- a/clients/gui-app/src/components/layout/shell/__tests__/use-system-back.test.tsx
+++ b/clients/gui-app/src/components/layout/shell/__tests__/use-system-back.test.tsx
@@ -1,0 +1,155 @@
+/**
+ * What an OS back request does, in the order Android users expect: an open
+ * drawer closes, a covering modal dismisses, otherwise the app's own history
+ * steps back through the SAME `goBack` the edge swipe and the desktop arrows
+ * call, and with nothing behind the app steps out of the way.
+ *
+ * The shell is a fake `systemBack` capability; every other piece is real.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  act,
+  cleanup,
+  render,
+  renderHook,
+  waitFor,
+} from "@testing-library/react";
+import { QueryClient } from "@tanstack/react-query";
+import {
+  RouterContextProvider,
+  createMemoryHistory,
+  createRouter,
+  type RouterHistory,
+} from "@tanstack/react-router";
+import type { ISystemBackHost } from "@traycer-clients/shared/platform/runner-host";
+import { createFakeRunnerHost } from "../../../../../__tests__/create-fake-runner-host";
+import { routeTree } from "@/routeTree.gen";
+import type { AppRouter } from "@/router";
+import { RunnerHostProvider } from "@/providers/runner-host-provider";
+import { useAuthStore } from "@/stores/auth/auth-store";
+import { useMobileNavStore } from "@/stores/layout/mobile-nav-store";
+import { Sheet, SheetContent, SheetTitle } from "@/components/ui/sheet";
+import { useSystemBack } from "@/components/layout/shell/use-system-back";
+
+class FakeSystemBack implements ISystemBackHost {
+  private readonly handlers = new Set<() => void>();
+  readonly minimize = vi.fn(async (): Promise<void> => {});
+
+  onBack(handler: () => void): { dispose: () => void } {
+    this.handlers.add(handler);
+    return { dispose: () => this.handlers.delete(handler) };
+  }
+
+  press(): void {
+    for (const handler of this.handlers) handler();
+  }
+}
+
+function makeRouter(history: RouterHistory): AppRouter {
+  return createRouter({
+    routeTree,
+    history,
+    context: {
+      queryClient: new QueryClient(),
+      getAuthSnapshot: () => useAuthStore.getState(),
+      getHostClient: () => null,
+    },
+  });
+}
+
+function mount(history: RouterHistory): FakeSystemBack {
+  const systemBack = new FakeSystemBack();
+  const router = makeRouter(history);
+  renderHook(() => useSystemBack(), {
+    wrapper: ({ children }) => (
+      <RunnerHostProvider runnerHost={createFakeRunnerHost({ systemBack })}>
+        <RouterContextProvider router={router}>
+          {children}
+        </RouterContextProvider>
+      </RunnerHostProvider>
+    ),
+  });
+  return systemBack;
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  useMobileNavStore.setState({ open: false });
+});
+
+describe("useSystemBack", () => {
+  it("steps the app's history back on an OS back press", () => {
+    const history = createMemoryHistory({ initialEntries: ["/", "/epics"] });
+    const backSpy = vi.spyOn(history, "back");
+    const systemBack = mount(history);
+
+    act(() => systemBack.press());
+
+    expect(backSpy).toHaveBeenCalledTimes(1);
+    expect(systemBack.minimize).not.toHaveBeenCalled();
+  });
+
+  it("closes the navigation drawer instead of navigating", () => {
+    const history = createMemoryHistory({ initialEntries: ["/", "/epics"] });
+    const backSpy = vi.spyOn(history, "back");
+    const systemBack = mount(history);
+    useMobileNavStore.setState({ open: true });
+
+    act(() => systemBack.press());
+
+    expect(useMobileNavStore.getState().open).toBe(false);
+    expect(backSpy).not.toHaveBeenCalled();
+  });
+
+  it("asks the shell to step out of the way when nothing is behind", () => {
+    const history = createMemoryHistory({ initialEntries: ["/"] });
+    const backSpy = vi.spyOn(history, "back");
+    const systemBack = mount(history);
+
+    act(() => systemBack.press());
+
+    expect(backSpy).not.toHaveBeenCalled();
+    expect(systemBack.minimize).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * Driven through a REAL sheet, uncontrolled so that the dismissal the press
+   * triggers is the primitive's own. Setting the barrier style by hand would
+   * pass against a signal no surface ever produces.
+   */
+  it("dismisses a covering modal rather than navigating beneath it", async () => {
+    const history = createMemoryHistory({ initialEntries: ["/", "/epics"] });
+    const backSpy = vi.spyOn(history, "back");
+    const systemBack = new FakeSystemBack();
+    const router = makeRouter(history);
+    function UnderSheet() {
+      useSystemBack();
+      return (
+        <Sheet defaultOpen>
+          <SheetContent side="bottom">
+            <SheetTitle>Confirm</SheetTitle>
+          </SheetContent>
+        </Sheet>
+      );
+    }
+    const view = render(
+      <RunnerHostProvider runnerHost={createFakeRunnerHost({ systemBack })}>
+        <RouterContextProvider router={router}>
+          <UnderSheet />
+        </RouterContextProvider>
+      </RunnerHostProvider>,
+    );
+    await waitFor(() => {
+      expect(document.body.style.pointerEvents).toBe("none");
+    });
+
+    act(() => systemBack.press());
+
+    await waitFor(() => {
+      expect(view.queryByText("Confirm")).toBeNull();
+    });
+    expect(backSpy).not.toHaveBeenCalled();
+    expect(systemBack.minimize).not.toHaveBeenCalled();
+  });
+});

--- a/clients/gui-app/src/components/layout/shell/use-system-back.ts
+++ b/clients/gui-app/src/components/layout/shell/use-system-back.ts
@@ -7,7 +7,7 @@ import {
   type HistoryNavRouter,
 } from "@/lib/commands/actions";
 import { getHistoryController } from "@/lib/persistent-history";
-import { useRunnerHost } from "@/providers/use-runner-host";
+import { useRunnerHostOrNull } from "@/providers/use-runner-host";
 import { useMobileNavStore } from "@/stores/layout/mobile-nav-store";
 
 /**
@@ -24,13 +24,15 @@ import { useMobileNavStore } from "@/stores/layout/mobile-nav-store";
  * 4. With nothing behind, the shell is asked to step out of the way.
  *
  * Gated on the capability alone: shells with no OS back request pass `null`
- * and this attaches nothing. No platform is named here.
+ * and this attaches nothing. No platform is named here. A missing runner host
+ * (route-level tests that mount the shell bare) reads the same way - no shell,
+ * no request to answer - rather than as an error.
  */
 export function useSystemBack(): void {
   const router = useRouter();
-  const runnerHost = useRunnerHost();
+  const runnerHost = useRunnerHostOrNull();
   useEffect(() => {
-    const systemBack = runnerHost.systemBack;
+    const systemBack = runnerHost?.systemBack ?? null;
     if (systemBack === null) return;
     const subscription = systemBack.onBack(() => {
       const nav = useMobileNavStore.getState();

--- a/clients/gui-app/src/components/layout/shell/use-system-back.ts
+++ b/clients/gui-app/src/components/layout/shell/use-system-back.ts
@@ -1,0 +1,84 @@
+import { useEffect } from "react";
+import { useRouter } from "@tanstack/react-router";
+import { modalLayerCoversApp } from "@/components/layout/shell/shell-gestures";
+import {
+  goBack,
+  resolveEligibleHistoryTarget,
+  type HistoryNavRouter,
+} from "@/lib/commands/actions";
+import { getHistoryController } from "@/lib/persistent-history";
+import { useRunnerHost } from "@/providers/use-runner-host";
+import { useMobileNavStore } from "@/stores/layout/mobile-nav-store";
+
+/**
+ * Binds the shell's OS back request (`IRunnerHost.systemBack`) to what "back"
+ * means in this app, in the order the platform's users expect and one answer
+ * per press:
+ *
+ * 1. An open navigation drawer closes.
+ * 2. A modal layer covering the app is asked to dismiss - through the same
+ *    Escape its own primitive already answers, so nothing has to be enumerated
+ *    and a surface that refuses Escape (a required dialog) keeps refusing.
+ * 3. Otherwise the app's history steps back through the SAME `goBack` the
+ *    edge swipe and the desktop arrows call. One implementation of "go back".
+ * 4. With nothing behind, the shell is asked to step out of the way.
+ *
+ * Gated on the capability alone: shells with no OS back request pass `null`
+ * and this attaches nothing. No platform is named here.
+ */
+export function useSystemBack(): void {
+  const router = useRouter();
+  const runnerHost = useRunnerHost();
+  useEffect(() => {
+    const systemBack = runnerHost.systemBack;
+    if (systemBack === null) return;
+    const subscription = systemBack.onBack(() => {
+      const nav = useMobileNavStore.getState();
+      if (nav.open) {
+        nav.setOpen(false);
+        return;
+      }
+      if (modalLayerCoversApp()) {
+        dismissCoveringLayer();
+        return;
+      }
+      if (canStepBack(router)) {
+        goBack(router);
+        return;
+      }
+      void systemBack.minimize();
+    });
+    return () => {
+      subscription.dispose();
+    };
+  }, [router, runnerHost]);
+}
+
+/**
+ * Whether a back step would land somewhere. The branded history answers from
+ * its entry list, skipping entries a step would refuse; a plain history only
+ * knows whether it is on its first entry - the same split `goBack` itself has.
+ */
+function canStepBack(router: HistoryNavRouter): boolean {
+  if (getHistoryController(router.history) === null) {
+    return router.history.canGoBack();
+  }
+  return resolveEligibleHistoryTarget(router, -1) !== null;
+}
+
+/**
+ * Dispatched at the focused element so it travels the path a real key press
+ * would; the dismissable-layer primitive listens at the document in the
+ * capture phase and sees it either way.
+ */
+function dismissCoveringLayer(): void {
+  const active = document.activeElement;
+  const target = active instanceof HTMLElement ? active : document.body;
+  target.dispatchEvent(
+    new KeyboardEvent("keydown", {
+      key: "Escape",
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+}

--- a/clients/mobile/__tests__/mobile-runner-host.test.ts
+++ b/clients/mobile/__tests__/mobile-runner-host.test.ts
@@ -259,6 +259,9 @@ function runner(returnScheme: string | null): MobileRunnerHost {
     // Dev-web flavoured, matching `fileSave` above: a browser tab honours an
     // image clipboard write.
     canCopyImages: true,
+    // The Android back adapter has its own suite (`system-back.test.ts`);
+    // `null` is every other platform's answer.
+    systemBack: null,
   });
 }
 
@@ -328,6 +331,7 @@ function phoneRunner(input: {
     linkLoginDeepLinks: null,
     fileSave: null,
     canCopyImages: true,
+    systemBack: null,
   });
 }
 

--- a/clients/mobile/__tests__/system-back.test.ts
+++ b/clients/mobile/__tests__/system-back.test.ts
@@ -1,0 +1,102 @@
+/**
+ * The Android back adapter: the OS back request (hardware key or the system
+ * back gesture) arrives through the App plugin's `backButton` event, and the
+ * shell forwards it as a payload-free signal on `IRunnerHost.systemBack`.
+ *
+ * The plugin is faked at the package boundary, as everywhere else in this
+ * workspace. The claims: a press reaches the subscriber, a disposed
+ * subscription hears nothing more (including when disposal races the plugin's
+ * asynchronous attach), and `minimize` reaches the plugin's `minimizeApp`.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { PluginListenerHandle } from "@capacitor/core";
+import {
+  MobileSystemBack,
+  type BackButtonEvent,
+  type SystemBackPluginSlice,
+} from "../src/system-back";
+
+class FakeAppPlugin implements SystemBackPluginSlice {
+  private readonly listeners = new Set<(event: BackButtonEvent) => void>();
+  readonly minimizeApp = vi.fn(async (): Promise<void> => {});
+
+  async addListener(
+    _eventName: "backButton",
+    listener: (event: BackButtonEvent) => void,
+  ): Promise<PluginListenerHandle> {
+    this.listeners.add(listener);
+    return {
+      remove: async () => {
+        this.listeners.delete(listener);
+      },
+    };
+  }
+
+  press(): void {
+    for (const listener of this.listeners) listener({ canGoBack: false });
+  }
+
+  get attached(): number {
+    return this.listeners.size;
+  }
+}
+
+/** The plugin attaches asynchronously; let that promise settle. */
+async function settle(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("MobileSystemBack", () => {
+  it("delivers an OS back press to the subscriber", async () => {
+    const plugin = new FakeAppPlugin();
+    const systemBack = new MobileSystemBack(plugin);
+    const handler = vi.fn();
+
+    systemBack.onBack(handler);
+    await settle();
+    plugin.press();
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops delivering once the subscription is disposed", async () => {
+    const plugin = new FakeAppPlugin();
+    const systemBack = new MobileSystemBack(plugin);
+    const handler = vi.fn();
+
+    const subscription = systemBack.onBack(handler);
+    await settle();
+    subscription.dispose();
+    await settle();
+    plugin.press();
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(plugin.attached).toBe(0);
+  });
+
+  // React effects can tear down before the plugin's attach promise resolves;
+  // a listener attached after its own disposal would fire forever.
+  it("detaches a listener disposed before the plugin finished attaching", async () => {
+    const plugin = new FakeAppPlugin();
+    const systemBack = new MobileSystemBack(plugin);
+    const handler = vi.fn();
+
+    const subscription = systemBack.onBack(handler);
+    subscription.dispose();
+    await settle();
+    plugin.press();
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(plugin.attached).toBe(0);
+  });
+
+  it("sends the app to the background on minimize", async () => {
+    const plugin = new FakeAppPlugin();
+    const systemBack = new MobileSystemBack(plugin);
+
+    await systemBack.minimize();
+
+    expect(plugin.minimizeApp).toHaveBeenCalledTimes(1);
+  });
+});

--- a/clients/mobile/src/mobile-runner-host.ts
+++ b/clients/mobile/src/mobile-runner-host.ts
@@ -75,6 +75,7 @@ import type {
   IPushPermissionHost,
   IRunnerHost,
   ISecureStorage,
+  ISystemBackHost,
   ITokenStore,
   ITrayState,
   IWorkspaceFoldersHost,
@@ -188,6 +189,12 @@ export interface MobileRunnerHostOptions {
    * may branch on the answer.
    */
   readonly canCopyImages: boolean;
+  /**
+   * The OS back request, or `null` where the OS raises none - see
+   * `IRunnerHost.systemBack`. Decided by the entry point like the members
+   * above: which platform this is stays the entry's business.
+   */
+  readonly systemBack: ISystemBackHost | null;
 }
 
 const STEP_UP_EXPIRY_SKEW_MS = 5_000;
@@ -253,6 +260,7 @@ export class MobileRunnerHost implements IRunnerHost {
    * wherever it would have nothing to report or no working button.
    */
   readonly pushPermission: IPushPermissionHost | null;
+  readonly systemBack: ISystemBackHost | null;
   private retainedStepUpCredential: RetainedStepUpCredential | null = null;
   // One evidence pair per platform - see `resumeEvidenceModeFor` and the
   // MobileSystemResume class doc for why the same Capacitor event names mean
@@ -296,6 +304,7 @@ export class MobileRunnerHost implements IRunnerHost {
     this.linkLoginDeepLinks = options.linkLoginDeepLinks;
     this.fileSave = options.fileSave;
     this.canCopyImages = options.canCopyImages;
+    this.systemBack = options.systemBack;
     this.notifications = buildNotifications(options.pushRegistration);
     this.pushPermission = buildPushPermission(
       options.pushRegistration,

--- a/clients/mobile/src/system-back.ts
+++ b/clients/mobile/src/system-back.ts
@@ -1,0 +1,70 @@
+import type { PluginListenerHandle } from "@capacitor/core";
+import type { ISystemBackHost } from "@traycer-clients/shared/platform/runner-host";
+import type { Disposable } from "@traycer-clients/shared/platform/uri-callback";
+
+/** The App plugin's `backButton` payload; the WebView's own page history. */
+export interface BackButtonEvent {
+  readonly canGoBack: boolean;
+}
+
+/**
+ * The slice of `@capacitor/app` this adapter uses, so tests fake the plugin
+ * at the package boundary and the plugin import stays in the entry point.
+ */
+export interface SystemBackPluginSlice {
+  addListener(
+    eventName: "backButton",
+    listener: (event: BackButtonEvent) => void,
+  ): Promise<PluginListenerHandle>;
+  minimizeApp(): Promise<void>;
+}
+
+/**
+ * `IRunnerHost.systemBack` on Android.
+ *
+ * Registering ANY `backButton` listener is what takes the press away from the
+ * plugin's default handling, which on this app is nothing at all: the GUI
+ * keeps its history in its own in-memory stack, so the WebView's page history
+ * the default consults is always a single entry. `canGoBack` on the event
+ * describes that same page history and is deliberately not forwarded - the
+ * GUI answers "is there anything behind" from its own stack.
+ *
+ * Android-only by construction: the entry point builds this on that platform
+ * alone. iOS raises no such event and `minimizeApp` is unimplemented there.
+ */
+export class MobileSystemBack implements ISystemBackHost {
+  constructor(private readonly plugin: SystemBackPluginSlice) {}
+
+  onBack(handler: () => void): Disposable {
+    let disposed = false;
+    let handle: PluginListenerHandle | null = null;
+    void this.plugin
+      .addListener("backButton", () => {
+        // The attach is asynchronous, so a listener can be live for a press
+        // that lands after its subscription was disposed but before the
+        // removal below caught up.
+        if (!disposed) handler();
+      })
+      .then((attached) => {
+        if (disposed) {
+          void attached.remove();
+          return;
+        }
+        handle = attached;
+      })
+      .catch((error: unknown) => {
+        console.warn("[system-back] attach failed", error);
+      });
+    return {
+      dispose: () => {
+        disposed = true;
+        void handle?.remove();
+        handle = null;
+      },
+    };
+  }
+
+  minimize(): Promise<void> {
+    return this.plugin.minimizeApp();
+  }
+}

--- a/clients/mobile/src/web/main.tsx
+++ b/clients/mobile/src/web/main.tsx
@@ -35,6 +35,7 @@ import { MobileDeviceDescriber } from "../device-describer";
 import { MobileFileSave, supportsDirectDownload } from "../file-save";
 import { MobileLinkCodeScanner } from "../link-code-scanner";
 import { MobileLinkLoginDeepLinks } from "../link-login-deep-links";
+import { MobileSystemBack } from "../system-back";
 import {
   MobilePushRegistration,
   pushRegistrationTarget,
@@ -311,6 +312,13 @@ async function mount(input: {
     // would report a success the clipboard never received. The dev web entry
     // is a real browser tab, where the write works.
     canCopyImages: Capacitor.getPlatform() !== "android",
+    // The other place a platform is named. Android is the one shell whose OS
+    // raises a back request - the hardware key and the system back gesture,
+    // which the OS takes before the WebView sees a touch, so the GUI's own
+    // edge swipe never fires there. iOS has neither, and its edge swipe IS
+    // that recognizer; the dev web entry has the browser's own back.
+    systemBack:
+      Capacitor.getPlatform() === "android" ? new MobileSystemBack(App) : null,
   });
   // After the host exists: registration follows the token store (sign-in,
   // app start while signed in, sign-out) and the host's resume edge (a

--- a/clients/shared/host-client/mock/mock-runner-host.ts
+++ b/clients/shared/host-client/mock/mock-runner-host.ts
@@ -299,6 +299,7 @@ export class MockRunnerHost implements IRunnerHost {
   readonly hostTray: null = null;
   readonly zoom: null = null;
   readonly pushPermission: null = null;
+  readonly systemBack: null = null;
   readonly deviceFlow: MockDeviceFlowHost = new MockDeviceFlowHost();
 
   /**

--- a/clients/shared/platform/runner-host.ts
+++ b/clients/shared/platform/runner-host.ts
@@ -638,6 +638,33 @@ export interface IRunnerHost {
    * (desktop, dev web, tests), where the GUI hides the surface entirely.
    */
   readonly pushPermission: IPushPermissionHost | null;
+
+  /**
+   * The OS "back" request - Android's hardware key and its system back
+   * gesture, which the OS delivers as one event and which never reach the
+   * WebView as a touch. Present only on shells whose OS raises such a request
+   * (the Android shell) and `null` everywhere else: iOS has no back button
+   * and its edge swipe is the GUI's own recognizer; desktop and the browser
+   * have their own back affordances.
+   *
+   * The signal is payload-free. What "back" MEANS - close a drawer, dismiss a
+   * dialog, step the app's history - is the GUI's decision, made against the
+   * same in-app history the edge swipe and the desktop arrows walk. The
+   * shell's only other contribution is `minimize`, for a press with nothing
+   * left to go back to: the platform's answer is to step out of the way, not
+   * to sit on a press that visibly did nothing.
+   */
+  readonly systemBack: ISystemBackHost | null;
+}
+
+/**
+ * The OS back request, where one exists. See `IRunnerHost.systemBack`.
+ */
+export interface ISystemBackHost {
+  /** Fires once per OS back request; carries nothing. */
+  onBack(handler: () => void): Disposable;
+  /** Sends the app to the background, leaving it warm for the next resume. */
+  minimize(): Promise<void>;
 }
 
 /**


### PR DESCRIPTION
## Summary

On Android, the hardware back key and the system back gesture did nothing in the mobile app. iOS was fine.

**Why.** The GUI keeps its navigation history in its own in-memory stack, so the WebView's page history is always a single entry. Capacitor's App plugin, when no JavaScript `backButton` listener is registered, only consults that page history and then swallows the press. On iOS, back is the GUI's own edge-swipe recognizer, which the OS never intercepts, so nothing was missing there. On Android the OS takes the edge swipe as its system back gesture before the WebView sees a touch, so the swipe recognizer never fires either.

**Fix.** Add a `systemBack` capability to `IRunnerHost`: a payload-free "OS back requested" signal plus `minimize`. The Android shell backs it with the App plugin's `backButton` event and `minimizeApp`; iOS, desktop, the mock host, and the dev web entry pass `null`, so nothing changes for them. The GUI subscribes once in the app shell and answers a press in the order Android users expect, one answer per press:

1. An open navigation drawer closes.
2. A modal layer covering the app is sent Escape, which its dismissable-layer primitive already handles. A dialog that refuses Escape keeps refusing.
3. Otherwise the app's history steps back through the same `goBack` the iOS edge swipe and the desktop arrows call.
4. With nothing behind, the shell is asked to minimize the app.

Platform is named only in the mobile entry point, per the mobile client's working rules; the GUI gates on the capability alone.

## Related issue

None filed. Reported by hand: Android back button does not go back.

## Testing

- New `clients/mobile/__tests__/system-back.test.ts`: press reaches the subscriber, disposal stops delivery (including when it races the plugin's async attach), minimize reaches the plugin.
- New `clients/gui-app/.../use-system-back.test.tsx`: history steps back, drawer closes instead, a real uncontrolled sheet dismisses instead, and minimize is asked for with nothing behind.
- Full mobile suite, the mobile swipe navigation suite, and the fixtures that hand-build a runner host all pass. Typecheck, lint, and format are clean across mobile, gui-app, shared, and desktop.
- **Not verified on a device or emulator.** The wiring and decision order are covered by tests; the hardware key and gesture path should be tried by hand on Android before release.

## Checklist

- [x] Pre-commit static checks pass (`pre-commit run --all-files` for an explicit full-repo run)
- [ ] Separate CI test checks pass
- [x] Tests added/updated where it makes sense
- [x] Commits are signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#developer-certificate-of-origin-dco)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
