### PR TITLE
fix(host-update): park a busy update at staged, publish the marker before the download, derive the two record-only parks in the Overview

### DIFF
--- a/clients/desktop/src/electron-main/cli/cli-reconcile.ts
+++ b/clients/desktop/src/electron-main/cli/cli-reconcile.ts
@@ -1,5 +1,10 @@
 import { access } from "node:fs/promises";
-import { PACKAGE_MANAGER_UPGRADE_COMMAND } from "@traycer/protocol/config/installation-records";
+import {
+  CLI_NPM_PACKAGE_NAME,
+  isPackageManagerCliSource,
+  type PackageManagerCliSource,
+  PACKAGE_MANAGER_UPGRADE_COMMAND,
+} from "@traycer-clients/shared/cli-install/package-manager-upgrade-command";
 import {
   CLI_RECONCILE_PROBE_TIMEOUT_MS,
   cliBinariesDiffer,
@@ -20,14 +25,6 @@ import {
   type CliInstallManifest,
 } from "./cli-discovery";
 import { log } from "../app/logger";
-
-type PackageManagerSource =
-  | "homebrew"
-  | "npm"
-  | "winget"
-  | "scoop"
-  | "apt"
-  | "rpm";
 
 /**
  * Launch-time CLI reconciliation (Core Flow 2, "newest-wins"):
@@ -99,7 +96,7 @@ export type CliReconcileOutcome =
     }
   | {
       readonly kind: "package-manager-older";
-      readonly source: PackageManagerSource;
+      readonly source: PackageManagerCliSource;
       readonly installedVersion: string;
       readonly bundledVersion: string;
       readonly upgradeHint: string;
@@ -116,9 +113,6 @@ export type CliReconcileOutcome =
       readonly kind: "no-cli-anywhere";
     };
 
-const PACKAGE_MANAGER_SOURCES: ReadonlySet<CliInstallManifest["source"]> =
-  new Set(["homebrew", "npm", "winget", "scoop", "apt", "rpm"]);
-
 // Windows: EBUSY, EACCES, EPERM are all common when a process holds the
 // live binary open. POSIX: only EBUSY (and a textual "locked" tag) are
 // real transient locks; EACCES/EPERM mean a permission problem the
@@ -126,22 +120,17 @@ const PACKAGE_MANAGER_SOURCES: ReadonlySet<CliInstallManifest["source"]> =
 const WINDOWS_LOCK_RE = /EBUSY|EACCES|EPERM|locked/i;
 const POSIX_LOCK_RE = /EBUSY|locked/i;
 
-function isPackageManagerSource(
-  source: CliInstallManifest["source"],
-): source is PackageManagerSource {
-  return PACKAGE_MANAGER_SOURCES.has(source);
-}
-
 function packageManagerUpgradeHint(
-  source: PackageManagerSource,
+  source: PackageManagerCliSource,
   bundledVersion: string,
 ): string {
-  const command = PACKAGE_MANAGER_UPGRADE_COMMAND[source];
-  // `latest` can be older than an installed RC. Preserve Desktop's exact
-  // candidate, while sharing the package name and command with every caller.
+  // `latest` can be older than an installed RC, so npm pins Desktop's exact
+  // bundled version - built from the shared package name rather than by
+  // editing the shared command, which would silently fall back to `latest`
+  // the day that command stopped ending in `@latest`.
   return source === "npm"
-    ? command.replace(/@latest$/, `@${bundledVersion}`)
-    : command;
+    ? `npm install -g ${CLI_NPM_PACKAGE_NAME}@${bundledVersion}`
+    : PACKAGE_MANAGER_UPGRADE_COMMAND[source];
 }
 
 export interface ReconcileCliDeps {
@@ -171,7 +160,7 @@ export interface ReconcileCliDeps {
   ) => Promise<CliInstallManifest | null>;
   readonly writeDesktopReconcileState: (state: {
     readonly packageManagerUpgrade: {
-      readonly source: PackageManagerSource;
+      readonly source: PackageManagerCliSource;
       readonly installedVersion: string;
       readonly bundledVersion: string;
       readonly upgradeCommand: string;
@@ -483,7 +472,7 @@ export async function reconcileCli(
   }
 
   // Case 3: installed is older than bundled. Branch on source.
-  if (isPackageManagerSource(manifest.source)) {
+  if (isPackageManagerCliSource(manifest.source)) {
     const upgradeHint = await persistPackageManagerUpgradeHint(deps, {
       source: manifest.source,
       installedVersion,
@@ -639,7 +628,7 @@ export async function reconcileCli(
 async function persistPackageManagerUpgradeHint(
   deps: ReconcileCliDeps,
   args: {
-    readonly source: PackageManagerSource;
+    readonly source: PackageManagerCliSource;
     readonly installedVersion: string;
     readonly bundledVersion: string;
   },

--- a/clients/desktop/src/electron-main/cli/cli-reconcile.ts
+++ b/clients/desktop/src/electron-main/cli/cli-reconcile.ts
@@ -1,4 +1,5 @@
 import { access } from "node:fs/promises";
+import { PACKAGE_MANAGER_UPGRADE_COMMAND } from "@traycer/protocol/config/installation-records";
 import {
   CLI_RECONCILE_PROBE_TIMEOUT_MS,
   cliBinariesDiffer,
@@ -135,26 +136,12 @@ function packageManagerUpgradeHint(
   source: PackageManagerSource,
   bundledVersion: string,
 ): string {
-  switch (source) {
-    case "homebrew":
-      // Must match the Homebrew formula name shipped via
-      // scripts/native-packaging/publish-cli-package-managers.cjs
-      // (`Formula/traycer.rb`) and the CLI self-upgrade guidance in
-      // traycer-cli/src/commands/cli-upgrade.ts.
-      return "brew upgrade traycer";
-    case "npm":
-      // `latest` names stable builds, so it can be older than an installed RC.
-      // Name the version this reconciliation actually offered to upgrade to.
-      return `npm install -g @traycerai/cli@${bundledVersion}`;
-    case "winget":
-      return "winget upgrade Traycer.CLI";
-    case "scoop":
-      return "scoop update traycer-cli";
-    case "apt":
-      return "sudo apt update && sudo apt install --only-upgrade traycer-cli";
-    case "rpm":
-      return "sudo dnf upgrade traycer-cli";
-  }
+  const command = PACKAGE_MANAGER_UPGRADE_COMMAND[source];
+  // `latest` can be older than an installed RC. Preserve Desktop's exact
+  // candidate, while sharing the package name and command with every caller.
+  return source === "npm"
+    ? command.replace(/@latest$/, `@${bundledVersion}`)
+    : command;
 }
 
 export interface ReconcileCliDeps {

--- a/clients/gui-app/src/components/home/__tests__/host-update-banner-bound.test.tsx
+++ b/clients/gui-app/src/components/home/__tests__/host-update-banner-bound.test.tsx
@@ -947,6 +947,7 @@ describe("HostUpdateBanner — bound arm (Ticket 06 subject E)", () => {
         hostId: LOCAL_HOST_ID,
         status: attemptStatus(failedAttempt),
         nowMs: Date.now(),
+        legacyFacts: null,
       });
       const view = projectFleetUpdateView({
         observation,
@@ -958,6 +959,8 @@ describe("HostUpdateBanner — bound arm (Ticket 06 subject E)", () => {
           view={view}
           hostName="This computer"
           onForceRestart={() => undefined}
+          onRestart={null}
+          onForceUpdate={null}
         />,
       );
       const card = screen.getByTestId("host-overview-operation-card");

--- a/clients/gui-app/src/components/home/__tests__/host-update-banner-bound.test.tsx
+++ b/clients/gui-app/src/components/home/__tests__/host-update-banner-bound.test.tsx
@@ -413,7 +413,7 @@ describe("HostUpdateBanner — bound arm (Ticket 06 subject E)", () => {
         execution: "parked",
         busySessionCount: 2,
       }),
-      expectedPhrase: /Update will continue when 2 sessions finish/,
+      expectedPhrase: /Update waits for 2 sessions to finish/,
     },
     {
       name: "waiting-to-activate",
@@ -619,9 +619,7 @@ describe("HostUpdateBanner — bound arm (Ticket 06 subject E)", () => {
     renderBanner(undefined);
     // Positive control that the banner rendered at all - an absent button is
     // trivially "absent" if nothing rendered.
-    expect(await findPhaseText()).toMatch(
-      /Update will continue when work finishes/,
-    );
+    expect(await findPhaseText()).toMatch(/Update waits for work to finish/);
     expect(screen.queryByTestId("host-update-banner-force-restart")).toBeNull();
   });
 
@@ -673,7 +671,7 @@ describe("HostUpdateBanner — bound arm (Ticket 06 subject E)", () => {
     });
     expect(restartCalls).toBe(0);
     // The banner is untouched - still showing the same attempt.
-    expect(await findPhaseText()).toMatch(/Update will continue/);
+    expect(await findPhaseText()).toMatch(/Update waits for/);
   });
 
   it("Force restart… CONFIRM dispatches the cooperative host.restart RPC", async () => {

--- a/clients/gui-app/src/components/home/__tests__/host-update-banner.test.tsx
+++ b/clients/gui-app/src/components/home/__tests__/host-update-banner.test.tsx
@@ -367,6 +367,9 @@ describe("HostUpdateBanner (Host Update Layer Redesign, D4)", () => {
     fireEvent.click(button);
 
     const dialog = await screen.findByTestId("host-busy-force-defer-dialog");
+    // Shared with the restart flow's busy verdict; the purpose attribute is
+    // the one thing that distinguishes the two on a page rendering both.
+    expect(dialog.dataset.purpose).toBe("update");
     expect(dialog.textContent).toContain(
       "Another Traycer process is applying an update.",
     );

--- a/clients/gui-app/src/components/home/host-update-banner.tsx
+++ b/clients/gui-app/src/components/home/host-update-banner.tsx
@@ -346,6 +346,7 @@ function HostUpdateBannerInner(props: HostUpdateBannerInnerProps) {
         }}
       />
       <HostBusyForceDeferDialog
+        purpose="update"
         open={busy !== null}
         message={forceDialogProps.message}
         isForcing={isPending}

--- a/clients/gui-app/src/components/home/host-update-operation-copy.ts
+++ b/clients/gui-app/src/components/home/host-update-operation-copy.ts
@@ -152,11 +152,15 @@ function phaseSentence(
  * rather than saying "0".
  */
 function waitingForWorkSentence(blockingSessionCount: number | null): string {
+  // "Waits", not "will continue": the park is a fact about the stage, and
+  // what resumes it is the next update run - a host's own automatic check
+  // where one is enabled, or the next Update now - which this sentence has
+  // no evidence of. The same copy serves the attempt's own park and the
+  // record-derived legacy one.
   if (blockingSessionCount === null) {
-    return "Update will continue when work finishes";
+    return "Update waits for work to finish";
   }
-  const verb = blockingSessionCount === 1 ? "finishes" : "finish";
-  return `Update will continue when ${describeSessions(blockingSessionCount)} ${verb}`;
+  return `Update waits for ${describeSessions(blockingSessionCount)} to finish`;
 }
 
 function completeSentence(targetVersion: string | null): string {

--- a/clients/gui-app/src/components/host/__tests__/local-host-restart-flow.test.tsx
+++ b/clients/gui-app/src/components/host/__tests__/local-host-restart-flow.test.tsx
@@ -377,6 +377,9 @@ describe("<LocalHostRestartFlow /> - host runtime binding present, local host re
       const busyDialog = await screen.findByTestId(
         "host-busy-force-defer-dialog",
       );
+      // The same dialog serves the update banner's Force; `data-purpose`
+      // is what tells a page test which of the two it opened.
+      expect(busyDialog.dataset.purpose).toBe("restart");
       expect(busyDialog.textContent).toContain(busyMessage(subject));
       expect(
         screen.getByRole("button", { name: "Force restart" }),

--- a/clients/gui-app/src/components/host/client-update-required-action.tsx
+++ b/clients/gui-app/src/components/host/client-update-required-action.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, type ReactNode } from "react";
+import type { ReactNode } from "react";
 import {
   queryOptions,
   useMutation,
@@ -16,6 +16,7 @@ import {
   type MobileAppPlatform,
 } from "@/lib/mobile-app";
 import { useDesktopAppUpdates } from "@/hooks/runner/use-desktop-app-updates";
+import { useUpdateCheckOnBlockingMount } from "@/components/host/use-update-check-on-blocking-mount";
 import { useOpenLink } from "@/lib/links/open-link";
 import { useDesktopDialogStore } from "@/stores/dialogs/desktop-dialog-store";
 import { requestAppUpdateInstall } from "@/lib/app-update/request-app-update-install";
@@ -486,115 +487,4 @@ function useAppUpdateEnableRcRecovery(
       });
     },
   });
-}
-
-/**
- * Asks the updater ONCE, on mount, when it has never been asked.
- *
- * The desktop DOES auto-check at launch (`installAutoUpdater` ->
- * `checkForUpdatesNow(isDev, "automatic")` in
- * `clients/desktop/src/electron-main/app/updater.ts`), so most of the time the
- * updater has already answered by the time anyone sees this surface. But that
- * check is gated on `canCheckForUpdates` and happens exactly once, while this
- * surface is reachable hours later - a host can activate a floor, or a user can
- * point at a different host, long into a session. In those cases the updater
- * has genuinely never been asked, and without this the user is sent to download
- * by hand while their own updater could have delivered the build.
- *
- * IT READS THE BRIDGE, NOT THE RENDERED SNAPSHOT, and that is the whole
- * correctness of it. `useDesktopAppUpdates` primes its store ASYNCHRONOUSLY,
- * so the first render of any consumer sees the module's default
- * `idle / lastCheckedAt: null` placeholder no matter what the main process
- * actually holds. Deciding from that placeholder would fire a redundant check
- * on every single mount - precisely the loop this is supposed to avoid - and
- * would do it invisibly, because the placeholder and a genuinely-unchecked
- * updater are the same object shape.
- *
- * Two guards, closing different loops:
- *
- *  - `lastCheckedAt !== null` on the AUTHORITATIVE snapshot means a check has
- *    already happened in this process. "up-to-date" and "error" are real
- *    answers; re-asking them would turn a blocking dialog into a poller.
- *
- *    ONE GAP, deliberately left open: an AUTOMATIC check that ERRORS publishes
- *    nothing at all (`emitCheckErrorFromCatch` returns early for non-manual
- *    intent), so `lastCheckedAt` stays `null` and the next mount of this
- *    dialog asks again. That is one request per mount, bounded by the ref
- *    below and by main's own `checkInFlight` dedupe - not a loop - and asking
- *    again after a failed check is the behaviour you would want anyway. The
- *    alternative, tracking "we already tried" in renderer state, would survive
- *    neither a reload nor a second window.
- *  - `requested` is a per-mount ref, so a re-render (this dialog re-renders on
- *    every lease delivery) cannot start a second read while the first is in
- *    flight.
- *
- * The intent stays `"automatic"`. A `"manual"` check would render the pending
- * state below - which is the only reason to want it - but it also publishes
- * `checking`, then `up-to-date` or `error`, into the APP-WIDE snapshot every
- * other update surface reads. A dialog quietly making the header announce
- * "Traycer is up to date" is worse than a brief link-then-button flip.
- *
- * Both rejections are swallowed deliberately: the failure mode is "the manual
- * link is what the user gets", which is where the component was heading
- * anyway. An updater error stacked on top of "your app is too old" adds noise
- * to a state that already has one clear instruction.
- */
-function useUpdateCheckOnBlockingMount(
-  bridge: DesktopAppUpdatesBridge | null,
-): void {
-  const requested = useRef(false);
-  useEffect(() => {
-    if (bridge === null || requested.current) return;
-    requested.current = true;
-    let cancelled = false;
-    void bridge
-      .getSnapshot()
-      .then((snapshot) => {
-        if (cancelled) return;
-        if (!shouldCheckForUpdates(snapshot)) return;
-        return bridge.checkForUpdates("automatic").then(() => undefined);
-      })
-      .catch(() => undefined);
-    return () => {
-      cancelled = true;
-    };
-  }, [bridge]);
-}
-
-/**
- * Whether asking the updater again could change this surface's answer.
- *
- * EXACTLY ONE reason to ask: the updater has NEVER been asked - `idle` with no
- * `lastCheckedAt`. The launch check is gated on `canCheckForUpdates` and fires
- * once, while this surface is reachable hours later, so a genuinely
- * never-checked updater is worth one request.
- *
- * NOT a reason to ask, and this is the part worth knowing before anyone adds
- * one: the updater already HOLDING a build that cannot clear the host's floor.
- * That looks like the obvious second case - the user is on the releases link
- * while their own updater is seemingly one request away from the right build -
- * but the request cannot do anything. `checkForUpdatesNow` in
- * `clients/desktop/src/electron-main/app/updater.ts` returns the current
- * snapshot BEFORE any feed query when the status is `ready`, `downloading`, or
- * `available`, for EVERY intent (the `available` arm says so in as many
- * words). Only a channel change moves that snapshot back to a re-queryable
- * state, and it runs its own check. So asking here would dispatch an IPC that
- * provably changes nothing, and a renderer test could only ever assert that
- * the bridge recorded the call.
- *
- * The releases link is therefore the ONLY recovery past a stale cached build,
- * and the render gate above is what makes sure the user is sent there rather
- * than offered a build that restarts into the same rejection. Making the
- * in-app updater recover that case means changing main to discard an
- * `available` candidate on re-check - a desktop-side product decision, not
- * something this surface can reach.
- *
- * Also not a reason: an updater that already answered "nothing here"
- * (`idle` / `up-to-date` / `unavailable` / `error` after a check). That is a
- * real answer, and re-asking it on every mount is the poller the per-mount ref
- * exists to prevent.
- */
-function shouldCheckForUpdates(snapshot: DesktopAppUpdateSnapshot): boolean {
-  if (snapshot.installInFlight) return false;
-  return snapshot.status === "idle" && snapshot.lastCheckedAt === null;
 }

--- a/clients/gui-app/src/components/host/host-busy-force-defer-dialog.tsx
+++ b/clients/gui-app/src/components/host/host-busy-force-defer-dialog.tsx
@@ -8,6 +8,12 @@ import {
 } from "@/components/ui/dialog";
 
 export interface HostBusyForceDeferDialogProps {
+  /**
+   * What Force does here, exposed as `data-purpose` on the dialog: a page
+   * can mount one of each (the Overview's force-restart and force-update
+   * dialogs), and a pin on the shared test id alone cannot tell them apart.
+   */
+  readonly purpose: "restart" | "update";
   readonly open: boolean;
   readonly message: string;
   readonly isForcing: boolean;
@@ -43,6 +49,7 @@ export function HostBusyForceDeferDialog(props: HostBusyForceDeferDialogProps) {
         showCloseButton={false}
         className="w-[min(92vw,28rem)] gap-0 overflow-hidden p-0 sm:max-w-md"
         data-testid="host-busy-force-defer-dialog"
+        data-purpose={props.purpose}
       >
         <div className="flex flex-col gap-1.5 p-5">
           <DialogTitle className="text-ui font-semibold leading-snug">

--- a/clients/gui-app/src/components/host/local-host-restart-flow.tsx
+++ b/clients/gui-app/src/components/host/local-host-restart-flow.tsx
@@ -511,6 +511,7 @@ function CooperativeFirstRestartFlow(
         }}
       />
       <HostBusyForceDeferDialog
+        purpose="restart"
         open={busyOpen}
         message={forceOffer?.message ?? ""}
         isForcing={forceRestart.isPending || respawnInFlight}

--- a/clients/gui-app/src/components/host/use-update-check-on-blocking-mount.ts
+++ b/clients/gui-app/src/components/host/use-update-check-on-blocking-mount.ts
@@ -1,0 +1,120 @@
+import { useEffect, useRef } from "react";
+import type {
+  DesktopAppUpdateSnapshot,
+  DesktopAppUpdatesBridge,
+} from "@/lib/windows/types";
+
+// Its own module rather than an export beside the dialog it started in:
+// a component file that also exports a hook breaks Fast Refresh for the
+// whole file, and the Overview's CLI-floor remedy (`DesktopRemedyCheck`)
+// runs the SAME guarded check for the same reason.
+/**
+ * Asks the updater ONCE, on mount, when it has never been asked.
+ *
+ * The desktop DOES auto-check at launch (`installAutoUpdater` ->
+ * `checkForUpdatesNow(isDev, "automatic")` in
+ * `clients/desktop/src/electron-main/app/updater.ts`), so most of the time the
+ * updater has already answered by the time anyone sees this surface. But that
+ * check is gated on `canCheckForUpdates` and happens exactly once, while this
+ * surface is reachable hours later - a host can activate a floor, or a user can
+ * point at a different host, long into a session. In those cases the updater
+ * has genuinely never been asked, and without this the user is sent to download
+ * by hand while their own updater could have delivered the build.
+ *
+ * IT READS THE BRIDGE, NOT THE RENDERED SNAPSHOT, and that is the whole
+ * correctness of it. `useDesktopAppUpdates` primes its store ASYNCHRONOUSLY,
+ * so the first render of any consumer sees the module's default
+ * `idle / lastCheckedAt: null` placeholder no matter what the main process
+ * actually holds. Deciding from that placeholder would fire a redundant check
+ * on every single mount - precisely the loop this is supposed to avoid - and
+ * would do it invisibly, because the placeholder and a genuinely-unchecked
+ * updater are the same object shape.
+ *
+ * Two guards, closing different loops:
+ *
+ *  - `lastCheckedAt !== null` on the AUTHORITATIVE snapshot means a check has
+ *    already happened in this process. "up-to-date" and "error" are real
+ *    answers; re-asking them would turn a blocking dialog into a poller.
+ *
+ *    ONE GAP, deliberately left open: an AUTOMATIC check that ERRORS publishes
+ *    nothing at all (`emitCheckErrorFromCatch` returns early for non-manual
+ *    intent), so `lastCheckedAt` stays `null` and the next mount of this
+ *    dialog asks again. That is one request per mount, bounded by the ref
+ *    below and by main's own `checkInFlight` dedupe - not a loop - and asking
+ *    again after a failed check is the behaviour you would want anyway. The
+ *    alternative, tracking "we already tried" in renderer state, would survive
+ *    neither a reload nor a second window.
+ *  - `requested` is a per-mount ref, so a re-render (this dialog re-renders on
+ *    every lease delivery) cannot start a second read while the first is in
+ *    flight.
+ *
+ * The intent stays `"automatic"`. A `"manual"` check would render the pending
+ * state below - which is the only reason to want it - but it also publishes
+ * `checking`, then `up-to-date` or `error`, into the APP-WIDE snapshot every
+ * other update surface reads. A dialog quietly making the header announce
+ * "Traycer is up to date" is worse than a brief link-then-button flip.
+ *
+ * Both rejections are swallowed deliberately: the failure mode is "the manual
+ * link is what the user gets", which is where the component was heading
+ * anyway. An updater error stacked on top of "your app is too old" adds noise
+ * to a state that already has one clear instruction.
+ */
+export function useUpdateCheckOnBlockingMount(
+  bridge: DesktopAppUpdatesBridge | null,
+): void {
+  const requested = useRef(false);
+  useEffect(() => {
+    if (bridge === null || requested.current) return;
+    requested.current = true;
+    let cancelled = false;
+    void bridge
+      .getSnapshot()
+      .then((snapshot) => {
+        if (cancelled) return;
+        if (!shouldCheckForUpdates(snapshot)) return;
+        return bridge.checkForUpdates("automatic").then(() => undefined);
+      })
+      .catch(() => undefined);
+    return () => {
+      cancelled = true;
+    };
+  }, [bridge]);
+}
+
+/**
+ * Whether asking the updater again could change this surface's answer.
+ *
+ * EXACTLY ONE reason to ask: the updater has NEVER been asked - `idle` with no
+ * `lastCheckedAt`. The launch check is gated on `canCheckForUpdates` and fires
+ * once, while this surface is reachable hours later, so a genuinely
+ * never-checked updater is worth one request.
+ *
+ * NOT a reason to ask, and this is the part worth knowing before anyone adds
+ * one: the updater already HOLDING a build that cannot clear the host's floor.
+ * That looks like the obvious second case - the user is on the releases link
+ * while their own updater is seemingly one request away from the right build -
+ * but the request cannot do anything. `checkForUpdatesNow` in
+ * `clients/desktop/src/electron-main/app/updater.ts` returns the current
+ * snapshot BEFORE any feed query when the status is `ready`, `downloading`, or
+ * `available`, for EVERY intent (the `available` arm says so in as many
+ * words). Only a channel change moves that snapshot back to a re-queryable
+ * state, and it runs its own check. So asking here would dispatch an IPC that
+ * provably changes nothing, and a renderer test could only ever assert that
+ * the bridge recorded the call.
+ *
+ * The releases link is therefore the ONLY recovery past a stale cached build,
+ * and the render gate above is what makes sure the user is sent there rather
+ * than offered a build that restarts into the same rejection. Making the
+ * in-app updater recover that case means changing main to discard an
+ * `available` candidate on re-check - a desktop-side product decision, not
+ * something this surface can reach.
+ *
+ * Also not a reason: an updater that already answered "nothing here"
+ * (`idle` / `up-to-date` / `unavailable` / `error` after a check). That is a
+ * real answer, and re-asking it on every mount is the poller the per-mount ref
+ * exists to prevent.
+ */
+function shouldCheckForUpdates(snapshot: DesktopAppUpdateSnapshot): boolean {
+  if (snapshot.installInFlight) return false;
+  return snapshot.status === "idle" && snapshot.lastCheckedAt === null;
+}

--- a/clients/gui-app/src/components/layout/__tests__/host-tray-command-listener.mounted.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/host-tray-command-listener.mounted.test.tsx
@@ -430,6 +430,9 @@ describe("<HostTrayCommandListener /> - mounted in __root", () => {
     const busyDialog = await screen.findByTestId(
       "host-busy-force-defer-dialog",
     );
+    // The tray's busy verdict is the UPDATE commands' (apply / activate);
+    // its restart command confirms through `LocalHostRestartFlow`.
+    expect(busyDialog.dataset.purpose).toBe("update");
     expect(busyDialog.textContent).toContain(
       "Another Traycer process is applying an update.",
     );

--- a/clients/gui-app/src/components/layout/bridges/host-tray-command-listener.tsx
+++ b/clients/gui-app/src/components/layout/bridges/host-tray-command-listener.tsx
@@ -260,6 +260,7 @@ export function HostTrayCommandListener() {
         }}
       />
       <HostBusyForceDeferDialog
+        purpose="restart"
         open={busy !== null}
         message={busy?.message ?? ""}
         isForcing={

--- a/clients/gui-app/src/components/layout/bridges/host-tray-command-listener.tsx
+++ b/clients/gui-app/src/components/layout/bridges/host-tray-command-listener.tsx
@@ -260,7 +260,9 @@ export function HostTrayCommandListener() {
         }}
       />
       <HostBusyForceDeferDialog
-        purpose="restart"
+        // The UPDATE commands' busy verdict (`runApply` / `runActivate`);
+        // the restart command's lives in `LocalHostRestartFlow` above.
+        purpose="update"
         open={busy !== null}
         message={busy?.message ?? ""}
         isForcing={

--- a/clients/gui-app/src/components/layout/bridges/menu-command-listener.tsx
+++ b/clients/gui-app/src/components/layout/bridges/menu-command-listener.tsx
@@ -283,6 +283,7 @@ export function MenuCommandListener() {
         onClose={() => setPendingHostRestart(false)}
       />
       <HostBusyForceDeferDialog
+        purpose="restart"
         open={busy !== null}
         message={busy?.message ?? ""}
         isForcing={

--- a/clients/gui-app/src/components/layout/bridges/menu-command-listener.tsx
+++ b/clients/gui-app/src/components/layout/bridges/menu-command-listener.tsx
@@ -283,7 +283,9 @@ export function MenuCommandListener() {
         onClose={() => setPendingHostRestart(false)}
       />
       <HostBusyForceDeferDialog
-        purpose="restart"
+        // The UPDATE commands' busy verdict (`runApply` / `runActivate`);
+        // the restart command's lives in `LocalHostRestartFlow` above.
+        purpose="update"
         open={busy !== null}
         message={busy?.message ?? ""}
         isForcing={

--- a/clients/gui-app/src/components/settings/SETTINGS.md
+++ b/clients/gui-app/src/components/settings/SETTINGS.md
@@ -2410,7 +2410,9 @@ aria-live="polite"` carrying the equivalent text for
       an indefinitely retained payload. And a record leg that is not live is
       not "gone": the facts as read keep the catalog's comparison baseline
       (an activation debt read from the record still names the installed
-      version, and the region's sentence says "(last known)" rather than
+      version, and the region's sentence says "(last known)" - whenever
+      EITHER leg is not live, since the debt is the record's installed
+      version read against the status read's running version - rather than
       re-offering that version as available), while every offer and the
       projector's park take the live facts only. An open Force confirm
       closes only when a live leg no longer carries its stage (the running version moving re-keys the

--- a/clients/gui-app/src/components/settings/SETTINGS.md
+++ b/clients/gui-app/src/components/settings/SETTINGS.md
@@ -2351,6 +2351,35 @@ aria-live="polite"` carrying the equivalent text for
       attempt record, and it sat directly above the updates region saying
       "v1.3.0-rc.2 is available." about the same host. The landing banner hides
       on the same predicate, so the two cannot drift on where quiet begins.
+    - **The two parks the marker cannot carry come from the RECORDS.** A busy
+      host makes the legacy updater stop, and it stops by WITHDRAWING its
+      marker (a refusal on policy is not a failure), leaving either bytes
+      installed under a host still running the old version, or a newer host
+      staged and waiting. `legacy-update-facts.ts` derives both from
+      `host.getInstallationInfo` beside the same `host.status` read - debt by
+      the CLI's own `readActivationState` rule (runtime-stamp equality when
+      the record has a stamp, else comparable-and-unequal SemVer), staged wait
+      as a stage at a different version than the install while `busy` - and
+      the Overview hands them to the projector as
+      `FleetUpdateWireObservation.legacyFacts`. They project the existing
+      `waiting-to-activate` ("Update installed — restart host to finish") and
+      `waiting-for-work` ("Update will continue when N sessions finish")
+      kinds, AFTER the coarse marker and before `idle`, and like every park
+      they hold no lifecycle gate and earn no fast poll. The card offers
+      **Restart** on the debt FACT rather than on the view kind, so a retained
+      `failed` marker beside real debt keeps its failure text and still shows
+      the way forward, and **Force update…** on a staged wait with a positive
+      count, which confirms through `HostBusyForceDeferDialog` and dispatches
+      `host.update.install {version: staged, force: true}` through the page's
+      one install mutation. Under debt the updates sentence reads "v{installed}
+      is installed — restart host to finish." and the catalog is compared
+      against the INSTALLED version, so Update now stays only for something
+      newer than what is already on disk. Because the facts live in records
+      that change under a mounted page, `host.getInstallationInfo` polls at the
+      `host.status` cadence (10s) and an accepted install invalidates it beside
+      `host.status`. The Overview is the only leg that derives: the landing
+      banner keeps its desktop-status debt arm, and the fleet legs pass
+      `legacyFacts: null`, which the projector reads as "not observed".
   - **Installation** reads `host.getInstallationInfo`. `unmanaged` is a real
     state, not an error - a host run from a checkout has no install record - and
     it says so rather than claiming nothing is installed.

--- a/clients/gui-app/src/components/settings/SETTINGS.md
+++ b/clients/gui-app/src/components/settings/SETTINGS.md
@@ -2389,7 +2389,30 @@ aria-live="polite"` carrying the equivalent text for
       newer than what is already on disk. Because the facts live in records
       that change under a mounted page, `host.getInstallationInfo` polls at the
       `host.status` cadence (10s) and an accepted install invalidates it beside
-      `host.status`. The Overview is the only leg that derives: the landing
+      `host.status`. The record leg is held to the SAME liveness rule the
+      status leg is projected under (`canonicalReadIsLive`: not errored, not
+      paused, not aged past its staleness while not fetching, and the query
+      itself enabled) - not "has not failed" alone, and not a second
+      staleness rule with its own timestamp arithmetic: a read that is not
+      live yields NO facts, so the two record-derived rows and every offer
+      keyed on them (Restart on the debt fact, the installed-version
+      comparison under debt, Force update… and the confirm it opens) are
+      withdrawn until the next live read, and the projector falls through
+      to the status leg. The withdrawal is scoped to the record leg on
+      purpose: expiring the whole observation would demote a live attempt
+      the status leg is reporting (progress bar, lifecycle gate, fast poll)
+      on one failed `host.getInstallationInfo` poll - likeliest exactly
+      during a swap. An unusable scope, by contrast, demotes through the
+      status leg and keeps the record-derived sentence qualified ("Last
+      seen: …"). An in-flight refetch is live (still looking); a request
+      whose response never arrives ends as an error - each attempt bounded
+      by the transport's 30 s response timeout, one query retry - never as
+      an indefinitely retained payload. And a record leg that is not live is
+      not "gone": an open Force confirm closes only when a live leg no
+      longer carries its stage (the running version moving re-keys the
+      query, and the `usable` rule closes the confirm there), and an attempt
+      park's Restart is offered only when a live leg vouches that no stage
+      waits (Restart cannot activate a stage). The Overview is the only leg that derives: the landing
       banner keeps its desktop-status debt arm, and the fleet legs pass
       `legacyFacts: null`, which the projector reads as "not observed".
     - **A CLI requirement has a remedy in the card.** The best target's

--- a/clients/gui-app/src/components/settings/SETTINGS.md
+++ b/clients/gui-app/src/components/settings/SETTINGS.md
@@ -2371,7 +2371,19 @@ aria-live="polite"` carrying the equivalent text for
       the way forward, and **Force update…** on a staged wait with a positive
       count, which confirms through `HostBusyForceDeferDialog` and dispatches
       `host.update.install {version: staged, force: true}` through the page's
-      one install mutation. Under debt the updates sentence reads "v{installed}
+      one install mutation. The offer and the dispatch share ONE predicate
+      (`stagedEntryOfferable`, the refusal `describeForceUpdateRefusal`
+      derives for the staged version): the catalog must still list it, not
+      withdrawn, with an asset this page can resolve (a host whose record
+      carries no platform is not offered Force against a multi-platform
+      entry - a deliberate narrowing; the CLI's own `host update --force`
+      still works there) and no CLI floor. A
+      withdrawn stage is neither offered nor dispatched (the CLI would purge
+      the parked stage and then refuse the version) and carries no floor
+      remedy, since no CLI version installs a yanked release; an asset the
+      catalog has since marked unavailable does NOT refuse, because the
+      bytes are already staged and the CLI installs them without resolving
+      the asset again. Under debt the updates sentence reads "v{installed}
       is installed — restart host to finish." and the catalog is compared
       against the INSTALLED version, so Update now stays only for something
       newer than what is already on disk. Because the facts live in records

--- a/clients/gui-app/src/components/settings/SETTINGS.md
+++ b/clients/gui-app/src/components/settings/SETTINGS.md
@@ -2363,7 +2363,7 @@ aria-live="polite"` carrying the equivalent text for
       the Overview hands them to the projector as
       `FleetUpdateWireObservation.legacyFacts`. They project the existing
       `waiting-to-activate` ("Update installed — restart host to finish") and
-      `waiting-for-work` ("Update will continue when N sessions finish")
+      `waiting-for-work` ("Update waits for N sessions to finish")
       kinds, AFTER the coarse marker and before `idle`, and like every park
       they hold no lifecycle gate and earn no fast poll. The card offers
       **Restart** on the debt FACT rather than on the view kind, so a retained
@@ -2408,8 +2408,12 @@ aria-live="polite"` carrying the equivalent text for
       whose response never arrives ends as an error - each attempt bounded
       by the transport's 30 s response timeout, one query retry - never as
       an indefinitely retained payload. And a record leg that is not live is
-      not "gone": an open Force confirm closes only when a live leg no
-      longer carries its stage (the running version moving re-keys the
+      not "gone": the facts as read keep the catalog's comparison baseline
+      (an activation debt read from the record still names the installed
+      version, and the region's sentence says "(last known)" rather than
+      re-offering that version as available), while every offer and the
+      projector's park take the live facts only. An open Force confirm
+      closes only when a live leg no longer carries its stage (the running version moving re-keys the
       query, and the `usable` rule closes the confirm there), and an attempt
       park's Restart is offered only when a live leg vouches that no stage
       waits (Restart cannot activate a stage). The offers need a live STATUS
@@ -2430,29 +2434,48 @@ aria-live="polite"` carrying the equivalent text for
       `legacyFacts: null`, which the projector reads as "not observed".
     - **A CLI requirement has a remedy in the card.** The best target's
       projected unavailable asset is the executing CLI's verdict, recognized
-      by `HOST_CLIENT_FLOOR_REASON_PREFIX` from the shared release-line helpers.
+      by `HOST_CLIENT_FLOOR_REASON_PREFIX` from the shared
+      `host-version/client-floor-reason` module (the one authored reason a
+      client acts on; it lives in `clients/shared` because both endpoints are
+      OSS clients, and becomes protocol the day a host authors it). A floor
+      that is not a version - the pre-repair projector put the prefix on an
+      unreadable floor too - is not repairable: every route shows
+      installation help, and the recheck below does not run.
       A stored CLI version that already satisfies the requirement does not
       clear it: the host can still be executing an older copy. A retained hash
       on a withdrawn platform build is not evidence of a CLI requirement.
       `describeCliFloorRemedy` owns the sentence and actions together:
 
-      | Installation and update state                                                   | Card action                                                                                                                         |
-      | ------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-      | Local Desktop, update available                                                 | Download update, respecting the Desktop block reason                                                                                |
-      | Local Desktop, downloading                                                      | Disabled download progress                                                                                                          |
-      | Local Desktop, ready                                                            | Restart to update through the shared install flow, or Finish update for manual guidance; block reason and in-flight state still win |
-      | Local Desktop, up to date                                                       | Hint to restart Desktop to finish updating the host tools                                                                           |
-      | Local Desktop, other update state                                               | Checking sentence and one manual bridge check per mounted unknown-state episode                                                     |
-      | Package manager, local or remote                                                | Copy that manager's command from `PACKAGE_MANAGER_UPGRADE_COMMAND`                                                                  |
-      | Manual, remote Desktop, or local Desktop without a bridge; known POSIX platform | Copy the recorded absolute CLI path as one single-quoted shell token plus `cli upgrade`; otherwise copy `traycer cli upgrade`       |
-      | The same sources on Windows or an unknown platform                              | Copy `traycer cli upgrade` and `traycer host restart`; explicitly run outside Traycer on that machine                               |
-      | Installation manifest unreadable                                                | Show installation help, opening the Doctor sheet                                                                                    |
+      | Installation and update state                                                                               | Card action                                                                                                                                                                                                                               |
+      | ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+      | Any source, floor that is not a version                                                                     | Show installation help; no command, no recheck                                                                                                                                                                                            |
+      | Local Desktop, feed's latest (or the installed build, when up to date) below or incomparable with the floor | The Desktop floor fallback, decided before the available, downloading, ready and up-to-date rows below (never for a missing floor): a sentence naming the shortfall plus the copy-command route for the bundled CLI and installation help |
+      | Local Desktop, update available                                                                             | Download update, respecting the Desktop block reason                                                                                                                                                                                      |
+      | Local Desktop, downloading                                                                                  | Disabled download progress                                                                                                                                                                                                                |
+      | Local Desktop, ready                                                                                        | Restart to update through the shared install flow, or Finish update for manual guidance; block reason and in-flight state still win                                                                                                       |
+      | Local Desktop, up to date                                                                                   | Hint to restart Desktop to finish updating the host tools                                                                                                                                                                                 |
+      | Local Desktop, check failed or updater unavailable                                                          | The bridge's error message (or a fallback sentence), Check again, and installation help                                                                                                                                                   |
+      | Local Desktop, idle or checking                                                                             | Checking: the checking sentence. Idle: an invitation to check, one guarded automatic bridge check per mount (the authoritative snapshot, only an updater never asked, `automatic` intent) and a Check for updates button                  |
+      | npm, local or remote                                                                                        | Copy `npm install -g @traycerai/cli@<required version>` - the exact floor when the payload names one, RCs included; the table's stable `@latest` only when it names none                                                                  |
+      | Homebrew, winget, Scoop, apt, rpm; stable floor                                                             | Copy that manager's command from `PACKAGE_MANAGER_UPGRADE_COMMAND`                                                                                                                                                                        |
+      | Homebrew, winget, Scoop, apt, rpm; prerelease floor                                                         | Show installation help: those feeds carry stable releases (Homebrew's formula takes a prerelease only by manual dispatch), so the rolling command would report nothing newer                                                              |
+      | Manual, remote Desktop, or local Desktop without a bridge; known POSIX platform                             | Copy the recorded absolute CLI path as one single-quoted shell token plus `cli upgrade`; otherwise copy `traycer cli upgrade`                                                                                                             |
+      | The same sources on Windows with a recorded absolute path                                                   | Copy `& '<path>' cli upgrade` and `& '<path>' host restart` for PowerShell; explicitly run outside Traycer on that machine                                                                                                                |
+      | The same sources on Windows without a usable path, or an unknown platform                                   | Copy `traycer cli upgrade` and `traycer host restart`; explicitly run outside Traycer on that machine                                                                                                                                     |
+      | Installation manifest unreadable                                                                            | Show installation help, opening the Doctor sheet                                                                                                                                                                                          |
 
       The copy rows explain an older executing copy when the stored version
       already clears the requirement. No row opens an in-app terminal: the
       1.2.0 hosts needing this remedy cannot run a supplied command on ordinary
       terminal creation. Check now stays; the remedy replaces Update now until
-      the host accepts the candidate. Advanced rows retain their reasons.
+      the host accepts the candidate, and its copy says the page rechecks on
+      its own rather than asking for a click (the recheck below is what
+      restores Update now). Two pinned npm commands can be on screen in one
+      Settings dialog and disagree on purpose: the Desktop sidecar's hint
+      (`host-settings-package-manager-upgrade-hint.tsx`) pins the version
+      Desktop bundles, the answer to "your npm CLI is older than Desktop's";
+      this remedy pins the host's required floor, the answer to "this host
+      refuses the CLI it has". Advanced rows retain their reasons.
       Sentence precedence preserves the record-derived parks: **failure →
       activation debt → CLI remedy → checking → unreachable → no manifest →
       stranded on its release line / up to date → unavailable / available**.
@@ -2470,14 +2493,34 @@ aria-live="polite"` carrying the equivalent text for
       kept polling on floored rows of an `installed-rc` catalog that no
       remedy named, a release on another line included. The recheck stops
       with the remedy: a retired region (externally managed, unsupported
-      install) shows a notice in its place and is not re-asked. The table
-      keeps the `cli-unavailable` lane and the two error lanes for this
-      method, nothing data-driven beyond that. The existing 10-second
-      installation-info poll refreshes the stored CLI facts beside it.
-      A floored staged version, or one absent from the actionable manifest,
-      offers neither Force update nor Force restart: restarting cannot activate
-      a stage. An open Force confirmation rechecks its exact version at click
-      time, settles synchronously on refusal, and shows the reason inline.
+      install) shows a notice in its place and is not re-asked; so does a
+      floor that is not a version (`repairable` false - no upgrade can clear
+      it; a help-only remedy over a READABLE floor, such as a prerelease on
+      a manager that publishes none, keeps rechecking, because an install
+      made another way is what it waits for), and the page's own gate
+      (`enabled`) holds it as it holds the region. It is a flat 30 s, hotter
+      than the 5 s → 60 s lane it replaced but bounded by the remedy being on
+      screen; each tick refetches, so Check now briefly reads busy on its
+      own. The table keeps the `cli-unavailable` lane and the two error lanes
+      for this method, nothing data-driven beyond that. The existing
+      10-second installation-info poll refreshes the stored CLI facts beside
+      it. A floored staged version, or one absent from the actionable
+      manifest, offers neither Force update nor Force restart: restarting
+      cannot activate a stage. The Force gate reads the catalog ENTRY's own
+      floor too, apart from the asset's authored reason - staged bytes
+      install whatever the asset's availability says - so an entry whose
+      floor is not a version is refused even when the projector never
+      prefixed the asset. A readable floor stays the asset's verdict: the
+      stored CLI manifest is no substitute for the executing copy's own
+      comparison in either direction. An open
+      Force confirmation rechecks its exact version at click time, settles
+      synchronously on refusal, and shows the reason inline. The card's
+      Restart, Force update… and Force restart sit behind the same
+      capability and page-wide gates as the header's Restart and the region
+      (`restartDegrade`, `updates.degrade`, `anyPending`) - withheld rather
+      than disabled, since the card reports the park and the header's menu
+      item carries the reason - and an open confirm closes when its method
+      is withdrawn or its region retires.
   - **Installation** reads `host.getInstallationInfo`. `unmanaged` is a real
     state, not an error - a host run from a checkout has no install record - and
     it says so rather than claiming nothing is installed.

--- a/clients/gui-app/src/components/settings/SETTINGS.md
+++ b/clients/gui-app/src/components/settings/SETTINGS.md
@@ -2380,6 +2380,47 @@ aria-live="polite"` carrying the equivalent text for
       `host.status`. The Overview is the only leg that derives: the landing
       banner keeps its desktop-status debt arm, and the fleet legs pass
       `legacyFacts: null`, which the projector reads as "not observed".
+    - **A CLI requirement has a remedy in the card.** The best target's
+      projected unavailable asset is the executing CLI's verdict, recognized
+      by `HOST_CLIENT_FLOOR_REASON_PREFIX` from the shared release-line helpers.
+      A stored CLI version that already satisfies the requirement does not
+      clear it: the host can still be executing an older copy. A retained hash
+      on a withdrawn platform build is not evidence of a CLI requirement.
+      `describeCliFloorRemedy` owns the sentence and actions together:
+
+      | Installation and update state                                                   | Card action                                                                                                                         |
+      | ------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+      | Local Desktop, update available                                                 | Download update, respecting the Desktop block reason                                                                                |
+      | Local Desktop, downloading                                                      | Disabled download progress                                                                                                          |
+      | Local Desktop, ready                                                            | Restart to update through the shared install flow, or Finish update for manual guidance; block reason and in-flight state still win |
+      | Local Desktop, up to date                                                       | Hint to restart Desktop to finish updating the host tools                                                                           |
+      | Local Desktop, other update state                                               | Checking sentence and one manual bridge check per mounted unknown-state episode                                                     |
+      | Package manager, local or remote                                                | Copy that manager's command from `PACKAGE_MANAGER_UPGRADE_COMMAND`                                                                  |
+      | Manual, remote Desktop, or local Desktop without a bridge; known POSIX platform | Copy the recorded absolute CLI path as one single-quoted shell token plus `cli upgrade`; otherwise copy `traycer cli upgrade`       |
+      | The same sources on Windows or an unknown platform                              | Copy `traycer cli upgrade` and `traycer host restart`; explicitly run outside Traycer on that machine                               |
+      | Installation manifest unreadable                                                | Show installation help, opening the Doctor sheet                                                                                    |
+
+      The copy rows explain an older executing copy when the stored version
+      already clears the requirement. No row opens an in-app terminal: the
+      1.2.0 hosts needing this remedy cannot run a supplied command on ordinary
+      terminal creation. Check now stays; the remedy replaces Update now until
+      the host accepts the candidate. Advanced rows retain their reasons.
+      Sentence precedence preserves the record-derived parks: **failure →
+      activation debt → CLI remedy → checking → unreachable → no manifest →
+      stranded on its release line / up to date → unavailable / available**.
+      A failed catalog read drops the remedy along with the actionable catalog.
+
+    - **Repair rechecks while the Overview is open.** A table-owned condition
+      lane polls `host.update.check` every 30 seconds while the latest
+      non-yanked candidate carries the CLI refusal. For `installed-rc`, every
+      non-yanked entry is considered because the response has no installed
+      version with which to reconstruct the same-line walk. The first clear
+      response stops the lane and restores Update now. The existing 10-second
+      installation-info poll refreshes the stored CLI facts beside it.
+      A floored staged version, or one absent from the actionable manifest,
+      offers neither Force update nor Force restart: restarting cannot activate
+      a stage. An open Force confirmation rechecks its exact version at click
+      time, settles synchronously on refusal, and shows the reason inline.
   - **Installation** reads `host.getInstallationInfo`. `unmanaged` is a real
     state, not an error - a host run from a checkout has no install record - and
     it says so rather than claiming nothing is installed.

--- a/clients/gui-app/src/components/settings/SETTINGS.md
+++ b/clients/gui-app/src/components/settings/SETTINGS.md
@@ -2412,7 +2412,20 @@ aria-live="polite"` carrying the equivalent text for
       longer carries its stage (the running version moving re-keys the
       query, and the `usable` rule closes the confirm there), and an attempt
       park's Restart is offered only when a live leg vouches that no stage
-      waits (Restart cannot activate a stage). The Overview is the only leg that derives: the landing
+      waits (Restart cannot activate a stage). The offers need a live STATUS
+      read as well (`statusLive`: the same `canonicalReadIsLive` over the
+      status read's health, `usable` included). The retained status payload
+      stays in the facts so a park renders qualified ("Last seen: …"), but
+      Restart on the debt fact, Force update… and an attempt park's Force
+      restart are withdrawn while the status read has failed or aged - a
+      Restart pressed off an old `hostVersion` would restart a host that may
+      already have activated; the evidence stays, the dispatch does not. An
+      open restart confirm is closed by the `!usable` rule only when it was
+      armed for the cooperative `host.restart`; one armed for the bridge
+      respawn (`restartViaForceFallback`, captured at open) survives the
+      scope going unusable - the respawn needs no client and is the recovery
+      an unreachable local host needs most - and closes on its own
+      settlement or when this page's host stops being this machine's. The Overview is the only leg that derives: the landing
       banner keeps its desktop-status debt arm, and the fleet legs pass
       `legacyFacts: null`, which the projector reads as "not observed".
     - **A CLI requirement has a remedy in the card.** The best target's
@@ -2445,12 +2458,21 @@ aria-live="polite"` carrying the equivalent text for
       stranded on its release line / up to date → unavailable / available**.
       A failed catalog read drops the remedy along with the actionable catalog.
 
-    - **Repair rechecks while the Overview is open.** A table-owned condition
-      lane polls `host.update.check` every 30 seconds while the latest
-      non-yanked candidate carries the CLI refusal. For `installed-rc`, every
-      non-yanked entry is considered because the response has no installed
-      version with which to reconstruct the same-line walk. The first clear
-      response stops the lane and restores Update now. The existing 10-second
+    - **Repair rechecks while the Overview is open.** The Overview re-asks
+      `host.update.check` every 30 seconds while it renders a CLI-floor
+      remedy (`useHostOverviewUpdates`, invalidating the shared key the way
+      the active-update accelerator does), and the first answer that clears
+      the floor ends the recheck and restores Update now. Keyed on the
+      rendered remedy, not on the response: which floored row the remedy
+      names is the summary walk's answer (the installed line's matching
+      stable and later RCs, strictly newer than what runs), and the response
+      carries no installed version - a table lane over the response alone
+      kept polling on floored rows of an `installed-rc` catalog that no
+      remedy named, a release on another line included. The recheck stops
+      with the remedy: a retired region (externally managed, unsupported
+      install) shows a notice in its place and is not re-asked. The table
+      keeps the `cli-unavailable` lane and the two error lanes for this
+      method, nothing data-driven beyond that. The existing 10-second
       installation-info poll refreshes the stored CLI facts beside it.
       A floored staged version, or one absent from the actionable manifest,
       offers neither Force update nor Force restart: restarting cannot activate

--- a/clients/gui-app/src/components/settings/host-scope/add-host-dialog.tsx
+++ b/clients/gui-app/src/components/settings/host-scope/add-host-dialog.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/ui/dialog";
 import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { CLI_NPM_PACKAGE_NAME } from "@traycer-clients/shared/cli-install/package-manager-upgrade-command";
 import {
   HostGlyph,
   HostPresenceDot,
@@ -44,7 +45,7 @@ import { toast } from "sonner";
 // This is the terminal path only. A machine someone installs the desktop app on
 // registers its own host at sign-in and never needs these instructions — and
 // the download page it would point at is on THAT screen, not this one.
-const CLI_NPM_COMMAND = "npm install -g @traycerai/cli";
+const CLI_NPM_COMMAND = `npm install -g ${CLI_NPM_PACKAGE_NAME}`;
 const CLI_HOMEBREW_COMMAND = "brew install traycerai/traycer/traycer";
 const LOGIN_COMMAND = "traycer login";
 const HOST_ENSURE_COMMAND = "traycer host ensure";

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-overview-cli-floor-remedy-card.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-overview-cli-floor-remedy-card.test.tsx
@@ -1,5 +1,6 @@
 import type { ReactElement } from "react";
 import {
+  act,
   cleanup,
   fireEvent,
   render,
@@ -7,7 +8,15 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type Mock,
+} from "vitest";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { HostOverviewUpdatesRegion } from "@/components/settings/panels/host-overview-updates";
 import {
@@ -53,8 +62,15 @@ class FakeDesktopBridge implements DesktopAppUpdatesBridge {
     Promise.resolve(SNAPSHOT),
   );
 
-  getSnapshot(): Promise<DesktopAppUpdateSnapshot> {
-    return Promise.resolve(SNAPSHOT);
+  // What MAIN holds, as distinct from what the rendered remedy was derived
+  // from: the mount check reads this (`useUpdateCheckOnBlockingMount`), never
+  // the remedy's snapshot, which on the first commit is the store's
+  // placeholder. A spy, so a negative "did not check" can first prove the
+  // hook consulted the bridge at all.
+  readonly getSnapshot: Mock<() => Promise<DesktopAppUpdateSnapshot>>;
+
+  constructor(snapshot: DesktopAppUpdateSnapshot) {
+    this.getSnapshot = vi.fn(() => Promise.resolve(snapshot));
   }
 
   setAllowPrerelease(
@@ -201,7 +217,7 @@ describe("HostOverviewUpdatesRegion CLI floor remedy", () => {
   });
 
   it("downloads an available Desktop update and never installs directly", () => {
-    const bridge = new FakeDesktopBridge();
+    const bridge = new FakeDesktopBridge(SNAPSHOT);
     const remedy = describeCliFloorRemedy({
       isLocalMachine: true,
       platform: "darwin-arm64",
@@ -232,7 +248,7 @@ describe("HostOverviewUpdatesRegion CLI floor remedy", () => {
       },
       { ...SNAPSHOT, status: "ready" as const, installInFlight: true },
     ]) {
-      const bridge = new FakeDesktopBridge();
+      const bridge = new FakeDesktopBridge(SNAPSHOT);
       const remedy = describeCliFloorRemedy({
         isLocalMachine: true,
         platform: "darwin-arm64",
@@ -258,7 +274,7 @@ describe("HostOverviewUpdatesRegion CLI floor remedy", () => {
   });
 
   it("opens the manual Desktop guidance dialog for a ready update", () => {
-    const bridge = new FakeDesktopBridge();
+    const bridge = new FakeDesktopBridge(SNAPSHOT);
     const remedy = describeCliFloorRemedy({
       isLocalMachine: true,
       platform: "linux-x64",
@@ -289,7 +305,7 @@ describe("HostOverviewUpdatesRegion CLI floor remedy", () => {
   });
 
   it("routes a ready Desktop update through the shared install request door", () => {
-    const bridge = new FakeDesktopBridge();
+    const bridge = new FakeDesktopBridge(SNAPSHOT);
     const remedy = describeCliFloorRemedy({
       isLocalMachine: true,
       platform: "darwin-arm64",
@@ -325,7 +341,7 @@ describe("HostOverviewUpdatesRegion CLI floor remedy", () => {
       },
     ] as const;
     for (const failure of failures) {
-      const bridge = new FakeDesktopBridge();
+      const bridge = new FakeDesktopBridge(SNAPSHOT);
       const remedy = describeCliFloorRemedy({
         isLocalMachine: true,
         platform: "darwin-arm64",
@@ -385,8 +401,16 @@ describe("HostOverviewUpdatesRegion CLI floor remedy", () => {
     }
   });
 
-  it("checks an unknown Desktop state once and does not create an effect retry loop", async () => {
-    const bridge = new FakeDesktopBridge();
+  it("checks a never-asked updater once, with automatic intent, and does not create an effect retry loop", async () => {
+    // Main has never been asked: `idle` with no `lastCheckedAt`. That is
+    // the ONE reason the mount check fires (`shouldCheckForUpdates`).
+    const bridge = new FakeDesktopBridge({
+      ...SNAPSHOT,
+      status: "idle",
+      latestVersion: null,
+      lastCheckedAt: null,
+      lastCheckIntent: null,
+    });
     const remedy = describeCliFloorRemedy({
       isLocalMachine: true,
       platform: "darwin-arm64",
@@ -402,6 +426,12 @@ describe("HostOverviewUpdatesRegion CLI floor remedy", () => {
     await waitFor(() =>
       expect(bridge.checkForUpdates).toHaveBeenCalledTimes(1),
     );
+    // AUTOMATIC, not manual: a manual check publishes "Checking…" then
+    // "up to date" into the app-wide snapshot and pops toasts from a
+    // settings pane; the mount check is the app's own intent, and only
+    // the button below is the user's. Falsification: pass "manual" from
+    // the hook and this pin goes RED.
+    expect(bridge.checkForUpdates).toHaveBeenCalledWith("automatic");
     rendered.rerender(
       regionElement(
         describeCliFloorRemedy({
@@ -420,9 +450,63 @@ describe("HostOverviewUpdatesRegion CLI floor remedy", () => {
     await waitFor(() =>
       expect(bridge.checkForUpdates).toHaveBeenCalledTimes(1),
     );
-    // Removing ONLY `if (checkOnMount)` while retaining `[bridge, checkOnMount]`
-    // would call once on idle mount and again on the idle-to-checking
-    // transition; this negative call-count pin must turn RED under D04.
+    // Back to idle: a failed automatic check publishes nothing, so the
+    // remedy returns to `idle` with `lastCheckedAt` still null and the
+    // bridge handed to the hook again (the `checking` arm hands it null,
+    // so that transition alone proves nothing about the ref). The
+    // once-per-mount ref is what stops this from being a poller.
+    // Falsification: drop `requested` from `useUpdateCheckOnBlockingMount`
+    // and this commit reads the never-checked snapshot and dispatches a
+    // second automatic check - the count below goes to 2.
+    rendered.rerender(regionElement(remedy, bridge));
+    await waitFor(() => expect(bridge.getSnapshot).toHaveBeenCalledTimes(1));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(bridge.checkForUpdates).toHaveBeenCalledTimes(1);
+  });
+
+  it("decides from the bridge's own snapshot: an idle REMEDY over an updater main has already checked fires nothing on mount, and the button stays the manual route", async () => {
+    // The rendered remedy is `idle` - exactly what the store's placeholder
+    // reports on the first commit whatever main holds - while main's own
+    // snapshot records a completed check. Deciding from the rendered
+    // snapshot fired a check on every mount of this remedy; the guarded hook
+    // reads the bridge instead. Falsification: decide from `checkOnMount`
+    // alone (skip `bridge.getSnapshot()`) and the zero below goes RED.
+    const bridge = new FakeDesktopBridge({
+      ...SNAPSHOT,
+      status: "idle",
+      lastCheckedAt: "2026-09-06T00:00:00Z",
+      lastCheckIntent: "automatic",
+    });
+    const remedy = describeCliFloorRemedy({
+      isLocalMachine: true,
+      platform: "darwin-arm64",
+      cliSource: "desktop",
+      cliBinaryPath: null,
+      cliVersion: "1.2.0",
+      requiredCliVersion: "1.3.0",
+      desktopUpdate: { ...SNAPSHOT, status: "idle", lastCheckedAt: null },
+      hostName: "build-host",
+    });
+    renderRegion(remedy, bridge);
+
+    // The idle arm keeps a labelled button (the mount check publishes
+    // nothing on a failed check, so `idle` can be what remains AFTER it).
+    const button = await screen.findByRole("button", {
+      name: "Check for updates",
+    });
+    // The negative is observed AFTER the hook consulted the bridge and its
+    // read resolved, so a zero here is the hook's decision, not a race
+    // with the effect.
+    await waitFor(() => expect(bridge.getSnapshot).toHaveBeenCalled());
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(bridge.checkForUpdates).not.toHaveBeenCalled();
+
+    fireEvent.click(button);
+    expect(bridge.checkForUpdates).toHaveBeenCalledTimes(1);
     expect(bridge.checkForUpdates).toHaveBeenCalledWith("manual");
   });
 });

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-overview-cli-floor-remedy-card.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-overview-cli-floor-remedy-card.test.tsx
@@ -1,0 +1,428 @@
+import type { ReactElement } from "react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  type RenderResult,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { HostOverviewUpdatesRegion } from "@/components/settings/panels/host-overview-updates";
+import {
+  describeCliFloorRemedy,
+  type CliFloorRemedy,
+} from "@/components/settings/panels/host-overview-cli-floor-remedy";
+import type { HostOverviewUpdatesSummary } from "@/components/settings/panels/host-overview-updates-state";
+import type {
+  DesktopAppUpdateChannelChange,
+  DesktopAppUpdateCheckIntent,
+  DesktopAppUpdateSnapshot,
+  DesktopAppUpdatesBridge,
+  DesktopCompatRecoveryPlan,
+} from "@/lib/windows/types";
+import { useDesktopDialogStore } from "@/stores/dialogs/desktop-dialog-store";
+
+const requestInstallMock = vi.hoisted(() => vi.fn(() => Promise.resolve()));
+const clipboardWriteText = vi.fn(() => Promise.resolve());
+vi.mock("@/lib/app-update/request-app-update-install", () => ({
+  requestAppUpdateInstall: requestInstallMock,
+}));
+
+const SNAPSHOT: DesktopAppUpdateSnapshot = {
+  sequence: 1,
+  status: "available",
+  currentVersion: "1.2.0",
+  allowPrerelease: false,
+  latestVersion: "1.3.0",
+  latestCompatibilityEpoch: 1,
+  downloadProgress: null,
+  installBlockedReason: null,
+  installGuidance: null,
+  installInFlight: false,
+  errorMessage: null,
+  lastCheckedAt: "2026-09-06T00:00:00Z",
+  lastCheckIntent: "automatic",
+};
+
+class FakeDesktopBridge implements DesktopAppUpdatesBridge {
+  readonly downloadUpdate = vi.fn(() => Promise.resolve(SNAPSHOT));
+  readonly installUpdate = vi.fn(() => Promise.resolve(SNAPSHOT));
+  readonly checkForUpdates = vi.fn((_intent: DesktopAppUpdateCheckIntent) =>
+    Promise.resolve(SNAPSHOT),
+  );
+
+  getSnapshot(): Promise<DesktopAppUpdateSnapshot> {
+    return Promise.resolve(SNAPSHOT);
+  }
+
+  setAllowPrerelease(
+    _allowPrerelease: boolean,
+  ): Promise<DesktopAppUpdateChannelChange> {
+    return Promise.resolve({ outcome: "unchanged", snapshot: SNAPSHOT });
+  }
+
+  resolveCompatRecovery(_request: {
+    readonly minimumEpoch: number;
+    readonly hostAllowsRcRecovery: boolean;
+  }): Promise<DesktopCompatRecoveryPlan> {
+    return Promise.resolve({
+      route: "manual",
+      rcCandidateVersion: null,
+      stagedVersion: null,
+    });
+  }
+
+  onChange(_handler: (snapshot: DesktopAppUpdateSnapshot) => void): {
+    dispose(): void;
+  } {
+    return { dispose: () => undefined };
+  }
+}
+
+function summary(remedy: CliFloorRemedy): HostOverviewUpdatesSummary {
+  return {
+    hostName: "build-host",
+    description: remedy.sentence,
+    failureDescription: null,
+    remedy,
+    checking: false,
+    updatableVersion: null,
+    installing: false,
+    busy: false,
+    onCheck: vi.fn(),
+    onUpdateLatest: vi.fn(),
+  };
+}
+
+function regionElement(
+  remedy: CliFloorRemedy,
+  bridge: DesktopAppUpdatesBridge | null,
+): ReactElement {
+  return (
+    <TooltipProvider>
+      <HostOverviewUpdatesRegion
+        summary={summary(remedy)}
+        degrade={null}
+        desktopBridge={bridge}
+        onInstallationHelp={vi.fn()}
+      />
+    </TooltipProvider>
+  );
+}
+
+function renderRegion(
+  remedy: CliFloorRemedy,
+  bridge: DesktopAppUpdatesBridge | null,
+): RenderResult {
+  return render(regionElement(remedy, bridge));
+}
+
+function manualRemedy(binaryPath: string): CliFloorRemedy {
+  return describeCliFloorRemedy({
+    isLocalMachine: false,
+    platform: "darwin-arm64",
+    cliSource: "manual",
+    cliBinaryPath: binaryPath,
+    cliVersion: "1.2.0",
+    requiredCliVersion: "1.3.0",
+    desktopUpdate: null,
+    hostName: "build-host",
+  });
+}
+
+afterEach(() => {
+  cleanup();
+  requestInstallMock.mockClear();
+  clipboardWriteText.mockClear();
+  useDesktopDialogStore.getState().close();
+});
+
+describe("HostOverviewUpdatesRegion CLI floor remedy", () => {
+  beforeEach(() => {
+    clipboardWriteText.mockClear();
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: clipboardWriteText },
+    });
+  });
+
+  it("renders the sentence in the status span and copies the recorded path command", () => {
+    const remedy = manualRemedy("/home/u/.local/bin/traycer");
+    renderRegion(remedy, null);
+
+    expect(screen.getByRole("status").textContent).toBe(remedy.sentence);
+    fireEvent.click(screen.getByRole("button", { name: "Copy command" }));
+    expect(clipboardWriteText).toHaveBeenCalledWith(
+      "'/home/u/.local/bin/traycer' cli upgrade",
+    );
+  });
+
+  it("copies the bare command when the recorded path is unavailable", () => {
+    const remedy = manualRemedy("");
+    renderRegion(remedy, null);
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy command" }));
+    expect(clipboardWriteText).toHaveBeenCalledWith("traycer cli upgrade");
+  });
+
+  it("copies Windows Desktop fallback commands and renders PowerShell guidance", () => {
+    const binaryPath =
+      "C:\\Users\\x\\AppData\\Local\\Traycer\\cli\\traycer.exe";
+    const remedy = describeCliFloorRemedy({
+      isLocalMachine: true,
+      platform: "win32-x64",
+      cliSource: "desktop",
+      cliBinaryPath: binaryPath,
+      cliVersion: "1.2.0",
+      requiredCliVersion: "1.3.0",
+      desktopUpdate: {
+        ...SNAPSHOT,
+        latestVersion: "1.2.0",
+      },
+      hostName: "build-host",
+    });
+    renderRegion(remedy, null);
+
+    expect(screen.getByRole("status").textContent).toBe(remedy.sentence);
+    // E09: removing the PowerShell/outside wording would make this visible
+    // shell-guidance pin RED even if the copy payload remained unchanged.
+    expect(screen.getByRole("status").textContent).toContain(
+      "PowerShell window outside Traycer on that machine",
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Copy commands" }));
+    // E07: withholding Windows Desktop fallback commands would leave this
+    // exact clipboard payload unavailable; this positive copy pin must RED.
+    expect(clipboardWriteText).toHaveBeenCalledWith(
+      "& 'C:\\Users\\x\\AppData\\Local\\Traycer\\cli\\traycer.exe' cli upgrade\n& 'C:\\Users\\x\\AppData\\Local\\Traycer\\cli\\traycer.exe' host restart",
+    );
+    expect(requestInstallMock).not.toHaveBeenCalled();
+  });
+
+  it("downloads an available Desktop update and never installs directly", () => {
+    const bridge = new FakeDesktopBridge();
+    const remedy = describeCliFloorRemedy({
+      isLocalMachine: true,
+      platform: "darwin-arm64",
+      cliSource: "desktop",
+      cliBinaryPath: null,
+      cliVersion: "1.2.0",
+      requiredCliVersion: "1.3.0",
+      desktopUpdate: SNAPSHOT,
+      hostName: "build-host",
+    });
+    renderRegion(remedy, bridge);
+
+    fireEvent.click(screen.getByRole("button", { name: "Download update" }));
+    // Keep checking the forbidden routes when a mutation also misses download.
+    expect.soft(bridge.downloadUpdate).toHaveBeenCalledTimes(1);
+    expect(requestInstallMock).not.toHaveBeenCalled();
+    // Removing the available-state action gate would install from this row;
+    // this negative spy must turn RED under that concrete status-ablation.
+    expect(bridge.installUpdate).not.toHaveBeenCalled();
+  });
+
+  it("honors blocked and in-flight Desktop states as disabled, with no install route", () => {
+    for (const desktopUpdate of [
+      {
+        ...SNAPSHOT,
+        status: "ready" as const,
+        installBlockedReason: "Not in Applications",
+      },
+      { ...SNAPSHOT, status: "ready" as const, installInFlight: true },
+    ]) {
+      const bridge = new FakeDesktopBridge();
+      const remedy = describeCliFloorRemedy({
+        isLocalMachine: true,
+        platform: "darwin-arm64",
+        cliSource: "desktop",
+        cliBinaryPath: null,
+        cliVersion: "1.2.0",
+        requiredCliVersion: "1.3.0",
+        desktopUpdate,
+        hostName: "build-host",
+      });
+      renderRegion(remedy, bridge);
+      const button = screen.getByRole("button", { name: "Restart to update" });
+      // A broken disabled state must also reach the no-install assertions.
+      expect.soft(button.hasAttribute("disabled")).toBe(true);
+      fireEvent.click(button);
+      // Removing the blocked/in-flight disabled predicate would let this
+      // control reach an install route; these negative no-install pins must
+      // turn RED under that concrete state-gating ablation.
+      expect(requestInstallMock).not.toHaveBeenCalled();
+      expect(bridge.installUpdate).not.toHaveBeenCalled();
+      cleanup();
+    }
+  });
+
+  it("opens the manual Desktop guidance dialog for a ready update", () => {
+    const bridge = new FakeDesktopBridge();
+    const remedy = describeCliFloorRemedy({
+      isLocalMachine: true,
+      platform: "linux-x64",
+      cliSource: "desktop",
+      cliBinaryPath: null,
+      cliVersion: "1.2.0",
+      requiredCliVersion: "1.3.0",
+      desktopUpdate: {
+        ...SNAPSHOT,
+        status: "ready",
+        installGuidance: {
+          summary: "Use the package manager",
+          steps: ["Install the downloaded package"],
+          command: "sudo dpkg -i traycer.deb",
+          releaseUrl: "https://example.invalid/release",
+        },
+      },
+      hostName: "build-host",
+    });
+    renderRegion(remedy, bridge);
+
+    fireEvent.click(screen.getByRole("button", { name: "Finish update" }));
+    // A missing dialog must not hide a forbidden install in the same click.
+    expect
+      .soft(useDesktopDialogStore.getState().activeDialog)
+      .toBe("install-guidance");
+    expect(requestInstallMock).not.toHaveBeenCalled();
+  });
+
+  it("routes a ready Desktop update through the shared install request door", () => {
+    const bridge = new FakeDesktopBridge();
+    const remedy = describeCliFloorRemedy({
+      isLocalMachine: true,
+      platform: "darwin-arm64",
+      cliSource: "desktop",
+      cliBinaryPath: null,
+      cliVersion: "1.2.0",
+      requiredCliVersion: "1.3.0",
+      desktopUpdate: { ...SNAPSHOT, status: "ready" },
+      hostName: "build-host",
+    });
+    renderRegion(remedy, bridge);
+
+    fireEvent.click(screen.getByRole("button", { name: "Restart to update" }));
+    // Retain the direct-install negative when the shared call is also missing.
+    expect.soft(requestInstallMock).toHaveBeenCalledWith(bridge);
+    // Removing the shared request-door call and invoking bridge.installUpdate
+    // in the component would bypass cross-window protection; this negative
+    // spy must turn RED under that concrete routing ablation.
+    expect(bridge.installUpdate).not.toHaveBeenCalled();
+  });
+
+  it("shows manual retry and help for Desktop failures without automatic checks", async () => {
+    const failures = [
+      {
+        status: "error" as const,
+        errorMessage: "Updater failed",
+        sentence: "Updater failed",
+      },
+      {
+        status: "unavailable" as const,
+        errorMessage: null,
+        sentence: "Traycer Desktop couldn't check for updates.",
+      },
+    ] as const;
+    for (const failure of failures) {
+      const bridge = new FakeDesktopBridge();
+      const remedy = describeCliFloorRemedy({
+        isLocalMachine: true,
+        platform: "darwin-arm64",
+        cliSource: "desktop",
+        cliBinaryPath: null,
+        cliVersion: "1.2.0",
+        requiredCliVersion: "1.3.0",
+        desktopUpdate: {
+          ...SNAPSHOT,
+          status: failure.status,
+          errorMessage: failure.errorMessage,
+        },
+        hostName: "build-host",
+      });
+      const rendered = renderRegion(remedy, bridge);
+
+      expect(screen.getByRole("status").textContent).toBe(failure.sentence);
+      expect(screen.getByRole("button", { name: "Check again" })).toBeTruthy();
+      expect(
+        screen.getByRole("button", { name: "Show installation help" }),
+      ).toBeTruthy();
+      await waitFor(() =>
+        expect(bridge.checkForUpdates).not.toHaveBeenCalled(),
+      );
+      // D02's automatic retry mapping or D04's removal of only
+      // `if (checkOnMount)` would dispatch on this failure mount. Retaining
+      // `[bridge, checkOnMount]` isolates the mount guard; this count must
+      // remain zero through rerenders until the user clicks.
+      rendered.rerender(
+        regionElement(
+          describeCliFloorRemedy({
+            isLocalMachine: true,
+            platform: "darwin-arm64",
+            cliSource: "desktop",
+            cliBinaryPath: null,
+            cliVersion: "1.2.0",
+            requiredCliVersion: "1.3.0",
+            desktopUpdate: { ...SNAPSHOT, status: "checking" },
+            hostName: "build-host",
+          }),
+          bridge,
+        ),
+      );
+      rendered.rerender(regionElement(remedy, bridge));
+      await waitFor(() =>
+        expect(bridge.checkForUpdates).not.toHaveBeenCalled(),
+      );
+
+      // Removing the retry button's manual dispatch would keep this genuine
+      // spy at zero; these exact per-click counts must turn RED under D03.
+      fireEvent.click(screen.getByRole("button", { name: "Check again" }));
+      expect(bridge.checkForUpdates).toHaveBeenCalledTimes(1);
+      expect(bridge.checkForUpdates).toHaveBeenCalledWith("manual");
+      fireEvent.click(screen.getByRole("button", { name: "Check again" }));
+      expect(bridge.checkForUpdates).toHaveBeenCalledTimes(2);
+      cleanup();
+    }
+  });
+
+  it("checks an unknown Desktop state once and does not create an effect retry loop", async () => {
+    const bridge = new FakeDesktopBridge();
+    const remedy = describeCliFloorRemedy({
+      isLocalMachine: true,
+      platform: "darwin-arm64",
+      cliSource: "desktop",
+      cliBinaryPath: null,
+      cliVersion: "1.2.0",
+      requiredCliVersion: "1.3.0",
+      desktopUpdate: { ...SNAPSHOT, status: "idle" },
+      hostName: "build-host",
+    });
+    const rendered = renderRegion(remedy, bridge);
+
+    await waitFor(() =>
+      expect(bridge.checkForUpdates).toHaveBeenCalledTimes(1),
+    );
+    rendered.rerender(
+      regionElement(
+        describeCliFloorRemedy({
+          isLocalMachine: true,
+          platform: "darwin-arm64",
+          cliSource: "desktop",
+          cliBinaryPath: null,
+          cliVersion: "1.2.0",
+          requiredCliVersion: "1.3.0",
+          desktopUpdate: { ...SNAPSHOT, status: "checking" },
+          hostName: "build-host",
+        }),
+        bridge,
+      ),
+    );
+    await waitFor(() =>
+      expect(bridge.checkForUpdates).toHaveBeenCalledTimes(1),
+    );
+    // Removing ONLY `if (checkOnMount)` while retaining `[bridge, checkOnMount]`
+    // would call once on idle mount and again on the idle-to-checking
+    // transition; this negative call-count pin must turn RED under D04.
+    expect(bridge.checkForUpdates).toHaveBeenCalledWith("manual");
+  });
+});

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-overview-cli-floor-remedy.test.ts
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-overview-cli-floor-remedy.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "vitest";
+import type { CliInstallSource } from "@traycer/protocol/config/installation-records";
 import {
   CLI_NPM_PACKAGE_NAME,
   PACKAGE_MANAGER_UPGRADE_COMMAND,
-  type CliInstallSource,
-} from "@traycer/protocol/config/installation-records";
+} from "@traycer-clients/shared/cli-install/package-manager-upgrade-command";
 import {
   CLI_FLOOR_REMEDY_ACTION_KINDS,
   describeCliFloorRemedy,
@@ -235,8 +235,8 @@ describe("describeCliFloorRemedy", () => {
       {
         source: "homebrew" as const,
         stable: "brew upgrade traycer",
-        prerelease: "brew upgrade traycer",
-        rc: "brew upgrade traycer",
+        prerelease: null,
+        rc: null,
         missing: "brew upgrade traycer",
         build: "brew upgrade traycer",
       },
@@ -315,16 +315,20 @@ describe("describeCliFloorRemedy", () => {
       if (command === null) {
         // Removing the publisher guard would offer a command for a feed that
         // does not publish prereleases; this help-only pin must turn RED.
+        // Homebrew is in this set on purpose: its formula carries a prerelease
+        // only after a manual dispatch AND a merged tap PR, so `brew upgrade`
+        // under an RC floor usually reports nothing newer - a command that
+        // does not reach the floor (see the route's comment).
         expect(result.sentence).toBe(
-          `Traycer CLI prereleases aren't published through ${testCase.row.source}. Install Traycer CLI ${testCase.requiredVersion} another way, then select Check now.`,
+          `Traycer CLI prereleases aren't published through ${testCase.row.source}. Install Traycer CLI ${testCase.requiredVersion} another way; this page rechecks while it is open.`,
         );
         expect(result.actions).toEqual([
           { kind: "help", label: "Show installation help" },
         ]);
       } else {
         // Replacing exact npm floors with the generic latest table, or
-        // disabling the Homebrew/npm prerelease exemptions, makes these
-        // concrete package-manager command pins RED.
+        // disabling the npm prerelease exemption, makes these concrete
+        // package-manager command pins RED.
         // The npm missing-floor row additionally turns RED if only the
         // requiredVersion !== null guard is removed and @null is interpolated.
         expect(result.actions).toEqual([
@@ -350,6 +354,56 @@ describe("describeCliFloorRemedy", () => {
       );
       // Removing the isValidHostVersion guard would interpolate shell text
       // into the npm command; these malformed-floor help pins must turn RED.
+      expect(result.sentence).toBe(
+        "Traycer couldn't verify the required command-line tools version on build-host.",
+      );
+      expect(result.actions).toEqual([
+        { kind: "help", label: "Show installation help" },
+      ]);
+    }
+  });
+
+  it("a floor that is not a version is installation help on EVERY route, not only the one that interpolates it", () => {
+    // The validity check is hoisted into `describeCliFloorRemedy` itself,
+    // ahead of routing. Before that it lived in the package-manager route
+    // alone, so a Desktop, recorded-path or Windows route rendered a
+    // concrete command (and, on the Desktop route, an update offer) for a
+    // requirement this page cannot establish compatibility for - and the
+    // mounted recheck then polled a floor no upgrade can clear. Every
+    // route below must answer the same help-only remedy. Falsification:
+    // move the check back under `describePackageManagerRemedy` and every
+    // non-package-manager row goes RED.
+    const desktopStatuses: readonly DesktopAppUpdateStatus[] = [
+      "available",
+      "ready",
+      "idle",
+      "error",
+    ];
+    const cases = [true, false].flatMap((isLocalMachine) =>
+      sources.flatMap((source) =>
+        platforms.flatMap((platform) =>
+          [null, ...desktopStatuses.map((status) => snapshot(status, {}))].map(
+            (desktopUpdate) => ({
+              isLocalMachine,
+              source,
+              platform,
+              desktopUpdate,
+            }),
+          ),
+        ),
+      ),
+    );
+    expect(cases.length).toBeGreaterThan(300);
+    for (const testCase of cases) {
+      const result = describeCliFloorRemedy(
+        input({
+          source: testCase.source,
+          platform: testCase.platform,
+          isLocalMachine: testCase.isLocalMachine,
+          desktopUpdate: testCase.desktopUpdate,
+          overrides: { requiredCliVersion: "v1.3.0" },
+        }),
+      );
       expect(result.sentence).toBe(
         "Traycer couldn't verify the required command-line tools version on build-host.",
       );
@@ -448,7 +502,7 @@ describe("describeCliFloorRemedy", () => {
         },
       ]);
       expect(result.sentence).toBe(
-        "Run the copied commands on build-host from a PowerShell window outside Traycer on that machine (a Windows Terminal tab there, or an SSH session that opens PowerShell). Restarting briefly disconnects this host. When it reconnects, select Check now, then Update now.",
+        "Run the copied commands on build-host from a PowerShell window outside Traycer on that machine (a Windows Terminal tab there, or an SSH session that opens PowerShell). Restarting briefly disconnects this host. When it reconnects, this page rechecks on its own, and Update now appears once the host accepts the update.",
       );
     }
 
@@ -756,7 +810,7 @@ describe("describeCliFloorRemedy", () => {
           // Desktop action for this refusal; these fallback pins must turn RED
           // under the concrete D01 ablation.
           expect(result.sentence).toBe(
-            `Traycer v${candidate.version} is the latest on this update channel and its command-line tools are below 1.3.0-rc.4. Open a terminal on build-host and run the copied command, then select Check now.`,
+            `Traycer v${candidate.version} is the latest on this update channel and its command-line tools are below 1.3.0-rc.4. Open a terminal on build-host and run the copied command; this page rechecks while it is open.`,
           );
           expect(result.actions).toEqual([
             {
@@ -1004,9 +1058,12 @@ describe("describeCliFloorRemedy", () => {
     );
     // Changing idle's sentence back to Checking would claim work is in
     // flight before the initial check starts; this copy pin must turn RED.
+    // The idle arm keeps a labelled button: the mount check publishes
+    // nothing when it fails, so the updater can sit at `idle` AFTER that
+    // check and a label-less arm would be a dead end.
     expect(idle.sentence).toBe("Check for a Traycer Desktop update.");
     expect(idle.actions).toEqual([
-      { kind: "desktop-check", label: null, checkOnMount: true },
+      { kind: "desktop-check", label: "Check for updates", checkOnMount: true },
     ]);
   });
 

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-overview-cli-floor-remedy.test.ts
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-overview-cli-floor-remedy.test.ts
@@ -1,0 +1,1055 @@
+import { describe, expect, it } from "vitest";
+import {
+  CLI_NPM_PACKAGE_NAME,
+  PACKAGE_MANAGER_UPGRADE_COMMAND,
+  type CliInstallSource,
+} from "@traycer/protocol/config/installation-records";
+import {
+  CLI_FLOOR_REMEDY_ACTION_KINDS,
+  describeCliFloorRemedy,
+  type CliFloorRemedyAction,
+  type CliFloorRemedyInput,
+} from "@/components/settings/panels/host-overview-cli-floor-remedy";
+import type {
+  DesktopAppUpdateSnapshot,
+  DesktopAppUpdateStatus,
+} from "@/lib/windows/types";
+
+const PACKAGE_MANAGER_COMMANDS: Readonly<
+  Record<Exclude<CliInstallSource, "desktop" | "manual">, string>
+> = {
+  homebrew: "brew upgrade traycer",
+  npm: "npm install -g @traycerai/cli@latest",
+  winget: "winget upgrade Traycer.CLI",
+  scoop: "scoop update traycer-cli",
+  apt: "sudo apt update && sudo apt install --only-upgrade traycer-cli",
+  rpm: "sudo dnf upgrade traycer-cli",
+};
+
+const platforms: readonly (string | null)[] = [
+  "linux-x64",
+  "darwin-arm64",
+  "win32-x64",
+  null,
+];
+
+const sources: readonly (CliInstallSource | null)[] = [
+  "desktop",
+  "homebrew",
+  "npm",
+  "winget",
+  "scoop",
+  "apt",
+  "rpm",
+  "manual",
+  null,
+];
+
+function expectedDesktopKind(
+  status: DesktopAppUpdateStatus,
+): CliFloorRemedyAction["kind"] {
+  switch (status) {
+    case "available":
+      return "desktop-download";
+    case "downloading":
+      return "desktop-progress";
+    case "ready":
+      return "desktop-install";
+    case "up-to-date":
+      return "restart-desktop-hint";
+    default:
+      return "desktop-check";
+  }
+}
+
+function snapshot(
+  status: DesktopAppUpdateStatus,
+  overrides: Partial<DesktopAppUpdateSnapshot>,
+): DesktopAppUpdateSnapshot {
+  return {
+    sequence: 1,
+    status,
+    currentVersion: "1.3.0",
+    allowPrerelease: false,
+    latestVersion: "1.3.0",
+    latestCompatibilityEpoch: 1,
+    downloadProgress: status === "downloading" ? 42 : null,
+    installBlockedReason: null,
+    installGuidance: null,
+    installInFlight: false,
+    errorMessage: null,
+    lastCheckedAt: "2026-09-06T00:00:00Z",
+    lastCheckIntent: "automatic",
+    ...overrides,
+  };
+}
+
+function input(options: {
+  source: CliInstallSource | null;
+  platform: string | null;
+  isLocalMachine: boolean;
+  desktopUpdate: DesktopAppUpdateSnapshot | null;
+  overrides: Partial<CliFloorRemedyInput>;
+}): CliFloorRemedyInput {
+  return {
+    isLocalMachine: options.isLocalMachine,
+    platform: options.platform,
+    cliSource: options.source,
+    cliBinaryPath: "/home/u/.local/bin/traycer",
+    cliVersion: "1.2.0",
+    requiredCliVersion: "1.3.0",
+    desktopUpdate: options.desktopUpdate,
+    hostName: "build-host",
+    ...options.overrides,
+  };
+}
+
+describe("describeCliFloorRemedy", () => {
+  it("covers every locality/platform/source/bridge/status combination without inventing a terminal action", () => {
+    const desktopStatuses: readonly DesktopAppUpdateStatus[] = [
+      "available",
+      "downloading",
+      "ready",
+      "up-to-date",
+      "checking",
+      "error",
+      "unavailable",
+      "idle",
+    ];
+
+    const cases = [true, false].flatMap((isLocalMachine) =>
+      platforms.flatMap((platform) =>
+        sources.flatMap((source) =>
+          [false, true].flatMap((bridge) =>
+            desktopStatuses.map((status) => ({
+              bridge,
+              isLocalMachine,
+              platform,
+              source,
+              status,
+            })),
+          ),
+        ),
+      ),
+    );
+
+    for (const testCase of cases) {
+      const result = describeCliFloorRemedy(
+        input({
+          source: testCase.source,
+          platform: testCase.platform,
+          isLocalMachine: testCase.isLocalMachine,
+          desktopUpdate: testCase.bridge ? snapshot(testCase.status, {}) : null,
+          overrides: {},
+        }),
+      );
+      const kinds = result.actions.map((action) => action.kind);
+      // Removing the copy-only action union and restoring an
+      // open-terminal kind would violate the 1.2.0-host boundary;
+      // this negative union pin must turn RED under that ablation.
+      expect(kinds).not.toContain("open-terminal");
+
+      if (testCase.source === null) {
+        expect(kinds).toEqual(["help"]);
+        continue;
+      }
+      if (
+        testCase.source === "desktop" &&
+        testCase.isLocalMachine &&
+        testCase.bridge
+      ) {
+        if (testCase.status === "error" || testCase.status === "unavailable") {
+          expect(kinds).toEqual(["desktop-check", "help"]);
+        } else {
+          expect(kinds).toEqual([expectedDesktopKind(testCase.status)]);
+        }
+        continue;
+      }
+      expect(kinds).toEqual(["copy-command"]);
+    }
+  });
+
+  it("has no terminal action in the public action union", () => {
+    // expectTypeOf was rejected: plain Vitest erases it, so an addition could
+    // stay green without a typecheck. The tuple now owns the union; adding a
+    // kind must fail this runtime assertion on every normal CI test run.
+    expect(CLI_FLOOR_REMEDY_ACTION_KINDS).toEqual([
+      "desktop-download",
+      "desktop-progress",
+      "desktop-install",
+      "desktop-check",
+      "restart-desktop-hint",
+      "copy-command",
+      "help",
+    ]);
+    expect(CLI_FLOOR_REMEDY_ACTION_KINDS).not.toContain("open-terminal");
+  });
+
+  it("renders each package-manager command as a copy payload for local and remote hosts", () => {
+    for (const source of Object.keys(PACKAGE_MANAGER_COMMANDS) as Exclude<
+      CliInstallSource,
+      "desktop" | "manual"
+    >[]) {
+      for (const isLocalMachine of [true, false]) {
+        const command =
+          source === "npm"
+            ? `npm install -g ${CLI_NPM_PACKAGE_NAME}@1.3.0`
+            : PACKAGE_MANAGER_COMMANDS[source];
+        const result = describeCliFloorRemedy(
+          input({
+            source,
+            platform: "darwin-arm64",
+            isLocalMachine,
+            desktopUpdate: null,
+            overrides: {},
+          }),
+        );
+        expect(result.actions).toEqual([
+          {
+            kind: "copy-command",
+            label: "Copy command",
+            command,
+          },
+        ]);
+        expect(result.sentence).toContain(command);
+      }
+    }
+  });
+
+  it("pins the shared npm package constant and stable command table", () => {
+    // Mutating CLI_NPM_PACKAGE_NAME or the generic npm @latest suffix would
+    // make these shared literal pins RED before remedy-specific interpolation.
+    expect(CLI_NPM_PACKAGE_NAME).toBe("@traycerai/cli");
+    expect(PACKAGE_MANAGER_UPGRADE_COMMAND).toEqual({
+      homebrew: "brew upgrade traycer",
+      npm: "npm install -g @traycerai/cli@latest",
+      winget: "winget upgrade Traycer.CLI",
+      scoop: "scoop update traycer-cli",
+      apt: "sudo apt update && sudo apt install --only-upgrade traycer-cli",
+      rpm: "sudo dnf upgrade traycer-cli",
+    });
+  });
+
+  it("uses exact package-manager floors and publisher-specific prerelease guidance", () => {
+    const packageManagerRows = [
+      {
+        source: "homebrew" as const,
+        stable: "brew upgrade traycer",
+        prerelease: "brew upgrade traycer",
+        rc: "brew upgrade traycer",
+        missing: "brew upgrade traycer",
+        build: "brew upgrade traycer",
+      },
+      {
+        source: "npm" as const,
+        stable: "npm install -g @traycerai/cli@1.3.0",
+        prerelease: "npm install -g @traycerai/cli@1.3.0-beta.1",
+        rc: "npm install -g @traycerai/cli@1.3.0-rc.4",
+        missing: "npm install -g @traycerai/cli@latest",
+        build: "npm install -g @traycerai/cli@1.3.0+build.7",
+      },
+      {
+        source: "winget" as const,
+        stable: "winget upgrade Traycer.CLI",
+        prerelease: null,
+        rc: null,
+        missing: "winget upgrade Traycer.CLI",
+        build: "winget upgrade Traycer.CLI",
+      },
+      {
+        source: "scoop" as const,
+        stable: "scoop update traycer-cli",
+        prerelease: null,
+        rc: null,
+        missing: "scoop update traycer-cli",
+        build: "scoop update traycer-cli",
+      },
+      {
+        source: "apt" as const,
+        stable:
+          "sudo apt update && sudo apt install --only-upgrade traycer-cli",
+        prerelease: null,
+        rc: null,
+        missing:
+          "sudo apt update && sudo apt install --only-upgrade traycer-cli",
+        build: "sudo apt update && sudo apt install --only-upgrade traycer-cli",
+      },
+      {
+        source: "rpm" as const,
+        stable: "sudo dnf upgrade traycer-cli",
+        prerelease: null,
+        rc: null,
+        missing: "sudo dnf upgrade traycer-cli",
+        build: "sudo dnf upgrade traycer-cli",
+      },
+    ] as const;
+    const floorCases = [
+      { key: "stable" as const, requiredVersion: "1.3.0" },
+      { key: "prerelease" as const, requiredVersion: "1.3.0-beta.1" },
+      { key: "rc" as const, requiredVersion: "1.3.0-rc.4" },
+      { key: "missing" as const, requiredVersion: null },
+      { key: "build" as const, requiredVersion: "1.3.0+build.7" },
+    ] as const;
+    const cases = [true, false].flatMap((isLocalMachine) =>
+      packageManagerRows.flatMap((row) =>
+        floorCases.map((floorCase) => ({
+          isLocalMachine,
+          requiredVersion: floorCase.requiredVersion,
+          row,
+          floorKey: floorCase.key,
+        })),
+      ),
+    );
+
+    for (const testCase of cases) {
+      const command = testCase.row[testCase.floorKey];
+      const result = describeCliFloorRemedy(
+        input({
+          source: testCase.row.source,
+          platform: "darwin-arm64",
+          isLocalMachine: testCase.isLocalMachine,
+          desktopUpdate: null,
+          overrides: { requiredCliVersion: testCase.requiredVersion },
+        }),
+      );
+      if (command === null) {
+        // Removing the publisher guard would offer a command for a feed that
+        // does not publish prereleases; this help-only pin must turn RED.
+        expect(result.sentence).toBe(
+          `Traycer CLI prereleases aren't published through ${testCase.row.source}. Install Traycer CLI ${testCase.requiredVersion} another way, then select Check now.`,
+        );
+        expect(result.actions).toEqual([
+          { kind: "help", label: "Show installation help" },
+        ]);
+      } else {
+        // Replacing exact npm floors with the generic latest table, or
+        // disabling the Homebrew/npm prerelease exemptions, makes these
+        // concrete package-manager command pins RED.
+        // The npm missing-floor row additionally turns RED if only the
+        // requiredVersion !== null guard is removed and @null is interpolated.
+        expect(result.actions).toEqual([
+          { kind: "copy-command", label: "Copy command", command },
+        ]);
+        expect(result.sentence).toContain(command);
+      }
+    }
+
+    for (const requiredVersion of [
+      "1.3.0; rm -rf /",
+      "1.3.0' && echo unsafe",
+      "v1.3.0",
+    ]) {
+      const result = describeCliFloorRemedy(
+        input({
+          source: "npm",
+          platform: "darwin-arm64",
+          isLocalMachine: true,
+          desktopUpdate: null,
+          overrides: { requiredCliVersion: requiredVersion },
+        }),
+      );
+      // Removing the isValidHostVersion guard would interpolate shell text
+      // into the npm command; these malformed-floor help pins must turn RED.
+      expect(result.sentence).toBe(
+        "Traycer couldn't verify the required command-line tools version on build-host.",
+      );
+      expect(result.actions).toEqual([
+        { kind: "help", label: "Show installation help" },
+      ]);
+    }
+  });
+
+  it("uses the POSIX absolute path and protects spaces, apostrophes, dollars, and backticks", () => {
+    const paths = [
+      ["/home/u/bin/traycer", "'/home/u/bin/traycer' cli upgrade"],
+      ["/home/u/My Tools/traycer", "'/home/u/My Tools/traycer' cli upgrade"],
+      [
+        "/home/u/O'Reilly/$traycer`bin`/traycer",
+        "'/home/u/O'\\''Reilly/$traycer`bin`/traycer' cli upgrade",
+      ],
+    ] as const;
+    for (const [cliBinaryPath, command] of paths) {
+      const result = describeCliFloorRemedy(
+        input({
+          source: "manual",
+          platform: "darwin-arm64",
+          isLocalMachine: false,
+          desktopUpdate: null,
+          overrides: { cliBinaryPath },
+        }),
+      );
+      expect(result.actions[0]).toMatchObject({
+        kind: "copy-command",
+        command,
+      });
+    }
+  });
+
+  it("falls back to the bare POSIX command for relative and empty paths", () => {
+    for (const cliBinaryPath of ["traycer", "", null]) {
+      const result = describeCliFloorRemedy(
+        input({
+          source: "manual",
+          platform: "linux-x64",
+          isLocalMachine: false,
+          desktopUpdate: null,
+          overrides: { cliBinaryPath },
+        }),
+      );
+      expect(result.actions[0]).toMatchObject({
+        kind: "copy-command",
+        command: "traycer cli upgrade",
+      });
+    }
+  });
+
+  it("uses both outside-Traycer commands for Windows and unknown platforms", () => {
+    const windowsPathCases = [
+      {
+        binaryPath: "C:\\Users\\x\\AppData\\Local\\Traycer\\cli\\traycer.exe",
+        invocation:
+          "& 'C:\\Users\\x\\AppData\\Local\\Traycer\\cli\\traycer.exe'",
+      },
+      {
+        binaryPath: "C:\\Users\\x\\O'Brien\\Traycer\\traycer.exe",
+        invocation: "& 'C:\\Users\\x\\O''Brien\\Traycer\\traycer.exe'",
+      },
+      {
+        binaryPath: "\\\\server\\share\\Traycer\\traycer.exe",
+        invocation: "& '\\\\server\\share\\Traycer\\traycer.exe'",
+      },
+      {
+        binaryPath: "D:/Users/x/Traycer/cli/traycer.exe",
+        invocation: "& 'D:/Users/x/Traycer/cli/traycer.exe'",
+      },
+    ] as const;
+    const windowsSources = ["manual", "desktop"] as const;
+    const windowsCases = windowsSources.flatMap((source) =>
+      windowsPathCases.map((pathCase) => ({ source, ...pathCase })),
+    );
+    for (const testCase of windowsCases) {
+      const result = describeCliFloorRemedy(
+        input({
+          source: testCase.source,
+          platform: "win32-x64",
+          isLocalMachine: false,
+          desktopUpdate: null,
+          overrides: { cliBinaryPath: testCase.binaryPath },
+        }),
+      );
+      // E01/E02/E03/E04/E08: removing drive/UNC recognition, apostrophe
+      // doubling, PowerShell's `&`, or the second recorded invocation would
+      // make this exact two-line command RED.
+      expect(result.actions).toEqual([
+        {
+          kind: "copy-command",
+          label: "Copy commands",
+          command: `${testCase.invocation} cli upgrade\n${testCase.invocation} host restart`,
+        },
+      ]);
+      expect(result.sentence).toBe(
+        "Run the copied commands on build-host from a PowerShell window outside Traycer on that machine (a Windows Terminal tab there, or an SSH session that opens PowerShell). Restarting briefly disconnects this host. When it reconnects, select Check now, then Update now.",
+      );
+    }
+
+    const bareWindowsCases = [
+      null,
+      "",
+      "traycer",
+      "C:Users\\x\\Traycer\\traycer.exe",
+      "/home/u/bin/traycer",
+    ] as const;
+    const bareCases = windowsSources.flatMap((source) =>
+      bareWindowsCases.map((binaryPath) => ({ source, binaryPath })),
+    );
+    for (const testCase of bareCases) {
+      const result = describeCliFloorRemedy(
+        input({
+          source: testCase.source,
+          platform: "win32-arm64",
+          isLocalMachine: false,
+          desktopUpdate: null,
+          overrides: { cliBinaryPath: testCase.binaryPath },
+        }),
+      );
+      // E05: allowing relative, empty, drive-relative, or POSIX-shaped paths
+      // would guess a Windows executable instead of using bare traycer.
+      expect(result.actions).toEqual([
+        {
+          kind: "copy-command",
+          label: "Copy commands",
+          command: "traycer cli upgrade\ntraycer host restart",
+        },
+      ]);
+    }
+
+    // Unknown platform: the RECORDED PATH is the evidence. A POSIX-rooted path
+    // means a POSIX host, which has no PowerShell to open and DOES need the
+    // absolute path (a manual/private-slot install is exactly what is not on
+    // PATH). Falsification: restoring `platform === null` to the Windows arm
+    // turns this into "& '/home/u/bin/traycer'" under a PowerShell sentence.
+    const unknownPlatformPosixPath = describeCliFloorRemedy(
+      input({
+        source: "manual",
+        platform: null,
+        isLocalMachine: false,
+        desktopUpdate: null,
+        overrides: { cliBinaryPath: "/home/u/bin/traycer" },
+      }),
+    );
+    expect(unknownPlatformPosixPath.actions).toEqual([
+      {
+        kind: "copy-command",
+        label: "Copy command",
+        command: "'/home/u/bin/traycer' cli upgrade",
+      },
+    ]);
+    expect(unknownPlatformPosixPath.sentence).not.toContain("PowerShell");
+
+    // ...and a drive-rooted path means Windows, with the full Windows route.
+    const unknownPlatformWindowsPath = describeCliFloorRemedy(
+      input({
+        source: "manual",
+        platform: null,
+        isLocalMachine: false,
+        desktopUpdate: null,
+        overrides: { cliBinaryPath: "C:\\Traycer\\cli\\traycer.exe" },
+      }),
+    );
+    expect(unknownPlatformWindowsPath.actions).toEqual([
+      {
+        kind: "copy-command",
+        label: "Copy commands",
+        command:
+          "& 'C:\\Traycer\\cli\\traycer.exe' cli upgrade\n& 'C:\\Traycer\\cli\\traycer.exe' host restart",
+      },
+    ]);
+    expect(unknownPlatformWindowsPath.sentence).toContain("PowerShell");
+
+    // Neither platform nor a path shaped like either: bare commands, outside
+    // Traycer, and no shell named.
+    for (const binaryPath of [null, "traycer"] as const) {
+      const unknownEverything = describeCliFloorRemedy(
+        input({
+          source: "manual",
+          platform: null,
+          isLocalMachine: false,
+          desktopUpdate: null,
+          overrides: { cliBinaryPath: binaryPath },
+        }),
+      );
+      expect(unknownEverything.actions).toEqual([
+        {
+          kind: "copy-command",
+          label: "Copy commands",
+          command: "traycer cli upgrade\ntraycer host restart",
+        },
+      ]);
+      expect(unknownEverything.sentence).toContain("terminal outside Traycer");
+      expect(unknownEverything.sentence).not.toContain("PowerShell");
+    }
+  });
+
+  it("falls back to copy-only guidance for a local Desktop host without a bridge", () => {
+    const result = describeCliFloorRemedy(
+      input({
+        source: "desktop",
+        platform: "darwin-arm64",
+        isLocalMachine: true,
+        desktopUpdate: null,
+        overrides: {},
+      }),
+    );
+    expect(result.actions[0]).toMatchObject({
+      kind: "copy-command",
+      command: "'" + "/home/u/.local/bin/traycer" + "' cli upgrade",
+    });
+  });
+
+  it("keeps the older-copy sentence when the stored CLI version already clears the floor", () => {
+    const result = describeCliFloorRemedy(
+      input({
+        source: "manual",
+        platform: "darwin-arm64",
+        isLocalMachine: false,
+        desktopUpdate: null,
+        overrides: { cliVersion: "1.3.0" },
+      }),
+    );
+    expect(result.sentence).toContain(
+      "were updated, but the host is still using an older copy",
+    );
+    expect(result.sentence).toContain("Run the command again:");
+  });
+
+  it("never fabricates a missing required version in copy guidance", () => {
+    const available = describeCliFloorRemedy(
+      input({
+        source: "desktop",
+        platform: "darwin-arm64",
+        isLocalMachine: true,
+        desktopUpdate: snapshot("available", { latestVersion: null }),
+        overrides: { requiredCliVersion: null },
+      }),
+    );
+    // Removing describeDesktopRemedy's null-version guards would expose
+    // "null"/"undefined" in these natural versionless sentences; these
+    // negative text pins must turn RED under that concrete ablation.
+    expect(available.sentence).toBe(
+      "Update Traycer Desktop to install this host update.",
+    );
+    expect(available.sentence).not.toContain("undefined");
+    expect(available.sentence).not.toContain("null");
+
+    const ready = describeCliFloorRemedy(
+      input({
+        source: "desktop",
+        platform: "darwin-arm64",
+        isLocalMachine: true,
+        desktopUpdate: snapshot("ready", { latestVersion: null }),
+        overrides: { requiredCliVersion: null },
+      }),
+    );
+    expect(ready.sentence).toBe(
+      "Traycer Desktop is ready. Restart Traycer to finish, then this host update can install.",
+    );
+    expect(ready.sentence).not.toContain("undefined");
+    expect(ready.sentence).not.toContain("null");
+  });
+
+  it("reports an unreadable CLI manifest through installation help", () => {
+    const result = describeCliFloorRemedy(
+      input({
+        source: null,
+        platform: "darwin-arm64",
+        isLocalMachine: false,
+        desktopUpdate: null,
+        overrides: {},
+      }),
+    );
+    expect(result).toEqual({
+      sentence:
+        "Traycer couldn't determine how its command-line tools were installed on build-host.",
+      actions: [{ kind: "help", label: "Show installation help" }],
+    });
+  });
+
+  it("only offers download for available Desktop updates", () => {
+    const result = describeCliFloorRemedy(
+      input({
+        source: "desktop",
+        platform: "darwin-arm64",
+        isLocalMachine: true,
+        desktopUpdate: snapshot("available", {}),
+        overrides: {},
+      }),
+    );
+    expect(result.actions[0]).toMatchObject({
+      kind: "desktop-download",
+      label: "Download update",
+    });
+    // Removing the status === available predicate would make a ready Desktop
+    // incorrectly expose Download update and this negative pin would turn RED.
+    const ready = describeCliFloorRemedy(
+      input({
+        source: "desktop",
+        platform: "darwin-arm64",
+        isLocalMachine: true,
+        desktopUpdate: snapshot("ready", {}),
+        overrides: {},
+      }),
+    );
+    expect(ready.actions[0]?.kind).toBe("desktop-install");
+  });
+
+  it("only offers install for ready Desktop updates and carries blocked/guidance state", () => {
+    const blocked = describeCliFloorRemedy(
+      input({
+        source: "desktop",
+        platform: "darwin-arm64",
+        isLocalMachine: true,
+        desktopUpdate: snapshot("ready", {
+          installBlockedReason: "Not in Applications",
+        }),
+        overrides: {},
+      }),
+    );
+    expect(blocked.actions[0]).toMatchObject({
+      kind: "desktop-install",
+      disabled: true,
+      tooltip: "Not in Applications",
+      showGuidance: false,
+    });
+    const guided = describeCliFloorRemedy(
+      input({
+        source: "desktop",
+        platform: "linux-x64",
+        isLocalMachine: true,
+        desktopUpdate: snapshot("ready", {
+          installGuidance: {
+            summary: "Use the package manager",
+            steps: ["step"],
+            command: "sudo dpkg -i traycer.deb",
+            releaseUrl: "https://example.invalid/release",
+          },
+        }),
+        overrides: {},
+      }),
+    );
+    expect(guided.actions[0]).toMatchObject({
+      kind: "desktop-install",
+      label: "Finish update",
+      showGuidance: true,
+    });
+    // Removing the status === ready predicate would make an available Desktop
+    // incorrectly expose install, so this negative status pin must turn RED.
+    const available = describeCliFloorRemedy(
+      input({
+        source: "desktop",
+        platform: "linux-x64",
+        isLocalMachine: true,
+        desktopUpdate: snapshot("available", {}),
+        overrides: {},
+      }),
+    );
+    expect(available.actions[0]?.kind).toBe("desktop-download");
+
+    const inFlight = describeCliFloorRemedy(
+      input({
+        source: "desktop",
+        platform: "darwin-arm64",
+        isLocalMachine: true,
+        desktopUpdate: snapshot("ready", { installInFlight: true }),
+        overrides: {},
+      }),
+    );
+    expect(inFlight.actions[0]).toMatchObject({
+      kind: "desktop-install",
+      disabled: true,
+      installInFlight: true,
+    });
+  });
+
+  it("falls back when Desktop candidates are below a known CLI floor", () => {
+    const candidates = [
+      { version: "1.2.0", belowFloor: true },
+      { version: "1.3.0-rc.3", belowFloor: true },
+      { version: "1.3.0-rc.4", belowFloor: false },
+      { version: "1.3.0-rc.5", belowFloor: false },
+      { version: "1.3.0", belowFloor: false },
+    ] as const;
+    for (const status of ["available", "downloading", "ready"] as const) {
+      for (const candidate of candidates) {
+        const result = describeCliFloorRemedy(
+          input({
+            source: "desktop",
+            platform: "darwin-arm64",
+            isLocalMachine: true,
+            desktopUpdate: snapshot(status, {
+              latestVersion: candidate.version,
+            }),
+            overrides: { requiredCliVersion: "1.3.0-rc.4" },
+          }),
+        );
+        if (candidate.belowFloor) {
+          // Bypassing describeDesktopFloorFallback would expose a normal
+          // Desktop action for this refusal; these fallback pins must turn RED
+          // under the concrete D01 ablation.
+          expect(result.sentence).toBe(
+            `Traycer v${candidate.version} is the latest on this update channel and its command-line tools are below 1.3.0-rc.4. Open a terminal on build-host and run the copied command, then select Check now.`,
+          );
+          expect(result.actions).toEqual([
+            {
+              kind: "copy-command",
+              label: "Copy command",
+              command: "'/home/u/.local/bin/traycer' cli upgrade",
+            },
+            { kind: "help", label: "Show installation help" },
+          ]);
+          continue;
+        }
+        // Removing the comparable equal/greater floor check would make these
+        // clear candidates show repair guidance; this negative candidate pin
+        // must turn RED under that concrete semver-ablation.
+        expect(result.actions[0]?.kind).toBe(expectedDesktopKind(status));
+      }
+    }
+  });
+
+  it("uses help instead of guessing a Desktop CLI command when the floor fallback lacks a safe path", () => {
+    const pathCases = [
+      {
+        platform: "darwin-arm64",
+        cliBinaryPath: "/home/u/bin/traycer",
+        copy: true,
+      },
+      { platform: "linux-x64", cliBinaryPath: null, copy: false },
+      { platform: "linux-x64", cliBinaryPath: "traycer", copy: false },
+      {
+        platform: "win32-x64",
+        cliBinaryPath: "/home/u/bin/traycer",
+        copy: false,
+      },
+      // A null platform routes by the recorded path's shape, as the manual
+      // arm does; only a path shaped like neither stays copy-less.
+      { platform: null, cliBinaryPath: "/home/u/bin/traycer", copy: true },
+      {
+        platform: null,
+        cliBinaryPath: "C:\\Traycer\\cli\\traycer.exe",
+        copy: true,
+      },
+      { platform: null, cliBinaryPath: "traycer", copy: false },
+      { platform: null, cliBinaryPath: null, copy: false },
+    ] as const;
+    for (const pathCase of pathCases) {
+      const result = describeCliFloorRemedy(
+        input({
+          source: "desktop",
+          platform: pathCase.platform,
+          isLocalMachine: true,
+          desktopUpdate: snapshot("available", { latestVersion: "1.2.0" }),
+          overrides: {
+            cliBinaryPath: pathCase.cliBinaryPath,
+            requiredCliVersion: "1.3.0",
+          },
+        }),
+      );
+      // Removing the platform-specific absolute-path/no-PATH-guessing guard
+      // would guess a command for an unsafe case; these D06 pins must RED.
+      expect(
+        result.actions.some((action) => action.kind === "copy-command"),
+      ).toBe(pathCase.copy);
+      expect(result.actions.at(-1)).toEqual({
+        kind: "help",
+        label: "Show installation help",
+      });
+    }
+
+    const windowsFallbackCases = [
+      {
+        binaryPath: "C:\\Users\\x\\AppData\\Local\\Traycer\\cli\\traycer.exe",
+        command:
+          "& 'C:\\Users\\x\\AppData\\Local\\Traycer\\cli\\traycer.exe' cli upgrade\n& 'C:\\Users\\x\\AppData\\Local\\Traycer\\cli\\traycer.exe' host restart",
+        copy: true,
+      },
+      { binaryPath: null, command: null, copy: false },
+      { binaryPath: "", command: null, copy: false },
+      { binaryPath: "traycer", command: null, copy: false },
+      {
+        binaryPath: "C:Users\\x\\Traycer\\traycer.exe",
+        command: null,
+        copy: false,
+      },
+      { binaryPath: "/home/u/bin/traycer", command: null, copy: false },
+    ] as const;
+    for (const pathCase of windowsFallbackCases) {
+      const result = describeCliFloorRemedy(
+        input({
+          source: "desktop",
+          platform: "win32-x64",
+          isLocalMachine: true,
+          desktopUpdate: snapshot("available", { latestVersion: "1.2.0" }),
+          overrides: {
+            cliBinaryPath: pathCase.binaryPath,
+            requiredCliVersion: "1.3.0",
+          },
+        }),
+      );
+      if (pathCase.copy) {
+        // E07: withholding all Windows fallback commands would lose the
+        // usable recorded path and make this positive pin RED.
+        expect(result.actions).toEqual([
+          {
+            kind: "copy-command",
+            label: "Copy commands",
+            command: pathCase.command,
+          },
+          { kind: "help", label: "Show installation help" },
+        ]);
+        // E09: removing the PowerShell/outside wording would lose the shell
+        // guidance appended to the Desktop floor sentence.
+        expect(result.sentence).toContain(
+          "PowerShell window outside Traycer on that machine",
+        );
+      } else {
+        // E06: bypassing the Windows no-path gate would guess PATH for an
+        // absent or non-absolute recording; this exact help-only pin must RED.
+        expect(result.actions).toEqual([
+          { kind: "help", label: "Show installation help" },
+        ]);
+      }
+    }
+
+    const upToDate = describeCliFloorRemedy(
+      input({
+        source: "desktop",
+        platform: "darwin-arm64",
+        isLocalMachine: true,
+        desktopUpdate: snapshot("up-to-date", {
+          currentVersion: "1.2.0",
+          latestVersion: null,
+        }),
+        overrides: {
+          requiredCliVersion: "1.3.0",
+        },
+      }),
+    );
+    // Removing the up-to-date currentVersion fallback would lose a known
+    // below-floor candidate; this negative fallback pin must turn RED.
+    expect(upToDate.sentence).toContain("Traycer Desktop v1.2.0 is installed");
+
+    const installedVersionAheadOfFeed = describeCliFloorRemedy(
+      input({
+        source: "desktop",
+        platform: "darwin-arm64",
+        isLocalMachine: true,
+        desktopUpdate: snapshot("up-to-date", {
+          currentVersion: "1.3.0-rc.4",
+          latestVersion: "1.2.0",
+        }),
+        overrides: { requiredCliVersion: "1.3.0-rc.4" },
+      }),
+    );
+    // Restoring the prior candidate expression
+    // `snapshot.latestVersion ?? (snapshot.status === "up-to-date" ?
+    // snapshot.currentVersion : null)` would select the older feed version
+    // and expose floor fallback; this feed-behind pin must turn RED while the
+    // below-floor/null-latest case above remains green.
+    expect(installedVersionAheadOfFeed.actions).toEqual([
+      { kind: "restart-desktop-hint" },
+    ]);
+
+    for (const latestVersion of [null, "not-a-version"] as const) {
+      const unknown = describeCliFloorRemedy(
+        input({
+          source: "desktop",
+          platform: "darwin-arm64",
+          isLocalMachine: true,
+          desktopUpdate: snapshot("available", { latestVersion }),
+          overrides: { requiredCliVersion: "1.3.0" },
+        }),
+      );
+      // Removing the unknown-candidate fallback would fabricate a normal
+      // Desktop action; these negative missing/unparseable pins must RED.
+      expect(unknown.sentence).toContain(
+        "couldn't verify that this Desktop update includes Traycer CLI 1.3.0 or newer",
+      );
+      expect(unknown.actions.at(-1)).toEqual({
+        kind: "help",
+        label: "Show installation help",
+      });
+    }
+  });
+
+  it("shows retryable Desktop failures and only auto-checks an idle updater", () => {
+    const failures = [
+      {
+        status: "error" as const,
+        errorMessage: "  Desktop updater failed.  ",
+        sentence: "Desktop updater failed.",
+      },
+      {
+        status: "unavailable" as const,
+        errorMessage: null,
+        sentence: "Traycer Desktop couldn't check for updates.",
+      },
+    ] as const;
+    for (const failure of failures) {
+      const result = describeCliFloorRemedy(
+        input({
+          source: "desktop",
+          platform: "darwin-arm64",
+          isLocalMachine: true,
+          desktopUpdate: snapshot(failure.status, {
+            errorMessage: failure.errorMessage,
+          }),
+          overrides: {},
+        }),
+      );
+      expect(result.sentence).toBe(failure.sentence);
+      // Mapping failures back to Checking/null-label/checkOnMount true would
+      // hide recovery; this negative retry/help pin must RED under that D02
+      // ablation.
+      expect(result.actions).toEqual([
+        {
+          kind: "desktop-check",
+          label: "Check again",
+          checkOnMount: false,
+        },
+        { kind: "help", label: "Show installation help" },
+      ]);
+    }
+
+    const checking = describeCliFloorRemedy(
+      input({
+        source: "desktop",
+        platform: "darwin-arm64",
+        isLocalMachine: true,
+        desktopUpdate: snapshot("checking", {}),
+        overrides: {},
+      }),
+    );
+    expect(checking.sentence).toBe("Checking for a Traycer Desktop update…");
+    expect(checking.actions).toEqual([
+      { kind: "desktop-check", label: null, checkOnMount: false },
+    ]);
+    const idle = describeCliFloorRemedy(
+      input({
+        source: "desktop",
+        platform: "darwin-arm64",
+        isLocalMachine: true,
+        desktopUpdate: snapshot("idle", {}),
+        overrides: {},
+      }),
+    );
+    // Changing idle's sentence back to Checking would claim work is in
+    // flight before the initial check starts; this copy pin must turn RED.
+    expect(idle.sentence).toBe("Check for a Traycer Desktop update.");
+    expect(idle.actions).toEqual([
+      { kind: "desktop-check", label: null, checkOnMount: true },
+    ]);
+  });
+
+  it("uses a restart hint only when Desktop is up to date and checks unknown states", () => {
+    const current = describeCliFloorRemedy(
+      input({
+        source: "desktop",
+        platform: "darwin-arm64",
+        isLocalMachine: true,
+        desktopUpdate: snapshot("up-to-date", {
+          currentVersion: "1.3.0",
+        }),
+        overrides: {},
+      }),
+    );
+    expect(current.actions).toEqual([{ kind: "restart-desktop-hint" }]);
+    for (const status of ["checking", "error", "unavailable"] as const) {
+      const result = describeCliFloorRemedy(
+        input({
+          source: "desktop",
+          platform: "darwin-arm64",
+          isLocalMachine: true,
+          desktopUpdate: snapshot(status, {}),
+          overrides: {},
+        }),
+      );
+      if (status === "checking") {
+        expect(result.actions).toEqual([
+          { kind: "desktop-check", label: null, checkOnMount: false },
+        ]);
+      } else {
+        expect(result.actions).toEqual([
+          {
+            kind: "desktop-check",
+            label: "Check again",
+            checkOnMount: false,
+          },
+          { kind: "help", label: "Show installation help" },
+        ]);
+      }
+    }
+    // Removing the explicit up-to-date arm would turn a healthy Desktop state
+    // into a retrying check and this negative pin would turn RED.
+    expect(current.sentence).toContain("up to date");
+  });
+});

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-overview-lifecycle-gate.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-overview-lifecycle-gate.test.tsx
@@ -325,6 +325,53 @@ describe("HostOverviewPanel — lifecycle gate matrix (G1)", () => {
     });
   });
 
+  it("(d2) a pre-@1.3 peer's COARSE 'updating' marker releases the gate once the read goes unhealthy — the retained wire field must not outlive the projection's demotion", async () => {
+    // (c) for the coarse leg. The pre-@1.3 fallback used to read the RAW
+    // `view.updateProgress.state` off the retained response, which TanStack
+    // keeps verbatim across a failed background refetch - so an old host whose
+    // updater crashed mid-swap (marker left at `updating`, nothing alive to
+    // clear it) locked Restart for as long as the response was retained. The
+    // fallback now reads the PROJECTED kind, which `projectFleetUpdateView`
+    // demotes to `unknown` on an unhealthy read.
+    //
+    // Falsification: put `view.updateProgress?.state === "updating"` back in
+    // `host-overview-panel.tsx`'s `updateInFlight` fallback and the second
+    // assertion goes red while (d) above stays green.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    let statusCalls = 0;
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: true,
+      overrideHandlers: {
+        "host.status": () => {
+          statusCalls += 1;
+          if (statusCalls === 1) {
+            return statusWith(null, {
+              updateProgress: { state: "updating", error: null },
+            });
+          }
+          throw new Error("host unreachable");
+        },
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    hostBindingMock.current = { hostClient: fixture.client };
+    scopeOverrides.current = scopeFrom("host-a", fixture);
+    renderPanel();
+
+    // Healthy read: the released behaviour, gate HOLDS (same as (d)).
+    await waitFor(async () => {
+      expect(await editNameDisabled()).toBe(true);
+    });
+
+    // Past the 10s baseline poll: the refetch fails and the `updating`
+    // response is retained. The projection demotes it; the gate must follow.
+    await vi.advanceTimersByTimeAsync(11_000);
+    await waitFor(async () => {
+      expect(await editNameDisabled()).toBe(false);
+    });
+  });
+
   it("(c) THE DEFECT ITSELF — a retained active status whose READ THEN GOES UNHEALTHY must release the gate, and an already-open restart confirmation must STAY open", async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     let statusCalls = 0;

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-overview-lifecycle-gate.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-overview-lifecycle-gate.test.tsx
@@ -518,8 +518,8 @@ describe("HostOverviewPanel — lifecycle gate matrix (G1)", () => {
   });
 
   it("(c3) an open restart confirmation CLOSES when the scope turns unusable — the withdrawal of the Restart control, one commit late", async () => {
-    // `host-overview-panel.tsx`: `if (!usable && restartConfirmOpen)
-    // setRestartConfirmOpen(false);`. The control that OPENS this dialog is
+    // `host-overview-panel.tsx`: `if (!usable && restartConfirm ===
+    // "cooperative") closeRestartConfirm();`. The control that OPENS this dialog is
     // already withdrawn on `!usable` (c2's own assertion), but a confirmation
     // opened while the scope was still usable is not touched by that
     // withdrawal — answered, it would dispatch `host.restart` over a client

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-overview-lifecycle-gate.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-overview-lifecycle-gate.test.tsx
@@ -516,4 +516,53 @@ describe("HostOverviewPanel — lifecycle gate matrix (G1)", () => {
     expect(screen.queryByTestId("host-overview-edit-name")).toBeNull();
     expect(screen.queryByTestId("host-overview-menu")).toBeNull();
   });
+
+  it("(c3) an open restart confirmation CLOSES when the scope turns unusable — the withdrawal of the Restart control, one commit late", async () => {
+    // `host-overview-panel.tsx`: `if (!usable && restartConfirmOpen)
+    // setRestartConfirmOpen(false);`. The control that OPENS this dialog is
+    // already withdrawn on `!usable` (c2's own assertion), but a confirmation
+    // opened while the scope was still usable is not touched by that
+    // withdrawal — answered, it would dispatch `host.restart` over a client
+    // the scope no longer vouches for. Falsification: comment out that `if`
+    // in the panel and the final `waitFor` below goes red while the dialog
+    // stays on screen.
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: true,
+      overrideHandlers: {
+        // No active attempt (`updateOperation: null`) and no coarse marker,
+        // so the lifecycle gate is released and Restart is enabled from the
+        // first render.
+        "host.status": () => statusWith(null, undefined),
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    hostBindingMock.current = { hostClient: fixture.client };
+    scopeOverrides.current = scopeFrom("host-a", fixture);
+    const panel = renderPanelPersistent();
+
+    await screen.findByTestId("host-overview-edit-name");
+    expect(await restartMenuAriaDisabled()).not.toBe("true");
+    fireEvent.click(screen.getByTestId("host-overview-restart"));
+    await screen.findByTestId("confirm-destructive-dialog");
+
+    // Control: rerendering with the scope still usable keeps the dialog
+    // open — otherwise the assertion below would prove nothing about
+    // `usable` specifically.
+    panel.rerender();
+    expect(screen.getByTestId("confirm-destructive-dialog")).toBeTruthy();
+
+    // THE FIX: the scope turns unusable — same predicate (c2) demotes the
+    // operation card on — and the already-open confirmation closes, one
+    // commit late with the controls that open it.
+    scopeOverrides.current = {
+      ...scopeFrom("host-a", fixture),
+      status: "unreachable",
+    };
+    panel.rerender();
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("confirm-destructive-dialog")).toBeNull();
+    });
+  });
 });

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-overview-local-maintenance-fallback.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-overview-local-maintenance-fallback.test.tsx
@@ -113,6 +113,18 @@ const RELEASED_FLOOR_METHODS = ["host.status"] as const;
 const RPC_INSTALL_VERSION = "rpc-1.0.0";
 const BRIDGE_INSTALL_VERSION = "bridge-9.9.9";
 const BRIDGE_CHECK_VERSION = "1.2.0";
+/**
+ * What the running host reports. The two install-version sentinels above are
+ * deliberately not versions at all - they exist to prove which LANE a read
+ * came from - so the records built from them carry `runtimeVersion: null`:
+ * a sentinel declared as the runtime would read as activation debt against
+ * this version (`installRecord.runtimeVersion !== hostVersion`, see
+ * `legacy-update-facts.ts`) and the Overview would render "vbridge-9.9.9 is
+ * installed — restart host to finish." in place of the catalog sentence these
+ * tests wait for. With `null` the comparison falls to the version comparator,
+ * which finds the sentinel incomparable and reports no debt.
+ */
+const RUNNING_HOST_VERSION = "1.1.11";
 const RPC_CHECK_VERSION = "1.3.0";
 
 const SERVICE_STOPPED: HostDoctorIssue = {
@@ -226,7 +238,7 @@ function managedInstallationInfo(
     installRecord: {
       installId: `id-${version}`,
       version,
-      runtimeVersion: version,
+      runtimeVersion: null,
       platform: "darwin",
       arch: "arm64",
       installedAt: "2026-08-10T00:00:00Z",
@@ -337,7 +349,7 @@ function mountFallbackOverview(options: {
   const fixture = buildOverviewHostFixture({
     hostId: HOST_ID,
     isLocalMachine: true,
-    hostVersion: "1.1.11",
+    hostVersion: RUNNING_HOST_VERSION,
     effectiveName: HOST_NAME,
     invalidator: createHostQueryInvalidator(queryClient),
     overrideHandlers: {

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-overview-local-maintenance-fallback.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-overview-local-maintenance-fallback.test.tsx
@@ -312,17 +312,21 @@ function renderOverview(input: {
   readonly management: IHostManagement;
   readonly queryClient: QueryClient;
   readonly extra: ReactNode | undefined;
-}): void {
-  render(
+}): { readonly rerender: () => void } {
+  const runnerHost = makeRunnerHostWithManagement(input.management);
+  // A fresh element per call, as the lifecycle-gate suite's persistent render
+  // does: React skips a subtree whose element reference is unchanged, so a
+  // reused tree would never re-read a mutated `scopeOverrides.current`.
+  const buildTree = (): ReactNode => (
     <QueryClientProvider client={input.queryClient}>
-      <RunnerHostProvider
-        runnerHost={makeRunnerHostWithManagement(input.management)}
-      >
+      <RunnerHostProvider runnerHost={runnerHost}>
         {input.extra ?? null}
         <HostSettingsPanel />
       </RunnerHostProvider>
-    </QueryClientProvider>,
+    </QueryClientProvider>
   );
+  const { rerender } = render(buildTree());
+  return { rerender: () => rerender(buildTree()) };
 }
 
 function mountFallbackOverview(options: {
@@ -340,6 +344,7 @@ function mountFallbackOverview(options: {
   readonly fixture: OverviewHostFixture;
   readonly queryClient: QueryClient;
   readonly rpcLogCalls: { count: number };
+  readonly rerender: () => void;
 } {
   const rpcCheckCalls = options.rpcCheckCalls;
   const rpcLogCalls = { count: 0 };
@@ -426,12 +431,12 @@ function mountFallbackOverview(options: {
   localHostIdMock.current = HOST_ID;
   hostBindingMock.current = bindingWith(fixture.client);
   scopeOverrides.current = fallbackScope(fixture, management);
-  renderOverview({
+  const { rerender } = renderOverview({
     management,
     queryClient,
     extra: options.extra,
   });
-  return { management, fixture, queryClient, rpcLogCalls };
+  return { management, fixture, queryClient, rpcLogCalls, rerender };
 }
 
 function expectButtonEnabled(button: HTMLElement): void {
@@ -648,6 +653,118 @@ describe("<HostSettingsPanel /> local-maintenance CLI fallback", () => {
       description: "Another process holds the host lock.",
     });
     expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it("a bridge-route Restart confirm SURVIVES the scope turning unusable and still dispatches the respawn - the recovery this machine needs most while its host is unreachable", async () => {
+    // `host-overview-panel.tsx`: `if (!usable && restartConfirm ===
+    // "cooperative") closeRestartConfirm()`. The cooperative confirm closes
+    // under `!usable` (lifecycle-gate (c3)) because its dispatch needs the
+    // scope's client; this confirm was ARMED for the bridge respawn at open,
+    // which needs none. Falsification: close on `!usable` regardless of the
+    // armed route and the dialog below is gone before it can be answered.
+    let releaseRestart: (() => void) | null = null;
+    const gate = new Promise<void>((resolve) => {
+      releaseRestart = resolve;
+    });
+    const { management, fixture, rerender } = mountFallbackOverview({
+      installOutcome: {
+        kind: "ok",
+        value: { installedVersion: "1.2.0", runningActivated: true },
+      },
+      rpcCheckCalls: { count: 0 },
+      restartHostIfIdle: async () => {
+        await gate;
+        return {
+          kind: "declined" as const,
+          message: "Another process holds the host lock.",
+        };
+      },
+      extraHandshakeMethods: undefined,
+      extra: undefined,
+    });
+
+    await openHostOverviewMenu();
+    fireEvent.click(await screen.findByTestId("host-overview-restart"));
+    await screen.findByTestId("confirm-destructive-dialog");
+    expect(management.restartHostIfIdle).not.toHaveBeenCalled();
+
+    // The scope turns unusable under the open confirm - this machine's host
+    // stopped answering. The bridge is still right here.
+    scopeOverrides.current = {
+      ...fallbackScope(fixture, management),
+      status: "unreachable",
+    };
+    rerender();
+    expect(screen.getByTestId("confirm-destructive-dialog")).toBeTruthy();
+
+    // Answered, it dispatches the respawn over the bridge, never the client.
+    fireEvent.click(screen.getByTestId("confirm-action"));
+    await waitFor(() => {
+      expect(management.restartHostIfIdle).toHaveBeenCalledWith({
+        expectedHostId: HOST_ID,
+      });
+    });
+    expect(management.restartHost).not.toHaveBeenCalled();
+    expect(fixture.restartCalls()).toBe(0);
+
+    await act(async () => {
+      releaseRestart?.();
+      await gate;
+    });
+    await waitFor(() => {
+      expect(screen.queryByTestId("confirm-destructive-dialog")).toBeNull();
+    });
+  });
+
+  it("a cooperative confirm CLOSES when the handshake re-routes Restart to the bridge under it, and the re-opened confirm dispatches over the bridge", async () => {
+    // The route is armed at OPEN, so a confirm armed for the cooperative leg
+    // must not stay answerable once the page routes Restart to the bridge -
+    // it would send the refused `host.restart`. The reachable window in
+    // production is the handshake's tri-state `null` (Restart live, route
+    // cooperative) landing `false` under the open dialog; this pin drives the
+    // same rule from `true` to `false`, which is the transition the registry
+    // lets a test express. Falsification: drop the `restartConfirm ===
+    // "cooperative" && restartViaForceFallback` close in the panel and the
+    // first `waitFor` below goes red with the dialog still on screen.
+    const { management, fixture } = mountFallbackOverview({
+      installOutcome: {
+        kind: "ok",
+        value: { installedVersion: "1.2.0", runningActivated: true },
+      },
+      rpcCheckCalls: { count: 0 },
+      restartHostIfIdle: () => Promise.resolve({ kind: "restarted" as const }),
+      extraHandshakeMethods: ["host.restart"],
+      extra: undefined,
+    });
+
+    await openHostOverviewMenu();
+    fireEvent.click(await screen.findByTestId("host-overview-restart"));
+    await screen.findByTestId("confirm-destructive-dialog");
+
+    // The handshake lands without `host.restart`: the page now routes
+    // Restart to the bridge respawn.
+    act(() => {
+      recordNegotiatedHostMethods(HOST_ID, [
+        ...RELEASED_FLOOR_METHODS,
+        ...LOCAL_MAINTENANCE_FALLBACK_METHODS,
+      ]);
+    });
+    await waitFor(() => {
+      expect(screen.queryByTestId("confirm-destructive-dialog")).toBeNull();
+    });
+    expect(fixture.restartCalls()).toBe(0);
+    expect(management.restartHostIfIdle).not.toHaveBeenCalled();
+
+    // Re-opened, the confirm is armed for the bridge and dispatches there.
+    await openHostOverviewMenu();
+    fireEvent.click(await screen.findByTestId("host-overview-restart"));
+    fireEvent.click(await screen.findByTestId("confirm-action"));
+    await waitFor(() => {
+      expect(management.restartHostIfIdle).toHaveBeenCalledWith({
+        expectedHostId: HOST_ID,
+      });
+    });
+    expect(fixture.restartCalls()).toBe(0);
   });
 
   it("an external same-key hostRestart closes an open idle confirm without treating it as this dialog's dispatch", async () => {

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-overview-operation-card.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-overview-operation-card.test.tsx
@@ -787,4 +787,58 @@ describe("HostOverviewOperationCard — record-derived parks", () => {
       screen.queryByTestId("host-overview-operation-force-update"),
     ).toBeNull();
   });
+
+  it("(c4) an OPEN force-update offer CLOSES when the scope turns unusable — the withdrawal of the Force update… control, one commit late", async () => {
+    // Companion to `host-overview-lifecycle-gate.test.tsx`'s (c3), for the
+    // OTHER dialog `host-overview-panel.tsx`'s `!usable` rule closes:
+    // `if (!usable && forceUpdateOffer !== null) setForceUpdateOffer(null);`.
+    // The sibling test above ("staged wait ... withdraws Force update…")
+    // pins that the CONTROL disappears on an unusable scope; this pins the
+    // stronger claim - an offer already OPEN before the scope turned
+    // unusable does not survive either, because confirming it would dispatch
+    // `host.update.install {force: true}` over a client the scope no longer
+    // vouches for. Falsification: comment out that `if` in the panel and the
+    // final `waitFor` below goes red while the dialog stays on screen.
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: true,
+      hostVersion: "1.3.0-rc.2",
+      installation: managedInstallation(
+        installRecord("1.3.0-rc.2", "1.3.0-rc.2"),
+        stagedRecord("1.3.0-rc.3"),
+      ),
+      overrideHandlers: {
+        "host.status": () =>
+          statusWithBusy("1.3.0-rc.2", { kind: "none" }, true, 2),
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    hostBindingMock.current = { hostClient: fixture.client };
+    scopeOverrides.current = scopeFrom("host-a", fixture);
+    const panel = renderPanelPersistent();
+
+    fireEvent.click(
+      await screen.findByTestId("host-overview-operation-force-update"),
+    );
+    await screen.findByTestId("host-busy-force-defer-dialog");
+
+    // Control: rerendering with the scope still usable keeps the dialog
+    // open — otherwise the assertion below would prove nothing about
+    // `usable` specifically.
+    panel.rerender();
+    expect(screen.getByTestId("host-busy-force-defer-dialog")).toBeTruthy();
+
+    // THE FIX: the scope turns unusable — same predicate the sibling test
+    // above demotes the phase sentence and withdraws the control on — and
+    // the already-open offer closes, one commit late.
+    scopeOverrides.current = {
+      ...scopeFrom("host-a", fixture),
+      status: "unreachable",
+    };
+    panel.rerender();
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("host-busy-force-defer-dialog")).toBeNull();
+    });
+  });
 });

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-overview-operation-card.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-overview-operation-card.test.tsx
@@ -1229,11 +1229,15 @@ describe("HostOverviewOperationCard — installation query keyed by running vers
     vi.useRealTimers();
   });
 
-  it("a failed installation read hides the record-derived facts", async () => {
-    // Falsification: remove `|| installationQuery.isError` from the
-    // `legacyFacts` gate in `host-overview-panel.tsx` and the card keeps
-    // showing the LAST successful record's debt through a read that has
-    // since started failing.
+  it("a failed installation read withdraws the activation-debt park and its Restart - the status leg alone is projected", async () => {
+    // Falsification: drop `!installationLive` from the `legacyFacts`
+    // derivation in `host-overview-panel.tsx` (back to a bare data check)
+    // and the card keeps showing the LAST successful record's debt, with a
+    // live Restart, through a read that has since started failing.
+    // `canonicalReadIsLive` withdraws on `isError` too, so this pin
+    // exercises that arm specifically; the "activation debt + staged wait:
+    // an UNUSABLE scope…" pin above exercises the status-leg demotion via
+    // `usable`, which is the one that keeps a qualified sentence.
     vi.useFakeTimers({ shouldAdvanceTime: true });
     let installationCalls = 0;
     const fixture = buildOverviewHostFixture({
@@ -1257,21 +1261,315 @@ describe("HostOverviewOperationCard — installation query keyed by running vers
     scopeOverrides.current = scopeFrom("host-a", fixture);
     renderPanel();
 
-    // Debt visible: record rc.3 ahead of the running rc.2.
+    // Debt visible: record rc.3 ahead of the running rc.2 - live, unqualified.
     await screen.findByTestId("host-overview-operation-restart");
+    expect(
+      screen.getByTestId("host-overview-operation-card").textContent,
+    ).not.toContain("Last seen:");
 
     // The next installation poll throws - the status read keeps succeeding
-    // beside it, so this failure is the installation leg's alone.
+    // beside it, so this failure is the installation leg's alone. The
+    // record leg is WITHDRAWN, not demoted: `host.status` reports no
+    // operation, so with no facts there is nothing for the card to show -
+    // no "Last seen" sentence, no Restart. (An UNUSABLE scope is the case
+    // that keeps the sentence qualified; that demotion travels through the
+    // status leg - see the unusable-scope pins. Expiring the whole
+    // observation here instead would demote a live attempt on one failed
+    // record read.)
     await vi.advanceTimersByTimeAsync(11_000);
     await waitFor(() => expect(installationCalls).toBe(2));
     await waitFor(() => {
       expect(screen.queryByTestId("host-overview-operation-card")).toBeNull();
     });
+    expect(screen.queryByTestId("host-overview-operation-restart")).toBeNull();
 
-    // The next successful poll brings the debt card back.
+    // The next successful poll restores the live park and its control.
     await vi.advanceTimersByTimeAsync(11_000);
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("host-overview-operation-phase").textContent,
+      ).toBe("Update installed — restart host to finish");
+    });
     await screen.findByTestId("host-overview-operation-restart");
 
     vi.useRealTimers();
+  });
+
+  it("a failed installation read withdraws the staged-wait park and Force update…, not merely the debt row", async () => {
+    // The sibling of the activation-debt pin above, for the OTHER row
+    // `legacyFacts` feeds: `deriveLegacyUpdateFacts` computes `activationDebt`
+    // and `stagedWait` off the SAME object, so an isError read must withdraw
+    // both, not just whichever one an earlier pin happened to check.
+    // `host.status` keeps answering the whole time - the busy/session-count
+    // sentence and the Force offer both come from ONE `legacyFacts`
+    // derivation, so this is still the installation leg's own
+    // `!installationLive` gate, not a `host.status`-side demotion (the
+    // production doc's other two `canonicalReadIsLive` arms - `paused` and
+    // `isStale` - are exercised directly against the function in
+    // `canonical-status-observation.test.ts`; this app's queries run with
+    // `networkMode: "always"`, so a real installation-read outage always
+    // surfaces as `isError` here, per the production comment above
+    // `installationLive`).
+    //
+    // Falsification: drop `!installationLive` from the `legacyFacts`
+    // derivation and the card keeps offering Force update… through a read
+    // that has started failing.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    let installationCalls = 0;
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: true,
+      hostVersion: "1.3.0-rc.2",
+      overrideHandlers: {
+        "host.status": () =>
+          statusWithBusy("1.3.0-rc.2", { kind: "none" }, true, 2),
+        "host.getInstallationInfo": () => {
+          installationCalls += 1;
+          if (installationCalls === 2) {
+            throw new Error("host unreachable");
+          }
+          return managedInstallation(
+            installRecord("1.3.0-rc.2", "1.3.0-rc.2"),
+            stagedRecord("1.3.0-rc.3"),
+          );
+        },
+        "host.update.check": () => ({
+          outcome: "ok" as const,
+          effectiveIncludePreReleases: true,
+          includePreReleasesSource: "explicit-include" as const,
+          manifest: clearStagedManifest("1.3.0-rc.3"),
+        }),
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    hostBindingMock.current = { hostClient: fixture.client };
+    scopeOverrides.current = scopeFrom("host-a", fixture);
+    renderPanel();
+
+    // Positive control: the installation read is fresh, the staged-wait
+    // park and Force update… both show, live and unqualified.
+    await screen.findByTestId("host-overview-operation-force-update");
+    expect(
+      screen.getByTestId("host-overview-operation-phase").textContent,
+    ).toBe("Update will continue when 2 sessions finish");
+
+    // The next installation poll throws - `host.status` keeps succeeding
+    // beside it, so this failure is the installation leg's alone. The
+    // sentence is retained and qualified; Force update… is withdrawn.
+    await vi.advanceTimersByTimeAsync(11_000);
+    await waitFor(() => expect(installationCalls).toBe(2));
+    // Withdrawn, not demoted - see the sibling pin above.
+    await waitFor(() => {
+      expect(screen.queryByTestId("host-overview-operation-card")).toBeNull();
+    });
+    expect(
+      screen.queryByTestId("host-overview-operation-force-update"),
+    ).toBeNull();
+
+    // The next successful poll restores the live park and Force update….
+    await vi.advanceTimersByTimeAsync(11_000);
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("host-overview-operation-phase").textContent,
+      ).toBe("Update will continue when 2 sessions finish");
+    });
+    await screen.findByTestId("host-overview-operation-force-update");
+
+    vi.useRealTimers();
+  });
+
+  it("an OPEN force-update offer stays open while the installation read is merely unobserved - only an OBSERVED record leg that drops the stage closes it", async () => {
+    // Companion to "(c4)" (which closes the dialog on `!usable`): a demoted
+    // installation read is a DIFFERENT signal from scope reachability. The
+    // panel's close guard is `legacyFacts !== null && stagedVersion
+    // mismatch` - an unobserved read (`legacyFacts === null`) fails that
+    // first clause and leaves the dialog alone, because "we don't know
+    // right now" is not "the stage is gone".
+    //
+    // "Unobserved" is `installationQuery.data === undefined` - which, per
+    // the production comment above `installationLive`
+    // (`host-overview-panel.tsx`), only arises on first load or when the
+    // RUNNING version moves and the install query re-keys onto a fresh,
+    // still-pending read (`cacheKeyIdentity: [runningVersion]`). A read that
+    // has merely started failing is NOT this: `canonicalReadIsLive` demotes
+    // it, but the cache still carries its last successful payload, so
+    // `legacyFacts` stays non-null (retained) - the case the sibling pins
+    // above pin as a DEMOTION of the sentence, not an absence of facts. This
+    // pin therefore drives "unobserved" through a running-version bump
+    // whose fresh key is left pending, not through an `isError` read.
+    //
+    // Falsification: drop the `legacyFacts !== null` guard (close whenever
+    // `(legacyFacts?.stagedWait ?? null)?.stagedVersion !== offer.stagedVersion`,
+    // treating null facts as a mismatch) and the dialog closes as soon as
+    // the running version moves, before the fresh read ever answers.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    let statusCalls = 0;
+    let installationCalls = 0;
+    const secondRead = deferredInstallationResponse();
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: true,
+      overrideHandlers: {
+        "host.status": () => {
+          statusCalls += 1;
+          return statusWithBusy(
+            statusCalls === 1 ? "1.3.0-rc.2" : "1.3.0-rc.3",
+            { kind: "none" },
+            true,
+            2,
+          );
+        },
+        "host.getInstallationInfo": () => {
+          installationCalls += 1;
+          if (installationCalls === 1) {
+            return managedInstallation(
+              installRecord("1.3.0-rc.2", "1.3.0-rc.2"),
+              stagedRecord("1.3.0-rc.3"),
+            );
+          }
+          // The running version moved (rc.2 -> rc.3) - the install query
+          // re-keys onto a fresh key with no cached data, and this read is
+          // left pending: "not observed", not failed.
+          return secondRead.promise;
+        },
+        "host.update.check": () => ({
+          outcome: "ok" as const,
+          effectiveIncludePreReleases: true,
+          includePreReleasesSource: "explicit-include" as const,
+          manifest: clearStagedManifest("1.3.0-rc.3"),
+        }),
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    hostBindingMock.current = { hostClient: fixture.client };
+    scopeOverrides.current = scopeFrom("host-a", fixture);
+    renderPanel();
+
+    fireEvent.click(
+      await screen.findByTestId("host-overview-operation-force-update"),
+    );
+    await screen.findByTestId("host-busy-force-defer-dialog");
+
+    // The next `host.status` poll reports the running version moved - the
+    // install query re-keys onto a fresh, still-pending read. The dialog
+    // stays open through it.
+    await vi.advanceTimersByTimeAsync(11_000);
+    await waitFor(() => expect(installationCalls).toBe(2));
+    // Give any (incorrect) close a render cycle to have taken effect
+    // before asserting the dialog is still there.
+    await waitFor(() => {
+      expect(screen.getByTestId("host-busy-force-defer-dialog")).toBeTruthy();
+    });
+
+    // The pending read now answers - an OBSERVED record leg, under the new
+    // running version, that no longer carries the offer's stage. THIS is
+    // what closes the dialog.
+    await act(async () => {
+      secondRead.resolve(
+        managedInstallation(installRecord("1.3.0-rc.3", "1.3.0-rc.3"), null),
+      );
+      await secondRead.promise;
+    });
+    await waitFor(() => {
+      expect(screen.queryByTestId("host-busy-force-defer-dialog")).toBeNull();
+    });
+
+    vi.useRealTimers();
+  });
+});
+
+// `HostOverviewOperationCard` — `onForceRestart` (an ATTEMPT park's Force
+// restart…, as opposed to a legacy staged wait's Force update…): gated on
+// `legacyFacts !== null && legacyFacts.stagedWait === null` in
+// `host-overview-panel.tsx` - an attempt park offers no route to activate a
+// stage the records still describe, and an UNOBSERVED record leg does not
+// vouch that no stage waits either.
+describe("HostOverviewOperationCard — onForceRestart (attempt park)", () => {
+  function attemptParkStatus(
+    busySessionCount: number,
+  ): ResponseOfMethod<HostRpcRegistry, "host.status"> {
+    return statusWith(
+      attemptOperation({
+        phase: "waiting-for-work",
+        execution: "active",
+        liveness: "active",
+        busySessionCount,
+      }),
+    );
+  }
+
+  it("an attempt park with an UNOBSERVED installation read offers no Force restart…", async () => {
+    // Falsification: drop the `legacyFacts !== null` half of the gate
+    // (offer whenever `stagedWait === null`, treating an unobserved read as
+    // "no stage") and the button below appears despite the installation
+    // read never having answered.
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: true,
+      hostVersion: "1.5.0",
+      overrideHandlers: {
+        "host.status": () => attemptParkStatus(2),
+        // Never answers - `legacyFacts` stays "not observed" (`undefined`
+        // data), same gate `installationQuery.data === undefined` already
+        // gives it, no isError/isStale needed to prove this half.
+        "host.getInstallationInfo": () => new Promise(() => {}),
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    hostBindingMock.current = { hostClient: fixture.client };
+    scopeOverrides.current = scopeFrom("host-a", fixture);
+    renderPanel();
+
+    await screen.findByTestId("host-overview-operation-card");
+    expect(
+      screen.queryByTestId("host-overview-operation-force-restart"),
+    ).toBeNull();
+  });
+
+  it("an attempt park with an OBSERVED installation read carrying no staged wait offers Force restart…", async () => {
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: true,
+      hostVersion: "1.5.0",
+      // Default `host.getInstallationInfo` answers `{status: "unmanaged"}` -
+      // an OBSERVED read whose `deriveLegacyUpdateFacts` carries a null
+      // `stagedWait` (nothing to force-activate a stage into).
+      overrideHandlers: {
+        "host.status": () => attemptParkStatus(2),
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    hostBindingMock.current = { hostClient: fixture.client };
+    scopeOverrides.current = scopeFrom("host-a", fixture);
+    renderPanel();
+
+    await screen.findByTestId("host-overview-operation-force-restart");
+  });
+
+  it("an attempt park with an OBSERVED staged wait offers no Force restart… - Restart cannot activate a stage", async () => {
+    // The staged wait is a LEGACY fact from the records, independent of
+    // this attempt's own park - Force restart would relaunch the host
+    // without ever installing what the stage still waits to apply.
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: true,
+      hostVersion: "1.5.0",
+      installation: managedInstallation(
+        installRecord("1.5.0", "1.5.0"),
+        stagedRecord("1.6.0"),
+      ),
+      overrideHandlers: {
+        "host.status": () => attemptParkStatus(2),
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    hostBindingMock.current = { hostClient: fixture.client };
+    scopeOverrides.current = scopeFrom("host-a", fixture);
+    renderPanel();
+
+    await screen.findByTestId("host-overview-operation-card");
+    expect(
+      screen.queryByTestId("host-overview-operation-force-restart"),
+    ).toBeNull();
   });
 });

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-overview-operation-card.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-overview-operation-card.test.tsx
@@ -38,6 +38,7 @@ vi.mock("sonner", () => ({
   },
 }));
 
+import type { ReactNode } from "react";
 import {
   cleanup,
   fireEvent,
@@ -129,6 +130,29 @@ function renderPanel(): void {
       </RunnerHostProvider>
     </QueryClientProvider>,
   );
+}
+
+// Same `QueryClient`/tree kept alive across a `rerender` - the shape
+// `host-overview-lifecycle-gate.test.tsx`'s `renderPanelPersistent` uses -
+// so a later mutation of `scopeOverrides.current`/`hostBindingMock.current`
+// (a Settings host swap) is observed by the SAME mounted subtree rather than
+// torn down and rebuilt with it. A fresh element on every call, not a
+// captured/reused one: React bails out of re-rendering a subtree entirely
+// when the SAME element reference is passed to `rerender` twice.
+function renderPanelPersistent(): { rerender: () => void } {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  const runnerHost = makeRunnerHost();
+  const buildTree = (): ReactNode => (
+    <QueryClientProvider client={client}>
+      <RunnerHostProvider runnerHost={runnerHost}>
+        <HostSettingsPanel />
+      </RunnerHostProvider>
+    </QueryClientProvider>
+  );
+  const { rerender } = render(buildTree());
+  return { rerender: () => rerender(buildTree()) };
 }
 
 function attemptOperation(
@@ -662,5 +686,105 @@ describe("HostOverviewOperationCard — record-derived parks", () => {
     // frame.
     await screen.findByText(/1\.5\.0/);
     expect(screen.queryByTestId("host-overview-operation-card")).toBeNull();
+  });
+
+  it("activation debt + staged wait: an UNUSABLE scope keeps the sentence (qualified as retained) but withdraws Restart", async () => {
+    // Mirrors `host-overview-lifecycle-gate.test.tsx`'s (c2): the retained
+    // record-derived facts survive an unusable scope (nothing about the
+    // READ changes - same cached `host.status`/`host.getInstallationInfo`
+    // responses), but `hasLiveSource`/`connected` (both wired to `usable`)
+    // demote the projection to `unknown` with a retained `lastKnownKind`,
+    // which `describeUpdateOperation` renders as an inline "Last seen: …"
+    // qualification (`carriesQualificationInline`) rather than the separate
+    // `(last known)` marker - so the phase sentence itself is the proof of
+    // qualification here, exactly as (c2) reads it for the live attempt. The
+    // panel's own `!usable` guard on `onRestart` (`host-overview-panel.tsx`)
+    // withdraws the control entirely rather than merely disabling it - the
+    // same rule (c2) pins for the header actions.
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: true,
+      hostVersion: "1.3.0-rc.2",
+      installation: managedInstallation(
+        installRecord("1.3.0-rc.3", null),
+        null,
+      ),
+      overrideHandlers: {
+        "host.status": () =>
+          statusWithBusy("1.3.0-rc.2", { kind: "none" }, false, 0),
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    hostBindingMock.current = { hostClient: fixture.client };
+    scopeOverrides.current = scopeFrom("host-a", fixture);
+    const panel = renderPanelPersistent();
+
+    const card = await screen.findByTestId("host-overview-operation-card");
+    expect(card.textContent).toContain(
+      "Update installed — restart host to finish",
+    );
+    expect(card.textContent).not.toContain("Last seen:");
+    await screen.findByTestId("host-overview-operation-restart");
+
+    // Nothing about the read changes - only the scope stops being usable,
+    // the way a negotiated peer going unreachable would leave it.
+    scopeOverrides.current = {
+      ...scopeFrom("host-a", fixture),
+      status: "unreachable",
+    };
+    panel.rerender();
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("host-overview-operation-phase").textContent,
+      ).toBe("Last seen: Update installed — restart host to finish");
+    });
+    expect(screen.queryByTestId("host-overview-operation-restart")).toBeNull();
+  });
+
+  it("staged wait: an UNUSABLE scope keeps the sentence (qualified as retained) but withdraws Force update…", async () => {
+    // Doubly guaranteed here, unlike the Restart case above: `offersForceRestart`
+    // (`fleet-update-view.ts`) requires `view.kind === "waiting-for-work"`,
+    // and the SAME demotion that qualifies the sentence also flips `view.kind`
+    // to `unknown` - so the button's absence is not a clean isolation of the
+    // panel's own `!usable` guard on `onForceUpdate` the way the Restart
+    // button's absence isolates its `!usable` guard (that one has no
+    // `view.kind`-based gate of its own). Both guards agree here; this pins
+    // the observable requirement (no dispatch route on an unusable scope),
+    // not which of the two guards is doing the work for THIS control.
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: true,
+      hostVersion: "1.3.0-rc.2",
+      installation: managedInstallation(
+        installRecord("1.3.0-rc.2", "1.3.0-rc.2"),
+        stagedRecord("1.3.0-rc.3"),
+      ),
+      overrideHandlers: {
+        "host.status": () =>
+          statusWithBusy("1.3.0-rc.2", { kind: "none" }, true, 2),
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    hostBindingMock.current = { hostClient: fixture.client };
+    scopeOverrides.current = scopeFrom("host-a", fixture);
+    const panel = renderPanelPersistent();
+
+    await screen.findByTestId("host-overview-operation-force-update");
+
+    scopeOverrides.current = {
+      ...scopeFrom("host-a", fixture),
+      status: "unreachable",
+    };
+    panel.rerender();
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("host-overview-operation-phase").textContent,
+      ).toMatch(/^Last seen: Update will continue when/);
+    });
+    expect(
+      screen.queryByTestId("host-overview-operation-force-update"),
+    ).toBeNull();
   });
 });

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-overview-operation-card.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-overview-operation-card.test.tsx
@@ -1210,7 +1210,14 @@ describe("HostOverviewOperationCard — installation query keyed by running vers
     // installation query re-keys onto a fresh, still-pending read.
     await vi.advanceTimersByTimeAsync(11_000);
     await screen.findByText(/1\.3\.0-rc\.3/);
-    await waitFor(() => expect(installationCalls).toBe(2));
+    // AT LEAST two, not exactly two: the installation query's own 10 s poll
+    // and the status poll that re-keys it fire from the same tick, and their
+    // order is not this pin's to assume - when the installation poll lands
+    // first it is the second call (served the pending read below) and the
+    // re-key is the third. Every call past the first returns the still-pending
+    // read, so the count says only that the re-key asked afresh; the
+    // load-bearing assertions are the two card checks below.
+    await waitFor(() => expect(installationCalls).toBeGreaterThanOrEqual(2));
 
     // While that fresh read is pending, there is nothing to compare against -
     // "not observed", never a debt derived from the OLD rc.2 record.
@@ -1291,6 +1298,60 @@ describe("HostOverviewOperationCard — installation query keyed by running vers
       ).toBe("Update installed — restart host to finish");
     });
     await screen.findByTestId("host-overview-operation-restart");
+
+    vi.useRealTimers();
+  });
+
+  it("a failed STATUS read withdraws the debt park's Restart while its last-known sentence stays - the offer needs a live status read, the projection keeps the evidence", async () => {
+    // The status leg's twin of the installation-read pin above. `legacyFacts`
+    // keeps the retained status payload on purpose - its `hostVersion` is
+    // what lets the projection render the park qualified - but the OFFERS
+    // are gated on `statusLive` (`canonicalReadIsLive` over the status
+    // read's health, `usable` included): a Restart pressed off an old
+    // `hostVersion` would restart a host that may already have activated.
+    // Falsification: gate `onRestart` on `usable` alone again and the
+    // Restart below stays pressable under the "Last seen:" sentence.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    let statusCalls = 0;
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: true,
+      hostVersion: "1.3.0-rc.2",
+      overrideHandlers: {
+        "host.status": () => {
+          statusCalls += 1;
+          if (statusCalls > 1) {
+            throw new Error("host unreachable");
+          }
+          return statusWithBusy("1.3.0-rc.2", { kind: "none" }, false, 0);
+        },
+        "host.getInstallationInfo": () =>
+          managedInstallation(installRecord("1.3.0-rc.3", null), null),
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    hostBindingMock.current = { hostClient: fixture.client };
+    scopeOverrides.current = scopeFrom("host-a", fixture);
+    renderPanel();
+
+    // Debt visible and live: record rc.3 ahead of the running rc.2.
+    await screen.findByTestId("host-overview-operation-restart");
+    expect(
+      screen.getByTestId("host-overview-operation-card").textContent,
+    ).not.toContain("Last seen:");
+
+    // The next status poll throws; the installation read keeps succeeding
+    // beside it, so this is the status leg's own failure. The park is
+    // DEMOTED, not withdrawn - the retained payload still says what was last
+    // seen - and the control that would act on it is gone.
+    await vi.advanceTimersByTimeAsync(11_000);
+    await waitFor(() => expect(statusCalls).toBe(2));
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("host-overview-operation-phase").textContent,
+      ).toContain("Last seen:");
+    });
+    expect(screen.queryByTestId("host-overview-operation-restart")).toBeNull();
 
     vi.useRealTimers();
   });

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-overview-operation-card.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-overview-operation-card.test.tsx
@@ -697,9 +697,7 @@ describe("HostOverviewOperationCard — record-derived parks", () => {
     renderPanel();
 
     const card = await screen.findByTestId("host-overview-operation-card");
-    expect(card.textContent).toContain(
-      "Update will continue when 2 sessions finish",
-    );
+    expect(card.textContent).toContain("Update waits for 2 sessions to finish");
     expect(screen.queryByTestId("host-overview-operation-restart")).toBeNull();
     expect(
       screen.queryByTestId("host-overview-operation-force-restart"),
@@ -711,7 +709,10 @@ describe("HostOverviewOperationCard — record-derived parks", () => {
     const busyDialog = await screen.findByTestId(
       "host-busy-force-defer-dialog",
     );
-    expect(busyDialog).toBeTruthy();
+    // Force UPDATE, not the header's force restart: this page can open
+    // either verdict in the same dialog, and the purpose attribute is how
+    // a pin on the shared test id tells them apart.
+    expect(busyDialog.dataset.purpose).toBe("update");
     fireEvent.click(screen.getByTestId("host-busy-force"));
 
     await waitFor(() => {
@@ -753,7 +754,7 @@ describe("HostOverviewOperationCard — record-derived parks", () => {
     // staged-wait phase they are about.
     expect(
       screen.getByTestId("host-overview-operation-phase").textContent,
-    ).toBe("Update will continue when 2 sessions finish");
+    ).toBe("Update waits for 2 sessions to finish");
     // Removing `!updates.stagedEntryOfferable` from the panel's Force gate
     // would expose Force update for this CLI-floor refusal (the floored
     // staged version is not offerable); this negative affordance pin must
@@ -808,7 +809,7 @@ describe("HostOverviewOperationCard — record-derived parks", () => {
     // staged-wait card, not from some other view.
     expect(
       screen.getByTestId("host-overview-operation-phase").textContent,
-    ).toBe("Update will continue when 2 sessions finish");
+    ).toBe("Update waits for 2 sessions to finish");
     // Treating an absent staged entry as clear would make Force reachable while
     // its floor is unknown; this negative unknown-evidence pin must turn RED.
     expect(
@@ -1066,7 +1067,7 @@ describe("HostOverviewOperationCard — record-derived parks", () => {
     await waitFor(() => {
       expect(
         screen.getByTestId("host-overview-operation-phase").textContent,
-      ).toMatch(/^Last seen: Update will continue when/);
+      ).toMatch(/^Last seen: Update waits for/);
     });
     expect(
       screen.queryByTestId("host-overview-operation-force-update"),
@@ -1412,7 +1413,7 @@ describe("HostOverviewOperationCard — installation query keyed by running vers
     await screen.findByTestId("host-overview-operation-force-update");
     expect(
       screen.getByTestId("host-overview-operation-phase").textContent,
-    ).toBe("Update will continue when 2 sessions finish");
+    ).toBe("Update waits for 2 sessions to finish");
 
     // The next installation poll throws - `host.status` keeps succeeding
     // beside it, so this failure is the installation leg's alone. The
@@ -1432,7 +1433,7 @@ describe("HostOverviewOperationCard — installation query keyed by running vers
     await waitFor(() => {
       expect(
         screen.getByTestId("host-overview-operation-phase").textContent,
-      ).toBe("Update will continue when 2 sessions finish");
+      ).toBe("Update waits for 2 sessions to finish");
     });
     await screen.findByTestId("host-overview-operation-force-update");
 
@@ -1631,6 +1632,108 @@ describe("HostOverviewOperationCard — onForceRestart (attempt park)", () => {
     await screen.findByTestId("host-overview-operation-card");
     expect(
       screen.queryByTestId("host-overview-operation-force-restart"),
+    ).toBeNull();
+  });
+});
+
+describe("HostOverviewOperationCard — capability gates", () => {
+  it("Restart is withheld when host.restart is not negotiated, and an OPEN confirm closes the moment it drops out", async () => {
+    // The card's controls sit behind the same capability gates as the
+    // header's Restart: a method the handshake declined is not offered from
+    // the card either. Two halves, two falsifications: drop
+    // `restartDegrade === null` from the card's `onRestart` gate in
+    // `host-overview-panel.tsx` and the button survives the drop; drop the
+    // render-time close on `restartDegrade !== null` and the confirm stays
+    // open over a control the page no longer offers.
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: true,
+      hostVersion: "1.3.0-rc.2",
+      installation: managedInstallation(
+        installRecord("1.3.0-rc.3", null),
+        null,
+      ),
+      overrideHandlers: {
+        "host.status": () =>
+          statusWithBusy("1.3.0-rc.2", { kind: "none" }, false, 0),
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    hostBindingMock.current = { hostClient: fixture.client };
+    scopeOverrides.current = scopeFrom("host-a", fixture);
+    renderPanel();
+
+    fireEvent.click(
+      await screen.findByTestId("host-overview-operation-restart"),
+    );
+    await screen.findByTestId("confirm-destructive-dialog");
+
+    // The negotiated set is a subscribed store (`useHostMethodSupport`), so
+    // re-recording it under the mounted page is the same signal a
+    // re-handshake sends.
+    act(() => {
+      recordNegotiatedHostMethods(
+        "host-a",
+        ALL_OVERVIEW_METHODS.filter((method) => method !== "host.restart"),
+      );
+    });
+    await waitFor(() => {
+      expect(screen.queryByTestId("confirm-destructive-dialog")).toBeNull();
+    });
+    expect(screen.queryByTestId("host-overview-operation-restart")).toBeNull();
+    // The park itself is still reported - the evidence stays, the dispatch
+    // does not.
+    expect(
+      screen.getByTestId("host-overview-operation-phase").textContent,
+    ).toBe("Update installed — restart host to finish");
+  });
+
+  it("Force update… is withheld when host.update.install is not negotiated, while the check still runs and the staged entry is offerable", async () => {
+    // `installDegrade` retires the updates REGION but leaves the check
+    // query enabled, so the manifest still lists the staged version and
+    // `stagedEntryOfferable` is true - the only thing between this button
+    // and a dispatch the host would refuse is the card's own
+    // `updates.degrade !== null` gate. Falsification: drop it from
+    // `onForceUpdate` in `host-overview-panel.tsx` and the button renders.
+    let checks = 0;
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: true,
+      hostVersion: "1.3.0-rc.2",
+      installation: managedInstallation(
+        installRecord("1.3.0-rc.2", "1.3.0-rc.2"),
+        stagedRecord("1.3.0-rc.3"),
+      ),
+      overrideHandlers: {
+        "host.status": () =>
+          statusWithBusy("1.3.0-rc.2", { kind: "none" }, true, 2),
+        "host.update.check": () => {
+          checks += 1;
+          return {
+            outcome: "ok" as const,
+            effectiveIncludePreReleases: true,
+            includePreReleasesSource: "explicit-include" as const,
+            manifest: clearStagedManifest("1.3.0-rc.3"),
+          };
+        },
+      },
+    });
+    recordNegotiatedHostMethods(
+      "host-a",
+      ALL_OVERVIEW_METHODS.filter((method) => method !== "host.update.install"),
+    );
+    hostBindingMock.current = { hostClient: fixture.client };
+    scopeOverrides.current = scopeFrom("host-a", fixture);
+    renderPanel();
+
+    const card = await screen.findByTestId("host-overview-operation-card");
+    expect(card.textContent).toContain("Update waits for 2 sessions to finish");
+    // Wait for the check to answer so the absence is the gate's, not the
+    // loading frame's: the same fixture WITH the install method negotiated
+    // renders the button once this manifest lands (the dispatch pin above).
+    await waitFor(() => expect(checks).toBeGreaterThan(0));
+    expect(
+      screen.queryByTestId("host-overview-operation-force-update"),
     ).toBeNull();
   });
 });

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-overview-operation-card.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-overview-operation-card.test.tsx
@@ -38,7 +38,13 @@ vi.mock("sonner", () => ({
   },
 }));
 
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { MockRunnerHost } from "@traycer-clients/shared/host-client/mock/mock-runner-host";
@@ -49,6 +55,11 @@ import {
 import type { IRunnerHost } from "@traycer-clients/shared/platform/runner-host";
 import type { HostStatusUpdateOperation } from "@traycer/protocol/host/status/index";
 import type { ResponseOfMethod } from "@traycer-clients/shared/host-transport/host-messenger";
+import type { HostGetInstallationInfoResponseV11 } from "@traycer/protocol/host/maintenance/index";
+import type {
+  HostInstallRecord,
+  HostStagedRecord,
+} from "@traycer/protocol/config/installation-records";
 import type { HostRpcRegistry } from "@/lib/host";
 import { hostScopeOptionFixture } from "@/components/settings/host-scope/host-scope-fixture";
 import { resetHostServiceWriteLatchesForTest } from "@/components/settings/panels/host-service-write-latch-store";
@@ -172,6 +183,107 @@ function statusWithCoarseProgress(
   >["updateProgress"],
 ): ResponseOfMethod<HostRpcRegistry, "host.status"> {
   return { ...statusWith(operation), updateProgress };
+}
+
+// Same shape as `statusWith`, but with `hostVersion`/`busy`/`busySessionCount`
+// all explicit - `statusWith` hardcodes `hostVersion: "1.5.0"`, which the
+// staged-wait fixture below must NOT inherit: the facts read `busy` and
+// `busySessionCount` off this SAME `host.status` reply, and reusing
+// `statusWith`'s fixed version would mismatch the fixture's own installed
+// record and manufacture a spurious activation debt.
+function statusWithBusy(
+  hostVersion: string,
+  operation: HostStatusUpdateOperation,
+  busy: boolean,
+  busySessionCount: number,
+): ResponseOfMethod<HostRpcRegistry, "host.status"> {
+  return {
+    ready: true,
+    hostVersion,
+    protocolVersion: { major: 1, minor: 3 },
+    busy,
+    busySessionCount,
+    updateProgress: null,
+    busyBreakdown: null,
+    updateOperation: operation,
+    updateTransaction: { recordSchemaVersion: 2, authority: "attempt" },
+  };
+}
+
+// A pre-@1.3 peer: `updateOperation: null`, exactly what such a host sends -
+// it cannot report an attempt record at all, only the coarse marker (unused
+// here) and, since this feature, the install/staged records beside it.
+function statusOperationNull(
+  hostVersion: string,
+): ResponseOfMethod<HostRpcRegistry, "host.status"> {
+  return {
+    ready: true,
+    hostVersion,
+    protocolVersion: { major: 1, minor: 0 },
+    busy: false,
+    busySessionCount: 0,
+    updateProgress: null,
+    busyBreakdown: null,
+    updateOperation: null,
+    updateTransaction: null,
+  };
+}
+
+/**
+ * The minimum-viable `HostInstallRecord`/`HostStagedRecord` pair for the
+ * record-derived park suite below - every field the wire schema requires
+ * (`protocol/src/config/installation-records.ts`), populated with benign
+ * placeholders except `version`/`runtimeVersion`, which each test varies.
+ */
+function installRecord(
+  version: string,
+  runtimeVersion: string | null,
+): HostInstallRecord {
+  return {
+    installId: "install-1",
+    version,
+    runtimeVersion,
+    platform: "darwin",
+    arch: "arm64",
+    installedAt: "2026-08-10T00:00:00Z",
+    source: { kind: "registry", value: version },
+    archiveSha256: "a".repeat(64),
+    signatureVerifiedAt: "2026-08-10T00:00:00Z",
+    signatureKeyId: "key-1",
+    sizeBytes: 1024,
+    executablePath: `/tmp/traycer/${version}/host`,
+    executableSha256: "b".repeat(64),
+  };
+}
+
+function stagedRecord(version: string): HostStagedRecord {
+  return {
+    schemaVersion: 1,
+    stageId: null,
+    version,
+    runtimeVersion: null,
+    archiveSha256: "a".repeat(64),
+    sizeBytes: 1024,
+    source: { kind: "registry", value: version },
+    signatureKeyId: "key-1",
+    signatureVerifiedAt: "2026-08-10T00:00:00Z",
+    executablePath: `/tmp/traycer/${version}/host`,
+    platform: "darwin",
+    arch: "arm64",
+    executableSha256: "b".repeat(64),
+  };
+}
+
+function managedInstallation(
+  install: HostInstallRecord,
+  staged: HostStagedRecord | null,
+): HostGetInstallationInfoResponseV11 {
+  return {
+    status: "managed",
+    installRecord: install,
+    stagedRecord: staged,
+    cliManifest: null,
+  };
 }
 
 afterEach(() => {
@@ -373,5 +485,182 @@ describe("HostOverviewOperationCard - the coarse updateProgress marker beside {k
 
     const card = await screen.findByTestId("host-overview-operation-card");
     expect(card.textContent).toContain("Update failed: health probe failed");
+  });
+});
+
+// The two record-derived parks (`legacy-update-facts.ts`), mounted end to
+// end through `HostSettingsPanel`: the Overview derives `legacyFacts` from
+// `host.getInstallationInfo` beside `host.status`, and the card renders
+// exactly one control per park - Restart for activation debt, Force update…
+// for a staged wait blocked on live work.
+describe("HostOverviewOperationCard — record-derived parks", () => {
+  it("activation debt (kind:'none' peer) renders the restart sentence and ONLY the Restart control", async () => {
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: true,
+      hostVersion: "1.3.0-rc.2",
+      installation: managedInstallation(
+        installRecord("1.3.0-rc.3", null),
+        null,
+      ),
+      overrideHandlers: {
+        "host.status": () =>
+          statusWithBusy("1.3.0-rc.2", { kind: "none" }, false, 0),
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    hostBindingMock.current = { hostClient: fixture.client };
+    scopeOverrides.current = scopeFrom("host-a", fixture);
+    renderPanel();
+
+    const card = await screen.findByTestId("host-overview-operation-card");
+    expect(card.textContent).toContain(
+      "Update installed — restart host to finish",
+    );
+    await screen.findByTestId("host-overview-operation-restart");
+    // Falsification: gating `onForceUpdate` on the view kind instead of the
+    // `stagedWait` fact, or gating `onForceRestart`'s button on the wrong
+    // predicate, would put one of these on screen beside Restart.
+    expect(
+      screen.queryByTestId("host-overview-operation-force-update"),
+    ).toBeNull();
+    expect(
+      screen.queryByTestId("host-overview-operation-force-restart"),
+    ).toBeNull();
+
+    fireEvent.click(screen.getByTestId("host-overview-operation-restart"));
+    const dialog = await screen.findByTestId("confirm-destructive-dialog");
+    expect(dialog.textContent).toContain("Restart host?");
+  });
+
+  it("SAME activation debt under a pre-1.3 peer (updateOperation: null) - Restart still renders", async () => {
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: true,
+      hostVersion: "1.3.0-rc.2",
+      installation: managedInstallation(
+        installRecord("1.3.0-rc.3", null),
+        null,
+      ),
+      overrideHandlers: {
+        "host.status": () => statusOperationNull("1.3.0-rc.2"),
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    hostBindingMock.current = { hostClient: fixture.client };
+    scopeOverrides.current = scopeFrom("host-a", fixture);
+    renderPanel();
+
+    const card = await screen.findByTestId("host-overview-operation-card");
+    expect(card.textContent).toContain(
+      "Update installed — restart host to finish",
+    );
+    await screen.findByTestId("host-overview-operation-restart");
+
+    fireEvent.click(screen.getByTestId("host-overview-operation-restart"));
+    const dialog = await screen.findByTestId("confirm-destructive-dialog");
+    expect(dialog.textContent).toContain("Restart host?");
+  });
+
+  it("a coarse 'failed' marker beside debt keeps the failure text AND still offers Restart - real evidence is not papered over", async () => {
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: true,
+      hostVersion: "1.3.0-rc.2",
+      installation: managedInstallation(
+        installRecord("1.3.0-rc.3", null),
+        null,
+      ),
+      overrideHandlers: {
+        "host.status": () => ({
+          ...statusWithBusy("1.3.0-rc.2", { kind: "none" }, false, 0),
+          updateProgress: { state: "failed", error: "health probe failed" },
+        }),
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    hostBindingMock.current = { hostClient: fixture.client };
+    scopeOverrides.current = scopeFrom("host-a", fixture);
+    renderPanel();
+
+    const card = await screen.findByTestId("host-overview-operation-card");
+    expect(card.textContent).toContain("Update failed: health probe failed");
+    // Falsification: keying `onRestart` off `view.kind === "waiting-to-activate"`
+    // instead of the `activationDebt` fact would make this null once the
+    // coarse marker outranked the park's own kind.
+    await screen.findByTestId("host-overview-operation-restart");
+  });
+
+  it("staged wait renders the blocked-sessions sentence and Force update…, dispatching host.update.install with force:true on confirm", async () => {
+    const installCalls: Array<{ version: string; force: boolean }> = [];
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: true,
+      hostVersion: "1.3.0-rc.2",
+      installation: managedInstallation(
+        installRecord("1.3.0-rc.2", "1.3.0-rc.2"),
+        stagedRecord("1.3.0-rc.3"),
+      ),
+      overrideHandlers: {
+        "host.status": () =>
+          statusWithBusy("1.3.0-rc.2", { kind: "none" }, true, 2),
+        "host.update.install": (req) => {
+          installCalls.push({ version: req.version, force: req.force });
+          return { outcome: "accepted" as const, attemptId: null };
+        },
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    hostBindingMock.current = { hostClient: fixture.client };
+    scopeOverrides.current = scopeFrom("host-a", fixture);
+    renderPanel();
+
+    const card = await screen.findByTestId("host-overview-operation-card");
+    expect(card.textContent).toContain(
+      "Update will continue when 2 sessions finish",
+    );
+    expect(screen.queryByTestId("host-overview-operation-restart")).toBeNull();
+    expect(
+      screen.queryByTestId("host-overview-operation-force-restart"),
+    ).toBeNull();
+
+    fireEvent.click(
+      await screen.findByTestId("host-overview-operation-force-update"),
+    );
+    const busyDialog = await screen.findByTestId(
+      "host-busy-force-defer-dialog",
+    );
+    expect(busyDialog).toBeTruthy();
+    fireEvent.click(screen.getByTestId("host-busy-force"));
+
+    await waitFor(() => {
+      expect(installCalls).toEqual([{ version: "1.3.0-rc.3", force: true }]);
+    });
+  });
+
+  it("no park (install matches running, host idle, nothing staged) - no card at all", async () => {
+    // Regression pin. Falsification: `legacyFactsView` (or the panel's own
+    // `legacyFacts` derivation) returning a non-null park here would put the
+    // card back on screen for a host with nothing to report.
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: true,
+      hostVersion: "1.5.0",
+      installation: managedInstallation(installRecord("1.5.0", "1.5.0"), null),
+      overrideHandlers: {
+        "host.status": () => statusWith({ kind: "none" }),
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    hostBindingMock.current = { hostClient: fixture.client };
+    scopeOverrides.current = scopeFrom("host-a", fixture);
+    renderPanel();
+
+    // Wait for a render derived from the status/installation reply before
+    // asserting absence, exactly as the sibling "no coarse marker" test above
+    // does - otherwise the assertion would pass vacuously during the loading
+    // frame.
+    await screen.findByText(/1\.5\.0/);
+    expect(screen.queryByTestId("host-overview-operation-card")).toBeNull();
   });
 });

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-overview-operation-card.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-overview-operation-card.test.tsx
@@ -58,6 +58,7 @@ import type { IRunnerHost } from "@traycer-clients/shared/platform/runner-host";
 import type { HostStatusUpdateOperation } from "@traycer/protocol/host/status/index";
 import type { ResponseOfMethod } from "@traycer-clients/shared/host-transport/host-messenger";
 import type { HostGetInstallationInfoResponseV11 } from "@traycer/protocol/host/maintenance/index";
+import type { HostAvailableManifest } from "@traycer/protocol/host/maintenance/index";
 import type {
   HostInstallRecord,
   HostStagedRecord,
@@ -117,20 +118,18 @@ function makeRunnerHost(): IRunnerHost {
   });
 }
 
-function renderPanel(): void {
+function renderPanel(): QueryClient {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
   render(
-    <QueryClientProvider
-      client={
-        new QueryClient({
-          defaultOptions: { queries: { retry: false, gcTime: 0 } },
-        })
-      }
-    >
+    <QueryClientProvider client={queryClient}>
       <RunnerHostProvider runnerHost={makeRunnerHost()}>
         <HostSettingsPanel />
       </RunnerHostProvider>
     </QueryClientProvider>,
   );
+  return queryClient;
 }
 
 // Same `QueryClient`/tree kept alive across a `rerender` - the shape
@@ -308,6 +307,55 @@ function managedInstallation(
     installRecord: install,
     stagedRecord: staged,
     cliManifest: null,
+  };
+}
+
+function clearStagedManifest(version: string): HostAvailableManifest {
+  return {
+    schemaVersion: 1,
+    generatedAt: "2026-09-06T00:00:00Z",
+    latest: version,
+    versions: [
+      {
+        version,
+        releasedAt: "2026-09-06T00:00:00Z",
+        releaseNotesUrl: "https://example.invalid/notes",
+        yanked: false,
+        deprecationReason: null,
+        requiredCliVersion: null,
+        platforms: {
+          "darwin-arm64": {
+            available: true,
+            unavailableReason: null,
+            url: "https://example.invalid/host.tar.gz",
+            sizeBytes: 1024,
+            sha256: "a".repeat(64),
+            signatureUrl: "https://example.invalid/host.tar.gz.minisig",
+            signatureAlgorithm: "minisign",
+            publicKeyId: "key-1",
+          },
+        },
+      },
+    ],
+  };
+}
+
+function floorStagedManifest(version: string): HostAvailableManifest {
+  const manifest = clearStagedManifest(version);
+  return {
+    ...manifest,
+    versions: manifest.versions.map((entry) => ({
+      ...entry,
+      requiredCliVersion: "1.3.0",
+      platforms: {
+        "darwin-arm64": {
+          ...entry.platforms["darwin-arm64"],
+          available: false,
+          unavailableReason:
+            "Needs Traycer CLI 1.3.0 or newer (this host's CLI is 1.2.0).",
+        },
+      },
+    })),
   };
 }
 
@@ -629,6 +677,14 @@ describe("HostOverviewOperationCard — record-derived parks", () => {
       overrideHandlers: {
         "host.status": () =>
           statusWithBusy("1.3.0-rc.2", { kind: "none" }, true, 2),
+        "host.update.check": () => ({
+          outcome: "ok" as const,
+          effectiveIncludePreReleases: true,
+          includePreReleasesSource: "explicit-include" as const,
+          // Conservative staged-floor gating needs positive evidence for the
+          // staged version; an empty manifest means the entry is unknown.
+          manifest: clearStagedManifest("1.3.0-rc.3"),
+        }),
         "host.update.install": (req) => {
           installCalls.push({ version: req.version, force: req.force });
           return { outcome: "accepted" as const, attemptId: null };
@@ -660,6 +716,223 @@ describe("HostOverviewOperationCard — record-derived parks", () => {
 
     await waitFor(() => {
       expect(installCalls).toEqual([{ version: "1.3.0-rc.3", force: true }]);
+    });
+  });
+
+  it("hides both force controls when the staged version is explicitly floored", async () => {
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: true,
+      hostVersion: "1.3.0-rc.2",
+      installation: managedInstallation(
+        installRecord("1.3.0-rc.2", "1.3.0-rc.2"),
+        stagedRecord("1.3.0-rc.3"),
+      ),
+      overrideHandlers: {
+        "host.status": () =>
+          statusWithBusy("1.3.0-rc.2", { kind: "none" }, true, 2),
+        "host.update.check": () => ({
+          outcome: "ok" as const,
+          effectiveIncludePreReleases: true,
+          includePreReleasesSource: "explicit-include" as const,
+          manifest: floorStagedManifest("1.3.0-rc.3"),
+        }),
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    hostBindingMock.current = { hostClient: fixture.client };
+    scopeOverrides.current = scopeFrom("host-a", fixture);
+    renderPanel();
+
+    await screen.findByText(
+      "Traycer couldn't determine how its command-line tools were installed on host-a.",
+    );
+    await screen.findByTestId("host-overview-operation-card");
+    // The negatives below are half a pin on their own: a card rendered in some
+    // other view would also have no force controls. Anchor them to the
+    // staged-wait phase they are about.
+    expect(
+      screen.getByTestId("host-overview-operation-phase").textContent,
+    ).toBe("Update will continue when 2 sessions finish");
+    // Removing the stagedFloor gate would expose Force update for a CLI-floor
+    // refusal; this negative affordance pin must turn RED under that ablation.
+    expect(
+      screen.queryByTestId("host-overview-operation-force-update"),
+    ).toBeNull();
+    // Restoring a non-null onForceRestart for a staged wait would offer a
+    // fallback restart control that cannot activate the floored stage; this
+    // negative no-restart pin must turn RED under that ablation.
+    expect(
+      screen.queryByTestId("host-overview-operation-force-restart"),
+    ).toBeNull();
+  });
+
+  it("hides both force controls when the staged version is absent from the check manifest", async () => {
+    let checkCalls = 0;
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: true,
+      hostVersion: "1.3.0-rc.2",
+      installation: managedInstallation(
+        installRecord("1.3.0-rc.2", "1.3.0-rc.2"),
+        stagedRecord("1.3.0-rc.3"),
+      ),
+      overrideHandlers: {
+        "host.status": () =>
+          statusWithBusy("1.3.0-rc.2", { kind: "none" }, true, 2),
+        "host.update.check": () => {
+          checkCalls += 1;
+          return {
+            outcome: "ok" as const,
+            effectiveIncludePreReleases: true,
+            includePreReleasesSource: "explicit-include" as const,
+            manifest: {
+              ...clearStagedManifest("1.3.0-rc.2"),
+              latest: "1.3.0-rc.2",
+            },
+          };
+        },
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    hostBindingMock.current = { hostClient: fixture.client };
+    scopeOverrides.current = scopeFrom("host-a", fixture);
+    renderPanel();
+
+    await screen.findByTestId("host-overview-operation-card");
+    await screen.findByText("This host is running the latest version.");
+    await waitFor(() => expect(checkCalls).toBeGreaterThan(0));
+    // Same anchor as above: the absent controls must be absent FROM the
+    // staged-wait card, not from some other view.
+    expect(
+      screen.getByTestId("host-overview-operation-phase").textContent,
+    ).toBe("Update will continue when 2 sessions finish");
+    // Treating an absent staged entry as clear would make Force reachable while
+    // its floor is unknown; this negative unknown-evidence pin must turn RED.
+    expect(
+      screen.queryByTestId("host-overview-operation-force-update"),
+    ).toBeNull();
+    // Restoring a non-null onForceRestart for a staged wait would offer a
+    // fallback restart control that cannot activate the absent stage; this
+    // negative no-restart pin must turn RED under that ablation.
+    expect(
+      screen.queryByTestId("host-overview-operation-force-restart"),
+    ).toBeNull();
+  });
+
+  it("revalidates a changed staged entry at confirmation and settles refusal synchronously", async () => {
+    let checkCalls = 0;
+    const installCalls: Array<{ version: string; force: boolean }> = [];
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: true,
+      hostVersion: "1.3.0-rc.2",
+      installation: managedInstallation(
+        installRecord("1.3.0-rc.2", "1.3.0-rc.2"),
+        stagedRecord("1.3.0-rc.3"),
+      ),
+      overrideHandlers: {
+        "host.status": () =>
+          statusWithBusy("1.3.0-rc.2", { kind: "none" }, true, 2),
+        "host.update.check": () => {
+          checkCalls += 1;
+          return {
+            outcome: "ok" as const,
+            effectiveIncludePreReleases: true,
+            includePreReleasesSource: "explicit-include" as const,
+            manifest:
+              checkCalls === 1
+                ? clearStagedManifest("1.3.0-rc.3")
+                : floorStagedManifest("1.3.0-rc.3"),
+          };
+        },
+        "host.update.install": (req) => {
+          installCalls.push({ version: req.version, force: req.force });
+          return { outcome: "accepted" as const, attemptId: null };
+        },
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    hostBindingMock.current = { hostClient: fixture.client };
+    scopeOverrides.current = scopeFrom("host-a", fixture);
+    const queryClient = renderPanel();
+
+    const forceButton = await screen.findByTestId(
+      "host-overview-operation-force-update",
+    );
+    fireEvent.click(forceButton);
+    await screen.findByTestId("host-busy-force-defer-dialog");
+    await queryClient.invalidateQueries();
+    await waitFor(() => expect(checkCalls).toBeGreaterThan(1));
+    fireEvent.click(screen.getByTestId("host-busy-force"));
+    expect(screen.queryByTestId("host-busy-force-defer-dialog")).toBeNull();
+
+    await waitFor(() => {
+      // Removing click-time revalidation would dispatch the stale staged
+      // version; this negative mutation pin must turn RED under that ablation.
+      expect(installCalls).toEqual([]);
+      expect(screen.queryByTestId("host-busy-force-defer-dialog")).toBeNull();
+      expect(
+        screen.getByTestId("host-overview-update-attempt-failed").textContent,
+      ).toContain("v1.3.0-rc.3 needs Traycer CLI 1.3.0 or newer on host-a.");
+    });
+  });
+
+  it("refuses and closes when the staged entry disappears before confirmation", async () => {
+    let checkCalls = 0;
+    const installCalls: Array<{ version: string; force: boolean }> = [];
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: true,
+      hostVersion: "1.3.0-rc.2",
+      installation: managedInstallation(
+        installRecord("1.3.0-rc.2", "1.3.0-rc.2"),
+        stagedRecord("1.3.0-rc.3"),
+      ),
+      overrideHandlers: {
+        "host.status": () =>
+          statusWithBusy("1.3.0-rc.2", { kind: "none" }, true, 2),
+        "host.update.check": () => {
+          checkCalls += 1;
+          return {
+            outcome: "ok" as const,
+            effectiveIncludePreReleases: true,
+            includePreReleasesSource: "explicit-include" as const,
+            manifest:
+              checkCalls === 1
+                ? clearStagedManifest("1.3.0-rc.3")
+                : clearStagedManifest("1.3.0-rc.2"),
+          };
+        },
+        "host.update.install": (req) => {
+          installCalls.push({ version: req.version, force: req.force });
+          return { outcome: "accepted" as const, attemptId: null };
+        },
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    hostBindingMock.current = { hostClient: fixture.client };
+    scopeOverrides.current = scopeFrom("host-a", fixture);
+    const queryClient = renderPanel();
+
+    fireEvent.click(
+      await screen.findByTestId("host-overview-operation-force-update"),
+    );
+    await screen.findByTestId("host-busy-force-defer-dialog");
+    await queryClient.invalidateQueries();
+    await waitFor(() => expect(checkCalls).toBeGreaterThan(1));
+    fireEvent.click(screen.getByTestId("host-busy-force"));
+
+    await waitFor(() => {
+      // Bypassing describeForceUpdateRefusal would dispatch stale force:true;
+      // this no-mutation pin and closed-dialog assertion redden that ablation.
+      expect(installCalls).toEqual([]);
+      expect(
+        screen.getByTestId("host-overview-update-attempt-failed").textContent,
+      ).toContain(
+        "Traycer couldn't verify that v1.3.0-rc.3 can be installed on host-a.",
+      );
+      expect(screen.queryByTestId("host-busy-force-defer-dialog")).toBeNull();
     });
   });
 
@@ -764,6 +1037,15 @@ describe("HostOverviewOperationCard — record-derived parks", () => {
       overrideHandlers: {
         "host.status": () =>
           statusWithBusy("1.3.0-rc.2", { kind: "none" }, true, 2),
+        // Force update renders only once the check proves the staged entry
+        // clear of the CLI floor (`stagedEntryKnown`), same as the positive
+        // Force fixture above; without it the button never appears.
+        "host.update.check": () => ({
+          outcome: "ok" as const,
+          effectiveIncludePreReleases: true,
+          includePreReleasesSource: "explicit-include" as const,
+          manifest: clearStagedManifest("1.3.0-rc.3"),
+        }),
       },
     });
     recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
@@ -811,6 +1093,15 @@ describe("HostOverviewOperationCard — record-derived parks", () => {
       overrideHandlers: {
         "host.status": () =>
           statusWithBusy("1.3.0-rc.2", { kind: "none" }, true, 2),
+        // Force update renders only once the check proves the staged entry
+        // clear of the CLI floor (`stagedEntryKnown`), same as the positive
+        // Force fixture above; without it the button never appears.
+        "host.update.check": () => ({
+          outcome: "ok" as const,
+          effectiveIncludePreReleases: true,
+          includePreReleasesSource: "explicit-include" as const,
+          manifest: clearStagedManifest("1.3.0-rc.3"),
+        }),
       },
     });
     recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-overview-operation-card.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-overview-operation-card.test.tsx
@@ -40,6 +40,7 @@ vi.mock("sonner", () => ({
 
 import type { ReactNode } from "react";
 import {
+  act,
   cleanup,
   fireEvent,
   render,
@@ -840,5 +841,144 @@ describe("HostOverviewOperationCard — record-derived parks", () => {
     await waitFor(() => {
       expect(screen.queryByTestId("host-busy-force-defer-dialog")).toBeNull();
     });
+  });
+});
+
+/**
+ * A settable promise, so a fixture handler can hold `host.getInstallationInfo`
+ * pending until the test is ready to resolve it - the deferred install read
+ * these two pins each gate on a call count.
+ */
+function deferredInstallationResponse(): {
+  readonly promise: Promise<HostGetInstallationInfoResponseV11>;
+  readonly resolve: (value: HostGetInstallationInfoResponseV11) => void;
+} {
+  let resolve: (value: HostGetInstallationInfoResponseV11) => void = () => {
+    throw new Error("resolve called before assignment");
+  };
+  const promise = new Promise<HostGetInstallationInfoResponseV11>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+// `useHostInstallationInfoQuery` (`host-overview-rpc.ts`): keyed by the
+// RUNNING version the caller has observed (`cacheKeyIdentity: [runningVersion]`)
+// and disabled until one is known. Both pins ablate by reverting to the OLD
+// shape - no key, no gate - which is exactly what let a record fetched under
+// the PREVIOUS running version answer a comparison against a version that has
+// since moved.
+describe("HostOverviewOperationCard — installation query keyed by running version", () => {
+  it("a running-version change does not compare the OLD install record against the NEW version", async () => {
+    // Falsification: drop `cacheKeyIdentity: [runningVersion]` from
+    // `useHostInstallationInfoQuery` (set `undefined`) and the SAME query
+    // keeps serving the rc.2 install record while `host.status` already
+    // reports rc.3 - the debt card renders "v1.3.0-rc.2 is installed" for a
+    // host that has already moved past it.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    let statusCalls = 0;
+    let installationCalls = 0;
+    const secondRead = deferredInstallationResponse();
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: true,
+      overrideHandlers: {
+        "host.status": () => {
+          statusCalls += 1;
+          return statusWithBusy(
+            statusCalls === 1 ? "1.3.0-rc.2" : "1.3.0-rc.3",
+            { kind: "none" },
+            false,
+            0,
+          );
+        },
+        "host.getInstallationInfo": () => {
+          installationCalls += 1;
+          if (installationCalls === 1) {
+            return managedInstallation(installRecord("1.3.0-rc.2", null), null);
+          }
+          // The read for the NEW key (running = rc.3) is slow/pending -
+          // exactly the window a stale, unkeyed cache entry would otherwise
+          // paper over with the rc.2 answer.
+          return secondRead.promise;
+        },
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    hostBindingMock.current = { hostClient: fixture.client };
+    scopeOverrides.current = scopeFrom("host-a", fixture);
+    renderPanel();
+
+    // Baseline: install matches the running rc.2 - no debt.
+    await screen.findByText(/1\.3\.0-rc\.2/);
+    expect(screen.queryByTestId("host-overview-operation-card")).toBeNull();
+
+    // Advance past the 10s `host.status` poll: the host reports rc.3, and the
+    // installation query re-keys onto a fresh, still-pending read.
+    await vi.advanceTimersByTimeAsync(11_000);
+    await screen.findByText(/1\.3\.0-rc\.3/);
+    await waitFor(() => expect(installationCalls).toBe(2));
+
+    // While that fresh read is pending, there is nothing to compare against -
+    // "not observed", never a debt derived from the OLD rc.2 record.
+    expect(screen.queryByTestId("host-overview-operation-card")).toBeNull();
+
+    // Resolve it with the record a real host would now report - matching the
+    // new running version - and the card stays absent.
+    await act(async () => {
+      secondRead.resolve(
+        managedInstallation(installRecord("1.3.0-rc.3", null), null),
+      );
+      await secondRead.promise;
+    });
+    expect(screen.queryByTestId("host-overview-operation-card")).toBeNull();
+
+    vi.useRealTimers();
+  });
+
+  it("a failed installation read hides the record-derived facts", async () => {
+    // Falsification: remove `|| installationQuery.isError` from the
+    // `legacyFacts` gate in `host-overview-panel.tsx` and the card keeps
+    // showing the LAST successful record's debt through a read that has
+    // since started failing.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    let installationCalls = 0;
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: true,
+      hostVersion: "1.3.0-rc.2",
+      overrideHandlers: {
+        "host.status": () =>
+          statusWithBusy("1.3.0-rc.2", { kind: "none" }, false, 0),
+        "host.getInstallationInfo": () => {
+          installationCalls += 1;
+          if (installationCalls === 2) {
+            throw new Error("host unreachable");
+          }
+          return managedInstallation(installRecord("1.3.0-rc.3", null), null);
+        },
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    hostBindingMock.current = { hostClient: fixture.client };
+    scopeOverrides.current = scopeFrom("host-a", fixture);
+    renderPanel();
+
+    // Debt visible: record rc.3 ahead of the running rc.2.
+    await screen.findByTestId("host-overview-operation-restart");
+
+    // The next installation poll throws - the status read keeps succeeding
+    // beside it, so this failure is the installation leg's alone.
+    await vi.advanceTimersByTimeAsync(11_000);
+    await waitFor(() => expect(installationCalls).toBe(2));
+    await waitFor(() => {
+      expect(screen.queryByTestId("host-overview-operation-card")).toBeNull();
+    });
+
+    // The next successful poll brings the debt card back.
+    await vi.advanceTimersByTimeAsync(11_000);
+    await screen.findByTestId("host-overview-operation-restart");
+
+    vi.useRealTimers();
   });
 });

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-overview-operation-card.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-overview-operation-card.test.tsx
@@ -754,8 +754,10 @@ describe("HostOverviewOperationCard — record-derived parks", () => {
     expect(
       screen.getByTestId("host-overview-operation-phase").textContent,
     ).toBe("Update will continue when 2 sessions finish");
-    // Removing the stagedFloor gate would expose Force update for a CLI-floor
-    // refusal; this negative affordance pin must turn RED under that ablation.
+    // Removing `!updates.stagedEntryOfferable` from the panel's Force gate
+    // would expose Force update for this CLI-floor refusal (the floored
+    // staged version is not offerable); this negative affordance pin must
+    // turn RED under that ablation.
     expect(
       screen.queryByTestId("host-overview-operation-force-update"),
     ).toBeNull();
@@ -1038,7 +1040,7 @@ describe("HostOverviewOperationCard — record-derived parks", () => {
         "host.status": () =>
           statusWithBusy("1.3.0-rc.2", { kind: "none" }, true, 2),
         // Force update renders only once the check proves the staged entry
-        // clear of the CLI floor (`stagedEntryKnown`), same as the positive
+        // clear of the CLI floor (`stagedEntryOfferable`), same as the positive
         // Force fixture above; without it the button never appears.
         "host.update.check": () => ({
           outcome: "ok" as const,
@@ -1094,7 +1096,7 @@ describe("HostOverviewOperationCard — record-derived parks", () => {
         "host.status": () =>
           statusWithBusy("1.3.0-rc.2", { kind: "none" }, true, 2),
         // Force update renders only once the check proves the staged entry
-        // clear of the CLI floor (`stagedEntryKnown`), same as the positive
+        // clear of the CLI floor (`stagedEntryOfferable`), same as the positive
         // Force fixture above; without it the button never appears.
         "host.update.check": () => ({
           outcome: "ok" as const,

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-overview-updates.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-overview-updates.test.tsx
@@ -2392,9 +2392,10 @@ describe("Overview updates — CLI floor remedy", () => {
     const onSettled = vi.fn(() => {
       expect(returned).toBe(false);
     });
-    // Adding entry.yanked to readCliFloor's early return would authorize this
-    // staged release; the synchronous no-mutation pin must RED under that
-    // shared-reader ablation.
+    // This pins the WITHDRAWAL gate of `describeForceUpdateRefusal`, which
+    // is consulted before any floor: `readCliFloor` is never reached for a
+    // yanked entry, so no change to it can authorize this release. Dropping
+    // the `entry.yanked` refusal is what reddens the no-mutation pin.
     act(() => {
       yankedRendered.result.current.installForce("1.3.0", onSettled);
       returned = true;
@@ -2526,7 +2527,7 @@ describe("Overview updates — CLI floor remedy", () => {
     renderPanel();
 
     const sentence =
-      "On host-a, run this command to prepare the host update: npm install -g @traycerai/cli@1.3.0-rc.4. Then select Check now.";
+      "On host-a, run this command to prepare the host update: npm install -g @traycerai/cli@1.3.0-rc.4. This page rechecks while it is open, and Update now appears once the host accepts the update.";
     await screen.findByText(sentence);
     // Skipping floor acceptance after the unusable preferred stable would
     // remove this selected RC remedy; with no installable fallback, it would
@@ -2995,5 +2996,226 @@ describe("Overview updates — activation debt", () => {
     });
 
     await screen.findByTestId("host-overview-operation-restart");
+  });
+});
+
+describe("Overview updates — record-leg liveness and entry-level floor gates", () => {
+  it("a failed installation read keeps the debt sentence as (last known) and withholds Update now, instead of re-offering the installed version", async () => {
+    // The catalog's comparison baseline is the facts as READ, qualified by
+    // the record leg's liveness - not the live-only facts the card's
+    // controls take. Erasing the facts on one failed poll dropped the
+    // baseline, and the region then re-offered the version that is already
+    // on disk as "available" with a live Update now, for bytes a failed poll
+    // did not change. Falsification: build `activationDebt` from
+    // `legacyFacts` (live-only) instead of `legacyFactsRead` in
+    // `host-overview-panel.tsx` and the (last known) sentence below becomes
+    // "v1.3.0-rc.3 is available." beside an Update now button.
+    let installationCalls = 0;
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: true,
+      hostVersion: "1.3.0-rc.2",
+      overrideHandlers: {
+        "host.getInstallationInfo": () => {
+          installationCalls += 1;
+          if (installationCalls === 2) {
+            throw new Error("host unreachable");
+          }
+          return managedInstallation(installRecord("1.3.0-rc.3", null), null);
+        },
+        "host.update.check": () => ({
+          outcome: "ok" as const,
+          effectiveIncludePreReleases: true,
+          includePreReleasesSource: "installed-rc" as const,
+          manifest: multiVersionManifest(["1.3.0-rc.3"]),
+        }),
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    hostBindingMock.current = { hostClient: fixture.client };
+    scopeOverrides.current = scopeFrom("host-a", fixture);
+    const { queryClient } = renderPanel();
+
+    // Live debt: the record (rc.3) is ahead of the running host (rc.2), and
+    // the catalog's rc.3 is what is installed - no offer, a restart.
+    await waitFor(() => {
+      expect(screen.getByRole("status").textContent).toBe(
+        "v1.3.0-rc.3 is installed — restart host to finish.",
+      );
+    });
+    expect(screen.queryByRole("button", { name: "Update now" })).toBeNull();
+    await screen.findByTestId("host-overview-operation-restart");
+
+    // The record poll fails while the status read keeps succeeding beside
+    // it. The debt is retained as EVIDENCE (the comparison baseline), said
+    // as last known; the controls that would dispatch on it are withdrawn.
+    await act(async () => {
+      await queryClient.invalidateQueries();
+    });
+    await waitFor(() => expect(installationCalls).toBe(2));
+    await waitFor(() => {
+      expect(screen.getByRole("status").textContent).toBe(
+        "v1.3.0-rc.3 is installed (last known) — restart host to finish.",
+      );
+    });
+    expect(screen.queryByRole("button", { name: "Update now" })).toBeNull();
+    expect(screen.queryByTestId("host-overview-operation-restart")).toBeNull();
+
+    // The next successful read restores the live sentence and its control.
+    await act(async () => {
+      await queryClient.invalidateQueries();
+    });
+    await waitFor(() => expect(installationCalls).toBe(3));
+    await waitFor(() => {
+      expect(screen.getByRole("status").textContent).toBe(
+        "v1.3.0-rc.3 is installed — restart host to finish.",
+      );
+    });
+    await screen.findByTestId("host-overview-operation-restart");
+  });
+
+  it("a floor that is not a version renders help and does NOT arm the recheck; a readable floor beside it does", async () => {
+    // `CliFloor.repairable` is what the recheck is keyed on: the mounted
+    // 30 s recheck exists to notice a CLI upgrade clearing the floor, and no
+    // upgrade clears a requirement this page cannot read - so polling it
+    // would re-ask the host forever with nothing on screen able to end it.
+    // Falsification: drop `cliFloor.repairable` from `recheckFloor` in
+    // `host-overview-updates-state.ts` and the count climbs across the two
+    // quiet periods below.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    let checks = 0;
+    let floorReadable = false;
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: true,
+      hostVersion: "1.2.0",
+      installation: managedInstallationWithCli(
+        installRecord("1.2.0", null),
+        "1.2.0",
+        "manual",
+        "/home/u/.local/bin/traycer",
+      ),
+      overrideHandlers: {
+        "host.update.check": () => {
+          checks += 1;
+          const floored = floorManifest("1.3.0", false);
+          const declared = floorReadable ? "1.3.0" : "v1.3.0";
+          return Promise.resolve({
+            outcome: "ok" as const,
+            effectiveIncludePreReleases: false,
+            includePreReleasesSource: "stable-default" as const,
+            manifest: {
+              ...floored,
+              versions: floored.versions.map((entry) => ({
+                ...entry,
+                requiredCliVersion: declared,
+                platforms: {
+                  "darwin-arm64": {
+                    ...entry.platforms["darwin-arm64"],
+                    unavailableReason: `Needs Traycer CLI ${declared} or newer (this host's CLI is 1.2.0).`,
+                  },
+                },
+              })),
+            },
+          });
+        },
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    hostBindingMock.current = { hostClient: fixture.client };
+    scopeOverrides.current = scopeFrom("host-a", fixture);
+    renderPanel();
+
+    // Help on screen, no command - and no recheck behind it.
+    await waitFor(() => expect(checks).toBe(1));
+    await waitForButton("Show installation help");
+    expect(screen.getByRole("status").textContent).toBe(
+      "Traycer couldn't verify the required command-line tools version on host-a.",
+    );
+    expect(screen.queryByRole("button", { name: "Copy command" })).toBeNull();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(31_000);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(31_000);
+    });
+    expect(checks).toBe(1);
+
+    // Positive control, same host: a READABLE floor renders the command and
+    // arms the recheck.
+    floorReadable = true;
+    fireEvent.click(await waitForButton("Check now"));
+    await waitFor(() => expect(checks).toBe(2));
+    await waitForButton("Copy command");
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000);
+    });
+    await waitFor(() => expect(checks).toBe(3));
+
+    vi.useRealTimers();
+  });
+
+  it("Force update… is withheld for a staged version whose catalog entry declares a floor this page cannot read, even with the asset available", async () => {
+    // Staged bytes install whatever the asset's availability says: the
+    // CLI's already-staged short-circuit resolves no asset and applies no
+    // floor. So the Force gate reads the catalog ENTRY's own floor, apart
+    // from the asset's authored reason, and refuses one that is not a
+    // version - the executing CLI's verdict never reached it. A READABLE
+    // floor is left to the asset's verdict (`available` is the executing
+    // CLI's own comparison), which the positive control below relies on.
+    // Falsification: drop the `!isValidHostVersion(declaredFloor)` arm from
+    // `describeForceUpdateRefusal` and the first absence goes RED.
+    let declaredFloor = "v1.3.0";
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: true,
+      busy: true,
+      busySessionCount: 1,
+      hostVersion: "1.2.0",
+      installation: managedInstallationWithCliAndStage(
+        installRecord("1.2.0", null),
+        stagedRecord("1.3.0"),
+      ),
+      overrideHandlers: {
+        "host.update.check": () => {
+          const cleared = floorManifest("1.3.0", true);
+          return Promise.resolve({
+            outcome: "ok" as const,
+            effectiveIncludePreReleases: false,
+            includePreReleasesSource: "stable-default" as const,
+            manifest: {
+              ...cleared,
+              versions: cleared.versions.map((entry) => ({
+                ...entry,
+                requiredCliVersion: declaredFloor,
+              })),
+            },
+          });
+        },
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    hostBindingMock.current = { hostClient: fixture.client };
+    scopeOverrides.current = scopeFrom("host-a", fixture);
+    renderPanel();
+
+    const card = await screen.findByTestId("host-overview-operation-card");
+    expect(card.textContent).toContain("Update waits for 1 session to finish");
+    // The check has answered (the region left "Checking…") before the
+    // absence is read, so this is the gate's decision, not a loading frame.
+    await waitFor(() => {
+      expect(screen.getByRole("status").textContent).not.toBe(
+        "Checking for updates…",
+      );
+    });
+    expect(
+      screen.queryByTestId("host-overview-operation-force-update"),
+    ).toBeNull();
+
+    // Positive control: the same entry with a readable floor the asset
+    // clears offers Force.
+    declaredFloor = "1.3.0";
+    fireEvent.click(await waitForButton("Check now"));
+    await screen.findByTestId("host-overview-operation-force-update");
   });
 });

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-overview-updates.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-overview-updates.test.tsx
@@ -38,12 +38,13 @@ vi.mock("sonner", () => ({
   },
 }));
 
-import type { ReactElement } from "react";
+import type { ReactElement, ReactNode } from "react";
 import {
   act,
   cleanup,
   fireEvent,
   render,
+  renderHook,
   screen,
   waitFor,
   within,
@@ -59,6 +60,7 @@ import type {
 import type {
   HostInstallRecord,
   HostStagedRecord,
+  StoredCliInstallManifest,
 } from "@traycer/protocol/config/installation-records";
 import { MockRunnerHost } from "@traycer-clients/shared/host-client/mock/mock-runner-host";
 import {
@@ -79,6 +81,7 @@ import {
   openHostOverviewMenu,
   type OverviewHostFixture,
 } from "@/components/settings/panels/__tests__/host-overview-test-support";
+import { useHostOverviewUpdates } from "@/components/settings/panels/host-overview-updates-state";
 
 /**
  * The version PICKER that replaced the single "Update to v<latest>" button
@@ -93,6 +96,7 @@ afterEach(() => {
   resetNegotiatedManifests();
   scopeOverrides.current = {};
   hostBindingMock.current = null;
+  vi.useRealTimers();
 });
 
 const ALL_OVERVIEW_METHODS = [
@@ -324,6 +328,203 @@ function managedInstallation(
     stagedRecord: staged,
     cliManifest: null,
   };
+}
+
+function managedInstallationWithCli(
+  install: HostInstallRecord,
+  cliVersion: string,
+  source: StoredCliInstallManifest["source"],
+  binaryPath: string,
+): HostGetInstallationInfoResponseV11 {
+  // Built directly rather than spread from `managedInstallation`: that helper
+  // returns the response UNION, and TypeScript will not add `cliManifest` to a
+  // spread it cannot narrow to the managed arm.
+  return {
+    status: "managed",
+    installRecord: install,
+    stagedRecord: null,
+    cliManifest: {
+      version: cliVersion,
+      installedAt: "2026-09-06T00:00:00Z",
+      binaryPath,
+      source,
+      pendingUpgrade: null,
+    },
+  };
+}
+
+function stagedRecord(version: string): HostStagedRecord {
+  return {
+    schemaVersion: 1,
+    stageId: null,
+    version,
+    runtimeVersion: null,
+    archiveSha256: "a".repeat(64),
+    sizeBytes: 1024,
+    source: { kind: "registry", value: version },
+    signatureKeyId: "key-1",
+    signatureVerifiedAt: "2026-08-10T00:00:00Z",
+    executablePath: `/tmp/traycer/${version}/host`,
+    platform: "darwin",
+    arch: "arm64",
+    executableSha256: "b".repeat(64),
+  };
+}
+
+function managedInstallationWithCliAndStage(
+  install: HostInstallRecord,
+  staged: HostStagedRecord,
+): HostGetInstallationInfoResponseV11 {
+  return {
+    status: "managed",
+    installRecord: install,
+    stagedRecord: staged,
+    cliManifest: {
+      version: "1.2.0",
+      installedAt: "2026-09-06T00:00:00Z",
+      binaryPath: "/home/u/.local/bin/traycer",
+      source: "manual",
+      pendingUpgrade: null,
+    },
+  };
+}
+
+function floorManifest(
+  version: string,
+  available: boolean,
+): HostAvailableManifest {
+  const base = multiVersionManifest([version]);
+  return {
+    ...base,
+    versions: base.versions.map((entry) => ({
+      ...entry,
+      requiredCliVersion: "1.3.0",
+      platforms: {
+        "darwin-arm64": {
+          ...entry.platforms["darwin-arm64"],
+          available,
+          unavailableReason: available
+            ? null
+            : "Needs Traycer CLI 1.3.0 or newer (this host's CLI is 1.2.0).",
+        },
+      },
+    })),
+  };
+}
+
+function floorManifestWithoutRequiredVersion(
+  version: string,
+): HostAvailableManifest {
+  const manifest = floorManifest(version, false);
+  return {
+    ...manifest,
+    versions: manifest.versions.map((entry) => ({
+      ...entry,
+      requiredCliVersion: null,
+      platforms: {
+        "darwin-arm64": {
+          ...entry.platforms["darwin-arm64"],
+          unavailableReason: "Needs Traycer CLI ",
+        },
+      },
+    })),
+  };
+}
+
+function lowerRcFallbackManifest(): HostAvailableManifest {
+  const stableFloor = floorManifest("1.3.0", false).versions[0];
+  const rc = multiVersionManifest(["1.3.0-rc.2"]).versions[0];
+  return {
+    schemaVersion: 1,
+    generatedAt: "2026-09-06T00:00:00Z",
+    latest: "1.3.0",
+    versions: [stableFloor, { ...rc, requiredCliVersion: "1.2.0" }],
+  };
+}
+
+const SELECTED_RC_CASES = [
+  {
+    name: "a yanked floor-refused stable",
+    stableYanked: true,
+    stableReason:
+      "Needs Traycer CLI 1.3.0 or newer (this host's CLI is 1.2.0).",
+  },
+  {
+    name: "a non-floor unavailable stable",
+    stableYanked: false,
+    stableReason: "platform build withdrawn",
+  },
+] as const;
+
+type SelectedRcCase = (typeof SELECTED_RC_CASES)[number];
+
+function selectedRcManifest(testCase: SelectedRcCase): HostAvailableManifest {
+  const stableBase = multiVersionManifest(["1.3.0"]).versions[0];
+  const rcBase = multiVersionManifest(["1.3.0-rc.2"]).versions[0];
+  const stable = {
+    ...stableBase,
+    yanked: testCase.stableYanked,
+    requiredCliVersion: "1.3.0",
+    platforms: {
+      "darwin-arm64": {
+        ...stableBase.platforms["darwin-arm64"],
+        available: false,
+        unavailableReason: testCase.stableReason,
+      },
+    },
+  };
+  const rc = {
+    ...rcBase,
+    requiredCliVersion: "1.3.0-rc.4",
+    platforms: {
+      "darwin-arm64": {
+        ...rcBase.platforms["darwin-arm64"],
+        available: false,
+        unavailableReason:
+          "Needs Traycer CLI 1.3.0-rc.4 or newer (this host's CLI is 1.2.0).",
+      },
+    },
+  };
+  return {
+    ...multiVersionManifest(["1.3.0", "1.3.0-rc.2"]),
+    latest: "1.3.0",
+    versions: [stable, rc],
+  };
+}
+
+function renderUpdatesHook(
+  client: OverviewHostFixture["client"],
+  hostId: string,
+  runningVersion: string,
+  stagedVersion: string | null,
+) {
+  const queryClient = newQueryClient();
+  return renderHook(
+    () =>
+      useHostOverviewUpdates({
+        client,
+        hostName: "host-a",
+        hostId,
+        runningVersion,
+        activationDebt: null,
+        platformKey: "darwin-arm64",
+        cliManifest: null,
+        isLocalMachine: false,
+        desktopUpdate: null,
+        stagedVersion,
+        enabled: true,
+        checkDegrade: null,
+        installDegrade: null,
+        busy: false,
+      }),
+    {
+      wrapper: (props: { readonly children: ReactNode }) => (
+        <QueryClientProvider client={queryClient}>
+          {props.children}
+        </QueryClientProvider>
+      ),
+    },
+  );
 }
 
 describe("<HostSettingsPanel /> Overview updates — version picker", () => {
@@ -1458,6 +1659,713 @@ describe("<HostSettingsPanel /> Overview updates — version picker", () => {
         .getByRole("button", { name: "Install 2.0.0-rc.1" })
         .hasAttribute("disabled"),
     ).toBe(false);
+  });
+});
+
+describe("Overview updates — CLI floor remedy", () => {
+  it("projects the latest refusal over an old stored CLI and replaces Update now with copy guidance", async () => {
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: true,
+      hostVersion: "1.2.0",
+      installation: managedInstallationWithCli(
+        installRecord("1.2.0", null),
+        "1.2.0",
+        "manual",
+        "/home/u/.local/bin/traycer",
+      ),
+      overrideHandlers: {
+        "host.update.check": () =>
+          Promise.resolve({
+            outcome: "ok" as const,
+            effectiveIncludePreReleases: false,
+            includePreReleasesSource: "stable-default" as const,
+            manifest: floorManifest("1.3.0", false),
+          }),
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    hostBindingMock.current = { hostClient: fixture.client };
+    scopeOverrides.current = scopeFrom("host-a", fixture);
+    renderPanel();
+
+    await screen.findByText(
+      "First update Traycer's command-line tools on host-a. Open a terminal on that machine and run the copied command. When it finishes, come back here: this page rechecks while it is open, and Update now appears once the host accepts the update.",
+    );
+    // This lone unavailable asset keeps Update now hidden even if only the
+    // cliFloor suppression is removed: the asset gate independently rejects
+    // it. The lower-RC hook fixture below isolates that suppression by leaving
+    // a lower same-line RC offerable. This mounted negative instead catches a
+    // fabricated Update now that ignores both remedy and asset eligibility.
+    expect(screen.queryByRole("button", { name: "Update now" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Copy command" })).toBeTruthy();
+  });
+
+  it("retains the remedy when the stored CLI is new, with the older-copy sentence", async () => {
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: true,
+      hostVersion: "1.2.0",
+      installation: managedInstallationWithCli(
+        installRecord("1.2.0", null),
+        "1.3.0",
+        "manual",
+        "/home/u/.local/bin/traycer",
+      ),
+      overrideHandlers: {
+        "host.update.check": () =>
+          Promise.resolve({
+            outcome: "ok" as const,
+            effectiveIncludePreReleases: false,
+            includePreReleasesSource: "stable-default" as const,
+            manifest: floorManifest("1.3.0", false),
+          }),
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    hostBindingMock.current = { hostClient: fixture.client };
+    scopeOverrides.current = scopeFrom("host-a", fixture);
+    renderPanel();
+
+    await screen.findByText(
+      "Traycer's command-line tools on host-a were updated, but the host is still using an older copy. Run the command again: First update Traycer's command-line tools on host-a. Open a terminal on that machine and run the copied command. When it finishes, come back here: this page rechecks while it is open, and Update now appears once the host accepts the update.",
+    );
+    // Treating cliManifest.version as clearance while restoring updatableVersion
+    // would expose Update now; the meaningful positive pin above is the
+    // older-copy sentence itself, while the lower-RC hook case isolates
+    // suppression.
+    expect(screen.queryByRole("button", { name: "Update now" })).toBeNull();
+  });
+
+  it("lets activation debt win the sentence while retaining the floor remedy action", async () => {
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: true,
+      hostVersion: "1.2.0",
+      installation: managedInstallationWithCli(
+        installRecord("1.2.1", null),
+        "1.2.0",
+        "manual",
+        "/home/u/.local/bin/traycer",
+      ),
+      overrideHandlers: {
+        "host.update.check": () =>
+          Promise.resolve({
+            outcome: "ok" as const,
+            effectiveIncludePreReleases: false,
+            includePreReleasesSource: "stable-default" as const,
+            manifest: floorManifest("1.3.0", false),
+          }),
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    hostBindingMock.current = { hostClient: fixture.client };
+    scopeOverrides.current = scopeFrom("host-a", fixture);
+    renderPanel();
+
+    await screen.findByText("v1.2.1 is installed — restart host to finish.");
+    // Removing the activation-debt arm from describeCheckState would let the
+    // remedy sentence win; this negative precedence pin must turn RED under
+    // that concrete ablation while the remedy action remains available.
+    expect(screen.getByRole("button", { name: "Copy command" })).toBeTruthy();
+  });
+
+  it("turns an unreadable CLI manifest into installation help", async () => {
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: true,
+      hostVersion: "1.2.0",
+      installation: managedInstallation(installRecord("1.2.0", null), null),
+      overrideHandlers: {
+        "host.update.check": () =>
+          Promise.resolve({
+            outcome: "ok" as const,
+            effectiveIncludePreReleases: false,
+            includePreReleasesSource: "stable-default" as const,
+            manifest: floorManifest("1.3.0", false),
+          }),
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    hostBindingMock.current = { hostClient: fixture.client };
+    scopeOverrides.current = scopeFrom("host-a", fixture);
+    renderPanel();
+
+    await screen.findByText(
+      "Traycer couldn't determine how its command-line tools were installed on host-a.",
+    );
+    expect(
+      screen.getByRole("button", { name: "Show installation help" }),
+    ).toBeTruthy();
+  });
+
+  it("does not offer a CLI repair for a malformed required version reason", async () => {
+    const requiredCliVersion = "1.3.0; npm install -g @traycerai/cli@latest";
+    const base = floorManifest("1.3.0", false);
+    const baseEntry = base.versions[0];
+    const malformedManifest: HostAvailableManifest = {
+      ...base,
+      versions: [
+        {
+          ...baseEntry,
+          requiredCliVersion,
+          platforms: {
+            "darwin-arm64": {
+              ...baseEntry.platforms["darwin-arm64"],
+              unavailableReason: `host registry: version '1.3.0' declares requiredCliVersion ${JSON.stringify(requiredCliVersion)}, which is not a version this CLI can compare against. The manifest is wrong; do not work around it by installing a different version.`,
+            },
+          },
+        },
+      ],
+    };
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: true,
+      hostVersion: "1.2.0",
+      installation: managedInstallationWithCli(
+        installRecord("1.2.0", null),
+        "1.2.0",
+        "manual",
+        "/home/u/.local/bin/traycer",
+      ),
+      overrideHandlers: {
+        "host.update.check": () => ({
+          outcome: "ok" as const,
+          effectiveIncludePreReleases: false,
+          includePreReleasesSource: "stable-default" as const,
+          manifest: malformedManifest,
+        }),
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    const rendered = renderUpdatesHook(fixture.client, "host-a", "1.2.0", null);
+    await waitFor(() =>
+      expect(rendered.result.current.picker.awaitingFirstCheck).toBe(false),
+    );
+    // Broadening readCliFloor to every unavailable asset would misclassify
+    // this malformed reason as a repairable floor; these null hook fields must
+    // turn RED under that GUI predicate ablation.
+    expect(rendered.result.current.cliFloor).toBeNull();
+    expect(rendered.result.current.summary.remedy).toBeNull();
+    rendered.unmount();
+
+    hostBindingMock.current = { hostClient: fixture.client };
+    scopeOverrides.current = scopeFrom("host-a", fixture);
+    renderPanel();
+    await screen.findByText(
+      "v1.3.0 is available, but host-a can't install it.",
+    );
+    expect(screen.queryByRole("button", { name: "Copy command" })).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Show installation help" }),
+    ).toBeNull();
+    expect(screen.queryByRole("button", { name: "Update now" })).toBeNull();
+  });
+
+  it("does not classify a withdrawn platform build with a retained SHA as a floor", async () => {
+    const withdrawn = floorManifest("1.3.0", false);
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: true,
+      hostVersion: "1.2.0",
+      installation: managedInstallationWithCli(
+        installRecord("1.2.0", null),
+        "1.2.0",
+        "manual",
+        "/home/u/.local/bin/traycer",
+      ),
+      overrideHandlers: {
+        "host.update.check": () =>
+          Promise.resolve({
+            outcome: "ok" as const,
+            effectiveIncludePreReleases: false,
+            includePreReleasesSource: "stable-default" as const,
+            manifest: {
+              ...withdrawn,
+              versions: withdrawn.versions.map((entry) => ({
+                ...entry,
+                platforms: {
+                  "darwin-arm64": {
+                    ...entry.platforms["darwin-arm64"],
+                    unavailableReason: "platform build withdrawn",
+                    sha256: "b".repeat(64),
+                  },
+                },
+              })),
+            },
+          }),
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    hostBindingMock.current = { hostClient: fixture.client };
+    scopeOverrides.current = scopeFrom("host-a", fixture);
+    renderPanel();
+
+    await screen.findByText(
+      "v1.3.0 is available, but host-a can't install it.",
+    );
+    // Removing the authored floor-reason predicate would offer remedy copy for
+    // this withdrawn-with-hash counterexample; this negative pin must turn RED
+    // under that concrete structural-ablation.
+    expect(screen.queryByRole("button", { name: "Copy command" })).toBeNull();
+
+    cleanup();
+    const yankedFloored = floorManifest("1.3.0", false);
+    const yankedLatestManifest = {
+      ...yankedFloored,
+      versions: yankedFloored.versions.map((entry) => ({
+        ...entry,
+        yanked: true,
+      })),
+    };
+    const yankedLatestFixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: true,
+      hostVersion: "1.2.0",
+      installation: managedInstallationWithCli(
+        installRecord("1.2.0", null),
+        "1.2.0",
+        "manual",
+        "/home/u/.local/bin/traycer",
+      ),
+      overrideHandlers: {
+        "host.update.check": () =>
+          Promise.resolve({
+            outcome: "ok" as const,
+            effectiveIncludePreReleases: false,
+            includePreReleasesSource: "stable-default" as const,
+            manifest: yankedLatestManifest,
+          }),
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    hostBindingMock.current = { hostClient: yankedLatestFixture.client };
+    scopeOverrides.current = scopeFrom("host-a", yankedLatestFixture);
+    renderPanel();
+
+    await screen.findByText(
+      "v1.3.0 is available, but host-a can't install it.",
+    );
+    // Removing !entry.yanked from the summary target would expose the floor
+    // remedy for this release; these negative no-repair pins must turn RED.
+    expect(screen.queryByRole("button", { name: "Copy command" })).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Show installation help" }),
+    ).toBeNull();
+    expect(screen.queryByRole("button", { name: "Update now" })).toBeNull();
+  });
+
+  it("rechecks a repaired manifest and reveals Update now without a click", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    let checks = 0;
+    const installCalls: Array<{ version: string; force: boolean }> = [];
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: true,
+      busy: true,
+      busySessionCount: 1,
+      hostVersion: "1.2.0",
+      installation: managedInstallationWithCliAndStage(
+        installRecord("1.2.0", null),
+        stagedRecord("1.3.0"),
+      ),
+      overrideHandlers: {
+        "host.update.check": () => {
+          checks += 1;
+          if (checks >= 4) {
+            return Promise.resolve({ outcome: "cli-failed" as const });
+          }
+          return Promise.resolve({
+            outcome: "ok" as const,
+            effectiveIncludePreReleases: false,
+            includePreReleasesSource: "stable-default" as const,
+            manifest: floorManifest("1.3.0", checks === 1 || checks === 3),
+          });
+        },
+        "host.update.install": (request) => {
+          installCalls.push({ version: request.version, force: request.force });
+          return { outcome: "accepted" as const, attemptId: null };
+        },
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    hostBindingMock.current = { hostClient: fixture.client };
+    scopeOverrides.current = scopeFrom("host-a", fixture);
+    const { queryClient } = renderPanel();
+
+    await screen.findByTestId("host-overview-operation-force-update");
+    fireEvent.click(screen.getByTestId("host-overview-operation-force-update"));
+    await screen.findByTestId("host-busy-force-defer-dialog");
+    // The confirmation re-asks before dispatch so this rendered panel records
+    // a real refusal against the exact staged version, rather than a synthetic
+    // hook state. The repair below must come only from the condition poll.
+    await act(async () => {
+      await queryClient.invalidateQueries();
+    });
+    await waitFor(() => expect(checks).toBeGreaterThan(1));
+    fireEvent.click(screen.getByTestId("host-busy-force"));
+    await waitFor(() => {
+      expect(installCalls).toEqual([]);
+      expect(screen.getByRole("status").textContent).toContain(
+        "v1.3.0 needs Traycer CLI 1.3.0 or newer on host-a.",
+      );
+      expect(
+        screen.getByTestId("host-overview-update-attempt-failed").textContent,
+      ).toContain("v1.3.0 needs Traycer CLI 1.3.0 or newer on host-a.");
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000);
+    });
+    await screen.findByRole("button", { name: "Update now" });
+    const checksAfterRecovery = checks;
+    // Removing the floor recovery lane, or changing its fixed interval above
+    // 30s, would leave this refusal visible and fail the assertion above.
+    expect(checksAfterRecovery).toBeGreaterThan(1);
+    // Removing describeUpdateFailure's live-descriptor condition and returning
+    // stored refusal text whenever refusal exists would keep both stale
+    // surfaces visible after repair; these negative recovery pins must RED.
+    await waitFor(() => {
+      expect(screen.getByRole("status").textContent).toBe(
+        "v1.3.0 is available.",
+      );
+      expect(
+        screen.queryByTestId("host-overview-update-attempt-failed"),
+      ).toBeNull();
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(31_000);
+    });
+    // The available answer ends the condition-poll episode; retaining the
+    // lane after repair would keep shelling the host on every further tick.
+    expect(checks).toBe(checksAfterRecovery);
+    const checksBeforeFailure = checks;
+    await act(async () => {
+      await queryClient.invalidateQueries();
+    });
+    await waitFor(() => expect(checks).toBeGreaterThan(checksBeforeFailure));
+    // Deleting only the guarded checkRefutesForceRefusal/setForceRefusal(null)
+    // retirement block would keep every earlier repair assertion green but
+    // revive the old floor text after this later failed check; these negative
+    // current-failure pins must turn RED under that concrete ablation.
+    await waitFor(() => {
+      expect(screen.getByRole("status").textContent).toBe(
+        "host-a's Traycer CLI couldn't complete the request.",
+      );
+      const notice = screen.getByTestId("host-overview-update-attempt-failed");
+      expect(notice.textContent).toBe(
+        "host-a's Traycer CLI couldn't complete the request.",
+      );
+      expect(notice.textContent).not.toContain("needs Traycer CLI");
+    });
+    expect(installCalls).toEqual([]);
+  });
+
+  it("settles Force refusal synchronously exactly once for floored, absent, and incomplete-floor entries", async () => {
+    const scenarios = [
+      {
+        manifest: floorManifest("1.3.0", false),
+        version: "1.3.0",
+        expected: "v1.3.0 needs Traycer CLI 1.3.0 or newer on host-a.",
+      },
+      {
+        manifest: floorManifest("1.2.0", true),
+        version: "1.3.0",
+        expected:
+          "Traycer couldn't verify that v1.3.0 can be installed on host-a.",
+      },
+      {
+        manifest: floorManifestWithoutRequiredVersion("1.3.0"),
+        version: "1.3.0",
+        expected:
+          "Traycer couldn't verify that v1.3.0 can be installed on host-a.",
+      },
+    ] as const;
+
+    for (const scenario of scenarios) {
+      const installCalls: Array<{ version: string; force: boolean }> = [];
+      const fixture = buildOverviewHostFixture({
+        hostId: "host-a",
+        isLocalMachine: false,
+        hostVersion: "1.2.0",
+        overrideHandlers: {
+          "host.update.check": () => ({
+            outcome: "ok" as const,
+            effectiveIncludePreReleases: false,
+            includePreReleasesSource: "stable-default" as const,
+            manifest: scenario.manifest,
+          }),
+          "host.update.install": (request) => {
+            installCalls.push({
+              version: request.version,
+              force: request.force,
+            });
+            return { outcome: "accepted" as const, attemptId: null };
+          },
+        },
+      });
+      recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+      const rendered = renderUpdatesHook(
+        fixture.client,
+        "host-a",
+        "1.2.0",
+        scenario.version,
+      );
+      await waitFor(() =>
+        expect(rendered.result.current.picker.awaitingFirstCheck).toBe(false),
+      );
+
+      let returned = false;
+      const onSettled = vi.fn(() => {
+        expect(returned).toBe(false);
+      });
+      // Moving onSettled to a microtask or removing it would make this spy
+      // observe after installForce returns; this is the synchronous settlement
+      // pin. Bypassing describeForceUpdateRefusal would reach installForce's
+      // mutation and redden the no-mutation/failure assertions below.
+      act(() => {
+        rendered.result.current.installForce(scenario.version, onSettled);
+        returned = true;
+      });
+      expect(onSettled).toHaveBeenCalledTimes(1);
+      expect(installCalls).toEqual([]);
+      expect(rendered.result.current.summary.failureDescription).toContain(
+        scenario.expected,
+      );
+      // Missing required field/reason version must take the unknown branch,
+      // never interpolate a fabricated null or undefined requirement. Removing
+      // floor.requiredCliVersion's null guard would instead produce a rejected
+      // `null` requirement; this negative text pin must turn RED under that
+      // concrete ablation.
+      expect(rendered.result.current.summary.failureDescription).not.toContain(
+        "null",
+      );
+      expect(rendered.result.current.summary.failureDescription).not.toContain(
+        "undefined",
+      );
+      rendered.unmount();
+    }
+  });
+
+  it("suppresses Update now when the best stable target is floored even though a lower same-line RC is offerable", async () => {
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: false,
+      hostVersion: "1.3.0-rc.1",
+      overrideHandlers: {
+        "host.update.check": () => ({
+          outcome: "ok" as const,
+          effectiveIncludePreReleases: true,
+          includePreReleasesSource: "installed-rc" as const,
+          manifest: lowerRcFallbackManifest(),
+        }),
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    const rendered = renderUpdatesHook(
+      fixture.client,
+      "host-a",
+      "1.3.0-rc.1",
+      null,
+    );
+    await waitFor(() =>
+      expect(rendered.result.current.cliFloor).not.toBeNull(),
+    );
+    // Dropping `candidate.cliFloor !== null` in offerableLatestVersion would
+    // advertise this selected floored stable as Update now; this non-vacuous
+    // hook pin must RED at the actual candidate gate.
+    expect(rendered.result.current.summary.updatableVersion).toBeNull();
+    expect(rendered.result.current.summary.remedy).not.toBeNull();
+    expect(rendered.result.current.cliFloor?.requiredCliVersion).toBe("1.3.0");
+    rendered.unmount();
+
+    const yankedManifestBase = lowerRcFallbackManifest();
+    const yankedStable = { ...yankedManifestBase.versions[0], yanked: true };
+    const yankedManifest = {
+      ...yankedManifestBase,
+      versions: [yankedStable, yankedManifestBase.versions[1]],
+    };
+    const installCalls: Array<{ version: string; force: boolean }> = [];
+    const yankedFixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: false,
+      hostVersion: "1.3.0-rc.1",
+      overrideHandlers: {
+        "host.update.check": () => ({
+          outcome: "ok" as const,
+          effectiveIncludePreReleases: true,
+          includePreReleasesSource: "installed-rc" as const,
+          manifest: yankedManifest,
+        }),
+        "host.update.install": (request) => {
+          installCalls.push({ version: request.version, force: request.force });
+          return { outcome: "accepted" as const, attemptId: null };
+        },
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    const yankedRendered = renderUpdatesHook(
+      yankedFixture.client,
+      "host-a",
+      "1.3.0-rc.1",
+      "1.3.0",
+    );
+
+    await waitFor(() =>
+      expect(yankedRendered.result.current.summary.updatableVersion).toBe(
+        "1.3.0-rc.2",
+      ),
+    );
+    // Removing `entry.yanked` from selectSummaryCandidate would misclassify
+    // this yanked stable floor and hide the available RC fallback; this
+    // negative summary pin must turn RED under that source-predicate ablation.
+    expect(yankedRendered.result.current.cliFloor).toBeNull();
+    expect(yankedRendered.result.current.summary.remedy).toBeNull();
+    expect(yankedRendered.result.current.stagedFloor).not.toBeNull();
+
+    let returned = false;
+    const onSettled = vi.fn(() => {
+      expect(returned).toBe(false);
+    });
+    // Adding entry.yanked to readCliFloor's early return would authorize this
+    // staged release; the synchronous no-mutation pin must RED under that
+    // shared-reader ablation.
+    act(() => {
+      yankedRendered.result.current.installForce("1.3.0", onSettled);
+      returned = true;
+    });
+    expect(onSettled).toHaveBeenCalledTimes(1);
+    expect(installCalls).toEqual([]);
+    expect(yankedRendered.result.current.summary.failureDescription).toContain(
+      "v1.3.0 needs Traycer CLI 1.3.0 or newer on host-a.",
+    );
+    yankedRendered.unmount();
+  });
+
+  it("keeps an installable stable target ahead of a later floor-refused RC", async () => {
+    const stable = multiVersionManifest(["1.3.0"]).versions[0];
+    const rcBase = multiVersionManifest(["1.3.0-rc.2"]).versions[0];
+    const rc = {
+      ...rcBase,
+      requiredCliVersion: "1.4.0",
+      platforms: {
+        "darwin-arm64": {
+          ...rcBase.platforms["darwin-arm64"],
+          available: false,
+          unavailableReason:
+            "Needs Traycer CLI 1.4.0 or newer (this host's CLI is 1.2.0).",
+        },
+      },
+    };
+    const manifest: HostAvailableManifest = {
+      ...multiVersionManifest(["1.3.0", "1.3.0-rc.2"]),
+      latest: "1.3.0",
+      versions: [stable, rc],
+    };
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: false,
+      hostVersion: "1.3.0-rc.1",
+      overrideHandlers: {
+        "host.update.check": () => ({
+          outcome: "ok" as const,
+          effectiveIncludePreReleases: true,
+          includePreReleasesSource: "installed-rc" as const,
+          manifest,
+        }),
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    const rendered = renderUpdatesHook(
+      fixture.client,
+      "host-a",
+      "1.3.0-rc.1",
+      null,
+    );
+
+    await waitFor(() =>
+      expect(rendered.result.current.summary.updatableVersion).toBe("1.3.0"),
+    );
+    // Bypassing selectSummaryCandidate's installable-candidate return would
+    // let the later floored RC hide this usable stable target; these exact
+    // stable-selection pins must turn RED under that candidate-walk ablation.
+    expect(rendered.result.current.cliFloor).toBeNull();
+    expect(rendered.result.current.summary.remedy).toBeNull();
+    rendered.unmount();
+  });
+
+  it.each(SELECTED_RC_CASES)(
+    "selects the RC floor after $name",
+    async (testCase) => {
+      const manifest = selectedRcManifest(testCase);
+      const fixture = buildOverviewHostFixture({
+        hostId: "host-a",
+        isLocalMachine: false,
+        hostVersion: "1.3.0-rc.1",
+        overrideHandlers: {
+          "host.update.check": () => ({
+            outcome: "ok" as const,
+            effectiveIncludePreReleases: true,
+            includePreReleasesSource: "installed-rc" as const,
+            manifest,
+          }),
+        },
+      });
+      recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+      const rendered = renderUpdatesHook(
+        fixture.client,
+        "host-a",
+        "1.3.0-rc.1",
+        null,
+      );
+
+      await waitFor(() =>
+        expect(rendered.result.current.cliFloor?.requiredCliVersion).toBe(
+          "1.3.0-rc.4",
+        ),
+      );
+      // Restricting floor acceptance to targetCandidates[0] would miss the
+      // RC after this unusable preferred stable; both explicit variants must
+      // turn RED under that candidate-walk ablation.
+      expect(rendered.result.current.summary.updatableVersion).toBeNull();
+      expect(rendered.result.current.summary.remedy).not.toBeNull();
+      rendered.unmount();
+    },
+  );
+
+  it("shows the selected RC floor in the mounted npm remedy command", async () => {
+    const manifest = selectedRcManifest(SELECTED_RC_CASES[0]);
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: true,
+      hostVersion: "1.3.0-rc.1",
+      installation: managedInstallationWithCli(
+        installRecord("1.3.0-rc.1", null),
+        "1.2.0",
+        "npm",
+        "/home/u/.local/bin/traycer",
+      ),
+      overrideHandlers: {
+        "host.update.check": () => ({
+          outcome: "ok" as const,
+          effectiveIncludePreReleases: true,
+          includePreReleasesSource: "installed-rc" as const,
+          manifest,
+        }),
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    hostBindingMock.current = { hostClient: fixture.client };
+    scopeOverrides.current = scopeFrom("host-a", fixture);
+    renderPanel();
+
+    const sentence =
+      "On host-a, run this command to prepare the host update: npm install -g @traycerai/cli@1.3.0-rc.4. Then select Check now.";
+    await screen.findByText(sentence);
+    // Skipping floor acceptance after the unusable preferred stable would
+    // remove this selected RC remedy; with no installable fallback, it would
+    // not expose Update now. This visible npm-floor pin must turn RED.
+    expect(screen.getByRole("button", { name: "Copy command" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Update now" })).toBeNull();
   });
 });
 

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-overview-updates.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-overview-updates.test.tsx
@@ -48,6 +48,7 @@ import {
   screen,
   waitFor,
   within,
+  type RenderHookResult,
   type RenderResult,
 } from "@testing-library/react";
 import { toast } from "sonner";
@@ -81,7 +82,10 @@ import {
   openHostOverviewMenu,
   type OverviewHostFixture,
 } from "@/components/settings/panels/__tests__/host-overview-test-support";
-import { useHostOverviewUpdates } from "@/components/settings/panels/host-overview-updates-state";
+import {
+  useHostOverviewUpdates,
+  type HostOverviewUpdatesState,
+} from "@/components/settings/panels/host-overview-updates-state";
 
 /**
  * The version PICKER that replaced the single "Update to v<latest>" button
@@ -497,7 +501,10 @@ function renderUpdatesHook(
   hostId: string,
   runningVersion: string,
   stagedVersion: string | null,
-) {
+): RenderHookResult<
+  HostOverviewUpdatesState,
+  { readonly children: ReactNode }
+> {
   const queryClient = newQueryClient();
   return renderHook(
     () =>
@@ -2220,7 +2227,14 @@ describe("Overview updates — CLI floor remedy", () => {
     // negative summary pin must turn RED under that source-predicate ablation.
     expect(yankedRendered.result.current.cliFloor).toBeNull();
     expect(yankedRendered.result.current.summary.remedy).toBeNull();
-    expect(yankedRendered.result.current.stagedFloor).not.toBeNull();
+    // `describeForceUpdateRefusal` checks `entry.yanked` BEFORE it ever reads
+    // a CLI floor - a withdrawn release has no floor to remedy (no CLI
+    // version installs a yanked release), so the withdrawal text wins over
+    // the "needs Traycer CLI X" text this same staged version would
+    // otherwise carry. `stagedFloor` no longer exists as a separate field;
+    // `stagedEntryOfferable` is the one predicate both the offer and the
+    // dispatch read, and it is false here.
+    expect(yankedRendered.result.current.stagedEntryOfferable).toBe(false);
 
     let returned = false;
     const onSettled = vi.fn(() => {
@@ -2235,8 +2249,9 @@ describe("Overview updates — CLI floor remedy", () => {
     });
     expect(onSettled).toHaveBeenCalledTimes(1);
     expect(installCalls).toEqual([]);
+    // The withdrawal text, not the floor text: yanked is checked first.
     expect(yankedRendered.result.current.summary.failureDescription).toContain(
-      "v1.3.0 needs Traycer CLI 1.3.0 or newer on host-a.",
+      "v1.3.0 has been withdrawn and can't be installed on host-a.",
     );
     yankedRendered.unmount();
   });
@@ -2366,6 +2381,352 @@ describe("Overview updates — CLI floor remedy", () => {
     // not expose Update now. This visible npm-floor pin must turn RED.
     expect(screen.getByRole("button", { name: "Copy command" })).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Update now" })).toBeNull();
+  });
+});
+
+// `stagedEntryOfferable` (host-overview-updates-state.ts): the ONE predicate
+// that gates both whether the panel OFFERS Force for a staged-wait version
+// and whether `installForce` actually DISPATCHES it - both read
+// `describeForceUpdateRefusal` for the staged version. A withdrawn or
+// asset-unavailable stage is never offered; the CLI would purge the parked
+// stage and then refuse the version anyway, so offering it could only ever
+// destroy the stage for nothing.
+describe("Overview updates — stagedEntryOfferable", () => {
+  it("a yanked staged entry is not offerable, and installForce refuses with the withdrawal text without dispatching", async () => {
+    const base = multiVersionManifest(["1.3.0"]);
+    const yankedEntry = { ...base.versions[0], yanked: true };
+    const manifest = { ...base, versions: [yankedEntry] };
+    const installCalls: Array<{ version: string; force: boolean }> = [];
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: false,
+      hostVersion: "1.2.0",
+      overrideHandlers: {
+        "host.update.check": () => ({
+          outcome: "ok" as const,
+          effectiveIncludePreReleases: false,
+          includePreReleasesSource: "stable-default" as const,
+          manifest,
+        }),
+        "host.update.install": (request) => {
+          installCalls.push({ version: request.version, force: request.force });
+          return { outcome: "accepted" as const, attemptId: null };
+        },
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    const rendered = renderUpdatesHook(
+      fixture.client,
+      "host-a",
+      "1.2.0",
+      "1.3.0",
+    );
+    await waitFor(() =>
+      expect(rendered.result.current.picker.awaitingFirstCheck).toBe(false),
+    );
+    // Falsification: check `entry.yanked` after the floor read instead of
+    // before in `describeForceUpdateRefusal`, and `stagedEntryOfferable`
+    // would still read false here (no floor either), but the failure text
+    // asserted below would be the "couldn't verify" catch-all instead of
+    // naming the withdrawal specifically.
+    expect(rendered.result.current.stagedEntryOfferable).toBe(false);
+
+    let returned = false;
+    const onSettled = vi.fn(() => {
+      expect(returned).toBe(false);
+    });
+    act(() => {
+      rendered.result.current.installForce("1.3.0", onSettled);
+      returned = true;
+    });
+    expect(onSettled).toHaveBeenCalledTimes(1);
+    expect(installCalls).toEqual([]);
+    expect(rendered.result.current.summary.failureDescription).toContain(
+      "v1.3.0 has been withdrawn and can't be installed on host-a.",
+    );
+    rendered.unmount();
+  });
+
+  it("a staged entry whose asset RESOLVED but is unavailable for this platform (not a floor) IS offerable - an already-staged version installs from the stage regardless", async () => {
+    // `describeForceUpdateRefusal` checks the CATALOG's disposition of the
+    // version (absent, yanked, unresolvable asset, CLI floor) - it never
+    // reads `asset.available` on its own. The CLI's own
+    // `discardIneligibleStagedVersion` purges a parked stage only when the
+    // catalog no longer lists the version or has yanked it; an already-
+    // staged target then short-circuits before any asset is resolved again,
+    // so a platform build the catalog has since marked unavailable still
+    // installs from the stage. Refusing the offer here would strand a
+    // downloaded update behind a control that has already vanished.
+    const base = multiVersionManifest(["1.3.0"]);
+    const unavailableEntry = {
+      ...base.versions[0],
+      platforms: {
+        "darwin-arm64": {
+          ...base.versions[0].platforms["darwin-arm64"],
+          available: false,
+          unavailableReason: "platform build withdrawn",
+        },
+      },
+    };
+    const manifest = { ...base, versions: [unavailableEntry] };
+    const installCalls: Array<{ version: string; force: boolean }> = [];
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: false,
+      hostVersion: "1.2.0",
+      overrideHandlers: {
+        "host.update.check": () => ({
+          outcome: "ok" as const,
+          effectiveIncludePreReleases: false,
+          includePreReleasesSource: "stable-default" as const,
+          manifest,
+        }),
+        "host.update.install": (request) => {
+          installCalls.push({ version: request.version, force: request.force });
+          return { outcome: "accepted" as const, attemptId: null };
+        },
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    const rendered = renderUpdatesHook(
+      fixture.client,
+      "host-a",
+      "1.2.0",
+      "1.3.0",
+    );
+    await waitFor(() =>
+      expect(rendered.result.current.picker.awaitingFirstCheck).toBe(false),
+    );
+    // Not a floor: `requiredCliVersion` is null on this entry, so a bug that
+    // gated `stagedEntryOfferable` on the floor alone would wrongly read
+    // false here.
+    expect(rendered.result.current.cliFloor).toBeNull();
+    expect(rendered.result.current.stagedEntryOfferable).toBe(true);
+
+    // Falsification: add an `assetUnavailableReason` refusal back to
+    // `describeForceUpdateRefusal` and `installCalls` below stays empty.
+    act(() => {
+      rendered.result.current.installForce("1.3.0", () => {});
+    });
+    await waitFor(() => {
+      expect(installCalls).toEqual([{ version: "1.3.0", force: true }]);
+    });
+    rendered.unmount();
+  });
+
+  it("a staged entry that is known, not yanked, with a usable asset and no floor is offerable (positive control)", async () => {
+    const manifest = multiVersionManifest(["1.3.0"]);
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: false,
+      hostVersion: "1.2.0",
+      overrideHandlers: {
+        "host.update.check": () => ({
+          outcome: "ok" as const,
+          effectiveIncludePreReleases: false,
+          includePreReleasesSource: "stable-default" as const,
+          manifest,
+        }),
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    const rendered = renderUpdatesHook(
+      fixture.client,
+      "host-a",
+      "1.2.0",
+      "1.3.0",
+    );
+    await waitFor(() =>
+      expect(rendered.result.current.picker.awaitingFirstCheck).toBe(false),
+    );
+    expect(rendered.result.current.stagedEntryOfferable).toBe(true);
+    rendered.unmount();
+  });
+
+  it("an unresolved platform asset (null platformKey against a multi-platform entry) is not offerable, and reads as 'couldn't verify'", async () => {
+    // CodeRabbit r3944197329: a `platformKey` this page cannot resolve is
+    // NOT the same claim as "the release can't install here" - it is a
+    // claim this page cannot make at all, so the refusal text has to be the
+    // generic "couldn't verify" catch-all, never the asset-unavailable text
+    // (which would assert a fact the code does not actually know).
+    //
+    // A null `platformKey` is not reachable through the panel itself - the
+    // Force offer is gated by this same `describeForceUpdateRefusal`
+    // predicate, so a person never sees an offer this dispatch would then
+    // refuse. This test pins the dispatch guard as a contract in its own
+    // right, independent of whatever gates the offer above it.
+    const base = multiVersionManifest(["1.3.0"]);
+    const multiPlatformEntry = {
+      ...base.versions[0],
+      platforms: {
+        ...base.versions[0].platforms,
+        "linux-x64": {
+          ...base.versions[0].platforms["darwin-arm64"],
+        },
+      },
+    };
+    const manifest = { ...base, versions: [multiPlatformEntry] };
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: false,
+      hostVersion: "1.2.0",
+      overrideHandlers: {
+        "host.update.check": () => ({
+          outcome: "ok" as const,
+          effectiveIncludePreReleases: false,
+          includePreReleasesSource: "stable-default" as const,
+          manifest,
+        }),
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    const queryClient = newQueryClient();
+    const rendered = renderHook(
+      () =>
+        useHostOverviewUpdates({
+          client: fixture.client,
+          hostName: "host-a",
+          hostId: "host-a",
+          runningVersion: "1.2.0",
+          activationDebt: null,
+          platformKey: null,
+          cliManifest: null,
+          isLocalMachine: false,
+          desktopUpdate: null,
+          stagedVersion: "1.3.0",
+          enabled: true,
+          checkDegrade: null,
+          installDegrade: null,
+          busy: false,
+        }),
+      {
+        wrapper: (props: { readonly children: ReactNode }) => (
+          <QueryClientProvider client={queryClient}>
+            {props.children}
+          </QueryClientProvider>
+        ),
+      },
+    );
+    await waitFor(() =>
+      expect(rendered.result.current.picker.awaitingFirstCheck).toBe(false),
+    );
+    expect(rendered.result.current.stagedEntryOfferable).toBe(false);
+
+    let returned = false;
+    const onSettled = vi.fn(() => {
+      expect(returned).toBe(false);
+    });
+    act(() => {
+      rendered.result.current.installForce("1.3.0", onSettled);
+      returned = true;
+    });
+    expect(onSettled).toHaveBeenCalledTimes(1);
+    expect(rendered.result.current.summary.failureDescription).toContain(
+      "Traycer couldn't verify that v1.3.0 can be installed on host-a.",
+    );
+    rendered.unmount();
+  });
+
+  it("a force refusal for a yanked staged version is retired only once a later check lists it un-yanked", async () => {
+    // Exercised through the hook directly (not the panel/dialog chrome) so
+    // this pins `retireForceRefusalIfRefuted`'s own predicate - a strictly
+    // NEWER successful check whose manifest no longer refuses the exact
+    // refused version - rather than incidental dialog wiring. Fake timers
+    // (as the sibling "rechecks a repaired manifest" panel test above also
+    // needs) guarantee `checkQuery.dataUpdatedAt` strictly increases between
+    // the refusal and each recheck; without that, the retire predicate's
+    // strict `>` comparison could tie and never fire.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      const base = multiVersionManifest(["1.3.0"]);
+      let manifest: HostAvailableManifest = {
+        ...base,
+        versions: [{ ...base.versions[0], yanked: true }],
+      };
+      const fixture = buildOverviewHostFixture({
+        hostId: "host-a",
+        isLocalMachine: false,
+        hostVersion: "1.2.0",
+        overrideHandlers: {
+          "host.update.check": () =>
+            Promise.resolve({
+              outcome: "ok" as const,
+              effectiveIncludePreReleases: false,
+              includePreReleasesSource: "stable-default" as const,
+              manifest,
+            }),
+        },
+      });
+      recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+      const queryClient = newQueryClient();
+      const rendered = renderHook(
+        () =>
+          useHostOverviewUpdates({
+            client: fixture.client,
+            hostName: "host-a",
+            hostId: "host-a",
+            runningVersion: "1.2.0",
+            activationDebt: null,
+            platformKey: "darwin-arm64",
+            cliManifest: null,
+            isLocalMachine: false,
+            desktopUpdate: null,
+            stagedVersion: "1.3.0",
+            enabled: true,
+            checkDegrade: null,
+            installDegrade: null,
+            busy: false,
+          }),
+        {
+          wrapper: (props: { readonly children: ReactNode }) => (
+            <QueryClientProvider client={queryClient}>
+              {props.children}
+            </QueryClientProvider>
+          ),
+        },
+      );
+      await waitFor(() =>
+        expect(rendered.result.current.picker.awaitingFirstCheck).toBe(false),
+      );
+
+      act(() => {
+        rendered.result.current.installForce("1.3.0", () => {});
+      });
+      await waitFor(() =>
+        expect(rendered.result.current.summary.failureDescription).toContain(
+          "v1.3.0 has been withdrawn and can't be installed on host-a.",
+        ),
+      );
+
+      // A later successful check that STILL lists the version as yanked must
+      // NOT retire the refusal - the fact it was refused for has not changed.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1000);
+        await queryClient.invalidateQueries();
+      });
+      await waitFor(() =>
+        expect(rendered.result.current.summary.failureDescription).toContain(
+          "v1.3.0 has been withdrawn and can't be installed on host-a.",
+        ),
+      );
+
+      // A later check that lists the SAME version un-yanked retires it - the
+      // fact the refusal named is no longer true.
+      manifest = {
+        ...base,
+        versions: [{ ...base.versions[0], yanked: false }],
+      };
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1000);
+        await queryClient.invalidateQueries();
+      });
+      await waitFor(() =>
+        expect(rendered.result.current.summary.failureDescription).toBeNull(),
+      );
+      rendered.unmount();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-overview-updates.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-overview-updates.test.tsx
@@ -3074,6 +3074,73 @@ describe("Overview updates — record-leg liveness and entry-level floor gates",
     await screen.findByTestId("host-overview-operation-restart");
   });
 
+  it("a failed STATUS read qualifies the debt sentence as (last known) too - the running version it compares against is retained data", async () => {
+    // The debt is the record's installed version read against the status
+    // read's running version. A status poll that fails while the record
+    // poll keeps succeeding leaves `legacyFactsRead` built on a retained
+    // `hostVersion`, and the host may already have restarted onto the
+    // installed version - so the sentence must say "last known" exactly
+    // as it does for a failed record read (the pin above). Falsification:
+    // key `activationDebt.live` on `installationLive` alone and the
+    // qualified sentence below never appears.
+    let statusCalls = 0;
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: true,
+      hostVersion: "1.3.0-rc.2",
+      installation: managedInstallation(
+        installRecord("1.3.0-rc.3", null),
+        null,
+      ),
+      overrideHandlers: {
+        "host.status": () => {
+          statusCalls += 1;
+          if (statusCalls === 2) {
+            throw new Error("host unreachable");
+          }
+          return {
+            ready: true,
+            hostVersion: "1.3.0-rc.2",
+            protocolVersion: { major: 1, minor: 1 },
+            busy: false,
+            busySessionCount: 0,
+            updateProgress: null,
+            busyBreakdown: null,
+            updateOperation: null,
+            updateTransaction: null,
+          };
+        },
+        "host.update.check": () => ({
+          outcome: "ok" as const,
+          effectiveIncludePreReleases: true,
+          includePreReleasesSource: "installed-rc" as const,
+          manifest: multiVersionManifest(["1.3.0-rc.3"]),
+        }),
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    hostBindingMock.current = { hostClient: fixture.client };
+    scopeOverrides.current = scopeFrom("host-a", fixture);
+    const { queryClient } = renderPanel();
+
+    await waitFor(() => {
+      expect(screen.getByRole("status").textContent).toBe(
+        "v1.3.0-rc.3 is installed — restart host to finish.",
+      );
+    });
+
+    await act(async () => {
+      await queryClient.invalidateQueries();
+    });
+    await waitFor(() => expect(statusCalls).toBe(2));
+    await waitFor(() => {
+      expect(screen.getByRole("status").textContent).toBe(
+        "v1.3.0-rc.3 is installed (last known) — restart host to finish.",
+      );
+    });
+    expect(screen.queryByRole("button", { name: "Update now" })).toBeNull();
+  });
+
   it("a floor that is not a version renders help and does NOT arm the recheck; a readable floor beside it does", async () => {
     // `CliFloor.repairable` is what the recheck is keyed on: the mounted
     // 30 s recheck exists to notice a CLI upgrade clearing the floor, and no

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-overview-updates.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-overview-updates.test.tsx
@@ -2005,7 +2005,8 @@ describe("Overview updates — CLI floor remedy", () => {
     await screen.findByTestId("host-busy-force-defer-dialog");
     // The confirmation re-asks before dispatch so this rendered panel records
     // a real refusal against the exact staged version, rather than a synthetic
-    // hook state. The repair below must come only from the condition poll.
+    // hook state. The repair below must come only from the Overview's own
+    // floor recheck (`useHostOverviewUpdates`), never from a click.
     await act(async () => {
       await queryClient.invalidateQueries();
     });
@@ -2025,8 +2026,9 @@ describe("Overview updates — CLI floor remedy", () => {
     });
     await screen.findByRole("button", { name: "Update now" });
     const checksAfterRecovery = checks;
-    // Removing the floor recovery lane, or changing its fixed interval above
-    // 30s, would leave this refusal visible and fail the assertion above.
+    // Removing the Overview's floor recheck (`useHostOverviewUpdates`), or
+    // raising `CLI_FLOOR_RECHECK_MS` above 30s, would leave this refusal
+    // visible and fail the assertion above.
     expect(checksAfterRecovery).toBeGreaterThan(1);
     // Removing describeUpdateFailure's live-descriptor condition and returning
     // stored refusal text whenever refusal exists would keep both stale
@@ -2065,6 +2067,156 @@ describe("Overview updates — CLI floor remedy", () => {
       expect(notice.textContent).not.toContain("needs Traycer CLI");
     });
     expect(installCalls).toEqual([]);
+  });
+
+  it("rechecks only while a remedy is on screen: a floored row on ANOTHER release line under installed-rc earns no recheck, a floored later RC on the installed line does", async () => {
+    // The recheck is keyed on the rendered remedy (`useHostOverviewUpdates`),
+    // not on the response: the response carries no installed version, so a
+    // classifier over it alone - the table lane this replaced - re-asked the
+    // host every 30 s on ANY floored row of an `installed-rc` catalog, a
+    // release on another line included, with no remedy on screen to end it.
+    // Falsification: key the effect on "any floored row in the manifest" (or
+    // restore the table lane) and the first half goes RED - the 1.4.0-rc.1
+    // floor keeps re-asking a host that shows no remedy.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    let checks = 0;
+    let sameLineFloored = false;
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: true,
+      hostVersion: "1.3.0-rc.1",
+      installation: managedInstallationWithCli(
+        installRecord("1.3.0-rc.1", null),
+        "1.2.0",
+        "manual",
+        "/home/u/.local/bin/traycer",
+      ),
+      overrideHandlers: {
+        "host.update.check": () => {
+          checks += 1;
+          const base = multiVersionManifest(["1.2.0", "1.3.0-rc.1"]);
+          const flooredOtherLine = floorManifest("1.4.0-rc.1", false)
+            .versions[0];
+          const flooredSameLine = floorManifest("1.3.0-rc.2", false)
+            .versions[0];
+          return Promise.resolve({
+            outcome: "ok" as const,
+            effectiveIncludePreReleases: true,
+            includePreReleasesSource: "installed-rc" as const,
+            manifest: {
+              ...base,
+              versions: [
+                flooredOtherLine,
+                ...(sameLineFloored ? [flooredSameLine] : []),
+                ...base.versions,
+              ],
+            },
+          });
+        },
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    hostBindingMock.current = { hostClient: fixture.client };
+    scopeOverrides.current = scopeFrom("host-a", fixture);
+    renderPanel();
+
+    // The catalog answered. The installed line (1.3.0) has no matching stable
+    // and no later RC, so the summary walk names nothing and no remedy
+    // renders - the 1.4.0-rc.1 floor is another line's business.
+    await waitFor(() => expect(checks).toBe(1));
+    await waitForButton("Check now");
+    expect(screen.queryByRole("button", { name: "Copy command" })).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Show installation help" }),
+    ).toBeNull();
+    // Two full recheck periods pass and the host is not asked again.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(31_000);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(31_000);
+    });
+    expect(checks).toBe(1);
+
+    // Positive control, same host, same catalog plus a floored later RC on
+    // the INSTALLED line: the remedy renders and the recheck runs.
+    sameLineFloored = true;
+    fireEvent.click(await waitForButton("Check now"));
+    await waitFor(() => expect(checks).toBe(2));
+    await screen.findByRole("button", { name: "Copy command" });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000);
+    });
+    await waitFor(() => expect(checks).toBe(3));
+
+    vi.useRealTimers();
+  });
+
+  it("a retired region ends the recheck: an externally-managed discovery under a floored catalog stops re-asking the host", async () => {
+    // "On screen" is literal. `installDiscovered: "externally-managed"` is
+    // latched for the life of the mount (only `cli-unavailable` is ever
+    // refuted) and replaces the whole region with a notice, while the check
+    // query stays ENABLED - so a floor read before the retirement would keep
+    // re-asking a host with nothing on screen to end it, the very defect the
+    // table lane had. Falsification: drop `degrade === null` from
+    // `recheckFloor` and the count below climbs across the two periods.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    let checks = 0;
+    const floored = floorManifest("1.3.0", false);
+    const installable = multiVersionManifest(["1.2.5"]).versions[0];
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: true,
+      hostVersion: "1.2.0",
+      installation: managedInstallationWithCli(
+        installRecord("1.2.0", null),
+        "1.2.0",
+        "manual",
+        "/home/u/.local/bin/traycer",
+      ),
+      overrideHandlers: {
+        "host.update.check": () => {
+          checks += 1;
+          return Promise.resolve({
+            outcome: "ok" as const,
+            effectiveIncludePreReleases: false,
+            includePreReleasesSource: "stable-default" as const,
+            manifest: {
+              ...floored,
+              versions: [...floored.versions, installable],
+            },
+          });
+        },
+        "host.update.install": () =>
+          Promise.resolve({ outcome: "externally-managed" as const }),
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    hostBindingMock.current = { hostClient: fixture.client };
+    scopeOverrides.current = scopeFrom("host-a", fixture);
+    renderPanel();
+
+    // The floored latest renders the remedy: the recheck is armed.
+    await screen.findByRole("button", { name: "Copy command" });
+    await waitFor(() => expect(checks).toBe(1));
+
+    // An install of the lower installable row discovers the host is
+    // externally managed; the region retires behind its notice.
+    await openHostOverviewAdvanced();
+    fireEvent.click(await waitForButton("Install 1.2.5"));
+    await screen.findByTestId("host-overview-updates-degraded");
+    expect(screen.queryByRole("button", { name: "Copy command" })).toBeNull();
+
+    // Nothing on screen to repair, so nothing is re-asked.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(31_000);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(31_000);
+    });
+    expect(checks).toBe(1);
+
+    vi.useRealTimers();
   });
 
   it("settles Force refusal synchronously exactly once for floored, absent, and incomplete-floor entries", async () => {

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-overview-updates.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-overview-updates.test.tsx
@@ -52,7 +52,14 @@ import {
 import { toast } from "sonner";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { HostAvailableManifest } from "@traycer/protocol/host/maintenance/index";
+import type {
+  HostAvailableManifest,
+  HostGetInstallationInfoResponseV11,
+} from "@traycer/protocol/host/maintenance/index";
+import type {
+  HostInstallRecord,
+  HostStagedRecord,
+} from "@traycer/protocol/config/installation-records";
 import { MockRunnerHost } from "@traycer-clients/shared/host-client/mock/mock-runner-host";
 import {
   recordNegotiatedHostManifest,
@@ -278,6 +285,45 @@ function rowFor(rows: readonly HTMLElement[], version: string): HTMLElement {
     throw new Error(`no version row rendered for v${version}`);
   }
   return row;
+}
+
+/**
+ * The minimum-viable HostInstallRecord for the
+ * activation-debt suite below - every field the wire schema requires
+ * (protocol/src/config/installation-records.ts), populated with benign
+ * placeholders except version/runtimeVersion, which each test varies.
+ */
+function installRecord(
+  version: string,
+  runtimeVersion: string | null,
+): HostInstallRecord {
+  return {
+    installId: "install-1",
+    version,
+    runtimeVersion,
+    platform: "darwin",
+    arch: "arm64",
+    installedAt: "2026-08-10T00:00:00Z",
+    source: { kind: "registry", value: version },
+    archiveSha256: "a".repeat(64),
+    signatureVerifiedAt: "2026-08-10T00:00:00Z",
+    signatureKeyId: "key-1",
+    sizeBytes: 1024,
+    executablePath: `/tmp/traycer/${version}/host`,
+    executableSha256: "b".repeat(64),
+  };
+}
+
+function managedInstallation(
+  install: HostInstallRecord,
+  staged: HostStagedRecord | null,
+): HostGetInstallationInfoResponseV11 {
+  return {
+    status: "managed",
+    installRecord: install,
+    stagedRecord: staged,
+    cliManifest: null,
+  };
 }
 
 describe("<HostSettingsPanel /> Overview updates — version picker", () => {
@@ -1412,5 +1458,121 @@ describe("<HostSettingsPanel /> Overview updates — version picker", () => {
         .getByRole("button", { name: "Install 2.0.0-rc.1" })
         .hasAttribute("disabled"),
     ).toBe(false);
+  });
+});
+
+// The Overview's `legacyFacts` derivation (`legacy-update-facts.ts`): the
+// install RECORD is ahead of the running host. `describeCheckState` names
+// this "activation debt" and it outranks every catalog sentence except a
+// transient install failure - the summary should say so whether or not the
+// catalog ALSO has something newer than the installed version, and "Update
+// now" should track the INSTALLED version, not the running one.
+describe("Overview updates — activation debt", () => {
+  it("the debt sentence renders exactly, and Update now is absent when nothing beats the installed version", async () => {
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: true,
+      hostVersion: "1.3.0-rc.2",
+      installation: managedInstallation(
+        installRecord("1.3.0-rc.3", null),
+        null,
+      ),
+      overrideHandlers: {
+        "host.update.check": () =>
+          Promise.resolve({
+            outcome: "ok" as const,
+            effectiveIncludePreReleases: false,
+            includePreReleasesSource: "stable-default" as const,
+            manifest: multiVersionManifest(["1.3.0-rc.3"]),
+          }),
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    hostBindingMock.current = { hostClient: fixture.client };
+    scopeOverrides.current = scopeFrom("host-a", fixture);
+    renderPanel();
+
+    await screen.findByText(
+      "v1.3.0-rc.3 is installed — restart host to finish.",
+    );
+    // Falsification: comparing the catalog against the RUNNING version
+    // (1.3.0-rc.2) instead of the installed one would offer "Update now" for
+    // the very version already sitting on disk.
+    expect(screen.queryByRole("button", { name: "Update now" })).toBeNull();
+  });
+
+  it("the debt sentence stays, and Update now DOES appear when the catalog has something newer than the installed version", async () => {
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: true,
+      hostVersion: "1.3.0-rc.2",
+      installation: managedInstallation(
+        installRecord("1.3.0-rc.3", null),
+        null,
+      ),
+      overrideHandlers: {
+        "host.update.check": () =>
+          Promise.resolve({
+            outcome: "ok" as const,
+            effectiveIncludePreReleases: true,
+            includePreReleasesSource: "explicit-include" as const,
+            manifest: multiVersionManifest(["1.3.0-rc.4", "1.3.0-rc.3"]),
+          }),
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    hostBindingMock.current = { hostClient: fixture.client };
+    scopeOverrides.current = scopeFrom("host-a", fixture);
+    renderPanel();
+
+    // Debt outranks the catalog sentence even though there IS something to
+    // offer - see `describeCheckState`'s ordering comment.
+    await screen.findByText(
+      "v1.3.0-rc.3 is installed — restart host to finish.",
+    );
+    await screen.findByRole("button", { name: "Update now" });
+  });
+
+  it("host.getInstallationInfo's poll refreshes the debt card live, with no remount", async () => {
+    // Companion to the direct policy-table pin
+    // (host-method-policy-table.test.ts: "polls host.getInstallationInfo on a
+    // fixed 10s cadence, matching host.status") — that test proves the TABLE
+    // entry; this one proves the CONSEQUENCE reaches a mounted page. Driven
+    // through an explicit `invalidateQueries()` rather than fake timers,
+    // which fight this suite's real-timer TanStack Query scheduling; the
+    // 10s-cadence claim itself is covered by the policy-table pin, not here.
+    let installationCalls = 0;
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: true,
+      hostVersion: "1.3.0-rc.2",
+      overrideHandlers: {
+        "host.getInstallationInfo": () => {
+          installationCalls += 1;
+          return managedInstallation(
+            installRecord(
+              installationCalls === 1 ? "1.3.0-rc.2" : "1.3.0-rc.3",
+              null,
+            ),
+            null,
+          );
+        },
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    hostBindingMock.current = { hostClient: fixture.client };
+    scopeOverrides.current = scopeFrom("host-a", fixture);
+    const { queryClient } = renderPanel();
+
+    // First read: the install record matches the running host - no debt, no
+    // card.
+    await waitFor(() => expect(installationCalls).toBeGreaterThan(0));
+    expect(screen.queryByTestId("host-overview-operation-card")).toBeNull();
+
+    await act(async () => {
+      await queryClient.invalidateQueries();
+    });
+
+    await screen.findByTestId("host-overview-operation-restart");
   });
 });

--- a/clients/gui-app/src/components/settings/panels/host-overview-cli-floor-remedy-actions.tsx
+++ b/clients/gui-app/src/components/settings/panels/host-overview-cli-floor-remedy-actions.tsx
@@ -1,0 +1,146 @@
+import { useEffect, type ReactNode } from "react";
+import { Button } from "@/components/ui/button";
+import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
+import type { CliFloorRemedyAction } from "@/components/settings/panels/host-overview-cli-floor-remedy";
+import { copyTerminalCommand } from "@/components/settings/panels/host-doctor-actions";
+import { useDesktopDialogStore } from "@/stores/dialogs/desktop-dialog-store";
+import { requestAppUpdateInstall } from "@/lib/app-update/request-app-update-install";
+import type { DesktopAppUpdatesBridge } from "@/lib/windows/types";
+import { appLogger } from "@/lib/logger";
+
+export function CliFloorRemedyActions(props: {
+  readonly actions: readonly CliFloorRemedyAction[];
+  readonly desktopBridge: DesktopAppUpdatesBridge | null;
+  readonly onHelp: () => void;
+}): ReactNode {
+  return props.actions.map((action) => (
+    <CliFloorRemedyControl
+      key={action.kind}
+      action={action}
+      desktopBridge={props.desktopBridge}
+      onHelp={props.onHelp}
+    />
+  ));
+}
+
+function CliFloorRemedyControl(props: {
+  readonly action: CliFloorRemedyAction;
+  readonly desktopBridge: DesktopAppUpdatesBridge | null;
+  readonly onHelp: () => void;
+}): ReactNode {
+  const openInstallGuidance = useDesktopDialogStore(
+    (state) => state.openInstallGuidance,
+  );
+  const { action, desktopBridge } = props;
+  switch (action.kind) {
+    case "desktop-check":
+      return (
+        <DesktopRemedyCheck
+          bridge={desktopBridge}
+          label={action.label}
+          checkOnMount={action.checkOnMount}
+        />
+      );
+    case "restart-desktop-hint":
+      return null;
+    case "desktop-progress":
+      return (
+        <Button type="button" size="sm" disabled>
+          <AgentSpinningDots
+            className="mr-2 size-3"
+            testId={undefined}
+            variant={undefined}
+          />
+          {action.label}
+        </Button>
+      );
+    case "copy-command":
+      return (
+        <Button
+          type="button"
+          size="sm"
+          onClick={() => copyTerminalCommand(action.command)}
+        >
+          {action.label}
+        </Button>
+      );
+    case "help":
+      return (
+        <Button type="button" size="sm" onClick={props.onHelp}>
+          {action.label}
+        </Button>
+      );
+    case "desktop-download":
+    case "desktop-install":
+      return (
+        <TooltipWrapper
+          label={action.tooltip ?? action.label}
+          side="top"
+          sideOffset={6}
+          align={undefined}
+        >
+          {/* Disabled buttons do not receive pointer events; the wrapper keeps
+              the Desktop updater's block reason reachable, as in the header. */}
+          <span className="inline-flex">
+            <Button
+              type="button"
+              size="sm"
+              disabled={action.disabled || desktopBridge === null}
+              onClick={() => {
+                if (desktopBridge === null || action.disabled) return;
+                if (action.kind === "desktop-download") {
+                  void desktopBridge.downloadUpdate();
+                } else if (action.showGuidance) {
+                  openInstallGuidance();
+                } else {
+                  void requestAppUpdateInstall(desktopBridge);
+                }
+              }}
+            >
+              {action.kind === "desktop-install" && action.installInFlight ? (
+                <AgentSpinningDots
+                  className="mr-2 size-3"
+                  testId={undefined}
+                  variant={undefined}
+                />
+              ) : null}
+              {action.label}
+            </Button>
+          </span>
+        </TooltipWrapper>
+      );
+  }
+}
+
+function DesktopRemedyCheck(props: {
+  readonly bridge: DesktopAppUpdatesBridge | null;
+  readonly label: string | null;
+  readonly checkOnMount: boolean;
+}): ReactNode {
+  const { bridge, label, checkOnMount } = props;
+  // Only an idle updater needs an initial check. A failed check stays visible
+  // until the user retries; entering checking must not issue a second request.
+  // Keeping one component across these states avoids a mount-driven retry loop.
+  useEffect(() => {
+    if (checkOnMount) checkDesktopRemedy(bridge);
+  }, [bridge, checkOnMount]);
+  if (label === null) return null;
+  return (
+    <Button
+      type="button"
+      size="sm"
+      disabled={bridge === null}
+      onClick={() => checkDesktopRemedy(bridge)}
+    >
+      {label}
+    </Button>
+  );
+}
+
+function checkDesktopRemedy(bridge: DesktopAppUpdatesBridge | null): void {
+  if (bridge === null) return;
+  void bridge.checkForUpdates("manual").catch((error: unknown) => {
+    appLogger.error("[app-update] floor remedy check failed", {}, error);
+  });
+}

--- a/clients/gui-app/src/components/settings/panels/host-overview-cli-floor-remedy-actions.tsx
+++ b/clients/gui-app/src/components/settings/panels/host-overview-cli-floor-remedy-actions.tsx
@@ -1,9 +1,10 @@
-import { useEffect, type ReactNode } from "react";
+import type { ReactNode } from "react";
 import { Button } from "@/components/ui/button";
 import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 import type { CliFloorRemedyAction } from "@/components/settings/panels/host-overview-cli-floor-remedy";
 import { copyTerminalCommand } from "@/components/settings/panels/host-doctor-actions";
+import { useUpdateCheckOnBlockingMount } from "@/components/host/use-update-check-on-blocking-mount";
 import { useDesktopDialogStore } from "@/stores/dialogs/desktop-dialog-store";
 import { requestAppUpdateInstall } from "@/lib/app-update/request-app-update-install";
 import type { DesktopAppUpdatesBridge } from "@/lib/windows/types";
@@ -119,12 +120,17 @@ function DesktopRemedyCheck(props: {
   readonly checkOnMount: boolean;
 }): ReactNode {
   const { bridge, label, checkOnMount } = props;
-  // Only an idle updater needs an initial check. A failed check stays visible
-  // until the user retries; entering checking must not issue a second request.
-  // Keeping one component across these states avoids a mount-driven retry loop.
-  useEffect(() => {
-    if (checkOnMount) checkDesktopRemedy(bridge);
-  }, [bridge, checkOnMount]);
+  // The mount check is the SAME guarded one the client-update dialog runs,
+  // for the same reason (see `useUpdateCheckOnBlockingMount`): the rendered
+  // snapshot this remedy was derived from is the store's placeholder on the
+  // first commit - `idle`, never checked - whatever main actually holds, so
+  // deciding from it fired a check on every mount; and a MANUAL check
+  // publishes "Checking…" then "up to date" into the app-wide snapshot every
+  // other surface reads, popping toasts from a settings pane. The guarded
+  // hook reads the bridge's authoritative snapshot, asks only an updater
+  // that has never been asked, once per mount, with automatic intent. The
+  // button below is the user's own manual check.
+  useUpdateCheckOnBlockingMount(checkOnMount ? bridge : null);
   if (label === null) return null;
   return (
     <Button

--- a/clients/gui-app/src/components/settings/panels/host-overview-cli-floor-remedy.ts
+++ b/clients/gui-app/src/components/settings/panels/host-overview-cli-floor-remedy.ts
@@ -1,8 +1,10 @@
+import type { CliInstallSource } from "@traycer/protocol/config/installation-records";
 import {
   CLI_NPM_PACKAGE_NAME,
+  isPackageManagerCliSource,
   PACKAGE_MANAGER_UPGRADE_COMMAND,
-  type CliInstallSource,
-} from "@traycer/protocol/config/installation-records";
+  type PackageManagerCliSource,
+} from "@traycer-clients/shared/cli-install/package-manager-upgrade-command";
 import {
   compareHostVersions,
   isValidHostVersion,
@@ -84,6 +86,21 @@ export interface CliFloorRemedyInput {
 export function describeCliFloorRemedy(
   input: CliFloorRemedyInput,
 ): CliFloorRemedy {
+  // Decided BEFORE any route: a floor that is not a version is one no CLI
+  // upgrade can clear, on any install method. The hosts this remedy serves
+  // run the pre-repair projector, which put the repairable prefix on an
+  // unreadable floor too, and every route below would otherwise render the
+  // unparseable text verbatim and hand out an upgrade that changes nothing
+  // (`CliFloor.repairable` is the same predicate, and stops the recheck).
+  if (
+    input.requiredCliVersion !== null &&
+    !isValidHostVersion(input.requiredCliVersion)
+  ) {
+    return {
+      sentence: `Traycer couldn't verify the required command-line tools version on ${input.hostName}.`,
+      actions: [{ kind: "help", label: "Show installation help" }],
+    };
+  }
   if (input.cliSource === null) {
     return {
       sentence: `Traycer couldn't determine how its command-line tools were installed on ${input.hostName}.`,
@@ -97,7 +114,7 @@ export function describeCliFloorRemedy(
   ) {
     return describeDesktopRemedy(input.desktopUpdate, input);
   }
-  if (input.cliSource !== "desktop" && input.cliSource !== "manual") {
+  if (isPackageManagerCliSource(input.cliSource)) {
     return describePackageManagerRemedy(input, input.cliSource);
   }
   // The old Windows CLI finalizes its staged upgrade during host restart,
@@ -120,7 +137,7 @@ export function describeCliFloorRemedy(
     // named - a POSIX host has no PowerShell to open.
     return describeCopyRemedy(
       input,
-      `Run the copied commands on ${input.hostName} from a terminal outside Traycer on that machine: first the tools upgrade, then the host restart. Restarting briefly disconnects this host. When it reconnects, select Check now, then Update now.`,
+      `Run the copied commands on ${input.hostName} from a terminal outside Traycer on that machine: first the tools upgrade, then the host restart. Restarting briefly disconnects this host. When it reconnects, this page rechecks on its own, and Update now appears once the host accepts the update.`,
       "traycer cli upgrade\ntraycer host restart",
       "Copy commands",
     );
@@ -135,36 +152,38 @@ export function describeCliFloorRemedy(
 
 function describePackageManagerRemedy(
   input: CliFloorRemedyInput,
-  source: Exclude<CliInstallSource, "desktop" | "manual">,
+  source: PackageManagerCliSource,
 ): CliFloorRemedy {
+  // Validated by `describeCliFloorRemedy` before any route and not repeated
+  // here; this is the one route that interpolates the value into a shell
+  // command, so that hoisted check is load-bearing for it.
   const requiredVersion = input.requiredCliVersion;
-  // Legacy projections can mislabel a malformed floor as repairable. Never
-  // interpolate unchecked manifest text into the copied npm shell command.
-  if (requiredVersion !== null && !isValidHostVersion(requiredVersion)) {
-    return {
-      sentence: `Traycer couldn't verify the required command-line tools version on ${input.hostName}.`,
-      actions: [{ kind: "help", label: "Show installation help" }],
-    };
-  }
+  // Only npm can name a prerelease: its floor pins the exact published
+  // version (`latest` is stable-only). Every other manager's command is a
+  // rolling stable upgrade - Homebrew's formula included, which carries a
+  // prerelease only after a manual dispatch AND a merged tap PR (see the
+  // table's doc), so `brew upgrade traycer` under an RC floor usually
+  // reports nothing newer: a command that does not reach the floor is
+  // worse than help that says so. The recheck still runs behind the help
+  // (the floor is readable), which is what notices the install made
+  // another way.
   if (
     requiredVersion !== null &&
     isPreReleaseVersion(requiredVersion) &&
-    source !== "npm" &&
-    source !== "homebrew"
+    source !== "npm"
   ) {
     return {
-      sentence: `Traycer CLI prereleases aren't published through ${source}. Install Traycer CLI ${requiredVersion} another way, then select Check now.`,
+      sentence: `Traycer CLI prereleases aren't published through ${source}. Install Traycer CLI ${requiredVersion} another way; this page rechecks while it is open.`,
       actions: [{ kind: "help", label: "Show installation help" }],
     };
   }
-  // npm's `latest` is stable-only; pin the published floor, including RCs.
   const command =
     source === "npm" && requiredVersion !== null
       ? `npm install -g ${CLI_NPM_PACKAGE_NAME}@${requiredVersion}`
       : PACKAGE_MANAGER_UPGRADE_COMMAND[source];
   return describeCopyRemedy(
     input,
-    `On ${input.hostName}, run this command to prepare the host update: ${command}. Then select Check now.`,
+    `On ${input.hostName}, run this command to prepare the host update: ${command}. This page rechecks while it is open, and Update now appears once the host accepts the update.`,
     command,
     "Copy command",
   );
@@ -215,9 +234,19 @@ function describeDesktopRemedy(
     case "unavailable":
       return describeDesktopCheckFailed(snapshot);
     case "idle":
+      // The mount check is AUTOMATIC intent and publishes nothing on a
+      // failed check (see `DesktopRemedyCheck`), so the updater can stay
+      // `idle` after it; the button is what keeps that from being a dead
+      // end.
       return {
         sentence: "Check for a Traycer Desktop update.",
-        actions: [{ kind: "desktop-check", label: null, checkOnMount: true }],
+        actions: [
+          {
+            kind: "desktop-check",
+            label: "Check for updates",
+            checkOnMount: true,
+          },
+        ],
       };
     case "checking":
       return {
@@ -348,7 +377,7 @@ function describeDesktopCliUpgrade(
   }
   if (route !== "posix" || !input.cliBinaryPath.startsWith("/")) return null;
   return {
-    sentence: `Open a terminal on ${input.hostName} and run the copied command, then select Check now.`,
+    sentence: `Open a terminal on ${input.hostName} and run the copied command; this page rechecks while it is open.`,
     command: posixCliUpgradeCommand(input.cliBinaryPath),
     label: "Copy command",
   };
@@ -381,7 +410,7 @@ function describeWindowsCliUpgrade(
 ): CliUpgradeInstructions {
   const invocation = windowsCliInvocation(input.cliBinaryPath);
   return {
-    sentence: `Run the copied commands on ${input.hostName} from a PowerShell window outside Traycer on that machine (a Windows Terminal tab there, or an SSH session that opens PowerShell). Restarting briefly disconnects this host. When it reconnects, select Check now, then Update now.`,
+    sentence: `Run the copied commands on ${input.hostName} from a PowerShell window outside Traycer on that machine (a Windows Terminal tab there, or an SSH session that opens PowerShell). Restarting briefly disconnects this host. When it reconnects, this page rechecks on its own, and Update now appears once the host accepts the update.`,
     command: `${invocation} cli upgrade\n${invocation} host restart`,
     label: "Copy commands",
   };

--- a/clients/gui-app/src/components/settings/panels/host-overview-cli-floor-remedy.ts
+++ b/clients/gui-app/src/components/settings/panels/host-overview-cli-floor-remedy.ts
@@ -1,0 +1,436 @@
+import {
+  CLI_NPM_PACKAGE_NAME,
+  PACKAGE_MANAGER_UPGRADE_COMMAND,
+  type CliInstallSource,
+} from "@traycer/protocol/config/installation-records";
+import {
+  compareHostVersions,
+  isValidHostVersion,
+} from "@traycer-clients/shared/host-version/compare-host-versions";
+import { isPreReleaseVersion } from "@traycer-clients/shared/host-version/release-line";
+import type { DesktopAppUpdateSnapshot } from "@/lib/windows/types";
+
+// There is deliberately no terminal action: a 1.2.0 host ignores shellCommand
+// on ordinary terminal creates. Copying the recorded binary path works on the
+// hosts this remedy actually serves, without guessing what is on their PATH.
+export const CLI_FLOOR_REMEDY_ACTION_KINDS = [
+  "desktop-download",
+  "desktop-progress",
+  "desktop-install",
+  "desktop-check",
+  "restart-desktop-hint",
+  "copy-command",
+  "help",
+] as const;
+
+export type CliFloorRemedyActionKind =
+  (typeof CLI_FLOOR_REMEDY_ACTION_KINDS)[number];
+
+interface CliFloorRemedyActionPayloads {
+  readonly "desktop-download": {
+    readonly label: string;
+    readonly disabled: boolean;
+    readonly tooltip: string | null;
+  };
+  readonly "desktop-progress": { readonly label: string };
+  readonly "desktop-install": {
+    readonly label: string;
+    readonly disabled: boolean;
+    readonly tooltip: string | null;
+    readonly showGuidance: boolean;
+    readonly installInFlight: boolean;
+  };
+  readonly "desktop-check": {
+    readonly label: string | null;
+    readonly checkOnMount: boolean;
+  };
+  readonly "restart-desktop-hint": unknown;
+  readonly "copy-command": {
+    readonly label: string;
+    readonly command: string;
+  };
+  readonly help: { readonly label: string };
+}
+
+export type CliFloorRemedyAction = {
+  [Kind in CliFloorRemedyActionKind]: {
+    readonly kind: Kind;
+  } & CliFloorRemedyActionPayloads[Kind];
+}[CliFloorRemedyActionKind];
+
+export interface CliFloorRemedy {
+  readonly sentence: string;
+  readonly actions: readonly CliFloorRemedyAction[];
+}
+
+interface CliUpgradeInstructions {
+  readonly sentence: string;
+  readonly command: string;
+  readonly label: string;
+}
+
+export interface CliFloorRemedyInput {
+  readonly isLocalMachine: boolean;
+  readonly platform: string | null;
+  readonly cliSource: CliInstallSource | null;
+  readonly cliBinaryPath: string | null;
+  readonly cliVersion: string | null;
+  readonly requiredCliVersion: string | null;
+  readonly desktopUpdate: DesktopAppUpdateSnapshot | null;
+  readonly hostName: string;
+}
+
+/** Called only after the executing CLI has refused the projected asset. */
+export function describeCliFloorRemedy(
+  input: CliFloorRemedyInput,
+): CliFloorRemedy {
+  if (input.cliSource === null) {
+    return {
+      sentence: `Traycer couldn't determine how its command-line tools were installed on ${input.hostName}.`,
+      actions: [{ kind: "help", label: "Show installation help" }],
+    };
+  }
+  if (
+    input.isLocalMachine &&
+    input.cliSource === "desktop" &&
+    input.desktopUpdate !== null
+  ) {
+    return describeDesktopRemedy(input.desktopUpdate, input);
+  }
+  if (input.cliSource !== "desktop" && input.cliSource !== "manual") {
+    return describePackageManagerRemedy(input, input.cliSource);
+  }
+  // The old Windows CLI finalizes its staged upgrade during host restart,
+  // whose taskkill /T would kill that very CLI if the command ran in a
+  // Traycer-hosted terminal - so Windows gets both commands, outside Traycer.
+  const route = cliUpgradeRoute(input.platform, input.cliBinaryPath);
+  if (route === "windows") {
+    const instructions = describeWindowsCliUpgrade(input);
+    return describeCopyRemedy(
+      input,
+      instructions.sentence,
+      instructions.command,
+      instructions.label,
+    );
+  }
+  if (route === "unknown") {
+    // Nothing on the record says what kind of machine this is: no platform,
+    // and no recorded path shaped like either. Bare commands, outside
+    // Traycer (the Windows caution costs nothing elsewhere), with no shell
+    // named - a POSIX host has no PowerShell to open.
+    return describeCopyRemedy(
+      input,
+      `Run the copied commands on ${input.hostName} from a terminal outside Traycer on that machine: first the tools upgrade, then the host restart. Restarting briefly disconnects this host. When it reconnects, select Check now, then Update now.`,
+      "traycer cli upgrade\ntraycer host restart",
+      "Copy commands",
+    );
+  }
+  return describeCopyRemedy(
+    input,
+    `First update Traycer's command-line tools on ${input.hostName}. Open a terminal on that machine and run the copied command. When it finishes, come back here: this page rechecks while it is open, and Update now appears once the host accepts the update.`,
+    posixCliUpgradeCommand(input.cliBinaryPath),
+    "Copy command",
+  );
+}
+
+function describePackageManagerRemedy(
+  input: CliFloorRemedyInput,
+  source: Exclude<CliInstallSource, "desktop" | "manual">,
+): CliFloorRemedy {
+  const requiredVersion = input.requiredCliVersion;
+  // Legacy projections can mislabel a malformed floor as repairable. Never
+  // interpolate unchecked manifest text into the copied npm shell command.
+  if (requiredVersion !== null && !isValidHostVersion(requiredVersion)) {
+    return {
+      sentence: `Traycer couldn't verify the required command-line tools version on ${input.hostName}.`,
+      actions: [{ kind: "help", label: "Show installation help" }],
+    };
+  }
+  if (
+    requiredVersion !== null &&
+    isPreReleaseVersion(requiredVersion) &&
+    source !== "npm" &&
+    source !== "homebrew"
+  ) {
+    return {
+      sentence: `Traycer CLI prereleases aren't published through ${source}. Install Traycer CLI ${requiredVersion} another way, then select Check now.`,
+      actions: [{ kind: "help", label: "Show installation help" }],
+    };
+  }
+  // npm's `latest` is stable-only; pin the published floor, including RCs.
+  const command =
+    source === "npm" && requiredVersion !== null
+      ? `npm install -g ${CLI_NPM_PACKAGE_NAME}@${requiredVersion}`
+      : PACKAGE_MANAGER_UPGRADE_COMMAND[source];
+  return describeCopyRemedy(
+    input,
+    `On ${input.hostName}, run this command to prepare the host update: ${command}. Then select Check now.`,
+    command,
+    "Copy command",
+  );
+}
+
+function describeDesktopRemedy(
+  snapshot: DesktopAppUpdateSnapshot,
+  input: CliFloorRemedyInput,
+): CliFloorRemedy {
+  const fallback = describeDesktopFloorFallbackFor(snapshot, input);
+  if (fallback !== null) return fallback;
+  const version = snapshot.latestVersion ?? input.requiredCliVersion;
+  switch (snapshot.status) {
+    case "available":
+      return {
+        sentence: `Update Traycer Desktop${version === null ? "" : ` to ${version}`} to install this host update.`,
+        actions: [
+          {
+            kind: "desktop-download",
+            label: "Download update",
+            disabled: snapshot.installBlockedReason !== null,
+            tooltip: snapshot.installBlockedReason,
+          },
+        ],
+      };
+    case "downloading":
+      return {
+        sentence: "Downloading the Traycer Desktop update…",
+        actions: [
+          {
+            kind: "desktop-progress",
+            label:
+              snapshot.downloadProgress === null
+                ? "Downloading update"
+                : `Downloading ${snapshot.downloadProgress}%`,
+          },
+        ],
+      };
+    case "ready":
+      return describeDesktopReady(snapshot, version);
+    case "up-to-date":
+      return {
+        sentence:
+          "Traycer Desktop is up to date, but this computer still needs to finish updating its host tools. Restart Traycer Desktop to finish.",
+        actions: [{ kind: "restart-desktop-hint" }],
+      };
+    case "error":
+    case "unavailable":
+      return describeDesktopCheckFailed(snapshot);
+    case "idle":
+      return {
+        sentence: "Check for a Traycer Desktop update.",
+        actions: [{ kind: "desktop-check", label: null, checkOnMount: true }],
+      };
+    case "checking":
+      return {
+        sentence: "Checking for a Traycer Desktop update…",
+        actions: [{ kind: "desktop-check", label: null, checkOnMount: false }],
+      };
+  }
+}
+
+function describeDesktopReady(
+  snapshot: DesktopAppUpdateSnapshot,
+  version: string | null,
+): CliFloorRemedy {
+  // Same precedence as the header: a blocked location wins over manual
+  // install guidance, and main's in-flight snapshot disarms every surface.
+  const showGuidance =
+    snapshot.installBlockedReason === null && snapshot.installGuidance !== null;
+  return {
+    sentence: `Traycer Desktop${version === null ? "" : ` ${version}`} is ready. Restart Traycer to finish, then this host update can install.`,
+    actions: [
+      {
+        kind: "desktop-install",
+        label: showGuidance ? "Finish update" : "Restart to update",
+        disabled:
+          snapshot.installBlockedReason !== null || snapshot.installInFlight,
+        tooltip: snapshot.installBlockedReason,
+        showGuidance,
+        installInFlight: snapshot.installInFlight,
+      },
+    ],
+  };
+}
+
+function describeDesktopCheckFailed(
+  snapshot: DesktopAppUpdateSnapshot,
+): CliFloorRemedy {
+  return {
+    sentence:
+      snapshot.errorMessage?.trim() ||
+      "Traycer Desktop couldn't check for updates.",
+    actions: [
+      { kind: "desktop-check", label: "Check again", checkOnMount: false },
+      { kind: "help", label: "Show installation help" },
+    ],
+  };
+}
+
+// Desktop and its bundled CLI share a version. Downloading or restarting a
+// stable build below an RC host's floor would leave the same refusal. When no
+// update is offered, a restart runs the installed Desktop, and the feed's
+// latest version may be older than it (for example after leaving RCs).
+function describeDesktopFloorFallbackFor(
+  snapshot: DesktopAppUpdateSnapshot,
+  input: CliFloorRemedyInput,
+): CliFloorRemedy | null {
+  switch (snapshot.status) {
+    case "available":
+    case "downloading":
+    case "ready":
+      return describeDesktopFloorFallback(input, snapshot.latestVersion);
+    case "up-to-date":
+      return describeDesktopFloorFallback(input, snapshot.currentVersion);
+    default:
+      return null;
+  }
+}
+
+function describeDesktopFloorFallback(
+  input: CliFloorRemedyInput,
+  candidate: string | null,
+): CliFloorRemedy | null {
+  const { requiredCliVersion } = input;
+  if (requiredCliVersion === null) return null;
+  const comparison =
+    candidate === null
+      ? null
+      : compareHostVersions(candidate, requiredCliVersion);
+  if (
+    comparison !== null &&
+    comparison.comparable &&
+    comparison.ordering !== "less"
+  ) {
+    return null;
+  }
+  const versionDescription =
+    input.desktopUpdate?.status === "up-to-date"
+      ? `Traycer Desktop v${candidate} is installed`
+      : `Traycer v${candidate} is the latest on this update channel`;
+  const sentence =
+    comparison !== null && comparison.comparable
+      ? `${versionDescription} and its command-line tools are below ${requiredCliVersion}.`
+      : `Traycer couldn't verify that this Desktop update includes Traycer CLI ${requiredCliVersion} or newer.`;
+  const instructions = describeDesktopCliUpgrade(input);
+  const help: CliFloorRemedyAction = {
+    kind: "help",
+    label: "Show installation help",
+  };
+  return {
+    sentence:
+      instructions === null ? sentence : `${sentence} ${instructions.sentence}`,
+    actions:
+      instructions === null
+        ? [help]
+        : [
+            {
+              kind: "copy-command",
+              label: instructions.label,
+              command: instructions.command,
+            },
+            help,
+          ],
+  };
+}
+
+function describeDesktopCliUpgrade(
+  input: CliFloorRemedyInput,
+): CliUpgradeInstructions | null {
+  // Never guess PATH for a Desktop-owned CLI: its private slot or a manually
+  // re-anchored binary may not be registered there, or may name another copy.
+  // Same route decision as the manual arm - a null platform is answered by
+  // the recorded path's shape, never read as "no route".
+  if (input.cliBinaryPath === null) return null;
+  const route = cliUpgradeRoute(input.platform, input.cliBinaryPath);
+  if (route === "windows") {
+    return isAbsoluteWindowsPath(input.cliBinaryPath)
+      ? describeWindowsCliUpgrade(input)
+      : null;
+  }
+  if (route !== "posix" || !input.cliBinaryPath.startsWith("/")) return null;
+  return {
+    sentence: `Open a terminal on ${input.hostName} and run the copied command, then select Check now.`,
+    command: posixCliUpgradeCommand(input.cliBinaryPath),
+    label: "Copy command",
+  };
+}
+
+/**
+ * Which command shape to hand out. The platform decides when the record has
+ * one; when it does not (a legacy registry record with `platform: null`),
+ * the RECORDED BINARY PATH is the next best evidence - a drive-rooted or UNC
+ * path only exists on Windows, a `/`-rooted one only elsewhere. Reading
+ * `null` as Windows sent a Linux or macOS host to "open PowerShell" with a
+ * bare `traycer` in place of the absolute path it had recorded, which on a
+ * manual or private-slot install is exactly the path that is not on PATH.
+ */
+function cliUpgradeRoute(
+  platform: string | null,
+  binaryPath: string | null,
+): "windows" | "posix" | "unknown" {
+  if (platform !== null) {
+    return platform.startsWith("win32") ? "windows" : "posix";
+  }
+  if (binaryPath === null) return "unknown";
+  if (isAbsoluteWindowsPath(binaryPath)) return "windows";
+  if (binaryPath.startsWith("/")) return "posix";
+  return "unknown";
+}
+
+function describeWindowsCliUpgrade(
+  input: CliFloorRemedyInput,
+): CliUpgradeInstructions {
+  const invocation = windowsCliInvocation(input.cliBinaryPath);
+  return {
+    sentence: `Run the copied commands on ${input.hostName} from a PowerShell window outside Traycer on that machine (a Windows Terminal tab there, or an SSH session that opens PowerShell). Restarting briefly disconnects this host. When it reconnects, select Check now, then Update now.`,
+    command: `${invocation} cli upgrade\n${invocation} host restart`,
+    label: "Copy commands",
+  };
+}
+
+function describeCopyRemedy(
+  input: CliFloorRemedyInput,
+  sentence: string,
+  command: string,
+  label: string,
+): CliFloorRemedy {
+  const comparison =
+    input.cliVersion === null || input.requiredCliVersion === null
+      ? null
+      : compareHostVersions(input.cliVersion, input.requiredCliVersion);
+  const olderCopy =
+    comparison !== null &&
+    comparison.comparable &&
+    comparison.ordering !== "less";
+  return {
+    sentence: olderCopy
+      ? `Traycer's command-line tools on ${input.hostName} were updated, but the host is still using an older copy. Run the command again: ${sentence}`
+      : sentence,
+    actions: [{ kind: "copy-command", label, command }],
+  };
+}
+
+// Drive-rooted (`C:\`, `D:/`) or UNC (`\\server\share`). A drive-relative
+// `C:traycer.exe` or a bare name is not a path we can hand to a shell.
+function isAbsoluteWindowsPath(binaryPath: string): boolean {
+  return /^[A-Za-z]:[\\/]/.test(binaryPath) || binaryPath.startsWith("\\\\");
+}
+
+function windowsCliInvocation(binaryPath: string | null): string {
+  if (binaryPath === null || !isAbsoluteWindowsPath(binaryPath)) {
+    return "traycer";
+  }
+  // Windows Terminal's default profile is PowerShell: a double-quoted path
+  // at command position is a string expression, so invocation needs `&`.
+  // Single quotes keep the path literal; cmd users need double quotes
+  // without `&` instead.
+  return `& '${binaryPath.replaceAll("'", "''")}'`;
+}
+
+function posixCliUpgradeCommand(binaryPath: string | null): string {
+  if (binaryPath === null || !binaryPath.startsWith("/")) {
+    return "traycer cli upgrade";
+  }
+  // A path is one shell token. Double quotes would still expand dollars and
+  // backticks; single quotes with escaped apostrophes keep every byte literal.
+  return `'${binaryPath.replaceAll("'", "'\\''")}' cli upgrade`;
+}

--- a/clients/gui-app/src/components/settings/panels/host-overview-operation-card.tsx
+++ b/clients/gui-app/src/components/settings/panels/host-overview-operation-card.tsx
@@ -69,7 +69,7 @@ export function HostOverviewOperationCard(props: {
    * the ellipsis on the button is a promise, and the confirmation is what
    * re-reads live work before anything happens.
    */
-  readonly onForceRestart: () => void;
+  readonly onForceRestart: (() => void) | null;
   /**
    * The RECORDS say the install is ahead of the running host (activation
    * debt, `legacy-update-facts.ts`), and this is the page's cooperative
@@ -194,7 +194,7 @@ export function HostOverviewOperationCard(props: {
  */
 function ForceControl(props: {
   readonly onForceUpdate: (() => void) | null;
-  readonly onForceRestart: () => void;
+  readonly onForceRestart: (() => void) | null;
 }): ReactNode {
   if (props.onForceUpdate !== null) {
     return (
@@ -210,6 +210,7 @@ function ForceControl(props: {
       </Button>
     );
   }
+  if (props.onForceRestart === null) return null;
   return (
     <Button
       type="button"

--- a/clients/gui-app/src/components/settings/panels/host-overview-operation-card.tsx
+++ b/clients/gui-app/src/components/settings/panels/host-overview-operation-card.tsx
@@ -50,6 +50,16 @@ import { cn } from "@/lib/utils";
  * Doctor card is Diagnostics. The landing banner needs its own copies because
  * it is nowhere near either. Adding a second pair here would be the layered
  * narration this codebase keeps deleting.
+ *
+ * The two record-derived parks (`legacy-update-facts.ts`) are the exception
+ * that proves the rule, and each gets exactly one control. **Restart** on
+ * activation debt is not a second Restart: it opens the SAME confirmation the
+ * overflow Restart opens, and it exists because the card's own sentence
+ * ("Update installed — restart host to finish") names that action and a
+ * sentence that names an action three clicks away is a dead end. **Force
+ * update…** on a staged wait has no counterpart anywhere else on the page -
+ * the version rows install without force, and force is precisely what a
+ * parked stage needs.
  */
 export function HostOverviewOperationCard(props: {
   readonly view: FleetUpdateView;
@@ -60,6 +70,27 @@ export function HostOverviewOperationCard(props: {
    * re-reads live work before anything happens.
    */
   readonly onForceRestart: () => void;
+  /**
+   * The RECORDS say the install is ahead of the running host (activation
+   * debt, `legacy-update-facts.ts`), and this is the page's cooperative
+   * restart: the same confirm → transition id → busy verdict → force/defer
+   * flow the header's Restart runs. `null` when there is no debt.
+   *
+   * Keyed on the FACT rather than on `view.kind`, deliberately. The kind is
+   * `waiting-to-activate` when nothing outranks the fact, but a retained
+   * `failed` marker from an earlier run outranks it and keeps its failure
+   * text — real evidence, not to be papered over — and the person still needs
+   * the way forward. So Restart renders beside either sentence.
+   */
+  readonly onRestart: (() => void) | null;
+  /**
+   * The RECORDS say a newer host is staged and the running host is busy
+   * (staged wait): dispatch `host.update.install {version: staged, force}`
+   * through the page's existing install mutation. `null` when there is no
+   * stage waiting, or when the host reported no positive session count to
+   * name — `offersForceRestart` gates the button on exactly that count.
+   */
+  readonly onForceUpdate: (() => void) | null;
 }): ReactNode {
   const { view } = props;
   const copy = describeUpdateOperation({ view, hostName: props.hostName });
@@ -119,17 +150,25 @@ export function HostOverviewOperationCard(props: {
             {percent}%
           </span>
         )}
-        {offersForceRestart(view) ? (
+        {props.onRestart === null ? null : (
           <Button
             type="button"
             size="sm"
             variant="default"
             className="shrink-0"
-            onClick={props.onForceRestart}
-            data-testid="host-overview-operation-force-restart"
+            onClick={props.onRestart}
+            data-testid="host-overview-operation-restart"
           >
-            Force restart…
+            Restart
           </Button>
+        )}
+        {/* `offersForceRestart` gates both forces on a positive, host-reported
+            count; `ForceControl` picks which one. */}
+        {offersForceRestart(view) ? (
+          <ForceControl
+            onForceUpdate={props.onForceUpdate}
+            onForceRestart={props.onForceRestart}
+          />
         ) : null}
       </div>
       {showProgress ? (
@@ -140,5 +179,43 @@ export function HostOverviewOperationCard(props: {
         />
       ) : null}
     </div>
+  );
+}
+
+/**
+ * The one force control the card offers when `offersForceRestart` holds.
+ * Which force it is depends on WHO parked: a record-derived staged wait has
+ * no attempt to force-restart into, so its way forward is the updater itself
+ * re-run with `--force`; an attempt-record park keeps the force-restart route.
+ */
+function ForceControl(props: {
+  readonly onForceUpdate: (() => void) | null;
+  readonly onForceRestart: () => void;
+}): ReactNode {
+  if (props.onForceUpdate !== null) {
+    return (
+      <Button
+        type="button"
+        size="sm"
+        variant="default"
+        className="shrink-0"
+        onClick={props.onForceUpdate}
+        data-testid="host-overview-operation-force-update"
+      >
+        Force update…
+      </Button>
+    );
+  }
+  return (
+    <Button
+      type="button"
+      size="sm"
+      variant="default"
+      className="shrink-0"
+      onClick={props.onForceRestart}
+      data-testid="host-overview-operation-force-restart"
+    >
+      Force restart…
+    </Button>
   );
 }

--- a/clients/gui-app/src/components/settings/panels/host-overview-operation-card.tsx
+++ b/clients/gui-app/src/components/settings/panels/host-overview-operation-card.tsx
@@ -74,7 +74,10 @@ export function HostOverviewOperationCard(props: {
    * The RECORDS say the install is ahead of the running host (activation
    * debt, `legacy-update-facts.ts`), and this is the page's cooperative
    * restart: the same confirm → transition id → busy verdict → force/defer
-   * flow the header's Restart runs. `null` when there is no debt.
+   * flow the header's Restart runs. `null` when there is no debt, and
+   * `null` when the scope cannot reach the host: the fact is a cached read
+   * that outlives reachability, and the sentence (rendered qualified) is
+   * evidence worth keeping while a dispatch through a dead route is not.
    *
    * Keyed on the FACT rather than on `view.kind`, deliberately. The kind is
    * `waiting-to-activate` when nothing outranks the fact, but a retained
@@ -88,7 +91,8 @@ export function HostOverviewOperationCard(props: {
    * (staged wait): dispatch `host.update.install {version: staged, force}`
    * through the page's existing install mutation. `null` when there is no
    * stage waiting, or when the host reported no positive session count to
-   * name — `offersForceRestart` gates the button on exactly that count.
+   * name — `offersForceRestart` gates the button on exactly that count —
+   * and `null` when the scope cannot reach the host, as for `onRestart`.
    */
   readonly onForceUpdate: (() => void) | null;
 }): ReactNode {

--- a/clients/gui-app/src/components/settings/panels/host-overview-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/host-overview-panel.tsx
@@ -613,16 +613,25 @@ export function HostOverviewPanel(props: {
   //
   // `holdsLifecycleGate` answers the narrower question (`execution === "active"`)
   // that this gate actually wants. For a pre-@1.3 peer `updateOperation` is
-  // `null` and we fall back to the coarse field — which is exactly the
-  // behaviour those hosts ship with today, so no host regresses and only the
-  // ones that CAN tell us more get the fix. Keyed on the PEER's field rather
-  // than on whether a projection exists: the projection is now built for that
-  // peer too (so its parks reach the card), and its `updating` kind is
-  // deliberately fail-open in `holdsLifecycleGate`, which would have quietly
-  // dropped the gate those hosts ship with.
+  // `null` and we fall back to the coarse marker — the behaviour those hosts
+  // ship with, so no host regresses and only the ones that CAN tell us more
+  // get the fix. Keyed on the PEER's field rather than on whether a projection
+  // exists: the projection is now built for that peer too (so its parks reach
+  // the card), and its `updating` kind is deliberately fail-open in
+  // `holdsLifecycleGate`, which would have quietly dropped the gate those
+  // hosts ship with.
+  //
+  // The coarse fallback reads the PROJECTED kind, not the raw wire field. The
+  // two agree while the read is healthy; they part when it is not, and that
+  // is the case that matters: `projectFleetUpdateView` demotes a retained,
+  // failed, paused or aged read to `unknown`, while the raw `updateProgress`
+  // on the retained response still says `updating`. A pre-@1.3 host whose
+  // updater crashed mid-swap leaves that marker behind with nothing to clear
+  // it, and holding the gate on it would lock Restart — the one action that
+  // recovers the host — for as long as the response was retained.
   const updateInFlight =
     view.updateOperation === null || operationView === null
-      ? view.updateProgress?.state === "updating"
+      ? operationView?.kind === "updating"
       : holdsLifecycleGate(operationView);
   const corePending =
     restart.isPending ||

--- a/clients/gui-app/src/components/settings/panels/host-overview-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/host-overview-panel.tsx
@@ -24,7 +24,6 @@ import {
   HostOverviewHeaderActions,
   HostOverviewNameAction,
   HostOverviewNotice,
-  HostOverviewUpdateProgress,
 } from "@/components/settings/panels/host-overview-status-card";
 import { HostOverviewOperationCard } from "@/components/settings/panels/host-overview-operation-card";
 import { HostOverviewUpdatesRegion } from "@/components/settings/panels/host-overview-updates";
@@ -81,6 +80,7 @@ import {
   UNKNOWN_FLEET_UPDATE_VIEW,
 } from "@/lib/host/fleet-update/fleet-update-view";
 import { observationFromCanonicalRead } from "@/lib/host/fleet-update/canonical-status-observation";
+import { deriveLegacyUpdateFacts } from "@/lib/host/fleet-update/legacy-update-facts";
 import { useActiveUpdatePollAccelerator } from "@/hooks/host/use-active-update-poll-accelerator";
 import {
   toastHostRestartDeclined,
@@ -529,8 +529,34 @@ export function HostOverviewPanel(props: {
   // `observationFromCanonicalRead` now carries those conditions with the fact,
   // and it is the same function the landing banner and the fleet's coalesced
   // reads use, so a fourth staleness rule cannot appear here by accident.
+  //
+  // The parks the legacy updater leaves behind WITHOUT a marker - bytes
+  // installed under a host still running the old version, a stage waiting
+  // for a busy host to go idle - are derived from the install and staged
+  // records beside the same status read. This is the one leg that derives
+  // them: the banner keeps its desktop-status debt arm and the fleet legs
+  // read no installation info. `null` until both reads have answered, which
+  // the projector treats as "not observed", never as "no park".
+  const legacyFacts =
+    statusQuery.data === undefined || installationQuery.data === undefined
+      ? null
+      : deriveLegacyUpdateFacts({
+          installation: installationQuery.data,
+          runningVersion: statusQuery.data.hostVersion,
+          // The RAW read, not the live-source-demoted snapshot: the facts must
+          // describe one instant of one response, and staleness is already
+          // the observation deadline's job below.
+          busy: statusQuery.data.busy,
+          busySessionCount: statusQuery.data.busySessionCount,
+        });
+  // Built whenever there IS a status read - including for a pre-@1.3 peer
+  // whose `updateOperation` is `null`. This used to bail to `null` for that
+  // peer and render the coarse marker through a separate notice; the
+  // projector already has an arm for exactly that observation (coarse first,
+  // then the record-derived parks, then `unknown`), and routing the old peer
+  // through it is what lets its parks reach the card too.
   const operationObservation =
-    view.updateOperation === null || statusQuery.data === undefined
+    statusQuery.data === undefined
       ? null
       : observationFromCanonicalRead({
           hostId: scope.hostId ?? "",
@@ -543,6 +569,7 @@ export function HostOverviewPanel(props: {
             hasLiveSource: usable,
           },
           source: "selected",
+          legacyFacts,
         });
   const operationView =
     operationObservation === null
@@ -586,11 +613,15 @@ export function HostOverviewPanel(props: {
   //
   // `holdsLifecycleGate` answers the narrower question (`execution === "active"`)
   // that this gate actually wants. For a pre-@1.3 peer `updateOperation` is
-  // `null`, the projection is `unknown`, and we fall back to the coarse field —
-  // which is exactly the behaviour those hosts ship with today, so no host
-  // regresses and only the ones that CAN tell us more get the fix.
+  // `null` and we fall back to the coarse field — which is exactly the
+  // behaviour those hosts ship with today, so no host regresses and only the
+  // ones that CAN tell us more get the fix. Keyed on the PEER's field rather
+  // than on whether a projection exists: the projection is now built for that
+  // peer too (so its parks reach the card), and its `updating` kind is
+  // deliberately fail-open in `holdsLifecycleGate`, which would have quietly
+  // dropped the gate those hosts ship with.
   const updateInFlight =
-    operationView === null
+    view.updateOperation === null || operationView === null
       ? view.updateProgress?.state === "updating"
       : holdsLifecycleGate(operationView);
   const corePending =
@@ -693,7 +724,8 @@ export function HostOverviewPanel(props: {
     // swap the scoped host under a mounted subtree, and an override carried
     // across that swap would apply one machine's decision to another.
     hostId: scope.hostId,
-    installedVersion: view.hostVersion,
+    runningVersion: view.hostVersion,
+    activationDebt: legacyFacts?.activationDebt ?? null,
     platformKey: host?.platform ?? null,
     // The check reads on its own now, so this gate is load-bearing rather than
     // cosmetic: without it the page would spawn a CLI process on the host from
@@ -704,6 +736,37 @@ export function HostOverviewPanel(props: {
     busy: updateGatePending,
   });
   const anyPending = updateGatePending || updates.summary.installing;
+
+  // The staged-wait force, as the OFFER it is: a newer host is staged, the
+  // running host is busy, and "Force update…" on the card opens this before
+  // anything is dispatched — the ellipsis is a promise, and the count the
+  // dialog states is the count captured when the offer was made, not
+  // whatever the page shows when the button is pressed. Confirming dispatches
+  // `host.update.install {version: staged, force: true}` through the page's
+  // one install mutation, so the accepted latch, the invalidations and the
+  // outcome toasts are the ones every other install here gets.
+  const [forceUpdateOffer, setForceUpdateOffer] = useState<{
+    readonly stagedVersion: string;
+    readonly blockingSessionCount: number | null;
+  } | null>(null);
+  // Same stale-open rule as the restart confirm: close for every arming of
+  // the page-wide gate EXCEPT this offer's own dispatch, which keeps the
+  // dialog up to show its spinner. Adjust-during-render so the close lands in
+  // the arming commit.
+  if (forceUpdateOffer !== null && anyPending && !updates.summary.installing) {
+    setForceUpdateOffer(null);
+  }
+  // And when the fact it describes is gone - the stage was applied by another
+  // actor, or the host went idle and the next run is about to take it. A
+  // force over a stage that no longer waits would install something the
+  // dialog never described.
+  if (
+    forceUpdateOffer !== null &&
+    (legacyFacts?.stagedWait ?? null)?.stagedVersion !==
+      forceUpdateOffer.stagedVersion
+  ) {
+    setForceUpdateOffer(null);
+  }
 
   // Which write IS this dialog's own dispatch: the cooperative `host.restart`
   // ordinarily, the bridge respawn when the fallback routes Restart to the
@@ -949,12 +1012,28 @@ export function HostOverviewPanel(props: {
               // the first click and never consumes update-force authorization.
               setRestartConfirmOpen(true);
             }}
-          />
-        )}
-        {operationView !== null || view.updateProgress === null ? null : (
-          <HostOverviewUpdateProgress
-            state={view.updateProgress.state}
-            error={view.updateProgress.error}
+            // Keyed on the FACT, not the view kind: a retained `failed`
+            // marker beside real debt keeps its failure text and still gets
+            // the way forward. Same confirm the header's Restart opens, so
+            // the transition id, the busy verdict and the force/defer dialog
+            // are all the existing ones.
+            onRestart={
+              (legacyFacts?.activationDebt ?? null) === null
+                ? null
+                : () => setRestartConfirmOpen(true)
+            }
+            onForceUpdate={
+              legacyFacts === null || legacyFacts.stagedWait === null
+                ? null
+                : () => {
+                    if (legacyFacts.stagedWait === null) return;
+                    setForceUpdateOffer({
+                      stagedVersion: legacyFacts.stagedWait.stagedVersion,
+                      blockingSessionCount:
+                        legacyFacts.stagedWait.blockingSessionCount,
+                    });
+                  }
+            }
           />
         )}
         {/* The update ANSWER, on the card that describes the host — not under a
@@ -1171,6 +1250,37 @@ export function HostOverviewPanel(props: {
         }}
         onDefer={() => setForceRestartOffer(null)}
       />
+      {/* The staged-wait force's confirmation - the same busy/force/defer
+          dialog, because the decision is the same shape: live work stands
+          between the person and the update, and they choose whether to end
+          it. What "force" DOES differs and is named on the button: this one
+          re-runs the updater with `--force` against the kept stage; the one
+          above respawns the host process. */}
+      <HostBusyForceDeferDialog
+        open={forceUpdateOffer !== null}
+        message={
+          forceUpdateOffer === null
+            ? ""
+            : forceUpdateMessage(
+                displayName,
+                forceUpdateOffer.stagedVersion,
+                forceUpdateOffer.blockingSessionCount,
+              )
+        }
+        isForcing={updates.summary.installing}
+        forceLabel="Force update"
+        onForce={() => {
+          if (forceUpdateOffer === null) return;
+          // Closed on the ANSWER, whatever it is: an accepted force is now
+          // reported by the card and the toasts, and a refused one by the
+          // inline failure notice - leaving the dialog up over either would
+          // re-offer a decision already made.
+          updates.installForce(forceUpdateOffer.stagedVersion, () =>
+            setForceUpdateOffer(null),
+          );
+        }}
+        onDefer={() => setForceUpdateOffer(null)}
+      />
       <DoctorSheet
         open={doctorOpen}
         onOpenChange={setDoctorOpen}
@@ -1240,6 +1350,25 @@ export function HostOverviewPanel(props: {
       />
     </div>
   );
+}
+
+/**
+ * What the staged-wait force dialog says. The count is the one the card's
+ * sentence named when the offer was made; `null` (a busy host that counts no
+ * session) keeps the sentence unquantified rather than inventing a number.
+ */
+function forceUpdateMessage(
+  hostName: string,
+  stagedVersion: string,
+  blockingSessionCount: number | null,
+): string {
+  let work = "the work in progress";
+  if (blockingSessionCount === 1) {
+    work = "1 session";
+  } else if (blockingSessionCount !== null) {
+    work = `${String(blockingSessionCount)} sessions`;
+  }
+  return `v${stagedVersion} is downloaded and waiting. Installing it now ends ${work} on ${hostName} and restarts the host. Defer to let the update continue on its own once the host is idle.`;
 }
 
 /**

--- a/clients/gui-app/src/components/settings/panels/host-overview-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/host-overview-panel.tsx
@@ -1080,8 +1080,10 @@ export function HostOverviewPanel(props: {
               !usable ||
               legacyFacts === null ||
               legacyFacts.stagedWait === null ||
-              updates.stagedFloor !== null ||
-              !updates.stagedEntryKnown
+              // ONE gate, shared with the dispatch's revalidation: the
+              // catalog still lists the staged version, not withdrawn, no
+              // CLI floor, a usable asset for this platform.
+              !updates.stagedEntryOfferable
                 ? null
                 : () => {
                     if (legacyFacts.stagedWait === null) return;

--- a/clients/gui-app/src/components/settings/panels/host-overview-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/host-overview-panel.tsx
@@ -80,7 +80,10 @@ import {
   projectFleetUpdateView,
   UNKNOWN_FLEET_UPDATE_VIEW,
 } from "@/lib/host/fleet-update/fleet-update-view";
-import { observationFromCanonicalRead } from "@/lib/host/fleet-update/canonical-status-observation";
+import {
+  canonicalReadIsLive,
+  observationFromCanonicalRead,
+} from "@/lib/host/fleet-update/canonical-status-observation";
 import { deriveLegacyUpdateFacts } from "@/lib/host/fleet-update/legacy-update-facts";
 import { useActiveUpdatePollAccelerator } from "@/hooks/host/use-active-update-poll-accelerator";
 import {
@@ -543,14 +546,45 @@ export function HostOverviewPanel(props: {
   // Two reads, one snapshot: the installation query is keyed by the running
   // version the status read reported (`useHostInstallationInfoQuery`), so a
   // record fetched under the previous version is never compared against the
-  // new one - it is a different key with no data yet. And a read that has
-  // FAILED keeps its last payload in the cache; a comparison built on it
-  // would carry the status read's freshness while the record leg is
-  // anyone's guess, so it is "not observed" until the next poll answers.
+  // new one - it is a different key with no data yet. And the record leg is
+  // held to the SAME liveness rule the status leg is projected under
+  // (`canonicalReadIsLive` - not "has not failed" alone, and not a second
+  // staleness rule with its own timestamp arithmetic): a read that has
+  // failed, is paused, or has aged past its own staleness keeps its last
+  // payload in the cache, and a comparison built on it would carry the
+  // status read's freshness while the record leg is anyone's guess - a park
+  // derived from a record the host has since consumed or purged, still
+  // offering Force for a stage that is gone. Such a read yields NO facts:
+  // the parks it fed are withdrawn, the offers keyed on them with them,
+  // and the projector falls through to whatever the status leg says. The
+  // demotion is scoped to the record leg on purpose. Expiring the whole
+  // observation instead would demote a live attempt the status leg is
+  // reporting - progress bar, lifecycle gate, fast poll - on one failed
+  // `host.getInstallationInfo` poll, which is likeliest exactly during the
+  // swap; the record leg feeds only the two record-derived rows, so only
+  // those go. An in-flight refetch is live under the shared rule, and a
+  // request whose response never arrives ends as an error rather than as
+  // an indefinitely retained payload - each attempt is bounded by the
+  // transport's 30 s response timeout (`DEFAULT_HOST_RPC_FRAME_TIMEOUT_MS`
+  // on the local leg, `UNARY_RESPONSE_TIMEOUT_MS` on the remote one) and
+  // the query client retries once, so a silent poll withdraws after about
+  // a minute. (`paused` is part of the shared rule; this app's queries run
+  // with `networkMode: "always"`, so it does not arise here.) The source
+  // here is the query's own enablement, not the scope's: an unusable scope
+  // demotes the whole observation through the status leg already and keeps
+  // its retained sentence qualified, whereas a support flip that disables
+  // the query over a cached payload would otherwise read as live forever -
+  // a disabled query never ages (`isStale` is false while `enabled` is).
+  const installationLive = canonicalReadIsLive({
+    isError: installationQuery.isError,
+    fetchStatus: installationQuery.fetchStatus,
+    isStale: installationQuery.isStale,
+    hasLiveSource: installInfoDegrade === null,
+  });
   const legacyFacts =
     statusQuery.data === undefined ||
     installationQuery.data === undefined ||
-    installationQuery.isError
+    !installationLive
       ? null
       : deriveLegacyUpdateFacts({
           installation: installationQuery.data,
@@ -749,6 +783,11 @@ export function HostOverviewPanel(props: {
     runningVersion: view.hostVersion,
     activationDebt: legacyFacts?.activationDebt ?? null,
     platformKey: host?.platform ?? null,
+    // Deliberately NOT held to `installationLive`: the manifest describes
+    // the CLI installed on the host - a property of the installation, not
+    // of its stage - and the floor remedy it feeds belongs to Update now as
+    // much as to Force. The Force offer itself is gated through
+    // `stagedVersion`, which comes from the observed record leg only.
     cliManifest:
       managedInstallation(installationQuery.data)?.cliManifest ?? null,
     isLocalMachine: host?.isLocalMachine ?? false,
@@ -788,9 +827,17 @@ export function HostOverviewPanel(props: {
   // actor, or the host went idle and the next run is about to take it. A
   // force over a stage that no longer waits would install something the
   // dialog never described.
+  // "Gone" means OBSERVED gone: a record leg that is not live (`legacyFacts`
+  // null - not answered yet, failed, or aged) says nothing about the stage,
+  // and an open confirm closing itself on a poll that merely aged is the
+  // defect `canonicalReadIsLive` was written against. The one window this
+  // leaves - the running version moved, which re-keys the installation
+  // query and is itself evidence the stage was consumed - is closed by the
+  // `!usable` rule below: a restarted host drops reachability first.
   if (
     forceUpdateOffer !== null &&
-    (legacyFacts?.stagedWait ?? null)?.stagedVersion !==
+    legacyFacts !== null &&
+    (legacyFacts.stagedWait?.stagedVersion ?? null) !==
       forceUpdateOffer.stagedVersion
   ) {
     setForceUpdateOffer(null);
@@ -1051,15 +1098,17 @@ export function HostOverviewPanel(props: {
             view={operationView}
             hostName={displayName}
             // Restart cannot activate a stage. A floor gate must not turn a
-            // staged wait's Force update into a different, ineffective force.
+            // staged wait's Force update into a different, ineffective force
+            // - and a record leg that is not live does not vouch that no
+            // stage waits, so it offers nothing either.
             onForceRestart={
-              (legacyFacts?.stagedWait ?? null) !== null
-                ? null
-                : () => {
+              legacyFacts !== null && legacyFacts.stagedWait === null
+                ? () => {
                     // Attempt parks keep the existing cooperative restart
                     // confirmation and its fresh live-work check.
                     setRestartConfirmOpen(true);
                   }
+                : null
             }
             // Keyed on the FACT, not the view kind: a retained `failed`
             // marker beside real debt keeps its failure text and still gets

--- a/clients/gui-app/src/components/settings/panels/host-overview-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/host-overview-panel.tsx
@@ -221,7 +221,16 @@ export function HostOverviewPanel(props: {
     props.hasLocalBridge;
 
   const [doctorOpen, setDoctorOpen] = useState(false);
-  const [restartConfirmOpen, setRestartConfirmOpen] = useState(false);
+  // Which dispatch leg the open restart confirm is armed for - captured at
+  // OPEN, never re-derived at confirm. The cooperative `host.restart` needs
+  // the scope's client and is withdrawn with it (the `!usable` rule below);
+  // the bridge respawn (`restartViaForceFallback`: a host whose handshake
+  // refused `host.restart`, on a machine with a bridge) needs no client and
+  // survives the scope going unusable. `null` is "no confirm open".
+  const [restartConfirm, setRestartConfirm] = useState<
+    "cooperative" | "bridge" | null
+  >(null);
+  const closeRestartConfirm = (): void => setRestartConfirm(null);
   // The id of a restart whose DISPATCH OUTCOME IS UNKNOWN - the transport threw
   // after the host may already have granted the claim. `host.restart` is
   // claim-gated, so the retry has to carry that same id to adopt the claim it
@@ -278,6 +287,13 @@ export function HostOverviewPanel(props: {
     maintenanceFallback: scope.localMaintenanceFallback,
     restartForceRoute: forceRestartLocalHostId !== null,
   });
+  // Every surface that opens the restart confirm - the header's Restart, the
+  // card's Restart and its attempt-park Force, the Doctor sheet's bridge
+  // restart - arms it for the route the page routes Restart to at that
+  // moment. The dialog's dispatch and its close rules read the armed route,
+  // not the live fact, so the two cannot tear under an open dialog.
+  const openRestartConfirm = (): void =>
+    setRestartConfirm(restartViaForceFallback ? "bridge" : "cooperative");
 
   const statusQuery = useHostOverviewStatusQuery({
     client,
@@ -306,19 +322,29 @@ export function HostOverviewPanel(props: {
   // verbs live in exactly the window that write exists to make exclusive.
   const policyMutation = useHostRegistryUpdateMutation(scope.hostId);
 
+  // The status read's HEALTH, carried beside its value to every consumer
+  // that DISPATCHES on it: the drain count (`liveBusySessionCount`), the
+  // operation observation's deadline, and the record-derived offers below.
+  // One object, so those three cannot drift onto different liveness rules.
+  // Not every reader is held to it: the updates summary's comparison
+  // baseline (`hostVersion`, the debt's installed version) reads the
+  // retained payload as EVIDENCE - which version the catalog is compared
+  // against - and the install it leads to is revalidated by the host.
+  // `usable` is the health's source: an unusable scope is a read with no
+  // live source behind it, whatever the cache still holds.
+  const statusHealth = {
+    isError: statusQuery.isError,
+    fetchStatus: statusQuery.fetchStatus,
+    isStale: statusQuery.isStale,
+    hasLiveSource: usable,
+  };
+  const statusLive = canonicalReadIsLive(statusHealth);
   const view = useOverviewDisplay({
     scope,
     host,
     identity: identityQuery.data ?? null,
     status: statusQuery.data ?? null,
-    // The drain count is only as trustworthy as the read behind it, so the
-    // read's HEALTH travels with its value. See `liveBusySessionCount`.
-    statusHealth: {
-      isError: statusQuery.isError,
-      fetchStatus: statusQuery.fetchStatus,
-      isStale: statusQuery.isStale,
-      hasLiveSource: usable,
-    },
+    statusHealth,
   });
   const { identity, displayName } = view;
 
@@ -388,7 +414,7 @@ export function HostOverviewPanel(props: {
       // fallback confirm (a capability-`false` host's Restart dispatches the
       // respawn from the confirm dialog itself) closes for the same reason.
       setForceRestartOffer(null);
-      setRestartConfirmOpen(false);
+      closeRestartConfirm();
       // `declined` survives even a forced respawn (removed-by-user, another
       // process holds the management lock) - informational, not an error.
       if (result.kind === "declined") {
@@ -399,7 +425,7 @@ export function HostOverviewPanel(props: {
     },
     onError: (error) => {
       setForceRestartOffer(null);
-      setRestartConfirmOpen(false);
+      closeRestartConfirm();
       toastFromRunnerError(error, "Couldn't restart host");
     },
   });
@@ -608,12 +634,7 @@ export function HostOverviewPanel(props: {
           hostId: scope.hostId ?? "",
           status: statusQuery.data,
           dataUpdatedAt: statusQuery.dataUpdatedAt,
-          health: {
-            isError: statusQuery.isError,
-            fetchStatus: statusQuery.fetchStatus,
-            isStale: statusQuery.isStale,
-            hasLiveSource: usable,
-          },
+          health: statusHealth,
           source: "selected",
           legacyFacts,
         });
@@ -849,15 +870,37 @@ export function HostOverviewPanel(props: {
   // vouches for, and it cannot be re-opened either, so closing it is the
   // same withdrawal one commit late. Adjust-during-render like the gate rule
   // above, so no unusable render ever commits an answerable dialog and the
-  // handlers need no guard of their own. NOT the force-restart offer below:
-  // its Force is the bridge respawn, the one action that stays legitimate —
-  // and is most needed — while this machine's host is unreachable.
-  if (!usable && restartConfirmOpen) {
-    setRestartConfirmOpen(false);
+  // handlers need no guard of their own. NOT a restart confirm armed for the
+  // BRIDGE route, and NOT the force-restart offer below: both dispatch the
+  // bridge respawn, which needs no client — the one action that stays
+  // legitimate, and is most needed, while this machine's host is
+  // unreachable. The route is the one captured at OPEN (`restartConfirm`),
+  // so a fallback confirm keeps its dispatch leg however the handshake fact
+  // it was armed from moves underneath; it closes on its own settlement
+  // (`forceRestart`'s callbacks) and, below, when this page's host stops
+  // being this machine's.
+  if (!usable && restartConfirm === "cooperative") {
+    closeRestartConfirm();
   }
   if (!usable && forceUpdateOffer !== null) {
     setForceUpdateOffer(null);
   }
+  // A cooperative confirm armed while `host.restart`'s support was still
+  // unknown (the handshake tri-state's `null`, under which Restart is live)
+  // must not dispatch the cooperative leg once the handshake lands `false`:
+  // the page now routes Restart to the bridge, and a dialog armed for the
+  // other leg closes rather than switching legs under an answer nobody
+  // gave to the bridge respawn's consequences. Re-opening arms the bridge.
+  if (restartConfirm === "cooperative" && restartViaForceFallback) {
+    closeRestartConfirm();
+  }
+  // The DIALOGS are deliberately not held to `statusLive`, unlike the
+  // controls that open them: the Force offer's stage fact comes from the
+  // record leg (live by construction of `legacyFacts`) and its dispatch
+  // revalidates against the current catalog, and `host.restart` is
+  // claim-gated on the host. A dialog that closed itself on a poll that
+  // merely failed once would be the stale-open defect `canonicalReadIsLive`
+  // was written against, arriving from the other direction.
 
   // Which write IS this dialog's own dispatch: the cooperative `host.restart`
   // ordinarily, the bridge respawn when the fallback routes Restart to the
@@ -869,9 +912,14 @@ export function HostOverviewPanel(props: {
   // cache-wide `forceRestartInFlight` also counts a menu/tray respawn — which
   // must close this confirm like any competing write, not impersonate its
   // spinner and hand back an answerable dialog when the external settle lands.
-  const restartDialogOwnDispatch = restartViaForceFallback
-    ? forceRestart.isPending
-    : restart.isPending;
+  // The ARMED route while a confirm is open; the page's current routing
+  // otherwise (the header item's pending state has no dialog to read).
+  const restartDialogRoute =
+    restartConfirm ?? (restartViaForceFallback ? "bridge" : "cooperative");
+  const restartDialogOwnDispatch =
+    restartDialogRoute === "bridge"
+      ? forceRestart.isPending
+      : restart.isPending;
   // The restart confirmation has the same stale-open window the OS-service
   // confirms do (`host-overview-advanced.tsx`): opened while idle, it stays
   // answerable while an automatic install or another lifecycle write arms the
@@ -879,8 +927,8 @@ export function HostOverviewPanel(props: {
   // dispatch — this dialog deliberately stays open through its own dispatch
   // to show its spinner (and, on the cooperative leg, route the busy
   // verdict). Adjust-during-render so the close lands in the arming commit.
-  if (restartConfirmOpen && anyPending && !restartDialogOwnDispatch) {
-    setRestartConfirmOpen(false);
+  if (restartConfirm !== null && anyPending && !restartDialogOwnDispatch) {
+    closeRestartConfirm();
   }
   // The force offer has the same window and a sharper reason to close in it: no
   // lifecycle write on this page may dispatch beside a bridge respawn, and an
@@ -909,6 +957,13 @@ export function HostOverviewPanel(props: {
     forceRestartOffer.hostId !== forceRestartLocalHostId
   ) {
     setForceRestartOffer(null);
+  }
+  // A restart confirm armed for the bridge goes the same way, for the same
+  // reason: with no local bridge behind this page's host there is no respawn
+  // to dispatch, and the dialog survived `!usable` above only because there
+  // was one.
+  if (restartConfirm === "bridge" && forceRestartLocalHostId === null) {
+    closeRestartConfirm();
   }
 
   // The name edits in place, exactly as a tab title does — same hook, so Enter
@@ -1008,7 +1063,7 @@ export function HostOverviewPanel(props: {
             : () => submitRename(null)
         }
         resetNameDegrade={renameDegrade}
-        onRestart={() => setRestartConfirmOpen(true)}
+        onRestart={() => openRestartConfirm()}
         onOpenDoctor={() => setDoctorOpen(true)}
         onMakeActive={() => scope.makeActive(host.hostId)}
         activateBusy={scope.isActivating}
@@ -1100,19 +1155,22 @@ export function HostOverviewPanel(props: {
             // Restart cannot activate a stage. A floor gate must not turn a
             // staged wait's Force update into a different, ineffective force
             // - and a record leg that is not live does not vouch that no
-            // stage waits, so it offers nothing either. Gated on `usable`
-            // like its two siblings: the confirm it opens is closed by the
-            // `!usable` rule above, so an offer without a route would be a
-            // control that cannot open its own confirmation. (The projection
-            // withholds the whole force control under an unusable scope
-            // already - the view is demoted - but the dispatch gate belongs
-            // here, not in the card's layout.)
+            // stage waits, so it offers nothing either. Gated on a LIVE
+            // status read like its two siblings (`statusLive`, which
+            // subsumes `usable`): an offer made off a failed or aged read
+            // would act on a park the host may have left. (The projection
+            // withholds the whole force control under a demoted view
+            // already, but the dispatch gate belongs here, not in the
+            // card's layout.) The confirm it opens is armed for whichever
+            // route the page routes Restart to, like the header's.
             onForceRestart={
-              usable && legacyFacts !== null && legacyFacts.stagedWait === null
+              statusLive &&
+              legacyFacts !== null &&
+              legacyFacts.stagedWait === null
                 ? () => {
                     // Attempt parks keep the existing cooperative restart
                     // confirmation and its fresh live-work check.
-                    setRestartConfirmOpen(true);
+                    openRestartConfirm();
                   }
                 : null
             }
@@ -1122,17 +1180,24 @@ export function HostOverviewPanel(props: {
             // the transition id, the busy verdict and the force/defer dialog
             // are all the existing ones.
             onRestart={
-              !usable || (legacyFacts?.activationDebt ?? null) === null
+              !statusLive || (legacyFacts?.activationDebt ?? null) === null
                 ? null
-                : () => setRestartConfirmOpen(true)
+                : () => openRestartConfirm()
             }
-            // Both controls need a route to the host they act on. `usable`
-            // is the same gate the header's Restart is withheld under: the
-            // facts are cached reads and outlive reachability, and the
-            // projection already renders them qualified ("last known") -
-            // the evidence stays, the dispatch does not.
+            // All three controls need a LIVE status read behind the facts
+            // they act on - `statusLive`, not `usable` alone. `usable` is
+            // the gate the header's Restart is withheld under, and
+            // `statusLive` subsumes it (an unusable scope is a read with no
+            // live source); it ALSO withdraws them when the read has failed
+            // or aged with a payload still in the cache. `legacyFacts` keeps
+            // that payload on purpose, so the projection renders the park
+            // qualified ("last known"), but a Restart or Force offered off
+            // an old `hostVersion` or `busy` would dispatch against a host
+            // that may already have moved - the evidence stays, the dispatch
+            // does not. The record leg holds the same rule from the other
+            // side (`installationLive`).
             onForceUpdate={
-              !usable ||
+              !statusLive ||
               legacyFacts === null ||
               legacyFacts.stagedWait === null ||
               // ONE gate, shared with the dispatch's revalidation: the
@@ -1248,9 +1313,9 @@ export function HostOverviewPanel(props: {
       <HostDangerZone scope={scope} />
 
       <RestartHostConfirmDialog
-        open={restartConfirmOpen}
+        open={restartConfirm !== null}
         onOpenChange={(open) => {
-          if (!open) setRestartConfirmOpen(false);
+          if (!open) closeRestartConfirm();
         }}
         isPending={restartDialogOwnDispatch}
         onConfirm={() => {
@@ -1261,10 +1326,11 @@ export function HostOverviewPanel(props: {
           // fallback route the confirm IS the force consent: same click-time
           // identity guard and same shared mutation key as the busy-offer
           // dialog's Force, so menu/tray/Settings respawns keep deduping.
-          if (restartViaForceFallback) {
+          // The route ARMED at open, not the live fact: see `restartConfirm`.
+          if (restartConfirm === "bridge") {
             const liveHostId = liveLocalHostIdNow();
             if (liveHostId !== null && liveHostId !== forceRestartLocalHostId) {
-              setRestartConfirmOpen(false);
+              closeRestartConfirm();
               toast.info("Host changed", {
                 description: HOST_CHANGED_DESCRIPTION,
               });
@@ -1283,7 +1349,7 @@ export function HostOverviewPanel(props: {
             { transitionId },
             {
               onSuccess: (response) => {
-                setRestartConfirmOpen(false);
+                closeRestartConfirm();
                 // A definitive answer ends this action: accepted means the
                 // claim is spent, busy means it was refused outright. Either
                 // way the next confirm is a NEW action and must not adopt it.
@@ -1315,7 +1381,7 @@ export function HostOverviewPanel(props: {
                 toastHostRestartRequested();
               },
               onError: (error) => {
-                setRestartConfirmOpen(false);
+                closeRestartConfirm();
                 // Deliberately NOT cleared: a transport failure says nothing
                 // about whether the host granted the claim, so the id stays
                 // armed for the retry that adopts it.
@@ -1449,7 +1515,7 @@ export function HostOverviewPanel(props: {
                 // dispatch here was the one surface skipping all three.
                 onBridgeRestart: () => {
                   if (anyPending) return;
-                  setRestartConfirmOpen(true);
+                  openRestartConfirm();
                 },
                 bridgeRestartPending: forceRestartInFlight || anyPending,
                 // `diagnostics.logs.tail` is absent from every released host

--- a/clients/gui-app/src/components/settings/panels/host-overview-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/host-overview-panel.tsx
@@ -310,6 +310,9 @@ export function HostOverviewPanel(props: {
   });
   const installationQuery = useHostInstallationInfoQuery({
     client,
+    // The record leg's liveness rule (`installationLive` below) reads the
+    // support half of this (`installInfoDegrade`) and deliberately not the
+    // `usable` half - see the note there.
     enabled: usable && installInfoDegrade === null,
     runningVersion: statusQuery.data?.hostVersion ?? null,
   });
@@ -596,21 +599,31 @@ export function HostOverviewPanel(props: {
   // the query client retries once, so a silent poll withdraws after about
   // a minute. (`paused` is part of the shared rule; this app's queries run
   // with `networkMode: "always"`, so it does not arise here.) The source
-  // here is the query's own enablement, not the scope's: an unusable scope
-  // demotes the whole observation through the status leg already and keeps
-  // its retained sentence qualified, whereas a support flip that disables
-  // the query over a cached payload would otherwise read as live forever -
-  // a disabled query never ages (`isStale` is false while `enabled` is).
+  // here is the support flip alone (`installInfoDegrade`), deliberately NOT
+  // `usable`: an unusable scope is demoted through the status leg already,
+  // and that demotion KEEPS the record-derived park as a qualified "Last
+  // seen: …" sentence with its controls withdrawn. Erasing the facts here
+  // on `!usable` would drop the card outright instead (the lifecycle-gate
+  // suite pins the retained sentence). The support flip still has to be
+  // here, because it disables the query over a cached payload, and a
+  // disabled query never ages (`isStale` is false while `enabled` is) - so
+  // without it that payload would read as live forever.
   const installationLive = canonicalReadIsLive({
     isError: installationQuery.isError,
     fetchStatus: installationQuery.fetchStatus,
     isStale: installationQuery.isStale,
     hasLiveSource: installInfoDegrade === null,
   });
-  const legacyFacts =
-    statusQuery.data === undefined ||
-    installationQuery.data === undefined ||
-    !installationLive
+  // The facts as READ - from the last successful record response, live or
+  // not. Liveness is applied where each consumer needs it rather than by
+  // erasing the facts: every OFFER and the projector's park take the live
+  // facts below, while the catalog's comparison baseline keeps the read
+  // debt (`activationDebt.live`). Erasing the facts on one failed poll
+  // dropped the baseline, and the region then re-offered the version that
+  // is already installed as "available" with a live Update now - for bytes
+  // on disk that a failed poll did not change.
+  const legacyFactsRead =
+    statusQuery.data === undefined || installationQuery.data === undefined
       ? null
       : deriveLegacyUpdateFacts({
           installation: installationQuery.data,
@@ -621,6 +634,7 @@ export function HostOverviewPanel(props: {
           busy: statusQuery.data.busy,
           busySessionCount: statusQuery.data.busySessionCount,
         });
+  const legacyFacts = installationLive ? legacyFactsRead : null;
   // Built whenever there IS a status read - including for a pre-@1.3 peer
   // whose `updateOperation` is `null`. This used to bail to `null` for that
   // peer and render the coarse marker through a separate notice; the
@@ -802,7 +816,20 @@ export function HostOverviewPanel(props: {
     // across that swap would apply one machine's decision to another.
     hostId: scope.hostId,
     runningVersion: view.hostVersion,
-    activationDebt: legacyFacts?.activationDebt ?? null,
+    // From the facts as READ, qualified by the record leg's liveness - see
+    // `legacyFactsRead`.
+    activationDebt:
+      legacyFactsRead?.activationDebt === undefined ||
+      legacyFactsRead.activationDebt === null
+        ? null
+        : {
+            installedVersion: legacyFactsRead.activationDebt.installedVersion,
+            // The record leg's liveness alone: the sentence this qualifies
+            // renders only inside the updates region, which is withheld
+            // outright on an unusable scope (`!usable ? null : …` below), so
+            // the scope needs no second mention here.
+            live: installationLive,
+          },
     platformKey: host?.platform ?? null,
     // Deliberately NOT held to `installationLive`: the manifest describes
     // the CLI installed on the host - a property of the installation, not
@@ -842,6 +869,14 @@ export function HostOverviewPanel(props: {
   // dialog up to show its spinner. Adjust-during-render so the close lands in
   // the arming commit.
   if (forceUpdateOffer !== null && anyPending && !updates.summary.installing) {
+    setForceUpdateOffer(null);
+  }
+  // And when the region the offer belongs to retires under it: a handshake
+  // that withdraws `host.update.install`, or a discovered refusal
+  // (externally managed, unsupported install method), is the same fact the
+  // header and the region already act on, and an offer left answerable past
+  // it would dispatch a method the page knows it cannot perform.
+  if (forceUpdateOffer !== null && updates.degrade !== null) {
     setForceUpdateOffer(null);
   }
   // And when the fact it describes is gone - the stage was applied by another
@@ -928,6 +963,16 @@ export function HostOverviewPanel(props: {
   // to show its spinner (and, on the cooperative leg, route the busy
   // verdict). Adjust-during-render so the close lands in the arming commit.
   if (restartConfirm !== null && anyPending && !restartDialogOwnDispatch) {
+    closeRestartConfirm();
+  }
+  // A COOPERATIVE confirm answers a `host.restart` the handshake can withdraw
+  // while it is open (`restartDegrade`, the header's own gate); the bridge
+  // route needs no method and is unaffected.
+  if (
+    restartConfirm === "cooperative" &&
+    restartDegrade !== null &&
+    !restartDialogOwnDispatch
+  ) {
     closeRestartConfirm();
   }
   // The force offer has the same window and a sharper reason to close in it: no
@@ -1165,6 +1210,8 @@ export function HostOverviewPanel(props: {
             // route the page routes Restart to, like the header's.
             onForceRestart={
               statusLive &&
+              restartDegrade === null &&
+              !anyPending &&
               legacyFacts !== null &&
               legacyFacts.stagedWait === null
                 ? () => {
@@ -1180,10 +1227,26 @@ export function HostOverviewPanel(props: {
             // the transition id, the busy verdict and the force/defer dialog
             // are all the existing ones.
             onRestart={
-              !statusLive || (legacyFacts?.activationDebt ?? null) === null
+              !statusLive ||
+              restartDegrade !== null ||
+              anyPending ||
+              (legacyFacts?.activationDebt ?? null) === null
                 ? null
                 : () => openRestartConfirm()
             }
+            // The card's three controls sit behind the SAME capability and
+            // page-wide gates as the header's Restart and the region's
+            // Update now (`restartDegrade`, `updates.degrade`, `anyPending`):
+            // a method the handshake declined is not offered from the card
+            // either, and a control whose confirm the render-time rules
+            // would close in the same commit is not a control. That last
+            // case was the card's state under `anyPending` before this
+            // gate: the button rendered and its confirm closed as it
+            // opened - including for a pre-@1.3 peer whose stuck `updating`
+            // marker holds the gate while its read is healthy (see
+            // `updateInFlight`), where the header's Restart is disabled by
+            // the same gate. The gate makes that inertness visible; it
+            // withdraws nothing that could dispatch.
             // All three controls need a LIVE status read behind the facts
             // they act on - `statusLive`, not `usable` alone. `usable` is
             // the gate the header's Restart is withheld under, and
@@ -1198,6 +1261,8 @@ export function HostOverviewPanel(props: {
             // side (`installationLive`).
             onForceUpdate={
               !statusLive ||
+              updates.degrade !== null ||
+              anyPending ||
               legacyFacts === null ||
               legacyFacts.stagedWait === null ||
               // ONE gate, shared with the dispatch's revalidation: the
@@ -1209,7 +1274,16 @@ export function HostOverviewPanel(props: {
                     if (legacyFacts.stagedWait === null) return;
                     setForceUpdateOffer({
                       stagedVersion: legacyFacts.stagedWait.stagedVersion,
+                      // The count the card's control was offered on
+                      // (`offersForceRestart(view)`), so the dialog names
+                      // the same number - not the raw status read's, which
+                      // can differ when an attempt park and a staged wait
+                      // coexist and the view is the attempt's. The `??` arm
+                      // is the view type's null, unreachable here because
+                      // the control renders only when the view names a
+                      // positive count.
                       blockingSessionCount:
+                        operationView.blockingSessionCount ??
                         legacyFacts.stagedWait.blockingSessionCount,
                     });
                   }
@@ -1399,6 +1473,7 @@ export function HostOverviewPanel(props: {
           The amber band with an inline one-press Force that used to sit on the
           card is gone; see `host-overview-status-card.tsx`. */}
       <HostBusyForceDeferDialog
+        purpose="restart"
         open={forceRestartOffer !== null}
         message={
           forceRestartOffer === null
@@ -1440,6 +1515,7 @@ export function HostOverviewPanel(props: {
           re-runs the updater with `--force` against the kept stage; the one
           above respawns the host process. */}
       <HostBusyForceDeferDialog
+        purpose="update"
         open={forceUpdateOffer !== null}
         message={
           forceUpdateOffer === null
@@ -1551,7 +1627,12 @@ function forceUpdateMessage(
   } else if (blockingSessionCount !== null) {
     work = `${String(blockingSessionCount)} sessions`;
   }
-  return `v${stagedVersion} is downloaded and waiting. Installing it now ends ${work} on ${hostName} and restarts the host. Defer to let the update continue on its own once the host is idle.`;
+  // Defer keeps the stage; it does NOT schedule anything. The parked bytes
+  // install on the next update run - the host's own automatic check where
+  // one is enabled, or the next Update now - once the host is idle, so the
+  // sentence names that rather than promising a continuation this page has
+  // no evidence of.
+  return `v${stagedVersion} is downloaded and waiting. Installing it now ends ${work} on ${hostName} and restarts the host. Defer to keep it waiting; it installs on the next update once the host is idle, or select Update now again then.`;
 }
 
 /**

--- a/clients/gui-app/src/components/settings/panels/host-overview-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/host-overview-panel.tsx
@@ -1027,12 +1027,17 @@ export function HostOverviewPanel(props: {
             // the transition id, the busy verdict and the force/defer dialog
             // are all the existing ones.
             onRestart={
-              (legacyFacts?.activationDebt ?? null) === null
+              !usable || (legacyFacts?.activationDebt ?? null) === null
                 ? null
                 : () => setRestartConfirmOpen(true)
             }
+            // Both controls need a route to the host they act on. `usable`
+            // is the same gate the header's Restart is withheld under: the
+            // facts are cached reads and outlive reachability, and the
+            // projection already renders them qualified ("last known") -
+            // the evidence stays, the dispatch does not.
             onForceUpdate={
-              legacyFacts === null || legacyFacts.stagedWait === null
+              !usable || legacyFacts === null || legacyFacts.stagedWait === null
                 ? null
                 : () => {
                     if (legacyFacts.stagedWait === null) return;

--- a/clients/gui-app/src/components/settings/panels/host-overview-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/host-overview-panel.tsx
@@ -1100,9 +1100,15 @@ export function HostOverviewPanel(props: {
             // Restart cannot activate a stage. A floor gate must not turn a
             // staged wait's Force update into a different, ineffective force
             // - and a record leg that is not live does not vouch that no
-            // stage waits, so it offers nothing either.
+            // stage waits, so it offers nothing either. Gated on `usable`
+            // like its two siblings: the confirm it opens is closed by the
+            // `!usable` rule above, so an offer without a route would be a
+            // control that cannot open its own confirmation. (The projection
+            // withholds the whole force control under an unusable scope
+            // already - the view is demoted - but the dispatch gate belongs
+            // here, not in the card's layout.)
             onForceRestart={
-              legacyFacts !== null && legacyFacts.stagedWait === null
+              usable && legacyFacts !== null && legacyFacts.stagedWait === null
                 ? () => {
                     // Attempt parks keep the existing cooperative restart
                     // confirmation and its fresh live-work check.

--- a/clients/gui-app/src/components/settings/panels/host-overview-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/host-overview-panel.tsx
@@ -824,11 +824,14 @@ export function HostOverviewPanel(props: {
         ? null
         : {
             installedVersion: legacyFactsRead.activationDebt.installedVersion,
-            // The record leg's liveness alone: the sentence this qualifies
-            // renders only inside the updates region, which is withheld
-            // outright on an unusable scope (`!usable ? null : …` below), so
-            // the scope needs no second mention here.
-            live: installationLive,
+            // BOTH legs: the debt is the record's installed version read
+            // against the status read's running version, so a status read
+            // that failed or aged (the host may already have restarted
+            // onto the installed version) makes the sentence "last known"
+            // exactly as a failed record read does. `statusLive` carries
+            // `usable` too. The region renders only under `usable`, so an
+            // unusable scope never reaches this sentence at all.
+            live: installationLive && statusLive,
           },
     platformKey: host?.platform ?? null,
     // Deliberately NOT held to `installationLive`: the manifest describes

--- a/clients/gui-app/src/components/settings/panels/host-overview-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/host-overview-panel.tsx
@@ -776,6 +776,22 @@ export function HostOverviewPanel(props: {
   ) {
     setForceUpdateOffer(null);
   }
+  // And when the route to the host is gone. `usable` withdraws the controls
+  // that OPEN these two confirms (`onRestart` / `onForceUpdate` are `null`
+  // below), but a confirm opened while the route was up is not withdrawn by
+  // that: answered, it would dispatch over a client the scope no longer
+  // vouches for, and it cannot be re-opened either, so closing it is the
+  // same withdrawal one commit late. Adjust-during-render like the gate rule
+  // above, so no unusable render ever commits an answerable dialog and the
+  // handlers need no guard of their own. NOT the force-restart offer below:
+  // its Force is the bridge respawn, the one action that stays legitimate —
+  // and is most needed — while this machine's host is unreachable.
+  if (!usable && restartConfirmOpen) {
+    setRestartConfirmOpen(false);
+  }
+  if (!usable && forceUpdateOffer !== null) {
+    setForceUpdateOffer(null);
+  }
 
   // Which write IS this dialog's own dispatch: the cooperative `host.restart`
   // ordinarily, the bridge respawn when the fallback routes Restart to the

--- a/clients/gui-app/src/components/settings/panels/host-overview-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/host-overview-panel.tsx
@@ -28,6 +28,7 @@ import {
 import { HostOverviewOperationCard } from "@/components/settings/panels/host-overview-operation-card";
 import { HostOverviewUpdatesRegion } from "@/components/settings/panels/host-overview-updates";
 import { useHostOverviewUpdates } from "@/components/settings/panels/host-overview-updates-state";
+import { useDesktopAppUpdates } from "@/hooks/runner/use-desktop-app-updates";
 import { useOverviewOsService } from "@/components/settings/panels/host-overview-os-service";
 import { HostOverviewAdvancedDisclosure } from "@/components/settings/panels/host-overview-advanced";
 import {
@@ -737,6 +738,7 @@ export function HostOverviewPanel(props: {
   // drain gate and the auto-update switch write through. Two instances would
   // each track their own `isPending`, so one control would stay live while the
   // other's write was still going.
+  const desktopUpdates = useDesktopAppUpdates();
   const updates = useHostOverviewUpdates({
     client,
     hostName: displayName,
@@ -747,6 +749,12 @@ export function HostOverviewPanel(props: {
     runningVersion: view.hostVersion,
     activationDebt: legacyFacts?.activationDebt ?? null,
     platformKey: host?.platform ?? null,
+    cliManifest:
+      managedInstallation(installationQuery.data)?.cliManifest ?? null,
+    isLocalMachine: host?.isLocalMachine ?? false,
+    desktopUpdate:
+      desktopUpdates.bridge === null ? null : desktopUpdates.snapshot,
+    stagedVersion: legacyFacts?.stagedWait?.stagedVersion ?? null,
     // The check reads on its own now, so this gate is load-bearing rather than
     // cosmetic: without it the page would spawn a CLI process on the host from
     // a scope that has not resolved, and cache the answer under this page's key.
@@ -1042,12 +1050,17 @@ export function HostOverviewPanel(props: {
           <HostOverviewOperationCard
             view={operationView}
             hostName={displayName}
-            onForceRestart={() => {
-              // Same route as the overflow Restart: re-ask the host about live
-              // work, then the EXISTING confirmation. This never restarts on
-              // the first click and never consumes update-force authorization.
-              setRestartConfirmOpen(true);
-            }}
+            // Restart cannot activate a stage. A floor gate must not turn a
+            // staged wait's Force update into a different, ineffective force.
+            onForceRestart={
+              (legacyFacts?.stagedWait ?? null) !== null
+                ? null
+                : () => {
+                    // Attempt parks keep the existing cooperative restart
+                    // confirmation and its fresh live-work check.
+                    setRestartConfirmOpen(true);
+                  }
+            }
             // Keyed on the FACT, not the view kind: a retained `failed`
             // marker beside real debt keeps its failure text and still gets
             // the way forward. Same confirm the header's Restart opens, so
@@ -1064,7 +1077,11 @@ export function HostOverviewPanel(props: {
             // projection already renders them qualified ("last known") -
             // the evidence stays, the dispatch does not.
             onForceUpdate={
-              !usable || legacyFacts === null || legacyFacts.stagedWait === null
+              !usable ||
+              legacyFacts === null ||
+              legacyFacts.stagedWait === null ||
+              updates.stagedFloor !== null ||
+              !updates.stagedEntryKnown
                 ? null
                 : () => {
                     if (legacyFacts.stagedWait === null) return;
@@ -1087,6 +1104,8 @@ export function HostOverviewPanel(props: {
           <HostOverviewUpdatesRegion
             summary={updates.summary}
             degrade={updates.degrade}
+            desktopBridge={desktopUpdates.bridge}
+            onInstallationHelp={() => setDoctorOpen(true)}
           />
         )}
         {/* Stays OUT of Advanced, deliberately. This is the only control on the

--- a/clients/gui-app/src/components/settings/panels/host-overview-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/host-overview-panel.tsx
@@ -291,6 +291,7 @@ export function HostOverviewPanel(props: {
   const installationQuery = useHostInstallationInfoQuery({
     client,
     enabled: usable && installInfoDegrade === null,
+    runningVersion: statusQuery.data?.hostVersion ?? null,
   });
 
   const identitySet = useHostIdentitySet(client);
@@ -537,8 +538,18 @@ export function HostOverviewPanel(props: {
   // them: the banner keeps its desktop-status debt arm and the fleet legs
   // read no installation info. `null` until both reads have answered, which
   // the projector treats as "not observed", never as "no park".
+  //
+  // Two reads, one snapshot: the installation query is keyed by the running
+  // version the status read reported (`useHostInstallationInfoQuery`), so a
+  // record fetched under the previous version is never compared against the
+  // new one - it is a different key with no data yet. And a read that has
+  // FAILED keeps its last payload in the cache; a comparison built on it
+  // would carry the status read's freshness while the record leg is
+  // anyone's guess, so it is "not observed" until the next poll answers.
   const legacyFacts =
-    statusQuery.data === undefined || installationQuery.data === undefined
+    statusQuery.data === undefined ||
+    installationQuery.data === undefined ||
+    installationQuery.isError
       ? null
       : deriveLegacyUpdateFacts({
           installation: installationQuery.data,

--- a/clients/gui-app/src/components/settings/panels/host-overview-rpc.ts
+++ b/clients/gui-app/src/components/settings/panels/host-overview-rpc.ts
@@ -1,6 +1,7 @@
 import {
   keepPreviousData,
   useQueryClient,
+  type QueryClient,
   type UseMutationResult,
 } from "@tanstack/react-query";
 import type { HostClient } from "@traycer-clients/shared/host-client/host-client";
@@ -180,6 +181,15 @@ function scopedSessionMembershipSignature(hostId: string): string {
  * the difference matters on this page: "no install record" is a legitimate,
  * describable state (someone is running the host from a checkout), not an
  * error, and rendering it as one would put a red box on every dev machine.
+ *
+ * Polled (table-owned cadence, 10s), not merely stale-timed, because the
+ * Overview now DERIVES from it: the install record against the running
+ * version is what says "installed, restart to finish", and the staged record
+ * beside a busy host is what says "staged, waiting for work". Both change
+ * under a mounted page through actors this client never sees - a detached CLI
+ * run, the desktop's launch converge - and a 60s staleTime with no interval
+ * observed neither until the page was remounted. `staleTime` still exceeds
+ * the interval so a healthy poll never reads as stale.
  */
 export function useHostInstallationInfoQuery(input: {
   readonly client: HostClient<HostRpcRegistry> | null;
@@ -190,7 +200,7 @@ export function useHostInstallationInfoQuery(input: {
     client: input.client,
     method: "host.getInstallationInfo",
     params: EMPTY_PARAMS,
-    options: { enabled: input.enabled, staleTime: 60_000 },
+    options: { enabled: input.enabled, staleTime: 60_000, poll: true },
   });
 }
 
@@ -654,9 +664,7 @@ export function useHostUpdateInstall(
           useHostServiceWriteLatchStore
             .getState()
             .releaseUpdateInstallAccepted(context.hostId);
-          void queryClient.invalidateQueries({
-            queryKey: hostQueryKeys.methodScope(context.hostId, "host.status"),
-          });
+          invalidateUpdateReads(queryClient, context.hostId);
           return;
         }
         if (
@@ -677,9 +685,7 @@ export function useHostUpdateInstall(
         // against that active swap. The refresh below is how the progress
         // row appears once the CLI reports it, and the panel's release
         // effect (or the bounded timer) unwinds the latch from there.
-        void queryClient.invalidateQueries({
-          queryKey: hostQueryKeys.methodScope(context.hostId, "host.status"),
-        });
+        invalidateUpdateReads(queryClient, context.hostId);
       },
       onError: (_error, _variables, context) => {
         if (context === undefined || context.hostId === null) return;
@@ -689,6 +695,22 @@ export function useHostUpdateInstall(
       },
     },
   });
+}
+
+/**
+ * The two reads an accepted install changes: `host.status` for the coarse
+ * marker the detached updater publishes, and `host.getInstallationInfo` for
+ * the records it leaves behind when it PARKS instead - a stage kept because
+ * the host was busy, or an install committed under a host that refused to
+ * restart. The second used to wait for its own poll; a Settings click that
+ * parks within a second then showed nothing for up to ten.
+ */
+function invalidateUpdateReads(queryClient: QueryClient, hostId: string): void {
+  for (const method of ["host.status", "host.getInstallationInfo"] as const) {
+    void queryClient.invalidateQueries({
+      queryKey: hostQueryKeys.methodScope(hostId, method),
+    });
+  }
 }
 
 /** Narrowing helper so callers read the managed arm without re-checking. */

--- a/clients/gui-app/src/components/settings/panels/host-overview-rpc.ts
+++ b/clients/gui-app/src/components/settings/panels/host-overview-rpc.ts
@@ -387,10 +387,15 @@ export function useHostUpdateCheckQuery(input: {
       enabled: input.enabled,
       // Long, deliberately. This is the one read on the page that costs a
       // process on the host, and what it returns — which versions the registry
-      // publishes — changes on a release cadence, not a browsing one. The one
-      // exception — re-asking while the answer is `cli-unavailable`, so a
-      // reinstalled CLI revives the retired region — is table-owned condition
-      // polling (`host-method-policy-table.ts`), not an option here.
+      // publishes — changes on a release cadence, not a browsing one. The two
+      // exceptions are not options here. Re-asking while the answer is
+      // `cli-unavailable`, so a reinstalled CLI revives the retired region,
+      // is table-owned condition polling (`host-method-policy-table.ts`).
+      // Re-asking while the Overview shows a CLI-floor remedy, so a repaired
+      // CLI reveals Update now without a click, is the Overview's own
+      // invalidation (`useHostOverviewUpdates`): which floored row the
+      // remedy names depends on the installed version, which only that
+      // hook knows.
       staleTime: 5 * 60_000,
       refetchOnWindowFocus: false,
       // Keeps the PREVIOUS filter's list on screen while the new one loads.

--- a/clients/gui-app/src/components/settings/panels/host-overview-rpc.ts
+++ b/clients/gui-app/src/components/settings/panels/host-overview-rpc.ts
@@ -190,17 +190,32 @@ function scopedSessionMembershipSignature(hostId: string): string {
  * run, the desktop's launch converge - and a 60s staleTime with no interval
  * observed neither until the page was remounted. `staleTime` still exceeds
  * the interval so a healthy poll never reads as stale.
+ *
+ * Keyed by the RUNNING version the caller has observed. The facts derived
+ * from this read are comparisons against that version, and a version change
+ * is exactly the moment the install record moved under the page (the host
+ * restarted onto new bytes): a payload fetched under the old version is not
+ * a stale answer to the same question, it is an answer to a different one,
+ * and TanStack would otherwise keep serving it - "installed X, running Y,
+ * restart to finish" for a host that just finished. A new key has no data
+ * until the fresh read answers, which the derivation reads as "not observed".
+ * Disabled until a running version is known for the same reason.
  */
 export function useHostInstallationInfoQuery(input: {
   readonly client: HostClient<HostRpcRegistry> | null;
   readonly enabled: boolean;
+  readonly runningVersion: string | null;
 }) {
   return useHostQuery<HostRpcRegistry, "host.getInstallationInfo">({
-    cacheKeyIdentity: undefined,
+    cacheKeyIdentity: [input.runningVersion],
     client: input.client,
     method: "host.getInstallationInfo",
     params: EMPTY_PARAMS,
-    options: { enabled: input.enabled, staleTime: 60_000, poll: true },
+    options: {
+      enabled: input.enabled && input.runningVersion !== null,
+      staleTime: 60_000,
+      poll: true,
+    },
   });
 }
 

--- a/clients/gui-app/src/components/settings/panels/host-overview-status-card.tsx
+++ b/clients/gui-app/src/components/settings/panels/host-overview-status-card.tsx
@@ -1,6 +1,5 @@
 import type { ReactNode, RefObject } from "react";
 import {
-  AlertTriangle,
   Check,
   Copy,
   Info,
@@ -240,45 +239,6 @@ export function HostOverviewNameAction(props: {
  * `local-host-restart-flow.tsx`). Re-adding an inline force control here would
  * put the two surfaces back out of step.
  */
-
-/**
- * A host update in flight, as the HOST reports it on `host.status`.
- *
- * `host.update.install` returns the moment the detached swap is started, so
- * this — not that response — is the only thing that can say how it is going.
- */
-export function HostOverviewUpdateProgress(props: {
-  readonly state: "updating" | "failed";
-  readonly error: string | null;
-}): ReactNode {
-  const failed = props.state === "failed";
-  return (
-    <div
-      className={
-        failed
-          ? "flex items-start gap-2 border-b border-destructive/30 bg-destructive/10 px-5 py-3 text-ui-sm text-destructive"
-          : "flex items-center gap-2 border-b border-border/40 bg-foreground/3 px-5 py-3 text-ui-sm text-muted-foreground"
-      }
-      data-testid="host-overview-update-progress"
-      data-state={props.state}
-    >
-      {failed ? (
-        <AlertTriangle className="mt-px size-4 shrink-0" aria-hidden />
-      ) : (
-        <AgentSpinningDots
-          className="size-3"
-          testId={undefined}
-          variant={undefined}
-        />
-      )}
-      <span className="min-w-0 flex-1">
-        {failed
-          ? (props.error ?? "The last update attempt failed on this host.")
-          : "Updating this host…"}
-      </span>
-    </div>
-  );
-}
 
 /** A quiet, non-blocking explanation under a control that has degraded. */
 export function HostOverviewNotice(props: {

--- a/clients/gui-app/src/components/settings/panels/host-overview-updates-state.ts
+++ b/clients/gui-app/src/components/settings/panels/host-overview-updates-state.ts
@@ -4,11 +4,14 @@ import { toast } from "sonner";
 import type { HostClient } from "@traycer-clients/shared/host-client/host-client";
 import {
   compareHostVersions,
+  isValidHostVersion,
   isStrictlyNewerHostVersion,
 } from "@traycer-clients/shared/host-version/compare-host-versions";
 import {
   HOST_CLIENT_FLOOR_REASON_PREFIX,
   isHostClientFloorRefusedAsset,
+} from "@traycer-clients/shared/host-version/client-floor-reason";
+import {
   isMatchingStableRelease,
   isSameReleaseLine,
 } from "@traycer-clients/shared/host-version/release-line";
@@ -116,7 +119,18 @@ export function useHostOverviewUpdates(input: {
    * against the running version would re-offer the version that is already
    * installed as "Update now", and pressing it would find nothing to do.
    */
-  readonly activationDebt: { readonly installedVersion: string } | null;
+  readonly activationDebt: {
+    readonly installedVersion: string;
+    /**
+     * Whether the record read this debt came from is live
+     * (`canonicalReadIsLive` over the installation leg). A retained read
+     * still sets the comparison baseline - the bytes on disk do not change
+     * because a poll failed, and dropping the baseline would re-offer the
+     * installed version as "available" - but the sentence says so, and the
+     * page withholds the Restart until the read is live again.
+     */
+    readonly live: boolean;
+  } | null;
   readonly platformKey: string | null;
   readonly cliManifest: StoredCliInstallManifest | null;
   readonly isLocalMachine: boolean;
@@ -373,8 +387,18 @@ export function useHostOverviewUpdates(input: {
   // retirements leave the check query enabled, so a floor read before the
   // retirement would otherwise keep re-asking a host with nothing on screen
   // to end it - the defect this recheck exists to avoid, relocated.
+  //
+  // Two more things end it: a floor no upgrade can clear (`repairable`
+  // false - the remedy is help only, and re-asking cannot change the
+  // answer), and the page's own gate (`enabled`) - the region renders under
+  // it, and a timer ticking against a disabled query is a live timer for
+  // nothing.
   const queryClient = useQueryClient();
-  const recheckFloor = degrade === null && cliFloor !== null;
+  const recheckFloor = floorRecheckArmed({
+    enabled: input.enabled,
+    degrade,
+    cliFloor,
+  });
   const { hostId } = input;
   useEffect(() => {
     if (!recheckFloor || hostId === null) return;
@@ -913,6 +937,15 @@ type PlatformAsset =
 
 interface CliFloor {
   readonly requiredCliVersion: string | null;
+  /**
+   * Whether upgrading the CLI can clear this floor: the version it names is
+   * one (`isValidHostVersion`), or none is named at all (an older payload
+   * whose authored reason still says the CLI is too old). A floor naming
+   * something that is not a version came from the pre-repair projector,
+   * which put the repairable prefix on an unreadable floor too; no upgrade
+   * clears it, so the remedy is help only and the recheck does not run.
+   */
+  readonly repairable: boolean;
 }
 
 interface ForceUpdateRefusal {
@@ -987,8 +1020,11 @@ function readCliFloor(
   const reasonVersion = asset?.unavailableReason
     ?.slice(HOST_CLIENT_FLOOR_REASON_PREFIX.length)
     .match(/^(\S+) or newer\b/)?.[1];
+  const requiredCliVersion = entry.requiredCliVersion ?? reasonVersion ?? null;
   return {
-    requiredCliVersion: entry.requiredCliVersion ?? reasonVersion ?? null,
+    requiredCliVersion,
+    repairable:
+      requiredCliVersion === null || isValidHostVersion(requiredCliVersion),
   };
 }
 
@@ -1033,9 +1069,25 @@ function describeForceUpdateRefusal(input: {
     // unavailable here, only that this page cannot read a floor for it.
     return `Traycer couldn't verify that v${input.version} can be installed on ${input.hostName}. Select Check now and try again.`;
   }
+  // The catalog ENTRY's own floor, read apart from the asset's authored
+  // reason: staged bytes install whatever the asset's availability says
+  // (the CLI's already-staged short-circuit resolves no asset and applies no
+  // floor), so a floor that is not a version - one this page cannot
+  // establish compatibility for, the same rule the projector applies when
+  // it reads the manifest - is refused here whether or not the asset
+  // carries the repairable prefix. A READABLE floor is left to the asset's
+  // verdict below: `available` is the executing CLI's own comparison
+  // against its own version, and the stored CLI manifest is no substitute
+  // for it in either direction (the stored copy can be newer than the
+  // executing one - see the remedy's older-copy sentence - or stale behind
+  // an upgrade the record has not re-read yet).
+  const declaredFloor = entry.requiredCliVersion;
+  if (declaredFloor !== null && !isValidHostVersion(declaredFloor)) {
+    return `Traycer couldn't verify the command-line tools version v${input.version} needs on ${input.hostName}: its catalog entry declares a requirement this page cannot read.`;
+  }
   const floor = readCliFloor(entry, input.platformKey);
   if (floor !== null) {
-    return floor.requiredCliVersion !== null
+    return floor.repairable && floor.requiredCliVersion !== null
       ? `v${input.version} needs Traycer CLI ${floor.requiredCliVersion} or newer on ${input.hostName}. Update the command-line tools first.`
       : `Traycer couldn't verify that v${input.version} can be installed on ${input.hostName}. Select Check now and try again.`;
   }
@@ -1158,6 +1210,25 @@ function checkRefutesDiscoveredRefusal(input: {
 }
 
 /** Precedence over the region's four retirement sources, first one wins. */
+/**
+ * Whether the mounted CLI-floor recheck runs: a REPAIRABLE floor is on
+ * screen (the remedy names a command an upgrade can satisfy), in a region
+ * that is neither retired nor disabled. See the comment at its caller for
+ * why each of the three ends it.
+ */
+function floorRecheckArmed(input: {
+  readonly enabled: boolean;
+  readonly degrade: OverviewDegradeReason | null;
+  readonly cliFloor: CliFloor | null;
+}): boolean {
+  return (
+    input.enabled &&
+    input.degrade === null &&
+    input.cliFloor !== null &&
+    input.cliFloor.repairable
+  );
+}
+
 function resolveRegionDegrade(input: {
   readonly installDiscovered: OverviewDegradeReason | null;
   readonly checkSticky: OverviewDegradeReason | null;
@@ -1265,7 +1336,10 @@ function describeCheckState(input: {
   readonly hostName: string;
   readonly upToDate: boolean;
   /** The install record is ahead of the running host; see the hook's input. */
-  readonly activationDebt: { readonly installedVersion: string } | null;
+  readonly activationDebt: {
+    readonly installedVersion: string;
+    readonly live: boolean;
+  } | null;
   readonly remedy: CliFloorRemedy | null;
   /** `updatableVersion` resolved — the summary can actually OFFER the latest. */
   readonly offerable: boolean;
@@ -1292,7 +1366,12 @@ function describeCheckState(input: {
   // newer than the INSTALLED version, Update now stays beside this sentence
   // (see the hook's `installedVersion`); the button speaks for itself.
   if (input.activationDebt !== null) {
-    return `v${input.activationDebt.installedVersion} is installed — restart host to finish.`;
+    // Qualified when the record read behind it is not live: the debt was
+    // read, and still sets the baseline, but the page is not vouching for it
+    // right now (and withholds the Restart until it can).
+    return input.activationDebt.live
+      ? `v${input.activationDebt.installedVersion} is installed — restart host to finish.`
+      : `v${input.activationDebt.installedVersion} is installed (last known) — restart host to finish.`;
   }
   // Like debt, the remedy stays useful during the next check. The hook drops
   // it when that check fails or returns a catalog that clears the refusal.

--- a/clients/gui-app/src/components/settings/panels/host-overview-updates-state.ts
+++ b/clients/gui-app/src/components/settings/panels/host-overview-updates-state.ts
@@ -329,8 +329,8 @@ export function useHostOverviewUpdates(input: {
     platformKey: input.platformKey,
     source: check.source,
   });
-  const { cliFloor, stagedFloor, stagedEntryKnown, remedy } =
-    deriveFloorRemedies({
+  const { cliFloor, stagedEntryOfferable, remedy } = deriveCliFloorAndForceGate(
+    {
       manifest: actionableManifest,
       summaryCandidate,
       stagedVersion: input.stagedVersion,
@@ -339,7 +339,8 @@ export function useHostOverviewUpdates(input: {
       isLocalMachine: input.isLocalMachine,
       desktopUpdate: input.desktopUpdate,
       hostName,
-    });
+    },
+  );
   // Read off the resolved target rather than `manifest.latest`, which for an
   // installed-RC catalog is the WRONG pointer: `latest` tracks the stable
   // channel, so a host on `2.0.0-rc.1` sees `1.9.0` there and would be told it
@@ -370,8 +371,7 @@ export function useHostOverviewUpdates(input: {
   return {
     degrade,
     cliFloor,
-    stagedFloor,
-    stagedEntryKnown,
+    stagedEntryOfferable,
     // The staged-wait force: the SAME dispatch as a row's Install, with
     // `force: true`, so the accepted latch, the invalidations and the
     // outcome toasts are the ones every other install on this page gets.
@@ -495,8 +495,7 @@ export interface HostOverviewUpdatesState {
   readonly summary: HostOverviewUpdatesSummary;
   readonly picker: VersionPickerProps;
   readonly cliFloor: CliFloor | null;
-  readonly stagedFloor: CliFloor | null;
-  readonly stagedEntryKnown: boolean;
+  readonly stagedEntryOfferable: boolean;
   /**
    * `host.update.install {version, force: true}` — the staged-wait force.
    * `onSettled` runs once the request answers or fails, so the confirmation
@@ -877,7 +876,7 @@ interface ForceUpdateRefusal {
   readonly checkDataUpdatedAt: number;
 }
 
-function deriveFloorRemedies(input: {
+function deriveCliFloorAndForceGate(input: {
   readonly manifest: HostAvailableManifest | null;
   readonly summaryCandidate: SummaryUpdateCandidate | null;
   readonly stagedVersion: string | null;
@@ -888,20 +887,33 @@ function deriveFloorRemedies(input: {
   readonly hostName: string;
 }): {
   readonly cliFloor: CliFloor | null;
-  readonly stagedFloor: CliFloor | null;
-  readonly stagedEntryKnown: boolean;
+  readonly stagedEntryOfferable: boolean;
   readonly remedy: CliFloorRemedy | null;
 } {
-  // The shared summary walk skips yanked releases, but a staged floor must
-  // still refuse Force even when the staged release has been yanked.
-  const staged = input.manifest?.versions.find(
-    (entry) => entry.version === input.stagedVersion,
-  );
+  // The staged release is not part of the summary walk (it was chosen
+  // earlier, by a catalog that may since have withdrawn it); its gates live
+  // in `describeForceUpdateRefusal`, which the Force offer and the Force
+  // dispatch both read. A withdrawn stage has no floor to remedy - no CLI
+  // version installs a yanked release - so the refusal names the withdrawal
+  // rather than a CLI requirement.
   const cliFloor = input.summaryCandidate?.cliFloor ?? null;
   return {
     cliFloor,
-    stagedFloor: readCliFloor(staged, input.platformKey),
-    stagedEntryKnown: staged !== undefined,
+    // ONE predicate for "may Force be offered" and "may Force dispatch": the
+    // same refusal the dispatch revalidates at confirmation. A stage the
+    // catalog has dropped or withdrawn is not offered - the CLI would purge
+    // the stage (`discardIneligibleStagedVersion`) and then refuse the
+    // version, so the offer could only ever destroy the parked stage. See
+    // `describeForceUpdateRefusal` for why an unavailable asset is NOT in
+    // that set.
+    stagedEntryOfferable:
+      input.stagedVersion !== null &&
+      describeForceUpdateRefusal({
+        manifest: input.manifest,
+        version: input.stagedVersion,
+        platformKey: input.platformKey,
+        hostName: input.hostName,
+      }) === null,
     remedy:
       cliFloor === null
         ? null
@@ -944,13 +956,45 @@ function describeForceUpdateRefusal(input: {
   const entry = input.manifest?.versions.find(
     (candidate) => candidate.version === input.version,
   );
-  const floor = readCliFloor(entry, input.platformKey);
-  if (entry !== undefined && floor === null) return null;
-  if (floor !== null && floor.requiredCliVersion !== null) {
-    return `v${input.version} needs Traycer CLI ${floor.requiredCliVersion} or newer on ${input.hostName}. Update the command-line tools first.`;
+  // The gates that matter for the one version Force names - a version whose
+  // bytes are ALREADY staged, downloaded and verified. That is narrower than
+  // the summary walk's: the CLI's stage reconcile purges a stage only when
+  // the catalog no longer lists the version or has yanked it
+  // (`discardIneligibleStagedVersion`), and an already-staged target
+  // short-circuits before any asset is resolved again, so a platform build
+  // the catalog has since marked unavailable still installs from the stage.
+  // Refusing that would strand a downloaded update behind a control that
+  // vanished. What does refuse: an entry the catalog dropped or withdrew
+  // (the confirmation could only destroy the stage); an asset this page
+  // cannot RESOLVE (nothing about the floor can be read - a deliberate
+  // narrowing for a host whose record carries no platform against a
+  // multi-platform entry; the CLI's own `host update --force` still works
+  // there); and a CLI floor. The floor is a PRODUCT gate, not a CLI one:
+  // the CLI would install the staged bytes, and the resulting host would
+  // then refuse the client that installed it, which is not a state this
+  // page offers to enter. The staged version is normally also the best
+  // target, whose floor renders the remedy card.
+  if (entry === undefined) {
+    // An absent entry, failed check, or incomplete refusal cannot name a
+    // floor.
+    return `Traycer couldn't verify that v${input.version} can be installed on ${input.hostName}. Select Check now and try again.`;
   }
-  // An absent entry, failed check, or incomplete refusal cannot name a floor.
-  return `Traycer couldn't verify that v${input.version} can be installed on ${input.hostName}. Select Check now and try again.`;
+  if (entry.yanked) {
+    return `v${input.version} has been withdrawn and can't be installed on ${input.hostName}. Select Check now for the current catalog.`;
+  }
+  if (platformAssetFor(entry.platforms, input.platformKey) === null) {
+    // No asset RESOLVED - an unknown platform key against a multi-platform
+    // entry, or a key the entry does not carry. Not proof the release is
+    // unavailable here, only that this page cannot read a floor for it.
+    return `Traycer couldn't verify that v${input.version} can be installed on ${input.hostName}. Select Check now and try again.`;
+  }
+  const floor = readCliFloor(entry, input.platformKey);
+  if (floor !== null) {
+    return floor.requiredCliVersion !== null
+      ? `v${input.version} needs Traycer CLI ${floor.requiredCliVersion} or newer on ${input.hostName}. Update the command-line tools first.`
+      : `Traycer couldn't verify that v${input.version} can be installed on ${input.hostName}. Select Check now and try again.`;
+  }
+  return null;
 }
 
 interface ForceRefusalEvidence {

--- a/clients/gui-app/src/components/settings/panels/host-overview-updates-state.ts
+++ b/clients/gui-app/src/components/settings/panels/host-overview-updates-state.ts
@@ -34,6 +34,19 @@ import { toastFromHostError } from "@/lib/host-error-toast";
 import type { HostRpcRegistry } from "@/lib/host";
 
 /**
+ * The version the catalog is compared against: the install record's under
+ * activation debt, the process's otherwise. Kept out of the hook body so the
+ * hook stays under the complexity ceiling.
+ */
+function comparisonBaseline(
+  activationDebt: { readonly installedVersion: string } | null,
+  runningVersion: string | null,
+): string | null {
+  if (activationDebt !== null) return activationDebt.installedVersion;
+  return runningVersion;
+}
+
+/**
  * A host's update story: what it can install, and installing it.
  *
  * Check now shells `host available --json` on the SCOPED host and the answer is
@@ -76,7 +89,17 @@ export function useHostOverviewUpdates(input: {
   readonly hostName: string;
   /** The scoped host this panel is showing — see the override reset below. */
   readonly hostId: string | null;
-  readonly installedVersion: string | null;
+  /** What the PROCESS reports about itself (`host.status.hostVersion`). */
+  readonly runningVersion: string | null;
+  /**
+   * The install record is ahead of the running host (`legacy-update-facts.ts`).
+   * When set, every catalog comparison below is against the INSTALLED version,
+   * not the running one: the bytes on disk are what the next restart serves,
+   * so "is there something newer" is a question about them. Comparing
+   * against the running version would re-offer the version that is already
+   * installed as "Update now", and pressing it would find nothing to do.
+   */
+  readonly activationDebt: { readonly installedVersion: string } | null;
   readonly platformKey: string | null;
   /** Whether this host is worth asking at all — the page owns that gate. */
   readonly enabled: boolean;
@@ -84,7 +107,13 @@ export function useHostOverviewUpdates(input: {
   readonly installDegrade: OverviewDegradeReason | null;
   readonly busy: boolean;
 }): HostOverviewUpdatesState {
-  const { client, hostName, installedVersion } = input;
+  const { client, hostName } = input;
+  // The version the catalog is compared against. Under activation debt that
+  // is the install record's, not the process's - see `activationDebt`.
+  const installedVersion = comparisonBaseline(
+    input.activationDebt,
+    input.runningVersion,
+  );
   const installVersion = useHostNegotiatedMethodVersion(
     client,
     "host.update.install",
@@ -186,10 +215,18 @@ export function useHostOverviewUpdates(input: {
     void checkQuery.refetch();
   };
 
-  const install = (version: string): void => {
+  const install = (
+    version: string,
+    force: boolean,
+    // The caller's own settle hook, for UI that opened a confirmation over
+    // this dispatch and has to close it whatever the answer was. MOUNTED
+    // state only, like the callbacks beside it.
+    onSettled: (() => void) | null,
+  ): void => {
     installMutation.mutate(
-      { version, force: false },
+      { version, force },
       {
+        onSettled: () => onSettled?.(),
         // MOUNTED UI state only. The `host.status` invalidation this
         // used to do moved to `useHostUpdateInstall`'s hook-level
         // `onSuccess`: an install outlives a Settings scope switch,
@@ -283,6 +320,12 @@ export function useHostOverviewUpdates(input: {
 
   return {
     degrade,
+    // The staged-wait force: the SAME dispatch as a row's Install, with
+    // `force: true`, so the accepted latch, the invalidations and the
+    // outcome toasts are the ones every other install on this page gets.
+    // The confirmation that precedes it is the panel's (the ellipsis on
+    // "Force update…" is a promise); this is only the dispatch.
+    installForce: (version, onSettled) => install(version, true, onSettled),
     summary: {
       hostName,
       description: describeCheckState({
@@ -292,6 +335,7 @@ export function useHostOverviewUpdates(input: {
         unreachable: checkQuery.isError,
         hostName,
         upToDate,
+        activationDebt: input.activationDebt,
         offerable: updatableVersion !== null,
         // What the BUTTON will install, when it can install anything. The two
         // differ whenever the best candidate is unusable: with a yanked
@@ -313,7 +357,7 @@ export function useHostOverviewUpdates(input: {
       busy: input.busy,
       onCheck: runCheck,
       onUpdateLatest: () => {
-        if (updatableVersion !== null) install(updatableVersion);
+        if (updatableVersion !== null) install(updatableVersion, false, null);
       },
     },
     picker: {
@@ -351,7 +395,7 @@ export function useHostOverviewUpdates(input: {
       ),
       installingVersion,
       disabled: input.busy,
-      onInstall: install,
+      onInstall: (version) => install(version, false, null),
       awaitingFirstCheck: actionableManifest === null,
       checking,
     },
@@ -374,6 +418,12 @@ export interface HostOverviewUpdatesState {
   readonly degrade: OverviewDegradeReason | null;
   readonly summary: HostOverviewUpdatesSummary;
   readonly picker: VersionPickerProps;
+  /**
+   * `host.update.install {version, force: true}` — the staged-wait force.
+   * `onSettled` runs once the request answers or fails, so the confirmation
+   * that dispatched it can close on the answer rather than on a guess.
+   */
+  readonly installForce: (version: string, onSettled: () => void) => void;
 }
 
 /**
@@ -872,6 +922,8 @@ function describeCheckState(input: {
   readonly unreachable: boolean;
   readonly hostName: string;
   readonly upToDate: boolean;
+  /** The install record is ahead of the running host; see the hook's input. */
+  readonly activationDebt: { readonly installedVersion: string } | null;
   /** `updatableVersion` resolved — the summary can actually OFFER the latest. */
   readonly offerable: boolean;
   /** The strictly-newer version this sentence is about, if there is one. */
@@ -886,10 +938,20 @@ function describeCheckState(input: {
   // Ordered so a stale answer never outranks what is happening NOW: a refetch
   // keeps the previous manifest on screen, so "vX is available." would otherwise
   // sit there unchanged while a re-check ran, or failed.
-  if (input.checking) return "Checking for updates…";
   if (input.failure !== null) {
     return describeCliShellFailure(input.failure, input.hostName);
   }
+  // Debt outranks everything the CATALOG can say, including "checking": it is
+  // a fact about this host's own disk, true whether or not the registry
+  // answers, and the sentence names the one action that resolves it. Only a
+  // failed install attempt sits above it - that is the answer to something
+  // the person just pressed. When the catalog additionally offers something
+  // newer than the INSTALLED version, Update now stays beside this sentence
+  // (see the hook's `installedVersion`); the button speaks for itself.
+  if (input.activationDebt !== null) {
+    return `v${input.activationDebt.installedVersion} is installed — restart host to finish.`;
+  }
+  if (input.checking) return "Checking for updates…";
   if (input.unreachable) {
     // Deliberately NOT a toast, which is what the imperative check's `onError`
     // raised. This read now fires on its own, and an automatic request that

--- a/clients/gui-app/src/components/settings/panels/host-overview-updates-state.ts
+++ b/clients/gui-app/src/components/settings/panels/host-overview-updates-state.ts
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import type { HostClient } from "@traycer-clients/shared/host-client/host-client";
 import {
@@ -40,6 +41,14 @@ import {
 } from "@/hooks/host/use-host-negotiated-method-version";
 import { toastFromHostError } from "@/lib/host-error-toast";
 import type { HostRpcRegistry } from "@/lib/host";
+import { hostQueryKeys } from "@/lib/query-keys";
+
+/**
+ * How often the catalog is re-asked while a CLI-floor remedy is on screen. A
+ * fixed cadence, not a backoff: the thing being waited on is a person running
+ * the copied command, and the remedy's copy promises the page notices.
+ */
+export const CLI_FLOOR_RECHECK_MS = 30_000;
 
 /**
  * The version the catalog is compared against: the install record's under
@@ -341,6 +350,42 @@ export function useHostOverviewUpdates(input: {
       hostName,
     },
   );
+  // THE CLI-FLOOR RECHECK. While the remedy is on screen, re-ask the catalog
+  // every `CLI_FLOOR_RECHECK_MS` so a repaired CLI reveals Update now without
+  // a click - the remedy's own copy promises exactly that. Keyed on the
+  // REMEDY, not on the response: which floored catalog row the remedy names
+  // is the summary walk's answer (the matching stable and the later RCs on
+  // the installed line, strictly newer than what runs), and that walk needs
+  // the installed version, which the check's response does not carry. A
+  // classifier over the response alone - the table-owned condition lane this
+  // replaced - kept a 30 s cadence on ANY floored row of an `installed-rc`
+  // catalog, a release on another line included, with no remedy on screen to
+  // end it. Invalidating the shared key rather than holding a private query
+  // is the choice `useActiveUpdatePollAccelerator` makes, for the same
+  // reason: one key, one answer, every observer of it refreshed alike.
+  // Non-cancelling for the reason recorded there too - a round trip slower
+  // than the cadence is coalesced, never aborted by the next tick. The
+  // query's own scheduling stays table-owned; this only marks it stale.
+  //
+  // "On screen" is literal: a RETIRED region (`degrade` non-null - an
+  // externally-managed host discovered at install, an unsupported install
+  // method) renders a notice in place of the remedy, and two of those
+  // retirements leave the check query enabled, so a floor read before the
+  // retirement would otherwise keep re-asking a host with nothing on screen
+  // to end it - the defect this recheck exists to avoid, relocated.
+  const queryClient = useQueryClient();
+  const recheckFloor = degrade === null && cliFloor !== null;
+  const { hostId } = input;
+  useEffect(() => {
+    if (!recheckFloor || hostId === null) return;
+    const timer = setInterval(() => {
+      void queryClient.invalidateQueries(
+        { queryKey: hostQueryKeys.methodScope(hostId, "host.update.check") },
+        { cancelRefetch: false },
+      );
+    }, CLI_FLOOR_RECHECK_MS);
+    return () => clearInterval(timer);
+  }, [recheckFloor, hostId, queryClient]);
   // Read off the resolved target rather than `manifest.latest`, which for an
   // installed-RC catalog is the WRONG pointer: `latest` tracks the stable
   // channel, so a host on `2.0.0-rc.1` sees `1.9.0` there and would be told it

--- a/clients/gui-app/src/components/settings/panels/host-overview-updates-state.ts
+++ b/clients/gui-app/src/components/settings/panels/host-overview-updates-state.ts
@@ -6,6 +6,8 @@ import {
   isStrictlyNewerHostVersion,
 } from "@traycer-clients/shared/host-version/compare-host-versions";
 import {
+  HOST_CLIENT_FLOOR_REASON_PREFIX,
+  isHostClientFloorRefusedAsset,
   isMatchingStableRelease,
   isSameReleaseLine,
 } from "@traycer-clients/shared/host-version/release-line";
@@ -14,6 +16,12 @@ import type {
   HostIncludePreReleasesSource,
   HostUpdateCheckResponseV11,
 } from "@traycer/protocol/host/maintenance/index";
+import type { StoredCliInstallManifest } from "@traycer/protocol/config/installation-records";
+import type { DesktopAppUpdateSnapshot } from "@/lib/windows/types";
+import {
+  describeCliFloorRemedy,
+  type CliFloorRemedy,
+} from "@/components/settings/panels/host-overview-cli-floor-remedy";
 import type { VersionPickerProps } from "@/components/settings/panels/host-overview-advanced";
 import type { HostVersionRow } from "@/components/settings/panels/host-version-rows";
 import { VERSION_LIST_PREVIEW } from "@/components/settings/panels/host-settings-panel-model";
@@ -101,6 +109,10 @@ export function useHostOverviewUpdates(input: {
    */
   readonly activationDebt: { readonly installedVersion: string } | null;
   readonly platformKey: string | null;
+  readonly cliManifest: StoredCliInstallManifest | null;
+  readonly isLocalMachine: boolean;
+  readonly desktopUpdate: DesktopAppUpdateSnapshot | null;
+  readonly stagedVersion: string | null;
   /** Whether this host is worth asking at all — the page owns that gate. */
   readonly enabled: boolean;
   readonly checkDegrade: OverviewDegradeReason | null;
@@ -167,6 +179,9 @@ export function useHostOverviewUpdates(input: {
   const [installFailure, setInstallFailure] = useState<CliShellFailure | null>(
     null,
   );
+  const [forceRefusal, setForceRefusal] = useState<ForceUpdateRefusal | null>(
+    null,
+  );
 
   const checkQuery = useHostUpdateCheckQuery({
     client,
@@ -212,6 +227,7 @@ export function useHostOverviewUpdates(input: {
   const checking = checkQuery.isFetching;
 
   const runCheck = (): void => {
+    setForceRefusal(null);
     void checkQuery.refetch();
   };
 
@@ -223,6 +239,7 @@ export function useHostOverviewUpdates(input: {
     // state only, like the callbacks beside it.
     onSettled: (() => void) | null,
   ): void => {
+    setForceRefusal(null);
     installMutation.mutate(
       { version, force },
       {
@@ -271,6 +288,26 @@ export function useHostOverviewUpdates(input: {
   // versions the failed check could not confirm - under a summary that says
   // the host could not be checked.
   const actionableManifest = checkQuery.isError ? null : manifest;
+  // A repaired refusal must not return when a later check loses its catalog.
+  // Retire it on a newer successful answer, using the same guarded render
+  // adjustment as installDiscovered; hiding the text alone keeps stale state.
+  retireForceRefusalIfRefuted({
+    refusal: forceRefusal,
+    manifest: actionableManifest,
+    checkDataUpdatedAt: checkQuery.dataUpdatedAt,
+    checkSucceeded: checkQuery.isSuccess,
+    checkIsPlaceholderData: checkQuery.isPlaceholderData,
+    platformKey: input.platformKey,
+    hostName,
+    retire: () => setForceRefusal(null),
+  });
+  const failureDescription = describeUpdateFailure({
+    refusal: forceRefusal,
+    manifest: actionableManifest,
+    platformKey: input.platformKey,
+    failure: transientFailure,
+    hostName,
+  });
   // The best STRICTLY NEWER version this catalog offers, before the yanked and
   // platform-asset gates - what the sentence is about, where
   // `updatableVersion` below is what the button can act on.
@@ -286,6 +323,23 @@ export function useHostOverviewUpdates(input: {
     installedVersion,
     source: check.source,
   });
+  const summaryCandidate = selectSummaryCandidate({
+    manifest: actionableManifest,
+    installedVersion,
+    platformKey: input.platformKey,
+    source: check.source,
+  });
+  const { cliFloor, stagedFloor, stagedEntryKnown, remedy } =
+    deriveFloorRemedies({
+      manifest: actionableManifest,
+      summaryCandidate,
+      stagedVersion: input.stagedVersion,
+      platformKey: input.platformKey,
+      cliManifest: input.cliManifest,
+      isLocalMachine: input.isLocalMachine,
+      desktopUpdate: input.desktopUpdate,
+      hostName,
+    });
   // Read off the resolved target rather than `manifest.latest`, which for an
   // installed-RC catalog is the WRONG pointer: `latest` tracks the stable
   // channel, so a host on `2.0.0-rc.1` sees `1.9.0` there and would be told it
@@ -308,34 +362,54 @@ export function useHostOverviewUpdates(input: {
   // picker rows: a latest with no usable asset for this host is advertised
   // nowhere rather than installable in one surface and unavailable in the
   // other.
-  const updatableVersion = offerableLatestVersion({
-    manifest: actionableManifest,
-    installedVersion,
-    platformKey: input.platformKey,
-    source: check.source,
-  });
+  const updatableVersion = offerableLatestVersion(summaryCandidate);
   const installingVersion = installMutation.isPending
     ? installMutation.variables.version
     : null;
 
   return {
     degrade,
+    cliFloor,
+    stagedFloor,
+    stagedEntryKnown,
     // The staged-wait force: the SAME dispatch as a row's Install, with
     // `force: true`, so the accepted latch, the invalidations and the
     // outcome toasts are the ones every other install on this page gets.
     // The confirmation that precedes it is the panel's (the ellipsis on
     // "Force update…" is a promise); this is only the dispatch.
-    installForce: (version, onSettled) => install(version, true, onSettled),
+    installForce: (version, onSettled) => {
+      // Re-read the exact version named by the confirmation. A catalog poll
+      // can withdraw it or project a refusal after the offer was opened.
+      const refusal = describeForceUpdateRefusal({
+        manifest: actionableManifest,
+        version,
+        platformKey: input.platformKey,
+        hostName,
+      });
+      if (refusal !== null) {
+        setForceRefusal({
+          version,
+          text: refusal,
+          checkDataUpdatedAt: checkQuery.dataUpdatedAt,
+        });
+        // No mutation means no mutation settle callback. Close synchronously
+        // here or the confirmation would be stranded over the inline notice.
+        onSettled();
+        return;
+      }
+      install(version, true, onSettled);
+    },
     summary: {
       hostName,
       description: describeCheckState({
         manifest,
         checking,
-        failure: transientFailure,
+        failure: failureDescription,
         unreachable: checkQuery.isError,
         hostName,
         upToDate,
         activationDebt: input.activationDebt,
+        remedy,
         offerable: updatableVersion !== null,
         // What the BUTTON will install, when it can install anything. The two
         // differ whenever the best candidate is unusable: with a yanked
@@ -347,7 +421,8 @@ export function useHostOverviewUpdates(input: {
         strandedOnLine,
         installedVersion,
       }),
-      transientFailure,
+      failureDescription,
+      remedy,
       checking,
       // Offered only for a latest that is BOTH known and not already installed,
       // and never while the row is still reporting a failed attempt. "Update
@@ -405,7 +480,8 @@ export function useHostOverviewUpdates(input: {
 export interface HostOverviewUpdatesSummary {
   readonly hostName: string;
   readonly description: string;
-  readonly transientFailure: CliShellFailure | null;
+  readonly failureDescription: string | null;
+  readonly remedy: CliFloorRemedy | null;
   readonly checking: boolean;
   readonly updatableVersion: string | null;
   readonly installing: boolean;
@@ -418,6 +494,9 @@ export interface HostOverviewUpdatesState {
   readonly degrade: OverviewDegradeReason | null;
   readonly summary: HostOverviewUpdatesSummary;
   readonly picker: VersionPickerProps;
+  readonly cliFloor: CliFloor | null;
+  readonly stagedFloor: CliFloor | null;
+  readonly stagedEntryKnown: boolean;
   /**
    * `host.update.install {version, force: true}` — the staged-wait force.
    * `onSettled` runs once the request answers or fails, so the confirmation
@@ -486,12 +565,30 @@ function visibleVersionRows(input: {
  * explicit include: a user who asked for the broad catalog gets the broad
  * catalog's own pointer rather than a line restriction they did not request.
  */
-function offerableLatestVersion(input: {
+function offerableLatestVersion(
+  candidate: SummaryUpdateCandidate | null,
+): string | null {
+  if (candidate === null || candidate.cliFloor !== null) return null;
+  return candidate.version;
+}
+
+interface SummaryUpdateCandidate {
+  readonly version: string;
+  readonly cliFloor: CliFloor | null;
+}
+
+/**
+ * One ordered walk owns both the update and its CLI remedy. An unusable
+ * stable may leave an RC as the first repairable target; a floored stable
+ * must instead keep its priority over an already-installable lower RC.
+ * Yanked entries never become usable after a CLI repair, so skip them here.
+ */
+function selectSummaryCandidate(input: {
   readonly manifest: HostAvailableManifest | null;
   readonly installedVersion: string | null;
   readonly platformKey: string | null;
   readonly source: HostIncludePreReleasesSource | null;
-}): string | null {
+}): SummaryUpdateCandidate | null {
   const { manifest } = input;
   if (manifest === null) return null;
   for (const candidate of targetCandidates({
@@ -510,7 +607,11 @@ function offerableLatestVersion(input: {
     );
     if (entry === undefined || entry.yanked) continue;
     const asset = platformAssetFor(entry.platforms, input.platformKey);
-    if (assetUnavailableReason(asset) === null) return candidate;
+    if (assetUnavailableReason(asset) === null) {
+      return { version: candidate, cliFloor: null };
+    }
+    const cliFloor = readCliFloor(entry, input.platformKey);
+    if (cliFloor !== null) return { version: candidate, cliFloor };
   }
   return null;
 }
@@ -578,7 +679,7 @@ function targetCandidates(input: {
   );
   // EXCLUDING the matching stable, which also satisfies both predicates below
   // — it is on the line and strictly newer. Without this the stable is
-  // returned twice, and `offerableLatestVersion` pays for a second yanked and
+  // returned twice, and `selectSummaryCandidate` pays for a second yanked and
   // platform-asset probe on a candidate it already accepted or rejected.
   const laterOnLine = versions
     .filter(
@@ -766,6 +867,158 @@ function soleKeyBelongsToHost(
 type PlatformAsset =
   HostAvailableManifest["versions"][number]["platforms"][string];
 
+interface CliFloor {
+  readonly requiredCliVersion: string | null;
+}
+
+interface ForceUpdateRefusal {
+  readonly version: string;
+  readonly text: string;
+  readonly checkDataUpdatedAt: number;
+}
+
+function deriveFloorRemedies(input: {
+  readonly manifest: HostAvailableManifest | null;
+  readonly summaryCandidate: SummaryUpdateCandidate | null;
+  readonly stagedVersion: string | null;
+  readonly platformKey: string | null;
+  readonly cliManifest: StoredCliInstallManifest | null;
+  readonly isLocalMachine: boolean;
+  readonly desktopUpdate: DesktopAppUpdateSnapshot | null;
+  readonly hostName: string;
+}): {
+  readonly cliFloor: CliFloor | null;
+  readonly stagedFloor: CliFloor | null;
+  readonly stagedEntryKnown: boolean;
+  readonly remedy: CliFloorRemedy | null;
+} {
+  // The shared summary walk skips yanked releases, but a staged floor must
+  // still refuse Force even when the staged release has been yanked.
+  const staged = input.manifest?.versions.find(
+    (entry) => entry.version === input.stagedVersion,
+  );
+  const cliFloor = input.summaryCandidate?.cliFloor ?? null;
+  return {
+    cliFloor,
+    stagedFloor: readCliFloor(staged, input.platformKey),
+    stagedEntryKnown: staged !== undefined,
+    remedy:
+      cliFloor === null
+        ? null
+        : describeCliFloorRemedy({
+            isLocalMachine: input.isLocalMachine,
+            platform: input.platformKey,
+            cliSource: input.cliManifest?.source ?? null,
+            cliBinaryPath: input.cliManifest?.binaryPath ?? null,
+            cliVersion: input.cliManifest?.version ?? null,
+            requiredCliVersion: cliFloor.requiredCliVersion,
+            desktopUpdate: input.desktopUpdate,
+            hostName: input.hostName,
+          }),
+  };
+}
+
+function readCliFloor(
+  entry: HostAvailableManifest["versions"][number] | undefined,
+  platformKey: string | null,
+): CliFloor | null {
+  if (entry === undefined) return null;
+  const asset = platformAssetFor(entry.platforms, platformKey);
+  if (!isHostClientFloorRefusedAsset(asset)) return null;
+  // The version decorates the verdict; it never decides it. Older payloads
+  // can omit the field while the authored refusal still names the requirement.
+  const reasonVersion = asset?.unavailableReason
+    ?.slice(HOST_CLIENT_FLOOR_REASON_PREFIX.length)
+    .match(/^(\S+) or newer\b/)?.[1];
+  return {
+    requiredCliVersion: entry.requiredCliVersion ?? reasonVersion ?? null,
+  };
+}
+
+function describeForceUpdateRefusal(input: {
+  readonly manifest: HostAvailableManifest | null;
+  readonly version: string;
+  readonly platformKey: string | null;
+  readonly hostName: string;
+}): string | null {
+  const entry = input.manifest?.versions.find(
+    (candidate) => candidate.version === input.version,
+  );
+  const floor = readCliFloor(entry, input.platformKey);
+  if (entry !== undefined && floor === null) return null;
+  if (floor !== null && floor.requiredCliVersion !== null) {
+    return `v${input.version} needs Traycer CLI ${floor.requiredCliVersion} or newer on ${input.hostName}. Update the command-line tools first.`;
+  }
+  // An absent entry, failed check, or incomplete refusal cannot name a floor.
+  return `Traycer couldn't verify that v${input.version} can be installed on ${input.hostName}. Select Check now and try again.`;
+}
+
+interface ForceRefusalEvidence {
+  readonly refusal: ForceUpdateRefusal | null;
+  readonly manifest: HostAvailableManifest | null;
+  readonly checkDataUpdatedAt: number;
+  readonly checkSucceeded: boolean;
+  readonly checkIsPlaceholderData: boolean;
+  readonly platformKey: string | null;
+  readonly hostName: string;
+}
+
+/**
+ * The guarded render adjustment for a Force refusal: one decision, one
+ * action, stated beside its predicate rather than inline in the hook.
+ * `retire` is the state setter; calling it conditionally during render is
+ * the same pattern the `installDiscovered` adjustment uses.
+ */
+function retireForceRefusalIfRefuted(
+  input: ForceRefusalEvidence & { readonly retire: () => void },
+): void {
+  if (checkRefutesForceRefusal(input)) input.retire();
+}
+
+function checkRefutesForceRefusal(input: ForceRefusalEvidence): boolean {
+  // A retained or placeholder catalog cannot prove a subsequent repair.
+  // The exact refused version must be cleared by a newer successful answer.
+  return (
+    input.refusal !== null &&
+    input.checkSucceeded &&
+    !input.checkIsPlaceholderData &&
+    input.manifest !== null &&
+    input.checkDataUpdatedAt > input.refusal.checkDataUpdatedAt &&
+    describeForceUpdateRefusal({
+      manifest: input.manifest,
+      version: input.refusal.version,
+      platformKey: input.platformKey,
+      hostName: input.hostName,
+    }) === null
+  );
+}
+
+function describeUpdateFailure(input: {
+  readonly refusal: ForceUpdateRefusal | null;
+  readonly manifest: HostAvailableManifest | null;
+  readonly platformKey: string | null;
+  readonly failure: CliShellFailure | null;
+  readonly hostName: string;
+}): string | null {
+  // A successful poll can repair the exact version refused at confirmation.
+  // Derive visibility from the current catalog so both failure surfaces clear
+  // with that answer, without waiting for another click to reset local state.
+  if (
+    input.refusal !== null &&
+    describeForceUpdateRefusal({
+      manifest: input.manifest,
+      version: input.refusal.version,
+      platformKey: input.platformKey,
+      hostName: input.hostName,
+    }) !== null
+  ) {
+    return input.refusal.text;
+  }
+  return input.failure === null
+    ? null
+    : describeCliShellFailure(input.failure, input.hostName);
+}
+
 function assetUnavailableReason(asset: PlatformAsset | null): string | null {
   if (asset === null) return "No asset for this platform.";
   if (asset.available) return null;
@@ -917,13 +1170,14 @@ function handleInstallOutcome(input: {
 function describeCheckState(input: {
   readonly manifest: HostAvailableManifest | null;
   readonly checking: boolean;
-  readonly failure: CliShellFailure | null;
+  readonly failure: string | null;
   /** The RPC itself failed — a transport fault, not an answer from the host. */
   readonly unreachable: boolean;
   readonly hostName: string;
   readonly upToDate: boolean;
   /** The install record is ahead of the running host; see the hook's input. */
   readonly activationDebt: { readonly installedVersion: string } | null;
+  readonly remedy: CliFloorRemedy | null;
   /** `updatableVersion` resolved — the summary can actually OFFER the latest. */
   readonly offerable: boolean;
   /** The strictly-newer version this sentence is about, if there is one. */
@@ -939,7 +1193,7 @@ function describeCheckState(input: {
   // keeps the previous manifest on screen, so "vX is available." would otherwise
   // sit there unchanged while a re-check ran, or failed.
   if (input.failure !== null) {
-    return describeCliShellFailure(input.failure, input.hostName);
+    return input.failure;
   }
   // Debt outranks everything the CATALOG can say, including "checking": it is
   // a fact about this host's own disk, true whether or not the registry
@@ -951,6 +1205,9 @@ function describeCheckState(input: {
   if (input.activationDebt !== null) {
     return `v${input.activationDebt.installedVersion} is installed — restart host to finish.`;
   }
+  // Like debt, the remedy stays useful during the next check. The hook drops
+  // it when that check fails or returns a catalog that clears the refusal.
+  if (input.remedy !== null) return input.remedy.sentence;
   if (input.checking) return "Checking for updates…";
   if (input.unreachable) {
     // Deliberately NOT a toast, which is what the imperative check's `onError`

--- a/clients/gui-app/src/components/settings/panels/host-overview-updates.tsx
+++ b/clients/gui-app/src/components/settings/panels/host-overview-updates.tsx
@@ -3,11 +3,12 @@ import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 import { Button } from "@/components/ui/button";
 import { HostOverviewNotice } from "@/components/settings/panels/host-overview-status-card";
 import {
-  describeCliShellFailure,
   describeOverviewDegrade,
   type OverviewDegradeReason,
 } from "@/components/settings/panels/host-overview-model";
 import type { HostOverviewUpdatesSummary } from "@/components/settings/panels/host-overview-updates-state";
+import { CliFloorRemedyActions } from "@/components/settings/panels/host-overview-cli-floor-remedy-actions";
+import type { DesktopAppUpdatesBridge } from "@/lib/windows/types";
 import { SETTINGS_ROW_STACK } from "@/components/settings/settings-row-layout";
 import { cn } from "@/lib/utils";
 
@@ -22,6 +23,8 @@ import { cn } from "@/lib/utils";
 export function HostOverviewUpdatesRegion(props: {
   readonly summary: HostOverviewUpdatesSummary;
   readonly degrade: OverviewDegradeReason | null;
+  readonly desktopBridge: DesktopAppUpdatesBridge | null;
+  readonly onInstallationHelp: () => void;
 }): ReactNode {
   const { summary } = props;
   if (props.degrade !== null) {
@@ -60,25 +63,11 @@ export function HostOverviewUpdatesRegion(props: {
             SETTINGS_ROW_STACK.control,
           )}
         >
-          {summary.updatableVersion === null ? null : (
-            <Button
-              type="button"
-              variant="default"
-              size="sm"
-              disabled={summary.busy || summary.installing || summary.checking}
-              data-testid="host-overview-update-now"
-              onClick={summary.onUpdateLatest}
-            >
-              {summary.installing ? (
-                <AgentSpinningDots
-                  className="mr-2 size-3"
-                  testId={undefined}
-                  variant={undefined}
-                />
-              ) : null}
-              Update now
-            </Button>
-          )}
+          <OverviewUpdateControl
+            summary={summary}
+            desktopBridge={props.desktopBridge}
+            onInstallationHelp={props.onInstallationHelp}
+          />
           <Button
             type="button"
             variant="ghost"
@@ -98,11 +87,48 @@ export function HostOverviewUpdatesRegion(props: {
           </Button>
         </div>
       </div>
-      {summary.transientFailure === null ? null : (
+      {summary.failureDescription === null ? null : (
         <HostOverviewNotice testId="host-overview-update-attempt-failed">
-          {describeCliShellFailure(summary.transientFailure, summary.hostName)}
+          {summary.failureDescription}
         </HostOverviewNotice>
       )}
     </div>
+  );
+}
+
+function OverviewUpdateControl(props: {
+  readonly summary: HostOverviewUpdatesSummary;
+  readonly desktopBridge: DesktopAppUpdatesBridge | null;
+  readonly onInstallationHelp: () => void;
+}): ReactNode {
+  const { summary } = props;
+  if (summary.remedy !== null) {
+    return (
+      <CliFloorRemedyActions
+        actions={summary.remedy.actions}
+        desktopBridge={props.desktopBridge}
+        onHelp={props.onInstallationHelp}
+      />
+    );
+  }
+  if (summary.updatableVersion === null) return null;
+  return (
+    <Button
+      type="button"
+      variant="default"
+      size="sm"
+      disabled={summary.busy || summary.installing || summary.checking}
+      data-testid="host-overview-update-now"
+      onClick={summary.onUpdateLatest}
+    >
+      {summary.installing ? (
+        <AgentSpinningDots
+          className="mr-2 size-3"
+          testId={undefined}
+          variant={undefined}
+        />
+      ) : null}
+      Update now
+    </Button>
   );
 }

--- a/clients/gui-app/src/hooks/host/use-fleet-update-views.ts
+++ b/clients/gui-app/src/hooks/host/use-fleet-update-views.ts
@@ -277,6 +277,12 @@ function canonicalObservation(input: {
     // observation came from a Settings-scoped host over its own live
     // connection. `local` belongs to the landing banner's runner leg.
     source: "selected",
+    // A cache ENTRY for `host.status` alone: this leg reads no installation
+    // info, so it derives no park. The picker rows therefore show a parked
+    // legacy update as quiet while the Overview shows the park - the same
+    // asymmetry the coarse marker already has for a host whose status this
+    // leg cannot read at all.
+    legacyFacts: null,
   });
   // An errored or paused entry is EXPIRED, not absent. Discarding it here would
   // leave this host's picker row with a bare `unknown` and no retained phase,

--- a/clients/gui-app/src/hooks/host/use-local-host-update-operation.ts
+++ b/clients/gui-app/src/hooks/host/use-local-host-update-operation.ts
@@ -110,6 +110,12 @@ export function useLocalHostUpdateOperation(): LocalHostUpdateOperation {
             hasLiveSource: readiness.isReady,
           },
           source: "local",
+          // The landing banner already has a debt arm of its own, read off
+          // the desktop controller status (`activation: pendingActivation`),
+          // and it does not read `host.getInstallationInfo`. Deriving a
+          // second debt fact here would put two readers with two rules on one
+          // surface; the Overview is the leg that derives.
+          legacyFacts: null,
         });
 
   // `dataUpdatedAt`, not a clock — and on this leg that is the CORRECT input,

--- a/clients/gui-app/src/lib/host-rpc-policy/__tests__/host-method-policy-table.test.ts
+++ b/clients/gui-app/src/lib/host-rpc-policy/__tests__/host-method-policy-table.test.ts
@@ -37,6 +37,15 @@ import type {
   ConditionPollLane,
   ErasedConditionPollPolicy,
 } from "@/lib/host-rpc-policy/host-method-policy-table";
+import type {
+  HostAvailableManifest,
+  HostUpdateCheckResponseV11,
+} from "@traycer/protocol/host/maintenance/index";
+import {
+  UPDATE_CHECK_CLI_RECOVERY_POLL_LANE,
+  UPDATE_CHECK_FLOOR_RECOVERY_POLL_LANE,
+  responseHasFloorRefusedCandidate,
+} from "@/lib/host-rpc-policy/host-method-policy-table";
 
 const typedProvidersClassifier = (
   data: ResponseOfMethod<HostRpcRegistry, "providers.list"> | undefined,
@@ -51,6 +60,58 @@ const typedToErasedPolicy: ErasedConditionPollPolicy<"providers.list"> = {
   staleDataErrorLane: PROVIDERS_STALE_ERROR_POLL_LANE,
   resetLaneIds: new Set([PROVIDERS_STEADY_POLL_LANE.id]),
 };
+
+function floorManifest(options: {
+  latest: string;
+  floorVersion: string;
+  floorReason: string;
+  yanked: boolean;
+  floorSha256: string;
+}): HostAvailableManifest {
+  const { latest, floorVersion, floorReason, yanked, floorSha256 } = options;
+  const entry = (version: string, refused: boolean) => ({
+    version,
+    releasedAt: "2026-09-06T00:00:00Z",
+    releaseNotesUrl: "https://example.invalid/notes",
+    yanked: refused ? yanked : false,
+    deprecationReason: null,
+    requiredCliVersion: refused ? "1.3.0" : null,
+    platforms: {
+      "darwin-arm64": {
+        available: !refused,
+        unavailableReason: refused ? floorReason : null,
+        url: "https://example.invalid/host.tar.gz",
+        sizeBytes: 100,
+        sha256: refused ? floorSha256 : "a".repeat(64),
+        signatureUrl: "https://example.invalid/host.tar.gz.minisig",
+        signatureAlgorithm: "minisign" as const,
+        publicKeyId: "key-1",
+      },
+    },
+  });
+  const versions = [entry(latest, latest === floorVersion)];
+  if (floorVersion !== latest) {
+    versions.push(entry(floorVersion, true));
+  }
+  return {
+    schemaVersion: 1,
+    generatedAt: "2026-09-06T00:00:00Z",
+    latest,
+    versions,
+  };
+}
+
+function checkResponse(
+  manifest: HostAvailableManifest,
+  source: "stable-default" | "installed-rc",
+): HostUpdateCheckResponseV11 {
+  return {
+    outcome: "ok",
+    manifest,
+    effectiveIncludePreReleases: source === "installed-rc",
+    includePreReleasesSource: source,
+  };
+}
 
 // @ts-expect-error The phantom method field must reject a policy under another key.
 const wrongKeyPolicy: ErasedConditionPollPolicy<"agent.gui.listHarnesses"> =
@@ -184,6 +245,181 @@ describe("host method poll policy table", () => {
     const fixed = HOST_METHOD_POLL_TABLE["host.getRateLimitUsage"].poll;
     const intervalMs: number = fixed.intervalMs;
     expect(intervalMs).toBe(15 * 60 * 1_000);
+  });
+
+  describe("host.update.check CLI-floor recovery", () => {
+    const policy = HOST_METHOD_POLL_TABLE["host.update.check"].poll;
+
+    it("polls a latest candidate whose projected asset carries the authored floor reason", () => {
+      const response = checkResponse(
+        floorManifest({
+          latest: "1.3.0",
+          floorVersion: "1.3.0",
+          floorReason:
+            "Needs Traycer CLI 1.3.0 or newer (this host's CLI is 1.2.0).",
+          yanked: false,
+          floorSha256: "",
+        }),
+        "stable-default",
+      );
+      expect(responseHasFloorRefusedCandidate(response)).toBe(true);
+      expect(policy.classify(response)).toBe(
+        UPDATE_CHECK_FLOOR_RECOVERY_POLL_LANE,
+      );
+      expect(UPDATE_CHECK_FLOOR_RECOVERY_POLL_LANE.initialDelayMs).toBe(30_000);
+      expect(UPDATE_CHECK_FLOOR_RECOVERY_POLL_LANE.maxDelayMs).toBe(30_000);
+    });
+
+    it("rejects available and yanked candidates", () => {
+      const availableWithFloorReason = checkResponse(
+        {
+          ...floorManifest({
+            latest: "1.3.0",
+            floorVersion: "1.3.0",
+            floorReason:
+              "Needs Traycer CLI 1.3.0 or newer (this host's CLI is 1.2.0).",
+            yanked: false,
+            floorSha256: "c".repeat(64),
+          }),
+          versions: floorManifest({
+            latest: "1.3.0",
+            floorVersion: "1.3.0",
+            floorReason:
+              "Needs Traycer CLI 1.3.0 or newer (this host's CLI is 1.2.0).",
+            yanked: false,
+            floorSha256: "c".repeat(64),
+          }).versions.map((entry) => ({
+            ...entry,
+            platforms: {
+              "darwin-arm64": {
+                ...entry.platforms["darwin-arm64"],
+                available: true,
+                unavailableReason:
+                  "Needs Traycer CLI 1.3.0 or newer (this host's CLI is 1.2.0).",
+              },
+            },
+          })),
+        },
+        "stable-default",
+      );
+      // Removing the !asset.available predicate would classify this genuinely
+      // available asset as a floor despite its stale reason; this negative
+      // availability pin must turn RED under that concrete ablation.
+      expect(responseHasFloorRefusedCandidate(availableWithFloorReason)).toBe(
+        false,
+      );
+      expect(policy.classify(availableWithFloorReason)).toBe(false);
+      const nonFloorRefusal = checkResponse(
+        floorManifest({
+          latest: "1.3.0",
+          floorVersion: "1.3.0",
+          floorReason: "not a floor",
+          yanked: false,
+          floorSha256: "",
+        }),
+        "stable-default",
+      );
+      // Removing the authored prefix check would treat any unavailable asset
+      // as a floor; this negative available-asset pin must turn RED under that
+      // concrete classifier-ablation.
+      expect(responseHasFloorRefusedCandidate(nonFloorRefusal)).toBe(false);
+      const yanked = checkResponse(
+        floorManifest({
+          latest: "1.3.0",
+          floorVersion: "1.3.0",
+          floorReason:
+            "Needs Traycer CLI 1.3.0 or newer (this host's CLI is 1.2.0).",
+          yanked: true,
+          floorSha256: "",
+        }),
+        "stable-default",
+      );
+      // Removing the !entry.yanked predicate would poll a yanked catalog row
+      // as repairable; this negative pin must turn RED under that ablation.
+      expect(responseHasFloorRefusedCandidate(yanked)).toBe(false);
+      expect(policy.classify(yanked)).toBe(false);
+    });
+
+    it("does not mistake a withdrawn asset with a retained SHA for a CLI floor", () => {
+      const withdrawn = checkResponse(
+        floorManifest({
+          latest: "1.3.0",
+          floorVersion: "1.3.0",
+          floorReason: "platform build withdrawn",
+          yanked: false,
+          floorSha256: "b".repeat(64),
+        }),
+        "stable-default",
+      );
+      // Removing the authored-reason prefix predicate would classify this
+      // withdrawn-with-hash counterexample as a floor; this negative pin must
+      // turn RED under that concrete structural-ablation.
+      expect(responseHasFloorRefusedCandidate(withdrawn)).toBe(false);
+      expect(policy.classify(withdrawn)).toBe(false);
+    });
+
+    it("checks every non-yanked installed-RC candidate, but not ordinary nonlatest rows", () => {
+      const nonlatestFloor = checkResponse(
+        floorManifest({
+          latest: "1.2.0",
+          floorVersion: "1.3.0-rc.2",
+          floorReason:
+            "Needs Traycer CLI 1.3.0 or newer (this host's CLI is 1.2.0).",
+          yanked: false,
+          floorSha256: "",
+        }),
+        "stable-default",
+      );
+      // Removing the latest/installed-rc candidate constraint would poll this
+      // ordinary nonlatest row; this negative candidate-scope pin must turn
+      // RED under that source-predicate ablation.
+      expect(responseHasFloorRefusedCandidate(nonlatestFloor)).toBe(false);
+      // Removing the installed-rc expansion would miss this later RC refusal
+      // even though latest is clear; this negative source-expansion pin must
+      // turn RED under that concrete ablation.
+      expect(
+        responseHasFloorRefusedCandidate(
+          checkResponse(
+            floorManifest({
+              latest: "1.2.0",
+              floorVersion: "1.3.0-rc.2",
+              floorReason:
+                "Needs Traycer CLI 1.3.0 or newer (this host's CLI is 1.2.0).",
+              yanked: false,
+              floorSha256: "",
+            }),
+            "installed-rc",
+          ),
+        ),
+      ).toBe(true);
+      expect(
+        policy.classify(
+          checkResponse(
+            floorManifest({
+              latest: "1.2.0",
+              floorVersion: "1.3.0-rc.2",
+              floorReason:
+                "Needs Traycer CLI 1.3.0 or newer (this host's CLI is 1.2.0).",
+              yanked: false,
+              floorSha256: "",
+            }),
+            "installed-rc",
+          ),
+        ),
+      ).toBe(UPDATE_CHECK_FLOOR_RECOVERY_POLL_LANE);
+    });
+
+    it("preserves the existing cli-unavailable recovery lane", () => {
+      // Removing the explicit cli-unavailable arm would route this legacy
+      // response through the floor helper and lose its recovery polling;
+      // this negative lane pin must turn RED under that source-arm ablation.
+      const response: HostUpdateCheckResponseV11 = {
+        outcome: "cli-unavailable",
+      };
+      expect(policy.classify(response)).toBe(
+        UPDATE_CHECK_CLI_RECOVERY_POLL_LANE,
+      );
+    });
   });
 
   // `host.status` used to be un-polled entirely. It is now opted in

--- a/clients/gui-app/src/lib/host-rpc-policy/__tests__/host-method-policy-table.test.ts
+++ b/clients/gui-app/src/lib/host-rpc-policy/__tests__/host-method-policy-table.test.ts
@@ -201,6 +201,19 @@ describe("host method poll policy table", () => {
     expect(intervalMs).toBeLessThan(30_000);
   });
 
+  // `host.getInstallationInfo` used to have no cadence at all. It is now
+  // opted in for one caller: the Overview derives the two record-derived
+  // parks (`legacy-update-facts.ts`) from the install/staged records beside
+  // the live `host.status` read, and those records change UNDER a mounted
+  // page — a detached `traycer host update` commits or parks, Desktop's
+  // launch converge swaps bytes — so a read that only goes stale on its own
+  // never observes them.
+  it("polls host.getInstallationInfo on a fixed 10s cadence, matching host.status", () => {
+    const policy = HOST_METHOD_POLL_TABLE["host.getInstallationInfo"].poll;
+    const intervalMs: number = policy.intervalMs;
+    expect(intervalMs).toBe(10_000);
+  });
+
   it("consumes condition cache data as unknown", () => {
     const data: unknown = {
       providers: [

--- a/clients/gui-app/src/lib/host-rpc-policy/__tests__/host-method-policy-table.test.ts
+++ b/clients/gui-app/src/lib/host-rpc-policy/__tests__/host-method-policy-table.test.ts
@@ -41,11 +41,7 @@ import type {
   HostAvailableManifest,
   HostUpdateCheckResponseV11,
 } from "@traycer/protocol/host/maintenance/index";
-import {
-  UPDATE_CHECK_CLI_RECOVERY_POLL_LANE,
-  UPDATE_CHECK_FLOOR_RECOVERY_POLL_LANE,
-  responseHasFloorRefusedCandidate,
-} from "@/lib/host-rpc-policy/host-method-policy-table";
+import { UPDATE_CHECK_CLI_RECOVERY_POLL_LANE } from "@/lib/host-rpc-policy/host-method-policy-table";
 
 const typedProvidersClassifier = (
   data: ResponseOfMethod<HostRpcRegistry, "providers.list"> | undefined,
@@ -247,11 +243,20 @@ describe("host method poll policy table", () => {
     expect(intervalMs).toBe(15 * 60 * 1_000);
   });
 
-  describe("host.update.check CLI-floor recovery", () => {
+  describe("host.update.check recovery lanes", () => {
     const policy = HOST_METHOD_POLL_TABLE["host.update.check"].poll;
 
-    it("polls a latest candidate whose projected asset carries the authored floor reason", () => {
-      const response = checkResponse(
+    it("polls only the CLI's absence: a floor-refused catalog row is not a lane here", () => {
+      // The CLI-floor recheck used to be a lane in this table, keyed on the
+      // response alone. Which floored row the Overview offers a remedy for is
+      // its summary walk's answer - the matching stable and the later RCs on
+      // the INSTALLED line - and the response carries no installed version,
+      // so the classifier kept a 30 s cadence on floored rows no remedy named
+      // (any row of an `installed-rc` catalog, another release line included).
+      // The recheck belongs to the Overview now (`useHostOverviewUpdates`,
+      // keyed on the remedy it renders). Restoring a floor arm here would
+      // classify either response below to a lane and turn this pin RED.
+      const flooredLatest = checkResponse(
         floorManifest({
           latest: "1.3.0",
           floorVersion: "1.3.0",
@@ -262,157 +267,26 @@ describe("host method poll policy table", () => {
         }),
         "stable-default",
       );
-      expect(responseHasFloorRefusedCandidate(response)).toBe(true);
-      expect(policy.classify(response)).toBe(
-        UPDATE_CHECK_FLOOR_RECOVERY_POLL_LANE,
-      );
-      expect(UPDATE_CHECK_FLOOR_RECOVERY_POLL_LANE.initialDelayMs).toBe(30_000);
-      expect(UPDATE_CHECK_FLOOR_RECOVERY_POLL_LANE.maxDelayMs).toBe(30_000);
-    });
-
-    it("rejects available and yanked candidates", () => {
-      const availableWithFloorReason = checkResponse(
-        {
-          ...floorManifest({
-            latest: "1.3.0",
-            floorVersion: "1.3.0",
-            floorReason:
-              "Needs Traycer CLI 1.3.0 or newer (this host's CLI is 1.2.0).",
-            yanked: false,
-            floorSha256: "c".repeat(64),
-          }),
-          versions: floorManifest({
-            latest: "1.3.0",
-            floorVersion: "1.3.0",
-            floorReason:
-              "Needs Traycer CLI 1.3.0 or newer (this host's CLI is 1.2.0).",
-            yanked: false,
-            floorSha256: "c".repeat(64),
-          }).versions.map((entry) => ({
-            ...entry,
-            platforms: {
-              "darwin-arm64": {
-                ...entry.platforms["darwin-arm64"],
-                available: true,
-                unavailableReason:
-                  "Needs Traycer CLI 1.3.0 or newer (this host's CLI is 1.2.0).",
-              },
-            },
-          })),
-        },
-        "stable-default",
-      );
-      // Removing the !asset.available predicate would classify this genuinely
-      // available asset as a floor despite its stale reason; this negative
-      // availability pin must turn RED under that concrete ablation.
-      expect(responseHasFloorRefusedCandidate(availableWithFloorReason)).toBe(
-        false,
-      );
-      expect(policy.classify(availableWithFloorReason)).toBe(false);
-      const nonFloorRefusal = checkResponse(
-        floorManifest({
-          latest: "1.3.0",
-          floorVersion: "1.3.0",
-          floorReason: "not a floor",
-          yanked: false,
-          floorSha256: "",
-        }),
-        "stable-default",
-      );
-      // Removing the authored prefix check would treat any unavailable asset
-      // as a floor; this negative available-asset pin must turn RED under that
-      // concrete classifier-ablation.
-      expect(responseHasFloorRefusedCandidate(nonFloorRefusal)).toBe(false);
-      const yanked = checkResponse(
-        floorManifest({
-          latest: "1.3.0",
-          floorVersion: "1.3.0",
-          floorReason:
-            "Needs Traycer CLI 1.3.0 or newer (this host's CLI is 1.2.0).",
-          yanked: true,
-          floorSha256: "",
-        }),
-        "stable-default",
-      );
-      // Removing the !entry.yanked predicate would poll a yanked catalog row
-      // as repairable; this negative pin must turn RED under that ablation.
-      expect(responseHasFloorRefusedCandidate(yanked)).toBe(false);
-      expect(policy.classify(yanked)).toBe(false);
-    });
-
-    it("does not mistake a withdrawn asset with a retained SHA for a CLI floor", () => {
-      const withdrawn = checkResponse(
-        floorManifest({
-          latest: "1.3.0",
-          floorVersion: "1.3.0",
-          floorReason: "platform build withdrawn",
-          yanked: false,
-          floorSha256: "b".repeat(64),
-        }),
-        "stable-default",
-      );
-      // Removing the authored-reason prefix predicate would classify this
-      // withdrawn-with-hash counterexample as a floor; this negative pin must
-      // turn RED under that concrete structural-ablation.
-      expect(responseHasFloorRefusedCandidate(withdrawn)).toBe(false);
-      expect(policy.classify(withdrawn)).toBe(false);
-    });
-
-    it("checks every non-yanked installed-RC candidate, but not ordinary nonlatest rows", () => {
-      const nonlatestFloor = checkResponse(
+      expect(policy.classify(flooredLatest)).toBe(false);
+      const flooredRcOnAnyLine = checkResponse(
         floorManifest({
           latest: "1.2.0",
-          floorVersion: "1.3.0-rc.2",
+          floorVersion: "1.4.0-rc.1",
           floorReason:
             "Needs Traycer CLI 1.3.0 or newer (this host's CLI is 1.2.0).",
           yanked: false,
           floorSha256: "",
         }),
-        "stable-default",
+        "installed-rc",
       );
-      // Removing the latest/installed-rc candidate constraint would poll this
-      // ordinary nonlatest row; this negative candidate-scope pin must turn
-      // RED under that source-predicate ablation.
-      expect(responseHasFloorRefusedCandidate(nonlatestFloor)).toBe(false);
-      // Removing the installed-rc expansion would miss this later RC refusal
-      // even though latest is clear; this negative source-expansion pin must
-      // turn RED under that concrete ablation.
-      expect(
-        responseHasFloorRefusedCandidate(
-          checkResponse(
-            floorManifest({
-              latest: "1.2.0",
-              floorVersion: "1.3.0-rc.2",
-              floorReason:
-                "Needs Traycer CLI 1.3.0 or newer (this host's CLI is 1.2.0).",
-              yanked: false,
-              floorSha256: "",
-            }),
-            "installed-rc",
-          ),
-        ),
-      ).toBe(true);
-      expect(
-        policy.classify(
-          checkResponse(
-            floorManifest({
-              latest: "1.2.0",
-              floorVersion: "1.3.0-rc.2",
-              floorReason:
-                "Needs Traycer CLI 1.3.0 or newer (this host's CLI is 1.2.0).",
-              yanked: false,
-              floorSha256: "",
-            }),
-            "installed-rc",
-          ),
-        ),
-      ).toBe(UPDATE_CHECK_FLOOR_RECOVERY_POLL_LANE);
+      expect(policy.classify(flooredRcOnAnyLine)).toBe(false);
     });
 
     it("preserves the existing cli-unavailable recovery lane", () => {
-      // Removing the explicit cli-unavailable arm would route this legacy
-      // response through the floor helper and lose its recovery polling;
-      // this negative lane pin must turn RED under that source-arm ablation.
+      // Removing the cli-unavailable arm would classify this response to
+      // `false` and lose the one DATA-driven recovery poll this table still
+      // owns for the method (its two error lanes are separate); this lane pin
+      // must turn RED under that ablation.
       const response: HostUpdateCheckResponseV11 = {
         outcome: "cli-unavailable",
       };

--- a/clients/gui-app/src/lib/host-rpc-policy/host-method-policy-table.ts
+++ b/clients/gui-app/src/lib/host-rpc-policy/host-method-policy-table.ts
@@ -7,6 +7,8 @@ import type {
   RpcSchedulingPolicy,
 } from "@traycer-clients/shared/host-client/rpc-scheduling-policy";
 import { hostRpcRegistry, type HostRpcRegistry } from "@traycer/protocol/host";
+import { isHostClientFloorRefusedAsset } from "@traycer-clients/shared/host-version/release-line";
+import type { HostUpdateCheckResponseV11 } from "@traycer/protocol/host/maintenance/index";
 import type {
   ProviderManagedInstallState,
   ProviderManagedVersions,
@@ -312,6 +314,27 @@ export const UPDATE_CHECK_CLI_RECOVERY_POLL_LANE: ConditionPollLane = {
   initialDelayMs: 5 * SECOND_MS,
   maxDelayMs: 60 * SECOND_MS,
 };
+/** Fixed cadence while the Overview is mounted; the repaired answer ends it. */
+export const UPDATE_CHECK_FLOOR_RECOVERY_POLL_LANE: ConditionPollLane = {
+  id: "host-update-check.floor-recovery",
+  initialDelayMs: 30 * SECOND_MS,
+  maxDelayMs: 30 * SECOND_MS,
+};
+
+export function responseHasFloorRefusedCandidate(
+  response: HostUpdateCheckResponseV11,
+): boolean {
+  if (response.outcome !== "ok") return false;
+  return response.manifest.versions.some(
+    (entry) =>
+      !entry.yanked &&
+      // A response carries no installed version. Conservatively inspect all
+      // RC candidates rather than reconstructing the Overview's same-line walk.
+      (entry.version === response.manifest.latest ||
+        response.includePreReleasesSource === "installed-rc") &&
+      Object.values(entry.platforms).some(isHostClientFloorRefusedAsset),
+  );
+}
 /**
  * The check itself failed — a transport fault, not an answer. Same recovery
  * reasoning as the lane above ("Couldn't ask …" has no retry button either),
@@ -385,8 +408,11 @@ export const HOST_METHOD_POLL_TABLE = {
     poll: defineConditionPolicy("host.update.check", {
       classify: (data) => {
         if (data === undefined) return false;
-        return data.outcome === "cli-unavailable"
-          ? UPDATE_CHECK_CLI_RECOVERY_POLL_LANE
+        if (data.outcome === "cli-unavailable") {
+          return UPDATE_CHECK_CLI_RECOVERY_POLL_LANE;
+        }
+        return responseHasFloorRefusedCandidate(data)
+          ? UPDATE_CHECK_FLOOR_RECOVERY_POLL_LANE
           : false;
       },
       initialErrorLane: UPDATE_CHECK_ERROR_POLL_LANE,

--- a/clients/gui-app/src/lib/host-rpc-policy/host-method-policy-table.ts
+++ b/clients/gui-app/src/lib/host-rpc-policy/host-method-policy-table.ts
@@ -7,8 +7,6 @@ import type {
   RpcSchedulingPolicy,
 } from "@traycer-clients/shared/host-client/rpc-scheduling-policy";
 import { hostRpcRegistry, type HostRpcRegistry } from "@traycer/protocol/host";
-import { isHostClientFloorRefusedAsset } from "@traycer-clients/shared/host-version/release-line";
-import type { HostUpdateCheckResponseV11 } from "@traycer/protocol/host/maintenance/index";
 import type {
   ProviderManagedInstallState,
   ProviderManagedVersions,
@@ -314,27 +312,6 @@ export const UPDATE_CHECK_CLI_RECOVERY_POLL_LANE: ConditionPollLane = {
   initialDelayMs: 5 * SECOND_MS,
   maxDelayMs: 60 * SECOND_MS,
 };
-/** Fixed cadence while the Overview is mounted; the repaired answer ends it. */
-export const UPDATE_CHECK_FLOOR_RECOVERY_POLL_LANE: ConditionPollLane = {
-  id: "host-update-check.floor-recovery",
-  initialDelayMs: 30 * SECOND_MS,
-  maxDelayMs: 30 * SECOND_MS,
-};
-
-export function responseHasFloorRefusedCandidate(
-  response: HostUpdateCheckResponseV11,
-): boolean {
-  if (response.outcome !== "ok") return false;
-  return response.manifest.versions.some(
-    (entry) =>
-      !entry.yanked &&
-      // A response carries no installed version. Conservatively inspect all
-      // RC candidates rather than reconstructing the Overview's same-line walk.
-      (entry.version === response.manifest.latest ||
-        response.includePreReleasesSource === "installed-rc") &&
-      Object.values(entry.platforms).some(isHostClientFloorRefusedAsset),
-  );
-}
 /**
  * The check itself failed — a transport fault, not an answer. Same recovery
  * reasoning as the lane above ("Couldn't ask …" has no retry button either),
@@ -408,11 +385,16 @@ export const HOST_METHOD_POLL_TABLE = {
     poll: defineConditionPolicy("host.update.check", {
       classify: (data) => {
         if (data === undefined) return false;
-        if (data.outcome === "cli-unavailable") {
-          return UPDATE_CHECK_CLI_RECOVERY_POLL_LANE;
-        }
-        return responseHasFloorRefusedCandidate(data)
-          ? UPDATE_CHECK_FLOOR_RECOVERY_POLL_LANE
+        // ONLY the CLI's absence. The other repair this method is re-asked
+        // for - a CLI-floor refusal the Overview is showing a remedy for -
+        // is NOT a lane here: whether a floored catalog row is the row the
+        // Overview offers depends on the installed version and its release
+        // line, which the response does not carry, and a classifier over
+        // the response alone kept polling on floored rows no remedy named.
+        // The Overview owns that recheck (`useHostOverviewUpdates`), keyed
+        // on the remedy it renders.
+        return data.outcome === "cli-unavailable"
+          ? UPDATE_CHECK_CLI_RECOVERY_POLL_LANE
           : false;
       },
       initialErrorLane: UPDATE_CHECK_ERROR_POLL_LANE,

--- a/clients/gui-app/src/lib/host-rpc-policy/host-method-policy-table.ts
+++ b/clients/gui-app/src/lib/host-rpc-policy/host-method-policy-table.ts
@@ -399,7 +399,19 @@ export const HOST_METHOD_POLL_TABLE = {
     joinResponseTimeoutMs: null,
     poll: null,
   },
-  "host.getInstallationInfo": { ...LATEST_SCHEDULING, poll: null },
+  // Polled, at the `host.status` cadence, for one consumer: the Overview
+  // derives "installed, restart to finish" and "staged, waiting for work"
+  // from the install and staged records beside the live status. Those
+  // records change UNDER a mounted page - a detached `traycer host update`
+  // commits or parks, the desktop's launch converge swaps bytes - and a read
+  // that only goes stale never observes them, so the card that should offer
+  // the restart never appeared until the page was remounted. One host RPC
+  // over an open connection, only while the Overview is mounted (it is the
+  // only surface that opts into `poll: true` on this method).
+  "host.getInstallationInfo": {
+    ...LATEST_SCHEDULING,
+    poll: { kind: "fixed", intervalMs: 10_000 },
+  },
   "host.service.status": { ...LATEST_SCHEDULING, poll: null },
   // FIFO, like `host.update.install` and for the same reason: these mutate the
   // host's own lifecycle, so two in flight must never collapse to "the latest".

--- a/clients/gui-app/src/lib/host/fleet-update/__tests__/borrowed-status-read.test.ts
+++ b/clients/gui-app/src/lib/host/fleet-update/__tests__/borrowed-status-read.test.ts
@@ -21,6 +21,7 @@ import {
   runWithFleetReadSlot,
 } from "@/lib/host/fleet-update/fleet-read-gate";
 import { FLEET_MAX_CONCURRENT_READS } from "@/lib/host/fleet-update/fleet-poll-policy";
+import { isRecordObservation } from "@/lib/host/fleet-update/fleet-update-view";
 
 // G10(a): `observationFromStatus` builds a PROVISIONAL observation with a
 // synthetic `freshUntilMs: Number.POSITIVE_INFINITY` so the projection it
@@ -113,6 +114,7 @@ describe("observationFromStatus — the synthetic placeholder never escapes", ()
       hostId: "host-a",
       status: status(operation),
       nowMs: NOW_MS,
+      legacyFacts: null,
     });
     expect(Number.isFinite(observation.freshUntilMs)).toBe(true);
     expect(observation.freshUntilMs).not.toBe(Number.POSITIVE_INFINITY);
@@ -124,6 +126,7 @@ describe("observationFromStatus — the synthetic placeholder never escapes", ()
       hostId: "host-a",
       status: status(attemptOperation({})),
       nowMs: NOW_MS,
+      legacyFacts: null,
     });
     expect(observation.source).toBe("borrowed");
   });
@@ -139,6 +142,7 @@ describe("observationFromStatus — carries the coarse updateProgress marker thr
       hostId: "host-a",
       status: { ...status({ kind: "none" }), updateProgress: null },
       nowMs: NOW_MS,
+      legacyFacts: null,
     });
     expect(observation.coarseProgress).toBeNull();
   });
@@ -151,6 +155,7 @@ describe("observationFromStatus — carries the coarse updateProgress marker thr
         updateProgress: { state: "updating", error: null },
       },
       nowMs: NOW_MS,
+      legacyFacts: null,
     });
     expect(observation.coarseProgress).toEqual({
       state: "updating",
@@ -348,5 +353,55 @@ describe("readUpdateStatusOverBorrowedSession — actually enters the fleet read
     });
     await Promise.all(holderRuns);
     owner.close();
+  });
+});
+
+// `readUpdateStatusOverBorrowedSession` never has an installation read beside
+// its `host.status` round trip - it is one RPC and nothing more (module doc).
+// `legacyFacts: null` there means "not observed", never "no park", and it is
+// what keeps a borrowed row from claiming a park it never checked for.
+describe("readUpdateStatusOverBorrowedSession — never derives legacyFacts", () => {
+  it("the returned observation carries legacyFacts: null", async () => {
+    const hostId = "host-no-legacy-facts";
+    const session = readySession();
+    const owner = acquireRemoteSession(
+      remoteIdentity(hostId),
+      BORROW_READ_POLICY,
+      () => session,
+    );
+
+    const observation = await readUpdateStatusOverBorrowedSession({
+      hostId,
+      now: () => Date.now(),
+      abortSignal: null,
+    });
+
+    expect(observation).not.toBeNull();
+    if (observation === null || isRecordObservation(observation)) {
+      throw new Error("expected a wire observation");
+    }
+    expect(observation.legacyFacts).toBeNull();
+
+    owner.close();
+  });
+});
+
+// `observationFromStatus` copies whatever `legacyFacts` its caller hands it
+// onto the returned observation verbatim - it never derives or mutates the
+// value itself, so the LOCAL/SELECTED legs (which DO have an installation
+// read) get exactly what they computed.
+describe("observationFromStatus — copies the caller's legacyFacts through verbatim", () => {
+  it("carries a non-null legacyFacts value through unchanged", () => {
+    const facts = {
+      activationDebt: { installedVersion: "1.3.0-rc.3" },
+      stagedWait: null,
+    };
+    const observation = observationFromStatus({
+      hostId: "host-a",
+      status: status({ kind: "none" }),
+      nowMs: NOW_MS,
+      legacyFacts: facts,
+    });
+    expect(observation.legacyFacts).toEqual(facts);
   });
 });

--- a/clients/gui-app/src/lib/host/fleet-update/__tests__/canonical-status-observation.test.ts
+++ b/clients/gui-app/src/lib/host/fleet-update/__tests__/canonical-status-observation.test.ts
@@ -145,6 +145,7 @@ describe("observationFromCanonicalRead", () => {
       status: status(op),
       nowMs: NOW_MS,
       source: "selected",
+      legacyFacts: null,
     });
     const actual = observationFromCanonicalRead({
       hostId: "host-a",
@@ -152,6 +153,7 @@ describe("observationFromCanonicalRead", () => {
       dataUpdatedAt: NOW_MS,
       health: healthyHealth(),
       source: "selected",
+      legacyFacts: null,
     });
     expect(actual).toEqual(expected);
   });
@@ -167,6 +169,7 @@ describe("observationFromCanonicalRead", () => {
       dataUpdatedAt: NOW_MS,
       health: { ...healthyHealth(), isError: true },
       source: "selected",
+      legacyFacts: null,
     });
     expect(observation.operation).toEqual(op);
     // Already expired — `EXPIRED_FRESH_UNTIL_MS` is `Number.NEGATIVE_INFINITY`,
@@ -193,6 +196,7 @@ describe("observationFromCanonicalRead", () => {
       dataUpdatedAt: NOW_MS,
       health: { ...healthyHealth(), isError: true },
       source: "selected",
+      legacyFacts: null,
     });
     // A finite, already-expired deadline is what lets `projectFleetUpdateView`
     // demote this to `unknown` — the ABLATION below shows what happens
@@ -231,6 +235,7 @@ describe("observationFromCanonicalRead", () => {
       dataUpdatedAt: NOW_MS,
       health: { ...healthyHealth(), isError: true },
       source: "selected",
+      legacyFacts: null,
     });
     const view = projectFleetUpdateView({
       observation,
@@ -252,6 +257,7 @@ describe("observationFromCanonicalRead", () => {
       dataUpdatedAt: NOW_MS,
       health: healthyHealth(),
       source: "selected",
+      legacyFacts: null,
     });
     expect(withoutMarker.coarseProgress).toBeNull();
 
@@ -264,6 +270,7 @@ describe("observationFromCanonicalRead", () => {
       dataUpdatedAt: NOW_MS,
       health: healthyHealth(),
       source: "selected",
+      legacyFacts: null,
     });
     expect(withMarker.coarseProgress).toEqual({
       state: "failed",

--- a/clients/gui-app/src/lib/host/fleet-update/__tests__/fleet-update-view.test.ts
+++ b/clients/gui-app/src/lib/host/fleet-update/__tests__/fleet-update-view.test.ts
@@ -69,6 +69,7 @@ function observation(
     operation: attemptOperation({}),
     transaction: TRANSACTION,
     coarseProgress: null,
+    legacyFacts: null,
     ...overrides,
   };
 }
@@ -1167,5 +1168,237 @@ describe("isQuietUpdateView", () => {
 
   it("is false for a live 'failed' view", () => {
     expect(isQuietUpdateView(viewOf({ kind: "failed" }))).toBe(false);
+  });
+});
+
+// ---- record-derived parks (legacyFacts) — Ticket beside 07 §5.2.7 ----------
+//
+// `legacyFactsView` is consulted in BOTH the `operation === null` arm and the
+// `operation.kind === "none"` arm, AFTER the coarse `updateProgress` marker
+// and BEFORE `unknown`/`idle`. See the module's own doc on `legacyFactsView`
+// for the full precedence story; these tests pin it end to end through
+// `projectFleetUpdateView` rather than calling the (unexported) helper
+// directly, so a precedence regression shows up exactly where a surface would
+// see it.
+
+describe("projectFleetUpdateView — record-derived parks (legacyFacts)", () => {
+  it("activation debt under operation:{kind:'none'} projects waiting-to-activate, targetVersion = installed, unqualified, no blocking count", () => {
+    const view = projectFleetUpdateView({
+      observation: observation({
+        operation: { kind: "none" },
+        legacyFacts: {
+          activationDebt: { installedVersion: "1.3.0-rc.3" },
+          stagedWait: null,
+        },
+      }),
+      nowMs: NOW_MS,
+      connected: true,
+    });
+    expect(view.kind).toBe("waiting-to-activate");
+    expect(view.targetVersion).toBe("1.3.0-rc.3");
+    expect(view.qualified).toBe(false);
+    expect(view.blockingSessionCount).toBeNull();
+  });
+
+  it("SAME activation debt under operation: null (a pre-1.3 peer) - the legacy updater parks the same way on either cohort", () => {
+    const view = projectFleetUpdateView({
+      observation: observation({
+        operation: null,
+        legacyFacts: {
+          activationDebt: { installedVersion: "1.3.0-rc.3" },
+          stagedWait: null,
+        },
+      }),
+      nowMs: NOW_MS,
+      connected: true,
+    });
+    expect(view.kind).toBe("waiting-to-activate");
+    expect(view.targetVersion).toBe("1.3.0-rc.3");
+    expect(view.qualified).toBe(false);
+    expect(view.blockingSessionCount).toBeNull();
+  });
+
+  it("staged wait projects waiting-for-work, targetVersion = staged, and carries the blocking count - offersForceRestart follows it", () => {
+    const view = projectFleetUpdateView({
+      observation: observation({
+        operation: { kind: "none" },
+        legacyFacts: {
+          activationDebt: null,
+          stagedWait: { stagedVersion: "1.3.0-rc.4", blockingSessionCount: 2 },
+        },
+      }),
+      nowMs: NOW_MS,
+      connected: true,
+    });
+    expect(view.kind).toBe("waiting-for-work");
+    expect(view.targetVersion).toBe("1.3.0-rc.4");
+    expect(view.blockingSessionCount).toBe(2);
+    expect(offersForceRestart(view)).toBe(true);
+  });
+
+  it("staged wait with a null blocking count offers no force - a null count is a claim, not countable work", () => {
+    const view = projectFleetUpdateView({
+      observation: observation({
+        operation: { kind: "none" },
+        legacyFacts: {
+          activationDebt: null,
+          stagedWait: {
+            stagedVersion: "1.3.0-rc.4",
+            blockingSessionCount: null,
+          },
+        },
+      }),
+      nowMs: NOW_MS,
+      connected: true,
+    });
+    expect(view.kind).toBe("waiting-for-work");
+    expect(view.blockingSessionCount).toBeNull();
+    expect(offersForceRestart(view)).toBe(false);
+  });
+
+  it("debt AND staged wait both present - debt wins (the restart is the smaller, always-available step)", () => {
+    const view = projectFleetUpdateView({
+      observation: observation({
+        operation: { kind: "none" },
+        legacyFacts: {
+          activationDebt: { installedVersion: "1.3.0-rc.3" },
+          stagedWait: { stagedVersion: "1.3.0-rc.4", blockingSessionCount: 2 },
+        },
+      }),
+      nowMs: NOW_MS,
+      connected: true,
+    });
+    expect(view.kind).toBe("waiting-to-activate");
+    expect(view.targetVersion).toBe("1.3.0-rc.3");
+  });
+
+  it("a coarse 'updating' marker outranks the facts - a live updater is working right now, ahead of its own park", () => {
+    const view = projectFleetUpdateView({
+      observation: observation({
+        operation: { kind: "none" },
+        coarseProgress: { state: "updating", error: null },
+        legacyFacts: {
+          activationDebt: { installedVersion: "1.3.0-rc.3" },
+          stagedWait: null,
+        },
+      }),
+      nowMs: NOW_MS,
+      connected: true,
+    });
+    expect(view.kind).toBe("updating");
+  });
+
+  it("a coarse 'failed' marker outranks the facts and keeps its failure text - real evidence, not papered over", () => {
+    const view = projectFleetUpdateView({
+      observation: observation({
+        operation: { kind: "none" },
+        coarseProgress: { state: "failed", error: "health probe failed" },
+        legacyFacts: {
+          activationDebt: { installedVersion: "1.3.0-rc.3" },
+          stagedWait: null,
+        },
+      }),
+      nowMs: NOW_MS,
+      connected: true,
+    });
+    expect(view.kind).toBe("failed");
+    expect(view.errorMessage).toBe("health probe failed");
+  });
+
+  it("a genuine attempt record outranks the facts - the kind comes from the attempt's own phase", () => {
+    const view = projectFleetUpdateView({
+      observation: observation({
+        operation: attemptOperation({ phase: "applying" }),
+        legacyFacts: {
+          activationDebt: { installedVersion: "1.3.0-rc.3" },
+          stagedWait: null,
+        },
+      }),
+      nowMs: NOW_MS,
+      connected: true,
+    });
+    expect(view.kind).toBe("applying");
+  });
+
+  it("'unavailable' outranks the facts - fail-closed record evidence stays fail-closed", () => {
+    const view = projectFleetUpdateView({
+      observation: observation({
+        operation: { kind: "unavailable", reason: "corrupt", cause: null },
+        legacyFacts: {
+          activationDebt: { installedVersion: "1.3.0-rc.3" },
+          stagedWait: null,
+        },
+      }),
+      nowMs: NOW_MS,
+      connected: true,
+    });
+    expect(view.kind).toBe("unavailable");
+  });
+
+  it("a STALE park decays to unknown, retaining lastKnownKind, the observed time, and the target version", () => {
+    const view = projectFleetUpdateView({
+      observation: observation({
+        freshUntilMs: NOW_MS - 1,
+        operation: { kind: "none" },
+        legacyFacts: {
+          activationDebt: { installedVersion: "1.3.0-rc.3" },
+          stagedWait: null,
+        },
+      }),
+      nowMs: NOW_MS,
+      connected: true,
+    });
+    expect(view.kind).toBe("unknown");
+    expect(view.lastKnownKind).toBe("waiting-to-activate");
+    expect(view.lastObservedAtMs).toBe(NOW_MS);
+    expect(view.targetVersion).toBe("1.3.0-rc.3");
+  });
+
+  it("neither park kind holds the lifecycle gate or earns the fast poll, and neither reads as quiet", () => {
+    const debtView = projectFleetUpdateView({
+      observation: observation({
+        operation: { kind: "none" },
+        legacyFacts: {
+          activationDebt: { installedVersion: "1.3.0-rc.3" },
+          stagedWait: null,
+        },
+      }),
+      nowMs: NOW_MS,
+      connected: true,
+    });
+    const stagedView = projectFleetUpdateView({
+      observation: observation({
+        operation: { kind: "none" },
+        legacyFacts: {
+          activationDebt: null,
+          stagedWait: { stagedVersion: "1.3.0-rc.4", blockingSessionCount: 2 },
+        },
+      }),
+      nowMs: NOW_MS,
+      connected: true,
+    });
+    expect(holdsLifecycleGate(debtView)).toBe(false);
+    expect(holdsLifecycleGate(stagedView)).toBe(false);
+    expect(warrantsFastPoll(debtView)).toBe(false);
+    expect(warrantsFastPoll(stagedView)).toBe(false);
+    expect(isQuietUpdateView(debtView)).toBe(false);
+    expect(isQuietUpdateView(stagedView)).toBe(false);
+  });
+
+  // Regression pin: with `legacyFacts: null` (the fixture default) and no
+  // coarse marker, `{kind:"none"}` must still fall through to plain `idle` -
+  // exactly the pre-legacyFacts behaviour. Falsification: a bug that made
+  // `legacyFactsView` return a non-null park for `legacyFacts: null` would
+  // turn this into `waiting-to-activate` or `waiting-for-work`.
+  it("legacyFacts: null with kind:'none' and no coarse marker still projects idle - unchanged from before this feature", () => {
+    const view = projectFleetUpdateView({
+      observation: observation({
+        operation: { kind: "none" },
+        legacyFacts: null,
+      }),
+      nowMs: NOW_MS,
+      connected: true,
+    });
+    expect(view.kind).toBe("idle");
   });
 });

--- a/clients/gui-app/src/lib/host/fleet-update/__tests__/legacy-update-facts.test.ts
+++ b/clients/gui-app/src/lib/host/fleet-update/__tests__/legacy-update-facts.test.ts
@@ -16,7 +16,7 @@ function managed(
     readonly version: string;
     readonly runtimeVersion: string | null;
   },
-  stagedRecord: { readonly version: string } | null = null,
+  stagedRecord: { readonly version: string } | null,
 ): LegacyUpdateInstallation {
   return { status: "managed", installRecord, stagedRecord };
 }
@@ -24,7 +24,10 @@ function managed(
 describe("deriveLegacyUpdateFacts — activationDebt, runtimeVersion SET", () => {
   it("equal to the running stamp - no debt", () => {
     const facts = deriveLegacyUpdateFacts({
-      installation: managed({ version: "1.3.0", runtimeVersion: "1.3.0" }),
+      installation: managed(
+        { version: "1.3.0", runtimeVersion: "1.3.0" },
+        null,
+      ),
       runningVersion: "1.3.0",
       busy: false,
       busySessionCount: null,
@@ -34,7 +37,10 @@ describe("deriveLegacyUpdateFacts — activationDebt, runtimeVersion SET", () =>
 
   it("unequal (running AHEAD of the recorded stamp) - debt", () => {
     const facts = deriveLegacyUpdateFacts({
-      installation: managed({ version: "1.3.0", runtimeVersion: "1.2.0" }),
+      installation: managed(
+        { version: "1.3.0", runtimeVersion: "1.2.0" },
+        null,
+      ),
       runningVersion: "1.3.0",
       busy: false,
       busySessionCount: null,
@@ -44,7 +50,10 @@ describe("deriveLegacyUpdateFacts — activationDebt, runtimeVersion SET", () =>
 
   it("unequal (running BEHIND the recorded stamp) - debt, the other direction", () => {
     const facts = deriveLegacyUpdateFacts({
-      installation: managed({ version: "1.3.0", runtimeVersion: "1.3.0" }),
+      installation: managed(
+        { version: "1.3.0", runtimeVersion: "1.3.0" },
+        null,
+      ),
       runningVersion: "1.2.0",
       busy: false,
       busySessionCount: null,
@@ -54,10 +63,13 @@ describe("deriveLegacyUpdateFacts — activationDebt, runtimeVersion SET", () =>
 
   it("unequal NON-SemVer staging stamps - debt. The domain is EQUALITY, never ordering", () => {
     const facts = deriveLegacyUpdateFacts({
-      installation: managed({
-        version: "1.3.0",
-        runtimeVersion: "staging.2.abc",
-      }),
+      installation: managed(
+        {
+          version: "1.3.0",
+          runtimeVersion: "staging.2.abc",
+        },
+        null,
+      ),
       runningVersion: "staging.1.def",
       busy: false,
       busySessionCount: null,
@@ -67,10 +79,13 @@ describe("deriveLegacyUpdateFacts — activationDebt, runtimeVersion SET", () =>
 
   it("equal NON-SemVer staging stamps - no debt", () => {
     const facts = deriveLegacyUpdateFacts({
-      installation: managed({
-        version: "1.3.0",
-        runtimeVersion: "staging.5.xyz",
-      }),
+      installation: managed(
+        {
+          version: "1.3.0",
+          runtimeVersion: "staging.5.xyz",
+        },
+        null,
+      ),
       runningVersion: "staging.5.xyz",
       busy: false,
       busySessionCount: null,
@@ -81,12 +96,14 @@ describe("deriveLegacyUpdateFacts — activationDebt, runtimeVersion SET", () =>
 
 describe("deriveLegacyUpdateFacts — activationDebt, no runtimeVersion (catalog-version fallback)", () => {
   it("running version is not valid SemVer (a foreign runtime) - no debt", () => {
-    // Falsification: removing the `isValidHostVersion` guard and letting
-    // `compareHostVersions` alone decide would coincidentally also read
-    // "not comparable" here, so this case alone would not catch a dropped
-    // guard - the rc.2/rc.3 case right below is what would.
+    // `compareHostVersions` validates both operands itself and answers "not
+    // comparable" for a foreign runtime, so the explicit `isValidHostVersion`
+    // guard in `isActivationDebt` is redundant with it - kept because it
+    // states the rule where a reader looks for it. No pin in this file can
+    // see that guard removed: this case and the rc.2/rc.3 one below both
+    // reach the same answer through the comparator alone.
     const facts = deriveLegacyUpdateFacts({
-      installation: managed({ version: "1.3.0", runtimeVersion: null }),
+      installation: managed({ version: "1.3.0", runtimeVersion: null }, null),
       runningVersion: "staging.1.abc",
       busy: false,
       busySessionCount: null,
@@ -96,10 +113,13 @@ describe("deriveLegacyUpdateFacts — activationDebt, no runtimeVersion (catalog
 
   it("comparable and unequal (rc.2 running, rc.3 installed) - debt", () => {
     const facts = deriveLegacyUpdateFacts({
-      installation: managed({
-        version: "1.3.0-rc.3",
-        runtimeVersion: null,
-      }),
+      installation: managed(
+        {
+          version: "1.3.0-rc.3",
+          runtimeVersion: null,
+        },
+        null,
+      ),
       runningVersion: "1.3.0-rc.2",
       busy: false,
       busySessionCount: null,
@@ -112,7 +132,7 @@ describe("deriveLegacyUpdateFacts — activationDebt, no runtimeVersion (catalog
     // not: the CLI's own `readActivationState` gives the same answer, and the
     // module's doc calls this out by name so nobody "fixes" it on one side only.
     const facts = deriveLegacyUpdateFacts({
-      installation: managed({ version: "1.3.0", runtimeVersion: null }),
+      installation: managed({ version: "1.3.0", runtimeVersion: null }, null),
       runningVersion: "0.0.0-dev",
       busy: false,
       busySessionCount: null,
@@ -122,7 +142,7 @@ describe("deriveLegacyUpdateFacts — activationDebt, no runtimeVersion (catalog
 
   it("equal - no debt", () => {
     const facts = deriveLegacyUpdateFacts({
-      installation: managed({ version: "1.3.0", runtimeVersion: null }),
+      installation: managed({ version: "1.3.0", runtimeVersion: null }, null),
       runningVersion: "1.3.0",
       busy: false,
       busySessionCount: null,
@@ -132,10 +152,13 @@ describe("deriveLegacyUpdateFacts — activationDebt, no runtimeVersion (catalog
 
   it("incomparable (installed is a local-file pin) - no debt", () => {
     const facts = deriveLegacyUpdateFacts({
-      installation: managed({
-        version: "local-abc-1699999999999",
-        runtimeVersion: null,
-      }),
+      installation: managed(
+        {
+          version: "local-abc-1699999999999",
+          runtimeVersion: null,
+        },
+        null,
+      ),
       runningVersion: "1.3.0",
       busy: false,
       busySessionCount: null,

--- a/clients/gui-app/src/lib/host/fleet-update/__tests__/legacy-update-facts.test.ts
+++ b/clients/gui-app/src/lib/host/fleet-update/__tests__/legacy-update-facts.test.ts
@@ -1,0 +1,279 @@
+import { describe, expect, it } from "vitest";
+import {
+  deriveLegacyUpdateFacts,
+  NO_LEGACY_UPDATE_FACTS,
+  type LegacyUpdateInstallation,
+} from "@/lib/host/fleet-update/legacy-update-facts";
+
+// Table-driven over the module's own truth table (see its doc comment).
+// Real version strings throughout, run through the REAL comparator
+// (`@traycer-clients/shared/host-version/compare-host-versions`) rather than a
+// stub, so a change to SemVer precedence or the incomparable-version rule
+// shows up here rather than only in the comparator's own suite.
+
+function managed(
+  installRecord: {
+    readonly version: string;
+    readonly runtimeVersion: string | null;
+  },
+  stagedRecord: { readonly version: string } | null = null,
+): LegacyUpdateInstallation {
+  return { status: "managed", installRecord, stagedRecord };
+}
+
+describe("deriveLegacyUpdateFacts — activationDebt, runtimeVersion SET", () => {
+  it("equal to the running stamp - no debt", () => {
+    const facts = deriveLegacyUpdateFacts({
+      installation: managed({ version: "1.3.0", runtimeVersion: "1.3.0" }),
+      runningVersion: "1.3.0",
+      busy: false,
+      busySessionCount: null,
+    });
+    expect(facts.activationDebt).toBeNull();
+  });
+
+  it("unequal (running AHEAD of the recorded stamp) - debt", () => {
+    const facts = deriveLegacyUpdateFacts({
+      installation: managed({ version: "1.3.0", runtimeVersion: "1.2.0" }),
+      runningVersion: "1.3.0",
+      busy: false,
+      busySessionCount: null,
+    });
+    expect(facts.activationDebt).toEqual({ installedVersion: "1.3.0" });
+  });
+
+  it("unequal (running BEHIND the recorded stamp) - debt, the other direction", () => {
+    const facts = deriveLegacyUpdateFacts({
+      installation: managed({ version: "1.3.0", runtimeVersion: "1.3.0" }),
+      runningVersion: "1.2.0",
+      busy: false,
+      busySessionCount: null,
+    });
+    expect(facts.activationDebt).toEqual({ installedVersion: "1.3.0" });
+  });
+
+  it("unequal NON-SemVer staging stamps - debt. The domain is EQUALITY, never ordering", () => {
+    const facts = deriveLegacyUpdateFacts({
+      installation: managed({
+        version: "1.3.0",
+        runtimeVersion: "staging.2.abc",
+      }),
+      runningVersion: "staging.1.def",
+      busy: false,
+      busySessionCount: null,
+    });
+    expect(facts.activationDebt).toEqual({ installedVersion: "1.3.0" });
+  });
+
+  it("equal NON-SemVer staging stamps - no debt", () => {
+    const facts = deriveLegacyUpdateFacts({
+      installation: managed({
+        version: "1.3.0",
+        runtimeVersion: "staging.5.xyz",
+      }),
+      runningVersion: "staging.5.xyz",
+      busy: false,
+      busySessionCount: null,
+    });
+    expect(facts.activationDebt).toBeNull();
+  });
+});
+
+describe("deriveLegacyUpdateFacts — activationDebt, no runtimeVersion (catalog-version fallback)", () => {
+  it("running version is not valid SemVer (a foreign runtime) - no debt", () => {
+    // Falsification: removing the `isValidHostVersion` guard and letting
+    // `compareHostVersions` alone decide would coincidentally also read
+    // "not comparable" here, so this case alone would not catch a dropped
+    // guard - the rc.2/rc.3 case right below is what would.
+    const facts = deriveLegacyUpdateFacts({
+      installation: managed({ version: "1.3.0", runtimeVersion: null }),
+      runningVersion: "staging.1.abc",
+      busy: false,
+      busySessionCount: null,
+    });
+    expect(facts.activationDebt).toBeNull();
+  });
+
+  it("comparable and unequal (rc.2 running, rc.3 installed) - debt", () => {
+    const facts = deriveLegacyUpdateFacts({
+      installation: managed({
+        version: "1.3.0-rc.3",
+        runtimeVersion: null,
+      }),
+      runningVersion: "1.3.0-rc.2",
+      busy: false,
+      busySessionCount: null,
+    });
+    expect(facts.activationDebt).toEqual({ installedVersion: "1.3.0-rc.3" });
+  });
+
+  it("0.0.0-dev IS valid SemVer, so a dev host beside a released record reads as debt", () => {
+    // Stated explicitly because it looks like it should be an exemption and is
+    // not: the CLI's own `readActivationState` gives the same answer, and the
+    // module's doc calls this out by name so nobody "fixes" it on one side only.
+    const facts = deriveLegacyUpdateFacts({
+      installation: managed({ version: "1.3.0", runtimeVersion: null }),
+      runningVersion: "0.0.0-dev",
+      busy: false,
+      busySessionCount: null,
+    });
+    expect(facts.activationDebt).toEqual({ installedVersion: "1.3.0" });
+  });
+
+  it("equal - no debt", () => {
+    const facts = deriveLegacyUpdateFacts({
+      installation: managed({ version: "1.3.0", runtimeVersion: null }),
+      runningVersion: "1.3.0",
+      busy: false,
+      busySessionCount: null,
+    });
+    expect(facts.activationDebt).toBeNull();
+  });
+
+  it("incomparable (installed is a local-file pin) - no debt", () => {
+    const facts = deriveLegacyUpdateFacts({
+      installation: managed({
+        version: "local-abc-1699999999999",
+        runtimeVersion: null,
+      }),
+      runningVersion: "1.3.0",
+      busy: false,
+      busySessionCount: null,
+    });
+    expect(facts.activationDebt).toBeNull();
+  });
+});
+
+describe("deriveLegacyUpdateFacts — unmanaged / absent installation", () => {
+  it("unmanaged - both facts null", () => {
+    const facts = deriveLegacyUpdateFacts({
+      installation: { status: "unmanaged" },
+      runningVersion: "1.3.0",
+      busy: true,
+      busySessionCount: 4,
+    });
+    expect(facts).toEqual(NO_LEGACY_UPDATE_FACTS);
+  });
+
+  it("null installation - both facts null", () => {
+    const facts = deriveLegacyUpdateFacts({
+      installation: null,
+      runningVersion: "1.3.0",
+      busy: true,
+      busySessionCount: 4,
+    });
+    expect(facts).toEqual(NO_LEGACY_UPDATE_FACTS);
+  });
+});
+
+describe("deriveLegacyUpdateFacts — stagedWait", () => {
+  it("staged differs from installed, busy, positive count - present with that count", () => {
+    const facts = deriveLegacyUpdateFacts({
+      installation: managed(
+        { version: "1.3.0-rc.2", runtimeVersion: "1.3.0-rc.2" },
+        { version: "1.3.0-rc.3" },
+      ),
+      runningVersion: "1.3.0-rc.2",
+      busy: true,
+      busySessionCount: 2,
+    });
+    expect(facts.stagedWait).toEqual({
+      stagedVersion: "1.3.0-rc.3",
+      blockingSessionCount: 2,
+    });
+  });
+
+  it("busy but the host reported a count of exactly zero - stagedWait present, count null (a claim, not work)", () => {
+    const facts = deriveLegacyUpdateFacts({
+      installation: managed(
+        { version: "1.3.0-rc.2", runtimeVersion: "1.3.0-rc.2" },
+        { version: "1.3.0-rc.3" },
+      ),
+      runningVersion: "1.3.0-rc.2",
+      busy: true,
+      busySessionCount: 0,
+    });
+    expect(facts.stagedWait).toEqual({
+      stagedVersion: "1.3.0-rc.3",
+      blockingSessionCount: null,
+    });
+  });
+
+  it("busy but the host reported no count at all (null) - stagedWait present, count null", () => {
+    const facts = deriveLegacyUpdateFacts({
+      installation: managed(
+        { version: "1.3.0-rc.2", runtimeVersion: "1.3.0-rc.2" },
+        { version: "1.3.0-rc.3" },
+      ),
+      runningVersion: "1.3.0-rc.2",
+      busy: true,
+      busySessionCount: null,
+    });
+    expect(facts.stagedWait).toEqual({
+      stagedVersion: "1.3.0-rc.3",
+      blockingSessionCount: null,
+    });
+  });
+
+  it("not busy - stagedWait null even with a real stage and a positive count", () => {
+    // Falsification: dropping the `input.busy` conjunct from `stagedWait`'s
+    // guard would make this assert a non-null stagedWait.
+    const facts = deriveLegacyUpdateFacts({
+      installation: managed(
+        { version: "1.3.0-rc.2", runtimeVersion: "1.3.0-rc.2" },
+        { version: "1.3.0-rc.3" },
+      ),
+      runningVersion: "1.3.0-rc.2",
+      busy: false,
+      busySessionCount: 2,
+    });
+    expect(facts.stagedWait).toBeNull();
+  });
+
+  it("staged version equals the installed version - stagedWait null (nothing new parked)", () => {
+    // Falsification: dropping the `staged.version !== installed.version`
+    // conjunct would make this assert a non-null stagedWait.
+    const facts = deriveLegacyUpdateFacts({
+      installation: managed(
+        { version: "1.3.0-rc.2", runtimeVersion: "1.3.0-rc.2" },
+        { version: "1.3.0-rc.2" },
+      ),
+      runningVersion: "1.3.0-rc.2",
+      busy: true,
+      busySessionCount: 2,
+    });
+    expect(facts.stagedWait).toBeNull();
+  });
+
+  it("no staged record at all - stagedWait null", () => {
+    const facts = deriveLegacyUpdateFacts({
+      installation: managed(
+        { version: "1.3.0-rc.2", runtimeVersion: "1.3.0-rc.2" },
+        null,
+      ),
+      runningVersion: "1.3.0-rc.2",
+      busy: true,
+      busySessionCount: 2,
+    });
+    expect(facts.stagedWait).toBeNull();
+  });
+});
+
+describe("deriveLegacyUpdateFacts — debt and stagedWait can both be present", () => {
+  it("installed ahead of running (debt) AND a further stage waiting on busy work", () => {
+    const facts = deriveLegacyUpdateFacts({
+      installation: managed(
+        { version: "1.3.0-rc.3", runtimeVersion: null },
+        { version: "1.3.0-rc.4" },
+      ),
+      runningVersion: "1.3.0-rc.2",
+      busy: true,
+      busySessionCount: 1,
+    });
+    expect(facts.activationDebt).toEqual({ installedVersion: "1.3.0-rc.3" });
+    expect(facts.stagedWait).toEqual({
+      stagedVersion: "1.3.0-rc.4",
+      blockingSessionCount: 1,
+    });
+  });
+});

--- a/clients/gui-app/src/lib/host/fleet-update/borrowed-status-read.ts
+++ b/clients/gui-app/src/lib/host/fleet-update/borrowed-status-read.ts
@@ -73,6 +73,10 @@ export async function readUpdateStatusOverBorrowedSession(input: {
       status,
       // Stamped here, after the slot wait AND the round trip.
       nowMs: input.now(),
+      // A borrowed read is one `host.status` round trip and nothing more;
+      // this leg never asks for installation info, so it has no park to
+      // derive. `null` is "not observed" here, exactly as it is on the wire.
+      legacyFacts: null,
     });
   } catch {
     // Every failure mode lands here and all of them mean the same thing: we
@@ -109,6 +113,12 @@ export function observationFromStatus(input: {
   readonly status: ResponseOfMethod<HostRpcRegistry, "host.status">;
   readonly nowMs: number;
   readonly source?: FleetUpdateWireObservation["source"];
+  /**
+   * Record-derived park facts, or `null` when this leg had no installation
+   * read beside the status. Explicit rather than defaulted so a new caller
+   * has to SAY it did not look — the Overview is the one leg that does.
+   */
+  readonly legacyFacts: FleetUpdateWireObservation["legacyFacts"];
 }): FleetUpdateWireObservation {
   const provisional: FleetUpdateWireObservation = {
     hostId: input.hostId,
@@ -130,6 +140,7 @@ export function observationFromStatus(input: {
     operation: input.status.updateOperation,
     transaction: input.status.updateTransaction,
     coarseProgress: input.status.updateProgress,
+    legacyFacts: input.legacyFacts,
   };
   const view = projectFleetUpdateView({
     observation: provisional,

--- a/clients/gui-app/src/lib/host/fleet-update/canonical-status-observation.ts
+++ b/clients/gui-app/src/lib/host/fleet-update/canonical-status-observation.ts
@@ -128,12 +128,15 @@ export function observationFromCanonicalRead(input: {
   readonly dataUpdatedAt: number;
   readonly health: CanonicalReadHealth;
   readonly source: FleetUpdateSource;
+  /** See `FleetUpdateWireObservation.legacyFacts`; `null` = this leg did not look. */
+  readonly legacyFacts: FleetUpdateWireObservation["legacyFacts"];
 }): FleetUpdateWireObservation {
   const observation = observationFromStatus({
     hostId: input.hostId,
     status: input.status,
     nowMs: input.dataUpdatedAt,
     source: input.source,
+    legacyFacts: input.legacyFacts,
   });
   if (canonicalReadIsLive(input.health)) return observation;
   return { ...observation, freshUntilMs: EXPIRED_FRESH_UNTIL_MS };

--- a/clients/gui-app/src/lib/host/fleet-update/fleet-update-view.ts
+++ b/clients/gui-app/src/lib/host/fleet-update/fleet-update-view.ts
@@ -5,6 +5,7 @@ import type {
   HostUpdateTransactionCapability,
 } from "@traycer/protocol/host/status/index";
 import type { HostUpdateAttemptPhase } from "@traycer/protocol/config/host-update-attempt";
+import type { LegacyUpdateFacts } from "@/lib/host/fleet-update/legacy-update-facts";
 
 /**
  * The pure projection every update surface reads — landing banner, Settings
@@ -72,6 +73,23 @@ export interface FleetUpdateWireObservation {
    * `null` when the peer reported nothing in that field.
    */
   readonly coarseProgress: HostStatusUpdateProgress | null;
+  /**
+   * What the install and staged RECORDS say about a parked legacy update
+   * (`legacy-update-facts.ts`), derived by the caller from
+   * `host.getInstallationInfo` beside this same `host.status` read.
+   *
+   * The legacy updater WITHDRAWS its marker when a busy host makes it stop, so
+   * for the two parks it can leave behind — bytes installed but not running,
+   * bytes staged and waiting — the coarse field says nothing and these facts
+   * are the only signal. Consulted after the coarse marker and before `idle`.
+   *
+   * `null` when the caller had no installation read to derive from: the
+   * borrowed fleet leg, the landing banner (which keeps its own desktop-status
+   * debt arm), and a surface whose installation query has not answered. Like
+   * every other `null` on this record it means "not observed", never "no
+   * park".
+   */
+  readonly legacyFacts: LegacyUpdateFacts | null;
 }
 
 /**
@@ -294,13 +312,15 @@ export interface FleetUpdateViewInput {
  *    phase, so a surface can say "last seen downloading" rather than going
  *    blank. A missed poll is not a state change on the host.
  * 3. **`operation === null`** → the coarse `updateProgress` view when the peer
- *    reported one, else `unknown`. This is the one that is easy to get
+ *    reported one, else the record-derived park ({@link legacyFactsView}),
+ *    else `unknown`. This is the one that is easy to get
  *    wrong and expensive when wrong: for a REMOTE host on a per-host `manual`
  *    update policy this is potentially the indefinite steady state, not an
  *    upgrade transient. Reading it as "no update in progress" would show those
  *    users nothing during a real update, for as long as their host stayed on
  *    `@1.2`.
- * 4. **`kind: "none"`** → `idle`. The host looked and there is nothing.
+ * 4. **`kind: "none"`** → the coarse marker, else the record-derived park,
+ *    else `idle`. The host looked and there is nothing.
  * 5. **`kind: "unavailable"`** → `unavailable`. Fail-closed evidence stays
  *    distinct from both "no attempt" and "failed".
  * 6. **`kind: "attempt"`** → liveness first, then phase.
@@ -379,6 +399,11 @@ export function projectFleetUpdateView(
     // never `idle`, for the reasons above.
     const coarseView = coarseProgressView(observation, stale);
     if (coarseView !== null) return coarseView;
+    // Same order as the `none` arm below: a park the RECORDS describe is
+    // rendered for this cohort too, because a pre-@1.3 host's legacy updater
+    // parks in exactly the same way as a current one's.
+    const parkedView = legacyFactsView(observation, stale);
+    if (parkedView !== null) return parkedView;
     return UNKNOWN_FLEET_UPDATE_VIEW;
   }
 
@@ -394,6 +419,15 @@ export function projectFleetUpdateView(
     // marker is consulted FIRST, and only its absence means quiet.
     const coarseView = coarseProgressView(observation, stale);
     if (coarseView !== null) return coarseView;
+    // Then the parks the marker CANNOT carry. The legacy updater withdraws
+    // its marker when a busy host makes it stop, leaving either bytes
+    // installed under a host still running the old version, or a stage
+    // waiting for the host to go idle. Both are visible in the install and
+    // staged records and nowhere else, and reading the marker alone rendered
+    // them as "Host is up to date" - on an Overview whose header said rc.2
+    // and whose Installation card said rc.3.
+    const parkedView = legacyFactsView(observation, stale);
+    if (parkedView !== null) return parkedView;
     // A stale read of a quiet host is still unknown rather than idle: the
     // absence of an attempt was true when we looked, and we have since stopped
     // looking. Claiming "up to date" from a reading we cannot refresh is the
@@ -533,6 +567,76 @@ function coarseProgressView(
         ? { kind: "indeterminate", bytes: null, totalBytes: null }
         : { kind: "none" },
     errorMessage: coarse.errorMessage,
+  };
+}
+
+/**
+ * The view a parked legacy update projects from the RECORDS, or `null` when
+ * the caller derived no park (or had nothing to derive from).
+ *
+ * The two kinds already exist for the schema-v2 attempt's own parks and carry
+ * exactly the right copy, gates and cadence: `waiting-to-activate` ("Update
+ * installed — restart host to finish") and `waiting-for-work` ("Update will
+ * continue when N sessions finish", with **Force** when the count is
+ * positive). Neither holds the lifecycle gate nor earns the fast poll — a park
+ * can sit for days, and the restart it waits for must stay pressable.
+ *
+ * Debt outranks the staged wait when both hold (rc.3 installed, rc.4 staged,
+ * rc.2 running and busy): the restart is the smaller, always-available step,
+ * and the stage is applied by the next run once the host is idle anyway.
+ *
+ * Consulted AFTER the coarse marker on purpose. A live `updating` means an
+ * updater is working right now and its park, if any, is still ahead of it; a
+ * retained `failed` is real evidence about the last run that a derived park
+ * must not paper over — the Overview keeps the failure text and offers
+ * Restart from the debt fact directly, off the view kind.
+ */
+function legacyPark(facts: LegacyUpdateFacts): {
+  readonly kind: "waiting-to-activate" | "waiting-for-work";
+  readonly targetVersion: string;
+  readonly blockingSessionCount: number | null;
+} | null {
+  // Debt outranks a staged wait: the installed bytes are the nearer fact,
+  // and a restart resolves the debt before any stage can matter.
+  if (facts.activationDebt !== null) {
+    return {
+      kind: "waiting-to-activate",
+      targetVersion: facts.activationDebt.installedVersion,
+      blockingSessionCount: null,
+    };
+  }
+  if (facts.stagedWait !== null) {
+    return {
+      kind: "waiting-for-work",
+      targetVersion: facts.stagedWait.stagedVersion,
+      blockingSessionCount: facts.stagedWait.blockingSessionCount,
+    };
+  }
+  return null;
+}
+
+function legacyFactsView(
+  observation: FleetUpdateWireObservation,
+  stale: boolean,
+): FleetUpdateView | null {
+  const facts = observation.legacyFacts;
+  if (facts === null) return null;
+  const park = legacyPark(facts);
+  if (park === null) return null;
+  if (stale) {
+    return {
+      ...UNKNOWN_FLEET_UPDATE_VIEW,
+      targetVersion: park.targetVersion,
+      lastKnownKind: park.kind,
+      lastObservedAtMs: observation.observedAtMs,
+    };
+  }
+  return {
+    ...UNKNOWN_FLEET_UPDATE_VIEW,
+    kind: park.kind,
+    targetVersion: park.targetVersion,
+    blockingSessionCount: park.blockingSessionCount,
+    qualified: false,
   };
 }
 

--- a/clients/gui-app/src/lib/host/fleet-update/fleet-update-view.ts
+++ b/clients/gui-app/src/lib/host/fleet-update/fleet-update-view.ts
@@ -576,8 +576,8 @@ function coarseProgressView(
  *
  * The two kinds already exist for the schema-v2 attempt's own parks and carry
  * exactly the right copy, gates and cadence: `waiting-to-activate` ("Update
- * installed — restart host to finish") and `waiting-for-work` ("Update will
- * continue when N sessions finish", with **Force** when the count is
+ * installed — restart host to finish") and `waiting-for-work` ("Update
+ * waits for N sessions to finish", with **Force** when the count is
  * positive). Neither holds the lifecycle gate nor earns the fast poll — a park
  * can sit for days, and the restart it waits for must stay pressable.
  *

--- a/clients/gui-app/src/lib/host/fleet-update/legacy-update-facts.ts
+++ b/clients/gui-app/src/lib/host/fleet-update/legacy-update-facts.ts
@@ -15,10 +15,15 @@ import {
  *   did not) restart the host — Desktop's launch converge, or `traycer host
  *   update` declining to interrupt live work. The only way forward is a
  *   restart, and the Overview offers it.
- * - **Staged wait**: a newer host sits in `staged/` while the running host is
- *   busy. The updater downloaded it, found work in progress, and left it for
- *   the next idle run (or a forced one). The Overview says so and offers the
- *   force.
+ * - **Staged wait**: a host other than the installed one sits in `staged/`
+ *   while the running host is busy. The updater downloaded it, found work in
+ *   progress, and left it for the next idle run (or a forced one). The
+ *   Overview says so and offers the force. "Other than", not "newer": the
+ *   CLI's promotion rule stages a comparable-newer version, or an
+ *   INCOMPARABLE one on a non-automatic run (`decideHostDownloadPromotion`),
+ *   and applies either on the next run; a comparable-older stage never
+ *   reaches `staged/`. Requiring "newer" here would hide a wait the CLI
+ *   would honour.
  *
  * Derived CLIENT-SIDE from `host.getInstallationInfo` + `host.status`, on
  * purpose: both reads are already on the page, no host release is needed, and

--- a/clients/gui-app/src/lib/host/fleet-update/legacy-update-facts.ts
+++ b/clients/gui-app/src/lib/host/fleet-update/legacy-update-facts.ts
@@ -1,0 +1,126 @@
+import {
+  compareHostVersions,
+  isValidHostVersion,
+} from "@traycer-clients/shared/host-version/compare-host-versions";
+
+/**
+ * What the INSTALL and STAGED records say about an update the legacy path has
+ * parked — facts the coarse `updateProgress` marker cannot carry, because the
+ * legacy updater withdraws its marker when a busy host makes it stop.
+ *
+ * Two parks, both real states a person needs to see and act on:
+ *
+ * - **Activation debt**: `install.json` names a version the running process is
+ *   not. Bytes were swapped by an actor that could not (or, refused as busy,
+ *   did not) restart the host — Desktop's launch converge, or `traycer host
+ *   update` declining to interrupt live work. The only way forward is a
+ *   restart, and the Overview offers it.
+ * - **Staged wait**: a newer host sits in `staged/` while the running host is
+ *   busy. The updater downloaded it, found work in progress, and left it for
+ *   the next idle run (or a forced one). The Overview says so and offers the
+ *   force.
+ *
+ * Derived CLIENT-SIDE from `host.getInstallationInfo` + `host.status`, on
+ * purpose: both reads are already on the page, no host release is needed, and
+ * a remote host is described exactly as a local one. The cost is that these
+ * facts refresh at the installation-info poll's cadence, which is why that
+ * method polls at all.
+ */
+export interface LegacyUpdateFacts {
+  readonly activationDebt: { readonly installedVersion: string } | null;
+  readonly stagedWait: {
+    readonly stagedVersion: string;
+    /**
+     * From the SAME `host.status` read as `busy`. `null` when the host is busy
+     * but counts no session — a claim, not work — so the sentence stays
+     * unquantified rather than promising that "0 sessions" will finish.
+     */
+    readonly blockingSessionCount: number | null;
+  } | null;
+}
+
+/** The two records, in the minimum shape both wire minors satisfy. */
+export type LegacyUpdateInstallation =
+  | { readonly status: "unmanaged" }
+  | {
+      readonly status: "managed";
+      readonly installRecord: {
+        readonly version: string;
+        readonly runtimeVersion: string | null;
+      };
+      readonly stagedRecord: { readonly version: string } | null;
+    };
+
+export const NO_LEGACY_UPDATE_FACTS: LegacyUpdateFacts = {
+  activationDebt: null,
+  stagedWait: null,
+};
+
+/**
+ * Mirrors the CLI's `readActivationState` (`commands/host-update.ts`) rule for
+ * rule, so the Overview and the updater agree about what debt IS:
+ *
+ * | Install record          | Running version                                 | Debt |
+ * | ----------------------- | ----------------------------------------------- | ---- |
+ * | `runtimeVersion` set    | equal to the stamp                              | no   |
+ * | `runtimeVersion` set    | anything else (either direction, SemVer or not) | yes  |
+ * | no `runtimeVersion`     | not valid SemVer (a foreign runtime)            | no   |
+ * | no `runtimeVersion`     | comparable to `version` and unequal             | yes  |
+ * | no `runtimeVersion`     | equal, or incomparable                          | no   |
+ * | `unmanaged` / no record | anything                                        | no   |
+ *
+ * The runtime-stamp domain is EQUALITY, never ordering: a staging host's stamp
+ * is `staging.<epoch>.<sha>`, and a SemVer guard in front of that comparison
+ * would classify every staging host as foreign. The catalog-version fallback
+ * (a record with no stamp yet) keeps the CLI's release-version policy, under
+ * which `0.0.0-dev` IS valid SemVer and a dev host beside a `1.3.0` record reads
+ * as debt — the same answer the CLI gives, stated here so nobody "fixes" it on
+ * one side only.
+ *
+ * Desktop's `deriveActivationState` is deliberately NOT mirrored: it has no
+ * SemVer fallback and reports a stamp-less record as `activationUnknown`, which
+ * the landing banner treats as debt. That widening stays the banner's; a
+ * cross-reader unification is a separate decision.
+ */
+export function deriveLegacyUpdateFacts(input: {
+  readonly installation: LegacyUpdateInstallation | null;
+  readonly runningVersion: string;
+  readonly busy: boolean;
+  readonly busySessionCount: number | null;
+}): LegacyUpdateFacts {
+  const { installation } = input;
+  if (installation === null || installation.status !== "managed") {
+    return NO_LEGACY_UPDATE_FACTS;
+  }
+  const installed = installation.installRecord;
+  const activationDebt = isActivationDebt(installed, input.runningVersion)
+    ? { installedVersion: installed.version }
+    : null;
+  const staged = installation.stagedRecord;
+  const stagedWait =
+    staged !== null && staged.version !== installed.version && input.busy
+      ? {
+          stagedVersion: staged.version,
+          blockingSessionCount:
+            input.busySessionCount !== null && input.busySessionCount > 0
+              ? input.busySessionCount
+              : null,
+        }
+      : null;
+  return { activationDebt, stagedWait };
+}
+
+function isActivationDebt(
+  installed: {
+    readonly version: string;
+    readonly runtimeVersion: string | null;
+  },
+  runningVersion: string,
+): boolean {
+  if (installed.runtimeVersion !== null) {
+    return runningVersion !== installed.runtimeVersion;
+  }
+  if (!isValidHostVersion(runningVersion)) return false;
+  const comparison = compareHostVersions(runningVersion, installed.version);
+  return comparison.comparable && comparison.ordering !== "equal";
+}

--- a/clients/shared/cli-install/package-manager-upgrade-command.ts
+++ b/clients/shared/cli-install/package-manager-upgrade-command.ts
@@ -1,0 +1,71 @@
+import {
+  cliInstallSourceSchema,
+  type CliInstallSource,
+} from "@traycer/protocol/config/installation-records";
+
+/**
+ * The published npm name of the Traycer CLI. Client copy only - the wire and
+ * the persisted install records never carry it - which is why it lives here
+ * and not in `@traycer/protocol` (the client⇄host contract, which the CLI
+ * inlines and which a copy change must never rebuild). Coupled to the npm
+ * publish in `scripts/native-packaging/publish-cli-package-managers.cjs`.
+ */
+export const CLI_NPM_PACKAGE_NAME = "@traycerai/cli";
+
+/**
+ * One command vocabulary for every surface that tells a person how to
+ * upgrade a package-manager-owned CLI: the CLI's own refusal hints
+ * (`manifest/cli-manifest.ts` → `cli upgrade`, `host/compat-recovery.ts`),
+ * Desktop's launch reconciliation sidecar (`electron-main/cli/cli-reconcile`),
+ * the GUI's CLI-floor remedy and its add-host instructions. One table, so a
+ * manager's command cannot drift between them.
+ *
+ * Each entry is coupled to the artifact the same repo renders for that
+ * manager in `scripts/native-packaging/publish-cli-package-managers.cjs`:
+ * `brew upgrade traycer` to the tap's `Formula/traycer.rb`, `Traycer.CLI` to
+ * the winget manifest id, `traycer-cli` to the Scoop bucket and the deb/rpm
+ * package name. Rename one there and this row is the other end.
+ *
+ * What the feeds CARRY is only partly knowable from this repo, and the copy
+ * built on this table says no more than that: `publish-cli-package-managers.yml`
+ * runs on `release: released` (never a prerelease) and publishes npm - a
+ * prerelease reaches npm only by `workflow_dispatch`, under its own dist-tag -
+ * and opens the Homebrew formula PR; the winget/Scoop/deb/rpm renders exist in
+ * the script but no workflow here publishes them. So an npm floor remedy pins
+ * the exact required version (`latest` is stable-only), and every other
+ * manager's command - Homebrew's included - is a rolling stable upgrade that
+ * a prerelease floor cannot rely on; the GUI offers installation help there.
+ */
+export const PACKAGE_MANAGER_UPGRADE_COMMAND = {
+  homebrew: "brew upgrade traycer",
+  npm: `npm install -g ${CLI_NPM_PACKAGE_NAME}@latest`,
+  winget: "winget upgrade Traycer.CLI",
+  scoop: "scoop update traycer-cli",
+  apt: "sudo apt update && sudo apt install --only-upgrade traycer-cli",
+  rpm: "sudo dnf upgrade traycer-cli",
+} as const satisfies Record<
+  Exclude<CliInstallSource, "desktop" | "manual">,
+  string
+>;
+
+/**
+ * The package-manager-owned install sources, DERIVED from the table so there
+ * is one definition of the set: adding a manager to `cliInstallSourceSchema`
+ * fails the `satisfies` above until it has a command, and every consumer of
+ * the set (the CLI's upgrade-ownership contract, Desktop's reconcile branch,
+ * the GUI remedy's routing) reads the same keys. Before this, the CLI and
+ * Desktop each kept a hand-written copy that a new manager missed silently.
+ */
+export type PackageManagerCliSource =
+  keyof typeof PACKAGE_MANAGER_UPGRADE_COMMAND;
+
+export function isPackageManagerCliSource(
+  source: CliInstallSource,
+): source is PackageManagerCliSource {
+  return Object.hasOwn(PACKAGE_MANAGER_UPGRADE_COMMAND, source);
+}
+
+export const PACKAGE_MANAGER_CLI_SOURCES: ReadonlySet<CliInstallSource> =
+  new Set<CliInstallSource>(
+    cliInstallSourceSchema.options.filter(isPackageManagerCliSource),
+  );

--- a/clients/shared/host-lock/cross-process-lock.ts
+++ b/clients/shared/host-lock/cross-process-lock.ts
@@ -10,8 +10,8 @@ import {
   type ProcessStartIdentity,
 } from "@traycer/protocol/host/lifecycle";
 import {
-  readProcessStartIdentity,
-  readProcessStartTimeMs,
+  ownProcessStartIdentity,
+  ownProcessStartTimeMs,
   verifyProcessIdentity,
   type ProcessIdentityVerdict,
 } from "./process-identity";
@@ -497,8 +497,8 @@ async function acquireBreakLock(
   const payload: BreakLockPayload = {
     pid: process.pid,
     startedAt: nowIso(),
-    processStartedAtMs: readProcessStartTimeMs(process.pid),
-    processStartIdentity: readProcessStartIdentity(process.pid),
+    processStartedAtMs: ownProcessStartTimeMs(),
+    processStartIdentity: ownProcessStartIdentity(),
     token,
   };
   if ((await createBreakLockFile(breakLockPath, payload)) === "created") {
@@ -953,8 +953,9 @@ function newAcquisitionMetadata(reason: string): LockMetadata {
     startedAt: nowIso(),
     hostname: hostnameSafe(),
     token: randomUUID(),
-    processStartedAtMs: readProcessStartTimeMs(process.pid),
-    processStartIdentity: readProcessStartIdentity(process.pid),
+    // Cached own-process reads: an acquisition must not cost a spawn.
+    processStartedAtMs: ownProcessStartTimeMs(),
+    processStartIdentity: ownProcessStartIdentity(),
   };
 }
 

--- a/clients/shared/host-lock/process-identity.ts
+++ b/clients/shared/host-lock/process-identity.ts
@@ -287,7 +287,16 @@ export function computeProcessIdentityVerdict(
 // point of it). Backs the own-pid identity check below; unlike the general
 // cross-pid path there is nothing to gain from re-probing on every call.
 let cachedOwnStartIdentity: ProcessStartIdentity | null | "unread" = "unread";
-function ownProcessStartIdentity(): ProcessStartIdentity | null {
+/**
+ * This process's own creation stamp, or `null` when the platform probe could
+ * not produce one. Exported for a writer that stamps its own identity into a
+ * record another process will later hold against `verifyProcessIdentity`
+ * (the CLI's update-progress marker): stamping from the cached read that the
+ * own-pid verdict compares against keeps "what we wrote" and "what we are"
+ * one value, and a first call that fails stays `null` for the life of the
+ * process rather than flipping between reads.
+ */
+export function ownProcessStartIdentity(): ProcessStartIdentity | null {
   if (cachedOwnStartIdentity === "unread") {
     cachedOwnStartIdentity = readProcessStartIdentity(process.pid);
   }

--- a/clients/shared/host-lock/process-identity.ts
+++ b/clients/shared/host-lock/process-identity.ts
@@ -429,6 +429,21 @@ export function readProcessStartTimeMs(pid: number): number | null {
   return readProcessStartTimeMsImpl(pid);
 }
 
+// This process's own start time, read once and cached like
+// `ownProcessStartIdentity`: a process's start time never changes, and the
+// read is a `ps`/`powershell` spawn on macOS and Windows. Backs every lock
+// acquisition's metadata (`cross-process-lock.ts`), which used to pay the
+// spawn per acquisition - and the update-progress marker lock now
+// acquires several times per `host update`. Reads the raw reader, not the
+// test seam: the seam models OTHER processes' probes.
+let cachedOwnStartTimeMs: number | null | "unread" = "unread";
+export function ownProcessStartTimeMs(): number | null {
+  if (cachedOwnStartTimeMs === "unread") {
+    cachedOwnStartTimeMs = readProcessStartTimeMsImpl(process.pid);
+  }
+  return cachedOwnStartTimeMs;
+}
+
 function readProcessStartTimeMsImpl(pid: number): number | null {
   if (!Number.isInteger(pid) || pid <= 0) return null;
   return process.platform === "win32"

--- a/clients/shared/host-lock/process-identity.ts
+++ b/clients/shared/host-lock/process-identity.ts
@@ -36,8 +36,12 @@ export type ProcessLivenessVerdict = "alive" | "dead" | "indeterminate";
 
 // Cross-platform process-liveness probe. POSIX uses `process.kill(pid, 0)`;
 // Windows uses `tasklist /FI "PID eq <pid>" /NH /FO CSV` and asserts the
-// CSV body is non-empty.
-function probeProcessLiveness(pid: number): ProcessLivenessVerdict {
+// CSV body is non-empty. Exported for the one reader that needs the
+// tri-state itself outside this module (`host update`'s progress-marker
+// takeover keeps a displaced record for restore only on POSITIVE evidence
+// its writer is alive); `verifyProcessIdentity` below consumes it too, and
+// everything else goes through the collapsing `isProcessAlive`.
+export function probeProcessLiveness(pid: number): ProcessLivenessVerdict {
   if (!Number.isInteger(pid) || pid <= 0) return "dead";
   if (process.platform === "win32") {
     let stdout: string;

--- a/clients/shared/host-version/client-floor-reason.ts
+++ b/clients/shared/host-version/client-floor-reason.ts
@@ -1,0 +1,39 @@
+// The one authored reason on `host available`'s legacy wire contract that
+// a client may act on: "this asset is unavailable because the CLI executing
+// on the host is below the release's floor", which upgrading that CLI can
+// repair. The CLI authors it (`commands/host-available.ts`), the GUI's
+// Overview recognises it (`host-overview-updates-state.ts`) and renders the
+// remedy. Both endpoints are OSS clients, which is why this lives in
+// `clients/shared`: no host code authors `unavailableReason` today. The day
+// one does, this prefix is wire contract and belongs in `@traycer/protocol`.
+
+import type { HostAvailableManifest } from "@traycer/protocol/host/maintenance/schemas";
+
+/**
+ * The released CLI's projected refusal is the executing CLI's verdict. A
+ * stored version can be newer after a best-effort copy into the host's tools
+ * failed, and a withdrawn platform build can retain its hash. Neither is a
+ * substitute for this authored reason on the legacy wire contract. An
+ * UNREADABLE floor (registry text that is not a version) is deliberately
+ * authored WITHOUT this prefix (`registry/client-floor.ts`): no upgrade
+ * repairs it, and a reader keyed on the prefix would otherwise keep asking
+ * for one.
+ */
+export const HOST_CLIENT_FLOOR_REASON_PREFIX = "Needs Traycer CLI ";
+
+/** The wire asset's availability fields - what the predicate reads. */
+export type HostClientFloorAsset = Pick<
+  HostAvailableManifest["versions"][number]["platforms"][string],
+  "available" | "unavailableReason"
+>;
+
+export function isHostClientFloorRefusedAsset(
+  asset: HostClientFloorAsset | null,
+): boolean {
+  return (
+    asset !== null &&
+    !asset.available &&
+    asset.unavailableReason?.startsWith(HOST_CLIENT_FLOOR_REASON_PREFIX) ===
+      true
+  );
+}

--- a/clients/shared/host-version/release-line.ts
+++ b/clients/shared/host-version/release-line.ts
@@ -35,6 +35,28 @@
 import { isValidHostVersion } from "./compare-host-versions";
 
 /**
+ * The released CLI's projected refusal is the executing CLI's verdict. A
+ * stored version can be newer after a best-effort copy into the host's tools
+ * failed, and a withdrawn platform build can retain its hash. Neither is a
+ * substitute for this authored reason on the legacy wire contract.
+ */
+export const HOST_CLIENT_FLOOR_REASON_PREFIX = "Needs Traycer CLI ";
+
+export function isHostClientFloorRefusedAsset(
+  asset: {
+    readonly available: boolean;
+    readonly unavailableReason: string | null;
+  } | null,
+): boolean {
+  return (
+    asset !== null &&
+    !asset.available &&
+    asset.unavailableReason?.startsWith(HOST_CLIENT_FLOOR_REASON_PREFIX) ===
+      true
+  );
+}
+
+/**
  * A version's `X.Y.Z` core — the identity an implicit follow is scoped to.
  *
  * Module-private, like {@link hostReleaseLine} below: no caller outside this

--- a/clients/shared/host-version/release-line.ts
+++ b/clients/shared/host-version/release-line.ts
@@ -35,28 +35,6 @@
 import { isValidHostVersion } from "./compare-host-versions";
 
 /**
- * The released CLI's projected refusal is the executing CLI's verdict. A
- * stored version can be newer after a best-effort copy into the host's tools
- * failed, and a withdrawn platform build can retain its hash. Neither is a
- * substitute for this authored reason on the legacy wire contract.
- */
-export const HOST_CLIENT_FLOOR_REASON_PREFIX = "Needs Traycer CLI ";
-
-export function isHostClientFloorRefusedAsset(
-  asset: {
-    readonly available: boolean;
-    readonly unavailableReason: string | null;
-  } | null,
-): boolean {
-  return (
-    asset !== null &&
-    !asset.available &&
-    asset.unavailableReason?.startsWith(HOST_CLIENT_FLOOR_REASON_PREFIX) ===
-      true
-  );
-}
-
-/**
  * A version's `X.Y.Z` core — the identity an implicit follow is scoped to.
  *
  * Module-private, like {@link hostReleaseLine} below: no caller outside this

--- a/clients/traycer-cli/src/commands/__tests__/cli-entrypoint-registration.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/cli-entrypoint-registration.test.ts
@@ -177,6 +177,41 @@ vi.mock("../../installer/apply", () => ({
   },
 }));
 
+// SAFETY: `buildHostUpdateCommand` reads the REAL `~/.traycer/host/pid.json`
+// for activation debt and re-derives it after a no-op apply, and it writes
+// the REAL update-progress marker. Left unmocked on a developer machine, the
+// `applyHost` no-op above reads the developer's live host as debt against the
+// mocked 1.0.0 record, asks the live host whether it is busy, and tries to
+// restart it - and leaves a `failed` marker in the real host home when the
+// service mock cannot. Every test here that runs `host update` sees "no
+// running host" and an in-memory marker.
+vi.mock("../../host/pid-metadata", () => ({
+  readHostPidMetadata: vi.fn(async () => null),
+}));
+
+vi.mock("../../host/update-progress-marker", () => ({
+  claimUpdateProgressMarkerBeforeLock: vi.fn(async () => ({
+    outcome: "published",
+    displaced: null,
+  })),
+  createUpdateProgressMarkerIfAbsent: vi.fn(async () => "created"),
+  readUpdateProgressMarker: vi.fn(async () => null),
+  replaceUpdateProgressMarkerIfUnchanged: vi.fn(async () => "replaced"),
+  deleteUpdateProgressMarkerIfUnchanged: vi.fn(async () => "cleared"),
+  deleteUpdateProgressMarker: vi.fn(async () => {}),
+  writeUpdateProgressMarker: vi.fn(async () => {}),
+  progressRecord: (fields: {
+    state: "updating" | "failed";
+    error: string | null;
+    targetVersion: string;
+  }) => ({
+    ...fields,
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    writerId: "test-writer",
+  }),
+  sameProgress: () => true,
+}));
+
 vi.mock("../../host/free-port-kill", () => ({
   killConflictingPortOwner: async (opts: {
     readonly pid: number;

--- a/clients/traycer-cli/src/commands/__tests__/cli-entrypoint-registration.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/cli-entrypoint-registration.test.ts
@@ -221,6 +221,7 @@ vi.mock("../../host/update-progress-marker", async (importOriginal) => ({
     ...fields,
     updatedAt: "2026-01-01T00:00:00.000Z",
     writerId: "test-writer",
+    writerStartIdentity: null,
   }),
   sameProgress: () => true,
 }));

--- a/clients/traycer-cli/src/commands/__tests__/cli-entrypoint-registration.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/cli-entrypoint-registration.test.ts
@@ -185,14 +185,27 @@ vi.mock("../../installer/apply", () => ({
 // restart it - and leaves a `failed` marker in the real host home when the
 // service mock cannot. Every test here that runs `host update` sees "no
 // running host" and an in-memory marker.
-vi.mock("../../host/pid-metadata", () => ({
+//
+// Both factories SPREAD the real module rather than hand-list every export:
+// a hand-listed factory silently omits whatever the module adds later, and
+// vitest throws only on ACCESS of a missing mocked export - so the gap stays
+// invisible until some other registered module imports the omission
+// (CodeRabbit r3944370766 caught `isValidLocalHostWebsocketUrl` and
+// `removeHostPidMetadata` missing here) or a new export like
+// `updateProgressRecordHasLiveWriter` lands. Overriding on top of the spread
+// keeps every export this suite does not care about wired to the real
+// implementation instead of silently `undefined`.
+vi.mock("../../host/pid-metadata", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../host/pid-metadata")>()),
   readHostPidMetadata: vi.fn(async () => null),
 }));
 
-vi.mock("../../host/update-progress-marker", () => ({
+vi.mock("../../host/update-progress-marker", async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import("../../host/update-progress-marker")
+  >()),
   claimUpdateProgressMarkerBeforeLock: vi.fn(async () => ({
     outcome: "published",
-    displaced: null,
   })),
   createUpdateProgressMarkerIfAbsent: vi.fn(async () => "created"),
   readUpdateProgressMarker: vi.fn(async () => null),

--- a/clients/traycer-cli/src/commands/__tests__/host-available.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/host-available.test.ts
@@ -57,7 +57,7 @@ import {
 } from "../host-available";
 import type { HostInstallRecord } from "../../manifest/host-install";
 import type { CommandContext } from "../../runner/runner";
-import { HOST_CLIENT_FLOOR_REASON_PREFIX } from "@traycer-clients/shared/host-version/release-line";
+import { HOST_CLIENT_FLOOR_REASON_PREFIX } from "@traycer-clients/shared/host-version/client-floor-reason";
 
 const AVAILABLE_ASSET: HostPlatformAsset = {
   available: true,
@@ -184,11 +184,44 @@ describe("buildHostAvailableListing", () => {
     // reason pins must turn RED under that concrete ablation.
     // Treating floor-unreadable as a non-refusal reddens the unavailable pin.
     expect(asset?.available).toBe(false);
-    expect
-      .soft(reason)
-      .toBe(
-        `host registry: version '1.2.0' declares requiredCliVersion ${JSON.stringify(requiredCliVersion)}, which is not a version this CLI can compare against. The manifest is wrong; do not work around it by installing a different version.`,
-      );
+    expect(reason).toBe(
+      `host registry: version '1.2.0' declares requiredCliVersion ${JSON.stringify(requiredCliVersion)}, which is not a version this CLI can compare against. The manifest is wrong; do not work around it by installing a different version.`,
+    );
+    expect(reason?.startsWith(HOST_CLIENT_FLOOR_REASON_PREFIX)).toBe(false);
+  });
+
+  it("bounds an unreadable required CLI floor before rendering it into the reason", () => {
+    // The reason travels inside `host available`'s one unsplittable JSON
+    // line (see the pipe-buffer note above) and onto every GUI surface;
+    // registry text that failed to parse as a version is the one input
+    // with no bound of its own. Falsification: render the raw value and the
+    // length assertion below reddens.
+    const requiredCliVersion = `1.3.0\u0007${"x".repeat(500)}`;
+    const listing = buildHostAvailableListing({
+      manifest: {
+        schemaVersion: 1,
+        generatedAt: "2026-06-22T01:00:00.000Z",
+        latest: "1.2.0",
+        versions: [
+          {
+            ...createEntry("1.2.0"),
+            requiredCliVersion,
+            minimumEpoch: null,
+          },
+        ],
+      },
+      manifestUrl: "https://example.com/versions.json",
+      platformKey: "darwin-arm64",
+      includePreReleases: false,
+      includePreReleasesSource: "explicit-exclude",
+      cliVersion: "1.2.0",
+    });
+    const reason =
+      listing.manifest.versions[0].platforms["darwin-arm64"]?.unavailableReason;
+    expect(reason).toContain('declares requiredCliVersion "1.3.0?xxx');
+    expect(reason).toContain("... (506 characters)");
+    expect(reason).not.toContain("x".repeat(100));
+    expect(reason).not.toContain("\u0007");
     expect(reason?.startsWith(HOST_CLIENT_FLOOR_REASON_PREFIX)).toBe(false);
   });
 

--- a/clients/traycer-cli/src/commands/__tests__/host-available.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/host-available.test.ts
@@ -57,6 +57,7 @@ import {
 } from "../host-available";
 import type { HostInstallRecord } from "../../manifest/host-install";
 import type { CommandContext } from "../../runner/runner";
+import { HOST_CLIENT_FLOOR_REASON_PREFIX } from "@traycer-clients/shared/host-version/release-line";
 
 const AVAILABLE_ASSET: HostPlatformAsset = {
   available: true,
@@ -127,6 +128,68 @@ describe("buildHostAvailableListing", () => {
     expect(
       listing.manifest.versions[1].platforms["darwin-arm64"]?.available,
     ).toBe(true);
+  });
+
+  it("authors the floor reason with the shared literal prefix", () => {
+    const listing = buildHostAvailableListing({
+      manifest: {
+        schemaVersion: 1,
+        generatedAt: "2026-06-22T01:00:00.000Z",
+        latest: "1.2.0",
+        versions: [
+          {
+            ...createEntry("1.2.0"),
+            requiredCliVersion: "10.0.0",
+            minimumEpoch: null,
+          },
+        ],
+      },
+      manifestUrl: "https://example.com/versions.json",
+      platformKey: "darwin-arm64",
+      includePreReleases: false,
+      includePreReleasesSource: "explicit-exclude",
+      cliVersion: "9.9.9",
+    });
+    const reason =
+      listing.manifest.versions[0].platforms["darwin-arm64"]?.unavailableReason;
+    expect(reason?.startsWith(HOST_CLIENT_FLOOR_REASON_PREFIX)).toBe(true);
+    expect(HOST_CLIENT_FLOOR_REASON_PREFIX).toBe("Needs Traycer CLI ");
+  });
+
+  it("keeps a malformed required CLI floor unavailable without the repair prefix", () => {
+    const requiredCliVersion = "1.3.0; npm install -g @traycerai/cli@latest";
+    const listing = buildHostAvailableListing({
+      manifest: {
+        schemaVersion: 1,
+        generatedAt: "2026-06-22T01:00:00.000Z",
+        latest: "1.2.0",
+        versions: [
+          {
+            ...createEntry("1.2.0"),
+            requiredCliVersion,
+            minimumEpoch: null,
+          },
+        ],
+      },
+      manifestUrl: "https://example.com/versions.json",
+      platformKey: "darwin-arm64",
+      includePreReleases: false,
+      includePreReleasesSource: "explicit-exclude",
+      cliVersion: "1.2.0",
+    });
+    const asset = listing.manifest.versions[0].platforms["darwin-arm64"];
+    const reason = asset?.unavailableReason;
+    // Restoring the shared repair prefix for an unreadable floor would make
+    // the GUI offer an impossible upgrade command; these exact unreadable
+    // reason pins must turn RED under that concrete ablation.
+    // Treating floor-unreadable as a non-refusal reddens the unavailable pin.
+    expect(asset?.available).toBe(false);
+    expect
+      .soft(reason)
+      .toBe(
+        `host registry: version '1.2.0' declares requiredCliVersion ${JSON.stringify(requiredCliVersion)}, which is not a version this CLI can compare against. The manifest is wrong; do not work around it by installing a different version.`,
+      );
+    expect(reason?.startsWith(HOST_CLIENT_FLOOR_REASON_PREFIX)).toBe(false);
   });
 
   it("hides prerelease host versions by default", () => {

--- a/clients/traycer-cli/src/commands/__tests__/host-install.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/host-install.test.ts
@@ -491,6 +491,9 @@ describe("buildHostInstallCommand", () => {
       environment: "production",
       bootstrap: { enableLinger: false, allowSelfInvocation: true },
       force: false,
+      // A first install has no disruption boundary to report: there is no
+      // running host of this environment to stop, and no marker to stamp.
+      onWillStopHost: null,
     });
   });
 

--- a/clients/traycer-cli/src/commands/__tests__/host-update-downgrade-command-failure.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/host-update-downgrade-command-failure.test.ts
@@ -7,7 +7,8 @@ import { CLI_ERROR_CODES, cliError } from "../../runner/errors";
 const mocks = vi.hoisted(() => ({
   installHostDowngradeMock: vi.fn(),
   readHostInstallRecordMock: vi.fn(),
-  writeUpdateProgressMarkerMock: vi.fn(),
+  claimUpdateProgressMarkerBeforeLockMock: vi.fn(),
+  createUpdateProgressMarkerIfAbsentMock: vi.fn(),
   deleteUpdateProgressMarkerMock: vi.fn(),
   deleteUpdateProgressMarkerIfUnchangedMock: vi.fn(),
   replaceUpdateProgressMarkerMock: vi.fn(),
@@ -24,7 +25,10 @@ vi.mock("../../manifest/host-install", () => ({
 }));
 
 vi.mock("../../host/update-progress-marker", () => ({
-  writeUpdateProgressMarker: mocks.writeUpdateProgressMarkerMock,
+  claimUpdateProgressMarkerBeforeLock:
+    mocks.claimUpdateProgressMarkerBeforeLockMock,
+  createUpdateProgressMarkerIfAbsent:
+    mocks.createUpdateProgressMarkerIfAbsentMock,
   deleteUpdateProgressMarker: mocks.deleteUpdateProgressMarkerMock,
   readUpdateProgressMarker: async () => null,
   deleteUpdateProgressMarkerIfUnchanged:
@@ -118,6 +122,10 @@ describe("host update explicit downgrade failure", () => {
     mocks.installHostDowngradeMock.mockRejectedValue(
       new Error("downgrade commit failed"),
     );
+    mocks.claimUpdateProgressMarkerBeforeLockMock.mockResolvedValue({
+      outcome: "published",
+      displaced: null,
+    });
     mocks.replaceUpdateProgressMarkerMock.mockResolvedValue("replaced");
 
     await expect(
@@ -129,10 +137,14 @@ describe("host update explicit downgrade failure", () => {
       })(fakeCtx()),
     ).rejects.toThrow("downgrade commit failed");
 
-    // Only the initial `updating` write happens unconditionally; the
+    // The initial `updating` is the pre-lock CLAIM (conditional, once); the
     // `failed` stamp goes through the compare-and-swap against it.
-    expect(mocks.writeUpdateProgressMarkerMock).toHaveBeenCalledTimes(1);
-    expect(mocks.writeUpdateProgressMarkerMock).toHaveBeenNthCalledWith(
+    expect(mocks.claimUpdateProgressMarkerBeforeLockMock).toHaveBeenCalledTimes(
+      1,
+    );
+    expect(
+      mocks.claimUpdateProgressMarkerBeforeLockMock,
+    ).toHaveBeenNthCalledWith(
       1,
       "production",
       expect.objectContaining({
@@ -167,6 +179,10 @@ describe("host update explicit downgrade failure", () => {
         exitCode: 1,
       }),
     );
+    mocks.claimUpdateProgressMarkerBeforeLockMock.mockResolvedValue({
+      outcome: "published",
+      displaced: null,
+    });
     mocks.deleteUpdateProgressMarkerIfUnchangedMock.mockResolvedValue(
       "cleared",
     );
@@ -180,10 +196,12 @@ describe("host update explicit downgrade failure", () => {
       })(fakeCtx()),
     ).rejects.toMatchObject({ code: CLI_ERROR_CODES.HOST_BUSY });
 
-    // Only the initial `updating` write happens - the park withdraws it
+    // Only the initial `updating` claim happens - the park withdraws it
     // rather than stamping a second, `failed` one.
-    expect(mocks.writeUpdateProgressMarkerMock).toHaveBeenCalledTimes(1);
-    const written = mocks.writeUpdateProgressMarkerMock.mock
+    expect(mocks.claimUpdateProgressMarkerBeforeLockMock).toHaveBeenCalledTimes(
+      1,
+    );
+    const written = mocks.claimUpdateProgressMarkerBeforeLockMock.mock
       .calls[0][1] as HostUpdateProgress;
     expect(written.state).toBe("updating");
     expect(written.targetVersion).toBe("1.2.0");

--- a/clients/traycer-cli/src/commands/__tests__/host-update-downgrade-command-failure.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/host-update-downgrade-command-failure.test.ts
@@ -2,12 +2,14 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { CommandContext } from "../../runner/runner";
 import type { HostInstallRecord } from "../../manifest/host-install";
 import type { HostUpdateProgress } from "../../host/update-progress-marker";
+import { CLI_ERROR_CODES, cliError } from "../../runner/errors";
 
 const mocks = vi.hoisted(() => ({
   installHostDowngradeMock: vi.fn(),
   readHostInstallRecordMock: vi.fn(),
   writeUpdateProgressMarkerMock: vi.fn(),
   deleteUpdateProgressMarkerMock: vi.fn(),
+  deleteUpdateProgressMarkerIfUnchangedMock: vi.fn(),
   replaceUpdateProgressMarkerMock: vi.fn(),
   probeHostHealthMock: vi.fn(),
   installDispatchAckStamperMock: vi.fn(),
@@ -25,7 +27,8 @@ vi.mock("../../host/update-progress-marker", () => ({
   writeUpdateProgressMarker: mocks.writeUpdateProgressMarkerMock,
   deleteUpdateProgressMarker: mocks.deleteUpdateProgressMarkerMock,
   readUpdateProgressMarker: async () => null,
-  deleteUpdateProgressMarkerIfUnchanged: async () => "absent",
+  deleteUpdateProgressMarkerIfUnchanged:
+    mocks.deleteUpdateProgressMarkerIfUnchangedMock,
   replaceUpdateProgressMarkerIfUnchanged: mocks.replaceUpdateProgressMarkerMock,
   progressRecord: (fields: {
     state: "updating" | "failed";
@@ -149,6 +152,48 @@ describe("host update explicit downgrade failure", () => {
         error: "downgrade commit failed",
       }),
     );
+    expect(mocks.probeHostHealthMock).not.toHaveBeenCalled();
+    expect(mocks.deleteUpdateProgressMarkerMock).not.toHaveBeenCalled();
+  });
+
+  it("HOST_BUSY from installHostDowngrade parks: deletes the written updating marker and never stamps failed", async () => {
+    mocks.installDispatchAckStamperMock.mockReturnValue(null);
+    mocks.readHostInstallRecordMock.mockResolvedValue(installedRecord);
+    mocks.installHostDowngradeMock.mockRejectedValue(
+      cliError({
+        code: CLI_ERROR_CODES.HOST_BUSY,
+        message: "The running host has work in progress",
+        details: null,
+        exitCode: 1,
+      }),
+    );
+    mocks.deleteUpdateProgressMarkerIfUnchangedMock.mockResolvedValue(
+      "cleared",
+    );
+
+    await expect(
+      buildHostUpdateCommand({
+        allowDowngrade: true,
+        force: false,
+        versionRequest: "1.2.0",
+        ackNonce: null,
+      })(fakeCtx()),
+    ).rejects.toMatchObject({ code: CLI_ERROR_CODES.HOST_BUSY });
+
+    // Only the initial `updating` write happens - the park withdraws it
+    // rather than stamping a second, `failed` one.
+    expect(mocks.writeUpdateProgressMarkerMock).toHaveBeenCalledTimes(1);
+    const written = mocks.writeUpdateProgressMarkerMock.mock
+      .calls[0][1] as HostUpdateProgress;
+    expect(written.state).toBe("updating");
+    expect(written.targetVersion).toBe("1.2.0");
+    expect(
+      mocks.deleteUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenCalledWith("production", written);
+    // Falsification: drop the HOST_BUSY arm in the catch (fall through to
+    // the generic failure branch) and this goes red - `replace…` would be
+    // called with a `failed` record instead.
+    expect(mocks.replaceUpdateProgressMarkerMock).not.toHaveBeenCalled();
     expect(mocks.probeHostHealthMock).not.toHaveBeenCalled();
     expect(mocks.deleteUpdateProgressMarkerMock).not.toHaveBeenCalled();
   });

--- a/clients/traycer-cli/src/commands/__tests__/host-update-downgrade-command-failure.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/host-update-downgrade-command-failure.test.ts
@@ -47,6 +47,7 @@ vi.mock("../../host/update-progress-marker", () => ({
     ...fields,
     updatedAt: new Date().toISOString(),
     writerId: "test-writer",
+    writerStartIdentity: null,
   }),
   sameProgress: () => true,
 }));

--- a/clients/traycer-cli/src/commands/__tests__/host-update-downgrade-command-failure.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/host-update-downgrade-command-failure.test.ts
@@ -34,6 +34,11 @@ vi.mock("../../host/update-progress-marker", () => ({
   deleteUpdateProgressMarkerIfUnchanged:
     mocks.deleteUpdateProgressMarkerIfUnchangedMock,
   replaceUpdateProgressMarkerIfUnchanged: mocks.replaceUpdateProgressMarkerMock,
+  // No writer-liveness fixture here (this suite never exercises the
+  // takeover/pre-lock-replace paths that consult it) - a `failed` has no
+  // writer by construction, everything else is treated as live.
+  updateProgressRecordHasLiveWriter: (record: HostUpdateProgress) =>
+    record.state !== "failed",
   progressRecord: (fields: {
     state: "updating" | "failed";
     error: string | null;
@@ -124,7 +129,6 @@ describe("host update explicit downgrade failure", () => {
     );
     mocks.claimUpdateProgressMarkerBeforeLockMock.mockResolvedValue({
       outcome: "published",
-      displaced: null,
     });
     mocks.replaceUpdateProgressMarkerMock.mockResolvedValue("replaced");
 
@@ -181,7 +185,6 @@ describe("host update explicit downgrade failure", () => {
     );
     mocks.claimUpdateProgressMarkerBeforeLockMock.mockResolvedValue({
       outcome: "published",
-      displaced: null,
     });
     mocks.deleteUpdateProgressMarkerIfUnchangedMock.mockResolvedValue(
       "cleared",

--- a/clients/traycer-cli/src/commands/__tests__/host-update-downgrade.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/host-update-downgrade.test.ts
@@ -19,7 +19,10 @@ const mocks = vi.hoisted(() => ({
   createDefaultRegistryClientMock: vi.fn(),
   busy: false,
   beforeSwapError: false,
-  lifecycleCalls: [] as Array<{ readonly force: boolean }>,
+  lifecycleCalls: [] as Array<{
+    readonly force: boolean;
+    readonly onWillStopHost: (() => void) | null;
+  }>,
 }));
 
 // Keep the real staging and commit primitives, but route their host paths to a
@@ -101,8 +104,14 @@ vi.mock("../../host/busy-check", () => ({
 }));
 
 vi.mock("../../service/install-lifecycle", () => ({
-  createServiceInstallLifecycle: (options: { readonly force: boolean }) => {
-    mocks.lifecycleCalls.push({ force: options.force });
+  createServiceInstallLifecycle: (options: {
+    readonly force: boolean;
+    readonly onWillStopHost: (() => void) | null;
+  }) => {
+    mocks.lifecycleCalls.push({
+      force: options.force,
+      onWillStopHost: options.onWillStopHost,
+    });
     const state = {
       priorState: "running" as ServiceInstallLifecycleState["priorState"],
       stoppedBeforeSwap: false,
@@ -238,10 +247,49 @@ describe("installHostDowngrade", () => {
     expect(readFileSync(join(installDir(), "traycer-host"), "utf8")).toBe(
       "new",
     );
-    expect(mocks.lifecycleCalls).toEqual([{ force: true }]);
+    expect(mocks.lifecycleCalls).toMatchObject([{ force: true }]);
     expect(await readHostInstallRecord(ENV)).toMatchObject({
       version: "1.2.0",
     });
+  });
+
+  it("hands ONE disruption boundary to both actuators - the lifecycle's onWillStopHost and the commit's onWillSwap - and it fires before the install record changes", async () => {
+    // The downgrade forwards `onWillDisruptHost` to the lifecycle
+    // (`onWillStopHost`, fired before the stop under its authority check -
+    // mocked here, so the identity is what this half pins) and to the
+    // commit (`onWillSwap`, fired after the pre-swap verify - real here,
+    // so the ORDER is what that half pins: the record read inside the
+    // callback is still the old install). Falsification: drop either
+    // forward in `installHostDowngrade` - the identity assertion or the
+    // call count below goes red.
+    await writeInstalled("1.3.0-rc.1", "old");
+    configureRegistry("1.2.0", "new");
+    // The hook is synchronous, so what it can observe is read synchronously:
+    // the installed bytes at the instant it fires.
+    const bytesAtCall: string[] = [];
+    const onWillDisruptHost = (): void => {
+      bytesAtCall.push(
+        readFileSync(join(installDir(), "traycer-host"), "utf8"),
+      );
+    };
+    await installHostDowngrade({
+      environment: ENV,
+      version: "1.2.0",
+      force: false,
+      onProgress: noopProgress,
+      onBeforeCommit: async () => undefined,
+      onWillDisruptHost,
+    });
+
+    expect(mocks.lifecycleCalls).toHaveLength(1);
+    expect(mocks.lifecycleCalls[0].onWillStopHost).toBe(onWillDisruptHost);
+    // The real commit fired the same function exactly once (`onWillSwap`),
+    // while the old bytes were still installed; the mocked lifecycle never
+    // calls its copy, so the count isolates the commit's forward.
+    expect(bytesAtCall).toEqual(["old"]);
+    expect(readFileSync(join(installDir(), "traycer-host"), "utf8")).toBe(
+      "new",
+    );
   });
 
   it("checks busy before commit and discards the owned staged tree without replacing the install", async () => {

--- a/clients/traycer-cli/src/commands/__tests__/host-update-downgrade.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/host-update-downgrade.test.ts
@@ -289,18 +289,48 @@ describe("installHostDowngrade", () => {
     expect(readdirSync(stagingRoot())).toEqual([]);
   });
 
-  it("invokes onBeforeCommit exactly once, before the commit lands - even on the busy path, since the busy gate runs AFTER it", async () => {
-    // `onBeforeCommit` is `host update`'s re-assertion hook, run under the
-    // mutation lock before anything else touches the install - the source's
-    // own comment on the field says it runs "before the busy gate and the
-    // commit". Observing the install record from INSIDE the callback (rather
-    // than just counting calls) pins that ordering: a call that ran after
-    // the swap would see the NEW version already committed.
+  it("invokes onBeforeCommit exactly once, after the busy gate and before the commit lands", async () => {
+    // `onBeforeCommit` is `host update`'s marker-takeover hook, run under
+    // the mutation lock AFTER the busy gate and immediately before the
+    // commit - the first point at which this command is the only updater
+    // acting AND has committed to acting (a busy refusal must come first,
+    // so a parked run never seizes a marker for work it then does not do).
+    // Observing the install record from INSIDE the callback (rather than
+    // just counting calls) pins the "before the commit" half: a call that
+    // ran after the swap would see the NEW version already committed.
+    await writeInstalled("1.3.0-rc.1", "old");
+    configureRegistry("1.2.0", "new");
+    mocks.busy = false;
+    let beforeCommitCalls = 0;
+    let installedVersionAtCallTime: string | undefined;
+
+    await installHostDowngrade({
+      environment: ENV,
+      version: "1.2.0",
+      force: false,
+      onProgress: noopProgress,
+      onBeforeCommit: async () => {
+        beforeCommitCalls += 1;
+        const installed = await readHostInstallRecord(ENV);
+        installedVersionAtCallTime = installed?.version;
+      },
+    });
+
+    expect(beforeCommitCalls).toBe(1);
+    expect(installedVersionAtCallTime).toBe("1.3.0-rc.1");
+    expect(readFileSync(join(installDir(), "traycer-host"), "utf8")).toBe(
+      "new",
+    );
+  });
+
+  it("is NOT called when the busy gate throws - a parked run never seizes the marker for work it then does not do", async () => {
+    // Falsification: move the `onBeforeCommit()` call in
+    // `installHostDowngrade` to before `assertHostNotBusy` and
+    // `beforeCommitCalls` below goes to 1 even though the run is busy.
     await writeInstalled("1.3.0-rc.1", "old");
     configureRegistry("1.2.0", "new");
     mocks.busy = true;
     let beforeCommitCalls = 0;
-    let installedVersionAtCallTime: string | undefined;
 
     await expect(
       installHostDowngrade({
@@ -310,17 +340,11 @@ describe("installHostDowngrade", () => {
         onProgress: noopProgress,
         onBeforeCommit: async () => {
           beforeCommitCalls += 1;
-          const installed = await readHostInstallRecord(ENV);
-          installedVersionAtCallTime = installed?.version;
         },
       }),
     ).rejects.toThrow("host is busy");
 
-    // Falsification: move the `onBeforeCommit()` call in
-    // `installHostDowngrade` to after `assertHostNotBusy` and this goes red
-    // - a busy host would reject before the hook ever ran.
-    expect(beforeCommitCalls).toBe(1);
-    expect(installedVersionAtCallTime).toBe("1.3.0-rc.1");
+    expect(beforeCommitCalls).toBe(0);
     expect(readFileSync(join(installDir(), "traycer-host"), "utf8")).toBe(
       "old",
     );

--- a/clients/traycer-cli/src/commands/__tests__/host-update-downgrade.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/host-update-downgrade.test.ts
@@ -242,6 +242,7 @@ describe("installHostDowngrade", () => {
     });
 
     expect(outcome.outcome).toBe("applied");
+    if (outcome.outcome !== "applied") throw new Error("unreachable");
     expect(outcome.previous?.version).toBe("1.3.0-rc.1");
     expect(outcome.record.version).toBe("1.2.0");
     expect(readFileSync(join(installDir(), "traycer-host"), "utf8")).toBe(
@@ -251,6 +252,39 @@ describe("installHostDowngrade", () => {
     expect(await readHostInstallRecord(ENV)).toMatchObject({
       version: "1.2.0",
     });
+  });
+
+  it("re-derives the install record under its lock: the requested version already installed by another actor is a no-op - no commit, no busy gate, no onBeforeCommit, the owned staged tree discarded", async () => {
+    // The caller decided "requested below installed" before this lock. An
+    // explicit `host update 1.2.0` of another actor landed meanwhile.
+    // Falsification: drop the under-lock version check and identical bytes
+    // are committed over the install with a lifecycle stop/start.
+    await writeInstalled("1.2.0", "old");
+    configureRegistry("1.2.0", "new");
+    mocks.busy = true;
+    let onBeforeCommitCalls = 0;
+
+    const outcome = await installHostDowngrade({
+      environment: ENV,
+      version: "1.2.0",
+      force: false,
+      onProgress: noopProgress,
+      onBeforeCommit: async () => {
+        onBeforeCommitCalls += 1;
+      },
+      onWillDisruptHost: () => undefined,
+    });
+
+    expect(outcome).toEqual({ outcome: "no-op", installedVersion: "1.2.0" });
+    expect(onBeforeCommitCalls).toBe(0);
+    expect(mocks.lifecycleCalls).toEqual([]);
+    expect(readFileSync(join(installDir(), "traycer-host"), "utf8")).toBe(
+      "old",
+    );
+    expect(await readHostInstallRecord(ENV)).toMatchObject({
+      version: "1.2.0",
+    });
+    expect(readdirSync(stagingRoot())).toEqual([]);
   });
 
   it("hands ONE disruption boundary to both actuators - the lifecycle's onWillStopHost and the commit's onWillSwap - and it fires before the install record changes", async () => {

--- a/clients/traycer-cli/src/commands/__tests__/host-update-downgrade.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/host-update-downgrade.test.ts
@@ -229,6 +229,7 @@ describe("installHostDowngrade", () => {
       force: true,
       onProgress: noopProgress,
       onBeforeCommit: async () => undefined,
+      onWillDisruptHost: () => undefined,
     });
 
     expect(outcome.outcome).toBe("applied");
@@ -255,6 +256,7 @@ describe("installHostDowngrade", () => {
         force: false,
         onProgress: noopProgress,
         onBeforeCommit: async () => undefined,
+        onWillDisruptHost: () => undefined,
       }),
     ).rejects.toThrow("host is busy");
 
@@ -279,6 +281,7 @@ describe("installHostDowngrade", () => {
         force: false,
         onProgress: noopProgress,
         onBeforeCommit: async () => undefined,
+        onWillDisruptHost: () => undefined,
       }),
     ).rejects.toThrow("precommit failed");
 
@@ -314,6 +317,7 @@ describe("installHostDowngrade", () => {
         const installed = await readHostInstallRecord(ENV);
         installedVersionAtCallTime = installed?.version;
       },
+      onWillDisruptHost: () => undefined,
     });
 
     expect(beforeCommitCalls).toBe(1);
@@ -341,6 +345,7 @@ describe("installHostDowngrade", () => {
         onBeforeCommit: async () => {
           beforeCommitCalls += 1;
         },
+        onWillDisruptHost: () => undefined,
       }),
     ).rejects.toThrow("host is busy");
 

--- a/clients/traycer-cli/src/commands/__tests__/host-update-downgrade.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/host-update-downgrade.test.ts
@@ -228,6 +228,7 @@ describe("installHostDowngrade", () => {
       version: "1.2.0",
       force: true,
       onProgress: noopProgress,
+      onBeforeCommit: async () => undefined,
     });
 
     expect(outcome.outcome).toBe("applied");
@@ -253,6 +254,7 @@ describe("installHostDowngrade", () => {
         version: "1.2.0",
         force: false,
         onProgress: noopProgress,
+        onBeforeCommit: async () => undefined,
       }),
     ).rejects.toThrow("host is busy");
 
@@ -276,6 +278,7 @@ describe("installHostDowngrade", () => {
         version: "1.2.0",
         force: false,
         onProgress: noopProgress,
+        onBeforeCommit: async () => undefined,
       }),
     ).rejects.toThrow("precommit failed");
 
@@ -284,5 +287,42 @@ describe("installHostDowngrade", () => {
     );
     expect(existsSync(join(stagingRoot(), "install-"))).toBe(false);
     expect(readdirSync(stagingRoot())).toEqual([]);
+  });
+
+  it("invokes onBeforeCommit exactly once, before the commit lands - even on the busy path, since the busy gate runs AFTER it", async () => {
+    // `onBeforeCommit` is `host update`'s re-assertion hook, run under the
+    // mutation lock before anything else touches the install - the source's
+    // own comment on the field says it runs "before the busy gate and the
+    // commit". Observing the install record from INSIDE the callback (rather
+    // than just counting calls) pins that ordering: a call that ran after
+    // the swap would see the NEW version already committed.
+    await writeInstalled("1.3.0-rc.1", "old");
+    configureRegistry("1.2.0", "new");
+    mocks.busy = true;
+    let beforeCommitCalls = 0;
+    let installedVersionAtCallTime: string | undefined;
+
+    await expect(
+      installHostDowngrade({
+        environment: ENV,
+        version: "1.2.0",
+        force: false,
+        onProgress: noopProgress,
+        onBeforeCommit: async () => {
+          beforeCommitCalls += 1;
+          const installed = await readHostInstallRecord(ENV);
+          installedVersionAtCallTime = installed?.version;
+        },
+      }),
+    ).rejects.toThrow("host is busy");
+
+    // Falsification: move the `onBeforeCommit()` call in
+    // `installHostDowngrade` to after `assertHostNotBusy` and this goes red
+    // - a busy host would reject before the hook ever ran.
+    expect(beforeCommitCalls).toBe(1);
+    expect(installedVersionAtCallTime).toBe("1.3.0-rc.1");
+    expect(readFileSync(join(installDir(), "traycer-host"), "utf8")).toBe(
+      "old",
+    );
   });
 });

--- a/clients/traycer-cli/src/commands/__tests__/host-update.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/host-update.test.ts
@@ -1322,6 +1322,59 @@ describe("buildHostUpdateCommand — stage consumed by another actor while waiti
     );
   });
 
+  it("EXPLICIT request for 2.0.0+foo, another actor committed AND activated 2.0.0+bar: refused as E_UNEXPECTED and STAMPED - the comparator's 'equal' is not the artifact the caller named", async () => {
+    // Codex r3945265711: the binding refuses (string identity), but the
+    // catch's observed-running check compared with `compareHostVersions`,
+    // which calls `2.0.0+foo` and `2.0.0+bar` equal, and withdrew the
+    // refusal's record - remote clients saw no failure for an artifact
+    // that was never delivered. Falsification: compare the record with
+    // the target through the comparator in `targetObservedRunning` and the
+    // delete below fires while the `failed` replace does not.
+    mocks.downloadAndStageHostMock.mockResolvedValue({
+      outcome: "promoted",
+      stagedVersion: "2.0.0+foo",
+      installedVersion: "1.0.0",
+    } satisfies HostDownloadOutcome);
+    mocks.readHostInstallRecordMock.mockResolvedValue(
+      sampleRecord("2.0.0+bar"),
+    );
+    mocks.applyHostMock.mockResolvedValue({
+      outcome: "no-op",
+      installedVersion: "2.0.0+bar",
+    } satisfies ApplyHostOutcome);
+    mocks.readHostPidMetadataMock.mockResolvedValue(pidAt("2.0.0+bar"));
+    mocks.identityVerdictMock.mockResolvedValue("current");
+
+    await expect(
+      buildHostUpdateCommand({
+        force: false,
+        allowDowngrade: false,
+        versionRequest: "2.0.0+foo",
+        ackNonce: null,
+      })(fakeCtx()),
+    ).rejects.toMatchObject({
+      code: CLI_ERROR_CODES.UNEXPECTED,
+      details: {
+        expectedInstalledVersion: "2.0.0+foo",
+        actualInstalledVersion: "2.0.0+bar",
+      },
+    });
+    expect(mocks.stopHostForRestartWithAttemptMock).not.toHaveBeenCalled();
+    expect(
+      mocks.deleteUpdateProgressMarkerIfUnchangedMock,
+    ).not.toHaveBeenCalled();
+    expect(
+      mocks.replaceUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenCalledWith(
+      "production",
+      expect.objectContaining({
+        state: "updating",
+        targetVersion: "2.0.0+foo",
+      }),
+      expect.objectContaining({ state: "failed", targetVersion: "2.0.0+foo" }),
+    );
+  });
+
   it("EXPLICIT request, the running host is not a release version (`foreign-runtime` reading) over a record another actor moved: refused, never the no-op at that record", async () => {
     // Falsification: leave `installedVersion` off the `foreign-runtime`
     // reading (or skip it in the binding) and this reports "host already
@@ -2642,10 +2695,15 @@ describe("buildHostUpdateCommand update-progress marker (T16)", () => {
     ).not.toHaveBeenCalled();
   });
 
-  it("the observed-match comparator ignores build metadata: 2.0.0+build.7 satisfies an announced 2.0.0", async () => {
-    // `targetObservedRunning` uses `compareHostVersions` (the catalog-domain
-    // comparator, same as `readActivationState`), not `===` - the installed
-    // record's build metadata must not defeat a real match.
+  it("build metadata is artifact identity: a host observed at 2.0.0+build.7 does NOT satisfy an announced 2.0.0 - the lost download is stamped, not withdrawn", async () => {
+    // `targetObservedRunning` is string identity of the record with the
+    // target - the grain `installedVersionMismatch` binds an explicit
+    // request at, and the rule the host's `isStaleUpdateProgress` applies
+    // to this marker - not the catalog comparator, which ignores build
+    // metadata. Falsification: compare with `compareHostVersions` and this
+    // run's record is withdrawn over a host that never ran what it
+    // announced (round 15, Codex r3945265711 - the explicit variant is
+    // pinned beside the recovery arm).
     mocks.downloadAndStageHostMock.mockImplementation(
       async (opts: DownloadAndStageHostOptions) => {
         if (opts.onWillDownload === null) {
@@ -2682,14 +2740,61 @@ describe("buildHostUpdateCommand update-progress marker (T16)", () => {
       .calls[0][1] as HostUpdateProgress;
     expect(
       mocks.deleteUpdateProgressMarkerIfUnchangedMock,
-    ).toHaveBeenCalledWith("production", written);
+    ).not.toHaveBeenCalled();
     expect(
       mocks.replaceUpdateProgressMarkerIfUnchangedMock,
-    ).not.toHaveBeenCalledWith(
+    ).toHaveBeenCalledWith(
       "production",
       written,
-      expect.objectContaining({ state: "failed" }),
+      expect.objectContaining({
+        state: "failed",
+        targetVersion: "2.0.0",
+        error: "download failed: ECONNRESET",
+      }),
     );
+  });
+
+  it("the same artifact observed running - record 2.0.0 for an announced 2.0.0 - is withdrawn (control for the build-metadata pin)", async () => {
+    mocks.downloadAndStageHostMock.mockImplementation(
+      async (opts: DownloadAndStageHostOptions) => {
+        if (opts.onWillDownload === null) {
+          throw new Error("expected onWillDownload to be provided");
+        }
+        await opts.onWillDownload("2.0.0");
+        throw new Error("download failed: ECONNRESET");
+      },
+    );
+    mocks.readHostInstallRecordMock.mockResolvedValue(sampleRecord("2.0.0"));
+    mocks.readHostPidMetadataMock.mockResolvedValue({
+      pid: 4242,
+      hostId: "host-1",
+      version: "2.0.0",
+      websocketUrl: "ws://127.0.0.1:51820/rpc",
+      startedAt: "2026-01-01T00:00:00.000Z",
+      processStartIdentity: null,
+      layer0: null,
+      layer0Slot: null,
+    });
+    mocks.identityVerdictMock.mockResolvedValue("current");
+
+    await expect(
+      buildHostUpdateCommand({
+        force: false,
+        allowDowngrade: false,
+        ackNonce: null,
+      })(fakeCtx()),
+    ).rejects.toThrow("download failed: ECONNRESET");
+
+    const written = mocks.claimUpdateProgressMarkerBeforeLockMock.mock
+      .calls[0][1] as HostUpdateProgress;
+    expect(
+      mocks.deleteUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenCalledWith("production", written);
+    expect(
+      mocks.replaceUpdateProgressMarkerIfUnchangedMock.mock.calls.filter(
+        (call) => (call[2] as HostUpdateProgress).state === "failed",
+      ),
+    ).toEqual([]);
   });
 });
 
@@ -3735,6 +3840,51 @@ describe("buildHostUpdateCommand — activation debt (installed-up-to-date short
     ).toHaveBeenCalledWith(
       "production",
       expect.objectContaining({ state: "failed", targetVersion: "2.0.0" }),
+    );
+    expect(result.human).toContain("no-op");
+  });
+
+  it("a failed marker naming 2.0.0+foo over a host observed at 2.0.0+bar is NOT stale - build metadata is artifact identity for the stale-failed rule too, as it is for the host's", async () => {
+    // The same rule as `targetObservedRunning` (Codex r3945265711): the
+    // catalog comparator calls the two equal; the failure named an artifact
+    // this host never ran. Falsification: compare through
+    // `compareHostVersions` in `clearStaleFailedMarker` and the conditional
+    // delete below fires.
+    mocks.downloadAndStageHostMock.mockResolvedValue(upToDate("2.0.0+bar"));
+    mocks.readHostInstallRecordMock.mockResolvedValue(
+      sampleRecord("2.0.0+bar"),
+    );
+    mocks.readHostPidMetadataMock.mockResolvedValue(
+      pidRecord("2.0.0+bar", 4242),
+    );
+    mocks.identityVerdictMock.mockResolvedValue("current");
+    mocks.readUpdateProgressMarkerMock.mockResolvedValue({
+      state: "failed",
+      error: "host did not become healthy: tcp refused",
+      targetVersion: "2.0.0+foo",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      writerId: null,
+      writerStartIdentity: null,
+    });
+
+    const ctx = fakeCtx();
+    const result = await buildHostUpdateCommand({
+      force: false,
+      allowDowngrade: false,
+      ackNonce: null,
+    })(ctx);
+
+    expect(mocks.stopHostForRestartWithAttemptMock).not.toHaveBeenCalled();
+    expect(mocks.deleteUpdateProgressMarkerMock).not.toHaveBeenCalled();
+    expect(
+      mocks.deleteUpdateProgressMarkerIfUnchangedMock,
+    ).not.toHaveBeenCalled();
+    expect(vi.mocked(ctx.runtime.logger.info)).toHaveBeenCalledWith(
+      "Host update left the failed progress marker alone - it names a target the running host has not been observed at",
+      expect.objectContaining({
+        failedTargetVersion: "2.0.0+foo",
+        observedInstalledVersion: "2.0.0+bar",
+      }),
     );
     expect(result.human).toContain("no-op");
   });
@@ -5727,7 +5877,7 @@ describe("buildHostUpdateCommand — reassertMarkerUnderLock under the lock", ()
       {
         environment: "production",
         failedTargetVersion: "3.0.0",
-        observedRunningVersion: "2.0.0",
+        observedInstalledVersion: "2.0.0",
       },
     );
   });

--- a/clients/traycer-cli/src/commands/__tests__/host-update.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/host-update.test.ts
@@ -47,6 +47,12 @@ const mocks = vi.hoisted(() => ({
   deleteUpdateProgressMarkerIfUnchangedMock: vi.fn(),
   replaceUpdateProgressMarkerIfUnchangedMock: vi.fn(),
   createUpdateProgressMarkerIfAbsentMock: vi.fn(),
+  updateProgressRecordHasLiveWriterMock: vi.fn(),
+  // The writerIds `armActivationDefaults`'s `updateProgressRecordHasLiveWriterMock`
+  // wiring treats as dead - a fixture DECIDES liveness explicitly rather than
+  // shelling out to a real `isProcessAlive`. Reset per test by
+  // `armActivationDefaults` itself.
+  deadWriterIds: new Set<string>(),
   probeHostHealthMock: vi.fn(),
   readHostPidMetadataMock: vi.fn(),
   identityVerdictMock: vi.fn(),
@@ -77,6 +83,8 @@ vi.mock("../../host/update-progress-marker", () => ({
     mocks.replaceUpdateProgressMarkerIfUnchangedMock,
   createUpdateProgressMarkerIfAbsent:
     mocks.createUpdateProgressMarkerIfAbsentMock,
+  updateProgressRecordHasLiveWriter:
+    mocks.updateProgressRecordHasLiveWriterMock,
   progressRecord: (fields: {
     state: "updating" | "failed";
     error: string | null;
@@ -374,16 +382,26 @@ function fakeCtx(): CommandContext {
 // override wins for that call and simply does not touch `mocks.disk`.
 function armActivationDefaults(): void {
   mocks.disk.current = null;
+  mocks.deadWriterIds = new Set<string>();
   mocks.readUpdateProgressMarkerMock.mockImplementation(
     async () => mocks.disk.current,
   );
+  // The real rule shape (`updateProgressRecordHasLiveWriter`,
+  // `update-progress-marker.ts`): a `failed` has no writer by construction,
+  // and an `updating` is live unless the test has declared its writer dead
+  // in `mocks.deadWriterIds` - a fixture decides liveness explicitly rather
+  // than shelling out to a real `isProcessAlive`.
+  mocks.updateProgressRecordHasLiveWriterMock.mockImplementation(
+    (record: HostUpdateProgress) =>
+      record.state !== "failed" &&
+      (record.writerId === null || !mocks.deadWriterIds.has(record.writerId)),
+  );
   // Pre-lock claim: models the SAME rule `claimUpdateProgressMarkerBeforeLock`
   // applies against a real disk (see its production doc comment) - published
-  // into an empty path, deferred (nothing written) otherwise. `displaced` is
-  // null on both of these outcomes: a stale-record replace never happens
-  // against an initially-empty disk. A test that needs "replaced-stale" or
-  // "failed" overrides this mock directly; that override wins for its call
-  // and does not touch `mocks.disk`.
+  // into an empty path, deferred (nothing written) otherwise against a live
+  // writer's record. A test that needs "replaced-stale" or "failed"
+  // overrides this mock directly; that override wins for its call and does
+  // not touch `mocks.disk`.
   mocks.claimUpdateProgressMarkerBeforeLockMock.mockImplementation(
     async (
       _environment: string,
@@ -391,9 +409,9 @@ function armActivationDefaults(): void {
     ): Promise<UpdateProgressMarkerClaim> => {
       if (mocks.disk.current === null) {
         mocks.disk.current = next;
-        return { outcome: "published", displaced: null };
+        return { outcome: "published" };
       }
-      return { outcome: "deferred", displaced: null };
+      return { outcome: "deferred" };
     },
   );
   mocks.replaceUpdateProgressMarkerIfUnchangedMock.mockImplementation(
@@ -1306,7 +1324,6 @@ describe("buildHostUpdateCommand update-progress marker (T16)", () => {
     // under the lock either - `ownMarker.current` stays `null` end to end.
     mocks.claimUpdateProgressMarkerBeforeLockMock.mockResolvedValue({
       outcome: "failed",
-      displaced: null,
     });
 
     const result = await buildHostUpdateCommand({
@@ -1404,29 +1421,37 @@ describe("buildHostUpdateCommand update-progress marker (T16)", () => {
     expect(result.exitCode).toBe(0);
   });
 
-  it("a lost download after a deferred claim stamps nothing - the host was never disturbed", async () => {
-    // A download rejection that follows a deferred pre-lock claim never
+  it("a lost download after a deferred claim lands its failure into the path the other writer has since cleared", async () => {
+    // A download rejection that follows a deferred pre-lock claim still
     // reaches `markUpdateFailed`: the catch's `ownMarker.current === null`
-    // branch (host-update.ts) only stamps when `disruptionStarted` is true,
-    // and a download failure happens strictly before any disruptive work -
-    // `reportProgress` never saw `service-stop` or `swap`. The failure is
-    // reported by exit code and log alone, with zero marker mutation.
+    // branch (host-update.ts) stamps whenever `intendedTarget.current` was
+    // announced, regardless of `disruptionStarted` - a download failure
+    // happens strictly before any disruptive work, but the OTHER writer
+    // this run deferred to may have finished and cleared its own marker
+    // while this run was still downloading, leaving the path empty for
+    // this run's failure to claim.
     //
-    // Falsification: drop the `disruptionStarted` guard (call
-    // `markUpdateFailed` whenever `ownMarker.current === null`, regardless of
-    // whether the host was touched) and the "not called" assertions below go
-    // red - the catch would attempt a create-if-absent for a failure that
-    // never actually happened to the host.
-    mocks.claimUpdateProgressMarkerBeforeLockMock.mockResolvedValue({
-      outcome: "deferred",
-      displaced: null,
-    });
+    // Falsification: gate the null-record stamp on `disruptionStarted`
+    // again and `createUpdateProgressMarkerIfAbsentMock` below is never
+    // called - the catch would report nothing even though the announced
+    // target ("2.0.0") never landed anywhere.
+    const foreignRecord: HostUpdateProgress = {
+      state: "updating",
+      error: null,
+      targetVersion: "9.9.9",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      writerId: "foreign-writer",
+    };
+    mocks.disk.current = foreignRecord;
     mocks.downloadAndStageHostMock.mockImplementation(
       async (opts: DownloadAndStageHostOptions) => {
         if (opts.onWillDownload === null) {
           throw new Error("expected onWillDownload to be provided");
         }
         await opts.onWillDownload("2.0.0");
+        // The other writer's clear, mid-download: the disk is empty by the
+        // time this run's failure reaches `markUpdateFailed`.
+        mocks.disk.current = null;
         throw new Error("download failed: ECONNRESET");
       },
     );
@@ -1439,17 +1464,235 @@ describe("buildHostUpdateCommand update-progress marker (T16)", () => {
       })(fakeCtx()),
     ).rejects.toThrow("download failed: ECONNRESET");
 
-    // No marker write of any kind: `ownMarker.current` was `null` (the claim
-    // deferred) and the host was never disturbed, so the catch never calls
-    // `markUpdateFailed` at all.
+    // `ownMarker.current` was `null` (the claim deferred), so the stamp
+    // lands by create-if-absent against the announced target, never a CAS.
     expect(
       mocks.replaceUpdateProgressMarkerIfUnchangedMock,
     ).not.toHaveBeenCalled();
-    expect(mocks.createUpdateProgressMarkerIfAbsentMock).not.toHaveBeenCalled();
+    expect(mocks.createUpdateProgressMarkerIfAbsentMock).toHaveBeenCalledWith(
+      "production",
+      expect.objectContaining({
+        state: "failed",
+        targetVersion: "2.0.0",
+        error: "download failed: ECONNRESET",
+      }),
+    );
+    // Create-if-absent against an EMPTY path succeeds - nothing to replace
+    // or delete.
     expect(
       mocks.deleteUpdateProgressMarkerIfUnchangedMock,
     ).not.toHaveBeenCalled();
     expect(mocks.deleteUpdateProgressMarkerMock).not.toHaveBeenCalled();
+  });
+
+  it("a lost download after a deferred claim stamps nothing over the other writer's still-live marker", async () => {
+    // Same shape as above, but the other writer's marker is still on disk
+    // when this run's failure reaches `markUpdateFailed`: the create-if-
+    // absent primitive refuses to write over a live record, so the attempt
+    // is made and reported, but nothing on disk changes.
+    //
+    // Falsification: gate the null-record stamp on `disruptionStarted`
+    // again and `createUpdateProgressMarkerIfAbsentMock` below is never
+    // called, and the "did not stamp its failure" log line never fires.
+    const foreignRecord: HostUpdateProgress = {
+      state: "updating",
+      error: null,
+      targetVersion: "9.9.9",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      writerId: "foreign-writer",
+    };
+    mocks.disk.current = foreignRecord;
+    mocks.downloadAndStageHostMock.mockImplementation(
+      async (opts: DownloadAndStageHostOptions) => {
+        if (opts.onWillDownload === null) {
+          throw new Error("expected onWillDownload to be provided");
+        }
+        await opts.onWillDownload("2.0.0");
+        throw new Error("download failed: ECONNRESET");
+      },
+    );
+
+    const ctx = fakeCtx();
+    await expect(
+      buildHostUpdateCommand({
+        force: false,
+        allowDowngrade: false,
+        ackNonce: null,
+      })(ctx),
+    ).rejects.toThrow("download failed: ECONNRESET");
+
+    // The attempt is made exactly once - `armActivationDefaults`'s wiring
+    // reports "exists" against a still-live disk and leaves it untouched.
+    expect(mocks.createUpdateProgressMarkerIfAbsentMock).toHaveBeenCalledTimes(
+      1,
+    );
+    expect(mocks.createUpdateProgressMarkerIfAbsentMock).toHaveBeenCalledWith(
+      "production",
+      expect.objectContaining({
+        state: "failed",
+        targetVersion: "2.0.0",
+        error: "download failed: ECONNRESET",
+      }),
+    );
+    expect(ctx.runtime.logger.info).toHaveBeenCalledWith(
+      "Host update did not stamp its failure - the progress marker holds another record",
+      expect.objectContaining({
+        environment: "production",
+        targetVersion: "2.0.0",
+        outcome: "exists",
+      }),
+    );
+    expect(
+      mocks.replaceUpdateProgressMarkerIfUnchangedMock,
+    ).not.toHaveBeenCalled();
+    expect(
+      mocks.deleteUpdateProgressMarkerIfUnchangedMock,
+    ).not.toHaveBeenCalled();
+    expect(mocks.deleteUpdateProgressMarkerMock).not.toHaveBeenCalled();
+    // The foreign record on disk is byte-identical afterwards - the refused
+    // create-if-absent never touched it.
+    expect(mocks.disk.current).toEqual(foreignRecord);
+  });
+
+  it("a lost download after a deferred claim stamps nothing when the running host is OBSERVED at the announced target", async () => {
+    // `targetObservedRunning` (host-update.ts): the other writer this run
+    // deferred to has already delivered - the install record names the
+    // announced target and the live process is running it - so a `failed`
+    // for that target would report a failure that did not happen, and
+    // nothing short of the next no-work run's reconcile would ever clear
+    // it.
+    //
+    // Falsification: drop the `targetObservedRunning` guard (stamp
+    // whenever `intendedTarget.current !== null`, regardless of the
+    // observed state) and the "not called" assertion below goes red.
+    mocks.claimUpdateProgressMarkerBeforeLockMock.mockResolvedValue({
+      outcome: "deferred",
+    });
+    mocks.downloadAndStageHostMock.mockImplementation(
+      async (opts: DownloadAndStageHostOptions) => {
+        if (opts.onWillDownload === null) {
+          throw new Error("expected onWillDownload to be provided");
+        }
+        await opts.onWillDownload("2.0.0");
+        throw new Error("download failed: ECONNRESET");
+      },
+    );
+    mocks.readHostInstallRecordMock.mockResolvedValue(sampleRecord("2.0.0"));
+    mocks.readHostPidMetadataMock.mockResolvedValue({
+      pid: 4242,
+      hostId: "host-1",
+      version: "2.0.0",
+      websocketUrl: "ws://127.0.0.1:51820/rpc",
+      startedAt: "2026-01-01T00:00:00.000Z",
+      processStartIdentity: null,
+      layer0: null,
+      layer0Slot: null,
+    });
+    mocks.identityVerdictMock.mockResolvedValue("current");
+
+    const ctx = fakeCtx();
+    await expect(
+      buildHostUpdateCommand({
+        force: false,
+        allowDowngrade: false,
+        ackNonce: null,
+      })(ctx),
+    ).rejects.toThrow("download failed: ECONNRESET");
+
+    expect(mocks.createUpdateProgressMarkerIfAbsentMock).not.toHaveBeenCalled();
+    expect(ctx.runtime.logger.info).toHaveBeenCalledWith(
+      "Host update did not stamp its failure - the running host has been observed at the target it announced",
+      expect.objectContaining({
+        environment: "production",
+        targetVersion: "2.0.0",
+      }),
+    );
+  });
+
+  it("a lost download after a deferred claim still stamps when the running host is observed at an OLDER version", async () => {
+    // Same shape as the pin above, but the observed match is against the
+    // PREVIOUS version - the announced target ("2.0.0") was never actually
+    // delivered, so the failure is real and must land.
+    mocks.claimUpdateProgressMarkerBeforeLockMock.mockResolvedValue({
+      outcome: "deferred",
+    });
+    mocks.downloadAndStageHostMock.mockImplementation(
+      async (opts: DownloadAndStageHostOptions) => {
+        if (opts.onWillDownload === null) {
+          throw new Error("expected onWillDownload to be provided");
+        }
+        await opts.onWillDownload("2.0.0");
+        throw new Error("download failed: ECONNRESET");
+      },
+    );
+    mocks.readHostInstallRecordMock.mockResolvedValue(sampleRecord("1.0.0"));
+    mocks.readHostPidMetadataMock.mockResolvedValue({
+      pid: 4242,
+      hostId: "host-1",
+      version: "1.0.0",
+      websocketUrl: "ws://127.0.0.1:51820/rpc",
+      startedAt: "2026-01-01T00:00:00.000Z",
+      processStartIdentity: null,
+      layer0: null,
+      layer0Slot: null,
+    });
+    mocks.identityVerdictMock.mockResolvedValue("current");
+
+    await expect(
+      buildHostUpdateCommand({
+        force: false,
+        allowDowngrade: false,
+        ackNonce: null,
+      })(fakeCtx()),
+    ).rejects.toThrow("download failed: ECONNRESET");
+
+    expect(mocks.createUpdateProgressMarkerIfAbsentMock).toHaveBeenCalledWith(
+      "production",
+      expect.objectContaining({
+        state: "failed",
+        targetVersion: "2.0.0",
+        error: "download failed: ECONNRESET",
+      }),
+    );
+  });
+
+  it("a lost download after a deferred claim still stamps when the observed-state read itself fails - unreadable is not observed", async () => {
+    // `targetObservedRunning` never throws past its own boundary: a reading
+    // that cannot be taken (the install record read rejects) is "not
+    // observed", so the failure lands rather than being silently swallowed
+    // by an I/O error unrelated to the download.
+    mocks.claimUpdateProgressMarkerBeforeLockMock.mockResolvedValue({
+      outcome: "deferred",
+    });
+    mocks.downloadAndStageHostMock.mockImplementation(
+      async (opts: DownloadAndStageHostOptions) => {
+        if (opts.onWillDownload === null) {
+          throw new Error("expected onWillDownload to be provided");
+        }
+        await opts.onWillDownload("2.0.0");
+        throw new Error("download failed: ECONNRESET");
+      },
+    );
+    mocks.readHostInstallRecordMock.mockRejectedValue(
+      new Error("EACCES: permission denied"),
+    );
+
+    await expect(
+      buildHostUpdateCommand({
+        force: false,
+        allowDowngrade: false,
+        ackNonce: null,
+      })(fakeCtx()),
+    ).rejects.toThrow("download failed: ECONNRESET");
+
+    expect(mocks.createUpdateProgressMarkerIfAbsentMock).toHaveBeenCalledWith(
+      "production",
+      expect.objectContaining({
+        state: "failed",
+        targetVersion: "2.0.0",
+        error: "download failed: ECONNRESET",
+      }),
+    );
   });
 
   it("a deferred run that disturbed the host and failed lands its failure into an empty path", async () => {
@@ -1459,9 +1702,12 @@ describe("buildHostUpdateCommand update-progress marker (T16)", () => {
     // failure remotely - by creating a fresh `failed` record into whatever
     // empty path it finds, never by overwriting a live one.
     //
-    // Falsification: gate the stamp on `ownMarker.current !== null` only
-    // (drop the `disruptionStarted` branch) and `createUpdateProgressMarkerIfAbsentMock`
-    // below is never called.
+    // Falsification: gate the null-record stamp on `disruptionStarted`
+    // instead of `intendedTarget.current !== null` and
+    // `createUpdateProgressMarkerIfAbsentMock` below is still called here
+    // (this run did disturb the host) - the distinction only shows up in
+    // the two tests above, where disruption never started but a target was
+    // still announced.
     const foreignRecord: HostUpdateProgress = {
       state: "updating",
       error: null,
@@ -1525,20 +1771,19 @@ describe("buildHostUpdateCommand update-progress marker (T16)", () => {
 
   it("a marker-less run whose apply succeeds but whose host never becomes healthy lands its failure into an empty path - `markUpdateFailed`'s `ours === null` arm, the health-probe call site", async () => {
     // The OTHER call site that can pass `markUpdateFailed` a `null` `ours`
-    // (alongside the generic catch's `disruptionStarted` arm): the post-apply
-    // health-probe failure passes `ownMarker.current` unconditionally.
-    // Reached here by making BOTH pre-lock claims defer (a live foreign
-    // writer never let go of the marker) while the apply itself is mocked to
-    // succeed WITHOUT ever calling `onWillCommitStaged`, so
-    // `reassertMarkerUnderLock` never runs and `ownMarker.current` is still
-    // `null` when the probe fails.
+    // (alongside the generic catch's `intendedTarget.current !== null`
+    // arm): the post-apply health-probe failure passes `ownMarker.current`
+    // unconditionally. Reached here by making BOTH pre-lock claims defer (a
+    // live foreign writer never let go of the marker) while the apply
+    // itself is mocked to succeed WITHOUT ever calling `onWillCommitStaged`,
+    // so `reassertMarkerUnderLock` never runs and `ownMarker.current` is
+    // still `null` when the probe fails.
     //
     // Falsification: revert `markUpdateFailed`'s `ours === null` arm to a
     // log-only no-op and `createUpdateProgressMarkerIfAbsentMock` below is
     // never called.
     mocks.claimUpdateProgressMarkerBeforeLockMock.mockResolvedValue({
       outcome: "deferred",
-      displaced: null,
     });
     mocks.downloadAndStageHostMock.mockImplementation(
       async (opts: DownloadAndStageHostOptions) => {
@@ -1593,14 +1838,14 @@ describe("buildHostUpdateCommand update-progress marker (T16)", () => {
     // deferred would then reach the lock with no marker of its own even
     // though the other updater cleared meanwhile.
     mocks.claimUpdateProgressMarkerBeforeLockMock
-      .mockResolvedValueOnce({ outcome: "deferred", displaced: null })
+      .mockResolvedValueOnce({ outcome: "deferred" })
       .mockImplementationOnce(
         async (
           _environment: string,
           next: HostUpdateProgress,
         ): Promise<UpdateProgressMarkerClaim> => {
           mocks.disk.current = next;
-          return { outcome: "published", displaced: null };
+          return { outcome: "published" };
         },
       );
     mocks.downloadAndStageHostMock.mockImplementation(
@@ -1655,7 +1900,7 @@ describe("buildHostUpdateCommand update-progress marker (T16)", () => {
         next: HostUpdateProgress,
       ): Promise<UpdateProgressMarkerClaim> => {
         mocks.disk.current = next;
-        return { outcome: "replaced-stale", displaced: null };
+        return { outcome: "replaced-stale" };
       },
     );
     mocks.downloadAndStageHostMock.mockResolvedValue(promoted("2.0.0"));
@@ -1684,12 +1929,18 @@ describe("buildHostUpdateCommand update-progress marker (T16)", () => {
     expect(result.exitCode).toBe(0);
   });
 
-  it("a stale `failed` replaced by the pre-lock claim is put back when the run parks", async () => {
-    // Falsification: drop `displacedMarker.current = claim.displaced` in
-    // `publishUpdating` and the restore call below never happens - a park
-    // after a "replaced-stale" claim would instead withdraw (delete) this
-    // run's own record, erasing the still-possibly-true `failed` stamp the
-    // claim replaced.
+  it("a stale `failed` replaced by the pre-lock claim is NOT put back when the run parks - own is withdrawn and the path is left empty", async () => {
+    // `publishUpdating` no longer retains what a "replaced-stale" claim
+    // replaced (`displacedMarker.current` stays null on every pre-lock
+    // outcome - see its doc comment) - a `failed` no writer is acting on is
+    // not this run's to restore. A park after a "replaced-stale" claim
+    // therefore withdraws (deletes) this run's own record, same as any
+    // other run that never took over a live writer's marker.
+    //
+    // Falsification: retain the claim's replaced record and restore it on
+    // park (reintroduce `displacedMarker.current = claim.displaced`) and
+    // the `replaceUpdateProgressMarkerIfUnchangedMock` "not called with the
+    // stale record" assertion below goes red.
     const staleFailed: HostUpdateProgress = {
       state: "failed",
       error: "host did not become healthy: tcp refused",
@@ -1703,12 +1954,12 @@ describe("buildHostUpdateCommand update-progress marker (T16)", () => {
         next: HostUpdateProgress,
       ): Promise<UpdateProgressMarkerClaim> => {
         mocks.disk.current = next;
-        return { outcome: "replaced-stale", displaced: staleFailed };
+        return { outcome: "replaced-stale" };
       },
     );
     mocks.downloadAndStageHostMock.mockResolvedValue(promoted("2.0.0"));
     // Rejects busy WITHOUT ever calling `onWillCommitStaged` - the host is
-    // never disturbed, so the takeover restore (not a `failed` stamp) is
+    // never disturbed, so the park's withdrawal (not a `failed` stamp) is
     // what has to happen.
     mocks.applyHostMock.mockRejectedValue(
       cliError({
@@ -1730,14 +1981,354 @@ describe("buildHostUpdateCommand update-progress marker (T16)", () => {
 
     const written = mocks.claimUpdateProgressMarkerBeforeLockMock.mock
       .calls[0][1] as HostUpdateProgress;
-    // The park restores the STALE FAILED record the claim replaced, not a
-    // withdrawal (delete) of this run's own record.
+    // The park WITHDRAWS this run's own record - never a restore of the
+    // stale `failed` the claim replaced.
+    expect(
+      mocks.deleteUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenCalledWith("production", written);
     expect(
       mocks.replaceUpdateProgressMarkerIfUnchangedMock,
-    ).toHaveBeenCalledWith("production", written, staleFailed);
+    ).not.toHaveBeenCalledWith("production", written, staleFailed);
+    expect(mocks.disk.current).toBeNull();
+  });
+
+  it("a dead writer's `updating` replaced by the pre-lock claim is not re-planted by a busy park", async () => {
+    // Same shape as the stale-`failed` pin above, for the OTHER kind of
+    // stale record `updateProgressRecordHasLiveWriter` refuses to call
+    // live: an `updating` whose writer process is gone. Putting it back on
+    // a park would re-plant a marker no process will ever clear - a host
+    // without dead-writer suppression would render "updating" forever.
+    const deadWriterUpdating: HostUpdateProgress = {
+      state: "updating",
+      error: null,
+      targetVersion: "1.9.0",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      writerId: "424242-dead",
+    };
+    mocks.deadWriterIds.add("424242-dead");
+    mocks.claimUpdateProgressMarkerBeforeLockMock.mockImplementation(
+      async (
+        _environment: string,
+        next: HostUpdateProgress,
+      ): Promise<UpdateProgressMarkerClaim> => {
+        mocks.disk.current = next;
+        return { outcome: "replaced-stale" };
+      },
+    );
+    mocks.downloadAndStageHostMock.mockResolvedValue(promoted("2.0.0"));
+    mocks.applyHostMock.mockRejectedValue(
+      cliError({
+        code: CLI_ERROR_CODES.HOST_BUSY,
+        message: "The running host has work in progress",
+        details: null,
+        exitCode: 1,
+      }),
+    );
+    mocks.readHostStagedRecordMock.mockResolvedValue(null);
+
+    await expect(
+      buildHostUpdateCommand({
+        force: false,
+        allowDowngrade: false,
+        ackNonce: null,
+      })(fakeCtx()),
+    ).rejects.toMatchObject({ code: CLI_ERROR_CODES.HOST_BUSY });
+
+    const written = mocks.claimUpdateProgressMarkerBeforeLockMock.mock
+      .calls[0][1] as HostUpdateProgress;
+    expect(
+      mocks.deleteUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenCalledWith("production", written);
+    expect(
+      mocks.replaceUpdateProgressMarkerIfUnchangedMock,
+    ).not.toHaveBeenCalledWith("production", written, deadWriterUpdating);
+    expect(mocks.disk.current).toBeNull();
+  });
+
+  it("a retry whose download fails again stamps the NEW failure over its own record - the earlier `failed` is not restored", async () => {
+    // The pre-disruption failure counterpart to the two park pins above: a
+    // second failed attempt over a "replaced-stale" claim reports ITS OWN
+    // cause via the `ownMarker.current !== null` CAS branch, never a
+    // restore of the earlier attempt's `failed`.
+    const staleFailed: HostUpdateProgress = {
+      state: "failed",
+      error: "host did not become healthy: tcp refused",
+      targetVersion: "1.9.0",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      writerId: "dead-writer",
+    };
+    mocks.claimUpdateProgressMarkerBeforeLockMock.mockImplementation(
+      async (
+        _environment: string,
+        next: HostUpdateProgress,
+      ): Promise<UpdateProgressMarkerClaim> => {
+        mocks.disk.current = next;
+        return { outcome: "replaced-stale" };
+      },
+    );
+    mocks.downloadAndStageHostMock.mockImplementation(
+      async (opts: DownloadAndStageHostOptions) => {
+        if (opts.onWillDownload === null) {
+          throw new Error("expected onWillDownload to be provided");
+        }
+        await opts.onWillDownload("2.0.0");
+        throw new Error("download failed again: ECONNRESET");
+      },
+    );
+
+    await expect(
+      buildHostUpdateCommand({
+        force: false,
+        allowDowngrade: false,
+        ackNonce: null,
+      })(fakeCtx()),
+    ).rejects.toThrow("download failed again: ECONNRESET");
+
+    const written = mocks.claimUpdateProgressMarkerBeforeLockMock.mock
+      .calls[0][1] as HostUpdateProgress;
+    expect(
+      mocks.replaceUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenCalledWith(
+      "production",
+      written,
+      expect.objectContaining({
+        state: "failed",
+        error: "download failed again: ECONNRESET",
+        targetVersion: "2.0.0",
+      }),
+    );
+    expect(
+      mocks.replaceUpdateProgressMarkerIfUnchangedMock,
+    ).not.toHaveBeenCalledWith("production", written, staleFailed);
+  });
+
+  it("a pre-disruption failure over this run's own record is WITHDRAWN when the running host is OBSERVED at the announced target", async () => {
+    // The `ownMarker.current !== null` sibling of the null-arm
+    // `targetObservedRunning` pins above: an actor that writes no marker at
+    // all (`host apply --no-service`, Desktop's launch converge) can commit
+    // and activate the very target this run announced underneath its OWN
+    // live `updating`, consuming the shared stage its download then fails
+    // on. The record describes an update another actor completed, so it is
+    // WITHDRAWN, not stamped with a `failed` that would report a failure
+    // that did not happen.
+    //
+    // Falsification: drop the `targetObservedRunning` check from this arm
+    // (fall straight to the `else` stamp) and the "not called with a
+    // failed record" assertion below goes red.
+    mocks.downloadAndStageHostMock.mockImplementation(
+      async (opts: DownloadAndStageHostOptions) => {
+        if (opts.onWillDownload === null) {
+          throw new Error("expected onWillDownload to be provided");
+        }
+        await opts.onWillDownload("2.0.0");
+        throw new Error("download failed: ECONNRESET");
+      },
+    );
+    mocks.readHostInstallRecordMock.mockResolvedValue(sampleRecord("2.0.0"));
+    mocks.readHostPidMetadataMock.mockResolvedValue({
+      pid: 4242,
+      hostId: "host-1",
+      version: "2.0.0",
+      websocketUrl: "ws://127.0.0.1:51820/rpc",
+      startedAt: "2026-01-01T00:00:00.000Z",
+      processStartIdentity: null,
+      layer0: null,
+      layer0Slot: null,
+    });
+    mocks.identityVerdictMock.mockResolvedValue("current");
+
+    const ctx = fakeCtx();
+    await expect(
+      buildHostUpdateCommand({
+        force: false,
+        allowDowngrade: false,
+        ackNonce: null,
+      })(ctx),
+    ).rejects.toThrow("download failed: ECONNRESET");
+
+    const written = mocks.claimUpdateProgressMarkerBeforeLockMock.mock
+      .calls[0][1] as HostUpdateProgress;
+    expect(
+      mocks.deleteUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenCalledWith("production", written);
+    expect(
+      mocks.replaceUpdateProgressMarkerIfUnchangedMock,
+    ).not.toHaveBeenCalledWith(
+      "production",
+      written,
+      expect.objectContaining({ state: "failed" }),
+    );
+    expect(ctx.runtime.logger.info).toHaveBeenCalledWith(
+      "Host update failed before disturbing the host, and the running host has been observed at the target it announced; the progress marker was withdrawn",
+      expect.objectContaining({
+        environment: "production",
+        outcome: "cleared",
+      }),
+    );
+    expect(mocks.disk.current).toBeNull();
+  });
+
+  it("a pre-disruption failure over this run's own record still stamps `failed` when the observed version is OLDER", async () => {
+    // Same shape as the pin above, but the observed match is against the
+    // PREVIOUS version - the announced target was never actually
+    // delivered by anyone else, so this run's own failure is real.
+    mocks.downloadAndStageHostMock.mockImplementation(
+      async (opts: DownloadAndStageHostOptions) => {
+        if (opts.onWillDownload === null) {
+          throw new Error("expected onWillDownload to be provided");
+        }
+        await opts.onWillDownload("2.0.0");
+        throw new Error("download failed: ECONNRESET");
+      },
+    );
+    mocks.readHostInstallRecordMock.mockResolvedValue(sampleRecord("1.0.0"));
+    mocks.readHostPidMetadataMock.mockResolvedValue({
+      pid: 4242,
+      hostId: "host-1",
+      version: "1.0.0",
+      websocketUrl: "ws://127.0.0.1:51820/rpc",
+      startedAt: "2026-01-01T00:00:00.000Z",
+      processStartIdentity: null,
+      layer0: null,
+      layer0Slot: null,
+    });
+    mocks.identityVerdictMock.mockResolvedValue("current");
+
+    await expect(
+      buildHostUpdateCommand({
+        force: false,
+        allowDowngrade: false,
+        ackNonce: null,
+      })(fakeCtx()),
+    ).rejects.toThrow("download failed: ECONNRESET");
+
+    const written = mocks.claimUpdateProgressMarkerBeforeLockMock.mock
+      .calls[0][1] as HostUpdateProgress;
+    expect(
+      mocks.replaceUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenCalledWith(
+      "production",
+      written,
+      expect.objectContaining({
+        state: "failed",
+        targetVersion: "2.0.0",
+        error: "download failed: ECONNRESET",
+      }),
+    );
     expect(
       mocks.deleteUpdateProgressMarkerIfUnchangedMock,
     ).not.toHaveBeenCalled();
+  });
+
+  it("a failure AFTER disruption stamps `failed` over this run's own record even when the observed version matches the target - past the stop, whatever the host serves is reported", async () => {
+    // The `targetObservedRunning` withdrawal is pre-disruption ONLY: once
+    // `disruptionStarted` is true, this run's own stop/swap is what put the
+    // host in whatever state it now serves, and its failure must be
+    // reported regardless of an observed match.
+    //
+    // Falsification: drop the `!disruptionStarted` guard from the
+    // observed-match arm and this pin's stamp assertion goes red - the
+    // failure would be silently withdrawn instead.
+    mocks.downloadAndStageHostMock.mockResolvedValue(promoted("2.0.0"));
+    mocks.applyHostMock.mockImplementation(async (opts: ApplyHostOptions) => {
+      await opts.onWillCommitStaged?.("2.0.0");
+      opts.onProgress({
+        stage: "service-stop",
+        message: null,
+        percent: null,
+        bytes: null,
+        totalBytes: null,
+        workUnits: null,
+      });
+      throw new Error("commit failed");
+    });
+    mocks.readHostInstallRecordMock.mockResolvedValue(sampleRecord("2.0.0"));
+    mocks.readHostPidMetadataMock.mockResolvedValue({
+      pid: 4242,
+      hostId: "host-1",
+      version: "2.0.0",
+      websocketUrl: "ws://127.0.0.1:51820/rpc",
+      startedAt: "2026-01-01T00:00:00.000Z",
+      processStartIdentity: null,
+      layer0: null,
+      layer0Slot: null,
+    });
+    mocks.identityVerdictMock.mockResolvedValue("current");
+
+    await expect(
+      buildHostUpdateCommand({
+        force: false,
+        allowDowngrade: false,
+        ackNonce: null,
+      })(fakeCtx()),
+    ).rejects.toThrow("commit failed");
+
+    const written = mocks.claimUpdateProgressMarkerBeforeLockMock.mock
+      .calls[0][1] as HostUpdateProgress;
+    expect(
+      mocks.replaceUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenCalledWith(
+      "production",
+      written,
+      expect.objectContaining({
+        state: "failed",
+        targetVersion: "2.0.0",
+        error: "commit failed",
+      }),
+    );
+    expect(
+      mocks.deleteUpdateProgressMarkerIfUnchangedMock,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("the observed-match comparator ignores build metadata: 2.0.0+build.7 satisfies an announced 2.0.0", async () => {
+    // `targetObservedRunning` uses `compareHostVersions` (the catalog-domain
+    // comparator, same as `readActivationState`), not `===` - the installed
+    // record's build metadata must not defeat a real match.
+    mocks.downloadAndStageHostMock.mockImplementation(
+      async (opts: DownloadAndStageHostOptions) => {
+        if (opts.onWillDownload === null) {
+          throw new Error("expected onWillDownload to be provided");
+        }
+        await opts.onWillDownload("2.0.0");
+        throw new Error("download failed: ECONNRESET");
+      },
+    );
+    mocks.readHostInstallRecordMock.mockResolvedValue(
+      sampleRecord("2.0.0+build.7"),
+    );
+    mocks.readHostPidMetadataMock.mockResolvedValue({
+      pid: 4242,
+      hostId: "host-1",
+      version: "2.0.0+build.7",
+      websocketUrl: "ws://127.0.0.1:51820/rpc",
+      startedAt: "2026-01-01T00:00:00.000Z",
+      processStartIdentity: null,
+      layer0: null,
+      layer0Slot: null,
+    });
+    mocks.identityVerdictMock.mockResolvedValue("current");
+
+    await expect(
+      buildHostUpdateCommand({
+        force: false,
+        allowDowngrade: false,
+        ackNonce: null,
+      })(fakeCtx()),
+    ).rejects.toThrow("download failed: ECONNRESET");
+
+    const written = mocks.claimUpdateProgressMarkerBeforeLockMock.mock
+      .calls[0][1] as HostUpdateProgress;
+    expect(
+      mocks.deleteUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenCalledWith("production", written);
+    expect(
+      mocks.replaceUpdateProgressMarkerIfUnchangedMock,
+    ).not.toHaveBeenCalledWith(
+      "production",
+      written,
+      expect.objectContaining({ state: "failed" }),
+    );
   });
 });
 
@@ -2662,6 +3253,90 @@ describe("buildHostUpdateCommand — activation debt (installed-up-to-date short
     ).not.toHaveBeenCalled();
   });
 
+  it("a park whose withdrawal cannot land reports the I/O failure, not a withdrawal", async () => {
+    // Same shape as the plain busy park above, but the conditional delete's
+    // own write fails (`logConditionalMarkerOutcome`'s "failed" arm) - the
+    // marker stays put until the next update supersedes it, and the log
+    // must say so rather than the "was withdrawn" success line.
+    //
+    // Falsification: collapse `logConditionalMarkerOutcome` back to a
+    // two-way branch (done vs. everything else) and this pin goes red -
+    // the "could not be withdrawn" line would never fire for a "failed"
+    // outcome.
+    mocks.downloadAndStageHostMock.mockResolvedValue(upToDate("2.0.0"));
+    mocks.readHostInstallRecordMock.mockResolvedValue(sampleRecord("2.0.0"));
+    mocks.readHostPidMetadataMock.mockResolvedValue(pidRecord("1.0.0", 4242));
+    mocks.identityVerdictMock.mockResolvedValue("current");
+    mocks.assertHostNotBusyMock.mockRejectedValue(
+      cliError({
+        code: CLI_ERROR_CODES.HOST_BUSY,
+        message: "The running host has work in progress",
+        details: null,
+        exitCode: 1,
+      }),
+    );
+    mocks.deleteUpdateProgressMarkerIfUnchangedMock.mockResolvedValueOnce(
+      "failed",
+    );
+
+    const ctx = fakeCtx();
+    await expect(
+      buildHostUpdateCommand({
+        force: false,
+        allowDowngrade: false,
+        ackNonce: null,
+      })(ctx),
+    ).rejects.toMatchObject({ code: CLI_ERROR_CODES.HOST_BUSY });
+
+    expect(ctx.runtime.logger.info).toHaveBeenCalledWith(
+      "Host update parked - the host has work in progress; its progress marker could not be withdrawn and stays until the next update supersedes it",
+      expect.objectContaining({ environment: "production", outcome: "failed" }),
+    );
+    expect(ctx.runtime.logger.info).not.toHaveBeenCalledWith(
+      "Host update parked - the host has work in progress; the progress marker was withdrawn",
+      expect.anything(),
+    );
+  });
+
+  it("a park whose withdrawal finds the path already empty says so - not that another updater owns it", async () => {
+    // Falsification: drop the `gone` arm of `logConditionalMarkerOutcome`
+    // (route "absent" through `moved`) and the park narrates a record
+    // "another updater owns" over a path that is empty.
+    mocks.downloadAndStageHostMock.mockResolvedValue(upToDate("2.0.0"));
+    mocks.readHostInstallRecordMock.mockResolvedValue(sampleRecord("2.0.0"));
+    mocks.readHostPidMetadataMock.mockResolvedValue(pidRecord("1.0.0", 4242));
+    mocks.identityVerdictMock.mockResolvedValue("current");
+    mocks.assertHostNotBusyMock.mockRejectedValue(
+      cliError({
+        code: CLI_ERROR_CODES.HOST_BUSY,
+        message: "The running host has work in progress",
+        details: null,
+        exitCode: 1,
+      }),
+    );
+    mocks.deleteUpdateProgressMarkerIfUnchangedMock.mockResolvedValueOnce(
+      "absent",
+    );
+
+    const ctx = fakeCtx();
+    await expect(
+      buildHostUpdateCommand({
+        force: false,
+        allowDowngrade: false,
+        ackNonce: null,
+      })(ctx),
+    ).rejects.toMatchObject({ code: CLI_ERROR_CODES.HOST_BUSY });
+
+    expect(ctx.runtime.logger.info).toHaveBeenCalledWith(
+      "Host update parked - the host has work in progress; found no progress marker to withdraw",
+      expect.objectContaining({ environment: "production", outcome: "absent" }),
+    );
+    expect(ctx.runtime.logger.info).not.toHaveBeenCalledWith(
+      "Host update parked - the host has work in progress; the progress marker was left in place - another updater owns it now",
+      expect.anything(),
+    );
+  });
+
   it("the health probe fails after activation: rejects the health-check error, marks the marker failed, and never clears it", async () => {
     mocks.downloadAndStageHostMock.mockResolvedValue(upToDate("2.0.0"));
     mocks.readHostInstallRecordMock.mockResolvedValue(sampleRecord("2.0.0"));
@@ -2752,7 +3427,7 @@ describe("buildHostUpdateCommand busy park + early marker", () => {
       ): Promise<UpdateProgressMarkerClaim> => {
         mocks.callOrder.push("marker-written");
         mocks.disk.current = next;
-        return { outcome: "published", displaced: null };
+        return { outcome: "published" };
       },
     );
     mocks.applyHostMock.mockResolvedValue(
@@ -3212,6 +3887,240 @@ describe("buildHostUpdateCommand — reassertMarkerUnderLock under the lock", ()
     ).toHaveBeenCalledTimes(1);
   });
 
+  it("a takeover of a stale record under the lock does not restore it on a busy park", async () => {
+    // The takeover counterpart to the `publishUpdating` pins above: a
+    // record no writer is acting on (`updateProgressRecordHasLiveWriter`
+    // false) is replaced under the lock too, and `displacedMarker.current`
+    // stays null for it - so a busy park that follows withdraws this run's
+    // own record instead of restoring the stale one.
+    //
+    // Falsification: retain every taken-over record regardless of
+    // liveness (`displacedMarker.current = onDisk` unconditionally) and
+    // the "restore never happens" assertions below go red.
+    const staleFailed: HostUpdateProgress = {
+      state: "failed",
+      error: "host did not become healthy: tcp refused",
+      targetVersion: "1.9.0",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      writerId: "dead-writer",
+    };
+    mocks.downloadAndStageHostMock.mockImplementation(
+      async (opts: DownloadAndStageHostOptions) => {
+        await requireHook(opts)("2.0.0");
+        mocks.disk.current = staleFailed;
+        return {
+          outcome: "promoted",
+          stagedVersion: "2.0.0",
+          installedVersion: "1.0.0",
+        } satisfies HostDownloadOutcome;
+      },
+    );
+    // `applyHost` takes the marker over (replacing the stale `failed`) and
+    // only THEN rejects busy - same shape as the live-writer busy-park pin.
+    mocks.applyHostMock.mockImplementation(async (opts: ApplyHostOptions) => {
+      await opts.onWillCommitStaged?.("2.0.0");
+      throw cliError({
+        code: CLI_ERROR_CODES.HOST_BUSY,
+        message: "The running host has work in progress",
+        details: null,
+        exitCode: 1,
+      });
+    });
+    mocks.readHostStagedRecordMock.mockResolvedValue(null);
+
+    const ctx = fakeCtx();
+    await expect(
+      buildHostUpdateCommand({
+        force: false,
+        allowDowngrade: false,
+        ackNonce: null,
+      })(ctx),
+    ).rejects.toMatchObject({ code: CLI_ERROR_CODES.HOST_BUSY });
+
+    // The takeover itself still happens (one replace call, over the stale
+    // record) - what's under test is what the PARK does afterward.
+    expect(
+      mocks.replaceUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenCalledWith(
+      "production",
+      staleFailed,
+      expect.objectContaining({ state: "updating", targetVersion: "2.0.0" }),
+    );
+    const adopted = mocks.replaceUpdateProgressMarkerIfUnchangedMock.mock
+      .calls[0][2] as HostUpdateProgress;
+    expect(ctx.runtime.logger.info).toHaveBeenCalledWith(
+      "Host update replaced the progress marker under the lock - no writer is acting on it",
+      expect.objectContaining({
+        environment: "production",
+        targetVersion: "2.0.0",
+      }),
+    );
+    // The park WITHDRAWS this run's own (adopted) record - never a second
+    // replace call putting the stale `failed` back.
+    expect(
+      mocks.deleteUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenCalledWith("production", adopted);
+    expect(
+      mocks.replaceUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenCalledTimes(1);
+    expect(mocks.disk.current).toBeNull();
+  });
+
+  it("a takeover of a LIVE foreign record is not restored if that writer dies before the park re-checks it", async () => {
+    // Liveness is re-evaluated at the PARK, not trusted from the takeover
+    // (`liveDisplacedRecord`): the displaced writer had the whole stop
+    // attempt to die in between, and a park that restored its now-dead
+    // `updating` would re-plant exactly the record the retain rule exists
+    // to drop. `mocks.deadWriterIds.add` runs as a side effect INSIDE the
+    // apply mock's rejection path - after the takeover already read the
+    // writer as live - so this only passes if the re-check genuinely reads
+    // AGAIN at the restore rather than reusing a liveness verdict a
+    // constant fixture could not tell apart from a stale one.
+    //
+    // Falsification: cache the takeover's liveness verdict instead of
+    // re-reading it at the park (drop the second `updateProgressRecordHasLiveWriter`
+    // call) and this pin's "delete, not restore" assertions go red.
+    const foreignRecord: HostUpdateProgress = {
+      state: "updating",
+      error: null,
+      targetVersion: "2.0.0",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      writerId: "will-die-writer",
+    };
+    mocks.downloadAndStageHostMock.mockImplementation(
+      async (opts: DownloadAndStageHostOptions) => {
+        await requireHook(opts)("2.0.0");
+        mocks.disk.current = foreignRecord;
+        return {
+          outcome: "promoted",
+          stagedVersion: "2.0.0",
+          installedVersion: "1.0.0",
+        } satisfies HostDownloadOutcome;
+      },
+    );
+    mocks.applyHostMock.mockImplementation(async (opts: ApplyHostOptions) => {
+      await opts.onWillCommitStaged?.("2.0.0");
+      // The takeover above already read this writer as live. It dies here,
+      // mid-swap-attempt, before the busy rejection reaches the park.
+      mocks.deadWriterIds.add("will-die-writer");
+      throw cliError({
+        code: CLI_ERROR_CODES.HOST_BUSY,
+        message: "The running host has work in progress",
+        details: null,
+        exitCode: 1,
+      });
+    });
+    mocks.readHostStagedRecordMock.mockResolvedValue(null);
+
+    const ctx = fakeCtx();
+    await expect(
+      buildHostUpdateCommand({
+        force: false,
+        allowDowngrade: false,
+        ackNonce: null,
+      })(ctx),
+    ).rejects.toMatchObject({ code: CLI_ERROR_CODES.HOST_BUSY });
+
+    // The takeover itself read the writer as live (still one replace call
+    // over the foreign record).
+    expect(
+      mocks.replaceUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenCalledWith(
+      "production",
+      foreignRecord,
+      expect.objectContaining({ state: "updating", targetVersion: "2.0.0" }),
+    );
+    const adopted = mocks.replaceUpdateProgressMarkerIfUnchangedMock.mock
+      .calls[0][2] as HostUpdateProgress;
+    // The park DELETES own - never a second replace restoring the now-dead
+    // writer's record.
+    expect(
+      mocks.deleteUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenCalledWith("production", adopted);
+    expect(
+      mocks.replaceUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenCalledTimes(1);
+    expect(mocks.disk.current).toBeNull();
+  });
+
+  it("a failure after a takeover of a LIVE foreign record stamps `failed` if that writer dies before the restore re-checks it", async () => {
+    // The pre-disruption-failure sibling of the park pin above: same
+    // dies-between-takeover-and-restore shape, reached through the OTHER
+    // arm that consults `liveDisplacedRecord`.
+    const foreignRecord: HostUpdateProgress = {
+      state: "updating",
+      error: null,
+      targetVersion: "2.0.0",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      writerId: "will-die-writer",
+    };
+    mocks.downloadAndStageHostMock.mockImplementation(
+      async (opts: DownloadAndStageHostOptions) => {
+        await requireHook(opts)("2.0.0");
+        mocks.disk.current = foreignRecord;
+        return {
+          outcome: "promoted",
+          stagedVersion: "2.0.0",
+          installedVersion: "1.0.0",
+        } satisfies HostDownloadOutcome;
+      },
+    );
+    // Takes the marker over, then rejects a NON-busy error WITHOUT ever
+    // reporting progress - no `service-stop` or `swap` reached the host.
+    mocks.applyHostMock.mockImplementation(async (opts: ApplyHostOptions) => {
+      await opts.onWillCommitStaged?.("2.0.0");
+      mocks.deadWriterIds.add("will-die-writer");
+      throw cliError({
+        code: CLI_ERROR_CODES.SERVICE_CONTROL_FAILED,
+        message: "could not stop the service",
+        details: null,
+        exitCode: 1,
+      });
+    });
+
+    const ctx = fakeCtx();
+    await expect(
+      buildHostUpdateCommand({
+        force: false,
+        allowDowngrade: false,
+        ackNonce: null,
+      })(ctx),
+    ).rejects.toMatchObject({
+      code: CLI_ERROR_CODES.SERVICE_CONTROL_FAILED,
+    });
+
+    expect(
+      mocks.replaceUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenNthCalledWith(
+      1,
+      "production",
+      foreignRecord,
+      expect.objectContaining({
+        state: "updating",
+        targetVersion: "2.0.0",
+      }),
+    );
+    const adopted = mocks.replaceUpdateProgressMarkerIfUnchangedMock.mock
+      .calls[0][2] as HostUpdateProgress;
+    // The SECOND replace call stamps `failed` over own (the now-dead
+    // writer is not restored) - never a restore of the foreign record.
+    expect(
+      mocks.replaceUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenNthCalledWith(
+      2,
+      "production",
+      adopted,
+      expect.objectContaining({
+        state: "failed",
+        targetVersion: "2.0.0",
+        error: "could not stop the service",
+      }),
+    );
+    expect(
+      mocks.replaceUpdateProgressMarkerIfUnchangedMock,
+    ).not.toHaveBeenCalledWith("production", adopted, foreignRecord);
+  });
+
   it("busy park after a takeover: the displaced record is RESTORED, and no `failed` stamp lands", async () => {
     // Falsification: withdraw this run's own record unconditionally on
     // park instead of restoring the displaced one when
@@ -3356,6 +4265,80 @@ describe("buildHostUpdateCommand — reassertMarkerUnderLock under the lock", ()
     expect(ctx.runtime.logger.info).toHaveBeenCalledWith(
       "Host update failed before disturbing the host; the progress marker it took over was restored to its previous writer",
       expect.objectContaining({ environment: "production" }),
+    );
+  });
+
+  it("a live-writer restore that loses the CAS reports it was not restored, not silence", async () => {
+    // The `logConditionalMarkerOutcome` "moved" arm for the pre-disruption
+    // restore: the takeover's own record changed underneath the restore
+    // attempt (a newer updater already claimed the path), so the restore's
+    // compare-and-swap reports "changed" rather than landing.
+    //
+    // Falsification: log the "done" ("was restored to its previous
+    // writer") message unconditionally instead of branching on the
+    // restore's own outcome, and this pin goes red.
+    const foreignRecord: HostUpdateProgress = {
+      state: "updating",
+      error: null,
+      targetVersion: "2.0.0",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      writerId: "foreign-writer",
+    };
+    mocks.downloadAndStageHostMock.mockImplementation(
+      async (opts: DownloadAndStageHostOptions) => {
+        await requireHook(opts)("2.0.0");
+        mocks.disk.current = foreignRecord;
+        return {
+          outcome: "promoted",
+          stagedVersion: "2.0.0",
+          installedVersion: "1.0.0",
+        } satisfies HostDownloadOutcome;
+      },
+    );
+    mocks.applyHostMock.mockImplementation(async (opts: ApplyHostOptions) => {
+      await opts.onWillCommitStaged?.("2.0.0");
+      throw cliError({
+        code: CLI_ERROR_CODES.SERVICE_CONTROL_FAILED,
+        message: "could not stop the service",
+        details: null,
+        exitCode: 1,
+      });
+    });
+    // First replace call is the takeover itself (still lands, same as the
+    // sibling pin above); the SECOND - the restore attempt - loses its CAS.
+    mocks.replaceUpdateProgressMarkerIfUnchangedMock
+      .mockImplementationOnce(
+        async (
+          _environment: string,
+          _expected: HostUpdateProgress,
+          next: HostUpdateProgress,
+        ) => {
+          mocks.disk.current = next;
+          return "replaced";
+        },
+      )
+      .mockResolvedValueOnce("changed");
+
+    const ctx = fakeCtx();
+    await expect(
+      buildHostUpdateCommand({
+        force: false,
+        allowDowngrade: false,
+        ackNonce: null,
+      })(ctx),
+    ).rejects.toMatchObject({
+      code: CLI_ERROR_CODES.SERVICE_CONTROL_FAILED,
+    });
+
+    expect(
+      mocks.replaceUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenCalledTimes(2);
+    expect(ctx.runtime.logger.info).toHaveBeenCalledWith(
+      "Host update failed before disturbing the host; the progress marker it took over was not restored - another updater owns it now",
+      expect.objectContaining({
+        environment: "production",
+        outcome: "changed",
+      }),
     );
   });
 

--- a/clients/traycer-cli/src/commands/__tests__/host-update.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/host-update.test.ts
@@ -42,6 +42,7 @@ const mocks = vi.hoisted(() => ({
   readUpdateProgressMarkerMock: vi.fn(),
   deleteUpdateProgressMarkerIfUnchangedMock: vi.fn(),
   replaceUpdateProgressMarkerIfUnchangedMock: vi.fn(),
+  createUpdateProgressMarkerIfAbsentMock: vi.fn(),
   probeHostHealthMock: vi.fn(),
   readHostPidMetadataMock: vi.fn(),
   identityVerdictMock: vi.fn(),
@@ -69,6 +70,8 @@ vi.mock("../../host/update-progress-marker", () => ({
     mocks.deleteUpdateProgressMarkerIfUnchangedMock,
   replaceUpdateProgressMarkerIfUnchanged:
     mocks.replaceUpdateProgressMarkerIfUnchangedMock,
+  createUpdateProgressMarkerIfAbsent:
+    mocks.createUpdateProgressMarkerIfAbsentMock,
   progressRecord: (fields: {
     state: "updating" | "failed";
     error: string | null;
@@ -395,6 +398,17 @@ function armActivationDefaults(): void {
         return "cleared";
       }
       return "changed";
+    },
+  );
+  // Create-if-absent: `"exists"` when the fixture already holds a marker
+  // (the live path is not empty), else stores `next` and reports
+  // `"created"` - mirrors the real module's create-vs-refuse contract
+  // against the same shared disk fixture the other four primitives use.
+  mocks.createUpdateProgressMarkerIfAbsentMock.mockImplementation(
+    async (_environment: string, next: HostUpdateProgress) => {
+      if (mocks.disk.current !== null) return "exists";
+      mocks.disk.current = next;
+      return "created";
     },
   );
   mocks.readHostPidMetadataMock.mockResolvedValue(null);
@@ -2226,8 +2240,8 @@ describe("buildHostUpdateCommand — reassertMarkerUnderLock under the lock", ()
 
   it("marker withdrawn while waiting: republished under the lock before the apply", async () => {
     // Falsification: stub `reassertMarkerUnderLock` to return early instead
-    // of republishing on an empty disk, and `writeUpdateProgressMarker`
-    // below is called once instead of twice.
+    // of republishing on an empty disk, and `createUpdateProgressMarkerIfAbsent`
+    // below is never called (the second-write assertion drops to zero).
     mocks.downloadAndStageHostMock.mockImplementation(
       async (opts: DownloadAndStageHostOptions) => {
         await requireHook(opts)("2.0.0");
@@ -2251,23 +2265,30 @@ describe("buildHostUpdateCommand — reassertMarkerUnderLock under the lock", ()
       ackNonce: null,
     })(fakeCtx());
 
-    expect(mocks.writeUpdateProgressMarkerMock).toHaveBeenCalledTimes(2);
+    // The pre-lock publish is the only unconditional write; the empty-path
+    // republish under the lock goes through the create-if-absent primitive
+    // instead, never through `writeUpdateProgressMarker` again.
+    expect(mocks.writeUpdateProgressMarkerMock).toHaveBeenCalledTimes(1);
     const firstWrite = mocks.writeUpdateProgressMarkerMock.mock
       .calls[0][1] as HostUpdateProgress;
-    const secondWrite = mocks.writeUpdateProgressMarkerMock.mock
-      .calls[1][1] as HostUpdateProgress;
+    expect(mocks.createUpdateProgressMarkerIfAbsentMock).toHaveBeenCalledTimes(
+      1,
+    );
+    const republished = mocks.createUpdateProgressMarkerIfAbsentMock.mock
+      .calls[0][1] as HostUpdateProgress;
     expect(firstWrite.targetVersion).toBe("2.0.0");
-    expect(secondWrite.targetVersion).toBe("2.0.0");
+    expect(republished.targetVersion).toBe("2.0.0");
     // The republish happens under the lock, strictly before the apply half
     // - `invocationCallOrder` gives a global ordering across every mock.
-    const secondWriteOrder =
-      mocks.writeUpdateProgressMarkerMock.mock.invocationCallOrder[1];
+    const createOrder =
+      mocks.createUpdateProgressMarkerIfAbsentMock.mock.invocationCallOrder[0];
     const applyOrder = mocks.applyHostMock.mock.invocationCallOrder[0];
-    expect(secondWriteOrder).toBeLessThan(applyOrder);
-    // The final clear follows the republished record, not the withdrawn one.
+    expect(createOrder).toBeLessThan(applyOrder);
+    // The final clear follows the republished record, not the withdrawn one -
+    // `ownMarker.current` was adopted from the create call's own argument.
     expect(
       mocks.deleteUpdateProgressMarkerIfUnchangedMock,
-    ).toHaveBeenCalledWith("production", secondWrite);
+    ).toHaveBeenCalledWith("production", republished);
     expect(result.exitCode).toBe(0);
   });
 
@@ -2337,8 +2358,8 @@ describe("buildHostUpdateCommand — reassertMarkerUnderLock under the lock", ()
   it("downgrade arm passes onBeforeCommit and it re-asserts", async () => {
     // Falsification: pass a no-op callback as `onBeforeCommit` from the
     // downgrade arm in `host-update.ts` instead of
-    // `() => reassertMarkerUnderLock(downgradeTarget)`, and the second
-    // write below never happens.
+    // `() => reassertMarkerUnderLock(downgradeTarget)`, and the create call
+    // below never happens.
     mocks.readHostInstallRecordMock.mockResolvedValue(
       sampleRecord("1.3.0-rc.1"),
     );
@@ -2362,9 +2383,126 @@ describe("buildHostUpdateCommand — reassertMarkerUnderLock under the lock", ()
     expect(mocks.installHostDowngradeMock).toHaveBeenCalledWith(
       expect.objectContaining({ onBeforeCommit: expect.any(Function) }),
     );
-    expect(mocks.writeUpdateProgressMarkerMock).toHaveBeenCalledTimes(2);
-    expect(mocks.writeUpdateProgressMarkerMock.mock.calls[1][1]).toEqual(
+    // The pre-lock publish is the only `writeUpdateProgressMarker` call; the
+    // empty-path republish under the lock lands through the create-if-absent
+    // primitive instead.
+    expect(mocks.writeUpdateProgressMarkerMock).toHaveBeenCalledTimes(1);
+    expect(mocks.createUpdateProgressMarkerIfAbsentMock).toHaveBeenCalledTimes(
+      1,
+    );
+    expect(
+      mocks.createUpdateProgressMarkerIfAbsentMock.mock.calls[0][1],
+    ).toEqual(
       expect.objectContaining({ state: "updating", targetVersion: "1.2.0" }),
     );
+  });
+
+  it("empty path, but a marker lands between the read and the republish \u2192 the create refuses and this run proceeds under the other updater's marker", async () => {
+    // Falsification: revert the empty arm to `publishUpdating` and this pin
+    // reddens on the write assertion.
+    mocks.downloadAndStageHostMock.mockImplementation(
+      async (opts: DownloadAndStageHostOptions) => {
+        await requireHook(opts)("2.0.0");
+        // Another updater's run cleared our marker while this run waited
+        // for admission - reassertMarkerUnderLock's disk read sees an
+        // empty path.
+        mocks.disk.current = null;
+        return {
+          outcome: "promoted",
+          stagedVersion: "2.0.0",
+          installedVersion: "1.0.0",
+        } satisfies HostDownloadOutcome;
+      },
+    );
+    mocks.applyHostMock.mockResolvedValue(
+      appliedOutcome("1.0.0", "2.0.0", null),
+    );
+    const foreignRecord: HostUpdateProgress = {
+      state: "updating",
+      error: null,
+      targetVersion: "2.0.0",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      writerId: "foreign-writer",
+    };
+    // A marker lands at the live path in the gap between
+    // reassertMarkerUnderLock's read and its create-if-absent call, so the
+    // create itself refuses rather than overwriting it.
+    mocks.createUpdateProgressMarkerIfAbsentMock.mockImplementationOnce(
+      async () => {
+        mocks.disk.current = foreignRecord;
+        return "exists";
+      },
+    );
+
+    const ctx = fakeCtx();
+    const result = await buildHostUpdateCommand({
+      force: false,
+      allowDowngrade: false,
+      ackNonce: null,
+    })(ctx);
+
+    // No second unconditional write - the refusal is the create call
+    // itself, never a `writeUpdateProgressMarker`.
+    expect(mocks.writeUpdateProgressMarkerMock).toHaveBeenCalledTimes(1);
+    const firstWrite = mocks.writeUpdateProgressMarkerMock.mock
+      .calls[0][1] as HostUpdateProgress;
+    expect(mocks.createUpdateProgressMarkerIfAbsentMock).toHaveBeenCalledTimes(
+      1,
+    );
+    expect(ctx.runtime.logger.info).toHaveBeenCalledWith(
+      "Host update proceeds under another updater's progress marker; it landed while this run re-asserted its own",
+      expect.objectContaining({
+        environment: "production",
+        targetVersion: "2.0.0",
+      }),
+    );
+    // `ownMarker` was never replaced - the later conditional clear/stamp is
+    // still CAS'd against THIS run's ORIGINAL pre-lock record, not the
+    // foreign one that won the race.
+    expect(
+      mocks.deleteUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenCalledWith("production", firstWrite);
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("the create fails \u2192 nothing changes, the update continues", async () => {
+    // Falsification: revert the empty arm to `publishUpdating` and this pin
+    // reddens on the write assertion.
+    mocks.downloadAndStageHostMock.mockImplementation(
+      async (opts: DownloadAndStageHostOptions) => {
+        await requireHook(opts)("2.0.0");
+        mocks.disk.current = null;
+        return {
+          outcome: "promoted",
+          stagedVersion: "2.0.0",
+          installedVersion: "1.0.0",
+        } satisfies HostDownloadOutcome;
+      },
+    );
+    mocks.applyHostMock.mockResolvedValue(
+      appliedOutcome("1.0.0", "2.0.0", null),
+    );
+    mocks.createUpdateProgressMarkerIfAbsentMock.mockImplementationOnce(
+      async () => "failed",
+    );
+
+    const result = await buildHostUpdateCommand({
+      force: false,
+      allowDowngrade: false,
+      ackNonce: null,
+    })(fakeCtx());
+
+    // The apply still runs to completion - a failed create is advisory
+    // state, never a reason to abort or throw.
+    expect(mocks.applyHostMock).toHaveBeenCalled();
+    expect(result.exitCode).toBe(0);
+    expect(mocks.writeUpdateProgressMarkerMock).toHaveBeenCalledTimes(1);
+    const firstWrite = mocks.writeUpdateProgressMarkerMock.mock
+      .calls[0][1] as HostUpdateProgress;
+    // `ownMarker` was never adopted from a failed create - the final clear
+    // is still CAS'd against this run's ORIGINAL pre-lock record.
+    expect(
+      mocks.deleteUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenCalledWith("production", firstWrite);
   });
 });

--- a/clients/traycer-cli/src/commands/__tests__/host-update.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/host-update.test.ts
@@ -47,11 +47,11 @@ const mocks = vi.hoisted(() => ({
   deleteUpdateProgressMarkerIfUnchangedMock: vi.fn(),
   replaceUpdateProgressMarkerIfUnchangedMock: vi.fn(),
   createUpdateProgressMarkerIfAbsentMock: vi.fn(),
-  updateProgressRecordHasLiveWriterMock: vi.fn(),
-  // The writerIds `armActivationDefaults`'s `updateProgressRecordHasLiveWriterMock`
-  // wiring treats as dead - a fixture DECIDES liveness explicitly rather than
-  // shelling out to a real `isProcessAlive`. Reset per test by
-  // `armActivationDefaults` itself.
+  updateProgressRecordHasProvenLiveWriterMock: vi.fn(),
+  // The writerIds `armActivationDefaults`'s
+  // `updateProgressRecordHasProvenLiveWriterMock` wiring treats as dead - a
+  // fixture DECIDES liveness explicitly rather than shelling out to a real
+  // liveness probe. Reset per test by `armActivationDefaults` itself.
   deadWriterIds: new Set<string>(),
   probeHostHealthMock: vi.fn(),
   readHostPidMetadataMock: vi.fn(),
@@ -83,8 +83,8 @@ vi.mock("../../host/update-progress-marker", () => ({
     mocks.replaceUpdateProgressMarkerIfUnchangedMock,
   createUpdateProgressMarkerIfAbsent:
     mocks.createUpdateProgressMarkerIfAbsentMock,
-  updateProgressRecordHasLiveWriter:
-    mocks.updateProgressRecordHasLiveWriterMock,
+  updateProgressRecordHasProvenLiveWriter:
+    mocks.updateProgressRecordHasProvenLiveWriterMock,
   progressRecord: (fields: {
     state: "updating" | "failed";
     error: string | null;
@@ -386,15 +386,17 @@ function armActivationDefaults(): void {
   mocks.readUpdateProgressMarkerMock.mockImplementation(
     async () => mocks.disk.current,
   );
-  // The real rule shape (`updateProgressRecordHasLiveWriter`,
+  // The real rule shape (`updateProgressRecordHasProvenLiveWriter`,
   // `update-progress-marker.ts`): a `failed` has no writer by construction,
-  // and an `updating` is live unless the test has declared its writer dead
-  // in `mocks.deadWriterIds` - a fixture decides liveness explicitly rather
-  // than shelling out to a real `isProcessAlive`.
-  mocks.updateProgressRecordHasLiveWriterMock.mockImplementation(
+  // a record with NO writer id has no PROVEN writer (it is replaced and not
+  // retained), and an `updating` with one is proven live unless the test
+  // has declared its writer dead in `mocks.deadWriterIds` - a fixture
+  // decides liveness explicitly rather than shelling out to a real probe.
+  mocks.updateProgressRecordHasProvenLiveWriterMock.mockImplementation(
     (record: HostUpdateProgress) =>
       record.state !== "failed" &&
-      (record.writerId === null || !mocks.deadWriterIds.has(record.writerId)),
+      record.writerId !== null &&
+      !mocks.deadWriterIds.has(record.writerId),
   );
   // Pre-lock claim: models the SAME rule `claimUpdateProgressMarkerBeforeLock`
   // applies against a real disk (see its production doc comment) - published
@@ -628,6 +630,7 @@ describe("buildHostUpdateCommand composite", () => {
       force: false,
       onProgress: expect.any(Function),
       onBeforeCommit: expect.any(Function),
+      onWillDisruptHost: expect.any(Function),
     });
     expect(mocks.claimUpdateProgressMarkerBeforeLockMock).toHaveBeenCalledWith(
       "production",
@@ -648,15 +651,19 @@ describe("buildHostUpdateCommand composite", () => {
   });
 
   it("keeps an explicit lower target on the monotonic stage path unless downgrade is explicitly enabled", async () => {
+    // Without `--allow-downgrade` an explicit lower target is an ordinary
+    // stage request, and the promoter short-circuits it before any
+    // transfer (the installed version is at or above the target). The
+    // fixture models that answer; a `discarded` outcome is the promote-time
+    // race, which an explicit request now refuses outright (see the
+    // "DISCARDED at promote time" pin).
     mocks.downloadAndStageHostMock.mockResolvedValue({
-      outcome: "discarded",
-      reason: "not-strictly-newer",
+      outcome: "short-circuit",
+      reason: "installed-up-to-date",
       targetVersion: "1.2.0",
-    } satisfies HostDownloadOutcome);
-    mocks.applyHostMock.mockResolvedValue({
-      outcome: "no-op",
       installedVersion: "1.3.0-rc.1",
-    } satisfies ApplyHostOutcome);
+      stagedVersion: null,
+    } satisfies HostDownloadOutcome);
     mocks.readHostInstallRecordMock.mockResolvedValue(
       sampleRecord("1.3.0-rc.1"),
     );
@@ -669,13 +676,14 @@ describe("buildHostUpdateCommand composite", () => {
     })(fakeCtx());
 
     expect(mocks.installHostDowngradeMock).not.toHaveBeenCalled();
+    expect(mocks.applyHostMock).not.toHaveBeenCalled();
     expect(mocks.downloadAndStageHostMock).toHaveBeenCalledWith(
       expect.objectContaining({
         versionRequest: "1.2.0",
         automatic: false,
       }),
     );
-    expect(result.human).toContain("host already at 1.3.0-rc.1 (no-op)");
+    expect(result.human).toContain("no-op");
   });
 
   it("keeps a null version request for latest semantics", async () => {
@@ -1222,7 +1230,7 @@ describe("buildHostUpdateCommand update-progress marker (T16)", () => {
 
     expect(result.exitCode).toBe(0);
     expect(ctx.runtime.logger.info).toHaveBeenCalledWith(
-      "Host update could not clear its progress marker; it stays until the next update supersedes it",
+      "Host update could not clear its progress marker - the marker log names what the path holds now",
       { environment: "production" },
     );
   });
@@ -1745,6 +1753,10 @@ describe("buildHostUpdateCommand update-progress marker (T16)", () => {
     );
     mocks.applyHostMock.mockImplementation(async (opts: ApplyHostOptions) => {
       await opts.onWillCommitStaged?.("2.0.0");
+      // The boundary is the ACTUATOR's report (`onWillDisruptHost`, fired
+      // by the lifecycle once its authority check passed), not the
+      // `service-stop` progress line - which is also emitted, and must not
+      // be what marks it.
       opts.onProgress({
         stage: "service-stop",
         message: null,
@@ -1753,6 +1765,7 @@ describe("buildHostUpdateCommand update-progress marker (T16)", () => {
         totalBytes: null,
         workUnits: null,
       });
+      opts.onWillDisruptHost?.();
       throw new Error("commit failed");
     });
 
@@ -2246,6 +2259,10 @@ describe("buildHostUpdateCommand update-progress marker (T16)", () => {
     mocks.downloadAndStageHostMock.mockResolvedValue(promoted("2.0.0"));
     mocks.applyHostMock.mockImplementation(async (opts: ApplyHostOptions) => {
       await opts.onWillCommitStaged?.("2.0.0");
+      // The boundary is the ACTUATOR's report (`onWillDisruptHost`, fired
+      // by the lifecycle once its authority check passed), not the
+      // `service-stop` progress line - which is also emitted, and must not
+      // be what marks it.
       opts.onProgress({
         stage: "service-stop",
         message: null,
@@ -2254,6 +2271,7 @@ describe("buildHostUpdateCommand update-progress marker (T16)", () => {
         totalBytes: null,
         workUnits: null,
       });
+      opts.onWillDisruptHost?.();
       throw new Error("commit failed");
     });
     mocks.readHostInstallRecordMock.mockResolvedValue(sampleRecord("2.0.0"));
@@ -3317,7 +3335,7 @@ describe("buildHostUpdateCommand — activation debt (installed-up-to-date short
     ).rejects.toMatchObject({ code: CLI_ERROR_CODES.HOST_BUSY });
 
     expect(ctx.runtime.logger.info).toHaveBeenCalledWith(
-      "Host update parked - the host has work in progress; its progress marker could not be withdrawn and stays until the next update supersedes it",
+      "Host update parked - the host has work in progress; its progress marker could not be withdrawn - the marker log names what the path holds now",
       expect.objectContaining({ environment: "production", outcome: "failed" }),
     );
     expect(ctx.runtime.logger.info).not.toHaveBeenCalledWith(
@@ -3360,7 +3378,7 @@ describe("buildHostUpdateCommand — activation debt (installed-up-to-date short
       expect.objectContaining({ environment: "production", outcome: "absent" }),
     );
     expect(ctx.runtime.logger.info).not.toHaveBeenCalledWith(
-      "Host update parked - the host has work in progress; the progress marker was left in place - another updater owns it now",
+      "Host update parked - the host has work in progress; the progress marker was not withdrawn - another updater owns it now",
       expect.anything(),
     );
   });
@@ -3917,8 +3935,9 @@ describe("buildHostUpdateCommand — reassertMarkerUnderLock under the lock", ()
 
   it("a takeover of a stale record under the lock does not restore it on a busy park", async () => {
     // The takeover counterpart to the `publishUpdating` pins above: a
-    // record no writer is acting on (`updateProgressRecordHasLiveWriter`
-    // false) is replaced under the lock too, and `displacedMarker.current`
+    // record without a PROVEN live writer
+    // (`updateProgressRecordHasProvenLiveWriter` false) is replaced under
+    // the lock too, and `displacedMarker.current`
     // stays null for it - so a busy park that follows withdraws this run's
     // own record instead of restoring the stale one.
     //
@@ -3977,7 +3996,7 @@ describe("buildHostUpdateCommand — reassertMarkerUnderLock under the lock", ()
     const adopted = mocks.replaceUpdateProgressMarkerIfUnchangedMock.mock
       .calls[0][2] as HostUpdateProgress;
     expect(ctx.runtime.logger.info).toHaveBeenCalledWith(
-      "Host update replaced the progress marker under the lock - no writer is acting on it",
+      "Host update replaced the progress marker under the lock - no writer is proven to be acting on it",
       expect.objectContaining({
         environment: "production",
         targetVersion: "2.0.0",
@@ -4006,8 +4025,9 @@ describe("buildHostUpdateCommand — reassertMarkerUnderLock under the lock", ()
     // constant fixture could not tell apart from a stale one.
     //
     // Falsification: cache the takeover's liveness verdict instead of
-    // re-reading it at the park (drop the second `updateProgressRecordHasLiveWriter`
-    // call) and this pin's "delete, not restore" assertions go red.
+    // re-reading it at the park (have the park reuse the takeover's answer
+    // instead of calling `liveDisplacedRecord` again) and this pin's
+    // "delete, not restore" assertions go red.
     const foreignRecord: HostUpdateProgress = {
       state: "updating",
       error: null,
@@ -4395,6 +4415,10 @@ describe("buildHostUpdateCommand — reassertMarkerUnderLock under the lock", ()
     // is now being disturbed - and only then rejects a NON-busy error.
     mocks.applyHostMock.mockImplementation(async (opts: ApplyHostOptions) => {
       await opts.onWillCommitStaged?.("2.0.0");
+      // The boundary is the ACTUATOR's report (`onWillDisruptHost`, fired
+      // by the lifecycle once its authority check passed), not the
+      // `service-stop` progress line - which is also emitted, and must not
+      // be what marks it.
       opts.onProgress({
         stage: "service-stop",
         message: null,
@@ -4403,6 +4427,7 @@ describe("buildHostUpdateCommand — reassertMarkerUnderLock under the lock", ()
         totalBytes: null,
         workUnits: null,
       });
+      opts.onWillDisruptHost?.();
       throw cliError({
         code: CLI_ERROR_CODES.SERVICE_CONTROL_FAILED,
         message: "could not stop the service",
@@ -5025,5 +5050,428 @@ describe("buildHostUpdateCommand — reassertMarkerUnderLock under the lock", ()
         .value;
     expect(outcome).toBe("changed");
     expect(mocks.disk.current).toEqual(foreignRecord);
+  });
+
+  // ---- Ownership residuals: every arm of "who owns the marker now" that
+  // the takeover, the park and the failure stamp can reach.
+
+  it("a `failed` pre-lock claim is warned about by this command, not only by the marker layer", async () => {
+    // Falsification: drop the warn from `publishUpdating`'s `failed` arm and
+    // the CLI's own log carries nothing for a transfer that runs
+    // unannounced.
+    mocks.downloadAndStageHostMock.mockImplementation(
+      async (opts: DownloadAndStageHostOptions) => {
+        await requireHook(opts)("2.0.0");
+        return {
+          outcome: "promoted",
+          stagedVersion: "2.0.0",
+          installedVersion: "1.0.0",
+        } satisfies HostDownloadOutcome;
+      },
+    );
+    mocks.claimUpdateProgressMarkerBeforeLockMock.mockResolvedValue({
+      outcome: "failed",
+    });
+    mocks.applyHostMock.mockResolvedValue(
+      appliedOutcome("1.0.0", "2.0.0", null),
+    );
+
+    const ctx = fakeCtx();
+    const result = await buildHostUpdateCommand({
+      force: false,
+      allowDowngrade: false,
+      ackNonce: null,
+    })(ctx);
+
+    expect(result.exitCode).toBe(0);
+    expect(ctx.runtime.logger.warn).toHaveBeenCalledWith(
+      "Host update could not publish its progress marker before the lock; the transfer proceeds unannounced until this run holds the lock",
+      { environment: "production", targetVersion: "2.0.0" },
+    );
+  });
+
+  it("the takeover under the lock gives up after three refused creates over a path that reads empty, warns, and the update proceeds without a marker", async () => {
+    // The "file is there but is not a record" wedge, as the marker layer
+    // reports it to this command: every read answers `null`, every create
+    // answers `exists` (an unreadable file, see `MarkerRead`). Bounded:
+    // three iterations, one warning, no marker - never a spin, never a
+    // failed update. Falsification: make the loop unbounded (`while
+    // (true)`) and this hangs; drop the warn and the log assertion reddens.
+    mocks.downloadAndStageHostMock.mockImplementation(
+      async (opts: DownloadAndStageHostOptions) => {
+        await requireHook(opts)("2.0.0");
+        mocks.disk.current = null;
+        return {
+          outcome: "promoted",
+          stagedVersion: "2.0.0",
+          installedVersion: "1.0.0",
+        } satisfies HostDownloadOutcome;
+      },
+    );
+    mocks.createUpdateProgressMarkerIfAbsentMock.mockResolvedValue("exists");
+    mocks.applyHostMock.mockImplementation(async (opts: ApplyHostOptions) => {
+      await opts.onWillCommitStaged?.("2.0.0");
+      return appliedOutcome("1.0.0", "2.0.0", null);
+    });
+
+    const ctx = fakeCtx();
+    const result = await buildHostUpdateCommand({
+      force: false,
+      allowDowngrade: false,
+      ackNonce: null,
+    })(ctx);
+
+    expect(result.exitCode).toBe(0);
+    expect(mocks.createUpdateProgressMarkerIfAbsentMock).toHaveBeenCalledTimes(
+      3,
+    );
+    expect(
+      mocks.replaceUpdateProgressMarkerIfUnchangedMock,
+    ).not.toHaveBeenCalled();
+    expect(ctx.runtime.logger.warn).toHaveBeenCalledWith(
+      "Host update could not establish ownership of the progress marker under the lock; proceeding without re-asserting it",
+      { environment: "production", targetVersion: "2.0.0" },
+    );
+    // The run still holds the record it published BEFORE the lock (the
+    // takeover never replaced it), so the success path's clear is CAS'd
+    // against that record - and finds the path empty rather than clearing
+    // whatever stands there.
+    const preLock = mocks.claimUpdateProgressMarkerBeforeLockMock.mock
+      .calls[0][1] as HostUpdateProgress;
+    expect(
+      mocks.deleteUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenCalledWith("production", preLock);
+    expect(mocks.disk.current).toBeNull();
+  });
+
+  it("no work owed: a `failed` marker naming a target OTHER than the observed running version is left alone", async () => {
+    // The host's own rule (`isStaleUpdateProgress`): a `failed` is stale
+    // only when the version it names is the one now running. An attempt at
+    // 3.0.0 that failed before its swap is not contradicted by a host
+    // observed at 2.0.0 while the registry offers only 2.0.0.
+    // Falsification: drop the target comparison from
+    // `clearStaleFailedMarker` and the conditional delete below fires.
+    mocks.downloadAndStageHostMock.mockResolvedValue({
+      outcome: "short-circuit",
+      reason: "installed-up-to-date",
+      targetVersion: "2.0.0",
+      installedVersion: "2.0.0",
+      stagedVersion: null,
+    } satisfies HostDownloadOutcome);
+    mocks.readHostInstallRecordMock.mockResolvedValue(sampleRecord("2.0.0"));
+    mocks.readHostPidMetadataMock.mockResolvedValue({
+      pid: 4242,
+      hostId: "host-1",
+      version: "2.0.0",
+      websocketUrl: "ws://127.0.0.1:1/ws",
+      startedAt: "2026-01-01T00:00:00.000Z",
+      processStartIdentity: null,
+      layer0: null,
+      layer0Slot: null,
+    });
+    mocks.identityVerdictMock.mockResolvedValue("current");
+    mocks.readUpdateProgressMarkerMock.mockResolvedValue({
+      state: "failed",
+      error: "download failed",
+      targetVersion: "3.0.0",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      writerId: null,
+    });
+
+    const ctx = fakeCtx();
+    const result = await buildHostUpdateCommand({
+      force: false,
+      allowDowngrade: false,
+      ackNonce: null,
+    })(ctx);
+
+    expect(result.exitCode).toBe(0);
+    expect(
+      mocks.deleteUpdateProgressMarkerIfUnchangedMock,
+    ).not.toHaveBeenCalled();
+    expect(mocks.deleteUpdateProgressMarkerMock).not.toHaveBeenCalled();
+    expect(ctx.runtime.logger.info).toHaveBeenCalledWith(
+      "Host update left the failed progress marker alone - it names a target the running host has not been observed at",
+      {
+        environment: "production",
+        failedTargetVersion: "3.0.0",
+        observedRunningVersion: "2.0.0",
+      },
+    );
+  });
+
+  it("a refused re-point under the lock: the failure past the disruption boundary is stamped with the INTENDED target, not the pre-lock record's", async () => {
+    // The pre-lock record names 2.0.0; `applyHost` commits 2.1.0 (a later
+    // promoter's stage) and the re-point's CAS fails (I/O). The run goes
+    // on, disturbs the host and fails: the stamp lands over the pre-lock
+    // record (the CAS expectation) but NAMES 2.1.0 - "update to 2.0.0
+    // failed" would report an attempt this run never made, and the host's
+    // target-running suppression would then mis-handle it. Falsification:
+    // stamp with `ownMarker.current.targetVersion` and the third replace
+    // call below names 2.0.0.
+    mocks.downloadAndStageHostMock.mockImplementation(
+      async (opts: DownloadAndStageHostOptions) => {
+        await requireHook(opts)("2.0.0");
+        return {
+          outcome: "promoted",
+          stagedVersion: "2.0.0",
+          installedVersion: "1.0.0",
+        } satisfies HostDownloadOutcome;
+      },
+    );
+    mocks.replaceUpdateProgressMarkerIfUnchangedMock.mockResolvedValue(
+      "failed",
+    );
+    mocks.applyHostMock.mockImplementation(async (opts: ApplyHostOptions) => {
+      await opts.onWillCommitStaged?.("2.1.0");
+      opts.onWillDisruptHost?.();
+      throw new Error("commit failed");
+    });
+
+    await expect(
+      buildHostUpdateCommand({
+        force: false,
+        allowDowngrade: false,
+        ackNonce: null,
+      })(fakeCtx()),
+    ).rejects.toThrow("commit failed");
+
+    const preLock = mocks.claimUpdateProgressMarkerBeforeLockMock.mock
+      .calls[0][1] as HostUpdateProgress;
+    expect(preLock.targetVersion).toBe("2.0.0");
+    const calls = mocks.replaceUpdateProgressMarkerIfUnchangedMock.mock.calls;
+    // The refused re-point (2.0.0 → 2.1.0), then the failure stamp over the
+    // SAME pre-lock record, naming the version this run intended.
+    expect(calls).toHaveLength(2);
+    expect(calls[0][1]).toEqual(preLock);
+    expect(calls[0][2]).toMatchObject({
+      state: "updating",
+      targetVersion: "2.1.0",
+    });
+    expect(calls[1][1]).toEqual(preLock);
+    expect(calls[1][2]).toMatchObject({
+      state: "failed",
+      targetVersion: "2.1.0",
+      error: "commit failed",
+    });
+  });
+
+  it("busy park after taking over a record with NO writer id: it is not restored - this run's own record is withdrawn and the path is left empty", async () => {
+    // An older CLI's `updating` carries no writer id. The host renders such
+    // a record FOREVER (its dead-writer suppression needs a pid), so the
+    // takeover retains for restore only a record whose writer is PROVEN
+    // live - and a park then withdraws this run's own record instead of
+    // re-planting the immortal one. Falsification: retain on the fail-open
+    // predicate and the replace count below becomes two (takeover, then a
+    // restore of `foreignRecord`).
+    const foreignRecord: HostUpdateProgress = {
+      state: "updating",
+      error: null,
+      targetVersion: "2.0.0",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      writerId: null,
+    };
+    mocks.downloadAndStageHostMock.mockImplementation(
+      async (opts: DownloadAndStageHostOptions) => {
+        await requireHook(opts)("2.0.0");
+        mocks.disk.current = foreignRecord;
+        return {
+          outcome: "promoted",
+          stagedVersion: "2.0.0",
+          installedVersion: "1.0.0",
+        } satisfies HostDownloadOutcome;
+      },
+    );
+    mocks.applyHostMock.mockImplementation(async (opts: ApplyHostOptions) => {
+      await opts.onWillCommitStaged?.("2.0.0");
+      throw cliError({
+        code: CLI_ERROR_CODES.HOST_BUSY,
+        message: "The running host has work in progress",
+        details: null,
+        exitCode: 1,
+      });
+    });
+    mocks.readHostStagedRecordMock.mockResolvedValue(null);
+
+    const ctx = fakeCtx();
+    await expect(
+      buildHostUpdateCommand({
+        force: false,
+        allowDowngrade: false,
+        ackNonce: null,
+      })(ctx),
+    ).rejects.toMatchObject({ code: CLI_ERROR_CODES.HOST_BUSY });
+
+    expect(
+      mocks.replaceUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenCalledTimes(1);
+    expect(ctx.runtime.logger.info).toHaveBeenCalledWith(
+      "Host update replaced the progress marker under the lock - no writer is proven to be acting on it",
+      expect.objectContaining({
+        environment: "production",
+        previousWriterId: null,
+      }),
+    );
+    const adopted = mocks.replaceUpdateProgressMarkerIfUnchangedMock.mock
+      .calls[0][2] as HostUpdateProgress;
+    expect(
+      mocks.deleteUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenCalledWith("production", adopted);
+    expect(mocks.disk.current).toBeNull();
+  });
+
+  it("an EXPLICIT version request binds the apply to the version it resolved to; an implicit latest does not", async () => {
+    // `--version 2.0.0` confirmed 2.0.0 (a Settings click checked its
+    // catalog entry and floor); a `host download 2.1.0` that replaced the
+    // shared stage during the unlocked wait must not be committed under that
+    // confirmation. `applyHost` refuses it before its busy gate and hook;
+    // this command reports it and stamps its own `failed` naming 2.0.0.
+    // Falsification: pass `expectedStagedVersion: null` for the explicit
+    // request and the first assertion reddens.
+    mocks.downloadAndStageHostMock.mockImplementation(
+      async (opts: DownloadAndStageHostOptions) => {
+        await requireHook(opts)("2.0.0");
+        return {
+          outcome: "promoted",
+          stagedVersion: "2.0.0",
+          installedVersion: "1.0.0",
+        } satisfies HostDownloadOutcome;
+      },
+    );
+    const seenExpectations: Array<string | null> = [];
+    mocks.applyHostMock.mockImplementation(async (opts: ApplyHostOptions) => {
+      seenExpectations.push(opts.expectedStagedVersion);
+      if (opts.expectedStagedVersion === null) {
+        await opts.onWillCommitStaged?.("2.1.0");
+        return appliedOutcome("1.0.0", "2.1.0", null);
+      }
+      return {
+        outcome: "stage-version-mismatch",
+        installedVersion: "1.0.0",
+        expectedStagedVersion: opts.expectedStagedVersion,
+        actualStagedVersion: "2.1.0",
+      } satisfies ApplyHostOutcome;
+    });
+
+    await expect(
+      buildHostUpdateCommand({
+        force: false,
+        allowDowngrade: false,
+        versionRequest: "2.0.0",
+        ackNonce: null,
+      })(fakeCtx()),
+    ).rejects.toThrow(
+      "the staged host is 2.1.0, not the requested 2.0.0; another download replaced the stage before it could be applied",
+    );
+    expect(seenExpectations).toEqual(["2.0.0"]);
+    // Nothing was disturbed and no takeover happened: the failure stamp
+    // is the only replace, over this run's own pre-lock record, naming the
+    // version it announced.
+    const calls = mocks.replaceUpdateProgressMarkerIfUnchangedMock.mock.calls;
+    expect(calls).toHaveLength(1);
+    expect(calls[0][2]).toMatchObject({
+      state: "failed",
+      targetVersion: "2.0.0",
+    });
+
+    vi.clearAllMocks();
+    armActivationDefaults();
+    mocks.probeHostHealthMock.mockResolvedValue({
+      healthy: true,
+      detail: "ok",
+    });
+    mocks.downloadAndStageHostMock.mockImplementation(
+      async (opts: DownloadAndStageHostOptions) => {
+        await requireHook(opts)("2.0.0");
+        return {
+          outcome: "promoted",
+          stagedVersion: "2.0.0",
+          installedVersion: "1.0.0",
+        } satisfies HostDownloadOutcome;
+      },
+    );
+    const result = await buildHostUpdateCommand({
+      force: false,
+      allowDowngrade: false,
+      ackNonce: null,
+    })(fakeCtx());
+    expect(result.exitCode).toBe(0);
+    expect(seenExpectations).toEqual(["2.0.0", null]);
+  });
+
+  it("an explicit request whose download was DISCARDED at promote time is refused with the discard's own reason, and never reaches the apply", async () => {
+    // The race the promoter guards: the installed version moved past the
+    // explicit target during the unlocked transfer (a plain older request
+    // never gets here - it short-circuits as installed-up-to-date before
+    // any transfer). Reaching `applyHost` would either commit a stage
+    // another promoter left (refused by the version binding, but with a
+    // "replaced stage" sentence naming a cause that did not happen) or
+    // find nothing and run the "stage consumed" recovery. Falsification:
+    // drop the discard check ahead of `applyAndProjectLegacy` and the
+    // apply mock below is called with the binding.
+    mocks.downloadAndStageHostMock.mockImplementation(
+      async (opts: DownloadAndStageHostOptions) => {
+        await requireHook(opts)("2.0.0");
+        return {
+          outcome: "discarded",
+          reason: "not-newer-than-installed",
+          targetVersion: "2.0.0",
+        } satisfies HostDownloadOutcome;
+      },
+    );
+
+    await expect(
+      buildHostUpdateCommand({
+        force: false,
+        allowDowngrade: false,
+        versionRequest: "2.0.0",
+        ackNonce: null,
+      })(fakeCtx()),
+    ).rejects.toMatchObject({
+      code: CLI_ERROR_CODES.HOST_UPDATE_NOT_NEWER,
+      message: expect.stringContaining(
+        "2.0.0 was downloaded, but the installed host is no longer older than it",
+      ),
+    });
+    expect(mocks.applyHostMock).not.toHaveBeenCalled();
+    // The pre-lock record announced 2.0.0; the refusal stamps it as the
+    // failure it is, naming the announced target.
+    const calls = mocks.replaceUpdateProgressMarkerIfUnchangedMock.mock.calls;
+    expect(calls).toHaveLength(1);
+    expect(calls[0][2]).toMatchObject({
+      state: "failed",
+      targetVersion: "2.0.0",
+    });
+
+    // Positive control: the SAME discard under an implicit "latest"
+    // still applies whatever newer stage is there.
+    vi.clearAllMocks();
+    armActivationDefaults();
+    mocks.probeHostHealthMock.mockResolvedValue({
+      healthy: true,
+      detail: "ok",
+    });
+    mocks.downloadAndStageHostMock.mockImplementation(
+      async (opts: DownloadAndStageHostOptions) => {
+        await requireHook(opts)("2.0.0");
+        return {
+          outcome: "discarded",
+          reason: "not-strictly-newer",
+          targetVersion: "2.0.0",
+        } satisfies HostDownloadOutcome;
+      },
+    );
+    mocks.applyHostMock.mockImplementation(async (opts: ApplyHostOptions) => {
+      expect(opts.expectedStagedVersion).toBeNull();
+      await opts.onWillCommitStaged?.("2.1.0");
+      return appliedOutcome("1.0.0", "2.1.0", null);
+    });
+    const result = await buildHostUpdateCommand({
+      force: false,
+      allowDowngrade: false,
+      ackNonce: null,
+    })(fakeCtx());
+    expect(result.exitCode).toBe(0);
+    expect(mocks.applyHostMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/clients/traycer-cli/src/commands/__tests__/host-update.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/host-update.test.ts
@@ -454,9 +454,23 @@ function armActivationDefaults(): void {
   mocks.readHostPidMetadataMock.mockResolvedValue(null);
   mocks.identityVerdictMock.mockResolvedValue("current");
   mocks.assertHostNotBusyMock.mockResolvedValue(undefined);
-  mocks.stopHostForRestartWithAttemptMock.mockResolvedValue({
-    forcedRecycle: false,
-  });
+  // Models the facade's boundary: the capability check passed and the
+  // actuator is about to stop the host, so `onAuthorityVerified` fires
+  // before the (mock) stop returns. A test that needs the check to FAIL
+  // rejects WITHOUT calling it.
+  mocks.stopHostForRestartWithAttemptMock.mockImplementation(
+    async (
+      _capability: unknown,
+      _contenderOptions: unknown,
+      _controller: unknown,
+      _label: unknown,
+      _options: unknown,
+      onAuthorityVerified: (() => void) | null,
+    ) => {
+      onAuthorityVerified?.();
+      return { forcedRecycle: false };
+    },
+  );
   mocks.relaunchHostAfterRestartWithAttemptMock.mockResolvedValue(undefined);
 }
 
@@ -2562,11 +2576,25 @@ describe("buildHostUpdateCommand — activation debt (installed-up-to-date short
     mocks.downloadAndStageHostMock.mockResolvedValue(upToDate("2.0.0"));
     mocks.readHostInstallRecordMock.mockResolvedValue(sampleRecord("2.0.0"));
     mocks.readHostPidMetadataMock.mockResolvedValue(pidRecord("1.0.0", 4242));
-    // A REAL failure under the lock - the stop half throws. Not a busy
-    // refusal: that one is a park now (see "the host is busy" below) and
-    // never reaches the failure stamp this test is about.
-    mocks.stopHostForRestartWithAttemptMock.mockRejectedValue(
-      new Error("stop failed"),
+    // A REAL failure under the lock - the stop half throws AFTER it has
+    // reported the disruption boundary, the way the actuator does. Not a
+    // busy refusal: that one is a park now (see "the host is busy" below)
+    // and never reaches the failure stamp this test is about. And not a
+    // capability refusal either - that rejects BEFORE the boundary and is
+    // the subject of "the activation arm's stop refused by its capability
+    // check" below.
+    mocks.stopHostForRestartWithAttemptMock.mockImplementation(
+      async (
+        _capability: unknown,
+        _contenderOptions: unknown,
+        _controller: unknown,
+        _label: unknown,
+        _options: unknown,
+        onAuthorityVerified: (() => void) | null,
+      ) => {
+        onAuthorityVerified?.();
+        throw new Error("stop failed");
+      },
     );
     // By the time the failure is stamped, a third updater has already
     // landed its own `updating` at the live path - the compare-and-swap
@@ -4413,10 +4441,13 @@ describe("buildHostUpdateCommand — reassertMarkerUnderLock under the lock", ()
     );
   });
 
-  it("the activation arm counts as disturbing the host from its hook on", async () => {
-    // Falsification: replace `reassertMarkerThenDisrupt` with
-    // `reassertMarkerUnderLock` at the debt call site and this restores
-    // instead.
+  it("the activation arm's stop refused by its capability check, before the actuator, restores a live writer's taken-over record", async () => {
+    // Falsification: set `disruptionStarted` around the stop call (the old
+    // `reassertMarkerThenDisrupt`) instead of from the facade's
+    // `onAuthorityVerified`, and a refused check stamps this run's `failed`
+    // over the live writer's record - which that writer's later clear can
+    // never land. The stop mock here rejects WITHOUT calling the boundary
+    // callback: the check failed, the actuator never ran.
     mocks.downloadAndStageHostMock.mockResolvedValue({
       outcome: "short-circuit",
       reason: "installed-up-to-date",
@@ -4456,7 +4487,7 @@ describe("buildHostUpdateCommand — reassertMarkerUnderLock under the lock", ()
     mocks.stopHostForRestartWithAttemptMock.mockRejectedValue(
       cliError({
         code: CLI_ERROR_CODES.SERVICE_CONTROL_FAILED,
-        message: "could not stop the service",
+        message: "mutation capability refused",
         details: null,
         exitCode: 1,
       }),
@@ -4486,8 +4517,114 @@ describe("buildHostUpdateCommand — reassertMarkerUnderLock under the lock", ()
     );
     const adopted = mocks.replaceUpdateProgressMarkerIfUnchangedMock.mock
       .calls[0][2] as HostUpdateProgress;
-    // The hook already ran (the takeover above proves it) before the stop
-    // rejected, so this is a `failed` stamp, never a restore.
+    // The takeover happened (above), the boundary never did: the second
+    // conditional write RESTORES the foreign record over the adopted one.
+    expect(
+      mocks.replaceUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenNthCalledWith(2, "production", adopted, foreignRecord);
+    expect(
+      mocks.replaceUpdateProgressMarkerIfUnchangedMock,
+    ).not.toHaveBeenCalledWith(
+      "production",
+      expect.anything(),
+      expect.objectContaining({ state: "failed" }),
+    );
+    expect(mocks.disk.current).toEqual(foreignRecord);
+    expect(ctx.runtime.logger.info).toHaveBeenCalledWith(
+      "Host update failed before disturbing the host; the progress marker it took over was restored to its previous writer",
+      expect.objectContaining({
+        environment: "production",
+        outcome: "replaced",
+      }),
+    );
+  });
+
+  it("the activation arm counts as disturbing the host from the stop's authority check on", async () => {
+    // Falsification: drop `onWillDisruptHost` from the activation arm's stop
+    // call (pass `null`) and this restores instead of stamping. The stop
+    // mock here CALLS the boundary callback - the check passed, the actuator
+    // ran and failed - and then rejects.
+    mocks.downloadAndStageHostMock.mockResolvedValue({
+      outcome: "short-circuit",
+      reason: "installed-up-to-date",
+      targetVersion: "2.0.0",
+      installedVersion: "2.0.0",
+      stagedVersion: null,
+    } satisfies HostDownloadOutcome);
+    mocks.readHostInstallRecordMock.mockResolvedValue(sampleRecord("2.0.0"));
+    const runningAt1 = {
+      pid: 4242,
+      hostId: "host-1",
+      version: "1.0.0",
+      websocketUrl: "ws://127.0.0.1:51820/rpc",
+      startedAt: "2026-01-01T00:00:00.000Z",
+      processStartIdentity: null,
+      layer0: null,
+      layer0Slot: null,
+    };
+    const foreignRecord: HostUpdateProgress = {
+      state: "updating",
+      error: null,
+      targetVersion: "2.0.0",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      writerId: "foreign-writer",
+    };
+    // Debt on both reads (out of the lock, and again under the activation
+    // arm's own lock) - the SECOND read's side effect is what lands the
+    // foreign marker under the lock, between this run's pre-lock publish
+    // and the activation arm's takeover hook.
+    mocks.readHostPidMetadataMock
+      .mockResolvedValueOnce(runningAt1)
+      .mockImplementationOnce(async () => {
+        mocks.disk.current = foreignRecord;
+        return runningAt1;
+      });
+    mocks.identityVerdictMock.mockResolvedValue("current");
+    mocks.stopHostForRestartWithAttemptMock.mockImplementation(
+      async (
+        _capability: unknown,
+        _contenderOptions: unknown,
+        _controller: unknown,
+        _label: unknown,
+        _options: unknown,
+        onAuthorityVerified: (() => void) | null,
+      ) => {
+        onAuthorityVerified?.();
+        throw cliError({
+          code: CLI_ERROR_CODES.SERVICE_CONTROL_FAILED,
+          message: "could not stop the service",
+          details: null,
+          exitCode: 1,
+        });
+      },
+    );
+
+    const ctx = fakeCtx();
+    await expect(
+      buildHostUpdateCommand({
+        force: false,
+        allowDowngrade: false,
+        ackNonce: null,
+      })(ctx),
+    ).rejects.toMatchObject({
+      code: CLI_ERROR_CODES.SERVICE_CONTROL_FAILED,
+    });
+
+    expect(
+      mocks.replaceUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenNthCalledWith(
+      1,
+      "production",
+      foreignRecord,
+      expect.objectContaining({
+        state: "updating",
+        targetVersion: "2.0.0",
+      }),
+    );
+    const adopted = mocks.replaceUpdateProgressMarkerIfUnchangedMock.mock
+      .calls[0][2] as HostUpdateProgress;
+    // The boundary fired before the stop rejected, so this is a `failed`
+    // stamp, never a restore.
     expect(
       mocks.replaceUpdateProgressMarkerIfUnchangedMock,
     ).toHaveBeenNthCalledWith(

--- a/clients/traycer-cli/src/commands/__tests__/host-update.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/host-update.test.ts
@@ -93,6 +93,7 @@ vi.mock("../../host/update-progress-marker", () => ({
     ...fields,
     updatedAt: new Date().toISOString(),
     writerId: "test-writer",
+    writerStartIdentity: null,
   }),
   // Pure comparator; the real one, so the "is this marker still ours"
   // decisions under test compare the way production does.
@@ -103,6 +104,7 @@ vi.mock("../../host/update-progress-marker", () => ({
       updatedAt: string;
       error: string | null;
       writerId: string | null;
+      writerStartIdentity: string | null;
     },
     b: {
       state: string;
@@ -110,13 +112,15 @@ vi.mock("../../host/update-progress-marker", () => ({
       updatedAt: string;
       error: string | null;
       writerId: string | null;
+      writerStartIdentity: string | null;
     },
   ) =>
     a.state === b.state &&
     a.targetVersion === b.targetVersion &&
     a.updatedAt === b.updatedAt &&
     a.error === b.error &&
-    a.writerId === b.writerId,
+    a.writerId === b.writerId &&
+    a.writerStartIdentity === b.writerStartIdentity,
 }));
 
 vi.mock("../../service/health-probe", () => ({
@@ -1381,6 +1385,7 @@ describe("buildHostUpdateCommand update-progress marker (T16)", () => {
       targetVersion: "9.9.9",
       updatedAt: "2026-01-01T00:00:00.000Z",
       writerId: "999999-abc",
+      writerStartIdentity: null,
     };
     mocks.disk.current = foreignRecord;
     mocks.downloadAndStageHostMock.mockImplementation(
@@ -1463,6 +1468,7 @@ describe("buildHostUpdateCommand update-progress marker (T16)", () => {
       targetVersion: "9.9.9",
       updatedAt: "2026-01-01T00:00:00.000Z",
       writerId: "foreign-writer",
+      writerStartIdentity: null,
     };
     mocks.disk.current = foreignRecord;
     mocks.downloadAndStageHostMock.mockImplementation(
@@ -1522,6 +1528,7 @@ describe("buildHostUpdateCommand update-progress marker (T16)", () => {
       targetVersion: "9.9.9",
       updatedAt: "2026-01-01T00:00:00.000Z",
       writerId: "foreign-writer",
+      writerStartIdentity: null,
     };
     mocks.disk.current = foreignRecord;
     mocks.downloadAndStageHostMock.mockImplementation(
@@ -1736,6 +1743,7 @@ describe("buildHostUpdateCommand update-progress marker (T16)", () => {
       targetVersion: "2.0.0",
       updatedAt: "2026-01-01T00:00:00.000Z",
       writerId: "foreign-writer",
+      writerStartIdentity: null,
     };
     mocks.disk.current = foreignRecord;
     mocks.downloadAndStageHostMock.mockImplementation(
@@ -1974,6 +1982,7 @@ describe("buildHostUpdateCommand update-progress marker (T16)", () => {
       targetVersion: "1.9.0",
       updatedAt: "2026-01-01T00:00:00.000Z",
       writerId: "dead-writer",
+      writerStartIdentity: null,
     };
     mocks.claimUpdateProgressMarkerBeforeLockMock.mockImplementation(
       async (
@@ -2031,6 +2040,7 @@ describe("buildHostUpdateCommand update-progress marker (T16)", () => {
       targetVersion: "1.9.0",
       updatedAt: "2026-01-01T00:00:00.000Z",
       writerId: "424242-dead",
+      writerStartIdentity: null,
     };
     mocks.deadWriterIds.add("424242-dead");
     mocks.claimUpdateProgressMarkerBeforeLockMock.mockImplementation(
@@ -2083,6 +2093,7 @@ describe("buildHostUpdateCommand update-progress marker (T16)", () => {
       targetVersion: "1.9.0",
       updatedAt: "2026-01-01T00:00:00.000Z",
       writerId: "dead-writer",
+      writerStartIdentity: null,
     };
     mocks.claimUpdateProgressMarkerBeforeLockMock.mockImplementation(
       async (
@@ -2827,6 +2838,7 @@ describe("buildHostUpdateCommand — activation debt (installed-up-to-date short
       targetVersion: "2.0.0",
       updatedAt: "2026-01-01T00:00:00.000Z",
       writerId: null,
+      writerStartIdentity: null,
     });
 
     const result = await buildHostUpdateCommand({
@@ -2867,6 +2879,7 @@ describe("buildHostUpdateCommand — activation debt (installed-up-to-date short
       targetVersion: "2.0.0",
       updatedAt: "2026-01-01T00:00:00.000Z",
       writerId: null,
+      writerStartIdentity: null,
     });
     mocks.deleteUpdateProgressMarkerIfUnchangedMock.mockResolvedValue("failed");
 
@@ -2903,6 +2916,7 @@ describe("buildHostUpdateCommand — activation debt (installed-up-to-date short
       targetVersion: "2.0.0",
       updatedAt: "2026-01-01T00:00:00.000Z",
       writerId: null,
+      writerStartIdentity: null,
     });
 
     const result = await buildHostUpdateCommand({
@@ -2949,6 +2963,7 @@ describe("buildHostUpdateCommand — activation debt (installed-up-to-date short
       targetVersion: "2.0.0",
       updatedAt: "2026-01-01T00:00:00.000Z",
       writerId: null,
+      writerStartIdentity: null,
     });
 
     await buildHostUpdateCommand({
@@ -2975,6 +2990,7 @@ describe("buildHostUpdateCommand — activation debt (installed-up-to-date short
       targetVersion: "2.1.0",
       updatedAt: "2026-01-01T00:00:00.000Z",
       writerId: null,
+      writerStartIdentity: null,
     });
 
     await buildHostUpdateCommand({
@@ -3197,6 +3213,7 @@ describe("buildHostUpdateCommand — activation debt (installed-up-to-date short
       targetVersion: "2.0.0",
       updatedAt: "2026-01-01T00:00:00.000Z",
       writerId: null,
+      writerStartIdentity: null,
     });
 
     const result = await buildHostUpdateCommand({
@@ -3866,6 +3883,7 @@ describe("buildHostUpdateCommand — reassertMarkerUnderLock under the lock", ()
       targetVersion: "2.0.0",
       updatedAt: "2026-01-01T00:00:00.000Z",
       writerId: "foreign-writer",
+      writerStartIdentity: null,
     };
     mocks.downloadAndStageHostMock.mockImplementation(
       async (opts: DownloadAndStageHostOptions) => {
@@ -3950,6 +3968,7 @@ describe("buildHostUpdateCommand — reassertMarkerUnderLock under the lock", ()
       targetVersion: "1.9.0",
       updatedAt: "2026-01-01T00:00:00.000Z",
       writerId: "dead-writer",
+      writerStartIdentity: null,
     };
     mocks.downloadAndStageHostMock.mockImplementation(
       async (opts: DownloadAndStageHostOptions) => {
@@ -4034,6 +4053,7 @@ describe("buildHostUpdateCommand — reassertMarkerUnderLock under the lock", ()
       targetVersion: "2.0.0",
       updatedAt: "2026-01-01T00:00:00.000Z",
       writerId: "will-die-writer",
+      writerStartIdentity: null,
     };
     mocks.downloadAndStageHostMock.mockImplementation(
       async (opts: DownloadAndStageHostOptions) => {
@@ -4101,6 +4121,7 @@ describe("buildHostUpdateCommand — reassertMarkerUnderLock under the lock", ()
       targetVersion: "2.0.0",
       updatedAt: "2026-01-01T00:00:00.000Z",
       writerId: "will-die-writer",
+      writerStartIdentity: null,
     };
     mocks.downloadAndStageHostMock.mockImplementation(
       async (opts: DownloadAndStageHostOptions) => {
@@ -4180,6 +4201,7 @@ describe("buildHostUpdateCommand — reassertMarkerUnderLock under the lock", ()
       targetVersion: "2.0.0",
       updatedAt: "2026-01-01T00:00:00.000Z",
       writerId: "foreign-writer",
+      writerStartIdentity: null,
     };
     mocks.downloadAndStageHostMock.mockImplementation(
       async (opts: DownloadAndStageHostOptions) => {
@@ -4250,6 +4272,7 @@ describe("buildHostUpdateCommand — reassertMarkerUnderLock under the lock", ()
       targetVersion: "2.0.0",
       updatedAt: "2026-01-01T00:00:00.000Z",
       writerId: "foreign-writer",
+      writerStartIdentity: null,
     };
     mocks.downloadAndStageHostMock.mockImplementation(
       async (opts: DownloadAndStageHostOptions) => {
@@ -4331,6 +4354,7 @@ describe("buildHostUpdateCommand — reassertMarkerUnderLock under the lock", ()
       targetVersion: "2.0.0",
       updatedAt: "2026-01-01T00:00:00.000Z",
       writerId: "foreign-writer",
+      writerStartIdentity: null,
     };
     mocks.downloadAndStageHostMock.mockImplementation(
       async (opts: DownloadAndStageHostOptions) => {
@@ -4399,6 +4423,7 @@ describe("buildHostUpdateCommand — reassertMarkerUnderLock under the lock", ()
       targetVersion: "2.0.0",
       updatedAt: "2026-01-01T00:00:00.000Z",
       writerId: "foreign-writer",
+      writerStartIdentity: null,
     };
     mocks.downloadAndStageHostMock.mockImplementation(
       async (opts: DownloadAndStageHostOptions) => {
@@ -4497,6 +4522,7 @@ describe("buildHostUpdateCommand — reassertMarkerUnderLock under the lock", ()
       targetVersion: "2.0.0",
       updatedAt: "2026-01-01T00:00:00.000Z",
       writerId: "foreign-writer",
+      writerStartIdentity: null,
     };
     // Debt on both reads (out of the lock, and again under the activation
     // arm's own lock) - the SECOND read's side effect is what lands the
@@ -4593,6 +4619,7 @@ describe("buildHostUpdateCommand — reassertMarkerUnderLock under the lock", ()
       targetVersion: "2.0.0",
       updatedAt: "2026-01-01T00:00:00.000Z",
       writerId: "foreign-writer",
+      writerStartIdentity: null,
     };
     // Debt on both reads (out of the lock, and again under the activation
     // arm's own lock) - the SECOND read's side effect is what lands the
@@ -4738,6 +4765,7 @@ describe("buildHostUpdateCommand — reassertMarkerUnderLock under the lock", ()
       targetVersion: "2.0.0",
       updatedAt: "2026-01-01T00:00:00.000Z",
       writerId: "foreign-writer",
+      writerStartIdentity: null,
     };
     // A marker lands at the live path in the gap between
     // reassertMarkerUnderLock's read and its create-if-absent call, so the
@@ -4915,6 +4943,7 @@ describe("buildHostUpdateCommand — reassertMarkerUnderLock under the lock", ()
       targetVersion: "2.0.0",
       updatedAt: "2026-01-01T00:00:00.000Z",
       writerId: "foreign-writer",
+      writerStartIdentity: null,
     };
     mocks.disk.current = foreignRecord;
     mocks.downloadAndStageHostMock.mockImplementation(
@@ -4933,6 +4962,7 @@ describe("buildHostUpdateCommand — reassertMarkerUnderLock under the lock", ()
       targetVersion: "2.0.0",
       updatedAt: "2026-01-01T00:00:01.000Z",
       writerId: "newer-writer",
+      writerStartIdentity: null,
     };
     // The FIRST replace attempt (against `foreignRecord`) reports "changed"
     // AND lands a DIFFERENT, even newer updater's record on the disk fixture
@@ -4998,6 +5028,7 @@ describe("buildHostUpdateCommand — reassertMarkerUnderLock under the lock", ()
       targetVersion: "9.9.9",
       updatedAt: "2026-01-01T00:00:00.000Z",
       writerId: "foreign-writer",
+      writerStartIdentity: null,
     };
     mocks.downloadAndStageHostMock.mockImplementation(
       async (opts: DownloadAndStageHostOptions) => {
@@ -5176,6 +5207,7 @@ describe("buildHostUpdateCommand — reassertMarkerUnderLock under the lock", ()
       targetVersion: "3.0.0",
       updatedAt: "2026-01-01T00:00:00.000Z",
       writerId: null,
+      writerStartIdentity: null,
     });
 
     const ctx = fakeCtx();
@@ -5270,6 +5302,7 @@ describe("buildHostUpdateCommand — reassertMarkerUnderLock under the lock", ()
       targetVersion: "2.0.0",
       updatedAt: "2026-01-01T00:00:00.000Z",
       writerId: null,
+      writerStartIdentity: null,
     };
     mocks.downloadAndStageHostMock.mockImplementation(
       async (opts: DownloadAndStageHostOptions) => {

--- a/clients/traycer-cli/src/commands/__tests__/host-update.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/host-update.test.ts
@@ -48,6 +48,17 @@ const mocks = vi.hoisted(() => ({
   assertHostNotBusyMock: vi.fn(),
   stopHostForRestartWithAttemptMock: vi.fn(),
   relaunchHostAfterRestartWithAttemptMock: vi.fn(),
+  // The fixture's model of the on-disk marker file. `armActivationDefaults`
+  // wires the four marker primitives above to read/write/CAS against this
+  // single holder, so `reassertMarkerUnderLock`'s "is the disk still ours"
+  // decisions see a coherent file instead of the four mocks disagreeing with
+  // each other. A plain field (not a `vi.fn()`), reset per test by
+  // `armActivationDefaults` itself.
+  disk: { current: null } as {
+    current:
+      | import("../../host/update-progress-marker").HostUpdateProgress
+      | null;
+  },
 }));
 
 vi.mock("../../host/update-progress-marker", () => ({
@@ -188,6 +199,13 @@ import type {
 } from "../../installer/download-stage";
 import type { ApplyHostOutcome } from "../../installer/apply";
 import type { HostUpdateProgress } from "../../host/update-progress-marker";
+// Value import (not type-only): the module is mocked above, and that mock
+// factory defines `sameProgress` as the REAL comparator (not a `vi.fn()`), so
+// this import gets production comparison logic - the same test double the
+// mocked `../../host/update-progress-marker` module hands the CLI code under
+// test. Used by `armActivationDefaults`'s disk fixture below to decide CAS
+// outcomes the way the real marker module would.
+import { sameProgress } from "../../host/update-progress-marker";
 
 // Mirrors host-management-ipc.ts's `projectInstallResult` field-by-field,
 // including its tolerant fallbacks - the contract this suite pins.
@@ -331,11 +349,53 @@ function fakeCtx(): CommandContext {
 // every existing short-circuit test keeps its no-op contract. Tests that
 // exercise activation opt in with an explicit pid record. Re-armed per test
 // because `resetAllMocks` wipes return values.
+//
+// The four marker primitives are wired to `mocks.disk` - a single fixture
+// modeling the on-disk marker file - rather than given independent canned
+// return values. `reassertMarkerUnderLock` (host-update.ts) reads the disk,
+// compares it against the marker THIS run wrote, and CAS-replaces or CAS-
+// deletes it; a `readUpdateProgressMarker` that always answers `null`
+// (the old default) makes every under-lock reassertion see an "empty disk"
+// and republish over its own still-live marker - a write this run did not
+// intend and tests must not double-count. A test that needs to simulate a
+// FOREIGN writer or a lost CAS race still overrides the individual mock
+// (`.mockResolvedValue(...)` on top of this wiring) exactly as before; that
+// override wins for that call and simply does not touch `mocks.disk`.
 function armActivationDefaults(): void {
-  mocks.readUpdateProgressMarkerMock.mockResolvedValue(null);
-  mocks.deleteUpdateProgressMarkerIfUnchangedMock.mockResolvedValue("cleared");
-  mocks.replaceUpdateProgressMarkerIfUnchangedMock.mockResolvedValue(
-    "replaced",
+  mocks.disk.current = null;
+  mocks.readUpdateProgressMarkerMock.mockImplementation(
+    async () => mocks.disk.current,
+  );
+  mocks.writeUpdateProgressMarkerMock.mockImplementation(
+    async (_environment: string, record: HostUpdateProgress) => {
+      mocks.disk.current = record;
+    },
+  );
+  mocks.replaceUpdateProgressMarkerIfUnchangedMock.mockImplementation(
+    async (
+      _environment: string,
+      expected: HostUpdateProgress,
+      next: HostUpdateProgress,
+    ) => {
+      if (
+        mocks.disk.current !== null &&
+        sameProgress(mocks.disk.current, expected)
+      ) {
+        mocks.disk.current = next;
+        return "replaced";
+      }
+      return "changed";
+    },
+  );
+  mocks.deleteUpdateProgressMarkerIfUnchangedMock.mockImplementation(
+    async (_environment: string, expected: HostUpdateProgress) => {
+      if (mocks.disk.current === null) return "absent";
+      if (sameProgress(mocks.disk.current, expected)) {
+        mocks.disk.current = null;
+        return "cleared";
+      }
+      return "changed";
+    },
   );
   mocks.readHostPidMetadataMock.mockResolvedValue(null);
   mocks.identityVerdictMock.mockResolvedValue("current");
@@ -499,6 +559,7 @@ describe("buildHostUpdateCommand composite", () => {
       version: "1.2.0",
       force: false,
       onProgress: expect.any(Function),
+      onBeforeCommit: expect.any(Function),
     });
     expect(mocks.writeUpdateProgressMarkerMock).toHaveBeenCalledWith(
       "production",
@@ -1905,9 +1966,12 @@ describe("buildHostUpdateCommand busy park + early marker", () => {
         } satisfies HostDownloadOutcome;
       },
     );
-    mocks.writeUpdateProgressMarkerMock.mockImplementation(async () => {
-      mocks.callOrder.push("marker-written");
-    });
+    mocks.writeUpdateProgressMarkerMock.mockImplementation(
+      async (_environment: string, record: HostUpdateProgress) => {
+        mocks.callOrder.push("marker-written");
+        mocks.disk.current = record;
+      },
+    );
     mocks.applyHostMock.mockResolvedValue(
       appliedOutcome("1.0.0", "2.0.0", null),
     );
@@ -2128,5 +2192,179 @@ describe("buildHostUpdateCommand busy park + early marker", () => {
       expect.objectContaining({ force: true }),
     );
     expect(result.exitCode).toBe(0);
+  });
+});
+
+// `reassertMarkerUnderLock` (host-update.ts): under the contender lock, right
+// before the disruptive half of every arm, re-establish what the pre-lock
+// marker only claimed. These pin the three cases named in its own doc
+// comment against the DISK FIXTURE (`mocks.disk`, wired by
+// `armActivationDefaults`) rather than canned per-call return values, so a
+// test can simulate the disk changing out from under this run mid-flight.
+describe("buildHostUpdateCommand — reassertMarkerUnderLock under the lock", () => {
+  beforeEach(() => {
+    mocks.probeHostHealthMock.mockResolvedValue({
+      healthy: true,
+      detail: "ok",
+    });
+    armActivationDefaults();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+    mocks.callOrder = [];
+  });
+
+  function requireHook(
+    opts: DownloadAndStageHostOptions,
+  ): (targetVersion: string) => Promise<void> {
+    if (opts.onWillDownload === null) {
+      throw new Error("expected onWillDownload to be provided");
+    }
+    return opts.onWillDownload;
+  }
+
+  it("marker withdrawn while waiting: republished under the lock before the apply", async () => {
+    // Falsification: stub `reassertMarkerUnderLock` to return early instead
+    // of republishing on an empty disk, and `writeUpdateProgressMarker`
+    // below is called once instead of twice.
+    mocks.downloadAndStageHostMock.mockImplementation(
+      async (opts: DownloadAndStageHostOptions) => {
+        await requireHook(opts)("2.0.0");
+        // Another updater's run cleared our marker while this run waited
+        // for admission - a wait this run controls none of.
+        mocks.disk.current = null;
+        return {
+          outcome: "promoted",
+          stagedVersion: "2.0.0",
+          installedVersion: "1.0.0",
+        } satisfies HostDownloadOutcome;
+      },
+    );
+    mocks.applyHostMock.mockResolvedValue(
+      appliedOutcome("1.0.0", "2.0.0", null),
+    );
+
+    const result = await buildHostUpdateCommand({
+      force: false,
+      allowDowngrade: false,
+      ackNonce: null,
+    })(fakeCtx());
+
+    expect(mocks.writeUpdateProgressMarkerMock).toHaveBeenCalledTimes(2);
+    const firstWrite = mocks.writeUpdateProgressMarkerMock.mock
+      .calls[0][1] as HostUpdateProgress;
+    const secondWrite = mocks.writeUpdateProgressMarkerMock.mock
+      .calls[1][1] as HostUpdateProgress;
+    expect(firstWrite.targetVersion).toBe("2.0.0");
+    expect(secondWrite.targetVersion).toBe("2.0.0");
+    // The republish happens under the lock, strictly before the apply half
+    // - `invocationCallOrder` gives a global ordering across every mock.
+    const secondWriteOrder =
+      mocks.writeUpdateProgressMarkerMock.mock.invocationCallOrder[1];
+    const applyOrder = mocks.applyHostMock.mock.invocationCallOrder[0];
+    expect(secondWriteOrder).toBeLessThan(applyOrder);
+    // The final clear follows the republished record, not the withdrawn one.
+    expect(
+      mocks.deleteUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenCalledWith("production", secondWrite);
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("another updater's marker on disk under the lock: left alone", async () => {
+    // Falsification: collapse `reassertMarkerUnderLock` to an
+    // unconditional `publishUpdating(targetVersion)` (drop the disk read
+    // and the ownership check entirely) and `writeUpdateProgressMarker`
+    // below is called twice, with the second write stamping over the
+    // foreign record instead of leaving it alone.
+    const foreignRecord: HostUpdateProgress = {
+      state: "updating",
+      error: null,
+      targetVersion: "2.0.0",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      writerId: "foreign-writer",
+    };
+    mocks.downloadAndStageHostMock.mockImplementation(
+      async (opts: DownloadAndStageHostOptions) => {
+        await requireHook(opts)("2.0.0");
+        // Another updater's `updating` has landed at the same path by the
+        // time this run reaches the lock - a live progress signal that is
+        // not this run's to touch.
+        mocks.disk.current = foreignRecord;
+        return {
+          outcome: "promoted",
+          stagedVersion: "2.0.0",
+          installedVersion: "1.0.0",
+        } satisfies HostDownloadOutcome;
+      },
+    );
+    // The apply half then genuinely fails busy - the park path, which only
+    // ever WITHDRAWS (conditionally) and never stamps `failed`, is what
+    // lets this test observe the foreign record surviving untouched.
+    mocks.applyHostMock.mockRejectedValue(
+      cliError({
+        code: CLI_ERROR_CODES.HOST_BUSY,
+        message: "The running host has work in progress",
+        details: null,
+        exitCode: 1,
+      }),
+    );
+    mocks.readHostStagedRecordMock.mockResolvedValue(null);
+
+    await expect(
+      buildHostUpdateCommand({
+        force: false,
+        allowDowngrade: false,
+        ackNonce: null,
+      })(fakeCtx()),
+    ).rejects.toMatchObject({ code: CLI_ERROR_CODES.HOST_BUSY });
+
+    expect(mocks.writeUpdateProgressMarkerMock).toHaveBeenCalledTimes(1);
+    const written = mocks.writeUpdateProgressMarkerMock.mock
+      .calls[0][1] as HostUpdateProgress;
+    expect(
+      mocks.replaceUpdateProgressMarkerIfUnchangedMock,
+    ).not.toHaveBeenCalled();
+    // The withdrawal on park is ASKED for (against our own pre-lock
+    // record), but the CAS refuses it because the disk holds someone
+    // else's marker now.
+    expect(
+      mocks.deleteUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenCalledWith("production", written);
+    expect(mocks.disk.current).toEqual(foreignRecord);
+  });
+
+  it("downgrade arm passes onBeforeCommit and it re-asserts", async () => {
+    // Falsification: pass a no-op callback as `onBeforeCommit` from the
+    // downgrade arm in `host-update.ts` instead of
+    // `() => reassertMarkerUnderLock(downgradeTarget)`, and the second
+    // write below never happens.
+    mocks.readHostInstallRecordMock.mockResolvedValue(
+      sampleRecord("1.3.0-rc.1"),
+    );
+    mocks.installHostDowngradeMock.mockImplementation(
+      async (opts: { readonly onBeforeCommit: () => Promise<void> }) => {
+        // Simulate another updater withdrawing our marker before this run
+        // reaches the mutation lock's commit point.
+        mocks.disk.current = null;
+        await opts.onBeforeCommit();
+        return appliedOutcome("1.3.0-rc.1", "1.2.0", null);
+      },
+    );
+
+    await buildHostUpdateCommand({
+      force: false,
+      allowDowngrade: true,
+      versionRequest: "1.2.0",
+      ackNonce: null,
+    })(fakeCtx());
+
+    expect(mocks.installHostDowngradeMock).toHaveBeenCalledWith(
+      expect.objectContaining({ onBeforeCommit: expect.any(Function) }),
+    );
+    expect(mocks.writeUpdateProgressMarkerMock).toHaveBeenCalledTimes(2);
+    expect(mocks.writeUpdateProgressMarkerMock.mock.calls[1][1]).toEqual(
+      expect.objectContaining({ state: "updating", targetVersion: "1.2.0" }),
+    );
   });
 });

--- a/clients/traycer-cli/src/commands/__tests__/host-update.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/host-update.test.ts
@@ -654,6 +654,114 @@ describe("buildHostUpdateCommand composite", () => {
     expect(result.human).toContain("updated host 1.3.0-rc.1 → 1.2.0");
   });
 
+  it("EXPLICIT request for another build of the installed release with --allow-downgrade (2.0.0+foo over 2.0.0+bar): the owned installer installs it - never the shared stage's up-to-date no-op", async () => {
+    // Codex r3945280604. Falsification: keep the downgrade arm to
+    // `ordering === "less"` and the request takes the shared stage, whose
+    // phase 1 refuses the pair (or, before that refusal, reported it up to
+    // date) - the download mock is called and the installer is not.
+    mocks.readHostInstallRecordMock.mockResolvedValue(
+      sampleRecord("2.0.0+bar"),
+    );
+    mocks.installHostDowngradeMock.mockResolvedValue(
+      appliedOutcome("2.0.0+bar", "2.0.0+foo", null),
+    );
+
+    const result = await buildHostUpdateCommand({
+      force: false,
+      allowDowngrade: true,
+      versionRequest: "2.0.0+foo",
+      ackNonce: null,
+    })(fakeCtx());
+
+    expect(mocks.downloadAndStageHostMock).not.toHaveBeenCalled();
+    expect(mocks.installHostDowngradeMock).toHaveBeenCalledWith(
+      expect.objectContaining({ version: "2.0.0+foo" }),
+    );
+    expect(mocks.claimUpdateProgressMarkerBeforeLockMock).toHaveBeenCalledWith(
+      "production",
+      expect.objectContaining({
+        state: "updating",
+        targetVersion: "2.0.0+foo",
+      }),
+    );
+    expect(result.human).toContain("updated host 2.0.0+bar → 2.0.0+foo");
+  });
+
+  it("EXPLICIT request for the installed record's own string with --allow-downgrade (2.0.0+bar over 2.0.0+bar): the shared stage's up-to-date no-op, the installer never runs (control)", async () => {
+    mocks.readHostInstallRecordMock.mockResolvedValue(
+      sampleRecord("2.0.0+bar"),
+    );
+    mocks.downloadAndStageHostMock.mockResolvedValue({
+      outcome: "short-circuit",
+      reason: "installed-up-to-date",
+      targetVersion: "2.0.0+bar",
+      installedVersion: "2.0.0+bar",
+      stagedVersion: null,
+    } satisfies HostDownloadOutcome);
+    mocks.readHostPidMetadataMock.mockResolvedValue({
+      pid: 4242,
+      hostId: "host-1",
+      version: "2.0.0+bar",
+      websocketUrl: "ws://127.0.0.1:51820/rpc",
+      startedAt: "2026-01-01T00:00:00.000Z",
+      processStartIdentity: null,
+      layer0: null,
+      layer0Slot: null,
+    });
+    mocks.identityVerdictMock.mockResolvedValue("current");
+
+    const result = await buildHostUpdateCommand({
+      force: false,
+      allowDowngrade: true,
+      versionRequest: "2.0.0+bar",
+      ackNonce: null,
+    })(fakeCtx());
+
+    expect(mocks.installHostDowngradeMock).not.toHaveBeenCalled();
+    expect(mocks.stopHostForRestartWithAttemptMock).not.toHaveBeenCalled();
+    expect(result.human).toContain("no-op");
+  });
+
+  it("EXPLICIT request refused by the download before any transfer (no --allow-downgrade): the refusal surfaces with its code, nothing is announced and nothing is stamped (control - the seam, not the round's fix)", async () => {
+    // The download's phase-1 refusal is pinned in download-stage.test.ts;
+    // here it is a fixture. What this pins is the seam: a
+    // `E_HOST_UPDATE_NOT_NEWER` that arrives before `onWillDownload` has no
+    // announced target, so the catch stamps nothing and withdraws nothing
+    // (the same arm a manifest failure takes). The message is synthetic.
+    mocks.readHostInstallRecordMock.mockResolvedValue(
+      sampleRecord("2.0.0+bar"),
+    );
+    mocks.downloadAndStageHostMock.mockRejectedValue(
+      cliError({
+        code: CLI_ERROR_CODES.HOST_UPDATE_NOT_NEWER,
+        message: "synthetic phase-1 refusal",
+        details: { targetVersion: "2.0.0+foo", installedVersion: "2.0.0+bar" },
+        exitCode: 1,
+      }),
+    );
+
+    await expect(
+      buildHostUpdateCommand({
+        force: false,
+        allowDowngrade: false,
+        versionRequest: "2.0.0+foo",
+        ackNonce: null,
+      })(fakeCtx()),
+    ).rejects.toMatchObject({ code: CLI_ERROR_CODES.HOST_UPDATE_NOT_NEWER });
+    expect(mocks.installHostDowngradeMock).not.toHaveBeenCalled();
+    expect(mocks.stopHostForRestartWithAttemptMock).not.toHaveBeenCalled();
+    expect(
+      mocks.claimUpdateProgressMarkerBeforeLockMock,
+    ).not.toHaveBeenCalled();
+    expect(mocks.createUpdateProgressMarkerIfAbsentMock).not.toHaveBeenCalled();
+    expect(
+      mocks.replaceUpdateProgressMarkerIfUnchangedMock,
+    ).not.toHaveBeenCalled();
+    expect(
+      mocks.deleteUpdateProgressMarkerIfUnchangedMock,
+    ).not.toHaveBeenCalled();
+  });
+
   it("downgrade arm no-op (another actor installed the requested version under the lock) with the record not yet running: the same bound activation arm restarts onto it", async () => {
     // Falsification: treat the downgrade's no-op as applied and this
     // throws on the outcome's shape; skip the re-derivation and the debt
@@ -2754,6 +2862,59 @@ describe("buildHostUpdateCommand update-progress marker (T16)", () => {
     );
   });
 
+  it("catalog domain: the record IS the announced 2.0.0+foo but the host runs 2.0.0+bar - the lost download is stamped, not withdrawn (CodeRabbit r3945309408)", async () => {
+    // `targetObservedRunning` is record-string identity AND an `activated`
+    // reading; in the catalog domain that reading is now string identity of
+    // the running host with the record. Falsification: compare the running
+    // host with the record through the comparator and this run's record
+    // is withdrawn over a host that never ran what it announced.
+    mocks.downloadAndStageHostMock.mockImplementation(
+      async (opts: DownloadAndStageHostOptions) => {
+        if (opts.onWillDownload === null) {
+          throw new Error("expected onWillDownload to be provided");
+        }
+        await opts.onWillDownload("2.0.0+foo");
+        throw new Error("download failed: ECONNRESET");
+      },
+    );
+    mocks.readHostInstallRecordMock.mockResolvedValue(
+      sampleRecord("2.0.0+foo"),
+    );
+    mocks.readHostPidMetadataMock.mockResolvedValue({
+      pid: 4242,
+      hostId: "host-1",
+      version: "2.0.0+bar",
+      websocketUrl: "ws://127.0.0.1:51820/rpc",
+      startedAt: "2026-01-01T00:00:00.000Z",
+      processStartIdentity: null,
+      layer0: null,
+      layer0Slot: null,
+    });
+    mocks.identityVerdictMock.mockResolvedValue("current");
+
+    await expect(
+      buildHostUpdateCommand({
+        force: false,
+        allowDowngrade: false,
+        versionRequest: "2.0.0+foo",
+        ackNonce: null,
+      })(fakeCtx()),
+    ).rejects.toThrow("download failed: ECONNRESET");
+
+    const written = mocks.claimUpdateProgressMarkerBeforeLockMock.mock
+      .calls[0][1] as HostUpdateProgress;
+    expect(
+      mocks.deleteUpdateProgressMarkerIfUnchangedMock,
+    ).not.toHaveBeenCalled();
+    expect(
+      mocks.replaceUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenCalledWith(
+      "production",
+      written,
+      expect.objectContaining({ state: "failed", targetVersion: "2.0.0+foo" }),
+    );
+  });
+
   it("the same artifact observed running - record 2.0.0 for an announced 2.0.0 - is withdrawn (control for the build-metadata pin)", async () => {
     mocks.downloadAndStageHostMock.mockImplementation(
       async (opts: DownloadAndStageHostOptions) => {
@@ -2994,12 +3155,15 @@ describe("buildHostUpdateCommand — activation debt (installed-up-to-date short
     );
   });
 
-  it("EXPLICIT request BELOW the install record (installed-up-to-date) with debt: the record's debt is left and logged, no restart, the no-op, exit 0", async () => {
-    // `--version 1.2.0` against an installed 2.0.0 short-circuits as
-    // installed-up-to-date (at or above the request). The 2.0.0 record's
-    // debt is not this run's to pay: the caller confirmed 1.2.0 and nothing
-    // else. Falsification: gate the pre-lock debt on the record alone and
-    // the host restarts onto 2.0.0 under a confirmation for 1.2.0.
+  it("EXPLICIT request whose record MOVED above it between the download's check and the debt read, with debt: the record's debt is left and logged, no restart, the no-op, exit 0", async () => {
+    // The download's phase 1 refuses an explicit request below the record
+    // before any transfer (round 16, pinned in download-stage.test.ts), so
+    // installed-up-to-date for `--version 1.2.0` means the record WAS
+    // 1.2.0 at that check; the 2.0.0 the debt read sees moved in the gap
+    // (another actor's commit). Its debt is not this run's to pay: the
+    // caller confirmed 1.2.0 and nothing else. Falsification: gate the
+    // pre-lock debt on the record alone and the host restarts onto 2.0.0
+    // under a confirmation for 1.2.0.
     mocks.downloadAndStageHostMock.mockResolvedValue({
       outcome: "short-circuit",
       reason: "installed-up-to-date",
@@ -3887,6 +4051,71 @@ describe("buildHostUpdateCommand — activation debt (installed-up-to-date short
       }),
     );
     expect(result.human).toContain("no-op");
+  });
+
+  it("catalog domain (no runtime stamp): another build of the record's release running (2.0.0+bar under a 2.0.0+foo record) is DEBT, not activated - the host restarts onto the committed artifact", async () => {
+    // CodeRabbit r3945309408: the comparator called the pair equal, so a
+    // record without a stamp read as activated over a host serving another
+    // build - the debt gate saw nothing to collect, `targetObservedRunning`
+    // withdrew a failure naming 2.0.0+foo, and `clearStaleFailedMarker`
+    // cleared one. A release host publishes exactly its catalog version,
+    // so string identity is the rule in this domain too. Falsification:
+    // compare through `compareHostVersions` and no restart happens.
+    mocks.downloadAndStageHostMock.mockResolvedValue(upToDate("2.0.0+foo"));
+    mocks.readHostInstallRecordMock.mockResolvedValue(
+      sampleRecord("2.0.0+foo"),
+    );
+    mocks.readHostPidMetadataMock.mockResolvedValue(
+      pidRecord("2.0.0+bar", 4242),
+    );
+    mocks.identityVerdictMock.mockResolvedValue("current");
+
+    const result = await buildHostUpdateCommand({
+      force: false,
+      allowDowngrade: false,
+      ackNonce: null,
+    })(fakeCtx());
+
+    expect(mocks.stopHostForRestartWithAttemptMock).toHaveBeenCalledTimes(1);
+    const projected = projectInstallResultLikeDesktop(result.data);
+    expect(projected.previousVersion).toBe("2.0.0+bar");
+    expect(projected.version).toBe("2.0.0+foo");
+  });
+
+  it("catalog domain (no runtime stamp): a failed marker naming the record 2.0.0+foo while 2.0.0+bar runs is NOT cleared - the reading is debt, so the stale-failed reconcile never runs", async () => {
+    mocks.downloadAndStageHostMock.mockResolvedValue(upToDate("2.0.0+foo"));
+    mocks.readHostInstallRecordMock.mockResolvedValue(
+      sampleRecord("2.0.0+foo"),
+    );
+    mocks.readHostPidMetadataMock.mockResolvedValue(
+      pidRecord("2.0.0+bar", 4242),
+    );
+    mocks.identityVerdictMock.mockResolvedValue("current");
+    mocks.readUpdateProgressMarkerMock.mockResolvedValue({
+      state: "failed",
+      error: "host did not become healthy: tcp refused",
+      targetVersion: "2.0.0+foo",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      writerId: null,
+      writerStartIdentity: null,
+    });
+
+    await buildHostUpdateCommand({
+      force: false,
+      allowDowngrade: false,
+      ackNonce: null,
+    })(fakeCtx());
+
+    // The debt arm's own marker takes over the stale `failed` by CAS; the
+    // stale-failed reconcile's conditional delete of the FAILED record
+    // never fires. Falsification: compare through `compareHostVersions`
+    // and the reading is `activated`, the reconcile runs and deletes it.
+    expect(
+      mocks.deleteUpdateProgressMarkerIfUnchangedMock.mock.calls.filter(
+        (call) => (call[1] as HostUpdateProgress).state === "failed",
+      ),
+    ).toEqual([]);
+    expect(mocks.stopHostForRestartWithAttemptMock).toHaveBeenCalledTimes(1);
   });
 
   it("a non-SemVer runtime stamp the running host does NOT match: debt, activated - a staging host is never 'foreign'", async () => {

--- a/clients/traycer-cli/src/commands/__tests__/host-update.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/host-update.test.ts
@@ -200,7 +200,7 @@ import type {
   DownloadAndStageHostOptions,
   HostDownloadOutcome,
 } from "../../installer/download-stage";
-import type { ApplyHostOutcome } from "../../installer/apply";
+import type { ApplyHostOptions, ApplyHostOutcome } from "../../installer/apply";
 import type { HostUpdateProgress } from "../../host/update-progress-marker";
 // Value import (not type-only): the module is mocked above, and that mock
 // factory defines `sameProgress` as the REAL comparator (not a `vi.fn()`), so
@@ -867,11 +867,16 @@ describe("buildHostUpdateCommand composite", () => {
     // The read happens strictly BETWEEN lock-enter and lock-exit - the
     // exact coherence guarantee Finding 8 requires (a read after
     // lock-exit could observe a stage a different, now-unblocked actor
-    // already mutated).
+    // already mutated). Only the HOST_BUSY catch itself reads the staged
+    // record now (for the error payload) - `applyAndProjectLegacy` no
+    // longer pre-reads it before `applyHost`, so there is exactly ONE read.
     expect(mocks.callOrder).toEqual(["lock-enter", "read-staged", "lock-exit"]);
   });
 
   it("propagates a non-busy applyHost error unchanged, without reading the staged record", async () => {
+    // Falsification: read the staged record in the generic (non-HOST_BUSY)
+    // catch arm, or pre-read it before calling `applyHost`, and
+    // `readHostStagedRecordMock` below is called.
     mocks.downloadAndStageHostMock.mockResolvedValue({
       outcome: "promoted",
       stagedVersion: "2.0.0",
@@ -916,6 +921,178 @@ describe("buildHostUpdateCommand composite", () => {
       code: CLI_ERROR_CODES.HOST_NOT_INSTALLED,
     });
     expect(mocks.applyHostMock).not.toHaveBeenCalled();
+  });
+});
+
+// The stage this run promoted before it waited for the contender lock can
+// be consumed by another actor - Desktop's launch converge runs
+// `host apply --no-service`, which commits the bytes and restarts nothing -
+// by the time this run holds the lock. `applyHost` then reports the no-op
+// it saw (`needsApply && !apply.applied`), and the command re-derives
+// `readActivationState` UNDER the same "only `debt` is a reason to act"
+// rule the pre-lock check applies (see `ActivationReading`'s doc comment:
+// "before the lock, only `debt` is a reason to act"). These pin every
+// reading that rule can land on.
+describe("buildHostUpdateCommand — stage consumed by another actor while waiting", () => {
+  beforeEach(() => {
+    mocks.probeHostHealthMock.mockResolvedValue({
+      healthy: true,
+      detail: "ok",
+    });
+    armActivationDefaults();
+    mocks.downloadAndStageHostMock.mockResolvedValue({
+      outcome: "promoted",
+      stagedVersion: "2.0.0",
+      installedVersion: "1.0.0",
+    } satisfies HostDownloadOutcome);
+    // The stage was consumed by the time this run holds the lock.
+    mocks.readHostStagedRecordMock.mockResolvedValue(null);
+    mocks.applyHostMock.mockResolvedValue({
+      outcome: "no-op",
+      installedVersion: "2.0.0",
+    } satisfies ApplyHostOutcome);
+    mocks.readHostInstallRecordMock.mockResolvedValue(sampleRecord("2.0.0"));
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+    mocks.callOrder = [];
+  });
+
+  function pidAt(version: string): {
+    pid: number;
+    hostId: string;
+    version: string;
+    websocketUrl: string;
+    startedAt: string;
+    processStartIdentity: null;
+    layer0: null;
+    layer0Slot: null;
+  } {
+    return {
+      pid: 4242,
+      hostId: "host-1",
+      version,
+      websocketUrl: "ws://127.0.0.1:51820/rpc",
+      startedAt: "2026-01-01T00:00:00.000Z",
+      processStartIdentity: null,
+      layer0: null,
+      layer0Slot: null,
+    };
+  }
+
+  it("reading DEBT: activates the committed install instead of reporting a false no-op", async () => {
+    // Falsification: gate the re-derived activation on any predicate other
+    // than `reading.kind === "debt"` (e.g. `!== "no-install"`) and this
+    // still passes for the right reason but the `activated`/`no-live-host`
+    // pins below would then wrongly activate too.
+    mocks.readHostPidMetadataMock.mockResolvedValue(pidAt("1.0.0"));
+    mocks.identityVerdictMock.mockResolvedValue("current");
+
+    const ctx = fakeCtx();
+    const result = await buildHostUpdateCommand({
+      force: false,
+      allowDowngrade: false,
+      ackNonce: null,
+    })(ctx);
+
+    expect(ctx.runtime.logger.info).toHaveBeenCalledWith(
+      "Host update found its stage consumed by another actor without activation; activating the committed install",
+      expect.objectContaining({
+        environment: "production",
+        installedVersion: "2.0.0",
+        runningVersion: "1.0.0",
+      }),
+    );
+    expect(mocks.stopHostForRestartWithAttemptMock).toHaveBeenCalledTimes(1);
+    expect(mocks.relaunchHostAfterRestartWithAttemptMock).toHaveBeenCalledTimes(
+      1,
+    );
+    expect(mocks.probeHostHealthMock).toHaveBeenCalledTimes(1);
+    expect(result.exitCode).toBe(0);
+    expect(result.human).toContain("updated host 1.0.0 → 2.0.0");
+  });
+
+  it("reading ACTIVATED: no activation, no probe - the running host already matches the record", async () => {
+    // Falsification: widen the re-derived guard to also cover `activated`
+    // and the activation arm fires despite the running host already
+    // matching the install record.
+    mocks.readHostPidMetadataMock.mockResolvedValue(pidAt("2.0.0"));
+    mocks.identityVerdictMock.mockResolvedValue("current");
+
+    const result = await buildHostUpdateCommand({
+      force: false,
+      allowDowngrade: false,
+      ackNonce: null,
+    })(fakeCtx());
+
+    expect(mocks.stopHostForRestartWithAttemptMock).not.toHaveBeenCalled();
+    expect(
+      mocks.relaunchHostAfterRestartWithAttemptMock,
+    ).not.toHaveBeenCalled();
+    expect(mocks.probeHostHealthMock).not.toHaveBeenCalled();
+    const written = mocks.writeUpdateProgressMarkerMock.mock
+      .calls[0][1] as HostUpdateProgress;
+    expect(
+      mocks.deleteUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenCalledWith("production", written);
+    expect(result.exitCode).toBe(0);
+    expect(result.human).toContain("host already at 2.0.0 (no-op)");
+  });
+
+  it("reading NO-LIVE-HOST: no activation, no probe - the out-of-lock rule is debt-only, same as the pre-lock check", async () => {
+    // Per `ActivationReading`'s own doc comment: "before the lock, only
+    // `debt` is a reason to act". This re-derived check runs OUT of the
+    // lock too (the stage-consumed no-op was observed before this
+    // command's own `withCliUpdateContender` call in the activation arm),
+    // so it applies the SAME rule rather than a wider one that would also
+    // fire on a host that is merely down.
+    mocks.readHostPidMetadataMock.mockResolvedValue(null);
+
+    const result = await buildHostUpdateCommand({
+      force: false,
+      allowDowngrade: false,
+      ackNonce: null,
+    })(fakeCtx());
+
+    expect(mocks.stopHostForRestartWithAttemptMock).not.toHaveBeenCalled();
+    expect(
+      mocks.relaunchHostAfterRestartWithAttemptMock,
+    ).not.toHaveBeenCalled();
+    expect(mocks.probeHostHealthMock).not.toHaveBeenCalled();
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("raced-stage debt clears under the activation arm's own lock: activationClearedWhileWaiting is true, not activatedInstalled", async () => {
+    // Falsification: revert the field to
+    // `needsActivate && !activationPerformed` and it logs false - this
+    // raced-stage debt never sets `needsActivate` (only the pre-lock
+    // short-circuit does), so the old field would miss this case entirely.
+    mocks.readHostPidMetadataMock
+      .mockResolvedValueOnce(pidAt("1.0.0"))
+      .mockResolvedValue(pidAt("2.0.0"));
+    mocks.identityVerdictMock.mockResolvedValue("current");
+
+    const ctx = fakeCtx();
+    const result = await buildHostUpdateCommand({
+      force: false,
+      allowDowngrade: false,
+      ackNonce: null,
+    })(ctx);
+
+    expect(mocks.stopHostForRestartWithAttemptMock).not.toHaveBeenCalled();
+    expect(
+      mocks.relaunchHostAfterRestartWithAttemptMock,
+    ).not.toHaveBeenCalled();
+    expect(mocks.probeHostHealthMock).not.toHaveBeenCalled();
+    expect(result.exitCode).toBe(0);
+    expect(ctx.runtime.logger.info).toHaveBeenCalledWith(
+      "Host update command completed",
+      expect.objectContaining({
+        activatedInstalled: false,
+        activationClearedWhileWaiting: true,
+      }),
+    );
   });
 });
 
@@ -1190,6 +1367,14 @@ describe("buildHostUpdateCommand — activation debt (installed-up-to-date short
     // parked-registration fallback runs `host restart` on this very host -
     // has already brought 2.0.0 up. Restarting again would cost the fresh
     // host its connections and report a transition this command did not make.
+    //
+    // This is also the raced-stage `debt` case for `activationClearedWhileWaiting`:
+    // the activation arm was ENTERED (the pre-lock read saw debt) but its
+    // under-lock re-read now says `activated`, so no activation is
+    // performed. Falsification: revert the field to
+    // `needsActivate && !activationPerformed` (both are true/false the same
+    // way here, so a plain `needsActivate` read cannot tell this apart from
+    // debt that was never entered - but `activationAttempted` can).
     mocks.downloadAndStageHostMock.mockResolvedValue(upToDate("2.0.0"));
     mocks.readHostInstallRecordMock.mockResolvedValue(sampleRecord("2.0.0"));
     mocks.readHostPidMetadataMock
@@ -1197,11 +1382,12 @@ describe("buildHostUpdateCommand — activation debt (installed-up-to-date short
       .mockResolvedValue(pidRecord("2.0.0", 4343));
     mocks.identityVerdictMock.mockResolvedValue("current");
 
+    const ctx = fakeCtx();
     const result = await buildHostUpdateCommand({
       force: false,
       allowDowngrade: false,
       ackNonce: null,
-    })(fakeCtx());
+    })(ctx);
 
     expect(mocks.readHostPidMetadataMock).toHaveBeenCalledTimes(2);
     expect(mocks.stopHostForRestartWithAttemptMock).not.toHaveBeenCalled();
@@ -1209,6 +1395,13 @@ describe("buildHostUpdateCommand — activation debt (installed-up-to-date short
     expect(projected.previousVersion).toBe("2.0.0");
     expect(projected.version).toBe("2.0.0");
     expect(result.human).toContain("no-op");
+    expect(ctx.runtime.logger.info).toHaveBeenCalledWith(
+      "Host update command completed",
+      expect.objectContaining({
+        activatedInstalled: false,
+        activationClearedWhileWaiting: true,
+      }),
+    );
   });
 
   it("debt cleared under the lock while the health probe would FAIL: no probe, no failed marker, the updating marker is cleared, exit 0", async () => {
@@ -1375,10 +1568,16 @@ describe("buildHostUpdateCommand — activation debt (installed-up-to-date short
   });
 
   it("the record moved under the lock but the marker is no longer ours: the re-point is refused, and the final clear still targets the ORIGINAL marker", async () => {
-    // Same setup as the re-point test above, but the compare-and-swap reports
-    // the pre-lock marker no longer matches what is on disk (a newer updater
-    // owns it now). The activation still proceeds - the debt clears either
-    // way - but the progress marker this run tracks must stay pinned to the
+    // Same setup as the re-point test above, but the compare-and-swap always
+    // reports "changed" - the pre-lock marker no longer matches what is on
+    // disk (a newer updater owns it now). Under the new retry loop this
+    // means: the FIRST replace attempt reports "changed", the loop re-reads
+    // the disk to tell a moved record from a merely-failed write apart, and
+    // the re-read shows the SAME record it just tried to replace (this
+    // fixture's disk never actually changes) - so the loop concludes the
+    // write itself failed, warns, and stops trying rather than retrying
+    // forever. The activation still proceeds - the debt clears either way -
+    // but the progress marker this run tracks must stay pinned to the
     // ORIGINAL pre-lock record rather than following a re-point that never
     // actually landed.
     mocks.downloadAndStageHostMock.mockResolvedValue(upToDate("2.0.0"));
@@ -1391,22 +1590,33 @@ describe("buildHostUpdateCommand — activation debt (installed-up-to-date short
       "changed",
     );
 
+    const ctx = fakeCtx();
     const result = await buildHostUpdateCommand({
       force: false,
       allowDowngrade: false,
       ackNonce: null,
-    })(fakeCtx());
+    })(ctx);
 
     expect(mocks.writeUpdateProgressMarkerMock).toHaveBeenCalledTimes(1);
     const written = mocks.writeUpdateProgressMarkerMock.mock
       .calls[0][1] as HostUpdateProgress;
     expect(written.targetVersion).toBe("2.0.0");
+    // Exactly ONE replace attempt - the loop stops after the re-read shows
+    // the write did not land, rather than retrying against an unchanging
+    // disk.
+    expect(
+      mocks.replaceUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenCalledTimes(1);
     expect(
       mocks.replaceUpdateProgressMarkerIfUnchangedMock,
     ).toHaveBeenCalledWith(
       "production",
       written,
       expect.objectContaining({ state: "updating", targetVersion: "2.1.0" }),
+    );
+    expect(ctx.runtime.logger.warn).toHaveBeenCalledWith(
+      "Host update could not write the progress marker under the lock; proceeding without re-asserting it",
+      expect.objectContaining({ environment: "production" }),
     );
     // Activation still proceeds: a refused re-point does not block the
     // restart, it only leaves the progress marker pointed at the stale
@@ -2255,9 +2465,14 @@ describe("buildHostUpdateCommand — reassertMarkerUnderLock under the lock", ()
         } satisfies HostDownloadOutcome;
       },
     );
-    mocks.applyHostMock.mockResolvedValue(
-      appliedOutcome("1.0.0", "2.0.0", null),
-    );
+    // The hook now fires INSIDE `applyHost` (after its own reconcile and
+    // busy gate, immediately before it commits) rather than from
+    // `applyAndProjectLegacy` directly, so the mock standing in for
+    // `applyHost` has to invoke it itself to exercise the republish.
+    mocks.applyHostMock.mockImplementation(async (opts: ApplyHostOptions) => {
+      await opts.onWillCommitStaged?.("2.0.0");
+      return appliedOutcome("1.0.0", "2.0.0", null);
+    });
 
     const result = await buildHostUpdateCommand({
       force: false,
@@ -2278,12 +2493,14 @@ describe("buildHostUpdateCommand — reassertMarkerUnderLock under the lock", ()
       .calls[0][1] as HostUpdateProgress;
     expect(firstWrite.targetVersion).toBe("2.0.0");
     expect(republished.targetVersion).toBe("2.0.0");
-    // The republish happens under the lock, strictly before the apply half
-    // - `invocationCallOrder` gives a global ordering across every mock.
+    // The republish happens while `applyHost` is in flight - INSIDE its own
+    // call, via the `onWillCommitStaged` hook - not before `applyHost` is
+    // invoked. `invocationCallOrder` gives a global ordering across every
+    // mock, so the create's order comes out AFTER applyHost's own entry.
     const createOrder =
       mocks.createUpdateProgressMarkerIfAbsentMock.mock.invocationCallOrder[0];
     const applyOrder = mocks.applyHostMock.mock.invocationCallOrder[0];
-    expect(createOrder).toBeLessThan(applyOrder);
+    expect(createOrder).toBeGreaterThan(applyOrder);
     // The final clear follows the republished record, not the withdrawn one -
     // `ownMarker.current` was adopted from the create call's own argument.
     expect(
@@ -2292,12 +2509,62 @@ describe("buildHostUpdateCommand — reassertMarkerUnderLock under the lock", ()
     expect(result.exitCode).toBe(0);
   });
 
-  it("another updater's marker on disk under the lock: left alone", async () => {
-    // Falsification: collapse `reassertMarkerUnderLock` to an
-    // unconditional `publishUpdating(targetVersion)` (drop the disk read
-    // and the ownership check entirely) and `writeUpdateProgressMarker`
-    // below is called twice, with the second write stamping over the
-    // foreign record instead of leaving it alone.
+  it("under the lock, the marker target follows the version applyHost is committing, not the pre-lock download target", async () => {
+    // Falsification: pass the pre-lock download target to
+    // `onWillCommitStaged` instead of the version `applyHost` is actually
+    // committing, and the re-point call below never happens - the marker
+    // stays pointed at 2.0.0 while `applyHost` actually installs 2.1.0.
+    mocks.downloadAndStageHostMock.mockResolvedValue({
+      outcome: "promoted",
+      stagedVersion: "2.0.0",
+      installedVersion: "1.0.0",
+    } satisfies HostDownloadOutcome);
+    // `applyHost` commits a NEWER version than the one this run promoted
+    // before it waited for the lock - a later promoter left it on the
+    // shared stage, and `applyHost` reports the version it is actually
+    // committing through the hook.
+    mocks.applyHostMock.mockImplementation(async (opts: ApplyHostOptions) => {
+      await opts.onWillCommitStaged?.("2.1.0");
+      return appliedOutcome("1.0.0", "2.1.0", null);
+    });
+
+    const result = await buildHostUpdateCommand({
+      force: false,
+      allowDowngrade: false,
+      ackNonce: null,
+    })(fakeCtx());
+
+    expect(mocks.writeUpdateProgressMarkerMock).toHaveBeenCalledTimes(1);
+    const preLock = mocks.writeUpdateProgressMarkerMock.mock
+      .calls[0][1] as HostUpdateProgress;
+    expect(preLock.targetVersion).toBe("2.0.0");
+    // The re-point happens INSIDE `applyHost` (via `onWillCommitStaged`),
+    // against this run's own pre-lock record, naming the version
+    // `applyHost` is actually committing.
+    expect(
+      mocks.replaceUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenCalledWith(
+      "production",
+      preLock,
+      expect.objectContaining({ state: "updating", targetVersion: "2.1.0" }),
+    );
+    const repointed = mocks.replaceUpdateProgressMarkerIfUnchangedMock.mock
+      .calls[0][2] as HostUpdateProgress;
+    const replaceOrder =
+      mocks.replaceUpdateProgressMarkerIfUnchangedMock.mock
+        .invocationCallOrder[0];
+    const applyOrder = mocks.applyHostMock.mock.invocationCallOrder[0];
+    expect(replaceOrder).toBeGreaterThan(applyOrder);
+    // The final clear is CAS'd against the re-pointed 2.1.0 record.
+    expect(
+      mocks.deleteUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenCalledWith("production", repointed);
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("another updater's marker on disk under the lock: taken over (the lock holder owns the marker)", async () => {
+    // Falsification: revert the takeover branch to a `return` and the
+    // replace call below never happens.
     const foreignRecord: HostUpdateProgress = {
       state: "updating",
       error: null,
@@ -2309,8 +2576,9 @@ describe("buildHostUpdateCommand — reassertMarkerUnderLock under the lock", ()
       async (opts: DownloadAndStageHostOptions) => {
         await requireHook(opts)("2.0.0");
         // Another updater's `updating` has landed at the same path by the
-        // time this run reaches the lock - a live progress signal that is
-        // not this run's to touch.
+        // time this run reaches the lock - a live progress signal, but
+        // from a writer that is NOT doing disruptive work right now (it
+        // is waiting for this same lock, or already released it).
         mocks.disk.current = foreignRecord;
         return {
           outcome: "promoted",
@@ -2319,40 +2587,363 @@ describe("buildHostUpdateCommand — reassertMarkerUnderLock under the lock", ()
         } satisfies HostDownloadOutcome;
       },
     );
-    // The apply half then genuinely fails busy - the park path, which only
-    // ever WITHDRAWS (conditionally) and never stamps `failed`, is what
-    // lets this test observe the foreign record surviving untouched.
-    mocks.applyHostMock.mockRejectedValue(
-      cliError({
+    // `applyHost` proceeds past its own busy gate and calls the hook right
+    // before it commits - this run takes the marker over and the apply
+    // itself succeeds.
+    mocks.applyHostMock.mockImplementation(async (opts: ApplyHostOptions) => {
+      await opts.onWillCommitStaged?.("2.0.0");
+      return appliedOutcome("1.0.0", "2.0.0", null);
+    });
+
+    const ctx = fakeCtx();
+    const result = await buildHostUpdateCommand({
+      force: false,
+      allowDowngrade: false,
+      ackNonce: null,
+    })(ctx);
+
+    expect(result.exitCode).toBe(0);
+    // The pre-lock publish is the only `writeUpdateProgressMarker` call -
+    // the takeover itself goes through the CAS replace primitive.
+    expect(mocks.writeUpdateProgressMarkerMock).toHaveBeenCalledTimes(1);
+    // The takeover replaces the FOREIGN record with a fresh `updating`
+    // record naming the target this run is working toward.
+    expect(
+      mocks.replaceUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenCalledWith(
+      "production",
+      foreignRecord,
+      expect.objectContaining({ state: "updating", targetVersion: "2.0.0" }),
+    );
+    const adopted = mocks.replaceUpdateProgressMarkerIfUnchangedMock.mock
+      .calls[0][2] as HostUpdateProgress;
+    expect(ctx.runtime.logger.info).toHaveBeenCalledWith(
+      "Host update took over the progress marker under the lock - its writer is not doing disruptive work",
+      expect.objectContaining({
+        environment: "production",
+        targetVersion: "2.0.0",
+        previousState: "updating",
+        previousTarget: "2.0.0",
+      }),
+    );
+    // The final clear is CAS'd against the ADOPTED fresh record - not the
+    // pre-lock record this run originally wrote.
+    expect(
+      mocks.deleteUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenCalledWith("production", adopted);
+    expect(
+      mocks.deleteUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenCalledTimes(1);
+  });
+
+  it("busy park after a takeover: the displaced record is RESTORED, and no `failed` stamp lands", async () => {
+    // Falsification: withdraw this run's own record unconditionally on
+    // park instead of restoring the displaced one when
+    // `displacedMarker.current` is set, and the second replace call below
+    // never happens (or targets the wrong pair).
+    const foreignRecord: HostUpdateProgress = {
+      state: "updating",
+      error: null,
+      targetVersion: "2.0.0",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      writerId: "foreign-writer",
+    };
+    mocks.downloadAndStageHostMock.mockImplementation(
+      async (opts: DownloadAndStageHostOptions) => {
+        await requireHook(opts)("2.0.0");
+        mocks.disk.current = foreignRecord;
+        return {
+          outcome: "promoted",
+          stagedVersion: "2.0.0",
+          installedVersion: "1.0.0",
+        } satisfies HostDownloadOutcome;
+      },
+    );
+    // `applyHost` calls the hook - taking the marker over - and only THEN
+    // rejects busy: the stop's own cooperative claim can still be denied
+    // past `applyHost`'s pre-commit busy gate.
+    mocks.applyHostMock.mockImplementation(async (opts: ApplyHostOptions) => {
+      await opts.onWillCommitStaged?.("2.0.0");
+      throw cliError({
         code: CLI_ERROR_CODES.HOST_BUSY,
         message: "The running host has work in progress",
         details: null,
         exitCode: 1,
-      }),
-    );
+      });
+    });
+    // The busy catch re-reads the staged record for the error payload,
+    // still inside the same lock span - not read anywhere else in this
+    // scenario.
     mocks.readHostStagedRecordMock.mockResolvedValue(null);
 
+    const ctx = fakeCtx();
     await expect(
       buildHostUpdateCommand({
         force: false,
         allowDowngrade: false,
         ackNonce: null,
-      })(fakeCtx()),
+      })(ctx),
     ).rejects.toMatchObject({ code: CLI_ERROR_CODES.HOST_BUSY });
 
-    expect(mocks.writeUpdateProgressMarkerMock).toHaveBeenCalledTimes(1);
-    const written = mocks.writeUpdateProgressMarkerMock.mock
-      .calls[0][1] as HostUpdateProgress;
+    const adopted = mocks.replaceUpdateProgressMarkerIfUnchangedMock.mock
+      .calls[0][2] as HostUpdateProgress;
+    // The park RESTORES the displaced record (the foreign marker this run
+    // took over) rather than withdrawing this run's own - it did no
+    // disruptive work after all.
     expect(
       mocks.replaceUpdateProgressMarkerIfUnchangedMock,
-    ).not.toHaveBeenCalled();
-    // The withdrawal on park is ASKED for (against our own pre-lock
-    // record), but the CAS refuses it because the disk holds someone
-    // else's marker now.
+    ).toHaveBeenCalledWith("production", adopted, foreignRecord);
+    expect(ctx.runtime.logger.info).toHaveBeenCalledWith(
+      "Host update parked - the host has work in progress; the progress marker it took over was restored to its previous writer",
+      expect.objectContaining({ environment: "production" }),
+    );
     expect(
       mocks.deleteUpdateProgressMarkerIfUnchangedMock,
-    ).toHaveBeenCalledWith("production", written);
-    expect(mocks.disk.current).toEqual(foreignRecord);
+    ).not.toHaveBeenCalled();
+    // Exactly two replace calls - the takeover, then the restore - proves
+    // no `failed` stamp landed too: a PARK never reaches `markUpdateFailed`,
+    // which would have been a third replace call naming `state: "failed"`.
+    expect(
+      mocks.replaceUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenCalledTimes(2);
+  });
+
+  it("a failure after a takeover but before the host is disturbed restores the displaced record", async () => {
+    // Falsification: drop the `!disruptionStarted` restore branch in the
+    // generic catch and the second replace becomes a `failed` stamp.
+    const foreignRecord: HostUpdateProgress = {
+      state: "updating",
+      error: null,
+      targetVersion: "2.0.0",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      writerId: "foreign-writer",
+    };
+    mocks.downloadAndStageHostMock.mockImplementation(
+      async (opts: DownloadAndStageHostOptions) => {
+        await requireHook(opts)("2.0.0");
+        // Another updater's `updating` is on disk by the time this run
+        // reaches the lock - the takeover target below.
+        mocks.disk.current = foreignRecord;
+        return {
+          outcome: "promoted",
+          stagedVersion: "2.0.0",
+          installedVersion: "1.0.0",
+        } satisfies HostDownloadOutcome;
+      },
+    );
+    // `applyHost` takes the marker over via the hook, then rejects a
+    // NON-busy error WITHOUT ever reporting progress - no `service-stop`
+    // or `swap` reached the host at all.
+    mocks.applyHostMock.mockImplementation(async (opts: ApplyHostOptions) => {
+      await opts.onWillCommitStaged?.("2.0.0");
+      throw cliError({
+        code: CLI_ERROR_CODES.SERVICE_CONTROL_FAILED,
+        message: "could not stop the service",
+        details: null,
+        exitCode: 1,
+      });
+    });
+
+    const ctx = fakeCtx();
+    await expect(
+      buildHostUpdateCommand({
+        force: false,
+        allowDowngrade: false,
+        ackNonce: null,
+      })(ctx),
+    ).rejects.toMatchObject({
+      code: CLI_ERROR_CODES.SERVICE_CONTROL_FAILED,
+    });
+
+    expect(
+      mocks.replaceUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenNthCalledWith(
+      1,
+      "production",
+      foreignRecord,
+      expect.objectContaining({
+        state: "updating",
+        targetVersion: "2.0.0",
+      }),
+    );
+    const adopted = mocks.replaceUpdateProgressMarkerIfUnchangedMock.mock
+      .calls[0][2] as HostUpdateProgress;
+    expect(
+      mocks.replaceUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenNthCalledWith(2, "production", adopted, foreignRecord);
+    // Exactly two replace calls - the takeover, then the restore - proves
+    // no `failed` record ever landed on any marker mock: a third call
+    // naming `state: "failed"` would have shown up here.
+    expect(
+      mocks.replaceUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenCalledTimes(2);
+    expect(ctx.runtime.logger.info).toHaveBeenCalledWith(
+      "Host update failed before disturbing the host; the progress marker it took over was restored to its previous writer",
+      expect.objectContaining({ environment: "production" }),
+    );
+  });
+
+  it("a failure after the host was disturbed stamps `failed` over the taken-over record", async () => {
+    // Falsification: make `reportProgress` ignore `service-stop` and this
+    // stamps nothing / restores instead.
+    const foreignRecord: HostUpdateProgress = {
+      state: "updating",
+      error: null,
+      targetVersion: "2.0.0",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      writerId: "foreign-writer",
+    };
+    mocks.downloadAndStageHostMock.mockImplementation(
+      async (opts: DownloadAndStageHostOptions) => {
+        await requireHook(opts)("2.0.0");
+        mocks.disk.current = foreignRecord;
+        return {
+          outcome: "promoted",
+          stagedVersion: "2.0.0",
+          installedVersion: "1.0.0",
+        } satisfies HostDownloadOutcome;
+      },
+    );
+    // `applyHost` takes the marker over, reports `service-stop` - the host
+    // is now being disturbed - and only then rejects a NON-busy error.
+    mocks.applyHostMock.mockImplementation(async (opts: ApplyHostOptions) => {
+      await opts.onWillCommitStaged?.("2.0.0");
+      opts.onProgress({
+        stage: "service-stop",
+        message: null,
+        percent: null,
+        bytes: null,
+        totalBytes: null,
+        workUnits: null,
+      });
+      throw cliError({
+        code: CLI_ERROR_CODES.SERVICE_CONTROL_FAILED,
+        message: "could not stop the service",
+        details: null,
+        exitCode: 1,
+      });
+    });
+
+    const ctx = fakeCtx();
+    await expect(
+      buildHostUpdateCommand({
+        force: false,
+        allowDowngrade: false,
+        ackNonce: null,
+      })(ctx),
+    ).rejects.toMatchObject({
+      code: CLI_ERROR_CODES.SERVICE_CONTROL_FAILED,
+    });
+
+    const adopted = mocks.replaceUpdateProgressMarkerIfUnchangedMock.mock
+      .calls[0][2] as HostUpdateProgress;
+    expect(
+      mocks.replaceUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenNthCalledWith(
+      2,
+      "production",
+      adopted,
+      expect.objectContaining({
+        state: "failed",
+        targetVersion: "2.0.0",
+      }),
+    );
+    expect(ctx.runtime.logger.info).not.toHaveBeenCalledWith(
+      "Host update failed before disturbing the host; the progress marker it took over was restored to its previous writer",
+      expect.anything(),
+    );
+  });
+
+  it("the activation arm counts as disturbing the host from its hook on", async () => {
+    // Falsification: replace `reassertMarkerThenDisrupt` with
+    // `reassertMarkerUnderLock` at the debt call site and this restores
+    // instead.
+    mocks.downloadAndStageHostMock.mockResolvedValue({
+      outcome: "short-circuit",
+      reason: "installed-up-to-date",
+      targetVersion: "2.0.0",
+      installedVersion: "2.0.0",
+      stagedVersion: null,
+    } satisfies HostDownloadOutcome);
+    mocks.readHostInstallRecordMock.mockResolvedValue(sampleRecord("2.0.0"));
+    const runningAt1 = {
+      pid: 4242,
+      hostId: "host-1",
+      version: "1.0.0",
+      websocketUrl: "ws://127.0.0.1:51820/rpc",
+      startedAt: "2026-01-01T00:00:00.000Z",
+      processStartIdentity: null,
+      layer0: null,
+      layer0Slot: null,
+    };
+    const foreignRecord: HostUpdateProgress = {
+      state: "updating",
+      error: null,
+      targetVersion: "2.0.0",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      writerId: "foreign-writer",
+    };
+    // Debt on both reads (out of the lock, and again under the activation
+    // arm's own lock) - the SECOND read's side effect is what lands the
+    // foreign marker under the lock, between this run's pre-lock publish
+    // and the activation arm's takeover hook.
+    mocks.readHostPidMetadataMock
+      .mockResolvedValueOnce(runningAt1)
+      .mockImplementationOnce(async () => {
+        mocks.disk.current = foreignRecord;
+        return runningAt1;
+      });
+    mocks.identityVerdictMock.mockResolvedValue("current");
+    mocks.stopHostForRestartWithAttemptMock.mockRejectedValue(
+      cliError({
+        code: CLI_ERROR_CODES.SERVICE_CONTROL_FAILED,
+        message: "could not stop the service",
+        details: null,
+        exitCode: 1,
+      }),
+    );
+
+    const ctx = fakeCtx();
+    await expect(
+      buildHostUpdateCommand({
+        force: false,
+        allowDowngrade: false,
+        ackNonce: null,
+      })(ctx),
+    ).rejects.toMatchObject({
+      code: CLI_ERROR_CODES.SERVICE_CONTROL_FAILED,
+    });
+
+    expect(
+      mocks.replaceUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenNthCalledWith(
+      1,
+      "production",
+      foreignRecord,
+      expect.objectContaining({
+        state: "updating",
+        targetVersion: "2.0.0",
+      }),
+    );
+    const adopted = mocks.replaceUpdateProgressMarkerIfUnchangedMock.mock
+      .calls[0][2] as HostUpdateProgress;
+    // The hook already ran (the takeover above proves it) before the stop
+    // rejected, so this is a `failed` stamp, never a restore.
+    expect(
+      mocks.replaceUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenNthCalledWith(
+      2,
+      "production",
+      adopted,
+      expect.objectContaining({
+        state: "failed",
+        targetVersion: "2.0.0",
+      }),
+    );
+    expect(ctx.runtime.logger.info).not.toHaveBeenCalledWith(
+      "Host update failed before disturbing the host; the progress marker it took over was restored to its previous writer",
+      expect.anything(),
+    );
   });
 
   it("downgrade arm passes onBeforeCommit and it re-asserts", async () => {
@@ -2397,7 +2988,7 @@ describe("buildHostUpdateCommand — reassertMarkerUnderLock under the lock", ()
     );
   });
 
-  it("empty path, but a marker lands between the read and the republish \u2192 the create refuses and this run proceeds under the other updater's marker", async () => {
+  it("empty path, but a marker lands between the read and the republish \u2192 the create refuses, the next iteration reads it and takes it over", async () => {
     // Falsification: revert the empty arm to `publishUpdating` and this pin
     // reddens on the write assertion.
     mocks.downloadAndStageHostMock.mockImplementation(
@@ -2414,9 +3005,10 @@ describe("buildHostUpdateCommand — reassertMarkerUnderLock under the lock", ()
         } satisfies HostDownloadOutcome;
       },
     );
-    mocks.applyHostMock.mockResolvedValue(
-      appliedOutcome("1.0.0", "2.0.0", null),
-    );
+    mocks.applyHostMock.mockImplementation(async (opts: ApplyHostOptions) => {
+      await opts.onWillCommitStaged?.("2.0.0");
+      return appliedOutcome("1.0.0", "2.0.0", null);
+    });
     const foreignRecord: HostUpdateProgress = {
       state: "updating",
       error: null,
@@ -2434,34 +3026,36 @@ describe("buildHostUpdateCommand — reassertMarkerUnderLock under the lock", ()
       },
     );
 
-    const ctx = fakeCtx();
     const result = await buildHostUpdateCommand({
       force: false,
       allowDowngrade: false,
       ackNonce: null,
-    })(ctx);
+    })(fakeCtx());
 
     // No second unconditional write - the refusal is the create call
     // itself, never a `writeUpdateProgressMarker`.
     expect(mocks.writeUpdateProgressMarkerMock).toHaveBeenCalledTimes(1);
-    const firstWrite = mocks.writeUpdateProgressMarkerMock.mock
-      .calls[0][1] as HostUpdateProgress;
     expect(mocks.createUpdateProgressMarkerIfAbsentMock).toHaveBeenCalledTimes(
       1,
     );
-    expect(ctx.runtime.logger.info).toHaveBeenCalledWith(
-      "Host update proceeds under another updater's progress marker; it landed while this run re-asserted its own",
-      expect.objectContaining({
-        environment: "production",
-        targetVersion: "2.0.0",
-      }),
+    // The loop's NEXT iteration reads the record the refused create just
+    // observed on disk, and takes it over - the old "proceeds under
+    // another updater's marker" log line no longer exists.
+    expect(
+      mocks.replaceUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenCalledWith(
+      "production",
+      foreignRecord,
+      expect.objectContaining({ state: "updating", targetVersion: "2.0.0" }),
     );
-    // `ownMarker` was never replaced - the later conditional clear/stamp is
-    // still CAS'd against THIS run's ORIGINAL pre-lock record, not the
-    // foreign one that won the race.
+    const adopted = mocks.replaceUpdateProgressMarkerIfUnchangedMock.mock
+      .calls[0][2] as HostUpdateProgress;
+    // `ownMarker` was ADOPTED from the takeover - the later conditional
+    // clear/stamp is CAS'd against the newly taken-over record, not this
+    // run's original pre-lock one.
     expect(
       mocks.deleteUpdateProgressMarkerIfUnchangedMock,
-    ).toHaveBeenCalledWith("production", firstWrite);
+    ).toHaveBeenCalledWith("production", adopted);
     expect(result.exitCode).toBe(0);
   });
 
@@ -2479,9 +3073,10 @@ describe("buildHostUpdateCommand — reassertMarkerUnderLock under the lock", ()
         } satisfies HostDownloadOutcome;
       },
     );
-    mocks.applyHostMock.mockResolvedValue(
-      appliedOutcome("1.0.0", "2.0.0", null),
-    );
+    mocks.applyHostMock.mockImplementation(async (opts: ApplyHostOptions) => {
+      await opts.onWillCommitStaged?.("2.0.0");
+      return appliedOutcome("1.0.0", "2.0.0", null);
+    });
     mocks.createUpdateProgressMarkerIfAbsentMock.mockImplementationOnce(
       async () => "failed",
     );
@@ -2504,5 +3099,131 @@ describe("buildHostUpdateCommand — reassertMarkerUnderLock under the lock", ()
     expect(
       mocks.deleteUpdateProgressMarkerIfUnchangedMock,
     ).toHaveBeenCalledWith("production", firstWrite);
+  });
+
+  it('an I/O-failed CAS is not retried: the CAS reports "changed" but the re-read shows the same record, so the run stops trying', async () => {
+    // Falsification: retry against the same expected record on every
+    // "changed" answer instead of comparing the re-read against
+    // `lastExpected`, and this test would see more than one replace call.
+    mocks.downloadAndStageHostMock.mockImplementation(
+      async (opts: DownloadAndStageHostOptions) => {
+        await requireHook(opts)("2.0.0");
+        return {
+          outcome: "promoted",
+          stagedVersion: "2.0.0",
+          installedVersion: "1.0.0",
+        } satisfies HostDownloadOutcome;
+      },
+    );
+    // The hook reports a MOVED target ("2.1.0"), so the loop must re-point
+    // the record it already owns - and the CAS resolves "changed" while the
+    // disk fixture underneath it never actually moves (an I/O failure on
+    // the write itself, not a race with another writer).
+    mocks.applyHostMock.mockImplementation(async (opts: ApplyHostOptions) => {
+      await opts.onWillCommitStaged?.("2.1.0");
+      return appliedOutcome("1.0.0", "2.1.0", null);
+    });
+    mocks.replaceUpdateProgressMarkerIfUnchangedMock.mockResolvedValue(
+      "changed",
+    );
+
+    const ctx = fakeCtx();
+    const result = await buildHostUpdateCommand({
+      force: false,
+      allowDowngrade: false,
+      ackNonce: null,
+    })(ctx);
+
+    // Exactly ONE replace call - the re-read on the next iteration shows the
+    // SAME record it just tried to replace, so the loop concludes the write
+    // failed rather than retrying against an unmoving disk.
+    expect(
+      mocks.replaceUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenCalledTimes(1);
+    expect(ctx.runtime.logger.warn).toHaveBeenCalledWith(
+      "Host update could not write the progress marker under the lock; proceeding without re-asserting it",
+      expect.objectContaining({
+        environment: "production",
+        targetVersion: "2.1.0",
+      }),
+    );
+    // The update continues regardless - marker I/O never fails the command.
+    expect(result.exitCode).toBe(0);
+    // The final clear is CAS'd against the ORIGINAL pre-lock record - it
+    // was never adopted from the refused re-point.
+    const written = mocks.writeUpdateProgressMarkerMock.mock
+      .calls[0][1] as HostUpdateProgress;
+    expect(
+      mocks.deleteUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenCalledWith("production", written);
+  });
+
+  it("a park before the hook never touches the marker beyond this run's own record", async () => {
+    // Pins the COMMAND's park path, not `applyHost`'s own ordering:
+    // `applyHost` itself is mocked here, so moving `onWillCommitStaged`
+    // relative to the busy gate inside `apply.ts` cannot redden this test -
+    // that ordering is `apply.test.ts`'s "is not called when the busy check
+    // throws" to pin. What THIS test pins is that a busy rejection which
+    // never invokes the hook leaves `host-update.ts`'s park path with
+    // nothing to take over or replace - it only ever touches this run's own
+    // pre-lock record, exactly as if no foreign marker were on disk at all.
+    const foreignRecord: HostUpdateProgress = {
+      state: "updating",
+      error: null,
+      targetVersion: "9.9.9",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      writerId: "foreign-writer",
+    };
+    mocks.downloadAndStageHostMock.mockImplementation(
+      async (opts: DownloadAndStageHostOptions) => {
+        await requireHook(opts)("2.0.0");
+        // A foreign marker is already on disk BEFORE this run even reaches
+        // `applyHost` - it is never read or touched by the park below.
+        mocks.disk.current = foreignRecord;
+        return {
+          outcome: "promoted",
+          stagedVersion: "2.0.0",
+          installedVersion: "1.0.0",
+        } satisfies HostDownloadOutcome;
+      },
+    );
+    // `applyHost` rejects busy WITHOUT ever calling the hook - the real
+    // busy gate runs before `onWillCommitStaged`, so a run parked there
+    // never got the chance to take anything over.
+    mocks.applyHostMock.mockRejectedValue(
+      cliError({
+        code: CLI_ERROR_CODES.HOST_BUSY,
+        message: "The running host has work in progress",
+        details: null,
+        exitCode: 1,
+      }),
+    );
+    mocks.readHostStagedRecordMock.mockResolvedValue(null);
+
+    await expect(
+      buildHostUpdateCommand({
+        force: false,
+        allowDowngrade: false,
+        ackNonce: null,
+      })(fakeCtx()),
+    ).rejects.toMatchObject({ code: CLI_ERROR_CODES.HOST_BUSY });
+
+    // No takeover ever happened - the hook was never called.
+    expect(
+      mocks.replaceUpdateProgressMarkerIfUnchangedMock,
+    ).not.toHaveBeenCalled();
+    // The withdrawal is asked for against this run's OWN pre-lock record
+    // only - the foreign marker on disk means the CAS reports "changed"
+    // and leaves it alone, untouched.
+    const written = mocks.writeUpdateProgressMarkerMock.mock
+      .calls[0][1] as HostUpdateProgress;
+    expect(
+      mocks.deleteUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenCalledWith("production", written);
+    const outcome =
+      await mocks.deleteUpdateProgressMarkerIfUnchangedMock.mock.results[0]
+        .value;
+    expect(outcome).toBe("changed");
+    expect(mocks.disk.current).toEqual(foreignRecord);
   });
 });

--- a/clients/traycer-cli/src/commands/__tests__/host-update.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/host-update.test.ts
@@ -182,7 +182,10 @@ import { buildHostUpdateCommand } from "../host-update";
 import { CLI_ERROR_CODES, cliError } from "../../runner/errors";
 import type { CommandContext } from "../../runner/runner";
 import type { HostInstallRecord } from "../../manifest/host-install";
-import type { HostDownloadOutcome } from "../../installer/download-stage";
+import type {
+  DownloadAndStageHostOptions,
+  HostDownloadOutcome,
+} from "../../installer/download-stage";
 import type { ApplyHostOutcome } from "../../installer/apply";
 import type { HostUpdateProgress } from "../../host/update-progress-marker";
 
@@ -445,6 +448,7 @@ describe("buildHostUpdateCommand composite", () => {
       automatic: false,
       onProgress: expect.any(Function),
       registryClient: null,
+      onWillDownload: expect.any(Function),
     });
   });
 
@@ -1209,13 +1213,11 @@ describe("buildHostUpdateCommand — activation debt (installed-up-to-date short
     mocks.downloadAndStageHostMock.mockResolvedValue(upToDate("2.0.0"));
     mocks.readHostInstallRecordMock.mockResolvedValue(sampleRecord("2.0.0"));
     mocks.readHostPidMetadataMock.mockResolvedValue(pidRecord("1.0.0", 4242));
-    mocks.assertHostNotBusyMock.mockRejectedValue(
-      cliError({
-        code: CLI_ERROR_CODES.HOST_BUSY,
-        message: "host is busy",
-        details: {},
-        exitCode: 1,
-      }),
+    // A REAL failure under the lock - the stop half throws. Not a busy
+    // refusal: that one is a park now (see "the host is busy" below) and
+    // never reaches the failure stamp this test is about.
+    mocks.stopHostForRestartWithAttemptMock.mockRejectedValue(
+      new Error("stop failed"),
     );
     // By the time the failure is stamped, a third updater has already
     // landed its own `updating` at the live path - the compare-and-swap
@@ -1230,7 +1232,7 @@ describe("buildHostUpdateCommand — activation debt (installed-up-to-date short
         allowDowngrade: false,
         ackNonce: null,
       })(fakeCtx()),
-    ).rejects.toMatchObject({ code: CLI_ERROR_CODES.HOST_BUSY });
+    ).rejects.toThrow("stop failed");
 
     // Our own `updating` was written once; no unconditional `failed` write
     // ever happens - the failure goes through the compare-and-swap instead,
@@ -1776,7 +1778,17 @@ describe("buildHostUpdateCommand — activation debt (installed-up-to-date short
     expect(projected.previousVersion).toBe("staging.1783540000000.0a1b2c3d4");
   });
 
-  it("the host is busy: assertHostNotBusy rejects, the marker is left failed, and restart never runs", async () => {
+  it("the host is busy: assertHostNotBusy rejects, the run PARKS - its own updating marker is withdrawn, nothing is stamped failed, and restart never runs", async () => {
+    // A busy refusal is the policy working, not a failure: the install is
+    // committed and the running host is behind it, and the GUI derives
+    // "installed, restart to finish" from those two records. Stamping
+    // `failed` here painted "Update failed: work in progress" in red on
+    // every surface for a host doing exactly what it was asked to.
+    //
+    // Falsification: replace the `E_HOST_BUSY` catch arm in `host-update.ts`
+    // with a fall-through to `markUpdateFailed` and the `replace…` negative
+    // below goes red; drop the conditional delete and the `delete…` positive
+    // does.
     mocks.downloadAndStageHostMock.mockResolvedValue(upToDate("2.0.0"));
     mocks.readHostInstallRecordMock.mockResolvedValue(sampleRecord("2.0.0"));
     mocks.readHostPidMetadataMock.mockResolvedValue(pidRecord("1.0.0", 4242));
@@ -1802,13 +1814,18 @@ describe("buildHostUpdateCommand — activation debt (installed-up-to-date short
     expect(mocks.writeUpdateProgressMarkerMock).toHaveBeenCalledTimes(1);
     const written = mocks.writeUpdateProgressMarkerMock.mock
       .calls[0][1] as HostUpdateProgress;
+    expect(written).toEqual(
+      expect.objectContaining({ state: "updating", targetVersion: "2.0.0" }),
+    );
+    // Withdrawn CONDITIONALLY, against the record this run wrote - a newer
+    // updater's marker is not this run's to remove.
+    expect(
+      mocks.deleteUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenCalledWith("production", written);
+    expect(mocks.deleteUpdateProgressMarkerMock).not.toHaveBeenCalled();
     expect(
       mocks.replaceUpdateProgressMarkerIfUnchangedMock,
-    ).toHaveBeenCalledWith(
-      "production",
-      written,
-      expect.objectContaining({ state: "failed", targetVersion: "2.0.0" }),
-    );
+    ).not.toHaveBeenCalled();
   });
 
   it("the health probe fails after activation: rejects the health-check error, marks the marker failed, and never clears it", async () => {
@@ -1846,5 +1863,270 @@ describe("buildHostUpdateCommand — activation debt (installed-up-to-date short
       }),
     );
     expect(mocks.deleteUpdateProgressMarkerMock).not.toHaveBeenCalled();
+  });
+});
+
+// Busy park + early marker (Host Update Layer Redesign): `onWillDownload`
+// publishes the `updating` marker BEFORE the transfer starts, and a
+// HOST_BUSY rethrow from the apply arm withdraws that same marker instead of
+// stamping `failed` - the park is the policy working, not a failure.
+describe("buildHostUpdateCommand busy park + early marker", () => {
+  beforeEach(() => {
+    mocks.probeHostHealthMock.mockResolvedValue({
+      healthy: true,
+      detail: "ok",
+    });
+    armActivationDefaults();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+    mocks.callOrder = [];
+  });
+
+  function requireHook(
+    opts: DownloadAndStageHostOptions,
+  ): (targetVersion: string) => Promise<void> {
+    if (opts.onWillDownload === null) {
+      throw new Error("expected onWillDownload to be provided");
+    }
+    return opts.onWillDownload;
+  }
+
+  it("writes the updating marker from onWillDownload strictly before the download resolves, and clears it with the same written record", async () => {
+    mocks.downloadAndStageHostMock.mockImplementation(
+      async (opts: DownloadAndStageHostOptions) => {
+        await requireHook(opts)("2.0.0");
+        mocks.callOrder.push("download-resolved");
+        return {
+          outcome: "promoted",
+          stagedVersion: "2.0.0",
+          installedVersion: "1.0.0",
+        } satisfies HostDownloadOutcome;
+      },
+    );
+    mocks.writeUpdateProgressMarkerMock.mockImplementation(async () => {
+      mocks.callOrder.push("marker-written");
+    });
+    mocks.applyHostMock.mockResolvedValue(
+      appliedOutcome("1.0.0", "2.0.0", null),
+    );
+
+    const result = await buildHostUpdateCommand({
+      force: false,
+      allowDowngrade: false,
+      ackNonce: null,
+    })(fakeCtx());
+
+    expect(mocks.writeUpdateProgressMarkerMock).toHaveBeenCalledTimes(1);
+    expect(mocks.writeUpdateProgressMarkerMock).toHaveBeenCalledWith(
+      "production",
+      expect.objectContaining({ state: "updating", targetVersion: "2.0.0" }),
+    );
+    const markerIndex = mocks.callOrder.indexOf("marker-written");
+    const resolvedIndex = mocks.callOrder.indexOf("download-resolved");
+    expect(markerIndex).toBeGreaterThanOrEqual(0);
+    expect(resolvedIndex).toBeGreaterThanOrEqual(0);
+    // The load-bearing ordering: the marker is on disk before the download
+    // promise this command awaits ever resolves, not merely before `apply`.
+    expect(markerIndex).toBeLessThan(resolvedIndex);
+    const written = mocks.writeUpdateProgressMarkerMock.mock
+      .calls[0][1] as HostUpdateProgress;
+    expect(
+      mocks.deleteUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenCalledWith("production", written);
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("a transport failure that happens AFTER the hook fired stamps failed and does not delete", async () => {
+    mocks.downloadAndStageHostMock.mockImplementation(
+      async (opts: DownloadAndStageHostOptions) => {
+        await requireHook(opts)("2.0.0");
+        throw new Error("download failed: ECONNRESET");
+      },
+    );
+
+    await expect(
+      buildHostUpdateCommand({
+        force: false,
+        allowDowngrade: false,
+        ackNonce: null,
+      })(fakeCtx()),
+    ).rejects.toThrow("download failed: ECONNRESET");
+
+    expect(mocks.writeUpdateProgressMarkerMock).toHaveBeenCalledTimes(1);
+    const written = mocks.writeUpdateProgressMarkerMock.mock
+      .calls[0][1] as HostUpdateProgress;
+    expect(written.state).toBe("updating");
+    expect(written.targetVersion).toBe("2.0.0");
+    expect(
+      mocks.replaceUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenCalledWith(
+      "production",
+      written,
+      expect.objectContaining({
+        state: "failed",
+        error: "download failed: ECONNRESET",
+        targetVersion: "2.0.0",
+      }),
+    );
+    // Falsification: fold the HOST_BUSY delete-on-park branch into every
+    // catch arm (instead of gating it on the HOST_BUSY code check) and this
+    // goes red.
+    expect(
+      mocks.deleteUpdateProgressMarkerIfUnchangedMock,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("a failure BEFORE the hook fires writes no marker of any kind", async () => {
+    mocks.downloadAndStageHostMock.mockRejectedValue(
+      new Error("manifest unreachable"),
+    );
+
+    await expect(
+      buildHostUpdateCommand({
+        force: false,
+        allowDowngrade: false,
+        ackNonce: null,
+      })(fakeCtx()),
+    ).rejects.toThrow("manifest unreachable");
+
+    // Falsification: move `publishUpdating`'s first write to before
+    // `prepareHostUpdate` runs (outside the try that owns `onWillDownload`)
+    // and this goes red - a marker would appear for a run that never
+    // reached the hook.
+    expect(mocks.writeUpdateProgressMarkerMock).not.toHaveBeenCalled();
+    expect(
+      mocks.replaceUpdateProgressMarkerIfUnchangedMock,
+    ).not.toHaveBeenCalled();
+    expect(
+      mocks.deleteUpdateProgressMarkerIfUnchangedMock,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("apply-arm busy park: withdraws its own updating marker, never stamps failed, names the staged version in the message, and skips the health probe", async () => {
+    mocks.downloadAndStageHostMock.mockImplementation(
+      async (opts: DownloadAndStageHostOptions) => {
+        await requireHook(opts)("2.0.0");
+        return {
+          outcome: "promoted",
+          stagedVersion: "2.0.0",
+          installedVersion: "1.0.0",
+        } satisfies HostDownloadOutcome;
+      },
+    );
+    mocks.applyHostMock.mockRejectedValue(
+      cliError({
+        code: CLI_ERROR_CODES.HOST_BUSY,
+        message: "The running host has work in progress",
+        details: null,
+        exitCode: 1,
+      }),
+    );
+    mocks.readHostStagedRecordMock.mockResolvedValue({
+      schemaVersion: 1,
+      version: "2.0.0",
+      runtimeVersion: null,
+      archiveSha256: null,
+      sizeBytes: 1,
+      source: { kind: "registry", value: "2.0.0" },
+      signatureKeyId: "test-key",
+      signatureVerifiedAt: "2026-01-01T00:00:00.000Z",
+      executablePath: "traycer-host",
+      platform: "darwin",
+      arch: "arm64",
+    });
+
+    let caught: unknown;
+    try {
+      await buildHostUpdateCommand({
+        force: false,
+        allowDowngrade: false,
+        ackNonce: null,
+      })(fakeCtx());
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toMatchObject({
+      code: CLI_ERROR_CODES.HOST_BUSY,
+      details: { stagedVersion: "2.0.0" },
+    });
+    expect(caught).toBeInstanceOf(Error);
+    const message = (caught as Error).message;
+    expect(message).toContain("stays staged");
+    expect(message).toContain("--force");
+
+    expect(mocks.writeUpdateProgressMarkerMock).toHaveBeenCalledTimes(1);
+    const written = mocks.writeUpdateProgressMarkerMock.mock
+      .calls[0][1] as HostUpdateProgress;
+    expect(written.state).toBe("updating");
+    expect(
+      mocks.deleteUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenCalledTimes(1);
+    expect(
+      mocks.deleteUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenCalledWith("production", written);
+    // Falsification: drop the HOST_BUSY arm in the catch (let it fall
+    // through to the generic failure branch) and this goes red.
+    expect(
+      mocks.replaceUpdateProgressMarkerIfUnchangedMock,
+    ).not.toHaveBeenCalled();
+    // Falsification: probe health unconditionally instead of gating it on
+    // `workPerformed` and this goes red.
+    expect(mocks.probeHostHealthMock).not.toHaveBeenCalled();
+  });
+
+  it("already-staged short-circuit then apply: the marker is still written exactly once (the post-prepare write) and cleared conditionally", async () => {
+    mocks.downloadAndStageHostMock.mockResolvedValue({
+      outcome: "short-circuit",
+      reason: "already-staged",
+      targetVersion: "2.0.0",
+      installedVersion: "1.0.0",
+      stagedVersion: "2.0.0",
+    } satisfies HostDownloadOutcome);
+    mocks.applyHostMock.mockResolvedValue(
+      appliedOutcome("1.0.0", "2.0.0", null),
+    );
+
+    const result = await buildHostUpdateCommand({
+      force: false,
+      allowDowngrade: false,
+      ackNonce: null,
+    })(fakeCtx());
+
+    expect(mocks.writeUpdateProgressMarkerMock).toHaveBeenCalledTimes(1);
+    expect(mocks.writeUpdateProgressMarkerMock).toHaveBeenCalledWith(
+      "production",
+      expect.objectContaining({ state: "updating", targetVersion: "2.0.0" }),
+    );
+    const written = mocks.writeUpdateProgressMarkerMock.mock
+      .calls[0][1] as HostUpdateProgress;
+    expect(
+      mocks.deleteUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenCalledWith("production", written);
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("--force on the apply arm is unchanged (positive control)", async () => {
+    mocks.downloadAndStageHostMock.mockResolvedValue({
+      outcome: "promoted",
+      stagedVersion: "2.0.0",
+      installedVersion: "1.0.0",
+    } satisfies HostDownloadOutcome);
+    mocks.applyHostMock.mockResolvedValue(
+      appliedOutcome("1.0.0", "2.0.0", null),
+    );
+
+    const result = await buildHostUpdateCommand({
+      force: true,
+      allowDowngrade: false,
+      ackNonce: null,
+    })(fakeCtx());
+
+    expect(mocks.applyHostMock).toHaveBeenCalledWith(
+      expect.objectContaining({ force: true }),
+    );
+    expect(result.exitCode).toBe(0);
   });
 });

--- a/clients/traycer-cli/src/commands/__tests__/host-update.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/host-update.test.ts
@@ -654,6 +654,95 @@ describe("buildHostUpdateCommand composite", () => {
     expect(result.human).toContain("updated host 1.3.0-rc.1 → 1.2.0");
   });
 
+  it("downgrade arm no-op (another actor installed the requested version under the lock) with the record not yet running: the same bound activation arm restarts onto it", async () => {
+    // Falsification: treat the downgrade's no-op as applied and this
+    // throws on the outcome's shape; skip the re-derivation and the debt
+    // is reported as done with the old host still serving.
+    armActivationDefaults();
+    mocks.probeHostHealthMock.mockResolvedValue({
+      healthy: true,
+      detail: "ok",
+    });
+    // Pre-lock the record is ABOVE the request (that is what routes to the
+    // downgrade arm); under the arm's lock another actor has installed
+    // 1.2.0, and the arm reports the no-op.
+    let committedByAnotherActor = false;
+    mocks.readHostInstallRecordMock.mockImplementation(async () =>
+      sampleRecord(committedByAnotherActor ? "1.2.0" : "1.3.0-rc.1"),
+    );
+    mocks.installHostDowngradeMock.mockImplementation(async () => {
+      committedByAnotherActor = true;
+      return {
+        outcome: "no-op",
+        installedVersion: "1.2.0",
+      } satisfies ApplyHostOutcome;
+    });
+    mocks.readHostPidMetadataMock.mockResolvedValue({
+      pid: 4242,
+      hostId: "host-1",
+      version: "1.3.0-rc.1",
+      websocketUrl: "ws://127.0.0.1:51820/rpc",
+      startedAt: "2026-01-01T00:00:00.000Z",
+      processStartIdentity: null,
+      layer0: null,
+      layer0Slot: null,
+    });
+    mocks.identityVerdictMock.mockResolvedValue("current");
+
+    const result = await buildHostUpdateCommand({
+      force: false,
+      allowDowngrade: true,
+      versionRequest: "1.2.0",
+      ackNonce: null,
+    })(fakeCtx());
+
+    expect(mocks.stopHostForRestartWithAttemptMock).toHaveBeenCalledTimes(1);
+    expect(mocks.probeHostHealthMock).toHaveBeenCalledTimes(1);
+    expect(result.exitCode).toBe(0);
+    expect(result.human).toContain("updated host 1.3.0-rc.1 → 1.2.0");
+  });
+
+  it("downgrade arm no-op with the requested version already running: the no-op, exit 0, no restart", async () => {
+    armActivationDefaults();
+    // Pre-lock the record is ABOVE the request (that is what routes to the
+    // downgrade arm); under the arm's lock another actor has installed
+    // 1.2.0, and the arm reports the no-op.
+    let committedByAnotherActor = false;
+    mocks.readHostInstallRecordMock.mockImplementation(async () =>
+      sampleRecord(committedByAnotherActor ? "1.2.0" : "1.3.0-rc.1"),
+    );
+    mocks.installHostDowngradeMock.mockImplementation(async () => {
+      committedByAnotherActor = true;
+      return {
+        outcome: "no-op",
+        installedVersion: "1.2.0",
+      } satisfies ApplyHostOutcome;
+    });
+    mocks.readHostPidMetadataMock.mockResolvedValue({
+      pid: 4242,
+      hostId: "host-1",
+      version: "1.2.0",
+      websocketUrl: "ws://127.0.0.1:51820/rpc",
+      startedAt: "2026-01-01T00:00:00.000Z",
+      processStartIdentity: null,
+      layer0: null,
+      layer0Slot: null,
+    });
+    mocks.identityVerdictMock.mockResolvedValue("current");
+
+    const result = await buildHostUpdateCommand({
+      force: false,
+      allowDowngrade: true,
+      versionRequest: "1.2.0",
+      ackNonce: null,
+    })(fakeCtx());
+
+    expect(mocks.stopHostForRestartWithAttemptMock).not.toHaveBeenCalled();
+    expect(mocks.probeHostHealthMock).not.toHaveBeenCalled();
+    expect(result.exitCode).toBe(0);
+    expect(result.human).toContain("no-op");
+  });
+
   it("keeps an explicit lower target on the monotonic stage path unless downgrade is explicitly enabled", async () => {
     // Without `--allow-downgrade` an explicit lower target is an ordinary
     // stage request, and the promoter short-circuits it before any
@@ -1046,6 +1135,235 @@ describe("buildHostUpdateCommand — stage consumed by another actor while waiti
       layer0Slot: null,
     };
   }
+
+  // An EXPLICIT request recovers only onto its own version. The other actor
+  // committed whatever ITS stage held (Desktop's converge), which need not
+  // be the version this run was asked for and confirmed. Falsification:
+  // drop the pre-lock `installedVersionMismatch` in the recovery arm and
+  // the "activating the committed install" line is logged (the arm's own
+  // under-lock check still refuses); drop that too and the host restarts
+  // onto 2.1.0 under a confirmation for 2.0.0.
+  it("EXPLICIT request, another actor committed a NEWER version: refused as E_HOST_UPDATE_NOT_NEWER naming both, no restart, no activation log, this run's marker withdrawn - not stamped", async () => {
+    mocks.readHostInstallRecordMock.mockResolvedValue(sampleRecord("2.1.0"));
+    mocks.applyHostMock.mockResolvedValue({
+      outcome: "no-op",
+      installedVersion: "2.1.0",
+    } satisfies ApplyHostOutcome);
+    mocks.readHostPidMetadataMock.mockResolvedValue(pidAt("1.0.0"));
+    mocks.identityVerdictMock.mockResolvedValue("current");
+
+    const ctx = fakeCtx();
+    await expect(
+      buildHostUpdateCommand({
+        force: false,
+        allowDowngrade: false,
+        versionRequest: "2.0.0",
+        ackNonce: null,
+      })(ctx),
+    ).rejects.toMatchObject({
+      code: CLI_ERROR_CODES.HOST_UPDATE_NOT_NEWER,
+      message: expect.stringContaining(
+        "the installed host is 2.1.0, newer than the 2.0.0 this run was updating to",
+      ),
+    });
+    expect(
+      vi.mocked(ctx.runtime.logger.info).mock.calls.map((call) => call[0]),
+    ).not.toContain(
+      "Host update found its stage consumed by another actor without activation; activating the committed install",
+    );
+    expect(mocks.assertHostNotBusyMock).not.toHaveBeenCalled();
+    expect(mocks.stopHostForRestartWithAttemptMock).not.toHaveBeenCalled();
+    expect(
+      mocks.relaunchHostAfterRestartWithAttemptMock,
+    ).not.toHaveBeenCalled();
+    expect(mocks.probeHostHealthMock).not.toHaveBeenCalled();
+    // A SUPERSEDED request: nothing was wrong, so this run's own record is
+    // WITHDRAWN (conditional delete), never stamped `failed` - a `failed`
+    // naming 2.0.0 would stand over a host at 2.1.0 and neither
+    // stale-failed rule (target must equal the running version) would ever
+    // clear it. Falsification: drop `superseded` from the catch and the
+    // replace below carries a `failed`.
+    expect(
+      mocks.replaceUpdateProgressMarkerIfUnchangedMock.mock.calls.filter(
+        (call) => (call[2] as HostUpdateProgress).state === "failed",
+      ),
+    ).toEqual([]);
+    expect(
+      mocks.deleteUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenCalledWith(
+      "production",
+      expect.objectContaining({ state: "updating", targetVersion: "2.0.0" }),
+    );
+  });
+
+  it("EXPLICIT request, the other actor committed the SAME version: recovers onto it (control)", async () => {
+    mocks.readHostPidMetadataMock.mockResolvedValue(pidAt("1.0.0"));
+    mocks.identityVerdictMock.mockResolvedValue("current");
+
+    const result = await buildHostUpdateCommand({
+      force: false,
+      allowDowngrade: false,
+      versionRequest: "2.0.0",
+      ackNonce: null,
+    })(fakeCtx());
+
+    expect(mocks.stopHostForRestartWithAttemptMock).toHaveBeenCalledTimes(1);
+    expect(result.exitCode).toBe(0);
+    expect(result.human).toContain("updated host 1.0.0 → 2.0.0");
+  });
+
+  it("EXPLICIT request, another actor committed an OLDER version with debt: refused as E_UNEXPECTED, no restart", async () => {
+    mocks.readHostInstallRecordMock.mockResolvedValue(sampleRecord("1.5.0"));
+    mocks.applyHostMock.mockResolvedValue({
+      outcome: "no-op",
+      installedVersion: "1.5.0",
+    } satisfies ApplyHostOutcome);
+    mocks.readHostPidMetadataMock.mockResolvedValue(pidAt("1.0.0"));
+    mocks.identityVerdictMock.mockResolvedValue("current");
+
+    await expect(
+      buildHostUpdateCommand({
+        force: false,
+        allowDowngrade: false,
+        versionRequest: "2.0.0",
+        ackNonce: null,
+      })(fakeCtx()),
+    ).rejects.toMatchObject({
+      code: CLI_ERROR_CODES.UNEXPECTED,
+      message: expect.stringContaining(
+        "the installed host is 1.5.0, not the 2.0.0 this run was updating to",
+      ),
+    });
+    expect(mocks.stopHostForRestartWithAttemptMock).not.toHaveBeenCalled();
+    // Not a superseded request - something did go wrong - so the failure
+    // is stamped over this run's own record, naming the announced target.
+    const calls = mocks.replaceUpdateProgressMarkerIfUnchangedMock.mock.calls;
+    expect(calls).toHaveLength(1);
+    expect(calls[0][2]).toMatchObject({
+      state: "failed",
+      targetVersion: "2.0.0",
+    });
+  });
+
+  it("EXPLICIT request, another actor committed a build that is not a release version (`host install --file`) with debt: refused - identity is the string, an incomparable record is by construction not the requested one", async () => {
+    // Falsification: let an incomparable pair pass (the comparator's
+    // "cannot say") and the host restarts onto the local build under a
+    // confirmation for 2.0.0. The record carries a runtime stamp so the
+    // activation reading is decided in the runtime domain (debt) - the
+    // reading that would ACTIVATE; the catalog comparator would read the
+    // pair as `activated`, which the binding refuses too (see the
+    // activated pin below), so the stamp only picks which reading refuses.
+    mocks.readHostInstallRecordMock.mockResolvedValue({
+      ...sampleRecord("local-dev-1"),
+      runtimeVersion: "local-dev-1",
+    });
+    mocks.applyHostMock.mockResolvedValue({
+      outcome: "no-op",
+      installedVersion: "local-dev-1",
+    } satisfies ApplyHostOutcome);
+    mocks.readHostPidMetadataMock.mockResolvedValue(pidAt("1.0.0"));
+    mocks.identityVerdictMock.mockResolvedValue("current");
+
+    await expect(
+      buildHostUpdateCommand({
+        force: false,
+        allowDowngrade: false,
+        versionRequest: "2.0.0",
+        ackNonce: null,
+      })(fakeCtx()),
+    ).rejects.toMatchObject({
+      code: CLI_ERROR_CODES.UNEXPECTED,
+      message: expect.stringContaining(
+        "the installed host is local-dev-1, not the 2.0.0 this run was updating to",
+      ),
+    });
+    expect(mocks.stopHostForRestartWithAttemptMock).not.toHaveBeenCalled();
+  });
+
+  it("EXPLICIT request, another actor committed AND activated a newer version: refused as E_HOST_UPDATE_NOT_NEWER (never 'host already at 2.1.0' under a request for 2.0.0), this run's marker withdrawn", async () => {
+    // Falsification: hold only the `debt` reading in the recovery and this
+    // reports the no-op, exit 0, at a version the caller never confirmed -
+    // while the same fact at promote time is the discard refusal.
+    mocks.readHostInstallRecordMock.mockResolvedValue(sampleRecord("2.1.0"));
+    mocks.applyHostMock.mockResolvedValue({
+      outcome: "no-op",
+      installedVersion: "2.1.0",
+    } satisfies ApplyHostOutcome);
+    mocks.readHostPidMetadataMock.mockResolvedValue(pidAt("2.1.0"));
+    mocks.identityVerdictMock.mockResolvedValue("current");
+
+    await expect(
+      buildHostUpdateCommand({
+        force: false,
+        allowDowngrade: false,
+        versionRequest: "2.0.0",
+        ackNonce: null,
+      })(fakeCtx()),
+    ).rejects.toMatchObject({
+      code: CLI_ERROR_CODES.HOST_UPDATE_NOT_NEWER,
+    });
+    expect(mocks.stopHostForRestartWithAttemptMock).not.toHaveBeenCalled();
+    // A SUPERSEDED request: nothing was wrong, so this run's own record is
+    // WITHDRAWN (conditional delete), never stamped `failed` - a `failed`
+    // naming 2.0.0 would stand over a host at 2.1.0 and neither
+    // stale-failed rule (target must equal the running version) would ever
+    // clear it. Falsification: drop `superseded` from the catch and the
+    // replace below carries a `failed`.
+    expect(
+      mocks.replaceUpdateProgressMarkerIfUnchangedMock.mock.calls.filter(
+        (call) => (call[2] as HostUpdateProgress).state === "failed",
+      ),
+    ).toEqual([]);
+    expect(
+      mocks.deleteUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenCalledWith(
+      "production",
+      expect.objectContaining({ state: "updating", targetVersion: "2.0.0" }),
+    );
+  });
+
+  it("EXPLICIT request, the running host is not a release version (`foreign-runtime` reading) over a record another actor moved: refused, never the no-op at that record", async () => {
+    // Falsification: leave `installedVersion` off the `foreign-runtime`
+    // reading (or skip it in the binding) and this reports "host already
+    // at 2.1.0" under a request for 2.0.0.
+    mocks.readHostInstallRecordMock.mockResolvedValue(sampleRecord("2.1.0"));
+    mocks.applyHostMock.mockResolvedValue({
+      outcome: "no-op",
+      installedVersion: "2.1.0",
+    } satisfies ApplyHostOutcome);
+    mocks.readHostPidMetadataMock.mockResolvedValue(pidAt("local-dev-1"));
+    mocks.identityVerdictMock.mockResolvedValue("current");
+
+    await expect(
+      buildHostUpdateCommand({
+        force: false,
+        allowDowngrade: false,
+        versionRequest: "2.0.0",
+        ackNonce: null,
+      })(fakeCtx()),
+    ).rejects.toMatchObject({ code: CLI_ERROR_CODES.HOST_UPDATE_NOT_NEWER });
+    expect(mocks.stopHostForRestartWithAttemptMock).not.toHaveBeenCalled();
+  });
+
+  it("IMPLICIT request, another actor committed a different version: recovers onto whatever was committed (control - the binding is the explicit request's alone)", async () => {
+    mocks.readHostInstallRecordMock.mockResolvedValue(sampleRecord("2.1.0"));
+    mocks.applyHostMock.mockResolvedValue({
+      outcome: "no-op",
+      installedVersion: "2.1.0",
+    } satisfies ApplyHostOutcome);
+    mocks.readHostPidMetadataMock.mockResolvedValue(pidAt("1.0.0"));
+    mocks.identityVerdictMock.mockResolvedValue("current");
+
+    const result = await buildHostUpdateCommand({
+      force: false,
+      allowDowngrade: false,
+      ackNonce: null,
+    })(fakeCtx());
+
+    expect(mocks.stopHostForRestartWithAttemptMock).toHaveBeenCalledTimes(1);
+    expect(result.exitCode).toBe(0);
+    expect(result.human).toContain("updated host 1.0.0 → 2.1.0");
+  });
 
   it("reading DEBT: activates the committed install instead of reporting a false no-op", async () => {
     // Falsification: gate the re-derived activation on any predicate other
@@ -2388,6 +2706,9 @@ describe("buildHostUpdateCommand — activation debt (installed-up-to-date short
       detail: "ok",
     });
     armActivationDefaults();
+    // The activation arm names a stage waiting beside the debt in a park;
+    // none by default.
+    mocks.readHostStagedRecordMock.mockResolvedValue(null);
   });
 
   afterEach(() => {
@@ -2429,6 +2750,185 @@ describe("buildHostUpdateCommand — activation debt (installed-up-to-date short
       layer0Slot: null,
     };
   }
+
+  it("a park with a stage waiting beside the debt names it in the error details and message (D6), read under the arm's lock", async () => {
+    // Falsification: let `assertHostNotBusy`'s own error through and the
+    // park carries `details: null` - the apply arm's D6 contract, unmet on
+    // this arm.
+    mocks.downloadAndStageHostMock.mockResolvedValue({
+      outcome: "short-circuit",
+      reason: "installed-up-to-date",
+      targetVersion: "2.0.0",
+      installedVersion: "2.0.0",
+      stagedVersion: "2.1.0",
+    } satisfies HostDownloadOutcome);
+    mocks.readHostInstallRecordMock.mockResolvedValue(sampleRecord("2.0.0"));
+    mocks.readHostPidMetadataMock.mockResolvedValue(pidRecord("1.0.0", 4242));
+    mocks.identityVerdictMock.mockResolvedValue("current");
+    mocks.readHostStagedRecordMock.mockResolvedValue({
+      version: "2.1.0",
+      stageId: "stage-2.1.0",
+    });
+    mocks.assertHostNotBusyMock.mockRejectedValue(
+      cliError({
+        code: CLI_ERROR_CODES.HOST_BUSY,
+        message: "host update: host is busy.",
+        details: null,
+        exitCode: 3,
+      }),
+    );
+
+    await expect(
+      buildHostUpdateCommand({
+        force: false,
+        allowDowngrade: false,
+        ackNonce: null,
+      })(fakeCtx()),
+    ).rejects.toMatchObject({
+      code: CLI_ERROR_CODES.HOST_BUSY,
+      details: { stagedVersion: "2.1.0" },
+      message: expect.stringContaining("Host 2.1.0 stays staged"),
+    });
+    expect(mocks.stopHostForRestartWithAttemptMock).not.toHaveBeenCalled();
+  });
+
+  // An EXPLICIT request's activation is bound to the request, re-read
+  // under the lock: a record another actor committed while this run waited
+  // is a changed handoff, refused before the busy gate and the takeover.
+  // Falsification: drop the `installedVersionMismatch` check in
+  // `activateInstalledAndProjectLegacy` and the host restarts onto 2.1.0
+  // under a confirmation for 2.0.0.
+  it("EXPLICIT request: the record moved to a NEWER version while waiting for the lock, debt still owed - refused before the busy gate, no restart, this run's marker withdrawn", async () => {
+    mocks.downloadAndStageHostMock.mockResolvedValue(upToDate("2.0.0"));
+    // Pre-lock read: the record the decision saw. Under the lock: a record
+    // another actor committed meanwhile.
+    mocks.readHostInstallRecordMock
+      .mockResolvedValueOnce(sampleRecord("2.0.0"))
+      .mockResolvedValue(sampleRecord("2.1.0"));
+    mocks.readHostPidMetadataMock.mockResolvedValue(pidRecord("1.0.0", 4242));
+    mocks.identityVerdictMock.mockResolvedValue("current");
+
+    await expect(
+      buildHostUpdateCommand({
+        force: false,
+        allowDowngrade: false,
+        versionRequest: "2.0.0",
+        ackNonce: null,
+      })(fakeCtx()),
+    ).rejects.toMatchObject({
+      code: CLI_ERROR_CODES.HOST_UPDATE_NOT_NEWER,
+      message: expect.stringContaining(
+        "the installed host is 2.1.0, newer than the 2.0.0 this run was updating to",
+      ),
+    });
+    expect(mocks.assertHostNotBusyMock).not.toHaveBeenCalled();
+    expect(mocks.stopHostForRestartWithAttemptMock).not.toHaveBeenCalled();
+    expect(mocks.probeHostHealthMock).not.toHaveBeenCalled();
+    // A SUPERSEDED request: nothing was wrong, so this run's own record is
+    // WITHDRAWN (conditional delete), never stamped `failed` - a `failed`
+    // naming 2.0.0 would stand over a host at 2.1.0 and neither
+    // stale-failed rule (target must equal the running version) would ever
+    // clear it. Falsification: drop `superseded` from the catch and the
+    // replace below carries a `failed`.
+    expect(
+      mocks.replaceUpdateProgressMarkerIfUnchangedMock.mock.calls.filter(
+        (call) => (call[2] as HostUpdateProgress).state === "failed",
+      ),
+    ).toEqual([]);
+    expect(
+      mocks.deleteUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenCalledWith(
+      "production",
+      expect.objectContaining({ state: "updating", targetVersion: "2.0.0" }),
+    );
+  });
+
+  it("EXPLICIT request: the record moved to a newer version AND was activated while waiting for the lock - refused as E_HOST_UPDATE_NOT_NEWER, the marker withdrawn, no failed stamp", async () => {
+    // A request that delivered nothing does not report success at a
+    // version the caller never confirmed; and a superseded request is not
+    // a failure either, so nothing is stamped (a `failed` for 2.0.0 over a
+    // healthy host at 2.1.0 is a stamp no reader clears). An ORDERING pin:
+    // the arm refuses on the record before it reads the activation state,
+    // so the second pid value (2.1.0) is never consumed; it reddens only if
+    // the check moves behind an `activated` early return.
+    mocks.downloadAndStageHostMock.mockResolvedValue(upToDate("2.0.0"));
+    mocks.readHostInstallRecordMock
+      .mockResolvedValueOnce(sampleRecord("2.0.0"))
+      .mockResolvedValue(sampleRecord("2.1.0"));
+    mocks.readHostPidMetadataMock
+      .mockResolvedValueOnce(pidRecord("1.0.0", 4242))
+      .mockResolvedValue(pidRecord("2.1.0", 4343));
+    mocks.identityVerdictMock.mockResolvedValue("current");
+
+    await expect(
+      buildHostUpdateCommand({
+        force: false,
+        allowDowngrade: false,
+        versionRequest: "2.0.0",
+        ackNonce: null,
+      })(fakeCtx()),
+    ).rejects.toMatchObject({ code: CLI_ERROR_CODES.HOST_UPDATE_NOT_NEWER });
+
+    expect(mocks.stopHostForRestartWithAttemptMock).not.toHaveBeenCalled();
+    // A SUPERSEDED request: nothing was wrong, so this run's own record is
+    // WITHDRAWN (conditional delete), never stamped `failed` - a `failed`
+    // naming 2.0.0 would stand over a host at 2.1.0 and neither
+    // stale-failed rule (target must equal the running version) would ever
+    // clear it. Falsification: drop `superseded` from the catch and the
+    // replace below carries a `failed`.
+    expect(
+      mocks.replaceUpdateProgressMarkerIfUnchangedMock.mock.calls.filter(
+        (call) => (call[2] as HostUpdateProgress).state === "failed",
+      ),
+    ).toEqual([]);
+    expect(
+      mocks.deleteUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenCalledWith(
+      "production",
+      expect.objectContaining({ state: "updating", targetVersion: "2.0.0" }),
+    );
+  });
+
+  it("EXPLICIT request BELOW the install record (installed-up-to-date) with debt: the record's debt is left and logged, no restart, the no-op, exit 0", async () => {
+    // `--version 1.2.0` against an installed 2.0.0 short-circuits as
+    // installed-up-to-date (at or above the request). The 2.0.0 record's
+    // debt is not this run's to pay: the caller confirmed 1.2.0 and nothing
+    // else. Falsification: gate the pre-lock debt on the record alone and
+    // the host restarts onto 2.0.0 under a confirmation for 1.2.0.
+    mocks.downloadAndStageHostMock.mockResolvedValue({
+      outcome: "short-circuit",
+      reason: "installed-up-to-date",
+      targetVersion: "1.2.0",
+      installedVersion: "2.0.0",
+      stagedVersion: null,
+    } satisfies HostDownloadOutcome);
+    mocks.readHostInstallRecordMock.mockResolvedValue(sampleRecord("2.0.0"));
+    mocks.readHostPidMetadataMock.mockResolvedValue(pidRecord("1.0.0", 4242));
+    mocks.identityVerdictMock.mockResolvedValue("current");
+
+    const ctx = fakeCtx();
+    const result = await buildHostUpdateCommand({
+      force: false,
+      allowDowngrade: false,
+      versionRequest: "1.2.0",
+      ackNonce: null,
+    })(ctx);
+
+    expect(mocks.stopHostForRestartWithAttemptMock).not.toHaveBeenCalled();
+    expect(
+      mocks.claimUpdateProgressMarkerBeforeLockMock,
+    ).not.toHaveBeenCalled();
+    expect(ctx.runtime.logger.info).toHaveBeenCalledWith(
+      "Host update leaves the install record's activation debt: the explicit request names another version",
+      expect.objectContaining({
+        requestedVersion: "1.2.0",
+        installedVersion: "2.0.0",
+        runningVersion: "1.0.0",
+      }),
+    );
+    expect(result.exitCode).toBe(0);
+    expect(result.human).toContain("no-op");
+  });
 
   it("running behind the install record: activates, writes the updating marker, restarts under the busy gate, probes health, and clears the marker", async () => {
     mocks.downloadAndStageHostMock.mockResolvedValue(upToDate("2.0.0"));
@@ -5432,6 +5932,77 @@ describe("buildHostUpdateCommand — reassertMarkerUnderLock under the lock", ()
     expect(seenExpectations).toEqual(["2.0.0", null]);
   });
 
+  it("an explicit request whose download was discarded because the record REACHED the requested version during the transfer (another actor committed it): the request is delivered, not discarded - its debt is paid through the activation arm", async () => {
+    // `not-newer-than-installed` covers EQUAL. Falsification: throw the
+    // discard for every reason and this exits 1 "no longer older than it"
+    // with the 2.0.0 record's debt unpaid - the one timing at which the
+    // same event would not activate.
+    armActivationDefaults();
+    mocks.probeHostHealthMock.mockResolvedValue({
+      healthy: true,
+      detail: "ok",
+    });
+    mocks.downloadAndStageHostMock.mockImplementation(
+      async (opts: DownloadAndStageHostOptions) => {
+        await requireHook(opts)("2.0.0");
+        return {
+          outcome: "discarded",
+          reason: "not-newer-than-installed",
+          targetVersion: "2.0.0",
+        } satisfies HostDownloadOutcome;
+      },
+    );
+    mocks.readHostInstallRecordMock.mockResolvedValue(sampleRecord("2.0.0"));
+    mocks.readHostPidMetadataMock.mockResolvedValue({
+      pid: 4242,
+      hostId: "host-1",
+      version: "1.0.0",
+      websocketUrl: "ws://127.0.0.1:51820/rpc",
+      startedAt: "2026-01-01T00:00:00.000Z",
+      processStartIdentity: null,
+      layer0: null,
+      layer0Slot: null,
+    });
+    mocks.identityVerdictMock.mockResolvedValue("current");
+
+    const result = await buildHostUpdateCommand({
+      force: false,
+      allowDowngrade: false,
+      versionRequest: "2.0.0",
+      ackNonce: null,
+    })(fakeCtx());
+
+    expect(mocks.applyHostMock).not.toHaveBeenCalled();
+    expect(mocks.stopHostForRestartWithAttemptMock).toHaveBeenCalledTimes(1);
+    expect(mocks.probeHostHealthMock).toHaveBeenCalledTimes(1);
+    expect(result.exitCode).toBe(0);
+    expect(result.human).toContain("updated host 1.0.0 → 2.0.0");
+
+    // Control: a record at ANOTHER version is the discard's answer.
+    vi.clearAllMocks();
+    armActivationDefaults();
+    mocks.downloadAndStageHostMock.mockImplementation(
+      async (opts: DownloadAndStageHostOptions) => {
+        await requireHook(opts)("2.0.0");
+        return {
+          outcome: "discarded",
+          reason: "not-newer-than-installed",
+          targetVersion: "2.0.0",
+        } satisfies HostDownloadOutcome;
+      },
+    );
+    mocks.readHostInstallRecordMock.mockResolvedValue(sampleRecord("2.1.0"));
+    await expect(
+      buildHostUpdateCommand({
+        force: false,
+        allowDowngrade: false,
+        versionRequest: "2.0.0",
+        ackNonce: null,
+      })(fakeCtx()),
+    ).rejects.toMatchObject({ code: CLI_ERROR_CODES.HOST_UPDATE_NOT_NEWER });
+    expect(mocks.stopHostForRestartWithAttemptMock).not.toHaveBeenCalled();
+  });
+
   it("an explicit request whose download was DISCARDED at promote time is refused with the discard's own reason, and never reaches the apply", async () => {
     // The race the promoter guards: the installed version moved past the
     // explicit target during the unlocked transfer (a plain older request
@@ -5467,14 +6038,26 @@ describe("buildHostUpdateCommand — reassertMarkerUnderLock under the lock", ()
       ),
     });
     expect(mocks.applyHostMock).not.toHaveBeenCalled();
-    // The pre-lock record announced 2.0.0; the refusal stamps it as the
-    // failure it is, naming the announced target.
-    const calls = mocks.replaceUpdateProgressMarkerIfUnchangedMock.mock.calls;
-    expect(calls).toHaveLength(1);
-    expect(calls[0][2]).toMatchObject({
-      state: "failed",
-      targetVersion: "2.0.0",
-    });
+    // The pre-lock record announced 2.0.0; a newer host is installed, so
+    // the request is SUPERSEDED, not failed: the record is withdrawn and
+    // nothing is stamped (see the recovery suite for the rule).
+    // A SUPERSEDED request: nothing was wrong, so this run's own record is
+    // WITHDRAWN (conditional delete), never stamped `failed` - a `failed`
+    // naming 2.0.0 would stand over a host at 2.1.0 and neither
+    // stale-failed rule (target must equal the running version) would ever
+    // clear it. Falsification: drop `superseded` from the catch and the
+    // replace below carries a `failed`.
+    expect(
+      mocks.replaceUpdateProgressMarkerIfUnchangedMock.mock.calls.filter(
+        (call) => (call[2] as HostUpdateProgress).state === "failed",
+      ),
+    ).toEqual([]);
+    expect(
+      mocks.deleteUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenCalledWith(
+      "production",
+      expect.objectContaining({ state: "updating", targetVersion: "2.0.0" }),
+    );
 
     // Positive control: the SAME discard under an implicit "latest"
     // still applies whatever newer stage is there.

--- a/clients/traycer-cli/src/commands/__tests__/host-update.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/host-update.test.ts
@@ -37,7 +37,11 @@ const mocks = vi.hoisted(() => ({
   // daemon can fold in-flight/failed update state into `host.status@1.1`.
   // Mocked so this suite never touches the real marker file or opens a real
   // TCP probe against a host that isn't running.
-  writeUpdateProgressMarkerMock: vi.fn(),
+  //
+  // The pre-lock publish primitive (`host-update.ts`'s `publishUpdating`
+  // calls this, never `writeUpdateProgressMarker` - that unconditional write
+  // has no production caller left).
+  claimUpdateProgressMarkerBeforeLockMock: vi.fn(),
   deleteUpdateProgressMarkerMock: vi.fn(),
   readUpdateProgressMarkerMock: vi.fn(),
   deleteUpdateProgressMarkerIfUnchangedMock: vi.fn(),
@@ -63,7 +67,8 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("../../host/update-progress-marker", () => ({
-  writeUpdateProgressMarker: mocks.writeUpdateProgressMarkerMock,
+  claimUpdateProgressMarkerBeforeLock:
+    mocks.claimUpdateProgressMarkerBeforeLockMock,
   deleteUpdateProgressMarker: mocks.deleteUpdateProgressMarkerMock,
   readUpdateProgressMarker: mocks.readUpdateProgressMarkerMock,
   deleteUpdateProgressMarkerIfUnchanged:
@@ -201,7 +206,10 @@ import type {
   HostDownloadOutcome,
 } from "../../installer/download-stage";
 import type { ApplyHostOptions, ApplyHostOutcome } from "../../installer/apply";
-import type { HostUpdateProgress } from "../../host/update-progress-marker";
+import type {
+  HostUpdateProgress,
+  UpdateProgressMarkerClaim,
+} from "../../host/update-progress-marker";
 // Value import (not type-only): the module is mocked above, and that mock
 // factory defines `sameProgress` as the REAL comparator (not a `vi.fn()`), so
 // this import gets production comparison logic - the same test double the
@@ -369,9 +377,23 @@ function armActivationDefaults(): void {
   mocks.readUpdateProgressMarkerMock.mockImplementation(
     async () => mocks.disk.current,
   );
-  mocks.writeUpdateProgressMarkerMock.mockImplementation(
-    async (_environment: string, record: HostUpdateProgress) => {
-      mocks.disk.current = record;
+  // Pre-lock claim: models the SAME rule `claimUpdateProgressMarkerBeforeLock`
+  // applies against a real disk (see its production doc comment) - published
+  // into an empty path, deferred (nothing written) otherwise. `displaced` is
+  // null on both of these outcomes: a stale-record replace never happens
+  // against an initially-empty disk. A test that needs "replaced-stale" or
+  // "failed" overrides this mock directly; that override wins for its call
+  // and does not touch `mocks.disk`.
+  mocks.claimUpdateProgressMarkerBeforeLockMock.mockImplementation(
+    async (
+      _environment: string,
+      next: HostUpdateProgress,
+    ): Promise<UpdateProgressMarkerClaim> => {
+      if (mocks.disk.current === null) {
+        mocks.disk.current = next;
+        return { outcome: "published", displaced: null };
+      }
+      return { outcome: "deferred", displaced: null };
     },
   );
   mocks.replaceUpdateProgressMarkerIfUnchangedMock.mockImplementation(
@@ -575,7 +597,7 @@ describe("buildHostUpdateCommand composite", () => {
       onProgress: expect.any(Function),
       onBeforeCommit: expect.any(Function),
     });
-    expect(mocks.writeUpdateProgressMarkerMock).toHaveBeenCalledWith(
+    expect(mocks.claimUpdateProgressMarkerBeforeLockMock).toHaveBeenCalledWith(
       "production",
       expect.objectContaining({ state: "updating", targetVersion: "1.2.0" }),
     );
@@ -1031,7 +1053,7 @@ describe("buildHostUpdateCommand — stage consumed by another actor while waiti
       mocks.relaunchHostAfterRestartWithAttemptMock,
     ).not.toHaveBeenCalled();
     expect(mocks.probeHostHealthMock).not.toHaveBeenCalled();
-    const written = mocks.writeUpdateProgressMarkerMock.mock
+    const written = mocks.claimUpdateProgressMarkerBeforeLockMock.mock
       .calls[0][1] as HostUpdateProgress;
     expect(
       mocks.deleteUpdateProgressMarkerIfUnchangedMock,
@@ -1133,7 +1155,7 @@ describe("buildHostUpdateCommand update-progress marker (T16)", () => {
     })(fakeCtx());
 
     expect(result.exitCode).toBe(0);
-    expect(mocks.writeUpdateProgressMarkerMock).toHaveBeenCalledWith(
+    expect(mocks.claimUpdateProgressMarkerBeforeLockMock).toHaveBeenCalledWith(
       "production",
       expect.objectContaining({ state: "updating", targetVersion: "2.0.0" }),
     );
@@ -1146,6 +1168,30 @@ describe("buildHostUpdateCommand update-progress marker (T16)", () => {
     ).toHaveBeenCalledWith(
       "production",
       expect.objectContaining({ state: "updating" }),
+    );
+  });
+
+  it("the final clear could not be written: the update still succeeds, and the CLI logs why an `updating` outlives it", async () => {
+    // Falsification: collapse "failed" into "changed" in the final-clear
+    // branch and this log assertion goes red - "failed" is an I/O failure
+    // on the delete itself, not a race with a third updater's marker.
+    mocks.downloadAndStageHostMock.mockResolvedValue(promoted("2.0.0"));
+    mocks.applyHostMock.mockResolvedValue(
+      appliedOutcome("1.0.0", "2.0.0", null),
+    );
+    mocks.deleteUpdateProgressMarkerIfUnchangedMock.mockResolvedValue("failed");
+
+    const ctx = fakeCtx();
+    const result = await buildHostUpdateCommand({
+      force: false,
+      allowDowngrade: false,
+      ackNonce: null,
+    })(ctx);
+
+    expect(result.exitCode).toBe(0);
+    expect(ctx.runtime.logger.info).toHaveBeenCalledWith(
+      "Host update could not clear its progress marker; it stays until the next update supersedes it",
+      { environment: "production" },
     );
   });
 
@@ -1169,8 +1215,10 @@ describe("buildHostUpdateCommand update-progress marker (T16)", () => {
       code: CLI_ERROR_CODES.HOST_UPDATE_HEALTH_CHECK_FAILED,
     });
 
-    expect(mocks.writeUpdateProgressMarkerMock).toHaveBeenCalledTimes(1);
-    const written = mocks.writeUpdateProgressMarkerMock.mock
+    expect(mocks.claimUpdateProgressMarkerBeforeLockMock).toHaveBeenCalledTimes(
+      1,
+    );
+    const written = mocks.claimUpdateProgressMarkerBeforeLockMock.mock
       .calls[0][1] as HostUpdateProgress;
     expect(written.state).toBe("updating");
     expect(
@@ -1200,8 +1248,10 @@ describe("buildHostUpdateCommand update-progress marker (T16)", () => {
       })(fakeCtx()),
     ).rejects.toThrow("commit failed");
 
-    expect(mocks.writeUpdateProgressMarkerMock).toHaveBeenCalledTimes(1);
-    const written = mocks.writeUpdateProgressMarkerMock.mock
+    expect(mocks.claimUpdateProgressMarkerBeforeLockMock).toHaveBeenCalledTimes(
+      1,
+    );
+    const written = mocks.claimUpdateProgressMarkerBeforeLockMock.mock
       .calls[0][1] as HostUpdateProgress;
     expect(
       mocks.replaceUpdateProgressMarkerIfUnchangedMock,
@@ -1230,20 +1280,34 @@ describe("buildHostUpdateCommand update-progress marker (T16)", () => {
     })(fakeCtx());
 
     expect(result.exitCode).toBe(0);
-    expect(mocks.writeUpdateProgressMarkerMock).not.toHaveBeenCalled();
+    expect(
+      mocks.claimUpdateProgressMarkerBeforeLockMock,
+    ).not.toHaveBeenCalled();
     expect(mocks.deleteUpdateProgressMarkerMock).not.toHaveBeenCalled();
     // No install was touched, so there is nothing to health-check either.
     expect(mocks.probeHostHealthMock).not.toHaveBeenCalled();
   });
 
   it("keeps the update working when the marker write itself fails", async () => {
+    // Falsification: read `ownMarker.current` as non-null after a "failed"
+    // claim (`publishUpdating`'s `claim === "failed"` arm in host-update.ts
+    // sets `ownMarker.current = null` silently) and the final clear below
+    // would fire against a marker this run never actually landed.
     mocks.downloadAndStageHostMock.mockResolvedValue(promoted("2.0.0"));
     mocks.applyHostMock.mockResolvedValue(
       appliedOutcome("1.0.0", "2.0.0", null),
     );
-    mocks.writeUpdateProgressMarkerMock.mockRejectedValue(
-      new Error("EACCES: read-only home"),
-    );
+    // `downloadAndStageHostMock` here is `mockResolvedValue`, not a
+    // `mockImplementation` that invokes `onWillDownload` - so the pre-lock
+    // claim this run actually makes is the post-prepare guard's
+    // (`needsWork && ownMarker.current === null`), exactly once. It fails,
+    // and `applyHostMock`'s default resolved value never invokes
+    // `onWillCommitStaged`, so `reassertMarkerUnderLock` is never reached
+    // under the lock either - `ownMarker.current` stays `null` end to end.
+    mocks.claimUpdateProgressMarkerBeforeLockMock.mockResolvedValue({
+      outcome: "failed",
+      displaced: null,
+    });
 
     const result = await buildHostUpdateCommand({
       force: false,
@@ -1253,6 +1317,427 @@ describe("buildHostUpdateCommand update-progress marker (T16)", () => {
 
     // Degraded remote progress reporting must not fail a local update.
     expect(result.exitCode).toBe(0);
+    expect(mocks.claimUpdateProgressMarkerBeforeLockMock).toHaveBeenCalledTimes(
+      1,
+    );
+    // Never a fact about the disk - a `failed` claim writes nothing - so the
+    // final clear (gated on `ownMarker.current !== null`) never fires.
+    expect(
+      mocks.deleteUpdateProgressMarkerIfUnchangedMock,
+    ).not.toHaveBeenCalled();
+    expect(mocks.deleteUpdateProgressMarkerMock).not.toHaveBeenCalled();
+    expect(
+      mocks.replaceUpdateProgressMarkerIfUnchangedMock,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("pre-lock claim defers to a live writer's marker", async () => {
+    // Falsification: treat "deferred" like "published" in `publishUpdating`
+    // (set `ownMarker.current = fresh` regardless of the claim result) and
+    // the pre-lock write assertions below would see a record this run never
+    // actually landed.
+    const foreignRecord: HostUpdateProgress = {
+      state: "updating",
+      error: null,
+      targetVersion: "9.9.9",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      writerId: "999999-abc",
+    };
+    mocks.disk.current = foreignRecord;
+    mocks.downloadAndStageHostMock.mockImplementation(
+      async (opts: DownloadAndStageHostOptions) => {
+        if (opts.onWillDownload === null) {
+          throw new Error("expected onWillDownload to be provided");
+        }
+        await opts.onWillDownload("2.0.0");
+        return promoted("2.0.0");
+      },
+    );
+    mocks.applyHostMock.mockImplementation(async (opts: ApplyHostOptions) => {
+      await opts.onWillCommitStaged?.("2.0.0");
+      return appliedOutcome("1.0.0", "2.0.0", null);
+    });
+
+    const ctx = fakeCtx();
+    const result = await buildHostUpdateCommand({
+      force: false,
+      allowDowngrade: false,
+      ackNonce: null,
+    })(ctx);
+
+    // The claim is asked for a fresh `updating` record naming the download
+    // target - the disk fixture's default wiring (`armActivationDefaults`)
+    // answers "deferred" whenever it is non-null, exactly the fail-open rule
+    // `claimUpdateProgressMarkerBeforeLock` applies to a live foreign writer.
+    expect(mocks.claimUpdateProgressMarkerBeforeLockMock).toHaveBeenCalledWith(
+      "production",
+      expect.objectContaining({ state: "updating", targetVersion: "2.0.0" }),
+    );
+    expect(ctx.runtime.logger.info).toHaveBeenCalledWith(
+      "Host update left another updater's live progress marker in place; this run publishes its own once it holds the lock",
+      expect.objectContaining({
+        environment: "production",
+        targetVersion: "2.0.0",
+      }),
+    );
+    // Nothing was written pre-lock: the create-if-absent primitive is only
+    // reached on an EMPTY disk, and the disk was never empty here.
+    expect(mocks.createUpdateProgressMarkerIfAbsentMock).not.toHaveBeenCalled();
+    // Under the lock, `own` is still null (the claim never landed anything),
+    // so `reassertMarkerUnderLock` takes the foreign record over rather than
+    // treating it as this run's own.
+    expect(
+      mocks.replaceUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenCalledWith(
+      "production",
+      foreignRecord,
+      expect.objectContaining({ state: "updating", targetVersion: "2.0.0" }),
+    );
+    const adopted = mocks.replaceUpdateProgressMarkerIfUnchangedMock.mock
+      .calls[0][2] as HostUpdateProgress;
+    // The final clear is CAS'd against the record adopted under the lock,
+    // not against anything the pre-lock claim believed it held (it held
+    // nothing).
+    expect(
+      mocks.deleteUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenCalledWith("production", adopted);
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("a lost download after a deferred claim stamps nothing - the host was never disturbed", async () => {
+    // A download rejection that follows a deferred pre-lock claim never
+    // reaches `markUpdateFailed`: the catch's `ownMarker.current === null`
+    // branch (host-update.ts) only stamps when `disruptionStarted` is true,
+    // and a download failure happens strictly before any disruptive work -
+    // `reportProgress` never saw `service-stop` or `swap`. The failure is
+    // reported by exit code and log alone, with zero marker mutation.
+    //
+    // Falsification: drop the `disruptionStarted` guard (call
+    // `markUpdateFailed` whenever `ownMarker.current === null`, regardless of
+    // whether the host was touched) and the "not called" assertions below go
+    // red - the catch would attempt a create-if-absent for a failure that
+    // never actually happened to the host.
+    mocks.claimUpdateProgressMarkerBeforeLockMock.mockResolvedValue({
+      outcome: "deferred",
+      displaced: null,
+    });
+    mocks.downloadAndStageHostMock.mockImplementation(
+      async (opts: DownloadAndStageHostOptions) => {
+        if (opts.onWillDownload === null) {
+          throw new Error("expected onWillDownload to be provided");
+        }
+        await opts.onWillDownload("2.0.0");
+        throw new Error("download failed: ECONNRESET");
+      },
+    );
+
+    await expect(
+      buildHostUpdateCommand({
+        force: false,
+        allowDowngrade: false,
+        ackNonce: null,
+      })(fakeCtx()),
+    ).rejects.toThrow("download failed: ECONNRESET");
+
+    // No marker write of any kind: `ownMarker.current` was `null` (the claim
+    // deferred) and the host was never disturbed, so the catch never calls
+    // `markUpdateFailed` at all.
+    expect(
+      mocks.replaceUpdateProgressMarkerIfUnchangedMock,
+    ).not.toHaveBeenCalled();
+    expect(mocks.createUpdateProgressMarkerIfAbsentMock).not.toHaveBeenCalled();
+    expect(
+      mocks.deleteUpdateProgressMarkerIfUnchangedMock,
+    ).not.toHaveBeenCalled();
+    expect(mocks.deleteUpdateProgressMarkerMock).not.toHaveBeenCalled();
+  });
+
+  it("a deferred run that disturbed the host and failed lands its failure into an empty path", async () => {
+    // The other half of `markUpdateFailed`'s `ours === null` arm: a run that
+    // never landed a marker of its own but DID disturb the host (the apply
+    // reported `service-stop` before it failed) must still surface the
+    // failure remotely - by creating a fresh `failed` record into whatever
+    // empty path it finds, never by overwriting a live one.
+    //
+    // Falsification: gate the stamp on `ownMarker.current !== null` only
+    // (drop the `disruptionStarted` branch) and `createUpdateProgressMarkerIfAbsentMock`
+    // below is never called.
+    const foreignRecord: HostUpdateProgress = {
+      state: "updating",
+      error: null,
+      targetVersion: "2.0.0",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      writerId: "foreign-writer",
+    };
+    mocks.disk.current = foreignRecord;
+    mocks.downloadAndStageHostMock.mockImplementation(
+      async (opts: DownloadAndStageHostOptions) => {
+        if (opts.onWillDownload === null) {
+          throw new Error("expected onWillDownload to be provided");
+        }
+        await opts.onWillDownload("2.0.0");
+        return promoted("2.0.0");
+      },
+    );
+    // The takeover under the lock itself fails (I/O) - `own` stays null.
+    mocks.replaceUpdateProgressMarkerIfUnchangedMock.mockResolvedValue(
+      "failed",
+    );
+    mocks.applyHostMock.mockImplementation(async (opts: ApplyHostOptions) => {
+      await opts.onWillCommitStaged?.("2.0.0");
+      opts.onProgress({
+        stage: "service-stop",
+        message: null,
+        percent: null,
+        bytes: null,
+        totalBytes: null,
+        workUnits: null,
+      });
+      throw new Error("commit failed");
+    });
+
+    await expect(
+      buildHostUpdateCommand({
+        force: false,
+        allowDowngrade: false,
+        ackNonce: null,
+      })(fakeCtx()),
+    ).rejects.toThrow("commit failed");
+
+    expect(mocks.createUpdateProgressMarkerIfAbsentMock).toHaveBeenCalledWith(
+      "production",
+      expect.objectContaining({
+        state: "failed",
+        targetVersion: "2.0.0",
+        error: "commit failed",
+      }),
+    );
+    // Never a CAS against the foreign record - this run holds no marker of
+    // its own to compare against.
+    expect(
+      mocks.replaceUpdateProgressMarkerIfUnchangedMock,
+    ).not.toHaveBeenCalledWith(
+      "production",
+      foreignRecord,
+      expect.objectContaining({ state: "failed" }),
+    );
+  });
+
+  it("a marker-less run whose apply succeeds but whose host never becomes healthy lands its failure into an empty path - `markUpdateFailed`'s `ours === null` arm, the health-probe call site", async () => {
+    // The OTHER call site that can pass `markUpdateFailed` a `null` `ours`
+    // (alongside the generic catch's `disruptionStarted` arm): the post-apply
+    // health-probe failure passes `ownMarker.current` unconditionally.
+    // Reached here by making BOTH pre-lock claims defer (a live foreign
+    // writer never let go of the marker) while the apply itself is mocked to
+    // succeed WITHOUT ever calling `onWillCommitStaged`, so
+    // `reassertMarkerUnderLock` never runs and `ownMarker.current` is still
+    // `null` when the probe fails.
+    //
+    // Falsification: revert `markUpdateFailed`'s `ours === null` arm to a
+    // log-only no-op and `createUpdateProgressMarkerIfAbsentMock` below is
+    // never called.
+    mocks.claimUpdateProgressMarkerBeforeLockMock.mockResolvedValue({
+      outcome: "deferred",
+      displaced: null,
+    });
+    mocks.downloadAndStageHostMock.mockImplementation(
+      async (opts: DownloadAndStageHostOptions) => {
+        if (opts.onWillDownload === null) {
+          throw new Error("expected onWillDownload to be provided");
+        }
+        await opts.onWillDownload("2.0.0");
+        return promoted("2.0.0");
+      },
+    );
+    mocks.applyHostMock.mockResolvedValue(
+      appliedOutcome("1.0.0", "2.0.0", null),
+    );
+    mocks.probeHostHealthMock.mockResolvedValue({
+      healthy: false,
+      detail: "port 8765 never accepted a connection",
+    });
+
+    await expect(
+      buildHostUpdateCommand({
+        force: false,
+        allowDowngrade: false,
+        ackNonce: null,
+      })(fakeCtx()),
+    ).rejects.toMatchObject({
+      code: CLI_ERROR_CODES.HOST_UPDATE_HEALTH_CHECK_FAILED,
+    });
+
+    // `ours` was null, so the stamp lands by create-if-absent - never a CAS
+    // against a record this run never held.
+    expect(
+      mocks.replaceUpdateProgressMarkerIfUnchangedMock,
+    ).not.toHaveBeenCalled();
+    expect(mocks.createUpdateProgressMarkerIfAbsentMock).toHaveBeenCalledWith(
+      "production",
+      expect.objectContaining({
+        state: "failed",
+        targetVersion: "2.0.0",
+        error: "port 8765 never accepted a connection",
+      }),
+    );
+    expect(
+      mocks.deleteUpdateProgressMarkerIfUnchangedMock,
+    ).not.toHaveBeenCalled();
+    expect(mocks.deleteUpdateProgressMarkerMock).not.toHaveBeenCalled();
+  });
+
+  it("a deferred claim is retried after the download", async () => {
+    // Falsification: gate the post-prepare guard on anything other than
+    // `ownMarker.current === null` (e.g. on the download outcome alone) and
+    // the second claim call below never happens - a run whose pre-lock claim
+    // deferred would then reach the lock with no marker of its own even
+    // though the other updater cleared meanwhile.
+    mocks.claimUpdateProgressMarkerBeforeLockMock
+      .mockResolvedValueOnce({ outcome: "deferred", displaced: null })
+      .mockImplementationOnce(
+        async (
+          _environment: string,
+          next: HostUpdateProgress,
+        ): Promise<UpdateProgressMarkerClaim> => {
+          mocks.disk.current = next;
+          return { outcome: "published", displaced: null };
+        },
+      );
+    mocks.downloadAndStageHostMock.mockImplementation(
+      async (opts: DownloadAndStageHostOptions) => {
+        if (opts.onWillDownload === null) {
+          throw new Error("expected onWillDownload to be provided");
+        }
+        await opts.onWillDownload("2.0.0");
+        return promoted("2.0.0");
+      },
+    );
+    // No `onWillCommitStaged` invocation: `ownMarker.current` is left exactly
+    // as the second claim set it, so the final clear targets that record
+    // directly rather than something re-pointed under the lock.
+    mocks.applyHostMock.mockResolvedValue(
+      appliedOutcome("1.0.0", "2.0.0", null),
+    );
+
+    const result = await buildHostUpdateCommand({
+      force: false,
+      allowDowngrade: false,
+      ackNonce: null,
+    })(fakeCtx());
+
+    expect(mocks.claimUpdateProgressMarkerBeforeLockMock).toHaveBeenCalledTimes(
+      2,
+    );
+    expect(
+      mocks.claimUpdateProgressMarkerBeforeLockMock.mock.calls[0][1],
+    ).toEqual(
+      expect.objectContaining({ state: "updating", targetVersion: "2.0.0" }),
+    );
+    const second = mocks.claimUpdateProgressMarkerBeforeLockMock.mock
+      .calls[1][1] as HostUpdateProgress;
+    expect(second).toEqual(
+      expect.objectContaining({ state: "updating", targetVersion: "2.0.0" }),
+    );
+    expect(
+      mocks.deleteUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenCalledWith("production", second);
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("a stale record is replaced by the pre-lock claim", async () => {
+    // Falsification: treat "replaced-stale" like "deferred" in
+    // `publishUpdating` (set `ownMarker.current = null`) and the final clear
+    // assertion below would never fire - the run would believe it holds no
+    // marker despite having just landed one by CAS.
+    mocks.claimUpdateProgressMarkerBeforeLockMock.mockImplementation(
+      async (
+        _environment: string,
+        next: HostUpdateProgress,
+      ): Promise<UpdateProgressMarkerClaim> => {
+        mocks.disk.current = next;
+        return { outcome: "replaced-stale", displaced: null };
+      },
+    );
+    mocks.downloadAndStageHostMock.mockResolvedValue(promoted("2.0.0"));
+    mocks.applyHostMock.mockResolvedValue(
+      appliedOutcome("1.0.0", "2.0.0", null),
+    );
+
+    const result = await buildHostUpdateCommand({
+      force: false,
+      allowDowngrade: false,
+      ackNonce: null,
+    })(fakeCtx());
+
+    // `downloadAndStageHostMock` here is `mockResolvedValue`, so the only
+    // claim this run makes is the post-prepare guard's, exactly once.
+    expect(mocks.claimUpdateProgressMarkerBeforeLockMock).toHaveBeenCalledTimes(
+      1,
+    );
+    const written = mocks.claimUpdateProgressMarkerBeforeLockMock.mock
+      .calls[0][1] as HostUpdateProgress;
+    expect(written.state).toBe("updating");
+    expect(written.targetVersion).toBe("2.0.0");
+    expect(
+      mocks.deleteUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenCalledWith("production", written);
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("a stale `failed` replaced by the pre-lock claim is put back when the run parks", async () => {
+    // Falsification: drop `displacedMarker.current = claim.displaced` in
+    // `publishUpdating` and the restore call below never happens - a park
+    // after a "replaced-stale" claim would instead withdraw (delete) this
+    // run's own record, erasing the still-possibly-true `failed` stamp the
+    // claim replaced.
+    const staleFailed: HostUpdateProgress = {
+      state: "failed",
+      error: "host did not become healthy: tcp refused",
+      targetVersion: "1.9.0",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      writerId: "dead-writer",
+    };
+    mocks.claimUpdateProgressMarkerBeforeLockMock.mockImplementation(
+      async (
+        _environment: string,
+        next: HostUpdateProgress,
+      ): Promise<UpdateProgressMarkerClaim> => {
+        mocks.disk.current = next;
+        return { outcome: "replaced-stale", displaced: staleFailed };
+      },
+    );
+    mocks.downloadAndStageHostMock.mockResolvedValue(promoted("2.0.0"));
+    // Rejects busy WITHOUT ever calling `onWillCommitStaged` - the host is
+    // never disturbed, so the takeover restore (not a `failed` stamp) is
+    // what has to happen.
+    mocks.applyHostMock.mockRejectedValue(
+      cliError({
+        code: CLI_ERROR_CODES.HOST_BUSY,
+        message: "The running host has work in progress",
+        details: null,
+        exitCode: 1,
+      }),
+    );
+    mocks.readHostStagedRecordMock.mockResolvedValue(null);
+
+    await expect(
+      buildHostUpdateCommand({
+        force: false,
+        allowDowngrade: false,
+        ackNonce: null,
+      })(fakeCtx()),
+    ).rejects.toMatchObject({ code: CLI_ERROR_CODES.HOST_BUSY });
+
+    const written = mocks.claimUpdateProgressMarkerBeforeLockMock.mock
+      .calls[0][1] as HostUpdateProgress;
+    // The park restores the STALE FAILED record the claim replaced, not a
+    // withdrawal (delete) of this run's own record.
+    expect(
+      mocks.replaceUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenCalledWith("production", written, staleFailed);
+    expect(
+      mocks.deleteUpdateProgressMarkerIfUnchangedMock,
+    ).not.toHaveBeenCalled();
   });
 });
 
@@ -1323,7 +1808,7 @@ describe("buildHostUpdateCommand — activation debt (installed-up-to-date short
       ackNonce: null,
     })(fakeCtx());
 
-    expect(mocks.writeUpdateProgressMarkerMock).toHaveBeenCalledWith(
+    expect(mocks.claimUpdateProgressMarkerBeforeLockMock).toHaveBeenCalledWith(
       "production",
       expect.objectContaining({ state: "updating", targetVersion: "2.0.0" }),
     );
@@ -1428,8 +1913,10 @@ describe("buildHostUpdateCommand — activation debt (installed-up-to-date short
     })(fakeCtx());
 
     expect(mocks.probeHostHealthMock).not.toHaveBeenCalled();
-    expect(mocks.writeUpdateProgressMarkerMock).toHaveBeenCalledTimes(1);
-    expect(mocks.writeUpdateProgressMarkerMock).toHaveBeenCalledWith(
+    expect(mocks.claimUpdateProgressMarkerBeforeLockMock).toHaveBeenCalledTimes(
+      1,
+    );
+    expect(mocks.claimUpdateProgressMarkerBeforeLockMock).toHaveBeenCalledWith(
       "production",
       expect.objectContaining({ state: "updating" }),
     );
@@ -1464,8 +1951,11 @@ describe("buildHostUpdateCommand — activation debt (installed-up-to-date short
       ackNonce: null,
     })(fakeCtx());
 
-    expect(mocks.writeUpdateProgressMarkerMock).toHaveBeenCalledTimes(1);
-    const written = mocks.writeUpdateProgressMarkerMock.mock.calls[0][1];
+    expect(mocks.claimUpdateProgressMarkerBeforeLockMock).toHaveBeenCalledTimes(
+      1,
+    );
+    const written =
+      mocks.claimUpdateProgressMarkerBeforeLockMock.mock.calls[0][1];
     expect(
       mocks.deleteUpdateProgressMarkerIfUnchangedMock,
     ).toHaveBeenCalledTimes(1);
@@ -1505,8 +1995,10 @@ describe("buildHostUpdateCommand — activation debt (installed-up-to-date short
     // Our own `updating` was written once; no unconditional `failed` write
     // ever happens - the failure goes through the compare-and-swap instead,
     // and a "changed" answer means it never landed.
-    expect(mocks.writeUpdateProgressMarkerMock).toHaveBeenCalledTimes(1);
-    const written = mocks.writeUpdateProgressMarkerMock.mock
+    expect(mocks.claimUpdateProgressMarkerBeforeLockMock).toHaveBeenCalledTimes(
+      1,
+    );
+    const written = mocks.claimUpdateProgressMarkerBeforeLockMock.mock
       .calls[0][1] as HostUpdateProgress;
     expect(written.state).toBe("updating");
     expect(
@@ -1535,12 +2027,17 @@ describe("buildHostUpdateCommand — activation debt (installed-up-to-date short
       ackNonce: null,
     })(fakeCtx());
 
-    // The pre-lock `updating:2.0.0` is written once, unconditionally. The
-    // re-point under the lock is ownership-aware: it goes through the
-    // compare-and-swap against that same pre-lock marker, never a second
-    // unconditional write.
-    expect(mocks.writeUpdateProgressMarkerMock).toHaveBeenCalledTimes(1);
-    const written = mocks.writeUpdateProgressMarkerMock.mock
+    // The pre-lock `updating:2.0.0` is published once, as a CLAIM: the
+    // path was empty here, so the claim lands unconditionally against
+    // nothing, but it still goes through the conditional
+    // `claimUpdateProgressMarkerBeforeLock` primitive, never a blind write.
+    // The re-point under the lock is ownership-aware too: it goes through
+    // the compare-and-swap against that same pre-lock marker, never a
+    // second unconditional write.
+    expect(mocks.claimUpdateProgressMarkerBeforeLockMock).toHaveBeenCalledTimes(
+      1,
+    );
+    const written = mocks.claimUpdateProgressMarkerBeforeLockMock.mock
       .calls[0][1] as HostUpdateProgress;
     expect(written.state).toBe("updating");
     expect(written.targetVersion).toBe("2.0.0");
@@ -1569,17 +2066,14 @@ describe("buildHostUpdateCommand — activation debt (installed-up-to-date short
 
   it("the record moved under the lock but the marker is no longer ours: the re-point is refused, and the final clear still targets the ORIGINAL marker", async () => {
     // Same setup as the re-point test above, but the compare-and-swap always
-    // reports "changed" - the pre-lock marker no longer matches what is on
-    // disk (a newer updater owns it now). Under the new retry loop this
-    // means: the FIRST replace attempt reports "changed", the loop re-reads
-    // the disk to tell a moved record from a merely-failed write apart, and
-    // the re-read shows the SAME record it just tried to replace (this
-    // fixture's disk never actually changes) - so the loop concludes the
-    // write itself failed, warns, and stops trying rather than retrying
-    // forever. The activation still proceeds - the debt clears either way -
-    // but the progress marker this run tracks must stay pinned to the
-    // ORIGINAL pre-lock record rather than following a re-point that never
-    // actually landed.
+    // reports "failed" - an I/O failure landing the re-point, not a race
+    // with another writer. `reassertMarkerUnderLock`'s retry loop only
+    // re-reads on "changed" (a record that moved); a "failed" answer is
+    // never retried - it warns and stops immediately, on the FIRST attempt.
+    // The activation still proceeds - the debt clears either way - but the
+    // progress marker this run tracks must stay pinned to the ORIGINAL
+    // pre-lock record rather than following a re-point that never actually
+    // landed.
     mocks.downloadAndStageHostMock.mockResolvedValue(upToDate("2.0.0"));
     mocks.readHostInstallRecordMock
       .mockResolvedValueOnce(sampleRecord("2.0.0"))
@@ -1587,7 +2081,7 @@ describe("buildHostUpdateCommand — activation debt (installed-up-to-date short
     mocks.readHostPidMetadataMock.mockResolvedValue(pidRecord("1.0.0", 4242));
     mocks.identityVerdictMock.mockResolvedValue("current");
     mocks.replaceUpdateProgressMarkerIfUnchangedMock.mockResolvedValue(
-      "changed",
+      "failed",
     );
 
     const ctx = fakeCtx();
@@ -1597,8 +2091,10 @@ describe("buildHostUpdateCommand — activation debt (installed-up-to-date short
       ackNonce: null,
     })(ctx);
 
-    expect(mocks.writeUpdateProgressMarkerMock).toHaveBeenCalledTimes(1);
-    const written = mocks.writeUpdateProgressMarkerMock.mock
+    expect(mocks.claimUpdateProgressMarkerBeforeLockMock).toHaveBeenCalledTimes(
+      1,
+    );
+    const written = mocks.claimUpdateProgressMarkerBeforeLockMock.mock
       .calls[0][1] as HostUpdateProgress;
     expect(written.targetVersion).toBe("2.0.0");
     // Exactly ONE replace attempt - the loop stops after the re-read shows
@@ -1703,7 +2199,9 @@ describe("buildHostUpdateCommand — activation debt (installed-up-to-date short
     })(fakeCtx());
 
     expect(mocks.stopHostForRestartWithAttemptMock).not.toHaveBeenCalled();
-    expect(mocks.writeUpdateProgressMarkerMock).not.toHaveBeenCalled();
+    expect(
+      mocks.claimUpdateProgressMarkerBeforeLockMock,
+    ).not.toHaveBeenCalled();
     // CONDITIONAL on the marker still being the `failed` record that was
     // read - never the unconditional delete, which would erase a live
     // `updating` another updater wrote in between.
@@ -1713,6 +2211,41 @@ describe("buildHostUpdateCommand — activation debt (installed-up-to-date short
     ).toHaveBeenCalledWith(
       "production",
       expect.objectContaining({ state: "failed", targetVersion: "2.0.0" }),
+    );
+    expect(result.human).toContain("no-op");
+  });
+
+  it("the stale-failure clear could not be written: left alone, logged, no throw", async () => {
+    // Falsification: collapse "failed" into "changed" in
+    // `clearStaleFailedMarker` and this log assertion goes red - the
+    // "failed" arm names why a `failed` marker outlived an observed match
+    // (an I/O failure on the clear, not a race with another writer).
+    mocks.downloadAndStageHostMock.mockResolvedValue(upToDate("2.0.0"));
+    mocks.readHostInstallRecordMock.mockResolvedValue(sampleRecord("2.0.0"));
+    mocks.readHostPidMetadataMock.mockResolvedValue(pidRecord("2.0.0", 4242));
+    mocks.identityVerdictMock.mockResolvedValue("current");
+    mocks.readUpdateProgressMarkerMock.mockResolvedValue({
+      state: "failed",
+      error: "host did not become healthy: tcp refused",
+      targetVersion: "2.0.0",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      writerId: null,
+    });
+    mocks.deleteUpdateProgressMarkerIfUnchangedMock.mockResolvedValue("failed");
+
+    const ctx = fakeCtx();
+    const result = await buildHostUpdateCommand({
+      force: false,
+      allowDowngrade: false,
+      ackNonce: null,
+    })(ctx);
+
+    expect(ctx.runtime.logger.info).toHaveBeenCalledWith(
+      "Host update left the progress marker alone - the stale-failure clear could not be written",
+      expect.objectContaining({
+        environment: "production",
+        outcome: "failed",
+      }),
     );
     expect(result.human).toContain("no-op");
   });
@@ -1744,7 +2277,9 @@ describe("buildHostUpdateCommand — activation debt (installed-up-to-date short
     expect(mocks.identityVerdictMock).toHaveBeenCalledWith(4242, null);
     expect(mocks.stopHostForRestartWithAttemptMock).not.toHaveBeenCalled();
     expect(mocks.assertHostNotBusyMock).not.toHaveBeenCalled();
-    expect(mocks.writeUpdateProgressMarkerMock).not.toHaveBeenCalled();
+    expect(
+      mocks.claimUpdateProgressMarkerBeforeLockMock,
+    ).not.toHaveBeenCalled();
     expect(
       mocks.deleteUpdateProgressMarkerIfUnchangedMock,
     ).not.toHaveBeenCalled();
@@ -1839,7 +2374,9 @@ describe("buildHostUpdateCommand — activation debt (installed-up-to-date short
 
     expect(mocks.assertHostNotBusyMock).not.toHaveBeenCalled();
     expect(mocks.stopHostForRestartWithAttemptMock).not.toHaveBeenCalled();
-    expect(mocks.writeUpdateProgressMarkerMock).not.toHaveBeenCalledWith(
+    expect(
+      mocks.claimUpdateProgressMarkerBeforeLockMock,
+    ).not.toHaveBeenCalledWith(
       "production",
       expect.objectContaining({ state: "failed" }),
     );
@@ -1860,7 +2397,9 @@ describe("buildHostUpdateCommand — activation debt (installed-up-to-date short
     })(fakeCtx());
 
     expect(mocks.stopHostForRestartWithAttemptMock).not.toHaveBeenCalled();
-    expect(mocks.writeUpdateProgressMarkerMock).not.toHaveBeenCalled();
+    expect(
+      mocks.claimUpdateProgressMarkerBeforeLockMock,
+    ).not.toHaveBeenCalled();
     expect(mocks.deleteUpdateProgressMarkerMock).not.toHaveBeenCalled();
     expect(result.human).toContain("no-op");
   });
@@ -1878,7 +2417,9 @@ describe("buildHostUpdateCommand — activation debt (installed-up-to-date short
     })(fakeCtx());
 
     expect(mocks.stopHostForRestartWithAttemptMock).not.toHaveBeenCalled();
-    expect(mocks.writeUpdateProgressMarkerMock).not.toHaveBeenCalled();
+    expect(
+      mocks.claimUpdateProgressMarkerBeforeLockMock,
+    ).not.toHaveBeenCalled();
     expect(result.human).toContain("no-op");
   });
 
@@ -1897,7 +2438,9 @@ describe("buildHostUpdateCommand — activation debt (installed-up-to-date short
     })(fakeCtx());
 
     expect(mocks.stopHostForRestartWithAttemptMock).not.toHaveBeenCalled();
-    expect(mocks.writeUpdateProgressMarkerMock).not.toHaveBeenCalled();
+    expect(
+      mocks.claimUpdateProgressMarkerBeforeLockMock,
+    ).not.toHaveBeenCalled();
     expect(result.human).toContain("no-op");
   });
 
@@ -1966,7 +2509,9 @@ describe("buildHostUpdateCommand — activation debt (installed-up-to-date short
     })(fakeCtx());
 
     expect(mocks.stopHostForRestartWithAttemptMock).not.toHaveBeenCalled();
-    expect(mocks.writeUpdateProgressMarkerMock).not.toHaveBeenCalled();
+    expect(
+      mocks.claimUpdateProgressMarkerBeforeLockMock,
+    ).not.toHaveBeenCalled();
     expect(result.human).toContain("no-op");
   });
 
@@ -2024,7 +2569,9 @@ describe("buildHostUpdateCommand — activation debt (installed-up-to-date short
     })(fakeCtx());
 
     expect(mocks.stopHostForRestartWithAttemptMock).not.toHaveBeenCalled();
-    expect(mocks.writeUpdateProgressMarkerMock).not.toHaveBeenCalled();
+    expect(
+      mocks.claimUpdateProgressMarkerBeforeLockMock,
+    ).not.toHaveBeenCalled();
     // CONDITIONAL on the marker still being the `failed` record that was
     // read - never the unconditional delete, which would erase a live
     // `updating` another updater wrote in between.
@@ -2096,8 +2643,10 @@ describe("buildHostUpdateCommand — activation debt (installed-up-to-date short
     ).rejects.toMatchObject({ code: CLI_ERROR_CODES.HOST_BUSY });
 
     expect(mocks.stopHostForRestartWithAttemptMock).not.toHaveBeenCalled();
-    expect(mocks.writeUpdateProgressMarkerMock).toHaveBeenCalledTimes(1);
-    const written = mocks.writeUpdateProgressMarkerMock.mock
+    expect(mocks.claimUpdateProgressMarkerBeforeLockMock).toHaveBeenCalledTimes(
+      1,
+    );
+    const written = mocks.claimUpdateProgressMarkerBeforeLockMock.mock
       .calls[0][1] as HostUpdateProgress;
     expect(written).toEqual(
       expect.objectContaining({ state: "updating", targetVersion: "2.0.0" }),
@@ -2134,8 +2683,10 @@ describe("buildHostUpdateCommand — activation debt (installed-up-to-date short
     });
 
     expect(mocks.stopHostForRestartWithAttemptMock).toHaveBeenCalledTimes(1);
-    expect(mocks.writeUpdateProgressMarkerMock).toHaveBeenCalledTimes(1);
-    const written = mocks.writeUpdateProgressMarkerMock.mock
+    expect(mocks.claimUpdateProgressMarkerBeforeLockMock).toHaveBeenCalledTimes(
+      1,
+    );
+    const written = mocks.claimUpdateProgressMarkerBeforeLockMock.mock
       .calls[0][1] as HostUpdateProgress;
     expect(
       mocks.replaceUpdateProgressMarkerIfUnchangedMock,
@@ -2190,10 +2741,18 @@ describe("buildHostUpdateCommand busy park + early marker", () => {
         } satisfies HostDownloadOutcome;
       },
     );
-    mocks.writeUpdateProgressMarkerMock.mockImplementation(
-      async (_environment: string, record: HostUpdateProgress) => {
+    // Falsification: leave the claim mock's `armActivationDefaults` default
+    // wiring in place (it does not push into `callOrder`) and this test could
+    // not tell "claimed" from "claimed strictly before the download
+    // resolved" apart.
+    mocks.claimUpdateProgressMarkerBeforeLockMock.mockImplementation(
+      async (
+        _environment: string,
+        next: HostUpdateProgress,
+      ): Promise<UpdateProgressMarkerClaim> => {
         mocks.callOrder.push("marker-written");
-        mocks.disk.current = record;
+        mocks.disk.current = next;
+        return { outcome: "published", displaced: null };
       },
     );
     mocks.applyHostMock.mockResolvedValue(
@@ -2206,8 +2765,10 @@ describe("buildHostUpdateCommand busy park + early marker", () => {
       ackNonce: null,
     })(fakeCtx());
 
-    expect(mocks.writeUpdateProgressMarkerMock).toHaveBeenCalledTimes(1);
-    expect(mocks.writeUpdateProgressMarkerMock).toHaveBeenCalledWith(
+    expect(mocks.claimUpdateProgressMarkerBeforeLockMock).toHaveBeenCalledTimes(
+      1,
+    );
+    expect(mocks.claimUpdateProgressMarkerBeforeLockMock).toHaveBeenCalledWith(
       "production",
       expect.objectContaining({ state: "updating", targetVersion: "2.0.0" }),
     );
@@ -2218,7 +2779,7 @@ describe("buildHostUpdateCommand busy park + early marker", () => {
     // The load-bearing ordering: the marker is on disk before the download
     // promise this command awaits ever resolves, not merely before `apply`.
     expect(markerIndex).toBeLessThan(resolvedIndex);
-    const written = mocks.writeUpdateProgressMarkerMock.mock
+    const written = mocks.claimUpdateProgressMarkerBeforeLockMock.mock
       .calls[0][1] as HostUpdateProgress;
     expect(
       mocks.deleteUpdateProgressMarkerIfUnchangedMock,
@@ -2242,8 +2803,10 @@ describe("buildHostUpdateCommand busy park + early marker", () => {
       })(fakeCtx()),
     ).rejects.toThrow("download failed: ECONNRESET");
 
-    expect(mocks.writeUpdateProgressMarkerMock).toHaveBeenCalledTimes(1);
-    const written = mocks.writeUpdateProgressMarkerMock.mock
+    expect(mocks.claimUpdateProgressMarkerBeforeLockMock).toHaveBeenCalledTimes(
+      1,
+    );
+    const written = mocks.claimUpdateProgressMarkerBeforeLockMock.mock
       .calls[0][1] as HostUpdateProgress;
     expect(written.state).toBe("updating");
     expect(written.targetVersion).toBe("2.0.0");
@@ -2283,7 +2846,9 @@ describe("buildHostUpdateCommand busy park + early marker", () => {
     // `prepareHostUpdate` runs (outside the try that owns `onWillDownload`)
     // and this goes red - a marker would appear for a run that never
     // reached the hook.
-    expect(mocks.writeUpdateProgressMarkerMock).not.toHaveBeenCalled();
+    expect(
+      mocks.claimUpdateProgressMarkerBeforeLockMock,
+    ).not.toHaveBeenCalled();
     expect(
       mocks.replaceUpdateProgressMarkerIfUnchangedMock,
     ).not.toHaveBeenCalled();
@@ -2345,8 +2910,10 @@ describe("buildHostUpdateCommand busy park + early marker", () => {
     expect(message).toContain("stays staged");
     expect(message).toContain("--force");
 
-    expect(mocks.writeUpdateProgressMarkerMock).toHaveBeenCalledTimes(1);
-    const written = mocks.writeUpdateProgressMarkerMock.mock
+    expect(mocks.claimUpdateProgressMarkerBeforeLockMock).toHaveBeenCalledTimes(
+      1,
+    );
+    const written = mocks.claimUpdateProgressMarkerBeforeLockMock.mock
       .calls[0][1] as HostUpdateProgress;
     expect(written.state).toBe("updating");
     expect(
@@ -2383,12 +2950,14 @@ describe("buildHostUpdateCommand busy park + early marker", () => {
       ackNonce: null,
     })(fakeCtx());
 
-    expect(mocks.writeUpdateProgressMarkerMock).toHaveBeenCalledTimes(1);
-    expect(mocks.writeUpdateProgressMarkerMock).toHaveBeenCalledWith(
+    expect(mocks.claimUpdateProgressMarkerBeforeLockMock).toHaveBeenCalledTimes(
+      1,
+    );
+    expect(mocks.claimUpdateProgressMarkerBeforeLockMock).toHaveBeenCalledWith(
       "production",
       expect.objectContaining({ state: "updating", targetVersion: "2.0.0" }),
     );
-    const written = mocks.writeUpdateProgressMarkerMock.mock
+    const written = mocks.claimUpdateProgressMarkerBeforeLockMock.mock
       .calls[0][1] as HostUpdateProgress;
     expect(
       mocks.deleteUpdateProgressMarkerIfUnchangedMock,
@@ -2480,11 +3049,14 @@ describe("buildHostUpdateCommand — reassertMarkerUnderLock under the lock", ()
       ackNonce: null,
     })(fakeCtx());
 
-    // The pre-lock publish is the only unconditional write; the empty-path
-    // republish under the lock goes through the create-if-absent primitive
-    // instead, never through `writeUpdateProgressMarker` again.
-    expect(mocks.writeUpdateProgressMarkerMock).toHaveBeenCalledTimes(1);
-    const firstWrite = mocks.writeUpdateProgressMarkerMock.mock
+    // The pre-lock publish is the only conditional CLAIM (no unconditional
+    // write exists any more); the empty-path republish under the lock goes
+    // through the create-if-absent primitive instead, never through a
+    // second `claimUpdateProgressMarkerBeforeLock` call.
+    expect(mocks.claimUpdateProgressMarkerBeforeLockMock).toHaveBeenCalledTimes(
+      1,
+    );
+    const firstWrite = mocks.claimUpdateProgressMarkerBeforeLockMock.mock
       .calls[0][1] as HostUpdateProgress;
     expect(mocks.createUpdateProgressMarkerIfAbsentMock).toHaveBeenCalledTimes(
       1,
@@ -2534,8 +3106,10 @@ describe("buildHostUpdateCommand — reassertMarkerUnderLock under the lock", ()
       ackNonce: null,
     })(fakeCtx());
 
-    expect(mocks.writeUpdateProgressMarkerMock).toHaveBeenCalledTimes(1);
-    const preLock = mocks.writeUpdateProgressMarkerMock.mock
+    expect(mocks.claimUpdateProgressMarkerBeforeLockMock).toHaveBeenCalledTimes(
+      1,
+    );
+    const preLock = mocks.claimUpdateProgressMarkerBeforeLockMock.mock
       .calls[0][1] as HostUpdateProgress;
     expect(preLock.targetVersion).toBe("2.0.0");
     // The re-point happens INSIDE `applyHost` (via `onWillCommitStaged`),
@@ -2603,9 +3177,11 @@ describe("buildHostUpdateCommand — reassertMarkerUnderLock under the lock", ()
     })(ctx);
 
     expect(result.exitCode).toBe(0);
-    // The pre-lock publish is the only `writeUpdateProgressMarker` call -
-    // the takeover itself goes through the CAS replace primitive.
-    expect(mocks.writeUpdateProgressMarkerMock).toHaveBeenCalledTimes(1);
+    // The pre-lock publish is the only `claimUpdateProgressMarkerBeforeLock`
+    // call - the takeover itself goes through the CAS replace primitive.
+    expect(mocks.claimUpdateProgressMarkerBeforeLockMock).toHaveBeenCalledTimes(
+      1,
+    );
     // The takeover replaces the FOREIGN record with a fresh `updating`
     // record naming the target this run is working toward.
     expect(
@@ -2974,10 +3550,12 @@ describe("buildHostUpdateCommand — reassertMarkerUnderLock under the lock", ()
     expect(mocks.installHostDowngradeMock).toHaveBeenCalledWith(
       expect.objectContaining({ onBeforeCommit: expect.any(Function) }),
     );
-    // The pre-lock publish is the only `writeUpdateProgressMarker` call; the
-    // empty-path republish under the lock lands through the create-if-absent
-    // primitive instead.
-    expect(mocks.writeUpdateProgressMarkerMock).toHaveBeenCalledTimes(1);
+    // The pre-lock publish is the only `claimUpdateProgressMarkerBeforeLock`
+    // call; the empty-path republish under the lock lands through the
+    // create-if-absent primitive instead.
+    expect(mocks.claimUpdateProgressMarkerBeforeLockMock).toHaveBeenCalledTimes(
+      1,
+    );
     expect(mocks.createUpdateProgressMarkerIfAbsentMock).toHaveBeenCalledTimes(
       1,
     );
@@ -3032,9 +3610,11 @@ describe("buildHostUpdateCommand — reassertMarkerUnderLock under the lock", ()
       ackNonce: null,
     })(fakeCtx());
 
-    // No second unconditional write - the refusal is the create call
-    // itself, never a `writeUpdateProgressMarker`.
-    expect(mocks.writeUpdateProgressMarkerMock).toHaveBeenCalledTimes(1);
+    // No second pre-lock claim - the refusal is the create call itself,
+    // never a second `claimUpdateProgressMarkerBeforeLock`.
+    expect(mocks.claimUpdateProgressMarkerBeforeLockMock).toHaveBeenCalledTimes(
+      1,
+    );
     expect(mocks.createUpdateProgressMarkerIfAbsentMock).toHaveBeenCalledTimes(
       1,
     );
@@ -3081,19 +3661,32 @@ describe("buildHostUpdateCommand — reassertMarkerUnderLock under the lock", ()
       async () => "failed",
     );
 
+    const ctx = fakeCtx();
     const result = await buildHostUpdateCommand({
       force: false,
       allowDowngrade: false,
       ackNonce: null,
-    })(fakeCtx());
+    })(ctx);
 
     // The apply still runs to completion - a failed create is advisory
     // state, never a reason to abort or throw.
     expect(mocks.applyHostMock).toHaveBeenCalled();
     expect(result.exitCode).toBe(0);
-    expect(mocks.writeUpdateProgressMarkerMock).toHaveBeenCalledTimes(1);
-    const firstWrite = mocks.writeUpdateProgressMarkerMock.mock
+    expect(mocks.claimUpdateProgressMarkerBeforeLockMock).toHaveBeenCalledTimes(
+      1,
+    );
+    const firstWrite = mocks.claimUpdateProgressMarkerBeforeLockMock.mock
       .calls[0][1] as HostUpdateProgress;
+    // A "failed" create now warns exactly like a "failed" replace - the
+    // retry loop's I/O-failure arms report the same way regardless of which
+    // primitive hit it.
+    expect(ctx.runtime.logger.warn).toHaveBeenCalledWith(
+      "Host update could not write the progress marker under the lock; proceeding without re-asserting it",
+      expect.objectContaining({
+        environment: "production",
+        targetVersion: "2.0.0",
+      }),
+    );
     // `ownMarker` was never adopted from a failed create - the final clear
     // is still CAS'd against this run's ORIGINAL pre-lock record.
     expect(
@@ -3101,10 +3694,12 @@ describe("buildHostUpdateCommand — reassertMarkerUnderLock under the lock", ()
     ).toHaveBeenCalledWith("production", firstWrite);
   });
 
-  it('an I/O-failed CAS is not retried: the CAS reports "changed" but the re-read shows the same record, so the run stops trying', async () => {
-    // Falsification: retry against the same expected record on every
-    // "changed" answer instead of comparing the re-read against
-    // `lastExpected`, and this test would see more than one replace call.
+  it('an I/O-failed CAS is not retried: the replace reports "failed", so the run stops trying on the FIRST attempt', async () => {
+    // Falsification: retry on a "failed" answer the same way the loop
+    // retries on "changed" and this test would see more than one replace
+    // call - `reassertMarkerUnderLock` only re-reads on "changed" (a record
+    // that moved); "failed" (an I/O failure, already warned about by the
+    // marker layer) is never retried.
     mocks.downloadAndStageHostMock.mockImplementation(
       async (opts: DownloadAndStageHostOptions) => {
         await requireHook(opts)("2.0.0");
@@ -3116,15 +3711,14 @@ describe("buildHostUpdateCommand — reassertMarkerUnderLock under the lock", ()
       },
     );
     // The hook reports a MOVED target ("2.1.0"), so the loop must re-point
-    // the record it already owns - and the CAS resolves "changed" while the
-    // disk fixture underneath it never actually moves (an I/O failure on
-    // the write itself, not a race with another writer).
+    // the record it already owns - and the CAS resolves "failed": an I/O
+    // failure on the write itself, not a race with another writer.
     mocks.applyHostMock.mockImplementation(async (opts: ApplyHostOptions) => {
       await opts.onWillCommitStaged?.("2.1.0");
       return appliedOutcome("1.0.0", "2.1.0", null);
     });
     mocks.replaceUpdateProgressMarkerIfUnchangedMock.mockResolvedValue(
-      "changed",
+      "failed",
     );
 
     const ctx = fakeCtx();
@@ -3134,9 +3728,7 @@ describe("buildHostUpdateCommand — reassertMarkerUnderLock under the lock", ()
       ackNonce: null,
     })(ctx);
 
-    // Exactly ONE replace call - the re-read on the next iteration shows the
-    // SAME record it just tried to replace, so the loop concludes the write
-    // failed rather than retrying against an unmoving disk.
+    // Exactly ONE replace call - a "failed" answer is never retried.
     expect(
       mocks.replaceUpdateProgressMarkerIfUnchangedMock,
     ).toHaveBeenCalledTimes(1);
@@ -3149,13 +3741,101 @@ describe("buildHostUpdateCommand — reassertMarkerUnderLock under the lock", ()
     );
     // The update continues regardless - marker I/O never fails the command.
     expect(result.exitCode).toBe(0);
-    // The final clear is CAS'd against the ORIGINAL pre-lock record - it
-    // was never adopted from the refused re-point.
-    const written = mocks.writeUpdateProgressMarkerMock.mock
+    // This is now CORRECT behavior, not merely tolerated: a "failed" replace
+    // RESTORES the expected record it held in scratch (see the production
+    // comment on `swapMarkerIfUnchanged`'s stamp/restore branch), so the
+    // pre-lock record is still exactly what is on disk - which is why the
+    // final clear targeting it, rather than the refused re-point, is right.
+    const written = mocks.claimUpdateProgressMarkerBeforeLockMock.mock
       .calls[0][1] as HostUpdateProgress;
     expect(
       mocks.deleteUpdateProgressMarkerIfUnchangedMock,
     ).toHaveBeenCalledWith("production", written);
+  });
+
+  it('a "changed" replace re-reads and takes over the record a newer updater actually landed', async () => {
+    // Falsification: treat "changed" like "failed" (stop after one attempt)
+    // and the takeover below never happens - the loop would warn and leave
+    // the marker pointed at the stale record even though a fresh one is
+    // sitting right there to adopt.
+    //
+    // The pre-lock claim must defer (own stays null) for `reassertMarkerUnderLock`
+    // to ever reach the replace path at all - an ESTABLISHED own record whose
+    // target already matches returns immediately without a single replace
+    // call. Seed the disk with a live foreign record BEFORE the download
+    // hook fires so the claim defers.
+    const foreignRecord: HostUpdateProgress = {
+      state: "updating",
+      error: null,
+      targetVersion: "2.0.0",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      writerId: "foreign-writer",
+    };
+    mocks.disk.current = foreignRecord;
+    mocks.downloadAndStageHostMock.mockImplementation(
+      async (opts: DownloadAndStageHostOptions) => {
+        await requireHook(opts)("2.0.0");
+        return {
+          outcome: "promoted",
+          stagedVersion: "2.0.0",
+          installedVersion: "1.0.0",
+        } satisfies HostDownloadOutcome;
+      },
+    );
+    const newerRecord: HostUpdateProgress = {
+      state: "updating",
+      error: null,
+      targetVersion: "2.0.0",
+      updatedAt: "2026-01-01T00:00:01.000Z",
+      writerId: "newer-writer",
+    };
+    // The FIRST replace attempt (against `foreignRecord`) reports "changed"
+    // AND lands a DIFFERENT, even newer updater's record on the disk fixture
+    // at the same time - modeling a real race, not a static disk. The loop
+    // re-reads, sees the newer record, and its SECOND replace attempt takes
+    // it over via the default `armActivationDefaults` wiring.
+    mocks.replaceUpdateProgressMarkerIfUnchangedMock.mockImplementationOnce(
+      async () => {
+        mocks.disk.current = newerRecord;
+        return "changed";
+      },
+    );
+    mocks.applyHostMock.mockImplementation(async (opts: ApplyHostOptions) => {
+      await opts.onWillCommitStaged?.("2.0.0");
+      return appliedOutcome("1.0.0", "2.0.0", null);
+    });
+
+    const result = await buildHostUpdateCommand({
+      force: false,
+      allowDowngrade: false,
+      ackNonce: null,
+    })(fakeCtx());
+
+    expect(
+      mocks.replaceUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenCalledTimes(2);
+    expect(
+      mocks.replaceUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenNthCalledWith(
+      1,
+      "production",
+      foreignRecord,
+      expect.objectContaining({ state: "updating", targetVersion: "2.0.0" }),
+    );
+    expect(
+      mocks.replaceUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenNthCalledWith(
+      2,
+      "production",
+      newerRecord,
+      expect.objectContaining({ state: "updating", targetVersion: "2.0.0" }),
+    );
+    const adopted = mocks.replaceUpdateProgressMarkerIfUnchangedMock.mock
+      .calls[1][2] as HostUpdateProgress;
+    expect(
+      mocks.deleteUpdateProgressMarkerIfUnchangedMock,
+    ).toHaveBeenCalledWith("production", adopted);
+    expect(result.exitCode).toBe(0);
   });
 
   it("a park before the hook never touches the marker beyond this run's own record", async () => {
@@ -3215,7 +3895,7 @@ describe("buildHostUpdateCommand — reassertMarkerUnderLock under the lock", ()
     // The withdrawal is asked for against this run's OWN pre-lock record
     // only - the foreign marker on disk means the CAS reports "changed"
     // and leaves it alone, untouched.
-    const written = mocks.writeUpdateProgressMarkerMock.mock
+    const written = mocks.claimUpdateProgressMarkerBeforeLockMock.mock
       .calls[0][1] as HostUpdateProgress;
     expect(
       mocks.deleteUpdateProgressMarkerIfUnchangedMock,

--- a/clients/traycer-cli/src/commands/cli-mark-source.ts
+++ b/clients/traycer-cli/src/commands/cli-mark-source.ts
@@ -1,10 +1,10 @@
 import { stat } from "node:fs/promises";
 import type { Stats } from "node:fs";
 import { resolve } from "node:path";
+import { PACKAGE_MANAGER_CLI_SOURCES } from "@traycer-clients/shared/cli-install/package-manager-upgrade-command";
 import {
   type CliInstallManifest,
   type CliInstallSource,
-  PACKAGE_MANAGER_CLI_SOURCES,
   readCliManifest,
   VALID_CLI_INSTALL_SOURCES,
   writeCliManifest,

--- a/clients/traycer-cli/src/commands/cli-upgrade.ts
+++ b/clients/traycer-cli/src/commands/cli-upgrade.ts
@@ -15,11 +15,11 @@ import {
   fetchCliVersions,
   resolveCliAsset,
 } from "../registry/cli-versions";
+import { PACKAGE_MANAGER_CLI_SOURCES } from "@traycer-clients/shared/cli-install/package-manager-upgrade-command";
 import {
   clearPendingUpgrade,
   type CliInstallSource,
   type CliPendingUpgrade,
-  PACKAGE_MANAGER_CLI_SOURCES,
   PACKAGE_MANAGER_UPGRADE_HINT,
   readCliManifest,
   updateCliManifest,

--- a/clients/traycer-cli/src/commands/host-apply.ts
+++ b/clients/traycer-cli/src/commands/host-apply.ts
@@ -85,7 +85,10 @@ export function buildHostApplyCommand(args: HostApplyArgs): CommandFn {
           force: args.force,
           noService: args.noService,
           expectedStageFingerprint: args.expectedStageFingerprint,
+          expectedStagedVersion: null,
           onProgress: (info) => ctx.progress(info),
+          onWillCommitStaged: null,
+          onWillDisruptHost: null,
         }),
     );
     const activation = activationOf(outcome);
@@ -131,7 +134,8 @@ export function buildHostApplyCommand(args: HostApplyArgs): CommandFn {
  *                      case: that branch kickstarts the agent label and
  *                      reports "start".
  *   - `null`           nothing was committed (`no-op`,
- *                      `stage-fingerprint-mismatch`), so there is no
+ *                      `stage-fingerprint-mismatch`,
+ *                      `stage-version-mismatch`), so there is no
  *                      activation to report. NOT `failed`: those outcomes
  *                      never touch or probe the running host, and reporting a
  *                      failure for a healthy, already-current install would be
@@ -151,6 +155,11 @@ function humanSummary(outcome: ApplyHostOutcome): string {
   }
   if (outcome.outcome === "stage-fingerprint-mismatch") {
     return "staged host changed after eligibility; retry against the current stage";
+  }
+  if (outcome.outcome === "stage-version-mismatch") {
+    // Unreachable from this command (it pins no version), kept exhaustive
+    // so a caller that starts pinning one gets a sentence, not a crash.
+    return `staged host is ${outcome.actualStagedVersion}, not the requested ${outcome.expectedStagedVersion}; retry against the current stage`;
   }
   // These lines report the ACTIVATION, never liveness - the same distinction
   // `activation` draws in the payload, and for the same reason: nothing here

--- a/clients/traycer-cli/src/commands/host-available.ts
+++ b/clients/traycer-cli/src/commands/host-available.ts
@@ -1,5 +1,5 @@
+import { HOST_CLIENT_FLOOR_REASON_PREFIX } from "@traycer-clients/shared/host-version/client-floor-reason";
 import {
-  HOST_CLIENT_FLOOR_REASON_PREFIX,
   isCanonicalReleaseCandidate,
   isPreReleaseVersion,
 } from "@traycer-clients/shared/host-version/release-line";

--- a/clients/traycer-cli/src/commands/host-available.ts
+++ b/clients/traycer-cli/src/commands/host-available.ts
@@ -1,4 +1,5 @@
 import {
+  HOST_CLIENT_FLOOR_REASON_PREFIX,
   isCanonicalReleaseCandidate,
   isPreReleaseVersion,
 } from "@traycer-clients/shared/host-version/release-line";
@@ -10,6 +11,7 @@ import {
 } from "../registry";
 import {
   evaluateHostClientFloor,
+  hostClientFloorRefusalMessage,
   isHostClientFloorRefusal,
 } from "../registry/client-floor";
 import { resolveCliVersion } from "../cli-version";
@@ -299,13 +301,20 @@ function projectClientFloor(
     requiredCliVersion: entry.requiredCliVersion,
   });
   if (!isHostClientFloorRefusal(floor)) return entry;
+  // Only a valid floor can be repaired by upgrading the CLI. Keep malformed
+  // registry data outside the GUI's repairable-reason prefix or it will keep
+  // asking for an upgrade that cannot fix the manifest.
+  const unavailableReason =
+    floor.kind === "floor-unreadable"
+      ? hostClientFloorRefusalMessage(floor, entry.version)
+      : `${HOST_CLIENT_FLOOR_REASON_PREFIX}${floor.requiredCliVersion} or newer (this host's CLI is ${cliVersion}).`;
   return {
     ...entry,
     platforms: {
       [platformKey]: {
         ...asset,
         available: false,
-        unavailableReason: `Needs Traycer CLI ${floor.requiredCliVersion} or newer (this host's CLI is ${cliVersion}).`,
+        unavailableReason,
       },
     },
   };

--- a/clients/traycer-cli/src/commands/host-download.ts
+++ b/clients/traycer-cli/src/commands/host-download.ts
@@ -32,6 +32,10 @@ export function buildHostDownloadCommand(args: HostDownloadArgs): CommandFn {
       automatic: args.automatic,
       onProgress: (info) => ctx.progress(info),
       registryClient: null,
+      // No marker to publish from here: `host download` never touches the
+      // running host, so there is no in-flight update for a remote client to
+      // be told about.
+      onWillDownload: null,
     });
     ctx.runtime.logger.info("Host download command completed", {
       environment: ctx.runtime.environment,

--- a/clients/traycer-cli/src/commands/host-install.ts
+++ b/clients/traycer-cli/src/commands/host-install.ts
@@ -184,6 +184,7 @@ export function buildHostInstallCommand(args: HostInstallArgs): CommandFn {
             allowSelfInvocation: args.allowSelfInvocation,
           },
           force: args.force,
+          onWillStopHost: null,
         });
     const lifecycle =
       handle !== null
@@ -240,6 +241,7 @@ export function buildHostInstallCommand(args: HostInstallArgs): CommandFn {
                   staged,
                   onProgress: (info) => ctx.progress(info),
                   lifecycle,
+                  onWillSwap: null,
                 },
               );
             },

--- a/clients/traycer-cli/src/commands/host-restart.ts
+++ b/clients/traycer-cli/src/commands/host-restart.ts
@@ -279,6 +279,7 @@ async function restartWithPendingCliUpgradeFinalizeWithAttempt(
         args.controller,
         args.label,
         { force: args.force },
+        null,
       ),
     relaunch: (stopped) =>
       relaunchHostAfterRestartWithAttempt(

--- a/clients/traycer-cli/src/commands/host-update-downgrade.ts
+++ b/clients/traycer-cli/src/commands/host-update-downgrade.ts
@@ -27,6 +27,13 @@ export async function installHostDowngrade(input: {
   readonly version: string;
   readonly force: boolean;
   readonly onProgress: (info: ProgressInfo) => void;
+  /**
+   * Runs under the mutation lock, before the busy gate and the commit - the
+   * first point at which this command is the only updater acting. `host
+   * update` re-establishes its progress marker here, since the one it wrote
+   * before waiting for admission may have been withdrawn by another run.
+   */
+  readonly onBeforeCommit: () => Promise<void>;
 }): Promise<Extract<ApplyHostOutcome, { outcome: "applied" }>> {
   const contenderOptions: WithCliUpdateContenderOptions = {
     environment: input.environment,
@@ -61,6 +68,7 @@ export async function installHostDowngrade(input: {
               exitCode: 1,
             });
           }
+          await input.onBeforeCommit();
           if (!input.force) await assertHostNotBusy(input.environment);
           const handle = createServiceInstallLifecycle({
             environment: input.environment,

--- a/clients/traycer-cli/src/commands/host-update-downgrade.ts
+++ b/clients/traycer-cli/src/commands/host-update-downgrade.ts
@@ -37,6 +37,8 @@ export async function installHostDowngrade(input: {
    * not do.
    */
   readonly onBeforeCommit: () => Promise<void>;
+  /** See `ApplyHostOptions.onWillDisruptHost`: the same actuator-reported boundary. */
+  readonly onWillDisruptHost: () => void;
 }): Promise<Extract<ApplyHostOutcome, { outcome: "applied" }>> {
   const contenderOptions: WithCliUpdateContenderOptions = {
     environment: input.environment,
@@ -77,6 +79,7 @@ export async function installHostDowngrade(input: {
             environment: input.environment,
             bootstrap: null,
             force: input.force,
+            onWillStopHost: input.onWillDisruptHost,
           });
           const result = await commitHostInstallSourceWithAttempt(
             capability,
@@ -86,6 +89,7 @@ export async function installHostDowngrade(input: {
               staged,
               onProgress: input.onProgress,
               lifecycle: handle.lifecycle,
+              onWillSwap: input.onWillDisruptHost,
             },
           );
           return {

--- a/clients/traycer-cli/src/commands/host-update-downgrade.ts
+++ b/clients/traycer-cli/src/commands/host-update-downgrade.ts
@@ -28,10 +28,13 @@ export async function installHostDowngrade(input: {
   readonly force: boolean;
   readonly onProgress: (info: ProgressInfo) => void;
   /**
-   * Runs under the mutation lock, before the busy gate and the commit - the
-   * first point at which this command is the only updater acting. `host
-   * update` re-establishes its progress marker here, since the one it wrote
-   * before waiting for admission may have been withdrawn by another run.
+   * Runs under the mutation lock, AFTER the busy gate and immediately before
+   * the commit - the first point at which this command is the only updater
+   * acting and has committed to acting. `host update` takes ownership of the
+   * progress marker here (the one it wrote before waiting for admission may
+   * have been withdrawn or replaced by another run); a busy refusal must
+   * come first, so a parked run never seizes a marker for work it then does
+   * not do.
    */
   readonly onBeforeCommit: () => Promise<void>;
 }): Promise<Extract<ApplyHostOutcome, { outcome: "applied" }>> {
@@ -68,8 +71,8 @@ export async function installHostDowngrade(input: {
               exitCode: 1,
             });
           }
-          await input.onBeforeCommit();
           if (!input.force) await assertHostNotBusy(input.environment);
+          await input.onBeforeCommit();
           const handle = createServiceInstallLifecycle({
             environment: input.environment,
             bootstrap: null,

--- a/clients/traycer-cli/src/commands/host-update-downgrade.ts
+++ b/clients/traycer-cli/src/commands/host-update-downgrade.ts
@@ -39,7 +39,7 @@ export async function installHostDowngrade(input: {
   readonly onBeforeCommit: () => Promise<void>;
   /** See `ApplyHostOptions.onWillDisruptHost`: the same actuator-reported boundary. */
   readonly onWillDisruptHost: () => void;
-}): Promise<Extract<ApplyHostOutcome, { outcome: "applied" }>> {
+}): Promise<Extract<ApplyHostOutcome, { outcome: "applied" | "no-op" }>> {
   const contenderOptions: WithCliUpdateContenderOptions = {
     environment: input.environment,
     reason: "host-update-downgrade",
@@ -57,14 +57,16 @@ export async function installHostDowngrade(input: {
       recordVersionOverride: null,
       verifyMutationCapability: verify,
     });
+    let outcome: Extract<ApplyHostOutcome, { outcome: "applied" | "no-op" }>;
     try {
-      return await withCliAttemptMutation(
+      outcome = await withCliAttemptMutation(
         capability,
         contenderOptions,
         async () => {
           // Recheck under the mutation lock: uninstall may have won before this
           // execution segment was claimed. An update never bootstraps a host.
-          if ((await readHostInstallRecord(input.environment)) === null) {
+          const installed = await readHostInstallRecord(input.environment);
+          if (installed === null) {
             throw cliError({
               code: CLI_ERROR_CODES.HOST_NOT_INSTALLED,
               message:
@@ -72,6 +74,21 @@ export async function installHostDowngrade(input: {
               details: { environment: input.environment },
               exitCode: 1,
             });
+          }
+          // The caller decided "requested below installed" before this
+          // lock; re-derived here like every pre-lock fact. Another actor
+          // may have installed the requested version meanwhile (an explicit
+          // `host update` of its own): committing identical bytes again
+          // would restart the host for nothing. The no-op is decided before
+          // the busy gate - a host with nothing owed is not asked - and
+          // before `onBeforeCommit`, so the marker is never taken over for
+          // work that is not done. The caller re-derives the activation
+          // state, as it does for a consumed stage.
+          if (installed.version === input.version) {
+            return {
+              outcome: "no-op",
+              installedVersion: installed.version,
+            } satisfies Extract<ApplyHostOutcome, { outcome: "no-op" }>;
           }
           if (!input.force) await assertHostNotBusy(input.environment);
           await input.onBeforeCommit();
@@ -113,5 +130,10 @@ export async function installHostDowngrade(input: {
       await discardStagedHostInstallSource(input.environment, staged, verify);
       throw error;
     }
+    if (outcome.outcome === "no-op") {
+      // The private source was staged for a commit that is not needed.
+      await discardStagedHostInstallSource(input.environment, staged, verify);
+    }
+    return outcome;
   });
 }

--- a/clients/traycer-cli/src/commands/host-update-downgrade.ts
+++ b/clients/traycer-cli/src/commands/host-update-downgrade.ts
@@ -18,9 +18,11 @@ import type { ProgressInfo } from "../runner/output";
 import { CLI_ERROR_CODES, cliError } from "../runner/errors";
 
 /**
- * Explicit rollback uses the install primitive, whose private verified source
- * survives independently of the monotonic background-update stage. Keep the
- * update command's progress marker and health check around this operation.
+ * An explicit install the monotonic shared stage would refuse - a rollback
+ * below the record, or another build of the record's release - uses the
+ * install primitive, whose private verified source survives independently
+ * of the background-update stage. Keep the update command's progress marker
+ * and health check around this operation.
  */
 export async function installHostDowngrade(input: {
   readonly environment: Environment;
@@ -75,8 +77,9 @@ export async function installHostDowngrade(input: {
               exitCode: 1,
             });
           }
-          // The caller decided "requested below installed" before this
-          // lock; re-derived here like every pre-lock fact. Another actor
+          // The caller decided "requested below installed, or another
+          // build of its release" before this lock; re-derived here like
+          // every pre-lock fact. Another actor
           // may have installed the requested version meanwhile (an explicit
           // `host update` of its own): committing identical bytes again
           // would restart the host for nothing. The no-op is decided before

--- a/clients/traycer-cli/src/commands/host-update.ts
+++ b/clients/traycer-cli/src/commands/host-update.ts
@@ -61,7 +61,9 @@ import { createServiceController, serviceLabelFor } from "../service";
 // Busy (D6): the stage is kept - `applyHost`'s busy check runs before it
 // touches the stage - and this command re-throws `E_HOST_BUSY` with the
 // staged version attached to `details`, rather than the generic
-// `details: null` `assertHostNotBusy` throws on its own. A busy exit is a
+// `details: null` `assertHostNotBusy` throws on its own; the activation arm
+// names a stage waiting beside the debt the same way. The downgrade arm's
+// park carries `details: null`: its private stage is discarded by design. A busy exit is a
 // PARK, not a failure: the run withdraws its own `updating` marker (or puts
 // back the record it took over under the lock) and stamps no `failed` (see
 // the catch below), because the refusal was the policy working and the
@@ -86,7 +88,9 @@ import { createServiceController, serviceLabelFor } from "../service";
 //     and performs it - restart, marker, probe - see `readActivationState`.
 //     The same debt can appear AFTER the lock wait: a stage this run
 //     promoted and then found consumed by such an apply is re-derived and
-//     activated the same way (see the staged arm);
+//     activated the same way (see the staged arm) - for an explicit
+//     request, only when the committed record IS the requested version
+//     (`installedVersionMismatch`);
 //   - `probeHostHealth` asks "is the recorded pid alive and its port
 //     accepting?" - it does not compare versions. On the Desktop-managed macOS
 //     degraded path a surviving OLD host can answer it, so a healthy probe is
@@ -508,6 +512,46 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
     const markDisruptionStarted = (): void => {
       disruptionStarted = true;
     };
+    // Shared by the three arms that find the REQUESTED work already done by
+    // another actor - a stage consumed under the lock, a downgrade whose
+    // version is already installed, an explicit download discarded because
+    // the record reached its version during the transfer: re-derive the
+    // activation state out of lock (the debt-only rule, see
+    // `ActivationReading`), hold every reading that names a record to the
+    // request (`installedVersionMismatch`), and pay a debt through the same
+    // activation arm, which re-reads under its own lock. `null` is "nothing
+    // to activate": the caller reports the no-op.
+    const activateCommittedByAnotherActor = async (
+      requested: string | null,
+      logLine: string,
+    ): Promise<{
+      readonly legacy: LegacyHostUpdateResult;
+      readonly activated: boolean;
+    } | null> => {
+      const reading = await readActivationState(environment);
+      if (reading.kind !== "no-install") {
+        const changedHandoff = installedVersionMismatch(
+          requested,
+          reading.installedVersion,
+        );
+        if (changedHandoff !== null) throw changedHandoff;
+      }
+      if (reading.kind !== "debt") return null;
+      activationAttempted = true;
+      ctx.runtime.logger.info(logLine, {
+        environment,
+        installedVersion: reading.installedVersion,
+        runningVersion: reading.runningVersion,
+      });
+      return activateInstalledAndProjectLegacy(
+        environment,
+        args.force,
+        requested,
+        reading.runningVersion,
+        reassertMarkerUnderLock,
+        markDisruptionStarted,
+      );
+    };
     // The preparation runs INSIDE the try whose catch owns the marker. The
     // marker is published from within it - `onWillDownload`, before the first
     // byte - so a transfer that rejects has a marker to stamp `failed` onto;
@@ -524,6 +568,16 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
         onProgress: reportProgress,
         onWillDownload: publishUpdating,
       });
+      // An EXPLICIT `host update <version>` acts on the version its
+      // decision resolved to and on nothing else - see
+      // `installedVersionMismatch` for the arms this binds and what each
+      // binds to. `null` for an implicit "latest".
+      const requestedVersion =
+        args.versionRequest === undefined || args.versionRequest === null
+          ? null
+          : preparation.kind === "downgrade"
+            ? preparation.version
+            : downloadTargetVersion(preparation.download);
       const installedUpToDate =
         preparation.kind === "staged" &&
         preparation.download.outcome === "short-circuit" &&
@@ -542,13 +596,38 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
       const activationReading = installedUpToDate
         ? await readActivationState(environment)
         : null;
-      const activationDebt =
+      const debtRead =
         activationReading !== null && activationReading.kind === "debt"
           ? activationReading
           : null;
+      // An EXPLICIT request owes the activation of ITS version and no other.
+      // The installed-up-to-date short-circuit fires for a record AT OR
+      // ABOVE the request, and a record above it (`--version 1.2.0` against
+      // an installed 2.0.0) is not this run's to restart onto - the caller
+      // confirmed 1.2.0 and nothing else (`installedVersionMismatch`). That
+      // record's debt is left, logged, to an implicit `host update` or a
+      // `host restart`, and this run reports the no-op the short-circuit
+      // always reported.
+      const activationDebt =
+        debtRead !== null &&
+        (requestedVersion === null ||
+          debtRead.installedVersion === requestedVersion)
+          ? debtRead
+          : null;
+      if (debtRead !== null && activationDebt === null) {
+        ctx.runtime.logger.info(
+          "Host update leaves the install record's activation debt: the explicit request names another version",
+          {
+            environment,
+            requestedVersion,
+            installedVersion: debtRead.installedVersion,
+            runningVersion: debtRead.runningVersion,
+          },
+        );
+      }
       if (activationDebt !== null) {
         ctx.runtime.logger.info(
-          "Host update found the install record ahead of the running host; activating",
+          "Host update found the install record differing from the running host; activating",
           {
             environment,
             installedVersion: activationDebt.installedVersion,
@@ -590,6 +669,38 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
       // claim DEFERRED (another writer's live marker stood there) has no
       // record and claims again here - the other update may have finished
       // during the download - under the same conditional rule.
+      // An EXPLICIT request whose download was DISCARDED at promote time
+      // (the installed version moved past it in the unlocked transfer
+      // window, or the install record vanished) has nothing of its own to
+      // apply. Going on to `applyHost` would either commit whatever stage
+      // another promoter left - the version binding refuses that, but with
+      // a sentence about a replaced stage that names the wrong cause - or
+      // find nothing and report the "stage consumed" recovery. The discard
+      // IS the answer; say it and stop - BEFORE the publish below, which
+      // would announce work this run has already decided not to do. An
+      // implicit "latest" discarded by a newer stage still applies that
+      // stage.
+      if (
+        requestedVersion !== null &&
+        preparation.kind === "staged" &&
+        preparation.download.outcome === "discarded"
+      ) {
+        // `not-newer-than-installed` covers EQUAL: the record can BE the
+        // request, committed by another actor during the transfer
+        // (Desktop's converge). That is the request delivered, not
+        // discarded - this run owes its activation exactly as it does for a
+        // consumed stage (the staged arm below), and the same event at
+        // every other timing already activates. Only a record at ANOTHER
+        // version is the discard's answer.
+        const committedByAnotherActor =
+          preparation.download.reason === "not-newer-than-installed" &&
+          (await readHostInstallRecord(environment))?.version ===
+            requestedVersion;
+        if (!committedByAnotherActor) {
+          throw discardedExplicitRequestError(preparation.download);
+        }
+      }
+
       if (needsWork && ownMarker.current === null) {
         await publishUpdating(
           activationDebt !== null
@@ -605,6 +716,10 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
         const activation = await activateInstalledAndProjectLegacy(
           environment,
           args.force,
+          // The record equals the request at this point (the gate above);
+          // under the lock the arm holds it to the request again, so a
+          // record another actor committed during the wait is refused.
+          requestedVersion,
           activationDebt.runningVersion,
           // The record is read again under the lock; the marker is made this
           // run's there, naming the version as read, and the stop follows.
@@ -613,23 +728,23 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
         );
         legacy = activation.legacy;
         activationPerformed = activation.activated;
+      } else if (
+        preparation.kind === "staged" &&
+        preparation.download.outcome === "discarded" &&
+        requestedVersion !== null
+      ) {
+        // The explicit request the transfer found already committed (see
+        // the discard check above): nothing to apply, a debt to pay.
+        const activation = await activateCommittedByAnotherActor(
+          requestedVersion,
+          "Host update found the requested version committed by another actor during its transfer; activating it",
+        );
+        legacy =
+          activation === null
+            ? projectNoOp(await requireInstalled(environment))
+            : activation.legacy;
+        activationPerformed = activation !== null && activation.activated;
       } else if (preparation.kind === "staged") {
-        // An EXPLICIT request whose download was DISCARDED at promote time
-        // (the installed version moved past it in the unlocked transfer
-        // window, or the install record vanished) has nothing of its own
-        // to apply. Going on to `applyHost` would either commit whatever
-        // stage another promoter left - the version-binding below refuses
-        // that, but with a sentence about a replaced stage that names the
-        // wrong cause - or find nothing and report the "stage consumed"
-        // recovery. The discard IS the answer; say it and stop. An implicit
-        // "latest" discarded by a newer stage still applies that stage.
-        if (
-          args.versionRequest !== undefined &&
-          args.versionRequest !== null &&
-          preparation.download.outcome === "discarded"
-        ) {
-          throw discardedExplicitRequestError(preparation.download);
-        }
         const apply = await applyAndProjectLegacy(
           environment,
           args.force,
@@ -646,9 +761,7 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
           // and checked its floor, and a stage another promoter replaced in
           // the unlocked wait must not be committed under that confirmation.
           // An implicit "latest" takes whatever newer stage it finds.
-          args.versionRequest === undefined || args.versionRequest === null
-            ? null
-            : downloadTargetVersion(preparation.download),
+          requestedVersion,
         );
         legacy = apply.legacy;
         applyPerformed = apply.applied;
@@ -666,43 +779,51 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
           // and run the same activation arm the debt path runs: it re-reads
           // under its own lock and is the plain no-op if the debt cleared
           // meanwhile.
-          const reading = await readActivationState(environment);
-          if (reading.kind === "debt") {
-            activationAttempted = true;
-            ctx.runtime.logger.info(
-              "Host update found its stage consumed by another actor without activation; activating the committed install",
-              {
-                environment,
-                installedVersion: reading.installedVersion,
-                runningVersion: reading.runningVersion,
-              },
-            );
-            const activation = await activateInstalledAndProjectLegacy(
-              environment,
-              args.force,
-              reading.runningVersion,
-              reassertMarkerUnderLock,
-              markDisruptionStarted,
-            );
+          // The record the other actor committed is not necessarily the
+          // version this run was asked for: Desktop's converge commits
+          // whatever ITS stage held. An explicit request delivers only its
+          // own version, on EVERY reading that names a record - held in
+          // `activateCommittedByAnotherActor`, which also pays the debt.
+          const activation = await activateCommittedByAnotherActor(
+            requestedVersion,
+            "Host update found its stage consumed by another actor without activation; activating the committed install",
+          );
+          if (activation !== null) {
             legacy = activation.legacy;
             activationPerformed = activation.activated;
           }
         }
       } else {
         const downgradeTarget = preparation.version;
-        legacy = projectApplied(
-          await installHostDowngrade({
-            environment,
-            version: downgradeTarget,
-            force: args.force,
-            onProgress: reportProgress,
-            onBeforeCommit: () => reassertMarkerUnderLock(downgradeTarget),
-            onWillDisruptHost: markDisruptionStarted,
-          }),
-        );
-        // `installHostDowngrade` returns only an `applied` outcome; a park
-        // or a failure throws past this line.
-        applyPerformed = true;
+        const downgrade = await installHostDowngrade({
+          environment,
+          version: downgradeTarget,
+          force: args.force,
+          onProgress: reportProgress,
+          onBeforeCommit: () => reassertMarkerUnderLock(downgradeTarget),
+          onWillDisruptHost: markDisruptionStarted,
+        });
+        // A park or a failure throws past this line.
+        if (downgrade.outcome === "applied") {
+          legacy = projectApplied(downgrade);
+          applyPerformed = true;
+        } else {
+          // Another actor installed the requested version while this run
+          // staged its private source (re-derived under the mutation lock;
+          // the source is discarded). What remains is the question the
+          // staged arm asks of a consumed stage - is the committed record
+          // running? - held to the request on every reading that names a
+          // record, and answered by the same activation arm.
+          const activation = await activateCommittedByAnotherActor(
+            downgradeTarget,
+            "Host update found the requested version installed by another actor without activation; activating it",
+          );
+          legacy =
+            activation === null
+              ? projectNoOp(await requireInstalled(environment))
+              : activation.legacy;
+          activationPerformed = activation !== null && activation.activated;
+        }
       }
     } catch (err) {
       if (err instanceof CliError && err.code === CLI_ERROR_CODES.HOST_BUSY) {
@@ -761,6 +882,23 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
         }
         throw err;
       }
+      // A refusal because a NEWER host is installed than the version this
+      // run was asked for - `E_HOST_UPDATE_NOT_NEWER`, from the promote-time
+      // discard or from `installedVersionMismatch`'s newer arm - is a
+      // SUPERSEDED request, not a failure: another actor delivered
+      // something newer and nothing was wrong. It is treated exactly like a
+      // target observed running: this run's record is WITHDRAWN, never
+      // stamped. A `failed` naming the announced version would stand over a
+      // host that is, or is about to be, serving a newer one - and neither
+      // stale-failed rule (this command's `clearStaleFailedMarker`, the
+      // host's `isStaleUpdateProgress`) clears a `failed` whose target is
+      // not the running version, so nothing but a later update that does
+      // work would ever remove it. Any other refusal (an OLDER or
+      // non-release record under an explicit request) names something that
+      // did go wrong and is stamped as before.
+      const superseded =
+        err instanceof CliError &&
+        err.code === CLI_ERROR_CODES.HOST_UPDATE_NOT_NEWER;
       if (ownMarker.current === null) {
         // No record of this run's on disk (the pre-lock claim deferred to
         // another writer's live marker, or no conditional write ever
@@ -783,6 +921,15 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
         // suppression hides it. Same observed-state rule as
         // `clearStaleFailedMarker`.
         if (
+          intendedTarget.current !== null &&
+          superseded &&
+          !disruptionStarted
+        ) {
+          ctx.runtime.logger.info(
+            "Host update did not stamp its refusal - a newer host than the target it announced is installed; nothing was wrong",
+            { environment, targetVersion: intendedTarget.current },
+          );
+        } else if (
           intendedTarget.current !== null &&
           !(await targetObservedRunning(environment, intendedTarget.current))
         ) {
@@ -826,12 +973,13 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
           });
         } else if (
           !disruptionStarted &&
-          (await targetObservedRunning(
-            environment,
-            // `intendedTarget` is set before any record of this run's
-            // exists; the fallback is the type's null arm.
-            intendedTarget.current ?? ownMarker.current.targetVersion,
-          ))
+          (superseded ||
+            (await targetObservedRunning(
+              environment,
+              // `intendedTarget` is set before any record of this run's
+              // exists; the fallback is the type's null arm.
+              intendedTarget.current ?? ownMarker.current.targetVersion,
+            )))
         ) {
           // Same observed-state rule as the null arm above, reached with a
           // record of this run's own on disk: an actor that writes no
@@ -843,19 +991,21 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
           // stamped: "update to X failed" over a host serving X is the
           // false report the rule exists to withhold. Pre-disruption only:
           // past the stop, the host's state is this run's doing and its
-          // failure is reported whatever the host now serves.
+          // failure is reported whatever the host now serves. A SUPERSEDED
+          // request (see `superseded`) takes the same withdrawal.
           const withdrawn = await deleteUpdateProgressMarkerIfUnchanged(
             environment,
             ownMarker.current,
           );
+          const lead = superseded
+            ? "Host update stopped before disturbing the host - a newer host than the target it announced is installed"
+            : "Host update failed before disturbing the host, and the running host has been observed at the target it announced";
           logConditionalMarkerOutcome(ctx.runtime.logger, environment, {
             outcome: withdrawn,
-            done: "Host update failed before disturbing the host, and the running host has been observed at the target it announced; the progress marker was withdrawn",
-            moved:
-              "Host update failed before disturbing the host, and the running host has been observed at the target it announced; the progress marker was not withdrawn - another updater owns it now",
-            gone: "Host update failed before disturbing the host, and the running host has been observed at the target it announced; found no progress marker to withdraw",
-            failed:
-              "Host update failed before disturbing the host, and the running host has been observed at the target it announced; its progress marker could not be withdrawn - the marker log names what the path holds now",
+            done: `${lead}; the progress marker was withdrawn`,
+            moved: `${lead}; the progress marker was not withdrawn - another updater owns it now`,
+            gone: `${lead}; found no progress marker to withdraw`,
+            failed: `${lead}; its progress marker could not be withdrawn - the marker log names what the path holds now`,
           });
         } else {
           // Stamped with the target this run was working toward. The two
@@ -863,7 +1013,8 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
           // on disk still names the pre-lock target while the run went on
           // to commit the version `applyHost` reported, and "update to
           // <old> failed" would name a version this run never installed -
-          // which the host's target-running suppression then mis-handles.
+          // and the host's narrower, string-equal suppression would then
+          // never retire it.
           await markUpdateFailed(
             ctx.runtime.logger,
             environment,
@@ -982,7 +1133,10 @@ interface ActivationDebt {
  * reading is named rather than collapsed to "debt or not", because the
  * places that consult it need different things from the non-debt cases:
  * OUT of the contender lock (before it, and again after a staged apply that
- * found its stage consumed), only `debt` is a reason to act; UNDER the
+ * found its stage consumed), only `debt` is a reason to ACTIVATE (the other
+ * readings are still consulted out of lock: `activated` for the
+ * stale-failed clear and the observed-running withhold, and every reading
+ * that names a record for an explicit request's binding); UNDER the
  * activation arm's lock, `debt` and `no-live-host` both are, while
  * `activated` is the reason NOT to.
  *
@@ -1006,7 +1160,7 @@ interface ActivationDebt {
 type ActivationReading =
   | { readonly kind: "no-install" }
   | { readonly kind: "no-live-host"; readonly installedVersion: string }
-  | { readonly kind: "foreign-runtime" }
+  | { readonly kind: "foreign-runtime"; readonly installedVersion: string }
   | { readonly kind: "activated"; readonly installedVersion: string }
   | ActivationDebt;
 
@@ -1080,7 +1234,9 @@ async function readActivationState(
   // Catalog-version domain (a record with no runtime stamp yet): the
   // release-version policy applies. A running version that is not a release
   // version is not a host this command reasons about.
-  if (!isValidHostVersion(running.version)) return { kind: "foreign-runtime" };
+  if (!isValidHostVersion(running.version)) {
+    return { kind: "foreign-runtime", installedVersion: installed.version };
+  }
   const comparison = compareHostVersions(running.version, installed.version);
   if (!comparison.comparable || comparison.ordering === "equal") {
     return { kind: "activated", installedVersion: installed.version };
@@ -1133,8 +1289,12 @@ async function targetObservedRunning(
  * immediately before the unlink. Marker I/O never fails the command (same
  * rule as the writes).
  *
- * "Contradicts" is the host's own rule (`isStaleUpdateProgress`): a `failed`
- * is stale when the version it names is the one now running. A `failed`
+ * "Contradicts" is the rule the host's `isStaleUpdateProgress` applies in
+ * its narrower form (string equality of the marker's target with the
+ * runtime version it publishes, so a staging host's `staging.<epoch>.<sha>`
+ * never matches a catalog target there): a `failed` is stale when the
+ * version it names is the one now running. Here the comparison is the
+ * catalog comparator's, the domain the record and the target share. A `failed`
  * naming ANOTHER version - an attempt at 2.0.0 that failed before the swap,
  * read by a later `host update` while the registry offers only 1.9.0 - is
  * a report the observed state does not contradict, and it stays until an
@@ -1199,22 +1359,27 @@ async function clearStaleFailedMarker(
  * was serving, so the human summary and Desktop's legacy projection both say
  * `rc.1 → rc.2`, which is what actually happened from the operator's seat.
  *
- * The debt the caller detected is deliberately NOT a parameter: it was read
- * outside the contender lock, and `host restart` shares that lock. Desktop's
+ * The debt the caller detected is deliberately NOT a parameter (the
+ * BINDING is - `expectedInstalledVersion` - the decision is not): it was
+ * read outside the contender lock, and `host restart` shares that lock. Desktop's
  * parked-registration fallback runs exactly that command on exactly this
  * host, so a Settings click that arrives while it holds the lock would
  * otherwise wait its turn and then restart a host that had just come up on
  * the committed bytes - costing it its connections and reporting a
  * `rc.1 → rc.2` transition that the other actor performed. The debt is
- * re-derived under the lock and a cleared debt is the plain no-op.
+ * re-derived under the lock and a cleared debt is the plain no-op - for an
+ * explicit request too, when the record still names the request; a record
+ * another actor moved to another version is refused above, activated or
+ * not.
  *
  * `activated` tells the caller which of the two happened, because the two
  * need different aftercare (a health probe for a restart, none for a no-op).
  * `onInstalledVersionUnderLock` is called with the record's version as read
  * under the lock, after the busy gate and before anything is restarted, so
- * the caller can take ownership of the progress marker (and re-point it if
- * another actor installed a different version in between) only once this
- * arm has committed to restarting.
+ * the caller can take ownership of the progress marker (and, for an
+ * implicit request, re-point it if another actor installed a different
+ * version in between - an explicit request was refused above before this
+ * point) only once this arm has committed to restarting.
  *
  * A debt is CLEARED only by observing the running host at the installed
  * version. A host that is simply gone under the lock - it exited, crashed,
@@ -1230,6 +1395,12 @@ async function clearStaleFailedMarker(
 async function activateInstalledAndProjectLegacy(
   environment: Environment,
   force: boolean,
+  /**
+   * The install record version this activation is bound to (an explicit
+   * request), or `null` (an implicit "latest" activates whatever record the
+   * lock reveals). See `installedVersionMismatch`.
+   */
+  expectedInstalledVersion: string | null,
   lastSeenRunningVersion: string,
   onInstalledVersionUnderLock: (installedVersion: string) => Promise<void>,
   /**
@@ -1257,6 +1428,20 @@ async function activateInstalledAndProjectLegacy(
     // nothing, so its live work is no reason to fail the command (and stamp
     // a failed marker) - it is the no-op, busy or not.
     const installed = await requireInstalled(environment);
+    // Decided first, on the record as read UNDER the lock, before the
+    // activation reading, the busy gate and the marker takeover: an
+    // explicit request restarts the host onto its own version or refuses.
+    // A record another actor committed AND activated meanwhile is refused
+    // too, not reported as "host already at Y" under a request for X - the
+    // same fact at promote time is the discard refusal, and a request that
+    // delivered nothing does not report success. The refusal is a
+    // superseded request when the record is newer (`E_HOST_UPDATE_NOT_NEWER`),
+    // which the catch WITHDRAWS rather than stamps - see `superseded`.
+    const changedHandoff = installedVersionMismatch(
+      expectedInstalledVersion,
+      installed.version,
+    );
+    if (changedHandoff !== null) throw changedHandoff;
     const reading = await readActivationState(environment);
     if (reading.kind !== "debt" && reading.kind !== "no-live-host") {
       return { legacy: projectNoOp(installed), activated: false };
@@ -1267,7 +1452,30 @@ async function activateInstalledAndProjectLegacy(
     // live work is not restarted under it unless the caller said `--force`.
     // A host that is gone has no work to protect, so the gate is not asked.
     if (!force && reading.kind === "debt") {
-      await assertHostNotBusy(environment);
+      try {
+        await assertHostNotBusy(environment);
+      } catch (err) {
+        if (
+          !(err instanceof CliError) ||
+          err.code !== CLI_ERROR_CODES.HOST_BUSY
+        ) {
+          throw err;
+        }
+        // D6, as the apply arm reports it: a stage waiting beside the debt
+        // (a `host download` this run did not consume) is named in the
+        // park, read HERE under the same lock the busy decision was made
+        // under. Nothing here touches the stage.
+        const staged = await readHostStagedRecord(environment);
+        throw cliError({
+          code: CLI_ERROR_CODES.HOST_BUSY,
+          message:
+            staged === null
+              ? err.message
+              : `${err.message} Host ${staged.version} stays staged; it installs on the next update once the host is idle, or now with --force.`,
+          details: { stagedVersion: staged?.version ?? null },
+          exitCode: err.exitCode,
+        });
+      }
     }
     // After the gate (where one runs - a host that is gone is not asked),
     // not before: the caller takes the progress marker over here, and a park
@@ -1354,6 +1562,72 @@ async function prepareHostUpdate(input: {
 // replaced the stage", which is not what happened. `not-newer-than-installed`
 // carries the code the downgrade gate uses for the same fact, so a caller
 // keyed on it (Desktop's Settings click) can offer `--allow-downgrade`.
+/**
+ * An EXPLICIT `host update <version>` delivers the version it resolved to
+ * and nothing else: the caller (a Settings click, `--version X`) confirmed
+ * that version and the GUI checked the CLI floor for it, and no arm of this
+ * command restarts the host onto another version under that confirmation.
+ * An implicit "latest" is bound nowhere: it takes whatever newer state each
+ * re-derivation reveals. The arms that can deliver a version, and what each
+ * holds an explicit request to:
+ *
+ * | arm                                   | holds the request to                                              |
+ * | ------------------------------------- | ----------------------------------------------------------------- |
+ * | staged apply (`applyHost`)            | the staged record: `expectedStagedVersion` → `stage-version-mismatch` |
+ * | download discarded at promote time    | nothing - refused outright (`discardedExplicitRequestError`), before the publish; unless the record IS the request (committed by another actor during the transfer), which is the request delivered and takes the recovery below |
+ * | pre-lock debt (installed-up-to-date)  | the record the short-circuit saw: a record ABOVE the request keeps its debt, this run reports the no-op (never enters the arm) |
+ * | consumed-stage recovery (apply no-op) | the re-derived record on EVERY reading that names one (`debt`, `activated`, `no-live-host`), before the log line and the arm |
+ * | activation arm (every route)          | the record read UNDER the lock, before the activation reading, the busy gate and the takeover |
+ * | downgrade (`installHostDowngrade`)    | its own download of `preparation.version`; a record another actor moved to that version under the lock is a no-op, re-derived here like a consumed stage |
+ *
+ * Identity is the STRING, the grain the apply binding uses: the request
+ * resolved to a catalog version and the record names the catalog version
+ * it committed, so the same artifact reads equal and `2.0.0+hotfix` is
+ * another artifact. A record that is not a release version (`local-*`,
+ * `host install --file`) is by construction not the requested one - it
+ * cannot be compared, and it is exactly a record another actor wrote. A
+ * record NEWER than the request is the fact the promote-time discard
+ * reports as `E_HOST_UPDATE_NOT_NEWER`, so it carries that code and the
+ * same remedies - and, like it, is a SUPERSEDED request the catch that
+ * owns the marker withdraws rather than stamps (see `superseded` there);
+ * any other mismatch is `E_UNEXPECTED`, a failure before any disruption
+ * that the catch stamps over this run's own record, naming the version it
+ * announced.
+ */
+function installedVersionMismatch(
+  expectedInstalledVersion: string | null,
+  installedVersion: string,
+): CliError | null {
+  if (
+    expectedInstalledVersion === null ||
+    installedVersion === expectedInstalledVersion
+  ) {
+    return null;
+  }
+  const comparison = compareHostVersions(
+    installedVersion,
+    expectedInstalledVersion,
+  );
+  const details = {
+    expectedInstalledVersion,
+    actualInstalledVersion: installedVersion,
+  };
+  if (comparison.comparable && comparison.ordering === "greater") {
+    return cliError({
+      code: CLI_ERROR_CODES.HOST_UPDATE_NOT_NEWER,
+      message: `host update: the installed host is ${installedVersion}, newer than the ${expectedInstalledVersion} this run was updating to - another actor installed it meanwhile; nothing was restarted. Run 'traycer host status' to see what is installed and running, or pass --allow-downgrade to install ${expectedInstalledVersion} over it`,
+      details,
+      exitCode: 1,
+    });
+  }
+  return cliError({
+    code: CLI_ERROR_CODES.UNEXPECTED,
+    message: `host update: the installed host is ${installedVersion}, not the ${expectedInstalledVersion} this run was updating to - another actor changed the install before it could be activated; nothing was restarted. Run the update again`,
+    details,
+    exitCode: 1,
+  });
+}
+
 function discardedExplicitRequestError(
   outcome: Extract<HostDownloadOutcome, { readonly outcome: "discarded" }>,
 ): CliError {
@@ -1461,9 +1735,11 @@ function logConditionalMarkerOutcome(
  * into a path that READS empty. Against another writer's live marker that
  * is the correct no-op; against the empty path that writer's clear left
  * behind, it is the only record of what went wrong. One residual race is
- * accepted and named: create-if-absent has no record to compare against,
- * so it cannot tell an empty path from the few milliseconds in which
- * another writer's conditional swap holds ITS record in scratch (see
+ * accepted and named - closed among writers that take the marker lock
+ * (`underMarkerLock`), open only against a CLI from before it:
+ * create-if-absent has no record to compare against, so it cannot tell an
+ * empty path from the few milliseconds in which such a writer's
+ * conditional swap holds ITS record in scratch (see
  * `replaceUpdateProgressMarkerIfUnchanged`, which maps that same "absent"
  * reading to `changed` for exactly this reason). A stamp that lands in that
  * window wins the other writer's `link` with EEXIST; its swap reports

--- a/clients/traycer-cli/src/commands/host-update.ts
+++ b/clients/traycer-cli/src/commands/host-update.ts
@@ -15,6 +15,7 @@ import {
   replaceUpdateProgressMarkerIfUnchanged,
   writeUpdateProgressMarker,
   type HostUpdateProgress,
+  sameProgress,
 } from "../host/update-progress-marker";
 import { probeHostHealth } from "../service/health-probe";
 import {
@@ -202,6 +203,11 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
     // write landed (a failed write is warned about, not retried). The version
     // it names is the one a `failed` stamp has to name too, which is why the
     // re-point under the lock replaces the whole record rather than one field.
+    //
+    // It is a CLAIM about the disk, not a fact: the one write that is not
+    // conditional on it is `reassertMarkerUnderLock` below, which republishes
+    // only into an EMPTY path - the case where a faster updater cleared this
+    // run's marker while it waited - and erases nothing.
     const ownMarker: { current: HostUpdateProgress | null } = { current: null };
     const publishUpdating = async (targetVersion: string): Promise<void> => {
       ownMarker.current = progressRecord({
@@ -214,6 +220,61 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
         environment,
         ownMarker.current,
       );
+    };
+    // Under the contender lock, before the disruptive half, re-establish
+    // what the pre-lock marker only claimed. The marker is published BEFORE
+    // this run waits for admission (`onWillDownload`, or the no-transfer
+    // arms above), and the wait is unbounded by anything this run controls:
+    // a second `host update` can land its own `updating` over ours, do its
+    // work, and clear it while we were still downloading. Reaching the apply
+    // with `ownMarker.current` non-null then proves nothing about the disk -
+    // the swap and restart would run with no marker at all, and the `failed`
+    // stamp (CAS against a record that is long gone) could never land.
+    //
+    // Three cases, decided from the file rather than from memory:
+    //  - ours is still there → keep it, re-pointed if the target moved under
+    //    the lock (the activation arm reads the record again there);
+    //  - another updater's is there → leave it. It is that updater's only
+    //    progress signal and this run's later stamp/clear are conditional on
+    //    a record the disk no longer holds, so they degrade to no-ops rather
+    //    than erase it;
+    //  - none → republish. Nothing is erased, and this run's work is once
+    //    again visible to every remote surface.
+    const reassertMarkerUnderLock = async (
+      targetVersion: string,
+    ): Promise<void> => {
+      const own = ownMarker.current;
+      const onDisk = await readUpdateProgressMarker(environment);
+      if (own !== null && onDisk !== null && sameProgress(onDisk, own)) {
+        if (own.targetVersion === targetVersion) return;
+        const repointed = progressRecord({
+          state: "updating",
+          error: null,
+          targetVersion,
+        });
+        const outcome = await replaceUpdateProgressMarkerIfUnchanged(
+          environment,
+          own,
+          repointed,
+        );
+        if (outcome === "replaced") {
+          ownMarker.current = repointed;
+        } else {
+          ctx.runtime.logger.info(
+            "Host update did not re-point the progress marker - another updater owns it now",
+            { environment, targetVersion },
+          );
+        }
+        return;
+      }
+      if (onDisk !== null) {
+        ctx.runtime.logger.info(
+          "Host update proceeds under another updater's progress marker; this run's own marker was withdrawn while it waited",
+          { environment, targetVersion: onDisk.targetVersion },
+        );
+        return;
+      }
+      await publishUpdating(targetVersion);
     };
 
     let preparation: HostUpdatePreparation;
@@ -319,74 +380,32 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
           environment,
           args.force,
           activationDebt.runningVersion,
-          async (installedVersion) => {
-            // Re-point the marker when the activation path finds the record
-            // moved under the lock, so a `failed` stamp names the version
-            // that was actually being activated.
-            if (
-              ownMarker.current !== null &&
-              installedVersion === ownMarker.current.targetVersion
-            ) {
-              return;
-            }
-            const repointed = progressRecord({
-              state: "updating",
-              error: null,
-              targetVersion: installedVersion,
-            });
-            // Ownership-aware like every other write after the first: a newer
-            // updater's pre-lock `updating` may already sit at the path, and
-            // an unconditional re-point would replace it with a record THIS
-            // run then clears at the end - leaving that updater's whole
-            // apply/restart without its progress signal. The re-point lands
-            // only over this run's own marker, and `ownMarker.current` follows
-            // what is actually on disk: if the swap reports the marker is no
-            // longer ours, it stays pointed at the old record, so the later
-            // stamp and clear (both conditional on it) leave the newer
-            // updater's marker alone.
-            if (ownMarker.current === null) {
-              ownMarker.current = repointed;
-              await writeUpdateProgressMarkerSafely(
-                ctx.runtime.logger,
-                environment,
-                repointed,
-              );
-              return;
-            }
-            const outcome = await replaceUpdateProgressMarkerIfUnchanged(
-              environment,
-              ownMarker.current,
-              repointed,
-            );
-            if (outcome === "replaced") {
-              ownMarker.current = repointed;
-            } else {
-              ctx.runtime.logger.info(
-                "Host update did not re-point the progress marker - another updater owns it now",
-                { environment, installedVersion },
-              );
-            }
-          },
+          // The record is read again under the lock; the marker follows it
+          // (or is re-established if another updater withdrew it meanwhile).
+          (installedVersion) => reassertMarkerUnderLock(installedVersion),
         );
         legacy = activation.legacy;
         activationPerformed = activation.activated;
+      } else if (preparation.kind === "staged") {
+        const stagedTarget = downloadTargetVersion(preparation.download);
+        legacy = await applyAndProjectLegacy(
+          environment,
+          args.force,
+          needsApply,
+          (info) => ctx.progress(info),
+          () => reassertMarkerUnderLock(stagedTarget),
+        );
       } else {
-        legacy =
-          preparation.kind === "staged"
-            ? await applyAndProjectLegacy(
-                environment,
-                args.force,
-                needsApply,
-                (info) => ctx.progress(info),
-              )
-            : projectApplied(
-                await installHostDowngrade({
-                  environment,
-                  version: preparation.version,
-                  force: args.force,
-                  onProgress: (info) => ctx.progress(info),
-                }),
-              );
+        const downgradeTarget = preparation.version;
+        legacy = projectApplied(
+          await installHostDowngrade({
+            environment,
+            version: downgradeTarget,
+            force: args.force,
+            onProgress: (info) => ctx.progress(info),
+            onBeforeCommit: () => reassertMarkerUnderLock(downgradeTarget),
+          }),
+        );
       }
     } catch (err) {
       if (err instanceof CliError && err.code === CLI_ERROR_CODES.HOST_BUSY) {
@@ -885,6 +904,8 @@ async function applyAndProjectLegacy(
   force: boolean,
   needsApply: boolean,
   onProgress: (info: ProgressInfo) => void,
+  /** Runs under the contender lock, after the no-op decision, before the apply. */
+  onUnderLock: () => Promise<void>,
 ): Promise<LegacyHostUpdateResult> {
   // ONE options value for acquisition and revalidation: two literals that
   // must stay identical are how admission policies drift.
@@ -899,6 +920,7 @@ async function applyAndProjectLegacy(
     if (!needsApply) {
       return projectNoOp(await requireInstalled(environment));
     }
+    await onUnderLock();
     let outcome: ApplyHostOutcome;
     try {
       outcome = await applyHostWithAttempt(capability, contenderOptions, {

--- a/clients/traycer-cli/src/commands/host-update.ts
+++ b/clients/traycer-cli/src/commands/host-update.ts
@@ -232,10 +232,12 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
     // writer's update is the one still in progress and removing its record
     // would hide the whole update until its own re-assert. Only a record
     // with a PROVEN live writer (`updateProgressRecordHasProvenLiveWriter`:
-    // the probe answered alive) is retained here. Every other record -
-    // a `failed`, an `updating` whose writer is dead, or one whose writer
-    // is UNKNOWN (no id, an unparseable id, a probe that could not answer)
-    // - is replaced and GONE at the takeover. The pre-lock claim treats
+    // the pid is alive and, where the record carries the writer's creation
+    // stamp, belongs to the process that wrote it) is retained here. Every
+    // other record - a `failed`, an `updating` whose writer is dead (or
+    // whose pid the OS recycled onto an unrelated process), or one whose
+    // writer is UNKNOWN (no id, an unparseable id, a probe that could not
+    // answer) - is replaced and GONE at the takeover. The pre-lock claim treats
     // the unknown-writer case the other way round (it DEFERS, fail-open,
     // since it holds no lock and may not stamp over a possibly-live
     // update); under the lock this run is the owner and a record it

--- a/clients/traycer-cli/src/commands/host-update.ts
+++ b/clients/traycer-cli/src/commands/host-update.ts
@@ -454,9 +454,14 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
     // is the truth the next updater takes over in turn. The apply and
     // downgrade arms report the boundary through the progress stream -
     // `commitInstallFromSource` emits `service-stop` immediately before the
-    // stop and `swap` before the rename - and the activation arm's hook
-    // runs immediately before its stop (see `reassertMarkerThenDisrupt` for
-    // the one check between).
+    // stop and `swap` before the rename - and the activation arm's stop
+    // reports it once its mutation-capability check has passed, immediately
+    // before the actuator (`stopHostForRestartWithAttempt`'s
+    // `onAuthorityVerified`). Not before that check: a capability that is
+    // refused has touched nothing, and marking the boundary around the call
+    // would have a failed check stamp this run's `failed` over a live
+    // writer's taken-over record, which that writer's later clear could
+    // never land.
     let disruptionStarted = false;
     const reportProgress = (info: ProgressInfo): void => {
       if (info.stage === "service-stop" || info.stage === "swap") {
@@ -464,15 +469,8 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
       }
       ctx.progress(info);
     };
-    // The activation arm's hook runs after its busy gate and immediately
-    // before its stop; the only thing between is the mutation-capability
-    // check the stop performs, and a failure there lands a `failed` into an
-    // EMPTY path at most (a taken-over record is stamped, which is the
-    // outcome the next updater takes over anyway).
-    const reassertMarkerThenDisrupt = async (
-      targetVersion: string,
-    ): Promise<void> => {
-      await reassertMarkerUnderLock(targetVersion);
+    // The activation arm's boundary, handed to its stop facade.
+    const markDisruptionStarted = (): void => {
       disruptionStarted = true;
     };
     // The preparation runs INSIDE the try whose catch owns the marker. The
@@ -571,7 +569,8 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
           activationDebt.runningVersion,
           // The record is read again under the lock; the marker is made this
           // run's there, naming the version as read, and the stop follows.
-          reassertMarkerThenDisrupt,
+          reassertMarkerUnderLock,
+          markDisruptionStarted,
         );
         legacy = activation.legacy;
         activationPerformed = activation.activated;
@@ -618,7 +617,8 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
               environment,
               args.force,
               reading.runningVersion,
-              reassertMarkerThenDisrupt,
+              reassertMarkerUnderLock,
+              markDisruptionStarted,
             );
             legacy = activation.legacy;
             activationPerformed = activation.activated;
@@ -1136,6 +1136,12 @@ async function activateInstalledAndProjectLegacy(
   force: boolean,
   lastSeenRunningVersion: string,
   onInstalledVersionUnderLock: (installedVersion: string) => Promise<void>,
+  /**
+   * Runs once the stop's mutation-capability check has passed and
+   * immediately before the actuator stops the host: the first point at
+   * which this arm can have disturbed it. See `disruptionStarted`.
+   */
+  onWillDisruptHost: () => void,
 ): Promise<{
   readonly legacy: LegacyHostUpdateResult;
   readonly activated: boolean;
@@ -1171,7 +1177,9 @@ async function activateInstalledAndProjectLegacy(
     // not before: the caller takes the progress marker over here, and a park
     // must not follow a takeover for work never done. The stop below is the
     // only thing that can still park, and the caller's park path restores
-    // a live writer's displaced record for that case.
+    // a live writer's displaced record for that case; a stop refused by its
+    // own capability check, before the actuator, is reported the same way
+    // (`onWillDisruptHost` has not run).
     await onInstalledVersionUnderLock(installed.version);
     // The stop → relaunch pair `host restart` drives, with `force` threaded
     // into the stop half. The busy gate above is only the pre-check: on a
@@ -1189,6 +1197,7 @@ async function activateInstalledAndProjectLegacy(
       controller,
       label,
       { force },
+      onWillDisruptHost,
     );
     await relaunchHostAfterRestartWithAttempt(
       capability,

--- a/clients/traycer-cli/src/commands/host-update.ts
+++ b/clients/traycer-cli/src/commands/host-update.ts
@@ -1186,8 +1186,9 @@ type ActivationReading =
  * equal, or restart a correctly activated host on every run when they do
  * not; equality of runtime stamps is the test Desktop uses, and it is the
  * one used here. Only a record with no runtime stamp yet falls back to the
- * catalog version, compared with the same comparator the update decision
- * itself uses (comparable and unequal).
+ * catalog version - string identity there too; the comparator is consulted
+ * only to exempt a record it cannot order (`local-*`), which stays activated
+ * by policy.
  *
  * The comparison is on VERSION rather than on install generation because
  * `pid.json` publishes the version and nothing finer; a swap to the same
@@ -1247,17 +1248,20 @@ async function readActivationState(
   }
   // A release host publishes exactly its catalog version (the build stamps
   // `src/config.ts`'s version into the binary and into the archive's
-  // `version.json` alike), so the record's string IS what an activated host
-  // of that record publishes: identity is the string here as in the
-  // runtime-stamp domain, and another build of the same release
+  // `version.json` alike), so a registry record's string IS what an
+  // activated host of that record publishes (an own-build record from
+  // `host ensure` names the CLI's version and relies on its runtime stamp,
+  // which its archive always carries): identity is the string here as in
+  // the runtime-stamp domain, and another build of the same release
   // (`2.0.0+bar` running under a `2.0.0+foo` record) is debt - the committed
   // artifact is not the one serving. The comparator's build-metadata-blind
   // "equal" would read it as activated, and every consumer keyed on
   // `activated` - the debt gate, `targetObservedRunning`'s withdrawal, the
   // stale-failed clear - would then treat an artifact that never ran as
-  // delivered. The comparator is kept for what it is for: a pair it
-  // cannot ORDER (a `local-*` record, a runtime the catalog does not name)
-  // is not this command's debt to collect and stays activated by policy.
+  // delivered. The comparator is kept for what it is for: a record it
+  // cannot ORDER (`local-*`; the running version passed the SemVer guard
+  // above) is not this command's debt to collect and stays activated by
+  // policy.
   if (running.version === installed.version) {
     return { kind: "activated", installedVersion: installed.version };
   }

--- a/clients/traycer-cli/src/commands/host-update.ts
+++ b/clients/traycer-cli/src/commands/host-update.ts
@@ -19,7 +19,7 @@ import {
   replaceUpdateProgressMarkerIfUnchanged,
   type HostUpdateProgress,
   sameProgress,
-  updateProgressRecordHasLiveWriter,
+  updateProgressRecordHasProvenLiveWriter,
 } from "../host/update-progress-marker";
 import { probeHostHealth } from "../service/health-probe";
 import {
@@ -71,8 +71,10 @@ import { createServiceController, serviceLabelFor } from "../service";
 // The `updating` marker is published from `onWillDownload` - after the
 // short-circuit decision, before the first byte - so the whole transfer is
 // visible as an update in progress and a transfer failure has a marker to
-// stamp `failed` onto. The no-transfer arms (already staged, activation debt,
-// explicit downgrade) publish it just before the apply half instead.
+// stamp `failed` onto. The arms that do not go through that download stage
+// (already staged, activation debt, and the explicit downgrade - which
+// stages its own source under its own lock) publish it just before their
+// apply half instead.
 //
 // SUCCESS CONTRACT: when an update is actually applied, exit 0 here means a
 // host came back healthy after the swap. Two limits are deliberate and worth
@@ -229,11 +231,16 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
     // busy gate) or a failure before the stop - puts it back, because that
     // writer's update is the one still in progress and removing its record
     // would hide the whole update until its own re-assert. Only a record
-    // some writer is acting on (`updateProgressRecordHasLiveWriter`) is
-    // retained here. A record no writer is acting on - a `failed`, or an
-    // `updating` whose writer is dead - is replaced and GONE, at the
-    // pre-lock claim and at the takeover alike, exactly as the blind
-    // publish treated it: put back on a park it re-plants a dead writer's
+    // with a PROVEN live writer (`updateProgressRecordHasProvenLiveWriter`:
+    // the probe answered alive) is retained here. Every other record -
+    // a `failed`, an `updating` whose writer is dead, or one whose writer
+    // is UNKNOWN (no id, an unparseable id, a probe that could not answer)
+    // - is replaced and GONE at the takeover. The pre-lock claim treats
+    // the unknown-writer case the other way round (it DEFERS, fail-open,
+    // since it holds no lock and may not stamp over a possibly-live
+    // update); under the lock this run is the owner and a record it
+    // cannot prove alive is not worth re-planting. Put back on a park such
+    // a record re-plants a dead writer's
     // `updating` that nobody will ever clear (a host without dead-writer
     // suppression renders it for as long as the park lives) or paints an
     // earlier attempt's `failed` over the staged-wait park the GUI derives
@@ -248,18 +255,21 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
     // restore is not loss-free in one corner: a live writer that finished
     // while its record was displaced found the path changed, left it, and
     // exited, so the restored record has no writer left to clear it. The
-    // host side suppresses an `updating` whose writer is dead, which is
-    // what makes that corner the lesser harm.
+    // host side suppresses an `updating` whose writer id names a dead pid,
+    // which is what makes that corner the lesser harm - and why only a
+    // record with a PROVEN live writer is retained at all: one with no
+    // writer id (an older CLI) the host renders forever, and restoring it
+    // would re-plant exactly that.
     const displacedMarker: { current: HostUpdateProgress | null } = {
       current: null,
     };
     // The record as the park and failure arms consume it: retained at the
-    // takeover while its writer was live, and live STILL at the moment of
-    // the restore - otherwise treated as no record at all.
+    // takeover while its writer was proven live, and proven live STILL at
+    // the moment of the restore - otherwise treated as no record at all.
     const liveDisplacedRecord = (
       record: HostUpdateProgress | null,
     ): HostUpdateProgress | null =>
-      record !== null && updateProgressRecordHasLiveWriter(record)
+      record !== null && updateProgressRecordHasProvenLiveWriter(record)
         ? record
         : null;
     // The version this run is working toward, as last announced to the
@@ -302,9 +312,17 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
           "Host update left another updater's live progress marker in place; this run publishes its own once it holds the lock",
           { environment, targetVersion },
         );
+        return;
       }
-      // "failed" was warned about by the marker layer; the update itself
-      // must not fail on its progress signal.
+      // The marker layer warned about the I/O itself (and about a
+      // displaced record it could not put back); this line is what the
+      // CLI's own log shows for why the transfer is invisible until the
+      // takeover under the lock. The update must not fail on its progress
+      // signal.
+      ctx.runtime.logger.warn(
+        "Host update could not publish its progress marker before the lock; the transfer proceeds unannounced until this run holds the lock",
+        { environment, targetVersion },
+      );
     };
     // Under the contender lock, before the disruptive half, make the marker
     // THIS run's. The marker is published BEFORE this run waits for admission
@@ -371,26 +389,41 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
           if (replaced === "replaced") {
             ownMarker.current = fresh;
             if (!isOwn) {
-              const writerLive = updateProgressRecordHasLiveWriter(onDisk);
+              // Retained for the restore only on POSITIVE evidence of a
+              // live writer (see `displacedMarker`): a record whose writer
+              // cannot be proven alive is replaced and gone, whether its
+              // writer is proven dead or simply unknown.
+              const writerLive =
+                updateProgressRecordHasProvenLiveWriter(onDisk);
               displacedMarker.current = writerLive ? onDisk : null;
               ctx.runtime.logger.info(
                 writerLive
                   ? "Host update took over the progress marker under the lock - its writer is not doing disruptive work"
-                  : "Host update replaced the progress marker under the lock - no writer is acting on it",
+                  : "Host update replaced the progress marker under the lock - no writer is proven to be acting on it",
                 {
                   environment,
                   targetVersion,
                   previousState: onDisk.state,
                   previousTarget: onDisk.targetVersion,
+                  previousWriterId: onDisk.writerId,
                 },
               );
             }
             return;
           }
           if (replaced === "failed") {
+            // `ownMarker.current` still names what it named: the marker
+            // layer either left the live path as it was or emptied it and
+            // said so. A failure past this point is stamped with the
+            // target this run INTENDED (`intendedTarget`), not the one the
+            // surviving record names.
             ctx.runtime.logger.warn(
               "Host update could not write the progress marker under the lock; proceeding without re-asserting it",
-              { environment, targetVersion },
+              {
+                environment,
+                targetVersion,
+                markerTargetVersion: own?.targetVersion ?? null,
+              },
             );
             return;
           }
@@ -452,24 +485,24 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
     // it - its stamp and clear CAS against a record that is gone). From
     // this point on the host's state is this run's doing, and its `failed`
     // is the truth the next updater takes over in turn. The apply and
-    // downgrade arms report the boundary through the progress stream -
-    // `commitInstallFromSource` emits `service-stop` immediately before the
-    // stop and `swap` before the rename - and the activation arm's stop
-    // reports it once its mutation-capability check has passed, immediately
-    // before the actuator (`stopHostForRestartWithAttempt`'s
-    // `onAuthorityVerified`). Not before that check: a capability that is
-    // refused has touched nothing, and marking the boundary around the call
-    // would have a failed check stamp this run's `failed` over a live
-    // writer's taken-over record, which that writer's later clear could
-    // never land.
+    // downgrade arms report it from their actuators - the lifecycle's
+    // pre-swap stop once its mutation-capability check has passed
+    // (`onWillStopHost`), or the swap itself when the lifecycle decided not
+    // to stop (`onWillSwap`) - and the activation arm's stop reports it the
+    // same way (`stopHostForRestartWithAttempt`'s `onAuthorityVerified`).
+    // NEVER from the `service-stop` / `swap` progress lines: those precede
+    // the status probe and the authority check, and a probe that throws or
+    // a capability that is refused has touched nothing - marking the
+    // boundary there would have such a failure stamp this run's `failed`
+    // over a live writer's taken-over record, which that writer's later
+    // clear could never land.
     let disruptionStarted = false;
+    // A free function over the runner's method for the arms' `onProgress`;
+    // it reports and infers nothing (the boundary is `markDisruptionStarted`).
     const reportProgress = (info: ProgressInfo): void => {
-      if (info.stage === "service-stop" || info.stage === "swap") {
-        disruptionStarted = true;
-      }
       ctx.progress(info);
     };
-    // The activation arm's boundary, handed to its stop facade.
+    // The one boundary, handed to every arm's actuator.
     const markDisruptionStarted = (): void => {
       disruptionStarted = true;
     };
@@ -538,7 +571,11 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
         activationReading !== null &&
         activationReading.kind === "activated"
       ) {
-        await clearStaleFailedMarker(ctx.runtime.logger, environment);
+        await clearStaleFailedMarker(
+          ctx.runtime.logger,
+          environment,
+          activationReading.installedVersion,
+        );
       }
 
       // The arms that reached here WITHOUT a transfer - an already-staged
@@ -575,6 +612,22 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
         legacy = activation.legacy;
         activationPerformed = activation.activated;
       } else if (preparation.kind === "staged") {
+        // An EXPLICIT request whose download was DISCARDED at promote time
+        // (the installed version moved past it in the unlocked transfer
+        // window, or the install record vanished) has nothing of its own
+        // to apply. Going on to `applyHost` would either commit whatever
+        // stage another promoter left - the version-binding below refuses
+        // that, but with a sentence about a replaced stage that names the
+        // wrong cause - or find nothing and report the "stage consumed"
+        // recovery. The discard IS the answer; say it and stop. An implicit
+        // "latest" discarded by a newer stage still applies that stage.
+        if (
+          args.versionRequest !== undefined &&
+          args.versionRequest !== null &&
+          preparation.download.outcome === "discarded"
+        ) {
+          throw discardedExplicitRequestError(preparation.download);
+        }
         const apply = await applyAndProjectLegacy(
           environment,
           args.force,
@@ -585,6 +638,15 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
           // directory holds whatever the latest promoter left there, and
           // `applyHost` installs what its reconcile leaves.
           (stagedVersion) => reassertMarkerUnderLock(stagedVersion),
+          markDisruptionStarted,
+          // An EXPLICIT request is bound to the version it resolved to: the
+          // caller (a Settings click, `--version X`) confirmed that version
+          // and checked its floor, and a stage another promoter replaced in
+          // the unlocked wait must not be committed under that confirmation.
+          // An implicit "latest" takes whatever newer stage it finds.
+          args.versionRequest === undefined || args.versionRequest === null
+            ? null
+            : downloadTargetVersion(preparation.download),
         );
         legacy = apply.legacy;
         applyPerformed = apply.applied;
@@ -633,6 +695,7 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
             force: args.force,
             onProgress: reportProgress,
             onBeforeCommit: () => reassertMarkerUnderLock(downgradeTarget),
+            onWillDisruptHost: markDisruptionStarted,
           }),
         );
         // `installHostDowngrade` returns only an `applied` outcome; a park
@@ -673,10 +736,10 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
               outcome: withdrawn,
               done: "Host update parked - the host has work in progress; the progress marker was withdrawn",
               moved:
-                "Host update parked - the host has work in progress; the progress marker was left in place - another updater owns it now",
+                "Host update parked - the host has work in progress; the progress marker was not withdrawn - another updater owns it now",
               gone: "Host update parked - the host has work in progress; found no progress marker to withdraw",
               failed:
-                "Host update parked - the host has work in progress; its progress marker could not be withdrawn and stays until the next update supersedes it",
+                "Host update parked - the host has work in progress; its progress marker could not be withdrawn - the marker log names what the path holds now",
             });
           } else {
             const restored = await replaceUpdateProgressMarkerIfUnchanged(
@@ -689,9 +752,8 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
               done: "Host update parked - the host has work in progress; the progress marker it took over was restored to its previous writer",
               moved:
                 "Host update parked - the host has work in progress; the progress marker it took over was not restored - another updater owns it now",
-              gone: "Host update parked - the host has work in progress; the progress marker it took over was not restored - the path is empty",
               failed:
-                "Host update parked - the host has work in progress; the progress marker it took over could not be restored and stays until the next update supersedes it",
+                "Host update parked - the host has work in progress; the progress marker it took over could not be restored - the marker log names what the path holds now",
             });
           }
         }
@@ -757,15 +819,16 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
             done: "Host update failed before disturbing the host; the progress marker it took over was restored to its previous writer",
             moved:
               "Host update failed before disturbing the host; the progress marker it took over was not restored - another updater owns it now",
-            gone: "Host update failed before disturbing the host; the progress marker it took over was not restored - the path is empty",
             failed:
-              "Host update failed before disturbing the host; the progress marker it took over could not be restored and stays until the next update supersedes it",
+              "Host update failed before disturbing the host; the progress marker it took over could not be restored - the marker log names what the path holds now",
           });
         } else if (
           !disruptionStarted &&
           (await targetObservedRunning(
             environment,
-            ownMarker.current.targetVersion,
+            // `intendedTarget` is set before any record of this run's
+            // exists; the fallback is the type's null arm.
+            intendedTarget.current ?? ownMarker.current.targetVersion,
           ))
         ) {
           // Same observed-state rule as the null arm above, reached with a
@@ -787,16 +850,24 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
             outcome: withdrawn,
             done: "Host update failed before disturbing the host, and the running host has been observed at the target it announced; the progress marker was withdrawn",
             moved:
-              "Host update failed before disturbing the host, and the running host has been observed at the target it announced; the progress marker was left in place - another updater owns it now",
+              "Host update failed before disturbing the host, and the running host has been observed at the target it announced; the progress marker was not withdrawn - another updater owns it now",
             gone: "Host update failed before disturbing the host, and the running host has been observed at the target it announced; found no progress marker to withdraw",
             failed:
-              "Host update failed before disturbing the host, and the running host has been observed at the target it announced; its progress marker could not be withdrawn and stays until the next update supersedes it",
+              "Host update failed before disturbing the host, and the running host has been observed at the target it announced; its progress marker could not be withdrawn - the marker log names what the path holds now",
           });
         } else {
+          // Stamped with the target this run was working toward. The two
+          // differ when a re-point under the lock FAILED (I/O): the record
+          // on disk still names the pre-lock target while the run went on
+          // to commit the version `applyHost` reported, and "update to
+          // <old> failed" would name a version this run never installed -
+          // which the host's target-running suppression then mis-handles.
           await markUpdateFailed(
             ctx.runtime.logger,
             environment,
-            ownMarker.current.targetVersion,
+            // Same null arm as above: the intended target is always set
+            // once a record of this run's is on disk.
+            intendedTarget.current ?? ownMarker.current.targetVersion,
             err instanceof Error ? err.message : String(err),
             ownMarker.current,
           );
@@ -866,7 +937,7 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
         // Warned about by the marker layer; named here so the CLI's own
         // log shows why an `updating` outlived a successful update.
         ctx.runtime.logger.info(
-          "Host update could not clear its progress marker; it stays until the next update supersedes it",
+          "Host update could not clear its progress marker - the marker log names what the path holds now",
           { environment },
         );
       }
@@ -1059,13 +1130,36 @@ async function targetObservedRunning(
  * writer's lock acquisition), so the marker module re-reads and compares
  * immediately before the unlink. Marker I/O never fails the command (same
  * rule as the writes).
+ *
+ * "Contradicts" is the host's own rule (`isStaleUpdateProgress`): a `failed`
+ * is stale when the version it names is the one now running. A `failed`
+ * naming ANOTHER version - an attempt at 2.0.0 that failed before the swap,
+ * read by a later `host update` while the registry offers only 1.9.0 - is
+ * a report the observed state does not contradict, and it stays until an
+ * attempt at that target supersedes it.
  */
 async function clearStaleFailedMarker(
   logger: ILogger,
   environment: Environment,
+  observedRunningVersion: string,
 ): Promise<void> {
   const marker = await readUpdateProgressMarker(environment);
   if (marker === null || marker.state !== "failed") return;
+  const comparison = compareHostVersions(
+    marker.targetVersion,
+    observedRunningVersion,
+  );
+  if (!comparison.comparable || comparison.ordering !== "equal") {
+    logger.info(
+      "Host update left the failed progress marker alone - it names a target the running host has not been observed at",
+      {
+        environment,
+        failedTargetVersion: marker.targetVersion,
+        observedRunningVersion,
+      },
+    );
+    return;
+  }
   const outcome = await deleteUpdateProgressMarkerIfUnchanged(
     environment,
     marker,
@@ -1252,6 +1346,48 @@ async function prepareHostUpdate(input: {
   };
 }
 
+// The refusal for an explicit request whose completed download was discarded
+// at promote time. Each reason is a fact the promoter established under its
+// lock; the sentence names it rather than the apply's "another download
+// replaced the stage", which is not what happened. `not-newer-than-installed`
+// carries the code the downgrade gate uses for the same fact, so a caller
+// keyed on it (Desktop's Settings click) can offer `--allow-downgrade`.
+function discardedExplicitRequestError(
+  outcome: Extract<HostDownloadOutcome, { readonly outcome: "discarded" }>,
+): CliError {
+  const target = outcome.targetVersion;
+  switch (outcome.reason) {
+    case "not-newer-than-installed":
+      return cliError({
+        code: CLI_ERROR_CODES.HOST_UPDATE_NOT_NEWER,
+        message: `host update: ${target} was downloaded, but the installed host is no longer older than it - another update landed meanwhile; nothing was applied. Run 'traycer host status' to see what is installed, or pass --allow-downgrade to install ${target} over it`,
+        details: { targetVersion: target, reason: outcome.reason },
+        exitCode: 1,
+      });
+    case "not-strictly-newer":
+      return cliError({
+        code: CLI_ERROR_CODES.UNEXPECTED,
+        message: `host update: a newer host was staged while ${target} downloaded; nothing was applied - run the update again to install what is staged`,
+        details: { targetVersion: target, reason: outcome.reason },
+        exitCode: 1,
+      });
+    case "install-record-vanished":
+      return cliError({
+        code: CLI_ERROR_CODES.UNEXPECTED,
+        message: `host update: the install record vanished while ${target} downloaded; nothing was applied - run 'traycer host doctor'`,
+        details: { targetVersion: target, reason: outcome.reason },
+        exitCode: 1,
+      });
+    case "automatic-refused-incomparable-installed":
+      return cliError({
+        code: CLI_ERROR_CODES.UNEXPECTED,
+        message: `host update: the installed host's version cannot be compared with ${target}; nothing was applied - run 'traycer host status' to see what is installed`,
+        details: { targetVersion: target, reason: outcome.reason },
+        exitCode: 1,
+      });
+  }
+}
+
 // Every `HostDownloadOutcome` branch names the version this invocation was
 // working toward; `promoted` reports it as the staged version it just placed.
 function downloadTargetVersion(outcome: HostDownloadOutcome): string {
@@ -1266,33 +1402,42 @@ function downloadTargetVersion(outcome: HostDownloadOutcome): string {
  * `replaced` is the operation done; `changed` is a record that moved under
  * this run (another updater's, left alone); `absent` (a delete only) is a
  * path already empty, nothing left to report on; `failed` is an I/O
- * failure the marker layer already warned about, named here so the
- * CLI's own log shows why a marker outlived the run that wrote it. All
- * INFO: none of these fails the update, and the marker layer owns the WARN.
- * (`replaceUpdateProgressMarkerIfUnchanged` reports an empty path as
- * `changed`, so `gone` is reachable from the delete sites only.)
+ * failure the marker layer already warned about - nothing of the intended
+ * write landed, and what the path holds now (the record as it was, or an
+ * empty path with the displaced record retained in a scratch) is in that
+ * warning - named here so the CLI's own log shows why a marker outlived the
+ * run that wrote it. All INFO: none of these fails the update, and the
+ * marker layer owns the WARN. `replaceUpdateProgressMarkerIfUnchanged`
+ * reports an empty path as `changed`, so a replace has no `gone` line: the
+ * type makes that arm unwritable rather than a dead string.
  */
 function logConditionalMarkerOutcome(
   logger: ILogger,
   environment: Environment,
-  lines: {
-    readonly outcome: ConditionalMarkerDelete | ConditionalMarkerReplace;
-    readonly done: string;
-    readonly moved: string;
-    readonly gone: string;
-    readonly failed: string;
-  },
+  lines:
+    | {
+        readonly outcome: ConditionalMarkerDelete;
+        readonly done: string;
+        readonly moved: string;
+        readonly gone: string;
+        readonly failed: string;
+      }
+    | {
+        readonly outcome: ConditionalMarkerReplace;
+        readonly done: string;
+        readonly moved: string;
+        readonly failed: string;
+      },
 ): void {
-  const { outcome } = lines;
   const message =
-    outcome === "cleared" || outcome === "replaced"
+    lines.outcome === "cleared" || lines.outcome === "replaced"
       ? lines.done
-      : outcome === "failed"
+      : lines.outcome === "failed"
         ? lines.failed
-        : outcome === "absent"
+        : lines.outcome === "absent"
           ? lines.gone
           : lines.moved;
-  logger.info(message, { environment, outcome });
+  logger.info(message, { environment, outcome: lines.outcome });
 }
 
 // Terminates the "updating" marker with the real cause so the daemon reports
@@ -1381,6 +1526,10 @@ async function applyAndProjectLegacy(
    * it; there is then no disruptive work to announce.
    */
   onWillCommitStaged: (stagedVersion: string) => Promise<void>,
+  /** `ApplyHostOptions.onWillDisruptHost`: the actuator-reported boundary. */
+  onWillDisruptHost: () => void,
+  /** `ApplyHostOptions.expectedStagedVersion`: the confirmed version, or `null`. */
+  expectedStagedVersion: string | null,
 ): Promise<{
   readonly legacy: LegacyHostUpdateResult;
   /** Whether bytes were swapped under the lock; a no-op is `false`. */
@@ -1409,13 +1558,16 @@ async function applyAndProjectLegacy(
         force,
         noService: false,
         expectedStageFingerprint: null,
+        expectedStagedVersion,
         onProgress,
         // What this run promoted before it waited is a pre-lock fact: the
         // shared stage may have been replaced (a later promoter, a parked
         // explicit `--version`), consumed, or reconciled away since, and a
         // read from HERE would still be on the wrong side of `applyHost`'s
-        // own reconcile. `applyHost` reports the version it is committing.
+        // own reconcile. `applyHost` reports the version it is committing
+        // (and refuses one other than `expectedStagedVersion` when set).
         onWillCommitStaged,
+        onWillDisruptHost,
       });
     } catch (err) {
       if (err instanceof CliError && err.code === CLI_ERROR_CODES.HOST_BUSY) {
@@ -1460,6 +1612,22 @@ async function applyAndProjectLegacy(
         details: {
           expectedStageFingerprint: outcome.expectedStageFingerprint,
           actualStageFingerprint: outcome.actualStageFingerprint,
+        },
+        exitCode: 1,
+      });
+    }
+    if (outcome.outcome === "stage-version-mismatch") {
+      // Nothing was consumed, announced or disturbed: the stage another
+      // promoter left is theirs, and the version this run was asked for is
+      // no longer staged. The caller re-runs its request; the marker this
+      // run published for the requested version is stamped `failed` by the
+      // catch that owns it, naming the version it announced.
+      throw cliError({
+        code: CLI_ERROR_CODES.UNEXPECTED,
+        message: `host update: the staged host is ${outcome.actualStagedVersion}, not the requested ${outcome.expectedStagedVersion}; another download replaced the stage before it could be applied - run the update again`,
+        details: {
+          expectedStagedVersion: outcome.expectedStagedVersion,
+          actualStagedVersion: outcome.actualStagedVersion,
         },
         exitCode: 1,
       });

--- a/clients/traycer-cli/src/commands/host-update.ts
+++ b/clients/traycer-cli/src/commands/host-update.ts
@@ -59,10 +59,11 @@ import { createServiceController, serviceLabelFor } from "../service";
 // touches the stage - and this command re-throws `E_HOST_BUSY` with the
 // staged version attached to `details`, rather than the generic
 // `details: null` `assertHostNotBusy` throws on its own. A busy exit is a
-// PARK, not a failure: the run withdraws its own `updating` marker and stamps
-// no `failed` (see the catch below), because the refusal was the policy
-// working and the surfaces derive "staged, waiting" / "installed, restart to
-// finish" from the install and staged records instead.
+// PARK, not a failure: the run withdraws its own `updating` marker (or puts
+// back the record it took over under the lock) and stamps no `failed` (see
+// the catch below), because the refusal was the policy working and the
+// surfaces derive "staged, waiting" / "installed, restart to finish" from
+// the install and staged records instead.
 //
 // The `updating` marker is published from `onWillDownload` - after the
 // short-circuit decision, before the first byte - so the whole transfer is
@@ -77,7 +78,10 @@ import { createServiceController, serviceLabelFor } from "../service";
 //     target short-circuits before the probe and re-checks nothing. When the
 //     running host is NOT at the target (bytes committed by `host apply
 //     --no-service` and never activated), this command owes the activation
-//     and performs it - restart, marker, probe - see `readActivationState`;
+//     and performs it - restart, marker, probe - see `readActivationState`.
+//     The same debt can appear AFTER the lock wait: a stage this run
+//     promoted and then found consumed by such an apply is re-derived and
+//     activated the same way (see the staged arm);
 //   - `probeHostHealth` asks "is the recorded pid alive and its port
 //     accepting?" - it does not compare versions. On the Desktop-managed macOS
 //     degraded path a surviving OLD host can answer it, so a healthy probe is
@@ -195,22 +199,40 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
     // allowed to fail the update itself - a missing marker degrades the
     // remote progress readout, it must not break the local update.
     //
-    // The marker THIS invocation wrote, kept so every later write is
-    // conditional on it: marker writes happen before their writer takes the
-    // contender lock, so by the time this command reaches its stamp or clear
-    // another updater may have landed its own `updating` at the same path,
-    // and an unconditional write would erase that updater's only progress
-    // signal. Non-null from the first write attempt on, whether or not the
-    // write landed (a failed write is warned about, not retried). The version
-    // it names is the one a `failed` stamp has to name too, which is why the
-    // re-point under the lock replaces the whole record rather than one field.
+    // The marker THIS invocation wrote (or, under the lock, took over), kept
+    // so every later write is conditional on it: marker writes happen before
+    // their writer takes the contender lock, so by the time this command
+    // reaches its stamp or clear another updater may have landed its own
+    // `updating` at the same path, and an unconditional write would erase
+    // that updater's only progress signal. Non-null from the first write
+    // attempt on, whether or not the write landed (a failed write is warned
+    // about, not retried). The version it names is the one a `failed` stamp
+    // has to name too, which is why the re-point under the lock replaces the
+    // whole record rather than one field.
     //
     // It is a CLAIM about the disk, not a fact: every write after the
-    // pre-lock publish is conditional on it, including the republish in
-    // `reassertMarkerUnderLock` below, which lands only into a path that is
-    // STILL empty at the write (create-if-absent) - the case where a faster
-    // updater cleared this run's marker while it waited - and erases nothing.
+    // pre-lock publish is conditional on it. The one place the claim is
+    // turned into a fact is `reassertMarkerUnderLock` below, which runs
+    // under the contender lock and makes the path this run's whatever it
+    // holds by then - by conditional replace or conditional create, never
+    // by a blind write.
     const ownMarker: { current: HostUpdateProgress | null } = { current: null };
+    // The record `reassertMarkerUnderLock` displaced when it took the marker
+    // over, kept for one purpose: an exit that follows the takeover WITHOUT
+    // this run having disturbed the host - a busy park (the stop's
+    // cooperative stand-down claim can still be denied past the busy gate)
+    // or a failure before the stop - puts it back. The displaced writer's
+    // marker, or a dead writer's `failed` that may still be exactly true, is
+    // not this run's to remove when this run ends up doing nothing. The
+    // restore is not loss-free in one corner: a writer that finished while
+    // its record was displaced found the path changed, left it, and exited,
+    // so the restored record has no writer left to clear it. The host side
+    // suppresses an `updating` whose writer is dead, which is what makes
+    // the restore the lesser harm; removing the record outright would hide
+    // a live writer's whole update.
+    const displacedMarker: { current: HostUpdateProgress | null } = {
+      current: null,
+    };
     const publishUpdating = async (targetVersion: string): Promise<void> => {
       ownMarker.current = progressRecord({
         state: "updating",
@@ -223,87 +245,119 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
         ownMarker.current,
       );
     };
-    // Under the contender lock, before the disruptive half, re-establish
-    // what the pre-lock marker only claimed. The marker is published BEFORE
-    // this run waits for admission (`onWillDownload`, or the no-transfer
-    // arms above), and the wait is unbounded by anything this run controls:
-    // a second `host update` can land its own `updating` over ours, do its
-    // work, and clear it while we were still downloading. Reaching the apply
-    // with `ownMarker.current` non-null then proves nothing about the disk -
-    // the swap and restart would run with no marker at all, and the `failed`
-    // stamp (CAS against a record that is long gone) could never land.
+    // Under the contender lock, before the disruptive half, make the marker
+    // THIS run's. The marker is published BEFORE this run waits for admission
+    // (`onWillDownload`, or the no-transfer publish below), and the wait is
+    // unbounded by anything this run controls: a second `host update` can
+    // land its own `updating` over ours, do its work, and clear it while we
+    // were still downloading. Reaching the apply with `ownMarker.current`
+    // non-null then proves nothing about the disk - the swap and restart
+    // would run with no marker at all, and the `failed` stamp (CAS against a
+    // record that is long gone) could never land.
     //
-    // Three cases, decided from the file rather than from memory:
-    //  - ours is still there → keep it, re-pointed if the target moved under
-    //    the lock (the activation arm reads the record again there);
-    //  - another updater's is there → leave it. It is that updater's only
-    //    progress signal and this run's later stamp/clear are conditional on
-    //    a record the disk no longer holds, so they degrade to no-ops rather
-    //    than erase it;
-    //  - none → republish. Nothing is erased, and this run's work is once
-    //    again visible to every remote surface.
+    // THE RULE: the contender lock's holder owns the marker. Whatever the
+    // path holds when this run is about to do the disruptive work is either
+    // this run's own record (kept, re-pointed if the target moved under the
+    // lock), a record of an updater that is NOT doing disruptive work right
+    // now (it is waiting for this lock, or it released it and is probing out
+    // of lock, or it died), or nothing. The middle case is taken OVER, not
+    // deferred to: a prior updater's post-lock probe ends in a conditional
+    // clear, and had this run kept swapping under that marker the clear
+    // would have landed mid-swap and left the restart invisible, with this
+    // run's own stamp CAS'd against a record no longer on disk. Every write
+    // here is conditional on what was read (replace-if-unchanged,
+    // create-if-absent), so a marker that lands between the read and the
+    // write wins that round and is read again; nothing is ever overwritten
+    // blind. The displaced updater's later stamp/clear are CAS'd against ITS
+    // record and degrade to no-ops - correct, because the marker now
+    // describes the update that is actually in progress.
+    //
+    // WHEN it runs matters as much as what it does: every arm calls it only
+    // once that arm has committed to the disruptive half - after the apply's
+    // reconcile has settled what is staged, after the no-op decision, after
+    // the busy gate. A run that takes the marker over and then does nothing
+    // would end by clearing a record that was never about it (see
+    // `displacedMarker` for the one park that can still follow).
     const reassertMarkerUnderLock = async (
       targetVersion: string,
     ): Promise<void> => {
-      const own = ownMarker.current;
-      const onDisk = await readUpdateProgressMarker(environment);
-      if (own !== null && onDisk !== null && sameProgress(onDisk, own)) {
-        if (own.targetVersion === targetVersion) return;
-        const repointed = progressRecord({
+      // What the previous iteration's conditional write was compared
+      // against. `replaceUpdateProgressMarkerIfUnchanged` answers "changed"
+      // for a record that moved AND for a write that failed (the marker
+      // layer has warned about the latter); reading the same record back
+      // tells the two apart, and a failed write is not retried - the update
+      // must not fail, or spin, on its progress signal.
+      let lastExpected: HostUpdateProgress | null = null;
+      // Bounded: each iteration either settles or observed a concurrent
+      // write, and concurrent marker writers are the handful of updaters
+      // racing one lock, not an unbounded stream.
+      for (let attempt = 0; attempt < 3; attempt += 1) {
+        const own = ownMarker.current;
+        const onDisk = await readUpdateProgressMarker(environment);
+        if (
+          lastExpected !== null &&
+          onDisk !== null &&
+          sameProgress(onDisk, lastExpected)
+        ) {
+          ctx.runtime.logger.warn(
+            "Host update could not write the progress marker under the lock; proceeding without re-asserting it",
+            { environment, targetVersion },
+          );
+          return;
+        }
+        const fresh = progressRecord({
           state: "updating",
           error: null,
           targetVersion,
         });
-        const outcome = await replaceUpdateProgressMarkerIfUnchanged(
-          environment,
-          own,
-          repointed,
-        );
-        if (outcome === "replaced") {
-          ownMarker.current = repointed;
-        } else {
-          ctx.runtime.logger.info(
-            "Host update did not re-point the progress marker - another updater owns it now",
-            { environment, targetVersion },
+        if (onDisk !== null) {
+          const isOwn = own !== null && sameProgress(onDisk, own);
+          if (isOwn && onDisk.targetVersion === targetVersion) return;
+          const replaced = await replaceUpdateProgressMarkerIfUnchanged(
+            environment,
+            onDisk,
+            fresh,
           );
+          if (replaced === "replaced") {
+            ownMarker.current = fresh;
+            if (!isOwn) {
+              displacedMarker.current = onDisk;
+              ctx.runtime.logger.info(
+                "Host update took over the progress marker under the lock - its writer is not doing disruptive work",
+                {
+                  environment,
+                  targetVersion,
+                  previousState: onDisk.state,
+                  previousTarget: onDisk.targetVersion,
+                },
+              );
+            }
+            return;
+          }
+          lastExpected = onDisk;
+          continue;
         }
-        return;
-      }
-      if (onDisk !== null) {
-        ctx.runtime.logger.info(
-          "Host update proceeds under another updater's progress marker; this run's own marker was withdrawn while it waited",
-          { environment, targetVersion: onDisk.targetVersion },
+        const created = await createUpdateProgressMarkerIfAbsent(
+          environment,
+          fresh,
         );
-        return;
+        if (created === "created") {
+          ownMarker.current = fresh;
+          return;
+        }
+        if (created === "failed") {
+          // Already warned by the marker layer; the update itself must not
+          // fail on its progress signal.
+          return;
+        }
+        // "exists": a marker landed between the read and the create; the
+        // next iteration reads it and takes it over.
+        lastExpected = null;
       }
-      // The path read empty - but the read is not the write. A second
-      // updater publishes its marker BEFORE its own lock wait, so one can
-      // land here between that read and this republish; a plain write would
-      // overwrite it with this run's record, and this run's conditional
-      // clear after the apply - CAS'd against exactly that record - would
-      // then erase what stood in the other updater's place, hiding its whole
-      // download from every remote surface until it re-asserted under the
-      // lock. Create-if-absent lands only into a still-empty path; losing the
-      // race is the same answer as the non-empty arm above.
-      const republished = progressRecord({
-        state: "updating",
-        error: null,
-        targetVersion,
-      });
-      const created = await createUpdateProgressMarkerIfAbsent(
-        environment,
-        republished,
+      ctx.runtime.logger.warn(
+        "Host update could not establish ownership of the progress marker under the lock; proceeding without re-asserting it",
+        { environment, targetVersion },
       );
-      if (created === "created") {
-        ownMarker.current = republished;
-        return;
-      }
-      if (created === "exists") {
-        ctx.runtime.logger.info(
-          "Host update proceeds under another updater's progress marker; it landed while this run re-asserted its own",
-          { environment, targetVersion },
-        );
-      }
     };
 
     let preparation: HostUpdatePreparation;
@@ -319,6 +373,42 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
     // stamping the no-op `failed` when that probe misses, would report a
     // failure for an update that did not happen.
     let activationPerformed = false;
+    // Likewise for the apply: `needsApply` is what the PRE-lock preparation
+    // decided, `applyPerformed` is whether bytes were actually swapped under
+    // the lock. They part when the stage is consumed by another actor while
+    // this run waits (see the staged arm), and only the second is work worth
+    // probing.
+    let applyPerformed = false;
+    // Whether the activation arm was entered at all, from either of its two
+    // call sites (the pre-lock debt, or a stage consumed while waiting):
+    // "attempted but not performed" is the debt another actor paid first.
+    let activationAttempted = false;
+    // Whether this run has begun to disturb the host: the stop before a swap
+    // (or a swap with no service to stop), or the activation arm's stop. It
+    // decides what a failure AFTER a marker takeover leaves behind. Before
+    // this point the host is exactly as the displaced writer left it, so its
+    // record goes back (a `failed` stamped there would stand over that
+    // writer's live update, which could never repair it - its stamp and
+    // clear CAS against a record that is gone). From this point on the
+    // host's state is this run's doing, and its `failed` is the truth the
+    // next updater takes over in turn. The apply and downgrade arms report
+    // the boundary through the progress stream - `commitInstallFromSource`
+    // emits `service-stop` immediately before the stop and `swap` before
+    // the rename - and the activation arm's hook runs immediately before
+    // its stop, with nothing that can fail in between.
+    let disruptionStarted = false;
+    const reportProgress = (info: ProgressInfo): void => {
+      if (info.stage === "service-stop" || info.stage === "swap") {
+        disruptionStarted = true;
+      }
+      ctx.progress(info);
+    };
+    const reassertMarkerThenDisrupt = async (
+      targetVersion: string,
+    ): Promise<void> => {
+      await reassertMarkerUnderLock(targetVersion);
+      disruptionStarted = true;
+    };
     // The preparation runs INSIDE the try whose catch owns the marker. The
     // marker is published from within it - `onWillDownload`, before the first
     // byte - so a transfer that rejects has a marker to stamp `failed` onto;
@@ -332,7 +422,7 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
         environment,
         version: args.versionRequest ?? null,
         allowDowngrade: args.allowDowngrade,
-        onProgress: (info) => ctx.progress(info),
+        onProgress: reportProgress,
         onWillDownload: publishUpdating,
       });
       const installedUpToDate =
@@ -405,25 +495,66 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
       }
 
       if (activationDebt !== null) {
+        activationAttempted = true;
         const activation = await activateInstalledAndProjectLegacy(
           environment,
           args.force,
           activationDebt.runningVersion,
-          // The record is read again under the lock; the marker follows it
-          // (or is re-established if another updater withdrew it meanwhile).
-          (installedVersion) => reassertMarkerUnderLock(installedVersion),
+          // The record is read again under the lock; the marker is made this
+          // run's there, naming the version as read, and the stop follows.
+          reassertMarkerThenDisrupt,
         );
         legacy = activation.legacy;
         activationPerformed = activation.activated;
       } else if (preparation.kind === "staged") {
-        const stagedTarget = downloadTargetVersion(preparation.download);
-        legacy = await applyAndProjectLegacy(
+        const apply = await applyAndProjectLegacy(
           environment,
           args.force,
           needsApply,
-          (info) => ctx.progress(info),
-          () => reassertMarkerUnderLock(stagedTarget),
+          reportProgress,
+          // The marker names the version `applyHost` is committing, not the
+          // one this run promoted before it waited - the shared stage
+          // directory holds whatever the latest promoter left there, and
+          // `applyHost` installs what its reconcile leaves.
+          (stagedVersion) => reassertMarkerUnderLock(stagedVersion),
         );
+        legacy = apply.legacy;
+        applyPerformed = apply.applied;
+        if (needsApply && !apply.applied) {
+          // The stage this run promoted was gone by the time it held the
+          // lock: another actor consumed it - Desktop's launch converge runs
+          // `host apply --no-service`, which commits the bytes and restarts
+          // nothing. `applyHost` reported the no-op it saw, and the debt that
+          // this command checks BEFORE the lock (only on the up-to-date
+          // short-circuit) was not there to be seen then. Treating this as
+          // done would probe the still-healthy OLD process, clear the marker
+          // and exit 0 over an install nobody activated. Re-derive the state
+          // now, under the same rule the pre-lock check applies (only a
+          // `debt` is a reason to act out of lock - see `ActivationReading`),
+          // and run the same activation arm the debt path runs: it re-reads
+          // under its own lock and is the plain no-op if the debt cleared
+          // meanwhile.
+          const reading = await readActivationState(environment);
+          if (reading.kind === "debt") {
+            activationAttempted = true;
+            ctx.runtime.logger.info(
+              "Host update found its stage consumed by another actor without activation; activating the committed install",
+              {
+                environment,
+                installedVersion: reading.installedVersion,
+                runningVersion: reading.runningVersion,
+              },
+            );
+            const activation = await activateInstalledAndProjectLegacy(
+              environment,
+              args.force,
+              reading.runningVersion,
+              reassertMarkerThenDisrupt,
+            );
+            legacy = activation.legacy;
+            activationPerformed = activation.activated;
+          }
+        }
       } else {
         const downgradeTarget = preparation.version;
         legacy = projectApplied(
@@ -431,10 +562,13 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
             environment,
             version: downgradeTarget,
             force: args.force,
-            onProgress: (info) => ctx.progress(info),
+            onProgress: reportProgress,
             onBeforeCommit: () => reassertMarkerUnderLock(downgradeTarget),
           }),
         );
+        // `installHostDowngrade` returns only an `applied` outcome; a park
+        // or a failure throws past this line.
+        applyPerformed = true;
       }
     } catch (err) {
       if (err instanceof CliError && err.code === CLI_ERROR_CODES.HOST_BUSY) {
@@ -448,32 +582,64 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
         // asked to; the GUI derives the truth - installed-but-not-running, or
         // staged-and-waiting - from the records, and the marker's job is only
         // to get out of the way. Withdrawn CONDITIONALLY, like the clear
-        // below: a newer updater's marker is not this run's to remove.
+        // below: a newer updater's marker is not this run's to remove. And
+        // a marker this run took over under the lock is put BACK rather than
+        // removed: the park means this run did no disruptive work after all,
+        // so the record it displaced - another updater's live `updating`, or
+        // a `failed` whose failure may still be exactly true - is what the
+        // path should hold.
         if (ownMarker.current !== null) {
-          const withdrawn = await deleteUpdateProgressMarkerIfUnchanged(
-            environment,
-            ownMarker.current,
-          );
+          const displaced = displacedMarker.current;
+          const withdrawn =
+            displaced === null
+              ? await deleteUpdateProgressMarkerIfUnchanged(
+                  environment,
+                  ownMarker.current,
+                )
+              : await replaceUpdateProgressMarkerIfUnchanged(
+                  environment,
+                  ownMarker.current,
+                  displaced,
+                );
           ctx.runtime.logger.info(
-            "Host update parked - the host has work in progress; the progress marker was withdrawn",
+            displaced === null
+              ? "Host update parked - the host has work in progress; the progress marker was withdrawn"
+              : "Host update parked - the host has work in progress; the progress marker it took over was restored to its previous writer",
             { environment, withdrawn },
           );
         }
         throw err;
       }
       if (ownMarker.current !== null) {
-        await markUpdateFailed(
-          ctx.runtime.logger,
-          environment,
-          ownMarker.current.targetVersion,
-          err instanceof Error ? err.message : String(err),
-          ownMarker.current,
-        );
+        const displaced = displacedMarker.current;
+        if (displaced !== null && !disruptionStarted) {
+          // Failed after taking the marker over but before touching the
+          // host (a lost mutation capability, a stop that could not be
+          // issued): the host is as the displaced writer left it, and so is
+          // its marker. See `disruptionStarted`.
+          const restored = await replaceUpdateProgressMarkerIfUnchanged(
+            environment,
+            ownMarker.current,
+            displaced,
+          );
+          ctx.runtime.logger.info(
+            "Host update failed before disturbing the host; the progress marker it took over was restored to its previous writer",
+            { environment, restored },
+          );
+        } else {
+          await markUpdateFailed(
+            ctx.runtime.logger,
+            environment,
+            ownMarker.current.targetVersion,
+            err instanceof Error ? err.message : String(err),
+            ownMarker.current,
+          );
+        }
       }
       throw err;
     }
 
-    const workPerformed = needsApply || activationPerformed;
+    const workPerformed = applyPerformed || activationPerformed;
     if (workPerformed) {
       // Verify the host the swap just installed actually comes back before
       // reporting success: a binary that commits cleanly but never listens
@@ -542,7 +708,8 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
       version: legacy.version,
       changed: legacy.previousVersion !== legacy.version,
       activatedInstalled: activationPerformed,
-      activationClearedWhileWaiting: needsActivate && !activationPerformed,
+      activationClearedWhileWaiting:
+        activationAttempted && !activationPerformed,
       hasPostSwapError: legacy.serviceLifecycle.postSwapError !== null,
     });
     return {
@@ -566,10 +733,12 @@ interface ActivationDebt {
 
 /**
  * What the install record and the live process say about each other. Every
- * reading is named rather than collapsed to "debt or not", because the two
+ * reading is named rather than collapsed to "debt or not", because the
  * places that consult it need different things from the non-debt cases:
- * before the lock, only `debt` is a reason to act; under the lock, `debt`
- * and `no-live-host` both are, while `activated` is the reason NOT to.
+ * OUT of the contender lock (before it, and again after a staged apply that
+ * found its stage consumed), only `debt` is a reason to act; UNDER the
+ * activation arm's lock, `debt` and `no-live-host` both are, while
+ * `activated` is the reason NOT to.
  *
  * - `no-install`: nothing to activate (the caller throws later anyway);
  * - `no-live-host`: no pid metadata, or a pid that is not alive. Before the
@@ -737,9 +906,10 @@ async function clearStaleFailedMarker(
  * `activated` tells the caller which of the two happened, because the two
  * need different aftercare (a health probe for a restart, none for a no-op).
  * `onInstalledVersionUnderLock` is called with the record's version as read
- * under the lock, before anything is restarted, so the caller can re-point a
- * progress marker it wrote from the pre-lock record if another actor
- * installed a different version in between.
+ * under the lock, after the busy gate and before anything is restarted, so
+ * the caller can take ownership of the progress marker (and re-point it if
+ * another actor installed a different version in between) only once this
+ * arm has committed to restarting.
  *
  * A debt is CLEARED only by observing the running host at the installed
  * version. A host that is simply gone under the lock - it exited, crashed,
@@ -782,13 +952,18 @@ async function activateInstalledAndProjectLegacy(
     }
     const previousVersion =
       reading.kind === "debt" ? reading.runningVersion : lastSeenRunningVersion;
-    await onInstalledVersionUnderLock(installed.version);
     // Same gate `applyHost` runs before it touches anything: a host with
     // live work is not restarted under it unless the caller said `--force`.
     // A host that is gone has no work to protect, so the gate is not asked.
     if (!force && reading.kind === "debt") {
       await assertHostNotBusy(environment);
     }
+    // After the gate (where one runs - a host that is gone is not asked),
+    // not before: the caller takes the progress marker over here, and a park
+    // must not follow a takeover for work never done. The stop below is the
+    // only thing that can still park, and the caller's park path restores
+    // the displaced record for that case.
+    await onInstalledVersionUnderLock(installed.version);
     // The stop → relaunch pair `host restart` drives, with `force` threaded
     // into the stop half. The busy gate above is only the pre-check: on a
     // Desktop-managed macOS host the stop itself claims a cooperative
@@ -898,7 +1073,10 @@ async function writeUpdateProgressMarkerSafely(
  * still reported by exit code and log. `ours` is `null` only when this run
  * never wrote a marker, in which case there is nothing to compare against and
  * the stamp lands unconditionally - every caller today passes the marker it
- * wrote, so that arm is a contract for the signature rather than a live path.
+ * wrote or took over under the lock, so that arm is a contract for the
+ * signature rather than a live path. A stamp over a TAKEN-OVER record is
+ * right: this run did the disruptive work, so its failure is the host's
+ * current state, and the next updater takes the `failed` over in turn.
  */
 async function markUpdateFailed(
   logger: ILogger,
@@ -933,9 +1111,18 @@ async function applyAndProjectLegacy(
   force: boolean,
   needsApply: boolean,
   onProgress: (info: ProgressInfo) => void,
-  /** Runs under the contender lock, after the no-op decision, before the apply. */
-  onUnderLock: () => Promise<void>,
-): Promise<LegacyHostUpdateResult> {
+  /**
+   * `ApplyHostOptions.onWillCommitStaged`: runs inside `applyHost`, after
+   * its reconcile has settled what is staged and after its busy gate, with
+   * the version of the stage it is about to commit. A no-op never reaches
+   * it; there is then no disruptive work to announce.
+   */
+  onWillCommitStaged: (stagedVersion: string) => Promise<void>,
+): Promise<{
+  readonly legacy: LegacyHostUpdateResult;
+  /** Whether bytes were swapped under the lock; a no-op is `false`. */
+  readonly applied: boolean;
+}> {
   // ONE options value for acquisition and revalidation: two literals that
   // must stay identical are how admission policies drift.
   const contenderOptions: WithCliUpdateContenderOptions = {
@@ -947,9 +1134,11 @@ async function applyAndProjectLegacy(
   };
   return withCliUpdateContender(contenderOptions, async (capability) => {
     if (!needsApply) {
-      return projectNoOp(await requireInstalled(environment));
+      return {
+        legacy: projectNoOp(await requireInstalled(environment)),
+        applied: false,
+      };
     }
-    await onUnderLock();
     let outcome: ApplyHostOutcome;
     try {
       outcome = await applyHostWithAttempt(capability, contenderOptions, {
@@ -958,6 +1147,12 @@ async function applyAndProjectLegacy(
         noService: false,
         expectedStageFingerprint: null,
         onProgress,
+        // What this run promoted before it waited is a pre-lock fact: the
+        // shared stage may have been replaced (a later promoter, a parked
+        // explicit `--version`), consumed, or reconciled away since, and a
+        // read from HERE would still be on the wrong side of `applyHost`'s
+        // own reconcile. `applyHost` reports the version it is committing.
+        onWillCommitStaged,
       });
     } catch (err) {
       if (err instanceof CliError && err.code === CLI_ERROR_CODES.HOST_BUSY) {
@@ -990,7 +1185,10 @@ async function applyAndProjectLegacy(
       // (it assumes the caller holds `cli-lock`, never re-acquires)
       // - this re-read observes exactly the state `applyHost` had
       // internal access to but didn't return, not a fresh race.
-      return projectNoOp(await requireInstalled(environment));
+      return {
+        legacy: projectNoOp(await requireInstalled(environment)),
+        applied: false,
+      };
     }
     if (outcome.outcome === "stage-fingerprint-mismatch") {
       throw cliError({
@@ -1003,7 +1201,7 @@ async function applyAndProjectLegacy(
         exitCode: 1,
       });
     }
-    return projectApplied(outcome);
+    return { legacy: projectApplied(outcome), applied: true };
   });
 }
 

--- a/clients/traycer-cli/src/commands/host-update.ts
+++ b/clients/traycer-cli/src/commands/host-update.ts
@@ -9,6 +9,7 @@ import {
   type HostDownloadOutcome,
 } from "../installer/download-stage";
 import {
+  createUpdateProgressMarkerIfAbsent,
   deleteUpdateProgressMarkerIfUnchanged,
   progressRecord,
   readUpdateProgressMarker,
@@ -204,10 +205,11 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
     // it names is the one a `failed` stamp has to name too, which is why the
     // re-point under the lock replaces the whole record rather than one field.
     //
-    // It is a CLAIM about the disk, not a fact: the one write that is not
-    // conditional on it is `reassertMarkerUnderLock` below, which republishes
-    // only into an EMPTY path - the case where a faster updater cleared this
-    // run's marker while it waited - and erases nothing.
+    // It is a CLAIM about the disk, not a fact: every write after the
+    // pre-lock publish is conditional on it, including the republish in
+    // `reassertMarkerUnderLock` below, which lands only into a path that is
+    // STILL empty at the write (create-if-absent) - the case where a faster
+    // updater cleared this run's marker while it waited - and erases nothing.
     const ownMarker: { current: HostUpdateProgress | null } = { current: null };
     const publishUpdating = async (targetVersion: string): Promise<void> => {
       ownMarker.current = progressRecord({
@@ -274,7 +276,34 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
         );
         return;
       }
-      await publishUpdating(targetVersion);
+      // The path read empty - but the read is not the write. A second
+      // updater publishes its marker BEFORE its own lock wait, so one can
+      // land here between that read and this republish; a plain write would
+      // overwrite it with this run's record, and this run's conditional
+      // clear after the apply - CAS'd against exactly that record - would
+      // then erase what stood in the other updater's place, hiding its whole
+      // download from every remote surface until it re-asserted under the
+      // lock. Create-if-absent lands only into a still-empty path; losing the
+      // race is the same answer as the non-empty arm above.
+      const republished = progressRecord({
+        state: "updating",
+        error: null,
+        targetVersion,
+      });
+      const created = await createUpdateProgressMarkerIfAbsent(
+        environment,
+        republished,
+      );
+      if (created === "created") {
+        ownMarker.current = republished;
+        return;
+      }
+      if (created === "exists") {
+        ctx.runtime.logger.info(
+          "Host update proceeds under another updater's progress marker; it landed while this run re-asserted its own",
+          { environment, targetVersion },
+        );
+      }
     };
 
     let preparation: HostUpdatePreparation;

--- a/clients/traycer-cli/src/commands/host-update.ts
+++ b/clients/traycer-cli/src/commands/host-update.ts
@@ -1013,8 +1013,8 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
           // on disk still names the pre-lock target while the run went on
           // to commit the version `applyHost` reported, and "update to
           // <old> failed" would name a version this run never installed -
-          // and the host's narrower, string-equal suppression would then
-          // never retire it.
+          // and neither string-equal stale-failed rule would then ever
+          // retire it.
           await markUpdateFailed(
             ctx.runtime.logger,
             environment,
@@ -1252,10 +1252,21 @@ async function readActivationState(
  * Whether the running host has been OBSERVED serving `targetVersion`: the
  * install record names it and the live process is at the record
  * (`readActivationState` → `activated`, with its identity verdict). Used by
- * the failure path of a run that holds no marker of its own to withhold a
- * `failed` for a target another updater has since delivered. Never throws:
- * a reading that cannot be taken is "not observed", and the stamp lands -
- * a failure that cannot be contradicted is reported, not swallowed.
+ * the failure path to withhold a `failed` for a target another updater has
+ * since delivered. Never throws: a reading that cannot be taken is "not
+ * observed", and the stamp lands - a failure that cannot be contradicted is
+ * reported, not swallowed.
+ *
+ * "Names it" is STRING identity of the record with the target, the grain
+ * the version binding uses (`installedVersionMismatch`) and the rule the
+ * host's `isStaleUpdateProgress` applies to the same marker: `2.0.0+foo` is
+ * another artifact than `2.0.0+bar`, and a run for one that finds the other
+ * running was not delivered - its failure stands, whatever the catalog
+ * comparator (build-metadata-blind, right for ORDERING) would call equal.
+ * Another actor delivering the same registry artifact writes the same
+ * string, so a real match is never defeated. The activation reading above
+ * it keeps the comparator: running-vs-record is a runtime-stamp question,
+ * record-vs-target is an artifact one.
  */
 async function targetObservedRunning(
   environment: Environment,
@@ -1263,15 +1274,9 @@ async function targetObservedRunning(
 ): Promise<boolean> {
   try {
     const reading = await readActivationState(environment);
-    if (reading.kind !== "activated") return false;
-    // The catalog-domain comparator `readActivationState` itself uses, not
-    // `===`: it ignores build metadata, so `1.3.0+abc` and `1.3.0` are one
-    // release to it and must be one release here.
-    const comparison = compareHostVersions(
-      reading.installedVersion,
-      targetVersion,
+    return (
+      reading.kind === "activated" && reading.installedVersion === targetVersion
     );
-    return comparison.comparable && comparison.ordering === "equal";
   } catch {
     return false;
   }
@@ -1289,35 +1294,35 @@ async function targetObservedRunning(
  * immediately before the unlink. Marker I/O never fails the command (same
  * rule as the writes).
  *
- * "Contradicts" is the rule the host's `isStaleUpdateProgress` applies in
- * its narrower form (string equality of the marker's target with the
- * runtime version it publishes, so a staging host's `staging.<epoch>.<sha>`
- * never matches a catalog target there): a `failed` is stale when the
- * version it names is the one now running. Here the comparison is the
- * catalog comparator's, the domain the record and the target share. A `failed`
- * naming ANOTHER version - an attempt at 2.0.0 that failed before the swap,
- * read by a later `host update` while the registry offers only 1.9.0 - is
- * a report the observed state does not contradict, and it stays until an
- * attempt at that target supersedes it.
+ * "Contradicts" is the rule the host's `isStaleUpdateProgress` applies to
+ * the same marker: a `failed` is stale when the version it names IS the one
+ * now running - string identity, the artifact grain (see
+ * `targetObservedRunning`). The host compares against the runtime version
+ * it publishes, so a staging host's `staging.<epoch>.<sha>` never matches a
+ * catalog target there; here the comparison is against the install record
+ * the running host has been observed at, the domain the marker's target was
+ * written in. A `failed` naming ANOTHER version - an attempt at 2.0.0 that
+ * failed before the swap, read by a later `host update` while the registry
+ * offers only 1.9.0, or an attempt at `2.0.0+foo` over a host that runs
+ * `2.0.0+bar` - is a report the observed state does not contradict, and it
+ * stays until a later run that does work replaces it (a retry at that
+ * target over a record at or above it short-circuits and never touches
+ * the marker).
  */
 async function clearStaleFailedMarker(
   logger: ILogger,
   environment: Environment,
-  observedRunningVersion: string,
+  observedInstalledVersion: string,
 ): Promise<void> {
   const marker = await readUpdateProgressMarker(environment);
   if (marker === null || marker.state !== "failed") return;
-  const comparison = compareHostVersions(
-    marker.targetVersion,
-    observedRunningVersion,
-  );
-  if (!comparison.comparable || comparison.ordering !== "equal") {
+  if (marker.targetVersion !== observedInstalledVersion) {
     logger.info(
       "Host update left the failed progress marker alone - it names a target the running host has not been observed at",
       {
         environment,
         failedTargetVersion: marker.targetVersion,
-        observedRunningVersion,
+        observedInstalledVersion,
       },
     );
     return;

--- a/clients/traycer-cli/src/commands/host-update.ts
+++ b/clients/traycer-cli/src/commands/host-update.ts
@@ -10,6 +10,8 @@ import {
 } from "../installer/download-stage";
 import {
   claimUpdateProgressMarkerBeforeLock,
+  type ConditionalMarkerDelete,
+  type ConditionalMarkerReplace,
   createUpdateProgressMarkerIfAbsent,
   deleteUpdateProgressMarkerIfUnchanged,
   progressRecord,
@@ -17,6 +19,7 @@ import {
   replaceUpdateProgressMarkerIfUnchanged,
   type HostUpdateProgress,
   sameProgress,
+  updateProgressRecordHasLiveWriter,
 } from "../host/update-progress-marker";
 import { probeHostHealth } from "../service/health-probe";
 import {
@@ -219,26 +222,50 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
     // whatever it holds by then - by conditional replace or conditional
     // create, never by a blind write.
     const ownMarker: { current: HostUpdateProgress | null } = { current: null };
-    // The record `reassertMarkerUnderLock` displaced when it took the marker
-    // over, kept for one purpose: an exit that follows the takeover WITHOUT
-    // this run having disturbed the host - a busy park (the stop's
-    // cooperative stand-down claim can still be denied past the busy gate)
-    // or a failure before the stop - puts it back. The displaced writer's
-    // marker, or a dead writer's `failed` that may still be exactly true, is
-    // not this run's to remove when this run ends up doing nothing. The
-    // restore is not loss-free in one corner: a writer that finished while
-    // its record was displaced found the path changed, left it, and exited,
-    // so the restored record has no writer left to clear it. The host side
-    // suppresses an `updating` whose writer is dead, which is what makes
-    // the restore the lesser harm; removing the record outright would hide
-    // a live writer's whole update.
+    // A LIVE writer's record that `reassertMarkerUnderLock` displaced when
+    // it took the marker over, kept for one purpose: an exit that follows
+    // the takeover WITHOUT this run having disturbed the host - a busy park
+    // (the stop's cooperative stand-down claim can still be denied past the
+    // busy gate) or a failure before the stop - puts it back, because that
+    // writer's update is the one still in progress and removing its record
+    // would hide the whole update until its own re-assert. Only a record
+    // some writer is acting on (`updateProgressRecordHasLiveWriter`) is
+    // retained here. A record no writer is acting on - a `failed`, or an
+    // `updating` whose writer is dead - is replaced and GONE, at the
+    // pre-lock claim and at the takeover alike, exactly as the blind
+    // publish treated it: put back on a park it re-plants a dead writer's
+    // `updating` that nobody will ever clear (a host without dead-writer
+    // suppression renders it for as long as the park lives) or paints an
+    // earlier attempt's `failed` over the staged-wait park the GUI derives
+    // from the records; put back on a failure it reports the earlier
+    // attempt's cause, and target, over this run's own. The one thing a
+    // dropped `failed` could still have told a reader - an earlier
+    // attempt's post-swap probe miss, say - is carried by the records
+    // the park is derived from: a park means the host is up and answering,
+    // and the install record beside the running version is what the GUI
+    // renders as activation debt or a staged wait. That loss is accepted
+    // here, and the takeover logs the record's state and target. The
+    // restore is not loss-free in one corner: a live writer that finished
+    // while its record was displaced found the path changed, left it, and
+    // exited, so the restored record has no writer left to clear it. The
+    // host side suppresses an `updating` whose writer is dead, which is
+    // what makes that corner the lesser harm.
     const displacedMarker: { current: HostUpdateProgress | null } = {
       current: null,
     };
+    // The record as the park and failure arms consume it: retained at the
+    // takeover while its writer was live, and live STILL at the moment of
+    // the restore - otherwise treated as no record at all.
+    const liveDisplacedRecord = (
+      record: HostUpdateProgress | null,
+    ): HostUpdateProgress | null =>
+      record !== null && updateProgressRecordHasLiveWriter(record)
+        ? record
+        : null;
     // The version this run is working toward, as last announced to the
     // marker (pre-lock claim, or the re-point under the lock). Kept apart
     // from `ownMarker` because a run whose claim DEFERRED holds no record
-    // and still has a target to name if it fails after disturbing the host.
+    // and still has a target to name if it fails.
     const intendedTarget: { current: string | null } = { current: null };
     // The pre-lock publish. NOT a blind write: the path may hold the marker
     // of the updater currently holding the contender lock, mid-swap, and a
@@ -264,11 +291,9 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
         fresh,
       );
       if (claim.outcome === "published" || claim.outcome === "replaced-stale") {
+        // A stale record the claim replaced is not retained: see
+        // `displacedMarker`.
         ownMarker.current = fresh;
-        // What a stale-record replace displaced is kept for the same reason
-        // a takeover under the lock keeps it: a park or a pre-disruption
-        // failure puts it back.
-        displacedMarker.current = claim.displaced;
         return;
       }
       ownMarker.current = null;
@@ -306,7 +331,10 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
     // write wins that round and is read again; nothing is ever overwritten
     // blind. The displaced updater's later stamp/clear are CAS'd against ITS
     // record and degrade to no-ops - correct, because the marker now
-    // describes the update that is actually in progress.
+    // describes the update that is actually in progress. A displaced record
+    // whose writer is live is retained in `displacedMarker` for the restore
+    // a park or a pre-disruption failure performs; one no writer is acting
+    // on is gone (see `displacedMarker`).
     //
     // WHEN it runs matters as much as what it does: every arm calls it only
     // once that arm has committed to the disruptive half - after the apply's
@@ -343,9 +371,12 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
           if (replaced === "replaced") {
             ownMarker.current = fresh;
             if (!isOwn) {
-              displacedMarker.current = onDisk;
+              const writerLive = updateProgressRecordHasLiveWriter(onDisk);
+              displacedMarker.current = writerLive ? onDisk : null;
               ctx.runtime.logger.info(
-                "Host update took over the progress marker under the lock - its writer is not doing disruptive work",
+                writerLive
+                  ? "Host update took over the progress marker under the lock - its writer is not doing disruptive work"
+                  : "Host update replaced the progress marker under the lock - no writer is acting on it",
                 {
                   environment,
                   targetVersion,
@@ -414,17 +445,18 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
     let activationAttempted = false;
     // Whether this run has begun to disturb the host: the stop before a swap
     // (or a swap with no service to stop), or the activation arm's stop. It
-    // decides what a failure AFTER a marker takeover leaves behind. Before
-    // this point the host is exactly as the displaced writer left it, so its
-    // record goes back (a `failed` stamped there would stand over that
-    // writer's live update, which could never repair it - its stamp and
-    // clear CAS against a record that is gone). From this point on the
-    // host's state is this run's doing, and its `failed` is the truth the
-    // next updater takes over in turn. The apply and downgrade arms report
-    // the boundary through the progress stream - `commitInstallFromSource`
-    // emits `service-stop` immediately before the stop and `swap` before
-    // the rename - and the activation arm's hook runs immediately before
-    // its stop (see `reassertMarkerThenDisrupt` for the one check between).
+    // decides what a failure AFTER a takeover of a LIVE writer's marker
+    // leaves behind. Before this point the host is exactly as the displaced
+    // writer left it, so its record goes back (a `failed` stamped there
+    // would stand over that writer's live update, which could never repair
+    // it - its stamp and clear CAS against a record that is gone). From
+    // this point on the host's state is this run's doing, and its `failed`
+    // is the truth the next updater takes over in turn. The apply and
+    // downgrade arms report the boundary through the progress stream -
+    // `commitInstallFromSource` emits `service-stop` immediately before the
+    // stop and `swap` before the rename - and the activation arm's hook
+    // runs immediately before its stop (see `reassertMarkerThenDisrupt` for
+    // the one check between).
     let disruptionStarted = false;
     const reportProgress = (info: ProgressInfo): void => {
       if (info.stage === "service-stop" || info.stage === "swap") {
@@ -620,68 +652,146 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
         // staged-and-waiting - from the records, and the marker's job is only
         // to get out of the way. Withdrawn CONDITIONALLY, like the clear
         // below: a newer updater's marker is not this run's to remove. And
-        // a marker this run took over under the lock is put BACK rather than
-        // removed: the park means this run did no disruptive work after all,
-        // so the record it displaced - another updater's live `updating`, or
-        // a `failed` whose failure may still be exactly true - is what the
-        // path should hold.
+        // a LIVE writer's marker this run took over under the lock is put
+        // BACK rather than removed: the park means this run did no
+        // disruptive work after all, so that writer's `updating` is what
+        // the path should hold. A stale record this run replaced is not put
+        // back (see `displacedMarker`): the path is left empty, and the
+        // GUI derives the park from the records.
         if (ownMarker.current !== null) {
-          const displaced = displacedMarker.current;
-          const withdrawn =
-            displaced === null
-              ? await deleteUpdateProgressMarkerIfUnchanged(
-                  environment,
-                  ownMarker.current,
-                )
-              : await replaceUpdateProgressMarkerIfUnchanged(
-                  environment,
-                  ownMarker.current,
-                  displaced,
-                );
-          ctx.runtime.logger.info(
-            displaced === null
-              ? "Host update parked - the host has work in progress; the progress marker was withdrawn"
-              : "Host update parked - the host has work in progress; the progress marker it took over was restored to its previous writer",
-            { environment, withdrawn },
-          );
+          // Liveness is re-read HERE, not trusted from the takeover: the
+          // displaced writer had the whole stop attempt to die in between,
+          // and a park that restored its now-dead `updating` would re-plant
+          // exactly the record the retain rule exists to drop.
+          const displaced = liveDisplacedRecord(displacedMarker.current);
+          if (displaced === null) {
+            const withdrawn = await deleteUpdateProgressMarkerIfUnchanged(
+              environment,
+              ownMarker.current,
+            );
+            logConditionalMarkerOutcome(ctx.runtime.logger, environment, {
+              outcome: withdrawn,
+              done: "Host update parked - the host has work in progress; the progress marker was withdrawn",
+              moved:
+                "Host update parked - the host has work in progress; the progress marker was left in place - another updater owns it now",
+              gone: "Host update parked - the host has work in progress; found no progress marker to withdraw",
+              failed:
+                "Host update parked - the host has work in progress; its progress marker could not be withdrawn and stays until the next update supersedes it",
+            });
+          } else {
+            const restored = await replaceUpdateProgressMarkerIfUnchanged(
+              environment,
+              ownMarker.current,
+              displaced,
+            );
+            logConditionalMarkerOutcome(ctx.runtime.logger, environment, {
+              outcome: restored,
+              done: "Host update parked - the host has work in progress; the progress marker it took over was restored to its previous writer",
+              moved:
+                "Host update parked - the host has work in progress; the progress marker it took over was not restored - another updater owns it now",
+              gone: "Host update parked - the host has work in progress; the progress marker it took over was not restored - the path is empty",
+              failed:
+                "Host update parked - the host has work in progress; the progress marker it took over could not be restored and stays until the next update supersedes it",
+            });
+          }
         }
         throw err;
       }
       if (ownMarker.current === null) {
-        // No record of this run's on disk (the pre-lock claim deferred, or
-        // no conditional write ever landed). A failure BEFORE the host was
-        // disturbed then has nothing to report on the marker - the update
-        // it deferred to is the one in progress. A failure AFTER is this
-        // run's doing and must be visible remotely: `markUpdateFailed`
-        // lands it into an EMPTY path only, never over a live record.
-        if (disruptionStarted) {
+        // No record of this run's on disk (the pre-lock claim deferred to
+        // another writer's live marker, or no conditional write ever
+        // landed). The failure is still this run's to report whenever it
+        // announced a target: `markUpdateFailed` with no record lands the
+        // `failed` by create-if-absent, into an EMPTY path only. While the
+        // other writer's marker is still live that is the no-op it should
+        // be - its update is the one in progress - but that writer may have
+        // finished and cleared while this run was still downloading, and
+        // a lost download then has nothing on the path to defer to. A run
+        // that never announced a target (failed before `onWillDownload`)
+        // has nothing to name and stamps nothing, as before.
+        // ...unless the host is already RUNNING that target: the other
+        // writer's update to the same version succeeded while this one was
+        // still downloading (its reconcile consumed the shared stage, which
+        // is the usual way this download fails), and "update to X failed"
+        // over a host that is serving X reports a failure that did not
+        // happen - persistently, since only a later no-work `host update`
+        // reconciles a stale `failed`, and only a host with target-running
+        // suppression hides it. Same observed-state rule as
+        // `clearStaleFailedMarker`.
+        if (
+          intendedTarget.current !== null &&
+          !(await targetObservedRunning(environment, intendedTarget.current))
+        ) {
           await markUpdateFailed(
             ctx.runtime.logger,
             environment,
-            // Every arm announces its target before it can disturb the host,
-            // so this is set whenever `disruptionStarted` is; the fallback
-            // is a type-level courtesy, not a reachable branch.
-            intendedTarget.current ?? "unknown",
+            intendedTarget.current,
             err instanceof Error ? err.message : String(err),
             null,
           );
+        } else if (intendedTarget.current !== null) {
+          ctx.runtime.logger.info(
+            "Host update did not stamp its failure - the running host has been observed at the target it announced",
+            { environment, targetVersion: intendedTarget.current },
+          );
         }
       } else {
-        const displaced = displacedMarker.current;
+        // Liveness re-read here for the same reason as in the park arm.
+        const displaced = liveDisplacedRecord(displacedMarker.current);
         if (displaced !== null && !disruptionStarted) {
-          // Failed after taking the marker over but before touching the
-          // host (a lost mutation capability, a stop that could not be
-          // issued): the host is as the displaced writer left it, and so is
-          // its marker. See `disruptionStarted`.
+          // Failed after taking a LIVE writer's marker over but before
+          // touching the host (a lost mutation capability, a stop that
+          // could not be issued): the host is as that writer left it, and
+          // so is its marker. See `disruptionStarted`. Every other failure
+          // with a record of this run's on disk - a lost download over a
+          // stale record the claim replaced included - stamps this run's
+          // own cause over its own record: a retry's second failure
+          // reports the second failure, not the first.
           const restored = await replaceUpdateProgressMarkerIfUnchanged(
             environment,
             ownMarker.current,
             displaced,
           );
-          ctx.runtime.logger.info(
-            "Host update failed before disturbing the host; the progress marker it took over was restored to its previous writer",
-            { environment, restored },
+          logConditionalMarkerOutcome(ctx.runtime.logger, environment, {
+            outcome: restored,
+            done: "Host update failed before disturbing the host; the progress marker it took over was restored to its previous writer",
+            moved:
+              "Host update failed before disturbing the host; the progress marker it took over was not restored - another updater owns it now",
+            gone: "Host update failed before disturbing the host; the progress marker it took over was not restored - the path is empty",
+            failed:
+              "Host update failed before disturbing the host; the progress marker it took over could not be restored and stays until the next update supersedes it",
+          });
+        } else if (
+          !disruptionStarted &&
+          (await targetObservedRunning(
+            environment,
+            ownMarker.current.targetVersion,
+          ))
+        ) {
+          // Same observed-state rule as the null arm above, reached with a
+          // record of this run's own on disk: an actor that writes no
+          // marker at all - `host apply --no-service`, Desktop's launch
+          // converge - can commit and activate the very target this run
+          // announced underneath its live `updating`, consuming the shared
+          // stage its download then fails on. The record describes an
+          // update another actor completed, so it is WITHDRAWN, not
+          // stamped: "update to X failed" over a host serving X is the
+          // false report the rule exists to withhold. Pre-disruption only:
+          // past the stop, the host's state is this run's doing and its
+          // failure is reported whatever the host now serves.
+          const withdrawn = await deleteUpdateProgressMarkerIfUnchanged(
+            environment,
+            ownMarker.current,
           );
+          logConditionalMarkerOutcome(ctx.runtime.logger, environment, {
+            outcome: withdrawn,
+            done: "Host update failed before disturbing the host, and the running host has been observed at the target it announced; the progress marker was withdrawn",
+            moved:
+              "Host update failed before disturbing the host, and the running host has been observed at the target it announced; the progress marker was left in place - another updater owns it now",
+            gone: "Host update failed before disturbing the host, and the running host has been observed at the target it announced; found no progress marker to withdraw",
+            failed:
+              "Host update failed before disturbing the host, and the running host has been observed at the target it announced; its progress marker could not be withdrawn and stays until the next update supersedes it",
+          });
         } else {
           await markUpdateFailed(
             ctx.runtime.logger,
@@ -815,14 +925,16 @@ interface ActivationDebt {
  *   version. A record WITH a runtime stamp never reads this way: the stamp is
  *   whatever the archive reported about itself (a staging host's is
  *   `staging.<epoch>.<sha>`), and equality with it is the whole test;
- * - `activated`: the committed archive is what is running;
+ * - `activated`: the committed archive is what is running, carrying the
+ *   record's catalog `version` so a caller can ask WHICH archive
+ *   (`targetObservedRunning`; the other readers only ask whether);
  * - `debt`: the record and the process disagree.
  */
 type ActivationReading =
   | { readonly kind: "no-install" }
   | { readonly kind: "no-live-host"; readonly installedVersion: string }
   | { readonly kind: "foreign-runtime" }
-  | { readonly kind: "activated" }
+  | { readonly kind: "activated"; readonly installedVersion: string }
   | ActivationDebt;
 
 /**
@@ -885,7 +997,7 @@ async function readActivationState(
     // comparison would classify every staging host as foreign and turn both
     // its activated and its indebted states into no-ops.
     return running.version === installed.runtimeVersion
-      ? { kind: "activated" }
+      ? { kind: "activated", installedVersion: installed.version }
       : {
           kind: "debt",
           installedVersion: installed.version,
@@ -898,13 +1010,42 @@ async function readActivationState(
   if (!isValidHostVersion(running.version)) return { kind: "foreign-runtime" };
   const comparison = compareHostVersions(running.version, installed.version);
   if (!comparison.comparable || comparison.ordering === "equal") {
-    return { kind: "activated" };
+    return { kind: "activated", installedVersion: installed.version };
   }
   return {
     kind: "debt",
     installedVersion: installed.version,
     runningVersion: running.version,
   };
+}
+
+/**
+ * Whether the running host has been OBSERVED serving `targetVersion`: the
+ * install record names it and the live process is at the record
+ * (`readActivationState` → `activated`, with its identity verdict). Used by
+ * the failure path of a run that holds no marker of its own to withhold a
+ * `failed` for a target another updater has since delivered. Never throws:
+ * a reading that cannot be taken is "not observed", and the stamp lands -
+ * a failure that cannot be contradicted is reported, not swallowed.
+ */
+async function targetObservedRunning(
+  environment: Environment,
+  targetVersion: string,
+): Promise<boolean> {
+  try {
+    const reading = await readActivationState(environment);
+    if (reading.kind !== "activated") return false;
+    // The catalog-domain comparator `readActivationState` itself uses, not
+    // `===`: it ignores build metadata, so `1.3.0+abc` and `1.3.0` are one
+    // release to it and must be one release here.
+    const comparison = compareHostVersions(
+      reading.installedVersion,
+      targetVersion,
+    );
+    return comparison.comparable && comparison.ordering === "equal";
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -1030,7 +1171,7 @@ async function activateInstalledAndProjectLegacy(
     // not before: the caller takes the progress marker over here, and a park
     // must not follow a takeover for work never done. The stop below is the
     // only thing that can still park, and the caller's park path restores
-    // the displaced record for that case.
+    // a live writer's displaced record for that case.
     await onInstalledVersionUnderLock(installed.version);
     // The stop → relaunch pair `host restart` drives, with `force` threaded
     // into the stop half. The busy gate above is only the pre-check: on a
@@ -1110,6 +1251,41 @@ function downloadTargetVersion(outcome: HostDownloadOutcome): string {
     : outcome.targetVersion;
 }
 
+/**
+ * One log line per conditional-marker outcome, so a withdrawal or restore
+ * that did NOT happen is never reported as if it had: `cleared` /
+ * `replaced` is the operation done; `changed` is a record that moved under
+ * this run (another updater's, left alone); `absent` (a delete only) is a
+ * path already empty, nothing left to report on; `failed` is an I/O
+ * failure the marker layer already warned about, named here so the
+ * CLI's own log shows why a marker outlived the run that wrote it. All
+ * INFO: none of these fails the update, and the marker layer owns the WARN.
+ * (`replaceUpdateProgressMarkerIfUnchanged` reports an empty path as
+ * `changed`, so `gone` is reachable from the delete sites only.)
+ */
+function logConditionalMarkerOutcome(
+  logger: ILogger,
+  environment: Environment,
+  lines: {
+    readonly outcome: ConditionalMarkerDelete | ConditionalMarkerReplace;
+    readonly done: string;
+    readonly moved: string;
+    readonly gone: string;
+    readonly failed: string;
+  },
+): void {
+  const { outcome } = lines;
+  const message =
+    outcome === "cleared" || outcome === "replaced"
+      ? lines.done
+      : outcome === "failed"
+        ? lines.failed
+        : outcome === "absent"
+          ? lines.gone
+          : lines.moved;
+  logger.info(message, { environment, outcome });
+}
+
 // Terminates the "updating" marker with the real cause so the daemon reports
 // a failed update instead of an update that appears to still be running.
 /**
@@ -1125,10 +1301,20 @@ function downloadTargetVersion(outcome: HostDownloadOutcome): string {
  * still reported by exit code and log. `ours` is `null` when this run has no
  * record of its own on disk - the pre-lock claim deferred to another
  * writer's live marker, or no conditional write ever landed - and the
- * caller asks for a stamp anyway only when it DID disturb the host: the
- * failure is then real and must reach the remote surfaces, so it lands by
- * create-if-absent - into an empty path only, never over a live record,
- * which is the one blind write the conditional primitives exist to refuse.
+ * failure is still this run's to report, so it lands by create-if-absent -
+ * into a path that READS empty. Against another writer's live marker that
+ * is the correct no-op; against the empty path that writer's clear left
+ * behind, it is the only record of what went wrong. One residual race is
+ * accepted and named: create-if-absent has no record to compare against,
+ * so it cannot tell an empty path from the few milliseconds in which
+ * another writer's conditional swap holds ITS record in scratch (see
+ * `replaceUpdateProgressMarkerIfUnchanged`, which maps that same "absent"
+ * reading to `changed` for exactly this reason). A stamp that lands in that
+ * window wins the other writer's `link` with EEXIST; its swap reports
+ * `failed`, warned about by the marker layer, and this run's `failed`
+ * stands until the next update supersedes it. The caller narrows the
+ * window's cost by not stamping at all when the running host has been
+ * observed at the very target this run announced (`targetObservedRunning`).
  * A stamp over a TAKEN-OVER record is right when it happens: this run did
  * the disruptive work, so its failure is the host's current state, and the
  * next updater takes the `failed` over in turn.

--- a/clients/traycer-cli/src/commands/host-update.ts
+++ b/clients/traycer-cli/src/commands/host-update.ts
@@ -55,8 +55,9 @@ import { createServiceController, serviceLabelFor } from "../service";
 // apply half below acquires the lock, matching `host apply`'s own
 // contract that the caller holds it across reconcile/read/no-op/busy/
 // commit. An explicit `--release X --allow-downgrade` below the installed
-// version uses a private install source instead, with the same progress,
-// mutation authority, busy checks, and post-swap health verification.
+// version, or naming another build of its release, uses a private install
+// source instead, with the same progress, mutation authority, busy checks,
+// and post-swap health verification.
 //
 // Busy (D6): the stage is kept - `applyHost`'s busy check runs before it
 // touches the stage - and this command re-throws `E_HOST_BUSY` with the
@@ -601,9 +602,13 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
           ? activationReading
           : null;
       // An EXPLICIT request owes the activation of ITS version and no other.
-      // The installed-up-to-date short-circuit fires for a record AT OR
-      // ABOVE the request, and a record above it (`--version 1.2.0` against
-      // an installed 2.0.0) is not this run's to restart onto - the caller
+      // For an explicit request the installed-up-to-date short-circuit
+      // fires only for a record that IS the request (the download refuses
+      // any other record at or above it before a transfer), so the record
+      // the debt read sees can name another version only if it MOVED since
+      // that check - another actor's commit in the gap - and a record above
+      // the request (2.0.0 after a request for 1.2.0) is not this run's to
+      // restart onto - the caller
       // confirmed 1.2.0 and nothing else (`installedVersionMismatch`). That
       // record's debt is left, logged, to an implicit `host update` or a
       // `host restart`, and this run reports the no-op the short-circuit
@@ -884,7 +889,10 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
       }
       // A refusal because a NEWER host is installed than the version this
       // run was asked for - `E_HOST_UPDATE_NOT_NEWER`, from the promote-time
-      // discard or from `installedVersionMismatch`'s newer arm - is a
+      // discard or from `installedVersionMismatch`'s newer arm (the
+      // download's phase-1 refusal carries the same code, but arrives
+      // before any target is announced, so no record of this run's exists
+      // and none of the arms below runs) - is a
       // SUPERSEDED request, not a failure: another actor delivered
       // something newer and nothing was wrong. It is treated exactly like a
       // target observed running: this run's record is WITHDRAWN, never
@@ -1237,8 +1245,24 @@ async function readActivationState(
   if (!isValidHostVersion(running.version)) {
     return { kind: "foreign-runtime", installedVersion: installed.version };
   }
+  // A release host publishes exactly its catalog version (the build stamps
+  // `src/config.ts`'s version into the binary and into the archive's
+  // `version.json` alike), so the record's string IS what an activated host
+  // of that record publishes: identity is the string here as in the
+  // runtime-stamp domain, and another build of the same release
+  // (`2.0.0+bar` running under a `2.0.0+foo` record) is debt - the committed
+  // artifact is not the one serving. The comparator's build-metadata-blind
+  // "equal" would read it as activated, and every consumer keyed on
+  // `activated` - the debt gate, `targetObservedRunning`'s withdrawal, the
+  // stale-failed clear - would then treat an artifact that never ran as
+  // delivered. The comparator is kept for what it is for: a pair it
+  // cannot ORDER (a `local-*` record, a runtime the catalog does not name)
+  // is not this command's debt to collect and stays activated by policy.
+  if (running.version === installed.version) {
+    return { kind: "activated", installedVersion: installed.version };
+  }
   const comparison = compareHostVersions(running.version, installed.version);
-  if (!comparison.comparable || comparison.ordering === "equal") {
+  if (!comparison.comparable) {
     return { kind: "activated", installedVersion: installed.version };
   }
   return {
@@ -1305,9 +1329,9 @@ async function targetObservedRunning(
  * failed before the swap, read by a later `host update` while the registry
  * offers only 1.9.0, or an attempt at `2.0.0+foo` over a host that runs
  * `2.0.0+bar` - is a report the observed state does not contradict, and it
- * stays until a later run that does work replaces it (a retry at that
- * target over a record at or above it short-circuits and never touches
- * the marker).
+ * stays until a later run that does work replaces it (an implicit retry
+ * over a record at or above it short-circuits; an explicit retry at that
+ * target is refused before any transfer; neither touches the marker).
  */
 async function clearStaleFailedMarker(
   logger: ILogger,
@@ -1542,7 +1566,21 @@ async function prepareHostUpdate(input: {
   if (input.allowDowngrade && input.version !== null) {
     const installed = await requireInstalled(input.environment);
     const comparison = compareHostVersions(input.version, installed.version);
-    if (comparison.comparable && comparison.ordering === "less") {
+    // Below the record, or ANOTHER BUILD of the record's release (the
+    // comparator's "equal" over a different string - `2.0.0+foo` over an
+    // installed `2.0.0+bar`): the shared stage would refuse both as not
+    // newer, so both take the owned installer. The record's own string
+    // falls through to the download's up-to-date short-circuit: delivered.
+    // This read is out of lock, like the shared stage's own pre-lock
+    // reads: a record another actor moves in the gap meets the shared
+    // stage's phase-1 refusal, whose remedy names a flag this caller
+    // already passed - a retry takes the owned installer. Accepted.
+    if (
+      comparison.comparable &&
+      (comparison.ordering === "less" ||
+        (comparison.ordering === "equal" &&
+          input.version !== installed.version))
+    ) {
       // Reconciliation deliberately deletes older shared stages. The explicit
       // install keeps its verified source private until the locked swap.
       return { kind: "downgrade", version: input.version };
@@ -1580,7 +1618,7 @@ async function prepareHostUpdate(input: {
  * | ------------------------------------- | ----------------------------------------------------------------- |
  * | staged apply (`applyHost`)            | the staged record: `expectedStagedVersion` → `stage-version-mismatch` |
  * | download discarded at promote time    | nothing - refused outright (`discardedExplicitRequestError`), before the publish; unless the record IS the request (committed by another actor during the transfer), which is the request delivered and takes the recovery below |
- * | pre-lock debt (installed-up-to-date)  | the record the short-circuit saw: a record ABOVE the request keeps its debt, this run reports the no-op (never enters the arm) |
+ * | pre-lock debt (installed-up-to-date)  | the record the debt read sees: the request's own string enters the arm; any other record at or above an explicit request is refused by the download before a transfer (`E_HOST_UPDATE_NOT_NEWER`, remedy `--allow-downgrade`, which takes the downgrade arm), so a record ABOVE the request here is one that moved since - it keeps its debt, this run reports the no-op (never enters the arm) |
  * | consumed-stage recovery (apply no-op) | the re-derived record on EVERY reading that names one (`debt`, `activated`, `no-live-host`), before the log line and the arm |
  * | activation arm (every route)          | the record read UNDER the lock, before the activation reading, the busy gate and the takeover |
  * | downgrade (`installHostDowngrade`)    | its own download of `preparation.version`; a record another actor moved to that version under the lock is a no-op, re-derived here like a consumed stage |

--- a/clients/traycer-cli/src/commands/host-update.ts
+++ b/clients/traycer-cli/src/commands/host-update.ts
@@ -9,12 +9,12 @@ import {
   type HostDownloadOutcome,
 } from "../installer/download-stage";
 import {
+  claimUpdateProgressMarkerBeforeLock,
   createUpdateProgressMarkerIfAbsent,
   deleteUpdateProgressMarkerIfUnchanged,
   progressRecord,
   readUpdateProgressMarker,
   replaceUpdateProgressMarkerIfUnchanged,
-  writeUpdateProgressMarker,
   type HostUpdateProgress,
   sameProgress,
 } from "../host/update-progress-marker";
@@ -204,18 +204,20 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
     // their writer takes the contender lock, so by the time this command
     // reaches its stamp or clear another updater may have landed its own
     // `updating` at the same path, and an unconditional write would erase
-    // that updater's only progress signal. Non-null from the first write
-    // attempt on, whether or not the write landed (a failed write is warned
-    // about, not retried). The version it names is the one a `failed` stamp
-    // has to name too, which is why the re-point under the lock replaces the
-    // whole record rather than one field.
+    // that updater's only progress signal. Non-null only once a record of
+    // this run's has actually landed - published before the lock, or taken
+    // over / created under it - and null while the pre-lock claim deferred
+    // to another writer's live marker or failed to land (warned about, not
+    // retried). The version it names is the one a `failed` stamp has to
+    // name too, which is why the re-point under the lock replaces the whole
+    // record rather than one field.
     //
-    // It is a CLAIM about the disk, not a fact: every write after the
-    // pre-lock publish is conditional on it. The one place the claim is
-    // turned into a fact is `reassertMarkerUnderLock` below, which runs
-    // under the contender lock and makes the path this run's whatever it
-    // holds by then - by conditional replace or conditional create, never
-    // by a blind write.
+    // It is a CLAIM about the disk, not a fact: every write, the pre-lock
+    // publish included, is conditional on what the path held. The one place
+    // the claim is turned into a fact is `reassertMarkerUnderLock` below,
+    // which runs under the contender lock and makes the path this run's
+    // whatever it holds by then - by conditional replace or conditional
+    // create, never by a blind write.
     const ownMarker: { current: HostUpdateProgress | null } = { current: null };
     // The record `reassertMarkerUnderLock` displaced when it took the marker
     // over, kept for one purpose: an exit that follows the takeover WITHOUT
@@ -233,17 +235,51 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
     const displacedMarker: { current: HostUpdateProgress | null } = {
       current: null,
     };
+    // The version this run is working toward, as last announced to the
+    // marker (pre-lock claim, or the re-point under the lock). Kept apart
+    // from `ownMarker` because a run whose claim DEFERRED holds no record
+    // and still has a target to name if it fails after disturbing the host.
+    const intendedTarget: { current: string | null } = { current: null };
+    // The pre-lock publish. NOT a blind write: the path may hold the marker
+    // of the updater currently holding the contender lock, mid-swap, and a
+    // write over it would leave that updater's stamp and clear (CAS against
+    // its own record) unable to land while this run's later `failed` on a
+    // lost download stood over a live mutation as a terminal outcome. The
+    // claim lands only into an empty path or over a record no writer is
+    // acting on; a live writer's `updating` is left as it is and this run
+    // proceeds with no marker of its own until it takes the marker over
+    // under the lock (`reassertMarkerUnderLock`).
     const publishUpdating = async (targetVersion: string): Promise<void> => {
-      ownMarker.current = progressRecord({
+      intendedTarget.current = targetVersion;
+      // Idempotent: a second call while this run's record is on disk would
+      // read its own live `updating`, defer to itself and orphan the record.
+      if (ownMarker.current !== null) return;
+      const fresh = progressRecord({
         state: "updating",
         error: null,
         targetVersion,
       });
-      await writeUpdateProgressMarkerSafely(
-        ctx.runtime.logger,
+      const claim = await claimUpdateProgressMarkerBeforeLock(
         environment,
-        ownMarker.current,
+        fresh,
       );
+      if (claim.outcome === "published" || claim.outcome === "replaced-stale") {
+        ownMarker.current = fresh;
+        // What a stale-record replace displaced is kept for the same reason
+        // a takeover under the lock keeps it: a park or a pre-disruption
+        // failure puts it back.
+        displacedMarker.current = claim.displaced;
+        return;
+      }
+      ownMarker.current = null;
+      if (claim.outcome === "deferred") {
+        ctx.runtime.logger.info(
+          "Host update left another updater's live progress marker in place; this run publishes its own once it holds the lock",
+          { environment, targetVersion },
+        );
+      }
+      // "failed" was warned about by the marker layer; the update itself
+      // must not fail on its progress signal.
     };
     // Under the contender lock, before the disruptive half, make the marker
     // THIS run's. The marker is published BEFORE this run waits for admission
@@ -281,30 +317,16 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
     const reassertMarkerUnderLock = async (
       targetVersion: string,
     ): Promise<void> => {
-      // What the previous iteration's conditional write was compared
-      // against. `replaceUpdateProgressMarkerIfUnchanged` answers "changed"
-      // for a record that moved AND for a write that failed (the marker
-      // layer has warned about the latter); reading the same record back
-      // tells the two apart, and a failed write is not retried - the update
-      // must not fail, or spin, on its progress signal.
-      let lastExpected: HostUpdateProgress | null = null;
+      intendedTarget.current = targetVersion;
       // Bounded: each iteration either settles or observed a concurrent
       // write, and concurrent marker writers are the handful of updaters
-      // racing one lock, not an unbounded stream.
+      // racing one lock, not an unbounded stream. Only `changed` (a record
+      // that moved) is re-read; a `failed` write (I/O, warned about by the
+      // marker layer) is not retried - the update must not fail, or spin,
+      // on its progress signal.
       for (let attempt = 0; attempt < 3; attempt += 1) {
         const own = ownMarker.current;
         const onDisk = await readUpdateProgressMarker(environment);
-        if (
-          lastExpected !== null &&
-          onDisk !== null &&
-          sameProgress(onDisk, lastExpected)
-        ) {
-          ctx.runtime.logger.warn(
-            "Host update could not write the progress marker under the lock; proceeding without re-asserting it",
-            { environment, targetVersion },
-          );
-          return;
-        }
         const fresh = progressRecord({
           state: "updating",
           error: null,
@@ -334,7 +356,13 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
             }
             return;
           }
-          lastExpected = onDisk;
+          if (replaced === "failed") {
+            ctx.runtime.logger.warn(
+              "Host update could not write the progress marker under the lock; proceeding without re-asserting it",
+              { environment, targetVersion },
+            );
+            return;
+          }
           continue;
         }
         const created = await createUpdateProgressMarkerIfAbsent(
@@ -346,13 +374,14 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
           return;
         }
         if (created === "failed") {
-          // Already warned by the marker layer; the update itself must not
-          // fail on its progress signal.
+          ctx.runtime.logger.warn(
+            "Host update could not write the progress marker under the lock; proceeding without re-asserting it",
+            { environment, targetVersion },
+          );
           return;
         }
         // "exists": a marker landed between the read and the create; the
         // next iteration reads it and takes it over.
-        lastExpected = null;
       }
       ctx.runtime.logger.warn(
         "Host update could not establish ownership of the progress marker under the lock; proceeding without re-asserting it",
@@ -395,7 +424,7 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
     // the boundary through the progress stream - `commitInstallFromSource`
     // emits `service-stop` immediately before the stop and `swap` before
     // the rename - and the activation arm's hook runs immediately before
-    // its stop, with nothing that can fail in between.
+    // its stop (see `reassertMarkerThenDisrupt` for the one check between).
     let disruptionStarted = false;
     const reportProgress = (info: ProgressInfo): void => {
       if (info.stage === "service-stop" || info.stage === "swap") {
@@ -403,6 +432,11 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
       }
       ctx.progress(info);
     };
+    // The activation arm's hook runs after its busy gate and immediately
+    // before its stop; the only thing between is the mutation-capability
+    // check the stop performs, and a failure there lands a `failed` into an
+    // EMPTY path at most (a taken-over record is stamped, which is the
+    // outcome the next updater takes over anyway).
     const reassertMarkerThenDisrupt = async (
       targetVersion: string,
     ): Promise<void> => {
@@ -481,9 +515,12 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
       // target, an activation debt, an explicit downgrade - publish now,
       // before the apply half touches the install. A transfer already
       // published from `onWillDownload`, and the version it named is the one
-      // that was staged; a second write here would replace this run's own
+      // that was staged; a second claim here would replace this run's own
       // record with an identical-looking one and cost nothing but the
-      // certainty of what `ownMarker.current` refers to.
+      // certainty of what `ownMarker.current` refers to. A transfer whose
+      // claim DEFERRED (another writer's live marker stood there) has no
+      // record and claims again here - the other update may have finished
+      // during the download - under the same conditional rule.
       if (needsWork && ownMarker.current === null) {
         await publishUpdating(
           activationDebt !== null
@@ -610,7 +647,26 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
         }
         throw err;
       }
-      if (ownMarker.current !== null) {
+      if (ownMarker.current === null) {
+        // No record of this run's on disk (the pre-lock claim deferred, or
+        // no conditional write ever landed). A failure BEFORE the host was
+        // disturbed then has nothing to report on the marker - the update
+        // it deferred to is the one in progress. A failure AFTER is this
+        // run's doing and must be visible remotely: `markUpdateFailed`
+        // lands it into an EMPTY path only, never over a live record.
+        if (disruptionStarted) {
+          await markUpdateFailed(
+            ctx.runtime.logger,
+            environment,
+            // Every arm announces its target before it can disturb the host,
+            // so this is set whenever `disruptionStarted` is; the fallback
+            // is a type-level courtesy, not a reachable branch.
+            intendedTarget.current ?? "unknown",
+            err instanceof Error ? err.message : String(err),
+            null,
+          );
+        }
+      } else {
         const displaced = displacedMarker.current;
         if (displaced !== null && !disruptionStarted) {
           // Failed after taking the marker over but before touching the
@@ -694,6 +750,13 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
         // something else removed it; nothing is left to report on.
         ctx.runtime.logger.info(
           "Host update found no progress marker to clear",
+          { environment },
+        );
+      } else if (cleared === "failed") {
+        // Warned about by the marker layer; named here so the CLI's own
+        // log shows why an `updating` outlived a successful update.
+        ctx.runtime.logger.info(
+          "Host update could not clear its progress marker; it stays until the next update supersedes it",
           { environment },
         );
       }
@@ -871,6 +934,11 @@ async function clearStaleFailedMarker(
       "Host update cleared a stale failed progress marker - the running host is at the installed version",
       { environment, staleTargetVersion: marker.targetVersion },
     );
+  } else if (outcome === "failed") {
+    logger.info(
+      "Host update left the progress marker alone - the stale-failure clear could not be written",
+      { environment, outcome },
+    );
   } else {
     logger.info(
       "Host update left the progress marker alone - it changed under the stale-failure check",
@@ -1042,22 +1110,6 @@ function downloadTargetVersion(outcome: HostDownloadOutcome): string {
     : outcome.targetVersion;
 }
 
-async function writeUpdateProgressMarkerSafely(
-  logger: ILogger,
-  environment: Environment,
-  progress: Parameters<typeof writeUpdateProgressMarker>[1],
-): Promise<void> {
-  try {
-    await writeUpdateProgressMarker(environment, progress);
-  } catch (err) {
-    logger.warn("Host update failed to persist progress marker", {
-      environment,
-      state: progress.state,
-      errorMessage: err instanceof Error ? err.message : String(err),
-    });
-  }
-}
-
 // Terminates the "updating" marker with the real cause so the daemon reports
 // a failed update instead of an update that appears to still be running.
 /**
@@ -1070,13 +1122,16 @@ async function writeUpdateProgressMarkerSafely(
  * whole update and report a failure that is not about it. An absent marker
  * does not get the stamp either (see `replaceUpdateProgressMarkerIfUnchanged`
  * for why an empty live path is not proof of an idle peer); the failure is
- * still reported by exit code and log. `ours` is `null` only when this run
- * never wrote a marker, in which case there is nothing to compare against and
- * the stamp lands unconditionally - every caller today passes the marker it
- * wrote or took over under the lock, so that arm is a contract for the
- * signature rather than a live path. A stamp over a TAKEN-OVER record is
- * right: this run did the disruptive work, so its failure is the host's
- * current state, and the next updater takes the `failed` over in turn.
+ * still reported by exit code and log. `ours` is `null` when this run has no
+ * record of its own on disk - the pre-lock claim deferred to another
+ * writer's live marker, or no conditional write ever landed - and the
+ * caller asks for a stamp anyway only when it DID disturb the host: the
+ * failure is then real and must reach the remote surfaces, so it lands by
+ * create-if-absent - into an empty path only, never over a live record,
+ * which is the one blind write the conditional primitives exist to refuse.
+ * A stamp over a TAKEN-OVER record is right when it happens: this run did
+ * the disruptive work, so its failure is the host's current state, and the
+ * next updater takes the `failed` over in turn.
  */
 async function markUpdateFailed(
   logger: ILogger,
@@ -1087,7 +1142,18 @@ async function markUpdateFailed(
 ): Promise<void> {
   const failed = progressRecord({ state: "failed", error, targetVersion });
   if (ours === null) {
-    await writeUpdateProgressMarkerSafely(logger, environment, failed);
+    const created = await createUpdateProgressMarkerIfAbsent(
+      environment,
+      failed,
+    );
+    if (created !== "created") {
+      logger.info(
+        created === "exists"
+          ? "Host update did not stamp its failure - the progress marker holds another record"
+          : "Host update did not stamp its failure - the progress marker could not be written",
+        { environment, targetVersion, outcome: created },
+      );
+    }
     return;
   }
   // One atomic compare-and-swap, not a read followed by a write: the other
@@ -1100,7 +1166,9 @@ async function markUpdateFailed(
   );
   if (outcome !== "replaced") {
     logger.info(
-      "Host update did not stamp its failure - another updater owns the progress marker now",
+      outcome === "failed"
+        ? "Host update did not stamp its failure - the progress marker could not be written"
+        : "Host update did not stamp its failure - another updater owns the progress marker now",
       { environment, outcome },
     );
   }

--- a/clients/traycer-cli/src/commands/host-update.ts
+++ b/clients/traycer-cli/src/commands/host-update.ts
@@ -56,7 +56,17 @@ import { createServiceController, serviceLabelFor } from "../service";
 // Busy (D6): the stage is kept - `applyHost`'s busy check runs before it
 // touches the stage - and this command re-throws `E_HOST_BUSY` with the
 // staged version attached to `details`, rather than the generic
-// `details: null` `assertHostNotBusy` throws on its own.
+// `details: null` `assertHostNotBusy` throws on its own. A busy exit is a
+// PARK, not a failure: the run withdraws its own `updating` marker and stamps
+// no `failed` (see the catch below), because the refusal was the policy
+// working and the surfaces derive "staged, waiting" / "installed, restart to
+// finish" from the install and staged records instead.
+//
+// The `updating` marker is published from `onWillDownload` - after the
+// short-circuit decision, before the first byte - so the whole transfer is
+// visible as an update in progress and a transfer failure has a marker to
+// stamp `failed` onto. The no-transfer arms (already staged, activation debt,
+// explicit downgrade) publish it just before the apply half instead.
 //
 // SUCCESS CONTRACT: when an update is actually applied, exit 0 here means a
 // host came back healthy after the swap. Two limits are deliberate and worth
@@ -175,85 +185,26 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
     // a real dependency of the run rather than a value the compiler can drop.
     void dispatchAckAcknowledgement;
 
-    const preparation = await prepareHostUpdate({
-      environment,
-      version: args.versionRequest ?? null,
-      allowDowngrade: args.allowDowngrade,
-      onProgress: (info) => ctx.progress(info),
-    });
-    const installedUpToDate =
-      preparation.kind === "staged" &&
-      preparation.download.outcome === "short-circuit" &&
-      preparation.download.reason === "installed-up-to-date";
-    const needsApply = !installedUpToDate;
-    // "Installed" is a fact about `install.json`; "running" is a fact about
-    // the process. The two disagree whenever the bytes were swapped by a
-    // caller that could not (or did not) restart the host - Desktop's launch
-    // reconcile runs `host apply --no-service` and then activates through
-    // SMAppService, and when that cycle parks the OLD host keeps serving on
-    // top of the NEW install record indefinitely. This command then answered
-    // "installed-up-to-date" to a Settings click made precisely BECAUSE the
-    // live version was behind, exited 0 having changed nothing, and the GUI
-    // toasted "Updating…" over a host that never moved. Activation debt is
-    // therefore an update this command owes, not a no-op it may report.
-    const activationReading = installedUpToDate
-      ? await readActivationState(environment)
-      : null;
-    const activationDebt =
-      activationReading !== null && activationReading.kind === "debt"
-        ? activationReading
-        : null;
-    if (activationDebt !== null) {
-      ctx.runtime.logger.info(
-        "Host update found the install record ahead of the running host; activating",
-        {
-          environment,
-          installedVersion: activationDebt.installedVersion,
-          runningVersion: activationDebt.runningVersion,
-        },
-      );
-    }
-    const needsActivate = activationDebt !== null;
-    const needsWork = needsApply || needsActivate;
-
-    // A `failed` marker outlives the failure it reported: the post-swap
-    // health probe can time out on a host that finishes starting a moment
-    // later, and nothing on the legacy path ever revisits the file. Every
-    // @1.3 host then renders that stale failure indefinitely, and a retry
-    // cannot clear it because a retry with nothing to do returns before the
-    // marker is touched. So the no-work path reconciles it here - and ONLY
-    // when the running host has been OBSERVED at the installed version. A
-    // host that is down, or a dev build, leaves the marker alone: for those
-    // the failure may still be exactly true.
-    if (
-      !needsWork &&
-      activationReading !== null &&
-      activationReading.kind === "activated"
-    ) {
-      await clearStaleFailedMarker(ctx.runtime.logger, environment);
-    }
-
     // Remote Host Support T16: the daemon polls `update-progress.json` and
     // folds it into `host.status@1.1` / the drain gate, so an update that is
     // in flight (or that failed) is visible to a remote client that cannot
-    // watch this process. Written BEFORE the apply half touches the install
-    // and terminated on every exit path below. Marker I/O is deliberately
-    // never allowed to fail the update itself - a missing marker degrades
-    // the remote progress readout, it must not break the local update.
-    const targetVersion =
-      activationDebt !== null
-        ? activationDebt.installedVersion
-        : preparation.kind === "downgrade"
-          ? preparation.version
-          : downloadTargetVersion(preparation.download);
-    // The marker THIS invocation wrote, kept so the clear at the end can be
+    // watch this process. Written the moment the work becomes certain and
+    // terminated on every exit path below. Marker I/O is deliberately never
+    // allowed to fail the update itself - a missing marker degrades the
+    // remote progress readout, it must not break the local update.
+    //
+    // The marker THIS invocation wrote, kept so every later write is
     // conditional on it: marker writes happen before their writer takes the
-    // contender lock, so by the time this command reaches its clear another
-    // updater may have landed its own `updating` at the same path, and an
-    // unconditional delete would erase that updater's only progress signal.
-    let writtenMarker: HostUpdateProgress | null = null;
-    if (needsWork) {
-      writtenMarker = progressRecord({
+    // contender lock, so by the time this command reaches its stamp or clear
+    // another updater may have landed its own `updating` at the same path,
+    // and an unconditional write would erase that updater's only progress
+    // signal. Non-null from the first write attempt on, whether or not the
+    // write landed (a failed write is warned about, not retried). The version
+    // it names is the one a `failed` stamp has to name too, which is why the
+    // re-point under the lock replaces the whole record rather than one field.
+    const ownMarker: { current: HostUpdateProgress | null } = { current: null };
+    const publishUpdating = async (targetVersion: string): Promise<void> => {
+      ownMarker.current = progressRecord({
         state: "updating",
         error: null,
         targetVersion,
@@ -261,10 +212,13 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
       await writeUpdateProgressMarkerSafely(
         ctx.runtime.logger,
         environment,
-        writtenMarker,
+        ownMarker.current,
       );
-    }
+    };
 
+    let preparation: HostUpdatePreparation;
+    let needsApply = false;
+    let needsActivate = false;
     let legacy: LegacyHostUpdateResult;
     // What was decided BEFORE the lock is whether to enter the activation
     // path; what happened UNDER it is a separate fact, because the debt can
@@ -275,19 +229,106 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
     // stamping the no-op `failed` when that probe misses, would report a
     // failure for an update that did not happen.
     let activationPerformed = false;
-    // The version the progress marker names. Written pre-lock from the
-    // record as it stood; re-pointed when the activation path finds the
-    // record moved under the lock, so a `failed` stamp names the version
-    // that was actually being activated.
-    let markerTargetVersion = targetVersion;
+    // The preparation runs INSIDE the try whose catch owns the marker. The
+    // marker is published from within it - `onWillDownload`, before the first
+    // byte - so a transfer that rejects has a marker to stamp `failed` onto;
+    // with the download outside the try, a network failure twenty seconds in
+    // rendered as nothing at all, on every surface, while the exit code said
+    // otherwise. A failure BEFORE the hook (manifest unreachable, invalid
+    // target) never wrote a marker and stamps none: `ownMarker.current` is still
+    // `null` and the error carries the report on its own.
     try {
+      preparation = await prepareHostUpdate({
+        environment,
+        version: args.versionRequest ?? null,
+        allowDowngrade: args.allowDowngrade,
+        onProgress: (info) => ctx.progress(info),
+        onWillDownload: publishUpdating,
+      });
+      const installedUpToDate =
+        preparation.kind === "staged" &&
+        preparation.download.outcome === "short-circuit" &&
+        preparation.download.reason === "installed-up-to-date";
+      needsApply = !installedUpToDate;
+      // "Installed" is a fact about `install.json`; "running" is a fact about
+      // the process. The two disagree whenever the bytes were swapped by a
+      // caller that could not (or did not) restart the host - Desktop's launch
+      // reconcile runs `host apply --no-service` and then activates through
+      // SMAppService, and when that cycle parks the OLD host keeps serving on
+      // top of the NEW install record indefinitely. This command then answered
+      // "installed-up-to-date" to a Settings click made precisely BECAUSE the
+      // live version was behind, exited 0 having changed nothing, and the GUI
+      // toasted "Updating…" over a host that never moved. Activation debt is
+      // therefore an update this command owes, not a no-op it may report.
+      const activationReading = installedUpToDate
+        ? await readActivationState(environment)
+        : null;
+      const activationDebt =
+        activationReading !== null && activationReading.kind === "debt"
+          ? activationReading
+          : null;
+      if (activationDebt !== null) {
+        ctx.runtime.logger.info(
+          "Host update found the install record ahead of the running host; activating",
+          {
+            environment,
+            installedVersion: activationDebt.installedVersion,
+            runningVersion: activationDebt.runningVersion,
+          },
+        );
+      }
+      needsActivate = activationDebt !== null;
+      const needsWork = needsApply || needsActivate;
+
+      // A `failed` marker outlives the failure it reported: the post-swap
+      // health probe can time out on a host that finishes starting a moment
+      // later, and nothing on the legacy path ever revisits the file. Every
+      // @1.3 host then renders that stale failure indefinitely, and a retry
+      // cannot clear it because a retry with nothing to do returns before the
+      // marker is touched. So the no-work path reconciles it here - and ONLY
+      // when the running host has been OBSERVED at the installed version. A
+      // host that is down, or a dev build, leaves the marker alone: for those
+      // the failure may still be exactly true.
+      if (
+        !needsWork &&
+        activationReading !== null &&
+        activationReading.kind === "activated"
+      ) {
+        await clearStaleFailedMarker(ctx.runtime.logger, environment);
+      }
+
+      // The arms that reached here WITHOUT a transfer - an already-staged
+      // target, an activation debt, an explicit downgrade - publish now,
+      // before the apply half touches the install. A transfer already
+      // published from `onWillDownload`, and the version it named is the one
+      // that was staged; a second write here would replace this run's own
+      // record with an identical-looking one and cost nothing but the
+      // certainty of what `ownMarker.current` refers to.
+      if (needsWork && ownMarker.current === null) {
+        await publishUpdating(
+          activationDebt !== null
+            ? activationDebt.installedVersion
+            : preparation.kind === "downgrade"
+              ? preparation.version
+              : downloadTargetVersion(preparation.download),
+        );
+      }
+
       if (activationDebt !== null) {
         const activation = await activateInstalledAndProjectLegacy(
           environment,
           args.force,
           activationDebt.runningVersion,
           async (installedVersion) => {
-            if (installedVersion === markerTargetVersion) return;
+            // Re-point the marker when the activation path finds the record
+            // moved under the lock, so a `failed` stamp names the version
+            // that was actually being activated.
+            if (
+              ownMarker.current !== null &&
+              installedVersion === ownMarker.current.targetVersion
+            ) {
+              return;
+            }
             const repointed = progressRecord({
               state: "updating",
               error: null,
@@ -298,14 +339,13 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
             // an unconditional re-point would replace it with a record THIS
             // run then clears at the end - leaving that updater's whole
             // apply/restart without its progress signal. The re-point lands
-            // only over this run's own marker, and `writtenMarker` follows
+            // only over this run's own marker, and `ownMarker.current` follows
             // what is actually on disk: if the swap reports the marker is no
             // longer ours, it stays pointed at the old record, so the later
             // stamp and clear (both conditional on it) leave the newer
             // updater's marker alone.
-            if (writtenMarker === null) {
-              writtenMarker = repointed;
-              markerTargetVersion = installedVersion;
+            if (ownMarker.current === null) {
+              ownMarker.current = repointed;
               await writeUpdateProgressMarkerSafely(
                 ctx.runtime.logger,
                 environment,
@@ -315,12 +355,11 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
             }
             const outcome = await replaceUpdateProgressMarkerIfUnchanged(
               environment,
-              writtenMarker,
+              ownMarker.current,
               repointed,
             );
             if (outcome === "replaced") {
-              writtenMarker = repointed;
-              markerTargetVersion = installedVersion;
+              ownMarker.current = repointed;
             } else {
               ctx.runtime.logger.info(
                 "Host update did not re-point the progress marker - another updater owns it now",
@@ -350,13 +389,37 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
               );
       }
     } catch (err) {
-      if (needsWork) {
+      if (err instanceof CliError && err.code === CLI_ERROR_CODES.HOST_BUSY) {
+        // A PARK, not a failure. The host has work in progress and this run
+        // declined to interrupt it - a policy decision that every busy gate
+        // on this path makes BEFORE it touches the install (`applyHost`,
+        // `installHostDowngrade`, the activation arm's `assertHostNotBusy`),
+        // so nothing has changed except that a stage may now be waiting. A
+        // `failed` stamp here rendered "Update failed: work in progress" in
+        // red on every surface for a host that was doing exactly what it was
+        // asked to; the GUI derives the truth - installed-but-not-running, or
+        // staged-and-waiting - from the records, and the marker's job is only
+        // to get out of the way. Withdrawn CONDITIONALLY, like the clear
+        // below: a newer updater's marker is not this run's to remove.
+        if (ownMarker.current !== null) {
+          const withdrawn = await deleteUpdateProgressMarkerIfUnchanged(
+            environment,
+            ownMarker.current,
+          );
+          ctx.runtime.logger.info(
+            "Host update parked - the host has work in progress; the progress marker was withdrawn",
+            { environment, withdrawn },
+          );
+        }
+        throw err;
+      }
+      if (ownMarker.current !== null) {
         await markUpdateFailed(
           ctx.runtime.logger,
           environment,
-          markerTargetVersion,
+          ownMarker.current.targetVersion,
           err instanceof Error ? err.message : String(err),
-          writtenMarker,
+          ownMarker.current,
         );
       }
       throw err;
@@ -385,7 +448,7 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
           environment,
           legacy.version,
           probe.detail,
-          writtenMarker,
+          ownMarker.current,
         );
         throw cliError({
           code: CLI_ERROR_CODES.HOST_UPDATE_HEALTH_CHECK_FAILED,
@@ -395,7 +458,7 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
         });
       }
     }
-    if (writtenMarker !== null) {
+    if (ownMarker.current !== null) {
       // Written above whenever work was OWED, so it is cleared whenever it
       // was - including the activation debt that another actor paid while
       // this command waited, which leaves nothing to probe but a marker
@@ -405,7 +468,7 @@ export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
       // above belongs to someone whose update is still to come.
       const cleared = await deleteUpdateProgressMarkerIfUnchanged(
         environment,
-        writtenMarker,
+        ownMarker.current,
       );
       if (cleared === "changed") {
         ctx.runtime.logger.info(
@@ -723,6 +786,8 @@ async function prepareHostUpdate(input: {
   readonly version: string | null;
   readonly allowDowngrade: boolean;
   readonly onProgress: (info: ProgressInfo) => void;
+  /** See `DownloadAndStageHostOptions.onWillDownload`; the downgrade arm never fires it. */
+  readonly onWillDownload: (targetVersion: string) => Promise<void>;
 }): Promise<HostUpdatePreparation> {
   if (input.allowDowngrade && input.version !== null) {
     const installed = await requireInstalled(input.environment);
@@ -741,6 +806,7 @@ async function prepareHostUpdate(input: {
       automatic: false,
       onProgress: input.onProgress,
       registryClient: null,
+      onWillDownload: input.onWillDownload,
     }),
   };
 }
@@ -783,7 +849,8 @@ async function writeUpdateProgressMarkerSafely(
  * for why an empty live path is not proof of an idle peer); the failure is
  * still reported by exit code and log. `ours` is `null` only when this run
  * never wrote a marker, in which case there is nothing to compare against and
- * the stamp lands unconditionally.
+ * the stamp lands unconditionally - every caller today passes the marker it
+ * wrote, so that arm is a contract for the signature rather than a live path.
  */
 async function markUpdateFailed(
   logger: ILogger,
@@ -853,7 +920,14 @@ async function applyAndProjectLegacy(
         const staged = await readHostStagedRecord(environment);
         throw cliError({
           code: CLI_ERROR_CODES.HOST_BUSY,
-          message: err.message,
+          // The park, in words: the bytes are kept, and the two ways forward
+          // are named. This message is what a person reads at the terminal
+          // and in the host's log after a Settings click; the GUI derives the
+          // same fact from the staged record rather than from this text.
+          message:
+            staged === null
+              ? err.message
+              : `${err.message} Host ${staged.version} stays staged; it installs on the next update once the host is idle, or now with --force.`,
           details: { stagedVersion: staged?.version ?? null },
           exitCode: err.exitCode,
         });

--- a/clients/traycer-cli/src/host/__tests__/update-mutation.test.ts
+++ b/clients/traycer-cli/src/host/__tests__/update-mutation.test.ts
@@ -435,6 +435,7 @@ describe("CLI capability-consuming mutation facades", () => {
             staged: stagedSource,
             onProgress: () => undefined,
             lifecycle: null,
+            onWillSwap: null,
           }),
         ).rejects.toMatchObject({ code: "E_CLI_LOCK_BUSY" });
         return "must-not-report-ran";

--- a/clients/traycer-cli/src/host/__tests__/update-mutation.test.ts
+++ b/clients/traycer-cli/src/host/__tests__/update-mutation.test.ts
@@ -32,9 +32,10 @@ vi.mock("../host-start-adoption", () => ({
 import {
   installHostServiceWithAttempt,
   commitHostInstallSourceWithAttempt,
+  stopHostForRestartWithAttempt,
 } from "../update-mutation";
 import { withCliUpdateExecutionSegment } from "../update-contender";
-import type { InstallServiceOptions } from "../../service";
+import type { InstallServiceOptions, RestartStop } from "../../service";
 import type {
   CommitHostInstallSourceOptions,
   StagedHostInstallSource,
@@ -489,5 +490,78 @@ describe("CLI capability-consuming mutation facades", () => {
         phase: "applying",
       },
     });
+  });
+
+  // The stop facade's disruption boundary. `host update` keys "have I begun
+  // to disturb the host?" on `onAuthorityVerified`, so where the facade fires
+  // it is load-bearing: BEFORE the capability check and a refused stop would
+  // be stamped as a failed update over a live writer's marker; AFTER the
+  // actuator and a stop that threw mid-flight would be read as untouched.
+  // Every `host update` pin mocks this facade at the module boundary, so
+  // these two are the only pins that see its body.
+  it("the stop facade does not report the disruption boundary when its capability check refuses", async () => {
+    const hostHomeDir = await freshHome();
+    homeRef.current = hostHomeDir;
+    const stopForRestart = vi
+      .fn<() => Promise<RestartStop>>()
+      .mockResolvedValue({ forcedRecycle: false });
+    const onAuthorityVerified = vi.fn<() => void>();
+    const forged = { hostHomeDir } as UpdateMutationCapability;
+
+    await expect(
+      stopHostForRestartWithAttempt(
+        forged,
+        contenderOptions,
+        { stopForRestart },
+        serviceOptions.label,
+        { force: false },
+        onAuthorityVerified,
+      ),
+    ).rejects.toMatchObject({ code: "E_CLI_LOCK_BUSY" });
+    expect(onAuthorityVerified).not.toHaveBeenCalled();
+    expect(stopForRestart).not.toHaveBeenCalled();
+  });
+
+  it("the stop facade reports the disruption boundary once, after the capability check and before the actuator, even when the actuator then throws", async () => {
+    const hostHomeDir = await freshHome();
+    homeRef.current = hostHomeDir;
+    const order: string[] = [];
+    const stopForRestart = vi
+      .fn<() => Promise<RestartStop>>()
+      .mockImplementation(async () => {
+        order.push("actuator");
+        throw new Error("stop failed");
+      });
+    const onAuthorityVerified = vi.fn<() => void>(() => {
+      order.push("boundary");
+    });
+
+    const outcome = await withUpdateContender(
+      {
+        hostHomeDir,
+        reason: contenderOptions.reason,
+        waitMs: 0,
+        pollIntervalMs: 10,
+        admission: contenderOptions.admission,
+      },
+      async (capability) => {
+        await expect(
+          stopHostForRestartWithAttempt(
+            capability,
+            contenderOptions,
+            { stopForRestart },
+            serviceOptions.label,
+            { force: false },
+            onAuthorityVerified,
+          ),
+        ).rejects.toThrow("stop failed");
+        return "ran";
+      },
+    );
+
+    expect(outcome).toEqual({ kind: "ran", result: "ran" });
+    expect(order).toEqual(["boundary", "actuator"]);
+    expect(onAuthorityVerified).toHaveBeenCalledTimes(1);
+    expect(stopForRestart).toHaveBeenCalledTimes(1);
   });
 });

--- a/clients/traycer-cli/src/host/__tests__/update-progress-marker.test.ts
+++ b/clients/traycer-cli/src/host/__tests__/update-progress-marker.test.ts
@@ -572,6 +572,49 @@ describe("update-progress-marker", () => {
   // the same path before the stamp writes. Replacing unconditionally there
   // would bury that updater's live progress under a failure that is not
   // about it.
+  describe("createUpdateProgressMarkerIfAbsent when the landing cannot happen", () => {
+    it("answers `failed` (never `created`) when neither landing route finds the file or its directory, and leaves no staging file", async () => {
+      // `link` answers ENOENT and the `wx` fallback's read of the staged
+      // file answers ENOENT too - the staged file vanished between staging
+      // and landing. `landMarkerAtomically` reports that as its own value
+      // so callers do not name a retained scratch; the create must still
+      // read it as a FAILURE. Falsification: handle only `"failed"` at the
+      // create's landing check (the round-10 shape) and this returns
+      // `created` over an EMPTY live path - `host update` then records
+      // ownership of a marker that does not exist.
+      vi.doMock("node:fs/promises", async (importOriginal) => {
+        const actual =
+          await importOriginal<typeof import("node:fs/promises")>();
+        const enoent = (): never => {
+          throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+        };
+        return {
+          ...actual,
+          link: async () => enoent(),
+          readFile: async () => enoent(),
+        };
+      });
+      try {
+        const { createUpdateProgressMarkerIfAbsent, readUpdateProgressMarker } =
+          await import("../update-progress-marker");
+        const next = {
+          state: "updating" as const,
+          error: null,
+          targetVersion: "1.4.0",
+          updatedAt: "2026-07-03T00:00:00.000Z",
+          writerId: "writer-a",
+        };
+        expect(
+          await createUpdateProgressMarkerIfAbsent("production", next),
+        ).toBe("failed");
+        expect(await readUpdateProgressMarker("production")).toBeNull();
+        expect(scratchAndStagingFiles()).toEqual([]);
+      } finally {
+        vi.doUnmock("node:fs/promises");
+      }
+    });
+  });
+
   describe("replaceUpdateProgressMarkerIfUnchanged", () => {
     const expectedUpdating = {
       state: "updating" as const,

--- a/clients/traycer-cli/src/host/__tests__/update-progress-marker.test.ts
+++ b/clients/traycer-cli/src/host/__tests__/update-progress-marker.test.ts
@@ -1,3 +1,4 @@
+import { spawn } from "node:child_process";
 import {
   mkdirSync,
   mkdtempSync,
@@ -9,6 +10,29 @@ import {
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// A genuinely dead pid, established the same way
+// `store/__tests__/cli-lock.test.ts` does for its cross-process tests: spawn
+// a short-lived real process, wait for it to exit, then use that now-dead
+// pid - never a magic number that might collide with an unrelated live
+// process on the test machine.
+async function deadPid(): Promise<number> {
+  const shortLived = spawn("sleep", ["0.1"]);
+  const pid = await new Promise<number>((resolve, reject) => {
+    shortLived.once("spawn", () => {
+      if (shortLived.pid === undefined) {
+        reject(new Error("spawned short-lived process has no pid"));
+        return;
+      }
+      resolve(shortLived.pid);
+    });
+    shortLived.once("error", reject);
+  });
+  await new Promise<void>((resolve) =>
+    shortLived.once("exit", () => resolve()),
+  );
+  return pid;
+}
 
 // The update-progress marker is the cross-process handoff the host daemon
 // polls after spawning `traycer host update` detached (it does not wait
@@ -672,6 +696,384 @@ describe("update-progress-marker", () => {
         expect(await readUpdateProgressMarker("production")).toEqual(
           failedNext,
         );
+      } finally {
+        vi.doUnmock("node:fs/promises");
+      }
+    });
+
+    // The new record is staged (`ensureHostHomeDir` + `stageMarkerFile`)
+    // BEFORE the live record is ever taken into the scratch, precisely so
+    // nothing after the take can throw. A throw at the STAGING write itself
+    // - before the take - must therefore leave the live path completely
+    // untouched: still `expected`, byte-identical, with no `.reconcile-*`
+    // or `.tmp-*` leftover from a take that never happened.
+    //
+    // Falsification: move the staging call back below the take (the shape
+    // this replaced) and the live path reads null instead of `expected` -
+    // the take would have already moved the record into the scratch before
+    // the staging write throws, so the "failed, nothing changed" promise
+    // breaks.
+    it('reports "failed" and leaves the live path untouched when the STAGING write throws, before the live record is ever taken', async () => {
+      let plainWriteCalls = 0;
+      vi.doMock("node:fs/promises", async (importOriginal) => {
+        const actual =
+          await importOriginal<typeof import("node:fs/promises")>();
+        return {
+          ...actual,
+          writeFile: async (
+            path: Parameters<typeof actual.writeFile>[0],
+            data: Parameters<typeof actual.writeFile>[1],
+            options: Parameters<typeof actual.writeFile>[2],
+          ) => {
+            const isWx =
+              typeof options === "object" &&
+              options !== null &&
+              "flag" in options &&
+              options.flag === "wx";
+            if (!isWx) {
+              plainWriteCalls += 1;
+              // The first plain write is this test's own setup
+              // (`writeUpdateProgressMarker`, seeding `expected`) - it must
+              // land. The second is `stageMarkerFile`'s write for `next`,
+              // inside the call under test - that one throws.
+              if (plainWriteCalls === 2) {
+                throw Object.assign(new Error("ENOSPC"), {
+                  code: "ENOSPC",
+                });
+              }
+            }
+            return actual.writeFile(path, data, options);
+          },
+        };
+      });
+      try {
+        const {
+          writeUpdateProgressMarker,
+          readUpdateProgressMarker,
+          replaceUpdateProgressMarkerIfUnchanged,
+        } = await import("../update-progress-marker");
+        await writeUpdateProgressMarker("production", expectedUpdating);
+        expect(
+          await replaceUpdateProgressMarkerIfUnchanged(
+            "production",
+            expectedUpdating,
+            failedNext,
+          ),
+        ).toBe("failed");
+        expect(await readUpdateProgressMarker("production")).toEqual(
+          expectedUpdating,
+        );
+        expect(scratchAndStagingFiles()).toEqual([]);
+      } finally {
+        vi.doUnmock("node:fs/promises");
+      }
+    });
+  });
+
+  // The pre-lock publish: claim the live path for `next` without overwriting
+  // a marker whose writer may still be acting on it. Backs `host update`'s
+  // `publishUpdating` (see the production comment on
+  // `claimUpdateProgressMarkerBeforeLock`). Returns
+  // `{outcome, displaced}` - `displaced` carries the record a
+  // "replaced-stale" claim replaced (so the caller can put it back on a
+  // park), and is `null` for every other outcome.
+  describe("claimUpdateProgressMarkerBeforeLock", () => {
+    const next = {
+      state: "updating" as const,
+      error: null,
+      targetVersion: "1.8.0",
+      updatedAt: "2026-07-03T00:03:00.000Z",
+      writerId: "writer-next",
+    };
+
+    it("publishes into an empty path", async () => {
+      const { claimUpdateProgressMarkerBeforeLock, readUpdateProgressMarker } =
+        await import("../update-progress-marker");
+      expect(
+        await claimUpdateProgressMarkerBeforeLock("production", next),
+      ).toEqual({ outcome: "published", displaced: null });
+      expect(await readUpdateProgressMarker("production")).toEqual(next);
+    });
+
+    it("replaces a `failed` record regardless of its writerId - no writer is acting on a stamped failure - and returns it as `displaced`", async () => {
+      const {
+        writeUpdateProgressMarker,
+        claimUpdateProgressMarkerBeforeLock,
+        readUpdateProgressMarker,
+      } = await import("../update-progress-marker");
+      await writeUpdateProgressMarker("production", failed);
+      expect(
+        await claimUpdateProgressMarkerBeforeLock("production", next),
+      ).toEqual({ outcome: "replaced-stale", displaced: failed });
+      expect(await readUpdateProgressMarker("production")).toEqual(next);
+    });
+
+    // `deadPid()` spawns a real `sleep` process to get a genuinely dead pid -
+    // not available on win32 (no `sleep`), the same reason
+    // `store/__tests__/cli-lock.test.ts` skips its own real-process tests
+    // there.
+    it.skipIf(process.platform === "win32")(
+      "replaces an `updating` record whose writer process is dead, and returns it as `displaced`",
+      async () => {
+        const {
+          writeUpdateProgressMarker,
+          claimUpdateProgressMarkerBeforeLock,
+          readUpdateProgressMarker,
+        } = await import("../update-progress-marker");
+        const pid = await deadPid();
+        const deadWriterRecord = {
+          state: "updating" as const,
+          error: null,
+          targetVersion: "1.4.0",
+          updatedAt: "2026-07-03T00:00:00.000Z",
+          writerId: `${pid}-abcdef`,
+        };
+        await writeUpdateProgressMarker("production", deadWriterRecord);
+        expect(
+          await claimUpdateProgressMarkerBeforeLock("production", next),
+        ).toEqual({ outcome: "replaced-stale", displaced: deadWriterRecord });
+        expect(await readUpdateProgressMarker("production")).toEqual(next);
+      },
+    );
+
+    it("defers to an `updating` record whose writer process is this very (live) process, leaving the file untouched", async () => {
+      const {
+        writeUpdateProgressMarker,
+        claimUpdateProgressMarkerBeforeLock,
+        readUpdateProgressMarker,
+      } = await import("../update-progress-marker");
+      const theirs = {
+        state: "updating" as const,
+        error: null,
+        targetVersion: "1.4.0",
+        updatedAt: "2026-07-03T00:00:00.000Z",
+        writerId: `${process.pid}-abcdef`,
+      };
+      await writeUpdateProgressMarker("production", theirs);
+      expect(
+        await claimUpdateProgressMarkerBeforeLock("production", next),
+      ).toEqual({ outcome: "deferred", displaced: null });
+      expect(await readUpdateProgressMarker("production")).toEqual(theirs);
+      expect(scratchAndStagingFiles()).toEqual([]);
+    });
+
+    it("defers (fail-open) when the on-disk `updating` record has writerId null - an older CLI's marker, unprovable as abandoned", async () => {
+      const { claimUpdateProgressMarkerBeforeLock, readUpdateProgressMarker } =
+        await import("../update-progress-marker");
+      const { hostUpdateProgressMarkerPath } =
+        await import("../../store/paths");
+      const path = hostUpdateProgressMarkerPath("production");
+      mkdirSync(dirname(path), { recursive: true });
+      const legacyRecord = {
+        state: "updating" as const,
+        error: null,
+        targetVersion: "1.4.0",
+        updatedAt: "2026-07-03T00:00:00.000Z",
+      };
+      writeFileSync(path, `${JSON.stringify(legacyRecord, null, 2)}\n`, "utf8");
+      expect(
+        await claimUpdateProgressMarkerBeforeLock("production", next),
+      ).toEqual({ outcome: "deferred", displaced: null });
+      expect(await readUpdateProgressMarker("production")).toEqual({
+        ...legacyRecord,
+        writerId: null,
+      });
+    });
+
+    it("defers (fail-open) when the on-disk `updating` record's writerId is unparseable", async () => {
+      const {
+        writeUpdateProgressMarker,
+        claimUpdateProgressMarkerBeforeLock,
+        readUpdateProgressMarker,
+      } = await import("../update-progress-marker");
+      const theirs = {
+        state: "updating" as const,
+        error: null,
+        targetVersion: "1.4.0",
+        updatedAt: "2026-07-03T00:00:00.000Z",
+        writerId: "not-a-pid",
+      };
+      await writeUpdateProgressMarker("production", theirs);
+      expect(
+        await claimUpdateProgressMarkerBeforeLock("production", next),
+      ).toEqual({ outcome: "deferred", displaced: null });
+      expect(await readUpdateProgressMarker("production")).toEqual(theirs);
+      expect(scratchAndStagingFiles()).toEqual([]);
+    });
+
+    // I/O-failure trio: the same non-EEXIST landing failure
+    // (`link` throws EPERM, the `wx` create fallback throws ENOSPC) drives
+    // `createUpdateProgressMarkerIfAbsent`, `replaceUpdateProgressMarkerIfUnchanged`,
+    // and `claimUpdateProgressMarkerBeforeLock` all to their `"failed"`
+    // outcome - never silently collapsed into `"exists"` / `"changed"` /
+    // `"deferred"`, which callers retry or defer to differently. Reuses the
+    // exact double-mock shape `deleteUpdateProgressMarkerIfUnchanged`'s
+    // "retains the displaced marker in its scratch" test above provokes the
+    // same failure with.
+    function mockUnlandableWrites(): void {
+      vi.doMock("node:fs/promises", async (importOriginal) => {
+        const actual =
+          await importOriginal<typeof import("node:fs/promises")>();
+        return {
+          ...actual,
+          link: async () => {
+            throw Object.assign(new Error("EPERM"), { code: "EPERM" });
+          },
+          writeFile: async (
+            path: Parameters<typeof actual.writeFile>[0],
+            data: Parameters<typeof actual.writeFile>[1],
+            options: Parameters<typeof actual.writeFile>[2],
+          ) => {
+            if (
+              typeof options === "object" &&
+              options !== null &&
+              "flag" in options &&
+              options.flag === "wx"
+            ) {
+              throw Object.assign(new Error("ENOSPC"), { code: "ENOSPC" });
+            }
+            return actual.writeFile(path, data, options);
+          },
+        };
+      });
+    }
+
+    // Same failure, but only for the STAMP landing: the `wx` fallback throws
+    // ENOSPC on its first call, then succeeds - so the swap's restore of the
+    // record it still holds in scratch (the "expected record is still held
+    // in the scratch while `next` lands" branch in the production comment)
+    // actually lands.
+    function mockStampFailsRestoreSucceeds(): void {
+      let wxWriteCalls = 0;
+      vi.doMock("node:fs/promises", async (importOriginal) => {
+        const actual =
+          await importOriginal<typeof import("node:fs/promises")>();
+        return {
+          ...actual,
+          link: async () => {
+            throw Object.assign(new Error("EPERM"), { code: "EPERM" });
+          },
+          writeFile: async (
+            path: Parameters<typeof actual.writeFile>[0],
+            data: Parameters<typeof actual.writeFile>[1],
+            options: Parameters<typeof actual.writeFile>[2],
+          ) => {
+            if (
+              typeof options === "object" &&
+              options !== null &&
+              "flag" in options &&
+              options.flag === "wx"
+            ) {
+              wxWriteCalls += 1;
+              if (wxWriteCalls === 1) {
+                throw Object.assign(new Error("ENOSPC"), {
+                  code: "ENOSPC",
+                });
+              }
+            }
+            return actual.writeFile(path, data, options);
+          },
+        };
+      });
+    }
+
+    it('createUpdateProgressMarkerIfAbsent reports "failed" (not "exists") when neither the link nor the wx-create route can land it', async () => {
+      mockUnlandableWrites();
+      try {
+        const { createUpdateProgressMarkerIfAbsent, readUpdateProgressMarker } =
+          await import("../update-progress-marker");
+        expect(
+          await createUpdateProgressMarkerIfAbsent("production", next),
+        ).toBe("failed");
+        // The path is left exactly as it was found - empty, not `next`.
+        expect(await readUpdateProgressMarker("production")).toBeNull();
+      } finally {
+        vi.doUnmock("node:fs/promises");
+      }
+    });
+
+    it('replaceUpdateProgressMarkerIfUnchanged reports "failed" and RESTORES the expected record when the stamp landing fails but the restore lands', async () => {
+      mockStampFailsRestoreSucceeds();
+      try {
+        const {
+          writeUpdateProgressMarker,
+          replaceUpdateProgressMarkerIfUnchanged,
+          readUpdateProgressMarker,
+        } = await import("../update-progress-marker");
+        const expected = {
+          state: "updating" as const,
+          error: null,
+          targetVersion: "1.4.0",
+          updatedAt: "2026-07-03T00:00:00.000Z",
+          writerId: "writer-a",
+        };
+        await writeUpdateProgressMarker("production", expected);
+        expect(
+          await replaceUpdateProgressMarkerIfUnchanged(
+            "production",
+            expected,
+            next,
+          ),
+        ).toBe("failed");
+        // `failed` now means "nothing on the live path changed": the swap
+        // kept `expected` in scratch while `next` tried to land, and puts it
+        // back byte-for-byte once the stamp can't land but the restore can -
+        // neither the old record nor `next` is lost.
+        expect(await readUpdateProgressMarker("production")).toEqual(expected);
+      } finally {
+        vi.doUnmock("node:fs/promises");
+      }
+    });
+
+    it('replaceUpdateProgressMarkerIfUnchanged reports "failed" with an EMPTY live path when neither the stamp nor the restore can land', async () => {
+      mockUnlandableWrites();
+      try {
+        const {
+          writeUpdateProgressMarker,
+          replaceUpdateProgressMarkerIfUnchanged,
+          readUpdateProgressMarker,
+        } = await import("../update-progress-marker");
+        const expected = {
+          state: "updating" as const,
+          error: null,
+          targetVersion: "1.4.0",
+          updatedAt: "2026-07-03T00:00:00.000Z",
+          writerId: "writer-a",
+        };
+        await writeUpdateProgressMarker("production", expected);
+        expect(
+          await replaceUpdateProgressMarkerIfUnchanged(
+            "production",
+            expected,
+            next,
+          ),
+        ).toBe("failed");
+        // The one case `failed` cannot promise "nothing changed": the
+        // restore attempt (putting `expected` back from scratch) fails the
+        // same way the stamp did, so the live path is left empty and the
+        // marker layer warns about it by name.
+        expect(await readUpdateProgressMarker("production")).toBeNull();
+      } finally {
+        vi.doUnmock("node:fs/promises");
+      }
+    });
+
+    it('returns {outcome: "failed", displaced: null} when its internal replace cannot land the claim', async () => {
+      mockUnlandableWrites();
+      try {
+        const {
+          writeUpdateProgressMarker,
+          claimUpdateProgressMarkerBeforeLock,
+          readUpdateProgressMarker,
+        } = await import("../update-progress-marker");
+        // A `failed` record replaces unconditionally regardless of writerId,
+        // so this drives the claim straight into the replace call that then
+        // fails to land.
+        await writeUpdateProgressMarker("production", failed);
+        expect(
+          await claimUpdateProgressMarkerBeforeLock("production", next),
+        ).toEqual({ outcome: "failed", displaced: null });
+        expect(await readUpdateProgressMarker("production")).toBeNull();
       } finally {
         vi.doUnmock("node:fs/promises");
       }

--- a/clients/traycer-cli/src/host/__tests__/update-progress-marker.test.ts
+++ b/clients/traycer-cli/src/host/__tests__/update-progress-marker.test.ts
@@ -408,6 +408,80 @@ describe("update-progress-marker", () => {
     });
   });
 
+  // `host update`'s republish-under-the-lock (the empty-path arm of
+  // `reassertMarkerUnderLock`): land `next` only into a still-empty live
+  // path, refusing rather than overwriting a marker another updater landed
+  // first. Unlike a read-then-rename, the refusal leaves the existing
+  // marker's bytes completely untouched.
+  describe("createUpdateProgressMarkerIfAbsent", () => {
+    it("creates the marker when none exists, and the file decodes to `next`", async () => {
+      const { createUpdateProgressMarkerIfAbsent, readUpdateProgressMarker } =
+        await import("../update-progress-marker");
+      const next = {
+        state: "updating" as const,
+        error: null,
+        targetVersion: "1.6.0",
+        updatedAt: "2026-07-03T00:00:00.000Z",
+        writerId: "writer-a",
+      };
+      expect(await createUpdateProgressMarkerIfAbsent("production", next)).toBe(
+        "created",
+      );
+      expect(await readUpdateProgressMarker("production")).toEqual(next);
+      expect(scratchAndStagingFiles()).toEqual([]);
+    });
+
+    it("reports `exists` when a marker already stands, leaving its bytes byte-identical - the read-then-rename could not guarantee this", async () => {
+      const { writeUpdateProgressMarker, createUpdateProgressMarkerIfAbsent } =
+        await import("../update-progress-marker");
+      const { hostUpdateProgressMarkerPath } =
+        await import("../../store/paths");
+      await writeUpdateProgressMarker("production", failed);
+      const path = hostUpdateProgressMarkerPath("production");
+      const before = readFileSync(path, "utf8");
+      const next = {
+        state: "updating" as const,
+        error: null,
+        targetVersion: "1.7.0",
+        updatedAt: "2026-07-03T00:02:00.000Z",
+        writerId: "writer-b",
+      };
+      expect(await createUpdateProgressMarkerIfAbsent("production", next)).toBe(
+        "exists",
+      );
+      // Byte-identical, not merely equivalent JSON - the old read-then-rename
+      // could still land its own write over what it read.
+      expect(readFileSync(path, "utf8")).toBe(before);
+      expect(scratchAndStagingFiles()).toEqual([]);
+    });
+
+    it("leaves no stray `.tmp-*` staging file behind after either outcome", async () => {
+      const { createUpdateProgressMarkerIfAbsent } =
+        await import("../update-progress-marker");
+      const created = {
+        state: "updating" as const,
+        error: null,
+        targetVersion: "1.6.0",
+        updatedAt: "2026-07-03T00:00:00.000Z",
+        writerId: "writer-a",
+      };
+      // Absent path: the create outcome.
+      expect(
+        await createUpdateProgressMarkerIfAbsent("production", created),
+      ).toBe("created");
+      expect(scratchAndStagingFiles()).toEqual([]);
+
+      // Present path: the refuse outcome, against the marker just created.
+      expect(
+        await createUpdateProgressMarkerIfAbsent("production", {
+          ...created,
+          targetVersion: "1.7.0",
+        }),
+      ).toBe("exists");
+      expect(scratchAndStagingFiles()).toEqual([]);
+    });
+  });
+
   // The conditional replace backs `host update`'s failure stamp: it computes
   // `next` from a record it already holds (the `updating` marker THIS
   // invocation wrote), and another updater can land its own `updating` at

--- a/clients/traycer-cli/src/host/__tests__/update-progress-marker.test.ts
+++ b/clients/traycer-cli/src/host/__tests__/update-progress-marker.test.ts
@@ -78,6 +78,7 @@ describe("update-progress-marker", () => {
       targetVersion: "1.4.0",
       updatedAt: "2026-07-03T00:00:00.000Z",
       writerId: "writer-a",
+      writerStartIdentity: null,
     });
     const raw = readFileSync(
       hostUpdateProgressMarkerPath("production"),
@@ -89,6 +90,7 @@ describe("update-progress-marker", () => {
       targetVersion: "1.4.0",
       updatedAt: "2026-07-03T00:00:00.000Z",
       writerId: "writer-a",
+      writerStartIdentity: null,
     });
   });
 
@@ -101,6 +103,7 @@ describe("update-progress-marker", () => {
       targetVersion: "1.4.0",
       updatedAt: "2026-07-03T00:00:00.000Z",
       writerId: "writer-a",
+      writerStartIdentity: null,
     });
     await writeUpdateProgressMarker("production", {
       state: "failed",
@@ -108,6 +111,7 @@ describe("update-progress-marker", () => {
       targetVersion: "1.4.0",
       updatedAt: "2026-07-03T00:01:00.000Z",
       writerId: "writer-a",
+      writerStartIdentity: null,
     });
     const progress = await readUpdateProgressMarker("production");
     expect(progress).toEqual({
@@ -116,6 +120,7 @@ describe("update-progress-marker", () => {
       targetVersion: "1.4.0",
       updatedAt: "2026-07-03T00:01:00.000Z",
       writerId: "writer-a",
+      writerStartIdentity: null,
     });
   });
 
@@ -131,6 +136,7 @@ describe("update-progress-marker", () => {
       targetVersion: "1.4.0",
       updatedAt: "2026-07-03T00:00:00.000Z",
       writerId: "writer-a",
+      writerStartIdentity: null,
     });
     await deleteUpdateProgressMarker("production");
     expect(await readUpdateProgressMarker("production")).toBeNull();
@@ -145,6 +151,7 @@ describe("update-progress-marker", () => {
       targetVersion: "1.0.0",
       updatedAt: "2026-07-03T00:00:00.000Z",
       writerId: "writer-a",
+      writerStartIdentity: null,
     });
     await writeUpdateProgressMarker("dev", {
       state: "failed",
@@ -152,6 +159,7 @@ describe("update-progress-marker", () => {
       targetVersion: "2.0.0",
       updatedAt: "2026-07-03T00:00:00.000Z",
       writerId: "writer-b",
+      writerStartIdentity: null,
     });
     expect((await readUpdateProgressMarker("production"))?.state).toBe(
       "updating",
@@ -181,6 +189,7 @@ describe("update-progress-marker", () => {
     expect(await readUpdateProgressMarker("production")).toEqual({
       ...legacyRecord,
       writerId: null,
+      writerStartIdentity: null,
     });
   });
 
@@ -200,6 +209,19 @@ describe("update-progress-marker", () => {
     expect(a.writerId).toMatch(/^\d+-[0-9a-f]{12}$/);
     expect(b.writerId).toBe(a.writerId);
     expect(sameProgress(a, { ...a, writerId: "someone-else" })).toBe(false);
+    // The creation stamp is this process's own, as the shared reader
+    // reports it (every CI platform produces one - the shared suite pins
+    // that), and the comparator holds it like every other field.
+    const { readProcessStartIdentity } =
+      await import("../../store/process-identity");
+    const own = readProcessStartIdentity(process.pid);
+    expect(own).not.toBeNull();
+    expect(a.writerStartIdentity).toBe(own);
+    expect(b.writerStartIdentity).toBe(own);
+    expect(
+      sameProgress(a, { ...a, writerStartIdentity: `${own} recycled` }),
+    ).toBe(false);
+    expect(sameProgress(a, { ...a, writerStartIdentity: null })).toBe(false);
   });
 
   // Shared by the delete and replace conditional-swap suites: both back
@@ -212,6 +234,7 @@ describe("update-progress-marker", () => {
     targetVersion: "1.4.0",
     updatedAt: "2026-07-03T00:00:00.000Z",
     writerId: "writer-a",
+    writerStartIdentity: null,
   };
 
   function scratchAndStagingFiles(): string[] {
@@ -268,6 +291,7 @@ describe("update-progress-marker", () => {
         targetVersion: "1.5.0",
         updatedAt: "2026-07-03T00:00:01.000Z",
         writerId: "writer-b",
+        writerStartIdentity: null,
       });
       expect(
         await deleteUpdateProgressMarkerIfUnchanged("production", failed),
@@ -280,6 +304,7 @@ describe("update-progress-marker", () => {
         targetVersion: "1.5.0",
         updatedAt: "2026-07-03T00:00:01.000Z",
         writerId: "writer-b",
+        writerStartIdentity: null,
       });
       expect(scratchAndStagingFiles()).toEqual([]);
     });
@@ -314,6 +339,7 @@ describe("update-progress-marker", () => {
         await deleteUpdateProgressMarkerIfUnchanged("production", {
           ...theirRecord,
           writerId: "writer-a",
+          writerStartIdentity: null,
         }),
       ).toBe("changed");
       expect(await readUpdateProgressMarker("production")).toEqual(theirRecord);
@@ -343,6 +369,7 @@ describe("update-progress-marker", () => {
           targetVersion: "1.4.0",
           updatedAt: "2026-07-03T00:00:00.000Z",
           writerId: "writer-a",
+          writerStartIdentity: null,
         };
         const b = {
           state: "updating" as const,
@@ -350,6 +377,7 @@ describe("update-progress-marker", () => {
           targetVersion: "1.5.0",
           updatedAt: "2026-07-03T00:00:01.000Z",
           writerId: "writer-b",
+          writerStartIdentity: null,
         };
         await writeUpdateProgressMarker("production", a);
         await writeUpdateProgressMarker("production", b);
@@ -404,6 +432,7 @@ describe("update-progress-marker", () => {
           targetVersion: "1.4.0",
           updatedAt: "2026-07-03T00:00:00.000Z",
           writerId: "writer-a",
+          writerStartIdentity: null,
         };
         const b = {
           state: "updating" as const,
@@ -411,6 +440,7 @@ describe("update-progress-marker", () => {
           targetVersion: "1.5.0",
           updatedAt: "2026-07-03T00:00:01.000Z",
           writerId: "writer-b",
+          writerStartIdentity: null,
         };
         await writeUpdateProgressMarker("production", a);
         await writeUpdateProgressMarker("production", b);
@@ -453,6 +483,7 @@ describe("update-progress-marker", () => {
         targetVersion: "1.6.0",
         updatedAt: "2026-07-03T00:00:00.000Z",
         writerId: "writer-a",
+        writerStartIdentity: null,
       };
       expect(await createUpdateProgressMarkerIfAbsent("production", next)).toBe(
         "created",
@@ -475,6 +506,7 @@ describe("update-progress-marker", () => {
         targetVersion: "1.7.0",
         updatedAt: "2026-07-03T00:02:00.000Z",
         writerId: "writer-b",
+        writerStartIdentity: null,
       };
       expect(await createUpdateProgressMarkerIfAbsent("production", next)).toBe(
         "exists",
@@ -494,6 +526,7 @@ describe("update-progress-marker", () => {
         targetVersion: "1.6.0",
         updatedAt: "2026-07-03T00:00:00.000Z",
         writerId: "writer-a",
+        writerStartIdentity: null,
       };
       // Absent path: the create outcome.
       expect(
@@ -529,6 +562,7 @@ describe("update-progress-marker", () => {
         targetVersion: "1.6.0",
         updatedAt: "2026-07-03T00:00:00.000Z",
         writerId: "writer-a",
+        writerStartIdentity: null,
       };
       expect(await createUpdateProgressMarkerIfAbsent("production", next)).toBe(
         "created",
@@ -559,6 +593,7 @@ describe("update-progress-marker", () => {
           targetVersion: "1.6.0",
           updatedAt: "2026-07-03T00:00:00.000Z",
           writerId: "writer-a",
+          writerStartIdentity: null,
         }),
       ).toBe("exists");
       expect(readFileSync(path, "utf8")).toBe(foreign);
@@ -603,6 +638,7 @@ describe("update-progress-marker", () => {
           targetVersion: "1.4.0",
           updatedAt: "2026-07-03T00:00:00.000Z",
           writerId: "writer-a",
+          writerStartIdentity: null,
         };
         expect(
           await createUpdateProgressMarkerIfAbsent("production", next),
@@ -622,6 +658,7 @@ describe("update-progress-marker", () => {
       targetVersion: "1.4.0",
       updatedAt: "2026-07-03T00:00:00.000Z",
       writerId: "writer-a",
+      writerStartIdentity: null,
     };
     const failedNext = {
       state: "failed" as const,
@@ -629,6 +666,7 @@ describe("update-progress-marker", () => {
       targetVersion: "1.4.0",
       updatedAt: "2026-07-03T00:01:00.000Z",
       writerId: "writer-a",
+      writerStartIdentity: null,
     };
 
     it("replaces the marker when it still reads exactly as expected", async () => {
@@ -663,6 +701,7 @@ describe("update-progress-marker", () => {
         targetVersion: "1.5.0",
         updatedAt: "2026-07-03T00:00:01.000Z",
         writerId: "writer-b",
+        writerStartIdentity: null,
       };
       await writeUpdateProgressMarker("production", theirs);
       expect(
@@ -886,6 +925,7 @@ describe("update-progress-marker", () => {
       targetVersion: "1.8.0",
       updatedAt: "2026-07-03T00:03:00.000Z",
       writerId: "writer-next",
+      writerStartIdentity: null,
     };
 
     it("publishes into an empty path", async () => {
@@ -949,6 +989,7 @@ describe("update-progress-marker", () => {
           targetVersion: "1.4.0",
           updatedAt: "2026-07-03T00:00:00.000Z",
           writerId: `${pid}-abcdef`,
+          writerStartIdentity: null,
         };
         await writeUpdateProgressMarker("production", deadWriterRecord);
         expect(
@@ -970,6 +1011,7 @@ describe("update-progress-marker", () => {
         targetVersion: "1.4.0",
         updatedAt: "2026-07-03T00:00:00.000Z",
         writerId: `${process.pid}-abcdef`,
+        writerStartIdentity: null,
       };
       await writeUpdateProgressMarker("production", theirs);
       expect(
@@ -999,6 +1041,7 @@ describe("update-progress-marker", () => {
       expect(await readUpdateProgressMarker("production")).toEqual({
         ...legacyRecord,
         writerId: null,
+        writerStartIdentity: null,
       });
     });
 
@@ -1014,6 +1057,7 @@ describe("update-progress-marker", () => {
         targetVersion: "1.4.0",
         updatedAt: "2026-07-03T00:00:00.000Z",
         writerId: "not-a-pid",
+        writerStartIdentity: null,
       };
       await writeUpdateProgressMarker("production", theirs);
       expect(
@@ -1128,6 +1172,7 @@ describe("update-progress-marker", () => {
           targetVersion: "1.4.0",
           updatedAt: "2026-07-03T00:00:00.000Z",
           writerId: "writer-a",
+          writerStartIdentity: null,
         };
         await writeUpdateProgressMarker("production", expected);
         expect(
@@ -1161,6 +1206,7 @@ describe("update-progress-marker", () => {
           targetVersion: "1.4.0",
           updatedAt: "2026-07-03T00:00:00.000Z",
           writerId: "writer-a",
+          writerStartIdentity: null,
         };
         await writeUpdateProgressMarker("production", expected);
         expect(
@@ -1217,6 +1263,7 @@ describe("update-progress-marker", () => {
           targetVersion: "1.4.0",
           updatedAt: "2026-07-03T00:00:00.000Z",
           writerId: `${process.pid}-abcdef`,
+          writerStartIdentity: null,
         }),
       ).toBe(false);
     });
@@ -1231,6 +1278,7 @@ describe("update-progress-marker", () => {
           targetVersion: "1.4.0",
           updatedAt: "2026-07-03T00:00:00.000Z",
           writerId: `${process.pid}-abcdef`,
+          writerStartIdentity: null,
         }),
       ).toBe(true);
     });
@@ -1248,6 +1296,7 @@ describe("update-progress-marker", () => {
             targetVersion: "1.4.0",
             updatedAt: "2026-07-03T00:00:00.000Z",
             writerId: `${pid}-abcdef`,
+            writerStartIdentity: null,
           }),
         ).toBe(false);
       },
@@ -1263,6 +1312,7 @@ describe("update-progress-marker", () => {
           targetVersion: "1.4.0",
           updatedAt: "2026-07-03T00:00:00.000Z",
           writerId: null,
+          writerStartIdentity: null,
         }),
       ).toBe(true);
     });
@@ -1277,6 +1327,7 @@ describe("update-progress-marker", () => {
           targetVersion: "1.4.0",
           updatedAt: "2026-07-03T00:00:00.000Z",
           writerId: "not-a-pid",
+          writerStartIdentity: null,
         }),
       ).toBe(true);
     });
@@ -1297,6 +1348,7 @@ describe("update-progress-marker", () => {
         targetVersion: "1.4.0",
         updatedAt: "2026-07-03T00:00:00.000Z",
         writerId: null,
+        writerStartIdentity: null,
       };
       expect(updateProgressRecordHasProvenLiveWriter(record)).toBe(false);
       expect(updateProgressRecordHasLiveWriter(record)).toBe(true);
@@ -1312,6 +1364,7 @@ describe("update-progress-marker", () => {
           targetVersion: "1.4.0",
           updatedAt: "2026-07-03T00:00:00.000Z",
           writerId: "not-a-pid",
+          writerStartIdentity: null,
         }),
       ).toBe(false);
     });
@@ -1324,6 +1377,7 @@ describe("update-progress-marker", () => {
         targetVersion: "1.4.0",
         updatedAt: "2026-07-03T00:00:00.000Z",
         writerId: `${process.pid}-abcdef`,
+        writerStartIdentity: null,
       };
       expect(
         updateProgressRecordHasProvenLiveWriter({
@@ -1353,6 +1407,7 @@ describe("update-progress-marker", () => {
             targetVersion: "1.4.0",
             updatedAt: "2026-07-03T00:00:00.000Z",
             writerId: `${pid}-abcdef`,
+            writerStartIdentity: null,
           }),
         ).toBe(false);
       },
@@ -1379,6 +1434,7 @@ describe("update-progress-marker", () => {
       targetVersion: "1.6.0",
       updatedAt: "2026-07-03T00:00:00.000Z",
       writerId: "writer-a",
+      writerStartIdentity: null,
     };
     const contents =
       '{"state":"updating","error":null,"targetVersion":"1.5.0","updatedAt":"2026-07-03T00:00:00.000Z","writerId":"7-ab"}';
@@ -1423,5 +1479,207 @@ describe("update-progress-marker", () => {
       expect(readFileSync(path, "utf8")).toBe(contents);
       expect(scratchAndStagingFiles()).toEqual([]);
     });
+  });
+
+  // A pid alone is not the writer: the OS reuses pids, so a record whose
+  // pid is alive is the writer's only if the process behind the pid was
+  // created when the writer was. The record carries the writer's creation
+  // stamp (`writerStartIdentity`) and both predicates hold the pid against
+  // it. Every pin here uses THIS process's pid with a stamp that is, or is
+  // not, this process's own - the recycled-pid case made real without
+  // waiting for the OS to recycle one. Falsification: judge the pid alone
+  // (the pre-round rule) and every "recycled" pin reports live; map a
+  // mismatch to `unknown` instead of `dead` and the claim pin defers.
+  describe("writer identity - a live pid with another process's creation stamp is not the writer", () => {
+    const next = {
+      state: "updating" as const,
+      error: null,
+      targetVersion: "1.8.0",
+      updatedAt: "2026-07-03T00:03:00.000Z",
+      writerId: "writer-next",
+      writerStartIdentity: null,
+    };
+    const ownWriterId = `${process.pid}-abcdef`;
+
+    async function ownStamp(): Promise<string> {
+      const { readProcessStartIdentity } =
+        await import("../../store/process-identity");
+      const own = readProcessStartIdentity(process.pid);
+      expect(own).not.toBeNull();
+      if (own === null) throw new Error("unreachable");
+      return own;
+    }
+
+    // A well-formed token on this platform whose canonical payload differs
+    // from this process's: the shape of a token some OTHER process, created
+    // at another moment, would have stamped before the OS handed its pid to
+    // us.
+    async function recycledStamp(): Promise<string> {
+      return `${await ownStamp()} recycled`;
+    }
+
+    it("this process's pid with its own stamp is live and proven live (control)", async () => {
+      const {
+        updateProgressRecordHasLiveWriter,
+        updateProgressRecordHasProvenLiveWriter,
+      } = await import("../update-progress-marker");
+      const record = {
+        state: "updating" as const,
+        error: null,
+        targetVersion: "1.4.0",
+        updatedAt: "2026-07-03T00:00:00.000Z",
+        writerId: ownWriterId,
+        writerStartIdentity: await ownStamp(),
+      };
+      expect(updateProgressRecordHasLiveWriter(record)).toBe(true);
+      expect(updateProgressRecordHasProvenLiveWriter(record)).toBe(true);
+    });
+
+    it("this process's pid with another process's stamp is a recycled pid: not live, not proven live", async () => {
+      const {
+        updateProgressRecordHasLiveWriter,
+        updateProgressRecordHasProvenLiveWriter,
+      } = await import("../update-progress-marker");
+      const record = {
+        state: "updating" as const,
+        error: null,
+        targetVersion: "1.4.0",
+        updatedAt: "2026-07-03T00:00:00.000Z",
+        writerId: ownWriterId,
+        writerStartIdentity: await recycledStamp(),
+      };
+      expect(updateProgressRecordHasLiveWriter(record)).toBe(false);
+      expect(updateProgressRecordHasProvenLiveWriter(record)).toBe(false);
+    });
+
+    // The own-pid arm above compares against a cached self-read and maps a
+    // mismatch straight to `dead`; ANOTHER live pid goes through the
+    // liveness probe and a fresh stamp read (`alive-different`). This
+    // worker's parent (the vitest main process) is a live pid that is not
+    // us. Falsification: map `alive-different` to `unknown` and the
+    // recycled pin here still passes the fail-open predicate.
+    it("another live process's pid with a stamp that is not that process's own is a recycled pid; with its own stamp it is live (control)", async () => {
+      const {
+        updateProgressRecordHasLiveWriter,
+        updateProgressRecordHasProvenLiveWriter,
+      } = await import("../update-progress-marker");
+      const { readProcessStartIdentity } =
+        await import("../../store/process-identity");
+      const parentStamp = readProcessStartIdentity(process.ppid);
+      expect(parentStamp).not.toBeNull();
+      const base = {
+        state: "updating" as const,
+        error: null,
+        targetVersion: "1.4.0",
+        updatedAt: "2026-07-03T00:00:00.000Z",
+        writerId: `${process.ppid}-abcdef`,
+      };
+      const recycled = {
+        ...base,
+        writerStartIdentity: `${parentStamp} recycled`,
+      };
+      expect(updateProgressRecordHasLiveWriter(recycled)).toBe(false);
+      expect(updateProgressRecordHasProvenLiveWriter(recycled)).toBe(false);
+      const theirs = { ...base, writerStartIdentity: parentStamp };
+      expect(updateProgressRecordHasLiveWriter(theirs)).toBe(true);
+      expect(updateProgressRecordHasProvenLiveWriter(theirs)).toBe(true);
+    });
+
+    it("the pre-lock claim replaces an `updating` whose live pid carries another process's stamp, instead of deferring to it", async () => {
+      const {
+        writeUpdateProgressMarker,
+        claimUpdateProgressMarkerBeforeLock,
+        readUpdateProgressMarker,
+      } = await import("../update-progress-marker");
+      await writeUpdateProgressMarker("production", {
+        state: "updating",
+        error: null,
+        targetVersion: "1.4.0",
+        updatedAt: "2026-07-03T00:00:00.000Z",
+        writerId: ownWriterId,
+        writerStartIdentity: await recycledStamp(),
+      });
+      expect(
+        await claimUpdateProgressMarkerBeforeLock("production", next),
+      ).toEqual({ outcome: "replaced-stale" });
+      expect(await readUpdateProgressMarker("production")).toEqual(next);
+      expect(scratchAndStagingFiles()).toEqual([]);
+    });
+
+    it("a record whose stamp survives the file round trip is still held to it", async () => {
+      // The on-disk bytes are what a later `host update` reads; a stamp
+      // that did not survive the write or the parse would silently fall
+      // back to the pid-alone rule and call the recycled pid live.
+      const { writeUpdateProgressMarker, readUpdateProgressMarker } =
+        await import("../update-progress-marker");
+      const stamp = await recycledStamp();
+      await writeUpdateProgressMarker("production", {
+        state: "updating",
+        error: null,
+        targetVersion: "1.4.0",
+        updatedAt: "2026-07-03T00:00:00.000Z",
+        writerId: ownWriterId,
+        writerStartIdentity: stamp,
+      });
+      const onDisk = await readUpdateProgressMarker("production");
+      expect(onDisk).not.toBeNull();
+      expect(onDisk?.writerStartIdentity).toBe(stamp);
+    });
+
+    // A record with NO stamp (an older CLI's, or a writer whose probe
+    // failed) is judged by the pid alone - the documented residual. The
+    // `updateProgressRecordHasLiveWriter` / `...ProvenLiveWriter` suites
+    // above pin it: every `${process.pid}-abcdef` record there carries
+    // `writerStartIdentity: null` and reads live.
+
+    it("a stamp that is not a well-formed token reads back as `null` at the parse boundary and the record is judged by the pid alone", async () => {
+      const { readUpdateProgressMarker, updateProgressRecordHasLiveWriter } =
+        await import("../update-progress-marker");
+      const { hostUpdateProgressMarkerPath } =
+        await import("../../store/paths");
+      const path = hostUpdateProgressMarkerPath("production");
+      mkdirSync(dirname(path), { recursive: true });
+      writeFileSync(
+        path,
+        `${JSON.stringify(
+          {
+            state: "updating",
+            error: null,
+            targetVersion: "1.4.0",
+            updatedAt: "2026-07-03T00:00:00.000Z",
+            writerId: ownWriterId,
+            writerStartIdentity: "not-a-token",
+          },
+          null,
+          2,
+        )}\n`,
+        "utf8",
+      );
+      const onDisk = await readUpdateProgressMarker("production");
+      expect(onDisk?.writerStartIdentity).toBeNull();
+      expect(onDisk !== null && updateProgressRecordHasLiveWriter(onDisk)).toBe(
+        true,
+      );
+    });
+
+    it.skipIf(process.platform === "win32")(
+      "a dead pid is dead whatever stamp the record carries - liveness is read before identity",
+      async () => {
+        const {
+          updateProgressRecordHasLiveWriter,
+          updateProgressRecordHasProvenLiveWriter,
+        } = await import("../update-progress-marker");
+        const record = {
+          state: "updating" as const,
+          error: null,
+          targetVersion: "1.4.0",
+          updatedAt: "2026-07-03T00:00:00.000Z",
+          writerId: `${await deadPid()}-abcdef`,
+          writerStartIdentity: await ownStamp(),
+        };
+        expect(updateProgressRecordHasLiveWriter(record)).toBe(false);
+        expect(updateProgressRecordHasProvenLiveWriter(record)).toBe(false);
+      },
+    );
   });
 });

--- a/clients/traycer-cli/src/host/__tests__/update-progress-marker.test.ts
+++ b/clients/traycer-cli/src/host/__tests__/update-progress-marker.test.ts
@@ -773,10 +773,10 @@ describe("update-progress-marker", () => {
   // The pre-lock publish: claim the live path for `next` without overwriting
   // a marker whose writer may still be acting on it. Backs `host update`'s
   // `publishUpdating` (see the production comment on
-  // `claimUpdateProgressMarkerBeforeLock`). Returns
-  // `{outcome, displaced}` - `displaced` carries the record a
-  // "replaced-stale" claim replaced (so the caller can put it back on a
-  // park), and is `null` for every other outcome.
+  // `claimUpdateProgressMarkerBeforeLock`). Returns `{outcome}` - a
+  // "replaced-stale" claim's replaced record is gone, not returned: see
+  // `updateProgressRecordHasLiveWriter` for why putting a record no writer
+  // is acting on back would be worse than the blind publish it replaces.
   describe("claimUpdateProgressMarkerBeforeLock", () => {
     const next = {
       state: "updating" as const,
@@ -791,11 +791,11 @@ describe("update-progress-marker", () => {
         await import("../update-progress-marker");
       expect(
         await claimUpdateProgressMarkerBeforeLock("production", next),
-      ).toEqual({ outcome: "published", displaced: null });
+      ).toEqual({ outcome: "published" });
       expect(await readUpdateProgressMarker("production")).toEqual(next);
     });
 
-    it("replaces a `failed` record regardless of its writerId - no writer is acting on a stamped failure - and returns it as `displaced`", async () => {
+    it("replaces a `failed` record regardless of its writerId - no writer is acting on a stamped failure - the replaced record is gone", async () => {
       const {
         writeUpdateProgressMarker,
         claimUpdateProgressMarkerBeforeLock,
@@ -804,7 +804,7 @@ describe("update-progress-marker", () => {
       await writeUpdateProgressMarker("production", failed);
       expect(
         await claimUpdateProgressMarkerBeforeLock("production", next),
-      ).toEqual({ outcome: "replaced-stale", displaced: failed });
+      ).toEqual({ outcome: "replaced-stale" });
       expect(await readUpdateProgressMarker("production")).toEqual(next);
     });
 
@@ -813,7 +813,7 @@ describe("update-progress-marker", () => {
     // `store/__tests__/cli-lock.test.ts` skips its own real-process tests
     // there.
     it.skipIf(process.platform === "win32")(
-      "replaces an `updating` record whose writer process is dead, and returns it as `displaced`",
+      "replaces an `updating` record whose writer process is dead - the replaced record is gone",
       async () => {
         const {
           writeUpdateProgressMarker,
@@ -831,7 +831,7 @@ describe("update-progress-marker", () => {
         await writeUpdateProgressMarker("production", deadWriterRecord);
         expect(
           await claimUpdateProgressMarkerBeforeLock("production", next),
-        ).toEqual({ outcome: "replaced-stale", displaced: deadWriterRecord });
+        ).toEqual({ outcome: "replaced-stale" });
         expect(await readUpdateProgressMarker("production")).toEqual(next);
       },
     );
@@ -852,7 +852,7 @@ describe("update-progress-marker", () => {
       await writeUpdateProgressMarker("production", theirs);
       expect(
         await claimUpdateProgressMarkerBeforeLock("production", next),
-      ).toEqual({ outcome: "deferred", displaced: null });
+      ).toEqual({ outcome: "deferred" });
       expect(await readUpdateProgressMarker("production")).toEqual(theirs);
       expect(scratchAndStagingFiles()).toEqual([]);
     });
@@ -873,7 +873,7 @@ describe("update-progress-marker", () => {
       writeFileSync(path, `${JSON.stringify(legacyRecord, null, 2)}\n`, "utf8");
       expect(
         await claimUpdateProgressMarkerBeforeLock("production", next),
-      ).toEqual({ outcome: "deferred", displaced: null });
+      ).toEqual({ outcome: "deferred" });
       expect(await readUpdateProgressMarker("production")).toEqual({
         ...legacyRecord,
         writerId: null,
@@ -896,7 +896,7 @@ describe("update-progress-marker", () => {
       await writeUpdateProgressMarker("production", theirs);
       expect(
         await claimUpdateProgressMarkerBeforeLock("production", next),
-      ).toEqual({ outcome: "deferred", displaced: null });
+      ).toEqual({ outcome: "deferred" });
       expect(await readUpdateProgressMarker("production")).toEqual(theirs);
       expect(scratchAndStagingFiles()).toEqual([]);
     });
@@ -1058,7 +1058,7 @@ describe("update-progress-marker", () => {
       }
     });
 
-    it('returns {outcome: "failed", displaced: null} when its internal replace cannot land the claim', async () => {
+    it('returns {outcome: "failed"} when its internal replace cannot land the claim', async () => {
       mockUnlandableWrites();
       try {
         const {
@@ -1072,11 +1072,91 @@ describe("update-progress-marker", () => {
         await writeUpdateProgressMarker("production", failed);
         expect(
           await claimUpdateProgressMarkerBeforeLock("production", next),
-        ).toEqual({ outcome: "failed", displaced: null });
+        ).toEqual({ outcome: "failed" });
         expect(await readUpdateProgressMarker("production")).toBeNull();
       } finally {
         vi.doUnmock("node:fs/promises");
       }
+    });
+  });
+
+  // `updateProgressRecordHasLiveWriter`: the one predicate behind every
+  // "is this record mine to replace/restore?" decision (see its own doc
+  // comment). Direct pins, independent of the claim/replace/delete
+  // primitives that consult it.
+  describe("updateProgressRecordHasLiveWriter", () => {
+    it("a `failed` record is never live, even with a live pid's writerId", async () => {
+      const { updateProgressRecordHasLiveWriter } =
+        await import("../update-progress-marker");
+      expect(
+        updateProgressRecordHasLiveWriter({
+          state: "failed",
+          error: "host did not become healthy",
+          targetVersion: "1.4.0",
+          updatedAt: "2026-07-03T00:00:00.000Z",
+          writerId: `${process.pid}-abcdef`,
+        }),
+      ).toBe(false);
+    });
+
+    it("an `updating` record whose writer is this very (live) process is live", async () => {
+      const { updateProgressRecordHasLiveWriter } =
+        await import("../update-progress-marker");
+      expect(
+        updateProgressRecordHasLiveWriter({
+          state: "updating",
+          error: null,
+          targetVersion: "1.4.0",
+          updatedAt: "2026-07-03T00:00:00.000Z",
+          writerId: `${process.pid}-abcdef`,
+        }),
+      ).toBe(true);
+    });
+
+    it.skipIf(process.platform === "win32")(
+      "an `updating` record whose writer process is dead is not live",
+      async () => {
+        const { updateProgressRecordHasLiveWriter } =
+          await import("../update-progress-marker");
+        const pid = await deadPid();
+        expect(
+          updateProgressRecordHasLiveWriter({
+            state: "updating",
+            error: null,
+            targetVersion: "1.4.0",
+            updatedAt: "2026-07-03T00:00:00.000Z",
+            writerId: `${pid}-abcdef`,
+          }),
+        ).toBe(false);
+      },
+    );
+
+    it("an `updating` record with writerId null (an older CLI's marker) fails open as live - unprovable as abandoned", async () => {
+      const { updateProgressRecordHasLiveWriter } =
+        await import("../update-progress-marker");
+      expect(
+        updateProgressRecordHasLiveWriter({
+          state: "updating",
+          error: null,
+          targetVersion: "1.4.0",
+          updatedAt: "2026-07-03T00:00:00.000Z",
+          writerId: null,
+        }),
+      ).toBe(true);
+    });
+
+    it("an `updating` record with an unparseable writerId fails open as live", async () => {
+      const { updateProgressRecordHasLiveWriter } =
+        await import("../update-progress-marker");
+      expect(
+        updateProgressRecordHasLiveWriter({
+          state: "updating",
+          error: null,
+          targetVersion: "1.4.0",
+          updatedAt: "2026-07-03T00:00:00.000Z",
+          writerId: "not-a-pid",
+        }),
+      ).toBe(true);
     });
   });
 });

--- a/clients/traycer-cli/src/host/__tests__/update-progress-marker.test.ts
+++ b/clients/traycer-cli/src/host/__tests__/update-progress-marker.test.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
 import {
+  chmodSync,
   mkdirSync,
   mkdtempSync,
   readdirSync,
@@ -362,7 +363,10 @@ describe("update-progress-marker", () => {
       }
     });
 
-    it("retains the displaced marker in its scratch when neither restore route can land it", async () => {
+    it("reports `failed` (not `changed`) and retains the displaced marker in its scratch when neither restore route can land it", async () => {
+      // Falsification: discard the restore's landing and return `changed`
+      // (the old shape) - the caller then logs "another updater owns it
+      // now" over an EMPTY live path.
       vi.doMock("node:fs/promises", async (importOriginal) => {
         const actual =
           await importOriginal<typeof import("node:fs/promises")>();
@@ -412,10 +416,12 @@ describe("update-progress-marker", () => {
         await writeUpdateProgressMarker("production", b);
         expect(
           await deleteUpdateProgressMarkerIfUnchanged("production", a),
-        ).toBe("changed");
+        ).toBe("failed");
         // Neither `link` nor the `wx` fallback could land the displaced
         // marker back at the live path - it stays retained in its scratch
-        // rather than being dropped, and the live path is left empty.
+        // rather than being dropped, the live path is left empty, and the
+        // outcome says so: a `changed` here would promise a record that is
+        // not there.
         expect(await readUpdateProgressMarker("production")).toBeNull();
         const scratchFiles = scratchAndStagingFiles().filter((name) =>
           name.includes(".reconcile-"),
@@ -502,6 +508,60 @@ describe("update-progress-marker", () => {
           targetVersion: "1.7.0",
         }),
       ).toBe("exists");
+      expect(scratchAndStagingFiles()).toEqual([]);
+    });
+
+    it("replaces a MALFORMED file (a crash mid-write) instead of reporting `exists` forever", async () => {
+      // Falsification: return `landing` unchanged for `exists` (the old
+      // shape) and this reports `exists` while the read answers `null` - the
+      // pair every caller loops on until it gives up, on every later update.
+      const { createUpdateProgressMarkerIfAbsent, readUpdateProgressMarker } =
+        await import("../update-progress-marker");
+      const { hostUpdateProgressMarkerPath } =
+        await import("../../store/paths");
+      const path = hostUpdateProgressMarkerPath("production");
+      mkdirSync(dirname(path), { recursive: true });
+      writeFileSync(path, '{"state":"updating","targetVer');
+      expect(await readUpdateProgressMarker("production")).toBeNull();
+      const next = {
+        state: "updating" as const,
+        error: null,
+        targetVersion: "1.6.0",
+        updatedAt: "2026-07-03T00:00:00.000Z",
+        writerId: "writer-a",
+      };
+      expect(await createUpdateProgressMarkerIfAbsent("production", next)).toBe(
+        "created",
+      );
+      expect(await readUpdateProgressMarker("production")).toEqual(next);
+      expect(scratchAndStagingFiles()).toEqual([]);
+    });
+
+    it("leaves an UNRECOGNISED record (a shape this CLI does not read) in place as `exists`", async () => {
+      // A valid JSON object with a state this CLI predates is another
+      // writer's marker, not garbage: its liveness cannot be honoured, so it
+      // is never replaced outside the lock. Falsification: fold
+      // `unrecognised` into `malformed` and this replaces it.
+      const { createUpdateProgressMarkerIfAbsent, readUpdateProgressMarker } =
+        await import("../update-progress-marker");
+      const { hostUpdateProgressMarkerPath } =
+        await import("../../store/paths");
+      const path = hostUpdateProgressMarkerPath("production");
+      mkdirSync(dirname(path), { recursive: true });
+      const foreign =
+        '{"state":"verifying","error":null,"targetVersion":"9.0.0","updatedAt":"2026-07-03T00:00:00.000Z","writerId":"7-ab"}';
+      writeFileSync(path, foreign);
+      expect(await readUpdateProgressMarker("production")).toBeNull();
+      expect(
+        await createUpdateProgressMarkerIfAbsent("production", {
+          state: "updating",
+          error: null,
+          targetVersion: "1.6.0",
+          updatedAt: "2026-07-03T00:00:00.000Z",
+          writerId: "writer-a",
+        }),
+      ).toBe("exists");
+      expect(readFileSync(path, "utf8")).toBe(foreign);
       expect(scratchAndStagingFiles()).toEqual([]);
     });
   });
@@ -730,17 +790,15 @@ describe("update-progress-marker", () => {
               options !== null &&
               "flag" in options &&
               options.flag === "wx";
-            if (!isWx) {
+            // Keyed on the BYTES being staged, not on a call count: this
+            // test's own setup (`writeUpdateProgressMarker`, seeding the
+            // `updating` record) must land, and only `stageMarkerFile`'s
+            // write of the `failed` record inside the call under test
+            // throws. A count would silently retarget the injection if
+            // setup ever gained a write.
+            if (!isWx && String(data).includes('"state": "failed"')) {
               plainWriteCalls += 1;
-              // The first plain write is this test's own setup
-              // (`writeUpdateProgressMarker`, seeding `expected`) - it must
-              // land. The second is `stageMarkerFile`'s write for `next`,
-              // inside the call under test - that one throws.
-              if (plainWriteCalls === 2) {
-                throw Object.assign(new Error("ENOSPC"), {
-                  code: "ENOSPC",
-                });
-              }
+              throw Object.assign(new Error("ENOSPC"), { code: "ENOSPC" });
             }
             return actual.writeFile(path, data, options);
           },
@@ -763,6 +821,7 @@ describe("update-progress-marker", () => {
         expect(await readUpdateProgressMarker("production")).toEqual(
           expectedUpdating,
         );
+        expect(plainWriteCalls).toBe(1);
         expect(scratchAndStagingFiles()).toEqual([]);
       } finally {
         vi.doUnmock("node:fs/promises");
@@ -793,6 +852,26 @@ describe("update-progress-marker", () => {
         await claimUpdateProgressMarkerBeforeLock("production", next),
       ).toEqual({ outcome: "published" });
       expect(await readUpdateProgressMarker("production")).toEqual(next);
+    });
+
+    it("publishes over a MALFORMED file instead of deferring forever", async () => {
+      // A crash mid-write left bytes that are not a record. The read answers
+      // `null`, the create used to answer `exists`, and three rounds of that
+      // ended `deferred` - on this update and every later one, until someone
+      // deleted the file by hand. Falsification: make the create report
+      // `exists` for a malformed file again and this claim reads `deferred`.
+      const { claimUpdateProgressMarkerBeforeLock, readUpdateProgressMarker } =
+        await import("../update-progress-marker");
+      const { hostUpdateProgressMarkerPath } =
+        await import("../../store/paths");
+      const path = hostUpdateProgressMarkerPath("production");
+      mkdirSync(dirname(path), { recursive: true });
+      writeFileSync(path, '{"state":"upd');
+      expect(
+        await claimUpdateProgressMarkerBeforeLock("production", next),
+      ).toEqual({ outcome: "published" });
+      expect(await readUpdateProgressMarker("production")).toEqual(next);
+      expect(scratchAndStagingFiles()).toEqual([]);
     });
 
     it("replaces a `failed` record regardless of its writerId - no writer is acting on a stamped failure - the replaced record is gone", async () => {
@@ -1157,6 +1236,149 @@ describe("update-progress-marker", () => {
           writerId: "not-a-pid",
         }),
       ).toBe(true);
+    });
+  });
+
+  describe("updateProgressRecordHasProvenLiveWriter", () => {
+    // The takeover under the lock retains a displaced record for restore on
+    // POSITIVE evidence only. Falsification: implement it as the fail-open
+    // predicate and the first two pins report `true`.
+    it("a record with NO writer id is not proven live (the fail-open predicate still calls it live)", async () => {
+      const {
+        updateProgressRecordHasLiveWriter,
+        updateProgressRecordHasProvenLiveWriter,
+      } = await import("../update-progress-marker");
+      const record = {
+        state: "updating" as const,
+        error: null,
+        targetVersion: "1.4.0",
+        updatedAt: "2026-07-03T00:00:00.000Z",
+        writerId: null,
+      };
+      expect(updateProgressRecordHasProvenLiveWriter(record)).toBe(false);
+      expect(updateProgressRecordHasLiveWriter(record)).toBe(true);
+    });
+
+    it("an unparseable writer id is not proven live", async () => {
+      const { updateProgressRecordHasProvenLiveWriter } =
+        await import("../update-progress-marker");
+      expect(
+        updateProgressRecordHasProvenLiveWriter({
+          state: "updating",
+          error: null,
+          targetVersion: "1.4.0",
+          updatedAt: "2026-07-03T00:00:00.000Z",
+          writerId: "not-a-pid",
+        }),
+      ).toBe(false);
+    });
+
+    it("this very (live) process's writer id is proven live; a `failed` with the same id is not", async () => {
+      const { updateProgressRecordHasProvenLiveWriter } =
+        await import("../update-progress-marker");
+      const base = {
+        error: null,
+        targetVersion: "1.4.0",
+        updatedAt: "2026-07-03T00:00:00.000Z",
+        writerId: `${process.pid}-abcdef`,
+      };
+      expect(
+        updateProgressRecordHasProvenLiveWriter({
+          state: "updating",
+          ...base,
+        }),
+      ).toBe(true);
+      expect(
+        updateProgressRecordHasProvenLiveWriter({
+          state: "failed",
+          ...base,
+          error: "host did not become healthy",
+        }),
+      ).toBe(false);
+    });
+
+    it.skipIf(process.platform === "win32")(
+      "a dead writer process is not proven live",
+      async () => {
+        const { updateProgressRecordHasProvenLiveWriter } =
+          await import("../update-progress-marker");
+        const pid = await deadPid();
+        expect(
+          updateProgressRecordHasProvenLiveWriter({
+            state: "updating",
+            error: null,
+            targetVersion: "1.4.0",
+            updatedAt: "2026-07-03T00:00:00.000Z",
+            writerId: `${pid}-abcdef`,
+          }),
+        ).toBe(false);
+      },
+    );
+  });
+
+  // A file that is there but cannot be READ (a marker a `sudo traycer host
+  // update` left root-owned; here, mode 000) is neither absent nor a record
+  // this CLI can compare. Nothing is replaced: the create answers `exists`
+  // (the caller's bounded loop then gives up with its own warning) and the
+  // claim defers. Root reads a 000 file, so the pin is skipped there.
+  // Falsification: fold `unreadable` into `absent` in `readMarkerState` and
+  // the create tries to replace the file it could not read - answering
+  // `exists` only because its swap's compare fails - while the claim pin
+  // still holds; fold it into `malformed` (with empty bytes) and the create
+  // REPLACES the file, reddening the byte-identical assertion.
+  describe.skipIf(
+    process.platform === "win32" ||
+      (typeof process.getuid === "function" && process.getuid() === 0),
+  )("an UNREADABLE marker file", () => {
+    const next = {
+      state: "updating" as const,
+      error: null,
+      targetVersion: "1.6.0",
+      updatedAt: "2026-07-03T00:00:00.000Z",
+      writerId: "writer-a",
+    };
+    const contents =
+      '{"state":"updating","error":null,"targetVersion":"1.5.0","updatedAt":"2026-07-03T00:00:00.000Z","writerId":"7-ab"}';
+
+    it("is left in place as `exists` by the create-if-absent", async () => {
+      const { createUpdateProgressMarkerIfAbsent, readUpdateProgressMarker } =
+        await import("../update-progress-marker");
+      const { hostUpdateProgressMarkerPath } =
+        await import("../../store/paths");
+      const path = hostUpdateProgressMarkerPath("production");
+      mkdirSync(dirname(path), { recursive: true });
+      writeFileSync(path, contents);
+      chmodSync(path, 0o000);
+      try {
+        expect(await readUpdateProgressMarker("production")).toBeNull();
+        expect(
+          await createUpdateProgressMarkerIfAbsent("production", next),
+        ).toBe("exists");
+      } finally {
+        chmodSync(path, 0o600);
+      }
+      expect(readFileSync(path, "utf8")).toBe(contents);
+      expect(scratchAndStagingFiles()).toEqual([]);
+    });
+
+    it("is deferred to by the pre-lock claim", async () => {
+      const { claimUpdateProgressMarkerBeforeLock } =
+        await import("../update-progress-marker");
+      const { hostUpdateProgressMarkerPath } =
+        await import("../../store/paths");
+      const path = hostUpdateProgressMarkerPath("production");
+      mkdirSync(dirname(path), { recursive: true });
+      writeFileSync(path, contents);
+      chmodSync(path, 0o000);
+      try {
+        expect(
+          await claimUpdateProgressMarkerBeforeLock("production", next),
+        ).toEqual({ outcome: "deferred" });
+      } finally {
+        chmodSync(path, 0o600);
+      }
+      expect(readFileSync(path, "utf8")).toBe(contents);
+      expect(scratchAndStagingFiles()).toEqual([]);
     });
   });
 });

--- a/clients/traycer-cli/src/host/__tests__/update-progress-marker.test.ts
+++ b/clients/traycer-cli/src/host/__tests__/update-progress-marker.test.ts
@@ -346,6 +346,90 @@ describe("update-progress-marker", () => {
       expect(scratchAndStagingFiles()).toEqual([]);
     });
 
+    // The marker lock (`underMarkerLock`): between a conditional swap's take
+    // (`rename(marker → scratch)`) and its restore the live path is EMPTY,
+    // and without the lock a create-if-absent lands there: A's stale clear
+    // takes B's live marker out, C's claim lands in the gap, A's restore
+    // loses to it and B's record ends in a scratch while B runs unannounced
+    // under C's marker. Falsification: run `fn` in `underMarkerLock` without
+    // taking the lock and C's claim answers `created`, the live path holds
+    // C's record, and B's is gone. Timing: C is BLOCKED on the lock (its
+    // poll sees a live holder and never breaks it), so the 150 ms check is
+    // deterministic; the one way this pin can flake is a runner stall of
+    // 2 s or more between C's start and the release, after which C answers
+    // `failed` on the lock's own wait - rerun, do not investigate.
+    it("holds the marker lock across the take and the restore: a create-if-absent racing a conditional clear WAITS, and the displaced live record is put back", async () => {
+      let releaseTake: () => void = () => undefined;
+      const takeHeld = new Promise<void>((resolve) => {
+        releaseTake = resolve;
+      });
+      let takeReached: () => void = () => undefined;
+      const takeStarted = new Promise<void>((resolve) => {
+        takeReached = resolve;
+      });
+      vi.doMock("node:fs/promises", async (importOriginal) => {
+        const actual =
+          await importOriginal<typeof import("node:fs/promises")>();
+        return {
+          ...actual,
+          // The take, then a pause with the live path empty and the lock
+          // held - the window the lock exists to cover.
+          rename: async (from: string, to: string) => {
+            await actual.rename(from, to);
+            if (to.includes(".reconcile-")) {
+              takeReached();
+              await takeHeld;
+            }
+          },
+        };
+      });
+      try {
+        const {
+          writeUpdateProgressMarker,
+          readUpdateProgressMarker,
+          deleteUpdateProgressMarkerIfUnchanged,
+          createUpdateProgressMarkerIfAbsent,
+        } = await import("../update-progress-marker");
+        const b = {
+          state: "updating" as const,
+          error: null,
+          targetVersion: "1.4.0",
+          updatedAt: "2026-07-03T00:00:00.000Z",
+          writerId: "writer-b",
+          writerStartIdentity: null,
+        };
+        await writeUpdateProgressMarker("production", b);
+        // A clears "its" record - stale: the path holds B's.
+        const clearByA = deleteUpdateProgressMarkerIfUnchanged("production", {
+          ...b,
+          writerId: "writer-a",
+        });
+        await takeStarted;
+        // C claims the (momentarily empty) path.
+        let cSettled = false;
+        const claimByC = createUpdateProgressMarkerIfAbsent("production", {
+          state: "updating",
+          error: null,
+          targetVersion: "1.8.0",
+          updatedAt: "2026-07-03T00:03:00.000Z",
+          writerId: "writer-c",
+          writerStartIdentity: null,
+        }).then((outcome) => {
+          cSettled = true;
+          return outcome;
+        });
+        await new Promise((resolve) => setTimeout(resolve, 150));
+        expect(cSettled).toBe(false);
+        releaseTake();
+        expect(await clearByA).toBe("changed");
+        expect(await claimByC).toBe("exists");
+        expect(await readUpdateProgressMarker("production")).toEqual(b);
+        expect(scratchAndStagingFiles()).toEqual([]);
+      } finally {
+        vi.doUnmock("node:fs/promises");
+      }
+    });
+
     it("restores via the wx fallback when link fails for a reason other than EEXIST", async () => {
       vi.doMock("node:fs/promises", async (importOriginal) => {
         const actual =

--- a/clients/traycer-cli/src/host/compat-recovery.ts
+++ b/clients/traycer-cli/src/host/compat-recovery.ts
@@ -2,6 +2,7 @@ import type {
   ClientCompatibilityRequirement,
   IncompatibilityUpgradeGuidance,
 } from "@traycer/protocol/framework/index";
+import { PACKAGE_MANAGER_UPGRADE_COMMAND } from "@traycer-clients/shared/cli-install/package-manager-upgrade-command";
 import {
   PACKAGE_MANAGER_UPGRADE_HINT,
   type CliInstallSource,
@@ -279,7 +280,7 @@ export function compatRecoveryHint(
     return "the host is out of date - run 'traycer host update' to reinstall the latest host";
   }
   if (client) {
-    return "this CLI is out of date - update it via your install method (e.g. 'traycer cli upgrade', 'brew upgrade traycer', or 'npm update -g @traycerai/cli')";
+    return `this CLI is out of date - update it via your install method (e.g. 'traycer cli upgrade', '${PACKAGE_MANAGER_UPGRADE_COMMAND.homebrew}', or '${PACKAGE_MANAGER_UPGRADE_COMMAND.npm}')`;
   }
   return "try 'traycer host restart'; if it persists, update the host and CLI";
 }

--- a/clients/traycer-cli/src/host/provision.ts
+++ b/clients/traycer-cli/src/host/provision.ts
@@ -577,6 +577,7 @@ async function commitInstall(
         // denied the cooperative shutdown claim and `--force` aborted
         // anyway.
         force: opts.force,
+        onWillStopHost: null,
       })
     : null;
   const lifecycle =
@@ -600,6 +601,7 @@ async function commitInstall(
       staged,
       onProgress: progress,
       lifecycle,
+      onWillSwap: null,
     },
   );
   const post = await readProvisionState(controller, label, opts.runtime);

--- a/clients/traycer-cli/src/host/update-mutation.ts
+++ b/clients/traycer-cli/src/host/update-mutation.ts
@@ -205,7 +205,7 @@ export async function stopHostForRestartWithAttempt(
   const verify = (): Promise<void> =>
     requireCliUpdateMutationCapability(capability, contenderOptions);
   return withServiceMutationAuthority(verify, () => {
-    onAuthorityVerified?.();
+    if (onAuthorityVerified !== null) onAuthorityVerified();
     return controller.stopForRestart(label, options);
   });
 }

--- a/clients/traycer-cli/src/host/update-mutation.ts
+++ b/clients/traycer-cli/src/host/update-mutation.ts
@@ -172,19 +172,42 @@ export async function startHostServiceWithAttempt(
   });
 }
 
-/** Final-actuator facade for the first half of a controlled restart. */
+/**
+ * Final-actuator facade for the first half of a controlled restart.
+ *
+ * `onAuthorityVerified` runs once the mutation-capability check has passed
+ * and immediately before the actuator is asked to stop the host - the last
+ * point at which THIS facade can still prove nothing was touched. A caller
+ * that keys "have I begun to disturb the host?" on this facade (the `host
+ * update` activation arm's progress-marker rule) marks the boundary here
+ * rather than around the call: a capability check that fails has touched
+ * nothing, and a failure reported from before the boundary must be treated
+ * as one. `null` when the caller keeps no such boundary.
+ *
+ * The boundary is the facade's, not the actuator's. Past it the controller
+ * still runs checks of its own before its first mutating command: the stop
+ * intent is announced first (`HOST_STOP_INTENT_UNWRITABLE` on `--force` or
+ * win32 when the host home cannot be written), and every platform controller
+ * re-verifies the same authority in front of EACH command it issues. A
+ * refusal from either lands after the boundary and is reported as a
+ * disruption even though the host is untouched. Both are narrow - the first
+ * needs the host home unwritable, the second needs the authority lost in the
+ * gap between two consecutive checks - and the caller's rule accepts them.
+ */
 export async function stopHostForRestartWithAttempt(
   capability: UpdateMutationCapability,
   contenderOptions: WithCliUpdateContenderOptions,
   controller: Pick<ServiceController, "stopForRestart">,
   label: ServiceLabel,
   options: StopServiceOptions,
+  onAuthorityVerified: (() => void) | null,
 ): Promise<RestartStop> {
   const verify = (): Promise<void> =>
     requireCliUpdateMutationCapability(capability, contenderOptions);
-  return withServiceMutationAuthority(verify, () =>
-    controller.stopForRestart(label, options),
-  );
+  return withServiceMutationAuthority(verify, () => {
+    onAuthorityVerified?.();
+    return controller.stopForRestart(label, options);
+  });
 }
 
 /** Final-actuator facade for the relaunch half of a controlled restart. */

--- a/clients/traycer-cli/src/host/update-progress-marker.ts
+++ b/clients/traycer-cli/src/host/update-progress-marker.ts
@@ -158,8 +158,9 @@ async function stageMarkerFile(
  * delete that cannot erase a marker another writer landed in between.
  *
  * For a clear that decided from a marker it READ ("this `failed` is stale,
- * the host is current") or WROTE (this invocation's own `updating`, by the
- * time the update finished). Another updater can replace that marker with a
+ * the host is current"), WROTE, or TOOK OVER under the contender lock (this
+ * invocation's own `updating`, by the time the update finished). Another
+ * updater can replace that marker with a
  * live `updating` at any point, and deleting that would erase the only
  * progress signal the legacy path has, rendering a real download → swap →
  * restart as a quiet host. A read-then-unlink pair leaves exactly that window
@@ -177,14 +178,17 @@ export async function deleteUpdateProgressMarkerIfUnchanged(
 
 /**
  * Replace the marker with `next` only if it still reads as `expected` - the
- * failure stamp's compare-and-swap.
+ * compare-and-swap behind `host update`'s failure stamp, its re-point and
+ * takeover under the contender lock, and the restore of a taken-over record
+ * when the run then does nothing.
  *
- * `host update` stamps `failed` over the `updating` IT wrote, and by then
- * another updater may have landed its own `updating` at the same path (its
- * write precedes its lock wait, so holding the lock proves nothing about the
- * marker). Stamping over that would report the old failure for the whole of
- * the new update. A read-then-write pair only narrows that window; this
- * closes it with the same rename/link protocol the conditional delete uses.
+ * `host update` stamps `failed` over the `updating` IT wrote or took over,
+ * and by then another updater may have landed its own `updating` at the
+ * same path (its write precedes its lock wait, so holding the lock proves
+ * nothing about the marker). Stamping over that would report the old failure
+ * for the whole of the new update. A read-then-write pair only narrows that
+ * window; this closes it with the same rename/link protocol the conditional
+ * delete uses.
  *
  * An ABSENT marker is `changed`, not a free slot: the live path is also empty
  * for the instant another conditional swap holds the current marker in its

--- a/clients/traycer-cli/src/host/update-progress-marker.ts
+++ b/clients/traycer-cli/src/host/update-progress-marker.ts
@@ -233,6 +233,119 @@ export async function replaceUpdateProgressMarkerIfUnchanged(
  * or pid would be one more concurrent actor in a directory whose whole
  * difficulty is concurrent actors, for a few hundred bytes per crash.
  */
+async function dropMarkerFile(
+  environment: Environment,
+  path: string,
+  step: string,
+): Promise<void> {
+  try {
+    await rm(path, { force: true });
+  } catch (err) {
+    createCliLogger(environment).warn(
+      "Host update progress marker scratch cleanup failed",
+      {
+        environment,
+        step,
+        errorName: errorFromUnknown(err).name,
+        errorMessage: errorFromUnknown(err).message,
+      },
+    );
+  }
+}
+
+// `link(from → target)` lands `from` at the live path only if that path is
+// empty; EEXIST means a newer marker is there and wins. A filesystem that
+// refuses hard links falls back to an exclusive create (`wx`) of the same
+// bytes - still create-if-absent, so a marker landed in between still wins
+// with EEXIST. A plain rename is never the fallback: it would overwrite
+// that marker and reopen exactly the race the conditional operations exist
+// to close. The cost of the `wx` path is a non-atomic content write - a
+// reader polling in that instant may see a partial file, which it parses as
+// "no marker" for one poll. Returns whether `from` is now the live marker.
+async function landMarkerAtomically(
+  environment: Environment,
+  target: string,
+  from: string,
+  step: string,
+): Promise<boolean> {
+  try {
+    await link(from, target);
+    await dropMarkerFile(environment, from, `${step}-unlink-source`);
+    return true;
+  } catch (err) {
+    if (errnoCode(err) === "EEXIST") {
+      await dropMarkerFile(environment, from, `${step}-newer-exists`);
+      return false;
+    }
+    try {
+      const bytes = await readFile(from);
+      await writeFile(target, bytes, { flag: "wx", mode: 0o600 });
+      await dropMarkerFile(environment, from, `${step}-unlink-source`);
+      return true;
+    } catch (createErr) {
+      if (errnoCode(createErr) === "EEXIST") {
+        await dropMarkerFile(environment, from, `${step}-newer-exists`);
+        return false;
+      }
+      // Neither route could land `from` (no hard links AND the create
+      // failed - ENOSPC, EIO). `from` may be the only complete copy of
+      // another updater's live marker, taken out of the live path in a
+      // swap's step 1; deleting it here would erase that marker while
+      // reporting `changed`. It is RETAINED and named in the log so an
+      // operator can find it. For a stamp or a create the leftover is this
+      // run's own staged record - harmless garbage next to the marker.
+      createCliLogger(environment).warn(
+        "Host update progress marker conditional swap failed - displaced file retained",
+        {
+          environment,
+          step,
+          retainedPath: from,
+          errorName: errorFromUnknown(createErr).name,
+          errorMessage: errorFromUnknown(createErr).message,
+        },
+      );
+      return false;
+    }
+  }
+}
+
+/**
+ * Create-if-absent: land `next` at the live path ONLY if no marker stands
+ * there, through the same `link` / `wx` landing the conditional swap uses.
+ * `"exists"` means a marker was there - possibly one that landed between the
+ * caller's read and this call, which is exactly the write this exists to
+ * refuse: a read-then-`rename` would have overwritten it. Never throws;
+ * `"failed"` is an I/O failure that landed nothing, reported by log.
+ */
+export async function createUpdateProgressMarkerIfAbsent(
+  environment: Environment,
+  next: HostUpdateProgress,
+): Promise<"created" | "exists" | "failed"> {
+  const logger = createCliLogger(environment);
+  try {
+    await ensureHostHomeDir(environment);
+    const target = hostUpdateProgressMarkerPath(environment);
+    const staged = await stageMarkerFile(target, next);
+    if (!(await landMarkerAtomically(environment, target, staged, "create"))) {
+      return "exists";
+    }
+    logger.info("Host update progress marker created (conditional)", {
+      environment,
+      state: next.state,
+      targetVersion: next.targetVersion,
+      hasError: next.error !== null,
+    });
+    return "created";
+  } catch (err) {
+    logger.warn("Host update progress marker conditional create failed", {
+      environment,
+      errorName: errorFromUnknown(err).name,
+      errorMessage: errorFromUnknown(err).message,
+    });
+    return "failed";
+  }
+}
+
 async function swapMarkerIfUnchanged(
   environment: Environment,
   expected: HostUpdateProgress,
@@ -241,71 +354,10 @@ async function swapMarkerIfUnchanged(
   const logger = createCliLogger(environment);
   const target = hostUpdateProgressMarkerPath(environment);
   const scratch = `${target}.reconcile-${process.pid}-${Date.now()}`;
-  const dropFile = async (path: string, step: string): Promise<void> => {
-    try {
-      await rm(path, { force: true });
-    } catch (err) {
-      logger.warn("Host update progress marker scratch cleanup failed", {
-        environment,
-        step,
-        errorName: errorFromUnknown(err).name,
-        errorMessage: errorFromUnknown(err).message,
-      });
-    }
-  };
-  // `link(from → target)` lands `from` at the live path only if that path is
-  // empty; EEXIST means a newer marker is there and wins. A filesystem that
-  // refuses hard links falls back to an exclusive create (`wx`) of the same
-  // bytes - still create-if-absent, so a marker landed in between still wins
-  // with EEXIST. A plain rename is never the fallback: it would overwrite
-  // that marker and reopen exactly the race this swap exists to close. The
-  // cost of the `wx` path is a non-atomic content write - a reader polling in
-  // that instant may see a partial file, which it parses as "no marker" for
-  // one poll. Returns whether `from` is now the live marker.
-  const landAtomically = async (
-    from: string,
-    step: string,
-  ): Promise<boolean> => {
-    try {
-      await link(from, target);
-      await dropFile(from, `${step}-unlink-source`);
-      return true;
-    } catch (err) {
-      if (errnoCode(err) === "EEXIST") {
-        await dropFile(from, `${step}-newer-exists`);
-        return false;
-      }
-      try {
-        const bytes = await readFile(from);
-        await writeFile(target, bytes, { flag: "wx", mode: 0o600 });
-        await dropFile(from, `${step}-unlink-source`);
-        return true;
-      } catch (createErr) {
-        if (errnoCode(createErr) === "EEXIST") {
-          await dropFile(from, `${step}-newer-exists`);
-          return false;
-        }
-        // Neither route could land `from` (no hard links AND the create
-        // failed - ENOSPC, EIO). `from` may be the only complete copy of
-        // another updater's live marker, taken out of the live path in step
-        // 1; deleting it here would erase that marker while reporting
-        // `changed`. It is RETAINED and named in the log so an operator can
-        // find it. For a stamp the leftover is this run's own staged record -
-        // harmless garbage next to the marker.
-        logger.warn(
-          "Host update progress marker conditional swap failed - displaced file retained",
-          {
-            environment,
-            step,
-            retainedPath: from,
-            errorName: errorFromUnknown(createErr).name,
-            errorMessage: errorFromUnknown(createErr).message,
-          },
-        );
-        return false;
-      }
-    }
-  };
+  const dropFile = (path: string, step: string): Promise<void> =>
+    dropMarkerFile(environment, path, step);
+  const landAtomically = (from: string, step: string): Promise<boolean> =>
+    landMarkerAtomically(environment, target, from, step);
   const changed = (currentState: HostUpdateProgressState | null): "changed" => {
     logger.info(
       "Host update progress marker changed under a conditional swap",

--- a/clients/traycer-cli/src/host/update-progress-marker.ts
+++ b/clients/traycer-cli/src/host/update-progress-marker.ts
@@ -2,6 +2,7 @@ import { randomBytes } from "node:crypto";
 import { link, readFile, rename, rm, writeFile } from "node:fs/promises";
 import type { Environment } from "../runner/environment";
 import { createCliLogger, errorFromUnknown } from "../logger";
+import { isProcessAlive } from "../store/cli-lock";
 import {
   ensureHostHomeDir,
   hostUpdateProgressMarkerPath,
@@ -65,6 +66,14 @@ export function progressRecord(fields: {
   };
 }
 
+/**
+ * The one UNCONDITIONAL write in this module: `rename` over whatever the
+ * live path holds. No production path calls it any more - `host update`'s
+ * pre-lock publish goes through `claimUpdateProgressMarkerBeforeLock` and
+ * everything after it through the conditional primitives - and none should:
+ * a blind write here is exactly what lets one updater bury another's live
+ * marker. Kept for test fixtures that need to seed a marker file.
+ */
 export async function writeUpdateProgressMarker(
   environment: Environment,
   progress: HostUpdateProgress,
@@ -102,8 +111,17 @@ export async function deleteUpdateProgressMarker(
   }
 }
 
-export type ConditionalMarkerDelete = "cleared" | "changed" | "absent";
-export type ConditionalMarkerReplace = "replaced" | "changed";
+// `failed` is an I/O failure after which the live path still holds what it
+// held (the expected record is restored when a stamp cannot land; the one
+// exception - neither the stamp nor the restore could land - is warned
+// about by name). Callers never retry it - only `changed` (a record that
+// moved) is worth a re-read.
+export type ConditionalMarkerDelete =
+  | "cleared"
+  | "changed"
+  | "absent"
+  | "failed";
+export type ConditionalMarkerReplace = "replaced" | "changed" | "failed";
 
 /**
  * Identity of two marker records: every field, `writerId` included. Content
@@ -202,7 +220,9 @@ export async function replaceUpdateProgressMarkerIfUnchanged(
   next: HostUpdateProgress,
 ): Promise<ConditionalMarkerReplace> {
   const outcome = await swapMarkerIfUnchanged(environment, expected, next);
-  return outcome === "changed" ? "changed" : "replaced";
+  if (outcome === "swapped") return "replaced";
+  if (outcome === "failed") return "failed";
+  return "changed";
 }
 
 /**
@@ -265,31 +285,36 @@ async function dropMarkerFile(
 // that marker and reopen exactly the race the conditional operations exist
 // to close. The cost of the `wx` path is a non-atomic content write - a
 // reader polling in that instant may see a partial file, which it parses as
-// "no marker" for one poll. Returns whether `from` is now the live marker.
+// "no marker" for one poll. `landed` means `from` is now the live marker;
+// `exists` means a marker was already there and won; `failed` means neither
+// route could land it - two answers callers act on differently (a race is
+// re-read, an I/O failure is not retried), so they are never collapsed.
+type MarkerLanding = "landed" | "exists" | "failed";
+
 async function landMarkerAtomically(
   environment: Environment,
   target: string,
   from: string,
   step: string,
-): Promise<boolean> {
+): Promise<MarkerLanding> {
   try {
     await link(from, target);
     await dropMarkerFile(environment, from, `${step}-unlink-source`);
-    return true;
+    return "landed";
   } catch (err) {
     if (errnoCode(err) === "EEXIST") {
       await dropMarkerFile(environment, from, `${step}-newer-exists`);
-      return false;
+      return "exists";
     }
     try {
       const bytes = await readFile(from);
       await writeFile(target, bytes, { flag: "wx", mode: 0o600 });
       await dropMarkerFile(environment, from, `${step}-unlink-source`);
-      return true;
+      return "landed";
     } catch (createErr) {
       if (errnoCode(createErr) === "EEXIST") {
         await dropMarkerFile(environment, from, `${step}-newer-exists`);
-        return false;
+        return "exists";
       }
       // Neither route could land `from` (no hard links AND the create
       // failed - ENOSPC, EIO). `from` may be the only complete copy of
@@ -308,9 +333,109 @@ async function landMarkerAtomically(
           errorMessage: errorFromUnknown(createErr).message,
         },
       );
-      return false;
+      return "failed";
     }
   }
+}
+
+// `writerId` is `<pid>-<hex>`; the pid half is what a reader on the same
+// machine can check for liveness. The host daemon applies the same rule
+// (`isStaleUpdateProgress`) when it decides whether an `updating` marker
+// still describes a live update.
+const WRITER_ID_PID = /^(\d+)-[0-9a-f]+$/;
+
+/**
+ * Whether the record's writer is a process that may still be acting on it.
+ * Fail-open: a record with no writer id (an older CLI) or an unparseable
+ * one is treated as live, the same reading the host daemon takes - a marker
+ * that cannot be proven abandoned is not this reader's to replace.
+ */
+function progressWriterMayBeLive(record: HostUpdateProgress): boolean {
+  if (record.writerId === null) return true;
+  const match = WRITER_ID_PID.exec(record.writerId);
+  if (match === null) return true;
+  const pid = Number.parseInt(match[1], 10);
+  if (!Number.isSafeInteger(pid) || pid <= 0) return true;
+  return isProcessAlive(pid);
+}
+
+/**
+ * The pre-lock publish: claim the live path for `next` WITHOUT overwriting
+ * an update that may be in progress.
+ *
+ * `host update` publishes its `updating` before it waits for the contender
+ * lock, so the transfer is visible remotely from its first byte. That write
+ * used to be the one unconditional write on the path, and it could land over
+ * the marker of the updater currently HOLDING the lock - mid-swap, mid-
+ * restart - after which that updater's stamp and clear (CAS against its own
+ * record) could never land, and this run's `failed` on a lost download
+ * would stand over a live mutation as a terminal outcome. The rule is the
+ * same one the lock-holder applies under the lock: nothing is overwritten
+ * blind.
+ *
+ * - `published`: the path was empty and `next` is now there;
+ * - `replaced-stale`: the path held a record no writer is acting on - a
+ *   `failed` (its writer stamped and exited) or an `updating` whose writer
+ *   process is gone - and `next` replaced it by compare-and-swap;
+ * - `deferred`: the path holds another writer's live `updating`. Nothing
+ *   was written; the caller runs without a marker of its own until it
+ *   takes the marker over under the lock. Also the answer when concurrent
+ *   writers kept winning the bounded retry - someone live is writing;
+ * - `failed`: an I/O failure that landed nothing, reported by log.
+ *
+ * `displaced` is the record a `replaced-stale` claim replaced, returned so
+ * the caller can put it back if it then does no disruptive work (a busy
+ * park, a failure before the host is touched): a `failed` that was still
+ * exactly true is not this run's to remove. Null for every other outcome.
+ *
+ * The liveness check is synchronous (`isProcessAlive`; on Windows a
+ * `tasklist` spawn with a bounded timeout) and runs once per record read,
+ * at most three times per claim. Never throws.
+ */
+export interface UpdateProgressMarkerClaim {
+  readonly outcome: "published" | "replaced-stale" | "deferred" | "failed";
+  readonly displaced: HostUpdateProgress | null;
+}
+
+export async function claimUpdateProgressMarkerBeforeLock(
+  environment: Environment,
+  next: HostUpdateProgress,
+): Promise<UpdateProgressMarkerClaim> {
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    const onDisk = await readUpdateProgressMarker(environment);
+    if (onDisk === null) {
+      const created = await createUpdateProgressMarkerIfAbsent(
+        environment,
+        next,
+      );
+      if (created === "created")
+        return { outcome: "published", displaced: null };
+      if (created === "failed") return { outcome: "failed", displaced: null };
+      continue;
+    }
+    if (onDisk.state !== "failed" && progressWriterMayBeLive(onDisk)) {
+      return { outcome: "deferred", displaced: null };
+    }
+    const replaced = await replaceUpdateProgressMarkerIfUnchanged(
+      environment,
+      onDisk,
+      next,
+    );
+    if (replaced === "failed") return { outcome: "failed", displaced: null };
+    if (replaced === "replaced") {
+      createCliLogger(environment).info(
+        "Host update progress marker replaced a record no writer is acting on",
+        {
+          environment,
+          previousState: onDisk.state,
+          previousTarget: onDisk.targetVersion,
+          targetVersion: next.targetVersion,
+        },
+      );
+      return { outcome: "replaced-stale", displaced: onDisk };
+    }
+  }
+  return { outcome: "deferred", displaced: null };
 }
 
 /**
@@ -330,9 +455,13 @@ export async function createUpdateProgressMarkerIfAbsent(
     await ensureHostHomeDir(environment);
     const target = hostUpdateProgressMarkerPath(environment);
     const staged = await stageMarkerFile(target, next);
-    if (!(await landMarkerAtomically(environment, target, staged, "create"))) {
-      return "exists";
-    }
+    const landing = await landMarkerAtomically(
+      environment,
+      target,
+      staged,
+      "create",
+    );
+    if (landing !== "landed") return landing;
     logger.info("Host update progress marker created (conditional)", {
       environment,
       state: next.state,
@@ -354,13 +483,13 @@ async function swapMarkerIfUnchanged(
   environment: Environment,
   expected: HostUpdateProgress,
   next: HostUpdateProgress | null,
-): Promise<"swapped" | "changed" | "absent"> {
+): Promise<"swapped" | "changed" | "absent" | "failed"> {
   const logger = createCliLogger(environment);
   const target = hostUpdateProgressMarkerPath(environment);
   const scratch = `${target}.reconcile-${process.pid}-${Date.now()}`;
   const dropFile = (path: string, step: string): Promise<void> =>
     dropMarkerFile(environment, path, step);
-  const landAtomically = (from: string, step: string): Promise<boolean> =>
+  const landAtomically = (from: string, step: string): Promise<MarkerLanding> =>
     landMarkerAtomically(environment, target, from, step);
   const changed = (currentState: HostUpdateProgressState | null): "changed" => {
     logger.info(
@@ -375,6 +504,18 @@ async function swapMarkerIfUnchanged(
     return "changed";
   };
   try {
+    // Everything that can THROW happens before the live record is taken:
+    // once `target` is in the scratch, a throw would leave the live path
+    // empty under a `failed` that promises the opposite. From the take on,
+    // every call below reports through its return value (the landing and
+    // drop helpers catch internally).
+    let staged: string | null = null;
+    if (next !== null) {
+      await ensureHostHomeDir(environment);
+      staged = await stageMarkerFile(target, next);
+    }
+    const dropStaged = (): Promise<void> =>
+      staged === null ? Promise.resolve() : dropFile(staged, "stamp-unused");
     let absent = false;
     try {
       await rename(target, scratch);
@@ -386,7 +527,8 @@ async function swapMarkerIfUnchanged(
           errorName: errorFromUnknown(err).name,
           errorMessage: errorFromUnknown(err).message,
         });
-        return "changed";
+        await dropStaged();
+        return "failed";
       }
       absent = true;
     }
@@ -395,19 +537,20 @@ async function swapMarkerIfUnchanged(
       if (current === null || !sameProgress(current, expected)) {
         // Not ours: give it back unless a newer marker has since landed.
         await landAtomically(scratch, "restore");
+        await dropStaged();
         return changed(current?.state ?? null);
       }
-      await dropFile(scratch, "expected");
     }
     if (next === null) {
       if (absent) return "absent";
+      await dropFile(scratch, "expected");
       logger.info("Host update progress marker cleared (conditional)", {
         environment,
         state: expected.state,
       });
       return "swapped";
     }
-    if (absent) {
+    if (absent || staged === null) {
       // An empty live path is NOT proof that nobody else is in flight: another
       // conditional swap may hold the current marker in its scratch at this
       // instant (its step 1), and a stamp landed here now would win its
@@ -415,13 +558,32 @@ async function swapMarkerIfUnchanged(
       // live marker it then drops. Absence is a changed marker as far as a
       // replace is concerned; the failure is still reported by exit code and
       // log, and the only marker it can lose is one that was already gone.
+      // (`staged === null` cannot co-occur with `next !== null`; it is the
+      // narrowing the type needs.)
+      await dropStaged();
       return changed(null);
     }
-    await ensureHostHomeDir(environment);
-    const staged = await stageMarkerFile(target, next);
-    if (!(await landAtomically(staged, "stamp"))) {
-      return changed(null);
+    // The expected record is still held in the scratch while `next` lands,
+    // so a landing that FAILS can put it back: `failed` then means "nothing
+    // on the live path changed", which is what lets a caller keep trusting
+    // the record it holds. It is dropped only once `next` is the live
+    // marker. A landing that finds a marker already there (another writer's
+    // create-if-absent, in the instant the path was empty) is a changed
+    // marker: the restore is attempted for symmetry and loses to it.
+    const landing = await landAtomically(staged, "stamp");
+    if (landing !== "landed") {
+      const restored = await landAtomically(scratch, "restore");
+      if (landing === "exists") return changed(null);
+      if (restored === "exists") return changed(null);
+      if (restored === "failed") {
+        logger.warn(
+          "Host update progress marker conditional swap failed and could not restore the expected record - the live path is empty",
+          { environment, step: "stamp-restore" },
+        );
+      }
+      return "failed";
     }
+    await dropFile(scratch, "expected");
     logger.info("Host update progress marker replaced (conditional)", {
       environment,
       state: next.state,
@@ -437,7 +599,7 @@ async function swapMarkerIfUnchanged(
       errorName: errorFromUnknown(err).name,
       errorMessage: errorFromUnknown(err).message,
     });
-    return "changed";
+    return "failed";
   }
 }
 

--- a/clients/traycer-cli/src/host/update-progress-marker.ts
+++ b/clients/traycer-cli/src/host/update-progress-marker.ts
@@ -343,7 +343,11 @@ async function landMarkerAtomically(
         // `from` is gone (or the marker directory is) - nothing to retain,
         // so neither this warning nor the caller's may name a retained
         // path. Neither route landed anything; the distinct value is what
-        // keeps the callers' "retained at <path>" lines honest.
+        // keeps the callers' "retained at <path>" lines honest. The drop is
+        // a best-effort no-op on a path that is already gone; it matters
+        // only when `from` still exists and the wx create failed for a
+        // missing DIRECTORY on the target side, so no scratch is left.
+        await dropMarkerFile(environment, from, `${step}-gone`);
         createCliLogger(environment).warn(
           "Host update progress marker conditional swap failed - the file to land is gone, nothing was retained",
           {
@@ -563,7 +567,14 @@ export async function createUpdateProgressMarkerIfAbsent(
       staged,
       "create",
     );
-    if (landing === "failed") return "failed";
+    // BOTH failure landings: nothing of `next` is on the live path either
+    // way, and a `created` answered over an empty path would have `host
+    // update` record ownership of a marker that does not exist and skip
+    // every later claim - the download and the disruptive work would then
+    // run with no progress or drain protection at all.
+    if (landing === "failed" || landing === "failed-nothing-retained") {
+      return "failed";
+    }
     if (landing === "exists") {
       const standing = await readMarkerState(target, environment);
       if (standing.kind === "unrecognised") {

--- a/clients/traycer-cli/src/host/update-progress-marker.ts
+++ b/clients/traycer-cli/src/host/update-progress-marker.ts
@@ -360,6 +360,27 @@ function progressWriterMayBeLive(record: HostUpdateProgress): boolean {
 }
 
 /**
+ * Whether some writer is still acting on the record: an `updating` whose
+ * writer process may be alive (`progressWriterMayBeLive`, fail-open). A
+ * `failed` has no writer by construction - its writer stamped it and
+ * exited - whatever its `writerId` says. This is the one predicate behind
+ * every "is this record mine to replace?" decision `host update` makes: the
+ * pre-lock claim replaces a record without a live writer and defers to one
+ * with; the takeover under the lock replaces either, but retains only a
+ * live writer's record for the restore that a busy park or a
+ * pre-disruption failure performs. A record no writer is acting on is
+ * replaced and gone, exactly as the blind publish once treated it: putting
+ * it back would re-plant a dead writer's `updating` that no one will ever
+ * clear (a host without dead-writer suppression renders it forever), or an
+ * earlier attempt's `failed` over the newer attempt's own outcome.
+ */
+export function updateProgressRecordHasLiveWriter(
+  record: HostUpdateProgress,
+): boolean {
+  return record.state !== "failed" && progressWriterMayBeLive(record);
+}
+
+/**
  * The pre-lock publish: claim the live path for `next` WITHOUT overwriting
  * an update that may be in progress.
  *
@@ -374,19 +395,17 @@ function progressWriterMayBeLive(record: HostUpdateProgress): boolean {
  * blind.
  *
  * - `published`: the path was empty and `next` is now there;
- * - `replaced-stale`: the path held a record no writer is acting on - a
- *   `failed` (its writer stamped and exited) or an `updating` whose writer
- *   process is gone - and `next` replaced it by compare-and-swap;
+ * - `replaced-stale`: the path held a record no writer is acting on
+ *   (`updateProgressRecordHasLiveWriter` false - a `failed`, or an
+ *   `updating` whose writer process is gone) and `next` replaced it by
+ *   compare-and-swap. The replaced record is gone, not kept for a later
+ *   restore: see `updateProgressRecordHasLiveWriter` for why putting it
+ *   back would be worse than the blind publish it replaces;
  * - `deferred`: the path holds another writer's live `updating`. Nothing
  *   was written; the caller runs without a marker of its own until it
  *   takes the marker over under the lock. Also the answer when concurrent
  *   writers kept winning the bounded retry - someone live is writing;
  * - `failed`: an I/O failure that landed nothing, reported by log.
- *
- * `displaced` is the record a `replaced-stale` claim replaced, returned so
- * the caller can put it back if it then does no disruptive work (a busy
- * park, a failure before the host is touched): a `failed` that was still
- * exactly true is not this run's to remove. Null for every other outcome.
  *
  * The liveness check is synchronous (`isProcessAlive`; on Windows a
  * `tasklist` spawn with a bounded timeout) and runs once per record read,
@@ -394,7 +413,6 @@ function progressWriterMayBeLive(record: HostUpdateProgress): boolean {
  */
 export interface UpdateProgressMarkerClaim {
   readonly outcome: "published" | "replaced-stale" | "deferred" | "failed";
-  readonly displaced: HostUpdateProgress | null;
 }
 
 export async function claimUpdateProgressMarkerBeforeLock(
@@ -408,20 +426,19 @@ export async function claimUpdateProgressMarkerBeforeLock(
         environment,
         next,
       );
-      if (created === "created")
-        return { outcome: "published", displaced: null };
-      if (created === "failed") return { outcome: "failed", displaced: null };
+      if (created === "created") return { outcome: "published" };
+      if (created === "failed") return { outcome: "failed" };
       continue;
     }
-    if (onDisk.state !== "failed" && progressWriterMayBeLive(onDisk)) {
-      return { outcome: "deferred", displaced: null };
+    if (updateProgressRecordHasLiveWriter(onDisk)) {
+      return { outcome: "deferred" };
     }
     const replaced = await replaceUpdateProgressMarkerIfUnchanged(
       environment,
       onDisk,
       next,
     );
-    if (replaced === "failed") return { outcome: "failed", displaced: null };
+    if (replaced === "failed") return { outcome: "failed" };
     if (replaced === "replaced") {
       createCliLogger(environment).info(
         "Host update progress marker replaced a record no writer is acting on",
@@ -432,10 +449,10 @@ export async function claimUpdateProgressMarkerBeforeLock(
           targetVersion: next.targetVersion,
         },
       );
-      return { outcome: "replaced-stale", displaced: onDisk };
+      return { outcome: "replaced-stale" };
     }
   }
-  return { outcome: "deferred", displaced: null };
+  return { outcome: "deferred" };
 }
 
 /**

--- a/clients/traycer-cli/src/host/update-progress-marker.ts
+++ b/clients/traycer-cli/src/host/update-progress-marker.ts
@@ -1,5 +1,7 @@
 import { randomBytes } from "node:crypto";
 import { link, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { basename } from "node:path";
+import { withLock } from "@traycer-clients/shared/host-lock/cross-process-lock";
 import {
   isProcessStartIdentity,
   type ProcessStartIdentity,
@@ -134,7 +136,7 @@ export async function deleteUpdateProgressMarker(
     logger.warn("Host update progress marker clear failed", {
       environment,
       errorName: errorFromUnknown(err).name,
-      errorMessage: errorFromUnknown(err).message,
+      errorCode: errnoCode(err),
     });
   }
 }
@@ -228,6 +230,98 @@ async function stageMarkerFile(
  * its writer's lock acquisition. See `swapMarkerIfUnchanged` for how the
  * window is closed. Never throws (same rule as the other marker I/O).
  */
+// The marker lock. Every conditional primitive takes the CURRENT marker out
+// of the live path (`rename(marker → scratch)`) to compare it, and puts it
+// back when it is not the one expected. For the instant between the take
+// and the restore the live path is EMPTY - and an empty path is exactly
+// what a create-if-absent (the pre-lock claim, the no-transfer publish)
+// lands into. Without a lock that interleaving loses a LIVE writer's
+// record: A's stale clear takes B's marker out, C's claim lands in the
+// gap, A's restore finds the path taken and drops B's record (a restore
+// that loses to a newer marker does not retain it) while B - already past
+// its own reassert - runs unannounced under C's marker, which no CAS of
+// B's can later repair or clear. The retries under the install lock
+// repair a collision during a writer's OWN reassert, not another writer's
+// cleanup after it has started.
+//
+// So every conditional write - create, replace, delete - runs under one
+// short cross-process lock beside the marker (the shared `withLock`:
+// O_EXCL create, holder identity, a dead holder broken by liveness). The
+// hold is a handful of renames; the wait is bounded, and a holder that
+// outlives it (a live process stuck mid-swap) makes the primitive answer
+// `failed` - nothing of the intended write landed, warned by name - the
+// same answer as any other marker I/O failure. This lock is NOT the
+// install/contender lock: it is never held across a download or a wait,
+// and it nests inside the install lock (the reassert) without ordering
+// hazards because nothing takes the install lock while holding it. It is
+// NOT re-entrant: a nested take from the same process polls its own live
+// pid for the whole wait and answers `failed` - the locked bodies call the
+// `...Locked` inner functions, never the outer primitives. The host daemon
+// only reads the marker; every writer OF THIS VERSION takes the lock. A
+// CLI from before the lock (a terminal `traycer` beside Desktop's bundled
+// one, or mid self-upgrade) still writes into the window, which is why
+// the swap's "empty path is not proof" arms below stay.
+//
+// Cost: the acquisition is one O_EXCL create, a metadata write and an
+// unlink - no spawn: the holder's start time and stamp are the cached
+// own-process reads. A wedged lock (a holder alive past the wait, or one
+// whose identity cannot be verified so it is never broken) degrades every
+// conditional write to `failed` after the wait; the busy warn names the
+// lock file so an operator can remove it.
+const MARKER_LOCK_WAIT_MS = 2_000;
+const MARKER_LOCK_POLL_MS = 25;
+
+function markerLockPath(environment: Environment): string {
+  return `${hostUpdateProgressMarkerPath(environment)}.lock`;
+}
+
+/**
+ * Run `fn` holding the marker lock. `null` when the lock could not be
+ * held - busy past the bounded wait, or the acquisition itself failed -
+ * after a warn naming the operation; callers answer `failed`.
+ */
+async function underMarkerLock<T>(
+  environment: Environment,
+  operation: "create" | "replace" | "clear",
+  fn: () => Promise<T>,
+): Promise<T | null> {
+  const logger = createCliLogger(environment);
+  try {
+    await ensureHostHomeDir(environment);
+    const outcome = await withLock(
+      {
+        lockPath: markerLockPath(environment),
+        reason: `host-update-progress-marker-${operation}`,
+        waitMs: MARKER_LOCK_WAIT_MS,
+        pollIntervalMs: MARKER_LOCK_POLL_MS,
+      },
+      fn,
+    );
+    if (outcome.kind === "busy") {
+      logger.warn(
+        "Host update progress marker lock is held by another process past the wait - the conditional write did not run",
+        {
+          environment,
+          operation,
+          lockFile: basename(markerLockPath(environment)),
+          holderPid: outcome.holder?.pid ?? null,
+          holderReason: outcome.holder?.reason ?? null,
+        },
+      );
+      return null;
+    }
+    return outcome.result;
+  } catch (err) {
+    logger.warn("Host update progress marker lock could not be taken", {
+      environment,
+      operation,
+      errorName: errorFromUnknown(err).name,
+      errorCode: errnoCode(err),
+    });
+    return null;
+  }
+}
+
 export async function deleteUpdateProgressMarkerIfUnchanged(
   environment: Environment,
   expected: HostUpdateProgress,
@@ -321,7 +415,7 @@ async function dropMarkerFile(
         environment,
         step,
         errorName: errorFromUnknown(err).name,
-        errorMessage: errorFromUnknown(err).message,
+        errorCode: errnoCode(err),
       },
     );
   }
@@ -382,9 +476,8 @@ async function landMarkerAtomically(
           {
             environment,
             step,
-            path: from,
             errorName: errorFromUnknown(createErr).name,
-            errorMessage: errorFromUnknown(createErr).message,
+            errorCode: errnoCode(createErr),
           },
         );
         return "failed-nothing-retained";
@@ -401,9 +494,9 @@ async function landMarkerAtomically(
         {
           environment,
           step,
-          retainedPath: from,
+          retainedFile: basename(from),
           errorName: errorFromUnknown(createErr).name,
-          errorMessage: errorFromUnknown(createErr).message,
+          errorCode: errnoCode(createErr),
         },
       );
       return "failed";
@@ -563,7 +656,8 @@ export function updateProgressRecordHasProvenLiveWriter(
  * once per record read: at most three times per claim call. Per `host
  * update` that is at most eight checks - at most sixteen bounded spawns on
  * Windows, eight on macOS, none on Linux (`/proc` reads), plus one to read
- * this process's own stamp - the claim can run twice (a claim that
+ * this process's own stamp; the marker lock adds none (its metadata is the
+ * cached own-process reads) - the claim can run twice (a claim that
  * deferred at
  * `onWillDownload` claims again before the work), the takeover under the
  * lock reads once (only on the iteration that replaces), and the restore a
@@ -638,9 +732,19 @@ export async function createUpdateProgressMarkerIfAbsent(
   environment: Environment,
   next: HostUpdateProgress,
 ): Promise<"created" | "exists" | "failed"> {
+  const held = await underMarkerLock(environment, "create", () =>
+    createUpdateProgressMarkerIfAbsentLocked(environment, next),
+  );
+  return held ?? "failed";
+}
+
+async function createUpdateProgressMarkerIfAbsentLocked(
+  environment: Environment,
+  next: HostUpdateProgress,
+): Promise<"created" | "exists" | "failed"> {
   const logger = createCliLogger(environment);
   try {
-    await ensureHostHomeDir(environment);
+    // The directory exists: `underMarkerLock` ensured it before the take.
     const target = hostUpdateProgressMarkerPath(environment);
     const staged = await stageMarkerFile(target, next);
     const landing = await landMarkerAtomically(
@@ -677,7 +781,7 @@ export async function createUpdateProgressMarkerIfAbsent(
         "Host update progress marker is not a record - replacing the malformed file",
         { environment, length: standing.raw.length },
       );
-      const swapped = await swapMarkerIfUnchanged(
+      const swapped = await swapMarkerIfUnchangedLocked(
         environment,
         { kind: "malformed", raw: standing.raw },
         next,
@@ -706,8 +810,7 @@ export async function createUpdateProgressMarkerIfAbsent(
   } catch (err) {
     logger.warn("Host update progress marker conditional create failed", {
       environment,
-      errorName: errorFromUnknown(err).name,
-      errorMessage: errorFromUnknown(err).message,
+      ...unexpectedFailureFields(err),
     });
     return "failed";
   }
@@ -723,6 +826,22 @@ type SwapExpectation =
   | { readonly kind: "malformed"; readonly raw: string };
 
 async function swapMarkerIfUnchanged(
+  environment: Environment,
+  expected: SwapExpectation,
+  next: HostUpdateProgress | null,
+): Promise<"swapped" | "changed" | "absent" | "failed"> {
+  const held = await underMarkerLock(
+    environment,
+    next === null ? "clear" : "replace",
+    () => swapMarkerIfUnchangedLocked(environment, expected, next),
+  );
+  return held ?? "failed";
+}
+
+// The swap proper, with the marker lock HELD by the caller (see
+// `underMarkerLock`): from the take to the land or restore, no other
+// conditional writer can land in the empty path.
+async function swapMarkerIfUnchangedLocked(
   environment: Environment,
   expected: SwapExpectation,
   next: HostUpdateProgress | null,
@@ -755,7 +874,7 @@ async function swapMarkerIfUnchanged(
     // drop helpers catch internally).
     let staged: string | null = null;
     if (next !== null) {
-      await ensureHostHomeDir(environment);
+      // The directory exists: `underMarkerLock` ensured it before the take.
       staged = await stageMarkerFile(target, next);
     }
     const dropStaged = (): Promise<void> =>
@@ -769,7 +888,7 @@ async function swapMarkerIfUnchanged(
           environment,
           step: "take",
           errorName: errorFromUnknown(err).name,
-          errorMessage: errorFromUnknown(err).message,
+          errorCode: errnoCode(err),
         });
         await dropStaged();
         return "failed";
@@ -799,7 +918,11 @@ async function swapMarkerIfUnchanged(
         if (restored === "failed") {
           logger.warn(
             "Host update progress marker conditional swap could not restore the record it found - the live path is empty",
-            { environment, step: "restore-other", retainedPath: scratch },
+            {
+              environment,
+              step: "restore-other",
+              retainedFile: basename(scratch),
+            },
           );
           return "failed";
         }
@@ -823,8 +946,10 @@ async function swapMarkerIfUnchanged(
       return "swapped";
     }
     if (absent || staged === null) {
-      // An empty live path is NOT proof that nobody else is in flight: another
-      // conditional swap may hold the current marker in its scratch at this
+      // An empty live path is NOT proof that nobody else is in flight: a
+      // conditional swap of a CLI from before the marker lock (see
+      // `underMarkerLock` - among lock-taking writers no swap can be
+      // mid-take here) may hold the current marker in its scratch at this
       // instant (its step 1), and a stamp landed here now would win its
       // restore's `link` with EEXIST - our stale failure standing over the
       // live marker it then drops. Absence is a changed marker as far as a
@@ -842,9 +967,9 @@ async function swapMarkerIfUnchanged(
     // holds. When the restore ALSO fails the live path is empty and the
     // record is retained in the scratch, warned about by name below. It is
     // dropped only once `next` is the live marker. A landing that finds a
-    // marker already there (another writer's create-if-absent, in the
-    // instant the path was empty) is a changed marker: the restore is
-    // attempted for symmetry and loses to it.
+    // marker already there (a create-if-absent by a CLI from before the
+    // marker lock, in the instant the path was empty) is a changed marker:
+    // the restore is attempted for symmetry and loses to it.
     const landing = await landAtomically(staged, "stamp");
     if (landing !== "landed") {
       const restored = await landAtomically(scratch, "restore");
@@ -853,7 +978,11 @@ async function swapMarkerIfUnchanged(
       if (restored === "failed") {
         logger.warn(
           "Host update progress marker conditional swap failed and could not restore the expected record - the live path is empty",
-          { environment, step: "stamp-restore", retainedPath: scratch },
+          {
+            environment,
+            step: "stamp-restore",
+            retainedFile: basename(scratch),
+          },
         );
       }
       if (restored === "failed-nothing-retained") {
@@ -877,11 +1006,30 @@ async function swapMarkerIfUnchanged(
     logger.warn("Host update progress marker conditional swap failed", {
       environment,
       step: "unexpected",
-      errorName: errorFromUnknown(err).name,
-      errorMessage: errorFromUnknown(err).message,
+      ...unexpectedFailureFields(err),
     });
     return "failed";
   }
+}
+
+/**
+ * WARN fields for a catch-all: the errno code when the error is an fs
+ * error (its message would carry the marker's absolute path - the host
+ * home directory - which stays out of WARN), and the message ONLY when it
+ * is not (a programming error's message carries no path, and is the one
+ * string that locates the bug).
+ */
+function unexpectedFailureFields(err: unknown): {
+  readonly errorName: string;
+  readonly errorCode: string | null;
+  readonly errorMessage: string | null;
+} {
+  const code = errnoCode(err);
+  return {
+    errorName: errorFromUnknown(err).name,
+    errorCode: code,
+    errorMessage: code === null ? errorFromUnknown(err).message : null,
+  };
 }
 
 // Read-only accessor for Doctor / tests. Returns `null` when absent,
@@ -945,7 +1093,7 @@ async function readMarkerState(
     logger.warn("Host update progress marker could not be read", {
       environment,
       errorName: errorFromUnknown(err).name,
-      errorMessage: errorFromUnknown(err).message,
+      errorCode: errnoCode(err),
     });
     return { kind: "unreadable" };
   }

--- a/clients/traycer-cli/src/host/update-progress-marker.ts
+++ b/clients/traycer-cli/src/host/update-progress-marker.ts
@@ -2,7 +2,7 @@ import { randomBytes } from "node:crypto";
 import { link, readFile, rename, rm, writeFile } from "node:fs/promises";
 import type { Environment } from "../runner/environment";
 import { createCliLogger, errorFromUnknown } from "../logger";
-import { isProcessAlive } from "../store/cli-lock";
+import { probeProcessLiveness } from "../store/process-identity";
 import {
   ensureHostHomeDir,
   hostUpdateProgressMarkerPath,
@@ -111,11 +111,14 @@ export async function deleteUpdateProgressMarker(
   }
 }
 
-// `failed` is an I/O failure after which the live path still holds what it
-// held (the expected record is restored when a stamp cannot land; the one
-// exception - neither the stamp nor the restore could land - is warned
-// about by name). Callers never retry it - only `changed` (a record that
-// moved) is worth a re-read.
+// `failed` is an I/O failure after which nothing of `next` landed. The live
+// path USUALLY still holds what it held (a record taken into the scratch is
+// put back when the stamp cannot land); the exception - the take succeeded
+// and neither route could land the restore - leaves the live path empty
+// with the displaced bytes retained in a named `.reconcile-*` scratch and
+// warned about by name, or, when the marker directory itself is gone,
+// with nothing retained (warned about without a path). Callers never retry
+// it - only `changed` (a record that moved) is worth a re-read.
 export type ConditionalMarkerDelete =
   | "cleared"
   | "changed"
@@ -154,6 +157,16 @@ function errnoCode(err: unknown): string | null {
 }
 
 /**
+ * A per-file suffix unique across processes (pid) AND within one process
+ * (time plus random): two swaps in one millisecond of one command - a
+ * failed restore retains its scratch, and the next swap must not rename
+ * over it - get distinct names, the same way two concurrent stagers do.
+ */
+function markerScratchSuffix(): string {
+  return `${process.pid}-${Date.now()}-${randomBytes(3).toString("hex")}`;
+}
+
+/**
  * Write `progress` to a private sibling of `target` and return its path. The
  * name is unique per writer: a shared `${target}.tmp` let two concurrent
  * writers overwrite each other's staging file, so one renamed the OTHER's
@@ -163,7 +176,7 @@ async function stageMarkerFile(
   target: string,
   progress: HostUpdateProgress,
 ): Promise<string> {
-  const tmp = `${target}.tmp-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const tmp = `${target}.tmp-${markerScratchSuffix()}`;
   await writeFile(tmp, `${JSON.stringify(progress, null, 2)}\n`, {
     encoding: "utf8",
     mode: 0o600,
@@ -190,7 +203,11 @@ export async function deleteUpdateProgressMarkerIfUnchanged(
   environment: Environment,
   expected: HostUpdateProgress,
 ): Promise<ConditionalMarkerDelete> {
-  const outcome = await swapMarkerIfUnchanged(environment, expected, null);
+  const outcome = await swapMarkerIfUnchanged(
+    environment,
+    { kind: "record", record: expected },
+    null,
+  );
   return outcome === "swapped" ? "cleared" : outcome;
 }
 
@@ -219,7 +236,11 @@ export async function replaceUpdateProgressMarkerIfUnchanged(
   expected: HostUpdateProgress,
   next: HostUpdateProgress,
 ): Promise<ConditionalMarkerReplace> {
-  const outcome = await swapMarkerIfUnchanged(environment, expected, next);
+  const outcome = await swapMarkerIfUnchanged(
+    environment,
+    { kind: "record", record: expected },
+    next,
+  );
   if (outcome === "swapped") return "replaced";
   if (outcome === "failed") return "failed";
   return "changed";
@@ -289,7 +310,9 @@ async function dropMarkerFile(
 // `exists` means a marker was already there and won; `failed` means neither
 // route could land it - two answers callers act on differently (a race is
 // re-read, an I/O failure is not retried), so they are never collapsed.
-type MarkerLanding = "landed" | "exists" | "failed";
+// `failed-nothing-retained`: the file to land was gone (or its directory
+// was), so no scratch survives for a caller to name.
+type MarkerLanding = "landed" | "exists" | "failed" | "failed-nothing-retained";
 
 async function landMarkerAtomically(
   environment: Environment,
@@ -315,6 +338,23 @@ async function landMarkerAtomically(
       if (errnoCode(createErr) === "EEXIST") {
         await dropMarkerFile(environment, from, `${step}-newer-exists`);
         return "exists";
+      }
+      if (errnoCode(createErr) === "ENOENT") {
+        // `from` is gone (or the marker directory is) - nothing to retain,
+        // so neither this warning nor the caller's may name a retained
+        // path. Neither route landed anything; the distinct value is what
+        // keeps the callers' "retained at <path>" lines honest.
+        createCliLogger(environment).warn(
+          "Host update progress marker conditional swap failed - the file to land is gone, nothing was retained",
+          {
+            environment,
+            step,
+            path: from,
+            errorName: errorFromUnknown(createErr).name,
+            errorMessage: errorFromUnknown(createErr).message,
+          },
+        );
+        return "failed-nothing-retained";
       }
       // Neither route could land `from` (no hard links AND the create
       // failed - ENOSPC, EIO). `from` may be the only complete copy of
@@ -345,39 +385,60 @@ async function landMarkerAtomically(
 const WRITER_ID_PID = /^(\d+)-[0-9a-f]+$/;
 
 /**
- * Whether the record's writer is a process that may still be acting on it.
- * Fail-open: a record with no writer id (an older CLI) or an unparseable
- * one is treated as live, the same reading the host daemon takes - a marker
- * that cannot be proven abandoned is not this reader's to replace.
+ * What is known about the record's writer: `live` is positive evidence (a
+ * parseable pid the OS reports alive), `dead` is positive evidence of the
+ * opposite, and `unknown` is everything the probe cannot settle - no writer
+ * id (an older CLI), an id in another shape, or a probe that failed
+ * (`tasklist` missing on Windows). The two predicates below read this from
+ * opposite sides: what cannot be proven abandoned is not replaced outside
+ * the lock, and what cannot be proven live is not put back.
  */
-function progressWriterMayBeLive(record: HostUpdateProgress): boolean {
-  if (record.writerId === null) return true;
+function writerLiveness(
+  record: HostUpdateProgress,
+): "live" | "dead" | "unknown" {
+  if (record.writerId === null) return "unknown";
   const match = WRITER_ID_PID.exec(record.writerId);
-  if (match === null) return true;
+  if (match === null) return "unknown";
   const pid = Number.parseInt(match[1], 10);
-  if (!Number.isSafeInteger(pid) || pid <= 0) return true;
-  return isProcessAlive(pid);
+  if (!Number.isSafeInteger(pid) || pid <= 0) return "unknown";
+  const verdict = probeProcessLiveness(pid);
+  if (verdict === "alive") return "live";
+  if (verdict === "dead") return "dead";
+  return "unknown";
 }
 
 /**
- * Whether some writer is still acting on the record: an `updating` whose
- * writer process may be alive (`progressWriterMayBeLive`, fail-open). A
- * `failed` has no writer by construction - its writer stamped it and
- * exited - whatever its `writerId` says. This is the one predicate behind
- * every "is this record mine to replace?" decision `host update` makes: the
- * pre-lock claim replaces a record without a live writer and defers to one
- * with; the takeover under the lock replaces either, but retains only a
- * live writer's record for the restore that a busy park or a
- * pre-disruption failure performs. A record no writer is acting on is
- * replaced and gone, exactly as the blind publish once treated it: putting
- * it back would re-plant a dead writer's `updating` that no one will ever
- * clear (a host without dead-writer suppression renders it forever), or an
- * earlier attempt's `failed` over the newer attempt's own outcome.
+ * Whether some writer MAY still be acting on the record: an `updating`
+ * whose writer is not proven dead (fail-open, the same reading the host
+ * daemon takes for a parseable id). A `failed` has no writer by
+ * construction - its writer stamped it and exited - whatever its `writerId`
+ * says. This is the predicate behind the pre-lock claim: it replaces a
+ * record without a live writer and defers to one that may have. A record no
+ * writer is acting on is replaced and gone, exactly as the blind publish
+ * once treated it: putting it back would re-plant a dead writer's
+ * `updating` that no one will ever clear, or an earlier attempt's `failed`
+ * over the newer attempt's own outcome.
  */
 export function updateProgressRecordHasLiveWriter(
   record: HostUpdateProgress,
 ): boolean {
-  return record.state !== "failed" && progressWriterMayBeLive(record);
+  return record.state !== "failed" && writerLiveness(record) !== "dead";
+}
+
+/**
+ * Whether a writer is PROVEN to be acting on the record: an `updating`
+ * whose pid the OS reports alive. The takeover under the lock retains a
+ * displaced record for the restore a busy park or a pre-disruption failure
+ * performs only on this evidence. The fail-open reading is wrong there: a
+ * record with no writer id is one the host daemon renders FOREVER (its
+ * dead-writer suppression needs a pid to check), so restoring it re-plants
+ * a marker no one will clear, and a record whose probe failed is one whose
+ * writer, if any, re-asserts its own marker under the lock anyway.
+ */
+export function updateProgressRecordHasProvenLiveWriter(
+  record: HostUpdateProgress,
+): boolean {
+  return record.state !== "failed" && writerLiveness(record) === "live";
 }
 
 /**
@@ -404,12 +465,23 @@ export function updateProgressRecordHasLiveWriter(
  * - `deferred`: the path holds another writer's live `updating`. Nothing
  *   was written; the caller runs without a marker of its own until it
  *   takes the marker over under the lock. Also the answer when concurrent
- *   writers kept winning the bounded retry - someone live is writing;
- * - `failed`: an I/O failure that landed nothing, reported by log.
+ *   writers kept winning the bounded retry - someone live is writing - and
+ *   for a file this CLI cannot read or does not recognise as a record
+ *   (`MarkerRead`: a foreign shape, an unreadable file), which is left
+ *   standing;
+ * - `failed`: an I/O failure after which nothing of `next` landed. The
+ *   record it was replacing may have been displaced into a retained
+ *   scratch when neither restore route could land (`ConditionalMarker*`,
+ *   warned about by name); the caller does not hold a record of its own
+ *   either way.
  *
- * The liveness check is synchronous (`isProcessAlive`; on Windows a
- * `tasklist` spawn with a bounded timeout) and runs once per record read,
- * at most three times per claim. Never throws.
+ * The liveness check is synchronous (`probeProcessLiveness`; on Windows a
+ * `tasklist` spawn with a bounded timeout) and runs once per record read:
+ * at most three times per claim call. Per `host update` that is at most
+ * eight - the claim can run twice (a claim that deferred at
+ * `onWillDownload` claims again before the work), the takeover under the
+ * lock reads once (only on the iteration that replaces), and the restore a
+ * park or a pre-disruption failure performs reads once. Never throws.
  */
 export interface UpdateProgressMarkerClaim {
   readonly outcome: "published" | "replaced-stale" | "deferred" | "failed";
@@ -458,10 +530,23 @@ export async function claimUpdateProgressMarkerBeforeLock(
 /**
  * Create-if-absent: land `next` at the live path ONLY if no marker stands
  * there, through the same `link` / `wx` landing the conditional swap uses.
- * `"exists"` means a marker was there - possibly one that landed between the
+ * `"exists"` means a RECORD was there - possibly one that landed between the
  * caller's read and this call, which is exactly the write this exists to
  * refuse: a read-then-`rename` would have overwritten it. Never throws;
  * `"failed"` is an I/O failure that landed nothing, reported by log.
+ *
+ * A file that is there but is not a record (see `MarkerRead`) is NOT
+ * `exists`: the claim and the reassert answer `exists` by re-reading
+ * (`markUpdateFailed` logs once and stops), and a re-read answers "no
+ * marker", so the pair would loop and give up - with the
+ * malformed file standing over every later update too. Such a file is
+ * replaced through the conditional swap, keyed on its exact bytes, so a
+ * record another writer lands in the meantime still wins. The residual is
+ * the `wx` fallback's own non-atomic write: on a filesystem without hard
+ * links, another updater's partial marker read in the instant of its write
+ * looks malformed, and if its bytes have not moved by the swap's compare it
+ * is replaced - one lost marker for that updater, in a window the size of
+ * one small write, and only where `link` is unavailable.
  */
 export async function createUpdateProgressMarkerIfAbsent(
   environment: Environment,
@@ -478,7 +563,46 @@ export async function createUpdateProgressMarkerIfAbsent(
       staged,
       "create",
     );
-    if (landing !== "landed") return landing;
+    if (landing === "failed") return "failed";
+    if (landing === "exists") {
+      const standing = await readMarkerState(target, environment);
+      if (standing.kind === "unrecognised") {
+        logger.warn(
+          "Host update progress marker has a shape this CLI does not read - leaving it in place",
+          { environment },
+        );
+        return "exists";
+      }
+      if (standing.kind === "unreadable") {
+        // Already warned about by the read, with the errno. Nothing can be
+        // compared, so nothing is replaced: the caller re-reads, finds "no
+        // marker" and its bounded loop gives up with its own warning.
+        return "exists";
+      }
+      if (standing.kind !== "malformed") return "exists";
+      logger.warn(
+        "Host update progress marker is not a record - replacing the malformed file",
+        { environment, length: standing.raw.length },
+      );
+      const swapped = await swapMarkerIfUnchanged(
+        environment,
+        { kind: "malformed", raw: standing.raw },
+        next,
+      );
+      if (swapped === "failed") return "failed";
+      // `changed` / `absent`: the file moved under us - a record landed, or
+      // the malformed bytes changed. The caller re-reads, as for `exists`.
+      if (swapped !== "swapped") return "exists";
+      logger.info(
+        "Host update progress marker created over a malformed file (conditional)",
+        {
+          environment,
+          state: next.state,
+          targetVersion: next.targetVersion,
+        },
+      );
+      return "created";
+    }
     logger.info("Host update progress marker created (conditional)", {
       environment,
       state: next.state,
@@ -496,14 +620,23 @@ export async function createUpdateProgressMarkerIfAbsent(
   }
 }
 
+/**
+ * What a conditional swap expects to find in its scratch: the exact record a
+ * caller read, or the exact malformed bytes `createUpdateProgressMarkerIfAbsent`
+ * found standing where a record should be.
+ */
+type SwapExpectation =
+  | { readonly kind: "record"; readonly record: HostUpdateProgress }
+  | { readonly kind: "malformed"; readonly raw: string };
+
 async function swapMarkerIfUnchanged(
   environment: Environment,
-  expected: HostUpdateProgress,
+  expected: SwapExpectation,
   next: HostUpdateProgress | null,
 ): Promise<"swapped" | "changed" | "absent" | "failed"> {
   const logger = createCliLogger(environment);
   const target = hostUpdateProgressMarkerPath(environment);
-  const scratch = `${target}.reconcile-${process.pid}-${Date.now()}`;
+  const scratch = `${target}.reconcile-${markerScratchSuffix()}`;
   const dropFile = (path: string, step: string): Promise<void> =>
     dropMarkerFile(environment, path, step);
   const landAtomically = (from: string, step: string): Promise<MarkerLanding> =>
@@ -513,7 +646,8 @@ async function swapMarkerIfUnchanged(
       "Host update progress marker changed under a conditional swap",
       {
         environment,
-        expectedState: expected.state,
+        expectedState:
+          expected.kind === "record" ? expected.record.state : "malformed",
         currentState,
         operation: next === null ? "clear" : "replace",
       },
@@ -550,12 +684,40 @@ async function swapMarkerIfUnchanged(
       absent = true;
     }
     if (!absent) {
-      const current = await readMarkerFile(scratch, environment);
-      if (current === null || !sameProgress(current, expected)) {
-        // Not ours: give it back unless a newer marker has since landed.
-        await landAtomically(scratch, "restore");
+      const current = await readMarkerState(scratch, environment);
+      // A malformed expectation matches the SAME bytes only: a file that
+      // parses now, or malformed bytes that differ, is someone else's
+      // marker (or their write completing) and goes back.
+      const matches =
+        expected.kind === "record"
+          ? current.kind === "record" &&
+            sameProgress(current.record, expected.record)
+          : current.kind === "malformed" && current.raw === expected.raw;
+      if (!matches) {
+        // Not ours: give it back unless a newer marker has since landed. A
+        // restore that lands, or loses to a newer marker, is a `changed`
+        // marker the caller re-reads. One that neither route could land is
+        // NOT: the live path is empty and the other writer's record sits
+        // in the retained scratch, which no "another updater owns it now"
+        // line may claim. That is `failed`, named here so the CLI's log
+        // says where the bytes went.
+        const restored = await landAtomically(scratch, "restore");
         await dropStaged();
-        return changed(current?.state ?? null);
+        if (restored === "failed") {
+          logger.warn(
+            "Host update progress marker conditional swap could not restore the record it found - the live path is empty",
+            { environment, step: "restore-other", retainedPath: scratch },
+          );
+          return "failed";
+        }
+        if (restored === "failed-nothing-retained") {
+          logger.warn(
+            "Host update progress marker conditional swap could not restore the record it found - the live path is empty and nothing was retained",
+            { environment, step: "restore-other" },
+          );
+          return "failed";
+        }
+        return changed(current.kind === "record" ? current.record.state : null);
       }
     }
     if (next === null) {
@@ -563,7 +725,7 @@ async function swapMarkerIfUnchanged(
       await dropFile(scratch, "expected");
       logger.info("Host update progress marker cleared (conditional)", {
         environment,
-        state: expected.state,
+        state: expected.kind === "record" ? expected.record.state : "malformed",
       });
       return "swapped";
     }
@@ -582,11 +744,14 @@ async function swapMarkerIfUnchanged(
     }
     // The expected record is still held in the scratch while `next` lands,
     // so a landing that FAILS can put it back: `failed` then means "nothing
-    // on the live path changed", which is what lets a caller keep trusting
-    // the record it holds. It is dropped only once `next` is the live
-    // marker. A landing that finds a marker already there (another writer's
-    // create-if-absent, in the instant the path was empty) is a changed
-    // marker: the restore is attempted for symmetry and loses to it.
+    // of `next` landed", and when the restore lands too, "nothing on the
+    // live path changed" - what lets a caller keep trusting the record it
+    // holds. When the restore ALSO fails the live path is empty and the
+    // record is retained in the scratch, warned about by name below. It is
+    // dropped only once `next` is the live marker. A landing that finds a
+    // marker already there (another writer's create-if-absent, in the
+    // instant the path was empty) is a changed marker: the restore is
+    // attempted for symmetry and loses to it.
     const landing = await landAtomically(staged, "stamp");
     if (landing !== "landed") {
       const restored = await landAtomically(scratch, "restore");
@@ -595,6 +760,12 @@ async function swapMarkerIfUnchanged(
       if (restored === "failed") {
         logger.warn(
           "Host update progress marker conditional swap failed and could not restore the expected record - the live path is empty",
+          { environment, step: "stamp-restore", retainedPath: scratch },
+        );
+      }
+      if (restored === "failed-nothing-retained") {
+        logger.warn(
+          "Host update progress marker conditional swap failed and could not restore the expected record - the live path is empty and nothing was retained",
           { environment, step: "stamp-restore" },
         );
       }
@@ -620,25 +791,70 @@ async function swapMarkerIfUnchanged(
   }
 }
 
-// Read-only accessor for Doctor / tests. Returns `null` when absent or
-// malformed (a malformed marker is treated the same as "no marker" - it is
-// advisory UI state, not an authoritative record worth failing loudly on).
+// Read-only accessor for Doctor / tests. Returns `null` when absent,
+// unreadable, malformed or unrecognised (anything that is not a record is
+// treated the same as "no marker" - it is advisory UI state, not an
+// authoritative record worth failing loudly on). WRITERS do not collapse
+// these: see `MarkerRead` and the malformed arm of
+// `createUpdateProgressMarkerIfAbsent`.
 export async function readUpdateProgressMarker(
   environment: Environment,
 ): Promise<HostUpdateProgress | null> {
   return readMarkerFile(hostUpdateProgressMarkerPath(environment), environment);
 }
 
-async function readMarkerFile(
+/**
+ * What stands at a marker path, with "there is a file but it is not a
+ * record" kept apart from "there is no file". Readers collapse the two (a
+ * malformed marker is no marker as far as UI state goes), but a WRITER must
+ * not: a create-if-absent lands only on an empty path, so a malformed file -
+ * a crash between the `wx` fallback's open and its write, a truncated disk -
+ * would answer every later create with `exists` while every read answered
+ * "nothing there", and each update would run without its marker until
+ * someone deleted the file by hand. `createUpdateProgressMarkerIfAbsent`
+ * replaces such a file conditionally on its exact bytes.
+ *
+ * `malformed` is bytes that do not parse to a JSON object - what a crash
+ * mid-write leaves (invalid JSON, or a scalar). `unrecognised` is a JSON
+ * object (an array included) this CLI does not read as a record: another
+ * writer's shape, most likely a NEWER CLI's marker with a state this one
+ * predates. That is a foreign record, not garbage - its writer's liveness
+ * cannot be honoured because its `writerId` cannot be trusted to mean what
+ * ours does - so a writer treats it as `exists` and never replaces it: the
+ * takeover under the lock loops on it and gives up too, exactly as
+ * before. `unreadable` is a
+ * file that is there but cannot be read (EACCES on a marker a `sudo` run
+ * left root-owned, EISDIR): nothing can be compared, so nothing is
+ * replaced, and it too is `exists` to a writer - warned about with its
+ * errno by the read, then by the caller's bounded loop giving up.
+ */
+type MarkerRead =
+  | { readonly kind: "absent" }
+  | { readonly kind: "unreadable" }
+  | { readonly kind: "malformed"; readonly raw: string }
+  | { readonly kind: "unrecognised" }
+  | { readonly kind: "record"; readonly record: HostUpdateProgress };
+
+async function readMarkerState(
   path: string,
   environment: Environment,
-): Promise<HostUpdateProgress | null> {
+): Promise<MarkerRead> {
   const logger = createCliLogger(environment);
   let raw: string;
   try {
     raw = await readFile(path, "utf8");
-  } catch {
-    return null;
+  } catch (err) {
+    // ENOENT is the ordinary answer. Anything else (EACCES, EISDIR) is a
+    // file this module can neither read nor compare: `unreadable`, kept
+    // apart from `absent` so a create-if-absent does not answer it with a
+    // replacement, and named in the log with its errno.
+    if (errnoCode(err) === "ENOENT") return { kind: "absent" };
+    logger.warn("Host update progress marker could not be read", {
+      environment,
+      errorName: errorFromUnknown(err).name,
+      errorMessage: errorFromUnknown(err).message,
+    });
+    return { kind: "unreadable" };
   }
   let parsed: unknown;
   try {
@@ -648,9 +864,11 @@ async function readMarkerFile(
       environment,
       errorName: errorFromUnknown(err).name,
     });
-    return null;
+    return { kind: "malformed", raw };
   }
-  if (parsed === null || typeof parsed !== "object") return null;
+  if (parsed === null || typeof parsed !== "object") {
+    return { kind: "malformed", raw };
+  }
   const obj = parsed as Record<string, unknown>;
   if (
     (obj.state !== "updating" && obj.state !== "failed") ||
@@ -658,15 +876,26 @@ async function readMarkerFile(
     typeof obj.targetVersion !== "string" ||
     typeof obj.updatedAt !== "string"
   ) {
-    return null;
+    return { kind: "unrecognised" };
   }
   return {
-    state: obj.state,
-    error: obj.error === null ? null : obj.error,
-    targetVersion: obj.targetVersion,
-    updatedAt: obj.updatedAt,
-    // Absent on markers written before the field existed; carried through so
-    // a conditional swap compares what was actually written.
-    writerId: typeof obj.writerId === "string" ? obj.writerId : null,
+    kind: "record",
+    record: {
+      state: obj.state,
+      error: obj.error === null ? null : obj.error,
+      targetVersion: obj.targetVersion,
+      updatedAt: obj.updatedAt,
+      // Absent on markers written before the field existed; carried through
+      // so a conditional swap compares what was actually written.
+      writerId: typeof obj.writerId === "string" ? obj.writerId : null,
+    },
   };
+}
+
+async function readMarkerFile(
+  path: string,
+  environment: Environment,
+): Promise<HostUpdateProgress | null> {
+  const read = await readMarkerState(path, environment);
+  return read.kind === "record" ? read.record : null;
 }

--- a/clients/traycer-cli/src/host/update-progress-marker.ts
+++ b/clients/traycer-cli/src/host/update-progress-marker.ts
@@ -1,7 +1,6 @@
 import { randomBytes } from "node:crypto";
 import { link, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { basename } from "node:path";
-import { withLock } from "@traycer-clients/shared/host-lock/cross-process-lock";
 import {
   isProcessStartIdentity,
   type ProcessStartIdentity,
@@ -13,6 +12,7 @@ import {
   probeProcessLiveness,
   verifyProcessIdentity,
 } from "../store/process-identity";
+import { withCliScopedFileLock } from "../store/cli-lock";
 import {
   ensureHostHomeDir,
   hostUpdateProgressMarkerPath,
@@ -245,8 +245,9 @@ async function stageMarkerFile(
 // cleanup after it has started.
 //
 // So every conditional write - create, replace, delete - runs under one
-// short cross-process lock beside the marker (the shared `withLock`:
-// O_EXCL create, holder identity, a dead holder broken by liveness). The
+// short cross-process lock beside the marker (the shared lock protocol
+// through the CLI facade `withCliScopedFileLock`: O_EXCL create, holder
+// identity, a dead holder broken by liveness). The
 // hold is a handful of renames; the wait is bounded, and a holder that
 // outlives it (a live process stuck mid-swap) makes the primitive answer
 // `failed` - nothing of the intended write landed, warned by name - the
@@ -288,7 +289,7 @@ async function underMarkerLock<T>(
   const logger = createCliLogger(environment);
   try {
     await ensureHostHomeDir(environment);
-    const outcome = await withLock(
+    const outcome = await withCliScopedFileLock(
       {
         lockPath: markerLockPath(environment),
         reason: `host-update-progress-marker-${operation}`,

--- a/clients/traycer-cli/src/host/update-progress-marker.ts
+++ b/clients/traycer-cli/src/host/update-progress-marker.ts
@@ -1,8 +1,16 @@
 import { randomBytes } from "node:crypto";
 import { link, readFile, rename, rm, writeFile } from "node:fs/promises";
+import {
+  isProcessStartIdentity,
+  type ProcessStartIdentity,
+} from "@traycer/protocol/host/lifecycle";
 import type { Environment } from "../runner/environment";
 import { createCliLogger, errorFromUnknown } from "../logger";
-import { probeProcessLiveness } from "../store/process-identity";
+import {
+  ownProcessStartIdentity,
+  probeProcessLiveness,
+  verifyProcessIdentity,
+} from "../store/process-identity";
 import {
   ensureHostHomeDir,
   hostUpdateProgressMarkerPath,
@@ -42,6 +50,18 @@ export interface HostUpdateProgress {
    * reads back as `null`.
    */
   readonly writerId: string | null;
+  /**
+   * The writer process's creation stamp (`ProcessStartIdentity`, the same
+   * token the CLI lock and the host's `pid.json` carry), what lets a reader
+   * tell the writer from an unrelated process the OS later handed the same
+   * pid: a pid the OS reports alive is only the writer if the process
+   * behind it was created when the writer was. `null` when the platform
+   * probe could not produce a stamp at the write, and on a marker written
+   * by a CLI before the field existed - both read by pid alone
+   * (`writerLiveness`). Additive like `writerId`: the host daemon ignores
+   * it.
+   */
+  readonly writerStartIdentity: ProcessStartIdentity | null;
 }
 
 // One identity per process. Two `host update` invocations racing for the
@@ -51,7 +71,14 @@ export interface HostUpdateProgress {
 // never clear, because the stamp no longer matches what IT wrote.
 const PROGRESS_WRITER_ID = `${process.pid}-${randomBytes(6).toString("hex")}`;
 
-/** A marker record stamped with the current time and this process's identity. */
+/**
+ * A marker record stamped with the current time and this process's identity:
+ * the per-process writer id, and the creation stamp a later reader holds the
+ * pid against. The stamp is read lazily (the first record this process
+ * builds - a `ps`/`powershell` spawn on macOS and Windows) and cached by the
+ * shared module for the life of the process, so it is never paid by a CLI
+ * invocation that writes no marker.
+ */
 export function progressRecord(fields: {
   readonly state: HostUpdateProgressState;
   readonly error: string | null;
@@ -63,6 +90,7 @@ export function progressRecord(fields: {
     targetVersion: fields.targetVersion,
     updatedAt: new Date().toISOString(),
     writerId: PROGRESS_WRITER_ID,
+    writerStartIdentity: ownProcessStartIdentity(),
   };
 }
 
@@ -143,7 +171,8 @@ export function sameProgress(
     a.targetVersion === b.targetVersion &&
     a.updatedAt === b.updatedAt &&
     a.error === b.error &&
-    a.writerId === b.writerId
+    a.writerId === b.writerId &&
+    a.writerStartIdentity === b.writerStartIdentity
   );
 }
 
@@ -383,19 +412,44 @@ async function landMarkerAtomically(
 }
 
 // `writerId` is `<pid>-<hex>`; the pid half is what a reader on the same
-// machine can check for liveness. The host daemon applies the same rule
-// (`isStaleUpdateProgress`) when it decides whether an `updating` marker
-// still describes a live update.
+// machine can check for liveness. The shape is fixed: the host daemon parses
+// it with the same expression (`isStaleUpdateProgress`) to suppress an
+// `updating` whose pid is dead. The random half is never verified by anyone
+// - it only keeps two writers in one process generation apart.
 const WRITER_ID_PID = /^(\d+)-[0-9a-f]+$/;
 
 /**
- * What is known about the record's writer: `live` is positive evidence (a
- * parseable pid the OS reports alive), `dead` is positive evidence of the
- * opposite, and `unknown` is everything the probe cannot settle - no writer
- * id (an older CLI), an id in another shape, or a probe that failed
- * (`tasklist` missing on Windows). The two predicates below read this from
- * opposite sides: what cannot be proven abandoned is not replaced outside
- * the lock, and what cannot be proven live is not put back.
+ * What is known about the record's writer: `live` is positive evidence,
+ * `dead` is positive evidence of the opposite, and `unknown` is everything
+ * the probes cannot settle - no writer id (an older CLI), an id in another
+ * shape, a liveness probe that failed (`tasklist` missing on Windows), or a
+ * creation stamp that could not be read back. The two predicates below read
+ * this from opposite sides: what cannot be proven abandoned is not replaced
+ * outside the lock, and what cannot be proven live is not put back.
+ *
+ * A pid alone is not the writer. The OS reuses pids, so an updater that
+ * crashed after publishing its marker can leave a pid that some unrelated
+ * process holds by the time the next `host update` reads it - and a
+ * liveness probe then vouches for a writer that no longer exists (the
+ * pre-lock claim defers to it, and a park restores its marker as a proven
+ * live one). A record that carries the writer's creation stamp is therefore
+ * held to `verifyProcessIdentity`, the same verdict the CLI lock and the
+ * host's `pid.json` are judged by: `alive-same` (the pid is alive AND was
+ * created when the writer was) is `live`; `dead` and `alive-different` (an
+ * impostor behind a recycled pid) are `dead`; `indeterminate` is `unknown`.
+ * A record without a stamp - written by a CLI before the field existed, or
+ * by one whose probe failed at the write - is judged by the pid alone,
+ * which is the most that record can be held to; the host daemon judges
+ * every record that way today. That residual retires with those CLIs: a
+ * marker lives for one update attempt.
+ *
+ * The stamped path is strictly NARROWER than the pid-only one, on purpose:
+ * a pid the OS proves alive whose stamp cannot be read back (`powershell`
+ * refused or past its timeout, `ps` past its) is `unknown`, not `live` -
+ * the claim still defers to it, but the takeover does not retain it and a
+ * park does not put it back, and its writer, if live, re-asserts its own
+ * marker under the lock. Do not re-widen it "for safety": `live` is what
+ * authorises re-planting a record over an empty path.
  */
 function writerLiveness(
   record: HostUpdateProgress,
@@ -405,16 +459,37 @@ function writerLiveness(
   if (match === null) return "unknown";
   const pid = Number.parseInt(match[1], 10);
   if (!Number.isSafeInteger(pid) || pid <= 0) return "unknown";
-  const verdict = probeProcessLiveness(pid);
-  if (verdict === "alive") return "live";
-  if (verdict === "dead") return "dead";
-  return "unknown";
+  if (record.writerStartIdentity === null) {
+    const verdict = probeProcessLiveness(pid);
+    if (verdict === "alive") return "live";
+    if (verdict === "dead") return "dead";
+    return "unknown";
+  }
+  // `startedAtMs` is a legacy field no verdict reads (the stamp replaced
+  // it); the marker never recorded one.
+  switch (
+    verifyProcessIdentity({
+      pid,
+      startedAtMs: null,
+      startIdentity: record.writerStartIdentity,
+    })
+  ) {
+    case "alive-same":
+      return "live";
+    case "dead":
+    case "alive-different":
+      return "dead";
+    case "indeterminate":
+      return "unknown";
+  }
 }
 
 /**
  * Whether some writer MAY still be acting on the record: an `updating`
- * whose writer is not proven dead (fail-open, the same reading the host
- * daemon takes for a parseable id). A `failed` has no writer by
+ * whose writer is not proven dead (fail-open; for a record without a
+ * creation stamp, the reading the host daemon takes for a parseable id -
+ * a stamped record is held to `writerLiveness`'s identity rule, which the
+ * host does not apply). A `failed` has no writer by
  * construction - its writer stamped it and exited - whatever its `writerId`
  * says. This is the predicate behind the pre-lock claim: it replaces a
  * record without a live writer and defers to one that may have. A record no
@@ -431,7 +506,9 @@ export function updateProgressRecordHasLiveWriter(
 
 /**
  * Whether a writer is PROVEN to be acting on the record: an `updating`
- * whose pid the OS reports alive. The takeover under the lock retains a
+ * whose writer `writerLiveness` reports `live` - the pid is alive and, for
+ * a record that carries the writer's creation stamp, is the process that
+ * wrote it. The takeover under the lock retains a
  * displaced record for the restore a busy park or a pre-disruption failure
  * performs only on this evidence. The fail-open reading is wrong there: a
  * record with no writer id is one the host daemon renders FOREVER (its
@@ -480,9 +557,14 @@ export function updateProgressRecordHasProvenLiveWriter(
  *   either way.
  *
  * The liveness check is synchronous (`probeProcessLiveness`; on Windows a
- * `tasklist` spawn with a bounded timeout) and runs once per record read:
- * at most three times per claim call. Per `host update` that is at most
- * eight - the claim can run twice (a claim that deferred at
+ * `tasklist` spawn with a bounded timeout - and, for a record that carries
+ * a creation stamp whose pid is not proven dead, one more bounded spawn to
+ * read the stamp back: `ps` on macOS, `powershell` on Windows) and runs
+ * once per record read: at most three times per claim call. Per `host
+ * update` that is at most eight checks - at most sixteen bounded spawns on
+ * Windows, eight on macOS, none on Linux (`/proc` reads), plus one to read
+ * this process's own stamp - the claim can run twice (a claim that
+ * deferred at
  * `onWillDownload` claims again before the work), the takeover under the
  * lock reads once (only on the iteration that replaces), and the restore a
  * park or a pre-disruption failure performs reads once. Never throws.
@@ -899,6 +981,14 @@ async function readMarkerState(
       // Absent on markers written before the field existed; carried through
       // so a conditional swap compares what was actually written.
       writerId: typeof obj.writerId === "string" ? obj.writerId : null,
+      // Absent on markers written before the field existed, and `null` when
+      // the writer's own probe failed; a value that is not a well-formed
+      // token reads as "not recorded" at this boundary, the way
+      // `pid-metadata` reads the host's, so the comparator only ever sees
+      // tokens or `null`.
+      writerStartIdentity: isProcessStartIdentity(obj.writerStartIdentity)
+        ? obj.writerStartIdentity
+        : null,
     },
   };
 }

--- a/clients/traycer-cli/src/installer/__tests__/apply.test.ts
+++ b/clients/traycer-cli/src/installer/__tests__/apply.test.ts
@@ -43,6 +43,13 @@ const mocks = vi.hoisted(() => ({
   // sandboxRoot` - a direct reference there hits a TDZ `ReferenceError`,
   // so the live sandbox value has to live in this hoisted object instead.
   sandboxHome: "",
+  // Cross-mock ordering timeline for the `onWillCommitStaged` placement
+  // pins below: `assertHostNotBusy` and `createServiceInstallLifecycle`
+  // (whose construction is `applyHost`'s first commit-path step after the
+  // hook) both push into this SHARED array, alongside the hook itself, so
+  // a single assertion can pin the hook strictly between the busy check
+  // and the commit machinery.
+  callOrder: [] as string[],
 }));
 
 // `store/paths` computes `TRAYCER_HOME` from `os.homedir()` once at module
@@ -62,6 +69,7 @@ vi.mock("node:os", async (importOriginal) => {
 
 vi.mock("../../host/busy-check", () => ({
   assertHostNotBusy: async () => {
+    mocks.callOrder.push("busy-check");
     if (mocks.busyOverride === "busy") {
       throw Object.assign(new Error("host is busy"), { code: "E_HOST_BUSY" });
     }
@@ -73,6 +81,7 @@ vi.mock("../../service/install-lifecycle", () => ({
     bootstrap: unknown;
     force: boolean;
   }) => {
+    mocks.callOrder.push("lifecycle-created");
     mocks.lifecycleCalls.push({
       bootstrap: options.bootstrap,
       force: options.force,
@@ -221,6 +230,7 @@ describe("applyHost", () => {
     mocks.lifecycleBeforeSwapShouldThrow = false;
     mocks.lifecyclePostSwapAction = "restart";
     mocks.lifecyclePostSwapError = null;
+    mocks.callOrder = [];
     rmSync(sandboxRoot, { recursive: true, force: true });
   });
 
@@ -380,6 +390,96 @@ describe("applyHost", () => {
 
     expect(existsSync(stagedDirFor(ENV))).toBe(true);
     expect(existsSync(installDirFor(ENV))).toBe(true);
+  });
+
+  describe("onWillCommitStaged", () => {
+    it("is called exactly once with the staged version, after the busy check and before the commit", async () => {
+      // Falsification: move the `onWillCommitStaged` call above the busy
+      // gate in `apply.ts` and "busy-check" would land AFTER "hook" in the
+      // order below instead of before it.
+      await writeInstall("1.0.0", {});
+      await writeStaged("2.0.0", {});
+      const onWillCommitStaged = vi.fn(async (stagedVersion: string) => {
+        mocks.callOrder.push("hook");
+        expect(stagedVersion).toBe("2.0.0");
+      });
+
+      const result = await applyHost({
+        environment: ENV,
+        force: false,
+        noService: false,
+        expectedStageFingerprint: null,
+        onProgress: () => {},
+        onWillCommitStaged,
+      });
+
+      expect(result.outcome).toBe("applied");
+      expect(onWillCommitStaged).toHaveBeenCalledTimes(1);
+      expect(onWillCommitStaged).toHaveBeenCalledWith("2.0.0");
+      // Strictly between the busy check and the commit machinery
+      // (`createServiceInstallLifecycle` is `applyHost`'s first commit-path
+      // step once it decides to proceed).
+      expect(mocks.callOrder).toEqual([
+        "busy-check",
+        "hook",
+        "lifecycle-created",
+      ]);
+    });
+
+    it("is not called when nothing is staged (the no-op outcome)", async () => {
+      await writeInstall("1.0.0", {});
+      const onWillCommitStaged = vi.fn(async () => undefined);
+
+      const result = await applyHost({
+        environment: ENV,
+        force: false,
+        noService: false,
+        expectedStageFingerprint: null,
+        onProgress: () => {},
+        onWillCommitStaged,
+      });
+
+      expect(result).toEqual({ outcome: "no-op", installedVersion: "1.0.0" });
+      expect(onWillCommitStaged).not.toHaveBeenCalled();
+    });
+
+    it("is not called on a fingerprint mismatch", async () => {
+      await writeInstall("1.0.0", {});
+      await writeStaged("2.0.0", { stageId: "stage-a" });
+      const onWillCommitStaged = vi.fn(async () => undefined);
+
+      const result = await applyHost({
+        environment: ENV,
+        force: false,
+        noService: false,
+        expectedStageFingerprint: "stage-b",
+        onProgress: () => {},
+        onWillCommitStaged,
+      });
+
+      expect(result.outcome).toBe("stage-fingerprint-mismatch");
+      expect(onWillCommitStaged).not.toHaveBeenCalled();
+    });
+
+    it("is not called when the busy check throws", async () => {
+      await writeInstall("1.0.0", {});
+      await writeStaged("2.0.0", {});
+      mocks.busyOverride = "busy";
+      const onWillCommitStaged = vi.fn(async () => undefined);
+
+      await expect(
+        applyHost({
+          environment: ENV,
+          force: false,
+          noService: false,
+          expectedStageFingerprint: null,
+          onProgress: () => {},
+          onWillCommitStaged,
+        }),
+      ).rejects.toMatchObject({ code: "E_HOST_BUSY" });
+
+      expect(onWillCommitStaged).not.toHaveBeenCalled();
+    });
   });
 
   it("--force bypasses the busy check", async () => {

--- a/clients/traycer-cli/src/installer/__tests__/apply.test.ts
+++ b/clients/traycer-cli/src/installer/__tests__/apply.test.ts
@@ -32,6 +32,9 @@ const mocks = vi.hoisted(() => ({
   platformOverride: null as "win32" | null,
   busyOverride: null as "busy" | null,
   lifecycleCalls: [] as Array<{ bootstrap: unknown; force: boolean }>,
+  // What `applyHost` handed the lifecycle as its pre-stop boundary, so a
+  // pin can assert the SAME function reaches both actuators.
+  lifecycleStopHooks: [] as Array<(() => void) | null>,
   lifecycleBeforeSwapShouldThrow: false,
   lifecyclePostSwapAction: "restart" as
     | "restart"
@@ -80,12 +83,14 @@ vi.mock("../../service/install-lifecycle", () => ({
   createServiceInstallLifecycle: (options: {
     bootstrap: unknown;
     force: boolean;
+    onWillStopHost: (() => void) | null;
   }) => {
     mocks.callOrder.push("lifecycle-created");
     mocks.lifecycleCalls.push({
       bootstrap: options.bootstrap,
       force: options.force,
     });
+    mocks.lifecycleStopHooks.push(options.onWillStopHost);
     const state = {
       priorState: "running" as const,
       stoppedBeforeSwap: false,
@@ -149,14 +154,24 @@ import type { HostInstallRecord } from "../../manifest/host-install";
 
 const testMutationVerifier = async (): Promise<void> => undefined;
 type ApplyOptions = Parameters<typeof applyHostWithAuthority>[0];
+// The fields every call must state in production default to their "not
+// tracking / not pinning" values here: a test that pins one passes it.
+type ApplyDefaultedOptions =
+  | "verifyMutationCapability"
+  | "expectedStagedVersion"
+  | "onWillCommitStaged"
+  | "onWillDisruptHost";
 const applyHost = (
-  options: Omit<ApplyOptions, "verifyMutationCapability"> &
-    Partial<Pick<ApplyOptions, "verifyMutationCapability">>,
+  options: Omit<ApplyOptions, ApplyDefaultedOptions> &
+    Partial<Pick<ApplyOptions, ApplyDefaultedOptions>>,
 ) =>
   applyHostWithAuthority({
     ...options,
     verifyMutationCapability:
       options.verifyMutationCapability ?? testMutationVerifier,
+    expectedStagedVersion: options.expectedStagedVersion ?? null,
+    onWillCommitStaged: options.onWillCommitStaged ?? null,
+    onWillDisruptHost: options.onWillDisruptHost ?? null,
   });
 
 const ENV: Environment = "production";
@@ -231,6 +246,7 @@ describe("applyHost", () => {
     mocks.lifecyclePostSwapAction = "restart";
     mocks.lifecyclePostSwapError = null;
     mocks.callOrder = [];
+    mocks.lifecycleStopHooks = [];
     rmSync(sandboxRoot, { recursive: true, force: true });
   });
 
@@ -722,5 +738,121 @@ describe("applyHost", () => {
     // The busy refusal only swept trash litter - the live stage itself
     // is untouched (recovery table: busy -> stage kept).
     expect(existsSync(stagedDirFor(ENV))).toBe(true);
+  });
+
+  describe("expectedStagedVersion", () => {
+    it("refuses a stage naming another version before the busy gate and the hook, consuming nothing", async () => {
+      // Falsification: move the version check below the busy gate and
+      // "busy-check" appears in the order; drop it and the outcome is
+      // `applied` for a version the caller never confirmed.
+      await writeInstall("1.0.0", {});
+      await writeStaged("2.1.0", {});
+      const onWillCommitStaged = vi.fn(async () => undefined);
+
+      const result = await applyHost({
+        environment: ENV,
+        force: false,
+        noService: false,
+        expectedStageFingerprint: null,
+        expectedStagedVersion: "2.0.0",
+        onProgress: () => {},
+        onWillCommitStaged,
+      });
+
+      expect(result).toEqual({
+        outcome: "stage-version-mismatch",
+        installedVersion: "1.0.0",
+        expectedStagedVersion: "2.0.0",
+        actualStagedVersion: "2.1.0",
+      });
+      expect(mocks.callOrder).toEqual([]);
+      expect(onWillCommitStaged).not.toHaveBeenCalled();
+      expect(existsSync(stagedDirFor(ENV))).toBe(true);
+      expect((await readHostInstallRecord(ENV))?.version).toBe("1.0.0");
+    });
+
+    it("commits the stage that names the confirmed version", async () => {
+      await writeInstall("1.0.0", {});
+      await writeStaged("2.0.0", {});
+
+      const result = await applyHost({
+        environment: ENV,
+        force: false,
+        noService: false,
+        expectedStageFingerprint: null,
+        expectedStagedVersion: "2.0.0",
+        onProgress: () => {},
+      });
+
+      expect(result.outcome).toBe("applied");
+      expect((await readHostInstallRecord(ENV))?.version).toBe("2.0.0");
+    });
+  });
+
+  describe("onWillDisruptHost", () => {
+    it("reaches the lifecycle as its pre-stop boundary and, when the lifecycle does not stop, fires from the swap itself before the install directory changes", async () => {
+      // The mocked lifecycle's `beforeSwap` never calls the hook (it models
+      // "decided not to stop"), so the one call below is the swap's - and
+      // it sees the OLD install record. Falsification: fire the boundary
+      // from the `swap` progress line instead and it still fires once, but
+      // the lifecycle-side assertion reddens (no hook handed over); fire it
+      // after `atomicSwap` and the record read inside it is 2.0.0.
+      await writeInstall("1.0.0", {});
+      await writeStaged("2.0.0", {});
+      const versionsAtBoundary: string[] = [];
+      const onWillDisruptHost = (): void => {
+        mocks.callOrder.push("disrupt");
+        const record = JSON.parse(
+          readFileSync(join(installDirFor(ENV), "install.json"), "utf8"),
+        ) as { version: string };
+        versionsAtBoundary.push(record.version);
+      };
+
+      const result = await applyHost({
+        environment: ENV,
+        force: false,
+        noService: false,
+        expectedStageFingerprint: null,
+        onProgress: () => {},
+        onWillDisruptHost,
+      });
+
+      expect(result.outcome).toBe("applied");
+      expect(mocks.lifecycleStopHooks).toEqual([onWillDisruptHost]);
+      expect(versionsAtBoundary).toEqual(["1.0.0"]);
+      expect(mocks.callOrder).toEqual([
+        "busy-check",
+        "lifecycle-created",
+        "disrupt",
+      ]);
+    });
+
+    it("is NOT fired by the `service-stop` progress line: a lifecycle that fails before its actuator leaves the boundary unreported", async () => {
+      // Falsification: derive the boundary from progress stages (the shape
+      // `host update` used to have) and the hook fires here although the
+      // host was never touched.
+      await writeInstall("1.0.0", {});
+      await writeStaged("2.0.0", {});
+      mocks.lifecycleBeforeSwapShouldThrow = true;
+      const onWillDisruptHost = vi.fn();
+      const stages: string[] = [];
+
+      await expect(
+        applyHost({
+          environment: ENV,
+          force: false,
+          noService: false,
+          expectedStageFingerprint: null,
+          onProgress: (info) => {
+            stages.push(info.stage);
+          },
+          onWillDisruptHost,
+        }),
+      ).rejects.toThrow("simulated stop failure");
+
+      expect(stages).toContain("service-stop");
+      expect(onWillDisruptHost).not.toHaveBeenCalled();
+      expect((await readHostInstallRecord(ENV))?.version).toBe("1.0.0");
+    });
   });
 });

--- a/clients/traycer-cli/src/installer/__tests__/download-stage.test.ts
+++ b/clients/traycer-cli/src/installer/__tests__/download-stage.test.ts
@@ -413,6 +413,7 @@ describe("downloadAndStageHost", () => {
         automatic: false,
         onProgress: noopProgress,
         registryClient: client,
+        onWillDownload: null,
       }),
     ).rejects.toMatchObject({ code: CLI_ERROR_CODES.HOST_NOT_INSTALLED });
   });
@@ -436,6 +437,7 @@ describe("downloadAndStageHost", () => {
         automatic: false,
         onProgress: noopProgress,
         registryClient: client,
+        onWillDownload: null,
       }),
     ).rejects.toMatchObject({ code: CLI_ERROR_CODES.REGISTRY_UNAVAILABLE });
     expect(downloadStarted).toBe(false);
@@ -458,6 +460,7 @@ describe("downloadAndStageHost", () => {
       automatic: false,
       onProgress: noopProgress,
       registryClient: client,
+      onWillDownload: null,
     });
     expect(outcome).toMatchObject({
       outcome: "short-circuit",
@@ -485,6 +488,7 @@ describe("downloadAndStageHost", () => {
         downloadGate: null,
         onDownloadStart: null,
       }),
+      onWillDownload: null,
     });
     expect((await readHostStagedRecord(ENV))?.version).toBe("1.5.0");
 
@@ -501,6 +505,7 @@ describe("downloadAndStageHost", () => {
           downloadStarted = true;
         },
       }),
+      onWillDownload: null,
     });
     expect(outcome).toMatchObject({
       outcome: "short-circuit",
@@ -526,6 +531,7 @@ describe("downloadAndStageHost", () => {
         downloadGate: null,
         onDownloadStart: null,
       }),
+      onWillDownload: null,
     });
     const recordPath = join(stagedDirFor(ENV), "staged.json");
     const legacy = JSON.parse(readFileSync(recordPath, "utf8")) as {
@@ -548,6 +554,7 @@ describe("downloadAndStageHost", () => {
           downloadStarted = true;
         },
       }),
+      onWillDownload: null,
     });
 
     expect(outcome).toMatchObject({
@@ -575,6 +582,7 @@ describe("downloadAndStageHost", () => {
       automatic: false,
       onProgress: noopProgress,
       registryClient: client,
+      onWillDownload: null,
     });
     expect(outcome).toMatchObject({
       outcome: "promoted",
@@ -605,6 +613,7 @@ describe("downloadAndStageHost", () => {
       automatic: false,
       onProgress: noopProgress,
       registryClient: client,
+      onWillDownload: null,
     });
     // The archive now lives in the SHARED download cache keyed by
     // version+sha (registry/download-cache.ts), so the consumer must drop
@@ -643,6 +652,7 @@ describe("downloadAndStageHost", () => {
         automatic: false,
         onProgress: noopProgress,
         registryClient: client,
+        onWillDownload: null,
       }),
     ).rejects.toThrow(/expected executable/);
     // These bytes already cleared sha256 AND minisign. Whatever failed
@@ -671,6 +681,7 @@ describe("downloadAndStageHost", () => {
         downloadGate: null,
         onDownloadStart: null,
       }),
+      onWillDownload: null,
     });
     expect((await readHostStagedRecord(ENV))?.version).toBe("1.5.0");
 
@@ -693,6 +704,7 @@ describe("downloadAndStageHost", () => {
           downloadStarted = true;
         },
       }),
+      onWillDownload: null,
     });
     expect(downloadStarted).toBe(false);
     expect(outcome).toMatchObject({
@@ -718,6 +730,7 @@ describe("downloadAndStageHost", () => {
         downloadGate: null,
         onDownloadStart: null,
       }),
+      onWillDownload: null,
     });
     expect((await readHostStagedRecord(ENV))?.version).toBe("1.5.0");
 
@@ -737,6 +750,7 @@ describe("downloadAndStageHost", () => {
         downloadGate: null,
         onDownloadStart: null,
       }),
+      onWillDownload: null,
     });
     expect(outcome).toMatchObject({
       outcome: "promoted",
@@ -761,6 +775,7 @@ describe("downloadAndStageHost", () => {
           downloadStarted = true;
         },
       }),
+      onWillDownload: null,
     });
     expect(outcome).toMatchObject({
       outcome: "short-circuit",
@@ -781,6 +796,7 @@ describe("downloadAndStageHost", () => {
         downloadGate: null,
         onDownloadStart: null,
       }),
+      onWillDownload: null,
     });
     expect(outcome).toMatchObject({
       outcome: "promoted",
@@ -808,6 +824,7 @@ describe("downloadAndStageHost", () => {
       automatic: false,
       onProgress: noopProgress,
       registryClient: client,
+      onWillDownload: null,
     });
     await started.promise;
     // Simulate a concurrent, faster `host install 2.0.0` completing while
@@ -843,6 +860,7 @@ describe("downloadAndStageHost", () => {
       automatic: true,
       onProgress: noopProgress,
       registryClient: client,
+      onWillDownload: null,
     });
     await started.promise;
     // Simulate a concurrent local-file install swapping in an
@@ -877,6 +895,7 @@ describe("downloadAndStageHost", () => {
         downloadGate: null,
         onDownloadStart: null,
       }),
+      onWillDownload: null,
     });
     expect((await readHostStagedRecord(ENV))?.version).toBe("1.5.0");
 
@@ -891,6 +910,7 @@ describe("downloadAndStageHost", () => {
         downloadGate: null,
         onDownloadStart: null,
       }),
+      onWillDownload: null,
     });
     expect(outcome).toMatchObject({
       outcome: "promoted",
@@ -931,6 +951,7 @@ describe("downloadAndStageHost", () => {
       automatic: false,
       onProgress: noopProgress,
       registryClient: slowClient,
+      onWillDownload: null,
     });
     await slowStarted.promise;
     const firstFastAttempt = downloadAndStageHost({
@@ -939,6 +960,7 @@ describe("downloadAndStageHost", () => {
       automatic: false,
       onProgress: noopProgress,
       registryClient: fastClient,
+      onWillDownload: null,
     });
     const firstFastResult = firstFastAttempt.then(
       (outcome) => ({ kind: "outcome" as const, outcome }),
@@ -973,6 +995,7 @@ describe("downloadAndStageHost", () => {
       automatic: false,
       onProgress: noopProgress,
       registryClient: fastClient,
+      onWillDownload: null,
     });
     expect(fastOutcome).toMatchObject({
       outcome: "promoted",
@@ -1031,6 +1054,7 @@ describe("downloadAndStageHost", () => {
       automatic: false,
       onProgress: noopProgress,
       registryClient: client,
+      onWillDownload: null,
     });
     await started.promise;
     // Simulate a concurrent `host uninstall` completing while the download
@@ -1081,6 +1105,7 @@ describe("downloadAndStageHost", () => {
       automatic: false,
       onProgress: noopProgress,
       registryClient: client,
+      onWillDownload: null,
     });
     expect(lockAcquiredDuringTransfer).toBe(true);
   });
@@ -1103,6 +1128,7 @@ describe("downloadAndStageHost", () => {
         automatic: false,
         onProgress: noopProgress,
         registryClient: throwingRegistryClient(base),
+        onWillDownload: null,
       }),
     ).rejects.toThrow(/simulated download failure/);
 
@@ -1148,6 +1174,7 @@ describe("downloadAndStageHost", () => {
           downloadGate: null,
           onDownloadStart: null,
         }),
+        onWillDownload: null,
       });
       const stagedBefore = await readHostStagedRecord(ENV);
       expect(stagedBefore?.version).toBe("1.2.0");
@@ -1168,6 +1195,7 @@ describe("downloadAndStageHost", () => {
         automatic: true,
         onProgress: noopProgress,
         registryClient: client,
+        onWillDownload: null,
       });
       await started.promise;
       // Promote-time STATE INJECTION after the outer admission snapshot and
@@ -1227,6 +1255,7 @@ describe("downloadAndStageHost", () => {
           downloadGate: null,
           onDownloadStart: null,
         }),
+        onWillDownload: null,
       });
       const stagedBefore = await readHostStagedRecord(ENV);
       const executablePath = join(stagedDirFor(ENV), executableBasename());
@@ -1245,6 +1274,7 @@ describe("downloadAndStageHost", () => {
           downloadGate: gate.promise,
           onDownloadStart: () => started.release(),
         }),
+        onWillDownload: null,
       });
       await started.promise;
       writeFileSync(
@@ -1290,6 +1320,7 @@ describe("downloadAndStageHost", () => {
           downloadGate: null,
           onDownloadStart: null,
         }),
+        onWillDownload: null,
       });
 
       const gate = makeGate();
@@ -1306,6 +1337,7 @@ describe("downloadAndStageHost", () => {
         automatic: true,
         onProgress: noopProgress,
         registryClient: client,
+        onWillDownload: null,
       });
       await started.promise;
       // Same timing as the positive case above - only `phase`/`execution`
@@ -1347,6 +1379,7 @@ describe("downloadAndStageHost", () => {
           downloadGate: null,
           onDownloadStart: null,
         }),
+        onWillDownload: null,
       });
       const stagedBefore = await readHostStagedRecord(ENV);
       const executablePath = join(stagedDirFor(ENV), executableBasename());
@@ -1370,6 +1403,7 @@ describe("downloadAndStageHost", () => {
         automatic: false,
         onProgress: noopProgress,
         registryClient: client,
+        onWillDownload: null,
       });
       await started.promise;
       writeAttemptRecord({
@@ -1422,6 +1456,7 @@ describe("downloadAndStageHost", () => {
           downloadGate: null,
           onDownloadStart: null,
         }),
+        onWillDownload: null,
       });
 
       const gate = makeGate();
@@ -1438,6 +1473,7 @@ describe("downloadAndStageHost", () => {
         automatic: false,
         onProgress: noopProgress,
         registryClient: client,
+        onWillDownload: null,
       });
       await started.promise;
       writeAttemptRecord({
@@ -1463,6 +1499,184 @@ describe("downloadAndStageHost", () => {
     // existing stage, even a newer one" tests above - every test in this
     // file before this `describe` block runs with no attempt record ever
     // written, so those promotions already prove the absent direction.
+  });
+
+  // `onWillDownload` (Host Update Layer Redesign - busy park + early
+  // marker): awaited exactly once, after the phase-1 short-circuit decision
+  // and before the first network call of the transfer itself.
+  describe("onWillDownload hook", () => {
+    it("calls onWillDownload exactly once with the target version, before resolveAsset and before downloadAndVerify", async () => {
+      await writeInstall("1.0.0", {});
+      const order: string[] = [];
+      const baseClient = fakeRegistryClient({
+        latest: "1.5.0",
+        versions: [
+          { version: "1.0.0", yanked: false },
+          { version: "1.5.0", yanked: false },
+        ],
+        downloadGate: null,
+        onDownloadStart: () => {
+          order.push("download-start");
+        },
+      });
+      const client: RegistryClient = {
+        ...baseClient,
+        async resolveAsset(versionRequest, platformKey) {
+          order.push("resolve-asset");
+          return baseClient.resolveAsset(versionRequest, platformKey);
+        },
+      };
+      let willDownloadCalls = 0;
+      const outcome = await downloadAndStageHost({
+        environment: ENV,
+        versionRequest: null,
+        automatic: false,
+        onProgress: noopProgress,
+        registryClient: client,
+        onWillDownload: async (targetVersion) => {
+          willDownloadCalls += 1;
+          expect(targetVersion).toBe("1.5.0");
+          order.push("will-download");
+        },
+      });
+      expect(willDownloadCalls).toBe(1);
+      expect(order).toEqual([
+        "will-download",
+        "resolve-asset",
+        "download-start",
+      ]);
+      expect(outcome).toMatchObject({
+        outcome: "promoted",
+        stagedVersion: "1.5.0",
+      });
+    });
+
+    it("never calls onWillDownload on the installed-up-to-date short-circuit", async () => {
+      await writeInstall("1.5.0", {});
+      let called = false;
+      const outcome = await downloadAndStageHost({
+        environment: ENV,
+        versionRequest: null,
+        automatic: false,
+        onProgress: noopProgress,
+        registryClient: fakeRegistryClient({
+          latest: "1.5.0",
+          versions: [{ version: "1.5.0", yanked: false }],
+          downloadGate: null,
+          onDownloadStart: null,
+        }),
+        onWillDownload: async () => {
+          called = true;
+        },
+      });
+      expect(outcome).toMatchObject({
+        outcome: "short-circuit",
+        reason: "installed-up-to-date",
+      });
+      // Falsification: move the hook call above the phase-1 short-circuit
+      // return and this goes red.
+      expect(called).toBe(false);
+    });
+
+    it("never calls onWillDownload on the already-staged short-circuit", async () => {
+      await writeInstall("1.0.0", {});
+      const versions = [
+        { version: "1.0.0", yanked: false },
+        { version: "1.5.0", yanked: false },
+      ];
+      await downloadAndStageHost({
+        environment: ENV,
+        versionRequest: "1.5.0",
+        automatic: false,
+        onProgress: noopProgress,
+        registryClient: fakeRegistryClient({
+          latest: "1.5.0",
+          versions,
+          downloadGate: null,
+          onDownloadStart: null,
+        }),
+        onWillDownload: null,
+      });
+      let called = false;
+      const outcome = await downloadAndStageHost({
+        environment: ENV,
+        versionRequest: null,
+        automatic: false,
+        onProgress: noopProgress,
+        registryClient: fakeRegistryClient({
+          latest: "1.5.0",
+          versions,
+          downloadGate: null,
+          onDownloadStart: null,
+        }),
+        onWillDownload: async () => {
+          called = true;
+        },
+      });
+      expect(outcome).toMatchObject({
+        outcome: "short-circuit",
+        reason: "already-staged",
+      });
+      // Falsification: move the hook call above the phase-1 short-circuit
+      // return and this goes red.
+      expect(called).toBe(false);
+    });
+
+    it("never calls onWillDownload when the manifest's latest is not valid SemVer", async () => {
+      await writeInstall("1.0.0", {});
+      let called = false;
+      await expect(
+        downloadAndStageHost({
+          environment: ENV,
+          versionRequest: null,
+          automatic: false,
+          onProgress: noopProgress,
+          registryClient: fakeRegistryClient({
+            latest: "v2.0.0",
+            versions: [{ version: "v2.0.0", yanked: false }],
+            downloadGate: null,
+            onDownloadStart: null,
+          }),
+          onWillDownload: async () => {
+            called = true;
+          },
+        }),
+      ).rejects.toMatchObject({ code: CLI_ERROR_CODES.REGISTRY_UNAVAILABLE });
+      // Falsification: move the manifest-validity check below the hook call
+      // and this goes red.
+      expect(called).toBe(false);
+    });
+
+    it("propagates a rejecting onWillDownload and starts no transfer", async () => {
+      await writeInstall("1.0.0", {});
+      let downloadStarted = false;
+      await expect(
+        downloadAndStageHost({
+          environment: ENV,
+          versionRequest: null,
+          automatic: false,
+          onProgress: noopProgress,
+          registryClient: fakeRegistryClient({
+            latest: "1.5.0",
+            versions: [
+              { version: "1.0.0", yanked: false },
+              { version: "1.5.0", yanked: false },
+            ],
+            downloadGate: null,
+            onDownloadStart: () => {
+              downloadStarted = true;
+            },
+          }),
+          onWillDownload: async () => {
+            throw new Error("hook failed");
+          },
+        }),
+      ).rejects.toThrow("hook failed");
+      // Falsification: swallow the hook's rejection (e.g. wrap the `await
+      // opts.onWillDownload(...)` call in a try/catch) and this goes red.
+      expect(downloadStarted).toBe(false);
+      expect(await readHostStagedRecord(ENV)).toBeNull();
+    });
   });
 
   it("structurally pins capability checks on every deliberate discard and release edge", () => {

--- a/clients/traycer-cli/src/installer/__tests__/download-stage.test.ts
+++ b/clients/traycer-cli/src/installer/__tests__/download-stage.test.ts
@@ -759,9 +759,13 @@ describe("downloadAndStageHost", () => {
     expect((await readHostStagedRecord(ENV))?.version).toBe("2.0.0");
   });
 
-  it("--automatic refuses to stage over an incomparable (local-*) installed version", async () => {
+  it("--automatic refuses to stage over an incomparable (local-*) installed version, without announcing a download", async () => {
     await writeInstall("local-custom-build-2026", {});
     let downloadStarted = false;
+    // The third short-circuit named in `onWillDownload`'s doc: nothing is
+    // transferred, so nothing is announced. Falsification: move the hook
+    // above the promotion decision and it fires here.
+    const onWillDownload = vi.fn(async () => undefined);
     const outcome = await downloadAndStageHost({
       environment: ENV,
       versionRequest: null,
@@ -775,13 +779,14 @@ describe("downloadAndStageHost", () => {
           downloadStarted = true;
         },
       }),
-      onWillDownload: null,
+      onWillDownload,
     });
     expect(outcome).toMatchObject({
       outcome: "short-circuit",
       reason: "automatic-refused-incomparable-installed",
     });
     expect(downloadStarted).toBe(false);
+    expect(onWillDownload).not.toHaveBeenCalled();
   });
   it("an explicit version request proceeds over an incomparable (local-*) installed version", async () => {
     await writeInstall("local-custom-build-2026", {});

--- a/clients/traycer-cli/src/installer/__tests__/download-stage.test.ts
+++ b/clients/traycer-cli/src/installer/__tests__/download-stage.test.ts
@@ -469,6 +469,122 @@ describe("downloadAndStageHost", () => {
     expect(downloadStarted).toBe(false);
   });
 
+  it("EXPLICIT request for another build of the installed release (2.0.0+foo over 2.0.0+bar): refused as E_HOST_UPDATE_NOT_NEWER before any transfer, not 'up to date'", async () => {
+    // Codex r3945280604: the comparator calls the pair equal, so this read
+    // as installed-up-to-date and `host update --version 2.0.0+foo` exited 0
+    // with the requested artifact never delivered. Falsification: drop the
+    // string check in phase 1 and this resolves as a short-circuit.
+    await writeInstall("2.0.0+bar", {});
+    let downloadStarted = false;
+    let announced = false;
+    await expect(
+      downloadAndStageHost({
+        environment: ENV,
+        versionRequest: "2.0.0+foo",
+        automatic: false,
+        onProgress: noopProgress,
+        registryClient: fakeRegistryClient({
+          latest: "2.0.0+foo",
+          versions: [{ version: "2.0.0+foo", yanked: false }],
+          downloadGate: null,
+          onDownloadStart: () => {
+            downloadStarted = true;
+          },
+        }),
+        onWillDownload: async () => {
+          announced = true;
+        },
+      }),
+    ).rejects.toMatchObject({
+      code: CLI_ERROR_CODES.HOST_UPDATE_NOT_NEWER,
+      details: { targetVersion: "2.0.0+foo", installedVersion: "2.0.0+bar" },
+    });
+    expect(downloadStarted).toBe(false);
+    expect(announced).toBe(false);
+    expect(await readHostStagedRecord(ENV)).toBeNull();
+  });
+
+  it("EXPLICIT request BELOW the installed record (1.2.0 over 2.0.0): refused as E_HOST_UPDATE_NOT_NEWER before any transfer - a request that delivered nothing does not report 'up to date'", async () => {
+    // Falsification: narrow the phase-1 check back to the comparator's
+    // "equal" and this resolves as installed-up-to-date, exit 0, with
+    // nothing delivered for 1.2.0.
+    await writeInstall("2.0.0", {});
+    let downloadStarted = false;
+    await expect(
+      downloadAndStageHost({
+        environment: ENV,
+        versionRequest: "1.2.0",
+        automatic: false,
+        onProgress: noopProgress,
+        registryClient: fakeRegistryClient({
+          latest: "2.0.0",
+          versions: [
+            { version: "1.2.0", yanked: false },
+            { version: "2.0.0", yanked: false },
+          ],
+          downloadGate: null,
+          onDownloadStart: () => {
+            downloadStarted = true;
+          },
+        }),
+        onWillDownload: null,
+      }),
+    ).rejects.toMatchObject({
+      code: CLI_ERROR_CODES.HOST_UPDATE_NOT_NEWER,
+      message: expect.stringContaining("newer than the requested 1.2.0"),
+      details: { targetVersion: "1.2.0", installedVersion: "2.0.0" },
+    });
+    expect(downloadStarted).toBe(false);
+    expect(await readHostStagedRecord(ENV)).toBeNull();
+  });
+
+  it("EXPLICIT request for the installed record's own string (2.0.0+bar over 2.0.0+bar): up to date (control)", async () => {
+    await writeInstall("2.0.0+bar", {});
+    const outcome = await downloadAndStageHost({
+      environment: ENV,
+      versionRequest: "2.0.0+bar",
+      automatic: false,
+      onProgress: noopProgress,
+      registryClient: fakeRegistryClient({
+        latest: "2.0.0+bar",
+        versions: [{ version: "2.0.0+bar", yanked: false }],
+        downloadGate: null,
+        onDownloadStart: null,
+      }),
+      onWillDownload: null,
+    });
+    expect(outcome).toMatchObject({
+      outcome: "short-circuit",
+      reason: "installed-up-to-date",
+      installedVersion: "2.0.0+bar",
+    });
+  });
+
+  it("IMPLICIT latest 2.0.0 over an installed 2.0.0+bar: up to date - the registry's release is installed, in a build the promote gate would not replace (control)", async () => {
+    await writeInstall("2.0.0+bar", {});
+    let downloadStarted = false;
+    const outcome = await downloadAndStageHost({
+      environment: ENV,
+      versionRequest: null,
+      automatic: false,
+      onProgress: noopProgress,
+      registryClient: fakeRegistryClient({
+        latest: "2.0.0",
+        versions: [{ version: "2.0.0", yanked: false }],
+        downloadGate: null,
+        onDownloadStart: () => {
+          downloadStarted = true;
+        },
+      }),
+      onWillDownload: null,
+    });
+    expect(outcome).toMatchObject({
+      outcome: "short-circuit",
+      reason: "installed-up-to-date",
+    });
+    expect(downloadStarted).toBe(false);
+  });
+
   it("short-circuits when the target is already staged", async () => {
     await writeInstall("1.0.0", {});
     let downloadStarted = false;

--- a/clients/traycer-cli/src/installer/__tests__/install.test.ts
+++ b/clients/traycer-cli/src/installer/__tests__/install.test.ts
@@ -357,6 +357,7 @@ describe("commitInstallFromSource", () => {
         sizeBytes: 0,
         onProgress: () => {},
         lifecycle: null,
+        onWillSwap: null,
         onCommitted: () => {},
       }),
     ).rejects.toThrow();
@@ -393,6 +394,7 @@ describe("commitInstallFromSource", () => {
         sizeBytes: 0,
         onProgress: () => {},
         lifecycle: null,
+        onWillSwap: null,
         onCommitted: () => {
           committed = true;
         },
@@ -828,6 +830,7 @@ describe("commitHostInstallSource - reconcile runs BEFORE the commit (Finding 2)
         staged: freshStagedSource("2.0.0"),
         onProgress: () => {},
         lifecycle: null,
+        onWillSwap: null,
       }),
     ).rejects.toThrow();
 
@@ -850,6 +853,7 @@ describe("commitHostInstallSource - reconcile runs BEFORE the commit (Finding 2)
       staged: freshStagedSource("2.0.0"),
       onProgress: () => {},
       lifecycle: null,
+      onWillSwap: null,
     });
 
     expect(result.record.version).toBe("2.0.0");
@@ -872,6 +876,7 @@ describe("commitHostInstallSource - reconcile runs BEFORE the commit (Finding 2)
         staged,
         onProgress: () => {},
         lifecycle: null,
+        onWillSwap: null,
       }),
     ).rejects.toMatchObject({ code: "E_HOST_INSTALL_RECORD_INVALID" });
 

--- a/clients/traycer-cli/src/installer/apply.ts
+++ b/clients/traycer-cli/src/installer/apply.ts
@@ -36,6 +36,24 @@ export interface ApplyHostOptions {
   // value is checked after reconcile, while the caller holds cli-lock.
   // Null means "no fingerprint pin" - callers state that explicitly.
   readonly expectedStageFingerprint: string | null;
+  /**
+   * The version the caller resolved and CONFIRMED before it waited for the
+   * lock - `host update --version X` from a Settings click that validated
+   * X's catalog entry against this host's CLI floor and asked the user
+   * about X. The stage is shared and the wait is unlocked: a `host
+   * download Y` promoted in between leaves Y where X was, and the
+   * fingerprint pin above is `null` on that path. Committing Y would
+   * install a version nobody confirmed and no floor was checked for. A
+   * differing stage is `stage-version-mismatch`, decided before the busy
+   * gate and before `onWillCommitStaged`, so nothing is announced or
+   * disturbed for it. `null` for an implicit "latest": a newer stage
+   * another promoter left is then the better answer to the same request.
+   * Compared as a string, not through `compareHostVersions`: both sides
+   * are the catalog entry's own `version` (the staged record copies it,
+   * the caller resolved it), so this pins the ARTIFACT - build metadata
+   * included - not the release it belongs to.
+   */
+  readonly expectedStagedVersion: string | null;
   // Skips the busy check. Does NOT affect `--no-service`'s own busy-check
   // skip below - the two flags are independent knobs with the same effect
   // on this one gate.
@@ -62,10 +80,28 @@ export interface ApplyHostOptions {
    * fingerprint decisions, and after the busy gate where one runs (`force`
    * and `noService` skip it) - with the version of the stage about to be
    * committed. `host update` takes ownership of its progress marker here; a
-   * no-op, a fingerprint mismatch and a busy refusal never reach it, so
-   * nothing is announced for work that does not happen.
+   * no-op, a fingerprint or version mismatch and a busy refusal never reach
+   * it, so nothing is announced for work that does not happen. `null` for
+   * a caller with nothing to announce (`host apply`).
    */
-  readonly onWillCommitStaged?: (stagedVersion: string) => Promise<void>;
+  readonly onWillCommitStaged:
+    | ((stagedVersion: string) => Promise<void>)
+    | null;
+  /**
+   * The disruption boundary: runs once the commit's pre-stop (or, when the
+   * lifecycle decides not to stop, pre-swap) mutation-capability check has
+   * passed and immediately before that actuator - the first point at which
+   * this call can have disturbed the running host. A failure BEFORE it (a
+   * status probe that throws, a refused authority, a busy refusal) left the
+   * host as it was; `host update` uses that to restore a progress marker it
+   * took over instead of stamping its own failure over another updater's
+   * live record. Reported by the actuators
+   * (`CreateServiceInstallLifecycleOptions.onWillStopHost`,
+   * `CommitInstallFromSourceOptions.onWillSwap`), never inferred from the
+   * `service-stop` / `swap` progress lines, which precede those checks.
+   * `null` for a caller not tracking it.
+   */
+  readonly onWillDisruptHost: (() => void) | null;
 }
 
 // The facts `createServiceInstallLifecycle` observed around the swap -
@@ -122,6 +158,15 @@ export type ApplyHostOutcome =
       readonly installedVersion: string;
       readonly expectedStageFingerprint: string | null;
       readonly actualStageFingerprint: string | null;
+    }
+  | {
+      // The stage holds a version other than the one the caller confirmed
+      // (`expectedStagedVersion`). Nothing was consumed, announced or
+      // disturbed; the stage is left for its promoter.
+      readonly outcome: "stage-version-mismatch";
+      readonly installedVersion: string;
+      readonly expectedStagedVersion: string;
+      readonly actualStagedVersion: string;
     };
 
 export async function applyHost(
@@ -184,11 +229,30 @@ export async function applyHost(
     });
     return { outcome: "no-op", installedVersion: installed.version };
   }
+  if (
+    opts.expectedStagedVersion !== null &&
+    staged.version !== opts.expectedStagedVersion
+  ) {
+    logger.info(
+      "Host apply rejected a stage naming a version other than the one requested",
+      {
+        environment: opts.environment,
+        expectedStagedVersion: opts.expectedStagedVersion,
+        actualStagedVersion: staged.version,
+      },
+    );
+    return {
+      outcome: "stage-version-mismatch",
+      installedVersion: installed.version,
+      expectedStagedVersion: opts.expectedStagedVersion,
+      actualStagedVersion: staged.version,
+    };
+  }
 
   if (!opts.noService && !opts.force) {
     await assertHostNotBusy(opts.environment);
   }
-  if (opts.onWillCommitStaged !== undefined) {
+  if (opts.onWillCommitStaged !== null) {
     await opts.onWillCommitStaged(staged.version);
   }
 
@@ -206,6 +270,7 @@ export async function applyHost(
         // denied the cooperative shutdown claim and `--force` aborted
         // anyway.
         force: opts.force,
+        onWillStopHost: opts.onWillDisruptHost,
       });
   if (lifecycleHandle !== null && opts.publishHostStartAdoption !== undefined) {
     lifecycleHandle.lifecycle.setHostStartAdoptionPublisher?.(
@@ -229,6 +294,7 @@ export async function applyHost(
     lifecycle: lifecycleHandle?.lifecycle ?? null,
     onCommitted: () => {},
     verifyMutationCapability: opts.verifyMutationCapability,
+    onWillSwap: opts.onWillDisruptHost,
   });
 
   // `createServiceInstallLifecycle`'s `afterSwap` already swallows its own

--- a/clients/traycer-cli/src/installer/apply.ts
+++ b/clients/traycer-cli/src/installer/apply.ts
@@ -54,6 +54,18 @@ export interface ApplyHostOptions {
    * `host start` does not deadlock trying to reacquire the same outer lock.
    */
   readonly publishHostStartAdoption?: HostStartAdoptionPublisher;
+  /**
+   * Called once this function has committed to the disruptive half: after
+   * reconcile has settled what is staged (it deletes stale stages and
+   * restores an aside left by a crashed promoter, so what the caller read
+   * before this call is not what is applied), after the no-op and
+   * fingerprint decisions, and after the busy gate where one runs (`force`
+   * and `noService` skip it) - with the version of the stage about to be
+   * committed. `host update` takes ownership of its progress marker here; a
+   * no-op, a fingerprint mismatch and a busy refusal never reach it, so
+   * nothing is announced for work that does not happen.
+   */
+  readonly onWillCommitStaged?: (stagedVersion: string) => Promise<void>;
 }
 
 // The facts `createServiceInstallLifecycle` observed around the swap -
@@ -175,6 +187,9 @@ export async function applyHost(
 
   if (!opts.noService && !opts.force) {
     await assertHostNotBusy(opts.environment);
+  }
+  if (opts.onWillCommitStaged !== undefined) {
+    await opts.onWillCommitStaged(staged.version);
   }
 
   // `bootstrap: null` - apply is strictly an update over an existing,

--- a/clients/traycer-cli/src/installer/download-stage.ts
+++ b/clients/traycer-cli/src/installer/download-stage.ts
@@ -77,6 +77,20 @@ export interface DownloadAndStageHostOptions {
   // Test seam so unit tests can inject a fake `RegistryTransport` without
   // monkey-patching the module. `null` uses the real default client.
   readonly registryClient: RegistryClient | null;
+  /**
+   * Awaited once, AFTER the phase-1 short-circuit decision has said a transfer
+   * is needed and BEFORE the first byte is requested. Never fires on
+   * `installed-up-to-date`, `already-staged`, the automatic incomparable
+   * refusal, or a manifest/version failure - every one of those returns or
+   * throws above the call.
+   *
+   * Exists so `host update` can publish its coarse `updating` marker at the
+   * moment the work becomes visible to the user, rather than after a
+   * multi-minute transfer has already finished. `host download` passes
+   * `null`: it has no marker to write, and a hook that did nothing would only
+   * invite the next reader to wonder what it was for.
+   */
+  readonly onWillDownload: ((targetVersion: string) => Promise<void>) | null;
 }
 
 export type HostDownloadShortCircuitReason =
@@ -439,6 +453,13 @@ async function downloadAndStageHostInSegment(
       installedVersion: preDownload.installedVersion,
       stagedVersion: preDownload.stagedVersion,
     };
+  }
+
+  // The transfer is now certain. Told BEFORE `resolveAsset`, not merely before
+  // the byte stream: the asset lookup is itself a network call to the
+  // registry, and "the update has started" is true from here on.
+  if (opts.onWillDownload !== null) {
+    await opts.onWillDownload(targetVersion);
   }
 
   // Phase 2 - no lock: download, verify, extract into an owner-tokened

--- a/clients/traycer-cli/src/installer/download-stage.ts
+++ b/clients/traycer-cli/src/installer/download-stage.ts
@@ -406,6 +406,40 @@ async function downloadAndStageHostInSegment(
       );
       const installedAtOrAboveTarget =
         installedVsTarget.comparable && installedVsTarget.ordering !== "less";
+      // "Up to date" for an EXPLICIT request is the request's own string
+      // and nothing else. A record the comparator puts at or above the
+      // request by ANOTHER string - strictly newer (`--version 1.2.0` over
+      // an installed 2.0.0), or another build of the same release
+      // (`2.0.0+bar` over a requested `2.0.0+foo`: the comparator ignores
+      // build metadata) - is not the artifact the caller named. Reporting
+      // it as up to date handed `host update` a no-op, exit 0, with the
+      // requested artifact never delivered: a request that delivered
+      // nothing does not report success, the rule the promote gate and the
+      // version binding under the activation lock already apply to the same
+      // fact. Refused HERE, before any transfer, with the code that fact
+      // carries everywhere else and its remedy. An implicit "latest" keeps
+      // the at-or-above reading: the registry's release is installed, in a
+      // build the promote gate would not replace.
+      if (
+        !requestedLatest &&
+        installedAtOrAboveTarget &&
+        installed.version !== targetVersion
+      ) {
+        const relation =
+          installedVsTarget.ordering === "greater"
+            ? `newer than the requested ${targetVersion}`
+            : `another build of the same release as the requested ${targetVersion}`;
+        throw cliError({
+          code: CLI_ERROR_CODES.HOST_UPDATE_NOT_NEWER,
+          message: `host download: the installed host is ${installed.version}, ${relation}; nothing was transferred. Run 'traycer host status' to see what is installed, or pass --allow-downgrade to 'traycer host update' to install ${targetVersion} over it`,
+          details: {
+            environment: opts.environment,
+            targetVersion,
+            installedVersion: installed.version,
+          },
+          exitCode: 1,
+        });
+      }
       const alreadyStagedAtTarget =
         stagedAfterYankHeal !== null &&
         stagedAfterYankHeal.stageId !== null &&

--- a/clients/traycer-cli/src/installer/install.ts
+++ b/clients/traycer-cli/src/installer/install.ts
@@ -194,6 +194,7 @@ export async function installHost(
     onProgress: opts.onProgress,
     lifecycle: opts.lifecycle,
     verifyMutationCapability: legacyMutationVerifier,
+    onWillSwap: null,
   });
   logger.info("Host install completed", {
     environment: opts.environment,
@@ -379,6 +380,8 @@ export interface CommitHostInstallSourceOptions {
    * authority-checked one.
    */
   readonly verifyMutationCapability: () => Promise<void>;
+  /** See `CommitInstallFromSourceOptions.onWillSwap`. */
+  readonly onWillSwap: (() => void) | null;
 }
 
 export interface CommitHostInstallSourceResult {
@@ -429,6 +432,7 @@ export async function commitHostInstallSource(
       onProgress: opts.onProgress,
       lifecycle: opts.lifecycle,
       verifyMutationCapability: opts.verifyMutationCapability,
+      onWillSwap: opts.onWillSwap,
       onCommitted: () => {
         swapped = true;
       },
@@ -563,6 +567,17 @@ export interface CommitInstallFromSourceOptions {
   readonly onCommitted: () => void;
   /** See `CommitHostInstallSourceOptions.verifyMutationCapability`. */
   readonly verifyMutationCapability: () => Promise<void>;
+  /**
+   * Runs once the pre-swap mutation-capability check has passed and
+   * immediately before the rename replaces `install/`: the point at which
+   * this commit disturbs a host the lifecycle did not stop (a stopped or
+   * unregistered service on POSIX, or no lifecycle at all). The `swap`
+   * progress line precedes the check and says nothing about it. A stop
+   * that happened first already reported the boundary
+   * (`CreateServiceInstallLifecycleOptions.onWillStopHost`); a caller
+   * tracking it treats the two as one edge. `null` when no caller is.
+   */
+  readonly onWillSwap: (() => void) | null;
 }
 
 export interface CommitInstallFromSourceResult {
@@ -658,6 +673,7 @@ export async function commitInstallFromSource(
     workUnits: null,
   });
   await verifyMutationCapability();
+  if (opts.onWillSwap !== null) opts.onWillSwap();
   await atomicSwap({
     environment: opts.environment,
     stagingDir: opts.sourceDir,

--- a/clients/traycer-cli/src/manifest/cli-manifest.ts
+++ b/clients/traycer-cli/src/manifest/cli-manifest.ts
@@ -1,6 +1,9 @@
 import { readFile, rename, writeFile } from "node:fs/promises";
 import { readStoredCliInstallManifestAtPath } from "@traycer/protocol/config/installation";
-import { PACKAGE_MANAGER_UPGRADE_COMMAND } from "@traycer/protocol/config/installation-records";
+import {
+  PACKAGE_MANAGER_UPGRADE_COMMAND,
+  type PackageManagerCliSource,
+} from "@traycer-clients/shared/cli-install/package-manager-upgrade-command";
 import { ZodError } from "zod";
 import { createCliLogger } from "../logger";
 import { CLI_ERROR_CODES, cliError } from "../runner/errors";
@@ -65,25 +68,19 @@ export const VALID_CLI_INSTALL_SOURCES: ReadonlySet<CliInstallSource> =
     "manual",
   ]);
 
-// Package-manager-owned sources for the upgrade-ownership contract.
-// `cli upgrade` refuses to self-replace these binaries; `cli mark-source`
-// is the only entrypoint a PM hook should call. The dedicated
-// `cli re-anchor` command lives next to `cli mark-source` and is the
-// user-facing way to record a manual install - see `cli-re-anchor.ts`.
-export const PACKAGE_MANAGER_CLI_SOURCES: ReadonlySet<CliInstallSource> =
-  new Set<CliInstallSource>([
-    "homebrew",
-    "npm",
-    "winget",
-    "scoop",
-    "apt",
-    "rpm",
-  ]);
+// The package-manager-owned sources for the upgrade-ownership contract are
+// `PACKAGE_MANAGER_CLI_SOURCES` in `@traycer-clients/shared/cli-install`,
+// derived from the shared command table: `cli upgrade` refuses to
+// self-replace these binaries; `cli mark-source` is the only entrypoint a PM
+// hook should call. The dedicated `cli re-anchor` command lives next to
+// `cli mark-source` and is the user-facing way to record a manual install -
+// see `cli-re-anchor.ts`.
 
 // Keep the CLI's existing sentences (including the yum alternative), deriving
 // the command itself from the same table Desktop and the GUI remedy consume.
+// Read by `cli upgrade`'s refusal and by `host/compat-recovery.ts`.
 export const PACKAGE_MANAGER_UPGRADE_HINT: Record<
-  Exclude<CliInstallSource, "desktop" | "manual">,
+  PackageManagerCliSource,
   string
 > = {
   homebrew: `Run '${PACKAGE_MANAGER_UPGRADE_COMMAND.homebrew}'.`,

--- a/clients/traycer-cli/src/manifest/cli-manifest.ts
+++ b/clients/traycer-cli/src/manifest/cli-manifest.ts
@@ -1,5 +1,6 @@
 import { readFile, rename, writeFile } from "node:fs/promises";
 import { readStoredCliInstallManifestAtPath } from "@traycer/protocol/config/installation";
+import { PACKAGE_MANAGER_UPGRADE_COMMAND } from "@traycer/protocol/config/installation-records";
 import { ZodError } from "zod";
 import { createCliLogger } from "../logger";
 import { CLI_ERROR_CODES, cliError } from "../runner/errors";
@@ -79,22 +80,18 @@ export const PACKAGE_MANAGER_CLI_SOURCES: ReadonlySet<CliInstallSource> =
     "rpm",
   ]);
 
-// Canonical per-package-manager upgrade hint, written ONCE and shared by the
-// `cli upgrade` package-manager-owned refusal (cli-upgrade.ts) and the
-// protocol-incompatibility recovery hint (compat-recovery.ts). The desktop and
-// manual vectors are phrased differently per caller and are supplied by each
-// map, not here - so a package-manager command (e.g. the formula name) changes
-// in exactly one place instead of drifting between the two surfaces.
+// Keep the CLI's existing sentences (including the yum alternative), deriving
+// the command itself from the same table Desktop and the GUI remedy consume.
 export const PACKAGE_MANAGER_UPGRADE_HINT: Record<
   Exclude<CliInstallSource, "desktop" | "manual">,
   string
 > = {
-  homebrew: "Run 'brew upgrade traycer'.",
-  npm: "Run 'npm install -g @traycerai/cli@latest'.",
-  winget: "Run 'winget upgrade Traycer.CLI'.",
-  scoop: "Run 'scoop update traycer-cli'.",
-  apt: "Run 'sudo apt update && sudo apt install --only-upgrade traycer-cli'.",
-  rpm: "Run 'sudo dnf upgrade traycer-cli' (or 'yum upgrade').",
+  homebrew: `Run '${PACKAGE_MANAGER_UPGRADE_COMMAND.homebrew}'.`,
+  npm: `Run '${PACKAGE_MANAGER_UPGRADE_COMMAND.npm}'.`,
+  winget: `Run '${PACKAGE_MANAGER_UPGRADE_COMMAND.winget}'.`,
+  scoop: `Run '${PACKAGE_MANAGER_UPGRADE_COMMAND.scoop}'.`,
+  apt: `Run '${PACKAGE_MANAGER_UPGRADE_COMMAND.apt}'.`,
+  rpm: `Run '${PACKAGE_MANAGER_UPGRADE_COMMAND.rpm}' (or 'yum upgrade').`,
 };
 
 function currentProcessBinaryPath(): string {

--- a/clients/traycer-cli/src/registry/client-floor.ts
+++ b/clients/traycer-cli/src/registry/client-floor.ts
@@ -48,7 +48,8 @@ export type HostClientFloorVerdict =
    * policy reserved for the INSTALLED side - so this is a data-integrity
    * failure, and it refuses rather than degrading to "no floor". Degrading
    * would make a typo in the publisher the way to disable the floor fleet-
-   * wide, silently.
+   * wide, silently. `requiredCliVersion` here is the declared text BOUNDED
+   * for rendering (`describeUnreadableFloor`), not the raw value.
    */
   | { readonly kind: "floor-unreadable"; readonly requiredCliVersion: string };
 
@@ -63,7 +64,14 @@ export function evaluateHostClientFloor(
   const requiredCliVersion = input.requiredCliVersion;
   if (requiredCliVersion === null) return { kind: "unfloored" };
   if (!isValidHostVersion(requiredCliVersion)) {
-    return { kind: "floor-unreadable", requiredCliVersion };
+    // Bounded HERE, at the verdict's construction, so every consumer of
+    // the refusal - the message, the registry client's WARN lines, the
+    // error's `details` - carries the same bounded text (see
+    // `describeUnreadableFloor`).
+    return {
+      kind: "floor-unreadable",
+      requiredCliVersion: describeUnreadableFloor(requiredCliVersion),
+    };
   }
   if (input.cliVersion === LOCAL_CLI_VERSION) {
     return { kind: "unreleased-cli", requiredCliVersion };
@@ -112,4 +120,20 @@ export function hostClientFloorRefusalMessage(
     return `host registry: version '${resolvedVersion}' requires Traycer CLI ${refusal.requiredCliVersion} or newer, and this is ${refusal.cliVersion}. Update Traycer first, then install the host.`;
   }
   return `host registry: version '${resolvedVersion}' declares requiredCliVersion ${JSON.stringify(refusal.requiredCliVersion)}, which is not a version this CLI can compare against. The manifest is wrong; do not work around it by installing a different version.`;
+}
+
+// An unreadable floor is registry text this CLI could not parse. A valid
+// floor is a bounded token by construction; this one is not, so the
+// verdict carries it bounded - its charset (printable ASCII, the rest
+// shown as `?`) and its length - and every render of the REFUSAL (the
+// message, the WARN lines, `details`, the reason `host available` authors
+// onto its one unsplittable JSON line and every GUI surface) inherits
+// that bound. The catalog ENTRY itself travels as the manifest parsed it;
+// the GUI renders no floor it cannot read as a version.
+const UNREADABLE_FLOOR_RENDER_LIMIT = 64;
+
+function describeUnreadableFloor(value: string): string {
+  const printable = value.replace(/[^\x20-\x7e]/g, "?");
+  if (printable.length <= UNREADABLE_FLOOR_RENDER_LIMIT) return printable;
+  return `${printable.slice(0, UNREADABLE_FLOOR_RENDER_LIMIT)}... (${value.length} characters)`;
 }

--- a/clients/traycer-cli/src/service/__tests__/install-lifecycle.test.ts
+++ b/clients/traycer-cli/src/service/__tests__/install-lifecycle.test.ts
@@ -164,6 +164,7 @@ async function runLifecycle(
     environment: "production",
     bootstrap: options,
     force,
+    onWillStopHost: null,
   });
   await handle.lifecycle.beforeSwap();
   await handle.lifecycle.afterSwap();
@@ -274,6 +275,7 @@ describe("service install lifecycle re-registration", () => {
       environment: "production",
       bootstrap,
       force: false,
+      onWillStopHost: null,
     });
     runningHandle.lifecycle.setMutationVerifier?.(async () => {
       throw lost;
@@ -292,6 +294,7 @@ describe("service install lifecycle re-registration", () => {
       environment: "production",
       bootstrap,
       force: false,
+      onWillStopHost: null,
     });
     let verifierCalls = 0;
     externalHandle.lifecycle.setMutationVerifier?.(async () => {
@@ -316,6 +319,7 @@ describe("service install lifecycle re-registration", () => {
       environment: "production",
       bootstrap,
       force: false,
+      onWillStopHost: null,
     });
     bootstrapHandle.lifecycle.setMutationVerifier?.(async () => {
       throw lost;
@@ -466,6 +470,7 @@ describe("service install lifecycle re-registration", () => {
         environment: "production",
         bootstrap,
         force: false,
+        onWillStopHost: null,
       });
 
       await expect(handle.lifecycle.beforeSwap()).rejects.toMatchObject({
@@ -501,6 +506,7 @@ describe("service install lifecycle re-registration", () => {
         environment: "production",
         bootstrap,
         force: false,
+        onWillStopHost: null,
       });
 
       await expect(handle.lifecycle.beforeSwap()).resolves.toBeUndefined();
@@ -540,6 +546,7 @@ describe("service install lifecycle re-registration", () => {
         environment: "production",
         bootstrap,
         force: false,
+        onWillStopHost: null,
       });
 
       await expect(handle.lifecycle.beforeSwap()).resolves.toBeUndefined();
@@ -567,6 +574,7 @@ describe("service install lifecycle re-registration", () => {
         environment: "production",
         bootstrap,
         force: false,
+        onWillStopHost: null,
       });
       await handle.lifecycle.beforeSwap();
 
@@ -603,6 +611,7 @@ describe("service install lifecycle re-registration", () => {
       environment: "production",
       bootstrap,
       force: false,
+      onWillStopHost: null,
     });
     await handle.lifecycle.beforeSwap();
 
@@ -782,6 +791,7 @@ describe("runWithPublishedHostStartAdoption (via registerService's install)", ()
       environment: "production",
       bootstrap,
       force: false,
+      onWillStopHost: null,
     });
     const setPublisher = handle.lifecycle.setHostStartAdoptionPublisher;
     if (setPublisher === undefined) {
@@ -815,6 +825,7 @@ describe("runWithPublishedHostStartAdoption (via registerService's install)", ()
       environment: "production",
       bootstrap,
       force: false,
+      onWillStopHost: null,
     });
     const setPublisher = handle.lifecycle.setHostStartAdoptionPublisher;
     if (setPublisher === undefined) {
@@ -855,6 +866,7 @@ describe("runWithPublishedHostStartAdoption (via registerService's install)", ()
       environment: "production",
       bootstrap,
       force: false,
+      onWillStopHost: null,
     });
     const setPublisher = handle.lifecycle.setHostStartAdoptionPublisher;
     if (setPublisher === undefined) {
@@ -885,6 +897,7 @@ describe("runWithPublishedHostStartAdoption (via registerService's install)", ()
       environment: "production",
       bootstrap,
       force: false,
+      onWillStopHost: null,
     });
     const setPublisher = handle.lifecycle.setHostStartAdoptionPublisher;
     if (setPublisher === undefined) {
@@ -926,6 +939,7 @@ describe("runWithPublishedHostStartAdoption (via registerService's install)", ()
       environment: "production",
       bootstrap,
       force: false,
+      onWillStopHost: null,
     });
     const setPublisher = handle.lifecycle.setHostStartAdoptionPublisher;
     if (setPublisher === undefined) {
@@ -976,6 +990,7 @@ describe("swap-lock recovery wiring", () => {
         environment: "production",
         bootstrap: null,
         force: false,
+        onWillStopHost: null,
       });
       const bytesOnly = createBytesOnlyInstallLifecycle(
         harness.controller,
@@ -1016,6 +1031,7 @@ describe("swap-lock recovery wiring", () => {
         environment: "production",
         bootstrap: null,
         force: false,
+        onWillStopHost: null,
       });
       const bytesOnly = createBytesOnlyInstallLifecycle(
         harness.controller,
@@ -1024,5 +1040,103 @@ describe("swap-lock recovery wiring", () => {
       expect(serviceHandle.lifecycle.swapLockRecovery).toBeNull();
       expect(bytesOnly.swapLockRecovery).toBeNull();
     });
+  });
+});
+
+// The disruption boundary `host update` restores a taken-over progress
+// marker against: reported from the actuator, after the status probe and
+// the authority check, never before either.
+describe("service install lifecycle onWillStopHost", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.serviceLabelForMock.mockReturnValue(label);
+    mocks.resolveServiceCliInvocationMock.mockResolvedValue({
+      command: "/usr/local/bin/traycer",
+      args: [],
+    });
+    mocks.readRegisteredCliInvocationMock.mockResolvedValue(null);
+  });
+
+  it("fires once, after the authority check and immediately before the stop of a running host", async () => {
+    // Falsification: call it before `withServiceMutationAuthority` and the
+    // refused-authority pin below reddens; call it after `controller.stop`
+    // and the order here flips.
+    const harness = makeController("running");
+    mocks.createServiceControllerMock.mockReturnValue(harness.controller);
+    const order: string[] = [];
+    harness.stop.mockImplementation(async () => {
+      order.push("stop");
+    });
+    const handle = createServiceInstallLifecycle({
+      environment: "production",
+      bootstrap: null,
+      force: false,
+      onWillStopHost: () => {
+        order.push("boundary");
+      },
+    });
+
+    await handle.lifecycle.beforeSwap();
+
+    expect(order).toEqual(["boundary", "stop"]);
+    expect(handle.state.stoppedBeforeSwap).toBe(true);
+  });
+
+  it("does not fire when the mutation authority is refused - nothing was touched", async () => {
+    const harness = makeController("running");
+    mocks.createServiceControllerMock.mockReturnValue(harness.controller);
+    const onWillStopHost = vi.fn();
+    const handle = createServiceInstallLifecycle({
+      environment: "production",
+      bootstrap: null,
+      force: false,
+      onWillStopHost,
+    });
+    const lost = new Error("update attempt capability was lost");
+    handle.lifecycle.setMutationVerifier?.(async () => {
+      throw lost;
+    });
+
+    await expect(handle.lifecycle.beforeSwap()).rejects.toBe(lost);
+
+    expect(onWillStopHost).not.toHaveBeenCalled();
+    expect(harness.stop).not.toHaveBeenCalled();
+  });
+
+  it("does not fire when the status probe itself throws - nothing was touched", async () => {
+    const harness = makeController("running");
+    const probeFailure = new Error("launchctl print failed");
+    vi.mocked(harness.controller.status).mockRejectedValue(probeFailure);
+    mocks.createServiceControllerMock.mockReturnValue(harness.controller);
+    const onWillStopHost = vi.fn();
+    const handle = createServiceInstallLifecycle({
+      environment: "production",
+      bootstrap: null,
+      force: false,
+      onWillStopHost,
+    });
+
+    await expect(handle.lifecycle.beforeSwap()).rejects.toBe(probeFailure);
+
+    expect(onWillStopHost).not.toHaveBeenCalled();
+    expect(harness.stop).not.toHaveBeenCalled();
+  });
+
+  it("does not fire for a service the lifecycle decides not to stop (stopped, on POSIX) - the swap reports that boundary", async () => {
+    const harness = makeController("stopped");
+    mocks.createServiceControllerMock.mockReturnValue(harness.controller);
+    const onWillStopHost = vi.fn();
+    const handle = createServiceInstallLifecycle({
+      environment: "production",
+      bootstrap: null,
+      force: false,
+      onWillStopHost,
+    });
+
+    await withPlatformAsync("linux", () => handle.lifecycle.beforeSwap());
+
+    expect(onWillStopHost).not.toHaveBeenCalled();
+    expect(harness.stop).not.toHaveBeenCalled();
+    expect(handle.state.stoppedBeforeSwap).toBe(false);
   });
 });

--- a/clients/traycer-cli/src/service/install-lifecycle.ts
+++ b/clients/traycer-cli/src/service/install-lifecycle.ts
@@ -117,6 +117,20 @@ export interface CreateServiceInstallLifecycleOptions {
   // ensure/update/apply only skipped the busy PRE-check and the
   // cooperative stop's own busy denial still aborted the install.
   readonly force: boolean;
+  /**
+   * Runs once the pre-swap stop's mutation-capability check has passed and
+   * immediately before the actuator stops the host: the first point at
+   * which this lifecycle can have disturbed it. NOT before that check, and
+   * not on the status probe: a probe that throws, or an authority that is
+   * refused, has touched nothing - and `host update` restores a marker it
+   * took over only for a failure that touched nothing. The `service-stop`
+   * progress line precedes both and says nothing about either. A lifecycle
+   * that decides not to stop (a stopped or unregistered service on POSIX)
+   * never calls it; the swap itself reports that boundary
+   * (`CommitInstallFromSourceOptions.onWillSwap`). `null` when no caller is
+   * tracking the boundary.
+   */
+  readonly onWillStopHost: (() => void) | null;
 }
 
 // Build the lifecycle hooks `installHost` needs to keep the OS
@@ -155,9 +169,10 @@ export function createServiceInstallLifecycle(
       // open handles inside the install dir would fail the swap rename, so
       // it runs even when the service wasn't observed running.
       if (status.state === "running" || process.platform === "win32") {
-        await withServiceMutationAuthority(verifyMutationCapability, () =>
-          controller.stop(label, { force: options.force }),
-        );
+        await withServiceMutationAuthority(verifyMutationCapability, () => {
+          if (options.onWillStopHost !== null) options.onWillStopHost();
+          return controller.stop(label, { force: options.force });
+        });
         state.stoppedBeforeSwap = true;
         return;
       }
@@ -181,9 +196,13 @@ export function createServiceInstallLifecycle(
         process.platform === "darwin"
       ) {
         try {
-          await withServiceMutationAuthority(verifyMutationCapability, () =>
-            controller.stop(label, { force: options.force }),
-          );
+          await withServiceMutationAuthority(verifyMutationCapability, () => {
+            // Fired before a cooperative stop a busy host may still DENY;
+            // that denial is `HOST_BUSY`, which every caller routes to the
+            // park arm - the one exit that never reads the boundary.
+            if (options.onWillStopHost !== null) options.onWillStopHost();
+            return controller.stop(label, { force: options.force });
+          });
           state.stoppedBeforeSwap = true;
         } catch (cause) {
           if (isServiceMutationAuthorityError(cause)) throw cause;

--- a/clients/traycer-cli/src/store/cli-lock.ts
+++ b/clients/traycer-cli/src/store/cli-lock.ts
@@ -8,6 +8,7 @@ import {
   type AcquireLockOptions,
   type LockHandle,
   type LockMetadata,
+  type WithLockOutcome,
 } from "@traycer-clients/shared/host-lock/cross-process-lock";
 
 // Re-exported for existing callers (`host/busy-check.ts`, service
@@ -112,6 +113,39 @@ export async function __acquireCliLockAtPathForTest(
 
 // `withCliLock(opts, fn)` - acquire, run fn, release in finally. Catches
 // nothing on the inner function; the lock is released either way.
+export interface CliScopedFileLockOptions {
+  /** The lock file, beside the file it guards. */
+  readonly lockPath: string;
+  readonly reason: string;
+  readonly waitMs: number;
+  readonly pollIntervalMs: number;
+}
+
+/**
+ * A short cross-process lock at an explicit path, for a CLI writer that
+ * guards ONE file rather than the install (`host/update-progress-marker.ts`
+ * guards the progress marker's conditional writes with it). Same protocol as
+ * the CLI lock - O_EXCL create, holder identity, a dead holder broken by
+ * liveness - through this facade so the shared protocol keeps a single CLI
+ * importer (`clients/shared/__tests__/host-update-contender-architecture`).
+ * Never throws on contention: the outcome says `busy`, and the caller
+ * decides what a write it could not make means.
+ */
+export async function withCliScopedFileLock<T>(
+  opts: CliScopedFileLockOptions,
+  fn: () => Promise<T>,
+): Promise<WithLockOutcome<T>> {
+  return withLock(
+    {
+      lockPath: opts.lockPath,
+      reason: opts.reason,
+      waitMs: opts.waitMs,
+      pollIntervalMs: opts.pollIntervalMs,
+    },
+    () => fn(),
+  );
+}
+
 export async function withCliLock<T>(
   opts: AcquireCliLockOptions,
   fn: (handle: CliLockHandle) => Promise<T>,

--- a/clients/traycer-cli/src/store/process-identity.ts
+++ b/clients/traycer-cli/src/store/process-identity.ts
@@ -14,6 +14,7 @@ export {
   currentProcessIdentityToken,
   getPublishedProcessIdentityVerdict,
   isProcessAlive,
+  ownProcessStartIdentity,
   probeProcessLiveness,
   readLiveProcessStartTimeMs,
   readProcessStartIdentity,

--- a/clients/traycer-cli/src/store/process-identity.ts
+++ b/clients/traycer-cli/src/store/process-identity.ts
@@ -14,6 +14,7 @@ export {
   currentProcessIdentityToken,
   getPublishedProcessIdentityVerdict,
   isProcessAlive,
+  probeProcessLiveness,
   readLiveProcessStartTimeMs,
   readProcessStartIdentity,
   readProcessStartTimeMs,

--- a/protocol/src/config/installation-records.ts
+++ b/protocol/src/config/installation-records.ts
@@ -176,6 +176,31 @@ export const cliInstallSourceSchema = z.enum([
 ]);
 export type CliInstallSource = z.infer<typeof cliInstallSourceSchema>;
 
+export const CLI_NPM_PACKAGE_NAME = "@traycerai/cli";
+
+/**
+ * One command vocabulary for CLI refusals, Desktop reconciliation and the GUI remedy.
+ * `publish-cli-package-managers.yml` publishes npm prereleases under their own
+ * dist-tag (for example `rc`), while Homebrew's rolling formula can receive
+ * that same prerelease on manual dispatch. An npm floor remedy must therefore
+ * name its exact required version instead of the stable `latest` tag.
+ * Traycer does not publish prereleases to winget, Scoop, apt or rpm feeds:
+ * their renderers/release artifacts are not feed publishers. The GUI offers
+ * installation help for those sources under a prerelease floor; these generic
+ * upgrade commands remain available for stable floors.
+ */
+export const PACKAGE_MANAGER_UPGRADE_COMMAND: Record<
+  Exclude<CliInstallSource, "desktop" | "manual">,
+  string
+> = {
+  homebrew: "brew upgrade traycer",
+  npm: `npm install -g ${CLI_NPM_PACKAGE_NAME}@latest`,
+  winget: "winget upgrade Traycer.CLI",
+  scoop: "scoop update traycer-cli",
+  apt: "sudo apt update && sudo apt install --only-upgrade traycer-cli",
+  rpm: "sudo dnf upgrade traycer-cli",
+};
+
 export const cliPendingUpgradeSchema = z.object({
   version: z.string(),
   stagedBinaryPath: z.string(),

--- a/protocol/src/config/installation-records.ts
+++ b/protocol/src/config/installation-records.ts
@@ -176,31 +176,6 @@ export const cliInstallSourceSchema = z.enum([
 ]);
 export type CliInstallSource = z.infer<typeof cliInstallSourceSchema>;
 
-export const CLI_NPM_PACKAGE_NAME = "@traycerai/cli";
-
-/**
- * One command vocabulary for CLI refusals, Desktop reconciliation and the GUI remedy.
- * `publish-cli-package-managers.yml` publishes npm prereleases under their own
- * dist-tag (for example `rc`), while Homebrew's rolling formula can receive
- * that same prerelease on manual dispatch. An npm floor remedy must therefore
- * name its exact required version instead of the stable `latest` tag.
- * Traycer does not publish prereleases to winget, Scoop, apt or rpm feeds:
- * their renderers/release artifacts are not feed publishers. The GUI offers
- * installation help for those sources under a prerelease floor; these generic
- * upgrade commands remain available for stable floors.
- */
-export const PACKAGE_MANAGER_UPGRADE_COMMAND: Record<
-  Exclude<CliInstallSource, "desktop" | "manual">,
-  string
-> = {
-  homebrew: "brew upgrade traycer",
-  npm: `npm install -g ${CLI_NPM_PACKAGE_NAME}@latest`,
-  winget: "winget upgrade Traycer.CLI",
-  scoop: "scoop update traycer-cli",
-  apt: "sudo apt update && sudo apt install --only-upgrade traycer-cli",
-  rpm: "sudo dnf upgrade traycer-cli",
-};
-
 export const cliPendingUpgradeSchema = z.object({
   version: z.string(),
   stagedBinaryPath: z.string(),


### PR DESCRIPTION
## Why

`traycer host update` on a busy host stamped `failed` over its own `updating` marker ("host has work in progress") and the Settings Overview rendered that as a failure with no way forward. The refusal is a **park**, not a failure: the stage is already promoted and installs on the next idle update. Two further gaps in the same channel: the `updating` marker only appeared after the stage was promoted (nothing during the transfer), and neither "installed but not yet restarted" (activation debt) nor "staged, waiting for the host to go idle" could be expressed by the coarse marker at all.

Follow-up to the rc.1→rc.2 update RCA (#1741 / internal #5520, #5522).

## What

**CLI**
- `DownloadAndStageHostOptions.onWillDownload: ((targetVersion) => Promise<void>) | null` — fires once after the short-circuit decision (`installed-up-to-date`, `already-staged`, invalid `latest`) and before the first byte. `host download` passes `null`.
- `host update` writes its `updating` marker from that hook, CAS-re-points it for the activation arm, **withdraws it conditionally on `E_HOST_BUSY`** and stamps `failed` only on real failures. The busy exit message names the stage that stays staged and the `--force` way forward. `apply.ts` / downgrade / busy-check unchanged — their busy throw *is* the park.

**GUI**
- New `lib/host/fleet-update/legacy-update-facts.ts`: derives **activation debt** (install record ahead of the running host) and a **staged wait** (newer stage + busy) from `host.getInstallationInfo` + `host.status`, mirroring the CLI's `readActivationState` comparator.
- `FleetUpdateWireObservation.legacyFacts` feeds both parks into `projectFleetUpdateView` as `waiting-to-activate` / `waiting-for-work` when nothing outranks them (coarse marker, attempt record, `unavailable` all win). Borrowed fleet reads pass `null`; stale → `unknown` with retained kind. Neither park holds the lifecycle gate or earns the fast poll.
- Overview operation card: **Restart** on activation debt (opens the existing restart confirmation), **Force update…** on a staged wait (routes `host.update.install {force: true}` through the existing busy dialog). The catalog comparison and the "up to date" sentence use the *installed* version under debt.
- `host.getInstallationInfo` polls every 10 s so the debt appears without a remount; the install mutation invalidates both reads on success.
- The old `HostOverviewUpdateProgress` block is removed — the card is the one surface for update state on the Overview.

## Tests

- CLI: `download-stage.test.ts` (hook ordering + non-fire cases), `host-update.test.ts` (early marker, busy parks on the apply and debt arms, failure stamps, marker CAS), downgrade busy park. 85 passing.
- GUI: new `legacy-update-facts.test.ts` (truth table through the real comparator), `fleet-update-view.test.ts` (+22: both parks under `operation: null` and `kind: "none"`, precedence, stale), borrowed read passes `null`, policy table poll, operation card controls, mounted Overview (debt appears on a later poll without remount, retained `failed` beside debt keeps failure text + Restart, staged wait dispatches force install). 242 passing across the touched suites.

## Not in this PR

Detailed per-phase progress during the update and during the host's restart window — that needs `host update` on the attempt-record executor, planned separately.
