### PR TITLE
fix(protocol): keep backslashes inside code marks when serializing table cells

### DIFF
--- a/protocol/src/common/__tests__/json-content-serializer-tables.test.ts
+++ b/protocol/src/common/__tests__/json-content-serializer-tables.test.ts
@@ -110,6 +110,36 @@ describe("table cell escaping inside inline code", () => {
     ).toBe("| `a\\|\\|b` |");
   });
 
+  it("carries backslash parity across a code span split by an unrendered mark", () => {
+    // A thread anchor renders nothing, but it splits one code span into two
+    // text nodes - here between a trailing `\` and a leading `|`. The span
+    // stays open across that boundary, so the pipe must be escaped against
+    // the run that ends the previous node: `\|` on its own would hand the
+    // parser `a\\|b`, an even run, and the cell would split. Falsification:
+    // escape each node separately (drop the segment coalescing at the top of
+    // `serializeTextRunWith`) and this reads "| `a\\\\|b` |".
+    const doc = tableDoc([
+      text("a\\", [{ type: "code" }]),
+      text("|b", [
+        { type: "code" },
+        { type: "threadAnchor", attrs: { threadId: "t1" } },
+      ]),
+    ]);
+
+    expect(bodyRow(toMarkdown(doc))).toBe("| `a\\\\\\|b` |");
+  });
+
+  it("is unchanged by the same split in plain cell text (control)", () => {
+    // Plain text doubles every backslash, so its escape is context-free and
+    // per-node escaping already agreed with whole-span escaping here.
+    const doc = tableDoc([
+      text("a\\", undefined),
+      text("|b", [{ type: "threadAnchor", attrs: { threadId: "t1" } }]),
+    ]);
+
+    expect(bodyRow(toMarkdown(doc))).toBe("| a\\\\\\|b |");
+  });
+
   it("escapes plain cell text the CommonMark way around the code span", () => {
     const doc = tableDoc([
       text("see\\ ", undefined),

--- a/protocol/src/common/__tests__/json-content-serializer-tables.test.ts
+++ b/protocol/src/common/__tests__/json-content-serializer-tables.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vitest";
+
+import type { JsonContent } from "../registry";
+import { jsonContentToMarkdown } from "../json-content-serializer";
+
+/**
+ * GFM table-cell escaping must be mark-aware.
+ *
+ * A cell used to be escaped AFTER it was rendered: every `\` doubled, every
+ * `|` became `\|`. Outside inline code that is the ordinary CommonMark escape
+ * and the parser undoes it. Inside inline code CommonMark processes no
+ * escapes, so the doubled backslash came back doubled and doubled again on
+ * the next disk → doc → disk pass. One artifact row with three regex
+ * backslashes in a code span reached 3 × 2^21 characters after ~40 agent
+ * appends and blocked the host's event loop inside the markdown lexer for
+ * good. Code text therefore keeps its backslashes and escapes only the pipe.
+ *
+ * The parser (marked's `splitCells`) treats a pipe as escaped when an ODD
+ * number of backslashes precede it and then strips exactly one backslash from
+ * each `\|`, which is why a pipe after an odd backslash run inside code gets
+ * one extra backslash: GFM cannot represent a literal `\|` inside code, so
+ * that one case is lossy by design, but it converges instead of splitting the
+ * cell or growing.
+ */
+
+function text(
+  value: string,
+  marks: { type: string; attrs?: Record<string, unknown> }[] | undefined,
+): JsonContent {
+  return marks
+    ? { type: "text", text: value, marks }
+    : { type: "text", text: value };
+}
+
+function cell(content: JsonContent[], header: boolean): JsonContent {
+  return {
+    type: header ? "tableHeader" : "tableCell",
+    content: [{ type: "paragraph", content }],
+  };
+}
+
+// One header row (`h`) and one body row holding `content` in its only cell.
+function tableDoc(content: JsonContent[]): JsonContent {
+  return {
+    type: "doc",
+    content: [
+      {
+        type: "table",
+        content: [
+          { type: "tableRow", content: [cell([text("h", undefined)], true)] },
+          { type: "tableRow", content: [cell(content, false)] },
+        ],
+      },
+    ],
+  };
+}
+
+function paragraphDoc(content: JsonContent[]): JsonContent {
+  return {
+    type: "doc",
+    content: [{ type: "paragraph", content }],
+  };
+}
+
+function toMarkdown(content: JsonContent): string {
+  return jsonContentToMarkdown(content, {
+    mentionFormat: "llm",
+    platform: "POSIX",
+  });
+}
+
+function bodyRow(markdown: string): string {
+  const rows = markdown.split("\n");
+  expect(rows).toHaveLength(3);
+  expect(rows[0]).toBe("| h |");
+  expect(rows[1]).toBe("| --- |");
+  return rows[2];
+}
+
+describe("table cell escaping inside inline code", () => {
+  it("keeps backslashes inside an inline code cell exactly as stored", () => {
+    const doc = tableDoc([
+      text("grep ", undefined),
+      text("\\.tuple\\)", [{ type: "code" }]),
+      text(" found 1", undefined),
+    ]);
+
+    expect(bodyRow(toMarkdown(doc))).toBe("| grep `\\.tuple\\)` found 1 |");
+  });
+
+  it("escapes a pipe inside inline code without touching its backslashes", () => {
+    const doc = tableDoc([text("a|b\\c", [{ type: "code" }])]);
+
+    expect(bodyRow(toMarkdown(doc))).toBe("| `a\\|b\\c` |");
+  });
+
+  it("keeps the escaped pipe's backslash parity odd after a backslash run inside code", () => {
+    // One backslash before the pipe: `\|` alone would read as an even run and
+    // split the cell, so one more is added.
+    expect(
+      bodyRow(toMarkdown(tableDoc([text("a\\|b", [{ type: "code" }])]))),
+    ).toBe("| `a\\\\\\|b` |");
+    // Two backslashes before the pipe already leave `\|` as an odd run.
+    expect(
+      bodyRow(toMarkdown(tableDoc([text("a\\\\|b", [{ type: "code" }])]))),
+    ).toBe("| `a\\\\\\|b` |");
+    // Adjacent pipes are each escaped on their own.
+    expect(
+      bodyRow(toMarkdown(tableDoc([text("a||b", [{ type: "code" }])]))),
+    ).toBe("| `a\\|\\|b` |");
+  });
+
+  it("escapes plain cell text the CommonMark way around the code span", () => {
+    const doc = tableDoc([
+      text("see\\ ", undefined),
+      text("x|y", [{ type: "code" }]),
+      text(" done|", undefined),
+    ]);
+
+    expect(bodyRow(toMarkdown(doc))).toBe("| see\\\\ `x\\|y` done\\| |");
+  });
+});
+
+describe("table cell escaping outside inline code (unchanged)", () => {
+  it("doubles backslashes and escapes pipes in plain cell text", () => {
+    expect(bodyRow(toMarkdown(tableDoc([text("a\\b|c", undefined)])))).toBe(
+      "| a\\\\b\\|c |",
+    );
+  });
+
+  it("keeps a trailing backslash from escaping the pipe it precedes", () => {
+    expect(bodyRow(toMarkdown(tableDoc([text("a\\|", undefined)])))).toBe(
+      "| a\\\\\\| |",
+    );
+  });
+
+  it("escapes plain text inside a bold span in a cell", () => {
+    expect(
+      bodyRow(toMarkdown(tableDoc([text("a|b", [{ type: "bold" }])]))),
+    ).toBe("| **a\\|b** |");
+  });
+});
+
+describe("controls: the same code text outside a table is not escaped", () => {
+  it("leaves an inline code span in a paragraph alone", () => {
+    const doc = paragraphDoc([
+      text("grep ", undefined),
+      text("\\.tuple\\)|x", [{ type: "code" }]),
+    ]);
+
+    expect(toMarkdown(doc)).toBe("grep `\\.tuple\\)|x`");
+  });
+
+  it("leaves a fenced code block alone", () => {
+    const doc: JsonContent = {
+      type: "doc",
+      content: [
+        {
+          type: "codeBlock",
+          attrs: { language: "" },
+          content: [text("grep '\\.tuple\\)' | wc -l", undefined)],
+        },
+      ],
+    };
+
+    expect(toMarkdown(doc)).toBe("```\ngrep '\\.tuple\\)' | wc -l\n```");
+  });
+});

--- a/protocol/src/common/__tests__/json-content-serializer-tables.test.ts
+++ b/protocol/src/common/__tests__/json-content-serializer-tables.test.ts
@@ -139,6 +139,24 @@ describe("table cell escaping outside inline code (unchanged)", () => {
       bodyRow(toMarkdown(tableDoc([text("a|b", [{ type: "bold" }])]))),
     ).toBe("| **a\\|b** |");
   });
+
+  it("escapes a pipe and a backslash inside a link destination", () => {
+    const doc = tableDoc([
+      text("a|b", [{ type: "link", attrs: { href: "http://x/p|q\\r" } }]),
+    ]);
+
+    expect(bodyRow(toMarkdown(doc))).toBe("| [a\\|b](http://x/p\\|q\\\\r) |");
+  });
+
+  it("does not escape a code span's backticks or a link's brackets", () => {
+    const doc = tableDoc([
+      text("x", [{ type: "code" }]),
+      text(" ", undefined),
+      text("docs", [{ type: "link", attrs: { href: "http://x/" } }]),
+    ]);
+
+    expect(bodyRow(toMarkdown(doc))).toBe("| `x` [docs](http://x/) |");
+  });
 });
 
 describe("controls: the same code text outside a table is not escaped", () => {

--- a/protocol/src/common/json-content-serializer.ts
+++ b/protocol/src/common/json-content-serializer.ts
@@ -67,6 +67,10 @@ interface SerializerContext {
   listDepth: number;
   orderedListIndex: number;
   inListItem: boolean;
+  // True while rendering the content of a GFM table cell: inline text is
+  // escaped per text node, mark-aware, so a literal `|` cannot split the cell
+  // (see `escapeTableCellText` / `escapeTableCellCode`).
+  inTableCell: boolean;
 }
 
 function createContext(options: SerializerOptions): SerializerContext {
@@ -79,6 +83,7 @@ function createContext(options: SerializerOptions): SerializerContext {
     listDepth: 0,
     orderedListIndex: 0,
     inListItem: false,
+    inTableCell: false,
   };
 }
 
@@ -156,6 +161,60 @@ function renderableMarks(
   ];
 }
 
+type TextRunEscape = (text: string, marks: RenderableMark[]) => string;
+
+const keepText: TextRunEscape = (text) => text;
+
+// GFM table cells escape a literal `|` as `\|`. The parser (marked's
+// `splitCells`) decides whether a pipe is escaped by the PARITY of the
+// backslashes in front of it, then strips exactly one backslash from each
+// `\|`. Outside inline code that is the ordinary CommonMark escape: doubling
+// every backslash keeps a literal `\` literal and guarantees the `\|` we add
+// is read as escaped even after a trailing `\`.
+function escapeTableCellText(text: string): string {
+  return text.replace(/\\/g, "\\\\").replace(/\|/g, "\\|");
+}
+
+// Inside inline code CommonMark processes no escapes, so a doubled backslash
+// comes back doubled and doubles AGAIN on the next md → doc → md pass. Every
+// agent write to an artifact is such a pass; three regex backslashes in one
+// table row grew to 3 × 2^21 characters in ~40 appends and blocked the host's
+// event loop inside the markdown lexer for good. Code text therefore keeps
+// its backslashes and escapes only the pipe. When the pipe follows an ODD run
+// of backslashes one more is added so the parity still reads "escaped" and
+// the cell cannot split: GFM has no encoding for a literal `\|` inside code,
+// so that one case is lossy by design, but it converges after a single pass
+// instead of growing (pinned by `json-content-serializer-tables.test.ts`).
+function escapeTableCellCode(text: string): string {
+  return text.replace(
+    /\|/g,
+    (_pipe: string, offset: number, source: string): string => {
+      let run = 0;
+      for (let i = offset - 1; i >= 0 && source[i] === "\\"; i--) run++;
+      return run % 2 === 1 ? "\\\\|" : "\\|";
+    },
+  );
+}
+
+const escapeTableCellRun: TextRunEscape = (text, marks) =>
+  marks.some((mark) => mark.type === "code")
+    ? escapeTableCellCode(text)
+    : escapeTableCellText(text);
+
+// Node types whose serializer renders its inline content through
+// `serializeChildren` and therefore escapes it per text node while
+// `inTableCell` is set. Anything else that lands in a cell (mention, image,
+// hard break, unknown nodes) is escaped as a rendered whole, exactly as the
+// entire cell used to be.
+const TABLE_CELL_CONTAINER_TYPES: ReadonlySet<string> = new Set([
+  "paragraph",
+  "heading",
+  "bulletList",
+  "orderedList",
+  "listItem",
+  "table",
+]);
+
 /**
  * Exported for the composer's recovery seam, which quotes a dead send's text
  * back to its author and is held to PARITY with this serializer: the marks a
@@ -181,6 +240,16 @@ function renderableMarks(
  * after "b" would force italic closed and reopened, doubling delimiters.
  */
 export function serializeTextRun(nodes: JsonContent[]): string {
+  return serializeTextRunWith(nodes, keepText);
+}
+
+// `escapeText` sees each node's text together with its renderable marks, so
+// a table cell can escape plain text and code text differently (see
+// `escapeTableCellRun`). It runs on the text only - never on the delimiters.
+function serializeTextRunWith(
+  nodes: JsonContent[],
+  escapeText: TextRunEscape,
+): string {
   const textNodes = nodes.filter((node) => Boolean(node.text));
   const nodeMarks = textNodes.map((node) => renderableMarks(node.marks));
 
@@ -236,7 +305,7 @@ export function serializeTextRun(nodes: JsonContent[]): string {
       out += mark.open;
       open.push(mark);
     }
-    out += node.text ?? "";
+    out += escapeText(node.text ?? "", marks);
   });
 
   closeDownTo(0);
@@ -827,10 +896,12 @@ function serializeTable(node: JsonContent, ctx: SerializerContext): string {
         if (cell.type === "tableHeader") {
           isHeader = true;
         }
-        const cellContent = serializeChildren(cell.content, ctx);
-        // Escape backslashes before pipes so a literal trailing `\` in a cell
-        // can't escape the `\|` we add and merge two cells together.
-        cells.push(cellContent.replace(/\\/g, "\\\\").replace(/\|/g, "\\|"));
+        // Escaping happens per text node under `inTableCell` (mark-aware, see
+        // `escapeTableCellRun`) - never on the rendered cell string, which
+        // cannot tell code text from plain text.
+        cells.push(
+          serializeChildren(cell.content, { ...ctx, inTableCell: true }),
+        );
       }
     }
 
