### PR TITLE
fix(cli): host-stopping commands survive the stop they issue (Linux scope relocation and guard, Windows kill set without /T)

### DIFF
--- a/clients/desktop/src/electron-main/cli/traycer-cli.ts
+++ b/clients/desktop/src/electron-main/cli/traycer-cli.ts
@@ -9,9 +9,9 @@ import {
 
 /**
  * Fixup A8: every lock-taking CLI command this wrapper still carries
- * (`host service uninstall`, `host stamp-runtime`, `host free-port`,
- * `host purge-stage`, `host uninstall [--all]`; the long-running mutations -
- * install / apply / ensure / restart / service install - stream instead)
+ * (`host stamp-runtime`, `host free-port`, `host purge-stage`,
+ * `host uninstall [--all]`; the long-running mutations - install / apply /
+ * ensure / restart / service install / service uninstall - stream instead)
  * waits up to
  * `waitMs: 30_000` internally on the shared `cli-lock` before terminally
  * throwing `E_CLI_LOCK_BUSY` (every `withCliLock` call site under

--- a/clients/desktop/src/electron-main/cli/traycer-cli.ts
+++ b/clients/desktop/src/electron-main/cli/traycer-cli.ts
@@ -11,9 +11,10 @@ import {
  * Fixup A8: every lock-taking CLI command this wrapper still carries
  * (`host stamp-runtime`, `host free-port`, `host purge-stage`; the
  * long-running mutations - install / apply / ensure / restart / service
- * install / service uninstall / uninstall [--all] - stream instead, the last
- * three because on Windows they stop the host through a scan-then-kill loop
- * whose worst case is several 30 s scans)
+ * install / service uninstall / uninstall [--all] - stream instead. Service
+ * install can wait for post-registration credential provisioning; restart
+ * and the two uninstall commands can stop the host through Windows'
+ * scan-then-kill loop, whose worst case is several 30 s scans)
  * waits up to
  * `waitMs: 30_000` internally on the shared `cli-lock` before terminally
  * throwing `E_CLI_LOCK_BUSY` (every `withCliLock` call site under

--- a/clients/desktop/src/electron-main/cli/traycer-cli.ts
+++ b/clients/desktop/src/electron-main/cli/traycer-cli.ts
@@ -9,9 +9,11 @@ import {
 
 /**
  * Fixup A8: every lock-taking CLI command this wrapper still carries
- * (`host stamp-runtime`, `host free-port`, `host purge-stage`,
- * `host uninstall [--all]`; the long-running mutations - install / apply /
- * ensure / restart / service install / service uninstall - stream instead)
+ * (`host stamp-runtime`, `host free-port`, `host purge-stage`; the
+ * long-running mutations - install / apply / ensure / restart / service
+ * install / service uninstall / uninstall [--all] - stream instead, the last
+ * three because on Windows they stop the host through a scan-then-kill loop
+ * whose worst case is several 30 s scans)
  * waits up to
  * `waitMs: 30_000` internally on the shared `cli-lock` before terminally
  * throwing `E_CLI_LOCK_BUSY` (every `withCliLock` call site under

--- a/clients/desktop/src/electron-main/host/__tests__/host-controller.test.ts
+++ b/clients/desktop/src/electron-main/host/__tests__/host-controller.test.ts
@@ -3740,6 +3740,34 @@ describe("platform matrix", () => {
     expect(waitForHostReady).toHaveBeenCalledTimes(1);
   });
 
+  it("deregisterService streams `host service uninstall` on non-macOS rather than running it under the flat JSON timeout", async () => {
+    // On Windows the uninstall stops the host through the bounded
+    // scan-then-kill loop, whose worst case is several 30 s scans plus
+    // `schtasks /End` and `taskkill` before `/Delete`. The run path's flat
+    // 45 s budget would SIGKILL the CLI mid-loop and leave the host
+    // half-stopped with its task still registered; the streaming path's idle
+    // timeout (re-armed by output, ten minutes) is what `host restart`
+    // already relies on for the same loop.
+    vi.mocked(hostManagesHostLoginItem).mockResolvedValue(false);
+    const controller = newController("production");
+    writeInstallRecord("production", {
+      version: "1.7.0",
+      runtimeVersion: "1.7.0",
+    });
+
+    const outcome = await controller.deregisterService();
+
+    expect(outcome).toEqual({ kind: "ok", value: { registered: false } });
+    expect(runBundledTraycerCliJson).not.toHaveBeenCalled();
+    expect(streamBundledTraycerCliJson).toHaveBeenCalledTimes(1);
+    expect(streamBundledTraycerCliJson).toHaveBeenCalledWith(
+      expect.objectContaining({ args: ["host", "service", "uninstall"] }),
+    );
+
+    // Ablation: route the call back through `this.runBundled` → this test
+    // reddens on both mock assertions.
+  });
+
   // ---- user-repair reprovision intent -------------------------------------
   //
   // These pin the half of a Doctor lifecycle repair that the IPC handler

--- a/clients/desktop/src/electron-main/host/__tests__/host-controller.test.ts
+++ b/clients/desktop/src/electron-main/host/__tests__/host-controller.test.ts
@@ -4195,11 +4195,11 @@ describe("platform matrix", () => {
         return true;
       },
     );
-    vi.mocked(runBundledTraycerCliJson).mockImplementation(async (args) => {
-      if (args.includes("uninstall")) {
+    vi.mocked(streamBundledTraycerCliJson).mockImplementation(async (opts) => {
+      if (opts.args.includes("uninstall")) {
         sentinelWasSetWhenUninstallRan.push(await isHostRemovedByUser());
       }
-      return { removedInstallDir: true, serviceUninstalled: true };
+      return { data: { removedInstallDir: true, serviceUninstalled: true } };
     });
 
     expect(await isHostRemovedByUser()).toBe(false);
@@ -4209,6 +4209,14 @@ describe("platform matrix", () => {
     expect(sentinelWasSetWhenUnregisterRan).toEqual([true]);
     expect(sentinelWasSetWhenUninstallRan).toEqual([true]);
     expect(await isHostRemovedByUser()).toBe(true);
+    // Route pin: the removal streams `host uninstall --all` (the Windows
+    // kill loop can outlive the run path's flat timeout) and never runs it.
+    expect(streamBundledTraycerCliJson).toHaveBeenCalledWith(
+      expect.objectContaining({ args: ["host", "uninstall", "--all"] }),
+    );
+    expect(runBundledTraycerCliJson).not.toHaveBeenCalledWith(
+      expect.arrayContaining(["uninstall"]),
+    );
   });
 
   // P3: the signal must reach the real download child, and removal must wait
@@ -4228,10 +4236,7 @@ describe("platform matrix", () => {
       if (args.includes("available")) {
         return availableSnapshotFixture("1.8.0", ["1.8.0"]);
       }
-      if (args.includes("uninstall")) {
-        uninstallCalls += 1;
-      }
-      return { removedInstallDir: true, serviceUninstalled: true };
+      return {};
     });
     // Signals that the download is genuinely in flight WITH its abort
     // listener attached. Without this handshake the test has no in-flight
@@ -4272,6 +4277,13 @@ describe("platform matrix", () => {
         await downloadGate.promise;
         return { data: {} };
       }
+      if (opts.args.includes("uninstall")) {
+        // `host uninstall --all` is streamed too (the Windows kill loop can
+        // outlive the run path's flat timeout), so the removal's uninstall
+        // is counted here, on the same mock the download lane uses.
+        uninstallCalls += 1;
+        return { data: { removedInstallDir: true, serviceUninstalled: true } };
+      }
       return { data: {} };
     });
 
@@ -4310,13 +4322,20 @@ describe("platform matrix", () => {
       version: "1.7.0",
       runtimeVersion: "1.7.0",
     });
-    vi.mocked(runBundledTraycerCliJson).mockResolvedValue({
-      removedInstallDir: true,
-      serviceUninstalled: true,
+    vi.mocked(streamBundledTraycerCliJson).mockResolvedValue({
+      data: { removedInstallDir: true, serviceUninstalled: true },
     });
 
     await controller.uninstallHost(true);
     expect(await isHostRemovedByUser()).toBe(false);
+    // Route pin: `uninstallHost` streams `host uninstall --all` for the same
+    // reason `deregisterService` and `removeTraycer` do.
+    expect(streamBundledTraycerCliJson).toHaveBeenCalledWith(
+      expect.objectContaining({ args: ["host", "uninstall", "--all"] }),
+    );
+    expect(runBundledTraycerCliJson).not.toHaveBeenCalledWith(
+      expect.arrayContaining(["uninstall"]),
+    );
   });
 });
 

--- a/clients/desktop/src/electron-main/host/host-controller.ts
+++ b/clients/desktop/src/electron-main/host/host-controller.ts
@@ -4592,7 +4592,11 @@ export class HostController {
         }
         let raw: unknown;
         try {
-          raw = await this.runBundled<unknown>(
+          // Streamed for the same reason as `deregisterService`: `host
+          // uninstall` deregisters and then stops the host, and on Windows
+          // both steps run the bounded scan-then-kill loop, whose worst case
+          // is well past the run path's flat 45 s budget.
+          raw = await this.streamBundled<unknown>(
             all ? ["host", "uninstall", "--all"] : ["host", "uninstall"],
           );
         } catch (err) {
@@ -4654,7 +4658,13 @@ export class HostController {
         }
         let raw: unknown;
         try {
-          raw = await this.runBundled<unknown>(["host", "uninstall", "--all"]);
+          // Streamed: see `deregisterService` and `uninstallHost`. This is
+          // the third Desktop route that stops a host through the CLI.
+          raw = await this.streamBundled<unknown>([
+            "host",
+            "uninstall",
+            "--all",
+          ]);
         } catch (err) {
           return this.classifyMutationSubprocessError(err, "retry-with-force");
         }

--- a/clients/desktop/src/electron-main/host/host-controller.ts
+++ b/clients/desktop/src/electron-main/host/host-controller.ts
@@ -4593,9 +4593,11 @@ export class HostController {
         let raw: unknown;
         try {
           // Streamed for the same reason as `deregisterService`: `host
-          // uninstall` deregisters and then stops the host, and on Windows
-          // both steps run the bounded scan-then-kill loop, whose worst case
-          // is well past the run path's flat 45 s budget.
+          // uninstall --all` deregisters the service and then stops the host,
+          // and on Windows both steps run the bounded scan-then-kill loop,
+          // whose worst case is well past the run path's flat 45 s budget.
+          // The bare form leaves the service and a running host alone (the
+          // CLI gates both on `--all`) and merely shares the wrapper.
           raw = await this.streamBundled<unknown>(
             all ? ["host", "uninstall", "--all"] : ["host", "uninstall"],
           );

--- a/clients/desktop/src/electron-main/host/host-controller.ts
+++ b/clients/desktop/src/electron-main/host/host-controller.ts
@@ -3849,8 +3849,18 @@ export class HostController {
           }
           return { kind: "ok", value: { registered: false } };
         }
+        // Streamed, not run: on Windows `host service uninstall` stops the
+        // host through the bounded scan-then-kill loop, whose worst case is
+        // several 30 s scans plus `schtasks /End` and `taskkill` before the
+        // confirming scan and `schtasks /Delete`
+        // (`WINDOWS_RESTART_SEQUENCE_TIMEOUT_MS` in the protocol's
+        // lifecycle constants). The run path's flat 45 s budget could SIGKILL
+        // the CLI after a kill pass and before `/Delete`, leaving the host
+        // half-stopped with its task still registered. The streaming path's
+        // idle timeout is what `host restart` already relies on for the same
+        // loop.
         try {
-          await this.runBundled<unknown>(["host", "service", "uninstall"]);
+          await this.streamBundled<unknown>(["host", "service", "uninstall"]);
         } catch (err) {
           return this.classifyMutationSubprocessError(err, "retry-with-force");
         }

--- a/clients/traycer-cli/README.md
+++ b/clients/traycer-cli/README.md
@@ -128,6 +128,32 @@ If the service is registered but not responding, restart it:
 traycer host restart
 ```
 
+### Stopping the host from inside Traycer
+
+The commands that stop the host - `host update`, `host apply`, `host install`,
+`host ensure`, `host restart`, `host stop`, `host uninstall`,
+`host free-port-and-restart` and `host service uninstall` - are frequently run
+by the host itself, or by a person in a terminal the host opened. On those runs
+the command is a child of the host, so a naive stop kills the command that
+issued it, part-way through its own work.
+
+On Linux the CLI re-runs such a command in a transient systemd scope of its own
+(`systemd-run --user --scope`) before the command body starts. The relocated
+process is a sibling of `ai.traycer.host.service` rather than a child of it, and
+survives the stop; the CLI log records the move as `relocated host-stopping
+command into a transient scope`. The stop is also guarded: immediately before
+the host is stopped the CLI re-reads its own cgroup, and if it is still inside
+the host's unit - no `systemd-run` on `PATH`, no systemd user manager, or a
+scope that did not take - the command fails with `E_SERVICE_CONTROL_FAILED` and
+leaves the host running. Run it again from a shell outside Traycer.
+
+On Windows there is no re-exec. The host's processes are terminated
+individually, and the CLI running the command, its children, and the shell that
+launched it are excluded from that set - terminating the host's whole tree would
+take them down with it.
+
+macOS needs neither: stopping the host's launchd job does not touch the CLI.
+
 ## Links
 
 - Documentation: [docs.traycer.ai](https://docs.traycer.ai)

--- a/clients/traycer-cli/README.md
+++ b/clients/traycer-cli/README.md
@@ -140,12 +140,28 @@ issued it, part-way through its own work.
 On Linux the CLI re-runs such a command in a transient systemd scope of its own
 (`systemd-run --user --scope`) before the command body starts. The relocated
 process is a sibling of `ai.traycer.host.service` rather than a child of it, and
-survives the stop; the CLI log records the move as `relocated host-stopping
-command into a transient scope`. The stop is also guarded: immediately before
-the host is stopped the CLI re-reads its own cgroup, and if it is still inside
-the host's unit - no `systemd-run` on `PATH`, no systemd user manager, or a
-scope that did not take - the command fails with `E_SERVICE_CONTROL_FAILED` and
-leaves the host running. Run it again from a shell outside Traycer.
+survives the stop. The relocated CLI reports back to the process that launched
+it as soon as it starts, and only then is the move recorded in the CLI log as
+`relocated host-stopping command into a transient scope`.
+
+Every way that can fail leaves the host running and reports
+`E_SERVICE_CONTROL_FAILED` rather than proceeding:
+
+- `systemd-run` is missing, or starts and then exits before the command does -
+  there is no systemd user manager, or the transient scope was refused;
+- the CLI cannot read its own `/proc/self/cgroup`. An absent file (a container,
+  or WSL without systemd) means nothing can kill the command and it simply runs;
+  a file that exists but cannot be read says nothing either way, and is treated
+  as a failed check rather than permission to proceed;
+- an argument contains `$`. systemd 258 expands variables in scope arguments by
+  default, and the option to turn that off does not exist before systemd 254, so
+  a path such as `--from '/tmp/${BUILD}/host.tar.gz'` is refused instead of being
+  silently rewritten;
+- the stop is reached with the CLI still inside the host's own unit. This is
+  checked again immediately before the host is stopped, so a scope that did not
+  actually move the process is caught even if everything above appeared to work.
+
+In each case, run the command again from a shell outside Traycer.
 
 On Windows there is no re-exec. The host's processes are terminated
 individually, and the CLI running the command, its children, and the shell that

--- a/clients/traycer-cli/src/__tests__/cli-with-runner-relocation.test.ts
+++ b/clients/traycer-cli/src/__tests__/cli-with-runner-relocation.test.ts
@@ -8,7 +8,7 @@ import {
   type MockInstance,
 } from "vitest";
 import { Command } from "commander";
-import { buildProgram } from "../index";
+import { buildProgramWithAgentRoles } from "../index";
 import * as cgroupRelocationModule from "../host/cgroup-relocation";
 import * as hostStopModule from "../commands/host-stop";
 import * as cliLockModule from "../store/cli-lock";
@@ -75,7 +75,10 @@ function expectCommand(program: Command, path: readonly string[]): Command {
 }
 
 async function parseHostStop(argv: readonly string[]): Promise<void> {
-  const program = buildProgram();
+  // `buildProgramWithAgentRoles` rather than `buildProgram`: the latter calls
+  // `readFeatureSettingsSync()`, which synchronously reads the developer's real
+  // `~/.traycer/cli/config.json`. Agent roles are irrelevant to `host stop`.
+  const program = buildProgramWithAgentRoles(false);
   program.exitOverride();
   const stop = expectCommand(program, ["host", "stop"]);
   stop.exitOverride();
@@ -85,6 +88,7 @@ async function parseHostStop(argv: readonly string[]): Promise<void> {
 describe("withRunner - cgroup relocation hook", () => {
   let exitSpy: MockInstance;
   let relocationSpy: MockInstance;
+  let ackSpy: MockInstance;
   let hostStopSpy: MockInstance;
   let cliLockSpy: MockInstance;
   let updateContenderSpy: MockInstance;
@@ -101,6 +105,11 @@ describe("withRunner - cgroup relocation hook", () => {
       cgroupRelocationModule,
       "relocateOutOfHostCgroupIfNeeded",
     );
+    // Stubbed rather than observed only: the real one writes to raw fd 3, and
+    // nothing here should touch whatever that is in the test runner.
+    ackSpy = vi
+      .spyOn(cgroupRelocationModule, "acknowledgeRelocationEntry")
+      .mockImplementation(() => undefined);
     hostStopSpy = vi
       .spyOn(hostStopModule, "buildHostStopCommand")
       .mockImplementation(() => async () => ({
@@ -122,6 +131,7 @@ describe("withRunner - cgroup relocation hook", () => {
     process.exitCode = undefined;
     exitSpy.mockRestore();
     relocationSpy.mockRestore();
+    ackSpy.mockRestore();
     hostStopSpy.mockRestore();
     cliLockSpy.mockRestore();
     updateContenderSpy.mockRestore();
@@ -136,6 +146,27 @@ describe("withRunner - cgroup relocation hook", () => {
 
     expect(hostStopSpy).not.toHaveBeenCalled();
     expect(exitMocks.calls).toEqual([0]);
+  });
+
+  it("acknowledges relocation entry before anything else the action does", async () => {
+    // The relocated CLI's half of the parent's fd-3 handshake. It has to be
+    // first: until it is written, every failure in this action looks to the
+    // waiting parent like `systemd-run` failing to start a CLI at all.
+    relocationSpy.mockResolvedValue({ kind: "not-needed" });
+
+    await parseHostStop(["host", "stop"]);
+
+    expect(ackSpy).toHaveBeenCalledTimes(1);
+    expect(ackSpy.mock.invocationCallOrder[0]).toBeLessThan(
+      relocationSpy.mock.invocationCallOrder[0] ?? Number.MAX_SAFE_INTEGER,
+    );
+    expect(ackSpy.mock.invocationCallOrder[0]).toBeLessThan(
+      hostStopSpy.mock.invocationCallOrder[0] ?? Number.MAX_SAFE_INTEGER,
+    );
+
+    // Ablation: in `withRunner`, move `acknowledgeRelocationEntry();` below the
+    // relocation block → this test fails on the ordering assertion, and a
+    // relocated CLI would only say hello after the work that can fail first.
   });
 
   it("relocated (completed, non-zero exit): forwards the child's exact exit code", async () => {

--- a/clients/traycer-cli/src/__tests__/cli-with-runner-relocation.test.ts
+++ b/clients/traycer-cli/src/__tests__/cli-with-runner-relocation.test.ts
@@ -186,6 +186,20 @@ describe("withRunner - cgroup relocation hook", () => {
     expect(hostStopSpy).toHaveBeenCalledTimes(1);
   });
 
+  it("forwards the parsed options (optsBag), not just the command path, to the relocation predicate", async () => {
+    // The whole finding this task pins is that `HOST_STOPPING_COMMANDS` now
+    // reads OPTIONS, not just the command path - and that is worthless if
+    // `withRunner` never hands the parsed flags to the predicate at all.
+    relocationSpy.mockResolvedValue({ kind: "not-needed" });
+
+    await parseHostStop(["host", "stop", "--json"]);
+
+    expect(relocationSpy).toHaveBeenCalledTimes(1);
+    const [commandPath, options] = relocationSpy.mock.calls[0] ?? [];
+    expect(commandPath).toBe("host stop");
+    expect(options).toMatchObject({ json: true });
+  });
+
   it("relocation failure: keeps E_SERVICE_CONTROL_FAILED through the runner's error path under --json, and never builds the command body", async () => {
     const failure = cliError({
       code: CLI_ERROR_CODES.SERVICE_CONTROL_FAILED,

--- a/clients/traycer-cli/src/__tests__/cli-with-runner-relocation.test.ts
+++ b/clients/traycer-cli/src/__tests__/cli-with-runner-relocation.test.ts
@@ -1,0 +1,222 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type MockInstance,
+} from "vitest";
+import { Command } from "commander";
+import { buildProgram } from "../index";
+import * as cgroupRelocationModule from "../host/cgroup-relocation";
+import * as hostStopModule from "../commands/host-stop";
+import * as cliLockModule from "../store/cli-lock";
+import * as updateContenderModule from "../host/update-contender";
+import { CLI_ERROR_CODES, cliError } from "../runner/errors";
+
+// `withRunner`'s cgroup relocation hook (host/cgroup-relocation.ts) has to sit
+// BEFORE the command body runs, because the body is where the CLI lock,
+// the update-contender claim, the dispatch ACK, and the progress marker are
+// all taken - the relocated child must own every one of them and the parent
+// (about to die with the host's cgroup) must own none. These tests pin that
+// placement end-to-end through `buildProgram()` and real Commander parsing,
+// with the relocation itself, the command body, and process teardown all
+// stubbed so nothing here touches a real cgroup, spawns `systemd-run`, or
+// exits the test process.
+
+const loggerMock = vi.hoisted(() => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock("../logger", () => ({
+  createCliLogger: () => loggerMock,
+  errorFromUnknown: (value: unknown) =>
+    value instanceof Error ? value : new Error(String(value)),
+}));
+
+const exitMocks = vi.hoisted(() => ({
+  calls: [] as number[],
+}));
+
+vi.mock("../runner/exit", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../runner/exit")>();
+  return {
+    ...actual,
+    finishAndExit: async (exitCode: number) => {
+      exitMocks.calls.push(exitCode);
+      // Deliberately not draining anything real: the recorder's whole job is
+      // to prove WHETHER and WITH WHAT CODE the terminator was reached, not
+      // to reproduce its stdio/Sentry/dispatcher teardown.
+    },
+  };
+});
+
+function findSubcommand(parent: Command, name: string): Command | null {
+  for (const child of parent.commands) {
+    if (child.name() === name) return child;
+  }
+  return null;
+}
+
+function expectCommand(program: Command, path: readonly string[]): Command {
+  let cursor: Command = program;
+  for (const segment of path) {
+    const next = findSubcommand(cursor, segment);
+    if (next === null) {
+      throw new Error(`command '${path.join(" ")}' not found`);
+    }
+    cursor = next;
+  }
+  return cursor;
+}
+
+async function parseHostStop(argv: readonly string[]): Promise<void> {
+  const program = buildProgram();
+  program.exitOverride();
+  const stop = expectCommand(program, ["host", "stop"]);
+  stop.exitOverride();
+  await program.parseAsync(argv as string[], { from: "user" });
+}
+
+describe("withRunner - cgroup relocation hook", () => {
+  let exitSpy: MockInstance;
+  let relocationSpy: MockInstance;
+  let hostStopSpy: MockInstance;
+  let cliLockSpy: MockInstance;
+  let updateContenderSpy: MockInstance;
+  let stdoutWriteSpy: MockInstance;
+
+  beforeEach(() => {
+    exitMocks.calls.length = 0;
+    exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation((code: string | number | null | undefined): never => {
+        throw new Error(`__test_exit_${code ?? 0}`);
+      });
+    relocationSpy = vi.spyOn(
+      cgroupRelocationModule,
+      "relocateOutOfHostCgroupIfNeeded",
+    );
+    hostStopSpy = vi
+      .spyOn(hostStopModule, "buildHostStopCommand")
+      .mockImplementation(() => async () => ({
+        data: { stopped: true },
+        human: "stopped",
+        exitCode: 0,
+      }));
+    cliLockSpy = vi.spyOn(cliLockModule, "withCliLock");
+    updateContenderSpy = vi.spyOn(
+      updateContenderModule,
+      "withCliUpdateContender",
+    );
+    stdoutWriteSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    process.exitCode = undefined;
+    exitSpy.mockRestore();
+    relocationSpy.mockRestore();
+    hostStopSpy.mockRestore();
+    cliLockSpy.mockRestore();
+    updateContenderSpy.mockRestore();
+    stdoutWriteSpy.mockRestore();
+    vi.restoreAllMocks();
+  });
+
+  it("relocated (completed, exit 0): never builds the command body, exits with the child's code", async () => {
+    relocationSpy.mockResolvedValue({ kind: "completed", exitCode: 0 });
+
+    await parseHostStop(["host", "stop"]);
+
+    expect(hostStopSpy).not.toHaveBeenCalled();
+    expect(exitMocks.calls).toEqual([0]);
+  });
+
+  it("relocated (completed, non-zero exit): forwards the child's exact exit code", async () => {
+    relocationSpy.mockResolvedValue({ kind: "completed", exitCode: 7 });
+
+    await parseHostStop(["host", "stop"]);
+
+    expect(hostStopSpy).not.toHaveBeenCalled();
+    expect(exitMocks.calls).toEqual([7]);
+  });
+
+  it("not-needed: the ordinary command body runs (the hook does not swallow ordinary runs)", async () => {
+    relocationSpy.mockResolvedValue({ kind: "not-needed" });
+
+    await parseHostStop(["host", "stop"]);
+
+    expect(hostStopSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("relocation failure: keeps E_SERVICE_CONTROL_FAILED through the runner's error path under --json, and never builds the command body", async () => {
+    const failure = cliError({
+      code: CLI_ERROR_CODES.SERVICE_CONTROL_FAILED,
+      message: "could not move 'host stop' out of the host cgroup",
+      details: { unit: "ai.traycer.host.service" },
+      exitCode: 1,
+    });
+    relocationSpy.mockRejectedValue(failure);
+
+    await parseHostStop(["host", "stop", "--json"]);
+
+    expect(hostStopSpy).not.toHaveBeenCalled();
+    // The failure keeps its code instead of decaying to E_UNEXPECTED: it is
+    // rendered through the runner's normal error path (`runCommand`), which
+    // writes a `result`/`error` NDJSON envelope carrying `cliErr.code`
+    // verbatim rather than an entry-level generic handler that would lose it.
+    const written = stdoutWriteSpy.mock.calls
+      .map((call) => call[0])
+      .filter((chunk): chunk is string => typeof chunk === "string")
+      .join("");
+    expect(written).toContain("E_SERVICE_CONTROL_FAILED");
+    const errorLine = written
+      .split("\n")
+      .find((line) => line.includes("E_SERVICE_CONTROL_FAILED"));
+    expect(errorLine).toBeDefined();
+    const parsed: unknown = JSON.parse(errorLine ?? "{}");
+    expect(parsed).toMatchObject({
+      type: "result",
+      status: "error",
+      error: { code: "E_SERVICE_CONTROL_FAILED" },
+    });
+    expect(exitMocks.calls).toEqual([1]);
+
+    // Ablation: in `withRunner`, change the relocation try/catch so the
+    // caught error is re-thrown directly (e.g. `throw error;`) instead of
+    // routed through `await runCommand(() => Promise.reject(error), flags);`
+    // → this test fails: an error thrown straight out of a Commander action
+    // is not caught by `runCommand`'s try/catch, so no `result`/`error`
+    // NDJSON line is ever written and `toContain("E_SERVICE_CONTROL_FAILED")`
+    // finds nothing.
+  });
+
+  it("relocated path: the parent takes nothing command-owned (withCliLock / withCliUpdateContender never called)", async () => {
+    relocationSpy.mockResolvedValue({ kind: "completed", exitCode: 0 });
+
+    await parseHostStop(["host", "stop"]);
+
+    // The load-bearing half of this pin is `hostStopSpy` never running at
+    // all (asserted above and again here) - `withCliLock` and
+    // `withCliUpdateContender` are only ever reached from inside
+    // `buildHostStopCommand`'s body, so their zero-call counts follow
+    // directly from the body never running rather than from any guard of
+    // their own. This assertion exists to make that chain explicit, not to
+    // add independent coverage.
+    expect(hostStopSpy).not.toHaveBeenCalled();
+    expect(cliLockSpy).not.toHaveBeenCalled();
+    expect(updateContenderSpy).not.toHaveBeenCalled();
+  });
+
+  // Ablation (ordering): in `withRunner`, move the
+  // `relocation = await relocateOutOfHostCgroupIfNeeded(commandPath)` block
+  // to after `await runCommand(guarded, flags)` → the "never builds the
+  // command body" tests above fail: `hostStopSpy` would be called once
+  // before the (too-late) relocation check ever ran.
+});

--- a/clients/traycer-cli/src/__tests__/cli-with-runner-relocation.test.ts
+++ b/clients/traycer-cli/src/__tests__/cli-with-runner-relocation.test.ts
@@ -268,12 +268,15 @@ describe("withRunner - cgroup relocation hook", () => {
 });
 
 // `host maintenance-lease` is the one host-stopping route registered OUTSIDE
-// `withRunner` (it keeps its locks live while serving a stdin/stdout protocol
-// to the Desktop root scripts), so it takes the hook's two first steps itself.
-// The same placement argument applies with more force: the lease's attempt
-// capability and the protocol it serves must belong to the relocated child.
-describe("host maintenance-lease (outside withRunner) - cgroup relocation hook", () => {
-  const leaseArgv = [
+// `withRunner`, and it deliberately takes NEITHER of the hook's first steps:
+// its caller (the Desktop install/uninstall script) shares its cgroup, so a
+// relocated lease would let a stop proceed that kills the caller
+// mid-maintenance, and would put a waiting wrapper between the script and
+// the lease it cancels by signalling its direct child. The guard in
+// `withStopIntent` refuses instead, and the refusal reaches the script as the
+// protocol's own `refused` frame. This pins that the action does not relocate.
+describe("host maintenance-lease (outside withRunner) - deliberately not relocated", () => {
+  const leaseArgv: readonly string[] = [
     "host",
     "maintenance-lease",
     "--admission",
@@ -282,26 +285,11 @@ describe("host maintenance-lease (outside withRunner) - cgroup relocation hook",
     "/home/alice/.traycer/host",
     "--service-uid",
     "1000",
-  ] as const;
+  ];
 
   let relocationSpy: MockInstance;
-  let ackSpy: MockInstance;
   let leaseSpy: MockInstance;
   let stdoutWriteSpy: MockInstance;
-
-  async function parseLease(argv: readonly string[]): Promise<void> {
-    const program = buildProgramWithAgentRoles(false);
-    program.exitOverride();
-    expectCommand(program, ["host", "maintenance-lease"]).exitOverride();
-    await program.parseAsync(argv as string[], { from: "user" });
-  }
-
-  function writtenStdout(): string {
-    return stdoutWriteSpy.mock.calls
-      .map((call) => call[0])
-      .filter((chunk): chunk is string => typeof chunk === "string")
-      .join("");
-  }
 
   beforeEach(() => {
     exitMocks.calls.length = 0;
@@ -309,9 +297,6 @@ describe("host maintenance-lease (outside withRunner) - cgroup relocation hook",
       cgroupRelocationModule,
       "relocateOutOfHostCgroupIfNeeded",
     );
-    ackSpy = vi
-      .spyOn(cgroupRelocationModule, "acknowledgeRelocationEntry")
-      .mockImplementation(() => undefined);
     leaseSpy = vi
       .spyOn(hostMaintenanceLeaseModule, "runHostMaintenanceLease")
       .mockResolvedValue(undefined);
@@ -323,75 +308,23 @@ describe("host maintenance-lease (outside withRunner) - cgroup relocation hook",
   afterEach(() => {
     process.exitCode = undefined;
     relocationSpy.mockRestore();
-    ackSpy.mockRestore();
     leaseSpy.mockRestore();
     stdoutWriteSpy.mockRestore();
     vi.restoreAllMocks();
   });
 
-  it("relocated (completed): never serves the lease here, exits with the child's code", async () => {
-    relocationSpy.mockResolvedValue({ kind: "completed", exitCode: 3 });
+  it("serves the lease in place and never consults the relocation", async () => {
+    const program = buildProgramWithAgentRoles(false);
+    program.exitOverride();
+    expectCommand(program, ["host", "maintenance-lease"]).exitOverride();
+    await program.parseAsync([...leaseArgv], { from: "user" });
 
-    await parseLease(leaseArgv);
-
-    expect(relocationSpy).toHaveBeenCalledWith("host maintenance-lease", {});
-    expect(leaseSpy).not.toHaveBeenCalled();
-    expect(exitMocks.calls).toEqual([3]);
-    // Nothing of the protocol comes from this process: the child owns the
-    // pipes, and a `ready` or `refused` frame from the parent would be read
-    // by the script as the lease's own.
-    expect(writtenStdout()).toBe("");
-  });
-
-  it("acknowledges relocation entry before the relocation, and both before the lease", async () => {
-    relocationSpy.mockResolvedValue({ kind: "not-needed" });
-
-    await parseLease(leaseArgv);
-
-    expect(ackSpy).toHaveBeenCalledTimes(1);
-    expect(ackSpy.mock.invocationCallOrder[0]).toBeLessThan(
-      relocationSpy.mock.invocationCallOrder[0] ?? Number.MAX_SAFE_INTEGER,
-    );
-    expect(relocationSpy.mock.invocationCallOrder[0]).toBeLessThan(
-      leaseSpy.mock.invocationCallOrder[0] ?? Number.MAX_SAFE_INTEGER,
-    );
-  });
-
-  it("not-needed: the lease is served in place", async () => {
-    relocationSpy.mockResolvedValue({ kind: "not-needed" });
-
-    await parseLease(leaseArgv);
-
+    expect(relocationSpy).not.toHaveBeenCalled();
     expect(leaseSpy).toHaveBeenCalledTimes(1);
     expect(exitMocks.calls).toEqual([]);
-  });
 
-  it("relocation failure: reported as the protocol's own `refused` frame, exit 1, lease never served", async () => {
-    relocationSpy.mockRejectedValue(
-      cliError({
-        code: CLI_ERROR_CODES.SERVICE_CONTROL_FAILED,
-        message:
-          "refusing to relocate 'host maintenance-lease' out of the ai.traycer.host.service cgroup",
-        details: { unit: "ai.traycer.host.service" },
-        exitCode: 1,
-      }),
-    );
-
-    await parseLease(leaseArgv);
-
-    expect(leaseSpy).not.toHaveBeenCalled();
-    const frame: unknown = JSON.parse(writtenStdout().trim());
-    expect(frame).toMatchObject({
-      v: 1,
-      id: null,
-      kind: "refused",
-      message: expect.stringContaining("refusing to relocate"),
-    });
-    expect(process.exitCode).toBe(1);
-
-    // Ablation: in the `maintenance-lease` action (index.ts), delete the
-    // relocation block → the first test fails (`leaseSpy` is called and
-    // nothing reaches `finishAndExit`), and this one fails because the error
-    // is never raised at all.
+    // Ablation: route the lease through `withRunner` (or call
+    // `relocateOutOfHostCgroupIfNeeded` in its action) → `relocationSpy` is
+    // called once and this test fails.
   });
 });

--- a/clients/traycer-cli/src/__tests__/cli-with-runner-relocation.test.ts
+++ b/clients/traycer-cli/src/__tests__/cli-with-runner-relocation.test.ts
@@ -11,6 +11,7 @@ import { Command } from "commander";
 import { buildProgramWithAgentRoles } from "../index";
 import * as cgroupRelocationModule from "../host/cgroup-relocation";
 import * as hostStopModule from "../commands/host-stop";
+import * as hostMaintenanceLeaseModule from "../commands/host-maintenance-lease";
 import * as cliLockModule from "../store/cli-lock";
 import * as updateContenderModule from "../host/update-contender";
 import { CLI_ERROR_CODES, cliError } from "../runner/errors";
@@ -264,4 +265,133 @@ describe("withRunner - cgroup relocation hook", () => {
   // to after `await runCommand(guarded, flags)` → the "never builds the
   // command body" tests above fail: `hostStopSpy` would be called once
   // before the (too-late) relocation check ever ran.
+});
+
+// `host maintenance-lease` is the one host-stopping route registered OUTSIDE
+// `withRunner` (it keeps its locks live while serving a stdin/stdout protocol
+// to the Desktop root scripts), so it takes the hook's two first steps itself.
+// The same placement argument applies with more force: the lease's attempt
+// capability and the protocol it serves must belong to the relocated child.
+describe("host maintenance-lease (outside withRunner) - cgroup relocation hook", () => {
+  const leaseArgv = [
+    "host",
+    "maintenance-lease",
+    "--admission",
+    "uninstall-maintenance",
+    "--host-home",
+    "/home/alice/.traycer/host",
+    "--service-uid",
+    "1000",
+  ] as const;
+
+  let relocationSpy: MockInstance;
+  let ackSpy: MockInstance;
+  let leaseSpy: MockInstance;
+  let stdoutWriteSpy: MockInstance;
+
+  async function parseLease(argv: readonly string[]): Promise<void> {
+    const program = buildProgramWithAgentRoles(false);
+    program.exitOverride();
+    expectCommand(program, ["host", "maintenance-lease"]).exitOverride();
+    await program.parseAsync(argv as string[], { from: "user" });
+  }
+
+  function writtenStdout(): string {
+    return stdoutWriteSpy.mock.calls
+      .map((call) => call[0])
+      .filter((chunk): chunk is string => typeof chunk === "string")
+      .join("");
+  }
+
+  beforeEach(() => {
+    exitMocks.calls.length = 0;
+    relocationSpy = vi.spyOn(
+      cgroupRelocationModule,
+      "relocateOutOfHostCgroupIfNeeded",
+    );
+    ackSpy = vi
+      .spyOn(cgroupRelocationModule, "acknowledgeRelocationEntry")
+      .mockImplementation(() => undefined);
+    leaseSpy = vi
+      .spyOn(hostMaintenanceLeaseModule, "runHostMaintenanceLease")
+      .mockResolvedValue(undefined);
+    stdoutWriteSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    process.exitCode = undefined;
+    relocationSpy.mockRestore();
+    ackSpy.mockRestore();
+    leaseSpy.mockRestore();
+    stdoutWriteSpy.mockRestore();
+    vi.restoreAllMocks();
+  });
+
+  it("relocated (completed): never serves the lease here, exits with the child's code", async () => {
+    relocationSpy.mockResolvedValue({ kind: "completed", exitCode: 3 });
+
+    await parseLease(leaseArgv);
+
+    expect(relocationSpy).toHaveBeenCalledWith("host maintenance-lease", {});
+    expect(leaseSpy).not.toHaveBeenCalled();
+    expect(exitMocks.calls).toEqual([3]);
+    // Nothing of the protocol comes from this process: the child owns the
+    // pipes, and a `ready` or `refused` frame from the parent would be read
+    // by the script as the lease's own.
+    expect(writtenStdout()).toBe("");
+  });
+
+  it("acknowledges relocation entry before the relocation, and both before the lease", async () => {
+    relocationSpy.mockResolvedValue({ kind: "not-needed" });
+
+    await parseLease(leaseArgv);
+
+    expect(ackSpy).toHaveBeenCalledTimes(1);
+    expect(ackSpy.mock.invocationCallOrder[0]).toBeLessThan(
+      relocationSpy.mock.invocationCallOrder[0] ?? Number.MAX_SAFE_INTEGER,
+    );
+    expect(relocationSpy.mock.invocationCallOrder[0]).toBeLessThan(
+      leaseSpy.mock.invocationCallOrder[0] ?? Number.MAX_SAFE_INTEGER,
+    );
+  });
+
+  it("not-needed: the lease is served in place", async () => {
+    relocationSpy.mockResolvedValue({ kind: "not-needed" });
+
+    await parseLease(leaseArgv);
+
+    expect(leaseSpy).toHaveBeenCalledTimes(1);
+    expect(exitMocks.calls).toEqual([]);
+  });
+
+  it("relocation failure: reported as the protocol's own `refused` frame, exit 1, lease never served", async () => {
+    relocationSpy.mockRejectedValue(
+      cliError({
+        code: CLI_ERROR_CODES.SERVICE_CONTROL_FAILED,
+        message:
+          "refusing to relocate 'host maintenance-lease' out of the ai.traycer.host.service cgroup",
+        details: { unit: "ai.traycer.host.service" },
+        exitCode: 1,
+      }),
+    );
+
+    await parseLease(leaseArgv);
+
+    expect(leaseSpy).not.toHaveBeenCalled();
+    const frame: unknown = JSON.parse(writtenStdout().trim());
+    expect(frame).toMatchObject({
+      v: 1,
+      id: null,
+      kind: "refused",
+      message: expect.stringContaining("refusing to relocate"),
+    });
+    expect(process.exitCode).toBe(1);
+
+    // Ablation: in the `maintenance-lease` action (index.ts), delete the
+    // relocation block → the first test fails (`leaseSpy` is called and
+    // nothing reaches `finishAndExit`), and this one fails because the error
+    // is never raised at all.
+  });
 });

--- a/clients/traycer-cli/src/host/__tests__/cgroup-relocation.test.ts
+++ b/clients/traycer-cli/src/host/__tests__/cgroup-relocation.test.ts
@@ -285,8 +285,9 @@ describe("relocateOutOfHostCgroupIfNeeded", () => {
   });
 
   // The relocated CLI reaching `withRunner`: one byte on fd 3, the channel
-  // closing behind it, and then whatever the command itself exits with. This
-  // is the NODE ordering - the ack is delivered before the process is reaped.
+  // closing behind it, and then whatever the command itself exits with: ack
+  // and channel end BEFORE process exit, one of the supported orderings (the
+  // exit-first ordering has its own test below).
   function acknowledgeThenExit(code: number | null): (fake: FakeChild) => void {
     return (fake) => {
       fake.child.emit("spawn");
@@ -426,8 +427,9 @@ describe("relocateOutOfHostCgroupIfNeeded", () => {
     // And it is NOT reported as a successful relocation.
     expect(loggerMock.info).not.toHaveBeenCalled();
 
-    // Ablation: in `runInTransientScope`, drop the `if (!acknowledged)` branch
-    // from `settle` so it always resolves → this test fails: the call resolves
+    // Ablation: in `runInTransientScope`'s `settle`, replace everything after
+    // the `if (!exited) return` guard with an unconditional
+    // `resolve(exitCode ?? 1)` → this test fails: the call resolves
     // `{kind:"completed", exitCode:1}` and the caller silently exits 1 with no
     // error envelope, which is the bug this pin exists for.
   });

--- a/clients/traycer-cli/src/host/__tests__/cgroup-relocation.test.ts
+++ b/clients/traycer-cli/src/host/__tests__/cgroup-relocation.test.ts
@@ -755,31 +755,28 @@ describe("relocateOutOfHostCgroupIfNeeded", () => {
     // the relocation resolves `not-needed` without spawning.
   });
 
-  it("host maintenance-lease is in HOST_STOPPING_COMMANDS unconditionally: it serves host-stop and uninstall-all to the root scripts", async () => {
-    // The Desktop install/uninstall scripts hold this lease across app
-    // replacement and cloud uninstall on Linux too, and both of its actions go
-    // through the guarded stop routes. Started from a Traycer-hosted terminal
-    // the lease is spawned inside the host unit, and the guard would refuse
-    // the maintenance rather than let the lease perform it. The route is
-    // registered outside `withRunner`, so the map entry is only half of it;
-    // `cli-with-runner-relocation.test.ts` pins the action's own call.
-    expect(HOST_STOPPING_COMMANDS.get("host maintenance-lease")?.({})).toBe(
-      true,
-    );
+  it("host maintenance-lease is deliberately NOT in HOST_STOPPING_COMMANDS: its caller shares its cgroup, so the guard's refusal is the right outcome", async () => {
+    // The lease serves `host-stop` and `host-uninstall-all` to the Desktop
+    // install/uninstall script, which spawned it and therefore sits in the
+    // same cgroup. From a Traycer-hosted terminal that is the host unit, and
+    // the stop the lease would perform kills the script mid-maintenance
+    // whether or not the lease itself is moved out; a relocated lease would
+    // also hide behind a waiting wrapper, so the script's cancellation (a
+    // signal to its direct child, that child's exit as proof) would prove
+    // nothing about the holder. `withStopIntent`'s guard refuses, and the
+    // refusal reaches the script as a `refused` frame with nothing touched.
+    // `cli-with-runner-relocation.test.ts` pins that the action never calls
+    // the relocation either.
+    expect(HOST_STOPPING_COMMANDS.has("host maintenance-lease")).toBe(false);
     mocks.cgroup = V2_HOST_UNIT_CGROUP;
-    mocks.packaged = true;
-    process.argv = packagedArgv() as string[];
-    process.execPath = "/slot/traycer";
-    process.execArgv = [];
-    spawnMocks.respond = acknowledgeThenExit(0);
-
     await expect(
       relocateOutOfHostCgroupIfNeeded("host maintenance-lease", {}),
-    ).resolves.toEqual({ kind: "completed", exitCode: 0 });
-    expect(spawnMocks.recorded).toHaveLength(1);
+    ).resolves.toEqual({ kind: "not-needed" });
+    expect(spawnMocks.recorded).toHaveLength(0);
 
-    // Ablation: remove the `"host maintenance-lease"` entry → this test fails
-    // on the first assertion and the relocation resolves `not-needed`.
+    // Ablation: add `["host maintenance-lease", ALWAYS_STOPS]` to the map →
+    // this test fails on the first assertion, and the relocation spawns
+    // `systemd-run` for a lease whose caller is about to die with the host.
   });
 
   it("does nothing for a command outside HOST_STOPPING_COMMANDS, even inside a host unit", async () => {

--- a/clients/traycer-cli/src/host/__tests__/cgroup-relocation.test.ts
+++ b/clients/traycer-cli/src/host/__tests__/cgroup-relocation.test.ts
@@ -1,5 +1,6 @@
 import type { ChildProcess, SpawnOptions } from "node:child_process";
 import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // This module is Linux's first line of defence against the host stopping the
@@ -24,10 +25,15 @@ vi.mock("../../logger", () => ({
 
 const mocks = vi.hoisted(() => ({
   platform: "linux" as NodeJS.Platform,
-  // `null` means "no /proc/self/cgroup interception" - readFile delegates to
-  // the original implementation for every path.
-  cgroup: null as string | null | { reject: true },
+  // A string is the file's contents. `null` fails the read with ENOENT (no
+  // `/proc/self/cgroup`, the supported absence case); an object names the errno
+  // to fail with instead, which is how the "unreadable, so unanswerable" cases
+  // are driven.
+  cgroup: null as string | null | { readonly errno: string },
   packaged: false,
+  // Recorded fd-3 writes from `acknowledgeRelocationEntry`.
+  ackWrites: [] as { readonly fd: number; readonly payload: string }[],
+  ackWriteError: null as Error | null,
 }));
 
 vi.mock("node:os", async (importOriginal) => {
@@ -48,7 +54,9 @@ vi.mock("node:fs/promises", async (importOriginal) => {
           throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
         }
         if (typeof mocks.cgroup === "object") {
-          throw Object.assign(new Error("EACCES"), { code: "EACCES" });
+          throw Object.assign(new Error(mocks.cgroup.errno), {
+            code: mocks.cgroup.errno,
+          });
         }
         return mocks.cgroup;
       }
@@ -63,19 +71,41 @@ vi.mock("../../store/well-known-cli", () => ({
   isPackagedRun: async () => mocks.packaged,
 }));
 
+// `acknowledgeRelocationEntry` writes to a raw fd. Stubbed so no test can write
+// down whatever fd 3 happens to be in the process hosting this suite.
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    writeSync: ((fd: number, payload: string): number => {
+      mocks.ackWrites.push({ fd, payload });
+      if (mocks.ackWriteError !== null) throw mocks.ackWriteError;
+      return payload.length;
+    }) as typeof actual.writeSync,
+  };
+});
+
 interface RecordedSpawn {
   readonly command: string;
   readonly args: readonly string[];
   readonly options: SpawnOptions;
 }
 
+// The fake child, with the fd-3 ack pipe the production code reads through
+// `child.stdio[3]`. `ack.write(...)` is the relocated CLI saying it reached
+// `withRunner`; a responder that never writes to it is a `systemd-run` that
+// died before any CLI started.
+interface FakeChild {
+  readonly child: ChildProcess;
+  readonly ack: PassThrough;
+}
+
 const spawnMocks = vi.hoisted(() => ({
   recorded: [] as RecordedSpawn[],
-  // Each queued responder decides how the fake child behaves once `spawn`
-  // hands it back. `null` means "no fake child was queued" and the call
-  // throws synchronously, matching a real `spawn` that cannot resolve
-  // `systemd-run`.
-  respond: null as ((child: EventEmitter) => void) | null,
+  // Each queued responder drives the fake child once `spawn` has returned it.
+  // A `null` responder returns a child that never emits anything, which is how
+  // the "spawn threw synchronously" case is kept separate (`throwSync`).
+  respond: null as ((fake: FakeChild) => void) | null,
   throwSync: null as Error | null,
 }));
 
@@ -90,11 +120,15 @@ vi.mock("node:child_process", async (importOriginal) => {
     ): ChildProcess => {
       spawnMocks.recorded.push({ command, args, options });
       if (spawnMocks.throwSync !== null) throw spawnMocks.throwSync;
-      const child = new EventEmitter() as ChildProcess;
+      const ack = new PassThrough();
+      const stdio: ChildProcess["stdio"] = [null, null, null, ack, null];
+      const child = Object.assign(new EventEmitter(), {
+        stdio,
+      }) as ChildProcess;
       if (spawnMocks.respond !== null) {
         // Real `spawn` never emits synchronously - the caller has always
         // attached its listeners by the time anything fires.
-        Promise.resolve().then(() => spawnMocks.respond?.(child));
+        Promise.resolve().then(() => spawnMocks.respond?.({ child, ack }));
       }
       return child;
     },
@@ -105,6 +139,7 @@ const {
   findHostUnitCgroup,
   relocationArgv,
   relocateOutOfHostCgroupIfNeeded,
+  acknowledgeRelocationEntry,
   assertNotInsideHostUnit,
   HOST_STOPPING_COMMANDS,
   TRAYCER_CLI_RELOCATED_ENV,
@@ -240,12 +275,26 @@ describe("relocateOutOfHostCgroupIfNeeded", () => {
     mocks.platform = "linux";
     mocks.cgroup = null;
     mocks.packaged = false;
+    mocks.ackWrites = [];
+    mocks.ackWriteError = null;
     spawnMocks.recorded = [];
     spawnMocks.respond = null;
     spawnMocks.throwSync = null;
     loggerMock.debug.mockClear();
     loggerMock.info.mockClear();
   });
+
+  // The relocated CLI reaching `withRunner`: one byte on fd 3, then whatever
+  // the command itself exits with.
+  function acknowledgeThenExit(code: number | null): (fake: FakeChild) => void {
+    return (fake) => {
+      fake.child.emit("spawn");
+      fake.ack.write("\n");
+      // The ack has to be observable before `close`, exactly as a real pipe
+      // delivers it - `close` fires after the stdio streams are done.
+      setImmediate(() => fake.child.emit("close", code, null));
+    };
+  }
 
   afterEach(() => {
     delete process.env[TRAYCER_CLI_RELOCATED_ENV];
@@ -272,10 +321,7 @@ describe("relocateOutOfHostCgroupIfNeeded", () => {
     process.argv = packagedArgv() as string[];
     process.execPath = "/slot/traycer";
     process.execArgv = [];
-    spawnMocks.respond = (child) => {
-      child.emit("spawn");
-      child.emit("close", 0, null);
-    };
+    spawnMocks.respond = acknowledgeThenExit(0);
 
     const result = await relocateOutOfHostCgroupIfNeeded("host update");
 
@@ -296,41 +342,51 @@ describe("relocateOutOfHostCgroupIfNeeded", () => {
       "--ack-nonce",
       "n",
     ]);
-    expect(call?.options.stdio).toBe("inherit");
+    // stdio 0-2 inherited so the child owns the output stream; fd 3 piped for
+    // the entry acknowledgement.
+    expect(call?.options.stdio).toEqual([
+      "inherit",
+      "inherit",
+      "inherit",
+      "pipe",
+    ]);
     expect(call?.options.env?.[TRAYCER_CLI_RELOCATED_ENV]).toBe("1");
-    // The line the CLI docs tell an operator to look for in cli.log.
+    // The line the CLI docs tell an operator to look for in cli.log. It is
+    // written on the ACK, not on `spawn`: `systemd-run` starting proves
+    // nothing about a CLI existing in the new scope.
     expect(loggerMock.info).toHaveBeenCalledWith(
       "relocated host-stopping command into a transient scope",
       { command: "host update", unit: "ai.traycer.host.service" },
     );
+    // Never passed, on any systemd: the flag is rejected below 254, and the
+    // `$` refusal below is what covers the versions that would expand.
+    expect(
+      call?.args.some((arg) => arg.startsWith("--expand-environment")),
+    ).toBe(false);
   });
 
-  it("forwards a non-zero exit code", async () => {
+  it("forwards a non-zero exit code from a CLI that acknowledged - one result, no second envelope", async () => {
     mocks.cgroup = V2_HOST_UNIT_CGROUP;
     mocks.packaged = true;
     process.argv = packagedArgv() as string[];
     process.execPath = "/slot/traycer";
     process.execArgv = [];
-    spawnMocks.respond = (child) => {
-      child.emit("spawn");
-      child.emit("close", 3, null);
-    };
+    spawnMocks.respond = acknowledgeThenExit(3);
 
+    // `completed`, not a rejection: the relocated CLI ran and emitted its own
+    // terminal envelope, so this process forwards the code and writes nothing.
     await expect(
       relocateOutOfHostCgroupIfNeeded("host update"),
     ).resolves.toEqual({ kind: "completed", exitCode: 3 });
   });
 
-  it("treats a signal death (close code null) as exit code 1", async () => {
+  it("treats a signal death (close code null) after an acknowledgement as exit code 1", async () => {
     mocks.cgroup = V2_HOST_UNIT_CGROUP;
     mocks.packaged = true;
     process.argv = packagedArgv() as string[];
     process.execPath = "/slot/traycer";
     process.execArgv = [];
-    spawnMocks.respond = (child) => {
-      child.emit("spawn");
-      child.emit("close", null, "SIGKILL");
-    };
+    spawnMocks.respond = acknowledgeThenExit(null);
 
     await expect(
       relocateOutOfHostCgroupIfNeeded("host update"),
@@ -340,14 +396,47 @@ describe("relocateOutOfHostCgroupIfNeeded", () => {
     // `resolve(code ?? 0)` → this test fails (expects 1, gets 0).
   });
 
+  it("rejects when systemd-run starts and exits WITHOUT the child ever acknowledging", async () => {
+    // The failure this exists for: `systemd-run` itself runs, then fails to
+    // reach a user bus or is refused its transient scope. `spawn` fires and
+    // `close` carries an ordinary non-zero code, indistinguishable from the
+    // command's own failure - except that no CLI ever wrote to fd 3. Without
+    // the ack this resolved `completed`, the parent took `finishAndExit`, and
+    // a `--json` caller got no error envelope from anyone: the relocated CLI
+    // that owed it never existed.
+    mocks.cgroup = V2_HOST_UNIT_CGROUP;
+    mocks.packaged = true;
+    process.argv = packagedArgv() as string[];
+    process.execPath = "/slot/traycer";
+    process.execArgv = [];
+    spawnMocks.respond = (fake) => {
+      fake.child.emit("spawn");
+      fake.child.emit("close", 1, null);
+    };
+
+    await expect(
+      relocateOutOfHostCgroupIfNeeded("host update"),
+    ).rejects.toMatchObject({
+      code: "E_SERVICE_CONTROL_FAILED",
+      details: { systemdRunExitCode: 1 },
+    });
+    // And it is NOT reported as a successful relocation.
+    expect(loggerMock.info).not.toHaveBeenCalled();
+
+    // Ablation: in `runInTransientScope`, drop the `if (!acknowledged)` branch
+    // from the `close` handler so it always resolves → this test fails: the
+    // call resolves `{kind:"completed", exitCode:1}` and the caller silently
+    // exits 1 with no error envelope, which is the bug this pin exists for.
+  });
+
   it("rejects with E_SERVICE_CONTROL_FAILED when the child emits a spawn error", async () => {
     mocks.cgroup = V2_HOST_UNIT_CGROUP;
     mocks.packaged = true;
     process.argv = packagedArgv() as string[];
     process.execPath = "/slot/traycer";
     process.execArgv = [];
-    spawnMocks.respond = (child) => {
-      child.emit(
+    spawnMocks.respond = (fake) => {
+      fake.child.emit(
         "error",
         Object.assign(new Error("spawn systemd-run ENOENT"), {
           code: "ENOENT",
@@ -363,10 +452,10 @@ describe("relocateOutOfHostCgroupIfNeeded", () => {
     }
     expect(caught).toMatchObject({ code: "E_SERVICE_CONTROL_FAILED" });
 
-    // Ablation: in `runInTransientScope`, change the `error` handler from
-    // `reject(relocationFailed(...))` to `resolve({kind:"not-needed"})` →
-    // this test fails: the call resolves instead of rejecting, and the
-    // caller would go on to run the stop in the doomed cgroup.
+    // Ablation: in `runInTransientScope`, change the `error` handler's
+    // `reject(relocationFailed(...))` to `resolve(0)` → this test fails: the
+    // relocation reports `{kind:"completed", exitCode:0}`, so a `systemd-run`
+    // that never existed is recorded as a command that ran and succeeded.
   });
 
   it("does nothing and never spawns for a relocated scope cgroup (run-*.scope)", async () => {
@@ -410,6 +499,126 @@ describe("relocateOutOfHostCgroupIfNeeded", () => {
     ).resolves.toEqual({ kind: "not-needed" });
     expect(spawnMocks.recorded).toHaveLength(0);
   });
+
+  it("refuses BEFORE spawning when a composed argument contains a dollar sign", async () => {
+    // `host install --from '/tmp/${BUILD}/host.tar.gz'` is a supported input,
+    // and on systemd 258 a scope expands it - silently reading a different
+    // path, or failing because the variable is unset. `--expand-environment=no`
+    // cannot be passed unconditionally (rejected below 254) and probing the
+    // version would cost a process per relocation, so a `$` is refused instead
+    // of being rewritten by something we do not control.
+    mocks.cgroup = V2_HOST_UNIT_CGROUP;
+    mocks.packaged = true;
+    process.argv = [
+      "/slot/traycer",
+      "/slot/traycer",
+      "host",
+      "install",
+      "--from",
+      "/tmp/${BUILD}/host.tar.gz",
+    ];
+    process.execPath = "/slot/traycer";
+    process.execArgv = [];
+
+    await expect(
+      relocateOutOfHostCgroupIfNeeded("host install"),
+    ).rejects.toMatchObject({
+      code: "E_SERVICE_CONTROL_FAILED",
+      details: { argument: "/tmp/${BUILD}/host.tar.gz" },
+    });
+    // The refusal happens before anything is started.
+    expect(spawnMocks.recorded).toHaveLength(0);
+
+    // Ablation: in `relocateOutOfHostCgroupIfNeeded`, delete the
+    // `assertArgvSurvivesSystemdRun(argv, commandPath, inside);` call → this
+    // test fails: the relocation spawns and hands the dollar-bearing path to
+    // systemd-run.
+  });
+
+  it("relocates normally when no composed argument contains a dollar sign", async () => {
+    // The positive half of the refusal above - it must not reject every argv.
+    mocks.cgroup = V2_HOST_UNIT_CGROUP;
+    mocks.packaged = true;
+    process.argv = [
+      "/slot/traycer",
+      "/slot/traycer",
+      "host",
+      "install",
+      "--from",
+      "/tmp/build/host.tar.gz",
+    ];
+    process.execPath = "/slot/traycer";
+    process.execArgv = [];
+    spawnMocks.respond = acknowledgeThenExit(0);
+
+    await expect(
+      relocateOutOfHostCgroupIfNeeded("host install"),
+    ).resolves.toEqual({ kind: "completed", exitCode: 0 });
+    expect(spawnMocks.recorded).toHaveLength(1);
+  });
+
+  it("refuses when the cgroup cannot be READ, rather than treating the failure as being outside the unit", async () => {
+    // EACCES says nothing about membership. Treating it as "not inside" is
+    // permission to stop: relocation is skipped, the guard passes, intent is
+    // written, and the stop kills the process issuing it.
+    mocks.cgroup = { errno: "EACCES" };
+    await expect(
+      relocateOutOfHostCgroupIfNeeded("host update"),
+    ).rejects.toMatchObject({
+      code: "E_SERVICE_CONTROL_FAILED",
+      details: { path: "/proc/self/cgroup" },
+    });
+    expect(spawnMocks.recorded).toHaveLength(0);
+
+    // Ablation: in `readHostUnitCgroup`, replace the `isMissingCgroupFile`
+    // branch with a blanket `return null` → this test fails: EACCES resolves
+    // `not-needed` and the command runs in the cgroup that is about to kill it.
+  });
+
+  it("treats an ABSENT /proc/self/cgroup (ENOENT, ENOTDIR) as not inside a host unit", async () => {
+    // Containers, WSL without systemd, a kernel with no cgroup filesystem:
+    // there is no cgroup that can kill us, which is a real answer and not a
+    // failed check.
+    for (const errno of ["ENOENT", "ENOTDIR"]) {
+      mocks.cgroup = { errno };
+      await expect(
+        relocateOutOfHostCgroupIfNeeded("host update"),
+      ).resolves.toEqual({ kind: "not-needed" });
+    }
+    expect(spawnMocks.recorded).toHaveLength(0);
+  });
+});
+
+describe("acknowledgeRelocationEntry", () => {
+  beforeEach(() => {
+    mocks.ackWrites = [];
+    mocks.ackWriteError = null;
+  });
+
+  afterEach(() => {
+    delete process.env[TRAYCER_CLI_RELOCATED_ENV];
+  });
+
+  it("writes one byte to fd 3 on a relocated run", () => {
+    process.env[TRAYCER_CLI_RELOCATED_ENV] = "1";
+    acknowledgeRelocationEntry();
+    expect(mocks.ackWrites).toEqual([{ fd: 3, payload: "\n" }]);
+  });
+
+  it("writes nothing on an ordinary run - fd 3 belongs to whoever launched us", () => {
+    acknowledgeRelocationEntry();
+    expect(mocks.ackWrites).toEqual([]);
+
+    // Ablation: in `acknowledgeRelocationEntry`, drop the
+    // `TRAYCER_CLI_RELOCATED` early return → this test fails, and the CLI
+    // would write a stray byte into whatever fd 3 is on every ordinary run.
+  });
+
+  it("swallows a failed write - an older parent leaves no pipe on fd 3 (EBADF)", () => {
+    process.env[TRAYCER_CLI_RELOCATED_ENV] = "1";
+    mocks.ackWriteError = Object.assign(new Error("EBADF"), { code: "EBADF" });
+    expect(() => acknowledgeRelocationEntry()).not.toThrow();
+  });
 });
 
 describe("assertNotInsideHostUnit", () => {
@@ -446,8 +655,16 @@ describe("assertNotInsideHostUnit", () => {
     await expect(assertNotInsideHostUnit()).resolves.toBeUndefined();
   });
 
-  it("resolves when /proc/self/cgroup cannot be read", async () => {
-    mocks.cgroup = { reject: true };
+  it("REFUSES when /proc/self/cgroup cannot be read - an unreadable cgroup is not a negative answer", async () => {
+    mocks.cgroup = { errno: "EACCES" };
+    await expect(assertNotInsideHostUnit()).rejects.toMatchObject({
+      code: "E_SERVICE_CONTROL_FAILED",
+      details: { path: "/proc/self/cgroup" },
+    });
+  });
+
+  it("resolves when /proc/self/cgroup is ABSENT (ENOENT) - nothing there can kill us", async () => {
+    mocks.cgroup = { errno: "ENOENT" };
     await expect(assertNotInsideHostUnit()).resolves.toBeUndefined();
   });
 

--- a/clients/traycer-cli/src/host/__tests__/cgroup-relocation.test.ts
+++ b/clients/traycer-cli/src/host/__tests__/cgroup-relocation.test.ts
@@ -1,0 +1,473 @@
+import type { ChildProcess, SpawnOptions } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// This module is Linux's first line of defence against the host stopping the
+// CLI that just asked it to stop (see the module's own top-of-file comment).
+// Every seam that could touch a real machine is stubbed: `node:os.platform`,
+// `node:fs/promises.readFile` (only for `/proc/self/cgroup`), `node:child_process.spawn`,
+// `isPackagedRun`, and the logger - so no test here can spawn a real
+// `systemd-run`, read a real cgroup file, or append to a live `cli.log`.
+
+const loggerMock = vi.hoisted(() => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock("../../logger", () => ({
+  createCliLogger: () => loggerMock,
+  errorFromUnknown: (value: unknown) =>
+    value instanceof Error ? value : new Error(String(value)),
+}));
+
+const mocks = vi.hoisted(() => ({
+  platform: "linux" as NodeJS.Platform,
+  // `null` means "no /proc/self/cgroup interception" - readFile delegates to
+  // the original implementation for every path.
+  cgroup: null as string | null | { reject: true },
+  packaged: false,
+}));
+
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:os")>();
+  return { ...actual, platform: () => mocks.platform };
+});
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs/promises")>();
+  return {
+    ...actual,
+    readFile: (async (
+      path: Parameters<typeof actual.readFile>[0],
+      options: Parameters<typeof actual.readFile>[1] | undefined,
+    ) => {
+      if (path === "/proc/self/cgroup") {
+        if (mocks.cgroup === null) {
+          throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+        }
+        if (typeof mocks.cgroup === "object") {
+          throw Object.assign(new Error("EACCES"), { code: "EACCES" });
+        }
+        return mocks.cgroup;
+      }
+      return options === undefined
+        ? actual.readFile(path)
+        : actual.readFile(path, options);
+    }) as typeof actual.readFile,
+  };
+});
+
+vi.mock("../../store/well-known-cli", () => ({
+  isPackagedRun: async () => mocks.packaged,
+}));
+
+interface RecordedSpawn {
+  readonly command: string;
+  readonly args: readonly string[];
+  readonly options: SpawnOptions;
+}
+
+const spawnMocks = vi.hoisted(() => ({
+  recorded: [] as RecordedSpawn[],
+  // Each queued responder decides how the fake child behaves once `spawn`
+  // hands it back. `null` means "no fake child was queued" and the call
+  // throws synchronously, matching a real `spawn` that cannot resolve
+  // `systemd-run`.
+  respond: null as ((child: EventEmitter) => void) | null,
+  throwSync: null as Error | null,
+}));
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return {
+    ...actual,
+    spawn: (
+      command: string,
+      args: readonly string[],
+      options: SpawnOptions,
+    ): ChildProcess => {
+      spawnMocks.recorded.push({ command, args, options });
+      if (spawnMocks.throwSync !== null) throw spawnMocks.throwSync;
+      const child = new EventEmitter() as ChildProcess;
+      if (spawnMocks.respond !== null) {
+        // Real `spawn` never emits synchronously - the caller has always
+        // attached its listeners by the time anything fires.
+        Promise.resolve().then(() => spawnMocks.respond?.(child));
+      }
+      return child;
+    },
+  };
+});
+
+const {
+  findHostUnitCgroup,
+  relocationArgv,
+  relocateOutOfHostCgroupIfNeeded,
+  assertNotInsideHostUnit,
+  HOST_STOPPING_COMMANDS,
+  TRAYCER_CLI_RELOCATED_ENV,
+} = await import("../cgroup-relocation");
+
+const V2_HOST_UNIT_CGROUP =
+  "0::/user.slice/user-1000.slice/user@1000.service/app.slice/ai.traycer.host.service\n";
+
+const DEV_SLOT_HOST_UNIT_CGROUP =
+  "0::/user.slice/user-1000.slice/user@1000.service/app.slice/ai.traycer.host.staging.service\n";
+
+const SCOPE_CGROUP =
+  "0::/user.slice/user-1000.slice/user@1000.service/app.slice/run-r123.scope\n";
+
+describe("findHostUnitCgroup", () => {
+  it("finds the production host unit in a v2 cgroup line", () => {
+    expect(findHostUnitCgroup(V2_HOST_UNIT_CGROUP)).toEqual({
+      unit: "ai.traycer.host.service",
+      path: "/user.slice/user-1000.slice/user@1000.service/app.slice/ai.traycer.host.service",
+    });
+  });
+
+  it("finds a dev slot's host unit (ai.traycer.host.staging.service)", () => {
+    expect(findHostUnitCgroup(DEV_SLOT_HOST_UNIT_CGROUP)).toEqual({
+      unit: "ai.traycer.host.staging.service",
+      path: "/user.slice/user-1000.slice/user@1000.service/app.slice/ai.traycer.host.staging.service",
+    });
+  });
+
+  it("returns null for a relocated scope (run-*.scope)", () => {
+    expect(findHostUnitCgroup(SCOPE_CGROUP)).toBeNull();
+  });
+
+  it("finds the host unit in a hybrid machine's v1 systemd line even though the v2 line is bare", () => {
+    // The unified line answers "not inside a host unit" on its own; only the
+    // v1 `name=systemd` hierarchy carries the real placement here. Every
+    // candidate line must be checked, not just the first.
+    const hybrid = [
+      "0::/",
+      "1:name=systemd:/user.slice/.../ai.traycer.host.service",
+    ].join("\n");
+    expect(findHostUnitCgroup(hybrid)).toEqual({
+      unit: "ai.traycer.host.service",
+      path: "/user.slice/.../ai.traycer.host.service",
+    });
+  });
+
+  it("finds a bare v1 'systemd' hierarchy (kernels that drop the name= prefix)", () => {
+    expect(
+      findHostUnitCgroup("2:systemd:/user.slice/ai.traycer.host.service"),
+    ).toEqual({
+      unit: "ai.traycer.host.service",
+      path: "/user.slice/ai.traycer.host.service",
+    });
+  });
+
+  it("returns null for a controller hierarchy that carries no unit placement (e.g. memory)", () => {
+    expect(
+      findHostUnitCgroup("3:memory:/user.slice/ai.traycer.host.service"),
+    ).toBeNull();
+  });
+
+  it("returns null for empty contents", () => {
+    expect(findHostUnitCgroup("")).toBeNull();
+  });
+
+  // Ablation: in `findHostUnitCgroup`, change `if (unit !== null) return { unit, path };`
+  // to `return { unit, path };` unconditionally inside the loop (i.e. return
+  // after the FIRST candidate line regardless of match) → the hybrid test
+  // above fails because the bare `0::/` first line short-circuits before the
+  // v1 `name=systemd` line is ever checked.
+});
+
+describe("relocationArgv", () => {
+  it("packaged (SEA): drops the doubled binary token from argv[0..1] and keeps one", () => {
+    const argv = relocationArgv({
+      packaged: true,
+      execPath: "/slot/traycer",
+      execArgv: [],
+      argv: [
+        "/slot/traycer",
+        "/slot/traycer",
+        "host",
+        "update",
+        "--json",
+        "--ack-nonce",
+        "n",
+      ],
+    });
+    expect(argv).toEqual([
+      "/slot/traycer",
+      "host",
+      "update",
+      "--json",
+      "--ack-nonce",
+      "n",
+    ]);
+  });
+
+  it("interpreter: carries execPath, execArgv, and argv.slice(1)", () => {
+    const argv = relocationArgv({
+      packaged: false,
+      execPath: "/usr/bin/node",
+      execArgv: ["--import", "tsx"],
+      argv: ["/usr/bin/node", "/repo/src/index.ts", "host", "update"],
+    });
+    expect(argv).toEqual([
+      "/usr/bin/node",
+      "--import",
+      "tsx",
+      "/repo/src/index.ts",
+      "host",
+      "update",
+    ]);
+  });
+
+  // Ablation: in `relocationArgv`, change the packaged branch to
+  // `[run.execPath, ...run.argv.slice(1)]` (the doubled binary token) → the
+  // packaged test above fails: it would see `/slot/traycer` twice at the
+  // front of the argv instead of once.
+});
+
+describe("relocateOutOfHostCgroupIfNeeded", () => {
+  // These tests hand the module a fake launch shape by writing to `process`
+  // itself. Captured once here and restored after every test: a leaked
+  // `execPath` of `/slot/traycer` would follow this worker into any other
+  // file that spawns something real.
+  const originalArgv = process.argv;
+  const originalExecPath = process.execPath;
+  const originalExecArgv = process.execArgv;
+
+  beforeEach(() => {
+    mocks.platform = "linux";
+    mocks.cgroup = null;
+    mocks.packaged = false;
+    spawnMocks.recorded = [];
+    spawnMocks.respond = null;
+    spawnMocks.throwSync = null;
+    loggerMock.debug.mockClear();
+    loggerMock.info.mockClear();
+  });
+
+  afterEach(() => {
+    delete process.env[TRAYCER_CLI_RELOCATED_ENV];
+    process.argv = originalArgv;
+    process.execPath = originalExecPath;
+    process.execArgv = originalExecArgv;
+  });
+
+  function packagedArgv(): readonly string[] {
+    return [
+      "/slot/traycer",
+      "/slot/traycer",
+      "host",
+      "update",
+      "--json",
+      "--ack-nonce",
+      "n",
+    ];
+  }
+
+  it("spawns systemd-run with the exact scope args, inherited stdio, and the recursion flag, forwarding a zero exit", async () => {
+    mocks.cgroup = V2_HOST_UNIT_CGROUP;
+    mocks.packaged = true;
+    process.argv = packagedArgv() as string[];
+    process.execPath = "/slot/traycer";
+    process.execArgv = [];
+    spawnMocks.respond = (child) => {
+      child.emit("spawn");
+      child.emit("close", 0, null);
+    };
+
+    const result = await relocateOutOfHostCgroupIfNeeded("host update");
+
+    expect(result).toEqual({ kind: "completed", exitCode: 0 });
+    expect(spawnMocks.recorded).toHaveLength(1);
+    const call = spawnMocks.recorded[0];
+    expect(call?.command).toBe("systemd-run");
+    expect(call?.args).toEqual([
+      "--user",
+      "--scope",
+      "--quiet",
+      "--collect",
+      "--",
+      "/slot/traycer",
+      "host",
+      "update",
+      "--json",
+      "--ack-nonce",
+      "n",
+    ]);
+    expect(call?.options.stdio).toBe("inherit");
+    expect(call?.options.env?.[TRAYCER_CLI_RELOCATED_ENV]).toBe("1");
+    // The line the CLI docs tell an operator to look for in cli.log.
+    expect(loggerMock.info).toHaveBeenCalledWith(
+      "relocated host-stopping command into a transient scope",
+      { command: "host update", unit: "ai.traycer.host.service" },
+    );
+  });
+
+  it("forwards a non-zero exit code", async () => {
+    mocks.cgroup = V2_HOST_UNIT_CGROUP;
+    mocks.packaged = true;
+    process.argv = packagedArgv() as string[];
+    process.execPath = "/slot/traycer";
+    process.execArgv = [];
+    spawnMocks.respond = (child) => {
+      child.emit("spawn");
+      child.emit("close", 3, null);
+    };
+
+    await expect(
+      relocateOutOfHostCgroupIfNeeded("host update"),
+    ).resolves.toEqual({ kind: "completed", exitCode: 3 });
+  });
+
+  it("treats a signal death (close code null) as exit code 1", async () => {
+    mocks.cgroup = V2_HOST_UNIT_CGROUP;
+    mocks.packaged = true;
+    process.argv = packagedArgv() as string[];
+    process.execPath = "/slot/traycer";
+    process.execArgv = [];
+    spawnMocks.respond = (child) => {
+      child.emit("spawn");
+      child.emit("close", null, "SIGKILL");
+    };
+
+    await expect(
+      relocateOutOfHostCgroupIfNeeded("host update"),
+    ).resolves.toEqual({ kind: "completed", exitCode: 1 });
+
+    // Ablation: in `runInTransientScope`, change `resolve(code ?? 1)` to
+    // `resolve(code ?? 0)` → this test fails (expects 1, gets 0).
+  });
+
+  it("rejects with E_SERVICE_CONTROL_FAILED when the child emits a spawn error", async () => {
+    mocks.cgroup = V2_HOST_UNIT_CGROUP;
+    mocks.packaged = true;
+    process.argv = packagedArgv() as string[];
+    process.execPath = "/slot/traycer";
+    process.execArgv = [];
+    spawnMocks.respond = (child) => {
+      child.emit(
+        "error",
+        Object.assign(new Error("spawn systemd-run ENOENT"), {
+          code: "ENOENT",
+        }),
+      );
+    };
+
+    let caught: unknown = null;
+    try {
+      await relocateOutOfHostCgroupIfNeeded("host update");
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toMatchObject({ code: "E_SERVICE_CONTROL_FAILED" });
+
+    // Ablation: in `runInTransientScope`, change the `error` handler from
+    // `reject(relocationFailed(...))` to `resolve({kind:"not-needed"})` →
+    // this test fails: the call resolves instead of rejecting, and the
+    // caller would go on to run the stop in the doomed cgroup.
+  });
+
+  it("does nothing and never spawns for a relocated scope cgroup (run-*.scope)", async () => {
+    mocks.cgroup = SCOPE_CGROUP;
+    await expect(
+      relocateOutOfHostCgroupIfNeeded("host update"),
+    ).resolves.toEqual({ kind: "not-needed" });
+    expect(spawnMocks.recorded).toHaveLength(0);
+  });
+
+  it("does nothing for a command outside HOST_STOPPING_COMMANDS, even inside a host unit", async () => {
+    mocks.cgroup = V2_HOST_UNIT_CGROUP;
+    expect(HOST_STOPPING_COMMANDS.has("agent turn-ended-from-hook")).toBe(
+      false,
+    );
+    await expect(
+      relocateOutOfHostCgroupIfNeeded("agent turn-ended-from-hook"),
+    ).resolves.toEqual({ kind: "not-needed" });
+    expect(spawnMocks.recorded).toHaveLength(0);
+
+    // Ablation: in `cgroup-relocation.ts`, add
+    // `"agent turn-ended-from-hook"` to `HOST_STOPPING_COMMANDS` → this test
+    // fails: the relocation would spawn `systemd-run` for a command that is
+    // supposed to die with its host agent process.
+  });
+
+  it("does nothing when TRAYCER_CLI_RELOCATED is already set, even inside a host unit", async () => {
+    mocks.cgroup = V2_HOST_UNIT_CGROUP;
+    process.env[TRAYCER_CLI_RELOCATED_ENV] = "1";
+    await expect(
+      relocateOutOfHostCgroupIfNeeded("host update"),
+    ).resolves.toEqual({ kind: "not-needed" });
+    expect(spawnMocks.recorded).toHaveLength(0);
+  });
+
+  it("does nothing on a non-linux platform, and never reads /proc/self/cgroup", async () => {
+    mocks.platform = "darwin";
+    mocks.cgroup = V2_HOST_UNIT_CGROUP;
+    await expect(
+      relocateOutOfHostCgroupIfNeeded("host update"),
+    ).resolves.toEqual({ kind: "not-needed" });
+    expect(spawnMocks.recorded).toHaveLength(0);
+  });
+});
+
+describe("assertNotInsideHostUnit", () => {
+  beforeEach(() => {
+    mocks.platform = "linux";
+    mocks.cgroup = null;
+  });
+
+  afterEach(() => {
+    delete process.env[TRAYCER_CLI_RELOCATED_ENV];
+  });
+
+  it("throws E_SERVICE_CONTROL_FAILED naming the unit, with cgroup+unit details", async () => {
+    mocks.cgroup = V2_HOST_UNIT_CGROUP;
+    let caught: unknown = null;
+    try {
+      await assertNotInsideHostUnit();
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toMatchObject({
+      code: "E_SERVICE_CONTROL_FAILED",
+      details: {
+        unit: "ai.traycer.host.service",
+        cgroup:
+          "/user.slice/user-1000.slice/user@1000.service/app.slice/ai.traycer.host.service",
+      },
+    });
+    expect((caught as Error).message).toContain("ai.traycer.host.service");
+  });
+
+  it("resolves for a relocated scope cgroup", async () => {
+    mocks.cgroup = SCOPE_CGROUP;
+    await expect(assertNotInsideHostUnit()).resolves.toBeUndefined();
+  });
+
+  it("resolves when /proc/self/cgroup cannot be read", async () => {
+    mocks.cgroup = { reject: true };
+    await expect(assertNotInsideHostUnit()).resolves.toBeUndefined();
+  });
+
+  it("resolves on darwin even inside a host unit cgroup", async () => {
+    mocks.platform = "darwin";
+    mocks.cgroup = V2_HOST_UNIT_CGROUP;
+    await expect(assertNotInsideHostUnit()).resolves.toBeUndefined();
+  });
+
+  it("STILL throws when TRAYCER_CLI_RELOCATED=1 and we are inside a host unit - the env flag is never evidence", async () => {
+    mocks.cgroup = V2_HOST_UNIT_CGROUP;
+    process.env[TRAYCER_CLI_RELOCATED_ENV] = "1";
+    await expect(assertNotInsideHostUnit()).rejects.toMatchObject({
+      code: "E_SERVICE_CONTROL_FAILED",
+    });
+
+    // Ablation: in `assertNotInsideHostUnit`, add an early
+    // `if (process.env.TRAYCER_CLI_RELOCATED) return;` before the cgroup
+    // re-read → this test fails: the guard would resolve instead of
+    // throwing, defeating the entire point of the second line of defence
+    // (a relocation that silently did nothing would go undetected).
+  });
+});

--- a/clients/traycer-cli/src/host/__tests__/cgroup-relocation.test.ts
+++ b/clients/traycer-cli/src/host/__tests__/cgroup-relocation.test.ts
@@ -732,6 +732,29 @@ describe("relocateOutOfHostCgroupIfNeeded", () => {
     expect(spawnMocks.recorded).toHaveLength(0);
   });
 
+  it("host service install is in HOST_STOPPING_COMMANDS unconditionally: its rollback stops the live unit", async () => {
+    // `service/platforms/linux.ts` rolls a failed `enable --now` back with
+    // `disable --now` on the live unit. Run unrelocated from a Traycer-hosted
+    // terminal, that rollback kills the CLI with the host before the manifest
+    // is removed or the install's own error is reported.
+    expect(HOST_STOPPING_COMMANDS.get("host service install")?.({})).toBe(true);
+    mocks.cgroup = V2_HOST_UNIT_CGROUP;
+    mocks.packaged = true;
+    process.argv = packagedArgv() as string[];
+    process.execPath = "/slot/traycer";
+    process.execArgv = [];
+    spawnMocks.respond = acknowledgeThenExit(0);
+
+    await expect(
+      relocateOutOfHostCgroupIfNeeded("host service install", {}),
+    ).resolves.toEqual({ kind: "completed", exitCode: 0 });
+    expect(spawnMocks.recorded).toHaveLength(1);
+
+    // Ablation: remove the `"host service install"` entry from
+    // `HOST_STOPPING_COMMANDS` → this test fails on the first assertion and
+    // the relocation resolves `not-needed` without spawning.
+  });
+
   it("does nothing for a command outside HOST_STOPPING_COMMANDS, even inside a host unit", async () => {
     mocks.cgroup = V2_HOST_UNIT_CGROUP;
     expect(HOST_STOPPING_COMMANDS.has("agent turn-ended-from-hook")).toBe(

--- a/clients/traycer-cli/src/host/__tests__/cgroup-relocation.test.ts
+++ b/clients/traycer-cli/src/host/__tests__/cgroup-relocation.test.ts
@@ -755,6 +755,33 @@ describe("relocateOutOfHostCgroupIfNeeded", () => {
     // the relocation resolves `not-needed` without spawning.
   });
 
+  it("host maintenance-lease is in HOST_STOPPING_COMMANDS unconditionally: it serves host-stop and uninstall-all to the root scripts", async () => {
+    // The Desktop install/uninstall scripts hold this lease across app
+    // replacement and cloud uninstall on Linux too, and both of its actions go
+    // through the guarded stop routes. Started from a Traycer-hosted terminal
+    // the lease is spawned inside the host unit, and the guard would refuse
+    // the maintenance rather than let the lease perform it. The route is
+    // registered outside `withRunner`, so the map entry is only half of it;
+    // `cli-with-runner-relocation.test.ts` pins the action's own call.
+    expect(HOST_STOPPING_COMMANDS.get("host maintenance-lease")?.({})).toBe(
+      true,
+    );
+    mocks.cgroup = V2_HOST_UNIT_CGROUP;
+    mocks.packaged = true;
+    process.argv = packagedArgv() as string[];
+    process.execPath = "/slot/traycer";
+    process.execArgv = [];
+    spawnMocks.respond = acknowledgeThenExit(0);
+
+    await expect(
+      relocateOutOfHostCgroupIfNeeded("host maintenance-lease", {}),
+    ).resolves.toEqual({ kind: "completed", exitCode: 0 });
+    expect(spawnMocks.recorded).toHaveLength(1);
+
+    // Ablation: remove the `"host maintenance-lease"` entry → this test fails
+    // on the first assertion and the relocation resolves `not-needed`.
+  });
+
   it("does nothing for a command outside HOST_STOPPING_COMMANDS, even inside a host unit", async () => {
     mocks.cgroup = V2_HOST_UNIT_CGROUP;
     expect(HOST_STOPPING_COMMANDS.has("agent turn-ended-from-hook")).toBe(

--- a/clients/traycer-cli/src/host/__tests__/cgroup-relocation.test.ts
+++ b/clients/traycer-cli/src/host/__tests__/cgroup-relocation.test.ts
@@ -284,15 +284,14 @@ describe("relocateOutOfHostCgroupIfNeeded", () => {
     loggerMock.info.mockClear();
   });
 
-  // The relocated CLI reaching `withRunner`: one byte on fd 3, then whatever
-  // the command itself exits with.
+  // The relocated CLI reaching `withRunner`: one byte on fd 3, the channel
+  // closing behind it, and then whatever the command itself exits with. This
+  // is the NODE ordering - the ack is delivered before the process is reaped.
   function acknowledgeThenExit(code: number | null): (fake: FakeChild) => void {
     return (fake) => {
       fake.child.emit("spawn");
-      fake.ack.write("\n");
-      // The ack has to be observable before `close`, exactly as a real pipe
-      // delivers it - `close` fires after the stdio streams are done.
-      setImmediate(() => fake.child.emit("close", code, null));
+      fake.ack.end("\n");
+      setImmediate(() => fake.child.emit("exit", code, null));
     };
   }
 
@@ -409,9 +408,13 @@ describe("relocateOutOfHostCgroupIfNeeded", () => {
     process.argv = packagedArgv() as string[];
     process.execPath = "/slot/traycer";
     process.execArgv = [];
+    // Exit first, then the ack channel ends carrying nothing. Only an ENDED
+    // channel makes "no ack" final, so this is the ordering that proves the
+    // refusal rather than merely reaching it.
     spawnMocks.respond = (fake) => {
       fake.child.emit("spawn");
-      fake.child.emit("close", 1, null);
+      fake.child.emit("exit", 1, null);
+      fake.ack.end();
     };
 
     await expect(
@@ -424,9 +427,46 @@ describe("relocateOutOfHostCgroupIfNeeded", () => {
     expect(loggerMock.info).not.toHaveBeenCalled();
 
     // Ablation: in `runInTransientScope`, drop the `if (!acknowledged)` branch
-    // from the `close` handler so it always resolves → this test fails: the
-    // call resolves `{kind:"completed", exitCode:1}` and the caller silently
-    // exits 1 with no error envelope, which is the bug this pin exists for.
+    // from `settle` so it always resolves → this test fails: the call resolves
+    // `{kind:"completed", exitCode:1}` and the caller silently exits 1 with no
+    // error envelope, which is the bug this pin exists for.
+  });
+
+  it("resolves when the ack arrives AFTER the process exit - Bun does not drain fd 3 before it reports the child gone", async () => {
+    // Bun 1.3.12 counts stdout/stderr toward its child close accounting but
+    // returns the extra descriptor from `net.connect({fd})` without adding it,
+    // so with stdio 0-2 inherited the process can be reported gone while fd 3
+    // still holds the ack. Deciding on that report alone rejects a relocation
+    // that had already acknowledged AND completed: a false "never started", a
+    // second terminal envelope over the child's own, and the real exit code
+    // lost. The tree and dev paths of this CLI run under Bun.
+    mocks.cgroup = V2_HOST_UNIT_CGROUP;
+    mocks.packaged = true;
+    process.argv = packagedArgv() as string[];
+    process.execPath = "/slot/traycer";
+    process.execArgv = [];
+    spawnMocks.respond = (fake) => {
+      fake.child.emit("spawn");
+      fake.child.emit("exit", 7, null);
+      // The bytes were written before the child died; they are only delivered
+      // to this process afterwards.
+      setImmediate(() => fake.ack.end("\n"));
+    };
+
+    await expect(
+      relocateOutOfHostCgroupIfNeeded("host update"),
+    ).resolves.toEqual({ kind: "completed", exitCode: 7 });
+    expect(loggerMock.info).toHaveBeenCalledWith(
+      "relocated host-stopping command into a transient scope",
+      { command: "host update", unit: "ai.traycer.host.service" },
+    );
+
+    // Ablation: in `runInTransientScope`, decide on the child's `close` event
+    // alone again - `child.once("close", (code) => acknowledged ? resolve(code
+    // ?? 1) : reject(relocationNeverStarted(...)))`, with the fake emitting
+    // `close` in place of `exit` - → this test fails: the ack has not been
+    // delivered yet at that point, so a completed command is rejected as one
+    // that never started.
   });
 
   it("rejects with E_SERVICE_CONTROL_FAILED when the child emits a spawn error", async () => {
@@ -456,6 +496,30 @@ describe("relocateOutOfHostCgroupIfNeeded", () => {
     // `reject(relocationFailed(...))` to `resolve(0)` → this test fails: the
     // relocation reports `{kind:"completed", exitCode:0}`, so a `systemd-run`
     // that never existed is recorded as a command that ran and succeeded.
+  });
+
+  it("resolves on a late ack without waiting for the ack channel to end", async () => {
+    // Liveness, not correctness: once the byte is in hand the answer is known,
+    // so nothing here depends on the channel ever ending. Both runtimes mark
+    // descriptors above the explicit stdio set close-on-exec, so the child is
+    // the only writer and `end` does follow its exit - but a future leak of fd
+    // 3 into a long-lived grandchild would stall a decision this code can
+    // already make.
+    mocks.cgroup = V2_HOST_UNIT_CGROUP;
+    mocks.packaged = true;
+    process.argv = packagedArgv() as string[];
+    process.execPath = "/slot/traycer";
+    process.execArgv = [];
+    spawnMocks.respond = (fake) => {
+      fake.child.emit("spawn");
+      fake.child.emit("exit", 0, null);
+      // Written, never ended: the write end stays open.
+      setImmediate(() => fake.ack.write("\n"));
+    };
+
+    await expect(
+      relocateOutOfHostCgroupIfNeeded("host update"),
+    ).resolves.toEqual({ kind: "completed", exitCode: 0 });
   });
 
   it("does nothing and never spawns for a relocated scope cgroup (run-*.scope)", async () => {

--- a/clients/traycer-cli/src/host/__tests__/cgroup-relocation.test.ts
+++ b/clients/traycer-cli/src/host/__tests__/cgroup-relocation.test.ts
@@ -107,6 +107,13 @@ const spawnMocks = vi.hoisted(() => ({
   // the "spawn threw synchronously" case is kept separate (`throwSync`).
   respond: null as ((fake: FakeChild) => void) | null,
   throwSync: null as Error | null,
+  // `undefined` mimics the spawn-failure shape where Node hands back a child
+  // with no pid at all - the case `relayTerminationSignals` refuses to
+  // install a relay for.
+  childPid: undefined as number | undefined,
+  // The most recently created fake, for tests that drive the child by hand
+  // (no `respond` queued) rather than through a scripted responder.
+  lastFake: null as FakeChild | null,
 }));
 
 vi.mock("node:child_process", async (importOriginal) => {
@@ -124,11 +131,14 @@ vi.mock("node:child_process", async (importOriginal) => {
       const stdio: ChildProcess["stdio"] = [null, null, null, ack, null];
       const child = Object.assign(new EventEmitter(), {
         stdio,
+        pid: spawnMocks.childPid,
       }) as ChildProcess;
+      const fake: FakeChild = { child, ack };
+      spawnMocks.lastFake = fake;
       if (spawnMocks.respond !== null) {
         // Real `spawn` never emits synchronously - the caller has always
         // attached its listeners by the time anything fires.
-        Promise.resolve().then(() => spawnMocks.respond?.({ child, ack }));
+        Promise.resolve().then(() => spawnMocks.respond?.(fake));
       }
       return child;
     },
@@ -280,6 +290,8 @@ describe("relocateOutOfHostCgroupIfNeeded", () => {
     spawnMocks.recorded = [];
     spawnMocks.respond = null;
     spawnMocks.throwSync = null;
+    spawnMocks.childPid = undefined;
+    spawnMocks.lastFake = null;
     loggerMock.debug.mockClear();
     loggerMock.info.mockClear();
   });
@@ -301,6 +313,10 @@ describe("relocateOutOfHostCgroupIfNeeded", () => {
     process.argv = originalArgv;
     process.execPath = originalExecPath;
     process.execArgv = originalExecArgv;
+    // A safety net for the relay tests below: each restores its own
+    // `process.kill` spy in a `finally`, but this catches one left standing
+    // by a test that throws before reaching it.
+    vi.restoreAllMocks();
   });
 
   function packagedArgv(): readonly string[] {
@@ -350,6 +366,13 @@ describe("relocateOutOfHostCgroupIfNeeded", () => {
       "inherit",
       "pipe",
     ]);
+    // The scope moves the CGROUP, not the SESSION: without `detached`
+    // (setsid at spawn), the child stays in a Traycer-hosted terminal's
+    // session, and the moment the stop closes that PTY master the kernel
+    // SIGHUPs the relocated updater along with it. Asserted alongside
+    // `stdio` so a future change cannot quietly pipe stdio (losing visible
+    // progress) or drop `detached` (losing survival) without failing here.
+    expect(call?.options.detached).toBe(true);
     expect(call?.options.env?.[TRAYCER_CLI_RELOCATED_ENV]).toBe("1");
     // The line the CLI docs tell an operator to look for in cli.log. It is
     // written on the ACK, not on `spawn`: `systemd-run` starting proves
@@ -363,6 +386,10 @@ describe("relocateOutOfHostCgroupIfNeeded", () => {
     expect(
       call?.args.some((arg) => arg.startsWith("--expand-environment")),
     ).toBe(false);
+
+    // Ablation: in `runInTransientScope`, drop `detached: true` from the
+    // spawn options → this test fails: `call?.options.detached` is
+    // `undefined` instead of `true`.
   });
 
   it("forwards a non-zero exit code from a CLI that acknowledged - one result, no second envelope", async () => {
@@ -469,6 +496,109 @@ describe("relocateOutOfHostCgroupIfNeeded", () => {
     // `close` in place of `exit` - → this test fails: the ack has not been
     // delivered yet at that point, so a completed command is rejected as one
     // that never started.
+  });
+
+  it("forwards SIGINT/SIGTERM to the relocated child's PROCESS GROUP (-pid), and disposes both listeners once settled", async () => {
+    // Only needed because of `detached`: while the child shared this
+    // process's group, a terminal's Ctrl-C reached both at once. Detached,
+    // it does not - so without this relay Ctrl-C would kill the waiting
+    // parent and leave the update running unattended.
+    mocks.cgroup = V2_HOST_UNIT_CGROUP;
+    mocks.packaged = true;
+    process.argv = packagedArgv() as string[];
+    process.execPath = "/slot/traycer";
+    process.execArgv = [];
+    spawnMocks.childPid = 4242;
+    // No `respond` queued: this test drives the fake child by hand so it can
+    // emit the signals BEFORE the child ever exits.
+    spawnMocks.respond = null;
+    // Captured BEFORE the relay installs its own pair, so the "disposed"
+    // assertion below proves the count returns to what it actually was
+    // rather than to a baseline that already included the relay itself.
+    const sigintBefore = process.listenerCount("SIGINT");
+    const sigtermBefore = process.listenerCount("SIGTERM");
+
+    const promise = relocateOutOfHostCgroupIfNeeded("host update", {});
+    // Let the async chain (cgroup read, isPackagedRun, spawn) run far enough
+    // to reach `relayTerminationSignals` before this test drives any signal.
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Spied BEFORE emitting: an unspied call would signal this test runner's
+    // own process group.
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    try {
+      process.emit("SIGINT");
+      process.emit("SIGTERM");
+      expect(killSpy).toHaveBeenNthCalledWith(1, -4242, "SIGINT");
+      expect(killSpy).toHaveBeenNthCalledWith(2, -4242, "SIGTERM");
+
+      const fake = spawnMocks.lastFake;
+      if (fake === null) throw new Error("spawn was never called");
+      fake.child.emit("spawn");
+      fake.ack.end("\n");
+      await new Promise((resolve) => setImmediate(resolve));
+      fake.child.emit("exit", 0, null);
+
+      await expect(promise).resolves.toEqual({
+        kind: "completed",
+        exitCode: 0,
+      });
+      // The disposer removed both listeners once the promise settled - a
+      // leaked pair would still fire (and still try to signal a dead pid) on
+      // every SIGINT/SIGTERM this test worker receives afterwards.
+      expect(process.listenerCount("SIGINT")).toBe(sigintBefore);
+      expect(process.listenerCount("SIGTERM")).toBe(sigtermBefore);
+    } finally {
+      killSpy.mockRestore();
+    }
+
+    // Ablation: in `relayTerminationSignals`, change `process.kill(-pid,
+    // signal)` to `process.kill(pid, signal)` → this test fails: `killSpy` is
+    // called with the positive pid instead of `-pid`.
+  });
+
+  it("a child with no pid installs no relay - process.kill is never called", async () => {
+    // The spawn-failure shape: Node can hand back a `ChildProcess` with no
+    // pid at all. `relayTerminationSignals` refuses to install anything for
+    // it rather than signalling a pid that does not exist.
+    mocks.cgroup = V2_HOST_UNIT_CGROUP;
+    mocks.packaged = true;
+    process.argv = packagedArgv() as string[];
+    process.execPath = "/slot/traycer";
+    process.execArgv = [];
+    spawnMocks.childPid = undefined;
+    spawnMocks.respond = null;
+    const sigintBefore = process.listenerCount("SIGINT");
+
+    const promise = relocateOutOfHostCgroupIfNeeded("host update", {});
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    try {
+      process.emit("SIGINT");
+      expect(killSpy).not.toHaveBeenCalled();
+      // No listener was installed at all - not merely one that chose to do
+      // nothing.
+      expect(process.listenerCount("SIGINT")).toBe(sigintBefore);
+
+      const fake = spawnMocks.lastFake;
+      if (fake === null) throw new Error("spawn was never called");
+      fake.child.emit("spawn");
+      fake.ack.end("\n");
+      await new Promise((resolve) => setImmediate(resolve));
+      fake.child.emit("exit", 0, null);
+
+      await expect(promise).resolves.toEqual({
+        kind: "completed",
+        exitCode: 0,
+      });
+    } finally {
+      killSpy.mockRestore();
+    }
   });
 
   it("rejects with E_SERVICE_CONTROL_FAILED when the child emits a spawn error", async () => {
@@ -809,6 +939,13 @@ describe("acknowledgeRelocationEntry", () => {
 
   afterEach(() => {
     delete process.env[TRAYCER_CLI_RELOCATED_ENV];
+    // The function adds one 'error' listener to stdout/stderr per call and
+    // never removes it (there is nowhere left to report a later failure to,
+    // since the place we would report it to is what vanished) - a test file
+    // calling it repeatedly would otherwise accumulate listeners and trip
+    // Node's max-listeners warning.
+    process.stdout.removeAllListeners("error");
+    process.stderr.removeAllListeners("error");
   });
 
   it("writes one byte to fd 3 on a relocated run", () => {
@@ -830,6 +967,29 @@ describe("acknowledgeRelocationEntry", () => {
     process.env[TRAYCER_CLI_RELOCATED_ENV] = "1";
     mocks.ackWriteError = Object.assign(new Error("EBADF"), { code: "EBADF" });
     expect(() => acknowledgeRelocationEntry()).not.toThrow();
+  });
+
+  it("swallows an EIO write on stdout without throwing - the PTY master closed underneath a relocated child", () => {
+    process.env[TRAYCER_CLI_RELOCATED_ENV] = "1";
+    acknowledgeRelocationEntry();
+    const eio = Object.assign(new Error("write EIO"), { code: "EIO" });
+    expect(() => process.stdout.emit("error", eio)).not.toThrow();
+
+    // Ablation: in `acknowledgeRelocationEntry`, remove the
+    // `process.stdout.on("error", ignore);` line → this test fails: an
+    // unhandled 'error' event on a stream throws, which would kill the
+    // update at exactly the moment relocation exists to survive.
+  });
+
+  it("swallows an EIO write on stderr without throwing", () => {
+    process.env[TRAYCER_CLI_RELOCATED_ENV] = "1";
+    acknowledgeRelocationEntry();
+    const eio = Object.assign(new Error("write EIO"), { code: "EIO" });
+    expect(() => process.stderr.emit("error", eio)).not.toThrow();
+
+    // Ablation: in `acknowledgeRelocationEntry`, remove the
+    // `process.stderr.on("error", ignore);` line → this test fails the same
+    // way as its stdout twin above.
   });
 });
 

--- a/clients/traycer-cli/src/host/__tests__/cgroup-relocation.test.ts
+++ b/clients/traycer-cli/src/host/__tests__/cgroup-relocation.test.ts
@@ -323,7 +323,7 @@ describe("relocateOutOfHostCgroupIfNeeded", () => {
     process.execArgv = [];
     spawnMocks.respond = acknowledgeThenExit(0);
 
-    const result = await relocateOutOfHostCgroupIfNeeded("host update");
+    const result = await relocateOutOfHostCgroupIfNeeded("host update", {});
 
     expect(result).toEqual({ kind: "completed", exitCode: 0 });
     expect(spawnMocks.recorded).toHaveLength(1);
@@ -376,7 +376,7 @@ describe("relocateOutOfHostCgroupIfNeeded", () => {
     // `completed`, not a rejection: the relocated CLI ran and emitted its own
     // terminal envelope, so this process forwards the code and writes nothing.
     await expect(
-      relocateOutOfHostCgroupIfNeeded("host update"),
+      relocateOutOfHostCgroupIfNeeded("host update", {}),
     ).resolves.toEqual({ kind: "completed", exitCode: 3 });
   });
 
@@ -389,7 +389,7 @@ describe("relocateOutOfHostCgroupIfNeeded", () => {
     spawnMocks.respond = acknowledgeThenExit(null);
 
     await expect(
-      relocateOutOfHostCgroupIfNeeded("host update"),
+      relocateOutOfHostCgroupIfNeeded("host update", {}),
     ).resolves.toEqual({ kind: "completed", exitCode: 1 });
 
     // Ablation: in `runInTransientScope`, change `resolve(code ?? 1)` to
@@ -419,7 +419,7 @@ describe("relocateOutOfHostCgroupIfNeeded", () => {
     };
 
     await expect(
-      relocateOutOfHostCgroupIfNeeded("host update"),
+      relocateOutOfHostCgroupIfNeeded("host update", {}),
     ).rejects.toMatchObject({
       code: "E_SERVICE_CONTROL_FAILED",
       details: { systemdRunExitCode: 1 },
@@ -456,7 +456,7 @@ describe("relocateOutOfHostCgroupIfNeeded", () => {
     };
 
     await expect(
-      relocateOutOfHostCgroupIfNeeded("host update"),
+      relocateOutOfHostCgroupIfNeeded("host update", {}),
     ).resolves.toEqual({ kind: "completed", exitCode: 7 });
     expect(loggerMock.info).toHaveBeenCalledWith(
       "relocated host-stopping command into a transient scope",
@@ -488,7 +488,7 @@ describe("relocateOutOfHostCgroupIfNeeded", () => {
 
     let caught: unknown = null;
     try {
-      await relocateOutOfHostCgroupIfNeeded("host update");
+      await relocateOutOfHostCgroupIfNeeded("host update", {});
     } catch (error) {
       caught = error;
     }
@@ -520,14 +520,14 @@ describe("relocateOutOfHostCgroupIfNeeded", () => {
     };
 
     await expect(
-      relocateOutOfHostCgroupIfNeeded("host update"),
+      relocateOutOfHostCgroupIfNeeded("host update", {}),
     ).resolves.toEqual({ kind: "completed", exitCode: 0 });
   });
 
   it("does nothing and never spawns for a relocated scope cgroup (run-*.scope)", async () => {
     mocks.cgroup = SCOPE_CGROUP;
     await expect(
-      relocateOutOfHostCgroupIfNeeded("host update"),
+      relocateOutOfHostCgroupIfNeeded("host update", {}),
     ).resolves.toEqual({ kind: "not-needed" });
     expect(spawnMocks.recorded).toHaveLength(0);
   });
@@ -538,7 +538,7 @@ describe("relocateOutOfHostCgroupIfNeeded", () => {
       false,
     );
     await expect(
-      relocateOutOfHostCgroupIfNeeded("agent turn-ended-from-hook"),
+      relocateOutOfHostCgroupIfNeeded("agent turn-ended-from-hook", {}),
     ).resolves.toEqual({ kind: "not-needed" });
     expect(spawnMocks.recorded).toHaveLength(0);
 
@@ -552,7 +552,7 @@ describe("relocateOutOfHostCgroupIfNeeded", () => {
     mocks.cgroup = V2_HOST_UNIT_CGROUP;
     process.env[TRAYCER_CLI_RELOCATED_ENV] = "1";
     await expect(
-      relocateOutOfHostCgroupIfNeeded("host update"),
+      relocateOutOfHostCgroupIfNeeded("host update", {}),
     ).resolves.toEqual({ kind: "not-needed" });
     expect(spawnMocks.recorded).toHaveLength(0);
   });
@@ -561,7 +561,7 @@ describe("relocateOutOfHostCgroupIfNeeded", () => {
     mocks.platform = "darwin";
     mocks.cgroup = V2_HOST_UNIT_CGROUP;
     await expect(
-      relocateOutOfHostCgroupIfNeeded("host update"),
+      relocateOutOfHostCgroupIfNeeded("host update", {}),
     ).resolves.toEqual({ kind: "not-needed" });
     expect(spawnMocks.recorded).toHaveLength(0);
   });
@@ -587,7 +587,7 @@ describe("relocateOutOfHostCgroupIfNeeded", () => {
     process.execArgv = [];
 
     await expect(
-      relocateOutOfHostCgroupIfNeeded("host install"),
+      relocateOutOfHostCgroupIfNeeded("host install", {}),
     ).rejects.toMatchObject({
       code: "E_SERVICE_CONTROL_FAILED",
       details: { argument: "/tmp/${BUILD}/host.tar.gz" },
@@ -618,7 +618,7 @@ describe("relocateOutOfHostCgroupIfNeeded", () => {
     spawnMocks.respond = acknowledgeThenExit(0);
 
     await expect(
-      relocateOutOfHostCgroupIfNeeded("host install"),
+      relocateOutOfHostCgroupIfNeeded("host install", {}),
     ).resolves.toEqual({ kind: "completed", exitCode: 0 });
     expect(spawnMocks.recorded).toHaveLength(1);
   });
@@ -629,7 +629,7 @@ describe("relocateOutOfHostCgroupIfNeeded", () => {
     // written, and the stop kills the process issuing it.
     mocks.cgroup = { errno: "EACCES" };
     await expect(
-      relocateOutOfHostCgroupIfNeeded("host update"),
+      relocateOutOfHostCgroupIfNeeded("host update", {}),
     ).rejects.toMatchObject({
       code: "E_SERVICE_CONTROL_FAILED",
       details: { path: "/proc/self/cgroup" },
@@ -648,10 +648,156 @@ describe("relocateOutOfHostCgroupIfNeeded", () => {
     for (const errno of ["ENOENT", "ENOTDIR"]) {
       mocks.cgroup = { errno };
       await expect(
-        relocateOutOfHostCgroupIfNeeded("host update"),
+        relocateOutOfHostCgroupIfNeeded("host update", {}),
       ).resolves.toEqual({ kind: "not-needed" });
     }
     expect(spawnMocks.recorded).toHaveLength(0);
+  });
+
+  // The four commands whose reachability now depends on the parsed options,
+  // not just the command path (Codex review on #1755: command path alone
+  // relocated bytes-only forms that never reach a stop, exposing them to the
+  // `$` refusal and the "scope never started" refusal for nothing). Each gets
+  // a positive (skips relocation) and a negative (still relocates) case.
+  describe("option-gated commands", () => {
+    it("host install --no-service-register: not-needed, no refusal, no spawn - even with a $ in --from", async () => {
+      // The exact form from the Codex report. A composed --from path with a
+      // `$` WOULD trip `assertArgvSurvivesSystemdRun` if this reached
+      // relocation - it must not, because `createBytesOnlyInstallLifecycle`
+      // never calls `controller.stop` on any platform.
+      mocks.cgroup = V2_HOST_UNIT_CGROUP;
+      mocks.packaged = true;
+      process.argv = [
+        "/slot/traycer",
+        "/slot/traycer",
+        "host",
+        "install",
+        "--from",
+        "/tmp/${BUILD}/host.tar.gz",
+        "--no-service-register",
+      ];
+      process.execPath = "/slot/traycer";
+      process.execArgv = [];
+
+      await expect(
+        relocateOutOfHostCgroupIfNeeded("host install", {
+          serviceRegister: false,
+        }),
+      ).resolves.toEqual({ kind: "not-needed" });
+      expect(spawnMocks.recorded).toHaveLength(0);
+
+      // Ablation (§4): in `HOST_STOPPING_COMMANDS`, change the `host install`
+      // entry from `(options) => options.serviceRegister !== false` to
+      // `ALWAYS_STOPS` → this test fails: the `$` in `--from` now reaches
+      // `assertArgvSurvivesSystemdRun` and the call rejects with
+      // `E_SERVICE_CONTROL_FAILED` instead of resolving `not-needed`.
+    });
+
+    it("host install without --no-service-register still relocates (positive control)", async () => {
+      mocks.cgroup = V2_HOST_UNIT_CGROUP;
+      mocks.packaged = true;
+      process.argv = packagedArgv() as string[];
+      process.execPath = "/slot/traycer";
+      process.execArgv = [];
+      spawnMocks.respond = acknowledgeThenExit(0);
+
+      await expect(
+        relocateOutOfHostCgroupIfNeeded("host install", {}),
+      ).resolves.toEqual({ kind: "completed", exitCode: 0 });
+      expect(spawnMocks.recorded).toHaveLength(1);
+    });
+
+    it("host ensure --no-service-register: not-needed, no spawn", async () => {
+      // `provisionHost`'s bytes-only path is the ONLY reachable one when
+      // `serviceRegister` is false - its register/start branches cannot run.
+      mocks.cgroup = V2_HOST_UNIT_CGROUP;
+      await expect(
+        relocateOutOfHostCgroupIfNeeded("host ensure", {
+          serviceRegister: false,
+        }),
+      ).resolves.toEqual({ kind: "not-needed" });
+      expect(spawnMocks.recorded).toHaveLength(0);
+    });
+
+    it("host ensure without --no-service-register still relocates (positive control)", async () => {
+      mocks.cgroup = V2_HOST_UNIT_CGROUP;
+      mocks.packaged = true;
+      process.argv = packagedArgv() as string[];
+      process.execPath = "/slot/traycer";
+      process.execArgv = [];
+      spawnMocks.respond = acknowledgeThenExit(0);
+
+      await expect(
+        relocateOutOfHostCgroupIfNeeded("host ensure", {}),
+      ).resolves.toEqual({ kind: "completed", exitCode: 0 });
+      expect(spawnMocks.recorded).toHaveLength(1);
+    });
+
+    it("host apply --no-service: not-needed, no spawn", async () => {
+      // `lifecycle: null` is passed to the commit, so there is no
+      // `beforeSwap` - and therefore no `controller.stop` - on any platform.
+      mocks.cgroup = V2_HOST_UNIT_CGROUP;
+      await expect(
+        relocateOutOfHostCgroupIfNeeded("host apply", { service: false }),
+      ).resolves.toEqual({ kind: "not-needed" });
+      expect(spawnMocks.recorded).toHaveLength(0);
+    });
+
+    it("host apply without --no-service still relocates (positive control)", async () => {
+      mocks.cgroup = V2_HOST_UNIT_CGROUP;
+      mocks.packaged = true;
+      process.argv = packagedArgv() as string[];
+      process.execPath = "/slot/traycer";
+      process.execArgv = [];
+      spawnMocks.respond = acknowledgeThenExit(0);
+
+      await expect(
+        relocateOutOfHostCgroupIfNeeded("host apply", {}),
+      ).resolves.toEqual({ kind: "completed", exitCode: 0 });
+      expect(spawnMocks.recorded).toHaveLength(1);
+    });
+
+    it("host uninstall without --all: not-needed, no spawn - the default path tears nothing down", async () => {
+      mocks.cgroup = V2_HOST_UNIT_CGROUP;
+      await expect(
+        relocateOutOfHostCgroupIfNeeded("host uninstall", {}),
+      ).resolves.toEqual({ kind: "not-needed" });
+      expect(spawnMocks.recorded).toHaveLength(0);
+    });
+
+    it("host uninstall --all: still relocates (positive control) - the only inverted entry, where true means stop", async () => {
+      mocks.cgroup = V2_HOST_UNIT_CGROUP;
+      mocks.packaged = true;
+      process.argv = packagedArgv() as string[];
+      process.execPath = "/slot/traycer";
+      process.execArgv = [];
+      spawnMocks.respond = acknowledgeThenExit(0);
+
+      await expect(
+        relocateOutOfHostCgroupIfNeeded("host uninstall", { all: true }),
+      ).resolves.toEqual({ kind: "completed", exitCode: 0 });
+      expect(spawnMocks.recorded).toHaveLength(1);
+    });
+
+    it("host uninstall polarity is explicit: {all: false} skips, {all: true} relocates, in the same cgroup", async () => {
+      mocks.cgroup = V2_HOST_UNIT_CGROUP;
+
+      await expect(
+        relocateOutOfHostCgroupIfNeeded("host uninstall", { all: false }),
+      ).resolves.toEqual({ kind: "not-needed" });
+      expect(spawnMocks.recorded).toHaveLength(0);
+
+      mocks.packaged = true;
+      process.argv = packagedArgv() as string[];
+      process.execPath = "/slot/traycer";
+      process.execArgv = [];
+      spawnMocks.respond = acknowledgeThenExit(0);
+
+      await expect(
+        relocateOutOfHostCgroupIfNeeded("host uninstall", { all: true }),
+      ).resolves.toEqual({ kind: "completed", exitCode: 0 });
+      expect(spawnMocks.recorded).toHaveLength(1);
+    });
   });
 });
 

--- a/clients/traycer-cli/src/host/__tests__/cgroup-relocation.test.ts
+++ b/clients/traycer-cli/src/host/__tests__/cgroup-relocation.test.ts
@@ -498,7 +498,7 @@ describe("relocateOutOfHostCgroupIfNeeded", () => {
     // that never started.
   });
 
-  it("forwards SIGINT/SIGTERM to the relocated child's PROCESS GROUP (-pid), and disposes both listeners once settled", async () => {
+  it("forwards SIGINT to the relocated child's PROCESS GROUP (-pid), and disposes the listener once settled", async () => {
     // Only needed because of `detached`: while the child shared this
     // process's group, a terminal's Ctrl-C reached both at once. Detached,
     // it does not - so without this relay Ctrl-C would kill the waiting
@@ -510,17 +510,16 @@ describe("relocateOutOfHostCgroupIfNeeded", () => {
     process.execArgv = [];
     spawnMocks.childPid = 4242;
     // No `respond` queued: this test drives the fake child by hand so it can
-    // emit the signals BEFORE the child ever exits.
+    // emit the signal BEFORE the child ever exits.
     spawnMocks.respond = null;
-    // Captured BEFORE the relay installs its own pair, so the "disposed"
+    // Captured BEFORE the relay installs its own listener, so the "disposed"
     // assertion below proves the count returns to what it actually was
     // rather than to a baseline that already included the relay itself.
     const sigintBefore = process.listenerCount("SIGINT");
-    const sigtermBefore = process.listenerCount("SIGTERM");
 
     const promise = relocateOutOfHostCgroupIfNeeded("host update", {});
     // Let the async chain (cgroup read, isPackagedRun, spawn) run far enough
-    // to reach `relayTerminationSignals` before this test drives any signal.
+    // to reach `relayInterruptSignal` before this test drives any signal.
     await Promise.resolve();
     await Promise.resolve();
     await Promise.resolve();
@@ -528,41 +527,112 @@ describe("relocateOutOfHostCgroupIfNeeded", () => {
     // Spied BEFORE emitting: an unspied call would signal this test runner's
     // own process group.
     const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
-    try {
-      process.emit("SIGINT");
-      process.emit("SIGTERM");
-      expect(killSpy).toHaveBeenNthCalledWith(1, -4242, "SIGINT");
-      expect(killSpy).toHaveBeenNthCalledWith(2, -4242, "SIGTERM");
-
+    // Settling the fake child lives in its own `finally`-reached step: if an
+    // assertion above throws, the relay's listener must still be disposed of
+    // before this test ends, or it leaks into every test that runs after -
+    // exactly what happened while running this round's ablation.
+    let settled = false;
+    const settle = async (): Promise<void> => {
+      if (settled) return;
+      settled = true;
       const fake = spawnMocks.lastFake;
-      if (fake === null) throw new Error("spawn was never called");
+      if (fake === null) return;
       fake.child.emit("spawn");
       fake.ack.end("\n");
       await new Promise((resolve) => setImmediate(resolve));
       fake.child.emit("exit", 0, null);
+    };
+    try {
+      process.emit("SIGINT");
+      expect(killSpy).toHaveBeenCalledTimes(1);
+      expect(killSpy).toHaveBeenCalledWith(-4242, "SIGINT");
 
+      await settle();
       await expect(promise).resolves.toEqual({
         kind: "completed",
         exitCode: 0,
       });
-      // The disposer removed both listeners once the promise settled - a
-      // leaked pair would still fire (and still try to signal a dead pid) on
-      // every SIGINT/SIGTERM this test worker receives afterwards.
+      // The disposer removed the listener once the promise settled - a
+      // leaked one would still fire (and still try to signal a dead pid) on
+      // every SIGINT this test worker receives afterwards.
       expect(process.listenerCount("SIGINT")).toBe(sigintBefore);
-      expect(process.listenerCount("SIGTERM")).toBe(sigtermBefore);
     } finally {
+      await settle();
       killSpy.mockRestore();
     }
 
-    // Ablation: in `relayTerminationSignals`, change `process.kill(-pid,
-    // signal)` to `process.kill(pid, signal)` → this test fails: `killSpy` is
-    // called with the positive pid instead of `-pid`.
+    // Ablation: in `relayInterruptSignal`, change `process.kill(-pid,
+    // "SIGINT")` to `process.kill(pid, "SIGINT")` → this test fails:
+    // `killSpy` is called with the positive pid instead of `-pid`.
+  });
+
+  it("does NOT forward SIGTERM - unconditionally, because the likeliest sender is the host unit's own stop and relaying that would kill the update the child was sent away to finish", async () => {
+    // The P1 this test pins: `systemctl --user stop`'s default
+    // `KillMode=control-group` SIGTERMs every process in the host unit's
+    // cgroup, this waiting parent included. Forwarding that SIGTERM to the
+    // child's process group would hand the relocated update its own stop
+    // signal at exactly the moment relocation exists to survive it.
+    mocks.cgroup = V2_HOST_UNIT_CGROUP;
+    mocks.packaged = true;
+    process.argv = packagedArgv() as string[];
+    process.execPath = "/slot/traycer";
+    process.execArgv = [];
+    spawnMocks.childPid = 4242;
+    spawnMocks.respond = null;
+    // Captured BEFORE the relay runs, so this proves no SIGTERM listener was
+    // installed AT ALL - the stronger pin, since a listener that merely
+    // chooses not to fire today is a bug waiting to come back.
+    const sigtermBefore = process.listenerCount("SIGTERM");
+
+    const promise = relocateOutOfHostCgroupIfNeeded("host update", {});
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    // Settling the fake child lives in its own `finally`-reached step, same
+    // as the SIGINT test above: if an assertion throws (as the ablation for
+    // THIS test is designed to make happen), the promise must still be
+    // driven to completion, or this test's own relay listeners leak into
+    // every test that runs after it.
+    let settled = false;
+    const settle = async (): Promise<void> => {
+      if (settled) return;
+      settled = true;
+      const fake = spawnMocks.lastFake;
+      if (fake === null) return;
+      fake.child.emit("spawn");
+      fake.ack.end("\n");
+      await new Promise((resolve) => setImmediate(resolve));
+      fake.child.emit("exit", 0, null);
+    };
+    try {
+      expect(process.listenerCount("SIGTERM")).toBe(sigtermBefore);
+      process.emit("SIGTERM");
+      expect(killSpy).not.toHaveBeenCalled();
+
+      await settle();
+      await expect(promise).resolves.toEqual({
+        kind: "completed",
+        exitCode: 0,
+      });
+    } finally {
+      await settle();
+      killSpy.mockRestore();
+    }
+
+    // Ablation (§ablation table): reinstate a SIGTERM listener/forwarding in
+    // `relayInterruptSignal` → this test reddens on the FIRST assertion
+    // (`listenerCount("SIGTERM")` grows by one the moment the relay
+    // installs), before the emitted-signal assertion even runs. Once the
+    // isolation fix above is in place, THIS is the only test that reddens -
+    // the "no pid" test below must not be collateral damage any more.
   });
 
   it("a child with no pid installs no relay - process.kill is never called", async () => {
     // The spawn-failure shape: Node can hand back a `ChildProcess` with no
-    // pid at all. `relayTerminationSignals` refuses to install anything for
-    // it rather than signalling a pid that does not exist.
+    // pid at all. `relayInterruptSignal` refuses to install anything for it
+    // rather than signalling a pid that does not exist.
     mocks.cgroup = V2_HOST_UNIT_CGROUP;
     mocks.packaged = true;
     process.argv = packagedArgv() as string[];

--- a/clients/traycer-cli/src/host/cgroup-relocation.ts
+++ b/clients/traycer-cli/src/host/cgroup-relocation.ts
@@ -1,0 +1,333 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { platform as osPlatform } from "node:os";
+import { config } from "../config";
+import { createCliLogger, errorFromUnknown, type ILogger } from "../logger";
+import { CLI_ERROR_CODES, cliError, type CliError } from "../runner/errors";
+import { isPackagedRun } from "../store/well-known-cli";
+
+/**
+ * Linux: move a command that is about to stop the host OUT of the host's own
+ * cgroup before it runs.
+ *
+ * The host spawns the CLI for maintenance RPCs, for the reconciler, and for a
+ * person's command in a Traycer-hosted terminal. Every one of those children
+ * shares the host unit's cgroup, and the unit is `KillMode=control-group`: the
+ * `systemctl --user stop` the command itself issues kills the process that
+ * issued it, mid-update. The host is down, the updater is gone, and nothing
+ * finishes the swap or starts the new bytes.
+ *
+ * `systemd-run --user --scope` is the fix because a scope EXECS IN PLACE: the
+ * re-spawned CLI lands in its own `run-*.scope`, a sibling of the host unit
+ * rather than a child, and no wrapper process is left behind inside the host's
+ * cgroup. `setsid` does not help - it changes the session, not the cgroup - and
+ * relaxing the unit to `KillMode=process` would free every agent the host has
+ * spawned, not just this one command.
+ *
+ * Two lines of defence, in this order:
+ *
+ *   1. this module's relocation, which moves the process that is going to issue
+ *      the stop;
+ *   2. `assertNotInsideHostUnit` in the stop-intent wrapper (`service/index.ts`),
+ *      which re-reads the cgroup and refuses the stop outright if we are still
+ *      inside the unit.
+ *
+ * The second is what makes every failure mode closed rather than silent: no
+ * `systemd-run` on PATH, no user manager, a scope that failed to move us, or a
+ * recursion flag set without a real cgroup change all end at the refusal with
+ * the host still up. Which is also why the relocation env flag is never taken
+ * as evidence that the move happened - only the cgroup is.
+ */
+
+/**
+ * The commands whose bodies reach a host stop, keyed by Commander command path.
+ *
+ * Checked once in `withRunner`, the same shape as `READONLY_REFUSED_COMMANDS`,
+ * rather than at each stop site: the relocation has to happen BEFORE the
+ * command body so the relocated child - not the parent that is about to die -
+ * owns the CLI lock, the update contender claim, the dispatch ACK and the
+ * progress marker.
+ *
+ * `host start` is deliberately absent: it IS the unit's main process and never
+ * stops anything. So are the `agent *-from-hook` commands, which run inside an
+ * agent process and are supposed to die with the host.
+ */
+export const HOST_STOPPING_COMMANDS: ReadonlySet<string> = new Set([
+  "host update",
+  "host apply",
+  "host install",
+  "host ensure",
+  "host restart",
+  "host stop",
+  "host uninstall",
+  "host free-port-and-restart",
+  "host service uninstall",
+]);
+
+/**
+ * Recursion flag set on the relocated child.
+ *
+ * It stops a child from relocating itself again on a machine where the move
+ * silently did nothing. It is NOT proof that the move worked, and nothing in
+ * this file or in the guard treats it as such.
+ */
+export const TRAYCER_CLI_RELOCATED_ENV = "TRAYCER_CLI_RELOCATED";
+
+const SYSTEMD_RUN = "systemd-run";
+
+// `--quiet` keeps systemd-run's own "Running as unit" chatter off a stream the
+// child needs for NDJSON; `--collect` only garbage-collects the scope once it
+// exits. Neither is what makes the child survive - the cgroup separation is.
+const SYSTEMD_RUN_SCOPE_ARGS: readonly string[] = [
+  "--user",
+  "--scope",
+  "--quiet",
+  "--collect",
+  "--",
+];
+
+const PROC_SELF_CGROUP = "/proc/self/cgroup";
+
+const HOST_UNIT_PREFIX = "ai.traycer.host";
+const SYSTEMD_SERVICE_SUFFIX = ".service";
+
+const NOT_NEEDED: CgroupRelocation = { kind: "not-needed" };
+
+/** The host unit this process is running inside, as `/proc/self/cgroup` reports it. */
+export interface HostUnitCgroup {
+  // The unit as systemd names it, dev slots included
+  // (`ai.traycer.host.staging.service`). What the refusal message names, so an
+  // operator can act on the machine in front of them.
+  readonly unit: string;
+  // The full cgroup path the unit was found in, for the error details.
+  readonly path: string;
+}
+
+export type CgroupRelocation =
+  | { readonly kind: "not-needed" }
+  | { readonly kind: "completed"; readonly exitCode: number };
+
+/**
+ * Relocate, and report whether the command still has to run here.
+ *
+ * `completed` means the child ran the whole command and this process must exit
+ * with its code without running anything itself. `not-needed` means nothing was
+ * moved and the caller runs the command in place - which covers every machine
+ * where nothing can kill us for issuing a stop: a host started by hand, WSL
+ * without systemd, a container, and every non-Linux platform.
+ *
+ * Throws `SERVICE_CONTROL_FAILED` when the move was needed and could not be
+ * made. It deliberately does not fall through to running the command: doing so
+ * is what kills the host-spawned updater mid-update.
+ */
+export async function relocateOutOfHostCgroupIfNeeded(
+  commandPath: string,
+): Promise<CgroupRelocation> {
+  if (osPlatform() !== "linux") return NOT_NEEDED;
+  if (!HOST_STOPPING_COMMANDS.has(commandPath)) return NOT_NEEDED;
+  if ((process.env[TRAYCER_CLI_RELOCATED_ENV] ?? "").length > 0) {
+    return NOT_NEEDED;
+  }
+  const inside = await readHostUnitCgroup();
+  if (inside === null) return NOT_NEEDED;
+  const argv = relocationArgv({
+    packaged: await isPackagedRun(),
+    execPath: process.execPath,
+    execArgv: process.execArgv,
+    argv: process.argv,
+  });
+  return {
+    kind: "completed",
+    exitCode: await runInTransientScope(argv, commandPath, inside),
+  };
+}
+
+/**
+ * The second line: refuse a stop issued from inside the host's own cgroup.
+ *
+ * Called from the stop-intent wrapper BEFORE the intent is announced, so a
+ * refusal leaves no record of a stop that never happened.
+ */
+export async function assertNotInsideHostUnit(): Promise<void> {
+  if (osPlatform() !== "linux") return;
+  const inside = await readHostUnitCgroup();
+  if (inside === null) return;
+  throw cliError({
+    code: CLI_ERROR_CODES.SERVICE_CONTROL_FAILED,
+    message:
+      `refusing to stop ${inside.unit} from inside its own cgroup; ` +
+      "run this from a shell outside the Traycer host, or update the Traycer CLI",
+    details: { cgroup: inside.path, unit: inside.unit },
+    exitCode: 1,
+  });
+}
+
+/** How this process was launched, as `relocationArgv` needs to see it. */
+export interface RelocationRun {
+  readonly packaged: boolean;
+  readonly execPath: string;
+  readonly execArgv: readonly string[];
+  readonly argv: readonly string[];
+}
+
+/**
+ * The argv to hand `systemd-run`, built BY RUN KIND rather than by copying
+ * `process.argv`.
+ *
+ * The CLI's own convention is that command tokens start at `process.argv[2]`
+ * (`argvRequestsJson`, and the script-entry guard that treats `argv[1]` as the
+ * binary or script). The two run kinds put different things in front of that:
+ *
+ *   - packaged (SEA): `argv[1]` is the binary path the loader puts there, so
+ *     copying it would hand Commander `/slot/traycer` as the first command
+ *     token and fail the parse before the update ever starts;
+ *   - interpreter (tsx/node in a tree run): the loader flags in `execArgv` and
+ *     the script path in `argv[1]` are both needed, or the child has no CLI to
+ *     run.
+ *
+ * Every command flag - `--json`, `--ack-nonce`, `--version`, the runner flags -
+ * lives in `argv.slice(2)` and travels unchanged either way.
+ */
+export function relocationArgv(run: RelocationRun): readonly string[] {
+  return run.packaged
+    ? [run.execPath, ...run.argv.slice(2)]
+    : [run.execPath, ...run.execArgv, ...run.argv.slice(1)];
+}
+
+/**
+ * The host unit named by this process's cgroup, or `null`.
+ *
+ * Both cgroup layouts are read, and EVERY line that can carry unit placement is
+ * checked rather than the first one found: a hybrid machine reports a unified
+ * `0::/` line beside the `name=systemd` v1 hierarchy systemd is actually
+ * placing units in, and trusting the unified line there would answer "not
+ * inside a host unit" for a process that very much is.
+ */
+export function findHostUnitCgroup(contents: string): HostUnitCgroup | null {
+  for (const line of contents.split("\n")) {
+    const path = systemdCgroupPath(line);
+    if (path === null) continue;
+    const unit = hostUnitSegment(path);
+    if (unit !== null) return { unit, path };
+  }
+  return null;
+}
+
+async function readHostUnitCgroup(): Promise<HostUnitCgroup | null> {
+  let contents: string;
+  try {
+    contents = await readFile(PROC_SELF_CGROUP, "utf8");
+  } catch {
+    // No `/proc/self/cgroup` at all means no cgroup that can kill us, which is
+    // the same answer as "not inside a host unit".
+    return null;
+  }
+  return findHostUnitCgroup(contents);
+}
+
+// `<hierarchy>:<controllers>:<path>`. The unified v2 line is `0::<path>`; on v1
+// only the systemd hierarchy carries unit placement (`name=systemd`, or a bare
+// `systemd` on kernels that drop the prefix), and the controller hierarchies
+// beside it do not.
+function systemdCgroupPath(line: string): string | null {
+  const firstColon = line.indexOf(":");
+  if (firstColon < 0) return null;
+  const secondColon = line.indexOf(":", firstColon + 1);
+  if (secondColon < 0) return null;
+  const hierarchy = line.slice(0, firstColon);
+  const controllers = line.slice(firstColon + 1, secondColon);
+  const path = line.slice(secondColon + 1).trim();
+  if (path.length === 0) return null;
+  if (hierarchy === "0" && controllers.length === 0) return path;
+  return controllers === "name=systemd" || controllers === "systemd"
+    ? path
+    : null;
+}
+
+// A path segment naming a host unit - `ai.traycer.host.service` and every dev
+// slot (`ai.traycer.host.staging.service`). A relocated child sits in a
+// `run-*.scope` segment instead and matches nothing here, which is what makes
+// the guard's re-read meaningful.
+function hostUnitSegment(path: string): string | null {
+  for (const segment of path.split("/")) {
+    if (
+      segment.startsWith(HOST_UNIT_PREFIX) &&
+      segment.endsWith(SYSTEMD_SERVICE_SUFFIX)
+    ) {
+      return segment;
+    }
+  }
+  return null;
+}
+
+/**
+ * Run the command in a transient scope and forward its exit code.
+ *
+ * The parent WAITS, attached, and installs no signal forwarding. A person in a
+ * Traycer-hosted terminal keeps seeing output through the inherited stdio until
+ * the stop kills their terminal; a host-spawned parent dies with the cgroup,
+ * which is the expected end for it and is why nothing here tries to shepherd
+ * the child. Exiting immediately instead would lose that output and hand the
+ * host's `exited` promise a false early settle.
+ *
+ * `systemd-run` exiting non-zero before it execs is indistinguishable from the
+ * command's own failure and is forwarded as such; only a failure to spawn it at
+ * all (no such binary, no permission) is reported as the relocation failure it
+ * is.
+ */
+async function runInTransientScope(
+  argv: readonly string[],
+  commandPath: string,
+  inside: HostUnitCgroup,
+): Promise<number> {
+  const logger = createCliLogger(config.environment);
+  let child: ChildProcess;
+  try {
+    child = spawn(SYSTEMD_RUN, [...SYSTEMD_RUN_SCOPE_ARGS, ...argv], {
+      // Inherited, not piped: under `--json` the child owns the NDJSON stream
+      // and this process writes nothing to it.
+      stdio: "inherit",
+      env: { ...process.env, [TRAYCER_CLI_RELOCATED_ENV]: "1" },
+    });
+  } catch (cause) {
+    throw relocationFailed(logger, commandPath, inside, cause);
+  }
+  return await new Promise<number>((resolve, reject) => {
+    child.once("spawn", () => {
+      logger.info("relocated host-stopping command into a transient scope", {
+        command: commandPath,
+        unit: inside.unit,
+      });
+    });
+    child.once("error", (cause) => {
+      reject(relocationFailed(logger, commandPath, inside, cause));
+    });
+    // A child killed by a signal reports `null`, which is a failure the caller
+    // has to see as one.
+    child.once("close", (code) => resolve(code ?? 1));
+  });
+}
+
+function relocationFailed(
+  logger: ILogger,
+  commandPath: string,
+  inside: HostUnitCgroup,
+  cause: unknown,
+): CliError {
+  // The cause is a spawn errno, useful for diagnosis and nothing else; the
+  // message the operator acts on is the same whichever errno it was.
+  logger.debug("Failed to relocate a host-stopping command", {
+    command: commandPath,
+    unit: inside.unit,
+    cause: errorFromUnknown(cause).message,
+  });
+  return cliError({
+    code: CLI_ERROR_CODES.SERVICE_CONTROL_FAILED,
+    message:
+      `could not move '${commandPath}' out of the ${inside.unit} cgroup with ${SYSTEMD_RUN}, ` +
+      "and running it here would stop this process along with the host. " +
+      "Run it again from a shell outside the Traycer host.",
+    details: { command: commandPath, cgroup: inside.path, unit: inside.unit },
+    exitCode: 1,
+  });
+}

--- a/clients/traycer-cli/src/host/cgroup-relocation.ts
+++ b/clients/traycer-cli/src/host/cgroup-relocation.ts
@@ -53,7 +53,7 @@ import { isPackagedRun } from "../store/well-known-cli";
  * Whether THIS invocation of an allowlisted command can reach a host stop,
  * given the options Commander parsed for it.
  *
- * Command path alone is too coarse. Four of the nine have a documented
+ * Command path alone is too coarse. Four of the ten have a documented
  * bytes-only or leave-it-running form whose body provably never reaches
  * `withStopIntent` or `killHostProcessTree`, and relocating those buys nothing
  * while exposing them to two refusals they cannot deserve: a `$` in a `--from`
@@ -77,7 +77,10 @@ const ALWAYS_STOPS: HostStopReachable = () => true;
  * rather than at each stop site: the relocation has to happen BEFORE the
  * command body so the relocated child - not the parent that is about to die -
  * owns the CLI lock, the update contender claim, the dispatch ACK and the
- * progress marker.
+ * progress marker. The one host-stopping route registered OUTSIDE `withRunner`,
+ * `host maintenance-lease`, makes the same call itself, first thing in its
+ * action, for the same reason: the lease's attempt capability and its
+ * stdin/stdout protocol both belong to the relocated child.
  *
  * `host start` is deliberately absent: it IS the unit's main process and never
  * stops anything. So are the `agent *-from-hook` commands, which run inside an
@@ -119,6 +122,13 @@ export const HOST_STOPPING_COMMANDS: ReadonlyMap<string, HostStopReachable> =
     // line is the guard on the install actuator in `service/index.ts`, ahead
     // of the registration transaction.
     ["host service install", ALWAYS_STOPS],
+    // The root-maintenance lease serves `host-stop` and `host-uninstall-all`
+    // actions to the Desktop install/uninstall scripts over stdin/stdout, and
+    // both go through the guarded stop routes. A script started from a
+    // Traycer-hosted terminal spawns the lease inside the host unit (`sudo`
+    // changes nothing about a cgroup), so without this the guard would refuse
+    // the very maintenance the lease exists to perform.
+    ["host maintenance-lease", ALWAYS_STOPS],
     ["host install", (options) => options.serviceRegister !== false],
     ["host ensure", (options) => options.serviceRegister !== false],
     ["host apply", (options) => options.service !== false],

--- a/clients/traycer-cli/src/host/cgroup-relocation.ts
+++ b/clients/traycer-cli/src/host/cgroup-relocation.ts
@@ -458,8 +458,10 @@ async function runInTransientScope(
     } else {
       // No readable channel at all. Both supported runtimes hand back a
       // `net.Socket` here, so this is a runtime that cannot answer the
-      // question - and an unanswerable ack is treated as a missing one, which
-      // refuses the stop rather than performing it blind.
+      // question. An unanswerable ack is treated as a missing one: the parent
+      // rejects when the child exits rather than claiming an unconfirmed
+      // command completed. That governs the PARENT's result only - the child
+      // is already spawned and this does not cancel it.
       ackFinished = true;
     }
     child.once("error", (cause) => {

--- a/clients/traycer-cli/src/host/cgroup-relocation.ts
+++ b/clients/traycer-cli/src/host/cgroup-relocation.ts
@@ -77,10 +77,18 @@ const ALWAYS_STOPS: HostStopReachable = () => true;
  * rather than at each stop site: the relocation has to happen BEFORE the
  * command body so the relocated child - not the parent that is about to die -
  * owns the CLI lock, the update contender claim, the dispatch ACK and the
- * progress marker. The one host-stopping route registered OUTSIDE `withRunner`,
- * `host maintenance-lease`, makes the same call itself, first thing in its
- * action, for the same reason: the lease's attempt capability and its
- * stdin/stdout protocol both belong to the relocated child.
+ * progress marker.
+ *
+ * `host maintenance-lease` - the one host-stopping route registered outside
+ * `withRunner` - is deliberately absent. Its caller, the Desktop
+ * install/uninstall script, is in the same cgroup it is: started from a
+ * Traycer-hosted terminal, both sit inside the host unit, and the stop the
+ * lease performs kills the script mid-maintenance whether or not the lease is
+ * moved. Relocating it would also put a waiting wrapper between the script and
+ * the lease, so the script's cancellation (a signal to its direct child, and
+ * that child's exit as proof) would no longer prove the lease holder is gone.
+ * The guard in `withStopIntent` refuses instead, and the refusal reaches the
+ * script as a protocol `refused` frame with nothing touched.
  *
  * `host start` is deliberately absent: it IS the unit's main process and never
  * stops anything. So are the `agent *-from-hook` commands, which run inside an
@@ -122,13 +130,6 @@ export const HOST_STOPPING_COMMANDS: ReadonlyMap<string, HostStopReachable> =
     // line is the guard on the install actuator in `service/index.ts`, ahead
     // of the registration transaction.
     ["host service install", ALWAYS_STOPS],
-    // The root-maintenance lease serves `host-stop` and `host-uninstall-all`
-    // actions to the Desktop install/uninstall scripts over stdin/stdout, and
-    // both go through the guarded stop routes. A script started from a
-    // Traycer-hosted terminal spawns the lease inside the host unit (`sudo`
-    // changes nothing about a cgroup), so without this the guard would refuse
-    // the very maintenance the lease exists to perform.
-    ["host maintenance-lease", ALWAYS_STOPS],
     ["host install", (options) => options.serviceRegister !== false],
     ["host ensure", (options) => options.serviceRegister !== false],
     ["host apply", (options) => options.service !== false],

--- a/clients/traycer-cli/src/host/cgroup-relocation.ts
+++ b/clients/traycer-cli/src/host/cgroup-relocation.ts
@@ -50,6 +50,26 @@ import { isPackagedRun } from "../store/well-known-cli";
  */
 
 /**
+ * Whether THIS invocation of an allowlisted command can reach a host stop,
+ * given the options Commander parsed for it.
+ *
+ * Command path alone is too coarse. Four of the nine have a documented
+ * bytes-only or leave-it-running form whose body provably never reaches
+ * `withStopIntent` or `killHostProcessTree`, and relocating those buys nothing
+ * while exposing them to two refusals they cannot deserve: a `$` in a `--from`
+ * path, and a machine where a transient scope cannot be started at all.
+ *
+ * SAFE BECAUSE IT FAILS CLOSED. A predicate that wrongly says "no stop" does
+ * not remove the protection, it removes the FIRST line of it: the command runs
+ * in place, and `assertNotInsideHostUnit` - which is unconditional, on all four
+ * stop routes - refuses the stop before any intent is written. The cost of
+ * being wrong here is a refused command, not a killed updater.
+ */
+export type HostStopReachable = (options: Record<string, unknown>) => boolean;
+
+const ALWAYS_STOPS: HostStopReachable = () => true;
+
+/**
  * The commands whose bodies reach a host stop, keyed by Commander command path.
  *
  * Checked once in `withRunner`, the same shape as `READONLY_REFUSED_COMMANDS`,
@@ -61,18 +81,40 @@ import { isPackagedRun } from "../store/well-known-cli";
  * `host start` is deliberately absent: it IS the unit's main process and never
  * stops anything. So are the `agent *-from-hook` commands, which run inside an
  * agent process and are supposed to die with the host.
+ *
+ * The four conditional entries, each traced to the branch that decides it.
+ * They are Linux answers, which is all this map is ever asked for - the caller
+ * has already returned on every other platform, and each of these forms is
+ * refused outright on Windows anyway:
+ *
+ *   - `host install` / `host ensure` with `--no-service-register`
+ *     (`serviceRegister === false`) take `createBytesOnlyInstallLifecycle`,
+ *     whose `beforeSwap` returns immediately off win32, and
+ *     `swapLockRecoveryFor` - the only other kill seam in an install - is null
+ *     off win32. For `ensure` the bytes-only path is also the ONLY reachable
+ *     one: `provisionHost`'s `!registerService` branch either no-ops or
+ *     reinstalls, so its register and start branches cannot be reached.
+ *   - `host apply --no-service` (`service === false`) passes `lifecycle: null`
+ *     to the commit, so there is no `beforeSwap` on any platform.
+ *   - `host uninstall` stops only under `--all`; the default path removes bytes
+ *     and deliberately "tears nothing down", leaving a running host serving.
+ *
+ * Everything else stops unconditionally, `host update` included: whether it
+ * finds work to do is a question about STATE, and only options are consulted
+ * here.
  */
-export const HOST_STOPPING_COMMANDS: ReadonlySet<string> = new Set([
-  "host update",
-  "host apply",
-  "host install",
-  "host ensure",
-  "host restart",
-  "host stop",
-  "host uninstall",
-  "host free-port-and-restart",
-  "host service uninstall",
-]);
+export const HOST_STOPPING_COMMANDS: ReadonlyMap<string, HostStopReachable> =
+  new Map<string, HostStopReachable>([
+    ["host update", ALWAYS_STOPS],
+    ["host restart", ALWAYS_STOPS],
+    ["host stop", ALWAYS_STOPS],
+    ["host free-port-and-restart", ALWAYS_STOPS],
+    ["host service uninstall", ALWAYS_STOPS],
+    ["host install", (options) => options.serviceRegister !== false],
+    ["host ensure", (options) => options.serviceRegister !== false],
+    ["host apply", (options) => options.service !== false],
+    ["host uninstall", (options) => options.all === true],
+  ]);
 
 /**
  * Recursion flag set on the relocated child.
@@ -138,9 +180,11 @@ export type CgroupRelocation =
  */
 export async function relocateOutOfHostCgroupIfNeeded(
   commandPath: string,
+  options: Record<string, unknown>,
 ): Promise<CgroupRelocation> {
   if (osPlatform() !== "linux") return NOT_NEEDED;
-  if (!HOST_STOPPING_COMMANDS.has(commandPath)) return NOT_NEEDED;
+  const reachesStop = HOST_STOPPING_COMMANDS.get(commandPath);
+  if (reachesStop === undefined || !reachesStop(options)) return NOT_NEEDED;
   if ((process.env[TRAYCER_CLI_RELOCATED_ENV] ?? "").length > 0) {
     return NOT_NEEDED;
   }

--- a/clients/traycer-cli/src/host/cgroup-relocation.ts
+++ b/clients/traycer-cli/src/host/cgroup-relocation.ts
@@ -401,7 +401,38 @@ async function runInTransientScope(
     unit: inside.unit,
   });
   return await new Promise<number>((resolve, reject) => {
+    // TWO INDEPENDENT FACTS, and neither implies the other:
+    //
+    //   - the process ENDED, and with what code (`exit`);
+    //   - the ack channel is DONE, so no byte can still arrive (`end`).
+    //
+    // The obvious spelling - decide on `close`, which Node fires only once the
+    // stdio streams are finished - is wrong on the runtime half of this
+    // workspace. Bun counts stdout and stderr toward its close accounting but
+    // returns the extra descriptor from `net.connect({fd})` without adding it,
+    // so with stdio 0-2 inherited its `close` can fire while fd 3 still holds
+    // unread bytes. Deciding there would reject a relocation that had already
+    // acknowledged and completed - a false "never started", a second terminal
+    // envelope, and the child's real exit code lost.
     let acknowledged = false;
+    let exited = false;
+    let exitCode: number | null = null;
+    let ackFinished = false;
+    const settle = (): void => {
+      if (!exited) return;
+      // An ack already in hand answers the question; waiting for the stream to
+      // end as well would only add a way to hang.
+      if (acknowledged) {
+        // A child killed by a signal reports `null`, which is a failure the
+        // caller has to see as one.
+        resolve(exitCode ?? 1);
+        return;
+      }
+      // No ack YET. Only an ended channel makes that final: until then a byte
+      // may still be in flight behind the process's own exit.
+      if (!ackFinished) return;
+      reject(relocationNeverStarted(logger, commandPath, inside, exitCode));
+    };
     const ack = child.stdio[RELOCATION_ACK_FD];
     if (ack instanceof Readable) {
       ack.on("data", () => {
@@ -411,21 +442,36 @@ async function runInTransientScope(
           command: commandPath,
           unit: inside.unit,
         });
+        settle();
       });
+      // `end` is the ordinary finish; `close` covers a stream destroyed without
+      // ending, and `error` a channel that broke. Any of the three means no
+      // further byte is coming, which is all this flag claims.
+      const finishAck = (): void => {
+        if (ackFinished) return;
+        ackFinished = true;
+        settle();
+      };
+      ack.once("end", finishAck);
+      ack.once("close", finishAck);
+      ack.once("error", finishAck);
+    } else {
+      // No readable channel at all. Both supported runtimes hand back a
+      // `net.Socket` here, so this is a runtime that cannot answer the
+      // question - and an unanswerable ack is treated as a missing one, which
+      // refuses the stop rather than performing it blind.
+      ackFinished = true;
     }
     child.once("error", (cause) => {
       reject(relocationFailed(logger, commandPath, inside, cause));
     });
-    // `close` rather than `exit`: it fires once the stdio streams are done, so
-    // an ack already in the pipe has been delivered by the time we decide.
-    child.once("close", (code) => {
-      if (!acknowledged) {
-        reject(relocationNeverStarted(logger, commandPath, inside, code));
-        return;
-      }
-      // A child killed by a signal reports `null`, which is a failure the
-      // caller has to see as one.
-      resolve(code ?? 1);
+    // `exit`, not `close`: this listener is about the process ending, and
+    // nothing else. Whether the ack channel has drained is the other half,
+    // tracked above.
+    child.once("exit", (code) => {
+      exited = true;
+      exitCode = code;
+      settle();
     });
   });
 }

--- a/clients/traycer-cli/src/host/cgroup-relocation.ts
+++ b/clients/traycer-cli/src/host/cgroup-relocation.ts
@@ -1,9 +1,16 @@
 import { spawn, type ChildProcess } from "node:child_process";
+import { writeSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { platform as osPlatform } from "node:os";
+import { Readable } from "node:stream";
 import { config } from "../config";
 import { createCliLogger, errorFromUnknown, type ILogger } from "../logger";
-import { CLI_ERROR_CODES, cliError, type CliError } from "../runner/errors";
+import {
+  CLI_ERROR_CODES,
+  cliError,
+  isErrnoException,
+  type CliError,
+} from "../runner/errors";
 import { isPackagedRun } from "../store/well-known-cli";
 
 /**
@@ -36,7 +43,10 @@ import { isPackagedRun } from "../store/well-known-cli";
  * `systemd-run` on PATH, no user manager, a scope that failed to move us, or a
  * recursion flag set without a real cgroup change all end at the refusal with
  * the host still up. Which is also why the relocation env flag is never taken
- * as evidence that the move happened - only the cgroup is.
+ * as evidence that the move happened - only the cgroup is. Nor is the child's
+ * entry acknowledgement: it proves a CLI started in the new scope, never that
+ * the scope is outside the host unit, so the guard re-reads the cgroup either
+ * way.
  */
 
 /**
@@ -86,6 +96,11 @@ const SYSTEMD_RUN_SCOPE_ARGS: readonly string[] = [
   "--",
 ];
 
+// The ack channel: fd 3 on the relocated child, `stdio[3]` on the parent. One
+// byte, whose only meaning is "a CLI reached `withRunner` in the new scope".
+const RELOCATION_ACK_FD = 3;
+const RELOCATION_ACK_BYTE = "\n";
+
 const PROC_SELF_CGROUP = "/proc/self/cgroup";
 
 const HOST_UNIT_PREFIX = "ai.traycer.host";
@@ -117,8 +132,9 @@ export type CgroupRelocation =
  * without systemd, a container, and every non-Linux platform.
  *
  * Throws `SERVICE_CONTROL_FAILED` when the move was needed and could not be
- * made. It deliberately does not fall through to running the command: doing so
- * is what kills the host-spawned updater mid-update.
+ * made - including when membership itself could not be established. It
+ * deliberately does not fall through to running the command: doing so is what
+ * kills the host-spawned updater mid-update.
  */
 export async function relocateOutOfHostCgroupIfNeeded(
   commandPath: string,
@@ -136,10 +152,58 @@ export async function relocateOutOfHostCgroupIfNeeded(
     execArgv: process.execArgv,
     argv: process.argv,
   });
+  assertArgvSurvivesSystemdRun(argv, commandPath, inside);
   return {
     kind: "completed",
     exitCode: await runInTransientScope(argv, commandPath, inside),
   };
+}
+
+/**
+ * Refuse to relocate an argv `systemd-run` may rewrite.
+ *
+ * systemd's own boundary, read off upstream rather than assumed:
+ *
+ * | version | scope behaviour with no option passed                  |
+ * | ------- | ------------------------------------------------------ |
+ * | 249     | argv goes straight to `execvpe`; no expansion option    |
+ * | 254-257 | `--expand-environment` exists, scope expansion still    |
+ * |         | defaults OFF for compatibility                          |
+ * | 258     | scope expansion defaults ON                             |
+ *
+ * So `--expand-environment=no` cannot simply be passed: it is rejected outright
+ * below 254, which is most of the field. Probing the installed version would
+ * mean a second process on every relocation to decide something this CLI never
+ * composes - SemVer versions, UUIDs and ACK nonces carry no `$`. A path can
+ * (`host install --from '/tmp/${BUILD}/host.tar.gz'`, an `execPath` or a loader
+ * script under such a directory), and there the honest answer is to refuse: on
+ * 258 the value would silently become a different path, and `$$`-escaping it
+ * instead would corrupt that same filename on every older systemd.
+ *
+ * Relocation runs before the command body validates anything, so this is the
+ * only place that sees the composed argv.
+ */
+function assertArgvSurvivesSystemdRun(
+  argv: readonly string[],
+  commandPath: string,
+  inside: HostUnitCgroup,
+): void {
+  const expandable = argv.find((token) => token.includes("$"));
+  if (expandable === undefined) return;
+  throw cliError({
+    code: CLI_ERROR_CODES.SERVICE_CONTROL_FAILED,
+    message:
+      `refusing to relocate '${commandPath}' out of the ${inside.unit} cgroup: ` +
+      "an argument contains '$', which systemd-run can rewrite; " +
+      "run this from a shell outside the Traycer host.",
+    details: {
+      command: commandPath,
+      argument: expandable,
+      cgroup: inside.path,
+      unit: inside.unit,
+    },
+    exitCode: 1,
+  });
 }
 
 /**
@@ -213,16 +277,46 @@ export function findHostUnitCgroup(contents: string): HostUnitCgroup | null {
   return null;
 }
 
+/**
+ * Read our own cgroup membership, or refuse to answer.
+ *
+ * ABSENCE is an answer: no `/proc/self/cgroup` (ENOENT) and no `/proc` at all
+ * (ENOTDIR) mean there is no cgroup that can kill us - a container, WSL without
+ * systemd, a kernel without the filesystem mounted - and "not inside a host
+ * unit" is exactly right there.
+ *
+ * Every OTHER read failure is a FAILED CHECK, not a negative answer. EACCES,
+ * EMFILE and EIO say nothing about membership, and the earlier blanket catch
+ * turned each of them into permission to stop: relocation would be skipped, the
+ * guard would pass, intent would be written, and the stop would kill the process
+ * issuing it. So they refuse instead, with the errno recorded at DEBUG.
+ */
 async function readHostUnitCgroup(): Promise<HostUnitCgroup | null> {
   let contents: string;
   try {
     contents = await readFile(PROC_SELF_CGROUP, "utf8");
-  } catch {
-    // No `/proc/self/cgroup` at all means no cgroup that can kill us, which is
-    // the same answer as "not inside a host unit".
-    return null;
+  } catch (cause) {
+    if (isMissingCgroupFile(cause)) return null;
+    createCliLogger(config.environment).debug(
+      "Failed to read the cgroup this process belongs to",
+      { path: PROC_SELF_CGROUP, cause: errorFromUnknown(cause).message },
+    );
+    throw cliError({
+      code: CLI_ERROR_CODES.SERVICE_CONTROL_FAILED,
+      message:
+        `could not read ${PROC_SELF_CGROUP}, so this command cannot tell whether ` +
+        "stopping the Traycer host would also kill it. " +
+        "Run it again from a shell outside the Traycer host.",
+      details: { path: PROC_SELF_CGROUP },
+      exitCode: 1,
+    });
   }
   return findHostUnitCgroup(contents);
+}
+
+function isMissingCgroupFile(cause: unknown): boolean {
+  if (!isErrnoException(cause)) return false;
+  return cause.code === "ENOENT" || cause.code === "ENOTDIR";
 }
 
 // `<hierarchy>:<controllers>:<path>`. The unified v2 line is `0::<path>`; on v1
@@ -270,10 +364,19 @@ function hostUnitSegment(path: string): string | null {
  * the child. Exiting immediately instead would lose that output and hand the
  * host's `exited` promise a false early settle.
  *
- * `systemd-run` exiting non-zero before it execs is indistinguishable from the
- * command's own failure and is forwarded as such; only a failure to spawn it at
- * all (no such binary, no permission) is reported as the relocation failure it
- * is.
+ * THE ACK IS WHAT SEPARATES the two failures that both arrive as an exit code.
+ * Node's `spawn` event proves only that `systemd-run` started; a missing user
+ * bus, a refused transient scope, or a failed exec of the target all happen
+ * afterwards and show up as an ordinary non-zero `close`. Forwarding that code
+ * would report a relocation that never delivered a CLI - no `E_SERVICE_CONTROL_FAILED`
+ * envelope for a `--json` caller, and no relocated process alive to emit one -
+ * while the log claimed the move had worked.
+ *
+ * So the relocated CLI writes one byte to fd 3 the moment it reaches
+ * `withRunner` (`acknowledgeRelocationEntry`). An exit WITHOUT that byte is a
+ * relocation that failed before the command started, and it rejects. An exit
+ * WITH it is the command's own result and is forwarded verbatim, so the child
+ * remains the only writer of a terminal envelope.
  */
 async function runInTransientScope(
   argv: readonly string[],
@@ -284,27 +387,97 @@ async function runInTransientScope(
   let child: ChildProcess;
   try {
     child = spawn(SYSTEMD_RUN, [...SYSTEMD_RUN_SCOPE_ARGS, ...argv], {
-      // Inherited, not piped: under `--json` the child owns the NDJSON stream
-      // and this process writes nothing to it.
-      stdio: "inherit",
+      // stdio 0-2 inherited, not piped: under `--json` the child owns the
+      // NDJSON stream and this process writes nothing to it. fd 3 is the ack
+      // channel and carries one byte in the other direction.
+      stdio: ["inherit", "inherit", "inherit", "pipe"],
       env: { ...process.env, [TRAYCER_CLI_RELOCATED_ENV]: "1" },
     });
   } catch (cause) {
     throw relocationFailed(logger, commandPath, inside, cause);
   }
+  logger.debug("Spawned systemd-run for a host-stopping command", {
+    command: commandPath,
+    unit: inside.unit,
+  });
   return await new Promise<number>((resolve, reject) => {
-    child.once("spawn", () => {
-      logger.info("relocated host-stopping command into a transient scope", {
-        command: commandPath,
-        unit: inside.unit,
+    let acknowledged = false;
+    const ack = child.stdio[RELOCATION_ACK_FD];
+    if (ack instanceof Readable) {
+      ack.on("data", () => {
+        if (acknowledged) return;
+        acknowledged = true;
+        logger.info("relocated host-stopping command into a transient scope", {
+          command: commandPath,
+          unit: inside.unit,
+        });
       });
-    });
+    }
     child.once("error", (cause) => {
       reject(relocationFailed(logger, commandPath, inside, cause));
     });
-    // A child killed by a signal reports `null`, which is a failure the caller
-    // has to see as one.
-    child.once("close", (code) => resolve(code ?? 1));
+    // `close` rather than `exit`: it fires once the stdio streams are done, so
+    // an ack already in the pipe has been delivered by the time we decide.
+    child.once("close", (code) => {
+      if (!acknowledged) {
+        reject(relocationNeverStarted(logger, commandPath, inside, code));
+        return;
+      }
+      // A child killed by a signal reports `null`, which is a failure the
+      // caller has to see as one.
+      resolve(code ?? 1);
+    });
+  });
+}
+
+/**
+ * The relocated CLI's half of the ack: one byte on fd 3, at entry.
+ *
+ * Called first thing in `withRunner`, before the surface check, before argument
+ * parsing, before anything the command does - the parent is waiting to learn
+ * whether a CLI exists in the new scope at all, and every step taken before the
+ * answer is a step that can fail while looking like `systemd-run` failing.
+ *
+ * Gated on the recursion flag, because fd 3 belongs to whoever launched us on
+ * an ordinary run and must not be written to. Failures are swallowed: an older
+ * parent leaves no pipe there (EBADF), and a CLI that cannot say hello must
+ * still run the command it was asked to run.
+ */
+export function acknowledgeRelocationEntry(): void {
+  if ((process.env[TRAYCER_CLI_RELOCATED_ENV] ?? "").length === 0) return;
+  try {
+    writeSync(RELOCATION_ACK_FD, RELOCATION_ACK_BYTE);
+  } catch {
+    // Nothing is listening, or the write failed. Neither changes what this
+    // process was asked to do.
+  }
+}
+
+function relocationNeverStarted(
+  logger: ILogger,
+  commandPath: string,
+  inside: HostUnitCgroup,
+  exitCode: number | null,
+): CliError {
+  logger.debug("systemd-run exited before the relocated command started", {
+    command: commandPath,
+    unit: inside.unit,
+    exitCode,
+  });
+  return cliError({
+    code: CLI_ERROR_CODES.SERVICE_CONTROL_FAILED,
+    message:
+      `could not move '${commandPath}' out of the ${inside.unit} cgroup: ` +
+      "systemd-run exited before the command started, so there is no user " +
+      "manager or the transient scope was refused. " +
+      "Run it again from a shell outside the Traycer host.",
+    details: {
+      command: commandPath,
+      cgroup: inside.path,
+      unit: inside.unit,
+      systemdRunExitCode: exitCode,
+    },
+    exitCode: 1,
   });
 }
 

--- a/clients/traycer-cli/src/host/cgroup-relocation.ts
+++ b/clients/traycer-cli/src/host/cgroup-relocation.ts
@@ -404,9 +404,10 @@ function hostUnitSegment(path: string): string | null {
  * The parent WAITS. A person in a Traycer-hosted terminal keeps seeing output
  * through the inherited stdio until the stop kills their terminal; a
  * host-spawned parent dies with the cgroup, which is the expected end for it
- * and is why nothing here tries to shepherd the child beyond relaying
- * termination signals (`relayTerminationSignals`, which the detach makes
- * necessary). Exiting immediately instead would lose that output and hand the
+ * and is why nothing here tries to shepherd the child beyond relaying a Ctrl-C
+ * (`relayInterruptSignal`, which the detach makes necessary - and which
+ * relays NOTHING else, least of all the SIGTERM this unit's own stop
+ * delivers). Exiting immediately instead would lose that output and hand the
  * host's `exited` promise a false early settle.
  *
  * THE ACK IS WHAT SEPARATES the two failures that both arrive as an exit code.
@@ -442,8 +443,9 @@ async function runInTransientScope(
       // SIGHUPs the terminal's foreground group and takes the relocated updater
       // with it - the cgroup escape wasted. `detached` is setsid AT SPAWN, so
       // there is no window in which a handler has to be installed first, and
-      // `systemd-run` stays waiting on the command inside the new session.
-      // The inherited fds come along, which is deliberate: progress stays
+      // and `--scope` execs the CLI in place, so the process that lands in the
+      // new session IS the relocated CLI - no supervisor is left behind in the
+      // old one. The inherited fds come along, which is deliberate: progress stays
       // visible while the terminal lives, and the child tolerates it going away
       // (`acknowledgeRelocationEntry`).
       detached: true,
@@ -456,7 +458,7 @@ async function runInTransientScope(
     command: commandPath,
     unit: inside.unit,
   });
-  const stopRelay = relayTerminationSignals(child);
+  const stopRelay = relayInterruptSignal(child);
   try {
     return await waitForRelocatedExit(child, logger, commandPath, inside);
   } finally {
@@ -465,7 +467,7 @@ async function runInTransientScope(
 }
 
 /**
- * Forward this process's SIGINT/SIGTERM to the relocated child's process group.
+ * Forward a Ctrl-C - and ONLY a Ctrl-C - to the relocated child's process group.
  *
  * Only needed BECAUSE of the detach. While the child shared our process group,
  * a terminal's Ctrl-C went to both of us at once and no forwarding was called
@@ -473,32 +475,67 @@ async function runInTransientScope(
  * group, so without this relay Ctrl-C would kill the waiting parent and leave
  * the update running unattended: the opposite of the semantics it had.
  *
- * The group (`-pid`), not the pid: `systemd-run --scope` runs the command as
- * its own child, so signalling only `systemd-run` can leave the command itself
- * untouched. The child is a group leader by virtue of the detach, so its pgid
- * is its pid.
+ * SIGTERM IS DELIBERATELY NOT RELAYED, and this is the whole reason the
+ * function is named for one signal. This parent runs inside the host unit -
+ * that is the only situation relocation exists for - and the stop the child was
+ * sent away to perform is `systemctl --user stop`, whose default
+ * `KillMode=control-group` SIGTERMs every process in that cgroup. Relaying it
+ * would hand the child its own stop signal and kill the update at exactly the
+ * moment the relocation exists to survive.
+ *
+ * The overwhelmingly likely SIGTERM here is therefore this unit dying - though
+ * not provably so, since a person can always `kill -TERM` this pid directly.
+ * The policy does not depend on telling those apart: in both cases the parent
+ * takes the default action and dies, and in both cases the child outliving it
+ * is the point. Only the provenance is uncertain, never the response.
+ *
+ * SIGHUP is not relayed either, and the policy is unconditional rather than
+ * inferred from where the signal came from. A hangup here most often means the
+ * PTY closed, which is a teardown the child was deliberately moved out of the
+ * way of - it left that session at spawn and tolerates the lost fds
+ * (`acknowledgeRelocationEntry`) - but it can also be sent by hand. Either way
+ * it is not forwarded: nothing about a hangup delivered to THIS process is
+ * evidence that the work in the other session should stop.
+ *
+ * The group (`-pid`), not the pid. `--scope` EXECS in place, so `child.pid` is
+ * the relocated CLI itself and signalling the bare pid would in fact reach it -
+ * but the CLI is not necessarily alone. `setsid` made it the leader of a new
+ * group, and anything it spawns without detaching itself lands in that group
+ * too, so `-pid` delivers to the whole thing a Ctrl-C would have hit had the
+ * process never left the terminal's foreground group. That equivalence is the
+ * point: the relay exists to preserve the semantics the detach took away, not
+ * to invent narrower ones.
  *
  * Deliberately no `process.exit` here: the parent keeps waiting so the child
  * stays the only writer of a terminal envelope, and reports its code as always.
+ * A consequence worth naming: while this listener is installed, Ctrl-C no
+ * longer terminates THIS process the way an unhandled SIGINT would. It ends the
+ * command all the same - the child takes the signal, dies, and its code is
+ * reported here - but the parent outlives the keypress by however long the
+ * child takes to go. That is the same trade the whole function makes: the child
+ * is the thing running the work, so the child decides when there is an answer.
+ *
+ * There is one gap this cannot close, and it is deliberate: a SIGINT arriving
+ * between `spawn` returning and this listener being installed still takes the
+ * default action and kills the parent, leaving the child running unattended.
+ * Closing it would mean installing a handler before there is a pid to forward
+ * to. The outcome is the same as the SIGTERM case above - parent gone, work
+ * continues - which is the behaviour this design already treats as correct.
  */
-function relayTerminationSignals(child: ChildProcess): () => void {
+function relayInterruptSignal(child: ChildProcess): () => void {
   const pid = child.pid;
   if (pid === undefined) return () => undefined;
-  const forward = (signal: NodeJS.Signals): void => {
+  const onInterrupt = (): void => {
     try {
-      process.kill(-pid, signal);
+      process.kill(-pid, "SIGINT");
     } catch {
       // Already gone, or never became a group leader. Neither is actionable:
       // the exit we are waiting on is what reports the outcome.
     }
   };
-  const onInt = (): void => forward("SIGINT");
-  const onTerm = (): void => forward("SIGTERM");
-  process.on("SIGINT", onInt);
-  process.on("SIGTERM", onTerm);
+  process.on("SIGINT", onInterrupt);
   return () => {
-    process.removeListener("SIGINT", onInt);
-    process.removeListener("SIGTERM", onTerm);
+    process.removeListener("SIGINT", onInterrupt);
   };
 }
 
@@ -616,6 +653,12 @@ export function acknowledgeRelocationEntry(): void {
   // the moment the relocation exists to survive. There is nowhere left to
   // report a write failure to - the place we would report it to is what
   // vanished - so the only thing to do with it is nothing.
+  //
+  // fd 0 is deliberately left alone. Nothing on a host-stopping path reads
+  // stdin, and merely TOUCHING `process.stdin` is not free: the getter
+  // constructs the stream on first access, and on a TTY that is a ref'd handle
+  // that can hold the event loop open past the work being done. A guard against
+  // an error nobody can provoke is not worth a process that will not exit.
   const ignore = (): void => undefined;
   process.stdout.on("error", ignore);
   process.stderr.on("error", ignore);

--- a/clients/traycer-cli/src/host/cgroup-relocation.ts
+++ b/clients/traycer-cli/src/host/cgroup-relocation.ts
@@ -401,11 +401,12 @@ function hostUnitSegment(path: string): string | null {
 /**
  * Run the command in a transient scope and forward its exit code.
  *
- * The parent WAITS, attached, and installs no signal forwarding. A person in a
- * Traycer-hosted terminal keeps seeing output through the inherited stdio until
- * the stop kills their terminal; a host-spawned parent dies with the cgroup,
- * which is the expected end for it and is why nothing here tries to shepherd
- * the child. Exiting immediately instead would lose that output and hand the
+ * The parent WAITS. A person in a Traycer-hosted terminal keeps seeing output
+ * through the inherited stdio until the stop kills their terminal; a
+ * host-spawned parent dies with the cgroup, which is the expected end for it
+ * and is why nothing here tries to shepherd the child beyond relaying
+ * termination signals (`relayTerminationSignals`, which the detach makes
+ * necessary). Exiting immediately instead would lose that output and hand the
  * host's `exited` promise a false early settle.
  *
  * THE ACK IS WHAT SEPARATES the two failures that both arrive as an exit code.
@@ -435,6 +436,17 @@ async function runInTransientScope(
       // NDJSON stream and this process writes nothing to it. fd 3 is the ack
       // channel and carries one byte in the other direction.
       stdio: ["inherit", "inherit", "inherit", "pipe"],
+      // The scope moves the child's CGROUP; it does not move its SESSION. In a
+      // Traycer-hosted terminal the child would still be in the session whose
+      // PTY the host owns, so the moment the stop closes that master the kernel
+      // SIGHUPs the terminal's foreground group and takes the relocated updater
+      // with it - the cgroup escape wasted. `detached` is setsid AT SPAWN, so
+      // there is no window in which a handler has to be installed first, and
+      // `systemd-run` stays waiting on the command inside the new session.
+      // The inherited fds come along, which is deliberate: progress stays
+      // visible while the terminal lives, and the child tolerates it going away
+      // (`acknowledgeRelocationEntry`).
+      detached: true,
       env: { ...process.env, [TRAYCER_CLI_RELOCATED_ENV]: "1" },
     });
   } catch (cause) {
@@ -444,6 +456,58 @@ async function runInTransientScope(
     command: commandPath,
     unit: inside.unit,
   });
+  const stopRelay = relayTerminationSignals(child);
+  try {
+    return await waitForRelocatedExit(child, logger, commandPath, inside);
+  } finally {
+    stopRelay();
+  }
+}
+
+/**
+ * Forward this process's SIGINT/SIGTERM to the relocated child's process group.
+ *
+ * Only needed BECAUSE of the detach. While the child shared our process group,
+ * a terminal's Ctrl-C went to both of us at once and no forwarding was called
+ * for - which is why there never was any. `setsid` takes the child out of that
+ * group, so without this relay Ctrl-C would kill the waiting parent and leave
+ * the update running unattended: the opposite of the semantics it had.
+ *
+ * The group (`-pid`), not the pid: `systemd-run --scope` runs the command as
+ * its own child, so signalling only `systemd-run` can leave the command itself
+ * untouched. The child is a group leader by virtue of the detach, so its pgid
+ * is its pid.
+ *
+ * Deliberately no `process.exit` here: the parent keeps waiting so the child
+ * stays the only writer of a terminal envelope, and reports its code as always.
+ */
+function relayTerminationSignals(child: ChildProcess): () => void {
+  const pid = child.pid;
+  if (pid === undefined) return () => undefined;
+  const forward = (signal: NodeJS.Signals): void => {
+    try {
+      process.kill(-pid, signal);
+    } catch {
+      // Already gone, or never became a group leader. Neither is actionable:
+      // the exit we are waiting on is what reports the outcome.
+    }
+  };
+  const onInt = (): void => forward("SIGINT");
+  const onTerm = (): void => forward("SIGTERM");
+  process.on("SIGINT", onInt);
+  process.on("SIGTERM", onTerm);
+  return () => {
+    process.removeListener("SIGINT", onInt);
+    process.removeListener("SIGTERM", onTerm);
+  };
+}
+
+async function waitForRelocatedExit(
+  child: ChildProcess,
+  logger: ILogger,
+  commandPath: string,
+  inside: HostUnitCgroup,
+): Promise<number> {
   return await new Promise<number>((resolve, reject) => {
     // TWO INDEPENDENT FACTS, and neither implies the other:
     //
@@ -523,7 +587,9 @@ async function runInTransientScope(
 }
 
 /**
- * The relocated CLI's half of the ack: one byte on fd 3, at entry.
+ * The relocated CLI's entry duties: say hello on fd 3, and stop depending on a
+ * terminal that is about to be closed underneath it. Both belong at entry and
+ * both are no-ops on an ordinary run, which is why they share the gate.
  *
  * Called first thing in `withRunner`, before the surface check, before argument
  * parsing, before anything the command does - the parent is waiting to learn
@@ -543,6 +609,16 @@ export function acknowledgeRelocationEntry(): void {
     // Nothing is listening, or the write failed. Neither changes what this
     // process was asked to do.
   }
+  // The other half of surviving the stop. This process kept the terminal's fds
+  // 0-2 but left its session, so when the stop closes the PTY master the writes
+  // start failing with EIO instead of the process being SIGHUPed. An unhandled
+  // `error` on `process.stdout` throws, which would kill the update at exactly
+  // the moment the relocation exists to survive. There is nowhere left to
+  // report a write failure to - the place we would report it to is what
+  // vanished - so the only thing to do with it is nothing.
+  const ignore = (): void => undefined;
+  process.stdout.on("error", ignore);
+  process.stderr.on("error", ignore);
 }
 
 function relocationNeverStarted(

--- a/clients/traycer-cli/src/host/cgroup-relocation.ts
+++ b/clients/traycer-cli/src/host/cgroup-relocation.ts
@@ -62,8 +62,9 @@ import { isPackagedRun } from "../store/well-known-cli";
  * SAFE BECAUSE IT FAILS CLOSED. A predicate that wrongly says "no stop" does
  * not remove the protection, it removes the FIRST line of it: the command runs
  * in place, and `assertNotInsideHostUnit` - which is unconditional, on all four
- * stop routes - refuses the stop before any intent is written. The cost of
- * being wrong here is a refused command, not a killed updater.
+ * stop routes and on the install actuator, whose Linux rollback is a stop -
+ * refuses before any intent is written. The cost of being wrong here is a
+ * refused command, not a killed updater.
  */
 export type HostStopReachable = (options: Record<string, unknown>) => boolean;
 
@@ -114,7 +115,9 @@ export const HOST_STOPPING_COMMANDS: ReadonlyMap<string, HostStopReachable> =
     // unit when `enable --now` fails, `service/platforms/linux.ts`), but that
     // rollback is reachable from any failure of the enable, so it relocates
     // unconditionally: a CLI that dies with the unit it is rolling back never
-    // removes the manifest or reports the install's own error.
+    // removes the manifest or reports the install's own error. Its second
+    // line is the guard on the install actuator in `service/index.ts`, ahead
+    // of the registration transaction.
     ["host service install", ALWAYS_STOPS],
     ["host install", (options) => options.serviceRegister !== false],
     ["host ensure", (options) => options.serviceRegister !== false],

--- a/clients/traycer-cli/src/host/cgroup-relocation.ts
+++ b/clients/traycer-cli/src/host/cgroup-relocation.ts
@@ -110,6 +110,12 @@ export const HOST_STOPPING_COMMANDS: ReadonlyMap<string, HostStopReachable> =
     ["host stop", ALWAYS_STOPS],
     ["host free-port-and-restart", ALWAYS_STOPS],
     ["host service uninstall", ALWAYS_STOPS],
+    // Stops only in its rollback (`systemctl --user disable --now` on the live
+    // unit when `enable --now` fails, `service/platforms/linux.ts`), but that
+    // rollback is reachable from any failure of the enable, so it relocates
+    // unconditionally: a CLI that dies with the unit it is rolling back never
+    // removes the manifest or reports the install's own error.
+    ["host service install", ALWAYS_STOPS],
     ["host install", (options) => options.serviceRegister !== false],
     ["host ensure", (options) => options.serviceRegister !== false],
     ["host apply", (options) => options.service !== false],

--- a/clients/traycer-cli/src/index.ts
+++ b/clients/traycer-cli/src/index.ts
@@ -277,7 +277,10 @@ function withRunner(
     // behind this point too, so nothing the command does has happened yet.
     let relocation: CgroupRelocation;
     try {
-      relocation = await relocateOutOfHostCgroupIfNeeded(commandPath);
+      // Keyed by command path AND the parsed options: `host uninstall` without
+      // `--all`, and the bytes-only forms of install/ensure/apply, never reach
+      // a stop, so relocating them would only expose them to its failure modes.
+      relocation = await relocateOutOfHostCgroupIfNeeded(commandPath, optsBag);
     } catch (error) {
       // Rendered through the runner's normal error path rather than thrown from
       // the action: an error escaping Commander lands in the entry's generic

--- a/clients/traycer-cli/src/index.ts
+++ b/clients/traycer-cli/src/index.ts
@@ -1106,39 +1106,20 @@ function registerHostCommands(program: Command): void {
     )
     .requiredOption("--service-uid <uid>", "Internal: target GUI service uid")
     .action(async (opts) => {
-      // The same two steps `withRunner` takes first, taken here because this
-      // route is registered outside it: the fd-3 hello on a relocated run,
-      // then the Linux relocation out of the host's cgroup. The lease serves
-      // `host-stop` and `host-uninstall-all` actions, and a script started
-      // from a Traycer-hosted terminal spawns it inside the host unit, where
-      // the stop it performs would kill it - so the relocated child must be
-      // the process that acquires the attempt capability and serves the
-      // protocol, and this parent, which inherits nothing but the pipes,
-      // exits with the child's code. A relocation failure is reported in
-      // the protocol's own `refused` frame, which is what the script reads.
-      acknowledgeRelocationEntry();
-      let relocation: CgroupRelocation;
-      try {
-        relocation = await relocateOutOfHostCgroupIfNeeded(
-          "host maintenance-lease",
-          {},
-        );
-      } catch (err) {
-        writeStdout(
-          `${JSON.stringify({
-            v: 1,
-            id: null,
-            kind: "refused",
-            message: err instanceof Error ? err.message : String(err),
-          })}\n`,
-        );
-        process.exitCode = 1;
-        return;
-      }
-      if (relocation.kind === "completed") {
-        await finishAndExit(relocation.exitCode);
-        return;
-      }
+      // Deliberately NOT relocated out of the host's cgroup on Linux, unlike
+      // every other route that reaches a host stop (host/cgroup-relocation.ts).
+      // The script that spawns this lease is in the same cgroup as the lease:
+      // started from a Traycer-hosted terminal, the two land inside the host
+      // unit together, and the stop the lease would perform kills the script
+      // mid-maintenance whether or not the lease itself survives it. Moving
+      // the lease alone would also turn the script's direct child into a
+      // waiting wrapper, so its cancellation (TERM/KILL to that child, exit as
+      // death evidence) would no longer prove the lease holder is gone. The
+      // second-line guard in `withStopIntent` therefore refuses the action,
+      // the refusal travels to the script as the protocol's own `refused`
+      // frame ("run this from a shell outside the Traycer host"), and the
+      // lease releases with nothing touched - which is the outcome a caller
+      // that cannot outlive the stop should get.
       const admission =
         opts.admission === "desktop-activation-maintenance" ||
         opts.admission === "uninstall-maintenance"

--- a/clients/traycer-cli/src/index.ts
+++ b/clients/traycer-cli/src/index.ts
@@ -88,6 +88,10 @@ import {
 import { buildHostRestartCommand } from "./commands/host-restart";
 import { runHostStart, type RunHostStartOptions } from "./commands/host-start";
 import { readHostStartAdoptionNonce } from "./host/host-start-adoption";
+import {
+  relocateOutOfHostCgroupIfNeeded,
+  type CgroupRelocation,
+} from "./host/cgroup-relocation";
 import { buildHostStampRuntimeCommand } from "./commands/host-stamp-runtime";
 import { runHostCapabilities } from "./host/capabilities";
 import {
@@ -253,7 +257,37 @@ function withRunner(
       );
       return build(optsBag, positionals)(ctx);
     };
-    await runCommand(guarded, extractRunnerFlags(optsBag));
+    const flags = extractRunnerFlags(optsBag);
+    // Linux: a command that is about to stop the host runs in a transient
+    // scope of its own, because on this platform it would otherwise be killed
+    // by the stop it issues (see host/cgroup-relocation.ts).
+    //
+    // Here, once, for the same reason the capability check above is: BEFORE the
+    // command body, which is where every CLI lock, update-contender claim,
+    // dispatch ACK and progress marker is taken. The relocated child must own
+    // all of them, and the parent - which is about to die with the host's
+    // cgroup - must own none. Building `fn` lazily keeps argument parsing
+    // behind this point too, so nothing the command does has happened yet.
+    let relocation: CgroupRelocation;
+    try {
+      relocation = await relocateOutOfHostCgroupIfNeeded(commandPath);
+    } catch (error) {
+      // Rendered through the runner's normal error path rather than thrown from
+      // the action: an error escaping Commander lands in the entry's generic
+      // handler, which reports E_UNEXPECTED and loses the code the host and
+      // Desktop switch on.
+      await runCommand(() => Promise.reject(error), flags);
+      return;
+    }
+    if (relocation.kind === "completed") {
+      // The child ran the command and owned the output stream through inherited
+      // stdio. This process adds nothing to it - under `--json` writing a
+      // second terminal envelope would corrupt the child's NDJSON - and exits
+      // with the child's code through the runner's own terminator.
+      await finishAndExit(relocation.exitCode);
+      return;
+    }
+    await runCommand(guarded, flags);
   });
 }
 

--- a/clients/traycer-cli/src/index.ts
+++ b/clients/traycer-cli/src/index.ts
@@ -1106,6 +1106,39 @@ function registerHostCommands(program: Command): void {
     )
     .requiredOption("--service-uid <uid>", "Internal: target GUI service uid")
     .action(async (opts) => {
+      // The same two steps `withRunner` takes first, taken here because this
+      // route is registered outside it: the fd-3 hello on a relocated run,
+      // then the Linux relocation out of the host's cgroup. The lease serves
+      // `host-stop` and `host-uninstall-all` actions, and a script started
+      // from a Traycer-hosted terminal spawns it inside the host unit, where
+      // the stop it performs would kill it - so the relocated child must be
+      // the process that acquires the attempt capability and serves the
+      // protocol, and this parent, which inherits nothing but the pipes,
+      // exits with the child's code. A relocation failure is reported in
+      // the protocol's own `refused` frame, which is what the script reads.
+      acknowledgeRelocationEntry();
+      let relocation: CgroupRelocation;
+      try {
+        relocation = await relocateOutOfHostCgroupIfNeeded(
+          "host maintenance-lease",
+          {},
+        );
+      } catch (err) {
+        writeStdout(
+          `${JSON.stringify({
+            v: 1,
+            id: null,
+            kind: "refused",
+            message: err instanceof Error ? err.message : String(err),
+          })}\n`,
+        );
+        process.exitCode = 1;
+        return;
+      }
+      if (relocation.kind === "completed") {
+        await finishAndExit(relocation.exitCode);
+        return;
+      }
       const admission =
         opts.admission === "desktop-activation-maintenance" ||
         opts.admission === "uninstall-maintenance"

--- a/clients/traycer-cli/src/index.ts
+++ b/clients/traycer-cli/src/index.ts
@@ -89,6 +89,7 @@ import { buildHostRestartCommand } from "./commands/host-restart";
 import { runHostStart, type RunHostStartOptions } from "./commands/host-start";
 import { readHostStartAdoptionNonce } from "./host/host-start-adoption";
 import {
+  acknowledgeRelocationEntry,
   relocateOutOfHostCgroupIfNeeded,
   type CgroupRelocation,
 } from "./host/cgroup-relocation";
@@ -226,6 +227,12 @@ function withRunner(
   ) => CommandFn,
 ): CommanderCommand {
   return addRunnerFlags(cmd).action(async (...actionArgs: unknown[]) => {
+    // First, before anything else this action does. On a relocated run the
+    // parent is holding fd 3 open waiting to learn whether a CLI exists in the
+    // new scope at all; until this byte is written, every failure here is
+    // indistinguishable from `systemd-run` failing to start us. A no-op on an
+    // ordinary run. See host/cgroup-relocation.ts.
+    acknowledgeRelocationEntry();
     const command = actionArgs[actionArgs.length - 1] as CommanderCommand;
     const positionals = extractActionPositionals(actionArgs);
     const optsBag = command.optsWithGlobals() as Record<string, unknown>;

--- a/clients/traycer-cli/src/service/__tests__/install-lifecycle.test.ts
+++ b/clients/traycer-cli/src/service/__tests__/install-lifecycle.test.ts
@@ -12,6 +12,7 @@ import {
 } from "../install-lifecycle";
 import { CLI_ERROR_CODES, CliError } from "../../runner/errors";
 import type { SwapLockRecovery } from "../../installer";
+import { epochMicrosNow } from "../platforms/windows";
 
 const mocks = vi.hoisted(() => ({
   createServiceControllerMock: vi.fn(),
@@ -59,10 +60,21 @@ vi.mock("../platforms/macos", () => ({
 // The Windows swap-lock recovery functions shell out to schtasks /
 // powershell / taskkill - stub the module so the wiring tests can assert
 // the lifecycle hands the label through without touching the OS.
-vi.mock("../platforms/windows", () => ({
-  killLingeringSlotProcesses: mocks.killLingeringSlotProcessesMock,
-  describeSlotLockHolders: mocks.describeSlotLockHoldersMock,
-}));
+vi.mock("../platforms/windows", async () => {
+  // The REAL clock helper, re-exported through the mock: the wiring test
+  // below asserts by identity that this exact function reaches the platform
+  // seam, and separately that it reads in the unit the kill loop compares
+  // against. A reimplementation here would let both pass for a helper that
+  // drifted.
+  const actual = await vi.importActual<typeof import("../platforms/windows")>(
+    "../platforms/windows",
+  );
+  return {
+    killLingeringSlotProcesses: mocks.killLingeringSlotProcessesMock,
+    describeSlotLockHolders: mocks.describeSlotLockHoldersMock,
+    epochMicrosNow: actual.epochMicrosNow,
+  };
+});
 
 // Deliberately NOT mocked: `../cli-invocation-shape`. The self-naming
 // predicate under test in the preserve-path suite below must run for real -
@@ -1001,10 +1013,24 @@ describe("swap-lock recovery wiring", () => {
       await expect(recovery.describeLockHolders()).resolves.toEqual(holders);
     }
     expect(mocks.killLingeringSlotProcessesMock).toHaveBeenCalledTimes(2);
+    // The clock is a required dependency, not an ambient one: the kill loop
+    // bounds its cross-round victim memory with it, and a caller that forgot to
+    // pass one would fail at the call rather than quietly reading a global.
+    // Asserted by IDENTITY (the real `epochMicrosNow`, re-exported through the
+    // mock above) and by UNIT: the loop compares this clock against creation
+    // times the scan projects in epoch microseconds, so a clock in
+    // milliseconds would put every victim's window a thousand times too early.
     expect(mocks.killLingeringSlotProcessesMock).toHaveBeenCalledWith(
       label,
       null,
+      { now: epochMicrosNow },
     );
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
+    try {
+      expect(epochMicrosNow()).toBe(1_700_000_000_000_000);
+    } finally {
+      nowSpy.mockRestore();
+    }
     expect(mocks.describeSlotLockHoldersMock).toHaveBeenCalledWith(label, null);
   });
 

--- a/clients/traycer-cli/src/service/__tests__/stop-intent-cgroup-guard.test.ts
+++ b/clients/traycer-cli/src/service/__tests__/stop-intent-cgroup-guard.test.ts
@@ -81,7 +81,33 @@ vi.mock("node:fs/promises", async (importOriginal) => {
   };
 });
 
-const { withStopIntent } = await import("../index");
+// The record transaction is the thing the outer decorator must NOT open when
+// the guard refuses; a spy stands in for it so the ordering is observable.
+// The stand-in still runs the wrapped uninstall, as the real transaction does,
+// so the pass-through control below proves the controller is reached THROUGH
+// it and not around it.
+const recordMocks = vi.hoisted(() => ({
+  uninstallTransactions: 0,
+}));
+
+vi.mock("../cli-invocation-record", () => ({
+  CLI_INVOCATION_TXN_POLL_MS: 10,
+  CLI_INVOCATION_TXN_WAIT_MS: 100,
+  runServiceRegistrationWithInvocationRecord: async () => {
+    throw new Error("not used in this test");
+  },
+  runServiceRemovalWithInvocationRecord: async () => {
+    throw new Error("not used in this test");
+  },
+  runServiceUninstallWithInvocationRecord: async (options: {
+    readonly uninstall: () => Promise<void>;
+  }) => {
+    recordMocks.uninstallTransactions += 1;
+    await options.uninstall();
+  },
+}));
+
+const { withCliInvocationRecord, withStopIntent } = await import("../index");
 
 const label: ServiceLabel = {
   id: "ai.traycer.host",
@@ -117,6 +143,61 @@ beforeEach(() => {
   mocks.clears.length = 0;
   mocks.persisted = true;
   mocks.cgroup = HOST_UNIT_CGROUP;
+  recordMocks.uninstallTransactions = 0;
+});
+
+describe("withCliInvocationRecord(withStopIntent(...)) - the guard runs before the record transaction", () => {
+  // The production composition puts the record decorator OUTSIDE the
+  // stop-intent one, so its transaction would be acquired before the inner
+  // guard ever ran - and a refusal thrown inside the transaction is treated
+  // as an OS uninstall that threw, which marks an intact record stale. The
+  // outer decorator therefore runs the guard itself, ahead of the
+  // transaction; this pins that a refusal opens no transaction at all.
+  it("uninstall: a guard refusal opens no record transaction and announces nothing", async () => {
+    let ran = false;
+    const controller = withCliInvocationRecord(
+      withStopIntent(
+        baseController({
+          uninstall: async () => {
+            ran = true;
+          },
+        }),
+      ),
+    );
+
+    await expect(controller.uninstall({ label })).rejects.toMatchObject({
+      code: "E_SERVICE_CONTROL_FAILED",
+    });
+
+    expect(recordMocks.uninstallTransactions).toBe(0);
+    expect(mocks.writes).toEqual([]);
+    expect(ran).toBe(false);
+
+    // Ablation: remove the `await assertNotInsideHostUnit();` from
+    // `withCliInvocationRecord`'s uninstall → this test reddens on
+    // `uninstallTransactions` (1, not 0): the inner guard still refuses, but
+    // only after the transaction stand-in has been entered.
+  });
+
+  it("uninstall: outside a host unit the transaction is entered exactly once and the controller runs through it", async () => {
+    mocks.cgroup = SCOPE_CGROUP;
+    let ran = false;
+    const controller = withCliInvocationRecord(
+      withStopIntent(
+        baseController({
+          uninstall: async () => {
+            ran = true;
+          },
+        }),
+      ),
+    );
+
+    await controller.uninstall({ label });
+
+    expect(recordMocks.uninstallTransactions).toBe(1);
+    expect(mocks.writes).toEqual(["uninstall"]);
+    expect(ran).toBe(true);
+  });
 });
 
 describe("withStopIntent - Linux cgroup self-protection guard", () => {

--- a/clients/traycer-cli/src/service/__tests__/stop-intent-cgroup-guard.test.ts
+++ b/clients/traycer-cli/src/service/__tests__/stop-intent-cgroup-guard.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import type { ServiceController, ServiceLabel } from "../index";
+
+// The second line of defence behind `withRunner`'s relocation
+// (host/cgroup-relocation.ts): every stop-shaped route on `withStopIntent`
+// re-reads `/proc/self/cgroup` and refuses BEFORE `announceStop`, so a
+// refusal leaves no record of a stop that never happened.
+//
+// This file only exercises the guard's placement and its refusal/pass-through
+// behaviour. `stop-intent-decorator.test.ts` already covers the write/clear
+// ordering in full and must not be touched or duplicated here - node:os is
+// pinned to darwin there, so its assertions are untouched by this guard.
+
+const mocks = vi.hoisted(() => ({
+  writes: [] as string[],
+  clears: [] as string[],
+  persisted: true,
+  cgroup: null as string | null,
+}));
+
+vi.mock("../../logger", () => ({
+  createCliLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+  errorFromUnknown: (value: unknown) =>
+    value instanceof Error ? value : new Error(String(value)),
+}));
+
+vi.mock("../../host/stop-intent", () => ({
+  writeStopIntent: async (_environment: string, reason: string) => {
+    mocks.writes.push(reason);
+    return mocks.persisted;
+  },
+  clearStopIntent: async (environment: string) => {
+    mocks.clears.push(environment);
+  },
+}));
+
+vi.mock("../../host/incumbent-check", () => ({
+  findLiveIncumbentHost: async () => null,
+}));
+
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:os")>();
+  return { ...actual, platform: () => "linux" as NodeJS.Platform };
+});
+
+const HOST_UNIT_CGROUP =
+  "0::/user.slice/user-1000.slice/user@1000.service/app.slice/ai.traycer.host.service\n";
+const SCOPE_CGROUP =
+  "0::/user.slice/user-1000.slice/user@1000.service/app.slice/run-r123.scope\n";
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs/promises")>();
+  return {
+    ...actual,
+    readFile: (async (
+      path: Parameters<typeof actual.readFile>[0],
+      options: Parameters<typeof actual.readFile>[1] | undefined,
+    ) => {
+      if (path === "/proc/self/cgroup") {
+        if (mocks.cgroup === null) {
+          throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+        }
+        return mocks.cgroup;
+      }
+      return options === undefined
+        ? actual.readFile(path)
+        : actual.readFile(path, options);
+    }) as typeof actual.readFile,
+  };
+});
+
+const { withStopIntent } = await import("../index");
+
+const label: ServiceLabel = {
+  id: "ai.traycer.host",
+  displayName: "Traycer Host",
+  environment: "production",
+  devSlot: null,
+};
+
+function baseController(
+  overrides: Partial<ServiceController>,
+): ServiceController {
+  const unimplemented = (): never => {
+    throw new Error("not used in this test");
+  };
+  return {
+    install: unimplemented,
+    uninstall: unimplemented,
+    status: unimplemented,
+    stop: unimplemented,
+    start: unimplemented,
+    restart: unimplemented,
+    stopForRestart: unimplemented,
+    relaunchAfterRestart: unimplemented,
+    hostStartAdoptionLabel: unimplemented,
+    retireCompetingRegistration: unimplemented,
+    takeoverDesktopRegistration: unimplemented,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mocks.writes.length = 0;
+  mocks.clears.length = 0;
+  mocks.persisted = true;
+  mocks.cgroup = HOST_UNIT_CGROUP;
+});
+
+describe("withStopIntent - Linux cgroup self-protection guard", () => {
+  it("stop: refuses with E_SERVICE_CONTROL_FAILED before announcing, writing, or running the controller", async () => {
+    let stopped = false;
+    const controller = withStopIntent(
+      baseController({
+        stop: async () => {
+          stopped = true;
+        },
+      }),
+    );
+
+    await expect(
+      controller.stop(label, { force: false }),
+    ).rejects.toMatchObject({ code: "E_SERVICE_CONTROL_FAILED" });
+
+    expect(mocks.writes).toEqual([]);
+    expect(stopped).toBe(false);
+    expect(mocks.clears).toEqual([]);
+  });
+
+  it("stopForRestart: refuses before announcing, writing, or running the controller", async () => {
+    let ran = false;
+    const controller = withStopIntent(
+      baseController({
+        stopForRestart: async () => {
+          ran = true;
+          return { forcedRecycle: false };
+        },
+      }),
+    );
+
+    await expect(
+      controller.stopForRestart(label, { force: false }),
+    ).rejects.toMatchObject({ code: "E_SERVICE_CONTROL_FAILED" });
+
+    expect(mocks.writes).toEqual([]);
+    expect(ran).toBe(false);
+    expect(mocks.clears).toEqual([]);
+  });
+
+  it("uninstall: refuses before announcing, writing, or running the controller", async () => {
+    let ran = false;
+    const controller = withStopIntent(
+      baseController({
+        uninstall: async () => {
+          ran = true;
+        },
+      }),
+    );
+
+    await expect(controller.uninstall({ label })).rejects.toMatchObject({
+      code: "E_SERVICE_CONTROL_FAILED",
+    });
+
+    expect(mocks.writes).toEqual([]);
+    expect(ran).toBe(false);
+    expect(mocks.clears).toEqual([]);
+  });
+
+  it("restart: refuses before announcing, writing, or running the controller", async () => {
+    let ran = false;
+    const controller = withStopIntent(
+      baseController({
+        restart: async () => {
+          ran = true;
+        },
+      }),
+    );
+
+    await expect(controller.restart(label)).rejects.toMatchObject({
+      code: "E_SERVICE_CONTROL_FAILED",
+    });
+
+    expect(mocks.writes).toEqual([]);
+    expect(ran).toBe(false);
+    expect(mocks.clears).toEqual([]);
+  });
+
+  // Positive control: a relocated scope cgroup (`run-*.scope`) is not a host
+  // unit, so the guard resolves and every route proceeds exactly as it did
+  // before this change - `stop-intent-decorator.test.ts` covers the ordering
+  // and withdrawal semantics in full; this is just proof the guard is not
+  // gating every call unconditionally regardless of cgroup content.
+  it("proceeds through all four routes when outside a host unit (run-*.scope)", async () => {
+    mocks.cgroup = SCOPE_CGROUP;
+    let stopRan = false;
+    let stopForRestartRan = false;
+    let uninstallRan = false;
+    let restartRan = false;
+
+    const stopController = withStopIntent(
+      baseController({
+        stop: async () => {
+          stopRan = true;
+        },
+      }),
+    );
+    await stopController.stop(label, { force: false });
+
+    const stopForRestartController = withStopIntent(
+      baseController({
+        stopForRestart: async () => {
+          stopForRestartRan = true;
+          return { forcedRecycle: false };
+        },
+      }),
+    );
+    await stopForRestartController.stopForRestart(label, { force: false });
+
+    const uninstallController = withStopIntent(
+      baseController({
+        uninstall: async () => {
+          uninstallRan = true;
+        },
+      }),
+    );
+    await uninstallController.uninstall({ label });
+
+    const restartController = withStopIntent(
+      baseController({
+        restart: async () => {
+          restartRan = true;
+        },
+      }),
+    );
+    await restartController.restart(label);
+
+    expect(stopRan).toBe(true);
+    expect(stopForRestartRan).toBe(true);
+    expect(uninstallRan).toBe(true);
+    expect(restartRan).toBe(true);
+    expect(mocks.writes).toEqual(["stop", "restart", "uninstall", "restart"]);
+  });
+
+  // Ablation (run once per method, one at a time - four separate ablations):
+  // in `service/index.ts`'s `withStopIntent`, delete the
+  // `await assertNotInsideHostUnit();` line from `stop` → its refusal test
+  // above fails (the write/controller-call assertions flip: writes becomes
+  // ["stop"] and `stopped` becomes true instead of staying at their refused
+  // values). Same recipe for `stopForRestart`, `uninstall`, and `restart` -
+  // deleting any one of the four guard calls turns exactly that method's
+  // refusal test red while leaving the other three green, which is what
+  // proves the guard is wired into each route independently rather than
+  // shared through some common choke point that would fail all four at once.
+});

--- a/clients/traycer-cli/src/service/__tests__/stop-intent-cgroup-guard.test.ts
+++ b/clients/traycer-cli/src/service/__tests__/stop-intent-cgroup-guard.test.ts
@@ -15,7 +15,9 @@ const mocks = vi.hoisted(() => ({
   writes: [] as string[],
   clears: [] as string[],
   persisted: true,
-  cgroup: null as string | null,
+  // A string is the cgroup file's contents; an object is the errno the read
+  // fails with instead.
+  cgroup: null as string | null | { readonly errno: string },
 }));
 
 vi.mock("../../logger", () => ({
@@ -64,6 +66,11 @@ vi.mock("node:fs/promises", async (importOriginal) => {
       if (path === "/proc/self/cgroup") {
         if (mocks.cgroup === null) {
           throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+        }
+        if (typeof mocks.cgroup === "object") {
+          throw Object.assign(new Error(mocks.cgroup.errno), {
+            code: mocks.cgroup.errno,
+          });
         }
         return mocks.cgroup;
       }
@@ -243,6 +250,75 @@ describe("withStopIntent - Linux cgroup self-protection guard", () => {
     expect(stopForRestartRan).toBe(true);
     expect(uninstallRan).toBe(true);
     expect(restartRan).toBe(true);
+    expect(mocks.writes).toEqual(["stop", "restart", "uninstall", "restart"]);
+  });
+
+  // An unreadable cgroup is a FAILED membership check, not a negative answer,
+  // and it has to refuse on every route for the same reason the host-unit case
+  // does: EACCES leaves us just as likely to be inside the unit, and proceeding
+  // writes intent and then kills the process issuing the stop.
+  it("refuses on all four routes when the cgroup cannot be read (EACCES)", async () => {
+    mocks.cgroup = { errno: "EACCES" };
+    let ran = false;
+    const controller = withStopIntent(
+      baseController({
+        stop: async () => {
+          ran = true;
+        },
+        stopForRestart: async () => {
+          ran = true;
+          return { forcedRecycle: false };
+        },
+        uninstall: async () => {
+          ran = true;
+        },
+        restart: async () => {
+          ran = true;
+        },
+      }),
+    );
+
+    await expect(
+      controller.stop(label, { force: false }),
+    ).rejects.toMatchObject({ code: "E_SERVICE_CONTROL_FAILED" });
+    await expect(
+      controller.stopForRestart(label, { force: false }),
+    ).rejects.toMatchObject({ code: "E_SERVICE_CONTROL_FAILED" });
+    await expect(controller.uninstall({ label })).rejects.toMatchObject({
+      code: "E_SERVICE_CONTROL_FAILED",
+    });
+    await expect(controller.restart(label)).rejects.toMatchObject({
+      code: "E_SERVICE_CONTROL_FAILED",
+    });
+
+    expect(mocks.writes).toEqual([]);
+    expect(mocks.clears).toEqual([]);
+    expect(ran).toBe(false);
+
+    // Ablation: in `readHostUnitCgroup` (host/cgroup-relocation.ts), replace
+    // the `isMissingCgroupFile` branch with a blanket `return null` → this
+    // test fails on the first route: the guard resolves, intent is written,
+    // and the stop proceeds from inside a cgroup nobody could rule out.
+  });
+
+  // An ABSENT cgroup file is a different machine and a real answer: no cgroup
+  // exists that could kill us, so all four proceed.
+  it("proceeds on all four routes when /proc/self/cgroup is absent (ENOENT)", async () => {
+    mocks.cgroup = { errno: "ENOENT" };
+    const controller = withStopIntent(
+      baseController({
+        stop: async () => undefined,
+        stopForRestart: async () => ({ forcedRecycle: false }),
+        uninstall: async () => undefined,
+        restart: async () => undefined,
+      }),
+    );
+
+    await controller.stop(label, { force: false });
+    await controller.stopForRestart(label, { force: false });
+    await controller.uninstall({ label });
+    await controller.restart(label);
+
     expect(mocks.writes).toEqual(["stop", "restart", "uninstall", "restart"]);
   });
 

--- a/clients/traycer-cli/src/service/__tests__/stop-intent-cgroup-guard.test.ts
+++ b/clients/traycer-cli/src/service/__tests__/stop-intent-cgroup-guard.test.ts
@@ -88,13 +88,17 @@ vi.mock("node:fs/promises", async (importOriginal) => {
 // it and not around it.
 const recordMocks = vi.hoisted(() => ({
   uninstallTransactions: 0,
+  registrationTransactions: 0,
 }));
 
 vi.mock("../cli-invocation-record", () => ({
   CLI_INVOCATION_TXN_POLL_MS: 10,
   CLI_INVOCATION_TXN_WAIT_MS: 100,
-  runServiceRegistrationWithInvocationRecord: async () => {
-    throw new Error("not used in this test");
+  runServiceRegistrationWithInvocationRecord: async (options: {
+    readonly register: () => Promise<void>;
+  }) => {
+    recordMocks.registrationTransactions += 1;
+    await options.register();
   },
   runServiceRemovalWithInvocationRecord: async () => {
     throw new Error("not used in this test");
@@ -144,7 +148,14 @@ beforeEach(() => {
   mocks.persisted = true;
   mocks.cgroup = HOST_UNIT_CGROUP;
   recordMocks.uninstallTransactions = 0;
+  recordMocks.registrationTransactions = 0;
 });
+
+const installOptions = {
+  label,
+  cli: { command: "/opt/traycer/traycer", args: [] },
+  enableLinger: false,
+} as const;
 
 describe("withCliInvocationRecord(withStopIntent(...)) - the guard runs before the record transaction", () => {
   // The production composition puts the record decorator OUTSIDE the
@@ -198,6 +209,59 @@ describe("withCliInvocationRecord(withStopIntent(...)) - the guard runs before t
     expect(mocks.writes).toEqual(["uninstall"]);
     expect(ran).toBe(true);
   });
+
+  // The install actuator is the fifth guarded route, and the outer guard
+  // matters for it for the mirror-image reason: a throw from `register` inside
+  // `runServiceRegistrationWithInvocationRecord` marks the live record stale
+  // (the OS may describe a half-done registration), which a refusal that
+  // touched nothing must not do to an intact registration.
+  it("install: a guard refusal opens no registration transaction, announces nothing, and never reaches the controller", async () => {
+    let ran = false;
+    const controller = withCliInvocationRecord(
+      withStopIntent(
+        baseController({
+          install: async () => {
+            ran = true;
+          },
+        }),
+      ),
+    );
+
+    await expect(controller.install(installOptions)).rejects.toMatchObject({
+      code: "E_SERVICE_CONTROL_FAILED",
+    });
+
+    expect(recordMocks.registrationTransactions).toBe(0);
+    expect(mocks.writes).toEqual([]);
+    expect(ran).toBe(false);
+
+    // Ablation: remove the `await assertNotInsideHostUnit();` from
+    // `withCliInvocationRecord`'s install → this test reddens on
+    // `registrationTransactions` (1, not 0): the inner guard still refuses,
+    // but only after the transaction stand-in has been entered.
+  });
+
+  it("install: outside a host unit the registration transaction is entered exactly once, the controller runs through it, and no intent is written", async () => {
+    mocks.cgroup = SCOPE_CGROUP;
+    let ran = false;
+    const controller = withCliInvocationRecord(
+      withStopIntent(
+        baseController({
+          install: async () => {
+            ran = true;
+          },
+        }),
+      ),
+    );
+
+    await controller.install(installOptions);
+
+    expect(recordMocks.registrationTransactions).toBe(1);
+    // An install is not a stop: the guard is there for the Linux rollback's
+    // sake, and no stop intent is announced on the way in.
+    expect(mocks.writes).toEqual([]);
+    expect(ran).toBe(true);
+  });
 });
 
 describe("withStopIntent - Linux cgroup self-protection guard", () => {
@@ -218,6 +282,28 @@ describe("withStopIntent - Linux cgroup self-protection guard", () => {
     expect(mocks.writes).toEqual([]);
     expect(stopped).toBe(false);
     expect(mocks.clears).toEqual([]);
+  });
+
+  // Not a stop route, but its Linux failure path is one: `installService`
+  // rolls a failed `enable --now` back with `disable --now` on the unit, which
+  // stops the live host and, from inside the unit, the CLI issuing it.
+  it("install: refuses before running the controller, and writes no intent either way", async () => {
+    let ran = false;
+    const controller = withStopIntent(
+      baseController({
+        install: async () => {
+          ran = true;
+        },
+      }),
+    );
+
+    await expect(controller.install(installOptions)).rejects.toMatchObject({
+      code: "E_SERVICE_CONTROL_FAILED",
+    });
+
+    expect(mocks.writes).toEqual([]);
+    expect(mocks.clears).toEqual([]);
+    expect(ran).toBe(false);
   });
 
   it("stopForRestart: refuses before announcing, writing, or running the controller", async () => {
@@ -283,12 +369,13 @@ describe("withStopIntent - Linux cgroup self-protection guard", () => {
   // before this change - `stop-intent-decorator.test.ts` covers the ordering
   // and withdrawal semantics in full; this is just proof the guard is not
   // gating every call unconditionally regardless of cgroup content.
-  it("proceeds through all four routes when outside a host unit (run-*.scope)", async () => {
+  it("proceeds through all five routes when outside a host unit (run-*.scope)", async () => {
     mocks.cgroup = SCOPE_CGROUP;
     let stopRan = false;
     let stopForRestartRan = false;
     let uninstallRan = false;
     let restartRan = false;
+    let installRan = false;
 
     const stopController = withStopIntent(
       baseController({
@@ -327,10 +414,21 @@ describe("withStopIntent - Linux cgroup self-protection guard", () => {
     );
     await restartController.restart(label);
 
+    const installController = withStopIntent(
+      baseController({
+        install: async () => {
+          installRan = true;
+        },
+      }),
+    );
+    await installController.install(installOptions);
+
     expect(stopRan).toBe(true);
     expect(stopForRestartRan).toBe(true);
     expect(uninstallRan).toBe(true);
     expect(restartRan).toBe(true);
+    expect(installRan).toBe(true);
+    // Four intents for four stops; the install writes none.
     expect(mocks.writes).toEqual(["stop", "restart", "uninstall", "restart"]);
   });
 
@@ -338,11 +436,14 @@ describe("withStopIntent - Linux cgroup self-protection guard", () => {
   // and it has to refuse on every route for the same reason the host-unit case
   // does: EACCES leaves us just as likely to be inside the unit, and proceeding
   // writes intent and then kills the process issuing the stop.
-  it("refuses on all four routes when the cgroup cannot be read (EACCES)", async () => {
+  it("refuses on all five routes when the cgroup cannot be read (EACCES)", async () => {
     mocks.cgroup = { errno: "EACCES" };
     let ran = false;
     const controller = withStopIntent(
       baseController({
+        install: async () => {
+          ran = true;
+        },
         stop: async () => {
           ran = true;
         },
@@ -371,6 +472,9 @@ describe("withStopIntent - Linux cgroup self-protection guard", () => {
     await expect(controller.restart(label)).rejects.toMatchObject({
       code: "E_SERVICE_CONTROL_FAILED",
     });
+    await expect(controller.install(installOptions)).rejects.toMatchObject({
+      code: "E_SERVICE_CONTROL_FAILED",
+    });
 
     expect(mocks.writes).toEqual([]);
     expect(mocks.clears).toEqual([]);
@@ -383,11 +487,15 @@ describe("withStopIntent - Linux cgroup self-protection guard", () => {
   });
 
   // An ABSENT cgroup file is a different machine and a real answer: no cgroup
-  // exists that could kill us, so all four proceed.
-  it("proceeds on all four routes when /proc/self/cgroup is absent (ENOENT)", async () => {
+  // exists that could kill us, so all five proceed.
+  it("proceeds on all five routes when /proc/self/cgroup is absent (ENOENT)", async () => {
     mocks.cgroup = { errno: "ENOENT" };
+    let installRan = false;
     const controller = withStopIntent(
       baseController({
+        install: async () => {
+          installRan = true;
+        },
         stop: async () => undefined,
         stopForRestart: async () => ({ forcedRecycle: false }),
         uninstall: async () => undefined,
@@ -399,18 +507,23 @@ describe("withStopIntent - Linux cgroup self-protection guard", () => {
     await controller.stopForRestart(label, { force: false });
     await controller.uninstall({ label });
     await controller.restart(label);
+    await controller.install(installOptions);
 
     expect(mocks.writes).toEqual(["stop", "restart", "uninstall", "restart"]);
+    expect(installRan).toBe(true);
   });
 
-  // Ablation (run once per method, one at a time - four separate ablations):
+  // Ablation (run once per method, one at a time - five separate ablations):
   // in `service/index.ts`'s `withStopIntent`, delete the
   // `await assertNotInsideHostUnit();` line from `stop` → its refusal test
   // above fails (the write/controller-call assertions flip: writes becomes
   // ["stop"] and `stopped` becomes true instead of staying at their refused
-  // values). Same recipe for `stopForRestart`, `uninstall`, and `restart` -
-  // deleting any one of the four guard calls turns exactly that method's
-  // refusal test red while leaving the other three green, which is what
+  // values). Same recipe for `stopForRestart`, `uninstall`, `restart`, and
+  // `install` (whose `ran` flips to true; it writes nothing either way) -
+  // deleting any one of the five guard calls turns exactly that method's
+  // refusal test red (plus the combined EACCES test, which exercises every
+  // route) while leaving the other four refusal tests green, which is what
   // proves the guard is wired into each route independently rather than
-  // shared through some common choke point that would fail all four at once.
+  // shared through some common choke point that would fail all five at once.
+  // Run and confirmed for `install`: 2 failed, 10 passed.
 });

--- a/clients/traycer-cli/src/service/index.ts
+++ b/clients/traycer-cli/src/service/index.ts
@@ -367,8 +367,18 @@ export function withCliInvocationRecord(
 ): ServiceController {
   return {
     ...controller,
-    install: (options) =>
-      runServiceRegistrationWithInvocationRecord({
+    install: async (options) => {
+      // The Linux self-protection guard runs BEFORE the record transaction
+      // here too, for the mirror image of the `uninstall` reason below: a
+      // throw from `register` is treated as an OS registration that may be
+      // half-done and marks the live record stale, and a refusal that touched
+      // nothing must not do that to an intact registration. The guard is on
+      // `install` at all because the Linux install's failure path is a stop:
+      // `installService` rolls a failed `enable --now` back with
+      // `disable --now` on the unit, which stops the live host - and the CLI
+      // with it, if the relocation silently left it inside the unit.
+      await assertNotInsideHostUnit();
+      return runServiceRegistrationWithInvocationRecord({
         environment: options.label.environment,
         hostHomeDir: hostHomeDir(options.label.environment),
         serviceLabel: options.label.id,
@@ -376,7 +386,8 @@ export function withCliInvocationRecord(
         register: () => controller.install(options),
         waitMs: CLI_INVOCATION_TXN_WAIT_MS,
         pollIntervalMs: CLI_INVOCATION_TXN_POLL_MS,
-      }),
+      });
+    },
     uninstall: async (options) => {
       // The Linux self-protection guard runs BEFORE the record transaction,
       // not only inside `withStopIntent` beneath it. Inside the transaction a
@@ -463,7 +474,17 @@ export function withStopIntent(
     // refused here instead of killing the process issuing the stop. `restart`
     // is included because it is a real actuator - `systemctl --user restart`
     // goes through it, not through `stop` - and leaving it out would leave one
-    // allowlisted command with no second line.
+    // allowlisted command with no second line. `install` carries the guard for
+    // the same reason and nothing else: it is not a stop and announces no
+    // intent, but the Linux `installService` rolls a failed `enable --now`
+    // back with `disable --now` on the unit, and that rollback stops the live
+    // host. Every route into it - `host service install`, and the
+    // registration inside `host install` / `ensure` / `apply` / `update` -
+    // reaches this decorator through the production factory.
+    install: async (options) => {
+      await assertNotInsideHostUnit();
+      return controller.install(options);
+    },
     stop: async (label, options) => {
       await assertNotInsideHostUnit();
       await announceStop(label.environment, "stop", options.force);

--- a/clients/traycer-cli/src/service/index.ts
+++ b/clients/traycer-cli/src/service/index.ts
@@ -377,15 +377,26 @@ export function withCliInvocationRecord(
         waitMs: CLI_INVOCATION_TXN_WAIT_MS,
         pollIntervalMs: CLI_INVOCATION_TXN_POLL_MS,
       }),
-    uninstall: (options) =>
-      runServiceUninstallWithInvocationRecord({
+    uninstall: async (options) => {
+      // The Linux self-protection guard runs BEFORE the record transaction,
+      // not only inside `withStopIntent` beneath it. Inside the transaction a
+      // refusal is indistinguishable from an OS uninstall that threw, and
+      // `runServiceRemovalWithInvocationRecord` rightly treats that as "the
+      // service may be half-gone" and marks the live record stale - for a
+      // preflight that touched nothing, that would send every later host read
+      // through OS recovery for an intact registration. The inner guard stays:
+      // it is `withStopIntent`'s own contract for any composition that lacks
+      // this decorator, and a second cgroup read costs nothing.
+      await assertNotInsideHostUnit();
+      return runServiceUninstallWithInvocationRecord({
         environment: options.label.environment,
         hostHomeDir: hostHomeDir(options.label.environment),
         serviceLabel: options.label.id,
         uninstall: () => controller.uninstall(options),
         waitMs: CLI_INVOCATION_TXN_WAIT_MS,
         pollIntervalMs: CLI_INVOCATION_TXN_POLL_MS,
-      }),
+      });
+    },
     // The competing-registration repair removes THIS label's registration -
     // the one a live record describes - on macOS when Desktop owns host
     // registration, so it runs inside the same transaction as an uninstall.
@@ -506,6 +517,10 @@ export function withStopIntent(
  * supervisor would sit silenced for the intent's lifetime with no uninstall
  * having occurred. Inside the transaction, the intent is announced only once
  * the backend uninstall is actually about to run.
+ *
+ * The one thing that runs before BOTH is the Linux cgroup guard: the outer
+ * decorator's uninstall re-runs it ahead of acquiring the transaction, so a
+ * refusal neither publishes an intent nor invalidates the record.
  */
 export function createServiceController(): ServiceController {
   const platform = osPlatform();

--- a/clients/traycer-cli/src/service/index.ts
+++ b/clients/traycer-cli/src/service/index.ts
@@ -6,7 +6,7 @@ import type { CliInvocation } from "./cli-binary";
 import type { ServiceLabel } from "./label";
 import { createLinuxController } from "./platforms/linux";
 import { createMacosController } from "./platforms/macos";
-import { createWindowsController } from "./platforms/windows";
+import { createWindowsController, epochMicrosNow } from "./platforms/windows";
 import { assertNotInsideHostUnit } from "../host/cgroup-relocation";
 import { clearStopIntent, writeStopIntent } from "../host/stop-intent";
 import { findLiveIncumbentHost } from "../host/incumbent-check";
@@ -531,7 +531,7 @@ export function createServiceController(): ServiceController {
       environment: config.environment,
     });
     return withCliInvocationRecord(
-      withStopIntent(createWindowsController(null)),
+      withStopIntent(createWindowsController(null, { now: epochMicrosNow })),
     );
   }
   logger.error(

--- a/clients/traycer-cli/src/service/index.ts
+++ b/clients/traycer-cli/src/service/index.ts
@@ -7,6 +7,7 @@ import type { ServiceLabel } from "./label";
 import { createLinuxController } from "./platforms/linux";
 import { createMacosController } from "./platforms/macos";
 import { createWindowsController } from "./platforms/windows";
+import { assertNotInsideHostUnit } from "../host/cgroup-relocation";
 import { clearStopIntent, writeStopIntent } from "../host/stop-intent";
 import { findLiveIncumbentHost } from "../host/incumbent-check";
 import { hostHomeDir } from "../store/paths";
@@ -442,7 +443,18 @@ export function withStopIntent(
     // written - before it has spawned a child or published `pid.json`. Clearing
     // there hands the old supervisor a window in which it sees neither intent
     // nor an incumbent, and it relaunches. One restart, two hosts.
+    //
+    // Each route also carries the Linux self-protection guard, BEFORE its
+    // announcement so a refusal leaves no record of a stop that never happened.
+    // This is the second line behind the relocation in `withRunner`
+    // (host/cgroup-relocation.ts): it re-reads the cgroup, so a machine with no
+    // `systemd-run`, no user manager, or a scope that failed to move us is
+    // refused here instead of killing the process issuing the stop. `restart`
+    // is included because it is a real actuator - `systemctl --user restart`
+    // goes through it, not through `stop` - and leaving it out would leave one
+    // allowlisted command with no second line.
     stop: async (label, options) => {
+      await assertNotInsideHostUnit();
       await announceStop(label.environment, "stop", options.force);
       try {
         return await controller.stop(label, options);
@@ -452,6 +464,7 @@ export function withStopIntent(
       }
     },
     stopForRestart: async (label, options) => {
+      await assertNotInsideHostUnit();
       await announceStop(label.environment, "restart", options.force);
       try {
         return await controller.stopForRestart(label, options);
@@ -461,6 +474,7 @@ export function withStopIntent(
       }
     },
     uninstall: async (options) => {
+      await assertNotInsideHostUnit();
       await announceStop(options.label.environment, "uninstall", false);
       try {
         return await controller.uninstall(options);
@@ -470,6 +484,7 @@ export function withStopIntent(
       }
     },
     restart: async (label) => {
+      await assertNotInsideHostUnit();
       await announceStop(label.environment, "restart", false);
       try {
         return await controller.restart(label);

--- a/clients/traycer-cli/src/service/install-lifecycle.ts
+++ b/clients/traycer-cli/src/service/install-lifecycle.ts
@@ -14,6 +14,7 @@ import {
 import { readRegisteredCliInvocation } from "./platforms/macos";
 import {
   describeSlotLockHolders,
+  epochMicrosNow,
   killLingeringSlotProcesses,
 } from "./platforms/windows";
 import type { Environment } from "../runner/environment";
@@ -33,7 +34,8 @@ import type { HostStartAdoptionPublisher } from "../host/host-start-adoption";
 function swapLockRecoveryFor(label: ServiceLabel): SwapLockRecovery | null {
   if (process.platform !== "win32") return null;
   return {
-    killLingeringProcesses: () => killLingeringSlotProcesses(label, null),
+    killLingeringProcesses: () =>
+      killLingeringSlotProcesses(label, null, { now: epochMicrosNow }),
     describeLockHolders: () => describeSlotLockHolders(label, null),
   };
 }

--- a/clients/traycer-cli/src/service/platforms/__tests__/windows-hidden-launcher.test.ts
+++ b/clients/traycer-cli/src/service/platforms/__tests__/windows-hidden-launcher.test.ts
@@ -129,6 +129,84 @@ function assignmentLiteral(script: string, statement: string): string {
   return line.slice(line.indexOf("=") + 1).trim();
 }
 
+/**
+ * Evaluates the nonce-read expression the launcher emits, with VBScript's
+ * semantics for the pieces it uses: nested `Trim(...)` / `Replace(s, a, b)`
+ * calls over string literals, the `vbCr` / `vbLf` constants, and the probe's
+ * `nonceProbe.StdOut.ReadAll`, which is bound to `probeStdout`. The one
+ * semantic that matters is pinned rather than assumed: VBScript `Trim`
+ * strips SPACES only - not CR, not LF - which is exactly why `Trim` alone
+ * never yielded a nonce the pattern accepted.
+ */
+function evaluateVbsStringExpression(
+  expression: string,
+  probeStdout: string,
+): string {
+  let index = 0;
+  const peek = (): string => expression[index] ?? "";
+  const skipSpaces = (): void => {
+    while (peek() === " ") index += 1;
+  };
+  const parse = (): string => {
+    skipSpaces();
+    if (peek() === '"') {
+      const start = index;
+      index += 1;
+      while (index < expression.length) {
+        if (expression[index] === '"') {
+          if (expression[index + 1] === '"') {
+            index += 2;
+            continue;
+          }
+          index += 1;
+          break;
+        }
+        index += 1;
+      }
+      return decodeVbsStringLiteral(expression.slice(start, index));
+    }
+    const start = index;
+    while (/[A-Za-z0-9_.]/.test(peek())) index += 1;
+    const name = expression.slice(start, index);
+    skipSpaces();
+    if (peek() !== "(") {
+      if (name === "vbCr") return "\r";
+      if (name === "vbLf") return "\n";
+      if (name === "nonceProbe.StdOut.ReadAll") return probeStdout;
+      throw new Error(`unknown VBScript identifier: ${name}`);
+    }
+    index += 1;
+    const args: string[] = [];
+    for (;;) {
+      args.push(parse());
+      skipSpaces();
+      if (peek() === ",") {
+        index += 1;
+        continue;
+      }
+      if (peek() === ")") {
+        index += 1;
+        break;
+      }
+      throw new Error(`unterminated call in: ${expression}`);
+    }
+    if (name === "Trim" && args.length === 1) {
+      return (args[0] ?? "").replace(/^ +/, "").replace(/ +$/, "");
+    }
+    if (name === "Replace" && args.length === 3) {
+      const [subject, find, replacement] = args;
+      return (subject ?? "").split(find ?? "").join(replacement ?? "");
+    }
+    throw new Error(`unsupported VBScript call: ${name}/${args.length}`);
+  };
+  const value = parse();
+  skipSpaces();
+  if (index !== expression.length) {
+    throw new Error(`trailing input in: ${expression}`);
+  }
+  return value;
+}
+
 /** The single argument of the `shell.Run(<literal>, 0, True)` call in `line`. */
 function shellRunLiteral(script: string, marker: string): string {
   const line = script
@@ -234,6 +312,66 @@ describe("Windows hidden host launcher — decoded as Windows decodes it", () =>
     ]);
     expect(script).toContain("adoption-nonce");
     expect(script).toContain("noncePattern.Pattern");
+  });
+
+  it("still passes the nonce to the pattern when the probe's stdout ends in LF or CRLF", () => {
+    // `traycer host adoption-nonce` writes `${nonce}\n`. VBScript `Trim`
+    // removes spaces only, and `noncePattern` is anchored with `$` on a
+    // single-line RegExp, which does not match before a trailing LF - so a
+    // `Trim(...)`-only read failed the pattern on EVERY launch and the task
+    // started the host without `--adoption-nonce`; the supervisor then
+    // refused the pending grant until it aged out (~60 s) and every
+    // task-managed start reported failure while the host came up late.
+    // Falsification recipe (this file cannot run cscript): on Windows,
+    // `cscript //nologo t.vbs` with
+    //   s = "0f6c1b2e-8a44-4d19-9c3e-5b7a0d21f8ac" & vbLf
+    //   Set r = New RegExp : r.Pattern = "^[0-9A-Fa-f-]{36}$"
+    //   WScript.Echo Len(Trim(s)) & " " & r.Test(Trim(s))
+    // prints `37 False`; with the Replace pair it prints `36 True`
+    // (observed 2026-09-06 on Windows 11 26200).
+    const script = buildWindowsHiddenHostLauncher(cli, serviceLabel);
+    const readLine = script
+      .split("\r\n")
+      .map((line) => line.trim())
+      .find((line) => line.includes("nonceProbe.StdOut.ReadAll"));
+    const prefix = "If nonceProbe.ExitCode = 0 Then adoptionNonce = ";
+    expect(readLine?.startsWith(prefix)).toBe(true);
+    const expression = (readLine ?? "").slice(prefix.length);
+    // A JS RegExp without the `m` flag and a VBScript RegExp without
+    // `Multiline` agree on `$`: only the very end of the string, never before
+    // a trailing LF. The pattern is taken from the script, not restated.
+    const pattern = new RegExp(
+      decodeVbsStringLiteral(
+        assignmentLiteral(script, "noncePattern.Pattern ="),
+      ),
+    );
+    expect(script).not.toContain("noncePattern.Multiline");
+    const nonce = "0f6c1b2e-8a44-4d19-9c3e-5b7a0d21f8ac";
+    for (const stdout of [
+      `${nonce}\n`,
+      `${nonce}\r\n`,
+      `${nonce} \r\n`,
+      nonce,
+    ]) {
+      expect(
+        pattern.test(evaluateVbsStringExpression(expression, stdout)),
+      ).toBe(true);
+    }
+    // Control for the evaluator: with the pre-fix expression the same input
+    // must FAIL the same pattern, or `Trim` above would be stripping the
+    // newline and this test would be passing for the wrong reason.
+    expect(
+      pattern.test(
+        evaluateVbsStringExpression(
+          "Trim(nonceProbe.StdOut.ReadAll)",
+          `${nonce}\n`,
+        ),
+      ),
+    ).toBe(false);
+    // The strip must not widen what the pattern accepts.
+    expect(
+      pattern.test(evaluateVbsStringExpression(expression, "not a nonce\n")),
+    ).toBe(false);
   });
 
   it("degrades to the unlabelled start when the probe cannot even be launched", () => {

--- a/clients/traycer-cli/src/service/platforms/__tests__/windows.test.ts
+++ b/clients/traycer-cli/src/service/platforms/__tests__/windows.test.ts
@@ -448,38 +448,6 @@ describe("Windows service stale host cleanup", () => {
     ).toEqual(["402"]);
   });
 
-  it("falls back to the recorded pid when the slot scan cannot run", async () => {
-    mocks.readHostPidMetadata.mockResolvedValue({
-      pid: 401,
-      hostId: "host-test",
-      version: "1.0.0",
-      websocketUrl: "ws://127.0.0.1:54321/rpc",
-      startedAt: "2026-01-01T00:00:00.000Z",
-    });
-    const calls: RecordedCall[] = [];
-    const runner: ProcessRunner = async (command, args) => {
-      calls.push({ command, args });
-      if (command === "powershell.exe") throw new Error("spawn failed");
-      return success("");
-    };
-    const controller = createWindowsController(runner);
-
-    await controller.stop(serviceLabelFor("staging"), { force: false });
-
-    expect(
-      calls
-        .filter((call) => call.command === "taskkill")
-        .map((call) => call.args[2]),
-    ).toEqual(["401"]);
-    expect(calls.every((call) => !call.args.includes("/T"))).toBe(true);
-
-    // Ablation (for the "NEVER /T" pins in this describe block): in
-    // `killHostProcessTree`, put `"/T"` back into the `taskkill` argv (i.e.
-    // `run("taskkill", ["/T", "/F", "/PID", String(pid)], ...)`) → every
-    // `.toEqual([["/F", ...`) assertion above fails, and every
-    // `.every((call) => !call.args.includes("/T"))` check flips to false.
-  });
-
   it("purges pid metadata on uninstall like it does on stop", async () => {
     const runner: ProcessRunner = async (command) =>
       command === "powershell.exe" ? success("[]") : success("");
@@ -498,6 +466,29 @@ describe("Windows service stale host cleanup", () => {
     await controller.stop(serviceLabelFor("staging"), { force: false });
 
     expect(mocks.removeHostPidMetadata).toHaveBeenCalledWith("staging");
+  });
+
+  // The other side of the same rule as the test above: a stop that could not
+  // be VERIFIED must not purge pid.json either. Codex's finding in full was
+  // "`stopService` then deletes pid.json and `host stop` says success while
+  // descendants live" - a refused stop reporting the host gone would be that
+  // exact bug wearing a different trigger.
+  //
+  // Ablation (§ablation table, row 2): the same `scannedPids === null`
+  // `throw` → `return` mutation reddens this test too - the promise
+  // resolves, so `removeHostPidMetadata` gets called after all.
+  it("does NOT purge pid metadata when the stop refuses - a refusal must not read as a clean exit", async () => {
+    const runner: ProcessRunner = async (command) => {
+      if (command === "powershell.exe") throw new Error("spawn failed");
+      return success("");
+    };
+    const controller = createWindowsController(runner);
+
+    await expect(
+      controller.stop(serviceLabelFor("staging"), { force: false }),
+    ).rejects.toMatchObject({ code: "E_SERVICE_CONTROL_FAILED" });
+
+    expect(mocks.removeHostPidMetadata).not.toHaveBeenCalled();
   });
 });
 
@@ -594,12 +585,13 @@ describe("killHostProcessTree convergence loop", () => {
     // spawn - survives the stop exactly as the Codex finding describes.
   });
 
-  it("the bound holds: a host that never stops spawning is scanned and killed exactly WINDOWS_KILL_CONVERGENCE_ROUNDS times, not forever", async () => {
+  it("the bound holds AND the stop fails naming the survivors: a host that never stops spawning is not killed forever", async () => {
     // Every round's scan hands back a BRAND NEW pid, so the loop never
     // converges on its own - the only thing that ends it is the round bound.
     // Bounded is the right call: a host spawning faster than we can scan is
-    // not converging, and grinding on it forever is worse than stopping and
-    // reporting the swap's own EBUSY detail scan naming the survivors.
+    // not converging, and grinding on it forever is worse than refusing and
+    // naming the survivors so an operator (or the swap's own EBUSY detail
+    // scan) can act on them.
     let scanCount = 0;
     const calls: RecordedCall[] = [];
     const runner: ProcessRunner = async (command, args) => {
@@ -615,11 +607,19 @@ describe("killHostProcessTree convergence loop", () => {
     };
     const controller = createWindowsController(runner);
 
-    await controller.stop(serviceLabelFor("staging"), { force: false });
+    // One more scan than kills: the confirming scan after the last kill
+    // round is the one that catches the still-occupied slot and refuses,
+    // rather than a scan that silently reports converged.
+    await expect(
+      controller.stop(serviceLabelFor("staging"), { force: false }),
+    ).rejects.toMatchObject({
+      code: "E_SERVICE_CONTROL_FAILED",
+      details: { survivingPids: [800 + WINDOWS_KILL_CONVERGENCE_ROUNDS] },
+    });
 
     expect(
       calls.filter((call) => call.command === "powershell.exe"),
-    ).toHaveLength(WINDOWS_KILL_CONVERGENCE_ROUNDS);
+    ).toHaveLength(WINDOWS_KILL_CONVERGENCE_ROUNDS + 1);
     const taskkillPids = calls
       .filter((call) => call.command === "taskkill")
       .map((call) => call.args[2]);
@@ -629,62 +629,51 @@ describe("killHostProcessTree convergence loop", () => {
       ),
     );
 
-    // Ablation (§C): removing the round bound (e.g. `for (;;)` instead of
-    // `for (let round = 1; round <= WINDOWS_KILL_CONVERGENCE_ROUNDS; ...)`)
-    // has no one-line inverse that stays safe to run in a test process - a
-    // fixture that never converges would hang the suite instead of failing
-    // it. Nothing here exercises that mutation; the finite scan count this
-    // test asserts is what an unbounded loop would violate.
+    // Ablation (§ablation table, row 1): in `killHostProcessTree`, change
+    // the bound refusal's `throw cliError(...)` to `return;` (restore the
+    // silent fallthrough) → this test fails: the call resolves instead of
+    // rejecting, and the still-running pid (800 + ROUNDS) is reported as a
+    // successful stop.
   });
 
-  it("round-1 fallback stays a one-round affair: an unavailable scan is not retried", async () => {
-    mocks.readHostPidMetadata.mockResolvedValue({
-      pid: 401,
-      hostId: "host-test",
-      version: "1.0.0",
-      websocketUrl: "ws://127.0.0.1:54321/rpc",
-      startedAt: "2026-01-01T00:00:00.000Z",
-    });
+  it("refuses before killing anything when the scan is unavailable - the round-0 case of the general rule", async () => {
+    // There used to be a pid.json fallback here: kill the one recorded pid,
+    // unverified, and move on. That let a stop report success while
+    // descendants the fallback never enumerated kept running and kept the
+    // install dir open - the finding this pins the fix for. An unreadable
+    // scan now refuses the whole stop, before anything is touched, so the
+    // tree is left whole for the next attempt. The "NEVER /T" pin the old
+    // fallback test carried is still covered by "re-kills scan-verified
+    // processes" and "host-spawned" elsewhere in this file, which exercise a
+    // real kill.
     const { runner, calls } = roundedRunner([{ kind: "throw" }]);
     const controller = createWindowsController(runner);
 
-    await controller.stop(serviceLabelFor("staging"), { force: false });
+    await expect(
+      controller.stop(serviceLabelFor("staging"), { force: false }),
+    ).rejects.toMatchObject({ code: "E_SERVICE_CONTROL_FAILED" });
 
-    // Rescanning cannot help when the scan itself is what is unavailable, so
-    // round 1's fallback is the whole story: one attempt, one kill.
     expect(
       calls.filter((call) => call.command === "powershell.exe"),
     ).toHaveLength(1);
-    expect(
-      calls
-        .filter((call) => call.command === "taskkill")
-        .map((call) => call.args),
-    ).toEqual([["/F", "/PID", "401"]]);
+    expect(calls.filter((call) => call.command === "taskkill")).toHaveLength(0);
+    expect(mocks.readHostPidMetadata).not.toHaveBeenCalled();
 
-    // Ablation (§C): in `killHostProcessTree`, delete the `if (round > 1)
-    // return;` guard (letting the loop fall through to another
-    // `findSlotProcessIds` call after a round-1 failure) → this test still
-    // passes, because round 1 already `return`s unconditionally after the
-    // fallback kill. There is no one-line mutation of the round-1 path this
-    // test can distinguish from correct behaviour; test (d) below is what
-    // pins the guard that actually matters: a scan failure LATER than
-    // round 1.
+    // Ablation (§ablation table, row 2): in `killHostProcessTree`, change
+    // `if (scanned === null) throw cliError(...)` to `if (scanned === null)
+    // return;` → this test fails: the call resolves instead of rejecting,
+    // and a scan that never ran is reported as a clean stop.
   });
 
-  it("a later round's failed scan ends the loop without touching pid.json - a stale recorded pid is not a second opinion", async () => {
-    // Round 1 kills 901 normally. Round 2's scan is unavailable - and unlike
-    // round 1, this is NOT the moment to fall back to pid.json: round 1 may
-    // already have killed the recorded pid, so it now names a slot Windows is
-    // free to have recycled for something unrelated. Consulting it here would
-    // be exactly the recycled-pid kill the scan-verification exists to
-    // prevent.
-    mocks.readHostPidMetadata.mockResolvedValue({
-      pid: 901,
-      hostId: "host-test",
-      version: "1.0.0",
-      websocketUrl: "ws://127.0.0.1:54321/rpc",
-      startedAt: "2026-01-01T00:00:00.000Z",
-    });
+  it("a scan that fails after earlier kills still fails the stop - a stale recorded pid is not a second opinion", async () => {
+    // Round 0 kills 901 normally. Round 1's scan is unavailable - and this is
+    // NOT a moment for any fallback: round 0 may already have killed the one
+    // pid a fallback would have named, so consulting a recorded pid here
+    // would be exactly the recycled-pid kill the scan-verification exists to
+    // prevent. There is no fallback at all now, so the question this test
+    // pins is narrower than it used to be: does an EARLIER round's real kill
+    // still happen before the LATER round's refusal, and does the refusal
+    // still refuse rather than quietly accepting round 0's kill as enough.
     const { runner, calls } = roundedRunner([
       {
         kind: "table",
@@ -694,11 +683,15 @@ describe("killHostProcessTree convergence loop", () => {
     ]);
     const controller = createWindowsController(runner);
 
-    await controller.stop(serviceLabelFor("staging"), { force: false });
+    await expect(
+      controller.stop(serviceLabelFor("staging"), { force: false }),
+    ).rejects.toMatchObject({ code: "E_SERVICE_CONTROL_FAILED" });
 
     expect(
       calls.filter((call) => call.command === "powershell.exe"),
     ).toHaveLength(2);
+    // Round 0's kill still happened - the refusal is about round 1's scan,
+    // not a reason to have skipped work already done.
     expect(
       calls
         .filter((call) => call.command === "taskkill")
@@ -706,11 +699,10 @@ describe("killHostProcessTree convergence loop", () => {
     ).toEqual([["/F", "/PID", "901"]]);
     expect(mocks.readHostPidMetadata).not.toHaveBeenCalled();
 
-    // Ablation (§C): in `killHostProcessTree`, change `if (round > 1) return;`
-    // to `if (false) return;` (always falling through to the round-1
-    // fallback, whatever the round) → this test fails: `readHostPidMetadata`
-    // is called on round 2, and the stale pid 901 - already killed in round 1
-    // - is handed to `killProcessIds` a second time.
+    // Ablation (§ablation table, row 2): the same `scanned === null` `throw`
+    // → `return` mutation reddens this test too - round 1's unreadable scan
+    // stops refusing, so the whole stop resolves even though it never
+    // confirmed the tree came down.
   });
 });
 
@@ -873,30 +865,6 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
     ];
 
     expect(computeWindowsHostKillSet(rows, 200)).toEqual([100, 400]);
-  });
-
-  it("fallback: the powershell run throws, so the recorded pid.json pid is killed exactly once, without /T", async () => {
-    mocks.readHostPidMetadata.mockResolvedValue({
-      pid: 100,
-      hostId: "host-test",
-      version: "1.0.0",
-      websocketUrl: "ws://127.0.0.1:54321/rpc",
-      startedAt: "2026-01-01T00:00:00.000Z",
-    });
-    const calls: RecordedCall[] = [];
-    const runner: ProcessRunner = async (command, args) => {
-      calls.push({ command, args });
-      if (command === "powershell.exe") throw new Error("spawn failed");
-      return success("");
-    };
-    const controller = createWindowsController(runner);
-
-    await controller.stop(serviceLabelFor("staging"), { force: false });
-
-    const taskkillCalls = calls.filter((call) => call.command === "taskkill");
-    expect(taskkillCalls).toHaveLength(1);
-    expect(taskkillCalls[0]?.args).toEqual(["/F", "/PID", "100"]);
-    expect(taskkillCalls[0]?.args.includes("/T")).toBe(false);
   });
 
   // Direct algebra pins for the three subtraction terms, each isolating one

--- a/clients/traycer-cli/src/service/platforms/__tests__/windows.test.ts
+++ b/clients/traycer-cli/src/service/platforms/__tests__/windows.test.ts
@@ -2262,6 +2262,100 @@ describe("killHostProcessTree convergence loop", () => {
     // the stop RESOLVES after three scans with 888 and 889 alive.
   });
 
+  it("round-7 P2: the CLI's own scan is never remembered as a host suspect - a stranger reusing its pid does not refuse a later stop", async () => {
+    // The CLI (pid 9999) claims a host whose age is unreadable, so it is
+    // undecided for as long as that host is remembered - and every scan it
+    // runs is its validated child AND slot-matched (the scan's command line
+    // names the slot paths). Chronology (samples 5000, 7000, 9000):
+    //   R0 (sample 5000): host 100 (slot, `created` 0), the CLI (born 2500)
+    //       claiming it, and this round's own scan 555 (born 5500, under the
+    //       CLI, slot-matched). Memory is empty, so nothing is undecided yet.
+    //       kill=[100]; the CLI's branch is spared.
+    //   R1 (sample 7000): 100 lingers (seed), the CLI is now undecided
+    //       against victim 100 of unreadable age, and this round's scan 777
+    //       (born 7500) sits under it - in the suspect closure, spared from
+    //       the kill. kill=[100]. NOTHING is remembered as a suspect: the
+    //       CLI's branch is its own, not the host's.
+    //   R2 (sample 9000): scan 777 has long exited; an unrelated process
+    //       took pid 777 (born 8000), forked 888 (born 8500) and exited. 888
+    //       claims 777 as an orphan. Nothing remembers 777: converged. Had
+    //       777 been recorded as a host suspect, 888 would have refused the
+    //       stop over a stranger.
+    const samples = [5000, 7000, 9000];
+    let sample = 0;
+    const host100 = {
+      processId: 100,
+      parentProcessId: 1,
+      created: 0,
+      slot: true,
+    };
+    const cli = {
+      processId: 9999,
+      parentProcessId: 0,
+      claimedParentProcessId: 100,
+      created: 2500,
+      slot: false,
+    };
+    const ownScan = (pid: number, created: number): TableRowInput => ({
+      processId: pid,
+      parentProcessId: 9999,
+      claimedParentProcessId: 9999,
+      created,
+      slot: true,
+    });
+    const { runner, calls } = roundedRunner([
+      { kind: "table", rows: [host100, cli, ownScan(555, 5500)] },
+      { kind: "table", rows: [host100, cli, ownScan(777, 7500)] },
+      {
+        kind: "table",
+        rows: [
+          cli,
+          {
+            processId: 888,
+            parentProcessId: 0,
+            claimedParentProcessId: 777,
+            created: 8500,
+            slot: false,
+          },
+        ],
+      },
+    ]);
+    const controller = createWindowsController(runner, {
+      now: () => {
+        const value = samples[sample] ?? 9000;
+        sample += 1;
+        return value;
+      },
+    });
+
+    const originalPid = Object.getOwnPropertyDescriptor(process, "pid");
+    Object.defineProperty(process, "pid", { value: 9999, configurable: true });
+    try {
+      await controller.stop(serviceLabelFor("staging"), { force: false });
+    } finally {
+      if (originalPid !== undefined) {
+        Object.defineProperty(process, "pid", originalPid);
+      }
+    }
+
+    expect(
+      calls.filter((call) => call.command === "powershell.exe"),
+    ).toHaveLength(3);
+    expect(
+      calls
+        .filter((call) => call.command === "taskkill")
+        .map((call) => call.args),
+    ).toEqual([
+      ["/F", "/PID", "100"],
+      ["/F", "/PID", "100"],
+    ]);
+
+    // Ablation: in `computeWindowsHostKillSet`, drop `!cliBranch.has(pid)`
+    // from the `undecided` filter → this test reddens: round 1 remembers
+    // scan 777 (born 7500) as a suspect, round 2 finds 888 (born 8500)
+    // claiming it, and the stop REFUSES naming 888 - a stranger's child.
+  });
+
   // The unattributed refusal exercised through all four callers that run
   // `killHostProcessTree`: none of them may treat it as anything softer than
   // the scan-unavailable refusal already covered above. The fourth is the
@@ -2793,10 +2887,11 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
       // Traycer-hosted terminal whose shell happens to sit on a pid the host
       // once held.
       //
-      // Excluded from the REPORT, not from the memory feed: 700 and the CLI
-      // under it are still the round's undecided closure, and the loop
-      // remembers them as suspects so that a child of 700 that shows up after
-      // 700 has exited still finds its parent's pid remembered.
+      // Excluded from the REPORT, not from the memory feed: 700 is still the
+      // round's undecided closure, and the loop remembers it as a suspect so
+      // that a child of 700 that shows up after 700 has exited still finds
+      // its parent's pid remembered. The CLI itself, though under 700, is
+      // not: the CLI's own branch is never a host suspect.
       const table = rowsOf([
         victimRow(700, 0, 100, 6000, false),
         victimRow(cliPid, 700, 700, 6500, false),
@@ -2804,7 +2899,7 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
       expect(computeWindowsHostKillSet(table, cliPid, remembered)).toEqual({
         kill: [],
         protectedAncestors: [],
-        undecided: [700, cliPid],
+        undecided: [700],
         unattributed: [],
       });
     });
@@ -2831,7 +2926,7 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
       expect(computeWindowsHostKillSet(table, cliPid, unreadableHost)).toEqual({
         kill: [200],
         protectedAncestors: [],
-        undecided: [700, 888, cliPid],
+        undecided: [700, 888],
         unattributed: [888],
       });
 
@@ -2865,17 +2960,46 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
         kill: [100, 888],
         // 700 is a PLACED ancestor of the CLI (a validated child of the
         // lingering host, which is a seed): reported as lineage to remember
-        // with a window, and therefore out of `undecided`. The CLI, placed
-        // only through 700 and an ancestor of nothing, stays undecided.
+        // with a window, and therefore out of `undecided`. The CLI is out of
+        // it as its own branch.
         protectedAncestors: [700],
-        undecided: [cliPid],
+        undecided: [],
         unattributed: [],
       });
 
-      // Ablation: subtract `victims` (the closure) instead of `remembered`
-      // when building `undecided` → `undecided: []`; drop
-      // `protectedAncestors` from `remembered` → 700 is listed in BOTH
-      // `protectedAncestors` and `undecided`.
+      // Ablation: drop `protectedAncestors` from `remembered` → 700 is
+      // listed in BOTH `protectedAncestors` and `undecided`.
+    });
+
+    it("the CLI's own branch is never a host suspect: its slot-matched scan under an undecided CLI is neither reported nor remembered", () => {
+      // The cold review's round-7 P2, as one round. The host (100) was
+      // killed with an UNREADABLE age, so the CLI (9999, claiming it) is
+      // undecided this round, and its own PowerShell scan 777 - a validated
+      // child, slot-MATCHED because its command line names the slot paths -
+      // lands in the suspect closure. Spared from the kill and not an
+      // ancestor, it would otherwise stay in `undecided` and be remembered
+      // as a HOST suspect; a stranger that later reuses pid 777 would then
+      // have its child refuse a stop.
+      const unreadableHost = victimMemory(
+        new Map<number, readonly WindowsKillVictim[]>([
+          [100, [{ created: 0, seenAliveAt: 5000 }]],
+        ]),
+      );
+      const table = rowsOf([
+        victimRow(100, 1, 1, 0, true),
+        victimRow(cliPid, 0, 100, 2500, false),
+        victimRow(777, cliPid, cliPid, 7500, true),
+      ]);
+      expect(computeWindowsHostKillSet(table, cliPid, unreadableHost)).toEqual({
+        kill: [100],
+        protectedAncestors: [],
+        undecided: [],
+        unattributed: [],
+      });
+
+      // Ablation: in `computeWindowsHostKillSet`, drop `!cliBranch.has(pid)`
+      // from the `undecided` filter → `undecided: [777, 9999]`, and the
+      // loop-level "round-7 P2" test refuses a stop over a stranger's child.
     });
 
     it("both non-empty: a killable seed and an unattributed row coexist in the same verdict", () => {

--- a/clients/traycer-cli/src/service/platforms/__tests__/windows.test.ts
+++ b/clients/traycer-cli/src/service/platforms/__tests__/windows.test.ts
@@ -113,6 +113,29 @@ describe("Windows service stale host cleanup", () => {
         `{"ProcessId":${process.pid},"ParentProcessId":1,"Slot":false}`,
       ),
     ).toEqual([{ processId: process.pid, parentProcessId: 1, slot: false }]);
+    // The System Idle Process is pid 0 with parent 0, and `Get-CimInstance
+    // Win32_Process` always returns it. Rejecting it failed the WHOLE parse on
+    // every real machine, silently demoting every stop to the pid.json
+    // fallback. A parent of 0 ("no verified parent") is equally ordinary.
+    expect(
+      parseWindowsProcessTableJson(
+        '[{"ProcessId":0,"ParentProcessId":0,"Slot":false},{"ProcessId":100,"ParentProcessId":0,"Slot":true}]',
+      ),
+    ).toEqual([
+      { processId: 0, parentProcessId: 0, slot: false },
+      { processId: 100, parentProcessId: 0, slot: true },
+    ]);
+    // Negative ids are still malformed.
+    expect(
+      parseWindowsProcessTableJson(
+        '[{"ProcessId":-1,"ParentProcessId":0,"Slot":false}]',
+      ),
+    ).toBeNull();
+    expect(
+      parseWindowsProcessTableJson(
+        '[{"ProcessId":100,"ParentProcessId":-1,"Slot":false}]',
+      ),
+    ).toBeNull();
     expect(parseWindowsProcessTableJson("[]")).toEqual([]);
     // Empty output means the scan never ran - `null`, not `[]`: a real
     // Win32_Process scan is never empty.
@@ -144,7 +167,7 @@ describe("Windows service stale host cleanup", () => {
     const script = buildWindowsSlotProcessTableScanScript(
       "C:\\Users\\Traycer Dev\\.traycer\\host\\staging",
     );
-    expect(script).toContain("ParentProcessId = [int]$_.ParentProcessId");
+    expect(script).toContain("ParentProcessId = $parentId");
     expect(script).toContain("Slot = $hostMatch");
     expect(script).toContain(".traycer\\host\\staging\\install\\");
     expect(script).not.toContain("$excluded");
@@ -153,6 +176,42 @@ describe("Windows service stale host cleanup", () => {
     // Ablation: in `buildSlotProcessTableScanScript`, reintroduce
     // `$excluded = @(<pid>, $PID)` into the script → this test fails (the
     // `not.toContain("$PID")` assertion flips).
+  });
+
+  it("validates each parent edge against CreationDate from the same snapshot", () => {
+    // Windows keeps the creator's id in `ParentProcessId` after the parent
+    // exits, and may hand that id to an unrelated process. An edge is only
+    // believed when the claimed parent is still in this snapshot and is not
+    // YOUNGER than its claimed child; everything else is emitted as parent 0,
+    // which the algebra reads as "no verified parent".
+    //
+    // This is a script-text pin. The PowerShell half is only really proved by
+    // the live Windows run in the plan's release checklist - what the TS side
+    // can prove is what the algebra does once a stale id has arrived as 0,
+    // which the fixtures below cover.
+    const script = buildWindowsSlotProcessTableScanScript(
+      "C:\\Users\\Traycer Dev\\.traycer\\host",
+    );
+    // One read, materialised, so the ages compared come from the same
+    // snapshot as the matches.
+    expect(script).toContain("$table = @(Get-CimInstance Win32_Process)");
+    expect(script).toContain(
+      "foreach ($row in $table) { $created[[int]$row.ProcessId] = $row.CreationDate }",
+    );
+    expect(script).toContain(
+      "if ($parentId -le 0 -or -not $created.ContainsKey($parentId)) {",
+    );
+    expect(script).toContain("} elseif ($parentCreated -gt $childCreated) {");
+    // A missing CreationDate on either end (pid 0 and System have none) is
+    // uncertainty, so it fails closed to 0 like any other unverifiable edge.
+    expect(script).toContain(
+      "if ($null -eq $parentCreated -or $null -eq $childCreated) {",
+    );
+
+    // Ablation: in `buildSlotProcessTableScanScript`, drop
+    // `...PARENT_EDGE_VALIDATION_SCRIPT_LINES` and emit
+    // `ParentProcessId = [int]$_.ParentProcessId` again → this test fails, and
+    // a recycled creator id becomes a believed ancestry edge.
   });
 
   it("does not use broad production roots as process-match prefixes", () => {
@@ -462,11 +521,13 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
   });
 
   it("host-spawned: kills the host and its non-CLI-ancestor descendants, sparing the CLI's own subtree", async () => {
+    // idle 0 (the row every real scan returns)
     // host 100 (Slot) -> cli 200 -> powershell 250
     // cli 200 -> helper 300
     // host 100 -> agent 400
     // self = 200 (the CLI's own pid)
     const rows: WindowsProcessTableRow[] = [
+      { processId: 0, parentProcessId: 0, slot: false },
       { processId: 100, parentProcessId: 1, slot: true },
       { processId: 200, parentProcessId: 100, slot: false },
       { processId: 250, parentProcessId: 200, slot: false },
@@ -499,13 +560,23 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
       ["/F", "/PID", "400"],
     ]);
     expect(taskkillArgs.every((args) => !args.includes("/T"))).toBe(true);
+    // The scan ANSWERED, so the pid.json fallback must not be consulted at
+    // all. Before pid 0 was accepted, the idle row failed the whole parse and
+    // every stop silently degraded to that fallback.
+    expect(mocks.readHostPidMetadata).not.toHaveBeenCalled();
+
+    // Ablation: in `isProcessTableId`, require `value > 0` again → this test
+    // fails: the idle row rejects the table, `findSlotProcessIds` returns
+    // null, the fallback is read, and the kill set collapses to nothing.
   });
 
   it("terminal-run: a non-slot shell ancestor between the host and the CLI is spared", async () => {
+    // idle 0
     // host 100 (Slot) -> shell 50 -> cli 200 -> powershell 250
     // host 100 -> agent 400
     // self = 200
     const rows: WindowsProcessTableRow[] = [
+      { processId: 0, parentProcessId: 0, slot: false },
       { processId: 100, parentProcessId: 1, slot: true },
       { processId: 50, parentProcessId: 100, slot: false },
       { processId: 200, parentProcessId: 50, slot: false },
@@ -539,16 +610,20 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
     ]);
     // 50 (a non-slot ancestor of the CLI) is spared, and never appears.
     expect(taskkillArgs.some((args) => args[2] === "50")).toBe(false);
+    // Nor does pid 0, which is in the table and in nobody's kill set.
+    expect(taskkillArgs.some((args) => args[2] === "0")).toBe(false);
+    expect(mocks.readHostPidMetadata).not.toHaveBeenCalled();
   });
 
-  it("wrong-self regression: self must be the CLI's pid, not PowerShell's own - putting self at the powershell node does not spare the CLI's sibling", () => {
+  it("wrong-self regression: self must be the CLI's pid, not PowerShell's own - putting self at the powershell node kills the CLI's own child", () => {
     // Same host-spawned shape as above, but self is (wrongly) placed at the
-    // POWERSHELL node (250) instead of the CLI (200). This is the pin for
-    // "cliPid is the CLI's own pid, not `$PID` inside the scan script" - a
-    // wiring bug that fed PowerShell's own pid in would leave the CLI's
-    // sibling process (300, the detached upgrade finalizer stand-in) spared
-    // when it should be killed.
+    // POWERSHELL node (250) instead of the CLI (200). Helper 300 is the CLI's
+    // child and PowerShell's SIBLING, so seeding the spared set from 250 no
+    // longer covers it: it lands in the kill set and would be force-killed,
+    // which is exactly the damage `cliPid = process.pid` (not the scan
+    // script's `$PID`) prevents.
     const rows: WindowsProcessTableRow[] = [
+      { processId: 0, parentProcessId: 0, slot: false },
       { processId: 100, parentProcessId: 1, slot: true },
       { processId: 200, parentProcessId: 100, slot: false },
       { processId: 250, parentProcessId: 200, slot: false },
@@ -559,12 +634,45 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
     const killSet = computeWindowsHostKillSet(rows, 250);
 
     expect(killSet).toEqual([100, 300, 400]);
-    // Ablation: in `killHostProcessTree`, change
-    // `findSlotProcessIds(label, run, process.pid)` to pass PowerShell's own
-    // pid instead (e.g. hard-code a wrong id, or thread `$PID` from inside
-    // the script back out) → this assertion is exactly what would catch it,
-    // since seeding `spared` from the wrong pid changes which branch of the
-    // tree is protected.
+    // Ablation for the CALL SITE (`findSlotProcessIds(label, run, process.pid)`
+    // in `killHostProcessTree`): this test calls the algebra directly and
+    // would not see it. The host-spawned integration test above is the one
+    // that catches a wrong pid being threaded in, because it drives
+    // `controller.stop` and asserts the taskkill argv.
+  });
+
+  it("a stale parent id the scan could not verify (arriving as 0) does not make a stranger a victim", () => {
+    // The reuse the script's CreationDate check exists for: process 400
+    // outlived its creator, Windows later gave that id to the Traycer host,
+    // and 400's `ParentProcessId` still names it. The scan cannot vouch for
+    // that edge - the claimed parent is younger than its claimed child - so it
+    // emits 0, and 400 stays out of the host's subtree instead of being
+    // force-killed as a descendant.
+    const rows: WindowsProcessTableRow[] = [
+      { processId: 0, parentProcessId: 0, slot: false },
+      { processId: 100, parentProcessId: 1, slot: true },
+      { processId: 400, parentProcessId: 0, slot: false },
+      { processId: 200, parentProcessId: 100, slot: false },
+    ];
+
+    expect(computeWindowsHostKillSet(rows, 200)).toEqual([100]);
+  });
+
+  it("a recycled id on the CLI's own ancestry (arriving as 0) spares nothing extra", () => {
+    // The other direction of the same reuse: the CLI's claimed parent cannot
+    // be verified, so the ancestry walk ends immediately. The CLI and its
+    // subtree are still spared - that comes from the descendant closure, not
+    // from ancestry - and the host is still killed rather than being spared as
+    // a wrongly-believed ancestor.
+    const rows: WindowsProcessTableRow[] = [
+      { processId: 0, parentProcessId: 0, slot: false },
+      { processId: 100, parentProcessId: 1, slot: true },
+      { processId: 200, parentProcessId: 0, slot: false },
+      { processId: 300, parentProcessId: 200, slot: false },
+      { processId: 400, parentProcessId: 100, slot: false },
+    ];
+
+    expect(computeWindowsHostKillSet(rows, 200)).toEqual([100, 400]);
   });
 
   it("fallback: the powershell run throws, so the recorded pid.json pid is killed exactly once, without /T", async () => {

--- a/clients/traycer-cli/src/service/platforms/__tests__/windows.test.ts
+++ b/clients/traycer-cli/src/service/platforms/__tests__/windows.test.ts
@@ -1563,9 +1563,8 @@ describe("killHostProcessTree convergence loop", () => {
     //       match and becomes victim 777 = [8000, 9000].
     //   R3 (sample 11000): only 888. Against victim 777 (born 8000) it is
     //       "older than the victim" - decided, and wrongly, if that were the
-    //       only memory consulted. The suspect incarnation (6000) and 888's
-    //       own remembered identity both keep it undecided: refused, naming
-    //       888.
+    //       only memory consulted. The remembered suspect incarnation of 777
+    //       (born 6000) keeps it undecided: refused, naming 888.
     const samples = [5000, 7000, 9000, 11000];
     let sample = 0;
     const { runner, calls } = roundedRunner([
@@ -1651,6 +1650,91 @@ describe("killHostProcessTree convergence loop", () => {
     // return the first incarnation's verdict → this test reddens: round 3
     // decides 888 is older than victim 777 and the stop RESOLVES with it
     // alive. Either half alone is caught by the pure incarnation pins.
+  });
+
+  it("a suspicion earned while a live parent's age was unreadable is cleared once the age reads and the edge validates", async () => {
+    // Chronology (samples 5000, 7000, 9000):
+    //   R0 (sample 5000): host 100 (born 1000, slot). Killed.
+    //   R1 (sample 7000): slot 200 (born 6200); an unrelated replacement
+    //       wearing pid 100, whose creation time Windows would not report
+    //       this time (`created` 0); its child 888 (born 6500), whose edge
+    //       the scan therefore zeroes. 888 claims remembered 100 and is
+    //       born after the window: undecided. kill=[200],
+    //       unattributed=[888]; 888 is remembered as a suspect.
+    //   R2 (sample 9000): the replacement's age reads (6000, older than
+    //       888) and the scan validates 888's edge to it. That is lineage
+    //       the scan has proven; the earlier suspicion must not refuse the
+    //       stop over a stranger's child. Converged.
+    const samples = [5000, 7000, 9000];
+    let sample = 0;
+    const { runner, calls } = roundedRunner([
+      {
+        kind: "table",
+        rows: [
+          { processId: 100, parentProcessId: 1, created: 1000, slot: true },
+        ],
+      },
+      {
+        kind: "table",
+        rows: [
+          { processId: 200, parentProcessId: 1, created: 6200, slot: true },
+          {
+            processId: 100,
+            parentProcessId: 0,
+            claimedParentProcessId: 1,
+            created: 0,
+            slot: false,
+          },
+          {
+            processId: 888,
+            parentProcessId: 0,
+            claimedParentProcessId: 100,
+            created: 6500,
+            slot: false,
+          },
+        ],
+      },
+      {
+        kind: "table",
+        rows: [
+          {
+            processId: 100,
+            parentProcessId: 0,
+            claimedParentProcessId: 1,
+            created: 6000,
+            slot: false,
+          },
+          {
+            processId: 888,
+            parentProcessId: 100,
+            claimedParentProcessId: 100,
+            created: 6500,
+            slot: false,
+          },
+        ],
+      },
+    ]);
+    const controller = createWindowsController(runner, {
+      now: () => {
+        const value = samples[sample] ?? 9000;
+        sample += 1;
+        return value;
+      },
+    });
+
+    await controller.stop(serviceLabelFor("staging"), { force: false });
+
+    expect(
+      calls.filter((call) => call.command === "powershell.exe"),
+    ).toHaveLength(3);
+    expect(
+      calls
+        .filter((call) => call.command === "taskkill")
+        .map((call) => call.args),
+    ).toEqual([
+      ["/F", "/PID", "100"],
+      ["/F", "/PID", "200"],
+    ]);
   });
 
   // The unattributed refusal exercised through all four callers that run
@@ -2374,41 +2458,51 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
         });
       });
 
-      it("a remembered suspect stays undecided by its own identity, even once its edge validates against a newer holder of its parent's pid", () => {
-        // 888 (born 6500) was reported undecided in an earlier round. Now its
-        // dead parent's pid 777 is worn by a process born 5000 - OLDER than
-        // 888, so the scan validates the edge. The edge is a coincidence of
-        // pid reuse, not lineage; 888 is the same process it was, and the
-        // question about it has not been answered.
-        const suspected = suspectMemory(
-          new Map<number, readonly number[]>([[888, [6500]]]),
-        );
+      it("a later validated edge outranks an earlier suspicion about the same process: an unreadable parent age that becomes readable clears the row", () => {
+        // 888 (born 6500) was reported undecided in an earlier round because
+        // its live parent - an unrelated process wearing dead victim 100's
+        // pid, born 6000 - had an unreadable creation time then, so the scan
+        // zeroed the edge and 888's claim on remembered 100 fell after the
+        // window. This round the age is readable (6000, older than 888), the
+        // scan validates the edge, and that is real lineage: a reused pid
+        // always goes to a process younger than the old holder's children,
+        // so a validated edge can never be a coincidence of reuse. The
+        // remembered suspicion about 888 must not override it, or the stop
+        // would be refused over a stranger's child the scan has already
+        // placed.
+        const suspected: WindowsKillMemory = {
+          victims: new Map<number, readonly WindowsKillVictim[]>([
+            [100, [{ created: 1000, seenAliveAt: 5000 }]],
+          ]),
+          suspects: new Map<number, readonly number[]>([[888, [6500]]]),
+        };
         const table = rowsOf([
-          victimRow(777, 0, 0, 5000, false),
-          victimRow(888, 777, 777, 6500, false),
+          victimRow(100, 0, 0, 6000, false),
+          victimRow(888, 100, 100, 6500, false),
           cliRow,
         ]);
         expect(computeWindowsHostKillSet(table, cliPid, suspected)).toEqual({
           kill: [],
-          unattributed: [888],
-        });
-
-        // A DIFFERENT process wearing 888's pid (born 9000) is not the
-        // remembered suspect and is decided on its own terms.
-        const newcomer = rowsOf([
-          victimRow(777, 0, 0, 5000, false),
-          victimRow(888, 777, 777, 9000, false),
-          cliRow,
-        ]);
-        expect(computeWindowsHostKillSet(newcomer, cliPid, suspected)).toEqual({
-          kill: [],
           unattributed: [],
         });
 
-        // Ablation: remove the `isRememberedSuspect` check from
-        // `classifyCarryOverClaim` → the first assertion reddens
-        // (`unattributed: []`): the validated edge clears a question a pid
-        // reuse had no business answering.
+        // The descendant closure, not a self-identity rule, is what keeps a
+        // child undecided when its LIVE parent is itself undecided: the same
+        // 888 under a parent 777 that claims dead 100 and was born after the
+        // window is reported with it.
+        const underSuspectParent = rowsOf([
+          victimRow(777, 0, 100, 6000, false),
+          victimRow(888, 777, 777, 6500, false),
+          cliRow,
+        ]);
+        expect(
+          computeWindowsHostKillSet(underSuspectParent, cliPid, suspected),
+        ).toEqual({ kill: [], unattributed: [777, 888] });
+
+        // Ablation: in `classifyCarryOverClaim`, before the gate, return
+        // "unattributed" when `memory.suspects.get(row.processId)` contains
+        // `row.created` (the self-identity rule an earlier draft had) → the
+        // first assertion reddens (`unattributed: [888]`).
       });
     });
 

--- a/clients/traycer-cli/src/service/platforms/__tests__/windows.test.ts
+++ b/clients/traycer-cli/src/service/platforms/__tests__/windows.test.ts
@@ -1129,10 +1129,100 @@ describe("killHostProcessTree convergence loop", () => {
       ["/F", "/PID", "888"],
     ]);
 
-    // Ablation: in `killHostProcessTree`, clear `priorVictims` at the top of
-    // every round → this test reddens: round 2 remembers only 555, 700 is no
-    // longer a seed, and the stop resolves without ever issuing a kill for
-    // 888.
+    // Ablation: in `killHostProcessTree`, keep only the latest round's
+    // victims - `priorVictims.clear()` just before the recording loop at the
+    // END of each round → this test reddens: round 2 remembers only 555, 700
+    // is no longer a seed, and the stop resolves without ever issuing a kill
+    // for 888. (Clearing at the TOP of every round is the cruder mutation and
+    // reddens earlier: round 1 already remembers nothing, so 555 is never
+    // issued either and the stop resolves after the single kill of 100.)
+  });
+
+  it("the victim recorder APPENDS: a lingering victim is re-killed through the OLDER window after its parent's pid was killed again as a newcomer", async () => {
+    // The loop-level twin of the "two victim windows for one pid" algebra
+    // pin: that one builds its memory by hand, so only a fixture that runs
+    // `rememberIncarnation` twice for one pid in the SAME map can tell an
+    // append from an overwrite. Chronology (samples 5000, 7000, 9000,
+    // 11000):
+    //   R0 (sample 5000): host 100 (born 1000, slot) and its validated child
+    //       555 (born 2000). Both killed; victims 100 = [1000, 5000],
+    //       555 = [2000, 5000].
+    //   R1 (sample 7000): a re-launched slot process wears pid 100 again
+    //       (born 6000, slot-matched); 555 lingers in its asynchronous
+    //       `TerminateProcess`, and the scan zeroes its edge because the
+    //       holder of 100 is now younger than it. 555 claims remembered 100
+    //       and sits inside the OLD window: seed. Both killed again; 100 gains
+    //       a second window [6000, 7000].
+    //   R2 (sample 9000): 555 still lingers, still claiming 100. Against the
+    //       newer window it is "older than the victim" - none; against the
+    //       older one it is inside - seed. The older entry is what still
+    //       issues the kill.
+    //   R3 (sample 11000): empty. Converged.
+    const samples = [5000, 7000, 9000, 11000];
+    let sample = 0;
+    const lingering555: TableRowInput = {
+      processId: 555,
+      parentProcessId: 0,
+      claimedParentProcessId: 100,
+      created: 2000,
+      slot: false,
+    };
+    const { runner, calls } = roundedRunner([
+      {
+        kind: "table",
+        rows: [
+          { processId: 100, parentProcessId: 1, created: 1000, slot: true },
+          {
+            processId: 555,
+            parentProcessId: 100,
+            claimedParentProcessId: 100,
+            created: 2000,
+            slot: false,
+          },
+        ],
+      },
+      {
+        kind: "table",
+        rows: [
+          { processId: 100, parentProcessId: 1, created: 6000, slot: true },
+          lingering555,
+        ],
+      },
+      { kind: "table", rows: [lingering555] },
+      { kind: "table", rows: [] },
+    ]);
+    const controller = createWindowsController(runner, {
+      now: () => {
+        const value = samples[sample] ?? 11000;
+        sample += 1;
+        return value;
+      },
+    });
+
+    await controller.stop(serviceLabelFor("staging"), { force: false });
+
+    expect(
+      calls.filter((call) => call.command === "powershell.exe"),
+    ).toHaveLength(4);
+    expect(
+      calls
+        .filter((call) => call.command === "taskkill")
+        .map((call) => call.args),
+    ).toEqual([
+      ["/F", "/PID", "555"],
+      ["/F", "/PID", "100"],
+      ["/F", "/PID", "100"],
+      ["/F", "/PID", "555"],
+      ["/F", "/PID", "555"],
+    ]);
+
+    // Ablation: in `rememberIncarnation`, replace the push with an overwrite
+    // (`memory.set(pid, [incarnation])` on both arms) → this test reddens:
+    // round 2 remembers only the newcomer's window for 100, 555 (born 2000)
+    // reads as older than that victim, and the stop resolves after three
+    // scans and four kills with 555 still alive. Nothing else in the loop
+    // masks it - 555 is a victim, never a suspect, so no suspect entry keeps
+    // it in play.
   });
 
   it("kills within a round deepest-first: a 3-node chain is issued grandchild, child, host", async () => {
@@ -1547,7 +1637,9 @@ describe("killHostProcessTree convergence loop", () => {
     // `priorSuspects` recording loop (record victims only) → this test
     // reddens: round 2 finds nothing to kill and nothing it remembers, and
     // the stop RESOLVES with 888 alive. Alternatively make
-    // `classifyAgainstSuspect` return "none" → same outcome.
+    // `classifyAgainstSuspect` return "none" → same outcome. Neither is
+    // masked by 888's own suspect entry: a row's classification consults
+    // only its CLAIMED PARENT's incarnations, never its own.
   });
 
   it("P2 (round 5e): a newer incarnation of a suspect's pid does not erase the suspicion about the older one's child", async () => {
@@ -1645,11 +1737,15 @@ describe("killHostProcessTree convergence loop", () => {
       ["/F", "/PID", "777"],
     ]);
 
-    // Ablation: replace `rememberIncarnation`'s push with an overwrite
-    // (`memory.set(pid, [incarnation])`) AND make `classifyCarryOverClaim`
-    // return the first incarnation's verdict → this test reddens: round 3
-    // decides 888 is older than victim 777 and the stop RESOLVES with it
-    // alive. Either half alone is caught by the pure incarnation pins.
+    // Ablation: in `classifyCarryOverClaim`, return the FIRST verdict instead
+    // of the strongest (`return classifyAgainstVictim(...)` inside the
+    // victims loop) → this test reddens: round 3 consults victim 777 (born
+    // 8000) first, decides 888 is older than it, never reaches the remembered
+    // suspect, and the stop RESOLVES with 888 alive. The recorder's
+    // append-vs-overwrite is NOT what this fixture exercises - 777's suspect
+    // and victim incarnations live in different maps, and 888's two suspect
+    // entries are identical - so overwriting `rememberIncarnation` leaves it
+    // green; the lingering-victim loop test above is the one that reddens.
   });
 
   it("a suspicion earned while a live parent's age was unreadable is cleared once the age reads and the edge validates", async () => {

--- a/clients/traycer-cli/src/service/platforms/__tests__/windows.test.ts
+++ b/clients/traycer-cli/src/service/platforms/__tests__/windows.test.ts
@@ -131,7 +131,7 @@ const nothingRemembered: WindowsKillMemory = {
 // pins below reason about, where an earlier round killed a parent and this
 // round has to decide what may be attributed to it.
 function victimMemory(
-  victims: ReadonlyMap<number, WindowsKillVictim>,
+  victims: ReadonlyMap<number, readonly WindowsKillVictim[]>,
 ): WindowsKillMemory {
   return { victims, suspects: new Map() };
 }
@@ -140,7 +140,7 @@ function victimMemory(
 // suspect-inheritance pins reason about, where an earlier round could place a
 // pid neither in the slot nor out of it.
 function suspectMemory(
-  suspects: ReadonlyMap<number, number>,
+  suspects: ReadonlyMap<number, readonly number[]>,
 ): WindowsKillMemory {
   return { victims: new Map(), suspects };
 }
@@ -945,19 +945,32 @@ describe("killHostProcessTree convergence loop", () => {
   });
 
   it("carries the victim set BETWEEN rounds: round 1's orphan is only killable because round 0's victim is remembered", async () => {
-    // Round 0 kills host 100 (a genuine slot match). Round 1's snapshot shows
-    // orphan 555, spawned after round 0's kill destroyed the edge proving it
-    // belongs to the slot: its `parentProcessId` arrives as 0 (unverifiable,
-    // host is dead), and its own path/command line matches nothing (a shell
-    // or provider binary). Without `priorVictims` carrying host 100's
-    // creation time forward, 555 looks like an ordinary unrelated process and
-    // the loop would report convergence while it lives - the finding this
-    // whole carry-over mechanism exists to close.
+    // Chronology (sample 5000 before every scan; every row is born before
+    // it, so each is present in every scan taken while it lives):
+    //   R0: host 100 (born 1000, slot) and its validated child 555 (born
+    //       1500, a shell or provider binary whose own path matches nothing).
+    //       Both are killed, 555 first.
+    //   R1: 100 is gone. 555 is STILL listed - `taskkill /F` is
+    //       `TerminateProcess`, asynchronous, and the loop's own comment names
+    //       this case - and its edge now arrives as `parentProcessId` 0: the
+    //       parent that would have vouched for it is dead. Its own path
+    //       matches nothing. Without `priorVictims` carrying 100's window
+    //       forward, 555 is an ordinary unrelated process and the loop reports
+    //       convergence while it lives. With it, 555 (born 1500, inside
+    //       [1000, 5000]) is seeded and killed again.
+    //   R2: empty. Converged.
     const { runner, calls } = roundedRunner([
       {
         kind: "table",
         rows: [
           { processId: 100, parentProcessId: 1, created: 1000, slot: true },
+          {
+            processId: 555,
+            parentProcessId: 100,
+            claimedParentProcessId: 100,
+            created: 1500,
+            slot: false,
+          },
         ],
       },
       {
@@ -974,8 +987,6 @@ describe("killHostProcessTree convergence loop", () => {
       },
       { kind: "table", rows: [] },
     ]);
-    // A real clock, not 0: 555's window is [1000, seenAliveAt], and only a
-    // seenAliveAt at or above its own `created` (1500) can ever admit it.
     const controller = createWindowsController(runner, { now: () => 5000 });
 
     await controller.stop(serviceLabelFor("staging"), { force: false });
@@ -988,71 +999,122 @@ describe("killHostProcessTree convergence loop", () => {
         .filter((call) => call.command === "taskkill")
         .map((call) => call.args),
     ).toEqual([
+      ["/F", "/PID", "555"],
       ["/F", "/PID", "100"],
       ["/F", "/PID", "555"],
     ]);
 
     // Ablation (§ablation table): in `classifyCarryOverClaim`, replace the
     // body with `return "none";` → this test reddens alongside the direct
-    // "the finding" algebra pin below - 555 is never seeded, round 1's kill
-    // set comes back empty, and the stop resolves with 555 still alive.
+    // "the finding" algebra pin below - 555 is never seeded in round 1, that
+    // kill set comes back empty, and the stop resolves with 555 still alive.
   });
 
-  it("the victim map ACCUMULATES across rounds rather than being replaced - round 2 needs BOTH round 0's and round 1's victims remembered at once", async () => {
-    // Round 0 kills host 100. Round 1's orphan 555 is only killable because
-    // 100 is remembered. Round 2 contains TWO orphans at once: 777 claims
-    // 555 (round 1's victim) and 888 claims 100 (round 0's victim, still
-    // directly). 888 is born at 2200 - AFTER round 1's snapshot (1500) ran,
-    // so its absence from that snapshot is coherent history, not a process
-    // that should have already been visible and wasn't. A per-round RESET
-    // (keeping only the latest round's victims) would seed 777 but not 888,
-    // since 100 would have fallen out of the map the moment round 1 replaced
-    // it with 555 - so this only passes if the map is grown, never reset,
-    // across the whole loop.
+  it("the victim map ACCUMULATES across rounds rather than being replaced - round 2 still needs round 0's victim remembered", async () => {
+    // The CLI (this process, pid 9999 here) was launched from shell 700,
+    // which the host 100 spawned - the "terminal-run" topology. 700 is the
+    // CLI's ancestor and is SPARED every round, and that is what makes this
+    // history coherent: a long-lived row that keeps claiming a dead victim.
+    // Chronology (the clock is sampled before each scan: 5000, 7000, 9000,
+    // 11000):
+    //   R0 (sample 5000): 100 (born 1000, slot), 700 (born 2000, child of
+    //       100), CLI 9999 (born 2500, child of 700). Kill set: 100 only -
+    //       700 and the CLI are the spared branch.
+    //   R1 (sample 7000): 100 gone; 700 now claims a dead parent
+    //       (`parentProcessId` 0) and is a carry-over seed through remembered
+    //       100 (born 2000, inside [1000, 5000]); a NEW sibling of the CLI,
+    //       555 (born 6000, validated child of 700), is 700's descendant and
+    //       dies. 555 born after R0's sample is why it is absent from R0.
+    //   R2 (sample 9000): 700 and the CLI again, plus another new sibling
+    //       888 (born 8000). 888 dies for the same reason - and ONLY because
+    //       100 is still remembered: a per-round reset would leave just 555
+    //       in the map, 700 would no longer be a seed, and 888 would survive
+    //       into a "converged" stop.
+    //   R3 (sample 11000): 700 and the CLI. 700 is a seed with nothing
+    //       unspared beneath it. Converged.
+    const rows700 = (extra: readonly TableRowInput[]): TableRowInput[] => [
+      {
+        processId: 700,
+        parentProcessId: 0,
+        claimedParentProcessId: 100,
+        created: 2000,
+        slot: false,
+      },
+      {
+        processId: 9999,
+        parentProcessId: 700,
+        claimedParentProcessId: 700,
+        created: 2500,
+        slot: false,
+      },
+      ...extra,
+    ];
     const { runner, calls } = roundedRunner([
       {
         kind: "table",
         rows: [
           { processId: 100, parentProcessId: 1, created: 1000, slot: true },
-        ],
-      },
-      {
-        kind: "table",
-        rows: [
           {
-            processId: 555,
-            parentProcessId: 0,
+            processId: 700,
+            parentProcessId: 100,
             claimedParentProcessId: 100,
-            created: 1500,
-            slot: false,
-          },
-        ],
-      },
-      {
-        kind: "table",
-        rows: [
-          {
-            processId: 777,
-            parentProcessId: 0,
-            claimedParentProcessId: 555,
             created: 2000,
             slot: false,
           },
           {
-            processId: 888,
-            parentProcessId: 0,
-            claimedParentProcessId: 100,
-            created: 2200,
+            processId: 9999,
+            parentProcessId: 700,
+            claimedParentProcessId: 700,
+            created: 2500,
             slot: false,
           },
         ],
       },
-      { kind: "table", rows: [] },
+      {
+        kind: "table",
+        rows: rows700([
+          {
+            processId: 555,
+            parentProcessId: 700,
+            claimedParentProcessId: 700,
+            created: 6000,
+            slot: false,
+          },
+        ]),
+      },
+      {
+        kind: "table",
+        rows: rows700([
+          {
+            processId: 888,
+            parentProcessId: 700,
+            claimedParentProcessId: 700,
+            created: 8000,
+            slot: false,
+          },
+        ]),
+      },
+      { kind: "table", rows: rows700([]) },
     ]);
-    // A real clock covering every fixture's `created` value above (max 2200).
-    const controller = createWindowsController(runner, { now: () => 5000 });
+    const samples = [5000, 7000, 9000, 11000];
+    let sample = 0;
+    const controller = createWindowsController(runner, {
+      now: () => {
+        const value = samples[sample] ?? 11000;
+        sample += 1;
+        return value;
+      },
+    });
 
-    await controller.stop(serviceLabelFor("staging"), { force: false });
+    const originalPid = Object.getOwnPropertyDescriptor(process, "pid");
+    Object.defineProperty(process, "pid", { value: 9999, configurable: true });
+    try {
+      await controller.stop(serviceLabelFor("staging"), { force: false });
+    } finally {
+      if (originalPid !== undefined) {
+        Object.defineProperty(process, "pid", originalPid);
+      }
+    }
 
     expect(
       calls.filter((call) => call.command === "powershell.exe"),
@@ -1064,9 +1126,13 @@ describe("killHostProcessTree convergence loop", () => {
     ).toEqual([
       ["/F", "/PID", "100"],
       ["/F", "/PID", "555"],
-      ["/F", "/PID", "777"],
       ["/F", "/PID", "888"],
     ]);
+
+    // Ablation: in `killHostProcessTree`, clear `priorVictims` at the top of
+    // every round → this test reddens: round 2 remembers only 555, 700 is no
+    // longer a seed, and the stop resolves without ever issuing a kill for
+    // 888.
   });
 
   it("kills within a round deepest-first: a 3-node chain is issued grandchild, child, host", async () => {
@@ -1227,17 +1293,24 @@ describe("killHostProcessTree convergence loop", () => {
     // prove belonged to the host.
   });
 
-  // A pid killed again in a later round overwrites its `priorVictims` entry
+  // A pid killed again in a later round gets a SECOND `priorVictims` entry
   // with THAT round's `seenAliveAt` - never frozen at the round it was first
   // killed - so a later orphan's window is bounded by how long the victim was
   // actually still provably alive, not by the first round that happened to
   // notice it.
   it("a repeated victim's seenAliveAt advances across rounds, widening what a later orphan can be attributed to", async () => {
-    // 100 is killed in round 0, then found STILL present in round 1
-    // (`taskkill /F` is asynchronous - the loop's own comment names this
-    // exact case) and killed again there. Orphan 555 is born at 3000 - after
-    // round 0's seenAliveAt (2000) but before round 1's (4000) - so it is
-    // only killable if the map's bound for 100 actually moved forward.
+    // Chronology (samples 2000, 4000, 6000, 8000):
+    //   R0 (sample 2000): 100 (born 1000, slot). Killed.
+    //   R1 (sample 4000): 100 is STILL listed (`taskkill /F` is
+    //       asynchronous - the loop's own comment names this exact case) and
+    //       has meanwhile spawned 555 (born 3000, validated child). Both are
+    //       killed, 555 first. 100's window now extends to 4000.
+    //   R2 (sample 6000): 100 is gone; 555 lingers the same way, its edge
+    //       now `parentProcessId` 0. Born 3000, it is AFTER round 0's bound
+    //       (2000) but inside round 1's (4000): only the widened window can
+    //       attribute it, and it is killed again rather than reported as
+    //       undecided.
+    //   R3 (sample 8000): empty. Converged.
     const { runner, calls } = roundedRunner([
       {
         kind: "table",
@@ -1249,6 +1322,13 @@ describe("killHostProcessTree convergence loop", () => {
         kind: "table",
         rows: [
           { processId: 100, parentProcessId: 1, created: 1000, slot: true },
+          {
+            processId: 555,
+            parentProcessId: 100,
+            claimedParentProcessId: 100,
+            created: 3000,
+            slot: false,
+          },
         ],
       },
       {
@@ -1265,12 +1345,15 @@ describe("killHostProcessTree convergence loop", () => {
       },
       { kind: "table", rows: [] },
     ]);
-    let round = 0;
-    const now = (): number => {
-      round += 1;
-      return round === 1 ? 2000 : 4000;
-    };
-    const controller = createWindowsController(runner, { now });
+    const samples = [2000, 4000, 6000, 8000];
+    let sample = 0;
+    const controller = createWindowsController(runner, {
+      now: () => {
+        const value = samples[sample] ?? 8000;
+        sample += 1;
+        return value;
+      },
+    });
 
     await controller.stop(serviceLabelFor("staging"), { force: false });
 
@@ -1280,15 +1363,15 @@ describe("killHostProcessTree convergence loop", () => {
         .map((call) => call.args),
     ).toEqual([
       ["/F", "/PID", "100"],
+      ["/F", "/PID", "555"],
       ["/F", "/PID", "100"],
       ["/F", "/PID", "555"],
     ]);
 
-    // Ablation: in `killHostProcessTree`, only record a victim's
-    // `priorVictims` entry the FIRST time it is killed (skip the `.set` when
-    // an entry already exists) → this test reddens: 100's `seenAliveAt`
-    // freezes at round 0's 2000, 555 (born 3000) falls outside that stale
-    // window, and round 2 reports it unattributed instead of killing it.
+    // Ablation: in `rememberIncarnation`, skip the push when an entry already
+    // exists (first incarnation only) → this test reddens: 100's only window
+    // ends at round 0's 2000, 555 (born 3000) falls outside it, and round 2
+    // reports it unattributed instead of killing it.
   });
 
   // P2 (round 5c): a kill set of `[]` used to mean convergence unconditionally.
@@ -1301,6 +1384,14 @@ describe("killHostProcessTree convergence loop", () => {
   // and only refuses once a later round's kill set is empty with the
   // undecidable row still unexplained.
   it("kills happen first even when an unattributed row sits in the same round's scan; the throw only comes once nothing is left to kill", async () => {
+    // Chronology (samples 5000, 7000, 9000):
+    //   R0 (sample 5000): host 100 (born 1000, slot). Killed.
+    //   R1 (sample 7000): a NEW slot process 200 (born 6200 - a relaunch,
+    //       hence absent from R0) and 777 (born 6000, claims 100, after 100's
+    //       window closed at 5000, so undecided). kill=[200],
+    //       unattributed=[777]: 200 dies, the refusal waits.
+    //   R2 (sample 9000): only 777. Nothing to kill, 777 still undecided:
+    //       refused, naming it.
     const { runner, calls } = roundedRunner([
       {
         kind: "table",
@@ -1311,13 +1402,7 @@ describe("killHostProcessTree convergence loop", () => {
       {
         kind: "table",
         rows: [
-          {
-            processId: 555,
-            parentProcessId: 0,
-            claimedParentProcessId: 100,
-            created: 1500,
-            slot: false,
-          },
+          { processId: 200, parentProcessId: 1, created: 6200, slot: true },
           {
             processId: 777,
             parentProcessId: 0,
@@ -1340,7 +1425,15 @@ describe("killHostProcessTree convergence loop", () => {
         ],
       },
     ]);
-    const controller = createWindowsController(runner, { now: () => 5000 });
+    const samples = [5000, 7000, 9000];
+    let sample = 0;
+    const controller = createWindowsController(runner, {
+      now: () => {
+        const value = samples[sample] ?? 9000;
+        sample += 1;
+        return value;
+      },
+    });
 
     await expect(
       controller.stop(serviceLabelFor("staging"), { force: false }),
@@ -1349,15 +1442,15 @@ describe("killHostProcessTree convergence loop", () => {
       details: { unattributedPids: [777] },
     });
 
-    // 555 (born 1500, inside [1000, 5000]) was killed even though 777 (born
-    // 6000, outside it) sat alongside it in the very same round's scan.
+    // 200 (an ordinary slot match) was killed even though 777 (undecided)
+    // sat alongside it in the very same round's scan.
     expect(
       calls
         .filter((call) => call.command === "taskkill")
         .map((call) => call.args),
     ).toEqual([
       ["/F", "/PID", "100"],
-      ["/F", "/PID", "555"],
+      ["/F", "/PID", "200"],
     ]);
 
     // Ablation (§ablation table): in `killHostProcessTree`, return `kill`
@@ -1451,10 +1544,113 @@ describe("killHostProcessTree convergence loop", () => {
     ]);
 
     // Ablation (§ablation table): in `killHostProcessTree`, drop the
-    // `priorSuspects.set(...)` loop (record victims only) → this test
+    // `priorSuspects` recording loop (record victims only) → this test
     // reddens: round 2 finds nothing to kill and nothing it remembers, and
     // the stop RESOLVES with 888 alive. Alternatively make
     // `classifyAgainstSuspect` return "none" → same outcome.
+  });
+
+  it("P2 (round 5e): a newer incarnation of a suspect's pid does not erase the suspicion about the older one's child", async () => {
+    // Chronology (samples 5000, 7000, 9000, 11000):
+    //   R0 (sample 5000): host 100 (born 1000, slot). Killed.
+    //   R1 (sample 7000): slot 200 (born 6200), 777 (born 6000, claims dead
+    //       100 - undecided) and 777's validated child 888 (born 6500).
+    //       kill=[200], unattributed=[777, 888].
+    //   R2 (sample 9000): old 777 has exited; a NEW slot-matched process
+    //       wears pid 777 (born 8000). 888 is still there; the scan zeroes
+    //       its edge because the holder of 777 is younger than it. 888 is
+    //       undecided (suspect 777 at 6000); the newcomer is killed as a slot
+    //       match and becomes victim 777 = [8000, 9000].
+    //   R3 (sample 11000): only 888. Against victim 777 (born 8000) it is
+    //       "older than the victim" - decided, and wrongly, if that were the
+    //       only memory consulted. The suspect incarnation (6000) and 888's
+    //       own remembered identity both keep it undecided: refused, naming
+    //       888.
+    const samples = [5000, 7000, 9000, 11000];
+    let sample = 0;
+    const { runner, calls } = roundedRunner([
+      {
+        kind: "table",
+        rows: [
+          { processId: 100, parentProcessId: 1, created: 1000, slot: true },
+        ],
+      },
+      {
+        kind: "table",
+        rows: [
+          { processId: 200, parentProcessId: 1, created: 6200, slot: true },
+          {
+            processId: 777,
+            parentProcessId: 0,
+            claimedParentProcessId: 100,
+            created: 6000,
+            slot: false,
+          },
+          {
+            processId: 888,
+            parentProcessId: 777,
+            claimedParentProcessId: 777,
+            created: 6500,
+            slot: false,
+          },
+        ],
+      },
+      {
+        kind: "table",
+        rows: [
+          { processId: 777, parentProcessId: 1, created: 8000, slot: true },
+          {
+            processId: 888,
+            parentProcessId: 0,
+            claimedParentProcessId: 777,
+            created: 6500,
+            slot: false,
+          },
+        ],
+      },
+      {
+        kind: "table",
+        rows: [
+          {
+            processId: 888,
+            parentProcessId: 0,
+            claimedParentProcessId: 777,
+            created: 6500,
+            slot: false,
+          },
+        ],
+      },
+    ]);
+    const controller = createWindowsController(runner, {
+      now: () => {
+        const value = samples[sample] ?? 11000;
+        sample += 1;
+        return value;
+      },
+    });
+
+    await expect(
+      controller.stop(serviceLabelFor("staging"), { force: false }),
+    ).rejects.toMatchObject({
+      code: CLI_ERROR_CODES.SERVICE_CONTROL_FAILED,
+      details: { unattributedPids: [888] },
+    });
+
+    expect(
+      calls
+        .filter((call) => call.command === "taskkill")
+        .map((call) => call.args),
+    ).toEqual([
+      ["/F", "/PID", "100"],
+      ["/F", "/PID", "200"],
+      ["/F", "/PID", "777"],
+    ]);
+
+    // Ablation: replace `rememberIncarnation`'s push with an overwrite
+    // (`memory.set(pid, [incarnation])`) AND make `classifyCarryOverClaim`
+    // return the first incarnation's verdict → this test reddens: round 3
+    // decides 888 is older than victim 777 and the stop RESOLVES with it
+    // alive. Either half alone is caught by the pure incarnation pins.
   });
 
   // The unattributed refusal exercised through all four callers that run
@@ -1830,8 +2026,8 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
     }
 
     const remembered = victimMemory(
-      new Map<number, WindowsKillVictim>([
-        [100, { created: 1000, seenAliveAt: 5000 }],
+      new Map<number, readonly WindowsKillVictim[]>([
+        [100, [{ created: 1000, seenAliveAt: 5000 }]],
       ]),
     );
     const cliPid = 9999;
@@ -1906,8 +2102,8 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
       ).toEqual({ kill: [], unattributed: [777] });
 
       const unknownVictimAge = victimMemory(
-        new Map<number, WindowsKillVictim>([
-          [100, { created: 0, seenAliveAt: 5000 }],
+        new Map<number, readonly WindowsKillVictim[]>([
+          [100, [{ created: 0, seenAliveAt: 5000 }]],
         ]),
       );
       const ordinaryRow = rowsOf([victimRow(777, 0, 100, 3000, false), cliRow]);
@@ -1916,14 +2112,14 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
       ).toEqual({ kill: [], unattributed: [777] });
 
       // Ablation (§ablation table): drop the zero-age branch entirely
-      // (`victim.created === 0 || row.created === 0`) → only the SECOND
-      // assertion above reddens (`unknownVictimAge`, becoming `{ kill:
-      // [777], unattributed: [] }`). The first does not: with the branch
-      // gone, the range check runs directly, and `1000 <= 0` is already
-      // false on its own - a row's own zero age is caught by the ordinary
-      // lower bound without needing the special case. Only a VICTIM's zero
-      // age needs the guard, because `0 <= anything-non-negative` would
-      // otherwise be vacuously true.
+      // (`victim.created === 0 || row.created === 0`) → BOTH assertions
+      // above redden, in opposite directions. The row of age 0 falls into
+      // the lower bound (`0 < 1000`) and is DECIDED as older than the victim
+      // (`{ kill: [], unattributed: [] }`), which is "we could not read an
+      // age" masquerading as proof. The victim of age 0 admits everything
+      // (`3000 < 0` is false, `3000 <= 5000` is true) and 777 is killed
+      // (`{ kill: [777], unattributed: [] }`). Neither reading of an
+      // unreadable age is acceptable, which is why the guard runs first.
     });
 
     it("a validated live edge is neither killed nor unattributed - the carry-over is not even consulted", () => {
@@ -2067,21 +2263,40 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
       });
     });
 
-    it("the gate is checked before the window: defensive, synthetic input pins that a validated live edge is never a carry-over question", () => {
-      // Deliberately SYNTHETIC, defensive input - this exact shape cannot
-      // arise from a real scan. `classifyCarryOverClaim`'s own comment says
-      // so: a row with a validated live edge has a parent the scan found in
-      // this very table, and a live parent is never simultaneously a killed
-      // victim, so the gate is redundant on legitimate input. This fixture
-      // exists only to pin the ORDER of the checks - the gate is evaluated
-      // before the window is ever consulted - so a future change cannot
-      // quietly drop the gate and rely on the window alone without a test
-      // noticing. Widen `seenAliveAt` to 6000 here specifically so the
-      // window ALONE would have accepted 777 (1000 <= 4000 <= 6000) - the
-      // gate is what still refuses it.
+    it("the gate is not redundant: a validated live edge to a process wearing a victim's pid is decided by the edge, not by the window", () => {
+      // LEGITIMATE scan output: after victim 100 died, an unrelated process
+      // took pid 100 (born 6000, after the window closed at 5000) and forked
+      // 777 (born 7000). The scan validates 777's edge - its parent is live
+      // and older - so `parentProcessId` is 100. On the window alone 777 is
+      // born after `seenAliveAt` and would be reported as undecided, failing
+      // the stop over a stranger's child; the edge is the better fact, and
+      // the gate is what applies it.
+      const table = rowsOf([
+        victimRow(100, 0, 0, 6000, false),
+        victimRow(777, 100, 100, 7000, false),
+        cliRow,
+      ]);
+      expect(computeWindowsHostKillSet(table, cliPid, remembered)).toEqual({
+        kill: [],
+        unattributed: [],
+      });
+
+      // Ablation (§ablation table): drop `row.parentProcessId !== 0` → this
+      // test reddens, becoming `{ kill: [], unattributed: [777] }` - the
+      // window alone cannot place a row born after 5000, and a stop would be
+      // refused over a process the scan had already tied to a living,
+      // unrelated parent.
+    });
+
+    it("the gate is checked before the window: defensive, synthetic input pins the order of the checks", () => {
+      // Deliberately SYNTHETIC: a victim window wide enough (to 6000) to
+      // contain a row whose validated live parent (born 3000) is itself
+      // inside that window cannot be produced by the pre-scan loop. It pins
+      // the ORDER only - the gate is evaluated before the window is ever
+      // consulted - so a future change cannot quietly reorder them.
       const widerWindow = victimMemory(
-        new Map<number, WindowsKillVictim>([
-          [100, { created: 1000, seenAliveAt: 6000 }],
+        new Map<number, readonly WindowsKillVictim[]>([
+          [100, [{ created: 1000, seenAliveAt: 6000 }]],
         ]),
       );
       const table = rowsOf([
@@ -2093,11 +2308,108 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
         kill: [],
         unattributed: [],
       });
+    });
 
-      // Ablation (§ablation table): drop `row.parentProcessId !== 0` → this
-      // test reddens, becoming `{ kill: [777], unattributed: [] }` - the
-      // window alone accepts the row (1000 <= 4000 <= 6000) and wrongly
-      // seeds a stranger with a perfectly good live parent of its own.
+    // Round 5e: memory is per INCARNATION. A pid can be killed twice as two
+    // processes, or be a suspect in one round and a victim in the next, and
+    // each incarnation is evidence about the rows born during it. The
+    // strongest verdict across incarnations wins; a newer holder of a pid
+    // never erases what the loop learned about the older holder's children.
+    describe("incarnations - a later holder of a pid does not erase the earlier one", () => {
+      it("two victim windows for one pid: a row inside the OLDER window is still seeded", () => {
+        // 100 was killed at [1000, 2000], reused, and the newcomer (born
+        // 6000, slot-matched) killed at [6000, 9000]. 555 (born 1500) claims
+        // 100: against the newer incarnation it is "older than the victim",
+        // against the older one it is inside the window. Seed.
+        const twoWindows = victimMemory(
+          new Map<number, readonly WindowsKillVictim[]>([
+            [
+              100,
+              [
+                { created: 1000, seenAliveAt: 2000 },
+                { created: 6000, seenAliveAt: 9000 },
+              ],
+            ],
+          ]),
+        );
+        const table = rowsOf([victimRow(555, 0, 100, 1500, false), cliRow]);
+        expect(computeWindowsHostKillSet(table, cliPid, twoWindows)).toEqual({
+          kill: [555],
+          unattributed: [],
+        });
+
+        // Ablation: in `classifyCarryOverClaim`, consult only the LAST
+        // incarnation of the claimed pid → this test reddens
+        // (`{ kill: [], unattributed: [] }`): 555 is decided as somebody
+        // else's child and silently spared.
+      });
+
+      it("a suspect incarnation and a later victim incarnation of one pid: a row between them stays undecided", () => {
+        // 777 was undecided (born 6000), exited, and its pid was taken by a
+        // slot-matched process (born 8000) that was then killed. 888 (born
+        // 6500) claims 777: "older than the victim" against the newer
+        // incarnation, but born after the suspect's birth against the older
+        // one. The open question outranks the decided one.
+        const mixed: WindowsKillMemory = {
+          victims: new Map<number, readonly WindowsKillVictim[]>([
+            [777, [{ created: 8000, seenAliveAt: 9000 }]],
+          ]),
+          suspects: new Map<number, readonly number[]>([[777, [6000]]]),
+        };
+        const table = rowsOf([victimRow(888, 0, 777, 6500, false), cliRow]);
+        expect(computeWindowsHostKillSet(table, cliPid, mixed)).toEqual({
+          kill: [],
+          unattributed: [888],
+        });
+      });
+
+      it("two suspect incarnations of one pid: the older one still covers a row born before the newer", () => {
+        const twoSuspects = suspectMemory(
+          new Map<number, readonly number[]>([[777, [6000, 8000]]]),
+        );
+        const table = rowsOf([victimRow(888, 0, 777, 6500, false), cliRow]);
+        expect(computeWindowsHostKillSet(table, cliPid, twoSuspects)).toEqual({
+          kill: [],
+          unattributed: [888],
+        });
+      });
+
+      it("a remembered suspect stays undecided by its own identity, even once its edge validates against a newer holder of its parent's pid", () => {
+        // 888 (born 6500) was reported undecided in an earlier round. Now its
+        // dead parent's pid 777 is worn by a process born 5000 - OLDER than
+        // 888, so the scan validates the edge. The edge is a coincidence of
+        // pid reuse, not lineage; 888 is the same process it was, and the
+        // question about it has not been answered.
+        const suspected = suspectMemory(
+          new Map<number, readonly number[]>([[888, [6500]]]),
+        );
+        const table = rowsOf([
+          victimRow(777, 0, 0, 5000, false),
+          victimRow(888, 777, 777, 6500, false),
+          cliRow,
+        ]);
+        expect(computeWindowsHostKillSet(table, cliPid, suspected)).toEqual({
+          kill: [],
+          unattributed: [888],
+        });
+
+        // A DIFFERENT process wearing 888's pid (born 9000) is not the
+        // remembered suspect and is decided on its own terms.
+        const newcomer = rowsOf([
+          victimRow(777, 0, 0, 5000, false),
+          victimRow(888, 777, 777, 9000, false),
+          cliRow,
+        ]);
+        expect(computeWindowsHostKillSet(newcomer, cliPid, suspected)).toEqual({
+          kill: [],
+          unattributed: [],
+        });
+
+        // Ablation: remove the `isRememberedSuspect` check from
+        // `classifyCarryOverClaim` → the first assertion reddens
+        // (`unattributed: []`): the validated edge clears a question a pid
+        // reuse had no business answering.
+      });
     });
 
     // Round 5d: a pid an earlier round could place neither in the slot nor
@@ -2108,7 +2420,9 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
     // it the row may be the suspect's or a stranger's, and both are
     // undecided (see `classifyAgainstSuspect`).
     describe("suspect inheritance - claims on a pid an earlier round could not place", () => {
-      const suspected = suspectMemory(new Map<number, number>([[777, 6000]]));
+      const suspected = suspectMemory(
+        new Map<number, readonly number[]>([[777, [6000]]]),
+      );
 
       it("a row claiming a suspect and born after it is unattributed, with no upper bound to clear it", () => {
         const table = rowsOf([
@@ -2142,7 +2456,9 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
           kill: [],
           unattributed: [888],
         });
-        const zeroSuspect = suspectMemory(new Map<number, number>([[777, 0]]));
+        const zeroSuspect = suspectMemory(
+          new Map<number, readonly number[]>([[777, [0]]]),
+        );
         const table = rowsOf([victimRow(888, 0, 777, 5000, false), cliRow]);
         expect(computeWindowsHostKillSet(table, cliPid, zeroSuspect)).toEqual({
           kill: [],

--- a/clients/traycer-cli/src/service/platforms/__tests__/windows.test.ts
+++ b/clients/traycer-cli/src/service/platforms/__tests__/windows.test.ts
@@ -2288,9 +2288,13 @@ describe("killHostProcessTree convergence loop", () => {
     //       stop over a stranger.
     const samples = [5000, 7000, 9000];
     let sample = 0;
-    const host100 = {
+    // An unreadable age zeroes the row's own edge (the scan cannot validate
+    // a parent for a birth it cannot read), so the host carries its claim on
+    // pid 1 with `parentProcessId` 0.
+    const host100: TableRowInput = {
       processId: 100,
-      parentProcessId: 1,
+      parentProcessId: 0,
+      claimedParentProcessId: 1,
       created: 0,
       slot: true,
     };
@@ -2494,7 +2498,7 @@ describe("killHostProcessTree convergence loop", () => {
     // Ablation: in `killHostProcessTree`, drop the `priorProtected`
     // recording (or in `computeWindowsHostKillSet` the identity lookup) →
     // this test reddens: round 1 issues `taskkill /F /PID 700` as well -
-    // the shell this CLI is running in - before 888.
+    // the shell this CLI is running in - after 888 (descendants first).
   });
 
   // The unattributed refusal exercised through all four callers that run
@@ -3128,7 +3132,8 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
         ]),
       );
       const table = rowsOf([
-        victimRow(100, 1, 1, 0, true),
+        // Unreadable age, so the host's own edge is zeroed too.
+        victimRow(100, 0, 1, 0, true),
         victimRow(cliPid, 0, 100, 2500, false),
         victimRow(777, cliPid, cliPid, 7500, true),
       ]);

--- a/clients/traycer-cli/src/service/platforms/__tests__/windows.test.ts
+++ b/clients/traycer-cli/src/service/platforms/__tests__/windows.test.ts
@@ -19,6 +19,7 @@ import {
   type WindowsTaskInstallDeps,
 } from "../windows";
 import { serviceLabelFor } from "../../label";
+import { WINDOWS_KILL_CONVERGENCE_ROUNDS } from "@traycer/protocol/host/lifecycle-constants";
 import { ProcessRunError, type RunResult } from "../../process-runner";
 import type { SpawnEvidenceBaseline } from "../../../host/spawn-evidence";
 import { CLI_ERROR_CODES } from "../../../runner/errors";
@@ -74,6 +75,49 @@ function stagedTaskInstallDeps(): WindowsTaskInstallDeps {
     }),
     removeStagedTaskDefinition: async () => undefined,
   };
+}
+
+// Rows as the table scan's JSON, in the shape `parseWindowsProcessTableJson`
+// expects. Shared by every fixture below that needs to hand a fake table back
+// through `run("powershell.exe", ...)`.
+function tableJson(rows: readonly WindowsProcessTableRow[]): string {
+  return JSON.stringify(
+    rows.map((row) => ({
+      ProcessId: row.processId,
+      ParentProcessId: row.parentProcessId,
+      Slot: row.slot,
+    })),
+  );
+}
+
+// A fake scan-then-kill runner that CONVERGES the way the real scan does. A
+// real scan verifies by exe path/command line, not by remembering what an
+// earlier round saw, so a process this round's `taskkill` actually reached is
+// simply ABSENT from the next snapshot - it isn't "seen and skipped", it's
+// gone. `killHostProcessTree`'s bounded convergence loop (Codex round 2 on
+// #1755: the old single-pass scan left anything spawned after the snapshot
+// untouched) rescans after every kill, so a fixture that keeps returning one
+// constant table makes every pid look like a survivor and gets re-killed
+// `WINDOWS_KILL_CONVERGENCE_ROUNDS` times instead of once. This tracks which
+// pids a `taskkill` call has fired for and drops those rows from every later
+// snapshot, so a fixture built for the old one-pass code keeps its original
+// meaning under the new loop.
+function convergingTableRunner(rows: readonly WindowsProcessTableRow[]): {
+  readonly runner: ProcessRunner;
+  readonly calls: RecordedCall[];
+} {
+  const calls: RecordedCall[] = [];
+  let live = rows;
+  const runner: ProcessRunner = async (command, args) => {
+    calls.push({ command, args });
+    if (command === "powershell.exe") return success(tableJson(live));
+    if (command === "taskkill") {
+      const killedPid = Number(args[2]);
+      live = live.filter((row) => row.processId !== killedPid);
+    }
+    return success("");
+  };
+  return { runner, calls };
 }
 
 describe("Windows service stale host cleanup", () => {
@@ -315,26 +359,11 @@ describe("Windows service stale host cleanup", () => {
   // test process's own pid) as the CLI identity, so every fake table below
   // treats `process.pid` as an ordinary, unrelated process with no parent in
   // the table - it must never appear in a kill set built from these tables.
-  function tableJson(rows: readonly WindowsProcessTableRow[]): string {
-    return JSON.stringify(
-      rows.map((row) => ({
-        ProcessId: row.processId,
-        ParentProcessId: row.parentProcessId,
-        Slot: row.slot,
-      })),
-    );
-  }
 
   it("re-kills scan-verified processes through killLingeringSlotProcesses", async () => {
-    const calls: RecordedCall[] = [];
-    const runner: ProcessRunner = async (command, args) => {
-      calls.push({ command, args });
-      return command === "powershell.exe"
-        ? success(
-            tableJson([{ processId: 401, parentProcessId: 1, slot: true }]),
-          )
-        : success("");
-    };
+    const { runner, calls } = convergingTableRunner([
+      { processId: 401, parentProcessId: 1, slot: true },
+    ]);
 
     await killLingeringSlotProcesses(serviceLabelFor("staging"), runner);
 
@@ -347,18 +376,10 @@ describe("Windows service stale host cleanup", () => {
   });
 
   it("kills slot-scanned processes when pid metadata is missing", async () => {
-    const calls: RecordedCall[] = [];
-    const runner: ProcessRunner = async (command, args) => {
-      calls.push({ command, args });
-      return command === "powershell.exe"
-        ? success(
-            tableJson([
-              { processId: 401, parentProcessId: 1, slot: true },
-              { processId: 402, parentProcessId: 1, slot: true },
-            ]),
-          )
-        : success("");
-    };
+    const { runner, calls } = convergingTableRunner([
+      { processId: 401, parentProcessId: 1, slot: true },
+      { processId: 402, parentProcessId: 1, slot: true },
+    ]);
     const controller = createWindowsController(runner);
 
     await controller.stop(serviceLabelFor("staging"), { force: false });
@@ -386,18 +407,10 @@ describe("Windows service stale host cleanup", () => {
       websocketUrl: "ws://127.0.0.1:54321/rpc",
       startedAt: "2026-01-01T00:00:00.000Z",
     });
-    const calls: RecordedCall[] = [];
-    const runner: ProcessRunner = async (command, args) => {
-      calls.push({ command, args });
-      return command === "powershell.exe"
-        ? success(
-            tableJson([
-              { processId: 401, parentProcessId: 1, slot: true },
-              { processId: 402, parentProcessId: 1, slot: true },
-            ]),
-          )
-        : success("");
-    };
+    const { runner, calls } = convergingTableRunner([
+      { processId: 401, parentProcessId: 1, slot: true },
+      { processId: 402, parentProcessId: 1, slot: true },
+    ]);
     const controller = createWindowsController(runner);
 
     await controller.stop(serviceLabelFor("staging"), { force: false });
@@ -420,18 +433,10 @@ describe("Windows service stale host cleanup", () => {
       websocketUrl: "ws://127.0.0.1:54321/rpc",
       startedAt: "2026-01-01T00:00:00.000Z",
     });
-    const calls: RecordedCall[] = [];
-    const runner: ProcessRunner = async (command, args) => {
-      calls.push({ command, args });
-      return command === "powershell.exe"
-        ? success(
-            tableJson([
-              { processId: 401, parentProcessId: 1, slot: false },
-              { processId: 402, parentProcessId: 1, slot: true },
-            ]),
-          )
-        : success("");
-    };
+    const { runner, calls } = convergingTableRunner([
+      { processId: 401, parentProcessId: 1, slot: false },
+      { processId: 402, parentProcessId: 1, slot: true },
+    ]);
     const controller = createWindowsController(runner);
 
     await controller.stop(serviceLabelFor("staging"), { force: false });
@@ -496,6 +501,219 @@ describe("Windows service stale host cleanup", () => {
   });
 });
 
+// `killHostProcessTree` (Codex round 2 on #1755, one P2): the scan is a
+// SNAPSHOT, so a process the host or an agent under it spawns after
+// `Get-CimInstance` materializes the table is in no round's kill set - and
+// with no `/T`, nothing walks down to catch it. `killProcessIds`' argv is
+// covered above; these pin the ROUND STRUCTURE around it: a bounded
+// scan-then-kill loop that stops the moment a scan comes back empty.
+describe("killHostProcessTree convergence loop", () => {
+  beforeEach(() => {
+    mocks.readHostPidMetadata.mockReset();
+    mocks.readHostPidMetadata.mockResolvedValue(null);
+    mocks.removeHostPidMetadata.mockReset();
+    mocks.removeHostPidMetadata.mockResolvedValue(undefined);
+  });
+
+  // A per-round scripted scan, for scenarios `convergingTableRunner`'s
+  // kill-tracking can't express - a snapshot that materializes a pid no
+  // earlier round ever saw (a late spawn), or a scan that only fails on a
+  // LATER round. `responses[n]` is the table (or throw) the (n+1)th
+  // `powershell.exe` call answers with; once exhausted, further calls answer
+  // with an empty table (converged) rather than reusing the last response -
+  // a test that needs more rounds than it scripted should say so explicitly.
+  type RoundResponse =
+    | {
+        readonly kind: "table";
+        readonly rows: readonly WindowsProcessTableRow[];
+      }
+    | { readonly kind: "throw" };
+
+  function roundedRunner(responses: readonly RoundResponse[]): {
+    readonly runner: ProcessRunner;
+    readonly calls: RecordedCall[];
+  } {
+    const calls: RecordedCall[] = [];
+    let scanCount = 0;
+    const runner: ProcessRunner = async (command, args) => {
+      calls.push({ command, args });
+      if (command === "powershell.exe") {
+        const response = responses[scanCount] ?? { kind: "table", rows: [] };
+        scanCount += 1;
+        if (response.kind === "throw") throw new Error("spawn failed");
+        return success(tableJson(response.rows));
+      }
+      return success("");
+    };
+    return { runner, calls };
+  }
+
+  it("convergence catches a late spawn: a process absent from round 1's snapshot is still killed in round 2", async () => {
+    // Round 1 sees A and B; round 2's snapshot has C instead - a process that
+    // spawned only after round 1's `Get-CimInstance` ran, which a single-pass
+    // scan (the bug Codex found) would never enumerate at all; round 3 is
+    // clean. This is the exact finding: without the loop, C survives the stop.
+    const { runner, calls } = roundedRunner([
+      {
+        kind: "table",
+        rows: [
+          { processId: 401, parentProcessId: 1, slot: true },
+          { processId: 402, parentProcessId: 1, slot: true },
+        ],
+      },
+      {
+        kind: "table",
+        rows: [{ processId: 403, parentProcessId: 1, slot: true }],
+      },
+      { kind: "table", rows: [] },
+    ]);
+    const controller = createWindowsController(runner);
+
+    await controller.stop(serviceLabelFor("staging"), { force: false });
+
+    // The kill set is asserted FIRST on purpose: it is the finding's own
+    // symptom, so a regression here reports "403 was never killed" rather
+    // than an arithmetic complaint about how many times we scanned.
+    expect(
+      calls
+        .filter((call) => call.command === "taskkill")
+        .map((call) => call.args),
+    ).toEqual([
+      ["/F", "/PID", "401"],
+      ["/F", "/PID", "402"],
+      ["/F", "/PID", "403"],
+    ]);
+    expect(
+      calls.filter((call) => call.command === "powershell.exe"),
+    ).toHaveLength(3);
+
+    // Ablation (§C): in `killHostProcessTree`, change the loop bound from
+    // `round <= WINDOWS_KILL_CONVERGENCE_ROUNDS` to `round <= 1` (a single
+    // pass) → this test fails: only 401 and 402 are ever killed, one
+    // `powershell.exe` call is made instead of three, and 403 - the late
+    // spawn - survives the stop exactly as the Codex finding describes.
+  });
+
+  it("the bound holds: a host that never stops spawning is scanned and killed exactly WINDOWS_KILL_CONVERGENCE_ROUNDS times, not forever", async () => {
+    // Every round's scan hands back a BRAND NEW pid, so the loop never
+    // converges on its own - the only thing that ends it is the round bound.
+    // Bounded is the right call: a host spawning faster than we can scan is
+    // not converging, and grinding on it forever is worse than stopping and
+    // reporting the swap's own EBUSY detail scan naming the survivors.
+    let scanCount = 0;
+    const calls: RecordedCall[] = [];
+    const runner: ProcessRunner = async (command, args) => {
+      calls.push({ command, args });
+      if (command === "powershell.exe") {
+        const pid = 800 + scanCount;
+        scanCount += 1;
+        return success(
+          tableJson([{ processId: pid, parentProcessId: 1, slot: true }]),
+        );
+      }
+      return success("");
+    };
+    const controller = createWindowsController(runner);
+
+    await controller.stop(serviceLabelFor("staging"), { force: false });
+
+    expect(
+      calls.filter((call) => call.command === "powershell.exe"),
+    ).toHaveLength(WINDOWS_KILL_CONVERGENCE_ROUNDS);
+    const taskkillPids = calls
+      .filter((call) => call.command === "taskkill")
+      .map((call) => call.args[2]);
+    expect(taskkillPids).toEqual(
+      Array.from({ length: WINDOWS_KILL_CONVERGENCE_ROUNDS }, (_, index) =>
+        String(800 + index),
+      ),
+    );
+
+    // Ablation (§C): removing the round bound (e.g. `for (;;)` instead of
+    // `for (let round = 1; round <= WINDOWS_KILL_CONVERGENCE_ROUNDS; ...)`)
+    // has no one-line inverse that stays safe to run in a test process - a
+    // fixture that never converges would hang the suite instead of failing
+    // it. Nothing here exercises that mutation; the finite scan count this
+    // test asserts is what an unbounded loop would violate.
+  });
+
+  it("round-1 fallback stays a one-round affair: an unavailable scan is not retried", async () => {
+    mocks.readHostPidMetadata.mockResolvedValue({
+      pid: 401,
+      hostId: "host-test",
+      version: "1.0.0",
+      websocketUrl: "ws://127.0.0.1:54321/rpc",
+      startedAt: "2026-01-01T00:00:00.000Z",
+    });
+    const { runner, calls } = roundedRunner([{ kind: "throw" }]);
+    const controller = createWindowsController(runner);
+
+    await controller.stop(serviceLabelFor("staging"), { force: false });
+
+    // Rescanning cannot help when the scan itself is what is unavailable, so
+    // round 1's fallback is the whole story: one attempt, one kill.
+    expect(
+      calls.filter((call) => call.command === "powershell.exe"),
+    ).toHaveLength(1);
+    expect(
+      calls
+        .filter((call) => call.command === "taskkill")
+        .map((call) => call.args),
+    ).toEqual([["/F", "/PID", "401"]]);
+
+    // Ablation (§C): in `killHostProcessTree`, delete the `if (round > 1)
+    // return;` guard (letting the loop fall through to another
+    // `findSlotProcessIds` call after a round-1 failure) → this test still
+    // passes, because round 1 already `return`s unconditionally after the
+    // fallback kill. There is no one-line mutation of the round-1 path this
+    // test can distinguish from correct behaviour; test (d) below is what
+    // pins the guard that actually matters: a scan failure LATER than
+    // round 1.
+  });
+
+  it("a later round's failed scan ends the loop without touching pid.json - a stale recorded pid is not a second opinion", async () => {
+    // Round 1 kills 901 normally. Round 2's scan is unavailable - and unlike
+    // round 1, this is NOT the moment to fall back to pid.json: round 1 may
+    // already have killed the recorded pid, so it now names a slot Windows is
+    // free to have recycled for something unrelated. Consulting it here would
+    // be exactly the recycled-pid kill the scan-verification exists to
+    // prevent.
+    mocks.readHostPidMetadata.mockResolvedValue({
+      pid: 901,
+      hostId: "host-test",
+      version: "1.0.0",
+      websocketUrl: "ws://127.0.0.1:54321/rpc",
+      startedAt: "2026-01-01T00:00:00.000Z",
+    });
+    const { runner, calls } = roundedRunner([
+      {
+        kind: "table",
+        rows: [{ processId: 901, parentProcessId: 1, slot: true }],
+      },
+      { kind: "throw" },
+    ]);
+    const controller = createWindowsController(runner);
+
+    await controller.stop(serviceLabelFor("staging"), { force: false });
+
+    expect(
+      calls.filter((call) => call.command === "powershell.exe"),
+    ).toHaveLength(2);
+    expect(
+      calls
+        .filter((call) => call.command === "taskkill")
+        .map((call) => call.args),
+    ).toEqual([["/F", "/PID", "901"]]);
+    expect(mocks.readHostPidMetadata).not.toHaveBeenCalled();
+
+    // Ablation (§C): in `killHostProcessTree`, change `if (round > 1) return;`
+    // to `if (false) return;` (always falling through to the round-1
+    // fallback, whatever the round) → this test fails: `readHostPidMetadata`
+    // is called on round 2, and the stale pid 901 - already killed in round 1
+    // - is handed to `killProcessIds` a second time.
+  });
+});
+
 // `computeWindowsHostKillSet` is the algebra a host stop's kill set is built
 // from (victims = slot ∪ descendants(slot); spared = cli ∪ descendants(cli) ∪
 // (ancestors(cli) − slot); kill = victims − spared). These pins exercise it
@@ -503,16 +721,6 @@ describe("Windows service stale host cleanup", () => {
 // alone would not catch a wiring bug that hands the wrong pid in as `cliPid`
 // (`process.pid`, not PowerShell's own `$PID` inside the scan script).
 describe("computeWindowsHostKillSet and the taskkill self-protection it drives", () => {
-  function table(rows: readonly WindowsProcessTableRow[]): string {
-    return JSON.stringify(
-      rows.map((row) => ({
-        ProcessId: row.processId,
-        ParentProcessId: row.parentProcessId,
-        Slot: row.slot,
-      })),
-    );
-  }
-
   beforeEach(() => {
     mocks.readHostPidMetadata.mockReset();
     mocks.readHostPidMetadata.mockResolvedValue(null);
@@ -535,11 +743,7 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
       { processId: 400, parentProcessId: 100, slot: false },
     ];
 
-    const calls: RecordedCall[] = [];
-    const runner: ProcessRunner = async (command, args) => {
-      calls.push({ command, args });
-      return command === "powershell.exe" ? success(table(rows)) : success("");
-    };
+    const { runner, calls } = convergingTableRunner(rows);
     const controller = createWindowsController(runner);
 
     const originalPid = Object.getOwnPropertyDescriptor(process, "pid");
@@ -584,11 +788,7 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
       { processId: 400, parentProcessId: 100, slot: false },
     ];
 
-    const calls: RecordedCall[] = [];
-    const runner: ProcessRunner = async (command, args) => {
-      calls.push({ command, args });
-      return command === "powershell.exe" ? success(table(rows)) : success("");
-    };
+    const { runner, calls } = convergingTableRunner(rows);
     const controller = createWindowsController(runner);
 
     const originalPid = Object.getOwnPropertyDescriptor(process, "pid");

--- a/clients/traycer-cli/src/service/platforms/__tests__/windows.test.ts
+++ b/clients/traycer-cli/src/service/platforms/__tests__/windows.test.ts
@@ -2108,12 +2108,158 @@ describe("killHostProcessTree convergence loop", () => {
       ["/F", "/PID", "100"],
     ]);
 
-    // Ablation: in `computeWindowsHostKillSet`, subtract `victims` (the
-    // closure) instead of `killed` (the actual kill set) when building
-    // `undecided` → this test reddens: round 1 remembers no suspect, round
-    // 2 finds nothing that remembers 700, and the stop RESOLVES with 889
-    // alive. The pure overlap pin below reddens on `undecided` for the same
-    // mutation.
+    // 700 is remembered here as a PLACED ancestor (a validated child of the
+    // lingering host), with a window, which is what decides 889 in round 2.
+    // Ablation: in `killHostProcessTree`, drop the `protectedAncestors`
+    // recording loop → this test reddens: 700 is neither killed nor - being
+    // subtracted from `undecided` as something the loop was about to
+    // remember - a suspect, round 2 finds nothing that remembers it, and the
+    // stop RESOLVES with 889 alive. Subtracting the victim closure instead
+    // of `remembered` no longer reddens this fixture on its own (700's
+    // window carries it); the pure overlap pin below pins that subtraction.
+  });
+
+  it("a placed CLI ancestor is remembered with a window though it is never killed: its later children are placed after it exits", async () => {
+    // The all-known-age form of the same invariant - no unreadable age, no
+    // pid reuse. The host spawned shell 700 to run this CLI (pid 9999);
+    // ages are all readable, so 700 is PLACED every round (a validated
+    // child of the host, then a carry-over seed through the host's window),
+    // spared as the CLI's ancestor, and - before this fix - never recorded,
+    // because only kills were. Chronology (samples 5000, 7000, 9000,
+    // 11000):
+    //   R0 (sample 5000): host 100 (born 1000, slot) -> shell 700 (born
+    //       2000) -> CLI (born 2500). kill=[100]; 700 is a placed ancestor,
+    //       remembered as 700 = [2000, 5000].
+    //   R1 (sample 7000): 700 orphaned (claims dead 100, inside its window:
+    //       seed), the CLI, and a side worker 888 (born 6000) under 700.
+    //       kill=[888]; 700 placed again, second window [2000, 7000].
+    //   R2 (sample 9000): 700 spawned 889 (born 8000) and exited; 888
+    //       lingers. All three claim absent 700. The CLI (born 2500) and 888
+    //       (born 6000) fall inside 700's windows: seeds - the CLI is spared,
+    //       888 is killed. 889 falls after the last window: undecided.
+    //       kill=[888], unattributed=[889] - kills first.
+    //   R3 (sample 11000): the CLI and 889. Nothing to kill; 889 is still
+    //       undecided, and the stop refuses naming it. Before this fix round
+    //       2 already resolved: nothing remembered 700, so the CLI, 888 and
+    //       889 were three orphans claiming a pid nobody knew.
+    const samples = [5000, 7000, 9000, 11000];
+    let sample = 0;
+    const cliUnder = (parent: number): TableRowInput => ({
+      processId: 9999,
+      parentProcessId: parent,
+      claimedParentProcessId: 700,
+      created: 2500,
+      slot: false,
+    });
+    const { runner, calls } = roundedRunner([
+      {
+        kind: "table",
+        rows: [
+          { processId: 100, parentProcessId: 1, created: 1000, slot: true },
+          {
+            processId: 700,
+            parentProcessId: 100,
+            claimedParentProcessId: 100,
+            created: 2000,
+            slot: false,
+          },
+          cliUnder(700),
+        ],
+      },
+      {
+        kind: "table",
+        rows: [
+          {
+            processId: 700,
+            parentProcessId: 0,
+            claimedParentProcessId: 100,
+            created: 2000,
+            slot: false,
+          },
+          cliUnder(700),
+          {
+            processId: 888,
+            parentProcessId: 700,
+            claimedParentProcessId: 700,
+            created: 6000,
+            slot: false,
+          },
+        ],
+      },
+      {
+        kind: "table",
+        rows: [
+          cliUnder(0),
+          {
+            processId: 888,
+            parentProcessId: 0,
+            claimedParentProcessId: 700,
+            created: 6000,
+            slot: false,
+          },
+          {
+            processId: 889,
+            parentProcessId: 0,
+            claimedParentProcessId: 700,
+            created: 8000,
+            slot: false,
+          },
+        ],
+      },
+      {
+        kind: "table",
+        rows: [
+          cliUnder(0),
+          {
+            processId: 889,
+            parentProcessId: 0,
+            claimedParentProcessId: 700,
+            created: 8000,
+            slot: false,
+          },
+        ],
+      },
+    ]);
+    const controller = createWindowsController(runner, {
+      now: () => {
+        const value = samples[sample] ?? 11000;
+        sample += 1;
+        return value;
+      },
+    });
+
+    const originalPid = Object.getOwnPropertyDescriptor(process, "pid");
+    Object.defineProperty(process, "pid", { value: 9999, configurable: true });
+    try {
+      await expect(
+        controller.stop(serviceLabelFor("staging"), { force: false }),
+      ).rejects.toMatchObject({
+        code: CLI_ERROR_CODES.SERVICE_CONTROL_FAILED,
+        details: { unattributedPids: [889] },
+      });
+    } finally {
+      if (originalPid !== undefined) {
+        Object.defineProperty(process, "pid", originalPid);
+      }
+    }
+
+    expect(
+      calls.filter((call) => call.command === "powershell.exe"),
+    ).toHaveLength(4);
+    expect(
+      calls
+        .filter((call) => call.command === "taskkill")
+        .map((call) => call.args),
+    ).toEqual([
+      ["/F", "/PID", "100"],
+      ["/F", "/PID", "888"],
+      ["/F", "/PID", "888"],
+    ]);
+
+    // Ablation: in `killHostProcessTree`, drop the `protectedAncestors`
+    // recording loop → this test reddens: round 2 finds three orphans
+    // claiming a pid nothing remembers, kills nothing, reports nothing, and
+    // the stop RESOLVES after three scans with 888 and 889 alive.
   });
 
   // The unattributed refusal exercised through all four callers that run
@@ -2500,6 +2646,7 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
       const table = rowsOf([victimRow(777, 0, 100, 3000, false), cliRow]);
       expect(computeWindowsHostKillSet(table, cliPid, remembered)).toEqual({
         kill: [777],
+        protectedAncestors: [],
         undecided: [],
         unattributed: [],
       });
@@ -2515,6 +2662,7 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
       const table = rowsOf([victimRow(777, 0, 100, 6000, false), cliRow]);
       expect(computeWindowsHostKillSet(table, cliPid, remembered)).toEqual({
         kill: [],
+        protectedAncestors: [],
         undecided: [777],
         unattributed: [777],
       });
@@ -2533,6 +2681,7 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
       const table = rowsOf([victimRow(777, 0, 100, 900, false), cliRow]);
       expect(computeWindowsHostKillSet(table, cliPid, remembered)).toEqual({
         kill: [],
+        protectedAncestors: [],
         undecided: [],
         unattributed: [],
       });
@@ -2542,7 +2691,12 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
       const sameAsBirth = rowsOf([victimRow(777, 0, 100, 1000, false), cliRow]);
       expect(
         computeWindowsHostKillSet(sameAsBirth, cliPid, remembered),
-      ).toEqual({ kill: [777], undecided: [], unattributed: [] });
+      ).toEqual({
+        kill: [777],
+        protectedAncestors: [],
+        undecided: [],
+        unattributed: [],
+      });
 
       const sameAsSeenAliveAt = rowsOf([
         victimRow(777, 0, 100, 5000, false),
@@ -2550,11 +2704,16 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
       ]);
       expect(
         computeWindowsHostKillSet(sameAsSeenAliveAt, cliPid, remembered),
-      ).toEqual({ kill: [777], undecided: [], unattributed: [] });
+      ).toEqual({
+        kill: [777],
+        protectedAncestors: [],
+        undecided: [],
+        unattributed: [],
+      });
 
       // Ablation (§ablation table): change `created < victim.created` to
       // `return "unattributed"` → the P2-2 test above reddens, becoming
-      // `{ kill: [], undecided: [777], unattributed: [777] }` instead of deciding the row is
+      // `{ kill: [], protectedAncestors: [], undecided: [777], unattributed: [777] }` instead of deciding the row is
       // simply not the victim's child.
       // Ablation (§ablation table): drop `row.created <= victim.seenAliveAt`
       // → the P1-a test above reddens the same way - exactly the bug this
@@ -2565,7 +2724,12 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
       const unknownRowAge = rowsOf([victimRow(777, 0, 100, 0, false), cliRow]);
       expect(
         computeWindowsHostKillSet(unknownRowAge, cliPid, remembered),
-      ).toEqual({ kill: [], undecided: [777], unattributed: [777] });
+      ).toEqual({
+        kill: [],
+        protectedAncestors: [],
+        undecided: [777],
+        unattributed: [777],
+      });
 
       const unknownVictimAge = victimMemory(
         new Map<number, readonly WindowsKillVictim[]>([
@@ -2575,16 +2739,21 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
       const ordinaryRow = rowsOf([victimRow(777, 0, 100, 3000, false), cliRow]);
       expect(
         computeWindowsHostKillSet(ordinaryRow, cliPid, unknownVictimAge),
-      ).toEqual({ kill: [], undecided: [777], unattributed: [777] });
+      ).toEqual({
+        kill: [],
+        protectedAncestors: [],
+        undecided: [777],
+        unattributed: [777],
+      });
 
       // Ablation (§ablation table): drop the zero-age branch entirely
       // (`victim.created === 0 || row.created === 0`) → BOTH assertions
       // above redden, in opposite directions. The row of age 0 falls into
       // the lower bound (`0 < 1000`) and is DECIDED as older than the victim
-      // (`{ kill: [], undecided: [], unattributed: [] }`), which is "we could not read an
+      // (`{ kill: [], protectedAncestors: [], undecided: [], unattributed: [] }`), which is "we could not read an
       // age" masquerading as proof. The victim of age 0 admits everything
       // (`3000 < 0` is false, `3000 <= 5000` is true) and 777 is killed
-      // (`{ kill: [777], undecided: [], unattributed: [] }`). Neither reading of an
+      // (`{ kill: [777], protectedAncestors: [], undecided: [], unattributed: [] }`). Neither reading of an
       // unreadable age is acceptable, which is why the guard runs first.
     });
 
@@ -2599,6 +2768,7 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
       ]);
       expect(computeWindowsHostKillSet(table, cliPid, remembered)).toEqual({
         kill: [],
+        protectedAncestors: [],
         undecided: [],
         unattributed: [],
       });
@@ -2608,6 +2778,7 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
       const table = rowsOf([victimRow(777, 0, 424242, 3000, false), cliRow]);
       expect(computeWindowsHostKillSet(table, cliPid, remembered)).toEqual({
         kill: [],
+        protectedAncestors: [],
         undecided: [],
         unattributed: [],
       });
@@ -2632,6 +2803,7 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
       ]);
       expect(computeWindowsHostKillSet(table, cliPid, remembered)).toEqual({
         kill: [],
+        protectedAncestors: [],
         undecided: [700, cliPid],
         unattributed: [],
       });
@@ -2658,6 +2830,7 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
       ]);
       expect(computeWindowsHostKillSet(table, cliPid, unreadableHost)).toEqual({
         kill: [200],
+        protectedAncestors: [],
         undecided: [700, 888, cliPid],
         unattributed: [888],
       });
@@ -2690,11 +2863,19 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
       ]);
       expect(computeWindowsHostKillSet(table, cliPid, unreadableSlot)).toEqual({
         kill: [100, 888],
-        undecided: [700, cliPid],
+        // 700 is a PLACED ancestor of the CLI (a validated child of the
+        // lingering host, which is a seed): reported as lineage to remember
+        // with a window, and therefore out of `undecided`. The CLI, placed
+        // only through 700 and an ancestor of nothing, stays undecided.
+        protectedAncestors: [700],
+        undecided: [cliPid],
         unattributed: [],
       });
 
-      // Ablation: subtract `victims` instead of `killed` → `undecided: []`.
+      // Ablation: subtract `victims` (the closure) instead of `remembered`
+      // when building `undecided` → `undecided: []`; drop
+      // `protectedAncestors` from `remembered` → 700 is listed in BOTH
+      // `protectedAncestors` and `undecided`.
     });
 
     it("both non-empty: a killable seed and an unattributed row coexist in the same verdict", () => {
@@ -2705,6 +2886,7 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
       ]);
       expect(computeWindowsHostKillSet(table, cliPid, remembered)).toEqual({
         kill: [777],
+        protectedAncestors: [],
         undecided: [888],
         unattributed: [888],
       });
@@ -2714,6 +2896,7 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
       const table = rowsOf([victimRow(200, 0, 0, 2000, true), cliRow]);
       expect(computeWindowsHostKillSet(table, cliPid, remembered)).toEqual({
         kill: [200],
+        protectedAncestors: [],
         undecided: [],
         unattributed: [],
       });
@@ -2729,6 +2912,11 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
       // shell. A row that ends up spared can never be the reason a round's
       // kill set comes back non-empty - only an UNSPARED survivor can stall
       // convergence.
+      //
+      // The shell is spared from the kill and reported as a placed ancestor:
+      // the loop remembers it with the window it would have given a kill, so
+      // that a child it spawns after this scan is still placed once the shell
+      // has exited.
       const table = rowsOf([
         victimRow(700, 0, 100, 2000, false),
         victimRow(cliPid, 700, 700, 2500, false),
@@ -2736,6 +2924,7 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
       ]);
       expect(computeWindowsHostKillSet(table, cliPid, remembered)).toEqual({
         kill: [800],
+        protectedAncestors: [700],
         undecided: [],
         unattributed: [],
       });
@@ -2761,6 +2950,7 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
         ]);
         expect(computeWindowsHostKillSet(table, cliPid, remembered)).toEqual({
           kill: [100, 777],
+          protectedAncestors: [],
           undecided: [],
           unattributed: [],
         });
@@ -2778,6 +2968,7 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
         ]);
         expect(computeWindowsHostKillSet(table, cliPid, remembered)).toEqual({
           kill: [100, 777],
+          protectedAncestors: [],
           undecided: [],
           unattributed: [],
         });
@@ -2797,6 +2988,7 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
         ]);
         expect(computeWindowsHostKillSet(table, cliPid, remembered)).toEqual({
           kill: [200, 300, 400],
+          protectedAncestors: [],
           undecided: [],
           unattributed: [],
         });
@@ -2818,12 +3010,13 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
       ]);
       expect(computeWindowsHostKillSet(table, cliPid, remembered)).toEqual({
         kill: [],
+        protectedAncestors: [],
         undecided: [],
         unattributed: [],
       });
 
       // Ablation (§ablation table): drop `row.parentProcessId !== 0` → this
-      // test reddens, becoming `{ kill: [], undecided: [777], unattributed: [777] }` - the
+      // test reddens, becoming `{ kill: [], protectedAncestors: [], undecided: [777], unattributed: [777] }` - the
       // window alone cannot place a row born after 5000, and a stop would be
       // refused over a process the scan had already tied to a living,
       // unrelated parent.
@@ -2847,6 +3040,7 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
       ]);
       expect(computeWindowsHostKillSet(table, cliPid, widerWindow)).toEqual({
         kill: [],
+        protectedAncestors: [],
         undecided: [],
         unattributed: [],
       });
@@ -2877,13 +3071,14 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
         const table = rowsOf([victimRow(555, 0, 100, 1500, false), cliRow]);
         expect(computeWindowsHostKillSet(table, cliPid, twoWindows)).toEqual({
           kill: [555],
+          protectedAncestors: [],
           undecided: [],
           unattributed: [],
         });
 
         // Ablation: in `classifyCarryOverClaim`, consult only the LAST
         // incarnation of the claimed pid → this test reddens
-        // (`{ kill: [], undecided: [], unattributed: [] }`): 555 is decided as somebody
+        // (`{ kill: [], protectedAncestors: [], undecided: [], unattributed: [] }`): 555 is decided as somebody
         // else's child and silently spared.
       });
 
@@ -2902,6 +3097,7 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
         const table = rowsOf([victimRow(888, 0, 777, 6500, false), cliRow]);
         expect(computeWindowsHostKillSet(table, cliPid, mixed)).toEqual({
           kill: [],
+          protectedAncestors: [],
           undecided: [888],
           unattributed: [888],
         });
@@ -2914,6 +3110,7 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
         const table = rowsOf([victimRow(888, 0, 777, 6500, false), cliRow]);
         expect(computeWindowsHostKillSet(table, cliPid, twoSuspects)).toEqual({
           kill: [],
+          protectedAncestors: [],
           undecided: [888],
           unattributed: [888],
         });
@@ -2944,6 +3141,7 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
         ]);
         expect(computeWindowsHostKillSet(table, cliPid, suspected)).toEqual({
           kill: [],
+          protectedAncestors: [],
           undecided: [],
           unattributed: [],
         });
@@ -2961,6 +3159,7 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
           computeWindowsHostKillSet(underSuspectParent, cliPid, suspected),
         ).toEqual({
           kill: [],
+          protectedAncestors: [],
           undecided: [777, 888],
           unattributed: [777, 888],
         });
@@ -2992,6 +3191,7 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
         ]);
         expect(computeWindowsHostKillSet(table, cliPid, suspected)).toEqual({
           kill: [],
+          protectedAncestors: [],
           undecided: [888, 889],
           unattributed: [888, 889],
         });
@@ -3007,6 +3207,7 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
         const table = rowsOf([victimRow(888, 0, 777, 5000, false), cliRow]);
         expect(computeWindowsHostKillSet(table, cliPid, suspected)).toEqual({
           kill: [],
+          protectedAncestors: [],
           undecided: [],
           unattributed: [],
         });
@@ -3016,6 +3217,7 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
         const zeroRow = rowsOf([victimRow(888, 0, 777, 0, false), cliRow]);
         expect(computeWindowsHostKillSet(zeroRow, cliPid, suspected)).toEqual({
           kill: [],
+          protectedAncestors: [],
           undecided: [888],
           unattributed: [888],
         });
@@ -3025,6 +3227,7 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
         const table = rowsOf([victimRow(888, 0, 777, 5000, false), cliRow]);
         expect(computeWindowsHostKillSet(table, cliPid, zeroSuspect)).toEqual({
           kill: [],
+          protectedAncestors: [],
           undecided: [888],
           unattributed: [888],
         });
@@ -3042,6 +3245,7 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
         ]);
         expect(computeWindowsHostKillSet(table, cliPid, remembered)).toEqual({
           kill: [],
+          protectedAncestors: [],
           undecided: [777, 888],
           unattributed: [777, 888],
         });
@@ -3058,6 +3262,7 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
         ]);
         expect(computeWindowsHostKillSet(table, cliPid, remembered)).toEqual({
           kill: [888],
+          protectedAncestors: [],
           undecided: [777],
           unattributed: [777],
         });

--- a/clients/traycer-cli/src/service/platforms/__tests__/windows.test.ts
+++ b/clients/traycer-cli/src/service/platforms/__tests__/windows.test.ts
@@ -1833,6 +1833,134 @@ describe("killHostProcessTree convergence loop", () => {
     ]);
   });
 
+  it("round-6 P2: a spared shell's uncertainty outlives the shell - its children still refuse the stop after it exits", async () => {
+    // The CLI (this process, pid 9999 here) runs in a terminal shell 700 the
+    // host spawned - the "terminal-run" topology - and the host's own age is
+    // unreadable, so 700 can be placed neither way for the whole loop.
+    // Chronology (samples 5000, 7000, 9000):
+    //   R0 (sample 5000): host 100 (slot, `created` 0 - unreadable), shell
+    //       700 (born 2000) claiming it with a zeroed edge, the CLI (born
+    //       2500) as 700's validated child. kill=[100]; victim 100 =
+    //       [0, 5000]. 700 is spared by ancestry; nothing is undecided yet
+    //       because nothing was remembered yet.
+    //   R1 (sample 7000): 700 and the CLI again, a side worker 888 (born
+    //       6000, 700's validated child) and a re-launched slot 200 (born
+    //       6200). Against the unreadable victim 700 is undecided; the
+    //       closure is {700, CLI, 888}; 700 and the CLI are spared from the
+    //       REPORT, so unattributed=[888]. kill=[200]. The memory must take
+    //       the whole closure: 700 and 888 become suspects.
+    //   R2 (sample 9000): 700 has exited. The CLI and 888 now claim absent
+    //       700, and a NEW child 889 (born 8000) does too. Nothing was
+    //       killed, so the verdict rests on memory: suspect 700 (born 2000)
+    //       makes every claim born after it undecided. The CLI is spared;
+    //       888 and 889 are named, and the stop refuses. Before this fix
+    //       only 888 was remembered - by its own pid, not its parent's - and
+    //       the loop reported a converged stop with both alive.
+    const samples = [5000, 7000, 9000];
+    let sample = 0;
+    const shell700 = (parent: number): TableRowInput => ({
+      processId: 700,
+      parentProcessId: parent,
+      claimedParentProcessId: 100,
+      created: 2000,
+      slot: false,
+    });
+    const cli9999 = (parent: number): TableRowInput => ({
+      processId: 9999,
+      parentProcessId: parent,
+      claimedParentProcessId: 700,
+      created: 2500,
+      slot: false,
+    });
+    const { runner, calls } = roundedRunner([
+      {
+        kind: "table",
+        rows: [
+          { processId: 100, parentProcessId: 1, created: 0, slot: true },
+          shell700(0),
+          cli9999(700),
+        ],
+      },
+      {
+        kind: "table",
+        rows: [
+          shell700(0),
+          cli9999(700),
+          {
+            processId: 888,
+            parentProcessId: 700,
+            claimedParentProcessId: 700,
+            created: 6000,
+            slot: false,
+          },
+          { processId: 200, parentProcessId: 1, created: 6200, slot: true },
+        ],
+      },
+      {
+        kind: "table",
+        rows: [
+          cli9999(0),
+          {
+            processId: 888,
+            parentProcessId: 0,
+            claimedParentProcessId: 700,
+            created: 6000,
+            slot: false,
+          },
+          {
+            processId: 889,
+            parentProcessId: 0,
+            claimedParentProcessId: 700,
+            created: 8000,
+            slot: false,
+          },
+        ],
+      },
+    ]);
+    const controller = createWindowsController(runner, {
+      now: () => {
+        const value = samples[sample] ?? 9000;
+        sample += 1;
+        return value;
+      },
+    });
+
+    const originalPid = Object.getOwnPropertyDescriptor(process, "pid");
+    Object.defineProperty(process, "pid", { value: 9999, configurable: true });
+    try {
+      await expect(
+        controller.stop(serviceLabelFor("staging"), { force: false }),
+      ).rejects.toMatchObject({
+        code: CLI_ERROR_CODES.SERVICE_CONTROL_FAILED,
+        details: { unattributedPids: [888, 889] },
+      });
+    } finally {
+      if (originalPid !== undefined) {
+        Object.defineProperty(process, "pid", originalPid);
+      }
+    }
+
+    expect(
+      calls.filter((call) => call.command === "powershell.exe"),
+    ).toHaveLength(3);
+    expect(
+      calls
+        .filter((call) => call.command === "taskkill")
+        .map((call) => call.args),
+    ).toEqual([
+      ["/F", "/PID", "100"],
+      ["/F", "/PID", "200"],
+    ]);
+
+    // Ablation: in `killHostProcessTree`, record suspects from `unattributed`
+    // instead of `undecided` → this test reddens: round 2 remembers 888 but
+    // not 700, no row's claim on 700 matches anything, and the stop RESOLVES
+    // with 888 and 889 alive (same kills, same three scans). 889 is why a
+    // self-identity rule would not have been enough: it was never seen
+    // before, so nothing about its own pid could be remembered - only its
+    // parent's.
+  });
+
   // The unattributed refusal exercised through all four callers that run
   // `killHostProcessTree`: none of them may treat it as anything softer than
   // the scan-unavailable refusal already covered above. The fourth is the
@@ -2217,6 +2345,7 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
       const table = rowsOf([victimRow(777, 0, 100, 3000, false), cliRow]);
       expect(computeWindowsHostKillSet(table, cliPid, remembered)).toEqual({
         kill: [777],
+        undecided: [],
         unattributed: [],
       });
     });
@@ -2231,6 +2360,7 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
       const table = rowsOf([victimRow(777, 0, 100, 6000, false), cliRow]);
       expect(computeWindowsHostKillSet(table, cliPid, remembered)).toEqual({
         kill: [],
+        undecided: [777],
         unattributed: [777],
       });
     });
@@ -2248,6 +2378,7 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
       const table = rowsOf([victimRow(777, 0, 100, 900, false), cliRow]);
       expect(computeWindowsHostKillSet(table, cliPid, remembered)).toEqual({
         kill: [],
+        undecided: [],
         unattributed: [],
       });
     });
@@ -2256,7 +2387,7 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
       const sameAsBirth = rowsOf([victimRow(777, 0, 100, 1000, false), cliRow]);
       expect(
         computeWindowsHostKillSet(sameAsBirth, cliPid, remembered),
-      ).toEqual({ kill: [777], unattributed: [] });
+      ).toEqual({ kill: [777], undecided: [], unattributed: [] });
 
       const sameAsSeenAliveAt = rowsOf([
         victimRow(777, 0, 100, 5000, false),
@@ -2264,11 +2395,11 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
       ]);
       expect(
         computeWindowsHostKillSet(sameAsSeenAliveAt, cliPid, remembered),
-      ).toEqual({ kill: [777], unattributed: [] });
+      ).toEqual({ kill: [777], undecided: [], unattributed: [] });
 
       // Ablation (§ablation table): change `created < victim.created` to
       // `return "unattributed"` → the P2-2 test above reddens, becoming
-      // `{ kill: [], unattributed: [777] }` instead of deciding the row is
+      // `{ kill: [], undecided: [777], unattributed: [777] }` instead of deciding the row is
       // simply not the victim's child.
       // Ablation (§ablation table): drop `row.created <= victim.seenAliveAt`
       // → the P1-a test above reddens the same way - exactly the bug this
@@ -2279,7 +2410,7 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
       const unknownRowAge = rowsOf([victimRow(777, 0, 100, 0, false), cliRow]);
       expect(
         computeWindowsHostKillSet(unknownRowAge, cliPid, remembered),
-      ).toEqual({ kill: [], unattributed: [777] });
+      ).toEqual({ kill: [], undecided: [777], unattributed: [777] });
 
       const unknownVictimAge = victimMemory(
         new Map<number, readonly WindowsKillVictim[]>([
@@ -2289,16 +2420,16 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
       const ordinaryRow = rowsOf([victimRow(777, 0, 100, 3000, false), cliRow]);
       expect(
         computeWindowsHostKillSet(ordinaryRow, cliPid, unknownVictimAge),
-      ).toEqual({ kill: [], unattributed: [777] });
+      ).toEqual({ kill: [], undecided: [777], unattributed: [777] });
 
       // Ablation (§ablation table): drop the zero-age branch entirely
       // (`victim.created === 0 || row.created === 0`) → BOTH assertions
       // above redden, in opposite directions. The row of age 0 falls into
       // the lower bound (`0 < 1000`) and is DECIDED as older than the victim
-      // (`{ kill: [], unattributed: [] }`), which is "we could not read an
+      // (`{ kill: [], undecided: [], unattributed: [] }`), which is "we could not read an
       // age" masquerading as proof. The victim of age 0 admits everything
       // (`3000 < 0` is false, `3000 <= 5000` is true) and 777 is killed
-      // (`{ kill: [777], unattributed: [] }`). Neither reading of an
+      // (`{ kill: [777], undecided: [], unattributed: [] }`). Neither reading of an
       // unreadable age is acceptable, which is why the guard runs first.
     });
 
@@ -2313,6 +2444,7 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
       ]);
       expect(computeWindowsHostKillSet(table, cliPid, remembered)).toEqual({
         kill: [],
+        undecided: [],
         unattributed: [],
       });
     });
@@ -2321,6 +2453,7 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
       const table = rowsOf([victimRow(777, 0, 424242, 3000, false), cliRow]);
       expect(computeWindowsHostKillSet(table, cliPid, remembered)).toEqual({
         kill: [],
+        undecided: [],
         unattributed: [],
       });
     });
@@ -2333,14 +2466,51 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
       // classification - reporting it would fail every stop issued from a
       // Traycer-hosted terminal whose shell happens to sit on a pid the host
       // once held.
+      //
+      // Excluded from the REPORT, not from the memory feed: 700 and the CLI
+      // under it are still the round's undecided closure, and the loop
+      // remembers them as suspects so that a child of 700 that shows up after
+      // 700 has exited still finds its parent's pid remembered.
       const table = rowsOf([
         victimRow(700, 0, 100, 6000, false),
         victimRow(cliPid, 700, 700, 6500, false),
       ]);
       expect(computeWindowsHostKillSet(table, cliPid, remembered)).toEqual({
         kill: [],
+        undecided: [700, cliPid],
         unattributed: [],
       });
+    });
+
+    it("a spared undecided shell's unspared child is reported, and the shell itself is kept in the memory feed", () => {
+      // The cold review's round-6 P2, as one round: the host was killed with
+      // an UNREADABLE age, so shell 700 (claiming it, born 2000) can be
+      // placed neither way; the CLI (9999) is 700's validated child, and so
+      // is a side worker 888 (born 6000). 700 is spared by ancestry and 888
+      // is reported. Without 700 in `undecided` the loop would remember only
+      // 888, and once 700 exits nothing would remember the pid its children
+      // claim.
+      const unreadableHost = victimMemory(
+        new Map<number, readonly WindowsKillVictim[]>([
+          [100, [{ created: 0, seenAliveAt: 5000 }]],
+        ]),
+      );
+      const table = rowsOf([
+        victimRow(700, 0, 100, 2000, false),
+        victimRow(cliPid, 700, 700, 2500, false),
+        victimRow(888, 700, 700, 6000, false),
+        victimRow(200, 0, 0, 6200, true),
+      ]);
+      expect(computeWindowsHostKillSet(table, cliPid, unreadableHost)).toEqual({
+        kill: [200],
+        undecided: [700, 888, cliPid],
+        unattributed: [888],
+      });
+
+      // Ablation: in `computeWindowsHostKillSet`, build `undecided` with the
+      // `!spared.has(pid)` filter too (make it equal to `unattributed`) →
+      // this assertion and the one above redden on `undecided`, and the
+      // loop-level "round-6 P2" test reddens into a resolved stop.
     });
 
     it("both non-empty: a killable seed and an unattributed row coexist in the same verdict", () => {
@@ -2351,6 +2521,7 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
       ]);
       expect(computeWindowsHostKillSet(table, cliPid, remembered)).toEqual({
         kill: [777],
+        undecided: [888],
         unattributed: [888],
       });
     });
@@ -2359,6 +2530,7 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
       const table = rowsOf([victimRow(200, 0, 0, 2000, true), cliRow]);
       expect(computeWindowsHostKillSet(table, cliPid, remembered)).toEqual({
         kill: [200],
+        undecided: [],
         unattributed: [],
       });
     });
@@ -2380,6 +2552,7 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
       ]);
       expect(computeWindowsHostKillSet(table, cliPid, remembered)).toEqual({
         kill: [800],
+        undecided: [],
         unattributed: [],
       });
     });
@@ -2404,6 +2577,7 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
         ]);
         expect(computeWindowsHostKillSet(table, cliPid, remembered)).toEqual({
           kill: [100, 777],
+          undecided: [],
           unattributed: [],
         });
       });
@@ -2420,6 +2594,7 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
         ]);
         expect(computeWindowsHostKillSet(table, cliPid, remembered)).toEqual({
           kill: [100, 777],
+          undecided: [],
           unattributed: [],
         });
       });
@@ -2438,6 +2613,7 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
         ]);
         expect(computeWindowsHostKillSet(table, cliPid, remembered)).toEqual({
           kill: [200, 300, 400],
+          undecided: [],
           unattributed: [],
         });
       });
@@ -2458,11 +2634,12 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
       ]);
       expect(computeWindowsHostKillSet(table, cliPid, remembered)).toEqual({
         kill: [],
+        undecided: [],
         unattributed: [],
       });
 
       // Ablation (§ablation table): drop `row.parentProcessId !== 0` → this
-      // test reddens, becoming `{ kill: [], unattributed: [777] }` - the
+      // test reddens, becoming `{ kill: [], undecided: [777], unattributed: [777] }` - the
       // window alone cannot place a row born after 5000, and a stop would be
       // refused over a process the scan had already tied to a living,
       // unrelated parent.
@@ -2486,6 +2663,7 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
       ]);
       expect(computeWindowsHostKillSet(table, cliPid, widerWindow)).toEqual({
         kill: [],
+        undecided: [],
         unattributed: [],
       });
     });
@@ -2515,12 +2693,13 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
         const table = rowsOf([victimRow(555, 0, 100, 1500, false), cliRow]);
         expect(computeWindowsHostKillSet(table, cliPid, twoWindows)).toEqual({
           kill: [555],
+          undecided: [],
           unattributed: [],
         });
 
         // Ablation: in `classifyCarryOverClaim`, consult only the LAST
         // incarnation of the claimed pid → this test reddens
-        // (`{ kill: [], unattributed: [] }`): 555 is decided as somebody
+        // (`{ kill: [], undecided: [], unattributed: [] }`): 555 is decided as somebody
         // else's child and silently spared.
       });
 
@@ -2539,6 +2718,7 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
         const table = rowsOf([victimRow(888, 0, 777, 6500, false), cliRow]);
         expect(computeWindowsHostKillSet(table, cliPid, mixed)).toEqual({
           kill: [],
+          undecided: [888],
           unattributed: [888],
         });
       });
@@ -2550,6 +2730,7 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
         const table = rowsOf([victimRow(888, 0, 777, 6500, false), cliRow]);
         expect(computeWindowsHostKillSet(table, cliPid, twoSuspects)).toEqual({
           kill: [],
+          undecided: [888],
           unattributed: [888],
         });
       });
@@ -2579,6 +2760,7 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
         ]);
         expect(computeWindowsHostKillSet(table, cliPid, suspected)).toEqual({
           kill: [],
+          undecided: [],
           unattributed: [],
         });
 
@@ -2593,7 +2775,11 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
         ]);
         expect(
           computeWindowsHostKillSet(underSuspectParent, cliPid, suspected),
-        ).toEqual({ kill: [], unattributed: [777, 888] });
+        ).toEqual({
+          kill: [],
+          undecided: [777, 888],
+          unattributed: [777, 888],
+        });
 
         // Ablation: in `classifyCarryOverClaim`, before the gate, return
         // "unattributed" when `memory.suspects.get(row.processId)` contains
@@ -2622,6 +2808,7 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
         ]);
         expect(computeWindowsHostKillSet(table, cliPid, suspected)).toEqual({
           kill: [],
+          undecided: [888, 889],
           unattributed: [888, 889],
         });
 
@@ -2636,6 +2823,7 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
         const table = rowsOf([victimRow(888, 0, 777, 5000, false), cliRow]);
         expect(computeWindowsHostKillSet(table, cliPid, suspected)).toEqual({
           kill: [],
+          undecided: [],
           unattributed: [],
         });
       });
@@ -2644,6 +2832,7 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
         const zeroRow = rowsOf([victimRow(888, 0, 777, 0, false), cliRow]);
         expect(computeWindowsHostKillSet(zeroRow, cliPid, suspected)).toEqual({
           kill: [],
+          undecided: [888],
           unattributed: [888],
         });
         const zeroSuspect = suspectMemory(
@@ -2652,6 +2841,7 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
         const table = rowsOf([victimRow(888, 0, 777, 5000, false), cliRow]);
         expect(computeWindowsHostKillSet(table, cliPid, zeroSuspect)).toEqual({
           kill: [],
+          undecided: [888],
           unattributed: [888],
         });
       });
@@ -2668,6 +2858,7 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
         ]);
         expect(computeWindowsHostKillSet(table, cliPid, remembered)).toEqual({
           kill: [],
+          undecided: [777, 888],
           unattributed: [777, 888],
         });
       });
@@ -2683,6 +2874,7 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
         ]);
         expect(computeWindowsHostKillSet(table, cliPid, remembered)).toEqual({
           kill: [888],
+          undecided: [777],
           unattributed: [777],
         });
       });

--- a/clients/traycer-cli/src/service/platforms/__tests__/windows.test.ts
+++ b/clients/traycer-cli/src/service/platforms/__tests__/windows.test.ts
@@ -15,6 +15,9 @@ import {
   setWindowsStartEvidenceDepsForTests,
   setWindowsTaskInstallDepsForTests,
   type ProcessRunner,
+  type WindowsControllerDeps,
+  type WindowsKillMemory,
+  type WindowsKillVictim,
   type WindowsProcessTableRow,
   type WindowsStartEvidenceDeps,
   type WindowsTaskInstallDeps,
@@ -68,6 +71,16 @@ function emptySpawnBaseline(): SpawnEvidenceBaseline {
   };
 }
 
+// Most call sites below never exercise `stop`/`uninstall`/`restart` at all
+// (an install/start test never touches `killHostProcessTree`), and the ones
+// that do mostly use ordinary slot rows with no victim carry-over in play, so
+// the clock value itself is immaterial to them. A `now` of 0 is unsafe for a
+// fixture with a LIVE carry-over though: it would make every remembered
+// victim's window `[created, 0]`, which no positive `created` can ever fall
+// inside - see the tests that build their own `WindowsControllerDeps` with a
+// real clock value instead.
+const noTimingDeps: WindowsControllerDeps = { now: () => 0 };
+
 function stagedTaskInstallDeps(): WindowsTaskInstallDeps {
   return {
     stageTaskDefinition: async () => ({
@@ -105,6 +118,31 @@ function fullRow(row: TableRowInput): WindowsProcessTableRow {
 
 function rowsOf(rows: readonly TableRowInput[]): WindowsProcessTableRow[] {
   return rows.map(fullRow);
+}
+
+// An empty carry-over memory: the state of round 0, and what every pin that
+// exercises a single snapshot on its own needs.
+const nothingRemembered: WindowsKillMemory = {
+  victims: new Map(),
+  suspects: new Map(),
+};
+
+// A memory that remembers kills but nothing undecided - the shape the window
+// pins below reason about, where an earlier round killed a parent and this
+// round has to decide what may be attributed to it.
+function victimMemory(
+  victims: ReadonlyMap<number, WindowsKillVictim>,
+): WindowsKillMemory {
+  return { victims, suspects: new Map() };
+}
+
+// A memory that remembers something undecided but no kill - the shape the
+// suspect-inheritance pins reason about, where an earlier round could place a
+// pid neither in the slot nor out of it.
+function suspectMemory(
+  suspects: ReadonlyMap<number, number>,
+): WindowsKillMemory {
+  return { victims: new Map(), suspects };
 }
 
 // Rows as the table scan's JSON, in the shape `parseWindowsProcessTableJson`
@@ -293,12 +331,40 @@ describe("Windows service stale host cleanup", () => {
         '[{"ProcessId":100,"ParentProcessId":1,"Slot":true}]',
       ),
     ).toBeNull();
+    // Missing just ONE of the two new fields is equally malformed - the
+    // all-or-nothing parse does not partially trust a row.
+    expect(
+      parseWindowsProcessTableJson(
+        '[{"ProcessId":100,"ParentProcessId":1,"ClaimedParentProcessId":1,"Slot":true}]',
+      ),
+    ).toBeNull();
+    expect(
+      parseWindowsProcessTableJson(
+        '[{"ProcessId":100,"ParentProcessId":1,"Created":1000,"Slot":true}]',
+      ),
+    ).toBeNull();
     expect(parseWindowsProcessTableJson('[100, "not-a-row"]')).toBeNull();
+    // Two rows sharing a pid is not a table this code can reason over: the
+    // parent map, the child map and the age lookup would each silently keep
+    // a different one of the duplicates depending on iteration order, and
+    // the kill set would depend on which. `Get-CimInstance` cannot produce
+    // this, so a response that does is malformed - refused whole, like
+    // every other shape violation above.
+    expect(
+      parseWindowsProcessTableJson(
+        '[{"ProcessId":100,"ParentProcessId":1,"ClaimedParentProcessId":1,"Created":1000,"Slot":true},' +
+          '{"ProcessId":100,"ParentProcessId":2,"ClaimedParentProcessId":2,"Created":2000,"Slot":false}]',
+      ),
+    ).toBeNull();
 
     // Ablation: in `parseProcessTableJson`, change `return null;` on a
     // malformed row to `continue;` (skipping just that row instead of
     // failing the whole parse) → the malformed-row assertions above fail:
     // a partial table would come back instead of `null`.
+    // Ablation (§ablation table): drop the duplicate-pid rejection
+    // (`if (seenProcessIds.has(processId)) return null;`) → the
+    // duplicate-pid assertion above reddens: two rows sharing pid 100 parse
+    // successfully instead of failing the whole table.
   });
 
   it("builds a table scan with the slot's install\\ prefix, ParentProcessId, and Slot fields, and no $excluded/$PID", () => {
@@ -334,7 +400,10 @@ describe("Windows service stale host cleanup", () => {
     // snapshot as the matches.
     expect(script).toContain("$table = @(Get-CimInstance Win32_Process)");
     expect(script).toContain(
-      "foreach ($row in $table) { $created[[int]$row.ProcessId] = $row.CreationDate }",
+      "if ($null -eq $row.CreationDate) { $created[[int]$row.ProcessId] = $null }",
+    );
+    expect(script).toContain(
+      "else { $created[[int]$row.ProcessId] = $row.CreationDate.ToUniversalTime() }",
     );
     expect(script).toContain(
       "if ($parentId -le 0 -or -not $created.ContainsKey($parentId)) {",
@@ -350,16 +419,40 @@ describe("Windows service stale host cleanup", () => {
     expect(script).toContain(
       "ClaimedParentProcessId = [int]$_.ParentProcessId",
     );
-    expect(script).toContain("Created = $createdMs");
+    expect(script).toContain("Created = $createdMicros");
     // `Created`'s own guard: 0 when Windows reports no creation time at all
     // (pid 0 and System have none), never a stale or default timestamp.
-    expect(script).toContain("$createdMs = 0");
-    expect(script).toContain("if ($null -ne $_.CreationDate) {");
+    expect(script).toContain("$createdMicros = 0");
+    expect(script).toContain(
+      "if ($null -ne $_.CreationDate) { $childCreated = $_.CreationDate.ToUniversalTime() }",
+    );
+    // P1-c: both operands of the edge validation are normalised to UTC.
+    // `CreationDate` arrives as a local DateTime, and local time is not
+    // monotonic across a DST fall-back - dropping `ToUniversalTime()` on
+    // either side lets a process started in the second pass of the
+    // repeated hour compare as OLDER than one from the first, and the scan
+    // would VALIDATE that edge instead of refusing it. Nothing else pins
+    // this: it is only visible in the exact text used to build `$created`
+    // and `$childCreated`.
+    expect(script).toContain(
+      "$created[[int]$row.ProcessId] = $row.CreationDate.ToUniversalTime()",
+    );
+    expect(script).toContain(
+      "$childCreated = $_.CreationDate.ToUniversalTime()",
+    );
+    // P1-b: microseconds, not milliseconds - `Ticks / 10` converts the
+    // TimeSpan's 100ns units, floored to stay an integer.
+    expect(script).toContain(
+      "$createdMicros = [long][math]::Floor(($_.CreationDate.ToUniversalTime() - [datetime]'1970-01-01').Ticks / 10)",
+    );
 
     // Ablation: in `buildSlotProcessTableScanScript`, drop
     // `...PARENT_EDGE_VALIDATION_SCRIPT_LINES` and emit
     // `ParentProcessId = [int]$_.ParentProcessId` again → this test fails, and
     // a recycled creator id becomes a believed ancestry edge.
+    // Ablation (§ablation table): drop `.ToUniversalTime()` from either
+    // operand of the edge validation → the UTC-normalisation assertions
+    // above fail; a DST fall-back can then validate a stranger's edge.
   });
 
   it("does not use broad production roots as process-match prefixes", () => {
@@ -469,7 +562,11 @@ describe("Windows service stale host cleanup", () => {
       { processId: 401, parentProcessId: 1, slot: true },
     ]);
 
-    await killLingeringSlotProcesses(serviceLabelFor("staging"), runner);
+    await killLingeringSlotProcesses(
+      serviceLabelFor("staging"),
+      runner,
+      noTimingDeps,
+    );
 
     expect(
       calls
@@ -484,7 +581,7 @@ describe("Windows service stale host cleanup", () => {
       { processId: 401, parentProcessId: 1, slot: true },
       { processId: 402, parentProcessId: 1, slot: true },
     ]);
-    const controller = createWindowsController(runner);
+    const controller = createWindowsController(runner, noTimingDeps);
 
     await controller.stop(serviceLabelFor("staging"), { force: false });
 
@@ -515,7 +612,7 @@ describe("Windows service stale host cleanup", () => {
       { processId: 401, parentProcessId: 1, slot: true },
       { processId: 402, parentProcessId: 1, slot: true },
     ]);
-    const controller = createWindowsController(runner);
+    const controller = createWindowsController(runner, noTimingDeps);
 
     await controller.stop(serviceLabelFor("staging"), { force: false });
 
@@ -541,7 +638,7 @@ describe("Windows service stale host cleanup", () => {
       { processId: 401, parentProcessId: 1, slot: false },
       { processId: 402, parentProcessId: 1, slot: true },
     ]);
-    const controller = createWindowsController(runner);
+    const controller = createWindowsController(runner, noTimingDeps);
 
     await controller.stop(serviceLabelFor("staging"), { force: false });
 
@@ -555,7 +652,7 @@ describe("Windows service stale host cleanup", () => {
   it("purges pid metadata on uninstall like it does on stop", async () => {
     const runner: ProcessRunner = async (command) =>
       command === "powershell.exe" ? success("[]") : success("");
-    const controller = createWindowsController(runner);
+    const controller = createWindowsController(runner, noTimingDeps);
 
     await controller.uninstall({ label: serviceLabelFor("staging") });
 
@@ -565,7 +662,7 @@ describe("Windows service stale host cleanup", () => {
   it("purges pid metadata on stop so a deliberate stop never reads as a crash", async () => {
     const runner: ProcessRunner = async (command) =>
       command === "powershell.exe" ? success("[]") : success("");
-    const controller = createWindowsController(runner);
+    const controller = createWindowsController(runner, noTimingDeps);
 
     await controller.stop(serviceLabelFor("staging"), { force: false });
 
@@ -586,7 +683,7 @@ describe("Windows service stale host cleanup", () => {
       if (command === "powershell.exe") throw new Error("spawn failed");
       return success("");
     };
-    const controller = createWindowsController(runner);
+    const controller = createWindowsController(runner, noTimingDeps);
 
     await expect(
       controller.stop(serviceLabelFor("staging"), { force: false }),
@@ -662,7 +759,7 @@ describe("killHostProcessTree convergence loop", () => {
       },
       { kind: "table", rows: [] },
     ]);
-    const controller = createWindowsController(runner);
+    const controller = createWindowsController(runner, noTimingDeps);
 
     await controller.stop(serviceLabelFor("staging"), { force: false });
 
@@ -709,7 +806,7 @@ describe("killHostProcessTree convergence loop", () => {
       }
       return success("");
     };
-    const controller = createWindowsController(runner);
+    const controller = createWindowsController(runner, noTimingDeps);
 
     // One more scan than kills: the confirming scan after the last kill
     // round is the one that catches the still-occupied slot and refuses,
@@ -740,6 +837,44 @@ describe("killHostProcessTree convergence loop", () => {
     // successful stop.
   });
 
+  it("a lingering already-killed pid exhausts the bound - the same never-dying pid every round, not a fresh spawn", async () => {
+    // The OTHER honest-failure path the function comment's caveat names:
+    // `taskkill /F` is `TerminateProcess`, asynchronous, so a confirming scan
+    // can briefly still list a pid a previous round already killed. The
+    // bound absorbs ONE such round; this pushes that to its limit - the
+    // scan returns the exact SAME pid every round (as if `taskkill` never
+    // actually reaped it), never a fresh spawn - and the loop still refuses
+    // rather than grinding forever or quietly reporting success.
+    const calls: RecordedCall[] = [];
+    const runner: ProcessRunner = async (command, args) => {
+      calls.push({ command, args });
+      if (command === "powershell.exe") {
+        return success(
+          tableJson([{ processId: 900, parentProcessId: 1, slot: true }]),
+        );
+      }
+      return success("");
+    };
+    const controller = createWindowsController(runner, noTimingDeps);
+
+    await expect(
+      controller.stop(serviceLabelFor("staging"), { force: false }),
+    ).rejects.toMatchObject({
+      code: "E_SERVICE_CONTROL_FAILED",
+      details: { survivingPids: [900] },
+    });
+
+    expect(
+      calls.filter((call) => call.command === "powershell.exe"),
+    ).toHaveLength(WINDOWS_KILL_CONVERGENCE_ROUNDS + 1);
+    // taskkill fired every round, not skipped just because it is the "same"
+    // pid as last time - the loop has no way to know that without a scan
+    // proving it, and a scan proving it IS what this test denies it.
+    expect(calls.filter((call) => call.command === "taskkill")).toHaveLength(
+      WINDOWS_KILL_CONVERGENCE_ROUNDS,
+    );
+  });
+
   it("refuses before killing anything when the scan is unavailable - the round-0 case of the general rule", async () => {
     // There used to be a pid.json fallback here: kill the one recorded pid,
     // unverified, and move on. That let a stop report success while
@@ -751,7 +886,7 @@ describe("killHostProcessTree convergence loop", () => {
     // processes" and "host-spawned" elsewhere in this file, which exercise a
     // real kill.
     const { runner, calls } = roundedRunner([{ kind: "throw" }]);
-    const controller = createWindowsController(runner);
+    const controller = createWindowsController(runner, noTimingDeps);
 
     await expect(
       controller.stop(serviceLabelFor("staging"), { force: false }),
@@ -785,7 +920,7 @@ describe("killHostProcessTree convergence loop", () => {
       },
       { kind: "throw" },
     ]);
-    const controller = createWindowsController(runner);
+    const controller = createWindowsController(runner, noTimingDeps);
 
     await expect(
       controller.stop(serviceLabelFor("staging"), { force: false }),
@@ -839,7 +974,9 @@ describe("killHostProcessTree convergence loop", () => {
       },
       { kind: "table", rows: [] },
     ]);
-    const controller = createWindowsController(runner);
+    // A real clock, not 0: 555's window is [1000, seenAliveAt], and only a
+    // seenAliveAt at or above its own `created` (1500) can ever admit it.
+    const controller = createWindowsController(runner, { now: () => 5000 });
 
     await controller.stop(serviceLabelFor("staging"), { force: false });
 
@@ -855,10 +992,81 @@ describe("killHostProcessTree convergence loop", () => {
       ["/F", "/PID", "555"],
     ]);
 
-    // Ablation (§ablation table): in `isChildOfVictim`, replace the body with
-    // `return false;` → this test reddens alongside the direct "the finding"
-    // algebra pin below - 555 is never seeded, round 1's kill set comes back
-    // empty, and the stop resolves with 555 still alive.
+    // Ablation (§ablation table): in `classifyCarryOverClaim`, replace the
+    // body with `return "none";` → this test reddens alongside the direct
+    // "the finding" algebra pin below - 555 is never seeded, round 1's kill
+    // set comes back empty, and the stop resolves with 555 still alive.
+  });
+
+  it("the victim map ACCUMULATES across rounds rather than being replaced - round 2 needs BOTH round 0's and round 1's victims remembered at once", async () => {
+    // Round 0 kills host 100. Round 1's orphan 555 is only killable because
+    // 100 is remembered. Round 2 contains TWO orphans at once: 777 claims
+    // 555 (round 1's victim) and 888 claims 100 (round 0's victim, still
+    // directly). 888 is born at 2200 - AFTER round 1's snapshot (1500) ran,
+    // so its absence from that snapshot is coherent history, not a process
+    // that should have already been visible and wasn't. A per-round RESET
+    // (keeping only the latest round's victims) would seed 777 but not 888,
+    // since 100 would have fallen out of the map the moment round 1 replaced
+    // it with 555 - so this only passes if the map is grown, never reset,
+    // across the whole loop.
+    const { runner, calls } = roundedRunner([
+      {
+        kind: "table",
+        rows: [
+          { processId: 100, parentProcessId: 1, created: 1000, slot: true },
+        ],
+      },
+      {
+        kind: "table",
+        rows: [
+          {
+            processId: 555,
+            parentProcessId: 0,
+            claimedParentProcessId: 100,
+            created: 1500,
+            slot: false,
+          },
+        ],
+      },
+      {
+        kind: "table",
+        rows: [
+          {
+            processId: 777,
+            parentProcessId: 0,
+            claimedParentProcessId: 555,
+            created: 2000,
+            slot: false,
+          },
+          {
+            processId: 888,
+            parentProcessId: 0,
+            claimedParentProcessId: 100,
+            created: 2200,
+            slot: false,
+          },
+        ],
+      },
+      { kind: "table", rows: [] },
+    ]);
+    // A real clock covering every fixture's `created` value above (max 2200).
+    const controller = createWindowsController(runner, { now: () => 5000 });
+
+    await controller.stop(serviceLabelFor("staging"), { force: false });
+
+    expect(
+      calls.filter((call) => call.command === "powershell.exe"),
+    ).toHaveLength(4);
+    expect(
+      calls
+        .filter((call) => call.command === "taskkill")
+        .map((call) => call.args),
+    ).toEqual([
+      ["/F", "/PID", "100"],
+      ["/F", "/PID", "555"],
+      ["/F", "/PID", "777"],
+      ["/F", "/PID", "888"],
+    ]);
   });
 
   it("kills within a round deepest-first: a 3-node chain is issued grandchild, child, host", async () => {
@@ -877,7 +1085,7 @@ describe("killHostProcessTree convergence loop", () => {
       },
       { kind: "table", rows: [] },
     ]);
-    const controller = createWindowsController(runner);
+    const controller = createWindowsController(runner, noTimingDeps);
 
     await controller.stop(serviceLabelFor("staging"), { force: false });
 
@@ -893,6 +1101,455 @@ describe("killHostProcessTree convergence loop", () => {
     // do the standalone algebra pin below and the "host-spawned" /
     // "terminal-run" tests above, which also assert deepest-first order now
     // that the loop applies it.
+  });
+
+  // P2-2 (round 5d): an older stranger claiming a killed process as its
+  // parent is DECIDED, not undecided - a process cannot predate its own
+  // parent, so the claim is simply false, and every retry finds the same
+  // stranger sitting in exactly the same place. The stop must actually
+  // SUCCEED around it rather than refusing forever over a claim that can
+  // never resolve.
+  it("an older stranger claiming a killed victim as its parent, present in every scan, does not block a successful stop", async () => {
+    const { runner, calls } = roundedRunner([
+      {
+        kind: "table",
+        rows: [
+          { processId: 100, parentProcessId: 1, created: 1000, slot: true },
+          {
+            processId: 777,
+            parentProcessId: 0,
+            claimedParentProcessId: 100,
+            created: 500,
+            slot: false,
+          },
+        ],
+      },
+      {
+        kind: "table",
+        rows: [
+          {
+            processId: 777,
+            parentProcessId: 0,
+            claimedParentProcessId: 100,
+            created: 500,
+            slot: false,
+          },
+        ],
+      },
+    ]);
+    const controller = createWindowsController(runner, { now: () => 2000 });
+
+    await expect(
+      controller.stop(serviceLabelFor("staging"), { force: false }),
+    ).resolves.toBeUndefined();
+
+    expect(
+      calls
+        .filter((call) => call.command === "taskkill")
+        .map((call) => call.args[2]),
+    ).toEqual(["100"]);
+
+    // Ablation (§ablation table): change `created < victim.created` to
+    // `return "unattributed"` in `classifyAgainstVictim` → this test
+    // reddens: 777 (born 500, before 100's own birth at 1000) is reported
+    // unattributed forever, and the stop that should succeed refuses
+    // instead.
+  });
+
+  // P1-a (round 5c): `seenAliveAt` must be sampled BEFORE the scan that
+  // selects a round's victims, not before the kills that follow it. Before
+  // the scan is what lets the soundness argument hold: the scan then
+  // observes the victim alive at some instant AFTER the sample, so the pid
+  // was demonstrably still the victim's at the sampled instant. Sampled
+  // later, the clock could read a moment after the victim already exited,
+  // its pid was reused, and the replacement forked a child - all before the
+  // sample - and that child's birth would then fall inside a window it has
+  // no business being in.
+  it("the clock is sampled BEFORE the scan, not after: a row born during the scan is unattributed and the stop refuses", async () => {
+    let clock = 2000;
+    const now = (): number => clock;
+    const calls: RecordedCall[] = [];
+    let scanCount = 0;
+    const runner: ProcessRunner = async (command, args) => {
+      calls.push({ command, args });
+      if (command === "powershell.exe") {
+        scanCount += 1;
+        if (scanCount === 1) {
+          const stdout = tableJson([
+            { processId: 100, parentProcessId: 1, created: 1000, slot: true },
+          ]);
+          // Time passes WHILE this scan "runs" (the real analogue is
+          // `Get-CimInstance` taking real wall-clock time) - after the
+          // sample that fed round 0's `seenAliveAt`, before round 1's.
+          clock = 5000;
+          return success(stdout);
+        }
+        if (scanCount === 2) {
+          return success(
+            tableJson([
+              {
+                processId: 777,
+                parentProcessId: 0,
+                claimedParentProcessId: 100,
+                created: 3000,
+                slot: false,
+              },
+            ]),
+          );
+        }
+        return success(tableJson([]));
+      }
+      return success("");
+    };
+    const controller = createWindowsController(runner, { now });
+
+    await expect(
+      controller.stop(serviceLabelFor("staging"), { force: false }),
+    ).rejects.toMatchObject({
+      code: CLI_ERROR_CODES.SERVICE_CONTROL_FAILED,
+      details: { unattributedPids: [777] },
+    });
+
+    // Round 0 killed 100 using the sample taken BEFORE its scan (2000): 777
+    // was born at 3000, after that sample, so round 1 refuses it rather
+    // than silently killing or silently sparing it.
+    expect(
+      calls
+        .filter((call) => call.command === "taskkill")
+        .map((call) => call.args[2]),
+    ).toEqual(["100"]);
+
+    // Ablation (§ablation table): in `killHostProcessTree`, move the
+    // `deps.now()` sample to AFTER `scanSlotProcessTable` returns → this
+    // test reddens: round 0's sample would then read the clock post-bump
+    // (5000), 777's birth (3000) would fall inside `[1000, 5000]`, and the
+    // stop would resolve having force-killed a row it could never actually
+    // prove belonged to the host.
+  });
+
+  // A pid killed again in a later round overwrites its `priorVictims` entry
+  // with THAT round's `seenAliveAt` - never frozen at the round it was first
+  // killed - so a later orphan's window is bounded by how long the victim was
+  // actually still provably alive, not by the first round that happened to
+  // notice it.
+  it("a repeated victim's seenAliveAt advances across rounds, widening what a later orphan can be attributed to", async () => {
+    // 100 is killed in round 0, then found STILL present in round 1
+    // (`taskkill /F` is asynchronous - the loop's own comment names this
+    // exact case) and killed again there. Orphan 555 is born at 3000 - after
+    // round 0's seenAliveAt (2000) but before round 1's (4000) - so it is
+    // only killable if the map's bound for 100 actually moved forward.
+    const { runner, calls } = roundedRunner([
+      {
+        kind: "table",
+        rows: [
+          { processId: 100, parentProcessId: 1, created: 1000, slot: true },
+        ],
+      },
+      {
+        kind: "table",
+        rows: [
+          { processId: 100, parentProcessId: 1, created: 1000, slot: true },
+        ],
+      },
+      {
+        kind: "table",
+        rows: [
+          {
+            processId: 555,
+            parentProcessId: 0,
+            claimedParentProcessId: 100,
+            created: 3000,
+            slot: false,
+          },
+        ],
+      },
+      { kind: "table", rows: [] },
+    ]);
+    let round = 0;
+    const now = (): number => {
+      round += 1;
+      return round === 1 ? 2000 : 4000;
+    };
+    const controller = createWindowsController(runner, { now });
+
+    await controller.stop(serviceLabelFor("staging"), { force: false });
+
+    expect(
+      calls
+        .filter((call) => call.command === "taskkill")
+        .map((call) => call.args),
+    ).toEqual([
+      ["/F", "/PID", "100"],
+      ["/F", "/PID", "100"],
+      ["/F", "/PID", "555"],
+    ]);
+
+    // Ablation: in `killHostProcessTree`, only record a victim's
+    // `priorVictims` entry the FIRST time it is killed (skip the `.set` when
+    // an entry already exists) → this test reddens: 100's `seenAliveAt`
+    // freezes at round 0's 2000, 555 (born 3000) falls outside that stale
+    // window, and round 2 reports it unattributed instead of killing it.
+  });
+
+  // P2 (round 5c): a kill set of `[]` used to mean convergence unconditionally.
+  // A row claiming a killed process as parent but born after it was last
+  // proven alive is undecidable (a row born BEFORE the victim existed is not:
+  // it is decided to be somebody else's, see the P2-2 pin) - and reporting the
+  // stop successful while it survives is the bug this refusal exists to
+  // close. Kills still happen first: a round with
+  // BOTH a killable seed and an undecidable row proceeds to kill the seed,
+  // and only refuses once a later round's kill set is empty with the
+  // undecidable row still unexplained.
+  it("kills happen first even when an unattributed row sits in the same round's scan; the throw only comes once nothing is left to kill", async () => {
+    const { runner, calls } = roundedRunner([
+      {
+        kind: "table",
+        rows: [
+          { processId: 100, parentProcessId: 1, created: 1000, slot: true },
+        ],
+      },
+      {
+        kind: "table",
+        rows: [
+          {
+            processId: 555,
+            parentProcessId: 0,
+            claimedParentProcessId: 100,
+            created: 1500,
+            slot: false,
+          },
+          {
+            processId: 777,
+            parentProcessId: 0,
+            claimedParentProcessId: 100,
+            created: 6000,
+            slot: false,
+          },
+        ],
+      },
+      {
+        kind: "table",
+        rows: [
+          {
+            processId: 777,
+            parentProcessId: 0,
+            claimedParentProcessId: 100,
+            created: 6000,
+            slot: false,
+          },
+        ],
+      },
+    ]);
+    const controller = createWindowsController(runner, { now: () => 5000 });
+
+    await expect(
+      controller.stop(serviceLabelFor("staging"), { force: false }),
+    ).rejects.toMatchObject({
+      code: CLI_ERROR_CODES.SERVICE_CONTROL_FAILED,
+      details: { unattributedPids: [777] },
+    });
+
+    // 555 (born 1500, inside [1000, 5000]) was killed even though 777 (born
+    // 6000, outside it) sat alongside it in the very same round's scan.
+    expect(
+      calls
+        .filter((call) => call.command === "taskkill")
+        .map((call) => call.args),
+    ).toEqual([
+      ["/F", "/PID", "100"],
+      ["/F", "/PID", "555"],
+    ]);
+
+    // Ablation (§ablation table): in `killHostProcessTree`, return `kill`
+    // only (drop the `unattributed.length > 0` throw) → this test's
+    // rejection reddens into a resolve, reporting the host stopped with 777
+    // still alive.
+  });
+
+  it("P2-1: an undecided row that exits between rounds leaves its child undecided too - the suspect memory outlives the row that earned it", async () => {
+    // Chronology (epoch micros; the clock is sampled BEFORE each scan):
+    //   R0 sample 5000: host 100 (born 1000, slot) -> killed.
+    //   R1 sample 7000: slot 200 (born 6200, a re-launch), non-slot 777
+    //     (born 6000, claims 100, born AFTER 100's window closed at 5000)
+    //     and 777's live, validated child 888 (born 6500).
+    //     kill=[200], unattributed=[777, 888] -> 200 is killed, 777 and 888
+    //     are remembered as suspects.
+    //   R2 sample 9000: 777 has exited on its own. Only 888 remains, parent
+    //     0, claimed 777.
+    // 777 was never a victim, so without the suspect memory 888 is an
+    // ordinary orphan claiming a pid nothing remembers: empty kill, empty
+    // unattributed, and the stop reports success with a possible host
+    // grandchild alive. With it, 888 inherits 777's suspicion and the loop
+    // refuses, naming 888.
+    const samples = [5000, 7000, 9000, 11000];
+    let sample = 0;
+    const { runner, calls } = roundedRunner([
+      {
+        kind: "table",
+        rows: [
+          { processId: 100, parentProcessId: 1, created: 1000, slot: true },
+        ],
+      },
+      {
+        kind: "table",
+        rows: [
+          { processId: 200, parentProcessId: 1, created: 6200, slot: true },
+          {
+            processId: 777,
+            parentProcessId: 0,
+            claimedParentProcessId: 100,
+            created: 6000,
+            slot: false,
+          },
+          {
+            processId: 888,
+            parentProcessId: 777,
+            claimedParentProcessId: 777,
+            created: 6500,
+            slot: false,
+          },
+        ],
+      },
+      {
+        kind: "table",
+        rows: [
+          {
+            processId: 888,
+            parentProcessId: 0,
+            claimedParentProcessId: 777,
+            created: 6500,
+            slot: false,
+          },
+        ],
+      },
+    ]);
+    const controller = createWindowsController(runner, {
+      now: () => {
+        const value = samples[sample] ?? 11000;
+        sample += 1;
+        return value;
+      },
+    });
+
+    await expect(
+      controller.stop(serviceLabelFor("staging"), { force: false }),
+    ).rejects.toMatchObject({
+      code: CLI_ERROR_CODES.SERVICE_CONTROL_FAILED,
+      details: { unattributedPids: [888] },
+    });
+
+    expect(
+      calls.filter((call) => call.command === "powershell.exe"),
+    ).toHaveLength(3);
+    expect(
+      calls
+        .filter((call) => call.command === "taskkill")
+        .map((call) => call.args),
+    ).toEqual([
+      ["/F", "/PID", "100"],
+      ["/F", "/PID", "200"],
+    ]);
+
+    // Ablation (§ablation table): in `killHostProcessTree`, drop the
+    // `priorSuspects.set(...)` loop (record victims only) → this test
+    // reddens: round 2 finds nothing to kill and nothing it remembers, and
+    // the stop RESOLVES with 888 alive. Alternatively make
+    // `classifyAgainstSuspect` return "none" → same outcome.
+  });
+
+  // The unattributed refusal exercised through all four callers that run
+  // `killHostProcessTree`: none of them may treat it as anything softer than
+  // the scan-unavailable refusal already covered above. The fourth is the
+  // install swap's between-retry escalation, `killLingeringSlotProcesses`,
+  // which throws like the others; that `swapLockRetryHook` then logs the
+  // refusal and lets the rename retry anyway is existing, documented
+  // behaviour of the hook (see `killLingeringSlotProcesses`'s own comment),
+  // not of the function under test here.
+  describe("all four killHostProcessTree callers refuse the same way on an unattributed row", () => {
+    function unattributedRefusalRounds(): readonly RoundResponse[] {
+      return [
+        {
+          kind: "table",
+          rows: [
+            { processId: 100, parentProcessId: 1, created: 1000, slot: true },
+          ],
+        },
+        {
+          kind: "table",
+          rows: [
+            {
+              processId: 777,
+              parentProcessId: 0,
+              claimedParentProcessId: 100,
+              created: 999_999,
+              slot: false,
+            },
+          ],
+        },
+      ];
+    }
+    const unattributedDeps: WindowsControllerDeps = { now: () => 5000 };
+
+    it("stop does NOT purge pid metadata when the refusal is an unattributed row, not just when the scan itself fails", async () => {
+      const { runner } = roundedRunner(unattributedRefusalRounds());
+      const controller = createWindowsController(runner, unattributedDeps);
+
+      await expect(
+        controller.stop(serviceLabelFor("staging"), { force: false }),
+      ).rejects.toMatchObject({ code: CLI_ERROR_CODES.SERVICE_CONTROL_FAILED });
+
+      expect(mocks.removeHostPidMetadata).not.toHaveBeenCalled();
+    });
+
+    it("uninstall never reaches schtasks /Delete when the tree kill refuses on an unattributed row", async () => {
+      const { runner, calls } = roundedRunner(unattributedRefusalRounds());
+      const controller = createWindowsController(runner, unattributedDeps);
+
+      await expect(
+        controller.uninstall({ label: serviceLabelFor("staging") }),
+      ).rejects.toMatchObject({ code: CLI_ERROR_CODES.SERVICE_CONTROL_FAILED });
+
+      expect(
+        calls.some(
+          (call) => call.command === "schtasks" && call.args[0] === "/Delete",
+        ),
+      ).toBe(false);
+    });
+
+    it("restart never reaches schtasks /Run when the tree kill refuses on an unattributed row", async () => {
+      const { runner, calls } = roundedRunner(unattributedRefusalRounds());
+      const controller = createWindowsController(runner, unattributedDeps);
+
+      await expect(
+        controller.restart(serviceLabelFor("staging")),
+      ).rejects.toMatchObject({ code: CLI_ERROR_CODES.SERVICE_CONTROL_FAILED });
+
+      expect(
+        calls.some(
+          (call) => call.command === "schtasks" && call.args[0] === "/Run",
+        ),
+      ).toBe(false);
+    });
+
+    it("killLingeringSlotProcesses (the install swap's between-retry kill) throws the same refusal, naming the row", async () => {
+      // The swap path has no pid metadata to purge and no task to touch;
+      // what it must not do is resolve, because `swapLockRetryHook` reads a
+      // resolved kill as "the slot was cleared, retry the rename". The hook's
+      // own decision to log and retry anyway is its business; this function
+      // has to hand it the truth.
+      const { runner } = roundedRunner(unattributedRefusalRounds());
+
+      await expect(
+        killLingeringSlotProcesses(
+          serviceLabelFor("staging"),
+          runner,
+          unattributedDeps,
+        ),
+      ).rejects.toMatchObject({
+        code: CLI_ERROR_CODES.SERVICE_CONTROL_FAILED,
+        details: { unattributedPids: [777] },
+      });
+    });
   });
 });
 
@@ -926,7 +1583,7 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
     ];
 
     const { runner, calls } = convergingTableRunner(rows);
-    const controller = createWindowsController(runner);
+    const controller = createWindowsController(runner, noTimingDeps);
 
     const originalPid = Object.getOwnPropertyDescriptor(process, "pid");
     Object.defineProperty(process, "pid", { value: 200, configurable: true });
@@ -975,7 +1632,7 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
     ];
 
     const { runner, calls } = convergingTableRunner(rows);
-    const controller = createWindowsController(runner);
+    const controller = createWindowsController(runner, noTimingDeps);
 
     const originalPid = Object.getOwnPropertyDescriptor(process, "pid");
     Object.defineProperty(process, "pid", { value: 200, configurable: true });
@@ -1022,10 +1679,11 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
     const killSet = computeWindowsHostKillSet(
       rowsOf(rows),
       250,
-      new Map<number, number>(),
+      nothingRemembered,
     );
 
-    expect(killSet).toEqual([100, 300, 400]);
+    expect(killSet.kill).toEqual([100, 300, 400]);
+    expect(killSet.unattributed).toEqual([]);
     // Ablation for the CALL SITE (`findSlotProcessIds(label, run, process.pid)`
     // in `killHostProcessTree`): this test calls the algebra directly and
     // would not see it. The host-spawned integration test above is the one
@@ -1048,7 +1706,7 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
     ];
 
     expect(
-      computeWindowsHostKillSet(rowsOf(rows), 200, new Map<number, number>()),
+      computeWindowsHostKillSet(rowsOf(rows), 200, nothingRemembered).kill,
     ).toEqual([100]);
   });
 
@@ -1067,7 +1725,7 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
     ];
 
     expect(
-      computeWindowsHostKillSet(rowsOf(rows), 200, new Map<number, number>()),
+      computeWindowsHostKillSet(rowsOf(rows), 200, nothingRemembered).kill,
     ).toEqual([100, 400]);
   });
 
@@ -1084,7 +1742,7 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
 
     it("kills the slot and its descendants, sparing the CLI's ancestry and subtree", () => {
       expect(
-        computeWindowsHostKillSet(rowsOf(rows), 200, new Map<number, number>()),
+        computeWindowsHostKillSet(rowsOf(rows), 200, nothingRemembered).kill,
       ).toEqual([100, 400]);
 
       // Ablation: in `computeWindowsHostKillSet`, drop the
@@ -1105,11 +1763,8 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
         { processId: 300, parentProcessId: 200, slot: false },
       ];
       expect(
-        computeWindowsHostKillSet(
-          rowsOf(withChild),
-          200,
-          new Map<number, number>(),
-        ),
+        computeWindowsHostKillSet(rowsOf(withChild), 200, nothingRemembered)
+          .kill,
       ).toEqual([100]);
 
       // Ablation: in `computeWindowsHostKillSet`, change
@@ -1125,137 +1780,406 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
   // cannot vouch for a parent that is already dead - so a row is only linked
   // back to the slot through the UNVALIDATED `claimedParentProcessId`, made
   // safe against pid reuse by comparing creation times.
-  describe("computeWindowsHostKillSet - victim carry-over (claimedParentProcessId + created)", () => {
-    it("the finding: a live row whose claimed parent is a remembered victim is killed - the same table with an empty victim map is not", () => {
-      // Orphan 999 spawned after round 0 killed host 100: its real parent is
-      // dead, so `parentProcessId` arrives as 0, and its own path matches
-      // nothing (a shell or provider binary). Only `claimedParentProcessId`
-      // still names 100, and `created` (1500) is not earlier than the
-      // victim's own recorded creation time (1000).
-      const table = rowsOf([
-        {
-          processId: 999,
-          parentProcessId: 0,
-          claimedParentProcessId: 100,
-          created: 1500,
-          slot: false,
-        },
-      ]);
-      const priorVictims = new Map<number, number>([[100, 1000]]);
+  //
+  // Codex round 5b: an earlier version of this carry-over answered lineage -
+  // "which incarnation of this pid created this row" - by inspecting the
+  // pid's CURRENT holder. That cannot work: a pid reused and then vacated
+  // between two scans leaves no trace in the table at all, so a stranger
+  // forked by that intermediate holder arrives looking exactly like the
+  // victim's own child, and the occupant check passed it through. The
+  // replacement was a lifetime window, `pid -> { created, killedAt }`.
+  //
+  // Codex round 5c - an independent cold review found three P1s and a P2
+  // against that 5b window:
+  //   P1-a - the soundness argument assumed its own conclusion. Sampling the
+  //     clock before the KILL does not prove the victim was still alive at
+  //     that instant: it can exit on its own, its pid be reused, and the
+  //     replacement fork a child, all before the sample is taken. The bound
+  //     is now sampled BEFORE THE SCAN and renamed `seenAliveAt` - the scan
+  //     that follows observes the victim alive at some instant after the
+  //     sample, which is what makes the sample honest.
+  //   P1-b - millisecond rounding let a previous holder's fork-and-exit and
+  //     the victim's own birth project to the same millisecond, wrongly
+  //     admitting a stranger. `Created` is now epoch MICROSECONDS.
+  //   P1-c - the scan's edge validation compared LOCAL DateTimes; across a
+  //     DST fall-back a newer holder can look older and the scan would
+  //     VALIDATE a stranger's edge instead of refusing it. Both operands are
+  //     now `.ToUniversalTime()` (see the script-pin test above).
+  //   P2 - a row born after the bound but genuinely the host's own child was
+  //     refused forever and silently spared, and the loop reported the stop
+  //     successful with it alive. `computeWindowsHostKillSet` now returns
+  //     `unattributed` alongside `kill`, and the loop (below) throws rather
+  //     than reading an empty `kill` as convergence while `unattributed` is
+  //     non-empty.
+  describe("computeWindowsHostKillSet - victim carry-over (lifetime window: created..seenAliveAt)", () => {
+    // (processId, parentProcessId, claimedParentProcessId, created, slot).
+    function victimRow(
+      processId: number,
+      parentProcessId: number,
+      claimedParentProcessId: number,
+      created: number,
+      slot: boolean,
+    ): TableRowInput {
+      return {
+        processId,
+        parentProcessId,
+        claimedParentProcessId,
+        created,
+        slot,
+      };
+    }
 
-      expect(computeWindowsHostKillSet(table, 1, priorVictims)).toEqual([999]);
-      // The contrast IS the finding: without the remembered victim, 999 looks
-      // like an ordinary unrelated process and survives.
-      expect(
-        computeWindowsHostKillSet(table, 1, new Map<number, number>()),
-      ).toEqual([]);
+    const remembered = victimMemory(
+      new Map<number, WindowsKillVictim>([
+        [100, { created: 1000, seenAliveAt: 5000 }],
+      ]),
+    );
+    const cliPid = 9999;
+    const cliRow = victimRow(cliPid, 0, 0, 500, false);
 
-      // Ablation (§ablation table): in `isChildOfVictim`, replace the body
-      // with `return false;` → run and confirmed: the first assertion above
-      // reddens (`toEqual([999])` becomes `[]`, since the second already
-      // expects `[]`), and so do three others that depend on the same
-      // positive path - the loop-level carry-over test below, the
-      // same-millisecond half of the "recycled parent id" test, and the "CLI
-      // exclusion" test. The ablation table names only this test and the
-      // carry-over test; disabling the function outright reddens every test
-      // that seeds through it, which is wider than the table's own row.
+    it("born inside the lifetime window is killed", () => {
+      const table = rowsOf([victimRow(777, 0, 100, 3000, false), cliRow]);
+      expect(computeWindowsHostKillSet(table, cliPid, remembered)).toEqual({
+        kill: [777],
+        unattributed: [],
+      });
     });
 
-    it("recycled parent id: a claimed child OLDER than the victim is not killed; the SAME millisecond is", () => {
-      // A fork can land in the same millisecond as its parent's own
-      // creation, so equality must not invalidate - only a claimed child
-      // strictly OLDER than the victim it claims as parent is a recycled id
-      // wearing that victim's old pid.
-      const priorVictims = new Map<number, number>([[100, 2000]]);
-      const older = rowsOf([
-        {
-          processId: 999,
-          parentProcessId: 0,
-          claimedParentProcessId: 100,
-          created: 1500,
-          slot: false,
-        },
-      ]);
-      expect(computeWindowsHostKillSet(older, 1, priorVictims)).toEqual([]);
-
-      const sameMillisecond = rowsOf([
-        {
-          processId: 999,
-          parentProcessId: 0,
-          claimedParentProcessId: 100,
-          created: 2000,
-          slot: false,
-        },
-      ]);
-      expect(
-        computeWindowsHostKillSet(sameMillisecond, 1, priorVictims),
-      ).toEqual([999]);
-
-      // Ablation (§ablation table): in `isChildOfVictim`, drop the
-      // `victimCreated <= row.created` check (treat any claimed match as a
-      // hit) → the first assertion above reddens: the older row would be
-      // killed as though 999 were really the victim's child.
+    it("P1-a: born after seenAliveAt is unattributed, neither killed nor silently spared", () => {
+      // The cold review's finding: an earlier version sampled the clock
+      // before the KILL rather than before the SCAN, so a row born after the
+      // victim genuinely exited - but before that stale sample was taken -
+      // could pass as "still inside the window". Refusing to kill it is not
+      // enough on its own either: an even earlier version silently spared
+      // rows like this, which is the P2 the loop-level tests below cover.
+      const table = rowsOf([victimRow(777, 0, 100, 6000, false), cliRow]);
+      expect(computeWindowsHostKillSet(table, cliPid, remembered)).toEqual({
+        kill: [],
+        unattributed: [777],
+      });
     });
 
-    it("unknown age fails closed: created 0 on the row, and separately on the victim, both refuse the link", () => {
-      const priorVictims = new Map<number, number>([[100, 2000]]);
-      const unknownRowAge = rowsOf([
-        {
-          processId: 999,
-          parentProcessId: 0,
-          claimedParentProcessId: 100,
-          created: 0,
-          slot: false,
-        },
+    it("P2-2: a row older than the victim is DECIDED, not undecided - it cannot be the victim's child at all", () => {
+      // A process cannot predate its own parent, so 777 (born 900, before
+      // 100's own birth at 1000) never was 100's child - the claimed id is
+      // one 777 has worn since before 100 existed, which this scan simply
+      // cannot verify (no live parent survives to validate the edge). That
+      // is a decided "no", not an open question: reporting it as
+      // unattributed would fail the stop over a long-lived stranger that
+      // every retry finds sitting in exactly the same place - a refusal
+      // nothing can clear. The caller-level test below drives this through
+      // `controller.stop` and confirms the stop actually succeeds.
+      const table = rowsOf([victimRow(777, 0, 100, 900, false), cliRow]);
+      expect(computeWindowsHostKillSet(table, cliPid, remembered)).toEqual({
+        kill: [],
+        unattributed: [],
+      });
+    });
+
+    it("both window bounds are inclusive: the same microsecond as the parent's birth, and the same microsecond as seenAliveAt, are both killed", () => {
+      const sameAsBirth = rowsOf([victimRow(777, 0, 100, 1000, false), cliRow]);
+      expect(
+        computeWindowsHostKillSet(sameAsBirth, cliPid, remembered),
+      ).toEqual({ kill: [777], unattributed: [] });
+
+      const sameAsSeenAliveAt = rowsOf([
+        victimRow(777, 0, 100, 5000, false),
+        cliRow,
       ]);
-      expect(computeWindowsHostKillSet(unknownRowAge, 1, priorVictims)).toEqual(
-        [],
+      expect(
+        computeWindowsHostKillSet(sameAsSeenAliveAt, cliPid, remembered),
+      ).toEqual({ kill: [777], unattributed: [] });
+
+      // Ablation (§ablation table): change `created < victim.created` to
+      // `return "unattributed"` → the P2-2 test above reddens, becoming
+      // `{ kill: [], unattributed: [777] }` instead of deciding the row is
+      // simply not the victim's child.
+      // Ablation (§ablation table): drop `row.created <= victim.seenAliveAt`
+      // → the P1-a test above reddens the same way - exactly the bug this
+      // fix exists to close.
+    });
+
+    it("created 0 on the row, and separately on the victim, both refuse the link as unattributed", () => {
+      const unknownRowAge = rowsOf([victimRow(777, 0, 100, 0, false), cliRow]);
+      expect(
+        computeWindowsHostKillSet(unknownRowAge, cliPid, remembered),
+      ).toEqual({ kill: [], unattributed: [777] });
+
+      const unknownVictimAge = victimMemory(
+        new Map<number, WindowsKillVictim>([
+          [100, { created: 0, seenAliveAt: 5000 }],
+        ]),
       );
-
-      const unknownVictimAge = new Map<number, number>([[100, 0]]);
-      const ordinaryRow = rowsOf([
-        {
-          processId: 999,
-          parentProcessId: 0,
-          claimedParentProcessId: 100,
-          created: 1500,
-          slot: false,
-        },
-      ]);
+      const ordinaryRow = rowsOf([victimRow(777, 0, 100, 3000, false), cliRow]);
       expect(
-        computeWindowsHostKillSet(ordinaryRow, 1, unknownVictimAge),
-      ).toEqual([]);
+        computeWindowsHostKillSet(ordinaryRow, cliPid, unknownVictimAge),
+      ).toEqual({ kill: [], unattributed: [777] });
+
+      // Ablation (§ablation table): drop the zero-age branch entirely
+      // (`victim.created === 0 || row.created === 0`) → only the SECOND
+      // assertion above reddens (`unknownVictimAge`, becoming `{ kill:
+      // [777], unattributed: [] }`). The first does not: with the branch
+      // gone, the range check runs directly, and `1000 <= 0` is already
+      // false on its own - a row's own zero age is caught by the ordinary
+      // lower bound without needing the special case. Only a VICTIM's zero
+      // age needs the guard, because `0 <= anything-non-negative` would
+      // otherwise be vacuously true.
+    });
+
+    it("a validated live edge is neither killed nor unattributed - the carry-over is not even consulted", () => {
+      // 777 has a validated `parentProcessId` of its own (100, nonzero) - the
+      // scan found a live parent for it in this very table, so the
+      // carry-over question never arises for it at all.
+      const table = rowsOf([
+        victimRow(100, 0, 0, 3000, false),
+        victimRow(777, 100, 100, 4000, false),
+        cliRow,
+      ]);
+      expect(computeWindowsHostKillSet(table, cliPid, remembered)).toEqual({
+        kill: [],
+        unattributed: [],
+      });
+    });
+
+    it("a claimed parent that is not a remembered victim is neither killed nor unattributed", () => {
+      const table = rowsOf([victimRow(777, 0, 424242, 3000, false), cliRow]);
+      expect(computeWindowsHostKillSet(table, cliPid, remembered)).toEqual({
+        kill: [],
+        unattributed: [],
+      });
+    });
+
+    it("a spared row claiming a victim pid is excluded from unattributed too - a process already decided never to kill is not an open question", () => {
+      // 700 claims the dead host (100) as its parent, born after
+      // `seenAliveAt` - ordinarily unattributed on its own. But the CLI
+      // (9999) claims 700 as its own validated parent here, so 700 is spared
+      // by the ancestry exclusion regardless of its carry-over
+      // classification - reporting it would fail every stop issued from a
+      // Traycer-hosted terminal whose shell happens to sit on a pid the host
+      // once held.
+      const table = rowsOf([
+        victimRow(700, 0, 100, 6000, false),
+        victimRow(cliPid, 700, 700, 6500, false),
+      ]);
+      expect(computeWindowsHostKillSet(table, cliPid, remembered)).toEqual({
+        kill: [],
+        unattributed: [],
+      });
+    });
+
+    it("both non-empty: a killable seed and an unattributed row coexist in the same verdict", () => {
+      const table = rowsOf([
+        victimRow(777, 0, 100, 3000, false),
+        victimRow(888, 0, 100, 6000, false),
+        cliRow,
+      ]);
+      expect(computeWindowsHostKillSet(table, cliPid, remembered)).toEqual({
+        kill: [777],
+        unattributed: [888],
+      });
+    });
+
+    it("an ordinary slot row is killed through the ordinary walk, independent of any carry-over", () => {
+      const table = rowsOf([victimRow(200, 0, 0, 2000, true), cliRow]);
+      expect(computeWindowsHostKillSet(table, cliPid, remembered)).toEqual({
+        kill: [200],
+        unattributed: [],
+      });
     });
 
     it("the CLI exclusion holds against victim ancestry: a shell claiming the dead host as parent spares the CLI and the shell, but not the CLI's sibling", () => {
-      // Round 0 killed host 100. Round 1's table: shell 50 claims the dead
-      // host as its parent (a live edge the scan cannot verify, so
-      // `parentProcessId` is 0) and is itself old enough to be believed as
-      // host 100's child; the CLI (200) and a sibling (300) are both
-      // ordinary, VALIDATED children of the still-live shell 50.
-      const priorVictims = new Map<number, number>([[100, 1000]]);
+      // Shell 700 claims the dead host (100) as its parent - inside the
+      // window, so a carry-over seed - and the CLI is the shell's own,
+      // ordinary (validated) child. Sibling 800 is killed as 700's
+      // descendant, but the CLI and the shell above it are BOTH spared: the
+      // shell's status as a carry-over victim does not override the
+      // ancestry exclusion any more than it would for an ordinary non-slot
+      // shell. A row that ends up spared can never be the reason a round's
+      // kill set comes back non-empty - only an UNSPARED survivor can stall
+      // convergence.
       const table = rowsOf([
-        {
-          processId: 50,
-          parentProcessId: 0,
-          claimedParentProcessId: 100,
-          created: 1500,
-          slot: false,
-        },
-        { processId: 200, parentProcessId: 50, slot: false },
-        { processId: 300, parentProcessId: 50, slot: false },
+        victimRow(700, 0, 100, 2000, false),
+        victimRow(cliPid, 700, 700, 2500, false),
+        victimRow(800, 700, 700, 2500, false),
       ]);
+      expect(computeWindowsHostKillSet(table, cliPid, remembered)).toEqual({
+        kill: [800],
+        unattributed: [],
+      });
+    });
 
-      expect(computeWindowsHostKillSet(table, 200, priorVictims)).toEqual([
-        300,
+    // These three shapes are decided by the ORDINARY descendant walk, not by
+    // `classifyCarryOverClaim` - EXCEPT the seed row in the third case, which
+    // the carry-over does seed; its descendants are what the ordinary walk
+    // then reaches. They stay alongside the window tests because they were
+    // the ones the old occupant check risked getting wrong (a live parent
+    // that happens to be a former victim's pid, recycled).
+    describe("shapes the ordinary walk decides, not the carry-over", () => {
+      it("a lingering victim (still occupying its own pid) is killed through the ordinary walk", () => {
+        // `taskkill /F` is asynchronous: the confirming scan can briefly
+        // still list the exact pid a previous round already killed. 100 IS
+        // the victim, still there, and it is ALSO a genuine slot match
+        // (`slot: true`) - so it is killed as an ordinary slot-descendant
+        // walk. 777 comes along as its ordinary, validated child.
+        const table = rowsOf([
+          victimRow(100, 0, 0, 1000, true),
+          victimRow(777, 100, 100, 4000, false),
+          cliRow,
+        ]);
+        expect(computeWindowsHostKillSet(table, cliPid, remembered)).toEqual({
+          kill: [100, 777],
+          unattributed: [],
+        });
+      });
+
+      it("the pid was recycled by a process that is now ITSELF a slot match - killed regardless of the carry-over", () => {
+        // 100 is a stranger (not the victim) that happens to match the slot
+        // on its own path/command line. It is killed because it is a slot
+        // process, full stop - 777 already has a validated live parent (100)
+        // that is itself a victim through the ordinary walk.
+        const table = rowsOf([
+          victimRow(100, 0, 0, 3000, true),
+          victimRow(777, 100, 100, 4000, false),
+          cliRow,
+        ]);
+        expect(computeWindowsHostKillSet(table, cliPid, remembered)).toEqual({
+          kill: [100, 777],
+          unattributed: [],
+        });
+      });
+
+      it("a grandchild and great-grandchild of a carry-over seed are killed through the ordinary descendant walk", () => {
+        // 200 IS seeded through the carry-over (born inside the dead
+        // victim's window, claimed parent 100). 300 and 400 are NOT
+        // themselves carry-over candidates - they have validated live
+        // parents (200 and 300) - so they are killed as ordinary descendants
+        // of the seed.
+        const table = rowsOf([
+          victimRow(200, 0, 100, 2000, false),
+          victimRow(300, 200, 200, 2100, false),
+          victimRow(400, 300, 300, 2200, false),
+          cliRow,
+        ]);
+        expect(computeWindowsHostKillSet(table, cliPid, remembered)).toEqual({
+          kill: [200, 300, 400],
+          unattributed: [],
+        });
+      });
+    });
+
+    it("the gate is checked before the window: defensive, synthetic input pins that a validated live edge is never a carry-over question", () => {
+      // Deliberately SYNTHETIC, defensive input - this exact shape cannot
+      // arise from a real scan. `classifyCarryOverClaim`'s own comment says
+      // so: a row with a validated live edge has a parent the scan found in
+      // this very table, and a live parent is never simultaneously a killed
+      // victim, so the gate is redundant on legitimate input. This fixture
+      // exists only to pin the ORDER of the checks - the gate is evaluated
+      // before the window is ever consulted - so a future change cannot
+      // quietly drop the gate and rely on the window alone without a test
+      // noticing. Widen `seenAliveAt` to 6000 here specifically so the
+      // window ALONE would have accepted 777 (1000 <= 4000 <= 6000) - the
+      // gate is what still refuses it.
+      const widerWindow = victimMemory(
+        new Map<number, WindowsKillVictim>([
+          [100, { created: 1000, seenAliveAt: 6000 }],
+        ]),
+      );
+      const table = rowsOf([
+        victimRow(100, 0, 0, 3000, false),
+        victimRow(777, 100, 100, 4000, false),
+        cliRow,
       ]);
-      // The shell is a victim through the carry-over (it claims the dead
-      // host as parent), but it is ALSO an ancestor of the CLI, so ancestry
-      // spares it just as it would an ordinary non-slot shell. The CLI is
-      // spared through the descendant closure as always. Neither exclusion
-      // depends on the other - the sibling has no ancestry claim to the CLI
-      // and is not itself seeded, so only the shell's own victim-descendant
-      // closure could have reached it, and did.
+      expect(computeWindowsHostKillSet(table, cliPid, widerWindow)).toEqual({
+        kill: [],
+        unattributed: [],
+      });
+
+      // Ablation (§ablation table): drop `row.parentProcessId !== 0` → this
+      // test reddens, becoming `{ kill: [777], unattributed: [] }` - the
+      // window alone accepts the row (1000 <= 4000 <= 6000) and wrongly
+      // seeds a stranger with a perfectly good live parent of its own.
+    });
+
+    // Round 5d: a pid an earlier round could place neither in the slot nor
+    // out of it is remembered as a SUSPECT (by the age of the incarnation
+    // that round saw), and suspicion is inherited - a child of a process we
+    // cannot tie to the slot cannot be tied to it either. A suspect has no
+    // upper bound: inside it the row is provably the suspect's child, outside
+    // it the row may be the suspect's or a stranger's, and both are
+    // undecided (see `classifyAgainstSuspect`).
+    describe("suspect inheritance - claims on a pid an earlier round could not place", () => {
+      const suspected = suspectMemory(new Map<number, number>([[777, 6000]]));
+
+      it("a row claiming a suspect and born after it is unattributed, with no upper bound to clear it", () => {
+        const table = rowsOf([
+          victimRow(888, 0, 777, 6500, false),
+          victimRow(889, 0, 777, 900_000, false),
+          cliRow,
+        ]);
+        expect(computeWindowsHostKillSet(table, cliPid, suspected)).toEqual({
+          kill: [],
+          unattributed: [888, 889],
+        });
+
+        // Ablation (§ablation table): make `classifyAgainstSuspect` return
+        // "none" for a row born at or after the suspect → this test reddens
+        // (`unattributed: []`), and so does the loop-level P2-1 pin above.
+      });
+
+      it("a row provably older than the suspect's incarnation is decided, not undecided", () => {
+        // Same lower bound, same reason as the victim rule: a process cannot
+        // predate its parent, so the claimed id is an earlier holder's.
+        const table = rowsOf([victimRow(888, 0, 777, 5000, false), cliRow]);
+        expect(computeWindowsHostKillSet(table, cliPid, suspected)).toEqual({
+          kill: [],
+          unattributed: [],
+        });
+      });
+
+      it("an unreadable age on either side is undecided", () => {
+        const zeroRow = rowsOf([victimRow(888, 0, 777, 0, false), cliRow]);
+        expect(computeWindowsHostKillSet(zeroRow, cliPid, suspected)).toEqual({
+          kill: [],
+          unattributed: [888],
+        });
+        const zeroSuspect = suspectMemory(new Map<number, number>([[777, 0]]));
+        const table = rowsOf([victimRow(888, 0, 777, 5000, false), cliRow]);
+        expect(computeWindowsHostKillSet(table, cliPid, zeroSuspect)).toEqual({
+          kill: [],
+          unattributed: [888],
+        });
+      });
+
+      it("a validated live child of an undecided row is named with it - the closure is over the same children map the kill set walks", () => {
+        // 777 itself is undecided against the remembered victim (born after
+        // 100's window). 888 is 777's ordinary validated child and has no
+        // claim of its own; it is reported because uncertainty about its
+        // parent is uncertainty about it.
+        const table = rowsOf([
+          victimRow(777, 0, 100, 6000, false),
+          victimRow(888, 777, 777, 6500, false),
+          cliRow,
+        ]);
+        expect(computeWindowsHostKillSet(table, cliPid, remembered)).toEqual({
+          kill: [],
+          unattributed: [777, 888],
+        });
+      });
+
+      it("a pid this scan decides to kill is never also reported as undecided", () => {
+        // 777 is undecided; its child 888 is slot-matched in its own right
+        // and so is killed. Reporting 888 in both lists would put one pid in
+        // front of the user in two contradictory roles.
+        const table = rowsOf([
+          victimRow(777, 0, 100, 6000, false),
+          victimRow(888, 777, 777, 6500, true),
+          cliRow,
+        ]);
+        expect(computeWindowsHostKillSet(table, cliPid, remembered)).toEqual({
+          kill: [888],
+          unattributed: [777],
+        });
+      });
     });
   });
 
@@ -1276,6 +2200,26 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
     // Ablation (§ablation table): in `orderWindowsKillsDescendantsFirst`,
     // change the body to `return pids;` → this test reddens: the input order
     // ([10, 20, 15, 30]) comes back unchanged instead of deepest-first.
+  });
+
+  it("orderWindowsKillsDescendantsFirst terminates and orders sanely on a cycle - a torn table must not hang the kill", () => {
+    // 10's parent claims 20 and 20's parent claims 10: a cycle a real scan
+    // should never produce, but `depthOf`'s own `seen` set is what stands
+    // between a torn snapshot and an infinite loop, not an assumption that
+    // the table is well-formed.
+    const table = rowsOf([
+      { processId: 10, parentProcessId: 20, slot: false },
+      { processId: 20, parentProcessId: 10, slot: false },
+    ]);
+
+    expect(orderWindowsKillsDescendantsFirst([10, 20], table)).toEqual([
+      10, 20,
+    ]);
+
+    // The test terminating at all - within the suite's own timeout - is the
+    // pin. Both walks stop at depth 1 (the cycle guard turns back the moment
+    // it revisits a pid already on the chain), so the tie is broken by pid
+    // ascending like any other.
   });
 });
 
@@ -1390,7 +2334,7 @@ describe("Windows startService post-/Run spawn verification", () => {
     };
     setWindowsStartEvidenceDepsForTests(deps);
 
-    const controller = createWindowsController(runner);
+    const controller = createWindowsController(runner, noTimingDeps);
     await expect(
       controller.start(serviceLabelFor("staging")),
     ).rejects.toMatchObject({
@@ -1440,7 +2384,7 @@ describe("Windows startService post-/Run spawn verification", () => {
     setWindowsStartEvidenceDepsForTests(deps);
 
     const runner: ProcessRunner = async () => success("");
-    const controller = createWindowsController(runner);
+    const controller = createWindowsController(runner, noTimingDeps);
     await expect(
       controller.start(serviceLabelFor("staging")),
     ).resolves.toBeUndefined();
@@ -1469,7 +2413,7 @@ describe("Windows startService post-/Run spawn verification", () => {
       verifyPollMs: 1,
     });
 
-    await createWindowsController(runner).install({
+    await createWindowsController(runner, noTimingDeps).install({
       label: serviceLabelFor("staging"),
       cli: { command: "C:\\traycer.exe", args: [] },
       enableLinger: false,
@@ -1518,7 +2462,7 @@ describe("Windows startService post-/Run spawn verification", () => {
 
     let caught: unknown = null;
     try {
-      await createWindowsController(runner).install({
+      await createWindowsController(runner, noTimingDeps).install({
         label: serviceLabelFor("staging"),
         cli: { command: "C:\\traycer.exe", args: [] },
         enableLinger: false,
@@ -1555,7 +2499,9 @@ describe("Windows startService post-/Run spawn verification", () => {
 
     let caught: unknown = null;
     try {
-      await createWindowsController(runner).start(serviceLabelFor("staging"));
+      await createWindowsController(runner, noTimingDeps).start(
+        serviceLabelFor("staging"),
+      );
     } catch (error) {
       caught = error;
     }
@@ -1587,7 +2533,7 @@ describe("Windows startService post-/Run spawn verification", () => {
 
     let caught: unknown = null;
     try {
-      await createWindowsController(runner).install({
+      await createWindowsController(runner, noTimingDeps).install({
         label: serviceLabelFor("staging"),
         cli: { command: "C:\\traycer.exe", args: [] },
         enableLinger: false,
@@ -1627,7 +2573,7 @@ describe("Windows startService post-/Run spawn verification", () => {
 
     let caught: unknown = null;
     try {
-      await createWindowsController(runner).install({
+      await createWindowsController(runner, noTimingDeps).install({
         label: serviceLabelFor("staging"),
         cli: { command: "C:\\traycer.exe", args: [] },
         enableLinger: false,
@@ -1658,7 +2604,7 @@ describe("Windows startService post-/Run spawn verification", () => {
 
     let caught: unknown = null;
     try {
-      await createWindowsController(runner).install({
+      await createWindowsController(runner, noTimingDeps).install({
         label: serviceLabelFor("staging"),
         cli: { command: "C:\\traycer.exe", args: [] },
         enableLinger: false,
@@ -1698,7 +2644,7 @@ describe("Windows startService post-/Run spawn verification", () => {
 
     let caught: unknown = null;
     try {
-      await createWindowsController(runner).install({
+      await createWindowsController(runner, noTimingDeps).install({
         label: serviceLabelFor("staging"),
         cli: { command: "C:\\traycer.exe", args: [] },
         enableLinger: false,
@@ -1754,7 +2700,7 @@ describe("Windows startService post-/Run spawn verification", () => {
 
     let caught: unknown = null;
     try {
-      await createWindowsController(runner).install({
+      await createWindowsController(runner, noTimingDeps).install({
         label: serviceLabelFor("staging"),
         cli: { command: "C:\\traycer.exe", args: [] },
         enableLinger: false,
@@ -1798,7 +2744,7 @@ describe("Windows startService post-/Run spawn verification", () => {
 
     let caught: unknown = null;
     try {
-      await createWindowsController(runner).install({
+      await createWindowsController(runner, noTimingDeps).install({
         label: serviceLabelFor("staging"),
         cli: { command: "C:\\traycer.exe", args: [] },
         enableLinger: false,
@@ -1847,7 +2793,7 @@ describe("Windows startService post-/Run spawn verification", () => {
     });
 
     await expect(
-      createWindowsController(runner).install({
+      createWindowsController(runner, noTimingDeps).install({
         label: serviceLabelFor("staging"),
         cli: { command: "C:\\traycer.exe", args: [] },
         enableLinger: false,
@@ -1883,7 +2829,7 @@ describe("Windows startService post-/Run spawn verification", () => {
 
     let caught: unknown = null;
     try {
-      await createWindowsController(runner).install({
+      await createWindowsController(runner, noTimingDeps).install({
         label: serviceLabelFor("staging"),
         cli: { command: "C:\\traycer.exe", args: [] },
         enableLinger: false,
@@ -1921,7 +2867,7 @@ describe("Windows startService post-/Run spawn verification", () => {
 
     let caught: unknown = null;
     try {
-      await createWindowsController(runner).install({
+      await createWindowsController(runner, noTimingDeps).install({
         label: serviceLabelFor("staging"),
         cli: { command: "C:\\traycer.exe", args: [] },
         enableLinger: false,

--- a/clients/traycer-cli/src/service/platforms/__tests__/windows.test.ts
+++ b/clients/traycer-cli/src/service/platforms/__tests__/windows.test.ts
@@ -8,6 +8,7 @@ import {
   createWindowsController,
   describeSlotLockHolders,
   killLingeringSlotProcesses,
+  orderWindowsKillsDescendantsFirst,
   parseSchtasksLastRunResult,
   parseWindowsProcessDetailJson,
   parseWindowsProcessTableJson,
@@ -77,14 +78,45 @@ function stagedTaskInstallDeps(): WindowsTaskInstallDeps {
   };
 }
 
+// Most fixtures in this file only care about processId/parentProcessId/slot -
+// the victim carry-over fields (claimedParentProcessId, created) are only
+// meaningful to the tests that exercise that carry-over directly. This lets a
+// fixture specify just the three original fields and default the other two
+// (claimedParentProcessId = parentProcessId, created = 0) rather than forcing
+// every row literal in the file to spell out fields it does not test.
+// `created: 0` is what makes the default safe: `isChildOfVictim` refuses an
+// unknown age on either end, so a defaulted row can never be spuriously
+// seeded as a victim's descendant regardless of what its claimed parent is.
+type TableRowInput = Pick<
+  WindowsProcessTableRow,
+  "processId" | "parentProcessId" | "slot"
+> &
+  Partial<Pick<WindowsProcessTableRow, "claimedParentProcessId" | "created">>;
+
+function fullRow(row: TableRowInput): WindowsProcessTableRow {
+  return {
+    processId: row.processId,
+    parentProcessId: row.parentProcessId,
+    claimedParentProcessId: row.claimedParentProcessId ?? row.parentProcessId,
+    created: row.created ?? 0,
+    slot: row.slot,
+  };
+}
+
+function rowsOf(rows: readonly TableRowInput[]): WindowsProcessTableRow[] {
+  return rows.map(fullRow);
+}
+
 // Rows as the table scan's JSON, in the shape `parseWindowsProcessTableJson`
 // expects. Shared by every fixture below that needs to hand a fake table back
 // through `run("powershell.exe", ...)`.
-function tableJson(rows: readonly WindowsProcessTableRow[]): string {
+function tableJson(rows: readonly TableRowInput[]): string {
   return JSON.stringify(
-    rows.map((row) => ({
+    rowsOf(rows).map((row) => ({
       ProcessId: row.processId,
       ParentProcessId: row.parentProcessId,
+      ClaimedParentProcessId: row.claimedParentProcessId,
+      Created: row.created,
       Slot: row.slot,
     })),
   );
@@ -102,7 +134,7 @@ function tableJson(rows: readonly WindowsProcessTableRow[]): string {
 // pids a `taskkill` call has fired for and drops those rows from every later
 // snapshot, so a fixture built for the old one-pass code keeps its original
 // meaning under the new loop.
-function convergingTableRunner(rows: readonly WindowsProcessTableRow[]): {
+function convergingTableRunner(rows: readonly TableRowInput[]): {
   readonly runner: ProcessRunner;
   readonly calls: RecordedCall[];
 } {
@@ -138,46 +170,101 @@ describe("Windows service stale host cleanup", () => {
   it("parses PowerShell process table JSON", () => {
     expect(
       parseWindowsProcessTableJson(
-        '[{"ProcessId":100,"ParentProcessId":1,"Slot":true},{"ProcessId":200,"ParentProcessId":100,"Slot":false}]',
+        '[{"ProcessId":100,"ParentProcessId":1,"ClaimedParentProcessId":1,"Created":1000,"Slot":true},' +
+          '{"ProcessId":200,"ParentProcessId":100,"ClaimedParentProcessId":100,"Created":2000,"Slot":false}]',
       ),
     ).toEqual([
-      { processId: 100, parentProcessId: 1, slot: true },
-      { processId: 200, parentProcessId: 100, slot: false },
+      {
+        processId: 100,
+        parentProcessId: 1,
+        claimedParentProcessId: 1,
+        created: 1000,
+        slot: true,
+      },
+      {
+        processId: 200,
+        parentProcessId: 100,
+        claimedParentProcessId: 100,
+        created: 2000,
+        slot: false,
+      },
     ]);
     // Windows PowerShell 5.1 emits a bare object for a single row.
     expect(
       parseWindowsProcessTableJson(
-        '{"ProcessId":100,"ParentProcessId":1,"Slot":true}',
+        '{"ProcessId":100,"ParentProcessId":1,"ClaimedParentProcessId":1,"Created":1000,"Slot":true}',
       ),
-    ).toEqual([{ processId: 100, parentProcessId: 1, slot: true }]);
+    ).toEqual([
+      {
+        processId: 100,
+        parentProcessId: 1,
+        claimedParentProcessId: 1,
+        created: 1000,
+        slot: true,
+      },
+    ]);
     // A row whose ProcessId equals this test process's own pid parses fine -
     // the table scan is deliberately unfiltered.
     expect(
       parseWindowsProcessTableJson(
-        `{"ProcessId":${process.pid},"ParentProcessId":1,"Slot":false}`,
+        `{"ProcessId":${process.pid},"ParentProcessId":1,"ClaimedParentProcessId":1,"Created":1000,"Slot":false}`,
       ),
-    ).toEqual([{ processId: process.pid, parentProcessId: 1, slot: false }]);
+    ).toEqual([
+      {
+        processId: process.pid,
+        parentProcessId: 1,
+        claimedParentProcessId: 1,
+        created: 1000,
+        slot: false,
+      },
+    ]);
     // The System Idle Process is pid 0 with parent 0, and `Get-CimInstance
     // Win32_Process` always returns it. Rejecting it failed the WHOLE parse on
     // every real machine, silently demoting every stop to the pid.json
-    // fallback. A parent of 0 ("no verified parent") is equally ordinary.
+    // fallback. A parent of 0 ("no verified parent") is equally ordinary, and
+    // so is a `Created` of 0 ("no creation time Windows could report").
     expect(
       parseWindowsProcessTableJson(
-        '[{"ProcessId":0,"ParentProcessId":0,"Slot":false},{"ProcessId":100,"ParentProcessId":0,"Slot":true}]',
+        '[{"ProcessId":0,"ParentProcessId":0,"ClaimedParentProcessId":0,"Created":0,"Slot":false},' +
+          '{"ProcessId":100,"ParentProcessId":0,"ClaimedParentProcessId":0,"Created":0,"Slot":true}]',
       ),
     ).toEqual([
-      { processId: 0, parentProcessId: 0, slot: false },
-      { processId: 100, parentProcessId: 0, slot: true },
+      {
+        processId: 0,
+        parentProcessId: 0,
+        claimedParentProcessId: 0,
+        created: 0,
+        slot: false,
+      },
+      {
+        processId: 100,
+        parentProcessId: 0,
+        claimedParentProcessId: 0,
+        created: 0,
+        slot: true,
+      },
     ]);
-    // Negative ids are still malformed.
+    // Negative ids are still malformed, `ClaimedParentProcessId` and
+    // `Created` included - they are held to the same non-negative-integer
+    // shape as every other id/timestamp field.
     expect(
       parseWindowsProcessTableJson(
-        '[{"ProcessId":-1,"ParentProcessId":0,"Slot":false}]',
+        '[{"ProcessId":-1,"ParentProcessId":0,"ClaimedParentProcessId":0,"Created":0,"Slot":false}]',
       ),
     ).toBeNull();
     expect(
       parseWindowsProcessTableJson(
-        '[{"ProcessId":100,"ParentProcessId":-1,"Slot":false}]',
+        '[{"ProcessId":100,"ParentProcessId":-1,"ClaimedParentProcessId":0,"Created":0,"Slot":false}]',
+      ),
+    ).toBeNull();
+    expect(
+      parseWindowsProcessTableJson(
+        '[{"ProcessId":100,"ParentProcessId":1,"ClaimedParentProcessId":-1,"Created":0,"Slot":false}]',
+      ),
+    ).toBeNull();
+    expect(
+      parseWindowsProcessTableJson(
+        '[{"ProcessId":100,"ParentProcessId":1,"ClaimedParentProcessId":1,"Created":-1,"Slot":false}]',
       ),
     ).toBeNull();
     expect(parseWindowsProcessTableJson("[]")).toEqual([]);
@@ -188,7 +275,7 @@ describe("Windows service stale host cleanup", () => {
     // Any malformed row fails the WHOLE parse (all-or-nothing).
     expect(
       parseWindowsProcessTableJson(
-        '[{"ProcessId":"100","ParentProcessId":1,"Slot":true}]',
+        '[{"ProcessId":"100","ParentProcessId":1,"ClaimedParentProcessId":1,"Created":0,"Slot":true}]',
       ),
     ).toBeNull();
     expect(
@@ -196,7 +283,14 @@ describe("Windows service stale host cleanup", () => {
     ).toBeNull();
     expect(
       parseWindowsProcessTableJson(
-        '[{"ProcessId":100,"ParentProcessId":1,"Slot":"true"}]',
+        '[{"ProcessId":100,"ParentProcessId":1,"ClaimedParentProcessId":1,"Created":0,"Slot":"true"}]',
+      ),
+    ).toBeNull();
+    // Missing the new fields entirely is also malformed - a scan script that
+    // regresses to emitting the old three-field row must not silently parse.
+    expect(
+      parseWindowsProcessTableJson(
+        '[{"ProcessId":100,"ParentProcessId":1,"Slot":true}]',
       ),
     ).toBeNull();
     expect(parseWindowsProcessTableJson('[100, "not-a-row"]')).toBeNull();
@@ -251,6 +345,16 @@ describe("Windows service stale host cleanup", () => {
     expect(script).toContain(
       "if ($null -eq $parentCreated -or $null -eq $childCreated) {",
     );
+    // The two fields the victim carry-over needs: the RAW claimed parent
+    // (unvalidated, unlike `ParentProcessId` above) and the row's own age.
+    expect(script).toContain(
+      "ClaimedParentProcessId = [int]$_.ParentProcessId",
+    );
+    expect(script).toContain("Created = $createdMs");
+    // `Created`'s own guard: 0 when Windows reports no creation time at all
+    // (pid 0 and System have none), never a stale or default timestamp.
+    expect(script).toContain("$createdMs = 0");
+    expect(script).toContain("if ($null -ne $_.CreationDate) {");
 
     // Ablation: in `buildSlotProcessTableScanScript`, drop
     // `...PARENT_EDGE_VALIDATION_SCRIPT_LINES` and emit
@@ -516,7 +620,7 @@ describe("killHostProcessTree convergence loop", () => {
   type RoundResponse =
     | {
         readonly kind: "table";
-        readonly rows: readonly WindowsProcessTableRow[];
+        readonly rows: readonly TableRowInput[];
       }
     | { readonly kind: "throw" };
 
@@ -704,6 +808,92 @@ describe("killHostProcessTree convergence loop", () => {
     // stops refusing, so the whole stop resolves even though it never
     // confirmed the tree came down.
   });
+
+  it("carries the victim set BETWEEN rounds: round 1's orphan is only killable because round 0's victim is remembered", async () => {
+    // Round 0 kills host 100 (a genuine slot match). Round 1's snapshot shows
+    // orphan 555, spawned after round 0's kill destroyed the edge proving it
+    // belongs to the slot: its `parentProcessId` arrives as 0 (unverifiable,
+    // host is dead), and its own path/command line matches nothing (a shell
+    // or provider binary). Without `priorVictims` carrying host 100's
+    // creation time forward, 555 looks like an ordinary unrelated process and
+    // the loop would report convergence while it lives - the finding this
+    // whole carry-over mechanism exists to close.
+    const { runner, calls } = roundedRunner([
+      {
+        kind: "table",
+        rows: [
+          { processId: 100, parentProcessId: 1, created: 1000, slot: true },
+        ],
+      },
+      {
+        kind: "table",
+        rows: [
+          {
+            processId: 555,
+            parentProcessId: 0,
+            claimedParentProcessId: 100,
+            created: 1500,
+            slot: false,
+          },
+        ],
+      },
+      { kind: "table", rows: [] },
+    ]);
+    const controller = createWindowsController(runner);
+
+    await controller.stop(serviceLabelFor("staging"), { force: false });
+
+    expect(
+      calls.filter((call) => call.command === "powershell.exe"),
+    ).toHaveLength(3);
+    expect(
+      calls
+        .filter((call) => call.command === "taskkill")
+        .map((call) => call.args),
+    ).toEqual([
+      ["/F", "/PID", "100"],
+      ["/F", "/PID", "555"],
+    ]);
+
+    // Ablation (§ablation table): in `isChildOfVictim`, replace the body with
+    // `return false;` → this test reddens alongside the direct "the finding"
+    // algebra pin below - 555 is never seeded, round 1's kill set comes back
+    // empty, and the stop resolves with 555 still alive.
+  });
+
+  it("kills within a round deepest-first: a 3-node chain is issued grandchild, child, host", async () => {
+    // `orderWindowsKillsDescendantsFirst` at the LOOP level, not just as a
+    // standalone algebra pin: a round's kill set is issued in argv order
+    // grandchild -> child -> host, shrinking the window where a parent is
+    // already gone while its still-scanned child is not yet reaped.
+    const { runner, calls } = roundedRunner([
+      {
+        kind: "table",
+        rows: [
+          { processId: 100, parentProcessId: 1, slot: true },
+          { processId: 150, parentProcessId: 100, slot: false },
+          { processId: 160, parentProcessId: 150, slot: false },
+        ],
+      },
+      { kind: "table", rows: [] },
+    ]);
+    const controller = createWindowsController(runner);
+
+    await controller.stop(serviceLabelFor("staging"), { force: false });
+
+    expect(
+      calls
+        .filter((call) => call.command === "taskkill")
+        .map((call) => call.args[2]),
+    ).toEqual(["160", "150", "100"]);
+
+    // Ablation (§ablation table): in `orderWindowsKillsDescendantsFirst`,
+    // change the body to `return pids;` (issue order unchanged) → run and
+    // confirmed: this test reddens (order reverts to ascending-pid), and so
+    // do the standalone algebra pin below and the "host-spawned" /
+    // "terminal-run" tests above, which also assert deepest-first order now
+    // that the loop applies it.
+  });
 });
 
 // `computeWindowsHostKillSet` is the algebra a host stop's kill set is built
@@ -726,7 +916,7 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
     // cli 200 -> helper 300
     // host 100 -> agent 400
     // self = 200 (the CLI's own pid)
-    const rows: WindowsProcessTableRow[] = [
+    const rows: TableRowInput[] = [
       { processId: 0, parentProcessId: 0, slot: false },
       { processId: 100, parentProcessId: 1, slot: true },
       { processId: 200, parentProcessId: 100, slot: false },
@@ -751,9 +941,13 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
     const taskkillArgs = calls
       .filter((call) => call.command === "taskkill")
       .map((call) => call.args);
+    // Deepest-first (`orderWindowsKillsDescendantsFirst`): 400 hangs off 100,
+    // so it is issued first. The KILL SET is unchanged from before that
+    // ordering existed - both pids, nothing more, nothing less - only the
+    // argv order changed.
     expect(taskkillArgs).toEqual([
-      ["/F", "/PID", "100"],
       ["/F", "/PID", "400"],
+      ["/F", "/PID", "100"],
     ]);
     expect(taskkillArgs.every((args) => !args.includes("/T"))).toBe(true);
     // The scan ANSWERED, so the pid.json fallback must not be consulted at
@@ -771,7 +965,7 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
     // host 100 (Slot) -> shell 50 -> cli 200 -> powershell 250
     // host 100 -> agent 400
     // self = 200
-    const rows: WindowsProcessTableRow[] = [
+    const rows: TableRowInput[] = [
       { processId: 0, parentProcessId: 0, slot: false },
       { processId: 100, parentProcessId: 1, slot: true },
       { processId: 50, parentProcessId: 100, slot: false },
@@ -796,9 +990,11 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
     const taskkillArgs = calls
       .filter((call) => call.command === "taskkill")
       .map((call) => call.args);
+    // Deepest-first, same reasoning as the host-spawned test above: 400 hangs
+    // off 100, so it is issued first. The kill SET is unchanged.
     expect(taskkillArgs).toEqual([
-      ["/F", "/PID", "100"],
       ["/F", "/PID", "400"],
+      ["/F", "/PID", "100"],
     ]);
     // 50 (a non-slot ancestor of the CLI) is spared, and never appears.
     expect(taskkillArgs.some((args) => args[2] === "50")).toBe(false);
@@ -814,7 +1010,7 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
     // longer covers it: it lands in the kill set and would be force-killed,
     // which is exactly the damage `cliPid = process.pid` (not the scan
     // script's `$PID`) prevents.
-    const rows: WindowsProcessTableRow[] = [
+    const rows: TableRowInput[] = [
       { processId: 0, parentProcessId: 0, slot: false },
       { processId: 100, parentProcessId: 1, slot: true },
       { processId: 200, parentProcessId: 100, slot: false },
@@ -823,7 +1019,11 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
       { processId: 400, parentProcessId: 100, slot: false },
     ];
 
-    const killSet = computeWindowsHostKillSet(rows, 250);
+    const killSet = computeWindowsHostKillSet(
+      rowsOf(rows),
+      250,
+      new Map<number, number>(),
+    );
 
     expect(killSet).toEqual([100, 300, 400]);
     // Ablation for the CALL SITE (`findSlotProcessIds(label, run, process.pid)`
@@ -840,14 +1040,16 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
     // that edge - the claimed parent is younger than its claimed child - so it
     // emits 0, and 400 stays out of the host's subtree instead of being
     // force-killed as a descendant.
-    const rows: WindowsProcessTableRow[] = [
+    const rows: TableRowInput[] = [
       { processId: 0, parentProcessId: 0, slot: false },
       { processId: 100, parentProcessId: 1, slot: true },
       { processId: 400, parentProcessId: 0, slot: false },
       { processId: 200, parentProcessId: 100, slot: false },
     ];
 
-    expect(computeWindowsHostKillSet(rows, 200)).toEqual([100]);
+    expect(
+      computeWindowsHostKillSet(rowsOf(rows), 200, new Map<number, number>()),
+    ).toEqual([100]);
   });
 
   it("a recycled id on the CLI's own ancestry (arriving as 0) spares nothing extra", () => {
@@ -856,7 +1058,7 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
     // subtree are still spared - that comes from the descendant closure, not
     // from ancestry - and the host is still killed rather than being spared as
     // a wrongly-believed ancestor.
-    const rows: WindowsProcessTableRow[] = [
+    const rows: TableRowInput[] = [
       { processId: 0, parentProcessId: 0, slot: false },
       { processId: 100, parentProcessId: 1, slot: true },
       { processId: 200, parentProcessId: 0, slot: false },
@@ -864,13 +1066,15 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
       { processId: 400, parentProcessId: 100, slot: false },
     ];
 
-    expect(computeWindowsHostKillSet(rows, 200)).toEqual([100, 400]);
+    expect(
+      computeWindowsHostKillSet(rowsOf(rows), 200, new Map<number, number>()),
+    ).toEqual([100, 400]);
   });
 
   // Direct algebra pins for the three subtraction terms, each isolating one
   // ablation.
   describe("computeWindowsHostKillSet - algebra pins", () => {
-    const rows: WindowsProcessTableRow[] = [
+    const rows: TableRowInput[] = [
       { processId: 100, parentProcessId: 1, slot: true },
       { processId: 50, parentProcessId: 100, slot: false },
       { processId: 200, parentProcessId: 50, slot: false },
@@ -879,7 +1083,9 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
     ];
 
     it("kills the slot and its descendants, sparing the CLI's ancestry and subtree", () => {
-      expect(computeWindowsHostKillSet(rows, 200)).toEqual([100, 400]);
+      expect(
+        computeWindowsHostKillSet(rowsOf(rows), 200, new Map<number, number>()),
+      ).toEqual([100, 400]);
 
       // Ablation: in `computeWindowsHostKillSet`, drop the
       // `if (!slot.has(ancestor))` condition so every ancestor of the CLI is
@@ -893,12 +1099,18 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
       // finalizer - and it is a descendant of the slot-matched host too, so
       // only the descendant closure around the CLI keeps it out of the kill
       // set.
-      const withChild: WindowsProcessTableRow[] = [
+      const withChild: TableRowInput[] = [
         { processId: 100, parentProcessId: 1, slot: true },
         { processId: 200, parentProcessId: 100, slot: false },
         { processId: 300, parentProcessId: 200, slot: false },
       ];
-      expect(computeWindowsHostKillSet(withChild, 200)).toEqual([100]);
+      expect(
+        computeWindowsHostKillSet(
+          rowsOf(withChild),
+          200,
+          new Map<number, number>(),
+        ),
+      ).toEqual([100]);
 
       // Ablation: in `computeWindowsHostKillSet`, change
       // `withDescendants(new Set([cliPid]), children)` to `new Set([cliPid])`
@@ -906,6 +1118,164 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
       // test fails: the kill set becomes [100, 300], because 300 is a victim
       // through the host and nothing spares it any more.
     });
+  });
+
+  // `priorVictims` (Codex round 4): a process spawned by the host AFTER an
+  // earlier round killed it arrives with `parentProcessId` 0 - the table
+  // cannot vouch for a parent that is already dead - so a row is only linked
+  // back to the slot through the UNVALIDATED `claimedParentProcessId`, made
+  // safe against pid reuse by comparing creation times.
+  describe("computeWindowsHostKillSet - victim carry-over (claimedParentProcessId + created)", () => {
+    it("the finding: a live row whose claimed parent is a remembered victim is killed - the same table with an empty victim map is not", () => {
+      // Orphan 999 spawned after round 0 killed host 100: its real parent is
+      // dead, so `parentProcessId` arrives as 0, and its own path matches
+      // nothing (a shell or provider binary). Only `claimedParentProcessId`
+      // still names 100, and `created` (1500) is not earlier than the
+      // victim's own recorded creation time (1000).
+      const table = rowsOf([
+        {
+          processId: 999,
+          parentProcessId: 0,
+          claimedParentProcessId: 100,
+          created: 1500,
+          slot: false,
+        },
+      ]);
+      const priorVictims = new Map<number, number>([[100, 1000]]);
+
+      expect(computeWindowsHostKillSet(table, 1, priorVictims)).toEqual([999]);
+      // The contrast IS the finding: without the remembered victim, 999 looks
+      // like an ordinary unrelated process and survives.
+      expect(
+        computeWindowsHostKillSet(table, 1, new Map<number, number>()),
+      ).toEqual([]);
+
+      // Ablation (§ablation table): in `isChildOfVictim`, replace the body
+      // with `return false;` → run and confirmed: the first assertion above
+      // reddens (`toEqual([999])` becomes `[]`, since the second already
+      // expects `[]`), and so do three others that depend on the same
+      // positive path - the loop-level carry-over test below, the
+      // same-millisecond half of the "recycled parent id" test, and the "CLI
+      // exclusion" test. The ablation table names only this test and the
+      // carry-over test; disabling the function outright reddens every test
+      // that seeds through it, which is wider than the table's own row.
+    });
+
+    it("recycled parent id: a claimed child OLDER than the victim is not killed; the SAME millisecond is", () => {
+      // A fork can land in the same millisecond as its parent's own
+      // creation, so equality must not invalidate - only a claimed child
+      // strictly OLDER than the victim it claims as parent is a recycled id
+      // wearing that victim's old pid.
+      const priorVictims = new Map<number, number>([[100, 2000]]);
+      const older = rowsOf([
+        {
+          processId: 999,
+          parentProcessId: 0,
+          claimedParentProcessId: 100,
+          created: 1500,
+          slot: false,
+        },
+      ]);
+      expect(computeWindowsHostKillSet(older, 1, priorVictims)).toEqual([]);
+
+      const sameMillisecond = rowsOf([
+        {
+          processId: 999,
+          parentProcessId: 0,
+          claimedParentProcessId: 100,
+          created: 2000,
+          slot: false,
+        },
+      ]);
+      expect(
+        computeWindowsHostKillSet(sameMillisecond, 1, priorVictims),
+      ).toEqual([999]);
+
+      // Ablation (§ablation table): in `isChildOfVictim`, drop the
+      // `victimCreated <= row.created` check (treat any claimed match as a
+      // hit) → the first assertion above reddens: the older row would be
+      // killed as though 999 were really the victim's child.
+    });
+
+    it("unknown age fails closed: created 0 on the row, and separately on the victim, both refuse the link", () => {
+      const priorVictims = new Map<number, number>([[100, 2000]]);
+      const unknownRowAge = rowsOf([
+        {
+          processId: 999,
+          parentProcessId: 0,
+          claimedParentProcessId: 100,
+          created: 0,
+          slot: false,
+        },
+      ]);
+      expect(computeWindowsHostKillSet(unknownRowAge, 1, priorVictims)).toEqual(
+        [],
+      );
+
+      const unknownVictimAge = new Map<number, number>([[100, 0]]);
+      const ordinaryRow = rowsOf([
+        {
+          processId: 999,
+          parentProcessId: 0,
+          claimedParentProcessId: 100,
+          created: 1500,
+          slot: false,
+        },
+      ]);
+      expect(
+        computeWindowsHostKillSet(ordinaryRow, 1, unknownVictimAge),
+      ).toEqual([]);
+    });
+
+    it("the CLI exclusion holds against victim ancestry: a shell claiming the dead host as parent spares the CLI and the shell, but not the CLI's sibling", () => {
+      // Round 0 killed host 100. Round 1's table: shell 50 claims the dead
+      // host as its parent (a live edge the scan cannot verify, so
+      // `parentProcessId` is 0) and is itself old enough to be believed as
+      // host 100's child; the CLI (200) and a sibling (300) are both
+      // ordinary, VALIDATED children of the still-live shell 50.
+      const priorVictims = new Map<number, number>([[100, 1000]]);
+      const table = rowsOf([
+        {
+          processId: 50,
+          parentProcessId: 0,
+          claimedParentProcessId: 100,
+          created: 1500,
+          slot: false,
+        },
+        { processId: 200, parentProcessId: 50, slot: false },
+        { processId: 300, parentProcessId: 50, slot: false },
+      ]);
+
+      expect(computeWindowsHostKillSet(table, 200, priorVictims)).toEqual([
+        300,
+      ]);
+      // The shell is a victim through the carry-over (it claims the dead
+      // host as parent), but it is ALSO an ancestor of the CLI, so ancestry
+      // spares it just as it would an ordinary non-slot shell. The CLI is
+      // spared through the descendant closure as always. Neither exclusion
+      // depends on the other - the sibling has no ancestry claim to the CLI
+      // and is not itself seeded, so only the shell's own victim-descendant
+      // closure could have reached it, and did.
+    });
+  });
+
+  it("orderWindowsKillsDescendantsFirst: deepest first, ties broken by pid", () => {
+    // root(10) -> {15, 20} -> 30 (child of 20). 15 and 20 are both depth 1 and
+    // must sort by pid (15 before 20) rather than by Map iteration order.
+    const table = rowsOf([
+      { processId: 10, parentProcessId: 0, slot: false },
+      { processId: 20, parentProcessId: 10, slot: false },
+      { processId: 15, parentProcessId: 10, slot: false },
+      { processId: 30, parentProcessId: 20, slot: false },
+    ]);
+
+    expect(orderWindowsKillsDescendantsFirst([10, 20, 15, 30], table)).toEqual([
+      30, 15, 20, 10,
+    ]);
+
+    // Ablation (§ablation table): in `orderWindowsKillsDescendantsFirst`,
+    // change the body to `return pids;` → this test reddens: the input order
+    // ([10, 20, 15, 30]) comes back unchanged instead of deepest-first.
   });
 });
 

--- a/clients/traycer-cli/src/service/platforms/__tests__/windows.test.ts
+++ b/clients/traycer-cli/src/service/platforms/__tests__/windows.test.ts
@@ -1961,6 +1961,161 @@ describe("killHostProcessTree convergence loop", () => {
     // parent's.
   });
 
+  it("round-6 P2, overlap: a spared shell that is BOTH a victim's validated child and an undecided root is still remembered", async () => {
+    // The kill set is the victim closure minus the CLI's branch, and the
+    // memory feed must subtract THAT, not the closure: a spared shell can
+    // sit in both closures at once and is then neither killed (so never a
+    // victim) nor - if the closure were subtracted - undecided. Chronology
+    // (samples 5000, 7000, 9000; CLI is pid 9999):
+    //   R0 (sample 5000): slot 200 (age unreadable) and slot 100 (born
+    //       1000) claiming 200 with a zeroed edge; shell 700 (born 2000) is
+    //       100's validated child, the CLI (born 2500) is 700's. Kill 200
+    //       and 100; 700 and the CLI are spared. Victims 200 = [0, 5000],
+    //       100 = [1000, 5000].
+    //   R1 (sample 7000): 200 is gone; 100 lingers in its TerminateProcess,
+    //       700 and the CLI remain, and a side worker 888 (born 6000) sits
+    //       under 700. 100 is a slot seed AND, against the unreadable victim
+    //       200, undecided - so both closures are {100, 700, CLI, 888}. The
+    //       actual kill is [888, 100]; 700 and the CLI are what remains of
+    //       the undecided closure once the KILL is subtracted, and 700 must
+    //       reach the memory. (Subtracting the victim closure instead leaves
+    //       nothing, and 700 is remembered as nothing at all.)
+    //   R2 (sample 9000): 100 and 888 are gone, 700 spawned 889 (born 8000)
+    //       and exited. The CLI and 889 claim absent 700; suspect 700 (born
+    //       2000) keeps both undecided, the CLI is spared, and the stop
+    //       refuses naming 889.
+    const samples = [5000, 7000, 9000];
+    let sample = 0;
+    const { runner, calls } = roundedRunner([
+      {
+        kind: "table",
+        rows: [
+          { processId: 200, parentProcessId: 1, created: 0, slot: true },
+          {
+            processId: 100,
+            parentProcessId: 0,
+            claimedParentProcessId: 200,
+            created: 1000,
+            slot: true,
+          },
+          {
+            processId: 700,
+            parentProcessId: 100,
+            claimedParentProcessId: 100,
+            created: 2000,
+            slot: false,
+          },
+          {
+            processId: 9999,
+            parentProcessId: 700,
+            claimedParentProcessId: 700,
+            created: 2500,
+            slot: false,
+          },
+        ],
+      },
+      {
+        kind: "table",
+        rows: [
+          {
+            processId: 100,
+            parentProcessId: 0,
+            claimedParentProcessId: 200,
+            created: 1000,
+            slot: true,
+          },
+          {
+            processId: 700,
+            parentProcessId: 100,
+            claimedParentProcessId: 100,
+            created: 2000,
+            slot: false,
+          },
+          {
+            processId: 9999,
+            parentProcessId: 700,
+            claimedParentProcessId: 700,
+            created: 2500,
+            slot: false,
+          },
+          {
+            processId: 888,
+            parentProcessId: 700,
+            claimedParentProcessId: 700,
+            created: 6000,
+            slot: false,
+          },
+        ],
+      },
+      {
+        kind: "table",
+        rows: [
+          {
+            processId: 9999,
+            parentProcessId: 0,
+            claimedParentProcessId: 700,
+            created: 2500,
+            slot: false,
+          },
+          {
+            processId: 889,
+            parentProcessId: 0,
+            claimedParentProcessId: 700,
+            created: 8000,
+            slot: false,
+          },
+        ],
+      },
+    ]);
+    const controller = createWindowsController(runner, {
+      now: () => {
+        const value = samples[sample] ?? 9000;
+        sample += 1;
+        return value;
+      },
+    });
+
+    const originalPid = Object.getOwnPropertyDescriptor(process, "pid");
+    Object.defineProperty(process, "pid", { value: 9999, configurable: true });
+    try {
+      await expect(
+        controller.stop(serviceLabelFor("staging"), { force: false }),
+      ).rejects.toMatchObject({
+        code: CLI_ERROR_CODES.SERVICE_CONTROL_FAILED,
+        details: { unattributedPids: [889] },
+      });
+    } finally {
+      if (originalPid !== undefined) {
+        Object.defineProperty(process, "pid", originalPid);
+      }
+    }
+
+    expect(
+      calls.filter((call) => call.command === "powershell.exe"),
+    ).toHaveLength(3);
+    expect(
+      calls
+        .filter((call) => call.command === "taskkill")
+        .map((call) => call.args),
+    ).toEqual([
+      // R0: 200 is issued first - its edge to pid 1 counts as depth 1 in
+      // `orderWindowsKillsDescendantsFirst`, while 100's zeroed edge is
+      // depth 0.
+      ["/F", "/PID", "200"],
+      ["/F", "/PID", "100"],
+      // R1: 888 (depth 2) before the lingering 100.
+      ["/F", "/PID", "888"],
+      ["/F", "/PID", "100"],
+    ]);
+
+    // Ablation: in `computeWindowsHostKillSet`, subtract `victims` (the
+    // closure) instead of `killed` (the actual kill set) when building
+    // `undecided` → this test reddens: round 1 remembers no suspect, round
+    // 2 finds nothing that remembers 700, and the stop RESOLVES with 889
+    // alive. The pure overlap pin below reddens on `undecided` for the same
+    // mutation.
+  });
+
   // The unattributed refusal exercised through all four callers that run
   // `killHostProcessTree`: none of them may treat it as anything softer than
   // the scan-unavailable refusal already covered above. The fourth is the
@@ -2511,6 +2666,35 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
       // `!spared.has(pid)` filter too (make it equal to `unattributed`) →
       // this assertion and the one above redden on `undecided`, and the
       // loop-level "round-6 P2" test reddens into a resolved stop.
+    });
+
+    it("overlap: a spared shell in BOTH closures - the killed host's validated child and an undecided root's descendant - stays in the memory feed", () => {
+      // Round 1 of the loop-level overlap test: lingering host 100 is a slot
+      // seed and, against the unreadable victim 200 it claims, undecided at
+      // once. Shell 700 (the CLI's parent) and side worker 888 are its
+      // validated descendants. The kill is the victim closure minus the
+      // spared branch; `undecided` is the suspect closure minus THAT kill,
+      // so 700 and the CLI survive into it even though both are in the
+      // victim closure.
+      const unreadableSlot = victimMemory(
+        new Map<number, readonly WindowsKillVictim[]>([
+          [200, [{ created: 0, seenAliveAt: 5000 }]],
+          [100, [{ created: 1000, seenAliveAt: 5000 }]],
+        ]),
+      );
+      const table = rowsOf([
+        victimRow(100, 0, 200, 1000, true),
+        victimRow(700, 100, 100, 2000, false),
+        victimRow(cliPid, 700, 700, 2500, false),
+        victimRow(888, 700, 700, 6000, false),
+      ]);
+      expect(computeWindowsHostKillSet(table, cliPid, unreadableSlot)).toEqual({
+        kill: [100, 888],
+        undecided: [700, cliPid],
+        unattributed: [],
+      });
+
+      // Ablation: subtract `victims` instead of `killed` → `undecided: []`.
     });
 
     it("both non-empty: a killable seed and an unattributed row coexist in the same verdict", () => {

--- a/clients/traycer-cli/src/service/platforms/__tests__/windows.test.ts
+++ b/clients/traycer-cli/src/service/platforms/__tests__/windows.test.ts
@@ -3,16 +3,18 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   buildScheduledTaskXml,
   buildWindowsSlotProcessDetailScanScript,
-  buildWindowsSlotProcessScanScript,
+  buildWindowsSlotProcessTableScanScript,
+  computeWindowsHostKillSet,
   createWindowsController,
   describeSlotLockHolders,
   killLingeringSlotProcesses,
   parseSchtasksLastRunResult,
   parseWindowsProcessDetailJson,
-  parseWindowsProcessIdJson,
+  parseWindowsProcessTableJson,
   setWindowsStartEvidenceDepsForTests,
   setWindowsTaskInstallDepsForTests,
   type ProcessRunner,
+  type WindowsProcessTableRow,
   type WindowsStartEvidenceDeps,
   type WindowsTaskInstallDeps,
 } from "../windows";
@@ -89,51 +91,106 @@ describe("Windows service stale host cleanup", () => {
     setWindowsTaskInstallDepsForTests(null);
   });
 
-  it("parses PowerShell process id JSON", () => {
-    expect(parseWindowsProcessIdJson("123")).toEqual([123]);
-    expect(parseWindowsProcessIdJson("[123,456]")).toEqual([123, 456]);
-    expect(parseWindowsProcessIdJson("")).toEqual([]);
-    expect(parseWindowsProcessIdJson('"not-a-pid"')).toEqual([]);
+  it("parses PowerShell process table JSON", () => {
+    expect(
+      parseWindowsProcessTableJson(
+        '[{"ProcessId":100,"ParentProcessId":1,"Slot":true},{"ProcessId":200,"ParentProcessId":100,"Slot":false}]',
+      ),
+    ).toEqual([
+      { processId: 100, parentProcessId: 1, slot: true },
+      { processId: 200, parentProcessId: 100, slot: false },
+    ]);
+    // Windows PowerShell 5.1 emits a bare object for a single row.
+    expect(
+      parseWindowsProcessTableJson(
+        '{"ProcessId":100,"ParentProcessId":1,"Slot":true}',
+      ),
+    ).toEqual([{ processId: 100, parentProcessId: 1, slot: true }]);
+    // A row whose ProcessId equals this test process's own pid parses fine -
+    // the table scan is deliberately unfiltered.
+    expect(
+      parseWindowsProcessTableJson(
+        `{"ProcessId":${process.pid},"ParentProcessId":1,"Slot":false}`,
+      ),
+    ).toEqual([{ processId: process.pid, parentProcessId: 1, slot: false }]);
+    expect(parseWindowsProcessTableJson("[]")).toEqual([]);
+    // Empty output means the scan never ran - `null`, not `[]`: a real
+    // Win32_Process scan is never empty.
+    expect(parseWindowsProcessTableJson("")).toBeNull();
+    expect(parseWindowsProcessTableJson("not-json")).toBeNull();
+    // Any malformed row fails the WHOLE parse (all-or-nothing).
+    expect(
+      parseWindowsProcessTableJson(
+        '[{"ProcessId":"100","ParentProcessId":1,"Slot":true}]',
+      ),
+    ).toBeNull();
+    expect(
+      parseWindowsProcessTableJson('[{"ProcessId":100,"Slot":true}]'),
+    ).toBeNull();
+    expect(
+      parseWindowsProcessTableJson(
+        '[{"ProcessId":100,"ParentProcessId":1,"Slot":"true"}]',
+      ),
+    ).toBeNull();
+    expect(parseWindowsProcessTableJson('[100, "not-a-row"]')).toBeNull();
+
+    // Ablation: in `parseProcessTableJson`, change `return null;` on a
+    // malformed row to `continue;` (skipping just that row instead of
+    // failing the whole parse) → the malformed-row assertions above fail:
+    // a partial table would come back instead of `null`.
   });
 
-  it("builds a slot-scoped process scan that excludes the current CLI process", () => {
-    const script = buildWindowsSlotProcessScanScript({
-      hostHome: "C:\\Users\\Traycer Dev\\.traycer\\host\\staging",
-      currentPid: 1234,
-    });
-    expect(script).toContain("$excluded = @(1234, $PID)");
+  it("builds a table scan with the slot's install\\ prefix, ParentProcessId, and Slot fields, and no $excluded/$PID", () => {
+    const script = buildWindowsSlotProcessTableScanScript(
+      "C:\\Users\\Traycer Dev\\.traycer\\host\\staging",
+    );
+    expect(script).toContain("ParentProcessId = [int]$_.ParentProcessId");
+    expect(script).toContain("Slot = $hostMatch");
     expect(script).toContain(".traycer\\host\\staging\\install\\");
-    expect(script).toContain("Replace('/', '\\')");
+    expect(script).not.toContain("$excluded");
+    expect(script).not.toContain("$PID");
+
+    // Ablation: in `buildSlotProcessTableScanScript`, reintroduce
+    // `$excluded = @(<pid>, $PID)` into the script → this test fails (the
+    // `not.toContain("$PID")` assertion flips).
   });
 
   it("does not use broad production roots as process-match prefixes", () => {
-    const script = buildWindowsSlotProcessScanScript({
-      hostHome: "C:\\Users\\Traycer Dev\\.traycer\\host",
-      currentPid: 1234,
-    });
+    const script = buildWindowsSlotProcessTableScanScript(
+      "C:\\Users\\Traycer Dev\\.traycer\\host",
+    );
     expect(script).toContain(
       "c:\\users\\traycer dev\\.traycer\\host\\install\\",
     );
     expect(script).not.toContain("'c:\\users\\traycer dev\\.traycer\\host'");
   });
 
-  it("builds a detail scan sharing the pid scan's filter but projecting name and executable path", () => {
-    const options = {
+  it("builds a detail scan sharing the shared slot-match block with the table scan, projecting name and executable path", () => {
+    const detail = buildWindowsSlotProcessDetailScanScript({
       hostHome: "C:\\Users\\Traycer Dev\\.traycer\\host",
       currentPid: 1234,
-    };
-    const detail = buildWindowsSlotProcessDetailScanScript(options);
+    });
     expect(detail).toContain("$excluded = @(1234, $PID)");
     expect(detail).toContain(
       "c:\\users\\traycer dev\\.traycer\\host\\install\\",
     );
     expect(detail).toContain("Select-Object ProcessId, Name, ExecutablePath");
-    // Everything but the projection line is byte-identical to the pid scan
-    // - the filter must never drift between the kill and the diagnostic.
-    const pidScan = buildWindowsSlotProcessScanScript(options);
-    expect(detail.split("\n").slice(0, -1)).toEqual(
-      pidScan.split("\n").slice(0, -1),
+    // The anti-drift invariant that survives the scan split: both scripts
+    // must contain the identical shared slot-match block, verbatim.
+    const tableScan = buildWindowsSlotProcessTableScanScript(
+      "C:\\Users\\Traycer Dev\\.traycer\\host",
     );
+    const sharedBlock = [
+      "    $exe = ([string]$_.ExecutablePath).ToLowerInvariant().Replace('/', '\\')",
+      "    $cmd = ([string]$_.CommandLine).ToLowerInvariant().Replace('/', '\\')",
+      '    $text = $exe + "`n" + $cmd',
+      "    $hostMatch = $false",
+      "    foreach ($path in $hostPaths) {",
+      "      if ($text.Contains($path)) { $hostMatch = $true; break }",
+      "    }",
+    ].join("\n");
+    expect(detail).toContain(sharedBlock);
+    expect(tableScan).toContain(sharedBlock);
   });
 
   it("parses PowerShell process detail JSON in both array and single-object shape", () => {
@@ -195,11 +252,29 @@ describe("Windows service stale host cleanup", () => {
     ).resolves.toEqual([]);
   });
 
+  // The production `killHostProcessTree` always passes `process.pid` (this
+  // test process's own pid) as the CLI identity, so every fake table below
+  // treats `process.pid` as an ordinary, unrelated process with no parent in
+  // the table - it must never appear in a kill set built from these tables.
+  function tableJson(rows: readonly WindowsProcessTableRow[]): string {
+    return JSON.stringify(
+      rows.map((row) => ({
+        ProcessId: row.processId,
+        ParentProcessId: row.parentProcessId,
+        Slot: row.slot,
+      })),
+    );
+  }
+
   it("re-kills scan-verified processes through killLingeringSlotProcesses", async () => {
     const calls: RecordedCall[] = [];
     const runner: ProcessRunner = async (command, args) => {
       calls.push({ command, args });
-      return command === "powershell.exe" ? success("[401]") : success("");
+      return command === "powershell.exe"
+        ? success(
+            tableJson([{ processId: 401, parentProcessId: 1, slot: true }]),
+          )
+        : success("");
     };
 
     await killLingeringSlotProcesses(serviceLabelFor("staging"), runner);
@@ -208,14 +283,22 @@ describe("Windows service stale host cleanup", () => {
       calls
         .filter((call) => call.command === "taskkill")
         .map((call) => call.args),
-    ).toEqual([["/T", "/F", "/PID", "401"]]);
+    ).toEqual([["/F", "/PID", "401"]]);
+    expect(calls.every((call) => !call.args.includes("/T"))).toBe(true);
   });
 
   it("kills slot-scanned processes when pid metadata is missing", async () => {
     const calls: RecordedCall[] = [];
     const runner: ProcessRunner = async (command, args) => {
       calls.push({ command, args });
-      return command === "powershell.exe" ? success("[401,402]") : success("");
+      return command === "powershell.exe"
+        ? success(
+            tableJson([
+              { processId: 401, parentProcessId: 1, slot: true },
+              { processId: 402, parentProcessId: 1, slot: true },
+            ]),
+          )
+        : success("");
     };
     const controller = createWindowsController(runner);
 
@@ -231,8 +314,8 @@ describe("Windows service stale host cleanup", () => {
         .filter((call) => call.command === "taskkill")
         .map((call) => call.args),
     ).toEqual([
-      ["/T", "/F", "/PID", "401"],
-      ["/T", "/F", "/PID", "402"],
+      ["/F", "/PID", "401"],
+      ["/F", "/PID", "402"],
     ]);
   });
 
@@ -247,7 +330,14 @@ describe("Windows service stale host cleanup", () => {
     const calls: RecordedCall[] = [];
     const runner: ProcessRunner = async (command, args) => {
       calls.push({ command, args });
-      return command === "powershell.exe" ? success("[401,402]") : success("");
+      return command === "powershell.exe"
+        ? success(
+            tableJson([
+              { processId: 401, parentProcessId: 1, slot: true },
+              { processId: 402, parentProcessId: 1, slot: true },
+            ]),
+          )
+        : success("");
     };
     const controller = createWindowsController(runner);
 
@@ -256,13 +346,14 @@ describe("Windows service stale host cleanup", () => {
     expect(
       calls
         .filter((call) => call.command === "taskkill")
-        .map((call) => call.args[3]),
+        .map((call) => call.args[2]),
     ).toEqual(["401", "402"]);
   });
 
   it("does not kill the recorded pid when the scan verifies it no longer matches the host", async () => {
-    // pid.json says 401, but the verified slot scan only finds 402 - the OS
-    // recycled 401 for an unrelated process, which must survive.
+    // pid.json says 401, but the verified slot scan only shows 402 as a slot
+    // match - the OS recycled 401 for an unrelated (non-slot) process, which
+    // must survive.
     mocks.readHostPidMetadata.mockResolvedValue({
       pid: 401,
       hostId: "host-test",
@@ -273,7 +364,14 @@ describe("Windows service stale host cleanup", () => {
     const calls: RecordedCall[] = [];
     const runner: ProcessRunner = async (command, args) => {
       calls.push({ command, args });
-      return command === "powershell.exe" ? success("[402]") : success("");
+      return command === "powershell.exe"
+        ? success(
+            tableJson([
+              { processId: 401, parentProcessId: 1, slot: false },
+              { processId: 402, parentProcessId: 1, slot: true },
+            ]),
+          )
+        : success("");
     };
     const controller = createWindowsController(runner);
 
@@ -282,7 +380,7 @@ describe("Windows service stale host cleanup", () => {
     expect(
       calls
         .filter((call) => call.command === "taskkill")
-        .map((call) => call.args[3]),
+        .map((call) => call.args[2]),
     ).toEqual(["402"]);
   });
 
@@ -307,8 +405,15 @@ describe("Windows service stale host cleanup", () => {
     expect(
       calls
         .filter((call) => call.command === "taskkill")
-        .map((call) => call.args[3]),
+        .map((call) => call.args[2]),
     ).toEqual(["401"]);
+    expect(calls.every((call) => !call.args.includes("/T"))).toBe(true);
+
+    // Ablation (for the "NEVER /T" pins in this describe block): in
+    // `killHostProcessTree`, put `"/T"` back into the `taskkill` argv (i.e.
+    // `run("taskkill", ["/T", "/F", "/PID", String(pid)], ...)`) → every
+    // `.toEqual([["/F", ...`) assertion above fails, and every
+    // `.every((call) => !call.args.includes("/T"))` check flips to false.
   });
 
   it("purges pid metadata on uninstall like it does on stop", async () => {
@@ -329,6 +434,202 @@ describe("Windows service stale host cleanup", () => {
     await controller.stop(serviceLabelFor("staging"), { force: false });
 
     expect(mocks.removeHostPidMetadata).toHaveBeenCalledWith("staging");
+  });
+});
+
+// `computeWindowsHostKillSet` is the algebra a host stop's kill set is built
+// from (victims = slot ∪ descendants(slot); spared = cli ∪ descendants(cli) ∪
+// (ancestors(cli) − slot); kill = victims − spared). These pins exercise it
+// both directly and through `controller.stop`, because the direct unit tests
+// alone would not catch a wiring bug that hands the wrong pid in as `cliPid`
+// (`process.pid`, not PowerShell's own `$PID` inside the scan script).
+describe("computeWindowsHostKillSet and the taskkill self-protection it drives", () => {
+  function table(rows: readonly WindowsProcessTableRow[]): string {
+    return JSON.stringify(
+      rows.map((row) => ({
+        ProcessId: row.processId,
+        ParentProcessId: row.parentProcessId,
+        Slot: row.slot,
+      })),
+    );
+  }
+
+  beforeEach(() => {
+    mocks.readHostPidMetadata.mockReset();
+    mocks.readHostPidMetadata.mockResolvedValue(null);
+    mocks.removeHostPidMetadata.mockReset();
+    mocks.removeHostPidMetadata.mockResolvedValue(undefined);
+  });
+
+  it("host-spawned: kills the host and its non-CLI-ancestor descendants, sparing the CLI's own subtree", async () => {
+    // host 100 (Slot) -> cli 200 -> powershell 250
+    // cli 200 -> helper 300
+    // host 100 -> agent 400
+    // self = 200 (the CLI's own pid)
+    const rows: WindowsProcessTableRow[] = [
+      { processId: 100, parentProcessId: 1, slot: true },
+      { processId: 200, parentProcessId: 100, slot: false },
+      { processId: 250, parentProcessId: 200, slot: false },
+      { processId: 300, parentProcessId: 200, slot: false },
+      { processId: 400, parentProcessId: 100, slot: false },
+    ];
+
+    const calls: RecordedCall[] = [];
+    const runner: ProcessRunner = async (command, args) => {
+      calls.push({ command, args });
+      return command === "powershell.exe" ? success(table(rows)) : success("");
+    };
+    const controller = createWindowsController(runner);
+
+    const originalPid = Object.getOwnPropertyDescriptor(process, "pid");
+    Object.defineProperty(process, "pid", { value: 200, configurable: true });
+    try {
+      await controller.stop(serviceLabelFor("staging"), { force: false });
+    } finally {
+      if (originalPid !== undefined) {
+        Object.defineProperty(process, "pid", originalPid);
+      }
+    }
+
+    const taskkillArgs = calls
+      .filter((call) => call.command === "taskkill")
+      .map((call) => call.args);
+    expect(taskkillArgs).toEqual([
+      ["/F", "/PID", "100"],
+      ["/F", "/PID", "400"],
+    ]);
+    expect(taskkillArgs.every((args) => !args.includes("/T"))).toBe(true);
+  });
+
+  it("terminal-run: a non-slot shell ancestor between the host and the CLI is spared", async () => {
+    // host 100 (Slot) -> shell 50 -> cli 200 -> powershell 250
+    // host 100 -> agent 400
+    // self = 200
+    const rows: WindowsProcessTableRow[] = [
+      { processId: 100, parentProcessId: 1, slot: true },
+      { processId: 50, parentProcessId: 100, slot: false },
+      { processId: 200, parentProcessId: 50, slot: false },
+      { processId: 250, parentProcessId: 200, slot: false },
+      { processId: 400, parentProcessId: 100, slot: false },
+    ];
+
+    const calls: RecordedCall[] = [];
+    const runner: ProcessRunner = async (command, args) => {
+      calls.push({ command, args });
+      return command === "powershell.exe" ? success(table(rows)) : success("");
+    };
+    const controller = createWindowsController(runner);
+
+    const originalPid = Object.getOwnPropertyDescriptor(process, "pid");
+    Object.defineProperty(process, "pid", { value: 200, configurable: true });
+    try {
+      await controller.stop(serviceLabelFor("staging"), { force: false });
+    } finally {
+      if (originalPid !== undefined) {
+        Object.defineProperty(process, "pid", originalPid);
+      }
+    }
+
+    const taskkillArgs = calls
+      .filter((call) => call.command === "taskkill")
+      .map((call) => call.args);
+    expect(taskkillArgs).toEqual([
+      ["/F", "/PID", "100"],
+      ["/F", "/PID", "400"],
+    ]);
+    // 50 (a non-slot ancestor of the CLI) is spared, and never appears.
+    expect(taskkillArgs.some((args) => args[2] === "50")).toBe(false);
+  });
+
+  it("wrong-self regression: self must be the CLI's pid, not PowerShell's own - putting self at the powershell node does not spare the CLI's sibling", () => {
+    // Same host-spawned shape as above, but self is (wrongly) placed at the
+    // POWERSHELL node (250) instead of the CLI (200). This is the pin for
+    // "cliPid is the CLI's own pid, not `$PID` inside the scan script" - a
+    // wiring bug that fed PowerShell's own pid in would leave the CLI's
+    // sibling process (300, the detached upgrade finalizer stand-in) spared
+    // when it should be killed.
+    const rows: WindowsProcessTableRow[] = [
+      { processId: 100, parentProcessId: 1, slot: true },
+      { processId: 200, parentProcessId: 100, slot: false },
+      { processId: 250, parentProcessId: 200, slot: false },
+      { processId: 300, parentProcessId: 200, slot: false },
+      { processId: 400, parentProcessId: 100, slot: false },
+    ];
+
+    const killSet = computeWindowsHostKillSet(rows, 250);
+
+    expect(killSet).toEqual([100, 300, 400]);
+    // Ablation: in `killHostProcessTree`, change
+    // `findSlotProcessIds(label, run, process.pid)` to pass PowerShell's own
+    // pid instead (e.g. hard-code a wrong id, or thread `$PID` from inside
+    // the script back out) → this assertion is exactly what would catch it,
+    // since seeding `spared` from the wrong pid changes which branch of the
+    // tree is protected.
+  });
+
+  it("fallback: the powershell run throws, so the recorded pid.json pid is killed exactly once, without /T", async () => {
+    mocks.readHostPidMetadata.mockResolvedValue({
+      pid: 100,
+      hostId: "host-test",
+      version: "1.0.0",
+      websocketUrl: "ws://127.0.0.1:54321/rpc",
+      startedAt: "2026-01-01T00:00:00.000Z",
+    });
+    const calls: RecordedCall[] = [];
+    const runner: ProcessRunner = async (command, args) => {
+      calls.push({ command, args });
+      if (command === "powershell.exe") throw new Error("spawn failed");
+      return success("");
+    };
+    const controller = createWindowsController(runner);
+
+    await controller.stop(serviceLabelFor("staging"), { force: false });
+
+    const taskkillCalls = calls.filter((call) => call.command === "taskkill");
+    expect(taskkillCalls).toHaveLength(1);
+    expect(taskkillCalls[0]?.args).toEqual(["/F", "/PID", "100"]);
+    expect(taskkillCalls[0]?.args.includes("/T")).toBe(false);
+  });
+
+  // Direct algebra pins for the three subtraction terms, each isolating one
+  // ablation.
+  describe("computeWindowsHostKillSet - algebra pins", () => {
+    const rows: WindowsProcessTableRow[] = [
+      { processId: 100, parentProcessId: 1, slot: true },
+      { processId: 50, parentProcessId: 100, slot: false },
+      { processId: 200, parentProcessId: 50, slot: false },
+      { processId: 300, parentProcessId: 200, slot: false },
+      { processId: 400, parentProcessId: 100, slot: false },
+    ];
+
+    it("kills the slot and its descendants, sparing the CLI's ancestry and subtree", () => {
+      expect(computeWindowsHostKillSet(rows, 200)).toEqual([100, 400]);
+
+      // Ablation: in `computeWindowsHostKillSet`, drop the
+      // `if (!slot.has(ancestor))` condition so every ancestor of the CLI is
+      // spared unconditionally → this test fails: 100 would be spared even
+      // though it is the slot-matched host, changing the expected kill set
+      // from [100, 400] to [400].
+    });
+
+    it("spares the CLI's own descendants (not just the CLI itself)", () => {
+      // 300 is the CLI's own child - PowerShell, or the detached upgrade
+      // finalizer - and it is a descendant of the slot-matched host too, so
+      // only the descendant closure around the CLI keeps it out of the kill
+      // set.
+      const withChild: WindowsProcessTableRow[] = [
+        { processId: 100, parentProcessId: 1, slot: true },
+        { processId: 200, parentProcessId: 100, slot: false },
+        { processId: 300, parentProcessId: 200, slot: false },
+      ];
+      expect(computeWindowsHostKillSet(withChild, 200)).toEqual([100]);
+
+      // Ablation: in `computeWindowsHostKillSet`, change
+      // `withDescendants(new Set([cliPid]), children)` to `new Set([cliPid])`
+      // (seeding `spared` with the CLI's own pid but not its subtree) → this
+      // test fails: the kill set becomes [100, 300], because 300 is a victim
+      // through the host and nothing spares it any more.
+    });
   });
 });
 

--- a/clients/traycer-cli/src/service/platforms/__tests__/windows.test.ts
+++ b/clients/traycer-cli/src/service/platforms/__tests__/windows.test.ts
@@ -125,6 +125,7 @@ function rowsOf(rows: readonly TableRowInput[]): WindowsProcessTableRow[] {
 const nothingRemembered: WindowsKillMemory = {
   victims: new Map(),
   suspects: new Map(),
+  protectedAncestors: new Map(),
 };
 
 // A memory that remembers kills but nothing undecided - the shape the window
@@ -133,7 +134,7 @@ const nothingRemembered: WindowsKillMemory = {
 function victimMemory(
   victims: ReadonlyMap<number, readonly WindowsKillVictim[]>,
 ): WindowsKillMemory {
-  return { victims, suspects: new Map() };
+  return { victims, suspects: new Map(), protectedAncestors: new Map() };
 }
 
 // A memory that remembers something undecided but no kill - the shape the
@@ -142,7 +143,7 @@ function victimMemory(
 function suspectMemory(
   suspects: ReadonlyMap<number, readonly number[]>,
 ): WindowsKillMemory {
-  return { victims: new Map(), suspects };
+  return { victims: new Map(), suspects, protectedAncestors: new Map() };
 }
 
 // Rows as the table scan's JSON, in the shape `parseWindowsProcessTableJson`
@@ -1962,11 +1963,13 @@ describe("killHostProcessTree convergence loop", () => {
   });
 
   it("round-6 P2, overlap: a spared shell that is BOTH a victim's validated child and an undecided root is still remembered", async () => {
-    // The kill set is the victim closure minus the CLI's branch, and the
-    // memory feed must subtract THAT, not the closure: a spared shell can
-    // sit in both closures at once and is then neither killed (so never a
-    // victim) nor - if the closure were subtracted - undecided. Chronology
-    // (samples 5000, 7000, 9000; CLI is pid 9999):
+    // A spared shell can sit in both closures at once - the killed host's
+    // validated child AND a descendant of an undecided root - and it is
+    // never killed, so the kill bookkeeping alone would remember nothing
+    // about it. It is a PLACED ancestor of the CLI: reported as lineage,
+    // remembered with a window like a kill, and its later child is placed
+    // through that window. Chronology (samples 5000, 7000, 9000; CLI is
+    // pid 9999):
     //   R0 (sample 5000): slot 200 (age unreadable) and slot 100 (born
     //       1000) claiming 200 with a zeroed edge; shell 700 (born 2000) is
     //       100's validated child, the CLI (born 2500) is 700's. Kill 200
@@ -1976,21 +1979,29 @@ describe("killHostProcessTree convergence loop", () => {
     //       700 and the CLI remain, and a side worker 888 (born 6000) sits
     //       under 700. 100 is a slot seed AND, against the unreadable victim
     //       200, undecided - so both closures are {100, 700, CLI, 888}. The
-    //       actual kill is [888, 100]; 700 and the CLI are what remains of
-    //       the undecided closure once the KILL is subtracted, and 700 must
-    //       reach the memory. (Subtracting the victim closure instead leaves
-    //       nothing, and 700 is remembered as nothing at all.)
+    //       actual kill is [888, 100]; 700 is a placed ancestor, remembered
+    //       as 700 = [2000, 7000] (and by identity); the CLI is its own
+    //       branch. Nothing is left undecided.
     //   R2 (sample 9000): 100 and 888 are gone, 700 spawned 889 (born 8000)
-    //       and exited. The CLI and 889 claim absent 700; suspect 700 (born
-    //       2000) keeps both undecided, the CLI is spared, and the stop
-    //       refuses naming 889.
+    //       and exited. The CLI and 889 claim absent 700: the CLI (born 2500)
+    //       falls inside 700's window and is spared as itself; 889 falls
+    //       after it and is undecided. The stop refuses naming 889.
     const samples = [5000, 7000, 9000];
     let sample = 0;
     const { runner, calls } = roundedRunner([
       {
         kind: "table",
         rows: [
-          { processId: 200, parentProcessId: 1, created: 0, slot: true },
+          // An unreadable age zeroes the row's own edge too - the scan
+          // cannot validate a parent for a row whose birth it cannot read -
+          // so 200 carries its claim on pid 1 with `parentProcessId` 0.
+          {
+            processId: 200,
+            parentProcessId: 0,
+            claimedParentProcessId: 1,
+            created: 0,
+            slot: true,
+          },
           {
             processId: 100,
             parentProcessId: 0,
@@ -2098,25 +2109,19 @@ describe("killHostProcessTree convergence loop", () => {
         .filter((call) => call.command === "taskkill")
         .map((call) => call.args),
     ).toEqual([
-      // R0: 200 is issued first - its edge to pid 1 counts as depth 1 in
-      // `orderWindowsKillsDescendantsFirst`, while 100's zeroed edge is
-      // depth 0.
-      ["/F", "/PID", "200"],
+      // R0: both slot rows have zeroed edges (depth 0), so pid order.
       ["/F", "/PID", "100"],
+      ["/F", "/PID", "200"],
       // R1: 888 (depth 2) before the lingering 100.
       ["/F", "/PID", "888"],
       ["/F", "/PID", "100"],
     ]);
 
-    // 700 is remembered here as a PLACED ancestor (a validated child of the
-    // lingering host), with a window, which is what decides 889 in round 2.
     // Ablation: in `killHostProcessTree`, drop the `protectedAncestors`
     // recording loop → this test reddens: 700 is neither killed nor - being
     // subtracted from `undecided` as something the loop was about to
     // remember - a suspect, round 2 finds nothing that remembers it, and the
-    // stop RESOLVES with 889 alive. Subtracting the victim closure instead
-    // of `remembered` no longer reddens this fixture on its own (700's
-    // window carries it); the pure overlap pin below pins that subtraction.
+    // stop RESOLVES with 889 alive.
   });
 
   it("a placed CLI ancestor is remembered with a window though it is never killed: its later children are placed after it exits", async () => {
@@ -2354,6 +2359,142 @@ describe("killHostProcessTree convergence loop", () => {
     // from the `undecided` filter → this test reddens: round 1 remembers
     // scan 777 (born 7500) as a suspect, round 2 finds 888 (born 8500)
     // claiming it, and the stop REFUSES naming 888 - a stranger's child.
+  });
+
+  it("two missing wrappers: the shell above the CLI stays protected by identity after the edges that proved its ancestry are gone", async () => {
+    // Remembering a placed ancestor's WINDOW is what places its children;
+    // remembering its IDENTITY is what keeps the ancestor itself protected.
+    // Chronology (samples 5000, 7000, 9000; CLI is pid 9999):
+    //   R0 (sample 5000): slot 100 (born 1000) -> wrapper 600 (born 1500)
+    //       -> shell 700 (born 2000) -> wrapper 800 (born 2250) -> CLI (born
+    //       2500), every age readable. kill=[100]; 600, 700 and 800 are the
+    //       CLI's placed ancestors, remembered by window and by identity.
+    //   R1 (sample 7000): both wrappers have exited on their own. 700
+    //       claims absent 600 (inside 600's window: a seed) and the CLI
+    //       claims absent 800; a side worker 888 (born 6000) sits under 700.
+    //       The live walk from the CLI ends at its zeroed edge, so on the
+    //       window alone 700 is an ordinary host descendant to kill. Its
+    //       identity (700, born 2000) says it is the shell this CLI runs in:
+    //       spared, placed again, and only 888 is killed.
+    //   R2 (sample 9000): 700 and the CLI. Nothing to kill, nothing
+    //       undecided. Converged - with the shell alive.
+    const samples = [5000, 7000, 9000];
+    let sample = 0;
+    const { runner, calls } = roundedRunner([
+      {
+        kind: "table",
+        rows: [
+          { processId: 100, parentProcessId: 1, created: 1000, slot: true },
+          {
+            processId: 600,
+            parentProcessId: 100,
+            claimedParentProcessId: 100,
+            created: 1500,
+            slot: false,
+          },
+          {
+            processId: 700,
+            parentProcessId: 600,
+            claimedParentProcessId: 600,
+            created: 2000,
+            slot: false,
+          },
+          {
+            processId: 800,
+            parentProcessId: 700,
+            claimedParentProcessId: 700,
+            created: 2250,
+            slot: false,
+          },
+          {
+            processId: 9999,
+            parentProcessId: 800,
+            claimedParentProcessId: 800,
+            created: 2500,
+            slot: false,
+          },
+        ],
+      },
+      {
+        kind: "table",
+        rows: [
+          {
+            processId: 700,
+            parentProcessId: 0,
+            claimedParentProcessId: 600,
+            created: 2000,
+            slot: false,
+          },
+          {
+            processId: 9999,
+            parentProcessId: 0,
+            claimedParentProcessId: 800,
+            created: 2500,
+            slot: false,
+          },
+          {
+            processId: 888,
+            parentProcessId: 700,
+            claimedParentProcessId: 700,
+            created: 6000,
+            slot: false,
+          },
+        ],
+      },
+      {
+        kind: "table",
+        rows: [
+          {
+            processId: 700,
+            parentProcessId: 0,
+            claimedParentProcessId: 600,
+            created: 2000,
+            slot: false,
+          },
+          {
+            processId: 9999,
+            parentProcessId: 0,
+            claimedParentProcessId: 800,
+            created: 2500,
+            slot: false,
+          },
+        ],
+      },
+    ]);
+    const controller = createWindowsController(runner, {
+      now: () => {
+        const value = samples[sample] ?? 9000;
+        sample += 1;
+        return value;
+      },
+    });
+
+    const originalPid = Object.getOwnPropertyDescriptor(process, "pid");
+    Object.defineProperty(process, "pid", { value: 9999, configurable: true });
+    try {
+      await controller.stop(serviceLabelFor("staging"), { force: false });
+    } finally {
+      if (originalPid !== undefined) {
+        Object.defineProperty(process, "pid", originalPid);
+      }
+    }
+
+    expect(
+      calls.filter((call) => call.command === "powershell.exe"),
+    ).toHaveLength(3);
+    expect(
+      calls
+        .filter((call) => call.command === "taskkill")
+        .map((call) => call.args),
+    ).toEqual([
+      ["/F", "/PID", "100"],
+      ["/F", "/PID", "888"],
+    ]);
+
+    // Ablation: in `killHostProcessTree`, drop the `priorProtected`
+    // recording (or in `computeWindowsHostKillSet` the identity lookup) →
+    // this test reddens: round 1 issues `taskkill /F /PID 700` as well -
+    // the shell this CLI is running in - before 888.
   });
 
   // The unattributed refusal exercised through all four callers that run
@@ -2941,9 +3082,10 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
       // seed and, against the unreadable victim 200 it claims, undecided at
       // once. Shell 700 (the CLI's parent) and side worker 888 are its
       // validated descendants. The kill is the victim closure minus the
-      // spared branch; `undecided` is the suspect closure minus THAT kill,
-      // so 700 and the CLI survive into it even though both are in the
-      // victim closure.
+      // spared branch; 700 is a placed ancestor and is remembered with a
+      // window instead of being killed; `undecided` is the suspect closure
+      // minus everything that will be remembered that way and minus the
+      // CLI's own branch - here, nothing.
       const unreadableSlot = victimMemory(
         new Map<number, readonly WindowsKillVictim[]>([
           [200, [{ created: 0, seenAliveAt: 5000 }]],
@@ -3000,6 +3142,67 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
       // Ablation: in `computeWindowsHostKillSet`, drop `!cliBranch.has(pid)`
       // from the `undecided` filter → `undecided: [777, 9999]`, and the
       // loop-level "round-7 P2" test refuses a stop over a stranger's child.
+    });
+
+    it("a remembered ancestor is spared by IDENTITY once the wrappers between it and the CLI have exited; a reused pid with a different birth is not", () => {
+      // Round 1 of the loop-level "two missing wrappers" test. Round 0 saw
+      // slot 100 -> wrapper 600 -> shell 700 -> wrapper 800 -> CLI, killed
+      // 100 and remembered 600, 700 and 800 as placed ancestors, by window
+      // and by identity. Both wrappers have since exited: 700 (born 2000)
+      // claims absent 600 inside 600's window - a seed, an ordinary host
+      // descendant on the window alone - and the CLI claims absent 800. The
+      // live walk from the CLI stops at its zeroed edge, so nothing but the
+      // remembered identity says 700 is the shell this CLI runs in. Its
+      // other child 888 is still the host's and is killed.
+      const chainRemembered: WindowsKillMemory = {
+        victims: new Map<number, readonly WindowsKillVictim[]>([
+          [100, [{ created: 1000, seenAliveAt: 5000 }]],
+          [600, [{ created: 1500, seenAliveAt: 5000 }]],
+          [700, [{ created: 2000, seenAliveAt: 5000 }]],
+          [800, [{ created: 2250, seenAliveAt: 5000 }]],
+        ]),
+        suspects: new Map(),
+        protectedAncestors: new Map<number, readonly number[]>([
+          [600, [1500]],
+          [700, [2000]],
+          [800, [2250]],
+        ]),
+      };
+      const sameShell = rowsOf([
+        victimRow(700, 0, 600, 2000, false),
+        victimRow(cliPid, 0, 800, 2500, false),
+        victimRow(888, 700, 700, 6000, false),
+      ]);
+      expect(
+        computeWindowsHostKillSet(sameShell, cliPid, chainRemembered),
+      ).toEqual({
+        kill: [888],
+        protectedAncestors: [700],
+        undecided: [],
+        unattributed: [],
+      });
+
+      // A stranger wearing pid 700, born 9000: no identity match, and its
+      // claim on 600 falls after 600's window - undecided, reported, and
+      // certainly not spared as anybody's ancestor.
+      const reusedPid = rowsOf([
+        victimRow(700, 0, 600, 9000, false),
+        victimRow(cliPid, 0, 800, 2500, false),
+        victimRow(888, 700, 700, 9500, false),
+      ]);
+      expect(
+        computeWindowsHostKillSet(reusedPid, cliPid, chainRemembered),
+      ).toEqual({
+        kill: [],
+        protectedAncestors: [],
+        undecided: [700, 888],
+        unattributed: [700, 888],
+      });
+
+      // Ablation: in `computeWindowsHostKillSet`, drop the identity lookup
+      // (build `ancestors` from the live walk only) → the first assertion
+      // reddens with `kill: [700, 888]` and `protectedAncestors: []`: the
+      // shell this CLI runs in is killed as an ordinary host descendant.
     });
 
     it("both non-empty: a killable seed and an unattributed row coexist in the same verdict", () => {
@@ -3217,6 +3420,7 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
             [777, [{ created: 8000, seenAliveAt: 9000 }]],
           ]),
           suspects: new Map<number, readonly number[]>([[777, [6000]]]),
+          protectedAncestors: new Map(),
         };
         const table = rowsOf([victimRow(888, 0, 777, 6500, false), cliRow]);
         expect(computeWindowsHostKillSet(table, cliPid, mixed)).toEqual({
@@ -3257,6 +3461,7 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
             [100, [{ created: 1000, seenAliveAt: 5000 }]],
           ]),
           suspects: new Map<number, readonly number[]>([[888, [6500]]]),
+          protectedAncestors: new Map(),
         };
         const table = rowsOf([
           victimRow(100, 0, 0, 6000, false),

--- a/clients/traycer-cli/src/service/platforms/windows.ts
+++ b/clients/traycer-cli/src/service/platforms/windows.ts
@@ -657,10 +657,11 @@ async function killHostProcessTree(
     // that reaches the same pid again adds the incarnation it saw beside the
     // earlier one.
     //
-    // From the FULL undecided closure, not from the reported subset. The CLI's
-    // own branch is withheld from the report and the kill, but the shell above
+    // From `undecided`, not from the reported subset: the CLI's uncertain
+    // ancestors are withheld from the report and the kill, but the shell above
     // the CLI is under no obligation to still be there next round, and its
-    // other children then claim a pid that only this entry remembers.
+    // other children then claim a pid that only this entry remembers. The
+    // CLI's own descendants are in neither list - they are never the host's.
     for (const pid of undecided) {
       rememberIncarnation(priorSuspects, pid, created.get(pid) ?? 0);
     }
@@ -1500,8 +1501,9 @@ type CarryOverClaim = "seed" | "unattributed" | "none";
 // a child whose LIVE parent is itself undecided is preserved by the descendant
 // closure in `computeWindowsHostKillSet`, not here; and once that parent has
 // exited, by the suspect entry the loop recorded for it - for every member of
-// the closure, the CLI's protected branch included, so a child that outlives a
-// spared shell still finds its parent's pid remembered.
+// the closure outside the CLI's own descendant branch - its uncertain
+// ancestors included - so a child that outlives a spared shell still finds its
+// parent's pid remembered.
 //
 // The gate is NOT redundant with the rules below. The case it decides is a
 // live, validated parent wearing a pid this loop killed earlier: an unrelated

--- a/clients/traycer-cli/src/service/platforms/windows.ts
+++ b/clients/traycer-cli/src/service/platforms/windows.ts
@@ -487,11 +487,23 @@ async function killHostProcessTree(
   // that also cannot be placed must not narrow what an earlier holder's child
   // can be suspected of.
   const priorSuspects = new Map<number, number[]>();
-  // The pair, by reference: the maps below are mutated in place at the end of
-  // every round, so this is built once and always reflects the latest round.
+  // The third: this CLI's own ancestors, by IDENTITY (pid and creation time),
+  // for every incarnation a round saw them as ancestors. Their windows go into
+  // `priorVictims` like a kill's, which is what places their other children;
+  // this is what keeps THEM protected. The live ancestor walk proves ancestry
+  // only through live edges, and a wrapper between the shell and the CLI can
+  // exit between rounds - the shell then sits in the table as an orphan
+  // claiming a remembered pid, inside a remembered window, and would be seeded
+  // and killed as an ordinary host descendant. The identity says it is the
+  // same process the loop already decided never to kill; a reused pid with a
+  // different birth matches nothing.
+  const priorProtected = new Map<number, number[]>();
+  // The triple, by reference: the maps below are mutated in place at the end
+  // of every round, so this is built once and always reflects the latest round.
   const memory: WindowsKillMemory = {
     victims: priorVictims,
     suspects: priorSuspects,
+    protectedAncestors: priorProtected,
   };
   for (let round = 0; round <= WINDOWS_KILL_CONVERGENCE_ROUNDS; round += 1) {
     // BEFORE the scan, and that ordering is the soundness argument for the
@@ -629,6 +641,11 @@ async function killHostProcessTree(
         created: created.get(pid) ?? 0,
         seenAliveAt,
       });
+      // And by identity, so the next round still spares it when the edges
+      // that proved its ancestry are gone. An unreadable age is no identity:
+      // nothing can match it, so nothing is recorded.
+      const age = created.get(pid) ?? 0;
+      if (age !== 0) rememberIncarnation(priorProtected, pid, age);
     }
     // Recorded from the same snapshot, and only ever added to. What is kept is
     // evidence about CLAIMS: a later row that names this pid as its parent, born
@@ -1298,8 +1315,25 @@ export function computeWindowsHostKillSet(
   // claiming a pid nothing else remembers. Ancestors only: the CLI's own
   // descendants are its scan and kill subprocesses, and nothing below them is
   // ever the host's.
+  //
+  // Two ways to be an ancestor: the live edge walk from the CLI, and a
+  // remembered IDENTITY - the same pid with the same creation time an earlier
+  // round saw as an ancestor, now orphaned because a wrapper between it and the
+  // CLI has exited. The second is what keeps a shell protected after its
+  // ancestry can no longer be walked; without it the shell, claiming a
+  // remembered pid inside a remembered window, is seeded and killed as an
+  // ordinary host descendant. A row that is slot-matched THIS round is killed
+  // either way, and a reused pid with a different birth matches nothing.
+  const ancestors = new Set<number>(ancestorsOf(cliPid, parents));
+  for (const row of table) {
+    if (row.created === 0 || cliBranch.has(row.processId)) continue;
+    const incarnations = memory.protectedAncestors.get(row.processId);
+    if (incarnations !== undefined && incarnations.includes(row.created)) {
+      ancestors.add(row.processId);
+    }
+  }
   const protectedAncestors: number[] = [];
-  for (const ancestor of ancestorsOf(cliPid, parents)) {
+  for (const ancestor of ancestors) {
     if (slot.has(ancestor)) continue;
     spared.add(ancestor);
     if (victims.has(ancestor)) protectedAncestors.push(ancestor);
@@ -1416,13 +1450,22 @@ export interface WindowsKillVictim {
  * against. Neither list is ever shortened: a newer holder of a pid is new
  * evidence beside the old, never a replacement for it.
  *
- * One value rather than two parameters because the two halves are never
- * meaningful apart: every round records into both from the same snapshot, and
- * every classification consults both.
+ * `protectedAncestors` is the CLI's own ancestors by identity, so that a
+ * shell whose wrapper to the CLI has exited is still recognised as the process
+ * the loop decided never to kill (see `WindowsHostKillSet.protectedAncestors`).
+ *
+ * One value rather than three parameters because the halves are never
+ * meaningful apart: every round records into all of them from the same
+ * snapshot, and every classification consults them together.
  */
 export interface WindowsKillMemory {
   readonly victims: ReadonlyMap<number, readonly WindowsKillVictim[]>;
   readonly suspects: ReadonlyMap<number, readonly number[]>;
+  // This CLI's own ancestors by identity - pid to the creation time of each
+  // incarnation an earlier round saw as an ancestor. A later row with that pid
+  // AND that creation time is the same process, and stays spared even when the
+  // live edges that proved its ancestry are gone.
+  readonly protectedAncestors: ReadonlyMap<number, readonly number[]>;
 }
 
 // How a row that claims a remembered pid as its parent is classified.

--- a/clients/traycer-cli/src/service/platforms/windows.ts
+++ b/clients/traycer-cli/src/service/platforms/windows.ts
@@ -456,7 +456,16 @@ async function killHostProcessTree(
   // What earlier rounds killed, with the age each had when it was killed. The
   // loop's memory: once a parent is dead the table can no longer prove its
   // children belong to the slot, and this is the only thing that still can.
-  const priorVictims = new Map<number, WindowsKillVictim>();
+  //
+  // Per INCARNATION, appended and never replaced. A pid can be killed twice as
+  // two different processes (the first lingers in an asynchronous
+  // `TerminateProcess`, or is reused and the newcomer is slot-matched too), and
+  // each kill is evidence about the rows born during THAT holder's lifetime. A
+  // map that kept only the latest would let a newer holder of a pid erase what
+  // the loop learned about the previous holder's children, and a row born inside
+  // the older window would read as "older than the victim" - decided, and
+  // wrongly, as somebody else's.
+  const priorVictims = new Map<number, WindowsKillVictim[]>();
   // The other half of that memory: pids an earlier round could place neither in
   // the slot nor out of it, against the age the row wearing each one had then.
   // Uncertainty has to cross a round boundary for the same reason a kill does.
@@ -464,8 +473,11 @@ async function killHostProcessTree(
   // next round - it can exit, or spawn a child and then exit - and without this
   // the child arrives as an ordinary orphan claiming a pid nothing remembers,
   // which reads as convergence. Only the age is kept: `classifyAgainstSuspect`
-  // shows a suspect's upper bound cannot change any verdict.
-  const priorSuspects = new Map<number, number>();
+  // shows a suspect's upper bound cannot change any verdict. Per incarnation,
+  // for the same reason as the victims: a later, unrelated holder of the pid
+  // that also cannot be placed must not narrow what an earlier holder's child
+  // can be suspected of.
+  const priorSuspects = new Map<number, number[]>();
   // The pair, by reference: the maps below are mutated in place at the end of
   // every round, so this is built once and always reflects the latest round.
   const memory: WindowsKillMemory = {
@@ -518,11 +530,16 @@ async function killHostProcessTree(
       // off an undecided process is exactly as undecided as its root.
       if (unattributed.length > 0) {
         // "Run the command again" was the wrong advice and is deliberately
-        // gone: a rerun repeats this scan against the same processes and
-        // reaches the same verdict, so it sends the user around the loop
-        // rather than out of it. Ending the named processes is what changes
-        // the answer, and it is the one instruction that also works when they
-        // turn out to be strangers wearing recycled pids.
+        // gone, for the opposite of the obvious reason: a rerun would very
+        // likely SUCCEED, and that success would prove nothing. This memory
+        // is invocation-local; a fresh stop starts with no victims and no
+        // suspects, so the same orphan arrives as an ordinary process with a
+        // parent nobody remembers, and with no slot match left the loop
+        // converges around it. The rerun cannot certify the orphan as
+        // unrelated, it can only forget the question. Ending the named
+        // processes is what actually changes the answer, and it is the one
+        // instruction that also works when they turn out to be strangers
+        // wearing recycled pids.
         throw cliError({
           code: CLI_ERROR_CODES.SERVICE_CONTROL_FAILED,
           message:
@@ -576,22 +593,39 @@ async function killHostProcessTree(
     // unreachable; 0 is the value the next round refuses to link anything to,
     // which is the right way for it to be wrong.
     //
-    // A pid killed again in a later round overwrites its entry, and that
-    // round's `seenAliveAt` is the honest bound: its scan saw the pid alive
-    // too, so the interval in which the pid was demonstrably still the
-    // victim's genuinely extends to there.
+    // A pid killed again in a later round gets a second entry with that
+    // round's `seenAliveAt`, and the wider window is the honest bound: its
+    // scan saw the pid alive too, so the interval in which the pid was
+    // demonstrably still the victim's genuinely extends to there. The earlier
+    // entry stays; nothing it proved has become false.
     const created = new Map(table.map((row) => [row.processId, row.created]));
     for (const pid of pids) {
-      priorVictims.set(pid, { created: created.get(pid) ?? 0, seenAliveAt });
+      rememberIncarnation(priorVictims, pid, {
+        created: created.get(pid) ?? 0,
+        seenAliveAt,
+      });
     }
     // Recorded from the same snapshot, and only ever added to: a pid this round
     // could not place stays undecided for the rest of the loop even if the next
     // scan does not list it at all, which is precisely the case the memory
-    // exists for. A later round that reaches the same pid again overwrites the
-    // age with the incarnation that round saw.
+    // exists for. A later round that reaches the same pid again adds the
+    // incarnation that round saw beside the earlier one.
     for (const pid of unattributed) {
-      priorSuspects.set(pid, created.get(pid) ?? 0);
+      rememberIncarnation(priorSuspects, pid, created.get(pid) ?? 0);
     }
+  }
+}
+
+function rememberIncarnation<T>(
+  memory: Map<number, T[]>,
+  pid: number,
+  incarnation: T,
+): void {
+  const incarnations = memory.get(pid);
+  if (incarnations === undefined) {
+    memory.set(pid, [incarnation]);
+  } else {
+    incarnations.push(incarnation);
   }
 }
 
@@ -1261,18 +1295,20 @@ export interface WindowsKillVictim {
  * What earlier rounds of the kill loop remember, and the only thing carrying
  * either kind of knowledge across a scan boundary.
  *
- * `victims` is what the loop killed, by pid. `suspects` is what it could place
- * neither in the slot nor out of it, by pid, against the creation time of the
- * incarnation that round saw - the age is all a suspect needs, because
- * `classifyAgainstSuspect` has no upper bound to compare against.
+ * `victims` is what the loop killed, by pid, one entry per incarnation it
+ * killed. `suspects` is what it could place neither in the slot nor out of it,
+ * by pid, one creation time per incarnation it saw - the age is all a suspect
+ * needs, because `classifyAgainstSuspect` has no upper bound to compare
+ * against. Neither list is ever shortened: a newer holder of a pid is new
+ * evidence beside the old, never a replacement for it.
  *
  * One value rather than two parameters because the two halves are never
  * meaningful apart: every round records into both from the same snapshot, and
- * every classification consults both in a fixed order.
+ * every classification consults both.
  */
 export interface WindowsKillMemory {
-  readonly victims: ReadonlyMap<number, WindowsKillVictim>;
-  readonly suspects: ReadonlyMap<number, number>;
+  readonly victims: ReadonlyMap<number, readonly WindowsKillVictim[]>;
+  readonly suspects: ReadonlyMap<number, readonly number[]>;
 }
 
 /**
@@ -1298,31 +1334,78 @@ export interface WindowsHostKillSet {
 type CarryOverClaim = "seed" | "unattributed" | "none";
 
 // Whether this row was created BY a process an earlier round killed, or by one
-// it could not place.
+// it could not place - or IS one it could not place.
 //
-// The gate is the row's own validated edge, and it is kept honestly: under the
-// pre-scan bound it is redundant on legitimate input. A row with a validated
-// live edge has a parent the scan found in this very table, and a live parent is
-// neither a killed victim nor a vanished suspect, so the rules below would
-// refuse it anyway. It stays as the scan's own verdict, checked first because it
-// is the cheaper and more direct fact, and its test is framed as defensive
-// rather than as a behaviour only it produces.
+// A process this loop already failed to place stays undecided for as long as
+// that same incarnation (pid AND creation time) is alive, whatever its edge says
+// now. That check comes before the gate on purpose: the row's edge can change
+// under it between rounds - its parent exits and the claimed pid is reused by
+// something the scan validates - and a verdict that could be cleared by a
+// stranger taking a pid is not a verdict.
 //
-// Victims are checked before suspects because a pid can be both - a row this
-// loop could not place in one round can be killed in a later one, once
-// something in the table proves it belongs to the slot - and a kill is the
-// stronger fact: it says what the pid WAS, where a suspicion only says that
-// nobody could tell.
+// The gate is the row's own validated edge, and it is NOT redundant with the
+// rules below. The case it decides is a live, validated parent wearing a pid
+// this loop killed earlier: an unrelated process that took the pid after the
+// victim died and then forked. Its child is born after the victim's window and
+// would read as undecided on the window alone; the scan has already tied it to
+// a living parent, which is the better fact, so it is not a carry-over question.
+//
+// Every remembered incarnation of the claimed pid is consulted, and the
+// STRONGEST verdict wins. A pid can have been a suspect in one round and a
+// victim in a later one, or killed twice as two different processes, and each
+// incarnation is evidence about the rows born during it: a row older than the
+// newest incarnation is "none" against that one but may be inside an older
+// window (seed) or after an older suspect's birth (unattributed). Taking the
+// first answer would let the newest holder of a pid erase what the loop learned
+// about the previous holder's children.
 function classifyCarryOverClaim(
   row: WindowsProcessTableRow,
   memory: WindowsKillMemory,
 ): CarryOverClaim {
+  if (isRememberedSuspect(row, memory)) return "unattributed";
   if (row.parentProcessId !== 0) return "none";
-  const victim = memory.victims.get(row.claimedParentProcessId);
-  if (victim !== undefined) return classifyAgainstVictim(row.created, victim);
-  const suspectCreated = memory.suspects.get(row.claimedParentProcessId);
-  if (suspectCreated === undefined) return "none";
-  return classifyAgainstSuspect(row.created, suspectCreated);
+  let claim: CarryOverClaim = "none";
+  for (const victim of memory.victims.get(row.claimedParentProcessId) ?? []) {
+    claim = strongerClaim(claim, classifyAgainstVictim(row.created, victim));
+  }
+  for (const suspectCreated of memory.suspects.get(
+    row.claimedParentProcessId,
+  ) ?? []) {
+    claim = strongerClaim(
+      claim,
+      classifyAgainstSuspect(row.created, suspectCreated),
+    );
+  }
+  return claim;
+}
+
+// The same process (pid and creation time) an earlier round reported as
+// undecided. Identity by creation time, not pid alone: a different process
+// wearing a suspect's pid is a different question, decided by its own edge and
+// claim. An unreadable age (0) on a remembered suspect matches a row of
+// unreadable age, which is the undecided answer either way.
+function isRememberedSuspect(
+  row: WindowsProcessTableRow,
+  memory: WindowsKillMemory,
+): boolean {
+  const incarnations = memory.suspects.get(row.processId);
+  if (incarnations === undefined) return false;
+  return incarnations.includes(row.created);
+}
+
+const CLAIM_STRENGTH: Readonly<Record<CarryOverClaim, number>> = {
+  none: 0,
+  unattributed: 1,
+  seed: 2,
+};
+
+// "seed" outranks "unattributed" outranks "none": a proof beats an open
+// question beats the absence of one.
+function strongerClaim(
+  left: CarryOverClaim,
+  right: CarryOverClaim,
+): CarryOverClaim {
+  return CLAIM_STRENGTH[right] > CLAIM_STRENGTH[left] ? right : left;
 }
 
 // A claim on a pid this loop killed, decided by a LIFETIME WINDOW.

--- a/clients/traycer-cli/src/service/platforms/windows.ts
+++ b/clients/traycer-cli/src/service/platforms/windows.ts
@@ -1725,7 +1725,15 @@ function buildHiddenHostLauncher(
     "      Do While nonceProbe.Status = 0",
     "        WScript.Sleep 10",
     "      Loop",
-    "      If nonceProbe.ExitCode = 0 Then adoptionNonce = Trim(nonceProbe.StdOut.ReadAll)",
+    // The CLI prints the nonce with a trailing newline. VBScript `Trim`
+    // strips SPACES only, and a VBScript RegExp `$` (no Multiline) does not
+    // match before a trailing LF, so `Trim(...)` alone left a 37-char string
+    // the pattern below rejected: every task-managed start ran `host start`
+    // WITHOUT `--adoption-nonce`, the supervisor refused the still-valid
+    // grant until it expired (~60 s), and install / restart / update all
+    // reported failure while the host came up a minute later. Strip CR and
+    // LF explicitly; `$(...)` does this for free on the POSIX launchers.
+    '      If nonceProbe.ExitCode = 0 Then adoptionNonce = Trim(Replace(Replace(nonceProbe.StdOut.ReadAll, vbCr, ""), vbLf, ""))',
     "    End If",
     "  End If",
     "  Err.Clear",

--- a/clients/traycer-cli/src/service/platforms/windows.ts
+++ b/clients/traycer-cli/src/service/platforms/windows.ts
@@ -397,10 +397,14 @@ async function stopService(
 // terminal - and `taskkill /T` walks down from the host and kills it mid-update:
 // the host is gone, the updater is gone, and nothing finishes the swap. The
 // scan computes which pids to kill (`computeWindowsHostKillSet`) and each one is
-// killed individually. No ordering is imposed: `taskkill /F` on a parent leaves
-// its children running, the VBS launcher re-runs the host only on exit 75 (the
-// refreshed-slot signal) and never after a kill, and the CLI-side supervisor is
-// already silenced by the stop intent written before any of this.
+// killed individually, deepest first (`orderWindowsKillsDescendantsFirst`) so a
+// child is issued its kill before the parent whose death would orphan it. That
+// ordering is a courtesy, not a mechanism - the kills are issued concurrently,
+// and what actually catches a process spawned mid-kill is the victim carry-over
+// below. `taskkill /F` on a parent leaves its children running, the VBS launcher
+// re-runs the host only on exit 75 (the refreshed-slot signal) and never after a
+// kill, and the CLI-side supervisor is already silenced by the stop intent
+// written before any of this.
 //
 // Not `/T` also means nothing sweeps up what is spawned DURING the kill. The
 // scan is a snapshot, so a child the host or one of its agents starts after
@@ -425,9 +429,13 @@ async function killHostProcessTree(
   label: ServiceLabel,
   run: ProcessRunner,
 ): Promise<void> {
+  // What earlier rounds killed, with the age each had when it was killed. The
+  // loop's memory: once a parent is dead the table can no longer prove its
+  // children belong to the slot, and this is the only thing that still can.
+  const priorVictims = new Map<number, number>();
   for (let round = 0; round <= WINDOWS_KILL_CONVERGENCE_ROUNDS; round += 1) {
-    const scannedPids = await findSlotProcessIds(label, run, process.pid);
-    if (scannedPids === null) {
+    const table = await scanSlotProcessTable(label, run);
+    if (table === null) {
       // Before the first kill this refuses to start; after one it refuses to
       // claim the tree came down. Both are the same statement - we cannot see
       // the slot, so we cannot say what is in it - and neither may be softened
@@ -444,7 +452,9 @@ async function killHostProcessTree(
     // The kill boundary, and the only place a pid has to be POSITIVE: the scan
     // and its algebra work over an unfiltered table that includes pid 0, and
     // `isKillableProcessId` is what keeps 0 - and our own pid - out of an argv.
-    const pids = uniqueProcessIds(scannedPids);
+    const pids = uniqueProcessIds(
+      computeWindowsHostKillSet(table, process.pid, priorVictims),
+    );
     // Converged, and the only success: a scan taken AFTER the previous round's
     // kills found nothing left in this slot. Round 0 reaches here whenever
     // there was never anything to kill, which is the ordinary stop of a host
@@ -468,7 +478,14 @@ async function killHostProcessTree(
         exitCode: 1,
       });
     }
-    await killProcessIds(pids, run);
+    await killProcessIds(orderWindowsKillsDescendantsFirst(pids, table), run);
+    // Remembered AFTER the kill, from the snapshot the kill was computed from,
+    // so each victim's age is the one it had while it was alive. A row is
+    // always in the table it was selected from, so the fallback age is
+    // unreachable; 0 is the value the next round refuses to link anything to,
+    // which is the right way for it to be wrong.
+    const created = new Map(table.map((row) => [row.processId, row.created]));
+    for (const pid of pids) priorVictims.set(pid, created.get(pid) ?? 0);
   }
 }
 
@@ -690,11 +707,10 @@ function describeCause(cause: unknown): string {
 // Returns null (rather than an empty list) when the scan could not run at
 // all, so the caller can distinguish "verified: nothing to kill" from
 // "unknown: PowerShell unavailable".
-async function findSlotProcessIds(
+async function scanSlotProcessTable(
   label: ServiceLabel,
   run: ProcessRunner,
-  cliPid: number,
-): Promise<readonly number[] | null> {
+): Promise<readonly WindowsProcessTableRow[] | null> {
   try {
     const result = await run(
       "powershell.exe",
@@ -711,8 +727,7 @@ async function findSlotProcessIds(
         tolerateNonZeroExit: true,
       },
     );
-    const table = parseProcessTableJson(result.stdout);
-    return table === null ? null : computeWindowsHostKillSet(table, cliPid);
+    return parseProcessTableJson(result.stdout);
   } catch (cause) {
     if (isServiceMutationAuthorityError(cause)) throw cause;
     return null;
@@ -780,15 +795,36 @@ function buildSlotProcessTableScanScript(hostHome: string): string {
     "$rows = $table | ForEach-Object {",
     ...SLOT_MATCH_SCRIPT_LINES,
     ...PARENT_EDGE_VALIDATION_SCRIPT_LINES,
+    ...ROW_CREATION_SCRIPT_LINES,
     "    [pscustomobject]@{",
     "      ProcessId = [int]$_.ProcessId",
     "      ParentProcessId = $parentId",
+    // The id the row CLAIMS, unvalidated, alongside the validated one. A
+    // process whose parent this loop killed in an earlier round has a claimed
+    // parent that is in no live table, so the validation above zeroes it - and
+    // that is precisely the row the victim carry-over has to recognise.
+    "      ClaimedParentProcessId = [int]$_.ParentProcessId",
+    "      Created = $createdMs",
     "      Slot = $hostMatch",
     "    }",
     "}",
     "@($rows) | ConvertTo-Json -Compress",
   ].join("\n");
 }
+
+// Sets `$createdMs` for the pipeline row in `$_`: how old the process is, as
+// milliseconds since the Unix epoch, and 0 when Windows reports no creation
+// time at all (pid 0 and System have none). Milliseconds rather than the native
+// FILETIME because a FILETIME is ~1.3e17 - past the point where JSON numbers
+// stay exact - while epoch milliseconds is ~1.7e12 and survives the round trip
+// intact. The unit only ever gets COMPARED, never displayed, so its precision
+// just has to beat the gap between a parent and the child it forks.
+const ROW_CREATION_SCRIPT_LINES: readonly string[] = [
+  "    $createdMs = 0",
+  "    if ($null -ne $_.CreationDate) {",
+  "      $createdMs = [long]($_.CreationDate.ToUniversalTime() - [datetime]'1970-01-01').TotalMilliseconds",
+  "    }",
+];
 
 // Sets `$parentId` for the pipeline row in `$_`: the claimed parent when this
 // snapshot can still vouch for it, and 0 when it cannot. A missing
@@ -875,6 +911,18 @@ export interface WindowsProcessTableRow {
   // and may hand that id to somebody else, which is exactly the claim this
   // field refuses to carry.
   readonly parentProcessId: number;
+  // The parent id the row CLAIMS, with no validation applied. Its only use is
+  // the cross-round victim carry-over: a process whose parent this loop killed
+  // has a claimed parent that no longer appears in any table, so
+  // `parentProcessId` above is 0 and the claim is the only thing left linking
+  // the two. Never treat it as an edge on its own - `created` is what makes it
+  // safe (see `computeWindowsHostKillSet`).
+  readonly claimedParentProcessId: number;
+  // Milliseconds since the Unix epoch, or 0 when Windows reports no creation
+  // time. What turns a claimed parent id into evidence: a process cannot
+  // predate its own parent, so an id whose claimed parent is YOUNGER than it is
+  // a recycled id rather than an ancestry.
+  readonly created: number;
   // Whether the row's executable path or command line matches this slot.
   readonly slot: boolean;
 }
@@ -911,22 +959,34 @@ function parseProcessTableJson(
     const record = value as Record<string, unknown>;
     const processId = record.ProcessId;
     const parentProcessId = record.ParentProcessId;
+    const claimedParentProcessId = record.ClaimedParentProcessId;
+    const created = record.Created;
     const slot = record.Slot;
-    // Both ids are accepted at zero and above. The table is unfiltered, so it
+    // Every id is accepted at zero and above. The table is unfiltered, so it
     // legitimately contains pid 0 (the System Idle Process) and rows with no
     // verified parent; rejecting either would fail the WHOLE parse on every
-    // real machine and silently demote every stop to the pid.json fallback.
+    // real machine and silently refuse every stop on the machine.
     // Deliberately NOT `isKillableProcessId` either: that also rejects our own
     // pid, which is expected in the table too. What may be killed is the
-    // algebra's answer and the kill boundary's, not the parser's.
+    // algebra's answer and the kill boundary's, not the parser's. `Created` is
+    // held to the same shape and reads 0 for "Windows reported no creation
+    // time", which the algebra treats as unusable rather than as age zero.
     if (
       !isProcessTableId(processId) ||
       !isProcessTableId(parentProcessId) ||
+      !isProcessTableId(claimedParentProcessId) ||
+      !isProcessTableId(created) ||
       typeof slot !== "boolean"
     ) {
       return null;
     }
-    rows.push({ processId, parentProcessId, slot });
+    rows.push({
+      processId,
+      parentProcessId,
+      claimedParentProcessId,
+      created,
+      slot,
+    });
   }
   return rows;
 }
@@ -950,10 +1010,27 @@ function parseProcessTableJson(
  * process's child, so `$PID` inside it is a descendant of the answer, and
  * seeding from it spares the branch above the CLI while leaving the CLI's own
  * siblings - the detached upgrade finalizer among them - to be killed.
+ *
+ * `priorVictims` (pid -> creation time) is what the kill loop remembers from
+ * its earlier rounds, and it exists because killing a parent DESTROYS the
+ * evidence linking its children to the slot. A process the host spawned after
+ * round 0's snapshot shows up in round 1 with its parent already dead: the
+ * table cannot vouch for that edge, so the row arrives with `parentProcessId`
+ * 0, and if the child is a shell or a provider binary its own path matches
+ * nothing. It would be an orphan the loop calls convergence on. A row whose
+ * CLAIMED parent is a remembered victim is therefore treated as a descendant of
+ * a verified slot process - seeded, not merely walked to.
+ *
+ * Creation time is what keeps that safe against pid reuse: a child cannot
+ * predate its own parent, so a row claiming a recycled victim id is rejected
+ * the moment it turns out to be OLDER than the victim was. An unknown creation
+ * time on either end (0) is refused rather than assumed, which is the same way
+ * the scan script treats an age it cannot read.
  */
 export function computeWindowsHostKillSet(
   table: readonly WindowsProcessTableRow[],
   cliPid: number,
+  priorVictims: ReadonlyMap<number, number>,
 ): readonly number[] {
   const children = new Map<number, number[]>();
   const parents = new Map<number, number>();
@@ -968,7 +1045,15 @@ export function computeWindowsHostKillSet(
     }
     if (row.slot) slot.add(row.processId);
   }
-  const victims = withDescendants(slot, children);
+  const seeds = new Set<number>(slot);
+  for (const row of table) {
+    if (isChildOfVictim(row, priorVictims)) seeds.add(row.processId);
+  }
+  // Seeded from LIVE rows only. A victim's own pid is deliberately never seeded:
+  // it is dead, so a row bearing it again is a different process wearing a
+  // recycled id, and killing it is the exact mistake this whole scan exists to
+  // avoid.
+  const victims = withDescendants(seeds, children);
   const spared = withDescendants(new Set([cliPid]), children);
   for (const ancestor of ancestorsOf(cliPid, parents)) {
     if (!slot.has(ancestor)) spared.add(ancestor);
@@ -976,6 +1061,58 @@ export function computeWindowsHostKillSet(
   return [...victims]
     .filter((pid) => !spared.has(pid))
     .sort((left, right) => left - right);
+}
+
+// Whether this row is a child of a process an earlier kill round destroyed.
+// Both ages have to be known and the parent's must not be later than the
+// child's: an id whose claimed parent is YOUNGER than it cannot be its parent,
+// which is what a reused pid looks like from here.
+function isChildOfVictim(
+  row: WindowsProcessTableRow,
+  priorVictims: ReadonlyMap<number, number>,
+): boolean {
+  const victimCreated = priorVictims.get(row.claimedParentProcessId);
+  if (victimCreated === undefined) return false;
+  if (victimCreated === 0 || row.created === 0) return false;
+  return victimCreated <= row.created;
+}
+
+/**
+ * The same kill set, ordered so a process is issued its `taskkill` before its
+ * ancestors are. Cheap, and it shrinks the window in which a parent is already
+ * gone while its child is not yet reaped.
+ *
+ * It does NOT replace the victim carry-over, and must not be mistaken for it:
+ * the kills are issued concurrently, so this orders their ISSUE and nothing
+ * more, and a process spawned after the snapshot is not in this list at all at
+ * any ordering. The carry-over is what actually catches that one, a round later.
+ */
+export function orderWindowsKillsDescendantsFirst(
+  pids: readonly number[],
+  table: readonly WindowsProcessTableRow[],
+): readonly number[] {
+  const parents = new Map<number, number>();
+  for (const row of table) parents.set(row.processId, row.parentProcessId);
+  const depthOf = (pid: number): number => {
+    let depth = 0;
+    const seen = new Set<number>([pid]);
+    let cursor = pid;
+    for (;;) {
+      const parent = parents.get(cursor);
+      if (parent === undefined || parent <= 0 || seen.has(parent)) return depth;
+      seen.add(parent);
+      depth += 1;
+      cursor = parent;
+    }
+  };
+  const depths = new Map<number, number>();
+  for (const pid of pids) depths.set(pid, depthOf(pid));
+  // Ties broken by pid so the order is total: a partially-ordered kill list
+  // would make the argv pins below flake on Map iteration order.
+  return [...pids].sort(
+    (left, right) =>
+      (depths.get(right) ?? 0) - (depths.get(left) ?? 0) || left - right,
+  );
 }
 
 // The seeds plus everything under them, walked over the snapshot's own parent

--- a/clients/traycer-cli/src/service/platforms/windows.ts
+++ b/clients/traycer-cli/src/service/platforms/windows.ts
@@ -382,19 +382,34 @@ async function stopService(
 // is genuinely still the host. The raw recorded pid is used only when the scan
 // itself is unavailable: a host that died without cleanup leaves pid.json
 // behind, and Windows may have recycled that pid for an unrelated process an
-// unverified `taskkill /T /F` would take down.
+// unverified kill would take down.
+//
+// NEVER `/T`. This CLI is routinely a CHILD of the host it is stopping - a
+// maintenance RPC, the reconciler, or a person's command in a Traycer-hosted
+// terminal - and `taskkill /T` walks down from the host and kills it mid-update:
+// the host is gone, the updater is gone, and nothing finishes the swap. The
+// scan computes which pids to kill (`computeWindowsHostKillSet`) and each one is
+// killed individually. No ordering is imposed: `taskkill /F` on a parent leaves
+// its children running, the VBS launcher re-runs the host only on exit 75 (the
+// refreshed-slot signal) and never after a kill, and the CLI-side supervisor is
+// already silenced by the stop intent written before any of this.
 async function killHostProcessTree(
   label: ServiceLabel,
   run: ProcessRunner,
 ): Promise<void> {
-  const scannedPids = await findSlotProcessIds(label, run);
+  const scannedPids = await findSlotProcessIds(label, run, process.pid);
   const pidMetadata =
     scannedPids === null ? await readHostPidMetadata(label.environment) : null;
+  // The no-scan fallback: kill the recorded pid, still without `/T`. We cannot
+  // enumerate that pid's tree here, and a tree we cannot enumerate is a tree we
+  // cannot prove this process is outside of. Children that keep handles inside
+  // the install dir fail the swap loudly, naming themselves through the detail
+  // scan, which is the better failure of the two.
   const fallbackPids = pidMetadata === null ? [] : [pidMetadata.pid];
   const pids = uniqueProcessIds(scannedPids ?? fallbackPids);
   await Promise.all(
     pids.map((pid) =>
-      run("taskkill", ["/T", "/F", "/PID", String(pid)], {
+      run("taskkill", ["/F", "/PID", String(pid)], {
         env: undefined,
         cwd: undefined,
         timeoutMs: WINDOWS_TASKKILL_TIMEOUT_MS,
@@ -609,6 +624,7 @@ function describeCause(cause: unknown): string {
 async function findSlotProcessIds(
   label: ServiceLabel,
   run: ProcessRunner,
+  cliPid: number,
 ): Promise<readonly number[] | null> {
   try {
     const result = await run(
@@ -617,10 +633,7 @@ async function findSlotProcessIds(
         "-NoProfile",
         "-NonInteractive",
         "-Command",
-        buildSlotProcessScanScript({
-          hostHome: hostHomeDir(label.environment),
-          currentPid: process.pid,
-        }),
+        buildSlotProcessTableScanScript(hostHomeDir(label.environment)),
       ],
       {
         env: undefined,
@@ -629,7 +642,8 @@ async function findSlotProcessIds(
         tolerateNonZeroExit: true,
       },
     );
-    return parseProcessIdJson(result.stdout);
+    const table = parseProcessTableJson(result.stdout);
+    return table === null ? null : computeWindowsHostKillSet(table, cliPid);
   } catch (cause) {
     if (isServiceMutationAuthorityError(cause)) throw cause;
     return null;
@@ -641,28 +655,63 @@ interface SlotProcessScanOptions {
   readonly currentPid: number;
 }
 
-function buildSlotProcessScanScript(options: SlotProcessScanOptions): string {
-  return buildSlotProcessScanScriptWithProjection(
-    options,
-    "@($matches | Select-Object -ExpandProperty ProcessId) | ConvertTo-Json -Compress",
-  );
+// Sets `$hostMatch` for the pipeline row in `$_`. Shared verbatim by both
+// scans, so a change to what counts as a slot process cannot land in one and
+// miss the other.
+const SLOT_MATCH_SCRIPT_LINES: readonly string[] = [
+  "    $exe = ([string]$_.ExecutablePath).ToLowerInvariant().Replace('/', '\\')",
+  "    $cmd = ([string]$_.CommandLine).ToLowerInvariant().Replace('/', '\\')",
+  '    $text = $exe + "`n" + $cmd',
+  "    $hostMatch = $false",
+  "    foreach ($path in $hostPaths) {",
+  "      if ($text.Contains($path)) { $hostMatch = $true; break }",
+  "    }",
+];
+
+/**
+ * ONE pass over the UNFILTERED process table, projected to what the kill set is
+ * computed from: the pid, its parent, and whether the row matches this slot.
+ *
+ * Unfiltered is the point. The old scan excluded this process before the
+ * projection ran and returned bare pids, so it could not answer the only
+ * question that matters here - which of the slot's processes are ABOVE this CLI
+ * rather than beside it. Parent ids and slot matches now come from the same
+ * snapshot, which is what bounds pid reuse between the two reads.
+ *
+ * The script knows nothing about who we are: no `$excluded`, and emphatically
+ * no `$PID` - PowerShell is this CLI's own child, so its `$PID` is not the CLI
+ * and using it as "self" spares the wrong branch of the tree. Self-identity is
+ * `computeWindowsHostKillSet`'s input, applied to the table in-process.
+ *
+ * Command lines are matched inside the script and never leave it: they can name
+ * arbitrary user data, and the caller needs three fields per row, not a copy of
+ * the machine's process table.
+ */
+function buildSlotProcessTableScanScript(hostHome: string): string {
+  const hostPaths = powershellStringArray(slotHostProcessPaths(hostHome));
+  return [
+    "$ErrorActionPreference = 'SilentlyContinue'",
+    `$hostPaths = @(${hostPaths})`,
+    "$rows = Get-CimInstance Win32_Process | ForEach-Object {",
+    ...SLOT_MATCH_SCRIPT_LINES,
+    "    [pscustomobject]@{",
+    "      ProcessId = [int]$_.ProcessId",
+    "      ParentProcessId = [int]$_.ParentProcessId",
+    "      Slot = $hostMatch",
+    "    }",
+    "}",
+    "@($rows) | ConvertTo-Json -Compress",
+  ].join("\n");
 }
 
-// Same filter as the pid scan, projecting name + executable path as well so
-// the install swap's EBUSY error can NAME the processes still matching the
-// slot instead of surfacing a bare errno.
+// Same slot match as the table scan (`SLOT_MATCH_SCRIPT_LINES` is the shared
+// text - the filter must never drift between the kill and the diagnostic),
+// projecting name + executable path so the install swap's EBUSY error can NAME
+// the processes still matching the slot instead of surfacing a bare errno.
+// Unlike the table scan this one is a diagnostic, so it keeps its pre-filter:
+// naming ourselves as a lock holder would be noise, not evidence.
 function buildSlotProcessDetailScanScript(
   options: SlotProcessScanOptions,
-): string {
-  return buildSlotProcessScanScriptWithProjection(
-    options,
-    "@($matches | Select-Object ProcessId, Name, ExecutablePath) | ConvertTo-Json -Compress",
-  );
-}
-
-function buildSlotProcessScanScriptWithProjection(
-  options: SlotProcessScanOptions,
-  projection: string,
 ): string {
   const hostPaths = powershellStringArray(
     slotHostProcessPaths(options.hostHome),
@@ -676,17 +725,11 @@ function buildSlotProcessScanScriptWithProjection(
     "  if ($excluded -contains $pidValue) {",
     "    $false",
     "  } else {",
-    "    $exe = ([string]$_.ExecutablePath).ToLowerInvariant().Replace('/', '\\')",
-    "    $cmd = ([string]$_.CommandLine).ToLowerInvariant().Replace('/', '\\')",
-    '    $text = $exe + "`n" + $cmd',
-    "    $hostMatch = $false",
-    "    foreach ($path in $hostPaths) {",
-    "      if ($text.Contains($path)) { $hostMatch = $true; break }",
-    "    }",
+    ...SLOT_MATCH_SCRIPT_LINES,
     "    $hostMatch",
     "  }",
     "}",
-    projection,
+    "@($matches | Select-Object ProcessId, Name, ExecutablePath) | ConvertTo-Json -Compress",
   ].join("\n");
 }
 
@@ -715,18 +758,156 @@ function powershellStringArray(values: readonly string[]): string {
   return values.map((value) => `'${value.replace(/'/g, "''")}'`).join(", ");
 }
 
-function parseProcessIdJson(stdout: string): readonly number[] {
+// One row of the scanned process table.
+export interface WindowsProcessTableRow {
+  readonly processId: number;
+  // 0 for the rows whose parent is the system idle process, and for rows whose
+  // parent has already exited; both are ordinary and neither is an ancestor
+  // anything here can be spared through.
+  readonly parentProcessId: number;
+  // Whether the row's executable path or command line matches this slot.
+  readonly slot: boolean;
+}
+
+/**
+ * Parse the table scan's output, or `null` if ANY row is not the shape this
+ * module asked for.
+ *
+ * All-or-nothing on purpose. A partially-parsed table produces a kill set built
+ * from a partial ancestry, and a missing edge there does not read as an error -
+ * it reads as "this process has no parent", which spares nothing and kills a
+ * branch that should have been spared. `null` sends the caller to the pid.json
+ * fallback, which is weaker but honest about what it knows. Empty output is
+ * `null` for the same reason: a real Win32_Process scan is never empty, so
+ * nothing on stdout means the scan did not run.
+ */
+function parseProcessTableJson(
+  stdout: string,
+): readonly WindowsProcessTableRow[] | null {
   const trimmed = stdout.trim();
-  if (trimmed.length === 0) return [];
+  if (trimmed.length === 0) return null;
   let parsed: unknown;
   try {
     parsed = JSON.parse(trimmed);
-  } catch (cause) {
-    if (isServiceMutationAuthorityError(cause)) throw cause;
-    return [];
+  } catch {
+    return null;
   }
+  // `ConvertTo-Json` on a pipeline still emits a bare object for a single row
+  // on Windows PowerShell 5.1 - accept both shapes, like the detail parser.
   const values = Array.isArray(parsed) ? parsed : [parsed];
-  return values.filter(isKillableProcessId);
+  const rows: WindowsProcessTableRow[] = [];
+  for (const value of values) {
+    if (value === null || typeof value !== "object") return null;
+    const record = value as Record<string, unknown>;
+    const processId = record.ProcessId;
+    const parentProcessId = record.ParentProcessId;
+    const slot = record.Slot;
+    // Deliberately NOT `isKillableProcessId`: that one also rejects our own
+    // pid, and the table is unfiltered, so our row is expected in it. Whether
+    // we are killable is the algebra's answer, not the parser's.
+    if (
+      !isProcessTablePid(processId) ||
+      !isProcessTableParentId(parentProcessId) ||
+      typeof slot !== "boolean"
+    ) {
+      return null;
+    }
+    rows.push({ processId, parentProcessId, slot });
+  }
+  return rows;
+}
+
+/**
+ * Which pids a host stop may kill, given the whole process table and the pid of
+ * the CLI issuing the stop.
+ *
+ *   victims = slot ∪ descendants(slot)
+ *   spared  = cli ∪ descendants(cli) ∪ (ancestors(cli) − slot)
+ *   kill    = victims − spared
+ *
+ * The host is slot-matched AND an ancestor of a host-spawned CLI, so subtracting
+ * the slot from the spared ancestors is what keeps it in the kill set: "exclude
+ * the updater's ancestry" would spare the very process this stop exists to
+ * terminate. What the ancestor clause actually protects is a Traycer-hosted
+ * TERMINAL run, where the shell and its conpty sit between the host and this
+ * CLI and match nothing.
+ *
+ * `cliPid` is the CLI's own pid. Not PowerShell's: the scan runs as this
+ * process's child, so `$PID` inside it is a descendant of the answer, and
+ * seeding from it spares the branch above the CLI while leaving the CLI's own
+ * siblings - the detached upgrade finalizer among them - to be killed.
+ */
+export function computeWindowsHostKillSet(
+  table: readonly WindowsProcessTableRow[],
+  cliPid: number,
+): readonly number[] {
+  const children = new Map<number, number[]>();
+  const parents = new Map<number, number>();
+  const slot = new Set<number>();
+  for (const row of table) {
+    parents.set(row.processId, row.parentProcessId);
+    const siblings = children.get(row.parentProcessId);
+    if (siblings === undefined) {
+      children.set(row.parentProcessId, [row.processId]);
+    } else {
+      siblings.push(row.processId);
+    }
+    if (row.slot) slot.add(row.processId);
+  }
+  const victims = withDescendants(slot, children);
+  const spared = withDescendants(new Set([cliPid]), children);
+  for (const ancestor of ancestorsOf(cliPid, parents)) {
+    if (!slot.has(ancestor)) spared.add(ancestor);
+  }
+  return [...victims]
+    .filter((pid) => !spared.has(pid))
+    .sort((left, right) => left - right);
+}
+
+// The seeds plus everything under them, walked over the snapshot's own parent
+// edges. Traversal order is immaterial to a closure; `seen` is what matters,
+// doubling as the cycle guard a torn table would otherwise turn into a hang.
+function withDescendants(
+  seeds: ReadonlySet<number>,
+  children: ReadonlyMap<number, readonly number[]>,
+): Set<number> {
+  const seen = new Set<number>(seeds);
+  const pending: number[] = [...seeds];
+  for (;;) {
+    const current = pending.pop();
+    if (current === undefined) return seen;
+    for (const child of children.get(current) ?? []) {
+      if (seen.has(child)) continue;
+      seen.add(child);
+      pending.push(child);
+    }
+  }
+}
+
+// The chain above `pid`, nearest first. Stops at pid 0 (the idle process, and
+// what an exited parent reports) and at any pid already on the chain.
+function ancestorsOf(
+  pid: number,
+  parents: ReadonlyMap<number, number>,
+): readonly number[] {
+  const chain: number[] = [];
+  const seen = new Set<number>([pid]);
+  let cursor = pid;
+  for (;;) {
+    const parent = parents.get(cursor);
+    if (parent === undefined || parent <= 0 || seen.has(parent)) return chain;
+    seen.add(parent);
+    chain.push(parent);
+    cursor = parent;
+  }
+}
+
+function isProcessTablePid(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value > 0;
+}
+
+function isProcessTableParentId(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0;
 }
 
 function uniqueProcessIds(values: readonly number[]): readonly number[] {
@@ -755,7 +936,7 @@ function parseProcessDetailJson(
   }
   // `ConvertTo-Json` on `@(...)` still emits a bare object for a single
   // match on Windows PowerShell 5.1 - accept both shapes, like
-  // `parseProcessIdJson` above.
+  // `parseProcessTableJson` above.
   const values = Array.isArray(parsed) ? parsed : [parsed];
   const holders: WindowsSlotLockHolder[] = [];
   for (const value of values) {
@@ -1139,8 +1320,8 @@ function resolveTaskUserId(): string {
 export {
   buildTaskXml as buildScheduledTaskXml,
   buildHiddenHostLauncher as buildWindowsHiddenHostLauncher,
-  buildSlotProcessScanScript as buildWindowsSlotProcessScanScript,
+  buildSlotProcessTableScanScript as buildWindowsSlotProcessTableScanScript,
   buildSlotProcessDetailScanScript as buildWindowsSlotProcessDetailScanScript,
-  parseProcessIdJson as parseWindowsProcessIdJson,
+  parseProcessTableJson as parseWindowsProcessTableJson,
   parseProcessDetailJson as parseWindowsProcessDetailJson,
 };

--- a/clients/traycer-cli/src/service/platforms/windows.ts
+++ b/clients/traycer-cli/src/service/platforms/windows.ts
@@ -1284,7 +1284,11 @@ export function computeWindowsHostKillSet(
   // avoid.
   const victims = withDescendants(seeds, children);
   const suspects = withDescendants(undecided, children);
-  const spared = withDescendants(new Set([cliPid]), children);
+  // The CLI's own branch: itself and everything under it over validated edges.
+  // Positively identified, and never the host's - it is this process's scan
+  // and kill subprocesses.
+  const cliBranch = withDescendants(new Set([cliPid]), children);
+  const spared = new Set(cliBranch);
   // The CLI's non-slot ancestors are spared from the kill, and the ones the
   // scan has placed in the host's tree are ALSO reported as lineage to
   // remember. A shell the host spawned to run the CLI is a host descendant
@@ -1316,15 +1320,26 @@ export function computeWindowsHostKillSet(
   // and a spared row can sit in both closures at once; if it is not going to
   // be remembered with a window it has to stay undecided, or it is remembered
   // as nothing at all.
+  //
+  // The CLI's own branch is out of `undecided` altogether, and that is a
+  // different statement from the sparing above. The branch is positively
+  // identified - validated edges from this very process - and it is never the
+  // host's, but its scan subprocess is slot-MATCHED (its command line names the
+  // slot paths), so whenever the CLI itself is undecided (it claims a killed
+  // host of unreadable age, say) the scan lands in the suspect closure. Kept
+  // there it would be remembered as a HOST suspect, and a stranger that reuses
+  // the scan's pid after it exits would have its child refuse a later round.
+  // Only the uncertain non-slot ANCESTORS of the CLI stay undecided: sparing
+  // them answers nothing about their other children.
   const remembered = new Set([...kill, ...protectedAncestors]);
   const undecidedClosure = [...suspects]
-    .filter((pid) => !remembered.has(pid))
+    .filter((pid) => !remembered.has(pid) && !cliBranch.has(pid))
     .sort((left, right) => left - right);
   return {
     kill,
     protectedAncestors,
     undecided: undecidedClosure,
-    // The CLI's own branch is spared from the REPORT. A protected row that
+    // The uncertain ancestors are spared from the REPORT. A protected row that
     // happens to claim a victim pid is not an open question about the host - it
     // is a process we have already decided never to kill - and reporting it
     // would fail every stop issued from a Traycer-hosted terminal. It stays in

--- a/clients/traycer-cli/src/service/platforms/windows.ts
+++ b/clients/traycer-cli/src/service/platforms/windows.ts
@@ -1267,8 +1267,14 @@ function parseProcessTableJson(
  * from `kill` (killing on a claim we cannot verify is the mistake this scan
  * exists to prevent), and the loop must not read their absence from `kill` as
  * convergence, because a host child spawned just before its parent died looks
- * exactly like this. `unattributed` is the same list minus the CLI's own
- * protected branch - what the loop reports, as opposed to what it remembers.
+ * exactly like this.
+ *
+ * Precisely: `undecided` is that closure minus everything the loop is about to
+ * remember with a window (`kill` and `protectedAncestors`) and minus the CLI's
+ * own descendant branch, which is positively identified and never the host's
+ * even when its slot-matched scan lands in the closure under an undecided CLI.
+ * `unattributed` is `undecided` minus the CLI's uncertain ancestors as well -
+ * what the loop reports, as opposed to what it remembers.
  */
 export function computeWindowsHostKillSet(
   table: readonly WindowsProcessTableRow[],
@@ -1399,15 +1405,17 @@ export function computeWindowsHostKillSet(
  * `undecided` is the rows that claim a remembered process as their parent but
  * cannot be tied to it - born after the victim was last seen alive, or carrying
  * an unreadable creation time - plus everything that hangs off those rows,
- * minus what is being remembered with a window. They are neither killed (they
- * may be strangers) nor ignored (they may be the host's children).
+ * minus what is being remembered with a window (`kill` and
+ * `protectedAncestors`) and minus the CLI's own descendant branch, which is
+ * never the host's. They are neither killed (they may be strangers) nor ignored
+ * (they may be the host's children).
  *
  * `unattributed` is the subset of `undecided` the loop REPORTS - it refuses to
- * claim a stop rather than pick silently - and it leaves out the CLI's own
- * protected branch, which is never killed and never a reason to refuse. The
- * loop's suspect memory is fed from `undecided`, not from the report: a
- * protected root's uncertainty is inherited by its children whether or not the
- * root itself is ever named, and it has to outlive the root.
+ * claim a stop rather than pick silently - and it additionally leaves out the
+ * CLI's uncertain ancestors, which are never killed and never a reason to
+ * refuse. The loop's suspect memory is fed from `undecided`, not from the
+ * report: a protected root's uncertainty is inherited by its children whether
+ * or not the root itself is ever named, and it has to outlive the root.
  */
 export interface WindowsHostKillSet {
   readonly kill: readonly number[];

--- a/clients/traycer-cli/src/service/platforms/windows.ts
+++ b/clients/traycer-cli/src/service/platforms/windows.ts
@@ -428,7 +428,6 @@ async function killHostProcessTree(
   for (let round = 0; round <= WINDOWS_KILL_CONVERGENCE_ROUNDS; round += 1) {
     const scannedPids = await findSlotProcessIds(label, run, process.pid);
     if (scannedPids === null) {
-      return;
       // Before the first kill this refuses to start; after one it refuses to
       // claim the tree came down. Both are the same statement - we cannot see
       // the slot, so we cannot say what is in it - and neither may be softened

--- a/clients/traycer-cli/src/service/platforms/windows.ts
+++ b/clients/traycer-cli/src/service/platforms/windows.ts
@@ -380,10 +380,17 @@ async function stopService(
 // (worse) its CWD stays open inside the install dir, so the next install-swap
 // rename fails with EBUSY. Kill the processes a slot-scoped scan verifies by
 // exe path/command line - that covers the recorded pid.json host too, when it
-// is genuinely still the host. The raw recorded pid is used only when the scan
-// itself is unavailable: a host that died without cleanup leaves pid.json
-// behind, and Windows may have recycled that pid for an unrelated process an
-// unverified kill would take down.
+// is genuinely still the host.
+//
+// There is no unverified fallback. An unreadable scan used to degrade to
+// `taskkill` on the pid.json pid, which is both weaker than it looks (Windows
+// may have recycled that pid for an unrelated process) and, worse, silent: the
+// caller went on to delete the pid metadata and report the host stopped while
+// descendants the fallback never enumerated kept running and kept the install
+// dir open. Every exit below therefore either PROVES the slot is empty with a
+// scan or throws. Refusing before anything is killed is the safer half of that
+// trade: a stop that cannot be verified leaves the tree whole for the next
+// attempt instead of half torn down.
 //
 // NEVER `/T`. This CLI is routinely a CHILD of the host it is stopping - a
 // maintenance RPC, the reconciler, or a person's command in a Traycer-hosted
@@ -400,42 +407,68 @@ async function stopService(
 // `Get-CimInstance` materializes the table is in no round's kill set; killing
 // its parent orphans it, and the caller goes on to delete the pid metadata
 // while it still holds the install dir open. So this rescans and kills again
-// until a round comes back empty. Each round kills exactly what THAT round's
+// until a scan comes back empty. Each round kills exactly what THAT round's
 // scan returned - the scan verifies by exe path/command line, so a pid Windows
 // recycled between rounds is simply not in it.
+//
+// `WINDOWS_KILL_CONVERGENCE_ROUNDS` counts KILL passes, so the loop scans one
+// more time than it kills: the last scan is always a confirming one, and an
+// empty scan is the ONLY way out that reports success.
+//
+// Known and deliberately not mechanised: `taskkill /F` is `TerminateProcess`,
+// which is asynchronous - the confirming scan can briefly still list a pid the
+// previous round killed. The bound absorbs one such round (that pid is gone by
+// the next scan and the loop converges normally). If the live Windows run shows
+// this flaking, the lever is a short settle before the re-scan, NOT a wider
+// bound: more rounds would only spend more time re-killing the same pids.
 async function killHostProcessTree(
   label: ServiceLabel,
   run: ProcessRunner,
 ): Promise<void> {
-  for (let round = 1; round <= WINDOWS_KILL_CONVERGENCE_ROUNDS; round += 1) {
+  for (let round = 0; round <= WINDOWS_KILL_CONVERGENCE_ROUNDS; round += 1) {
     const scannedPids = await findSlotProcessIds(label, run, process.pid);
     if (scannedPids === null) {
-      // A LATER round without a scan is not the round-1 fallback below: the
-      // earlier rounds already killed the recorded pid, so pid.json is not a
-      // second opinion - it is a stale one, pointing at a pid Windows is now
-      // free to have recycled. And a round we cannot enumerate is a round we
-      // cannot call converged, so say nothing rather than claim it.
-      if (round > 1) return;
-      const pidMetadata = await readHostPidMetadata(label.environment);
-      // The no-scan fallback: kill the recorded pid, still without `/T`, and
-      // stop there - rescanning cannot help when the scan is the thing that is
-      // unavailable. We cannot enumerate that pid's tree here, and a tree we
-      // cannot enumerate is a tree we cannot prove this process is outside of.
-      // Children that keep handles inside the install dir fail the swap
-      // loudly, naming themselves through the detail scan, which is the better
-      // failure of the two.
-      const fallbackPids = pidMetadata === null ? [] : [pidMetadata.pid];
-      await killProcessIds(uniqueProcessIds(fallbackPids), run);
       return;
+      // Before the first kill this refuses to start; after one it refuses to
+      // claim the tree came down. Both are the same statement - we cannot see
+      // the slot, so we cannot say what is in it - and neither may be softened
+      // into a success the caller would act on by purging pid.json.
+      throw cliError({
+        code: CLI_ERROR_CODES.SERVICE_CONTROL_FAILED,
+        message:
+          `could not enumerate the ${label.id} host process tree: the PowerShell process scan failed or timed out. ` +
+          "Refusing to report the host stopped. Retry, or end the Traycer host processes from Task Manager.",
+        details: { label: label.id, killRoundsCompleted: round },
+        exitCode: 1,
+      });
     }
     // The kill boundary, and the only place a pid has to be POSITIVE: the scan
     // and its algebra work over an unfiltered table that includes pid 0, and
     // `isKillableProcessId` is what keeps 0 - and our own pid - out of an argv.
     const pids = uniqueProcessIds(scannedPids);
-    // Converged: a scan taken after the previous round's kills found nothing
-    // left in this slot. (Round 1 reaches here whenever there was never
-    // anything to kill, which is the ordinary stop of an already-dead host.)
+    // Converged, and the only success: a scan taken AFTER the previous round's
+    // kills found nothing left in this slot. Round 0 reaches here whenever
+    // there was never anything to kill, which is the ordinary stop of a host
+    // that already exited - one scan, no kills.
     if (pids.length === 0) return;
+    // Out of kill passes with the slot still occupied. Falling through here
+    // would report exactly what a converged scan reports, which is the one
+    // thing this function must never do: name the survivors instead, so the
+    // caller's error says which processes to deal with.
+    if (round === WINDOWS_KILL_CONVERGENCE_ROUNDS) {
+      throw cliError({
+        code: CLI_ERROR_CODES.SERVICE_CONTROL_FAILED,
+        message:
+          `${label.id} host processes are still running after ${WINDOWS_KILL_CONVERGENCE_ROUNDS} kill rounds (pids ${pids.join(", ")}). ` +
+          "Retry, or end them from Task Manager.",
+        details: {
+          label: label.id,
+          survivingPids: pids,
+          killRounds: WINDOWS_KILL_CONVERGENCE_ROUNDS,
+        },
+        exitCode: 1,
+      });
+    }
     await killProcessIds(pids, run);
   }
 }
@@ -1042,6 +1075,12 @@ function readNonEmptyString(value: unknown): string | null {
 // swap; anything the rename now trips over either outlived it (an orphan
 // re-matching the scan) or spawned since, and both answer to another pass.
 // Pass `null` to use the real process runner.
+//
+// This one is allowed to fail: `swapLockRetryHook` logs a refusal and lets the
+// rename retry anyway (only a lost mutation authority propagates), so a stop
+// that cannot be verified HERE degrades to the swap's own EBUSY reporting -
+// which names the lock holders - rather than aborting a swap that may yet
+// succeed.
 export async function killLingeringSlotProcesses(
   label: ServiceLabel,
   runner: ProcessRunner | null,

--- a/clients/traycer-cli/src/service/platforms/windows.ts
+++ b/clients/traycer-cli/src/service/platforms/windows.ts
@@ -1272,19 +1272,28 @@ export function computeWindowsHostKillSet(
   for (const ancestor of ancestorsOf(cliPid, parents)) {
     if (!slot.has(ancestor)) spared.add(ancestor);
   }
-  // Rows already in `kill` drop out of both undecided lists: a subtree can hang
-  // off an undecided root and still be slot-matched in its own right, and a pid
-  // this scan has decided to kill is not an open question - it is remembered as
-  // a victim, with a window, which is the stronger fact. Reporting it in both
+  const kill = [...victims]
+    .filter((pid) => !spared.has(pid))
+    .sort((left, right) => left - right);
+  const killed = new Set(kill);
+  // Rows in `kill` drop out of both undecided lists: a subtree can hang off an
+  // undecided root and still be slot-matched in its own right, and a pid this
+  // scan has decided to kill is not an open question - it is remembered as a
+  // victim, with a window, which is the stronger fact. Reporting it in both
   // lists would put the same pid in front of the user twice, in two
   // contradictory roles.
+  //
+  // What is subtracted is the ACTUAL kill set, not the victim closure it was
+  // cut from. The two differ by the spared branch, and a spared row can sit in
+  // both closures at once - a shell that is the killed host's validated child
+  // AND the CLI's ancestor. It is never killed, so it is never remembered as a
+  // victim; subtracting the closure would drop it from `undecided` too, and it
+  // would be remembered as nothing at all.
   const undecidedClosure = [...suspects]
-    .filter((pid) => !victims.has(pid))
+    .filter((pid) => !killed.has(pid))
     .sort((left, right) => left - right);
   return {
-    kill: [...victims]
-      .filter((pid) => !spared.has(pid))
-      .sort((left, right) => left - right),
+    kill,
     undecided: undecidedClosure,
     // The CLI's own branch is spared from the REPORT. A protected row that
     // happens to claim a victim pid is not an open question about the host - it

--- a/clients/traycer-cli/src/service/platforms/windows.ts
+++ b/clients/traycer-cli/src/service/platforms/windows.ts
@@ -1342,21 +1342,28 @@ export interface WindowsHostKillSet {
 type CarryOverClaim = "seed" | "unattributed" | "none";
 
 // Whether this row was created BY a process an earlier round killed, or by one
-// it could not place - or IS one it could not place.
+// it could not place.
 //
-// A process this loop already failed to place stays undecided for as long as
-// that same incarnation (pid AND creation time) is alive, whatever its edge says
-// now. That check comes before the gate on purpose: the row's edge can change
-// under it between rounds - its parent exits and the claimed pid is reused by
-// something the scan validates - and a verdict that could be cleared by a
-// stranger taking a pid is not a verdict.
+// The gate is the row's own validated edge, and it comes first because a
+// validated edge is real lineage. The scan validates an edge only when the
+// claimed parent is live and NOT younger than the row; a pid reused after its
+// holder died always goes to a process younger than any child of the old
+// holder, so a stranger wearing the parent's pid can never validate. What CAN
+// change between rounds is the scan's ability to read an age: a live parent
+// whose creation time was unreadable in one round zeroes its child's edge (and
+// the child, claiming a remembered pid, is reported undecided), and a later
+// round that reads the age validates the same edge. That later reading is new
+// evidence and outranks the earlier suspicion, which is why nothing here keeps a
+// row undecided by its own identity once its edge validates. Uncertainty about
+// a child whose LIVE parent is itself undecided is preserved by the descendant
+// closure in `computeWindowsHostKillSet`, not here.
 //
-// The gate is the row's own validated edge, and it is NOT redundant with the
-// rules below. The case it decides is a live, validated parent wearing a pid
-// this loop killed earlier: an unrelated process that took the pid after the
-// victim died and then forked. Its child is born after the victim's window and
-// would read as undecided on the window alone; the scan has already tied it to
-// a living parent, which is the better fact, so it is not a carry-over question.
+// The gate is NOT redundant with the rules below. The case it decides is a
+// live, validated parent wearing a pid this loop killed earlier: an unrelated
+// process that took the pid after the victim died and then forked. Its child is
+// born after the victim's window and would read as undecided on the window
+// alone; the scan has already tied it to a living parent, which is the better
+// fact, so it is not a carry-over question.
 //
 // Every remembered incarnation of the claimed pid is consulted, and the
 // STRONGEST verdict wins. A pid can have been a suspect in one round and a
@@ -1370,7 +1377,6 @@ function classifyCarryOverClaim(
   row: WindowsProcessTableRow,
   memory: WindowsKillMemory,
 ): CarryOverClaim {
-  if (isRememberedSuspect(row, memory)) return "unattributed";
   if (row.parentProcessId !== 0) return "none";
   let claim: CarryOverClaim = "none";
   for (const victim of memory.victims.get(row.claimedParentProcessId) ?? []) {
@@ -1385,20 +1391,6 @@ function classifyCarryOverClaim(
     );
   }
   return claim;
-}
-
-// The same process (pid and creation time) an earlier round reported as
-// undecided. Identity by creation time, not pid alone: a different process
-// wearing a suspect's pid is a different question, decided by its own edge and
-// claim. An unreadable age (0) on a remembered suspect matches a row of
-// unreadable age, which is the undecided answer either way.
-function isRememberedSuspect(
-  row: WindowsProcessTableRow,
-  memory: WindowsKillMemory,
-): boolean {
-  const incarnations = memory.suspects.get(row.processId);
-  if (incarnations === undefined) return false;
-  return incarnations.includes(row.created);
 }
 
 const CLAIM_STRENGTH: Readonly<Record<CarryOverClaim, number>> = {

--- a/clients/traycer-cli/src/service/platforms/windows.ts
+++ b/clients/traycer-cli/src/service/platforms/windows.ts
@@ -72,6 +72,14 @@ export function epochMicrosNow(): number {
 
 /** Seams the kill loop needs from the outside world. */
 export interface WindowsControllerDeps {
+  /**
+   * The current time in MICROSECONDS since the Unix epoch - the unit
+   * `WindowsProcessTableRow.created` is projected in, because the kill loop
+   * compares the two directly to bound each victim's lifetime. Production
+   * passes `epochMicrosNow`. A caller that passed `Date.now()` (milliseconds)
+   * would place every bound a thousand times too early and classify every
+   * carry-over row as unattributed, failing every stop that needed one.
+   */
   readonly now: () => number;
 }
 

--- a/clients/traycer-cli/src/service/platforms/windows.ts
+++ b/clients/traycer-cli/src/service/platforms/windows.ts
@@ -23,6 +23,7 @@ import {
   type SpawnEvidenceReader,
 } from "../../host/spawn-evidence";
 import {
+  WINDOWS_KILL_CONVERGENCE_ROUNDS,
   WINDOWS_PROCESS_SCAN_TIMEOUT_MS,
   WINDOWS_SCHTASKS_END_TIMEOUT_MS,
   WINDOWS_SCHTASKS_QUERY_TIMEOUT_MS,
@@ -393,23 +394,56 @@ async function stopService(
 // its children running, the VBS launcher re-runs the host only on exit 75 (the
 // refreshed-slot signal) and never after a kill, and the CLI-side supervisor is
 // already silenced by the stop intent written before any of this.
+//
+// Not `/T` also means nothing sweeps up what is spawned DURING the kill. The
+// scan is a snapshot, so a child the host or one of its agents starts after
+// `Get-CimInstance` materializes the table is in no round's kill set; killing
+// its parent orphans it, and the caller goes on to delete the pid metadata
+// while it still holds the install dir open. So this rescans and kills again
+// until a round comes back empty. Each round kills exactly what THAT round's
+// scan returned - the scan verifies by exe path/command line, so a pid Windows
+// recycled between rounds is simply not in it.
 async function killHostProcessTree(
   label: ServiceLabel,
   run: ProcessRunner,
 ): Promise<void> {
-  const scannedPids = await findSlotProcessIds(label, run, process.pid);
-  const pidMetadata =
-    scannedPids === null ? await readHostPidMetadata(label.environment) : null;
-  // The no-scan fallback: kill the recorded pid, still without `/T`. We cannot
-  // enumerate that pid's tree here, and a tree we cannot enumerate is a tree we
-  // cannot prove this process is outside of. Children that keep handles inside
-  // the install dir fail the swap loudly, naming themselves through the detail
-  // scan, which is the better failure of the two.
-  const fallbackPids = pidMetadata === null ? [] : [pidMetadata.pid];
-  // The kill boundary, and the only place a pid has to be POSITIVE: the scan
-  // and its algebra work over an unfiltered table that includes pid 0, and
-  // `isKillableProcessId` is what keeps 0 - and our own pid - out of an argv.
-  const pids = uniqueProcessIds(scannedPids ?? fallbackPids);
+  for (let round = 1; round <= WINDOWS_KILL_CONVERGENCE_ROUNDS; round += 1) {
+    const scannedPids = await findSlotProcessIds(label, run, process.pid);
+    if (scannedPids === null) {
+      // A LATER round without a scan is not the round-1 fallback below: the
+      // earlier rounds already killed the recorded pid, so pid.json is not a
+      // second opinion - it is a stale one, pointing at a pid Windows is now
+      // free to have recycled. And a round we cannot enumerate is a round we
+      // cannot call converged, so say nothing rather than claim it.
+      if (round > 1) return;
+      const pidMetadata = await readHostPidMetadata(label.environment);
+      // The no-scan fallback: kill the recorded pid, still without `/T`, and
+      // stop there - rescanning cannot help when the scan is the thing that is
+      // unavailable. We cannot enumerate that pid's tree here, and a tree we
+      // cannot enumerate is a tree we cannot prove this process is outside of.
+      // Children that keep handles inside the install dir fail the swap
+      // loudly, naming themselves through the detail scan, which is the better
+      // failure of the two.
+      const fallbackPids = pidMetadata === null ? [] : [pidMetadata.pid];
+      await killProcessIds(uniqueProcessIds(fallbackPids), run);
+      return;
+    }
+    // The kill boundary, and the only place a pid has to be POSITIVE: the scan
+    // and its algebra work over an unfiltered table that includes pid 0, and
+    // `isKillableProcessId` is what keeps 0 - and our own pid - out of an argv.
+    const pids = uniqueProcessIds(scannedPids);
+    // Converged: a scan taken after the previous round's kills found nothing
+    // left in this slot. (Round 1 reaches here whenever there was never
+    // anything to kill, which is the ordinary stop of an already-dead host.)
+    if (pids.length === 0) return;
+    await killProcessIds(pids, run);
+  }
+}
+
+async function killProcessIds(
+  pids: readonly number[],
+  run: ProcessRunner,
+): Promise<void> {
   await Promise.all(
     pids.map((pid) =>
       run("taskkill", ["/F", "/PID", String(pid)], {

--- a/clients/traycer-cli/src/service/platforms/windows.ts
+++ b/clients/traycer-cli/src/service/platforms/windows.ts
@@ -526,6 +526,7 @@ async function killHostProcessTree(
     const killSet = computeWindowsHostKillSet(table, process.pid, memory);
     const pids = uniqueProcessIds(killSet.kill);
     const unattributed = uniqueProcessIds(killSet.unattributed);
+    const undecided = uniqueProcessIds(killSet.undecided);
     if (pids.length === 0) {
       // Nothing left to kill - but that is only convergence if nothing is
       // UNDECIDED. A row claiming a killed host process as its parent, born
@@ -613,12 +614,21 @@ async function killHostProcessTree(
         seenAliveAt,
       });
     }
-    // Recorded from the same snapshot, and only ever added to: a pid this round
-    // could not place stays undecided for the rest of the loop even if the next
-    // scan does not list it at all, which is precisely the case the memory
-    // exists for. A later round that reaches the same pid again adds the
-    // incarnation that round saw beside the earlier one.
-    for (const pid of unattributed) {
+    // Recorded from the same snapshot, and only ever added to. What is kept is
+    // evidence about CLAIMS: a later row that names this pid as its parent, born
+    // after the incarnation seen here, is undecided - even if the next scan does
+    // not list the pid at all, which is precisely the case the memory exists
+    // for. It is not a verdict on the pid's own row: a row this round could not
+    // place is re-classified from scratch next round, and a live parent whose
+    // edge validates then clears it (`classifyCarryOverClaim`). A later round
+    // that reaches the same pid again adds the incarnation it saw beside the
+    // earlier one.
+    //
+    // From the FULL undecided closure, not from the reported subset. The CLI's
+    // own branch is withheld from the report and the kill, but the shell above
+    // the CLI is under no obligation to still be there next round, and its
+    // other children then claim a pid that only this entry remembers.
+    for (const pid of undecided) {
       rememberIncarnation(priorSuspects, pid, created.get(pid) ?? 0);
     }
   }
@@ -1215,7 +1225,7 @@ function parseProcessTableJson(
  * would mean deciding its parent, which is the thing this loop already said it
  * could not do.
  *
- * `unattributed` carries those undecidable rows out to the caller, TOGETHER WITH
+ * `undecided` carries those undecidable rows out to the caller, TOGETHER WITH
  * EVERYTHING BELOW THEM, walked over the same validated edges as the kill set.
  * An undecided root makes its whole subtree undecided - those children are
  * verified children of a process we cannot place, so they are exactly as
@@ -1224,7 +1234,8 @@ function parseProcessTableJson(
  * from `kill` (killing on a claim we cannot verify is the mistake this scan
  * exists to prevent), and the loop must not read their absence from `kill` as
  * convergence, because a host child spawned just before its parent died looks
- * exactly like this.
+ * exactly like this. `unattributed` is the same list minus the CLI's own
+ * protected branch - what the loop reports, as opposed to what it remembers.
  */
 export function computeWindowsHostKillSet(
   table: readonly WindowsProcessTableRow[],
@@ -1261,22 +1272,29 @@ export function computeWindowsHostKillSet(
   for (const ancestor of ancestorsOf(cliPid, parents)) {
     if (!slot.has(ancestor)) spared.add(ancestor);
   }
+  // Rows already in `kill` drop out of both undecided lists: a subtree can hang
+  // off an undecided root and still be slot-matched in its own right, and a pid
+  // this scan has decided to kill is not an open question - it is remembered as
+  // a victim, with a window, which is the stronger fact. Reporting it in both
+  // lists would put the same pid in front of the user twice, in two
+  // contradictory roles.
+  const undecidedClosure = [...suspects]
+    .filter((pid) => !victims.has(pid))
+    .sort((left, right) => left - right);
   return {
     kill: [...victims]
       .filter((pid) => !spared.has(pid))
       .sort((left, right) => left - right),
-    // The CLI's own branch is spared from this too. A protected row that
+    undecided: undecidedClosure,
+    // The CLI's own branch is spared from the REPORT. A protected row that
     // happens to claim a victim pid is not an open question about the host - it
     // is a process we have already decided never to kill - and reporting it
-    // would fail every stop issued from a Traycer-hosted terminal. Rows already
-    // in `kill` drop out for the mirror-image reason: a subtree can hang off an
-    // undecided root and still be slot-matched in its own right, and a pid this
-    // scan has decided to kill is not an open question either. Reporting it in
-    // both lists would put the same pid in front of the user twice, in two
-    // contradictory roles.
-    unattributed: [...suspects]
-      .filter((pid) => !spared.has(pid) && !victims.has(pid))
-      .sort((left, right) => left - right),
+    // would fail every stop issued from a Traycer-hosted terminal. It stays in
+    // `undecided`, because sparing it answers nothing about its children: the
+    // shell above the CLI can exit between rounds, and its other children then
+    // arrive as orphans claiming a pid that has to be remembered as undecided,
+    // or they read as convergence.
+    unattributed: undecidedClosure.filter((pid) => !spared.has(pid)),
   };
 }
 
@@ -1322,15 +1340,23 @@ export interface WindowsKillMemory {
 /**
  * What a round's scan says to do, split by what it can PROVE.
  *
- * `kill` is the ordinary answer. `unattributed` is the rows that claim a killed
- * or already-undecided process as their parent but cannot be tied to it - born
+ * `kill` is the ordinary answer. `undecided` is the rows that claim a killed or
+ * already-undecided process as their parent but cannot be tied to it - born
  * after the victim was last seen alive, or carrying an unreadable creation time
- * - plus everything that hangs off those rows. They are neither killed (they may
- * be strangers) nor ignored (they may be the host's children), and the loop
- * refuses to report a stop rather than pick one silently.
+ * - plus everything that hangs off those rows, minus what is being killed. They
+ * are neither killed (they may be strangers) nor ignored (they may be the
+ * host's children).
+ *
+ * `unattributed` is the subset of `undecided` the loop REPORTS - it refuses to
+ * claim a stop rather than pick silently - and it leaves out the CLI's own
+ * protected branch, which is never killed and never a reason to refuse. The
+ * loop's suspect memory is fed from `undecided`, not from the report: a
+ * protected root's uncertainty is inherited by its children whether or not the
+ * root itself is ever named, and it has to outlive the root.
  */
 export interface WindowsHostKillSet {
   readonly kill: readonly number[];
+  readonly undecided: readonly number[];
   readonly unattributed: readonly number[];
 }
 
@@ -1356,7 +1382,10 @@ type CarryOverClaim = "seed" | "unattributed" | "none";
 // evidence and outranks the earlier suspicion, which is why nothing here keeps a
 // row undecided by its own identity once its edge validates. Uncertainty about
 // a child whose LIVE parent is itself undecided is preserved by the descendant
-// closure in `computeWindowsHostKillSet`, not here.
+// closure in `computeWindowsHostKillSet`, not here; and once that parent has
+// exited, by the suspect entry the loop recorded for it - for every member of
+// the closure, the CLI's protected branch included, so a child that outlives a
+// spared shell still finds its parent's pid remembered.
 //
 // The gate is NOT redundant with the rules below. The case it decides is a
 // live, validated parent wearing a pid this loop killed earlier: an unrelated

--- a/clients/traycer-cli/src/service/platforms/windows.ts
+++ b/clients/traycer-cli/src/service/platforms/windows.ts
@@ -461,7 +461,8 @@ async function killHostProcessTree(
   run: ProcessRunner,
   deps: WindowsControllerDeps,
 ): Promise<void> {
-  // What earlier rounds killed, with the age each had when it was killed. The
+  // What earlier rounds placed in the host's tree - killed, or spared as one of
+  // this CLI's own ancestors - with the age each had when it was seen. The
   // loop's memory: once a parent is dead the table can no longer prove its
   // children belong to the slot, and this is the only thing that still can.
   //
@@ -527,6 +528,7 @@ async function killHostProcessTree(
     const pids = uniqueProcessIds(killSet.kill);
     const unattributed = uniqueProcessIds(killSet.unattributed);
     const undecided = uniqueProcessIds(killSet.undecided);
+    const protectedAncestors = uniqueProcessIds(killSet.protectedAncestors);
     if (pids.length === 0) {
       // Nothing left to kill - but that is only convergence if nothing is
       // UNDECIDED. A row claiming a killed host process as its parent, born
@@ -553,7 +555,7 @@ async function killHostProcessTree(
           code: CLI_ERROR_CODES.SERVICE_CONTROL_FAILED,
           message:
             `refusing to report the ${label.id} host stopped: ${unattributed.length} process(es) could be neither tied to this slot nor ruled out of it ` +
-            "(each claims a process this stop killed - or one it could not place - as its parent, or descends from one, " +
+            "(each claims a process this stop killed, spared as its own ancestor, or could not place, as its parent, or descends from one, " +
             "and was created after that parent was last seen alive or carries an unreadable creation time): " +
             `pids ${unattributed.join(", ")}. End them from Task Manager, then retry.`,
           details: { label: label.id, unattributedPids: unattributed },
@@ -609,6 +611,20 @@ async function killHostProcessTree(
     // entry stays; nothing it proved has become false.
     const created = new Map(table.map((row) => [row.processId, row.created]));
     for (const pid of pids) {
+      rememberIncarnation(priorVictims, pid, {
+        created: created.get(pid) ?? 0,
+        seenAliveAt,
+      });
+    }
+    // The CLI's own placed ancestors go into the same map, with the same
+    // window, though nothing was done to them: the shell the host spawned to
+    // run this CLI is a host descendant, its other children are the host's, and
+    // it can exit between rounds like anything else. A child it spawns after
+    // this scan then claims its pid as an orphan, and the window is what says
+    // whether that child was born while the shell was demonstrably the host's
+    // (seed) or after the last time this loop saw it (undecided). Without the
+    // entry the claim matches nothing and the child reads as convergence.
+    for (const pid of protectedAncestors) {
       rememberIncarnation(priorVictims, pid, {
         created: created.get(pid) ?? 0,
         seenAliveAt,
@@ -1269,31 +1285,44 @@ export function computeWindowsHostKillSet(
   const victims = withDescendants(seeds, children);
   const suspects = withDescendants(undecided, children);
   const spared = withDescendants(new Set([cliPid]), children);
+  // The CLI's non-slot ancestors are spared from the kill, and the ones the
+  // scan has placed in the host's tree are ALSO reported as lineage to
+  // remember. A shell the host spawned to run the CLI is a host descendant
+  // whose other children are the host's; it is never killed, so the kill
+  // bookkeeping never records it, and it is under no obligation to outlive the
+  // loop - a child it spawns after this scan arrives, once it has exited,
+  // claiming a pid nothing else remembers. Ancestors only: the CLI's own
+  // descendants are its scan and kill subprocesses, and nothing below them is
+  // ever the host's.
+  const protectedAncestors: number[] = [];
   for (const ancestor of ancestorsOf(cliPid, parents)) {
-    if (!slot.has(ancestor)) spared.add(ancestor);
+    if (slot.has(ancestor)) continue;
+    spared.add(ancestor);
+    if (victims.has(ancestor)) protectedAncestors.push(ancestor);
   }
+  protectedAncestors.sort((left, right) => left - right);
   const kill = [...victims]
     .filter((pid) => !spared.has(pid))
     .sort((left, right) => left - right);
-  const killed = new Set(kill);
-  // Rows in `kill` drop out of both undecided lists: a subtree can hang off an
-  // undecided root and still be slot-matched in its own right, and a pid this
-  // scan has decided to kill is not an open question - it is remembered as a
-  // victim, with a window, which is the stronger fact. Reporting it in both
-  // lists would put the same pid in front of the user twice, in two
-  // contradictory roles.
+  // What is remembered with a lifetime window: the kills, and the placed
+  // ancestors. Both drop out of the undecided lists - a subtree can hang off an
+  // undecided root and still be slot-matched in its own right, and a pid the
+  // scan has PLACED is not an open question; the window is the stronger fact.
+  // Reporting a pid in two lists would put it in front of the user twice, in
+  // two contradictory roles.
   //
-  // What is subtracted is the ACTUAL kill set, not the victim closure it was
-  // cut from. The two differ by the spared branch, and a spared row can sit in
-  // both closures at once - a shell that is the killed host's validated child
-  // AND the CLI's ancestor. It is never killed, so it is never remembered as a
-  // victim; subtracting the closure would drop it from `undecided` too, and it
-  // would be remembered as nothing at all.
+  // What is subtracted is what will actually be remembered that way, not the
+  // victim closure it was cut from. The two differ by the CLI's own branch,
+  // and a spared row can sit in both closures at once; if it is not going to
+  // be remembered with a window it has to stay undecided, or it is remembered
+  // as nothing at all.
+  const remembered = new Set([...kill, ...protectedAncestors]);
   const undecidedClosure = [...suspects]
-    .filter((pid) => !killed.has(pid))
+    .filter((pid) => !remembered.has(pid))
     .sort((left, right) => left - right);
   return {
     kill,
+    protectedAncestors,
     undecided: undecidedClosure,
     // The CLI's own branch is spared from the REPORT. A protected row that
     // happens to claim a victim pid is not an open question about the host - it
@@ -1308,8 +1337,40 @@ export function computeWindowsHostKillSet(
 }
 
 /**
- * A pid this loop has killed, and the interval in which that pid demonstrably
- * belonged to the victim.
+ * What a round's scan says to do, split by what it can PROVE.
+ *
+ * `kill` is the ordinary answer.
+ *
+ * `protectedAncestors` is the CLI's own non-slot ancestors that this scan has
+ * placed in the host's tree - a shell the host spawned to run the CLI. They are
+ * never killed, and they are remembered with the same lifetime window as a
+ * kill, because their children outside the CLI's branch are the host's and the
+ * shell can exit between rounds.
+ *
+ * `undecided` is the rows that claim a remembered process as their parent but
+ * cannot be tied to it - born after the victim was last seen alive, or carrying
+ * an unreadable creation time - plus everything that hangs off those rows,
+ * minus what is being remembered with a window. They are neither killed (they
+ * may be strangers) nor ignored (they may be the host's children).
+ *
+ * `unattributed` is the subset of `undecided` the loop REPORTS - it refuses to
+ * claim a stop rather than pick silently - and it leaves out the CLI's own
+ * protected branch, which is never killed and never a reason to refuse. The
+ * loop's suspect memory is fed from `undecided`, not from the report: a
+ * protected root's uncertainty is inherited by its children whether or not the
+ * root itself is ever named, and it has to outlive the root.
+ */
+export interface WindowsHostKillSet {
+  readonly kill: readonly number[];
+  readonly protectedAncestors: readonly number[];
+  readonly undecided: readonly number[];
+  readonly unattributed: readonly number[];
+}
+
+/**
+ * A pid this loop has placed in the host's tree - killed, or spared as one of
+ * the CLI's own ancestors - and the interval in which that pid demonstrably
+ * belonged to that process.
  *
  * `seenAliveAt` is the clock sampled once per round, in epoch microseconds,
  * BEFORE the scan that selects the round's victims runs. Before the scan, not
@@ -1330,8 +1391,11 @@ export interface WindowsKillVictim {
  * What earlier rounds of the kill loop remember, and the only thing carrying
  * either kind of knowledge across a scan boundary.
  *
- * `victims` is what the loop killed, by pid, one entry per incarnation it
- * killed. `suspects` is what it could place neither in the slot nor out of it,
+ * `victims` is what the loop has placed in the host's tree, by pid, one entry
+ * per incarnation: every pid it killed, and every ancestor of the CLI it placed
+ * and declined to kill (`WindowsHostKillSet.protectedAncestors`) - the name is
+ * the kill's, the evidence is the same lifetime window either way. `suspects`
+ * is what it could place neither in the slot nor out of it,
  * by pid, one creation time per incarnation it saw - the age is all a suspect
  * needs, because `classifyAgainstSuspect` has no upper bound to compare
  * against. Neither list is ever shortened: a newer holder of a pid is new
@@ -1344,29 +1408,6 @@ export interface WindowsKillVictim {
 export interface WindowsKillMemory {
   readonly victims: ReadonlyMap<number, readonly WindowsKillVictim[]>;
   readonly suspects: ReadonlyMap<number, readonly number[]>;
-}
-
-/**
- * What a round's scan says to do, split by what it can PROVE.
- *
- * `kill` is the ordinary answer. `undecided` is the rows that claim a killed or
- * already-undecided process as their parent but cannot be tied to it - born
- * after the victim was last seen alive, or carrying an unreadable creation time
- * - plus everything that hangs off those rows, minus what is being killed. They
- * are neither killed (they may be strangers) nor ignored (they may be the
- * host's children).
- *
- * `unattributed` is the subset of `undecided` the loop REPORTS - it refuses to
- * claim a stop rather than pick silently - and it leaves out the CLI's own
- * protected branch, which is never killed and never a reason to refuse. The
- * loop's suspect memory is fed from `undecided`, not from the report: a
- * protected root's uncertainty is inherited by its children whether or not the
- * root itself is ever named, and it has to outlive the root.
- */
-export interface WindowsHostKillSet {
-  readonly kill: readonly number[];
-  readonly undecided: readonly number[];
-  readonly unattributed: readonly number[];
 }
 
 // How a row that claims a remembered pid as its parent is classified.

--- a/clients/traycer-cli/src/service/platforms/windows.ts
+++ b/clients/traycer-cli/src/service/platforms/windows.ts
@@ -55,8 +55,29 @@ import type {
 // controller without touching schtasks/taskkill.
 export type ProcessRunner = typeof runCommand;
 
+/**
+ * The clock the kill loop bounds its carry-over with, in epoch MICROSECONDS -
+ * the same unit and epoch the scan projects `CreationDate` into, which is the
+ * only reason the two can be compared at all.
+ *
+ * `Date.now()` is milliseconds, so this is coarser than its unit suggests: it
+ * names an instant up to 999us EARLIER than the true one. That direction is the
+ * safe one. The value is only ever used as an upper bound on "the victim still
+ * held this pid", so being early can only refuse a row that might have been
+ * attributable - never admit one that is not.
+ */
+export function epochMicrosNow(): number {
+  return Date.now() * 1000;
+}
+
+/** Seams the kill loop needs from the outside world. */
+export interface WindowsControllerDeps {
+  readonly now: () => number;
+}
+
 export function createWindowsController(
   runner: ProcessRunner | null,
+  deps: WindowsControllerDeps,
 ): ServiceController {
   const unverifiedRun: ProcessRunner = runner ?? runCommand;
   const run: ProcessRunner = async (command, args, options) => {
@@ -65,11 +86,11 @@ export function createWindowsController(
   };
   return {
     install: (options) => installService(options, run),
-    uninstall: (options) => uninstallService(options, run),
+    uninstall: (options) => uninstallService(options, run, deps),
     status: (label) => statusService(label),
-    stop: (label) => stopService(label, run),
+    stop: (label) => stopService(label, run, deps),
     start: (label) => startService(label, run),
-    restart: (label) => restartService(label, run),
+    restart: (label) => restartService(label, run, deps),
     hostStartAdoptionLabel: (label) => Promise.resolve(label.id),
     // No Desktop/SMAppService split on Windows, so the restart halves are the
     // stop and start `host restart` already performed - the named seam exists
@@ -77,7 +98,7 @@ export function createWindowsController(
     // never set: `stopService` taskkills and waits, so nothing survives to
     // need a recycle.
     stopForRestart: async (label) => {
-      await stopService(label, run);
+      await stopService(label, run, deps);
       return { forcedRecycle: false };
     },
     relaunchAfterRestart: (label) => startService(label, run),
@@ -270,6 +291,7 @@ async function removeStagedTaskDefinition(
 async function uninstallService(
   options: UninstallServiceOptions,
   run: ProcessRunner,
+  deps: WindowsControllerDeps,
 ): Promise<void> {
   const taskName = windowsTaskName(options.label);
   await run("schtasks", ["/End", "/TN", taskName], {
@@ -280,7 +302,7 @@ async function uninstallService(
   });
   // Reap the orphaned host tree so the host doesn't keep running (and serving
   // its port) after the task is deleted.
-  await killHostProcessTree(options.label, run);
+  await killHostProcessTree(options.label, run, deps);
   await run("schtasks", ["/Delete", "/TN", taskName, "/F"], {
     env: undefined,
     cwd: undefined,
@@ -358,6 +380,7 @@ async function statusService(label: ServiceLabel): Promise<ServiceStatus> {
 async function stopService(
   label: ServiceLabel,
   run: ProcessRunner,
+  deps: WindowsControllerDeps,
 ): Promise<void> {
   await run("schtasks", ["/End", "/TN", windowsTaskName(label)], {
     env: undefined,
@@ -365,7 +388,7 @@ async function stopService(
     timeoutMs: WINDOWS_SCHTASKS_END_TIMEOUT_MS,
     tolerateNonZeroExit: true,
   });
-  await killHostProcessTree(label, run);
+  await killHostProcessTree(label, run, deps);
   // The force-kill above never lets the host honor its "remove pid.json on
   // graceful shutdown" contract, and metadata left behind makes this
   // deliberate stop indistinguishable from a crash - the desktop's health
@@ -428,12 +451,40 @@ async function stopService(
 async function killHostProcessTree(
   label: ServiceLabel,
   run: ProcessRunner,
+  deps: WindowsControllerDeps,
 ): Promise<void> {
   // What earlier rounds killed, with the age each had when it was killed. The
   // loop's memory: once a parent is dead the table can no longer prove its
   // children belong to the slot, and this is the only thing that still can.
-  const priorVictims = new Map<number, number>();
+  const priorVictims = new Map<number, WindowsKillVictim>();
+  // The other half of that memory: pids an earlier round could place neither in
+  // the slot nor out of it, against the age the row wearing each one had then.
+  // Uncertainty has to cross a round boundary for the same reason a kill does.
+  // The row that made a pid undecided is under no obligation to still be there
+  // next round - it can exit, or spawn a child and then exit - and without this
+  // the child arrives as an ordinary orphan claiming a pid nothing remembers,
+  // which reads as convergence. Only the age is kept: `classifyAgainstSuspect`
+  // shows a suspect's upper bound cannot change any verdict.
+  const priorSuspects = new Map<number, number>();
+  // The pair, by reference: the maps below are mutated in place at the end of
+  // every round, so this is built once and always reflects the latest round.
+  const memory: WindowsKillMemory = {
+    victims: priorVictims,
+    suspects: priorSuspects,
+  };
   for (let round = 0; round <= WINDOWS_KILL_CONVERGENCE_ROUNDS; round += 1) {
+    // BEFORE the scan, and that ordering is the soundness argument for the
+    // whole carry-over: every victim this round selects is one the scan below
+    // observed alive, so each was still holding its pid at this instant. Read
+    // after the scan - or worse, just before the kills - the bound would cover
+    // time in which the victim may already have exited and its pid been reused.
+    //
+    // Strictly, "existed at this instant" holds for every victim the scan could
+    // have observed: one BORN during the enumeration did not exist here, and
+    // gets `created > seenAliveAt` - an empty window that attributes nothing to
+    // it. That is the safe direction: an empty window refuses every claim on
+    // that pid rather than admitting one it cannot support.
+    const seenAliveAt = deps.now();
     const table = await scanSlotProcessTable(label, run);
     if (table === null) {
       // Before the first kill this refuses to start; after one it refuses to
@@ -452,27 +503,67 @@ async function killHostProcessTree(
     // The kill boundary, and the only place a pid has to be POSITIVE: the scan
     // and its algebra work over an unfiltered table that includes pid 0, and
     // `isKillableProcessId` is what keeps 0 - and our own pid - out of an argv.
-    const pids = uniqueProcessIds(
-      computeWindowsHostKillSet(table, process.pid, priorVictims),
-    );
-    // Converged, and the only success: a scan taken AFTER the previous round's
-    // kills found nothing left in this slot. Round 0 reaches here whenever
-    // there was never anything to kill, which is the ordinary stop of a host
-    // that already exited - one scan, no kills.
-    if (pids.length === 0) return;
+    const killSet = computeWindowsHostKillSet(table, process.pid, memory);
+    const pids = uniqueProcessIds(killSet.kill);
+    const unattributed = uniqueProcessIds(killSet.unattributed);
+    if (pids.length === 0) {
+      // Nothing left to kill - but that is only convergence if nothing is
+      // UNDECIDED. A row claiming a killed host process as its parent, born
+      // after that parent was last seen alive, may be a stranger wearing a
+      // recycled pid or may be a host child spawned in its parent's last
+      // moments. Killing it risks a stranger; ignoring it reports a stop while
+      // a host process runs on and the caller goes off to delete the pid
+      // metadata. Neither is ours to choose silently, so the stop fails and
+      // names them - them and everything under them, since a subtree hanging
+      // off an undecided process is exactly as undecided as its root.
+      if (unattributed.length > 0) {
+        // "Run the command again" was the wrong advice and is deliberately
+        // gone: a rerun repeats this scan against the same processes and
+        // reaches the same verdict, so it sends the user around the loop
+        // rather than out of it. Ending the named processes is what changes
+        // the answer, and it is the one instruction that also works when they
+        // turn out to be strangers wearing recycled pids.
+        throw cliError({
+          code: CLI_ERROR_CODES.SERVICE_CONTROL_FAILED,
+          message:
+            `refusing to report the ${label.id} host stopped: ${unattributed.length} process(es) could be neither tied to this slot nor ruled out of it ` +
+            "(each claims a process this stop killed - or one it could not place - as its parent, or descends from one, " +
+            "and was created after that parent was last seen alive or carries an unreadable creation time): " +
+            `pids ${unattributed.join(", ")}. End them from Task Manager, then retry.`,
+          details: { label: label.id, unattributedPids: unattributed },
+          exitCode: 1,
+        });
+      }
+      // Converged, and the only success: a scan taken AFTER the previous
+      // round's kills found nothing left in this slot and nothing undecided.
+      // Round 0 reaches here whenever there was never anything to kill, which
+      // is the ordinary stop of a host that already exited - one scan, no
+      // kills.
+      return;
+    }
     // Out of kill passes with the slot still occupied. Falling through here
     // would report exactly what a converged scan reports, which is the one
     // thing this function must never do: name the survivors instead, so the
     // caller's error says which processes to deal with.
     if (round === WINDOWS_KILL_CONVERGENCE_ROUNDS) {
+      // The undecided rows travel with the survivors. This exit is the one the
+      // user acts on, and a list that names only what we could prove sends
+      // them to Task Manager with half the slot: the pids we could not place
+      // are as likely to be what is holding the install dir open, and they are
+      // the ones nobody else is going to point at.
+      const undecided =
+        unattributed.length > 0
+          ? ` ${unattributed.length} further process(es) could not be placed either way: pids ${unattributed.join(", ")}.`
+          : "";
       throw cliError({
         code: CLI_ERROR_CODES.SERVICE_CONTROL_FAILED,
         message:
-          `${label.id} host processes are still running after ${WINDOWS_KILL_CONVERGENCE_ROUNDS} kill rounds (pids ${pids.join(", ")}). ` +
-          "Retry, or end them from Task Manager.",
+          `${label.id} host processes are still running after ${WINDOWS_KILL_CONVERGENCE_ROUNDS} kill rounds (pids ${pids.join(", ")}).${undecided} ` +
+          "End them from Task Manager, then retry.",
         details: {
           label: label.id,
           survivingPids: pids,
+          unattributedPids: unattributed,
           killRounds: WINDOWS_KILL_CONVERGENCE_ROUNDS,
         },
         exitCode: 1,
@@ -484,8 +575,23 @@ async function killHostProcessTree(
     // always in the table it was selected from, so the fallback age is
     // unreachable; 0 is the value the next round refuses to link anything to,
     // which is the right way for it to be wrong.
+    //
+    // A pid killed again in a later round overwrites its entry, and that
+    // round's `seenAliveAt` is the honest bound: its scan saw the pid alive
+    // too, so the interval in which the pid was demonstrably still the
+    // victim's genuinely extends to there.
     const created = new Map(table.map((row) => [row.processId, row.created]));
-    for (const pid of pids) priorVictims.set(pid, created.get(pid) ?? 0);
+    for (const pid of pids) {
+      priorVictims.set(pid, { created: created.get(pid) ?? 0, seenAliveAt });
+    }
+    // Recorded from the same snapshot, and only ever added to: a pid this round
+    // could not place stays undecided for the rest of the loop even if the next
+    // scan does not list it at all, which is precisely the case the memory
+    // exists for. A later round that reaches the same pid again overwrites the
+    // age with the incarnation that round saw.
+    for (const pid of unattributed) {
+      priorSuspects.set(pid, created.get(pid) ?? 0);
+    }
   }
 }
 
@@ -676,6 +782,7 @@ function parseSchtasksCsvRow(stdout: string): readonly string[] | null {
 async function restartService(
   label: ServiceLabel,
   run: ProcessRunner,
+  deps: WindowsControllerDeps,
 ): Promise<void> {
   const taskName = windowsTaskName(label);
   await run("schtasks", ["/End", "/TN", taskName], {
@@ -686,7 +793,7 @@ async function restartService(
   });
   // Reap the orphaned host tree before re-running, otherwise the old node keeps
   // its port + install dir and the fresh task races a stale host.
-  await killHostProcessTree(label, run);
+  await killHostProcessTree(label, run, deps);
   // Restart reuses the verified start path (baseline + post-/Run evidence)
   // so a stop-then-start that the scheduler accepts but never spawns fails
   // with Last Run Result instead of a silent no-op.
@@ -791,7 +898,10 @@ function buildSlotProcessTableScanScript(hostHome: string): string {
     // from the same snapshot, or the ages being compared are from two reads.
     "$table = @(Get-CimInstance Win32_Process)",
     "$created = @{}",
-    "foreach ($row in $table) { $created[[int]$row.ProcessId] = $row.CreationDate }",
+    "foreach ($row in $table) {",
+    "  if ($null -eq $row.CreationDate) { $created[[int]$row.ProcessId] = $null }",
+    "  else { $created[[int]$row.ProcessId] = $row.CreationDate.ToUniversalTime() }",
+    "}",
     "$rows = $table | ForEach-Object {",
     ...SLOT_MATCH_SCRIPT_LINES,
     ...PARENT_EDGE_VALIDATION_SCRIPT_LINES,
@@ -804,7 +914,7 @@ function buildSlotProcessTableScanScript(hostHome: string): string {
     // parent that is in no live table, so the validation above zeroes it - and
     // that is precisely the row the victim carry-over has to recognise.
     "      ClaimedParentProcessId = [int]$_.ParentProcessId",
-    "      Created = $createdMs",
+    "      Created = $createdMicros",
     "      Slot = $hostMatch",
     "    }",
     "}",
@@ -812,17 +922,31 @@ function buildSlotProcessTableScanScript(hostHome: string): string {
   ].join("\n");
 }
 
-// Sets `$createdMs` for the pipeline row in `$_`: how old the process is, as
-// milliseconds since the Unix epoch, and 0 when Windows reports no creation
-// time at all (pid 0 and System have none). Milliseconds rather than the native
-// FILETIME because a FILETIME is ~1.3e17 - past the point where JSON numbers
-// stay exact - while epoch milliseconds is ~1.7e12 and survives the round trip
-// intact. The unit only ever gets COMPARED, never displayed, so its precision
-// just has to beat the gap between a parent and the child it forks.
+// Sets `$createdMicros` for the pipeline row in `$_`: when the process started,
+// as MICROSECONDS since the Unix epoch, and 0 when Windows reports no creation
+// time at all (pid 0 and System have none).
+//
+// Microseconds, not milliseconds, because the carry-over compares a child's
+// birth against a victim's and milliseconds are too coarse to separate them: a
+// previous holder of a pid can fork a child and exit, and the replacement be
+// created, well inside one millisecond - both then project to the same value
+// and a `<=` comparison attributes the stranger to the victim. CIM datetimes
+// carry microseconds, so the precision is really there to be used.
+//
+// Not the native FILETIME (~1.3e17, past exact JSON integers) and not ticks
+// (100ns, ~1.7e16 - also past). Epoch microseconds is ~1.7e15, which is under
+// 2^53 and survives the round trip intact. `Ticks / 10` converts a TimeSpan's
+// 100ns units to microseconds; the floor keeps it an integer rather than
+// letting PowerShell hand back a rounded double.
+//
+// `.ToUniversalTime()` for the same reason the edge validation needs it: a
+// local DateTime is ambiguous across a DST fall-back, and an hour in which
+// every timestamp can mean two instants is an hour in which "older" is not a
+// fact. The epoch these are measured from is UTC, so the operand must be too.
 const ROW_CREATION_SCRIPT_LINES: readonly string[] = [
-  "    $createdMs = 0",
+  "    $createdMicros = 0",
   "    if ($null -ne $_.CreationDate) {",
-  "      $createdMs = [long]($_.CreationDate.ToUniversalTime() - [datetime]'1970-01-01').TotalMilliseconds",
+  "      $createdMicros = [long][math]::Floor(($_.CreationDate.ToUniversalTime() - [datetime]'1970-01-01').Ticks / 10)",
   "    }",
 ];
 
@@ -830,9 +954,17 @@ const ROW_CREATION_SCRIPT_LINES: readonly string[] = [
 // snapshot can still vouch for it, and 0 when it cannot. A missing
 // `CreationDate` on either end (pid 0 and System have none) is uncertainty, so
 // it fails closed to 0 like every other unverifiable edge.
+//
+// BOTH operands are normalised to UTC before they are compared. `CreationDate`
+// arrives as a local DateTime, and local time is not monotonic: across a DST
+// fall-back the same wall-clock hour happens twice, so a process started in the
+// second pass can compare as OLDER than one started in the first. That is not a
+// cosmetic ordering error here - it is an edge this scan would then VALIDATE,
+// attaching a stranger to a slot process and putting it in the kill set.
 const PARENT_EDGE_VALIDATION_SCRIPT_LINES: readonly string[] = [
   "    $parentId = [int]$_.ParentProcessId",
-  "    $childCreated = $_.CreationDate",
+  "    $childCreated = $null",
+  "    if ($null -ne $_.CreationDate) { $childCreated = $_.CreationDate.ToUniversalTime() }",
   "    if ($parentId -le 0 -or -not $created.ContainsKey($parentId)) {",
   "      $parentId = 0",
   "    } else {",
@@ -912,16 +1044,19 @@ export interface WindowsProcessTableRow {
   // field refuses to carry.
   readonly parentProcessId: number;
   // The parent id the row CLAIMS, with no validation applied. Its only use is
-  // the cross-round victim carry-over: a process whose parent this loop killed
-  // has a claimed parent that no longer appears in any table, so
-  // `parentProcessId` above is 0 and the claim is the only thing left linking
-  // the two. Never treat it as an edge on its own - `created` is what makes it
-  // safe (see `computeWindowsHostKillSet`).
+  // the cross-round carry-over: a process whose parent this loop killed - or
+  // could not place, and which has since gone - has a claimed parent that no
+  // longer appears in any table, so `parentProcessId` above is 0 and the claim
+  // is the only thing left linking the two. Never treat it as an edge on its
+  // own - `created` is what makes it safe (see `computeWindowsHostKillSet`).
   readonly claimedParentProcessId: number;
-  // Milliseconds since the Unix epoch, or 0 when Windows reports no creation
-  // time. What turns a claimed parent id into evidence: a process cannot
-  // predate its own parent, so an id whose claimed parent is YOUNGER than it is
-  // a recycled id rather than an ancestry.
+  // MICROSECONDS since the Unix epoch, or 0 when Windows reports no creation
+  // time. Microseconds because the scan floors `CreationDate` to them and the
+  // carry-over compares row ages against a `Date.now()`-derived bound in the
+  // same unit - a truncation to milliseconds on one side of that comparison
+  // would round a child's birth back below its parent's. What turns a claimed
+  // parent id into evidence: a process cannot predate its own parent, so an id
+  // whose claimed parent is YOUNGER than it is a recycled id, not an ancestry.
   readonly created: number;
   // Whether the row's executable path or command line matches this slot.
   readonly slot: boolean;
@@ -954,6 +1089,7 @@ function parseProcessTableJson(
   // on Windows PowerShell 5.1 - accept both shapes, like the detail parser.
   const values = Array.isArray(parsed) ? parsed : [parsed];
   const rows: WindowsProcessTableRow[] = [];
+  const seenProcessIds = new Set<number>();
   for (const value of values) {
     if (value === null || typeof value !== "object") return null;
     const record = value as Record<string, unknown>;
@@ -980,6 +1116,14 @@ function parseProcessTableJson(
     ) {
       return null;
     }
+    // A pid twice in one snapshot is not a table this code can reason over: the
+    // parent map, the child map and the age lookup would each silently keep a
+    // different one of the duplicates depending on iteration order, and the kill
+    // set would depend on which. `Get-CimInstance` cannot produce it, so a
+    // response that does is malformed - and malformed is refused whole, exactly
+    // like every other shape violation above.
+    if (seenProcessIds.has(processId)) return null;
+    seenProcessIds.add(processId);
     rows.push({
       processId,
       parentProcessId,
@@ -1011,27 +1155,40 @@ function parseProcessTableJson(
  * seeding from it spares the branch above the CLI while leaving the CLI's own
  * siblings - the detached upgrade finalizer among them - to be killed.
  *
- * `priorVictims` (pid -> creation time) is what the kill loop remembers from
- * its earlier rounds, and it exists because killing a parent DESTROYS the
- * evidence linking its children to the slot. A process the host spawned after
- * round 0's snapshot shows up in round 1 with its parent already dead: the
- * table cannot vouch for that edge, so the row arrives with `parentProcessId`
- * 0, and if the child is a shell or a provider binary its own path matches
- * nothing. It would be an orphan the loop calls convergence on. A row whose
- * CLAIMED parent is a remembered victim is therefore treated as a descendant of
- * a verified slot process - seeded, not merely walked to.
+ * `memory` is what the kill loop remembers from its earlier rounds. Its victims
+ * exist because killing a parent DESTROYS the evidence linking its children to
+ * the slot. A process the host spawned after round 0's snapshot shows up in
+ * round 1 with its parent already dead: the table cannot vouch for that edge, so
+ * the row arrives with `parentProcessId` 0, and if the child is a shell or a
+ * provider binary its own path matches nothing. It would be an orphan the loop
+ * calls convergence on. A row whose CLAIMED parent is a remembered victim, and
+ * whose birth falls inside that victim's known lifetime, is therefore treated as
+ * a descendant of a verified slot process - seeded, not merely walked to. See
+ * `classifyAgainstVictim` for why a lifetime, and why a claim that falls outside
+ * it is reported rather than decided.
  *
- * Creation time is what keeps that safe against pid reuse: a child cannot
- * predate its own parent, so a row claiming a recycled victim id is rejected
- * the moment it turns out to be OLDER than the victim was. An unknown creation
- * time on either end (0) is refused rather than assumed, which is the same way
- * the scan script treats an age it cannot read.
+ * Its suspects are the same memory for rows an earlier round could not place.
+ * They carry no verdict, only the fact that the pid is in question: a row
+ * claiming one is undecided too (`classifyAgainstSuspect`), because deciding it
+ * would mean deciding its parent, which is the thing this loop already said it
+ * could not do.
+ *
+ * `unattributed` carries those undecidable rows out to the caller, TOGETHER WITH
+ * EVERYTHING BELOW THEM, walked over the same validated edges as the kill set.
+ * An undecided root makes its whole subtree undecided - those children are
+ * verified children of a process we cannot place, so they are exactly as
+ * unplaceable - and naming only the root would send the caller after one pid
+ * while the rest of the branch keeps the install dir open. They are all spared
+ * from `kill` (killing on a claim we cannot verify is the mistake this scan
+ * exists to prevent), and the loop must not read their absence from `kill` as
+ * convergence, because a host child spawned just before its parent died looks
+ * exactly like this.
  */
 export function computeWindowsHostKillSet(
   table: readonly WindowsProcessTableRow[],
   cliPid: number,
-  priorVictims: ReadonlyMap<number, number>,
-): readonly number[] {
+  memory: WindowsKillMemory,
+): WindowsHostKillSet {
   const children = new Map<number, number[]>();
   const parents = new Map<number, number>();
   const slot = new Set<number>();
@@ -1046,35 +1203,196 @@ export function computeWindowsHostKillSet(
     if (row.slot) slot.add(row.processId);
   }
   const seeds = new Set<number>(slot);
+  const undecided = new Set<number>();
   for (const row of table) {
-    if (isChildOfVictim(row, priorVictims)) seeds.add(row.processId);
+    const claim = classifyCarryOverClaim(row, memory);
+    if (claim === "seed") seeds.add(row.processId);
+    else if (claim === "unattributed") undecided.add(row.processId);
   }
   // Seeded from LIVE rows only. A victim's own pid is deliberately never seeded:
   // it is dead, so a row bearing it again is a different process wearing a
   // recycled id, and killing it is the exact mistake this whole scan exists to
   // avoid.
   const victims = withDescendants(seeds, children);
+  const suspects = withDescendants(undecided, children);
   const spared = withDescendants(new Set([cliPid]), children);
   for (const ancestor of ancestorsOf(cliPid, parents)) {
     if (!slot.has(ancestor)) spared.add(ancestor);
   }
-  return [...victims]
-    .filter((pid) => !spared.has(pid))
-    .sort((left, right) => left - right);
+  return {
+    kill: [...victims]
+      .filter((pid) => !spared.has(pid))
+      .sort((left, right) => left - right),
+    // The CLI's own branch is spared from this too. A protected row that
+    // happens to claim a victim pid is not an open question about the host - it
+    // is a process we have already decided never to kill - and reporting it
+    // would fail every stop issued from a Traycer-hosted terminal. Rows already
+    // in `kill` drop out for the mirror-image reason: a subtree can hang off an
+    // undecided root and still be slot-matched in its own right, and a pid this
+    // scan has decided to kill is not an open question either. Reporting it in
+    // both lists would put the same pid in front of the user twice, in two
+    // contradictory roles.
+    unattributed: [...suspects]
+      .filter((pid) => !spared.has(pid) && !victims.has(pid))
+      .sort((left, right) => left - right),
+  };
 }
 
-// Whether this row is a child of a process an earlier kill round destroyed.
-// Both ages have to be known and the parent's must not be later than the
-// child's: an id whose claimed parent is YOUNGER than it cannot be its parent,
-// which is what a reused pid looks like from here.
-function isChildOfVictim(
+/**
+ * A pid this loop has killed, and the interval in which that pid demonstrably
+ * belonged to the victim.
+ *
+ * `seenAliveAt` is the clock sampled once per round, in epoch microseconds,
+ * BEFORE the scan that selects the round's victims runs. Before the scan, not
+ * before the kill, and the difference is the whole soundness argument: the scan
+ * observes the victim alive at some instant AFTER the sample, so the pid was
+ * still the victim's at the sampled instant. Sampling before the kill proves
+ * nothing of the sort - the victim can exit on its own between the scan and the
+ * kill, its pid be reused, and the replacement fork a child, all before the
+ * clock is read, and that child's birth then falls inside a window it has no
+ * business being in.
+ */
+export interface WindowsKillVictim {
+  readonly created: number;
+  readonly seenAliveAt: number;
+}
+
+/**
+ * What earlier rounds of the kill loop remember, and the only thing carrying
+ * either kind of knowledge across a scan boundary.
+ *
+ * `victims` is what the loop killed, by pid. `suspects` is what it could place
+ * neither in the slot nor out of it, by pid, against the creation time of the
+ * incarnation that round saw - the age is all a suspect needs, because
+ * `classifyAgainstSuspect` has no upper bound to compare against.
+ *
+ * One value rather than two parameters because the two halves are never
+ * meaningful apart: every round records into both from the same snapshot, and
+ * every classification consults both in a fixed order.
+ */
+export interface WindowsKillMemory {
+  readonly victims: ReadonlyMap<number, WindowsKillVictim>;
+  readonly suspects: ReadonlyMap<number, number>;
+}
+
+/**
+ * What a round's scan says to do, split by what it can PROVE.
+ *
+ * `kill` is the ordinary answer. `unattributed` is the rows that claim a killed
+ * or already-undecided process as their parent but cannot be tied to it - born
+ * after the victim was last seen alive, or carrying an unreadable creation time
+ * - plus everything that hangs off those rows. They are neither killed (they may
+ * be strangers) nor ignored (they may be the host's children), and the loop
+ * refuses to report a stop rather than pick one silently.
+ */
+export interface WindowsHostKillSet {
+  readonly kill: readonly number[];
+  readonly unattributed: readonly number[];
+}
+
+// How a row that claims a remembered pid as its parent is classified.
+//
+//   "seed"         - born inside the victim's proven lifetime; kill it.
+//   "unattributed" - claims the pid but cannot be tied to it or ruled out of it.
+//   "none"         - not a carry-over question at all.
+type CarryOverClaim = "seed" | "unattributed" | "none";
+
+// Whether this row was created BY a process an earlier round killed, or by one
+// it could not place.
+//
+// The gate is the row's own validated edge, and it is kept honestly: under the
+// pre-scan bound it is redundant on legitimate input. A row with a validated
+// live edge has a parent the scan found in this very table, and a live parent is
+// neither a killed victim nor a vanished suspect, so the rules below would
+// refuse it anyway. It stays as the scan's own verdict, checked first because it
+// is the cheaper and more direct fact, and its test is framed as defensive
+// rather than as a behaviour only it produces.
+//
+// Victims are checked before suspects because a pid can be both - a row this
+// loop could not place in one round can be killed in a later one, once
+// something in the table proves it belongs to the slot - and a kill is the
+// stronger fact: it says what the pid WAS, where a suspicion only says that
+// nobody could tell.
+function classifyCarryOverClaim(
   row: WindowsProcessTableRow,
-  priorVictims: ReadonlyMap<number, number>,
-): boolean {
-  const victimCreated = priorVictims.get(row.claimedParentProcessId);
-  if (victimCreated === undefined) return false;
-  if (victimCreated === 0 || row.created === 0) return false;
-  return victimCreated <= row.created;
+  memory: WindowsKillMemory,
+): CarryOverClaim {
+  if (row.parentProcessId !== 0) return "none";
+  const victim = memory.victims.get(row.claimedParentProcessId);
+  if (victim !== undefined) return classifyAgainstVictim(row.created, victim);
+  const suspectCreated = memory.suspects.get(row.claimedParentProcessId);
+  if (suspectCreated === undefined) return "none";
+  return classifyAgainstSuspect(row.created, suspectCreated);
+}
+
+// A claim on a pid this loop killed, decided by a LIFETIME WINDOW.
+//
+// The question is lineage, and lineage is a claim about the past: which
+// incarnation of this pid created this row. An earlier version of this code
+// tried to answer it by inspecting the pid's CURRENT holder, which cannot work
+// - a pid reused and vacated between two scans leaves no trace in the table, so
+// a stranger forked by that intermediate holder arrives looking exactly like the
+// victim's own child.
+//
+// The window does answer it, provided the upper bound is honest. Pid reuse is
+// sequential: from `victim.created` until the victim died, that pid was the
+// victim's and nobody else's. `seenAliveAt` is sampled before the scan that
+// found the victim alive, so the pid was still the victim's at that instant, and
+// a row claiming it that was born at or before then was created BY it.
+//
+// The order of the three answers is the order of what they can PROVE, and the
+// lower bound comes first because it proves the most. A row OLDER than the
+// victim cannot be the victim's child - a process cannot predate its own parent
+// - so the claimed id is somebody else's, an id this row has worn since before
+// the victim existed. That is a decided question, not an open one: reporting it
+// would fail the stop over a long-lived stranger that any retry finds sitting in
+// exactly the same place, which is a refusal nothing can clear.
+//
+// A row born after `seenAliveAt` is the genuinely open case. It may be the
+// host's child, spawned in the moments before its parent died; it may belong to
+// whoever holds that pid next. Nothing in the table distinguishes them, so it is
+// reported as `unattributed` and the caller fails the stop rather than silently
+// killing a stranger or silently sparing a host process.
+//
+// Both ends are `<=`. A child born in the same microsecond as its parent is
+// ordinary; a child born in the same microsecond as the sample was observed
+// alive by the scan that followed it.
+function classifyAgainstVictim(
+  created: number,
+  victim: WindowsKillVictim,
+): CarryOverClaim {
+  // An unreadable age on either side leaves nothing to compare. This is checked
+  // before the lower bound because 0 would pass it - a row of age 0 is older
+  // than every real victim - and "we could not read an age" must not be allowed
+  // to masquerade as the proof that clears a claim.
+  if (victim.created === 0 || created === 0) return "unattributed";
+  if (created < victim.created) return "none";
+  if (created <= victim.seenAliveAt) return "seed";
+  return "unattributed";
+}
+
+// A claim on a pid this loop could not place. Uncertainty is inherited: a
+// process whose parent we cannot tie to the slot cannot itself be tied to the
+// slot, and cannot be ruled out of it either.
+//
+// The one thing that CAN be ruled out is the same lower bound as above, for the
+// same reason - a row older than the pid's remembered incarnation was created by
+// an earlier holder, so this suspicion is not about it - and without it any
+// long-lived process that happened to claim a recycled pid would poison every
+// stop on the machine for as long as it ran.
+//
+// There is deliberately no upper bound here, and it is not a choice: a suspect's
+// `seenAliveAt` cannot change any verdict. Inside it the row is provably the
+// suspect's child, and a suspect's child inherits its suspicion; outside it the
+// row may be the suspect's or a stranger's, which is undecided too. Both arms
+// are `unattributed`, so the comparison is not worth the field it would need.
+function classifyAgainstSuspect(
+  created: number,
+  suspectCreated: number,
+): CarryOverClaim {
+  if (suspectCreated === 0 || created === 0) return "unattributed";
+  if (created < suspectCreated) return "none";
+  return "unattributed";
 }
 
 /**
@@ -1220,8 +1538,9 @@ function readNonEmptyString(value: unknown): string | null {
 export async function killLingeringSlotProcesses(
   label: ServiceLabel,
   runner: ProcessRunner | null,
+  deps: WindowsControllerDeps,
 ): Promise<void> {
-  await killHostProcessTree(label, runner ?? runCommand);
+  await killHostProcessTree(label, runner ?? runCommand, deps);
 }
 
 // The install swap's post-mortem (`SwapLockRecovery.describeLockHolders`):

--- a/clients/traycer-cli/src/service/platforms/windows.ts
+++ b/clients/traycer-cli/src/service/platforms/windows.ts
@@ -406,6 +406,9 @@ async function killHostProcessTree(
   // the install dir fail the swap loudly, naming themselves through the detail
   // scan, which is the better failure of the two.
   const fallbackPids = pidMetadata === null ? [] : [pidMetadata.pid];
+  // The kill boundary, and the only place a pid has to be POSITIVE: the scan
+  // and its algebra work over an unfiltered table that includes pid 0, and
+  // `isKillableProcessId` is what keeps 0 - and our own pid - out of an argv.
   const pids = uniqueProcessIds(scannedPids ?? fallbackPids);
   await Promise.all(
     pids.map((pid) =>
@@ -686,23 +689,59 @@ const SLOT_MATCH_SCRIPT_LINES: readonly string[] = [
  * Command lines are matched inside the script and never leave it: they can name
  * arbitrary user data, and the caller needs three fields per row, not a copy of
  * the machine's process table.
+ *
+ * PARENT IDS ARE VALIDATED HERE, against `CreationDate` from this same read.
+ * Windows does not clear `ParentProcessId` when the parent exits - the row keeps
+ * the creator's id, and Windows is free to hand that id to an unrelated process
+ * afterwards. Believing such an id would attach a stranger to the host's subtree
+ * and force-kill it, or attach the CLI to a recycled ancestor and spare a
+ * process that should die. A snapshot cannot undo reuse that already happened,
+ * but it can refuse to trust it: an edge survives only when the claimed parent
+ * is still in the table AND is not younger than its claimed child. Everything
+ * else is emitted as parent 0, which the kill-set algebra reads as "no verified
+ * parent" - never as an edge.
  */
 function buildSlotProcessTableScanScript(hostHome: string): string {
   const hostPaths = powershellStringArray(slotHostProcessPaths(hostHome));
   return [
     "$ErrorActionPreference = 'SilentlyContinue'",
     `$hostPaths = @(${hostPaths})`,
-    "$rows = Get-CimInstance Win32_Process | ForEach-Object {",
+    // Materialised once: the parent lookup and the row projection must come
+    // from the same snapshot, or the ages being compared are from two reads.
+    "$table = @(Get-CimInstance Win32_Process)",
+    "$created = @{}",
+    "foreach ($row in $table) { $created[[int]$row.ProcessId] = $row.CreationDate }",
+    "$rows = $table | ForEach-Object {",
     ...SLOT_MATCH_SCRIPT_LINES,
+    ...PARENT_EDGE_VALIDATION_SCRIPT_LINES,
     "    [pscustomobject]@{",
     "      ProcessId = [int]$_.ProcessId",
-    "      ParentProcessId = [int]$_.ParentProcessId",
+    "      ParentProcessId = $parentId",
     "      Slot = $hostMatch",
     "    }",
     "}",
     "@($rows) | ConvertTo-Json -Compress",
   ].join("\n");
 }
+
+// Sets `$parentId` for the pipeline row in `$_`: the claimed parent when this
+// snapshot can still vouch for it, and 0 when it cannot. A missing
+// `CreationDate` on either end (pid 0 and System have none) is uncertainty, so
+// it fails closed to 0 like every other unverifiable edge.
+const PARENT_EDGE_VALIDATION_SCRIPT_LINES: readonly string[] = [
+  "    $parentId = [int]$_.ParentProcessId",
+  "    $childCreated = $_.CreationDate",
+  "    if ($parentId -le 0 -or -not $created.ContainsKey($parentId)) {",
+  "      $parentId = 0",
+  "    } else {",
+  "      $parentCreated = $created[$parentId]",
+  "      if ($null -eq $parentCreated -or $null -eq $childCreated) {",
+  "        $parentId = 0",
+  "      } elseif ($parentCreated -gt $childCreated) {",
+  "        $parentId = 0",
+  "      }",
+  "    }",
+];
 
 // Same slot match as the table scan (`SLOT_MATCH_SCRIPT_LINES` is the shared
 // text - the filter must never drift between the kill and the diagnostic),
@@ -760,10 +799,15 @@ function powershellStringArray(values: readonly string[]): string {
 
 // One row of the scanned process table.
 export interface WindowsProcessTableRow {
+  // 0 is a real, expected row: `Get-CimInstance Win32_Process` reports the
+  // System Idle Process, and the scan is deliberately unfiltered.
   readonly processId: number;
-  // 0 for the rows whose parent is the system idle process, and for rows whose
-  // parent has already exited; both are ordinary and neither is an ancestor
-  // anything here can be spared through.
+  // 0 means "no VERIFIED parent" - either the row genuinely hangs off the idle
+  // process, or the scan could not vouch for the id the row claims (see the
+  // parent-edge validation in the scan script). It is deliberately NOT the same
+  // thing as "the parent exited": Windows keeps the creator's id in that case,
+  // and may hand that id to somebody else, which is exactly the claim this
+  // field refuses to carry.
   readonly parentProcessId: number;
   // Whether the row's executable path or command line matches this slot.
   readonly slot: boolean;
@@ -802,12 +846,16 @@ function parseProcessTableJson(
     const processId = record.ProcessId;
     const parentProcessId = record.ParentProcessId;
     const slot = record.Slot;
-    // Deliberately NOT `isKillableProcessId`: that one also rejects our own
-    // pid, and the table is unfiltered, so our row is expected in it. Whether
-    // we are killable is the algebra's answer, not the parser's.
+    // Both ids are accepted at zero and above. The table is unfiltered, so it
+    // legitimately contains pid 0 (the System Idle Process) and rows with no
+    // verified parent; rejecting either would fail the WHOLE parse on every
+    // real machine and silently demote every stop to the pid.json fallback.
+    // Deliberately NOT `isKillableProcessId` either: that also rejects our own
+    // pid, which is expected in the table too. What may be killed is the
+    // algebra's answer and the kill boundary's, not the parser's.
     if (
-      !isProcessTablePid(processId) ||
-      !isProcessTableParentId(parentProcessId) ||
+      !isProcessTableId(processId) ||
+      !isProcessTableId(parentProcessId) ||
       typeof slot !== "boolean"
     ) {
       return null;
@@ -884,8 +932,9 @@ function withDescendants(
   }
 }
 
-// The chain above `pid`, nearest first. Stops at pid 0 (the idle process, and
-// what an exited parent reports) and at any pid already on the chain.
+// The chain above `pid`, nearest first. Stops at 0 - which the scan emits for
+// any parent it could not vouch for, so an unverified edge ends the walk rather
+// than extending it - and at any pid already on the chain.
 function ancestorsOf(
   pid: number,
   parents: ReadonlyMap<number, number>,
@@ -902,11 +951,7 @@ function ancestorsOf(
   }
 }
 
-function isProcessTablePid(value: unknown): value is number {
-  return typeof value === "number" && Number.isInteger(value) && value > 0;
-}
-
-function isProcessTableParentId(value: unknown): value is number {
+function isProcessTableId(value: unknown): value is number {
   return typeof value === "number" && Number.isInteger(value) && value >= 0;
 }
 

--- a/protocol/src/host/lifecycle-constants.ts
+++ b/protocol/src/host/lifecycle-constants.ts
@@ -33,7 +33,8 @@ export const STOP_EXIT_GRACE_MARGIN_MS = 2_000;
  * single graceful-stop signal like launchd SIGTERM - `restart` runs a
  * sequence of independently-capped steps: `schtasks /End`, then up to
  * `WINDOWS_KILL_CONVERGENCE_ROUNDS` PowerShell process-tree scans each
- * followed by `taskkill` on the pids that scan returns, then `schtasks /Run`,
+ * followed by `taskkill` on the pids that scan returns plus one final
+ * confirming scan, then `schtasks /Run`,
  * post-`/Run` spawn-evidence verification, and (on verification failure) a
  * Last Run Result query.
  * Exported here (not left as local literals in `windows.ts`) so the outer
@@ -47,14 +48,19 @@ export const WINDOWS_SCHTASKS_RUN_TIMEOUT_MS = 30_000;
 export const WINDOWS_SCHTASKS_QUERY_TIMEOUT_MS = 10_000;
 
 /**
- * How many scan-then-kill passes `killHostProcessTree` may make before it
- * stops claiming convergence. The scan is a SNAPSHOT: a process the host (or
+ * How many KILL passes `killHostProcessTree` may make before it gives up and
+ * fails naming the survivors. The scan is a SNAPSHOT: a process the host (or
  * an agent under it) spawns after the table is materialized is in no round's
  * kill set, and `taskkill /T` - which this CLI must never use, being routinely
  * a child of the host it is stopping - is what used to sweep it up. Rescanning
  * is the only enumerator left. Bounded, because a host spawning faster than we
- * can scan is not converging and grinding on it is worse than stopping: the
- * install swap's own EBUSY detail scan already names the survivors.
+ * can scan is not converging and grinding on it is worse than failing: the
+ * error names the surviving pids, and the install swap's own EBUSY detail scan
+ * names the lock holders.
+ *
+ * The loop scans once MORE than it kills, so the last scan is always a
+ * confirming one: N kill passes, N+1 scans. Only an empty scan reports
+ * success, which is why the budget below counts scans and kills separately.
  */
 export const WINDOWS_KILL_CONVERGENCE_ROUNDS = 3;
 
@@ -87,8 +93,10 @@ export const WINDOWS_RESTART_SEQUENCE_TIMEOUT_MS =
   // worst case scales with the round bound. Leaving this as one scan + one
   // taskkill would understate the sequence and let the caller's SIGKILL land
   // mid-restart - the exact failure the outer budget below exists to prevent.
-  WINDOWS_KILL_CONVERGENCE_ROUNDS *
-    (WINDOWS_PROCESS_SCAN_TIMEOUT_MS + WINDOWS_TASKKILL_TIMEOUT_MS) +
+  // Scans and kills are counted separately because the loop confirms with a
+  // final scan it does not kill from: N+1 scans, N kills.
+  (WINDOWS_KILL_CONVERGENCE_ROUNDS + 1) * WINDOWS_PROCESS_SCAN_TIMEOUT_MS +
+  WINDOWS_KILL_CONVERGENCE_ROUNDS * WINDOWS_TASKKILL_TIMEOUT_MS +
   WINDOWS_SCHTASKS_RUN_TIMEOUT_MS +
   WINDOWS_START_SPAWN_VERIFY_MS +
   WINDOWS_SCHTASKS_QUERY_TIMEOUT_MS;

--- a/protocol/src/host/lifecycle-constants.ts
+++ b/protocol/src/host/lifecycle-constants.ts
@@ -31,8 +31,9 @@ export const STOP_EXIT_GRACE_MARGIN_MS = 2_000;
  * (`traycer-cli/src/service/platforms/windows.ts`: `stopService` /
  * `killHostProcessTree` / `startService` / `restartService`). Windows has no
  * single graceful-stop signal like launchd SIGTERM - `restart` runs a
- * sequence of independently-capped steps: `schtasks /End`, a PowerShell
- * process-tree scan, `taskkill` on any surviving pids, then `schtasks /Run`,
+ * sequence of independently-capped steps: `schtasks /End`, then up to
+ * `WINDOWS_KILL_CONVERGENCE_ROUNDS` PowerShell process-tree scans each
+ * followed by `taskkill` on the pids that scan returns, then `schtasks /Run`,
  * post-`/Run` spawn-evidence verification, and (on verification failure) a
  * Last Run Result query.
  * Exported here (not left as local literals in `windows.ts`) so the outer
@@ -44,6 +45,18 @@ export const WINDOWS_PROCESS_SCAN_TIMEOUT_MS = 10_000;
 export const WINDOWS_TASKKILL_TIMEOUT_MS = 30_000;
 export const WINDOWS_SCHTASKS_RUN_TIMEOUT_MS = 30_000;
 export const WINDOWS_SCHTASKS_QUERY_TIMEOUT_MS = 10_000;
+
+/**
+ * How many scan-then-kill passes `killHostProcessTree` may make before it
+ * stops claiming convergence. The scan is a SNAPSHOT: a process the host (or
+ * an agent under it) spawns after the table is materialized is in no round's
+ * kill set, and `taskkill /T` - which this CLI must never use, being routinely
+ * a child of the host it is stopping - is what used to sweep it up. Rescanning
+ * is the only enumerator left. Bounded, because a host spawning faster than we
+ * can scan is not converging and grinding on it is worse than stopping: the
+ * install swap's own EBUSY detail scan already names the survivors.
+ */
+export const WINDOWS_KILL_CONVERGENCE_ROUNDS = 3;
 
 /**
  * After `schtasks /Run`, how long `startService` polls for post-baseline
@@ -70,8 +83,12 @@ export const HOST_READY_EXTENDED_TIMEOUT_MS = 5 * 60_000;
  */
 export const WINDOWS_RESTART_SEQUENCE_TIMEOUT_MS =
   WINDOWS_SCHTASKS_END_TIMEOUT_MS +
-  WINDOWS_PROCESS_SCAN_TIMEOUT_MS +
-  WINDOWS_TASKKILL_TIMEOUT_MS +
+  // The kill step is a bounded scan-then-kill loop, not a single pass, so its
+  // worst case scales with the round bound. Leaving this as one scan + one
+  // taskkill would understate the sequence and let the caller's SIGKILL land
+  // mid-restart - the exact failure the outer budget below exists to prevent.
+  WINDOWS_KILL_CONVERGENCE_ROUNDS *
+    (WINDOWS_PROCESS_SCAN_TIMEOUT_MS + WINDOWS_TASKKILL_TIMEOUT_MS) +
   WINDOWS_SCHTASKS_RUN_TIMEOUT_MS +
   WINDOWS_START_SPAWN_VERIFY_MS +
   WINDOWS_SCHTASKS_QUERY_TIMEOUT_MS;

--- a/protocol/src/host/lifecycle-constants.ts
+++ b/protocol/src/host/lifecycle-constants.ts
@@ -42,7 +42,18 @@ export const STOP_EXIT_GRACE_MARGIN_MS = 2_000;
  * of duplicating these numbers as a second, driftable magic number.
  */
 export const WINDOWS_SCHTASKS_END_TIMEOUT_MS = 30_000;
-export const WINDOWS_PROCESS_SCAN_TIMEOUT_MS = 10_000;
+/**
+ * Bound on ONE `Get-CimInstance Win32_Process` scan. Sized from what the CLI
+ * actually spawns, not from an interactive shell: Traycer ships x64 only, so
+ * on Windows-on-ARM the child is the EMULATED x64 `powershell.exe`, whose bare
+ * startup measured 4.2–5.1 s and the scan 7.3–8.5 s on an idle 4-vCPU Windows
+ * 11 ARM64 VM (native ARM64 PowerShell: 1.4–1.7 s). At 10 s any load pushed
+ * the scan over the bound and `host stop` was refused fail-closed - 3 of 5
+ * loaded attempts on 2026-09-06 - before anything was killed. 30 s is the
+ * same ceiling the schtasks steps already carry; the loop's round bound, not
+ * this timeout, is what keeps a non-converging host from grinding.
+ */
+export const WINDOWS_PROCESS_SCAN_TIMEOUT_MS = 30_000;
 export const WINDOWS_TASKKILL_TIMEOUT_MS = 30_000;
 export const WINDOWS_SCHTASKS_RUN_TIMEOUT_MS = 30_000;
 export const WINDOWS_SCHTASKS_QUERY_TIMEOUT_MS = 10_000;


### PR DESCRIPTION
## Why

A `traycer` process the host spawns (a maintenance RPC, the update reconciler, or a person's command in a Traycer-hosted terminal) is a child of the host. On Linux it shares the host unit's cgroup, so the `systemctl --user stop` it issues kills it mid-update (`KillMode=control-group`). On Windows `killHostProcessTree`'s `taskkill /T` walks down from the host and kills it the same way. Every command that reaches a stop is exposed, not only `host update`. This is the CLI half of the 1.2.0 → 1.3.0 update fix; the host half (spawning old CLIs through a transient scope, floor bump) is traycerai/traycer-internal#5528.

## What

**Linux: relocate, then guard.**
- `withRunner` relocates the nine host-stopping commands into a transient scope (`systemd-run --user --scope --quiet --collect --`) before the command body runs, when `/proc/self/cgroup` places the CLI inside the host unit. The relocated child owns the CLI lock, the update contender claim, the dispatch ACK and the marker; the parent waits attached and forwards the exit code. Argv is built by run kind (packaged SEA vs interpreter).
- The relocated CLI acknowledges entry with one byte on fd 3 as the first statement of `withRunner`. A `systemd-run` that exits without it is a relocation that never started the command; it rejects through the runner's error path as `SERVICE_CONTROL_FAILED` rather than forwarding a code the log had already called a success. Process exit and ACK-stream completion are tracked separately, because Bun's `ChildProcess` does not include extra stdio pipes in its `close` accounting.
- Fail closed: only ENOENT/ENOTDIR on `/proc/self/cgroup` mean "not inside". Any other read error refuses the stop. An argv token containing `$` refuses relocation before spawning: `systemd-run` scopes expand `${VAR}` from systemd 258, the flag that disables it is rejected below 254, and a version probe would be a second process per relocation for an input this CLI never composes.
- The stop-intent wrapper re-reads the cgroup before announcing intent on `stop`, `stopForRestart`, `uninstall` and `restart`, and refuses a stop issued from inside the host unit. The relocation env flag is never taken as evidence.

**Windows: kill set without `/T`.**
- One PowerShell pass over the unfiltered process table emits `{ProcessId, ParentProcessId, Slot}` per row. The parent edge is validated against `CreationDate` from the same snapshot (Windows keeps a dead creator's id in `ParentProcessId` and may reuse it); an unvouched parent is emitted as 0.
- The kill set `(slot ∪ desc(slot)) − (cli ∪ desc(cli) ∪ (ancestors(cli) − slot))` is computed in-process with the CLI's own pid as self, and every pid is killed individually with `/F /PID`.
- The parser is all-or-nothing and accepts pid 0 (System Idle Process is in the table). A malformed or empty scan falls back to the pid.json pid, also without `/T`.

## Verification

- Narrow vitest on the six touched suites; every new guard has an ablation recorded in its test (the assertion that goes red when the guard is removed).
- Cold review rounds recorded in the epic; the remaining finding after the second round (Bun `close` accounting on fd 3) is fixed in the last commit.
- Live Linux packaged re-exec and a real Windows stop remain release gates and are not claimed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
