### PR TITLE
fix(gui-app): move the notification center chord off Cmd+Shift+N

### DIFF
--- a/clients/gui-app/src/components/notifications/__tests__/notifications-bell.test.tsx
+++ b/clients/gui-app/src/components/notifications/__tests__/notifications-bell.test.tsx
@@ -267,8 +267,8 @@ const DYNAMIC_ACTION_ROUTER: KeybindingRouter = {
  * hits, untested. */
 function pressNotificationsChord(): void {
   fireEvent.keyDown(window, {
-    key: "N",
-    code: "KeyN",
+    key: "B",
+    code: "KeyB",
     ...(isMac() ? { metaKey: true } : { ctrlKey: true }),
     shiftKey: true,
   });

--- a/clients/gui-app/src/lib/keybindings/actions.ts
+++ b/clients/gui-app/src/lib/keybindings/actions.ts
@@ -520,9 +520,12 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
       "Open the notification center, then use Up/Down to move between notifications. Pressing the chord again closes it.",
     category: "app",
     kind: "chord",
-    // ⌘⇧N - N for notifications, in the same ⌘⇧ family as the other global
-    // panel openers (⌘⇧U usage limits). ⌘N is taken by "New task".
-    defaultChord: "mod+shift+n",
+    // ⌘⇧B - B for the bell, in the same ⌘⇧ family as the other global panel
+    // openers (⌘⇧U usage limits). ⌘N is "New task" and ⌘⇧N is the desktop
+    // File → New Window accelerator (menu-builder.ts), which the main process
+    // consumes before the renderer ever sees the keystroke - so any chord
+    // here must also avoid the native menu's accelerators, not just this map.
+    defaultChord: "mod+shift+b",
     secondaryChord: undefined,
     terminalPolicy: "app",
     secondaryTerminalPolicy: undefined,

--- a/clients/gui-app/src/providers/__tests__/keybinding-provider.test.ts
+++ b/clients/gui-app/src/providers/__tests__/keybinding-provider.test.ts
@@ -253,8 +253,8 @@ describe("dispatchAction", () => {
   it("registers a default binding for the notification center", () => {
     const defaults = getDefaultBindings();
 
-    expect(defaults["app.notifications.open"]).toBe("mod+shift+n");
-    expect(findActionForChord("mod+shift+n")).toBe("app.notifications.open");
+    expect(defaults["app.notifications.open"]).toBe("mod+shift+b");
+    expect(findActionForChord("mod+shift+b")).toBe("app.notifications.open");
   });
 
   it("app.sidebar.toggle no-ops when no bridge is registered", () => {


### PR DESCRIPTION
## Problem

⌘⇧N / Ctrl+Shift+N was bound to `app.notifications.open` in #1270, but the desktop File → New Window menu item has carried `CmdOrCtrl+Shift+N` as its accelerator since the first commit. Electron registers menu accelerators in the main process, which consumes the keystroke before the renderer ever sees it, so the chord opened a new window and the notification center never opened by keyboard. The bell tooltip advertised a shortcut that did something else.

## Change

- Rebind `app.notifications.open` to **⌘⇧B / Ctrl+Shift+B** (B for the bell). It stays in the ⌘⇧ family with ⌘⇧U usage limits, and it collides with nothing in the keybinding map or the native menu (⌘⇧N New Window, ⌘⇧O Open Epic, ⌘⇧G find previous, Ctrl+Shift+I devtools).
- New Window keeps ⌘⇧N, the convention users know from VS Code, Cursor and Chrome.
- The comment on the action now records that a renderer chord must avoid the native menu accelerators too, not only the keybinding map.

The tooltip reads off the live binding, so it updates itself. Existing users who never rebound the action pick up the new default through `getDefaultBindings()`; no store migration is needed.

## Tests

Updated the two suites that assert the default chord: `keybinding-provider.test.ts` and `notifications-bell.test.tsx`. Both pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)