### PR TITLE
fix(gui-app): pick the onboarding tour by viewport, not by the installed-app flag

### DIFF
--- a/clients/gui-app/src/components/onboarding/__tests__/onboarding-acts.test.ts
+++ b/clients/gui-app/src/components/onboarding/__tests__/onboarding-acts.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import {
   actEyebrow,
   ONBOARDING_ACTS,
@@ -6,13 +6,18 @@ import {
   type OnboardingAct,
   type OnboardingActId,
 } from "@/components/onboarding/onboarding-acts";
-import { setMobileApp } from "@/lib/mobile-app";
 
-const FULL_TOUR = { sessionImportAvailable: true, loginImportAvailable: true };
+const FULL_TOUR = {
+  phoneLayout: false,
+  sessionImportAvailable: true,
+  loginImportAvailable: true,
+};
 const NO_IMPORTS = {
+  phoneLayout: false,
   sessionImportAvailable: false,
   loginImportAvailable: false,
 };
+const PHONE_TOUR = { ...FULL_TOUR, phoneLayout: true };
 
 function actById(
   acts: ReadonlyArray<OnboardingAct>,
@@ -24,10 +29,6 @@ function actById(
 }
 
 describe("onboardingActsFor", () => {
-  afterEach(() => {
-    setMobileApp(false);
-  });
-
   it("plays the full desktop tour when the host can scan sessions", () => {
     expect(onboardingActsFor(FULL_TOUR).map((act) => act.id)).toEqual([
       "task-tabs",
@@ -56,10 +57,8 @@ describe("onboardingActsFor", () => {
     expect(onboardingActsFor(NO_IMPORTS)).toBe(onboardingActsFor(NO_IMPORTS));
   });
 
-  it("plays the mobile tour inside the installed mobile app, capability aside", () => {
-    setMobileApp(true);
-
-    const withScan = onboardingActsFor(FULL_TOUR).map((act) => act.id);
+  it("plays the mobile tour under the phone layout, capability aside", () => {
+    const withScan = onboardingActsFor(PHONE_TOUR).map((act) => act.id);
     expect(withScan).toEqual([
       "mobile-tasks",
       "mobile-switcher",
@@ -69,20 +68,9 @@ describe("onboardingActsFor", () => {
     ]);
     // The phone tour never lists session-import, so the capability cannot
     // change its shape.
-    expect(onboardingActsFor(NO_IMPORTS)).toBe(onboardingActsFor(FULL_TOUR));
-  });
-
-  // The Capacitor entry sets the flag in its bootstrap, which runs AFTER
-  // gui-app's static module graph - including this module - has been
-  // evaluated. A list captured at module scope would pin the desktop tour on
-  // every phone.
-  it("resolves the platform per call rather than at module evaluation", () => {
-    const beforeFlag = onboardingActsFor(FULL_TOUR);
-
-    setMobileApp(true);
-
-    expect(onboardingActsFor(FULL_TOUR)).not.toBe(beforeFlag);
-    expect(onboardingActsFor(FULL_TOUR)[0].id).toBe("mobile-tasks");
+    expect(onboardingActsFor({ ...NO_IMPORTS, phoneLayout: true })).toBe(
+      onboardingActsFor(PHONE_TOUR),
+    );
   });
 
   it("numbers the eyebrow off the tour being shown, not the catalog", () => {
@@ -92,8 +80,7 @@ describe("onboardingActsFor", () => {
     expect(actEyebrow(shorterTour[5], 5)).toBe("ACT 06 - FLOW");
     expect(actEyebrow(ONBOARDING_ACTS[7], 7)).toBe("ACT 08 - YOUR WORK");
 
-    setMobileApp(true);
-    const mobileTour = onboardingActsFor(FULL_TOUR);
+    const mobileTour = onboardingActsFor(PHONE_TOUR);
     expect(mobileTour.map(actEyebrow)).toEqual([
       "ACT 01 - TASKS",
       "ACT 02 - LAYOUT",
@@ -110,12 +97,10 @@ describe("onboardingActsFor", () => {
     );
     const desktopProviders = actById(onboardingActsFor(FULL_TOUR), "providers");
 
-    setMobileApp(true);
-
-    expect(actById(onboardingActsFor(FULL_TOUR), "task-context")).toBe(
+    expect(actById(onboardingActsFor(PHONE_TOUR), "task-context")).toBe(
       desktopTaskContext,
     );
-    expect(actById(onboardingActsFor(FULL_TOUR), "providers")).toBe(
+    expect(actById(onboardingActsFor(PHONE_TOUR), "providers")).toBe(
       desktopProviders,
     );
   });
@@ -124,9 +109,7 @@ describe("onboardingActsFor", () => {
     const desktopGuide = actById(onboardingActsFor(FULL_TOUR), "agent-guide");
     expect(desktopGuide.addon).toBeNull();
 
-    setMobileApp(true);
-
-    expect(actById(onboardingActsFor(FULL_TOUR), "agent-guide")).toEqual({
+    expect(actById(onboardingActsFor(PHONE_TOUR), "agent-guide")).toEqual({
       ...desktopGuide,
       addon: "agent-guide",
     });
@@ -134,6 +117,7 @@ describe("onboardingActsFor", () => {
 
   it("adds the login-import act after providers when the machine can import logins", () => {
     const acts = onboardingActsFor({
+      phoneLayout: false,
       sessionImportAvailable: true,
       loginImportAvailable: true,
     });
@@ -145,6 +129,7 @@ describe("onboardingActsFor", () => {
 
   it("drops the login-import act entirely when the machine cannot import logins", () => {
     const acts = onboardingActsFor({
+      phoneLayout: false,
       sessionImportAvailable: true,
       loginImportAvailable: false,
     });
@@ -153,10 +138,12 @@ describe("onboardingActsFor", () => {
 
   it("positions login-import independent of session-import's own availability", () => {
     const withSessionImport = onboardingActsFor({
+      phoneLayout: false,
       sessionImportAvailable: true,
       loginImportAvailable: true,
     });
     const withoutSessionImport = onboardingActsFor({
+      phoneLayout: false,
       sessionImportAvailable: false,
       loginImportAvailable: true,
     });
@@ -172,6 +159,7 @@ describe("onboardingActsFor", () => {
 
   it("hands back a stable reference for the same capability pair across calls", () => {
     const capabilities = {
+      phoneLayout: false,
       sessionImportAvailable: false,
       loginImportAvailable: true,
     };
@@ -184,27 +172,40 @@ describe("onboardingActsFor", () => {
     expect(onboardingActsFor(FULL_TOUR)).toBe(ONBOARDING_ACTS);
   });
 
+  // The installed app on an iPad: the shell is still `isMobileApp()`, but the
+  // window is desktop width, so the LAYOUT read must pick the desktop acts -
+  // the ones that actually describe the tab strip and canvas it is showing.
+  it("plays the desktop tour on a wide window regardless of the installed app", () => {
+    const acts = onboardingActsFor({
+      phoneLayout: false,
+      sessionImportAvailable: true,
+      loginImportAvailable: true,
+    });
+    expect(acts).toBe(ONBOARDING_ACTS);
+    expect(acts[0].id).toBe("task-tabs");
+  });
+
   it("ignores both import capabilities on the mobile tour", () => {
-    setMobileApp(true);
     expect(
       onboardingActsFor({
+        phoneLayout: true,
         sessionImportAvailable: true,
         loginImportAvailable: true,
       }),
     ).toBe(
       onboardingActsFor({
+        phoneLayout: true,
         sessionImportAvailable: false,
         loginImportAvailable: false,
       }),
     );
-    expect(onboardingActsFor(FULL_TOUR).map((act) => act.id)).not.toContain(
+    expect(onboardingActsFor(PHONE_TOUR).map((act) => act.id)).not.toContain(
       "login-import",
     );
   });
 
   it("teaches the drawer and the switcher in place of desktop chrome", () => {
-    setMobileApp(true);
-    const acts = onboardingActsFor(FULL_TOUR);
+    const acts = onboardingActsFor(PHONE_TOUR);
 
     expect(actById(acts, "mobile-tasks")).toEqual({
       id: "mobile-tasks",

--- a/clients/gui-app/src/components/onboarding/__tests__/onboarding-page-mobile.test.tsx
+++ b/clients/gui-app/src/components/onboarding/__tests__/onboarding-page-mobile.test.tsx
@@ -100,6 +100,15 @@ vi.mock("@/components/onboarding/onboarding-phone-diorama", () => ({
   ),
 }));
 
+// LAYOUT signal, distinct from `isMobileApp()` - see `use-mobile-viewport.ts`.
+// A hoisted mutable box so each describe can flip it per its own beforeEach
+// without re-mocking the module.
+const viewportState = vi.hoisted(() => ({ isMobile: false }));
+vi.mock("@/hooks/ui/use-mobile-viewport", () => ({
+  useIsMobileViewport: () => viewportState.isMobile,
+  isMobileViewport: () => viewportState.isMobile,
+}));
+
 // The real pane is a CodeMirror surface - a `[contenteditable]` div, not a
 // `textarea` - so the mock renders both: the textarea drives the existing
 // value-plumbing tests, and the contenteditable sibling is what exercises the
@@ -224,6 +233,7 @@ function renderPage() {
 /** Which act is on screen, read from its rendered title. */
 function currentStage(): number {
   return onboardingActsFor({
+    phoneLayout: viewportState.isMobile,
     sessionImportAvailable: false,
     loginImportAvailable: false,
   }).findIndex(
@@ -312,7 +322,10 @@ function stage(container: HTMLElement): HTMLElement {
 
 describe("OnboardingPage on the installed mobile app", () => {
   beforeEach(() => {
+    // A phone is the installed app AND a phone-width window; the installed
+    // app on a TABLET is its own describe below, with the layout flag false.
     setMobileApp(true);
+    viewportState.isMobile = true;
     useOnboardingStore.setState({ completedAt: null, step: 0 });
     navigateMock.mockReset();
     historyBackMock.mockReset();
@@ -332,6 +345,7 @@ describe("OnboardingPage on the installed mobile app", () => {
   afterEach(() => {
     cleanup();
     setMobileApp(false);
+    viewportState.isMobile = false;
     useOnboardingStore.setState({ completedAt: null, step: 0 });
   });
 
@@ -430,6 +444,7 @@ describe("OnboardingPage on the installed mobile app", () => {
 
     const lastActIndex =
       onboardingActsFor({
+        phoneLayout: viewportState.isMobile,
         sessionImportAvailable: false,
         loginImportAvailable: false,
       }).length - 1;
@@ -474,6 +489,7 @@ describe("OnboardingPage on the installed mobile app", () => {
 describe("swiping between acts on the installed mobile app", () => {
   beforeEach(() => {
     setMobileApp(true);
+    viewportState.isMobile = true;
     useOnboardingStore.setState({ completedAt: null, step: 0 });
     navigateMock.mockReset();
     trackSpy.mockClear();
@@ -492,6 +508,7 @@ describe("swiping between acts on the installed mobile app", () => {
   afterEach(() => {
     cleanup();
     setMobileApp(false);
+    viewportState.isMobile = false;
     useOnboardingStore.setState({ completedAt: null, step: 0 });
   });
 
@@ -670,6 +687,7 @@ describe("swiping between acts on the installed mobile app", () => {
 
     await advanceToStage(
       onboardingActsFor({
+        phoneLayout: viewportState.isMobile,
         sessionImportAvailable: false,
         loginImportAvailable: false,
       }).length - 1,
@@ -697,9 +715,96 @@ describe("swiping between acts on the installed mobile app", () => {
   });
 });
 
+describe("the installed app on a tablet", () => {
+  beforeEach(() => {
+    // An iPad: the installed app, but at desktop width - the layout signal
+    // stays false, so the acts and miniature follow the desktop tour while
+    // the product-only touches (swipe, thumb-sized controls) stay on.
+    setMobileApp(true);
+    viewportState.isMobile = false;
+    useOnboardingStore.setState({ completedAt: null, step: 0 });
+    navigateMock.mockReset();
+    trackSpy.mockClear();
+    setGlobalGuideMock.mockClear();
+    safeAreaInsetsState = { left: 0, right: 0 };
+    guideQueryState = {
+      data: {
+        content: "saved guide",
+        generatedDefaultContent: "claude guide",
+        providersSettled: true,
+      },
+      isError: false,
+    };
+  });
+
+  afterEach(() => {
+    cleanup();
+    setMobileApp(false);
+    viewportState.isMobile = false;
+    useOnboardingStore.setState({ completedAt: null, step: 0 });
+  });
+
+  it("plays the desktop tour with the desktop miniature, never the drawer act", () => {
+    renderPage();
+
+    expect(screen.getByTestId("onboarding-diorama-stub")).not.toBeNull();
+    expect(screen.queryByTestId("onboarding-phone-diorama-stub")).toBeNull();
+    expect(
+      screen.getByTestId("onboarding-act").getAttribute("data-act-id"),
+    ).toBe("task-tabs");
+    expect(
+      screen.queryByText("The menu, top left", { exact: false }),
+    ).toBeNull();
+  });
+
+  it("keeps the thumb-sized controls and the act swipe", async () => {
+    const { container } = renderPage();
+
+    const advance = screen.getByTestId("onboarding-advance");
+    expect(advance.classList.contains("h-11")).toBe(true);
+    expect(advance.classList.contains("h-9")).toBe(false);
+
+    drag(
+      stage(container),
+      { clientX: 400, clientY: 300 },
+      { clientX: 280, clientY: 300 },
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("onboarding-act").getAttribute("data-act-id"),
+      ).toBe("navigation");
+    });
+    expect(trackSpy).toHaveBeenCalledWith(AnalyticsEvent.OnboardingNavigated, {
+      direction: "continue",
+      step: "navigation",
+    });
+  });
+
+  it("never lists the phone-only acts", () => {
+    const desktopActIds = onboardingActsFor({
+      phoneLayout: false,
+      sessionImportAvailable: true,
+      loginImportAvailable: false,
+    }).map((act) => act.id);
+    expect(desktopActIds).not.toContain("mobile-tasks");
+    expect(desktopActIds).not.toContain("mobile-switcher");
+  });
+
+  it("starts the session scan, since the desktop tour lists the import act", () => {
+    sessionImportScanMock.activeCalls.length = 0;
+    renderPage();
+
+    expect(sessionImportScanMock.activeCalls.some((active) => active)).toBe(
+      true,
+    );
+  });
+});
+
 describe("the desktop tour", () => {
   beforeEach(() => {
     setMobileApp(false);
+    viewportState.isMobile = false;
     useOnboardingStore.setState({ completedAt: null, step: 0 });
     trackSpy.mockClear();
   });

--- a/clients/gui-app/src/components/onboarding/__tests__/onboarding-page.test.tsx
+++ b/clients/gui-app/src/components/onboarding/__tests__/onboarding-page.test.tsx
@@ -410,6 +410,8 @@ function createRunnerHost() {
 /** The tour the mocked host actually runs - not always the whole catalog. */
 function visibleActs(): ReadonlyArray<OnboardingAct> {
   return onboardingActsFor({
+    // jsdom's default window is desktop-wide, so the page resolves the same.
+    phoneLayout: false,
     sessionImportAvailable: sessionImportAvailableMock.value,
     loginImportAvailable: loginImportAvailableMock.value,
   });

--- a/clients/gui-app/src/components/onboarding/onboarding-acts.ts
+++ b/clients/gui-app/src/components/onboarding/onboarding-acts.ts
@@ -1,5 +1,3 @@
-import { isMobileApp } from "@/lib/mobile-app";
-
 /**
  * The acts the desktop tour can play - and the only ids the desktop diorama
  * can draw, which is why it is a type of its own rather than the whole act
@@ -151,11 +149,13 @@ export const ONBOARDING_ACTS: ReadonlyArray<OnboardingAct> = [
 ];
 
 /**
- * The phone tour, five acts. Acts 1 and 2 replace the desktop lessons that
- * teach chrome a phone does not have (tab strip, drag-to-split canvas) with
- * the two things a phone user must actually find: the drawer and the switcher
- * sheet. Desktop's closing flow act (Cmd+K, the theme picker) has no phone
- * counterpart at all - the tour ends on delegation instead.
+ * The phone tour, five acts, played under the phone-width chrome only (a
+ * tablet running the installed app at desktop width plays the desktop tour).
+ * Acts 1 and 2 replace the desktop lessons that teach chrome a phone does not
+ * have (tab strip, drag-to-split canvas) with the two things a phone user must
+ * actually find: the drawer and the switcher sheet. Desktop's closing flow
+ * act (Cmd+K, the theme picker) has no phone counterpart at all - the tour
+ * ends on delegation instead.
  *
  * No session-import act here: its stage is the live desktop-sized wizard
  * reading the host's own disk, and the phone tour's fixed six-act arc was
@@ -186,10 +186,19 @@ const MOBILE_ONBOARDING_ACTS: ReadonlyArray<OnboardingAct> = [
 ];
 
 /**
- * What this shell can do, of the things the desktop tour has an act for.
- * Each false drops one act; see {@link onboardingActsFor}.
+ * What this shell can do, of the things the desktop tour has an act for, and
+ * which chrome it is showing. Each false capability drops one act; the layout
+ * picks the tour; see {@link onboardingActsFor}.
  */
 export interface OnboardingTourCapabilities {
+  /**
+   * The window is below the app's phone breakpoint (`useIsMobileViewport`),
+   * so the shell around the tour is the hamburger drawer and the switcher
+   * sheet. A LAYOUT read, deliberately not `isMobileApp()`: an iPad runs the
+   * installed app at desktop width, with the tab strip and the canvas, and a
+   * tour that taught it the drawer would be teaching chrome it never shows.
+   */
+  readonly phoneLayout: boolean;
   /** The bound host advertises `sessionImport.scan`. */
   readonly sessionImportAvailable: boolean;
   /** A desktop with a browser bridge and saved logins on. */
@@ -197,7 +206,7 @@ export interface OnboardingTourCapabilities {
 }
 
 // Precomputed per capability pair on first use, so the accessor hands back a
-// stable reference per (platform, capabilities) rather than filtering into a
+// stable reference per (layout, capabilities) rather than filtering into a
 // fresh array on every call - memoised consumers would re-render otherwise.
 const DESKTOP_TOURS = new Map<string, ReadonlyArray<OnboardingAct>>();
 
@@ -223,12 +232,16 @@ function desktopTourFor(
 }
 
 /**
- * The tour this shell will actually walk. Two facts pick it, and both are
- * resolved per CALL rather than into a module constant:
+ * The tour this shell will actually walk. Two facts pick it:
  *
- * Platform - `setMobileApp()` runs in the Capacitor entry's `bootstrap()`,
- * which is after this module has already been evaluated as part of gui-app's
- * static graph, so a constant would pin the desktop list on a phone.
+ * Layout - the phone tour plays under the phone chrome and nowhere else. The
+ * app itself switches between the hamburger header and the tab strip on the
+ * same breakpoint (`AppHeader`), so the tour reads the same signal and the
+ * two can never disagree: a phone gets the drawer and switcher acts, and an
+ * iPad - the installed app at desktop width - gets the desktop acts that
+ * describe the tab strip and canvas it is actually looking at. Stable on both
+ * by construction: the iPhone build is portrait-locked below the breakpoint,
+ * and an iPad's shorter side clears it in every orientation.
  *
  * Capability - session import is optional: an older or remote host never
  * advertises `sessionImport.scan`, and Settings and the task-list prompt
@@ -249,6 +262,6 @@ function desktopTourFor(
 export function onboardingActsFor(
   capabilities: OnboardingTourCapabilities,
 ): ReadonlyArray<OnboardingAct> {
-  if (isMobileApp()) return MOBILE_ONBOARDING_ACTS;
+  if (capabilities.phoneLayout) return MOBILE_ONBOARDING_ACTS;
   return desktopTourFor(capabilities);
 }

--- a/clients/gui-app/src/components/onboarding/onboarding-page.tsx
+++ b/clients/gui-app/src/components/onboarding/onboarding-page.tsx
@@ -61,6 +61,7 @@ import {
 import { isHostScopeUsable } from "@/components/settings/host-scope/host-scope-status";
 import { useScopedHostBinding } from "@/components/settings/host-scope/use-scoped-host-binding";
 import { useScopedStreamBinding } from "@/components/settings/host-scope/use-scoped-stream-binding";
+import { useIsMobileViewport } from "@/hooks/ui/use-mobile-viewport";
 import { isMobileApp } from "@/lib/mobile-app";
 import { readSafeAreaInsets } from "@/lib/safe-area-insets";
 import {
@@ -615,32 +616,36 @@ type OnboardingMiniature =
   | { readonly kind: "none" };
 
 /**
- * The tour's ONE diorama branch (the act list itself is the other platform
- * read). Narrowing happens per case, so the desktop miniature only ever
- * receives an id it can draw - no cast, and a new act id fails to compile until
- * it says what it shows.
+ * The tour's ONE diorama branch (the act list itself is the other layout
+ * read, and both take the SAME `phoneLayout` the page resolved once - the
+ * miniature must draw the chrome the act list is describing). Narrowing
+ * happens per case, so the desktop miniature only ever receives an id it can
+ * draw - no cast, and a new act id fails to compile until it says what it
+ * shows.
  *
  * The two acts that do real setup work drop the miniature on a phone: providers
  * already stacked to its list-only layout below `lg`, and the agent guide moves
  * its editor into the copy rail, where a phone keyboard can reach it. Session
- * import and login import are desktop-only (the mobile tour never lists
+ * import and login import are desktop-only (the phone tour never lists
  * them), and show no miniature at all - their stages are the live wizard and
  * the live import flow.
  */
-function miniatureForAct(actId: OnboardingActId): OnboardingMiniature {
-  const mobile = isMobileApp();
+function miniatureForAct(
+  actId: OnboardingActId,
+  phoneLayout: boolean,
+): OnboardingMiniature {
   switch (actId) {
     case "task-tabs":
     case "navigation":
     case "command-theme":
       return { kind: "desktop", actId };
     case "task-context":
-      return mobile
+      return phoneLayout
         ? { kind: "phone", scene: "story" }
         : { kind: "desktop", actId };
     case "providers":
     case "agent-guide":
-      return mobile ? { kind: "none" } : { kind: "desktop", actId };
+      return phoneLayout ? { kind: "none" } : { kind: "desktop", actId };
     case "session-import":
       return { kind: "session-import" };
     case "login-import":
@@ -925,13 +930,13 @@ function useOnboardingSessionImportScan(
 export function OnboardingPage(props: { readonly replay: boolean }) {
   const [scopedHostId, setScopedHostId] = useState<string | null>(null);
   const scope = useHostScopeFor({ scopedHostId, setScopedHostId });
-  // The tour this shell can run, not the full catalog: the installed app plays
-  // the phone tour, an AMBIENT host that cannot scan sessions never reaches the
-  // session-import act, whose stage is the live wizard, and a machine that
-  // cannot import logins (no browser bridge, or saving off) never reaches the
-  // login-import act, whose stage is the live import flow. Everything below
-  // counts acts off this list, so an omitted act is unreachable rather than
-  // merely blank.
+  // The tour this shell can run, not the full catalog: a phone-width window
+  // plays the phone tour, an AMBIENT host that cannot scan sessions never
+  // reaches the session-import act, whose stage is the live wizard, and a
+  // machine that cannot import logins (no browser bridge, or saving off) never
+  // reaches the login-import act, whose stage is the live import flow.
+  // Everything below counts acts off this list, so an omitted act is
+  // unreachable rather than merely blank.
   //
   // Read HERE, above the re-providers, so the tour's length is a fact about
   // this app and not about the machine the picker happens to point at. Read
@@ -940,11 +945,24 @@ export function OnboardingPage(props: { readonly replay: boolean }) {
   // stop. The cost of that choice is that the act can outlive its capability
   // on a PICKED host, so the session-import stage asks the same question again
   // of the client the import would run on and refuses there.
+  //
+  // The layout is the VIEWPORT, the same breakpoint `AppHeader` swaps the
+  // hamburger for the tab strip on - not `isMobileApp()`. An iPad is the
+  // installed app at desktop width: it shows the tab strip and the canvas, so
+  // it must be taught those and not a drawer it never renders. The product
+  // flag keeps only what is true of any touch shell (swipe, thumb-sized
+  // controls) - see `OnboardingTour`.
+  const phoneLayout = useIsMobileViewport();
   const sessionImportAvailable = useSessionImportAvailable();
   const loginImportAvailable = useLoginImportAvailable();
   const acts = useMemo(
-    () => onboardingActsFor({ sessionImportAvailable, loginImportAvailable }),
-    [loginImportAvailable, sessionImportAvailable],
+    () =>
+      onboardingActsFor({
+        phoneLayout,
+        sessionImportAvailable,
+        loginImportAvailable,
+      }),
+    [loginImportAvailable, phoneLayout, sessionImportAvailable],
   );
   const scopedBinding = useScopedHostBinding(scope);
   const ambientBinding = useHostBinding();
@@ -958,6 +976,7 @@ export function OnboardingPage(props: { readonly replay: boolean }) {
         <OnboardingTour
           replay={props.replay}
           acts={acts}
+          phoneLayout={phoneLayout}
           scope={scope}
           scopedHostId={scopedHostId}
           setScopedHostId={setScopedHostId}
@@ -1084,12 +1103,14 @@ function OnboardingTour(props: {
   readonly replay: boolean;
   /** The tour being played - see `OnboardingPage` for why it is decided there. */
   readonly acts: ReadonlyArray<OnboardingAct>;
+  /** The layout `acts` was picked for, so the miniature draws the same chrome. */
+  readonly phoneLayout: boolean;
   readonly scope: HostScope;
   /** `null` while the tour follows the host it opened on. */
   readonly scopedHostId: string | null;
   readonly setScopedHostId: (hostId: string) => void;
 }) {
-  const { acts, scope, scopedHostId, setScopedHostId } = props;
+  const { acts, phoneLayout, scope, scopedHostId, setScopedHostId } = props;
   // Draft + provider-derived default live in one state object so the
   // query-sync effect mirrors them through a single trailing setState call
   // (React's effect-sync rule only permits the final statement to set state).
@@ -1105,9 +1126,11 @@ function OnboardingTour(props: {
   const agentGuideAutoDefaultRef = useRef(false);
   const agentGuideLastDefaultRef = useRef("");
   const stageRef = useRef<HTMLDivElement | null>(null);
-  // The page's other platform read (`miniatureForAct` has the first): the
-  // interaction polish the installed app gets and a desktop window must not -
-  // swipe between acts, and controls a thumb can actually hit.
+  // The page's one PRODUCT read: the interaction polish the installed app
+  // gets and a desktop window must not - swipe between acts, and controls a
+  // thumb can actually hit. Deliberately not the layout signal: an iPad plays
+  // the desktop tour (its acts and miniature follow `phoneLayout`) but is
+  // still driven by a thumb, so it keeps both.
   const mobileApp = isMobileApp();
   const actionHeight = actionHeightClass(mobileApp);
   const navigate = useNavigate();
@@ -1168,7 +1191,7 @@ function OnboardingTour(props: {
   useLayoutEffect(() => {
     seatedActIdRef.current = act.id;
   });
-  const miniature = miniatureForAct(act.id);
+  const miniature = miniatureForAct(act.id, phoneLayout);
   const isAgentGuideAct = act.id === "agent-guide";
   const agentGuideQueryData = agentGuideQuery.data;
   const agentGuideWaitingForProviderSettlement =


### PR DESCRIPTION
## Problem

On iPad the tour played the **phone** onboarding: "the menu, top left", "the stack icon, top right", and a phone-shaped miniature floating in a column sized for the desktop mock-up. But an iPad runs the installed app at desktop width, so the app itself renders the tab strip, sidebar and canvas there (`AppHeader` swaps chrome on the 768px `useIsMobileViewport()` breakpoint). The tour was picking its content off `isMobileApp()`, which `lib/mobile-app.ts` documents as a product signal that is "NEVER layout".

## Change

- `onboardingActsFor` takes a `phoneLayout` capability instead of reading `isMobileApp()`. Phone width plays the five phone acts; anything wider plays the desktop acts, still filtered by session-import / login-import availability.
- `OnboardingPage` resolves `useIsMobileViewport()` once and hands the same boolean to both the act list and `miniatureForAct`, so the miniature draws the chrome the acts describe.
- `isMobileApp()` keeps only the touch polish that holds on any installed shell: swipe between acts, 44pt controls, hidden version footer. An iPad keeps all of those while playing the desktop tour.

Stable on both devices by construction: the iPhone build is portrait-locked below the breakpoint, and an iPad's shorter side clears it in every orientation.

## What an iPad sees now

Desktop acts. Login import drops out automatically (no browser bridge on mobile). Session import stays only when the connected host advertises the scan, and the wizard is already reachable from mobile Settings today.

## Tests

- `onboarding-acts.test.ts` passes the layout explicitly instead of flipping the app flag, and adds the iPad rule (wide window + installed app returns the desktop catalog).
- `onboarding-page-mobile.test.tsx` mocks the viewport and gains an "installed app on a tablet" describe: desktop acts and miniature, no drawer copy, swipe and thumb-sized controls intact, session scan starts.

Three onboarding suites: 70 passed. gui-app `compile` clean.

## Worth a look on a real iPad after merge

- The "Move fast" act's body still says "Use Cmd+K"; keyboard hints are hidden on the installed app but the copy names the chord.
- The desktop agent-guide act edits inside a modal in the miniature; with a software keyboard this may be cramped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