@@ -866,9 +937,10 @@ function serializeChildren(
   // hardBreak, …) end the run and close any open marks.
   const parts: string[] = [];
   let textRun: JsonContent[] = [];
+  const escapeText = ctx.inTableCell ? escapeTableCellRun : keepText;
   const flushTextRun = (): void => {
     if (textRun.length > 0) {
-      parts.push(serializeTextRun(textRun));
+      parts.push(serializeTextRunWith(textRun, escapeText));
       textRun = [];
     }
   };
@@ -878,7 +950,14 @@ function serializeChildren(
       textRun.push(child);
     } else {
       flushTextRun();
-      parts.push(serializeNode(child, ctx));
+      const rendered = serializeNode(child, ctx);
+      const escapesItsOwnText =
+        child.type !== undefined && TABLE_CELL_CONTAINER_TYPES.has(child.type);
+      parts.push(
+        ctx.inTableCell && !escapesItsOwnText
+          ? escapeTableCellText(rendered)
+          : rendered,
+      );
     }
   }
   flushTextRun();

--- a/protocol/src/common/json-content-serializer.ts
+++ b/protocol/src/common/json-content-serializer.ts
@@ -258,15 +258,50 @@ export function serializeTextRun(nodes: JsonContent[]): string {
   return serializeTextRunWith(nodes, noEscaping);
 }
 
