### PR TITLE
fix(host): restore explicit downgrades with update progress

### DIFF
--- a/clients/gui-app/src/components/settings/SETTINGS.md
+++ b/clients/gui-app/src/components/settings/SETTINGS.md
@@ -2286,6 +2286,19 @@ aria-live="polite"` carrying the equivalent text for
       first attempt). An install in flight freezes EVERY row, which is where the
       old `showUpdateNowInput` guard went - it existed so a second
       `desiredVersion` write could not retarget a draining update.
+    - **Explicit downgrades are supported.** The picker permits any available,
+      non-yanked version with different SemVer precedence from the installed
+      version (build metadata alone is not a distinct target). Hosts must
+      negotiate `host.update.install@1.2` before older rows are enabled; earlier
+      hosts show guidance to update first. The summary and automatic updater
+      still offer only newer versions. A downgrade dispatch
+      opts into `host update --allow-downgrade` after checking the host's CLI
+      supports it; the CLI uses a private verified install source while keeping
+      update progress, busy-host refusal, and the post-swap health check. An
+      older CLI that cannot honor a downgrade is refused before dispatch.
+      This installs a version once; it does not pin it against future updates.
+      Desktop launch reconciliation may install a newer resolved release, and
+      the host reconciler still enforces the channel's minimum supported version.
     - The asset lookup takes a SOLE `platforms` key as authoritative: the host's
       CLI projects each entry to `currentHostPlatformKey()` before emitting it,
       so re-deriving a key here would get win32-arm64 wrong (it resolves to the

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-overview-updates.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-overview-updates.test.tsx
@@ -55,9 +55,11 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { HostAvailableManifest } from "@traycer/protocol/host/maintenance/index";
 import { MockRunnerHost } from "@traycer-clients/shared/host-client/mock/mock-runner-host";
 import {
-  recordNegotiatedHostMethods,
+  recordNegotiatedHostManifest,
+  recordNegotiatedHostMethods as recordNegotiatedHostMethodsByName,
   resetNegotiatedManifests,
 } from "@traycer-clients/shared/host-transport/negotiated-manifest-registry";
+import type { ManifestMethodEntry } from "@traycer/protocol/framework/index";
 import type { IRunnerHost } from "@traycer-clients/shared/platform/runner-host";
 import { hostScopeOptionFixture } from "@/components/settings/host-scope/host-scope-fixture";
 import { resetHostServiceWriteLatchesForTest } from "@/components/settings/panels/host-service-write-latch-store";
@@ -97,6 +99,31 @@ const ALL_OVERVIEW_METHODS = [
   "host.update.install",
   "diagnostics.logs.tail",
 ] as const;
+
+function recordOverviewHostMethods(
+  hostId: string,
+  methods: readonly string[],
+  installMinor: number,
+): void {
+  recordNegotiatedHostMethodsByName(hostId, methods);
+  const manifest: Record<string, ManifestMethodEntry> = {};
+  for (const method of methods) {
+    manifest[method] = {
+      major: 1,
+      minor: method === "host.update.install" ? installMinor : 0,
+    };
+  }
+  recordNegotiatedHostManifest(hostId, manifest);
+}
+
+// Keep existing fixture call sites concise while retaining the negotiated
+// minor needed by explicit downgrade rows.
+function recordNegotiatedHostMethods(
+  hostId: string,
+  methods: readonly string[],
+): void {
+  recordOverviewHostMethods(hostId, methods, 2);
+}
 
 function scopeFrom(
   hostId: string,
@@ -441,34 +468,28 @@ describe("<HostSettingsPanel /> Overview updates — version picker", () => {
     });
   });
 
-  it("a row BELOW the installed version is not installable, because the CLI would short-circuit it and report nothing back", async () => {
-    // The picker's premise is that a row means what it says. The CLI computes
-    // `installedAtOrAboveTarget` and returns `installed-up-to-date` for a
-    // target at OR BELOW what is installed (`download-stage.ts`), then skips
-    // the apply and writes no progress marker — while `host.update.install`
-    // has already answered `accepted`, because it returns at spawn. So an
-    // enabled Install on an older row toasts "Updating…" for a host that will
-    // do nothing and then say nothing. Every up-to-date host hits this the
-    // moment "Show all" exposes its history.
+  it("allows an explicit RC-to-stable downgrade, sends the exact target, and freezes the other rows while it is in flight", async () => {
+    let releaseInstall: (() => void) | null = null;
+    const gate = new Promise<void>((resolve) => {
+      releaseInstall = resolve;
+    });
     const attempted: string[] = [];
     const fixture = buildOverviewHostFixture({
       hostId: "host-a",
       isLocalMachine: true,
-      hostVersion: "1.6.0",
+      hostVersion: "1.3.0-rc.1",
       overrideHandlers: {
         "host.update.check": () =>
           Promise.resolve({
             outcome: "ok" as const,
-            effectiveIncludePreReleases: false,
-            includePreReleasesSource: "stable-default" as const,
-            manifest: multiVersionManifest(["1.7.0", "1.6.0", "1.5.0"]),
+            effectiveIncludePreReleases: true,
+            includePreReleasesSource: "installed-rc" as const,
+            manifest: multiVersionManifest(["1.3.0-rc.1", "1.2.0", "1.1.0"]),
           }),
-        "host.update.install": (req) => {
+        "host.update.install": async (req) => {
           attempted.push(req.version);
-          return Promise.resolve({
-            outcome: "accepted" as const,
-            attemptId: null,
-          });
+          await gate;
+          return { outcome: "accepted" as const, attemptId: null };
         },
       },
     });
@@ -478,33 +499,112 @@ describe("<HostSettingsPanel /> Overview updates — version picker", () => {
     renderPanel();
 
     fireEvent.click(await waitForButton("Check now"));
-    // The list moved into the Advanced disclosure, which Radix does not mount
-    // while closed — so this is the difference between "no rows" and "no drawer".
     await openHostOverviewAdvanced();
     const picker = await screen.findByTestId("host-version-rows");
     const rows = within(picker).getAllByRole("listitem");
+    const downgrade = within(rowFor(rows, "1.2.0")).getByRole("button", {
+      name: "Install 1.2.0",
+    });
 
-    // Newer than installed — the one row that can actually do something.
+    expect(downgrade.hasAttribute("disabled")).toBe(false);
+    expect(rowFor(rows, "1.2.0").textContent).not.toContain(
+      "Already on v1.3.0-rc.1",
+    );
+
+    fireEvent.click(downgrade);
+    await waitFor(() => expect(attempted).toEqual(["1.2.0"]));
+
+    // The page-wide install latch freezes every other row while the detached
+    // update is in flight, including another older target.
+    await waitFor(() => {
+      expect(
+        within(rowFor(rows, "1.1.0"))
+          .getByRole("button", { name: "Install 1.1.0" })
+          .hasAttribute("disabled"),
+      ).toBe(true);
+      expect(downgrade.hasAttribute("disabled")).toBe(true);
+    });
+
+    await act(async () => {
+      releaseInstall?.();
+      await gate;
+    });
+  });
+
+  it("keeps lower rows disabled on a pre-downgrade host while leaving newer rows installable", async () => {
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: true,
+      hostVersion: "1.3.0-rc.1",
+      overrideHandlers: {
+        "host.update.check": () =>
+          Promise.resolve({
+            outcome: "ok" as const,
+            effectiveIncludePreReleases: true,
+            includePreReleasesSource: "installed-rc" as const,
+            manifest: multiVersionManifest(["1.4.0", "1.3.0-rc.1", "1.2.0"]),
+          }),
+      },
+    });
+    recordOverviewHostMethods("host-a", ALL_OVERVIEW_METHODS, 1);
+    hostBindingMock.current = { hostClient: fixture.client };
+    scopeOverrides.current = scopeFrom("host-a", fixture);
+    renderPanel();
+
+    await openHostOverviewAdvanced();
+    const rows = within(await screen.findByTestId("host-version-rows"));
     expect(
-      within(rowFor(rows, "1.7.0"))
-        .getByRole("button", { name: "Install 1.7.0" })
+      within(rowFor(rows.getAllByRole("listitem"), "1.4.0"))
+        .getByRole("button", { name: "Install 1.4.0" })
         .hasAttribute("disabled"),
     ).toBe(false);
-    // Older than installed — dead, and says why rather than leaving a person
-    // to discover it by clicking and watching nothing happen.
+    const olderRow = rowFor(rows.getAllByRole("listitem"), "1.2.0");
+    const older = within(olderRow);
     expect(
-      within(rowFor(rows, "1.5.0"))
-        .getByRole("button", { name: "Install 1.5.0" })
+      older
+        .getByRole("button", { name: "Install 1.2.0" })
         .hasAttribute("disabled"),
     ).toBe(true);
-    expect(rowFor(rows, "1.5.0").textContent).toContain("Already on v1.6.0");
-
-    fireEvent.click(
-      within(rowFor(rows, "1.5.0")).getByRole("button", {
-        name: "Install 1.5.0",
-      }),
+    expect(olderRow.textContent).toContain(
+      "Update this host to a release that supports downgrades from Settings.",
     );
-    expect(attempted).toEqual([]);
+  });
+
+  it("disables a metadata-only equal version while still allowing a genuinely older target", async () => {
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: true,
+      hostVersion: "1.2.0+build.1",
+      overrideHandlers: {
+        "host.update.check": () =>
+          Promise.resolve({
+            outcome: "ok" as const,
+            effectiveIncludePreReleases: false,
+            includePreReleasesSource: "stable-default" as const,
+            manifest: multiVersionManifest(["1.2.0+build.2", "1.1.0"]),
+          }),
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    hostBindingMock.current = { hostClient: fixture.client };
+    scopeOverrides.current = scopeFrom("host-a", fixture);
+    renderPanel();
+
+    await openHostOverviewAdvanced();
+    const rows = within(await screen.findByTestId("host-version-rows"));
+    const equalRow = rowFor(rows.getAllByRole("listitem"), "1.2.0+build.2");
+    const equal = within(equalRow);
+    expect(
+      equal
+        .getByRole("button", { name: "Install 1.2.0+build.2" })
+        .hasAttribute("disabled"),
+    ).toBe(true);
+    expect(equalRow.textContent).toContain("Already on v1.2.0+build.1");
+    expect(
+      within(rowFor(rows.getAllByRole("listitem"), "1.1.0"))
+        .getByRole("button", { name: "Install 1.1.0" })
+        .hasAttribute("disabled"),
+    ).toBe(false);
   });
 
   it("a YANKED latest is never offered by the summary — the row disables it and the CLI's resolveAsset refuses it, so an offer would dispatch a guaranteed rejection", async () => {

--- a/clients/gui-app/src/components/settings/panels/host-overview-advanced.tsx
+++ b/clients/gui-app/src/components/settings/panels/host-overview-advanced.tsx
@@ -133,14 +133,9 @@ function VersionPicker(props: VersionPickerProps): ReactNode {
         <div className="font-medium text-foreground">
           Pick a different version
         </div>
-        {/* No rolling-back claim: every row OLDER than the installed host is
-            deliberately disabled (`supersededReason`), and the CLI would
-            short-circuit such an install anyway — advertising rollback here
-            misleads exactly the person who opened this picker to escape a bad
-            upgrade. */}
         <p className="text-ui-sm text-muted-foreground">
-          Install a specific newer host version — useful for stepping up to a
-          release candidate or a hotfix ahead of auto-update.
+          Install a specific host version — upgrade to a release candidate or
+          hotfix, or downgrade to an earlier release.
         </p>
       </div>
       <div className="flex items-start gap-2 text-ui-sm text-muted-foreground">

--- a/clients/gui-app/src/components/settings/panels/host-overview-updates-state.ts
+++ b/clients/gui-app/src/components/settings/panels/host-overview-updates-state.ts
@@ -26,6 +26,10 @@ import {
   useHostUpdateCheckQuery,
   useHostUpdateInstall,
 } from "@/components/settings/panels/host-overview-rpc";
+import {
+  useHostNegotiatedMethodVersion,
+  type NegotiatedMethodVersion,
+} from "@/hooks/host/use-host-negotiated-method-version";
 import { toastFromHostError } from "@/lib/host-error-toast";
 import type { HostRpcRegistry } from "@/lib/host";
 
@@ -81,6 +85,11 @@ export function useHostOverviewUpdates(input: {
   readonly busy: boolean;
 }): HostOverviewUpdatesState {
   const { client, hostName, installedVersion } = input;
+  const installVersion = useHostNegotiatedMethodVersion(
+    client,
+    "host.update.install",
+  );
+  const supportsDowngrade = versionSupportsDowngrade(installVersion);
   const [showAllVersions, setShowAllVersions] = useState(false);
   // `undefined` until the user touches the checkbox: the DEFAULT is the host's
   // own derivation, not a value this component picked. Only a deliberate
@@ -230,9 +239,8 @@ export function useHostOverviewUpdates(input: {
   // `updatableVersion` below is what the button can act on.
   //
   // PRECEDENCE, not equality: a host running a hotfix or RC AHEAD of the
-  // stable channel is not outdated, and offering Update now there submits a
-  // target the CLI short-circuits as `installed-up-to-date` - an update that
-  // announces itself and performs no work. Equal precedence (build-metadata
+  // stable channel is not outdated. Only the picker may request a deliberate
+  // downgrade; the summary must never offer one as an update. Equal precedence (build-metadata
   // differences included) and incomparable pairs both count as up to date for
   // the SUMMARY - the picker stays the surface for deliberate cross-channel
   // moves.
@@ -314,6 +322,7 @@ export function useHostOverviewUpdates(input: {
         installedVersion,
         platformKey: input.platformKey,
         showAll: showAllVersions,
+        supportsDowngrade,
       }),
       totalCount: manifest?.versions.length ?? 0,
       showAll: showAllVersions,
@@ -381,6 +390,7 @@ function visibleVersionRows(input: {
   readonly installedVersion: string | null;
   readonly platformKey: string | null;
   readonly showAll: boolean;
+  readonly supportsDowngrade: boolean;
 }): readonly HostVersionRow[] {
   const { manifest } = input;
   if (manifest === null) return [];
@@ -398,9 +408,11 @@ function visibleVersionRows(input: {
       isInstalled,
       unavailableReason:
         assetUnavailableReason(asset) ??
-        (isInstalled
-          ? null
-          : supersededReason(input.installedVersion, entry.version)),
+        versionUnavailableReason(
+          input.installedVersion,
+          entry.version,
+          input.supportsDowngrade,
+        ),
     };
   });
 }
@@ -408,13 +420,11 @@ function visibleVersionRows(input: {
 /**
  * The version the summary's Update now may offer, or `null`.
  *
- * Four gates, all of which the picker enforces per row and the summary must
- * therefore enforce for its one target: the manifest must be from a check the
- * host CONFIRMED (not error-retained data), the target must be strictly newer
- * than what is installed, its entry must not be YANKED (the row disables it and
- * the CLI's `resolveAsset` refuses it before download, so an offer here would
- * dispatch an install the host is guaranteed to reject), and the entry must
- * resolve a usable asset for this host's platform.
+ * The summary additionally requires a strictly newer target; the picker also
+ * permits explicit downgrades. Both require a manifest from a check the
+ * host CONFIRMED (not error-retained data), a non-yanked entry, and a usable
+ * asset for this host's platform. The CLI also refuses yanked releases before
+ * downloading.
  *
  * WHICH version is the target depends on how the catalog was resolved, and
  * that is the whole reason provenance rides on the response. For an
@@ -619,30 +629,25 @@ function latestIsStrictlyNewer(
   return comparison.comparable && comparison.ordering === "less";
 }
 
-/**
- * Why a row below the installed version cannot be installed.
- *
- * This mirrors the CLI's own short-circuit rather than inventing a policy:
- * `download-stage.ts` computes `installedAtOrAboveTarget` and returns
- * `installed-up-to-date` for a target at OR BELOW what is installed, then skips
- * the apply and writes no progress marker. The RPC has already answered
- * `accepted` by then, so an enabled button here would toast "Updating…" for a
- * host that will do nothing and report nothing — the list would be lying about
- * an action it cannot perform.
- *
- * Incomparable pairs are deliberately left installable. `compareHostVersions`
- * refuses anything non-semver, a staging build id is not semver, and the CLI
- * applies the same refusal — an incomparable target does NOT short-circuit
- * there, so it must not be blocked here.
- */
-function supersededReason(
+function versionSupportsDowngrade(version: NegotiatedMethodVersion): boolean {
+  if (version === null || version === false) return false;
+  return version.major > 1 || (version.major === 1 && version.minor >= 2);
+}
+
+/** Only a host advertising downgrade support can honor an older target. */
+function versionUnavailableReason(
   installedVersion: string | null,
   rowVersion: string,
+  supportsDowngrade: boolean,
 ): string | null {
-  if (installedVersion === null) return null;
+  if (installedVersion === null || installedVersion === rowVersion) return null;
   const comparison = compareHostVersions(installedVersion, rowVersion);
-  if (!comparison.comparable || comparison.ordering === "less") return null;
-  return `Already on v${installedVersion}`;
+  if (!comparison.comparable) return null;
+  if (comparison.ordering === "equal") return `Already on v${installedVersion}`;
+  if (comparison.ordering === "greater" && !supportsDowngrade) {
+    return "Update this host to a release that supports downgrades from Settings.";
+  }
+  return null;
 }
 
 /**

--- a/clients/traycer-cli/src/commands/__tests__/ack-nonce-commander-bridge.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/ack-nonce-commander-bridge.test.ts
@@ -91,7 +91,12 @@ describe("--ack-nonce reaches the builder through the Commander bridge", () => {
     // translate every option, and a test watching one field would not notice a
     // sibling being dropped or crossed over in the same callback.
     expect(captured.args).toEqual([
-      { force: false, versionRequest: null, ackNonce: "nonce-abcdefgh" },
+      {
+        force: false,
+        allowDowngrade: false,
+        versionRequest: null,
+        ackNonce: "nonce-abcdefgh",
+      },
     ]);
   });
 
@@ -101,7 +106,12 @@ describe("--ack-nonce reaches the builder through the Commander bridge", () => {
   it("forwards null when the flag is absent", async () => {
     await buildProgram().parseAsync(["host", "update"], { from: "user" });
     expect(captured.args).toEqual([
-      { force: false, versionRequest: null, ackNonce: null },
+      {
+        force: false,
+        allowDowngrade: false,
+        versionRequest: null,
+        ackNonce: null,
+      },
     ]);
   });
 
@@ -114,7 +124,35 @@ describe("--ack-nonce reaches the builder through the Commander bridge", () => {
       { from: "user" },
     );
     expect(captured.args).toEqual([
-      { force: true, versionRequest: null, ackNonce: "nonce-abcdefgh" },
+      {
+        force: true,
+        allowDowngrade: false,
+        versionRequest: null,
+        ackNonce: "nonce-abcdefgh",
+      },
+    ]);
+  });
+
+  it("forwards an explicit downgrade flag with its exact version and nonce", async () => {
+    await buildProgram().parseAsync(
+      [
+        "host",
+        "update",
+        "--release",
+        "1.2.0",
+        "--allow-downgrade",
+        "--ack-nonce",
+        "nonce-downgrade",
+      ],
+      { from: "user" },
+    );
+    expect(captured.args).toEqual([
+      {
+        force: false,
+        allowDowngrade: true,
+        versionRequest: "1.2.0",
+        ackNonce: "nonce-downgrade",
+      },
     ]);
   });
 });

--- a/clients/traycer-cli/src/commands/__tests__/host-update-dispatch-ack-guard.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/host-update-dispatch-ack-guard.test.ts
@@ -59,6 +59,7 @@ describe("buildHostUpdateCommand — illegal ack nonce refuses before anything i
   it("rejects on an illegal nonce and never calls downloadAndStageHost", async () => {
     const command = buildHostUpdateCommand({
       force: false,
+      allowDowngrade: false,
       versionRequest: null,
       // Too short and outside the legal charset for
       // `isValidUpdateDispatchAckNonce` (`^[A-Za-z0-9_-]{8,128}$`).
@@ -81,6 +82,7 @@ describe("buildHostUpdateCommand — illegal ack nonce refuses before anything i
     );
     const command = buildHostUpdateCommand({
       force: false,
+      allowDowngrade: false,
       versionRequest: null,
       ackNonce: "nonce-abcdefgh",
     });

--- a/clients/traycer-cli/src/commands/__tests__/host-update-dispatch-ack-wiring.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/host-update-dispatch-ack-wiring.test.ts
@@ -68,6 +68,7 @@ describe("buildHostUpdateCommand — dispatch ACK stamper is installed as the FI
     );
     const command = buildHostUpdateCommand({
       force: false,
+      allowDowngrade: false,
       versionRequest: null,
       ackNonce: "nonce-abcdefgh",
     });
@@ -92,6 +93,7 @@ describe("buildHostUpdateCommand — dispatch ACK stamper is installed as the FI
     );
     const command = buildHostUpdateCommand({
       force: false,
+      allowDowngrade: false,
       versionRequest: null,
       ackNonce: null,
     });

--- a/clients/traycer-cli/src/commands/__tests__/host-update-downgrade-command-failure.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/host-update-downgrade-command-failure.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { CommandContext } from "../../runner/runner";
+import type { HostInstallRecord } from "../../manifest/host-install";
+
+const mocks = vi.hoisted(() => ({
+  installHostDowngradeMock: vi.fn(),
+  readHostInstallRecordMock: vi.fn(),
+  writeUpdateProgressMarkerMock: vi.fn(),
+  deleteUpdateProgressMarkerMock: vi.fn(),
+  probeHostHealthMock: vi.fn(),
+  installDispatchAckStamperMock: vi.fn(),
+}));
+
+vi.mock("../host-update-downgrade", () => ({
+  installHostDowngrade: mocks.installHostDowngradeMock,
+}));
+
+vi.mock("../../manifest/host-install", () => ({
+  readHostInstallRecord: mocks.readHostInstallRecordMock,
+}));
+
+vi.mock("../../host/update-progress-marker", () => ({
+  writeUpdateProgressMarker: mocks.writeUpdateProgressMarkerMock,
+  deleteUpdateProgressMarker: mocks.deleteUpdateProgressMarkerMock,
+}));
+
+vi.mock("../../service/health-probe", () => ({
+  probeHostHealth: mocks.probeHostHealthMock,
+}));
+
+vi.mock("../../host/update-dispatch-ack", () => ({
+  installDispatchAckStamper: mocks.installDispatchAckStamperMock,
+}));
+
+vi.mock("../../installer/download-stage", () => ({
+  downloadAndStageHost: vi.fn(),
+}));
+
+import { buildHostUpdateCommand } from "../host-update";
+
+const installedRecord: HostInstallRecord = {
+  installId: "install-1.3.0-rc.1",
+  version: "1.3.0-rc.1",
+  runtimeVersion: null,
+  platform: "darwin",
+  arch: "arm64",
+  installedAt: "2026-01-01T00:00:00.000Z",
+  source: { kind: "registry", value: "1.3.0-rc.1" },
+  archiveSha256: "a".repeat(64),
+  signatureVerifiedAt: "2026-01-01T00:00:00.000Z",
+  signatureKeyId: "test-key",
+  sizeBytes: 1,
+  executablePath: "/tmp/traycer-host",
+  executableSha256: null,
+};
+
+function fakeCtx(): CommandContext {
+  return {
+    runtime: {
+      json: false,
+      quiet: false,
+      noProgress: false,
+      noBootstrap: false,
+      nonInteractive: false,
+      environment: "production",
+      logger: {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      },
+    },
+    output: {
+      progress: vi.fn(),
+      human: vi.fn(),
+      humanRequired: vi.fn(),
+      emitResult: vi.fn(),
+      emitError: vi.fn(),
+    },
+    progress: vi.fn(),
+  };
+}
+
+describe("host update explicit downgrade failure", () => {
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("leaves a failed marker for the downgrade target and never claims host health", async () => {
+    mocks.installDispatchAckStamperMock.mockReturnValue(null);
+    mocks.readHostInstallRecordMock.mockResolvedValue(installedRecord);
+    mocks.installHostDowngradeMock.mockRejectedValue(
+      new Error("downgrade commit failed"),
+    );
+
+    await expect(
+      buildHostUpdateCommand({
+        allowDowngrade: true,
+        force: false,
+        versionRequest: "1.2.0",
+        ackNonce: null,
+      })(fakeCtx()),
+    ).rejects.toThrow("downgrade commit failed");
+
+    expect(mocks.writeUpdateProgressMarkerMock).toHaveBeenNthCalledWith(
+      1,
+      "production",
+      expect.objectContaining({
+        state: "updating",
+        targetVersion: "1.2.0",
+      }),
+    );
+    expect(mocks.writeUpdateProgressMarkerMock).toHaveBeenNthCalledWith(
+      2,
+      "production",
+      expect.objectContaining({
+        state: "failed",
+        targetVersion: "1.2.0",
+        error: "downgrade commit failed",
+      }),
+    );
+    expect(mocks.probeHostHealthMock).not.toHaveBeenCalled();
+    expect(mocks.deleteUpdateProgressMarkerMock).not.toHaveBeenCalled();
+  });
+});

--- a/clients/traycer-cli/src/commands/__tests__/host-update-downgrade.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/host-update-downgrade.test.ts
@@ -1,0 +1,288 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { HostInstallRecord } from "../../manifest/host-install";
+import type { Environment } from "../../runner/environment";
+import type { ServiceInstallLifecycleState } from "../../service/install-lifecycle";
+
+const mocks = vi.hoisted(() => ({
+  sandboxHome: "",
+  createDefaultRegistryClientMock: vi.fn(),
+  busy: false,
+  beforeSwapError: false,
+  lifecycleCalls: [] as Array<{ readonly force: boolean }>,
+}));
+
+// Keep the real staging and commit primitives, but route their host paths to a
+// disposable tree. The downgrade helper must therefore replace real bytes and
+// records, not merely pass a version through a mocked apply function.
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:os")>();
+  return {
+    ...actual,
+    homedir: () => mocks.sandboxHome || actual.tmpdir(),
+  };
+});
+
+vi.mock("../../store/paths", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../store/paths")>();
+  return {
+    ...actual,
+    hostHomeDir: (environment: Environment) =>
+      join(mocks.sandboxHome, "host", environment),
+    hostInstallDir: (environment: Environment) =>
+      join(mocks.sandboxHome, "host", environment, "install"),
+    hostInstallRecordPath: (environment: Environment) =>
+      join(mocks.sandboxHome, "host", environment, "install", "install.json"),
+    hostStagingRoot: (environment: Environment) =>
+      join(mocks.sandboxHome, "host", environment, "install-staging"),
+    hostStagedDir: (environment: Environment) =>
+      join(mocks.sandboxHome, "host", environment, "staged"),
+    hostStagedRecordPath: (environment: Environment) =>
+      join(mocks.sandboxHome, "host", environment, "staged", "staged.json"),
+    hostDownloadCacheDir: (environment: Environment) =>
+      join(mocks.sandboxHome, "host", environment, "download-cache"),
+    ensureHostHomeDir: async (environment: Environment) => {
+      mkdirSync(join(mocks.sandboxHome, "host", environment), {
+        recursive: true,
+      });
+    },
+    ensureHostInstallDir: async (environment: Environment) => {
+      mkdirSync(join(mocks.sandboxHome, "host", environment, "install"), {
+        recursive: true,
+      });
+    },
+    ensureHostStagingRoot: async (environment: Environment) => {
+      mkdirSync(
+        join(mocks.sandboxHome, "host", environment, "install-staging"),
+        { recursive: true },
+      );
+    },
+  };
+});
+
+vi.mock("../../registry", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../registry")>();
+  return {
+    ...actual,
+    createDefaultRegistryClient: mocks.createDefaultRegistryClientMock,
+  };
+});
+
+// The helper's real stage/commit primitives still run, while the contender
+// facade is reduced to a live capability callback so this suite focuses on
+// staging, the busy gate, swap, and cleanup rather than lock-process setup.
+vi.mock("../../host/update-contender", () => ({
+  withCliUpdateExecutionSegment: async (
+    _options: unknown,
+    run: (capability: { readonly hostHomeDir: string }) => Promise<unknown>,
+  ) => run({ hostHomeDir: mocks.sandboxHome }),
+  withCliAttemptMutation: async (
+    _capability: unknown,
+    _options: unknown,
+    run: () => Promise<unknown>,
+  ) => run(),
+  requireCliUpdateMutationCapability: async () => undefined,
+}));
+
+vi.mock("../../host/busy-check", () => ({
+  assertHostNotBusy: async () => {
+    if (mocks.busy) throw new Error("host is busy");
+  },
+}));
+
+vi.mock("../../service/install-lifecycle", () => ({
+  createServiceInstallLifecycle: (options: { readonly force: boolean }) => {
+    mocks.lifecycleCalls.push({ force: options.force });
+    const state = {
+      priorState: "running" as ServiceInstallLifecycleState["priorState"],
+      stoppedBeforeSwap: false,
+      postSwapAction: "none" as ServiceInstallLifecycleState["postSwapAction"],
+      postSwapError: null as ServiceInstallLifecycleState["postSwapError"],
+    };
+    return {
+      state,
+      lifecycle: {
+        beforeSwap: async () => {
+          if (mocks.beforeSwapError) throw new Error("precommit failed");
+          state.stoppedBeforeSwap = true;
+        },
+        afterSwap: async () => {
+          state.postSwapAction = "install";
+        },
+        swapLockRecovery: null,
+      },
+    };
+  },
+}));
+
+import {
+  readHostInstallRecord,
+  writeHostInstallRecord,
+} from "../../manifest/host-install";
+import { installHostDowngrade } from "../host-update-downgrade";
+
+const ENV: Environment = "production";
+
+function installDir(): string {
+  return join(mocks.sandboxHome, "host", ENV, "install");
+}
+
+function stagingRoot(): string {
+  return join(mocks.sandboxHome, "host", ENV, "install-staging");
+}
+
+function downloadCache(): string {
+  return join(mocks.sandboxHome, "host", ENV, "download-cache");
+}
+
+function record(version: string): HostInstallRecord {
+  return {
+    installId: `install-${version}`,
+    version,
+    runtimeVersion: null,
+    platform: "darwin",
+    arch: "arm64",
+    installedAt: "2026-01-01T00:00:00.000Z",
+    source: { kind: "registry", value: version },
+    archiveSha256: "a".repeat(64),
+    signatureVerifiedAt: "2026-01-01T00:00:00.000Z",
+    signatureKeyId: "test-key",
+    sizeBytes: 3,
+    executablePath: join(installDir(), "traycer-host"),
+    executableSha256: null,
+  };
+}
+
+function configureRegistry(version: string, bytes: string): void {
+  mkdirSync(downloadCache(), { recursive: true });
+  const archivePath = join(downloadCache(), "traycer-host");
+  writeFileSync(archivePath, bytes);
+  writeFileSync(
+    `${archivePath}.owner`,
+    JSON.stringify({ pid: process.pid, startedAtMs: null }),
+  );
+  mocks.createDefaultRegistryClientMock.mockResolvedValue({
+    resolveAsset: async () => ({
+      entry: { version },
+      asset: { sizeBytes: Buffer.byteLength(bytes) },
+    }),
+    downloadAndVerify: async (
+      _entry: unknown,
+      _asset: unknown,
+      onProgress: (progress: {
+        readonly downloadedBytes: number;
+        readonly totalBytes: number;
+      }) => void,
+    ) => {
+      onProgress({
+        downloadedBytes: Buffer.byteLength(bytes),
+        totalBytes: Buffer.byteLength(bytes),
+      });
+      return {
+        archivePath,
+        archiveSha256: "b".repeat(64),
+        signatureKeyId: "test-key",
+        signatureVerifiedAt: "2026-01-02T00:00:00.000Z",
+      };
+    },
+  });
+}
+
+async function writeInstalled(version: string, bytes: string): Promise<void> {
+  mkdirSync(installDir(), { recursive: true });
+  writeFileSync(join(installDir(), "traycer-host"), bytes);
+  await writeHostInstallRecord(ENV, record(version));
+}
+
+const noopProgress = (): void => undefined;
+
+describe("installHostDowngrade", () => {
+  beforeEach(() => {
+    mocks.sandboxHome = mkdtempSync(join(tmpdir(), "traycer-host-downgrade-"));
+    mocks.busy = false;
+    mocks.beforeSwapError = false;
+    mocks.lifecycleCalls = [];
+  });
+
+  afterEach(() => {
+    rmSync(mocks.sandboxHome, { recursive: true, force: true });
+    vi.resetAllMocks();
+  });
+
+  it("stages and commits lower-version bytes over the current install, preserving force", async () => {
+    await writeInstalled("1.3.0-rc.1", "old");
+    configureRegistry("1.2.0", "new");
+
+    const outcome = await installHostDowngrade({
+      environment: ENV,
+      version: "1.2.0",
+      force: true,
+      onProgress: noopProgress,
+    });
+
+    expect(outcome.outcome).toBe("applied");
+    expect(outcome.previous?.version).toBe("1.3.0-rc.1");
+    expect(outcome.record.version).toBe("1.2.0");
+    expect(readFileSync(join(installDir(), "traycer-host"), "utf8")).toBe(
+      "new",
+    );
+    expect(mocks.lifecycleCalls).toEqual([{ force: true }]);
+    expect(await readHostInstallRecord(ENV)).toMatchObject({
+      version: "1.2.0",
+    });
+  });
+
+  it("checks busy before commit and discards the owned staged tree without replacing the install", async () => {
+    await writeInstalled("1.3.0-rc.1", "old");
+    configureRegistry("1.2.0", "new");
+    mocks.busy = true;
+
+    await expect(
+      installHostDowngrade({
+        environment: ENV,
+        version: "1.2.0",
+        force: false,
+        onProgress: noopProgress,
+      }),
+    ).rejects.toThrow("host is busy");
+
+    expect(readFileSync(join(installDir(), "traycer-host"), "utf8")).toBe(
+      "old",
+    );
+    expect(await readHostInstallRecord(ENV)).toMatchObject({
+      version: "1.3.0-rc.1",
+    });
+    expect(readdirSync(stagingRoot())).toEqual([]);
+  });
+
+  it("cleans the owned staged tree when the precommit lifecycle fails", async () => {
+    await writeInstalled("1.3.0-rc.1", "old");
+    configureRegistry("1.2.0", "new");
+    mocks.beforeSwapError = true;
+
+    await expect(
+      installHostDowngrade({
+        environment: ENV,
+        version: "1.2.0",
+        force: false,
+        onProgress: noopProgress,
+      }),
+    ).rejects.toThrow("precommit failed");
+
+    expect(readFileSync(join(installDir(), "traycer-host"), "utf8")).toBe(
+      "old",
+    );
+    expect(existsSync(join(stagingRoot(), "install-"))).toBe(false);
+    expect(readdirSync(stagingRoot())).toEqual([]);
+  });
+});

--- a/clients/traycer-cli/src/commands/__tests__/host-update.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/host-update.test.ts
@@ -23,6 +23,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   downloadAndStageHostMock: vi.fn(),
   applyHostMock: vi.fn(),
+  installHostDowngradeMock: vi.fn(),
   readHostStagedRecordMock: vi.fn(),
   readHostInstallRecordMock: vi.fn(),
   // Cross-mock ordering timeline for the Finding 8 test below (ticket-2
@@ -56,6 +57,10 @@ vi.mock("../../installer/download-stage", () => ({
 
 vi.mock("../../installer/apply", () => ({
   applyHost: mocks.applyHostMock,
+}));
+
+vi.mock("../host-update-downgrade", () => ({
+  installHostDowngrade: mocks.installHostDowngradeMock,
 }));
 
 vi.mock("../../manifest/host-staged", () => ({
@@ -267,7 +272,11 @@ describe("buildHostUpdateCommand composite", () => {
     mocks.downloadAndStageHostMock.mockResolvedValue(outcome);
     mocks.readHostInstallRecordMock.mockResolvedValue(sampleRecord("2.0.0"));
 
-    const command = buildHostUpdateCommand({ force: false, ackNonce: null });
+    const command = buildHostUpdateCommand({
+      force: false,
+      allowDowngrade: false,
+      ackNonce: null,
+    });
     const result = await command(fakeCtx());
 
     expect(mocks.applyHostMock).not.toHaveBeenCalled();
@@ -302,7 +311,11 @@ describe("buildHostUpdateCommand composite", () => {
     } satisfies HostDownloadOutcome);
     mocks.readHostInstallRecordMock.mockResolvedValue(null);
 
-    const command = buildHostUpdateCommand({ force: false, ackNonce: null });
+    const command = buildHostUpdateCommand({
+      force: false,
+      allowDowngrade: false,
+      ackNonce: null,
+    });
     await expect(command(fakeCtx())).rejects.toMatchObject({
       code: CLI_ERROR_CODES.HOST_NOT_INSTALLED,
     });
@@ -318,7 +331,11 @@ describe("buildHostUpdateCommand composite", () => {
       appliedOutcome("local-abc123", "2.0.0", null),
     );
 
-    const command = buildHostUpdateCommand({ force: false, ackNonce: null });
+    const command = buildHostUpdateCommand({
+      force: false,
+      allowDowngrade: false,
+      ackNonce: null,
+    });
     await command(fakeCtx());
 
     expect(mocks.downloadAndStageHostMock).toHaveBeenCalledWith({
@@ -342,6 +359,7 @@ describe("buildHostUpdateCommand composite", () => {
 
     const command = buildHostUpdateCommand({
       force: false,
+      allowDowngrade: false,
       versionRequest: "2.1.0",
       ackNonce: null,
     });
@@ -353,6 +371,70 @@ describe("buildHostUpdateCommand composite", () => {
         automatic: false,
       }),
     );
+  });
+
+  it("uses the owned downgrade installer for an explicit lower target and keeps the normal progress and health flow", async () => {
+    mocks.readHostInstallRecordMock.mockResolvedValue(
+      sampleRecord("1.3.0-rc.1"),
+    );
+    mocks.installHostDowngradeMock.mockResolvedValue(
+      appliedOutcome("1.3.0-rc.1", "1.2.0", null),
+    );
+
+    const result = await buildHostUpdateCommand({
+      force: false,
+      allowDowngrade: true,
+      versionRequest: "1.2.0",
+      ackNonce: null,
+    })(fakeCtx());
+
+    expect(mocks.downloadAndStageHostMock).not.toHaveBeenCalled();
+    expect(mocks.installHostDowngradeMock).toHaveBeenCalledWith({
+      environment: "production",
+      version: "1.2.0",
+      force: false,
+      onProgress: expect.any(Function),
+    });
+    expect(mocks.writeUpdateProgressMarkerMock).toHaveBeenCalledWith(
+      "production",
+      expect.objectContaining({ state: "updating", targetVersion: "1.2.0" }),
+    );
+    expect(mocks.probeHostHealthMock).toHaveBeenCalledTimes(1);
+    expect(mocks.deleteUpdateProgressMarkerMock).toHaveBeenCalledWith(
+      "production",
+    );
+    expect(result.human).toContain("updated host 1.3.0-rc.1 → 1.2.0");
+  });
+
+  it("keeps an explicit lower target on the monotonic stage path unless downgrade is explicitly enabled", async () => {
+    mocks.downloadAndStageHostMock.mockResolvedValue({
+      outcome: "discarded",
+      reason: "not-strictly-newer",
+      targetVersion: "1.2.0",
+    } satisfies HostDownloadOutcome);
+    mocks.applyHostMock.mockResolvedValue({
+      outcome: "no-op",
+      installedVersion: "1.3.0-rc.1",
+    } satisfies ApplyHostOutcome);
+    mocks.readHostInstallRecordMock.mockResolvedValue(
+      sampleRecord("1.3.0-rc.1"),
+    );
+
+    const result = await buildHostUpdateCommand({
+      force: false,
+      allowDowngrade: false,
+      versionRequest: "1.2.0",
+      ackNonce: null,
+    })(fakeCtx());
+
+    expect(mocks.installHostDowngradeMock).not.toHaveBeenCalled();
+    expect(mocks.downloadAndStageHostMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        versionRequest: "1.2.0",
+        automatic: false,
+      }),
+    );
+    expect(result.human).toContain("host already at 1.3.0-rc.1 (no-op)");
   });
 
   it("keeps a null version request for latest semantics", async () => {
@@ -367,6 +449,7 @@ describe("buildHostUpdateCommand composite", () => {
 
     const command = buildHostUpdateCommand({
       force: false,
+      allowDowngrade: false,
       versionRequest: null,
       ackNonce: null,
     });
@@ -392,7 +475,11 @@ describe("buildHostUpdateCommand composite", () => {
       appliedOutcome("1.0.0", "2.0.0", null),
     );
 
-    const command = buildHostUpdateCommand({ force: false, ackNonce: null });
+    const command = buildHostUpdateCommand({
+      force: false,
+      allowDowngrade: false,
+      ackNonce: null,
+    });
     const result = await command(fakeCtx());
 
     expect(mocks.applyHostMock).toHaveBeenCalledWith(
@@ -428,7 +515,11 @@ describe("buildHostUpdateCommand composite", () => {
       appliedOutcome("2.0.0", "3.0.0", null),
     );
 
-    const command = buildHostUpdateCommand({ force: false, ackNonce: null });
+    const command = buildHostUpdateCommand({
+      force: false,
+      allowDowngrade: false,
+      ackNonce: null,
+    });
     const result = await command(fakeCtx());
 
     expect(mocks.downloadAndStageHostMock).toHaveBeenCalled();
@@ -446,7 +537,11 @@ describe("buildHostUpdateCommand composite", () => {
       appliedOutcome("1.0.0", "2.0.0", null),
     );
 
-    const command = buildHostUpdateCommand({ force: true, ackNonce: null });
+    const command = buildHostUpdateCommand({
+      force: true,
+      allowDowngrade: false,
+      ackNonce: null,
+    });
     await command(fakeCtx());
 
     expect(mocks.applyHostMock).toHaveBeenCalledWith(
@@ -464,7 +559,11 @@ describe("buildHostUpdateCommand composite", () => {
       appliedOutcome("1.0.0", "2.0.0", "service failed to start"),
     );
 
-    const command = buildHostUpdateCommand({ force: false, ackNonce: null });
+    const command = buildHostUpdateCommand({
+      force: false,
+      allowDowngrade: false,
+      ackNonce: null,
+    });
     const result = await command(fakeCtx());
 
     expect(result.human).toContain("service did not converge");
@@ -487,7 +586,11 @@ describe("buildHostUpdateCommand composite", () => {
     } satisfies ApplyHostOutcome);
     mocks.readHostInstallRecordMock.mockResolvedValue(sampleRecord("2.0.0"));
 
-    const command = buildHostUpdateCommand({ force: false, ackNonce: null });
+    const command = buildHostUpdateCommand({
+      force: false,
+      allowDowngrade: false,
+      ackNonce: null,
+    });
     const result = await command(fakeCtx());
 
     expect(mocks.applyHostMock).toHaveBeenCalled();
@@ -525,7 +628,11 @@ describe("buildHostUpdateCommand composite", () => {
       arch: "arm64",
     });
 
-    const command = buildHostUpdateCommand({ force: false, ackNonce: null });
+    const command = buildHostUpdateCommand({
+      force: false,
+      allowDowngrade: false,
+      ackNonce: null,
+    });
     await expect(command(fakeCtx())).rejects.toMatchObject({
       code: CLI_ERROR_CODES.HOST_BUSY,
       details: { stagedVersion: "2.0.0" },
@@ -560,7 +667,11 @@ describe("buildHostUpdateCommand composite", () => {
       arch: "arm64",
     });
 
-    const command = buildHostUpdateCommand({ force: false, ackNonce: null });
+    const command = buildHostUpdateCommand({
+      force: false,
+      allowDowngrade: false,
+      ackNonce: null,
+    });
     await expect(command(fakeCtx())).rejects.toMatchObject({
       code: CLI_ERROR_CODES.HOST_BUSY,
       details: { stagedVersion: "2.0.0" },
@@ -588,7 +699,11 @@ describe("buildHostUpdateCommand composite", () => {
       }),
     );
 
-    const command = buildHostUpdateCommand({ force: false, ackNonce: null });
+    const command = buildHostUpdateCommand({
+      force: false,
+      allowDowngrade: false,
+      ackNonce: null,
+    });
     await expect(command(fakeCtx())).rejects.toMatchObject({
       code: CLI_ERROR_CODES.HOST_NOT_INSTALLED,
     });
@@ -605,7 +720,11 @@ describe("buildHostUpdateCommand composite", () => {
       }),
     );
 
-    const command = buildHostUpdateCommand({ force: false, ackNonce: null });
+    const command = buildHostUpdateCommand({
+      force: false,
+      allowDowngrade: false,
+      ackNonce: null,
+    });
     await expect(command(fakeCtx())).rejects.toMatchObject({
       code: CLI_ERROR_CODES.HOST_NOT_INSTALLED,
     });
@@ -644,6 +763,7 @@ describe("buildHostUpdateCommand update-progress marker (T16)", () => {
 
     const result = await buildHostUpdateCommand({
       force: false,
+      allowDowngrade: false,
       ackNonce: null,
     })(fakeCtx());
 
@@ -668,7 +788,11 @@ describe("buildHostUpdateCommand update-progress marker (T16)", () => {
     });
 
     await expect(
-      buildHostUpdateCommand({ force: false, ackNonce: null })(fakeCtx()),
+      buildHostUpdateCommand({
+        force: false,
+        allowDowngrade: false,
+        ackNonce: null,
+      })(fakeCtx()),
     ).rejects.toMatchObject({
       code: CLI_ERROR_CODES.HOST_UPDATE_HEALTH_CHECK_FAILED,
     });
@@ -690,7 +814,11 @@ describe("buildHostUpdateCommand update-progress marker (T16)", () => {
     mocks.applyHostMock.mockRejectedValue(new Error("commit failed"));
 
     await expect(
-      buildHostUpdateCommand({ force: false, ackNonce: null })(fakeCtx()),
+      buildHostUpdateCommand({
+        force: false,
+        allowDowngrade: false,
+        ackNonce: null,
+      })(fakeCtx()),
     ).rejects.toThrow("commit failed");
 
     expect(mocks.writeUpdateProgressMarkerMock).toHaveBeenLastCalledWith(
@@ -712,6 +840,7 @@ describe("buildHostUpdateCommand update-progress marker (T16)", () => {
 
     const result = await buildHostUpdateCommand({
       force: false,
+      allowDowngrade: false,
       ackNonce: null,
     })(fakeCtx());
 
@@ -733,6 +862,7 @@ describe("buildHostUpdateCommand update-progress marker (T16)", () => {
 
     const result = await buildHostUpdateCommand({
       force: false,
+      allowDowngrade: false,
       ackNonce: null,
     })(fakeCtx());
 

--- a/clients/traycer-cli/src/commands/__tests__/rendered-help.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/rendered-help.test.ts
@@ -443,6 +443,7 @@ const EXPECTED_PUBLIC_SURFACE: readonly ExpectedSurfaceEntry[] = [
     path: "host update",
     options: [
       { flags: "--release <version>", mandatory: false },
+      { flags: "--allow-downgrade", mandatory: false },
       { flags: "--force", mandatory: false },
       { flags: "--json", mandatory: false },
       { flags: "--no-progress", mandatory: false },
@@ -1151,6 +1152,15 @@ describe("rendered root/parent/leaf --help (CLI command audit regression suite)"
     expect(help).toContain("Compatibility alias for --release");
     expect(help).toContain("--release <version>");
     expect(help).not.toContain("--host-update-version");
+  });
+
+  it("host update --help (real render) advertises the downgrade capability contract", () => {
+    const program = freshProgram();
+    const hostUpdate = findByPath(program, ["host", "update"]);
+    // Host maintenance probes this literal before dispatching an explicit
+    // lower target. Keep the flag visible so that probe is a real capability
+    // contract rather than an implementation detail hidden from users.
+    expect(renderHelp(hostUpdate)).toContain("--allow-downgrade");
   });
 
   // Encodes the standing user policy: every supported user-facing/invocable

--- a/clients/traycer-cli/src/commands/host-update-downgrade.ts
+++ b/clients/traycer-cli/src/commands/host-update-downgrade.ts
@@ -1,0 +1,102 @@
+import type { ApplyHostOutcome } from "../installer/apply";
+import {
+  discardStagedHostInstallSource,
+  stageHostInstallSource,
+} from "../installer/install";
+import { readHostInstallRecord } from "../manifest/host-install";
+import { assertHostNotBusy } from "../host/busy-check";
+import {
+  requireCliUpdateMutationCapability,
+  withCliAttemptMutation,
+  withCliUpdateExecutionSegment,
+  type WithCliUpdateContenderOptions,
+} from "../host/update-contender";
+import { commitHostInstallSourceWithAttempt } from "../host/update-mutation";
+import { createServiceInstallLifecycle } from "../service/install-lifecycle";
+import type { Environment } from "../runner/environment";
+import type { ProgressInfo } from "../runner/output";
+import { CLI_ERROR_CODES, cliError } from "../runner/errors";
+
+/**
+ * Explicit rollback uses the install primitive, whose private verified source
+ * survives independently of the monotonic background-update stage. Keep the
+ * update command's progress marker and health check around this operation.
+ */
+export async function installHostDowngrade(input: {
+  readonly environment: Environment;
+  readonly version: string;
+  readonly force: boolean;
+  readonly onProgress: (info: ProgressInfo) => void;
+}): Promise<Extract<ApplyHostOutcome, { outcome: "applied" }>> {
+  const contenderOptions: WithCliUpdateContenderOptions = {
+    environment: input.environment,
+    reason: "host-update-downgrade",
+    waitMs: 30_000,
+    pollIntervalMs: 100,
+    admission: "legacy-update-shadow",
+  };
+  return withCliUpdateExecutionSegment(contenderOptions, async (capability) => {
+    const verify = (): Promise<void> =>
+      requireCliUpdateMutationCapability(capability, contenderOptions);
+    const staged = await stageHostInstallSource({
+      environment: input.environment,
+      source: { kind: "registry", versionRequest: input.version },
+      onProgress: input.onProgress,
+      recordVersionOverride: null,
+      verifyMutationCapability: verify,
+    });
+    try {
+      return await withCliAttemptMutation(
+        capability,
+        contenderOptions,
+        async () => {
+          // Recheck under the mutation lock: uninstall may have won before this
+          // execution segment was claimed. An update never bootstraps a host.
+          if ((await readHostInstallRecord(input.environment)) === null) {
+            throw cliError({
+              code: CLI_ERROR_CODES.HOST_NOT_INSTALLED,
+              message:
+                "host update: no host installed; run 'traycer host install' first",
+              details: { environment: input.environment },
+              exitCode: 1,
+            });
+          }
+          if (!input.force) await assertHostNotBusy(input.environment);
+          const handle = createServiceInstallLifecycle({
+            environment: input.environment,
+            bootstrap: null,
+            force: input.force,
+          });
+          const result = await commitHostInstallSourceWithAttempt(
+            capability,
+            contenderOptions,
+            {
+              environment: input.environment,
+              staged,
+              onProgress: input.onProgress,
+              lifecycle: handle.lifecycle,
+            },
+          );
+          return {
+            outcome: "applied",
+            record: result.record,
+            previous: result.previous,
+            installGeneration: result.installGeneration,
+            runningActivated:
+              handle.state.postSwapError === null &&
+              handle.state.postSwapAction !== "none",
+            serviceLifecycle: {
+              priorServiceState: handle.state.priorState,
+              stoppedBeforeSwap: handle.state.stoppedBeforeSwap,
+              postSwapAction: handle.state.postSwapAction,
+            },
+            postSwapError: handle.state.postSwapError,
+          } satisfies Extract<ApplyHostOutcome, { outcome: "applied" }>;
+        },
+      );
+    } catch (error) {
+      await discardStagedHostInstallSource(input.environment, staged, verify);
+      throw error;
+    }
+  });
+}

--- a/clients/traycer-cli/src/commands/host-update.ts
+++ b/clients/traycer-cli/src/commands/host-update.ts
@@ -1,3 +1,5 @@
+import { compareHostVersions } from "@traycer-clients/shared/host-version/compare-host-versions";
+import { installHostDowngrade } from "./host-update-downgrade";
 import type { ApplyHostOutcome } from "../installer/apply";
 import {
   downloadAndStageHost,
@@ -32,7 +34,9 @@ import { applyHostWithAttempt } from "../host/update-mutation";
 // network transfer ever runs under `cli-lock` - plan rule 1); only the
 // apply half below acquires the lock, matching `host apply`'s own
 // contract that the caller holds it across reconcile/read/no-op/busy/
-// commit.
+// commit. An explicit `--release X --allow-downgrade` below the installed
+// version uses a private install source instead, with the same progress,
+// mutation authority, busy checks, and post-swap health verification.
 //
 // Busy (D6): the stage is kept - `applyHost`'s busy check runs before it
 // touches the stage - and this command re-throws `E_HOST_BUSY` with the
@@ -75,6 +79,8 @@ import { applyHostWithAttempt } from "../host/update-mutation";
 // compat boundary is scoped to `host update` alone - remove only when
 // Desktop's `host update` invocation is deleted (post ticket-4 cleanup).
 export interface HostUpdateArgs {
+  /** Explicit installs may downgrade; automatic update callers never opt in. */
+  readonly allowDowngrade: boolean;
   readonly force: boolean;
   /** `null` stages the latest registry version; an explicit value is a pin. */
   readonly versionRequest?: string | null;
@@ -151,27 +157,18 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
     // a real dependency of the run rather than a value the compiler can drop.
     void dispatchAckAcknowledgement;
 
-    const downloadOutcome = await downloadAndStageHost({
+    const preparation = await prepareHostUpdate({
       environment,
-      versionRequest: args.versionRequest ?? null,
-      automatic: false,
+      version: args.versionRequest ?? null,
+      allowDowngrade: args.allowDowngrade,
       onProgress: (info) => ctx.progress(info),
-      registryClient: null,
     });
-    ctx.runtime.logger.info("Host update stage phase completed", {
-      environment,
-      outcome: downloadOutcome.outcome,
-    });
-
-    // "Zero fetch beyond the manifest when at latest": already at (or
-    // past) the target, so the apply half never needs to run - still
-    // routed through the same locked projection below (not a bare
-    // early return) so the legacy backfill read is never a racy
-    // unlocked read.
-    const needsApply = !(
-      downloadOutcome.outcome === "short-circuit" &&
-      downloadOutcome.reason === "installed-up-to-date"
-    );
+    const needsApply =
+      preparation.kind === "downgrade" ||
+      !(
+        preparation.download.outcome === "short-circuit" &&
+        preparation.download.reason === "installed-up-to-date"
+      );
 
     // Remote Host Support T16: the daemon polls `update-progress.json` and
     // folds it into `host.status@1.1` / the drain gate, so an update that is
@@ -180,7 +177,10 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
     // and terminated on every exit path below. Marker I/O is deliberately
     // never allowed to fail the update itself - a missing marker degrades
     // the remote progress readout, it must not break the local update.
-    const targetVersion = downloadTargetVersion(downloadOutcome);
+    const targetVersion =
+      preparation.kind === "downgrade"
+        ? preparation.version
+        : downloadTargetVersion(preparation.download);
     if (needsApply) {
       await writeUpdateProgressMarkerSafely(ctx.runtime.logger, environment, {
         state: "updating",
@@ -192,12 +192,22 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
 
     let legacy: LegacyHostUpdateResult;
     try {
-      legacy = await applyAndProjectLegacy(
-        environment,
-        args.force,
-        needsApply,
-        (info) => ctx.progress(info),
-      );
+      legacy =
+        preparation.kind === "staged"
+          ? await applyAndProjectLegacy(
+              environment,
+              args.force,
+              needsApply,
+              (info) => ctx.progress(info),
+            )
+          : projectApplied(
+              await installHostDowngrade({
+                environment,
+                version: preparation.version,
+                force: args.force,
+                onProgress: (info) => ctx.progress(info),
+              }),
+            );
     } catch (err) {
       if (needsApply) {
         await markUpdateFailed(
@@ -245,7 +255,10 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
 
     ctx.runtime.logger.info("Host update command completed", {
       environment,
-      downloadOutcome: downloadOutcome.outcome,
+      downloadOutcome:
+        preparation.kind === "staged"
+          ? preparation.download.outcome
+          : "explicit-downgrade",
       version: legacy.version,
       changed: legacy.previousVersion !== legacy.version,
       hasPostSwapError: legacy.serviceLifecycle.postSwapError !== null,
@@ -255,6 +268,37 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
       human: humanSummary(legacy),
       exitCode: 0,
     };
+  };
+}
+
+type HostUpdatePreparation =
+  | { readonly kind: "downgrade"; readonly version: string }
+  | { readonly kind: "staged"; readonly download: HostDownloadOutcome };
+
+async function prepareHostUpdate(input: {
+  readonly environment: Environment;
+  readonly version: string | null;
+  readonly allowDowngrade: boolean;
+  readonly onProgress: (info: ProgressInfo) => void;
+}): Promise<HostUpdatePreparation> {
+  if (input.allowDowngrade && input.version !== null) {
+    const installed = await requireInstalled(input.environment);
+    const comparison = compareHostVersions(input.version, installed.version);
+    if (comparison.comparable && comparison.ordering === "less") {
+      // Reconciliation deliberately deletes older shared stages. The explicit
+      // install keeps its verified source private until the locked swap.
+      return { kind: "downgrade", version: input.version };
+    }
+  }
+  return {
+    kind: "staged",
+    download: await downloadAndStageHost({
+      environment: input.environment,
+      versionRequest: input.version,
+      automatic: false,
+      onProgress: input.onProgress,
+      registryClient: null,
+    }),
   };
 }
 

--- a/clients/traycer-cli/src/index.ts
+++ b/clients/traycer-cli/src/index.ts
@@ -1554,6 +1554,13 @@ function registerHostCommands(program: Command): void {
         "--release <version>",
         "Registry version to update to (defaults to the latest compatible release)",
       )
+      // Host maintenance probes `host update --help` for this literal before
+      // dispatching a downgrade. Keep the option visible: it is the capability
+      // contract for hosts paired with an independently installed CLI.
+      .option(
+        "--allow-downgrade",
+        "Allow an explicitly selected --release to replace a newer installed host",
+      )
       .option(
         "--force",
         "Update the host even if it has work in progress: skips the busy check and force-stops a busy host. Running terminal sessions and in-flight agent work are killed.",
@@ -1611,6 +1618,7 @@ function registerHostCommands(program: Command): void {
         }
         return buildHostUpdateCommand({
           force: opts.force === true,
+          allowDowngrade: opts.allowDowngrade === true,
           versionRequest: release,
           ackNonce: typeof opts.ackNonce === "string" ? opts.ackNonce : null,
         })(ctx);

--- a/protocol/src/host/maintenance/__tests__/contracts.test.ts
+++ b/protocol/src/host/maintenance/__tests__/contracts.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from "vitest";
 import { hostRpcRegistry } from "@traycer/protocol/host/index";
 import {
   hostUpdateInstallUpgradeV10ToV11,
+  hostUpdateInstallUpgradeV11ToV12,
   hostUpdateInstallV10,
   hostUpdateInstallV11,
+  hostUpdateInstallV12,
 } from "../contracts";
 
 // `host.update.install@1.1` (Ticket 06): the same dispatch, additionally
@@ -225,15 +227,31 @@ describe("hostUpdateInstallUpgradeV10ToV11", () => {
 });
 
 describe("host.update.install registry membership", () => {
-  it("installs @1.0 and @1.1 on the unary registry at major 1, with @1.1 wired to the v10->v11 upgrade", () => {
+  it("installs @1.0, @1.1, and @1.2 on the unary registry with identity v1.1->v1.2 bridging", () => {
     const entry = hostRpcRegistry["host.update.install"];
     expect(entry).toBeDefined();
-    expect(entry[1].latestMinor).toBe(1);
+    expect(entry[1].latestMinor).toBe(2);
     expect(entry[1].versions[0].contract).toBe(hostUpdateInstallV10);
     expect(entry[1].versions[0].upgradeFromPreviousVersion).toBeNull();
     expect(entry[1].versions[1].contract).toBe(hostUpdateInstallV11);
     expect(entry[1].versions[1].upgradeFromPreviousVersion).toBe(
       hostUpdateInstallUpgradeV10ToV11,
+    );
+    expect(entry[1].versions[2].contract).toBe(hostUpdateInstallV12);
+    expect(entry[1].versions[2].upgradeFromPreviousVersion).toBe(
+      hostUpdateInstallUpgradeV11ToV12,
+    );
+
+    const request = { version: "1.2.0", force: false };
+    const response = hostUpdateInstallV11.responseSchema.parse({
+      outcome: "accepted",
+      attemptId: null,
+    });
+    expect(hostUpdateInstallUpgradeV11ToV12.upgradeRequest(request)).toEqual(
+      request,
+    );
+    expect(hostUpdateInstallUpgradeV11ToV12.upgradeResponse(response)).toEqual(
+      response,
     );
   });
 });

--- a/protocol/src/host/maintenance/contracts.ts
+++ b/protocol/src/host/maintenance/contracts.ts
@@ -132,6 +132,28 @@ export const hostUpdateInstallV11 = defineRpcContract({
 });
 
 /**
+ * `@1.2` advertises explicit downgrade support. The wire shape is unchanged;
+ * clients gate older-version rows on this version because a pre-1.2 host
+ * dispatches an upgrade-only CLI command even when it accepts the request.
+ */
+export const hostUpdateInstallV12 = defineRpcContract({
+  method: "host.update.install",
+  schemaVersion: { major: 1, minor: 2 } as const,
+  requestSchema: hostUpdateInstallRequestSchema,
+  responseSchema: hostUpdateInstallResponseV11Schema,
+});
+
+export const hostUpdateInstallUpgradeV11ToV12 = defineUpgradePath<
+  typeof hostUpdateInstallV11,
+  typeof hostUpdateInstallV12
+>({
+  from: hostUpdateInstallV11.schemaVersion,
+  to: hostUpdateInstallV12.schemaVersion,
+  upgradeRequest: (request) => request,
+  upgradeResponse: (response) => response,
+});
+
+/**
  * A `@1.0` peer said nothing about attempts, so both arms upgrade to `null` —
  * the same "did not report" convention `busySessionCount` / `busyBreakdown` set
  * on `host.status`, and for the same reason: the upgrade path must not put an

--- a/protocol/src/host/maintenance/index.ts
+++ b/protocol/src/host/maintenance/index.ts
@@ -11,6 +11,8 @@ export {
   hostUpdateCheckV11,
   hostUpdateInstallV10,
   hostUpdateInstallV11,
+  hostUpdateInstallV12,
+  hostUpdateInstallUpgradeV11ToV12,
   hostUpdateInstallUpgradeV10ToV11,
 } from "./contracts";
 

--- a/protocol/src/host/registry.ts
+++ b/protocol/src/host/registry.ts
@@ -272,6 +272,8 @@ import {
   hostUpdateCheckV11,
   hostUpdateInstallV10,
   hostUpdateInstallV11,
+  hostUpdateInstallV12,
+  hostUpdateInstallUpgradeV11ToV12,
   hostUpdateInstallUpgradeV10ToV11,
 } from "@traycer/protocol/host/maintenance/contracts";
 import {
@@ -4421,7 +4423,7 @@ const HOST_RPC_REGISTRY_BASE_DEFINITION = {
   "host.update.install": {
     degrade: { kind: "unsupported" },
     1: {
-      latestMinor: 1,
+      latestMinor: 2,
       versions: {
         0: {
           contract: hostUpdateInstallV10,
@@ -4447,6 +4449,10 @@ const HOST_RPC_REGISTRY_BASE_DEFINITION = {
           // and neither is "we only call it from new clients": the validator
           // cannot check this, which is exactly why it is written down here.
           responseGrowthProjectionGated: true,
+        },
+        2: {
+          contract: hostUpdateInstallV12,
+          upgradeFromPreviousVersion: hostUpdateInstallUpgradeV11ToV12,
         },
       },
       downgradePathsFromLatest: {},


### PR DESCRIPTION
## Summary

Restore installation of older host releases from Settings, including `1.3.0-rc.1 → 1.2.0`, while retaining update progress, busy-host checks, signature verification, and post-install health checks. Explicit downgrades use a private verified install source; automatic download/stage policies remain upgrade-only.

The picker requires `host.update.install@1.2` before enabling lower-version rows. RC ordering follows SemVer, and build metadata alone does not create a new install target. The CLI exposes `--allow-downgrade` for the host dispatcher to probe and opt into.

## Coordination / landing requirement

Companion internal PR: https://github.com/traycerai/traycer-internal/pull/5513

This PR requires the companion internal host resolver change. The internal repository must land that resolver and the submodule pin containing this PR in the SAME commit. Do not publish an internal build that bumps the protocol to `@1.2` without the resolver: it would advertise downgrade support while still dispatching an upgrade-only command.

After this OSS PR merges, update the companion internal PR's pin to the final merged OSS commit before landing it. Existing pre-fix hosts must update once before Settings can downgrade them. Downgrading installs once; normal future update policies and the channel minimum version still apply.

## Validation

175 focused tests passed across CLI, GUI, protocol, and companion host resolver tests, including real temporary-install byte replacement, RC ordering, older-host capability gating, help probing, failure/retry handling, and released-protocol compatibility. CLI and GUI type checks passed. Cold Claude Fable audit found no blocking code defect; recommended hardening and test follow-ups were applied. No live host replacement was performed.

## Related issue

Regression introduced by #1156.

## Checklist

- [x] Pre-commit static checks pass
- [ ] Separate CI test checks pass
- [x] Tests added/updated where it makes sense
- [x] Commits are signed off (`git commit -s`) per the DCO