-// `escaping.text` sees each node's text together with its renderable marks,
-// so a table cell can escape plain text and code text differently (see
-// `tableCellEscaping`); `escaping.delimiter` sees each mark delimiter.
+interface TextSegment {
+  text: string;
+  marks: RenderableMark[];
+}
+
+function sameMarkKeys(a: RenderableMark[], b: RenderableMark[]): boolean {
+  if (a.length !== b.length) return false;
+  const keys = new Set(b.map((mark) => mark.key));
+  return a.every((mark) => keys.has(mark.key));
+}
+
+// Adjacent text nodes carrying the same renderable marks are one continuous
+// span in the output - nothing closes or opens between them under the
+// boundary rules in `serializeTextRunWith` - so they are joined here and
+// escaped as ONE string. For the plain-text cell escape that changes nothing
+// (it is context-free per character), but the inline-code pipe escape reads
+// the backslash PARITY in front of the pipe, and a mark that renders nothing
+// (a thread anchor) can split one code span between a trailing `\` and a
+// leading `|`. Escaped on its own the second node sees no backslash, emits
+// `\|`, and the parser reads `a\\|b` as an even run and splits the cell.
+function coalesceTextSegments(nodes: JsonContent[]): TextSegment[] {
+  const segments: TextSegment[] = [];
+  for (const node of nodes) {
+    if (!node.text) continue;
+    const marks = renderableMarks(node.marks);
+    const last = segments[segments.length - 1];
+    if (last !== undefined && sameMarkKeys(last.marks, marks)) {
+      last.text += node.text;
+    } else {
+      segments.push({ text: node.text, marks });
+    }
+  }
+  return segments;
+}
+
+// `escaping.text` sees each segment's text together with its renderable
+// marks, so a table cell can escape plain text and code text differently
+// (see `tableCellEscaping`); `escaping.delimiter` sees each mark delimiter.
 function serializeTextRunWith(
   nodes: JsonContent[],
   escaping: TextRunEscaping,
 ): string {
-  const textNodes = nodes.filter((node) => Boolean(node.text));
-  const nodeMarks = textNodes.map((node) => renderableMarks(node.marks));
+  const segments = coalesceTextSegments(nodes);
+  const nodeMarks = segments.map((segment) => segment.marks);
 
   const continuation = (key: string, start: number): number => {
     let end = start;
@@ -289,7 +324,7 @@ function serializeTextRunWith(
     open = open.slice(0, depth);
   };
 
-  textNodes.forEach((node, index) => {
+  segments.forEach((segment, index) => {
     const marks = nodeMarks[index];
     const nextKeys = new Set(marks.map((mark) => mark.key));
 
@@ -320,7 +355,7 @@ function serializeTextRunWith(
       out += escaping.delimiter(mark.open);
       open.push(mark);
     }
-    out += escaping.text(node.text ?? "", marks);
+    out += escaping.text(segment.text, marks);
   });
 
   closeDownTo(0);

--- a/protocol/src/common/json-content-serializer.ts
+++ b/protocol/src/common/json-content-serializer.ts
@@ -161,9 +161,18 @@ function renderableMarks(
   ];
 }
 
-type TextRunEscape = (text: string, marks: RenderableMark[]) => string;
+interface TextRunEscaping {
+  text: (text: string, marks: RenderableMark[]) => string;
+  // Applied to every mark delimiter. The only delimiter carrying variable
+  // content is a link's `](href)`; the fixed ones (`**`, `` ` ``, `~~`, `[`)
+  // contain nothing a cell escape touches, so this is a no-op for them.
+  delimiter: (delimiter: string) => string;
+}
 
-const keepText: TextRunEscape = (text) => text;
+const noEscaping: TextRunEscaping = {
+  text: (text) => text,
+  delimiter: (delimiter) => delimiter,
+};
 
 // GFM table cells escape a literal `|` as `\|`. The parser (marked's
 // `splitCells`) decides whether a pipe is escaped by the PARITY of the
@@ -196,10 +205,16 @@ function escapeTableCellCode(text: string): string {
   );
 }
 
-const escapeTableCellRun: TextRunEscape = (text, marks) =>
-  marks.some((mark) => mark.type === "code")
-    ? escapeTableCellCode(text)
-    : escapeTableCellText(text);
+const tableCellEscaping: TextRunEscaping = {
+  text: (text, marks) =>
+    marks.some((mark) => mark.type === "code")
+      ? escapeTableCellCode(text)
+      : escapeTableCellText(text),
+  // A link destination is parsed with CommonMark escapes (and marked strips
+  // the `\|`), so the plain-text escape round-trips it exactly as the whole
+  // cell used to.
+  delimiter: escapeTableCellText,
+};
 
 // Node types whose serializer renders its inline content through
 // `serializeChildren` and therefore escapes it per text node while
@@ -240,15 +255,15 @@ const TABLE_CELL_CONTAINER_TYPES: ReadonlySet<string> = new Set([
  * after "b" would force italic closed and reopened, doubling delimiters.
  */
 export function serializeTextRun(nodes: JsonContent[]): string {
-  return serializeTextRunWith(nodes, keepText);
+  return serializeTextRunWith(nodes, noEscaping);
 }
 
-// `escapeText` sees each node's text together with its renderable marks, so
-// a table cell can escape plain text and code text differently (see
-// `escapeTableCellRun`). It runs on the text only - never on the delimiters.
+// `escaping.text` sees each node's text together with its renderable marks,
+// so a table cell can escape plain text and code text differently (see
+// `tableCellEscaping`); `escaping.delimiter` sees each mark delimiter.
 function serializeTextRunWith(
   nodes: JsonContent[],
-  escapeText: TextRunEscape,
+  escaping: TextRunEscaping,
 ): string {
   const textNodes = nodes.filter((node) => Boolean(node.text));
   const nodeMarks = textNodes.map((node) => renderableMarks(node.marks));
@@ -269,7 +284,7 @@ function serializeTextRunWith(
 
   const closeDownTo = (depth: number): void => {
     for (let i = open.length - 1; i >= depth; i--) {
-      out += open[i].close;
+      out += escaping.delimiter(open[i].close);
     }
     open = open.slice(0, depth);
   };
@@ -302,10 +317,10 @@ function serializeTextRunWith(
       ...toOpen.filter((mark) => mark.type === "code"),
     ];
     for (const mark of ordered) {
-      out += mark.open;
+      out += escaping.delimiter(mark.open);
       open.push(mark);
     }
-    out += escapeText(node.text ?? "", marks);
+    out += escaping.text(node.text ?? "", marks);
   });
 
   closeDownTo(0);
@@ -937,10 +952,10 @@ function serializeChildren(
   // hardBreak, …) end the run and close any open marks.
   const parts: string[] = [];
   let textRun: JsonContent[] = [];
-  const escapeText = ctx.inTableCell ? escapeTableCellRun : keepText;
+  const escaping = ctx.inTableCell ? tableCellEscaping : noEscaping;
   const flushTextRun = (): void => {
     if (textRun.length > 0) {
-      parts.push(serializeTextRunWith(textRun, escapeText));
+      parts.push(serializeTextRunWith(textRun, escaping));
       textRun = [];
     }
   };


### PR DESCRIPTION
## Problem

`serializeTable` escaped the **rendered** cell string (`\` → `\\`, `|` → `\|`), so backslashes inside inline code were doubled too. CommonMark processes no escapes inside a code span, so the parser keeps the doubled run literal and the next md → doc → md pass doubles it again. Every agent write to an artifact is one such pass (`applyDiskUpdate` normalizes the disk body through this serializer and projects the doc back).

On 2026-09-06 three regex backslashes in one artifact table row grew to 3 × 2²¹ characters after ~40 agent appends. `marked`'s `inlineTokens` escape-masking loop then copied the 12.6 MB string once per escape and never returned: the staging host sat at 100% CPU with a silent log until it was SIGKILLed, and re-hung 90 s after every restart. Nine other artifacts on the same machine were already at 64–262,144 backslashes.

## Fix

Escaping moves from the rendered cell string down to the text nodes (`inTableCell` on the serializer context), where it can see marks:

- **plain text**: unchanged (`\` → `\\`, `|` → `\|`), which the parser undoes exactly;
- **code text**: backslashes untouched, only `|` → `\|`. `marked` treats a pipe as escaped when an **odd** number of backslashes precede it and strips one backslash from each `\|`, so a pipe after an odd run gets one extra backslash to keep the cell from splitting. GFM has no encoding for a literal `\|` inside code; that single case converges after one pass instead of growing;
- **non-container inline leaves** in a cell (mention, image, unknown nodes) are still escaped as a rendered whole, exactly as the entire cell used to be.

`serializeTextRun` keeps its exported identity behaviour for the composer's recovery seam; the escaping variant is internal.

## Tests

`json-content-serializer-tables.test.ts`: code span with backslashes stays byte-identical; pipe inside code; backslash-pipe parity (1 and 2 preceding backslashes, adjacent pipes); plain-text cells unchanged (incl. trailing `\` before `|`); paragraph and fenced-block controls. Red on `main` for the three code-span cases, green here; the six existing serializer suites still pass (56 tests).

The true round-trip fixed-point test (md → ProseMirror → Yjs → md, six passes, backslash count constant; counts were 4, 8, 16, 32, 64, 128 before) lives with the parser in the internal repo and lands with the submodule pin PR that follows this one.

## Deferred

- Host-side defence so `applyDiskUpdate` refuses a pathological body instead of parsing it on the main thread (internal).
- One-off repair of the artifacts that already carry doubled runs (internal, after this ships).
