### PR TITLE
feat(gui-app): turn a CLI-floor refusal on the host Overview into a guided remedy with automatic recheck

### DIFF
--- a/clients/desktop/src/electron-main/cli/cli-reconcile.ts
+++ b/clients/desktop/src/electron-main/cli/cli-reconcile.ts
@@ -1,4 +1,5 @@
 import { access } from "node:fs/promises";
+import { PACKAGE_MANAGER_UPGRADE_COMMAND } from "@traycer/protocol/config/installation-records";
 import {
   CLI_RECONCILE_PROBE_TIMEOUT_MS,
   cliBinariesDiffer,
@@ -135,26 +136,12 @@ function packageManagerUpgradeHint(
   source: PackageManagerSource,
   bundledVersion: string,
 ): string {
-  switch (source) {
-    case "homebrew":
-      // Must match the Homebrew formula name shipped via
-      // scripts/native-packaging/publish-cli-package-managers.cjs
-      // (`Formula/traycer.rb`) and the CLI self-upgrade guidance in
-      // traycer-cli/src/commands/cli-upgrade.ts.
-      return "brew upgrade traycer";
-    case "npm":
-      // `latest` names stable builds, so it can be older than an installed RC.
-      // Name the version this reconciliation actually offered to upgrade to.
-      return `npm install -g @traycerai/cli@${bundledVersion}`;
-    case "winget":
-      return "winget upgrade Traycer.CLI";
-    case "scoop":
-      return "scoop update traycer-cli";
-    case "apt":
-      return "sudo apt update && sudo apt install --only-upgrade traycer-cli";
-    case "rpm":
-      return "sudo dnf upgrade traycer-cli";
-  }
+  const command = PACKAGE_MANAGER_UPGRADE_COMMAND[source];
+  // `latest` can be older than an installed RC. Preserve Desktop's exact
+  // candidate, while sharing the package name and command with every caller.
+  return source === "npm"
+    ? command.replace(/@latest$/, `@${bundledVersion}`)
+    : command;
 }
 
 export interface ReconcileCliDeps {

--- a/clients/gui-app/src/components/settings/SETTINGS.md
+++ b/clients/gui-app/src/components/settings/SETTINGS.md
@@ -2380,6 +2380,47 @@ aria-live="polite"` carrying the equivalent text for
       `host.status`. The Overview is the only leg that derives: the landing
       banner keeps its desktop-status debt arm, and the fleet legs pass
       `legacyFacts: null`, which the projector reads as "not observed".
+    - **A CLI requirement has a remedy in the card.** The best target's
+      projected unavailable asset is the executing CLI's verdict, recognized
+      by `HOST_CLIENT_FLOOR_REASON_PREFIX` from the shared release-line helpers.
+      A stored CLI version that already satisfies the requirement does not
+      clear it: the host can still be executing an older copy. A retained hash
+      on a withdrawn platform build is not evidence of a CLI requirement.
+      `describeCliFloorRemedy` owns the sentence and actions together:
+
+      | Installation and update state                                                   | Card action                                                                                                                         |
+      | ------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+      | Local Desktop, update available                                                 | Download update, respecting the Desktop block reason                                                                                |
+      | Local Desktop, downloading                                                      | Disabled download progress                                                                                                          |
+      | Local Desktop, ready                                                            | Restart to update through the shared install flow, or Finish update for manual guidance; block reason and in-flight state still win |
+      | Local Desktop, up to date                                                       | Hint to restart Desktop to finish updating the host tools                                                                           |
+      | Local Desktop, other update state                                               | Checking sentence and one manual bridge check per mounted unknown-state episode                                                     |
+      | Package manager, local or remote                                                | Copy that manager's command from `PACKAGE_MANAGER_UPGRADE_COMMAND`                                                                  |
+      | Manual, remote Desktop, or local Desktop without a bridge; known POSIX platform | Copy the recorded absolute CLI path as one single-quoted shell token plus `cli upgrade`; otherwise copy `traycer cli upgrade`       |
+      | The same sources on Windows or an unknown platform                              | Copy `traycer cli upgrade` and `traycer host restart`; explicitly run outside Traycer on that machine                               |
+      | Installation manifest unreadable                                                | Show installation help, opening the Doctor sheet                                                                                    |
+
+      The copy rows explain an older executing copy when the stored version
+      already clears the requirement. No row opens an in-app terminal: the
+      1.2.0 hosts needing this remedy cannot run a supplied command on ordinary
+      terminal creation. Check now stays; the remedy replaces Update now until
+      the host accepts the candidate. Advanced rows retain their reasons.
+      Sentence precedence preserves the record-derived parks: **failure →
+      activation debt → CLI remedy → checking → unreachable → no manifest →
+      stranded on its release line / up to date → unavailable / available**.
+      A failed catalog read drops the remedy along with the actionable catalog.
+
+    - **Repair rechecks while the Overview is open.** A table-owned condition
+      lane polls `host.update.check` every 30 seconds while the latest
+      non-yanked candidate carries the CLI refusal. For `installed-rc`, every
+      non-yanked entry is considered because the response has no installed
+      version with which to reconstruct the same-line walk. The first clear
+      response stops the lane and restores Update now. The existing 10-second
+      installation-info poll refreshes the stored CLI facts beside it.
+      A floored staged version, or one absent from the actionable manifest,
+      offers neither Force update nor Force restart: restarting cannot activate
+      a stage. An open Force confirmation rechecks its exact version at click
+      time, settles synchronously on refusal, and shows the reason inline.
   - **Installation** reads `host.getInstallationInfo`. `unmanaged` is a real
     state, not an error - a host run from a checkout has no install record - and
     it says so rather than claiming nothing is installed.

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-overview-cli-floor-remedy-card.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-overview-cli-floor-remedy-card.test.tsx
@@ -278,6 +278,80 @@ describe("HostOverviewUpdatesRegion CLI floor remedy", () => {
     expect(bridge.installUpdate).not.toHaveBeenCalled();
   });
 
+  it("shows manual retry and help for Desktop failures without automatic checks", async () => {
+    const failures = [
+      {
+        status: "error" as const,
+        errorMessage: "Updater failed",
+        sentence: "Updater failed",
+      },
+      {
+        status: "unavailable" as const,
+        errorMessage: null,
+        sentence: "Traycer Desktop couldn't check for updates.",
+      },
+    ] as const;
+    for (const failure of failures) {
+      const bridge = new FakeDesktopBridge();
+      const remedy = describeCliFloorRemedy({
+        isLocalMachine: true,
+        platform: "darwin-arm64",
+        cliSource: "desktop",
+        cliBinaryPath: null,
+        cliVersion: "1.2.0",
+        requiredCliVersion: "1.3.0",
+        desktopUpdate: {
+          ...SNAPSHOT,
+          status: failure.status,
+          errorMessage: failure.errorMessage,
+        },
+        hostName: "build-host",
+      });
+      const rendered = renderRegion(remedy, bridge);
+
+      expect(screen.getByRole("status").textContent).toBe(failure.sentence);
+      expect(screen.getByRole("button", { name: "Check again" })).toBeTruthy();
+      expect(
+        screen.getByRole("button", { name: "Show installation help" }),
+      ).toBeTruthy();
+      await waitFor(() =>
+        expect(bridge.checkForUpdates).not.toHaveBeenCalled(),
+      );
+      // D02's automatic retry mapping or D04's removal of only
+      // `if (checkOnMount)` would dispatch on this failure mount. Retaining
+      // `[bridge, checkOnMount]` isolates the mount guard; this count must
+      // remain zero through rerenders until the user clicks.
+      rendered.rerender(
+        regionElement(
+          describeCliFloorRemedy({
+            isLocalMachine: true,
+            platform: "darwin-arm64",
+            cliSource: "desktop",
+            cliBinaryPath: null,
+            cliVersion: "1.2.0",
+            requiredCliVersion: "1.3.0",
+            desktopUpdate: { ...SNAPSHOT, status: "checking" },
+            hostName: "build-host",
+          }),
+          bridge,
+        ),
+      );
+      rendered.rerender(regionElement(remedy, bridge));
+      await waitFor(() =>
+        expect(bridge.checkForUpdates).not.toHaveBeenCalled(),
+      );
+
+      // Removing the retry button's manual dispatch would keep this genuine
+      // spy at zero; these exact per-click counts must turn RED under D03.
+      fireEvent.click(screen.getByRole("button", { name: "Check again" }));
+      expect(bridge.checkForUpdates).toHaveBeenCalledTimes(1);
+      expect(bridge.checkForUpdates).toHaveBeenCalledWith("manual");
+      fireEvent.click(screen.getByRole("button", { name: "Check again" }));
+      expect(bridge.checkForUpdates).toHaveBeenCalledTimes(2);
+      cleanup();
+    }
+  });
+
   it("checks an unknown Desktop state once and does not create an effect retry loop", async () => {
     const bridge = new FakeDesktopBridge();
     const remedy = describeCliFloorRemedy({
@@ -287,7 +361,7 @@ describe("HostOverviewUpdatesRegion CLI floor remedy", () => {
       cliBinaryPath: null,
       cliVersion: "1.2.0",
       requiredCliVersion: "1.3.0",
-      desktopUpdate: { ...SNAPSHOT, status: "error" },
+      desktopUpdate: { ...SNAPSHOT, status: "idle" },
       hostName: "build-host",
     });
     const rendered = renderRegion(remedy, bridge);
@@ -313,9 +387,9 @@ describe("HostOverviewUpdatesRegion CLI floor remedy", () => {
     await waitFor(() =>
       expect(bridge.checkForUpdates).toHaveBeenCalledTimes(1),
     );
-    // Removing the bridge dependency guard / stable unknown-state effect would
-    // call manual checks again on every render; this negative call-count pin
-    // must turn RED under that concrete retry-loop ablation.
+    // Removing ONLY `if (checkOnMount)` while retaining `[bridge, checkOnMount]`
+    // would call once on idle mount and again on the idle-to-checking
+    // transition; this negative call-count pin must turn RED under D04.
     expect(bridge.checkForUpdates).toHaveBeenCalledWith("manual");
   });
 });

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-overview-cli-floor-remedy-card.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-overview-cli-floor-remedy-card.test.tsx
@@ -167,6 +167,39 @@ describe("HostOverviewUpdatesRegion CLI floor remedy", () => {
     expect(clipboardWriteText).toHaveBeenCalledWith("traycer cli upgrade");
   });
 
+  it("copies Windows Desktop fallback commands and renders PowerShell guidance", () => {
+    const binaryPath =
+      "C:\\Users\\x\\AppData\\Local\\Traycer\\cli\\traycer.exe";
+    const remedy = describeCliFloorRemedy({
+      isLocalMachine: true,
+      platform: "win32-x64",
+      cliSource: "desktop",
+      cliBinaryPath: binaryPath,
+      cliVersion: "1.2.0",
+      requiredCliVersion: "1.3.0",
+      desktopUpdate: {
+        ...SNAPSHOT,
+        latestVersion: "1.2.0",
+      },
+      hostName: "build-host",
+    });
+    renderRegion(remedy, null);
+
+    expect(screen.getByRole("status").textContent).toBe(remedy.sentence);
+    // E09: removing the PowerShell/outside wording would make this visible
+    // shell-guidance pin RED even if the copy payload remained unchanged.
+    expect(screen.getByRole("status").textContent).toContain(
+      "PowerShell window outside Traycer on that machine",
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Copy commands" }));
+    // E07: withholding Windows Desktop fallback commands would leave this
+    // exact clipboard payload unavailable; this positive copy pin must RED.
+    expect(clipboardWriteText).toHaveBeenCalledWith(
+      "& 'C:\\Users\\x\\AppData\\Local\\Traycer\\cli\\traycer.exe' cli upgrade\n& 'C:\\Users\\x\\AppData\\Local\\Traycer\\cli\\traycer.exe' host restart",
+    );
+    expect(requestInstallMock).not.toHaveBeenCalled();
+  });
+
   it("downloads an available Desktop update and never installs directly", () => {
     const bridge = new FakeDesktopBridge();
     const remedy = describeCliFloorRemedy({

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-overview-cli-floor-remedy-card.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-overview-cli-floor-remedy-card.test.tsx
@@ -1,0 +1,321 @@
+import type { ReactElement } from "react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  type RenderResult,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { HostOverviewUpdatesRegion } from "@/components/settings/panels/host-overview-updates";
+import {
+  describeCliFloorRemedy,
+  type CliFloorRemedy,
+} from "@/components/settings/panels/host-overview-cli-floor-remedy";
+import type { HostOverviewUpdatesSummary } from "@/components/settings/panels/host-overview-updates-state";
+import type {
+  DesktopAppUpdateChannelChange,
+  DesktopAppUpdateCheckIntent,
+  DesktopAppUpdateSnapshot,
+  DesktopAppUpdatesBridge,
+  DesktopCompatRecoveryPlan,
+} from "@/lib/windows/types";
+import { useDesktopDialogStore } from "@/stores/dialogs/desktop-dialog-store";
+
+const requestInstallMock = vi.hoisted(() => vi.fn(() => Promise.resolve()));
+const clipboardWriteText = vi.fn(() => Promise.resolve());
+vi.mock("@/lib/app-update/request-app-update-install", () => ({
+  requestAppUpdateInstall: requestInstallMock,
+}));
+
+const SNAPSHOT: DesktopAppUpdateSnapshot = {
+  sequence: 1,
+  status: "available",
+  currentVersion: "1.2.0",
+  allowPrerelease: false,
+  latestVersion: "1.3.0",
+  latestCompatibilityEpoch: 1,
+  downloadProgress: null,
+  installBlockedReason: null,
+  installGuidance: null,
+  installInFlight: false,
+  errorMessage: null,
+  lastCheckedAt: "2026-09-06T00:00:00Z",
+  lastCheckIntent: "automatic",
+};
+
+class FakeDesktopBridge implements DesktopAppUpdatesBridge {
+  readonly downloadUpdate = vi.fn(() => Promise.resolve(SNAPSHOT));
+  readonly installUpdate = vi.fn(() => Promise.resolve(SNAPSHOT));
+  readonly checkForUpdates = vi.fn((_intent: DesktopAppUpdateCheckIntent) =>
+    Promise.resolve(SNAPSHOT),
+  );
+
+  getSnapshot(): Promise<DesktopAppUpdateSnapshot> {
+    return Promise.resolve(SNAPSHOT);
+  }
+
+  setAllowPrerelease(
+    _allowPrerelease: boolean,
+  ): Promise<DesktopAppUpdateChannelChange> {
+    return Promise.resolve({ outcome: "unchanged", snapshot: SNAPSHOT });
+  }
+
+  resolveCompatRecovery(_request: {
+    readonly minimumEpoch: number;
+    readonly hostAllowsRcRecovery: boolean;
+  }): Promise<DesktopCompatRecoveryPlan> {
+    return Promise.resolve({
+      route: "manual",
+      rcCandidateVersion: null,
+      stagedVersion: null,
+    });
+  }
+
+  onChange(_handler: (snapshot: DesktopAppUpdateSnapshot) => void): {
+    dispose(): void;
+  } {
+    return { dispose: () => undefined };
+  }
+}
+
+function summary(remedy: CliFloorRemedy): HostOverviewUpdatesSummary {
+  return {
+    hostName: "build-host",
+    description: remedy.sentence,
+    failureDescription: null,
+    remedy,
+    checking: false,
+    updatableVersion: null,
+    installing: false,
+    busy: false,
+    onCheck: vi.fn(),
+    onUpdateLatest: vi.fn(),
+  };
+}
+
+function regionElement(
+  remedy: CliFloorRemedy,
+  bridge: DesktopAppUpdatesBridge | null,
+): ReactElement {
+  return (
+    <TooltipProvider>
+      <HostOverviewUpdatesRegion
+        summary={summary(remedy)}
+        degrade={null}
+        desktopBridge={bridge}
+        onInstallationHelp={vi.fn()}
+      />
+    </TooltipProvider>
+  );
+}
+
+function renderRegion(
+  remedy: CliFloorRemedy,
+  bridge: DesktopAppUpdatesBridge | null,
+): RenderResult {
+  return render(regionElement(remedy, bridge));
+}
+
+function manualRemedy(binaryPath: string): CliFloorRemedy {
+  return describeCliFloorRemedy({
+    isLocalMachine: false,
+    platform: "darwin-arm64",
+    cliSource: "manual",
+    cliBinaryPath: binaryPath,
+    cliVersion: "1.2.0",
+    requiredCliVersion: "1.3.0",
+    desktopUpdate: null,
+    hostName: "build-host",
+  });
+}
+
+afterEach(() => {
+  cleanup();
+  requestInstallMock.mockClear();
+  clipboardWriteText.mockClear();
+  useDesktopDialogStore.getState().close();
+});
+
+describe("HostOverviewUpdatesRegion CLI floor remedy", () => {
+  beforeEach(() => {
+    clipboardWriteText.mockClear();
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: clipboardWriteText },
+    });
+  });
+
+  it("renders the sentence in the status span and copies the recorded path command", () => {
+    const remedy = manualRemedy("/home/u/.local/bin/traycer");
+    renderRegion(remedy, null);
+
+    expect(screen.getByRole("status").textContent).toBe(remedy.sentence);
+    fireEvent.click(screen.getByRole("button", { name: "Copy command" }));
+    expect(clipboardWriteText).toHaveBeenCalledWith(
+      "'/home/u/.local/bin/traycer' cli upgrade",
+    );
+  });
+
+  it("copies the bare command when the recorded path is unavailable", () => {
+    const remedy = manualRemedy("");
+    renderRegion(remedy, null);
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy command" }));
+    expect(clipboardWriteText).toHaveBeenCalledWith("traycer cli upgrade");
+  });
+
+  it("downloads an available Desktop update and never installs directly", () => {
+    const bridge = new FakeDesktopBridge();
+    const remedy = describeCliFloorRemedy({
+      isLocalMachine: true,
+      platform: "darwin-arm64",
+      cliSource: "desktop",
+      cliBinaryPath: null,
+      cliVersion: "1.2.0",
+      requiredCliVersion: "1.3.0",
+      desktopUpdate: SNAPSHOT,
+      hostName: "build-host",
+    });
+    renderRegion(remedy, bridge);
+
+    fireEvent.click(screen.getByRole("button", { name: "Download update" }));
+    // Keep checking the forbidden routes when a mutation also misses download.
+    expect.soft(bridge.downloadUpdate).toHaveBeenCalledTimes(1);
+    expect(requestInstallMock).not.toHaveBeenCalled();
+    // Removing the available-state action gate would install from this row;
+    // this negative spy must turn RED under that concrete status-ablation.
+    expect(bridge.installUpdate).not.toHaveBeenCalled();
+  });
+
+  it("honors blocked and in-flight Desktop states as disabled, with no install route", () => {
+    for (const desktopUpdate of [
+      {
+        ...SNAPSHOT,
+        status: "ready" as const,
+        installBlockedReason: "Not in Applications",
+      },
+      { ...SNAPSHOT, status: "ready" as const, installInFlight: true },
+    ]) {
+      const bridge = new FakeDesktopBridge();
+      const remedy = describeCliFloorRemedy({
+        isLocalMachine: true,
+        platform: "darwin-arm64",
+        cliSource: "desktop",
+        cliBinaryPath: null,
+        cliVersion: "1.2.0",
+        requiredCliVersion: "1.3.0",
+        desktopUpdate,
+        hostName: "build-host",
+      });
+      renderRegion(remedy, bridge);
+      const button = screen.getByRole("button", { name: "Restart to update" });
+      // A broken disabled state must also reach the no-install assertions.
+      expect.soft(button.hasAttribute("disabled")).toBe(true);
+      fireEvent.click(button);
+      // Removing the blocked/in-flight disabled predicate would let this
+      // control reach an install route; these negative no-install pins must
+      // turn RED under that concrete state-gating ablation.
+      expect(requestInstallMock).not.toHaveBeenCalled();
+      expect(bridge.installUpdate).not.toHaveBeenCalled();
+      cleanup();
+    }
+  });
+
+  it("opens the manual Desktop guidance dialog for a ready update", () => {
+    const bridge = new FakeDesktopBridge();
+    const remedy = describeCliFloorRemedy({
+      isLocalMachine: true,
+      platform: "linux-x64",
+      cliSource: "desktop",
+      cliBinaryPath: null,
+      cliVersion: "1.2.0",
+      requiredCliVersion: "1.3.0",
+      desktopUpdate: {
+        ...SNAPSHOT,
+        status: "ready",
+        installGuidance: {
+          summary: "Use the package manager",
+          steps: ["Install the downloaded package"],
+          command: "sudo dpkg -i traycer.deb",
+          releaseUrl: "https://example.invalid/release",
+        },
+      },
+      hostName: "build-host",
+    });
+    renderRegion(remedy, bridge);
+
+    fireEvent.click(screen.getByRole("button", { name: "Finish update" }));
+    // A missing dialog must not hide a forbidden install in the same click.
+    expect
+      .soft(useDesktopDialogStore.getState().activeDialog)
+      .toBe("install-guidance");
+    expect(requestInstallMock).not.toHaveBeenCalled();
+  });
+
+  it("routes a ready Desktop update through the shared install request door", () => {
+    const bridge = new FakeDesktopBridge();
+    const remedy = describeCliFloorRemedy({
+      isLocalMachine: true,
+      platform: "darwin-arm64",
+      cliSource: "desktop",
+      cliBinaryPath: null,
+      cliVersion: "1.2.0",
+      requiredCliVersion: "1.3.0",
+      desktopUpdate: { ...SNAPSHOT, status: "ready" },
+      hostName: "build-host",
+    });
+    renderRegion(remedy, bridge);
+
+    fireEvent.click(screen.getByRole("button", { name: "Restart to update" }));
+    // Retain the direct-install negative when the shared call is also missing.
+    expect.soft(requestInstallMock).toHaveBeenCalledWith(bridge);
+    // Removing the shared request-door call and invoking bridge.installUpdate
+    // in the component would bypass cross-window protection; this negative
+    // spy must turn RED under that concrete routing ablation.
+    expect(bridge.installUpdate).not.toHaveBeenCalled();
+  });
+
+  it("checks an unknown Desktop state once and does not create an effect retry loop", async () => {
+    const bridge = new FakeDesktopBridge();
+    const remedy = describeCliFloorRemedy({
+      isLocalMachine: true,
+      platform: "darwin-arm64",
+      cliSource: "desktop",
+      cliBinaryPath: null,
+      cliVersion: "1.2.0",
+      requiredCliVersion: "1.3.0",
+      desktopUpdate: { ...SNAPSHOT, status: "error" },
+      hostName: "build-host",
+    });
+    const rendered = renderRegion(remedy, bridge);
+
+    await waitFor(() =>
+      expect(bridge.checkForUpdates).toHaveBeenCalledTimes(1),
+    );
+    rendered.rerender(
+      regionElement(
+        describeCliFloorRemedy({
+          isLocalMachine: true,
+          platform: "darwin-arm64",
+          cliSource: "desktop",
+          cliBinaryPath: null,
+          cliVersion: "1.2.0",
+          requiredCliVersion: "1.3.0",
+          desktopUpdate: { ...SNAPSHOT, status: "checking" },
+          hostName: "build-host",
+        }),
+        bridge,
+      ),
+    );
+    await waitFor(() =>
+      expect(bridge.checkForUpdates).toHaveBeenCalledTimes(1),
+    );
+    // Removing the bridge dependency guard / stable unknown-state effect would
+    // call manual checks again on every render; this negative call-count pin
+    // must turn RED under that concrete retry-loop ablation.
+    expect(bridge.checkForUpdates).toHaveBeenCalledWith("manual");
+  });
+});

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-overview-cli-floor-remedy.test.ts
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-overview-cli-floor-remedy.test.ts
@@ -1,0 +1,477 @@
+import { describe, expect, it } from "vitest";
+import type { CliInstallSource } from "@traycer/protocol/config/installation-records";
+import {
+  CLI_FLOOR_REMEDY_ACTION_KINDS,
+  describeCliFloorRemedy,
+  type CliFloorRemedyAction,
+  type CliFloorRemedyInput,
+} from "@/components/settings/panels/host-overview-cli-floor-remedy";
+import type {
+  DesktopAppUpdateSnapshot,
+  DesktopAppUpdateStatus,
+} from "@/lib/windows/types";
+
+const PACKAGE_MANAGER_COMMANDS: Readonly<
+  Record<Exclude<CliInstallSource, "desktop" | "manual">, string>
+> = {
+  homebrew: "brew upgrade traycer",
+  npm: "npm install -g @traycerai/cli@latest",
+  winget: "winget upgrade Traycer.CLI",
+  scoop: "scoop update traycer-cli",
+  apt: "sudo apt update && sudo apt install --only-upgrade traycer-cli",
+  rpm: "sudo dnf upgrade traycer-cli",
+};
+
+const platforms: readonly (string | null)[] = [
+  "linux-x64",
+  "darwin-arm64",
+  "win32-x64",
+  null,
+];
+
+const sources: readonly (CliInstallSource | null)[] = [
+  "desktop",
+  "homebrew",
+  "npm",
+  "winget",
+  "scoop",
+  "apt",
+  "rpm",
+  "manual",
+  null,
+];
+
+function expectedDesktopKind(
+  status: DesktopAppUpdateStatus,
+): CliFloorRemedyAction["kind"] {
+  switch (status) {
+    case "available":
+      return "desktop-download";
+    case "downloading":
+      return "desktop-progress";
+    case "ready":
+      return "desktop-install";
+    case "up-to-date":
+      return "restart-desktop-hint";
+    default:
+      return "desktop-check";
+  }
+}
+
+function snapshot(
+  status: DesktopAppUpdateStatus,
+  overrides: Partial<DesktopAppUpdateSnapshot>,
+): DesktopAppUpdateSnapshot {
+  return {
+    sequence: 1,
+    status,
+    currentVersion: "1.2.0",
+    allowPrerelease: false,
+    latestVersion: "1.3.0",
+    latestCompatibilityEpoch: 1,
+    downloadProgress: status === "downloading" ? 42 : null,
+    installBlockedReason: null,
+    installGuidance: null,
+    installInFlight: false,
+    errorMessage: null,
+    lastCheckedAt: "2026-09-06T00:00:00Z",
+    lastCheckIntent: "automatic",
+    ...overrides,
+  };
+}
+
+function input(options: {
+  source: CliInstallSource | null;
+  platform: string | null;
+  isLocalMachine: boolean;
+  desktopUpdate: DesktopAppUpdateSnapshot | null;
+  overrides: Partial<CliFloorRemedyInput>;
+}): CliFloorRemedyInput {
+  return {
+    isLocalMachine: options.isLocalMachine,
+    platform: options.platform,
+    cliSource: options.source,
+    cliBinaryPath: "/home/u/.local/bin/traycer",
+    cliVersion: "1.2.0",
+    requiredCliVersion: "1.3.0",
+    desktopUpdate: options.desktopUpdate,
+    hostName: "build-host",
+    ...options.overrides,
+  };
+}
+
+describe("describeCliFloorRemedy", () => {
+  it("covers every locality/platform/source/bridge/status combination without inventing a terminal action", () => {
+    const desktopStatuses: readonly DesktopAppUpdateStatus[] = [
+      "available",
+      "downloading",
+      "ready",
+      "up-to-date",
+      "checking",
+      "error",
+      "unavailable",
+      "idle",
+    ];
+
+    const cases = [true, false].flatMap((isLocalMachine) =>
+      platforms.flatMap((platform) =>
+        sources.flatMap((source) =>
+          [false, true].flatMap((bridge) =>
+            desktopStatuses.map((status) => ({
+              bridge,
+              isLocalMachine,
+              platform,
+              source,
+              status,
+            })),
+          ),
+        ),
+      ),
+    );
+
+    for (const testCase of cases) {
+      const result = describeCliFloorRemedy(
+        input({
+          source: testCase.source,
+          platform: testCase.platform,
+          isLocalMachine: testCase.isLocalMachine,
+          desktopUpdate: testCase.bridge ? snapshot(testCase.status, {}) : null,
+          overrides: {},
+        }),
+      );
+      const kinds = result.actions.map((action) => action.kind);
+      // Removing the copy-only action union and restoring an
+      // open-terminal kind would violate the 1.2.0-host boundary;
+      // this negative union pin must turn RED under that ablation.
+      expect(kinds).not.toContain("open-terminal");
+
+      if (testCase.source === null) {
+        expect(kinds).toEqual(["help"]);
+        continue;
+      }
+      if (
+        testCase.source === "desktop" &&
+        testCase.isLocalMachine &&
+        testCase.bridge
+      ) {
+        expect(kinds).toEqual([expectedDesktopKind(testCase.status)]);
+        continue;
+      }
+      expect(kinds).toEqual(["copy-command"]);
+    }
+  });
+
+  it("has no terminal action in the public action union", () => {
+    // expectTypeOf was rejected: plain Vitest erases it, so an addition could
+    // stay green without a typecheck. The tuple now owns the union; adding a
+    // kind must fail this runtime assertion on every normal CI test run.
+    expect(CLI_FLOOR_REMEDY_ACTION_KINDS).toEqual([
+      "desktop-download",
+      "desktop-progress",
+      "desktop-install",
+      "desktop-check",
+      "restart-desktop-hint",
+      "copy-command",
+      "help",
+    ]);
+    expect(CLI_FLOOR_REMEDY_ACTION_KINDS).not.toContain("open-terminal");
+  });
+
+  it("renders each package-manager command as a copy payload for local and remote hosts", () => {
+    for (const source of Object.keys(PACKAGE_MANAGER_COMMANDS) as Exclude<
+      CliInstallSource,
+      "desktop" | "manual"
+    >[]) {
+      for (const isLocalMachine of [true, false]) {
+        const result = describeCliFloorRemedy(
+          input({
+            source,
+            platform: "darwin-arm64",
+            isLocalMachine,
+            desktopUpdate: null,
+            overrides: {},
+          }),
+        );
+        expect(result.actions).toEqual([
+          {
+            kind: "copy-command",
+            label: "Copy command",
+            command: PACKAGE_MANAGER_COMMANDS[source],
+          },
+        ]);
+        expect(result.sentence).toContain(PACKAGE_MANAGER_COMMANDS[source]);
+      }
+    }
+  });
+
+  it("uses the POSIX absolute path and protects spaces, apostrophes, dollars, and backticks", () => {
+    const paths = [
+      ["/home/u/bin/traycer", "'/home/u/bin/traycer' cli upgrade"],
+      ["/home/u/My Tools/traycer", "'/home/u/My Tools/traycer' cli upgrade"],
+      [
+        "/home/u/O'Reilly/$traycer`bin`/traycer",
+        "'/home/u/O'\\''Reilly/$traycer`bin`/traycer' cli upgrade",
+      ],
+    ] as const;
+    for (const [cliBinaryPath, command] of paths) {
+      const result = describeCliFloorRemedy(
+        input({
+          source: "manual",
+          platform: "darwin-arm64",
+          isLocalMachine: false,
+          desktopUpdate: null,
+          overrides: { cliBinaryPath },
+        }),
+      );
+      expect(result.actions[0]).toMatchObject({
+        kind: "copy-command",
+        command,
+      });
+    }
+  });
+
+  it("falls back to the bare POSIX command for relative and empty paths", () => {
+    for (const cliBinaryPath of ["traycer", "", null]) {
+      const result = describeCliFloorRemedy(
+        input({
+          source: "manual",
+          platform: "linux-x64",
+          isLocalMachine: false,
+          desktopUpdate: null,
+          overrides: { cliBinaryPath },
+        }),
+      );
+      expect(result.actions[0]).toMatchObject({
+        kind: "copy-command",
+        command: "traycer cli upgrade",
+      });
+    }
+  });
+
+  it("uses both outside-Traycer commands for Windows and unknown platforms", () => {
+    for (const platform of ["win32-x64", "win32-arm64", null]) {
+      const result = describeCliFloorRemedy(
+        input({
+          source: "manual",
+          platform,
+          isLocalMachine: false,
+          desktopUpdate: null,
+          overrides: {},
+        }),
+      );
+      expect(result.actions[0]).toMatchObject({
+        kind: "copy-command",
+        label: "Copy commands",
+        command: "traycer cli upgrade\ntraycer host restart",
+      });
+    }
+  });
+
+  it("falls back to copy-only guidance for a local Desktop host without a bridge", () => {
+    const result = describeCliFloorRemedy(
+      input({
+        source: "desktop",
+        platform: "darwin-arm64",
+        isLocalMachine: true,
+        desktopUpdate: null,
+        overrides: {},
+      }),
+    );
+    expect(result.actions[0]).toMatchObject({
+      kind: "copy-command",
+      command: "'" + "/home/u/.local/bin/traycer" + "' cli upgrade",
+    });
+  });
+
+  it("keeps the older-copy sentence when the stored CLI version already clears the floor", () => {
+    const result = describeCliFloorRemedy(
+      input({
+        source: "manual",
+        platform: "darwin-arm64",
+        isLocalMachine: false,
+        desktopUpdate: null,
+        overrides: { cliVersion: "1.3.0" },
+      }),
+    );
+    expect(result.sentence).toContain(
+      "were updated, but the host is still using an older copy",
+    );
+    expect(result.sentence).toContain("Run the command again:");
+  });
+
+  it("never fabricates a missing required version in copy guidance", () => {
+    const available = describeCliFloorRemedy(
+      input({
+        source: "desktop",
+        platform: "darwin-arm64",
+        isLocalMachine: true,
+        desktopUpdate: snapshot("available", { latestVersion: null }),
+        overrides: { requiredCliVersion: null },
+      }),
+    );
+    // Removing describeDesktopRemedy's null-version guards would expose
+    // "null"/"undefined" in these natural versionless sentences; these
+    // negative text pins must turn RED under that concrete ablation.
+    expect(available.sentence).toBe(
+      "Update Traycer Desktop to install this host update.",
+    );
+    expect(available.sentence).not.toContain("undefined");
+    expect(available.sentence).not.toContain("null");
+
+    const ready = describeCliFloorRemedy(
+      input({
+        source: "desktop",
+        platform: "darwin-arm64",
+        isLocalMachine: true,
+        desktopUpdate: snapshot("ready", { latestVersion: null }),
+        overrides: { requiredCliVersion: null },
+      }),
+    );
+    expect(ready.sentence).toBe(
+      "Traycer Desktop is ready. Restart Traycer to finish, then this host update can install.",
+    );
+    expect(ready.sentence).not.toContain("undefined");
+    expect(ready.sentence).not.toContain("null");
+  });
+
+  it("reports an unreadable CLI manifest through installation help", () => {
+    const result = describeCliFloorRemedy(
+      input({
+        source: null,
+        platform: "darwin-arm64",
+        isLocalMachine: false,
+        desktopUpdate: null,
+        overrides: {},
+      }),
+    );
+    expect(result).toEqual({
+      sentence:
+        "Traycer couldn't determine how its command-line tools were installed on build-host.",
+      actions: [{ kind: "help", label: "Show installation help" }],
+    });
+  });
+
+  it("only offers download for available Desktop updates", () => {
+    const result = describeCliFloorRemedy(
+      input({
+        source: "desktop",
+        platform: "darwin-arm64",
+        isLocalMachine: true,
+        desktopUpdate: snapshot("available", {}),
+        overrides: {},
+      }),
+    );
+    expect(result.actions[0]).toMatchObject({
+      kind: "desktop-download",
+      label: "Download update",
+    });
+    // Removing the status === available predicate would make a ready Desktop
+    // incorrectly expose Download update and this negative pin would turn RED.
+    const ready = describeCliFloorRemedy(
+      input({
+        source: "desktop",
+        platform: "darwin-arm64",
+        isLocalMachine: true,
+        desktopUpdate: snapshot("ready", {}),
+        overrides: {},
+      }),
+    );
+    expect(ready.actions[0]?.kind).toBe("desktop-install");
+  });
+
+  it("only offers install for ready Desktop updates and carries blocked/guidance state", () => {
+    const blocked = describeCliFloorRemedy(
+      input({
+        source: "desktop",
+        platform: "darwin-arm64",
+        isLocalMachine: true,
+        desktopUpdate: snapshot("ready", {
+          installBlockedReason: "Not in Applications",
+        }),
+        overrides: {},
+      }),
+    );
+    expect(blocked.actions[0]).toMatchObject({
+      kind: "desktop-install",
+      disabled: true,
+      tooltip: "Not in Applications",
+      showGuidance: false,
+    });
+    const guided = describeCliFloorRemedy(
+      input({
+        source: "desktop",
+        platform: "linux-x64",
+        isLocalMachine: true,
+        desktopUpdate: snapshot("ready", {
+          installGuidance: {
+            summary: "Use the package manager",
+            steps: ["step"],
+            command: "sudo dpkg -i traycer.deb",
+            releaseUrl: "https://example.invalid/release",
+          },
+        }),
+        overrides: {},
+      }),
+    );
+    expect(guided.actions[0]).toMatchObject({
+      kind: "desktop-install",
+      label: "Finish update",
+      showGuidance: true,
+    });
+    // Removing the status === ready predicate would make an available Desktop
+    // incorrectly expose install, so this negative status pin must turn RED.
+    const available = describeCliFloorRemedy(
+      input({
+        source: "desktop",
+        platform: "linux-x64",
+        isLocalMachine: true,
+        desktopUpdate: snapshot("available", {}),
+        overrides: {},
+      }),
+    );
+    expect(available.actions[0]?.kind).toBe("desktop-download");
+
+    const inFlight = describeCliFloorRemedy(
+      input({
+        source: "desktop",
+        platform: "darwin-arm64",
+        isLocalMachine: true,
+        desktopUpdate: snapshot("ready", { installInFlight: true }),
+        overrides: {},
+      }),
+    );
+    expect(inFlight.actions[0]).toMatchObject({
+      kind: "desktop-install",
+      disabled: true,
+      installInFlight: true,
+    });
+  });
+
+  it("uses a restart hint only when Desktop is up to date and checks unknown states", () => {
+    const current = describeCliFloorRemedy(
+      input({
+        source: "desktop",
+        platform: "darwin-arm64",
+        isLocalMachine: true,
+        desktopUpdate: snapshot("up-to-date", {}),
+        overrides: {},
+      }),
+    );
+    expect(current.actions).toEqual([{ kind: "restart-desktop-hint" }]);
+    for (const status of ["checking", "error", "unavailable"] as const) {
+      const result = describeCliFloorRemedy(
+        input({
+          source: "desktop",
+          platform: "darwin-arm64",
+          isLocalMachine: true,
+          desktopUpdate: snapshot(status, {}),
+          overrides: {},
+        }),
+      );
+      expect(result.actions).toEqual([{ kind: "desktop-check" }]);
+    }
+    // Removing the explicit up-to-date arm would turn a healthy Desktop state
+    // into a retrying check and this negative pin would turn RED.
+    expect(current.sentence).toContain("up to date");
+  });
+});

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-overview-cli-floor-remedy.test.ts
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-overview-cli-floor-remedy.test.ts
@@ -253,22 +253,103 @@ describe("describeCliFloorRemedy", () => {
   });
 
   it("uses both outside-Traycer commands for Windows and unknown platforms", () => {
-    for (const platform of ["win32-x64", "win32-arm64", null]) {
+    const windowsPathCases = [
+      {
+        binaryPath: "C:\\Users\\x\\AppData\\Local\\Traycer\\cli\\traycer.exe",
+        invocation:
+          "& 'C:\\Users\\x\\AppData\\Local\\Traycer\\cli\\traycer.exe'",
+      },
+      {
+        binaryPath: "C:\\Users\\x\\O'Brien\\Traycer\\traycer.exe",
+        invocation: "& 'C:\\Users\\x\\O''Brien\\Traycer\\traycer.exe'",
+      },
+      {
+        binaryPath: "\\\\server\\share\\Traycer\\traycer.exe",
+        invocation: "& '\\\\server\\share\\Traycer\\traycer.exe'",
+      },
+      {
+        binaryPath: "D:/Users/x/Traycer/cli/traycer.exe",
+        invocation: "& 'D:/Users/x/Traycer/cli/traycer.exe'",
+      },
+    ] as const;
+    const windowsSources = ["manual", "desktop"] as const;
+    const windowsCases = windowsSources.flatMap((source) =>
+      windowsPathCases.map((pathCase) => ({ source, ...pathCase })),
+    );
+    for (const testCase of windowsCases) {
       const result = describeCliFloorRemedy(
         input({
-          source: "manual",
-          platform,
+          source: testCase.source,
+          platform: "win32-x64",
           isLocalMachine: false,
           desktopUpdate: null,
-          overrides: {},
+          overrides: { cliBinaryPath: testCase.binaryPath },
         }),
       );
-      expect(result.actions[0]).toMatchObject({
+      // E01/E02/E03/E04/E08: removing drive/UNC recognition, apostrophe
+      // doubling, PowerShell's `&`, or the second recorded invocation would
+      // make this exact two-line command RED.
+      expect(result.actions).toEqual([
+        {
+          kind: "copy-command",
+          label: "Copy commands",
+          command: `${testCase.invocation} cli upgrade\n${testCase.invocation} host restart`,
+        },
+      ]);
+      expect(result.sentence).toBe(
+        "Run the copied commands on build-host from a PowerShell window outside Traycer on that machine (a Windows Terminal tab there, or an SSH session that opens PowerShell). Restarting briefly disconnects this host. When it reconnects, select Check now, then Update now.",
+      );
+    }
+
+    const bareWindowsCases = [
+      null,
+      "",
+      "traycer",
+      "C:Users\\x\\Traycer\\traycer.exe",
+      "/home/u/bin/traycer",
+    ] as const;
+    const bareCases = windowsSources.flatMap((source) =>
+      bareWindowsCases.map((binaryPath) => ({ source, binaryPath })),
+    );
+    for (const testCase of bareCases) {
+      const result = describeCliFloorRemedy(
+        input({
+          source: testCase.source,
+          platform: "win32-arm64",
+          isLocalMachine: false,
+          desktopUpdate: null,
+          overrides: { cliBinaryPath: testCase.binaryPath },
+        }),
+      );
+      // E05: allowing relative, empty, drive-relative, or POSIX-shaped paths
+      // would guess a Windows executable instead of using bare traycer.
+      expect(result.actions).toEqual([
+        {
+          kind: "copy-command",
+          label: "Copy commands",
+          command: "traycer cli upgrade\ntraycer host restart",
+        },
+      ]);
+    }
+
+    const unknownPlatform = describeCliFloorRemedy(
+      input({
+        source: "manual",
+        platform: null,
+        isLocalMachine: false,
+        desktopUpdate: null,
+        overrides: { cliBinaryPath: "/home/u/bin/traycer" },
+      }),
+    );
+    // Unknown platforms retain the safe outside-Traycer route and do not
+    // guess a PowerShell path from a POSIX-shaped recording.
+    expect(unknownPlatform.actions).toEqual([
+      {
         kind: "copy-command",
         label: "Copy commands",
         command: "traycer cli upgrade\ntraycer host restart",
-      });
-    }
+      },
+    ]);
   });
 
   it("falls back to copy-only guidance for a local Desktop host without a bridge", () => {
@@ -526,8 +607,8 @@ describe("describeCliFloorRemedy", () => {
           },
         }),
       );
-      // Removing the absolute-POSIX/non-Windows path guard would guess a
-      // command for an unsafe case; these negative fallback pins must RED.
+      // Removing the platform-specific absolute-path/no-PATH-guessing guard
+      // would guess a command for an unsafe case; these D06 pins must RED.
       expect(
         result.actions.some((action) => action.kind === "copy-command"),
       ).toBe(pathCase.copy);
@@ -535,6 +616,61 @@ describe("describeCliFloorRemedy", () => {
         kind: "help",
         label: "Show installation help",
       });
+    }
+
+    const windowsFallbackCases = [
+      {
+        binaryPath: "C:\\Users\\x\\AppData\\Local\\Traycer\\cli\\traycer.exe",
+        command:
+          "& 'C:\\Users\\x\\AppData\\Local\\Traycer\\cli\\traycer.exe' cli upgrade\n& 'C:\\Users\\x\\AppData\\Local\\Traycer\\cli\\traycer.exe' host restart",
+        copy: true,
+      },
+      { binaryPath: null, command: null, copy: false },
+      { binaryPath: "", command: null, copy: false },
+      { binaryPath: "traycer", command: null, copy: false },
+      {
+        binaryPath: "C:Users\\x\\Traycer\\traycer.exe",
+        command: null,
+        copy: false,
+      },
+      { binaryPath: "/home/u/bin/traycer", command: null, copy: false },
+    ] as const;
+    for (const pathCase of windowsFallbackCases) {
+      const result = describeCliFloorRemedy(
+        input({
+          source: "desktop",
+          platform: "win32-x64",
+          isLocalMachine: true,
+          desktopUpdate: snapshot("available", { latestVersion: "1.2.0" }),
+          overrides: {
+            cliBinaryPath: pathCase.binaryPath,
+            requiredCliVersion: "1.3.0",
+          },
+        }),
+      );
+      if (pathCase.copy) {
+        // E07: withholding all Windows fallback commands would lose the
+        // usable recorded path and make this positive pin RED.
+        expect(result.actions).toEqual([
+          {
+            kind: "copy-command",
+            label: "Copy commands",
+            command: pathCase.command,
+          },
+          { kind: "help", label: "Show installation help" },
+        ]);
+        // E09: removing the PowerShell/outside wording would lose the shell
+        // guidance appended to the Desktop floor sentence.
+        expect(result.sentence).toContain(
+          "PowerShell window outside Traycer on that machine",
+        );
+      } else {
+        // E06: bypassing the Windows no-path gate would guess PATH for an
+        // absent or non-absolute recording; this exact help-only pin must RED.
+        expect(result.actions).toEqual([
+          { kind: "help", label: "Show installation help" },
+        ]);
+      }
     }
 
     const upToDate = describeCliFloorRemedy(

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-overview-cli-floor-remedy.test.ts
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-overview-cli-floor-remedy.test.ts
@@ -790,7 +790,16 @@ describe("describeCliFloorRemedy", () => {
         cliBinaryPath: "/home/u/bin/traycer",
         copy: false,
       },
-      { platform: null, cliBinaryPath: "/home/u/bin/traycer", copy: false },
+      // A null platform routes by the recorded path's shape, as the manual
+      // arm does; only a path shaped like neither stays copy-less.
+      { platform: null, cliBinaryPath: "/home/u/bin/traycer", copy: true },
+      {
+        platform: null,
+        cliBinaryPath: "C:\\Traycer\\cli\\traycer.exe",
+        copy: true,
+      },
+      { platform: null, cliBinaryPath: "traycer", copy: false },
+      { platform: null, cliBinaryPath: null, copy: false },
     ] as const;
     for (const pathCase of pathCases) {
       const result = describeCliFloorRemedy(

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-overview-cli-floor-remedy.test.ts
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-overview-cli-floor-remedy.test.ts
@@ -65,7 +65,7 @@ function snapshot(
   return {
     sequence: 1,
     status,
-    currentVersion: "1.2.0",
+    currentVersion: "1.3.0",
     allowPrerelease: false,
     latestVersion: "1.3.0",
     latestCompatibilityEpoch: 1,
@@ -154,7 +154,11 @@ describe("describeCliFloorRemedy", () => {
         testCase.isLocalMachine &&
         testCase.bridge
       ) {
-        expect(kinds).toEqual([expectedDesktopKind(testCase.status)]);
+        if (testCase.status === "error" || testCase.status === "unavailable") {
+          expect(kinds).toEqual(["desktop-check", "help"]);
+        } else {
+          expect(kinds).toEqual([expectedDesktopKind(testCase.status)]);
+        }
         continue;
       }
       expect(kinds).toEqual(["copy-command"]);
@@ -447,13 +451,231 @@ describe("describeCliFloorRemedy", () => {
     });
   });
 
+  it("falls back when Desktop candidates are below a known CLI floor", () => {
+    const candidates = [
+      { version: "1.2.0", belowFloor: true },
+      { version: "1.3.0-rc.3", belowFloor: true },
+      { version: "1.3.0-rc.4", belowFloor: false },
+      { version: "1.3.0-rc.5", belowFloor: false },
+      { version: "1.3.0", belowFloor: false },
+    ] as const;
+    for (const status of ["available", "downloading", "ready"] as const) {
+      for (const candidate of candidates) {
+        const result = describeCliFloorRemedy(
+          input({
+            source: "desktop",
+            platform: "darwin-arm64",
+            isLocalMachine: true,
+            desktopUpdate: snapshot(status, {
+              latestVersion: candidate.version,
+            }),
+            overrides: { requiredCliVersion: "1.3.0-rc.4" },
+          }),
+        );
+        if (candidate.belowFloor) {
+          // Bypassing describeDesktopFloorFallback would expose a normal
+          // Desktop action for this refusal; these fallback pins must turn RED
+          // under the concrete D01 ablation.
+          expect(result.sentence).toBe(
+            `Traycer v${candidate.version} is the latest on this update channel and its command-line tools are below 1.3.0-rc.4. Open a terminal on build-host and run the copied command, then select Check now.`,
+          );
+          expect(result.actions).toEqual([
+            {
+              kind: "copy-command",
+              label: "Copy command",
+              command: "'/home/u/.local/bin/traycer' cli upgrade",
+            },
+            { kind: "help", label: "Show installation help" },
+          ]);
+          continue;
+        }
+        // Removing the comparable equal/greater floor check would make these
+        // clear candidates show repair guidance; this negative candidate pin
+        // must turn RED under that concrete semver-ablation.
+        expect(result.actions[0]?.kind).toBe(expectedDesktopKind(status));
+      }
+    }
+  });
+
+  it("uses help instead of guessing a Desktop CLI command when the floor fallback lacks a safe path", () => {
+    const pathCases = [
+      {
+        platform: "darwin-arm64",
+        cliBinaryPath: "/home/u/bin/traycer",
+        copy: true,
+      },
+      { platform: "linux-x64", cliBinaryPath: null, copy: false },
+      { platform: "linux-x64", cliBinaryPath: "traycer", copy: false },
+      {
+        platform: "win32-x64",
+        cliBinaryPath: "/home/u/bin/traycer",
+        copy: false,
+      },
+      { platform: null, cliBinaryPath: "/home/u/bin/traycer", copy: false },
+    ] as const;
+    for (const pathCase of pathCases) {
+      const result = describeCliFloorRemedy(
+        input({
+          source: "desktop",
+          platform: pathCase.platform,
+          isLocalMachine: true,
+          desktopUpdate: snapshot("available", { latestVersion: "1.2.0" }),
+          overrides: {
+            cliBinaryPath: pathCase.cliBinaryPath,
+            requiredCliVersion: "1.3.0",
+          },
+        }),
+      );
+      // Removing the absolute-POSIX/non-Windows path guard would guess a
+      // command for an unsafe case; these negative fallback pins must RED.
+      expect(
+        result.actions.some((action) => action.kind === "copy-command"),
+      ).toBe(pathCase.copy);
+      expect(result.actions.at(-1)).toEqual({
+        kind: "help",
+        label: "Show installation help",
+      });
+    }
+
+    const upToDate = describeCliFloorRemedy(
+      input({
+        source: "desktop",
+        platform: "darwin-arm64",
+        isLocalMachine: true,
+        desktopUpdate: snapshot("up-to-date", {
+          currentVersion: "1.2.0",
+          latestVersion: null,
+        }),
+        overrides: {
+          requiredCliVersion: "1.3.0",
+        },
+      }),
+    );
+    // Removing the up-to-date currentVersion fallback would lose a known
+    // below-floor candidate; this negative fallback pin must turn RED.
+    expect(upToDate.sentence).toContain("Traycer Desktop v1.2.0 is installed");
+
+    const installedVersionAheadOfFeed = describeCliFloorRemedy(
+      input({
+        source: "desktop",
+        platform: "darwin-arm64",
+        isLocalMachine: true,
+        desktopUpdate: snapshot("up-to-date", {
+          currentVersion: "1.3.0-rc.4",
+          latestVersion: "1.2.0",
+        }),
+        overrides: { requiredCliVersion: "1.3.0-rc.4" },
+      }),
+    );
+    // Restoring the prior candidate expression
+    // `snapshot.latestVersion ?? (snapshot.status === "up-to-date" ?
+    // snapshot.currentVersion : null)` would select the older feed version
+    // and expose floor fallback; this feed-behind pin must turn RED while the
+    // below-floor/null-latest case above remains green.
+    expect(installedVersionAheadOfFeed.actions).toEqual([
+      { kind: "restart-desktop-hint" },
+    ]);
+
+    for (const latestVersion of [null, "not-a-version"] as const) {
+      const unknown = describeCliFloorRemedy(
+        input({
+          source: "desktop",
+          platform: "darwin-arm64",
+          isLocalMachine: true,
+          desktopUpdate: snapshot("available", { latestVersion }),
+          overrides: { requiredCliVersion: "1.3.0" },
+        }),
+      );
+      // Removing the unknown-candidate fallback would fabricate a normal
+      // Desktop action; these negative missing/unparseable pins must RED.
+      expect(unknown.sentence).toContain(
+        "couldn't verify that this Desktop update includes Traycer CLI 1.3.0 or newer",
+      );
+      expect(unknown.actions.at(-1)).toEqual({
+        kind: "help",
+        label: "Show installation help",
+      });
+    }
+  });
+
+  it("shows retryable Desktop failures and only auto-checks an idle updater", () => {
+    const failures = [
+      {
+        status: "error" as const,
+        errorMessage: "  Desktop updater failed.  ",
+        sentence: "Desktop updater failed.",
+      },
+      {
+        status: "unavailable" as const,
+        errorMessage: null,
+        sentence: "Traycer Desktop couldn't check for updates.",
+      },
+    ] as const;
+    for (const failure of failures) {
+      const result = describeCliFloorRemedy(
+        input({
+          source: "desktop",
+          platform: "darwin-arm64",
+          isLocalMachine: true,
+          desktopUpdate: snapshot(failure.status, {
+            errorMessage: failure.errorMessage,
+          }),
+          overrides: {},
+        }),
+      );
+      expect(result.sentence).toBe(failure.sentence);
+      // Mapping failures back to Checking/null-label/checkOnMount true would
+      // hide recovery; this negative retry/help pin must RED under that D02
+      // ablation.
+      expect(result.actions).toEqual([
+        {
+          kind: "desktop-check",
+          label: "Check again",
+          checkOnMount: false,
+        },
+        { kind: "help", label: "Show installation help" },
+      ]);
+    }
+
+    const checking = describeCliFloorRemedy(
+      input({
+        source: "desktop",
+        platform: "darwin-arm64",
+        isLocalMachine: true,
+        desktopUpdate: snapshot("checking", {}),
+        overrides: {},
+      }),
+    );
+    expect(checking.sentence).toBe("Checking for a Traycer Desktop update…");
+    expect(checking.actions).toEqual([
+      { kind: "desktop-check", label: null, checkOnMount: false },
+    ]);
+    const idle = describeCliFloorRemedy(
+      input({
+        source: "desktop",
+        platform: "darwin-arm64",
+        isLocalMachine: true,
+        desktopUpdate: snapshot("idle", {}),
+        overrides: {},
+      }),
+    );
+    // Changing idle's sentence back to Checking would claim work is in
+    // flight before the initial check starts; this copy pin must turn RED.
+    expect(idle.sentence).toBe("Check for a Traycer Desktop update.");
+    expect(idle.actions).toEqual([
+      { kind: "desktop-check", label: null, checkOnMount: true },
+    ]);
+  });
+
   it("uses a restart hint only when Desktop is up to date and checks unknown states", () => {
     const current = describeCliFloorRemedy(
       input({
         source: "desktop",
         platform: "darwin-arm64",
         isLocalMachine: true,
-        desktopUpdate: snapshot("up-to-date", {}),
+        desktopUpdate: snapshot("up-to-date", {
+          currentVersion: "1.3.0",
+        }),
         overrides: {},
       }),
     );
@@ -468,7 +690,20 @@ describe("describeCliFloorRemedy", () => {
           overrides: {},
         }),
       );
-      expect(result.actions).toEqual([{ kind: "desktop-check" }]);
+      if (status === "checking") {
+        expect(result.actions).toEqual([
+          { kind: "desktop-check", label: null, checkOnMount: false },
+        ]);
+      } else {
+        expect(result.actions).toEqual([
+          {
+            kind: "desktop-check",
+            label: "Check again",
+            checkOnMount: false,
+          },
+          { kind: "help", label: "Show installation help" },
+        ]);
+      }
     }
     // Removing the explicit up-to-date arm would turn a healthy Desktop state
     // into a retrying check and this negative pin would turn RED.

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-overview-cli-floor-remedy.test.ts
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-overview-cli-floor-remedy.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import type { CliInstallSource } from "@traycer/protocol/config/installation-records";
+import {
+  CLI_NPM_PACKAGE_NAME,
+  PACKAGE_MANAGER_UPGRADE_COMMAND,
+  type CliInstallSource,
+} from "@traycer/protocol/config/installation-records";
 import {
   CLI_FLOOR_REMEDY_ACTION_KINDS,
   describeCliFloorRemedy,
@@ -187,6 +191,10 @@ describe("describeCliFloorRemedy", () => {
       "desktop" | "manual"
     >[]) {
       for (const isLocalMachine of [true, false]) {
+        const command =
+          source === "npm"
+            ? `npm install -g ${CLI_NPM_PACKAGE_NAME}@1.3.0`
+            : PACKAGE_MANAGER_COMMANDS[source];
         const result = describeCliFloorRemedy(
           input({
             source,
@@ -200,11 +208,154 @@ describe("describeCliFloorRemedy", () => {
           {
             kind: "copy-command",
             label: "Copy command",
-            command: PACKAGE_MANAGER_COMMANDS[source],
+            command,
           },
         ]);
-        expect(result.sentence).toContain(PACKAGE_MANAGER_COMMANDS[source]);
+        expect(result.sentence).toContain(command);
       }
+    }
+  });
+
+  it("pins the shared npm package constant and stable command table", () => {
+    // Mutating CLI_NPM_PACKAGE_NAME or the generic npm @latest suffix would
+    // make these shared literal pins RED before remedy-specific interpolation.
+    expect(CLI_NPM_PACKAGE_NAME).toBe("@traycerai/cli");
+    expect(PACKAGE_MANAGER_UPGRADE_COMMAND).toEqual({
+      homebrew: "brew upgrade traycer",
+      npm: "npm install -g @traycerai/cli@latest",
+      winget: "winget upgrade Traycer.CLI",
+      scoop: "scoop update traycer-cli",
+      apt: "sudo apt update && sudo apt install --only-upgrade traycer-cli",
+      rpm: "sudo dnf upgrade traycer-cli",
+    });
+  });
+
+  it("uses exact package-manager floors and publisher-specific prerelease guidance", () => {
+    const packageManagerRows = [
+      {
+        source: "homebrew" as const,
+        stable: "brew upgrade traycer",
+        prerelease: "brew upgrade traycer",
+        rc: "brew upgrade traycer",
+        missing: "brew upgrade traycer",
+        build: "brew upgrade traycer",
+      },
+      {
+        source: "npm" as const,
+        stable: "npm install -g @traycerai/cli@1.3.0",
+        prerelease: "npm install -g @traycerai/cli@1.3.0-beta.1",
+        rc: "npm install -g @traycerai/cli@1.3.0-rc.4",
+        missing: "npm install -g @traycerai/cli@latest",
+        build: "npm install -g @traycerai/cli@1.3.0+build.7",
+      },
+      {
+        source: "winget" as const,
+        stable: "winget upgrade Traycer.CLI",
+        prerelease: null,
+        rc: null,
+        missing: "winget upgrade Traycer.CLI",
+        build: "winget upgrade Traycer.CLI",
+      },
+      {
+        source: "scoop" as const,
+        stable: "scoop update traycer-cli",
+        prerelease: null,
+        rc: null,
+        missing: "scoop update traycer-cli",
+        build: "scoop update traycer-cli",
+      },
+      {
+        source: "apt" as const,
+        stable:
+          "sudo apt update && sudo apt install --only-upgrade traycer-cli",
+        prerelease: null,
+        rc: null,
+        missing:
+          "sudo apt update && sudo apt install --only-upgrade traycer-cli",
+        build: "sudo apt update && sudo apt install --only-upgrade traycer-cli",
+      },
+      {
+        source: "rpm" as const,
+        stable: "sudo dnf upgrade traycer-cli",
+        prerelease: null,
+        rc: null,
+        missing: "sudo dnf upgrade traycer-cli",
+        build: "sudo dnf upgrade traycer-cli",
+      },
+    ] as const;
+    const floorCases = [
+      { key: "stable" as const, requiredVersion: "1.3.0" },
+      { key: "prerelease" as const, requiredVersion: "1.3.0-beta.1" },
+      { key: "rc" as const, requiredVersion: "1.3.0-rc.4" },
+      { key: "missing" as const, requiredVersion: null },
+      { key: "build" as const, requiredVersion: "1.3.0+build.7" },
+    ] as const;
+    const cases = [true, false].flatMap((isLocalMachine) =>
+      packageManagerRows.flatMap((row) =>
+        floorCases.map((floorCase) => ({
+          isLocalMachine,
+          requiredVersion: floorCase.requiredVersion,
+          row,
+          floorKey: floorCase.key,
+        })),
+      ),
+    );
+
+    for (const testCase of cases) {
+      const command = testCase.row[testCase.floorKey];
+      const result = describeCliFloorRemedy(
+        input({
+          source: testCase.row.source,
+          platform: "darwin-arm64",
+          isLocalMachine: testCase.isLocalMachine,
+          desktopUpdate: null,
+          overrides: { requiredCliVersion: testCase.requiredVersion },
+        }),
+      );
+      if (command === null) {
+        // Removing the publisher guard would offer a command for a feed that
+        // does not publish prereleases; this help-only pin must turn RED.
+        expect(result.sentence).toBe(
+          `Traycer CLI prereleases aren't published through ${testCase.row.source}. Install Traycer CLI ${testCase.requiredVersion} another way, then select Check now.`,
+        );
+        expect(result.actions).toEqual([
+          { kind: "help", label: "Show installation help" },
+        ]);
+      } else {
+        // Replacing exact npm floors with the generic latest table, or
+        // disabling the Homebrew/npm prerelease exemptions, makes these
+        // concrete package-manager command pins RED.
+        // The npm missing-floor row additionally turns RED if only the
+        // requiredVersion !== null guard is removed and @null is interpolated.
+        expect(result.actions).toEqual([
+          { kind: "copy-command", label: "Copy command", command },
+        ]);
+        expect(result.sentence).toContain(command);
+      }
+    }
+
+    for (const requiredVersion of [
+      "1.3.0; rm -rf /",
+      "1.3.0' && echo unsafe",
+      "v1.3.0",
+    ]) {
+      const result = describeCliFloorRemedy(
+        input({
+          source: "npm",
+          platform: "darwin-arm64",
+          isLocalMachine: true,
+          desktopUpdate: null,
+          overrides: { requiredCliVersion: requiredVersion },
+        }),
+      );
+      // Removing the isValidHostVersion guard would interpolate shell text
+      // into the npm command; these malformed-floor help pins must turn RED.
+      expect(result.sentence).toBe(
+        "Traycer couldn't verify the required command-line tools version on build-host.",
+      );
+      expect(result.actions).toEqual([
+        { kind: "help", label: "Show installation help" },
+      ]);
     }
   });
 

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-overview-cli-floor-remedy.test.ts
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-overview-cli-floor-remedy.test.ts
@@ -483,7 +483,12 @@ describe("describeCliFloorRemedy", () => {
       ]);
     }
 
-    const unknownPlatform = describeCliFloorRemedy(
+    // Unknown platform: the RECORDED PATH is the evidence. A POSIX-rooted path
+    // means a POSIX host, which has no PowerShell to open and DOES need the
+    // absolute path (a manual/private-slot install is exactly what is not on
+    // PATH). Falsification: restoring `platform === null` to the Windows arm
+    // turns this into "& '/home/u/bin/traycer'" under a PowerShell sentence.
+    const unknownPlatformPosixPath = describeCliFloorRemedy(
       input({
         source: "manual",
         platform: null,
@@ -492,15 +497,57 @@ describe("describeCliFloorRemedy", () => {
         overrides: { cliBinaryPath: "/home/u/bin/traycer" },
       }),
     );
-    // Unknown platforms retain the safe outside-Traycer route and do not
-    // guess a PowerShell path from a POSIX-shaped recording.
-    expect(unknownPlatform.actions).toEqual([
+    expect(unknownPlatformPosixPath.actions).toEqual([
+      {
+        kind: "copy-command",
+        label: "Copy command",
+        command: "'/home/u/bin/traycer' cli upgrade",
+      },
+    ]);
+    expect(unknownPlatformPosixPath.sentence).not.toContain("PowerShell");
+
+    // ...and a drive-rooted path means Windows, with the full Windows route.
+    const unknownPlatformWindowsPath = describeCliFloorRemedy(
+      input({
+        source: "manual",
+        platform: null,
+        isLocalMachine: false,
+        desktopUpdate: null,
+        overrides: { cliBinaryPath: "C:\\Traycer\\cli\\traycer.exe" },
+      }),
+    );
+    expect(unknownPlatformWindowsPath.actions).toEqual([
       {
         kind: "copy-command",
         label: "Copy commands",
-        command: "traycer cli upgrade\ntraycer host restart",
+        command:
+          "& 'C:\\Traycer\\cli\\traycer.exe' cli upgrade\n& 'C:\\Traycer\\cli\\traycer.exe' host restart",
       },
     ]);
+    expect(unknownPlatformWindowsPath.sentence).toContain("PowerShell");
+
+    // Neither platform nor a path shaped like either: bare commands, outside
+    // Traycer, and no shell named.
+    for (const binaryPath of [null, "traycer"] as const) {
+      const unknownEverything = describeCliFloorRemedy(
+        input({
+          source: "manual",
+          platform: null,
+          isLocalMachine: false,
+          desktopUpdate: null,
+          overrides: { cliBinaryPath: binaryPath },
+        }),
+      );
+      expect(unknownEverything.actions).toEqual([
+        {
+          kind: "copy-command",
+          label: "Copy commands",
+          command: "traycer cli upgrade\ntraycer host restart",
+        },
+      ]);
+      expect(unknownEverything.sentence).toContain("terminal outside Traycer");
+      expect(unknownEverything.sentence).not.toContain("PowerShell");
+    }
   });
 
   it("falls back to copy-only guidance for a local Desktop host without a bridge", () => {

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-overview-operation-card.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-overview-operation-card.test.tsx
@@ -723,6 +723,12 @@ describe("HostOverviewOperationCard — record-derived parks", () => {
       "Traycer couldn't determine how its command-line tools were installed on host-a.",
     );
     await screen.findByTestId("host-overview-operation-card");
+    // The negatives below are half a pin on their own: a card rendered in some
+    // other view would also have no force controls. Anchor them to the
+    // staged-wait phase they are about.
+    expect(
+      screen.getByTestId("host-overview-operation-phase").textContent,
+    ).toBe("Update will continue when 2 sessions finish");
     // Removing the stagedFloor gate would expose Force update for a CLI-floor
     // refusal; this negative affordance pin must turn RED under that ablation.
     expect(
@@ -771,6 +777,11 @@ describe("HostOverviewOperationCard — record-derived parks", () => {
     await screen.findByTestId("host-overview-operation-card");
     await screen.findByText("This host is running the latest version.");
     await waitFor(() => expect(checkCalls).toBeGreaterThan(0));
+    // Same anchor as above: the absent controls must be absent FROM the
+    // staged-wait card, not from some other view.
+    expect(
+      screen.getByTestId("host-overview-operation-phase").textContent,
+    ).toBe("Update will continue when 2 sessions finish");
     // Treating an absent staged entry as clear would make Force reachable while
     // its floor is unknown; this negative unknown-evidence pin must turn RED.
     expect(

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-overview-operation-card.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-overview-operation-card.test.tsx
@@ -56,6 +56,7 @@ import type { IRunnerHost } from "@traycer-clients/shared/platform/runner-host";
 import type { HostStatusUpdateOperation } from "@traycer/protocol/host/status/index";
 import type { ResponseOfMethod } from "@traycer-clients/shared/host-transport/host-messenger";
 import type { HostGetInstallationInfoResponseV11 } from "@traycer/protocol/host/maintenance/index";
+import type { HostAvailableManifest } from "@traycer/protocol/host/maintenance/index";
 import type {
   HostInstallRecord,
   HostStagedRecord,
@@ -115,20 +116,18 @@ function makeRunnerHost(): IRunnerHost {
   });
 }
 
-function renderPanel(): void {
+function renderPanel(): QueryClient {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
   render(
-    <QueryClientProvider
-      client={
-        new QueryClient({
-          defaultOptions: { queries: { retry: false, gcTime: 0 } },
-        })
-      }
-    >
+    <QueryClientProvider client={queryClient}>
       <RunnerHostProvider runnerHost={makeRunnerHost()}>
         <HostSettingsPanel />
       </RunnerHostProvider>
     </QueryClientProvider>,
   );
+  return queryClient;
 }
 
 function attemptOperation(
@@ -283,6 +282,55 @@ function managedInstallation(
     installRecord: install,
     stagedRecord: staged,
     cliManifest: null,
+  };
+}
+
+function clearStagedManifest(version: string): HostAvailableManifest {
+  return {
+    schemaVersion: 1,
+    generatedAt: "2026-09-06T00:00:00Z",
+    latest: version,
+    versions: [
+      {
+        version,
+        releasedAt: "2026-09-06T00:00:00Z",
+        releaseNotesUrl: "https://example.invalid/notes",
+        yanked: false,
+        deprecationReason: null,
+        requiredCliVersion: null,
+        platforms: {
+          "darwin-arm64": {
+            available: true,
+            unavailableReason: null,
+            url: "https://example.invalid/host.tar.gz",
+            sizeBytes: 1024,
+            sha256: "a".repeat(64),
+            signatureUrl: "https://example.invalid/host.tar.gz.minisig",
+            signatureAlgorithm: "minisign",
+            publicKeyId: "key-1",
+          },
+        },
+      },
+    ],
+  };
+}
+
+function floorStagedManifest(version: string): HostAvailableManifest {
+  const manifest = clearStagedManifest(version);
+  return {
+    ...manifest,
+    versions: manifest.versions.map((entry) => ({
+      ...entry,
+      requiredCliVersion: "1.3.0",
+      platforms: {
+        "darwin-arm64": {
+          ...entry.platforms["darwin-arm64"],
+          available: false,
+          unavailableReason:
+            "Needs Traycer CLI 1.3.0 or newer (this host's CLI is 1.2.0).",
+        },
+      },
+    })),
   };
 }
 
@@ -604,6 +652,14 @@ describe("HostOverviewOperationCard — record-derived parks", () => {
       overrideHandlers: {
         "host.status": () =>
           statusWithBusy("1.3.0-rc.2", { kind: "none" }, true, 2),
+        "host.update.check": () => ({
+          outcome: "ok" as const,
+          effectiveIncludePreReleases: true,
+          includePreReleasesSource: "explicit-include" as const,
+          // Conservative staged-floor gating needs positive evidence for the
+          // staged version; an empty manifest means the entry is unknown.
+          manifest: clearStagedManifest("1.3.0-rc.3"),
+        }),
         "host.update.install": (req) => {
           installCalls.push({ version: req.version, force: req.force });
           return { outcome: "accepted" as const, attemptId: null };
@@ -635,6 +691,212 @@ describe("HostOverviewOperationCard — record-derived parks", () => {
 
     await waitFor(() => {
       expect(installCalls).toEqual([{ version: "1.3.0-rc.3", force: true }]);
+    });
+  });
+
+  it("hides both force controls when the staged version is explicitly floored", async () => {
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: true,
+      hostVersion: "1.3.0-rc.2",
+      installation: managedInstallation(
+        installRecord("1.3.0-rc.2", "1.3.0-rc.2"),
+        stagedRecord("1.3.0-rc.3"),
+      ),
+      overrideHandlers: {
+        "host.status": () =>
+          statusWithBusy("1.3.0-rc.2", { kind: "none" }, true, 2),
+        "host.update.check": () => ({
+          outcome: "ok" as const,
+          effectiveIncludePreReleases: true,
+          includePreReleasesSource: "explicit-include" as const,
+          manifest: floorStagedManifest("1.3.0-rc.3"),
+        }),
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    hostBindingMock.current = { hostClient: fixture.client };
+    scopeOverrides.current = scopeFrom("host-a", fixture);
+    renderPanel();
+
+    await screen.findByText(
+      "Traycer couldn't determine how its command-line tools were installed on host-a.",
+    );
+    await screen.findByTestId("host-overview-operation-card");
+    // Removing the stagedFloor gate would expose Force update for a CLI-floor
+    // refusal; this negative affordance pin must turn RED under that ablation.
+    expect(
+      screen.queryByTestId("host-overview-operation-force-update"),
+    ).toBeNull();
+    // Restoring a non-null onForceRestart for a staged wait would offer a
+    // fallback restart control that cannot activate the floored stage; this
+    // negative no-restart pin must turn RED under that ablation.
+    expect(
+      screen.queryByTestId("host-overview-operation-force-restart"),
+    ).toBeNull();
+  });
+
+  it("hides both force controls when the staged version is absent from the check manifest", async () => {
+    let checkCalls = 0;
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: true,
+      hostVersion: "1.3.0-rc.2",
+      installation: managedInstallation(
+        installRecord("1.3.0-rc.2", "1.3.0-rc.2"),
+        stagedRecord("1.3.0-rc.3"),
+      ),
+      overrideHandlers: {
+        "host.status": () =>
+          statusWithBusy("1.3.0-rc.2", { kind: "none" }, true, 2),
+        "host.update.check": () => {
+          checkCalls += 1;
+          return {
+            outcome: "ok" as const,
+            effectiveIncludePreReleases: true,
+            includePreReleasesSource: "explicit-include" as const,
+            manifest: {
+              ...clearStagedManifest("1.3.0-rc.2"),
+              latest: "1.3.0-rc.2",
+            },
+          };
+        },
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    hostBindingMock.current = { hostClient: fixture.client };
+    scopeOverrides.current = scopeFrom("host-a", fixture);
+    renderPanel();
+
+    await screen.findByTestId("host-overview-operation-card");
+    await screen.findByText("This host is running the latest version.");
+    await waitFor(() => expect(checkCalls).toBeGreaterThan(0));
+    // Treating an absent staged entry as clear would make Force reachable while
+    // its floor is unknown; this negative unknown-evidence pin must turn RED.
+    expect(
+      screen.queryByTestId("host-overview-operation-force-update"),
+    ).toBeNull();
+    // Restoring a non-null onForceRestart for a staged wait would offer a
+    // fallback restart control that cannot activate the absent stage; this
+    // negative no-restart pin must turn RED under that ablation.
+    expect(
+      screen.queryByTestId("host-overview-operation-force-restart"),
+    ).toBeNull();
+  });
+
+  it("revalidates a changed staged entry at confirmation and settles refusal synchronously", async () => {
+    let checkCalls = 0;
+    const installCalls: Array<{ version: string; force: boolean }> = [];
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: true,
+      hostVersion: "1.3.0-rc.2",
+      installation: managedInstallation(
+        installRecord("1.3.0-rc.2", "1.3.0-rc.2"),
+        stagedRecord("1.3.0-rc.3"),
+      ),
+      overrideHandlers: {
+        "host.status": () =>
+          statusWithBusy("1.3.0-rc.2", { kind: "none" }, true, 2),
+        "host.update.check": () => {
+          checkCalls += 1;
+          return {
+            outcome: "ok" as const,
+            effectiveIncludePreReleases: true,
+            includePreReleasesSource: "explicit-include" as const,
+            manifest:
+              checkCalls === 1
+                ? clearStagedManifest("1.3.0-rc.3")
+                : floorStagedManifest("1.3.0-rc.3"),
+          };
+        },
+        "host.update.install": (req) => {
+          installCalls.push({ version: req.version, force: req.force });
+          return { outcome: "accepted" as const, attemptId: null };
+        },
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    hostBindingMock.current = { hostClient: fixture.client };
+    scopeOverrides.current = scopeFrom("host-a", fixture);
+    const queryClient = renderPanel();
+
+    const forceButton = await screen.findByTestId(
+      "host-overview-operation-force-update",
+    );
+    fireEvent.click(forceButton);
+    await screen.findByTestId("host-busy-force-defer-dialog");
+    await queryClient.invalidateQueries();
+    await waitFor(() => expect(checkCalls).toBeGreaterThan(1));
+    fireEvent.click(screen.getByTestId("host-busy-force"));
+    expect(screen.queryByTestId("host-busy-force-defer-dialog")).toBeNull();
+
+    await waitFor(() => {
+      // Removing click-time revalidation would dispatch the stale staged
+      // version; this negative mutation pin must turn RED under that ablation.
+      expect(installCalls).toEqual([]);
+      expect(screen.queryByTestId("host-busy-force-defer-dialog")).toBeNull();
+      expect(
+        screen.getByTestId("host-overview-update-attempt-failed").textContent,
+      ).toContain("v1.3.0-rc.3 needs Traycer CLI 1.3.0 or newer on host-a.");
+    });
+  });
+
+  it("refuses and closes when the staged entry disappears before confirmation", async () => {
+    let checkCalls = 0;
+    const installCalls: Array<{ version: string; force: boolean }> = [];
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: true,
+      hostVersion: "1.3.0-rc.2",
+      installation: managedInstallation(
+        installRecord("1.3.0-rc.2", "1.3.0-rc.2"),
+        stagedRecord("1.3.0-rc.3"),
+      ),
+      overrideHandlers: {
+        "host.status": () =>
+          statusWithBusy("1.3.0-rc.2", { kind: "none" }, true, 2),
+        "host.update.check": () => {
+          checkCalls += 1;
+          return {
+            outcome: "ok" as const,
+            effectiveIncludePreReleases: true,
+            includePreReleasesSource: "explicit-include" as const,
+            manifest:
+              checkCalls === 1
+                ? clearStagedManifest("1.3.0-rc.3")
+                : clearStagedManifest("1.3.0-rc.2"),
+          };
+        },
+        "host.update.install": (req) => {
+          installCalls.push({ version: req.version, force: req.force });
+          return { outcome: "accepted" as const, attemptId: null };
+        },
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    hostBindingMock.current = { hostClient: fixture.client };
+    scopeOverrides.current = scopeFrom("host-a", fixture);
+    const queryClient = renderPanel();
+
+    fireEvent.click(
+      await screen.findByTestId("host-overview-operation-force-update"),
+    );
+    await screen.findByTestId("host-busy-force-defer-dialog");
+    await queryClient.invalidateQueries();
+    await waitFor(() => expect(checkCalls).toBeGreaterThan(1));
+    fireEvent.click(screen.getByTestId("host-busy-force"));
+
+    await waitFor(() => {
+      // Bypassing describeForceUpdateRefusal would dispatch stale force:true;
+      // this no-mutation pin and closed-dialog assertion redden that ablation.
+      expect(installCalls).toEqual([]);
+      expect(
+        screen.getByTestId("host-overview-update-attempt-failed").textContent,
+      ).toContain(
+        "Traycer couldn't verify that v1.3.0-rc.3 can be installed on host-a.",
+      );
+      expect(screen.queryByTestId("host-busy-force-defer-dialog")).toBeNull();
     });
   });
 

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-overview-updates.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-overview-updates.test.tsx
@@ -353,6 +353,42 @@ function managedInstallationWithCli(
   };
 }
 
+function stagedRecord(version: string): HostStagedRecord {
+  return {
+    schemaVersion: 1,
+    stageId: null,
+    version,
+    runtimeVersion: null,
+    archiveSha256: "a".repeat(64),
+    sizeBytes: 1024,
+    source: { kind: "registry", value: version },
+    signatureKeyId: "key-1",
+    signatureVerifiedAt: "2026-08-10T00:00:00Z",
+    executablePath: `/tmp/traycer/${version}/host`,
+    platform: "darwin",
+    arch: "arm64",
+    executableSha256: "b".repeat(64),
+  };
+}
+
+function managedInstallationWithCliAndStage(
+  install: HostInstallRecord,
+  staged: HostStagedRecord,
+): HostGetInstallationInfoResponseV11 {
+  return {
+    status: "managed",
+    installRecord: install,
+    stagedRecord: staged,
+    cliManifest: {
+      version: "1.2.0",
+      installedAt: "2026-09-06T00:00:00Z",
+      binaryPath: "/home/u/.local/bin/traycer",
+      source: "manual",
+      pendingUpgrade: null,
+    },
+  };
+}
+
 function floorManifest(
   version: string,
   available: boolean,
@@ -1759,12 +1795,17 @@ describe("Overview updates — CLI floor remedy", () => {
     // this withdrawn-with-hash counterexample; this negative pin must turn RED
     // under that concrete structural-ablation.
     expect(screen.queryByRole("button", { name: "Copy command" })).toBeNull();
-  });
 
-  it("rechecks a repaired manifest and reveals Update now without a click", async () => {
-    vi.useFakeTimers({ shouldAdvanceTime: true });
-    let checks = 0;
-    const fixture = buildOverviewHostFixture({
+    cleanup();
+    const yankedFloored = floorManifest("1.3.0", false);
+    const yankedLatestManifest = {
+      ...yankedFloored,
+      versions: yankedFloored.versions.map((entry) => ({
+        ...entry,
+        yanked: true,
+      })),
+    };
+    const yankedLatestFixture = buildOverviewHostFixture({
       hostId: "host-a",
       isLocalMachine: true,
       hostVersion: "1.2.0",
@@ -1775,23 +1816,90 @@ describe("Overview updates — CLI floor remedy", () => {
         "/home/u/.local/bin/traycer",
       ),
       overrideHandlers: {
+        "host.update.check": () =>
+          Promise.resolve({
+            outcome: "ok" as const,
+            effectiveIncludePreReleases: false,
+            includePreReleasesSource: "stable-default" as const,
+            manifest: yankedLatestManifest,
+          }),
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    hostBindingMock.current = { hostClient: yankedLatestFixture.client };
+    scopeOverrides.current = scopeFrom("host-a", yankedLatestFixture);
+    renderPanel();
+
+    await screen.findByText(
+      "v1.3.0 is available, but host-a can't install it.",
+    );
+    // Removing !entry.yanked from the summary target would expose the floor
+    // remedy for this release; these negative no-repair pins must turn RED.
+    expect(screen.queryByRole("button", { name: "Copy command" })).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Show installation help" }),
+    ).toBeNull();
+    expect(screen.queryByRole("button", { name: "Update now" })).toBeNull();
+  });
+
+  it("rechecks a repaired manifest and reveals Update now without a click", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    let checks = 0;
+    const installCalls: Array<{ version: string; force: boolean }> = [];
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: true,
+      busy: true,
+      busySessionCount: 1,
+      hostVersion: "1.2.0",
+      installation: managedInstallationWithCliAndStage(
+        installRecord("1.2.0", null),
+        stagedRecord("1.3.0"),
+      ),
+      overrideHandlers: {
         "host.update.check": () => {
           checks += 1;
           return Promise.resolve({
             outcome: "ok" as const,
             effectiveIncludePreReleases: false,
             includePreReleasesSource: "stable-default" as const,
-            manifest: floorManifest("1.3.0", checks > 1),
+            manifest:
+              checks === 1 || checks >= 3
+                ? floorManifest("1.3.0", true)
+                : floorManifest("1.3.0", false),
           });
+        },
+        "host.update.install": (request) => {
+          installCalls.push({ version: request.version, force: request.force });
+          return { outcome: "accepted" as const, attemptId: null };
         },
       },
     });
     recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
     hostBindingMock.current = { hostClient: fixture.client };
     scopeOverrides.current = scopeFrom("host-a", fixture);
-    renderPanel();
+    const { queryClient } = renderPanel();
 
-    await screen.findByRole("button", { name: "Copy command" });
+    await screen.findByTestId("host-overview-operation-force-update");
+    fireEvent.click(screen.getByTestId("host-overview-operation-force-update"));
+    await screen.findByTestId("host-busy-force-defer-dialog");
+    // The confirmation re-asks before dispatch so this rendered panel records
+    // a real refusal against the exact staged version, rather than a synthetic
+    // hook state. The repair below must come only from the condition poll.
+    await act(async () => {
+      await queryClient.invalidateQueries();
+    });
+    await waitFor(() => expect(checks).toBeGreaterThan(1));
+    fireEvent.click(screen.getByTestId("host-busy-force"));
+    await waitFor(() => {
+      expect(installCalls).toEqual([]);
+      expect(screen.getByRole("status").textContent).toContain(
+        "v1.3.0 needs Traycer CLI 1.3.0 or newer on host-a.",
+      );
+      expect(
+        screen.getByTestId("host-overview-update-attempt-failed").textContent,
+      ).toContain("v1.3.0 needs Traycer CLI 1.3.0 or newer on host-a.");
+    });
     await act(async () => {
       await vi.advanceTimersByTimeAsync(30_000);
     });
@@ -1800,6 +1908,17 @@ describe("Overview updates — CLI floor remedy", () => {
     // Removing the floor recovery lane, or changing its fixed interval above
     // 30s, would leave this refusal visible and fail the assertion above.
     expect(checksAfterRecovery).toBeGreaterThan(1);
+    // Removing describeUpdateFailure's live-descriptor condition and returning
+    // stored refusal text whenever refusal exists would keep both stale
+    // surfaces visible after repair; these negative recovery pins must RED.
+    await waitFor(() => {
+      expect(screen.getByRole("status").textContent).toBe(
+        "v1.3.0 is available.",
+      );
+      expect(
+        screen.queryByTestId("host-overview-update-attempt-failed"),
+      ).toBeNull();
+    });
     await act(async () => {
       await vi.advanceTimersByTimeAsync(31_000);
     });
@@ -1923,6 +2042,68 @@ describe("Overview updates — CLI floor remedy", () => {
     expect(rendered.result.current.summary.updatableVersion).toBeNull();
     expect(rendered.result.current.summary.remedy).not.toBeNull();
     rendered.unmount();
+
+    const yankedManifestBase = lowerRcFallbackManifest();
+    const yankedStable = { ...yankedManifestBase.versions[0], yanked: true };
+    const yankedManifest = {
+      ...yankedManifestBase,
+      versions: [yankedStable, yankedManifestBase.versions[1]],
+    };
+    const installCalls: Array<{ version: string; force: boolean }> = [];
+    const yankedFixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: false,
+      hostVersion: "1.3.0-rc.1",
+      overrideHandlers: {
+        "host.update.check": () => ({
+          outcome: "ok" as const,
+          effectiveIncludePreReleases: true,
+          includePreReleasesSource: "installed-rc" as const,
+          manifest: yankedManifest,
+        }),
+        "host.update.install": (request) => {
+          installCalls.push({ version: request.version, force: request.force });
+          return { outcome: "accepted" as const, attemptId: null };
+        },
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    const yankedRendered = renderUpdatesHook(
+      yankedFixture.client,
+      "host-a",
+      "1.3.0-rc.1",
+      "1.3.0",
+    );
+
+    await waitFor(() =>
+      expect(yankedRendered.result.current.summary.updatableVersion).toBe(
+        "1.3.0-rc.2",
+      ),
+    );
+    // Removing !entry.yanked from the summary target would misclassify this
+    // yanked stable floor and hide the available RC fallback; this negative
+    // summary pin must turn RED under that source-predicate ablation.
+    expect(yankedRendered.result.current.cliFloor).toBeNull();
+    expect(yankedRendered.result.current.summary.remedy).toBeNull();
+    expect(yankedRendered.result.current.stagedFloor).not.toBeNull();
+
+    let returned = false;
+    const onSettled = vi.fn(() => {
+      expect(returned).toBe(false);
+    });
+    // Adding entry.yanked to readCliFloor's early return would authorize this
+    // staged release; the synchronous no-mutation pin must RED under that
+    // shared-reader ablation.
+    act(() => {
+      yankedRendered.result.current.installForce("1.3.0", onSettled);
+      returned = true;
+    });
+    expect(onSettled).toHaveBeenCalledTimes(1);
+    expect(installCalls).toEqual([]);
+    expect(yankedRendered.result.current.summary.failureDescription).toContain(
+      "v1.3.0 needs Traycer CLI 1.3.0 or newer on host-a.",
+    );
+    yankedRendered.unmount();
   });
 });
 

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-overview-updates.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-overview-updates.test.tsx
@@ -438,7 +438,57 @@ function lowerRcFallbackManifest(): HostAvailableManifest {
     schemaVersion: 1,
     generatedAt: "2026-09-06T00:00:00Z",
     latest: "1.3.0",
-    versions: [stableFloor, rc],
+    versions: [stableFloor, { ...rc, requiredCliVersion: "1.2.0" }],
+  };
+}
+
+const SELECTED_RC_CASES = [
+  {
+    name: "a yanked floor-refused stable",
+    stableYanked: true,
+    stableReason:
+      "Needs Traycer CLI 1.3.0 or newer (this host's CLI is 1.2.0).",
+  },
+  {
+    name: "a non-floor unavailable stable",
+    stableYanked: false,
+    stableReason: "platform build withdrawn",
+  },
+] as const;
+
+type SelectedRcCase = (typeof SELECTED_RC_CASES)[number];
+
+function selectedRcManifest(testCase: SelectedRcCase): HostAvailableManifest {
+  const stableBase = multiVersionManifest(["1.3.0"]).versions[0];
+  const rcBase = multiVersionManifest(["1.3.0-rc.2"]).versions[0];
+  const stable = {
+    ...stableBase,
+    yanked: testCase.stableYanked,
+    requiredCliVersion: "1.3.0",
+    platforms: {
+      "darwin-arm64": {
+        ...stableBase.platforms["darwin-arm64"],
+        available: false,
+        unavailableReason: testCase.stableReason,
+      },
+    },
+  };
+  const rc = {
+    ...rcBase,
+    requiredCliVersion: "1.3.0-rc.4",
+    platforms: {
+      "darwin-arm64": {
+        ...rcBase.platforms["darwin-arm64"],
+        available: false,
+        unavailableReason:
+          "Needs Traycer CLI 1.3.0-rc.4 or newer (this host's CLI is 1.2.0).",
+      },
+    },
+  };
+  return {
+    ...multiVersionManifest(["1.3.0", "1.3.0-rc.2"]),
+    latest: "1.3.0",
+    versions: [stable, rc],
   };
 }
 
@@ -1749,6 +1799,69 @@ describe("Overview updates — CLI floor remedy", () => {
     ).toBeTruthy();
   });
 
+  it("does not offer a CLI repair for a malformed required version reason", async () => {
+    const requiredCliVersion = "1.3.0; npm install -g @traycerai/cli@latest";
+    const base = floorManifest("1.3.0", false);
+    const baseEntry = base.versions[0];
+    const malformedManifest: HostAvailableManifest = {
+      ...base,
+      versions: [
+        {
+          ...baseEntry,
+          requiredCliVersion,
+          platforms: {
+            "darwin-arm64": {
+              ...baseEntry.platforms["darwin-arm64"],
+              unavailableReason: `host registry: version '1.3.0' declares requiredCliVersion ${JSON.stringify(requiredCliVersion)}, which is not a version this CLI can compare against. The manifest is wrong; do not work around it by installing a different version.`,
+            },
+          },
+        },
+      ],
+    };
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: true,
+      hostVersion: "1.2.0",
+      installation: managedInstallationWithCli(
+        installRecord("1.2.0", null),
+        "1.2.0",
+        "manual",
+        "/home/u/.local/bin/traycer",
+      ),
+      overrideHandlers: {
+        "host.update.check": () => ({
+          outcome: "ok" as const,
+          effectiveIncludePreReleases: false,
+          includePreReleasesSource: "stable-default" as const,
+          manifest: malformedManifest,
+        }),
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    const rendered = renderUpdatesHook(fixture.client, "host-a", "1.2.0", null);
+    await waitFor(() =>
+      expect(rendered.result.current.picker.awaitingFirstCheck).toBe(false),
+    );
+    // Broadening readCliFloor to every unavailable asset would misclassify
+    // this malformed reason as a repairable floor; these null hook fields must
+    // turn RED under that GUI predicate ablation.
+    expect(rendered.result.current.cliFloor).toBeNull();
+    expect(rendered.result.current.summary.remedy).toBeNull();
+    rendered.unmount();
+
+    hostBindingMock.current = { hostClient: fixture.client };
+    scopeOverrides.current = scopeFrom("host-a", fixture);
+    renderPanel();
+    await screen.findByText(
+      "v1.3.0 is available, but host-a can't install it.",
+    );
+    expect(screen.queryByRole("button", { name: "Copy command" })).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Show installation help" }),
+    ).toBeNull();
+    expect(screen.queryByRole("button", { name: "Update now" })).toBeNull();
+  });
+
   it("does not classify a withdrawn platform build with a retained SHA as a floor", async () => {
     const withdrawn = floorManifest("1.3.0", false);
     const fixture = buildOverviewHostFixture({
@@ -2057,10 +2170,12 @@ describe("Overview updates — CLI floor remedy", () => {
     await waitFor(() =>
       expect(rendered.result.current.cliFloor).not.toBeNull(),
     );
-    // Removing only the cliFloor suppression would expose the lower RC's
-    // offerable fallback as Update now; this non-vacuous hook pin must RED.
+    // Dropping `candidate.cliFloor !== null` in offerableLatestVersion would
+    // advertise this selected floored stable as Update now; this non-vacuous
+    // hook pin must RED at the actual candidate gate.
     expect(rendered.result.current.summary.updatableVersion).toBeNull();
     expect(rendered.result.current.summary.remedy).not.toBeNull();
+    expect(rendered.result.current.cliFloor?.requiredCliVersion).toBe("1.3.0");
     rendered.unmount();
 
     const yankedManifestBase = lowerRcFallbackManifest();
@@ -2100,9 +2215,9 @@ describe("Overview updates — CLI floor remedy", () => {
         "1.3.0-rc.2",
       ),
     );
-    // Removing !entry.yanked from the summary target would misclassify this
-    // yanked stable floor and hide the available RC fallback; this negative
-    // summary pin must turn RED under that source-predicate ablation.
+    // Removing `entry.yanked` from selectSummaryCandidate would misclassify
+    // this yanked stable floor and hide the available RC fallback; this
+    // negative summary pin must turn RED under that source-predicate ablation.
     expect(yankedRendered.result.current.cliFloor).toBeNull();
     expect(yankedRendered.result.current.summary.remedy).toBeNull();
     expect(yankedRendered.result.current.stagedFloor).not.toBeNull();
@@ -2124,6 +2239,133 @@ describe("Overview updates — CLI floor remedy", () => {
       "v1.3.0 needs Traycer CLI 1.3.0 or newer on host-a.",
     );
     yankedRendered.unmount();
+  });
+
+  it("keeps an installable stable target ahead of a later floor-refused RC", async () => {
+    const stable = multiVersionManifest(["1.3.0"]).versions[0];
+    const rcBase = multiVersionManifest(["1.3.0-rc.2"]).versions[0];
+    const rc = {
+      ...rcBase,
+      requiredCliVersion: "1.4.0",
+      platforms: {
+        "darwin-arm64": {
+          ...rcBase.platforms["darwin-arm64"],
+          available: false,
+          unavailableReason:
+            "Needs Traycer CLI 1.4.0 or newer (this host's CLI is 1.2.0).",
+        },
+      },
+    };
+    const manifest: HostAvailableManifest = {
+      ...multiVersionManifest(["1.3.0", "1.3.0-rc.2"]),
+      latest: "1.3.0",
+      versions: [stable, rc],
+    };
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: false,
+      hostVersion: "1.3.0-rc.1",
+      overrideHandlers: {
+        "host.update.check": () => ({
+          outcome: "ok" as const,
+          effectiveIncludePreReleases: true,
+          includePreReleasesSource: "installed-rc" as const,
+          manifest,
+        }),
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    const rendered = renderUpdatesHook(
+      fixture.client,
+      "host-a",
+      "1.3.0-rc.1",
+      null,
+    );
+
+    await waitFor(() =>
+      expect(rendered.result.current.summary.updatableVersion).toBe("1.3.0"),
+    );
+    // Bypassing selectSummaryCandidate's installable-candidate return would
+    // let the later floored RC hide this usable stable target; these exact
+    // stable-selection pins must turn RED under that candidate-walk ablation.
+    expect(rendered.result.current.cliFloor).toBeNull();
+    expect(rendered.result.current.summary.remedy).toBeNull();
+    rendered.unmount();
+  });
+
+  it.each(SELECTED_RC_CASES)(
+    "selects the RC floor after $name",
+    async (testCase) => {
+      const manifest = selectedRcManifest(testCase);
+      const fixture = buildOverviewHostFixture({
+        hostId: "host-a",
+        isLocalMachine: false,
+        hostVersion: "1.3.0-rc.1",
+        overrideHandlers: {
+          "host.update.check": () => ({
+            outcome: "ok" as const,
+            effectiveIncludePreReleases: true,
+            includePreReleasesSource: "installed-rc" as const,
+            manifest,
+          }),
+        },
+      });
+      recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+      const rendered = renderUpdatesHook(
+        fixture.client,
+        "host-a",
+        "1.3.0-rc.1",
+        null,
+      );
+
+      await waitFor(() =>
+        expect(rendered.result.current.cliFloor?.requiredCliVersion).toBe(
+          "1.3.0-rc.4",
+        ),
+      );
+      // Restricting floor acceptance to targetCandidates[0] would miss the
+      // RC after this unusable preferred stable; both explicit variants must
+      // turn RED under that candidate-walk ablation.
+      expect(rendered.result.current.summary.updatableVersion).toBeNull();
+      expect(rendered.result.current.summary.remedy).not.toBeNull();
+      rendered.unmount();
+    },
+  );
+
+  it("shows the selected RC floor in the mounted npm remedy command", async () => {
+    const manifest = selectedRcManifest(SELECTED_RC_CASES[0]);
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: true,
+      hostVersion: "1.3.0-rc.1",
+      installation: managedInstallationWithCli(
+        installRecord("1.3.0-rc.1", null),
+        "1.2.0",
+        "npm",
+        "/home/u/.local/bin/traycer",
+      ),
+      overrideHandlers: {
+        "host.update.check": () => ({
+          outcome: "ok" as const,
+          effectiveIncludePreReleases: true,
+          includePreReleasesSource: "installed-rc" as const,
+          manifest,
+        }),
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    hostBindingMock.current = { hostClient: fixture.client };
+    scopeOverrides.current = scopeFrom("host-a", fixture);
+    renderPanel();
+
+    const sentence =
+      "On host-a, run this command to prepare the host update: npm install -g @traycerai/cli@1.3.0-rc.4. Then select Check now.";
+    await screen.findByText(sentence);
+    // Skipping floor acceptance after the unusable preferred stable would
+    // remove this selected RC remedy; with no installable fallback, it would
+    // not expose Update now. This visible npm-floor pin must turn RED.
+    expect(screen.getByRole("button", { name: "Copy command" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Update now" })).toBeNull();
   });
 });
 

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-overview-updates.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-overview-updates.test.tsx
@@ -38,12 +38,13 @@ vi.mock("sonner", () => ({
   },
 }));
 
-import type { ReactElement } from "react";
+import type { ReactElement, ReactNode } from "react";
 import {
   act,
   cleanup,
   fireEvent,
   render,
+  renderHook,
   screen,
   waitFor,
   within,
@@ -59,6 +60,7 @@ import type {
 import type {
   HostInstallRecord,
   HostStagedRecord,
+  StoredCliInstallManifest,
 } from "@traycer/protocol/config/installation-records";
 import { MockRunnerHost } from "@traycer-clients/shared/host-client/mock/mock-runner-host";
 import {
@@ -79,6 +81,7 @@ import {
   openHostOverviewMenu,
   type OverviewHostFixture,
 } from "@/components/settings/panels/__tests__/host-overview-test-support";
+import { useHostOverviewUpdates } from "@/components/settings/panels/host-overview-updates-state";
 
 /**
  * The version PICKER that replaced the single "Update to v<latest>" button
@@ -93,6 +96,7 @@ afterEach(() => {
   resetNegotiatedManifests();
   scopeOverrides.current = {};
   hostBindingMock.current = null;
+  vi.useRealTimers();
 });
 
 const ALL_OVERVIEW_METHODS = [
@@ -324,6 +328,117 @@ function managedInstallation(
     stagedRecord: staged,
     cliManifest: null,
   };
+}
+
+function managedInstallationWithCli(
+  install: HostInstallRecord,
+  cliVersion: string,
+  source: StoredCliInstallManifest["source"],
+  binaryPath: string,
+): HostGetInstallationInfoResponseV11 {
+  // Built directly rather than spread from `managedInstallation`: that helper
+  // returns the response UNION, and TypeScript will not add `cliManifest` to a
+  // spread it cannot narrow to the managed arm.
+  return {
+    status: "managed",
+    installRecord: install,
+    stagedRecord: null,
+    cliManifest: {
+      version: cliVersion,
+      installedAt: "2026-09-06T00:00:00Z",
+      binaryPath,
+      source,
+      pendingUpgrade: null,
+    },
+  };
+}
+
+function floorManifest(
+  version: string,
+  available: boolean,
+): HostAvailableManifest {
+  const base = multiVersionManifest([version]);
+  return {
+    ...base,
+    versions: base.versions.map((entry) => ({
+      ...entry,
+      requiredCliVersion: "1.3.0",
+      platforms: {
+        "darwin-arm64": {
+          ...entry.platforms["darwin-arm64"],
+          available,
+          unavailableReason: available
+            ? null
+            : "Needs Traycer CLI 1.3.0 or newer (this host's CLI is 1.2.0).",
+        },
+      },
+    })),
+  };
+}
+
+function floorManifestWithoutRequiredVersion(
+  version: string,
+): HostAvailableManifest {
+  const manifest = floorManifest(version, false);
+  return {
+    ...manifest,
+    versions: manifest.versions.map((entry) => ({
+      ...entry,
+      requiredCliVersion: null,
+      platforms: {
+        "darwin-arm64": {
+          ...entry.platforms["darwin-arm64"],
+          unavailableReason: "Needs Traycer CLI ",
+        },
+      },
+    })),
+  };
+}
+
+function lowerRcFallbackManifest(): HostAvailableManifest {
+  const stableFloor = floorManifest("1.3.0", false).versions[0];
+  const rc = multiVersionManifest(["1.3.0-rc.2"]).versions[0];
+  return {
+    schemaVersion: 1,
+    generatedAt: "2026-09-06T00:00:00Z",
+    latest: "1.3.0",
+    versions: [stableFloor, rc],
+  };
+}
+
+function renderUpdatesHook(
+  client: OverviewHostFixture["client"],
+  hostId: string,
+  runningVersion: string,
+  stagedVersion: string | null,
+) {
+  const queryClient = newQueryClient();
+  return renderHook(
+    () =>
+      useHostOverviewUpdates({
+        client,
+        hostName: "host-a",
+        hostId,
+        runningVersion,
+        activationDebt: null,
+        platformKey: "darwin-arm64",
+        cliManifest: null,
+        isLocalMachine: false,
+        desktopUpdate: null,
+        stagedVersion,
+        enabled: true,
+        checkDegrade: null,
+        installDegrade: null,
+        busy: false,
+      }),
+    {
+      wrapper: (props: { readonly children: ReactNode }) => (
+        <QueryClientProvider client={queryClient}>
+          {props.children}
+        </QueryClientProvider>
+      ),
+    },
+  );
 }
 
 describe("<HostSettingsPanel /> Overview updates — version picker", () => {
@@ -1458,6 +1573,356 @@ describe("<HostSettingsPanel /> Overview updates — version picker", () => {
         .getByRole("button", { name: "Install 2.0.0-rc.1" })
         .hasAttribute("disabled"),
     ).toBe(false);
+  });
+});
+
+describe("Overview updates — CLI floor remedy", () => {
+  it("projects the latest refusal over an old stored CLI and replaces Update now with copy guidance", async () => {
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: true,
+      hostVersion: "1.2.0",
+      installation: managedInstallationWithCli(
+        installRecord("1.2.0", null),
+        "1.2.0",
+        "manual",
+        "/home/u/.local/bin/traycer",
+      ),
+      overrideHandlers: {
+        "host.update.check": () =>
+          Promise.resolve({
+            outcome: "ok" as const,
+            effectiveIncludePreReleases: false,
+            includePreReleasesSource: "stable-default" as const,
+            manifest: floorManifest("1.3.0", false),
+          }),
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    hostBindingMock.current = { hostClient: fixture.client };
+    scopeOverrides.current = scopeFrom("host-a", fixture);
+    renderPanel();
+
+    await screen.findByText(
+      "First update Traycer's command-line tools on host-a. Open a terminal on that machine and run the copied command. When it finishes, come back here: this page rechecks while it is open, and Update now appears once the host accepts the update.",
+    );
+    // This lone unavailable asset keeps Update now hidden even if only the
+    // cliFloor suppression is removed: the asset gate independently rejects
+    // it. The lower-RC hook fixture below isolates that suppression by leaving
+    // a lower same-line RC offerable. This mounted negative instead catches a
+    // fabricated Update now that ignores both remedy and asset eligibility.
+    expect(screen.queryByRole("button", { name: "Update now" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Copy command" })).toBeTruthy();
+  });
+
+  it("retains the remedy when the stored CLI is new, with the older-copy sentence", async () => {
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: true,
+      hostVersion: "1.2.0",
+      installation: managedInstallationWithCli(
+        installRecord("1.2.0", null),
+        "1.3.0",
+        "manual",
+        "/home/u/.local/bin/traycer",
+      ),
+      overrideHandlers: {
+        "host.update.check": () =>
+          Promise.resolve({
+            outcome: "ok" as const,
+            effectiveIncludePreReleases: false,
+            includePreReleasesSource: "stable-default" as const,
+            manifest: floorManifest("1.3.0", false),
+          }),
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    hostBindingMock.current = { hostClient: fixture.client };
+    scopeOverrides.current = scopeFrom("host-a", fixture);
+    renderPanel();
+
+    await screen.findByText(
+      "Traycer's command-line tools on host-a were updated, but the host is still using an older copy. Run the command again: First update Traycer's command-line tools on host-a. Open a terminal on that machine and run the copied command. When it finishes, come back here: this page rechecks while it is open, and Update now appears once the host accepts the update.",
+    );
+    // Treating cliManifest.version as clearance while restoring updatableVersion
+    // would expose Update now; the meaningful positive pin above is the
+    // older-copy sentence itself, while the lower-RC hook case isolates
+    // suppression.
+    expect(screen.queryByRole("button", { name: "Update now" })).toBeNull();
+  });
+
+  it("lets activation debt win the sentence while retaining the floor remedy action", async () => {
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: true,
+      hostVersion: "1.2.0",
+      installation: managedInstallationWithCli(
+        installRecord("1.2.1", null),
+        "1.2.0",
+        "manual",
+        "/home/u/.local/bin/traycer",
+      ),
+      overrideHandlers: {
+        "host.update.check": () =>
+          Promise.resolve({
+            outcome: "ok" as const,
+            effectiveIncludePreReleases: false,
+            includePreReleasesSource: "stable-default" as const,
+            manifest: floorManifest("1.3.0", false),
+          }),
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    hostBindingMock.current = { hostClient: fixture.client };
+    scopeOverrides.current = scopeFrom("host-a", fixture);
+    renderPanel();
+
+    await screen.findByText("v1.2.1 is installed — restart host to finish.");
+    // Removing the activation-debt arm from describeCheckState would let the
+    // remedy sentence win; this negative precedence pin must turn RED under
+    // that concrete ablation while the remedy action remains available.
+    expect(screen.getByRole("button", { name: "Copy command" })).toBeTruthy();
+  });
+
+  it("turns an unreadable CLI manifest into installation help", async () => {
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: true,
+      hostVersion: "1.2.0",
+      installation: managedInstallation(installRecord("1.2.0", null), null),
+      overrideHandlers: {
+        "host.update.check": () =>
+          Promise.resolve({
+            outcome: "ok" as const,
+            effectiveIncludePreReleases: false,
+            includePreReleasesSource: "stable-default" as const,
+            manifest: floorManifest("1.3.0", false),
+          }),
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    hostBindingMock.current = { hostClient: fixture.client };
+    scopeOverrides.current = scopeFrom("host-a", fixture);
+    renderPanel();
+
+    await screen.findByText(
+      "Traycer couldn't determine how its command-line tools were installed on host-a.",
+    );
+    expect(
+      screen.getByRole("button", { name: "Show installation help" }),
+    ).toBeTruthy();
+  });
+
+  it("does not classify a withdrawn platform build with a retained SHA as a floor", async () => {
+    const withdrawn = floorManifest("1.3.0", false);
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: true,
+      hostVersion: "1.2.0",
+      installation: managedInstallationWithCli(
+        installRecord("1.2.0", null),
+        "1.2.0",
+        "manual",
+        "/home/u/.local/bin/traycer",
+      ),
+      overrideHandlers: {
+        "host.update.check": () =>
+          Promise.resolve({
+            outcome: "ok" as const,
+            effectiveIncludePreReleases: false,
+            includePreReleasesSource: "stable-default" as const,
+            manifest: {
+              ...withdrawn,
+              versions: withdrawn.versions.map((entry) => ({
+                ...entry,
+                platforms: {
+                  "darwin-arm64": {
+                    ...entry.platforms["darwin-arm64"],
+                    unavailableReason: "platform build withdrawn",
+                    sha256: "b".repeat(64),
+                  },
+                },
+              })),
+            },
+          }),
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    hostBindingMock.current = { hostClient: fixture.client };
+    scopeOverrides.current = scopeFrom("host-a", fixture);
+    renderPanel();
+
+    await screen.findByText(
+      "v1.3.0 is available, but host-a can't install it.",
+    );
+    // Removing the authored floor-reason predicate would offer remedy copy for
+    // this withdrawn-with-hash counterexample; this negative pin must turn RED
+    // under that concrete structural-ablation.
+    expect(screen.queryByRole("button", { name: "Copy command" })).toBeNull();
+  });
+
+  it("rechecks a repaired manifest and reveals Update now without a click", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    let checks = 0;
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: true,
+      hostVersion: "1.2.0",
+      installation: managedInstallationWithCli(
+        installRecord("1.2.0", null),
+        "1.2.0",
+        "manual",
+        "/home/u/.local/bin/traycer",
+      ),
+      overrideHandlers: {
+        "host.update.check": () => {
+          checks += 1;
+          return Promise.resolve({
+            outcome: "ok" as const,
+            effectiveIncludePreReleases: false,
+            includePreReleasesSource: "stable-default" as const,
+            manifest: floorManifest("1.3.0", checks > 1),
+          });
+        },
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    hostBindingMock.current = { hostClient: fixture.client };
+    scopeOverrides.current = scopeFrom("host-a", fixture);
+    renderPanel();
+
+    await screen.findByRole("button", { name: "Copy command" });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000);
+    });
+    await screen.findByRole("button", { name: "Update now" });
+    const checksAfterRecovery = checks;
+    // Removing the floor recovery lane, or changing its fixed interval above
+    // 30s, would leave this refusal visible and fail the assertion above.
+    expect(checksAfterRecovery).toBeGreaterThan(1);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(31_000);
+    });
+    // The available answer ends the condition-poll episode; retaining the
+    // lane after repair would keep shelling the host on every further tick.
+    expect(checks).toBe(checksAfterRecovery);
+  });
+
+  it("settles Force refusal synchronously exactly once for floored, absent, and incomplete-floor entries", async () => {
+    const scenarios = [
+      {
+        manifest: floorManifest("1.3.0", false),
+        version: "1.3.0",
+        expected: "v1.3.0 needs Traycer CLI 1.3.0 or newer on host-a.",
+      },
+      {
+        manifest: floorManifest("1.2.0", true),
+        version: "1.3.0",
+        expected:
+          "Traycer couldn't verify that v1.3.0 can be installed on host-a.",
+      },
+      {
+        manifest: floorManifestWithoutRequiredVersion("1.3.0"),
+        version: "1.3.0",
+        expected:
+          "Traycer couldn't verify that v1.3.0 can be installed on host-a.",
+      },
+    ] as const;
+
+    for (const scenario of scenarios) {
+      const installCalls: Array<{ version: string; force: boolean }> = [];
+      const fixture = buildOverviewHostFixture({
+        hostId: "host-a",
+        isLocalMachine: false,
+        hostVersion: "1.2.0",
+        overrideHandlers: {
+          "host.update.check": () => ({
+            outcome: "ok" as const,
+            effectiveIncludePreReleases: false,
+            includePreReleasesSource: "stable-default" as const,
+            manifest: scenario.manifest,
+          }),
+          "host.update.install": (request) => {
+            installCalls.push({
+              version: request.version,
+              force: request.force,
+            });
+            return { outcome: "accepted" as const, attemptId: null };
+          },
+        },
+      });
+      recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+      const rendered = renderUpdatesHook(
+        fixture.client,
+        "host-a",
+        "1.2.0",
+        scenario.version,
+      );
+      await waitFor(() =>
+        expect(rendered.result.current.picker.awaitingFirstCheck).toBe(false),
+      );
+
+      let returned = false;
+      const onSettled = vi.fn(() => {
+        expect(returned).toBe(false);
+      });
+      // Moving onSettled to a microtask or removing it would make this spy
+      // observe after installForce returns; this is the synchronous settlement
+      // pin. Bypassing describeForceUpdateRefusal would reach installForce's
+      // mutation and redden the no-mutation/failure assertions below.
+      act(() => {
+        rendered.result.current.installForce(scenario.version, onSettled);
+        returned = true;
+      });
+      expect(onSettled).toHaveBeenCalledTimes(1);
+      expect(installCalls).toEqual([]);
+      expect(rendered.result.current.summary.failureDescription).toContain(
+        scenario.expected,
+      );
+      // Missing required field/reason version must take the unknown branch,
+      // never interpolate a fabricated null or undefined requirement. Removing
+      // floor.requiredCliVersion's null guard would instead produce a rejected
+      // `null` requirement; this negative text pin must turn RED under that
+      // concrete ablation.
+      expect(rendered.result.current.summary.failureDescription).not.toContain(
+        "null",
+      );
+      expect(rendered.result.current.summary.failureDescription).not.toContain(
+        "undefined",
+      );
+      rendered.unmount();
+    }
+  });
+
+  it("suppresses Update now when the best stable target is floored even though a lower same-line RC is offerable", async () => {
+    const fixture = buildOverviewHostFixture({
+      hostId: "host-a",
+      isLocalMachine: false,
+      hostVersion: "1.3.0-rc.1",
+      overrideHandlers: {
+        "host.update.check": () => ({
+          outcome: "ok" as const,
+          effectiveIncludePreReleases: true,
+          includePreReleasesSource: "installed-rc" as const,
+          manifest: lowerRcFallbackManifest(),
+        }),
+      },
+    });
+    recordNegotiatedHostMethods("host-a", ALL_OVERVIEW_METHODS);
+    const rendered = renderUpdatesHook(
+      fixture.client,
+      "host-a",
+      "1.3.0-rc.1",
+      null,
+    );
+    await waitFor(() =>
+      expect(rendered.result.current.cliFloor).not.toBeNull(),
+    );
+    // Removing only the cliFloor suppression would expose the lower RC's
+    // offerable fallback as Update now; this non-vacuous hook pin must RED.
+    expect(rendered.result.current.summary.updatableVersion).toBeNull();
+    expect(rendered.result.current.summary.remedy).not.toBeNull();
+    rendered.unmount();
   });
 });
 

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-overview-updates.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-overview-updates.test.tsx
@@ -1859,14 +1859,14 @@ describe("Overview updates — CLI floor remedy", () => {
       overrideHandlers: {
         "host.update.check": () => {
           checks += 1;
+          if (checks >= 4) {
+            return Promise.resolve({ outcome: "cli-failed" as const });
+          }
           return Promise.resolve({
             outcome: "ok" as const,
             effectiveIncludePreReleases: false,
             includePreReleasesSource: "stable-default" as const,
-            manifest:
-              checks === 1 || checks >= 3
-                ? floorManifest("1.3.0", true)
-                : floorManifest("1.3.0", false),
+            manifest: floorManifest("1.3.0", checks === 1 || checks === 3),
           });
         },
         "host.update.install": (request) => {
@@ -1925,6 +1925,26 @@ describe("Overview updates — CLI floor remedy", () => {
     // The available answer ends the condition-poll episode; retaining the
     // lane after repair would keep shelling the host on every further tick.
     expect(checks).toBe(checksAfterRecovery);
+    const checksBeforeFailure = checks;
+    await act(async () => {
+      await queryClient.invalidateQueries();
+    });
+    await waitFor(() => expect(checks).toBeGreaterThan(checksBeforeFailure));
+    // Deleting only the guarded checkRefutesForceRefusal/setForceRefusal(null)
+    // retirement block would keep every earlier repair assertion green but
+    // revive the old floor text after this later failed check; these negative
+    // current-failure pins must turn RED under that concrete ablation.
+    await waitFor(() => {
+      expect(screen.getByRole("status").textContent).toBe(
+        "host-a's Traycer CLI couldn't complete the request.",
+      );
+      const notice = screen.getByTestId("host-overview-update-attempt-failed");
+      expect(notice.textContent).toBe(
+        "host-a's Traycer CLI couldn't complete the request.",
+      );
+      expect(notice.textContent).not.toContain("needs Traycer CLI");
+    });
+    expect(installCalls).toEqual([]);
   });
 
   it("settles Force refusal synchronously exactly once for floored, absent, and incomplete-floor entries", async () => {

--- a/clients/gui-app/src/components/settings/panels/host-overview-cli-floor-remedy-actions.tsx
+++ b/clients/gui-app/src/components/settings/panels/host-overview-cli-floor-remedy-actions.tsx
@@ -1,0 +1,124 @@
+import { useEffect, type ReactNode } from "react";
+import { Button } from "@/components/ui/button";
+import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
+import type { CliFloorRemedyAction } from "@/components/settings/panels/host-overview-cli-floor-remedy";
+import { copyTerminalCommand } from "@/components/settings/panels/host-doctor-actions";
+import { useDesktopDialogStore } from "@/stores/dialogs/desktop-dialog-store";
+import { requestAppUpdateInstall } from "@/lib/app-update/request-app-update-install";
+import type { DesktopAppUpdatesBridge } from "@/lib/windows/types";
+import { appLogger } from "@/lib/logger";
+
+export function CliFloorRemedyActions(props: {
+  readonly actions: readonly CliFloorRemedyAction[];
+  readonly desktopBridge: DesktopAppUpdatesBridge | null;
+  readonly onHelp: () => void;
+}): ReactNode {
+  return props.actions.map((action) => (
+    <CliFloorRemedyControl
+      key={action.kind}
+      action={action}
+      desktopBridge={props.desktopBridge}
+      onHelp={props.onHelp}
+    />
+  ));
+}
+
+function CliFloorRemedyControl(props: {
+  readonly action: CliFloorRemedyAction;
+  readonly desktopBridge: DesktopAppUpdatesBridge | null;
+  readonly onHelp: () => void;
+}): ReactNode {
+  const openInstallGuidance = useDesktopDialogStore(
+    (state) => state.openInstallGuidance,
+  );
+  const { action, desktopBridge } = props;
+  switch (action.kind) {
+    case "desktop-check":
+      return <DesktopRemedyCheck bridge={desktopBridge} />;
+    case "restart-desktop-hint":
+      return null;
+    case "desktop-progress":
+      return (
+        <Button type="button" size="sm" disabled>
+          <AgentSpinningDots
+            className="mr-2 size-3"
+            testId={undefined}
+            variant={undefined}
+          />
+          {action.label}
+        </Button>
+      );
+    case "copy-command":
+      return (
+        <Button
+          type="button"
+          size="sm"
+          onClick={() => copyTerminalCommand(action.command)}
+        >
+          {action.label}
+        </Button>
+      );
+    case "help":
+      return (
+        <Button type="button" size="sm" onClick={props.onHelp}>
+          {action.label}
+        </Button>
+      );
+    case "desktop-download":
+    case "desktop-install":
+      return (
+        <TooltipWrapper
+          label={action.tooltip ?? action.label}
+          side="top"
+          sideOffset={6}
+          align={undefined}
+        >
+          {/* Disabled buttons do not receive pointer events; the wrapper keeps
+              the Desktop updater's block reason reachable, as in the header. */}
+          <span className="inline-flex">
+            <Button
+              type="button"
+              size="sm"
+              disabled={action.disabled || desktopBridge === null}
+              onClick={() => {
+                if (desktopBridge === null || action.disabled) return;
+                if (action.kind === "desktop-download") {
+                  void desktopBridge.downloadUpdate();
+                } else if (action.showGuidance) {
+                  openInstallGuidance();
+                } else {
+                  void requestAppUpdateInstall(desktopBridge);
+                }
+              }}
+            >
+              {action.kind === "desktop-install" && action.installInFlight ? (
+                <AgentSpinningDots
+                  className="mr-2 size-3"
+                  testId={undefined}
+                  variant={undefined}
+                />
+              ) : null}
+              {action.label}
+            </Button>
+          </span>
+        </TooltipWrapper>
+      );
+  }
+}
+
+function DesktopRemedyCheck(props: {
+  readonly bridge: DesktopAppUpdatesBridge | null;
+}): ReactNode {
+  const { bridge } = props;
+  // One bridge check per mounted unknown-state episode. Checking/error remain
+  // this same action, so a failed check cannot create an effect retry loop.
+  // Host recovery polling belongs to the RPC table, never this component.
+  useEffect(() => {
+    if (bridge === null) return;
+    void bridge.checkForUpdates("manual").catch((error: unknown) => {
+      appLogger.error("[app-update] floor remedy check failed", {}, error);
+    });
+  }, [bridge]);
+  return null;
+}

--- a/clients/gui-app/src/components/settings/panels/host-overview-cli-floor-remedy-actions.tsx
+++ b/clients/gui-app/src/components/settings/panels/host-overview-cli-floor-remedy-actions.tsx
@@ -35,7 +35,13 @@ function CliFloorRemedyControl(props: {
   const { action, desktopBridge } = props;
   switch (action.kind) {
     case "desktop-check":
-      return <DesktopRemedyCheck bridge={desktopBridge} />;
+      return (
+        <DesktopRemedyCheck
+          bridge={desktopBridge}
+          label={action.label}
+          checkOnMount={action.checkOnMount}
+        />
+      );
     case "restart-desktop-hint":
       return null;
     case "desktop-progress":
@@ -109,16 +115,32 @@ function CliFloorRemedyControl(props: {
 
 function DesktopRemedyCheck(props: {
   readonly bridge: DesktopAppUpdatesBridge | null;
+  readonly label: string | null;
+  readonly checkOnMount: boolean;
 }): ReactNode {
-  const { bridge } = props;
-  // One bridge check per mounted unknown-state episode. Checking/error remain
-  // this same action, so a failed check cannot create an effect retry loop.
-  // Host recovery polling belongs to the RPC table, never this component.
+  const { bridge, label, checkOnMount } = props;
+  // Only an idle updater needs an initial check. A failed check stays visible
+  // until the user retries; entering checking must not issue a second request.
+  // Keeping one component across these states avoids a mount-driven retry loop.
   useEffect(() => {
-    if (bridge === null) return;
-    void bridge.checkForUpdates("manual").catch((error: unknown) => {
-      appLogger.error("[app-update] floor remedy check failed", {}, error);
-    });
-  }, [bridge]);
-  return null;
+    if (checkOnMount) checkDesktopRemedy(bridge);
+  }, [bridge, checkOnMount]);
+  if (label === null) return null;
+  return (
+    <Button
+      type="button"
+      size="sm"
+      disabled={bridge === null}
+      onClick={() => checkDesktopRemedy(bridge)}
+    >
+      {label}
+    </Button>
+  );
+}
+
+function checkDesktopRemedy(bridge: DesktopAppUpdatesBridge | null): void {
+  if (bridge === null) return;
+  void bridge.checkForUpdates("manual").catch((error: unknown) => {
+    appLogger.error("[app-update] floor remedy check failed", {}, error);
+  });
 }

--- a/clients/gui-app/src/components/settings/panels/host-overview-cli-floor-remedy.ts
+++ b/clients/gui-app/src/components/settings/panels/host-overview-cli-floor-remedy.ts
@@ -1,0 +1,211 @@
+import {
+  PACKAGE_MANAGER_UPGRADE_COMMAND,
+  type CliInstallSource,
+} from "@traycer/protocol/config/installation-records";
+import { compareHostVersions } from "@traycer-clients/shared/host-version/compare-host-versions";
+import type { DesktopAppUpdateSnapshot } from "@/lib/windows/types";
+
+// There is deliberately no terminal action: a 1.2.0 host ignores shellCommand
+// on ordinary terminal creates. Copying the recorded binary path works on the
+// hosts this remedy actually serves, without guessing what is on their PATH.
+export const CLI_FLOOR_REMEDY_ACTION_KINDS = [
+  "desktop-download",
+  "desktop-progress",
+  "desktop-install",
+  "desktop-check",
+  "restart-desktop-hint",
+  "copy-command",
+  "help",
+] as const;
+
+export type CliFloorRemedyActionKind =
+  (typeof CLI_FLOOR_REMEDY_ACTION_KINDS)[number];
+
+interface CliFloorRemedyActionPayloads {
+  readonly "desktop-download": {
+    readonly label: string;
+    readonly disabled: boolean;
+    readonly tooltip: string | null;
+  };
+  readonly "desktop-progress": { readonly label: string };
+  readonly "desktop-install": {
+    readonly label: string;
+    readonly disabled: boolean;
+    readonly tooltip: string | null;
+    readonly showGuidance: boolean;
+    readonly installInFlight: boolean;
+  };
+  readonly "desktop-check": unknown;
+  readonly "restart-desktop-hint": unknown;
+  readonly "copy-command": {
+    readonly label: string;
+    readonly command: string;
+  };
+  readonly help: { readonly label: string };
+}
+
+export type CliFloorRemedyAction = {
+  [Kind in CliFloorRemedyActionKind]: {
+    readonly kind: Kind;
+  } & CliFloorRemedyActionPayloads[Kind];
+}[CliFloorRemedyActionKind];
+
+export interface CliFloorRemedy {
+  readonly sentence: string;
+  readonly actions: readonly CliFloorRemedyAction[];
+}
+
+export interface CliFloorRemedyInput {
+  readonly isLocalMachine: boolean;
+  readonly platform: string | null;
+  readonly cliSource: CliInstallSource | null;
+  readonly cliBinaryPath: string | null;
+  readonly cliVersion: string | null;
+  readonly requiredCliVersion: string | null;
+  readonly desktopUpdate: DesktopAppUpdateSnapshot | null;
+  readonly hostName: string;
+}
+
+/** Called only after the executing CLI has refused the projected asset. */
+export function describeCliFloorRemedy(
+  input: CliFloorRemedyInput,
+): CliFloorRemedy {
+  if (input.cliSource === null) {
+    return {
+      sentence: `Traycer couldn't determine how its command-line tools were installed on ${input.hostName}.`,
+      actions: [{ kind: "help", label: "Show installation help" }],
+    };
+  }
+  if (
+    input.isLocalMachine &&
+    input.cliSource === "desktop" &&
+    input.desktopUpdate !== null
+  ) {
+    return describeDesktopRemedy(input.desktopUpdate, input.requiredCliVersion);
+  }
+  if (input.cliSource !== "desktop" && input.cliSource !== "manual") {
+    const command = PACKAGE_MANAGER_UPGRADE_COMMAND[input.cliSource];
+    return describeCopyRemedy(
+      input,
+      `On ${input.hostName}, run this command to prepare the host update: ${command}. Then select Check now.`,
+      command,
+      "Copy command",
+    );
+  }
+  // Unknown platforms take the Windows-safe route too. The old Windows CLI
+  // finalizes its staged upgrade during host restart, whose taskkill /T would
+  // kill that very CLI if the command ran in a Traycer-hosted terminal.
+  if (input.platform === null || input.platform.startsWith("win32")) {
+    return describeCopyRemedy(
+      input,
+      `Run traycer cli upgrade on ${input.hostName}, then traycer host restart, from a terminal outside Traycer on that machine (an SSH session or a Windows Terminal window there). Restarting briefly disconnects this host. When it reconnects, select Check now, then Update now.`,
+      "traycer cli upgrade\ntraycer host restart",
+      "Copy commands",
+    );
+  }
+  return describeCopyRemedy(
+    input,
+    `First update Traycer's command-line tools on ${input.hostName}. Open a terminal on that machine and run the copied command. When it finishes, come back here: this page rechecks while it is open, and Update now appears once the host accepts the update.`,
+    posixCliUpgradeCommand(input.cliBinaryPath),
+    "Copy command",
+  );
+}
+
+function describeDesktopRemedy(
+  snapshot: DesktopAppUpdateSnapshot,
+  requiredCliVersion: string | null,
+): CliFloorRemedy {
+  const version = snapshot.latestVersion ?? requiredCliVersion;
+  const versionSuffix = version === null ? "" : ` ${version}`;
+  switch (snapshot.status) {
+    case "available":
+      return {
+        sentence: `Update Traycer Desktop${version === null ? "" : ` to ${version}`} to install this host update.`,
+        actions: [
+          {
+            kind: "desktop-download",
+            label: "Download update",
+            disabled: snapshot.installBlockedReason !== null,
+            tooltip: snapshot.installBlockedReason,
+          },
+        ],
+      };
+    case "downloading":
+      return {
+        sentence: "Downloading the Traycer Desktop update…",
+        actions: [
+          {
+            kind: "desktop-progress",
+            label:
+              snapshot.downloadProgress === null
+                ? "Downloading update"
+                : `Downloading ${snapshot.downloadProgress}%`,
+          },
+        ],
+      };
+    case "ready": {
+      // Same precedence as the header: a blocked location wins over manual
+      // install guidance, and main's in-flight snapshot disarms every surface.
+      const showGuidance =
+        snapshot.installBlockedReason === null &&
+        snapshot.installGuidance !== null;
+      return {
+        sentence: `Traycer Desktop${versionSuffix} is ready. Restart Traycer to finish, then this host update can install.`,
+        actions: [
+          {
+            kind: "desktop-install",
+            label: showGuidance ? "Finish update" : "Restart to update",
+            disabled:
+              snapshot.installBlockedReason !== null ||
+              snapshot.installInFlight,
+            tooltip: snapshot.installBlockedReason,
+            showGuidance,
+            installInFlight: snapshot.installInFlight,
+          },
+        ],
+      };
+    }
+    case "up-to-date":
+      return {
+        sentence:
+          "Traycer Desktop is up to date, but this computer still needs to finish updating its host tools. Restart Traycer Desktop to finish.",
+        actions: [{ kind: "restart-desktop-hint" }],
+      };
+    default:
+      return {
+        sentence: "Checking for a Traycer Desktop update…",
+        actions: [{ kind: "desktop-check" }],
+      };
+  }
+}
+
+function describeCopyRemedy(
+  input: CliFloorRemedyInput,
+  sentence: string,
+  command: string,
+  label: string,
+): CliFloorRemedy {
+  const comparison =
+    input.cliVersion === null || input.requiredCliVersion === null
+      ? null
+      : compareHostVersions(input.cliVersion, input.requiredCliVersion);
+  const olderCopy =
+    comparison !== null &&
+    comparison.comparable &&
+    comparison.ordering !== "less";
+  return {
+    sentence: olderCopy
+      ? `Traycer's command-line tools on ${input.hostName} were updated, but the host is still using an older copy. Run the command again: ${sentence}`
+      : sentence,
+    actions: [{ kind: "copy-command", label, command }],
+  };
+}
+
+function posixCliUpgradeCommand(binaryPath: string | null): string {
+  if (binaryPath === null || !binaryPath.startsWith("/")) {
+    return "traycer cli upgrade";
+  }
+  // A path is one shell token. Double quotes would still expand dollars and
+  // backticks; single quotes with escaped apostrophes keep every byte literal.
+  return `'${binaryPath.replaceAll("'", "'\\''")}' cli upgrade`;
+}

--- a/clients/gui-app/src/components/settings/panels/host-overview-cli-floor-remedy.ts
+++ b/clients/gui-app/src/components/settings/panels/host-overview-cli-floor-remedy.ts
@@ -100,16 +100,29 @@ export function describeCliFloorRemedy(
   if (input.cliSource !== "desktop" && input.cliSource !== "manual") {
     return describePackageManagerRemedy(input, input.cliSource);
   }
-  // Unknown platforms take the Windows-safe route too. The old Windows CLI
-  // finalizes its staged upgrade during host restart, whose taskkill /T would
-  // kill that very CLI if the command ran in a Traycer-hosted terminal.
-  if (input.platform === null || input.platform.startsWith("win32")) {
+  // The old Windows CLI finalizes its staged upgrade during host restart,
+  // whose taskkill /T would kill that very CLI if the command ran in a
+  // Traycer-hosted terminal - so Windows gets both commands, outside Traycer.
+  const route = cliUpgradeRoute(input.platform, input.cliBinaryPath);
+  if (route === "windows") {
     const instructions = describeWindowsCliUpgrade(input);
     return describeCopyRemedy(
       input,
       instructions.sentence,
       instructions.command,
       instructions.label,
+    );
+  }
+  if (route === "unknown") {
+    // Nothing on the record says what kind of machine this is: no platform,
+    // and no recorded path shaped like either. Bare commands, outside
+    // Traycer (the Windows caution costs nothing elsewhere), with no shell
+    // named - a POSIX host has no PowerShell to open.
+    return describeCopyRemedy(
+      input,
+      `Run the copied commands on ${input.hostName} from a terminal outside Traycer on that machine: first the tools upgrade, then the host restart. Restarting briefly disconnects this host. When it reconnects, select Check now, then Update now.`,
+      "traycer cli upgrade\ntraycer host restart",
+      "Copy commands",
     );
   }
   return describeCopyRemedy(
@@ -336,6 +349,28 @@ function describeDesktopCliUpgrade(
     command: posixCliUpgradeCommand(input.cliBinaryPath),
     label: "Copy command",
   };
+}
+
+/**
+ * Which command shape to hand out. The platform decides when the record has
+ * one; when it does not (a legacy registry record with `platform: null`),
+ * the RECORDED BINARY PATH is the next best evidence - a drive-rooted or UNC
+ * path only exists on Windows, a `/`-rooted one only elsewhere. Reading
+ * `null` as Windows sent a Linux or macOS host to "open PowerShell" with a
+ * bare `traycer` in place of the absolute path it had recorded, which on a
+ * manual or private-slot install is exactly the path that is not on PATH.
+ */
+function cliUpgradeRoute(
+  platform: string | null,
+  binaryPath: string | null,
+): "windows" | "posix" | "unknown" {
+  if (platform !== null) {
+    return platform.startsWith("win32") ? "windows" : "posix";
+  }
+  if (binaryPath === null) return "unknown";
+  if (isAbsoluteWindowsPath(binaryPath)) return "windows";
+  if (binaryPath.startsWith("/")) return "posix";
+  return "unknown";
 }
 
 function describeWindowsCliUpgrade(

--- a/clients/gui-app/src/components/settings/panels/host-overview-cli-floor-remedy.ts
+++ b/clients/gui-app/src/components/settings/panels/host-overview-cli-floor-remedy.ts
@@ -35,7 +35,10 @@ interface CliFloorRemedyActionPayloads {
     readonly showGuidance: boolean;
     readonly installInFlight: boolean;
   };
-  readonly "desktop-check": unknown;
+  readonly "desktop-check": {
+    readonly label: string | null;
+    readonly checkOnMount: boolean;
+  };
   readonly "restart-desktop-hint": unknown;
   readonly "copy-command": {
     readonly label: string;
@@ -81,7 +84,7 @@ export function describeCliFloorRemedy(
     input.cliSource === "desktop" &&
     input.desktopUpdate !== null
   ) {
-    return describeDesktopRemedy(input.desktopUpdate, input.requiredCliVersion);
+    return describeDesktopRemedy(input.desktopUpdate, input);
   }
   if (input.cliSource !== "desktop" && input.cliSource !== "manual") {
     const command = PACKAGE_MANAGER_UPGRADE_COMMAND[input.cliSource];
@@ -113,10 +116,11 @@ export function describeCliFloorRemedy(
 
 function describeDesktopRemedy(
   snapshot: DesktopAppUpdateSnapshot,
-  requiredCliVersion: string | null,
+  input: CliFloorRemedyInput,
 ): CliFloorRemedy {
-  const version = snapshot.latestVersion ?? requiredCliVersion;
-  const versionSuffix = version === null ? "" : ` ${version}`;
+  const fallback = describeDesktopFloorFallbackFor(snapshot, input);
+  if (fallback !== null) return fallback;
+  const version = snapshot.latestVersion ?? input.requiredCliVersion;
   switch (snapshot.status) {
     case "available":
       return {
@@ -143,40 +147,137 @@ function describeDesktopRemedy(
           },
         ],
       };
-    case "ready": {
-      // Same precedence as the header: a blocked location wins over manual
-      // install guidance, and main's in-flight snapshot disarms every surface.
-      const showGuidance =
-        snapshot.installBlockedReason === null &&
-        snapshot.installGuidance !== null;
-      return {
-        sentence: `Traycer Desktop${versionSuffix} is ready. Restart Traycer to finish, then this host update can install.`,
-        actions: [
-          {
-            kind: "desktop-install",
-            label: showGuidance ? "Finish update" : "Restart to update",
-            disabled:
-              snapshot.installBlockedReason !== null ||
-              snapshot.installInFlight,
-            tooltip: snapshot.installBlockedReason,
-            showGuidance,
-            installInFlight: snapshot.installInFlight,
-          },
-        ],
-      };
-    }
+    case "ready":
+      return describeDesktopReady(snapshot, version);
     case "up-to-date":
       return {
         sentence:
           "Traycer Desktop is up to date, but this computer still needs to finish updating its host tools. Restart Traycer Desktop to finish.",
         actions: [{ kind: "restart-desktop-hint" }],
       };
-    default:
+    case "error":
+    case "unavailable":
+      return describeDesktopCheckFailed(snapshot);
+    case "idle":
+      return {
+        sentence: "Check for a Traycer Desktop update.",
+        actions: [{ kind: "desktop-check", label: null, checkOnMount: true }],
+      };
+    case "checking":
       return {
         sentence: "Checking for a Traycer Desktop update…",
-        actions: [{ kind: "desktop-check" }],
+        actions: [{ kind: "desktop-check", label: null, checkOnMount: false }],
       };
   }
+}
+
+function describeDesktopReady(
+  snapshot: DesktopAppUpdateSnapshot,
+  version: string | null,
+): CliFloorRemedy {
+  // Same precedence as the header: a blocked location wins over manual
+  // install guidance, and main's in-flight snapshot disarms every surface.
+  const showGuidance =
+    snapshot.installBlockedReason === null && snapshot.installGuidance !== null;
+  return {
+    sentence: `Traycer Desktop${version === null ? "" : ` ${version}`} is ready. Restart Traycer to finish, then this host update can install.`,
+    actions: [
+      {
+        kind: "desktop-install",
+        label: showGuidance ? "Finish update" : "Restart to update",
+        disabled:
+          snapshot.installBlockedReason !== null || snapshot.installInFlight,
+        tooltip: snapshot.installBlockedReason,
+        showGuidance,
+        installInFlight: snapshot.installInFlight,
+      },
+    ],
+  };
+}
+
+function describeDesktopCheckFailed(
+  snapshot: DesktopAppUpdateSnapshot,
+): CliFloorRemedy {
+  return {
+    sentence:
+      snapshot.errorMessage?.trim() ||
+      "Traycer Desktop couldn't check for updates.",
+    actions: [
+      { kind: "desktop-check", label: "Check again", checkOnMount: false },
+      { kind: "help", label: "Show installation help" },
+    ],
+  };
+}
+
+// Desktop and its bundled CLI share a version. Downloading or restarting a
+// stable build below an RC host's floor would leave the same refusal. When no
+// update is offered, a restart runs the installed Desktop, and the feed's
+// latest version may be older than it (for example after leaving RCs).
+function describeDesktopFloorFallbackFor(
+  snapshot: DesktopAppUpdateSnapshot,
+  input: CliFloorRemedyInput,
+): CliFloorRemedy | null {
+  switch (snapshot.status) {
+    case "available":
+    case "downloading":
+    case "ready":
+      return describeDesktopFloorFallback(input, snapshot.latestVersion);
+    case "up-to-date":
+      return describeDesktopFloorFallback(input, snapshot.currentVersion);
+    default:
+      return null;
+  }
+}
+
+function describeDesktopFloorFallback(
+  input: CliFloorRemedyInput,
+  candidate: string | null,
+): CliFloorRemedy | null {
+  const { requiredCliVersion } = input;
+  if (requiredCliVersion === null) return null;
+  const comparison =
+    candidate === null
+      ? null
+      : compareHostVersions(candidate, requiredCliVersion);
+  if (
+    comparison !== null &&
+    comparison.comparable &&
+    comparison.ordering !== "less"
+  ) {
+    return null;
+  }
+  const versionDescription =
+    input.desktopUpdate?.status === "up-to-date"
+      ? `Traycer Desktop v${candidate} is installed`
+      : `Traycer v${candidate} is the latest on this update channel`;
+  const sentence =
+    comparison !== null && comparison.comparable
+      ? `${versionDescription} and its command-line tools are below ${requiredCliVersion}.`
+      : `Traycer couldn't verify that this Desktop update includes Traycer CLI ${requiredCliVersion} or newer.`;
+  // A Desktop-owned CLI may have a separate recorded binary. Only reuse the
+  // model's existing absolute POSIX path route; guessing PATH could upgrade
+  // another copy and leave this host refused by the same bundled CLI.
+  const command =
+    input.platform !== null &&
+    !input.platform.startsWith("win32") &&
+    input.cliBinaryPath !== null &&
+    input.cliBinaryPath.startsWith("/")
+      ? posixCliUpgradeCommand(input.cliBinaryPath)
+      : null;
+  const help: CliFloorRemedyAction = {
+    kind: "help",
+    label: "Show installation help",
+  };
+  return {
+    sentence:
+      command === null
+        ? sentence
+        : `${sentence} Open a terminal on ${input.hostName} and run the copied command, then select Check now.`,
+    actions:
+      command === null
+        ? [help]
+        : [{ kind: "copy-command", label: "Copy command", command }, help],
+  };
 }
 
 function describeCopyRemedy(

--- a/clients/gui-app/src/components/settings/panels/host-overview-cli-floor-remedy.ts
+++ b/clients/gui-app/src/components/settings/panels/host-overview-cli-floor-remedy.ts
@@ -337,13 +337,16 @@ function describeDesktopCliUpgrade(
 ): CliUpgradeInstructions | null {
   // Never guess PATH for a Desktop-owned CLI: its private slot or a manually
   // re-anchored binary may not be registered there, or may name another copy.
-  if (input.platform === null || input.cliBinaryPath === null) return null;
-  if (input.platform.startsWith("win32")) {
+  // Same route decision as the manual arm - a null platform is answered by
+  // the recorded path's shape, never read as "no route".
+  if (input.cliBinaryPath === null) return null;
+  const route = cliUpgradeRoute(input.platform, input.cliBinaryPath);
+  if (route === "windows") {
     return isAbsoluteWindowsPath(input.cliBinaryPath)
       ? describeWindowsCliUpgrade(input)
       : null;
   }
-  if (!input.cliBinaryPath.startsWith("/")) return null;
+  if (route !== "posix" || !input.cliBinaryPath.startsWith("/")) return null;
   return {
     sentence: `Open a terminal on ${input.hostName} and run the copied command, then select Check now.`,
     command: posixCliUpgradeCommand(input.cliBinaryPath),

--- a/clients/gui-app/src/components/settings/panels/host-overview-cli-floor-remedy.ts
+++ b/clients/gui-app/src/components/settings/panels/host-overview-cli-floor-remedy.ts
@@ -58,6 +58,12 @@ export interface CliFloorRemedy {
   readonly actions: readonly CliFloorRemedyAction[];
 }
 
+interface CliUpgradeInstructions {
+  readonly sentence: string;
+  readonly command: string;
+  readonly label: string;
+}
+
 export interface CliFloorRemedyInput {
   readonly isLocalMachine: boolean;
   readonly platform: string | null;
@@ -99,11 +105,12 @@ export function describeCliFloorRemedy(
   // finalizes its staged upgrade during host restart, whose taskkill /T would
   // kill that very CLI if the command ran in a Traycer-hosted terminal.
   if (input.platform === null || input.platform.startsWith("win32")) {
+    const instructions = describeWindowsCliUpgrade(input);
     return describeCopyRemedy(
       input,
-      `Run traycer cli upgrade on ${input.hostName}, then traycer host restart, from a terminal outside Traycer on that machine (an SSH session or a Windows Terminal window there). Restarting briefly disconnects this host. When it reconnects, select Check now, then Update now.`,
-      "traycer cli upgrade\ntraycer host restart",
-      "Copy commands",
+      instructions.sentence,
+      instructions.command,
+      instructions.label,
     );
   }
   return describeCopyRemedy(
@@ -254,29 +261,55 @@ function describeDesktopFloorFallback(
     comparison !== null && comparison.comparable
       ? `${versionDescription} and its command-line tools are below ${requiredCliVersion}.`
       : `Traycer couldn't verify that this Desktop update includes Traycer CLI ${requiredCliVersion} or newer.`;
-  // A Desktop-owned CLI may have a separate recorded binary. Only reuse the
-  // model's existing absolute POSIX path route; guessing PATH could upgrade
-  // another copy and leave this host refused by the same bundled CLI.
-  const command =
-    input.platform !== null &&
-    !input.platform.startsWith("win32") &&
-    input.cliBinaryPath !== null &&
-    input.cliBinaryPath.startsWith("/")
-      ? posixCliUpgradeCommand(input.cliBinaryPath)
-      : null;
+  const instructions = describeDesktopCliUpgrade(input);
   const help: CliFloorRemedyAction = {
     kind: "help",
     label: "Show installation help",
   };
   return {
     sentence:
-      command === null
-        ? sentence
-        : `${sentence} Open a terminal on ${input.hostName} and run the copied command, then select Check now.`,
+      instructions === null ? sentence : `${sentence} ${instructions.sentence}`,
     actions:
-      command === null
+      instructions === null
         ? [help]
-        : [{ kind: "copy-command", label: "Copy command", command }, help],
+        : [
+            {
+              kind: "copy-command",
+              label: instructions.label,
+              command: instructions.command,
+            },
+            help,
+          ],
+  };
+}
+
+function describeDesktopCliUpgrade(
+  input: CliFloorRemedyInput,
+): CliUpgradeInstructions | null {
+  // Never guess PATH for a Desktop-owned CLI: its private slot or a manually
+  // re-anchored binary may not be registered there, or may name another copy.
+  if (input.platform === null || input.cliBinaryPath === null) return null;
+  if (input.platform.startsWith("win32")) {
+    return isAbsoluteWindowsPath(input.cliBinaryPath)
+      ? describeWindowsCliUpgrade(input)
+      : null;
+  }
+  if (!input.cliBinaryPath.startsWith("/")) return null;
+  return {
+    sentence: `Open a terminal on ${input.hostName} and run the copied command, then select Check now.`,
+    command: posixCliUpgradeCommand(input.cliBinaryPath),
+    label: "Copy command",
+  };
+}
+
+function describeWindowsCliUpgrade(
+  input: CliFloorRemedyInput,
+): CliUpgradeInstructions {
+  const invocation = windowsCliInvocation(input.cliBinaryPath);
+  return {
+    sentence: `Run the copied commands on ${input.hostName} from a PowerShell window outside Traycer on that machine (a Windows Terminal tab there, or an SSH session that opens PowerShell). Restarting briefly disconnects this host. When it reconnects, select Check now, then Update now.`,
+    command: `${invocation} cli upgrade\n${invocation} host restart`,
+    label: "Copy commands",
   };
 }
 
@@ -300,6 +333,23 @@ function describeCopyRemedy(
       : sentence,
     actions: [{ kind: "copy-command", label, command }],
   };
+}
+
+// Drive-rooted (`C:\`, `D:/`) or UNC (`\\server\share`). A drive-relative
+// `C:traycer.exe` or a bare name is not a path we can hand to a shell.
+function isAbsoluteWindowsPath(binaryPath: string): boolean {
+  return /^[A-Za-z]:[\\/]/.test(binaryPath) || binaryPath.startsWith("\\\\");
+}
+
+function windowsCliInvocation(binaryPath: string | null): string {
+  if (binaryPath === null || !isAbsoluteWindowsPath(binaryPath)) {
+    return "traycer";
+  }
+  // Windows Terminal's default profile is PowerShell: a double-quoted path
+  // at command position is a string expression, so invocation needs `&`.
+  // Single quotes keep the path literal; cmd users need double quotes
+  // without `&` instead.
+  return `& '${binaryPath.replaceAll("'", "''")}'`;
 }
 
 function posixCliUpgradeCommand(binaryPath: string | null): string {

--- a/clients/gui-app/src/components/settings/panels/host-overview-cli-floor-remedy.ts
+++ b/clients/gui-app/src/components/settings/panels/host-overview-cli-floor-remedy.ts
@@ -1,8 +1,13 @@
 import {
+  CLI_NPM_PACKAGE_NAME,
   PACKAGE_MANAGER_UPGRADE_COMMAND,
   type CliInstallSource,
 } from "@traycer/protocol/config/installation-records";
-import { compareHostVersions } from "@traycer-clients/shared/host-version/compare-host-versions";
+import {
+  compareHostVersions,
+  isValidHostVersion,
+} from "@traycer-clients/shared/host-version/compare-host-versions";
+import { isPreReleaseVersion } from "@traycer-clients/shared/host-version/release-line";
 import type { DesktopAppUpdateSnapshot } from "@/lib/windows/types";
 
 // There is deliberately no terminal action: a 1.2.0 host ignores shellCommand
@@ -93,13 +98,7 @@ export function describeCliFloorRemedy(
     return describeDesktopRemedy(input.desktopUpdate, input);
   }
   if (input.cliSource !== "desktop" && input.cliSource !== "manual") {
-    const command = PACKAGE_MANAGER_UPGRADE_COMMAND[input.cliSource];
-    return describeCopyRemedy(
-      input,
-      `On ${input.hostName}, run this command to prepare the host update: ${command}. Then select Check now.`,
-      command,
-      "Copy command",
-    );
+    return describePackageManagerRemedy(input, input.cliSource);
   }
   // Unknown platforms take the Windows-safe route too. The old Windows CLI
   // finalizes its staged upgrade during host restart, whose taskkill /T would
@@ -117,6 +116,43 @@ export function describeCliFloorRemedy(
     input,
     `First update Traycer's command-line tools on ${input.hostName}. Open a terminal on that machine and run the copied command. When it finishes, come back here: this page rechecks while it is open, and Update now appears once the host accepts the update.`,
     posixCliUpgradeCommand(input.cliBinaryPath),
+    "Copy command",
+  );
+}
+
+function describePackageManagerRemedy(
+  input: CliFloorRemedyInput,
+  source: Exclude<CliInstallSource, "desktop" | "manual">,
+): CliFloorRemedy {
+  const requiredVersion = input.requiredCliVersion;
+  // Legacy projections can mislabel a malformed floor as repairable. Never
+  // interpolate unchecked manifest text into the copied npm shell command.
+  if (requiredVersion !== null && !isValidHostVersion(requiredVersion)) {
+    return {
+      sentence: `Traycer couldn't verify the required command-line tools version on ${input.hostName}.`,
+      actions: [{ kind: "help", label: "Show installation help" }],
+    };
+  }
+  if (
+    requiredVersion !== null &&
+    isPreReleaseVersion(requiredVersion) &&
+    source !== "npm" &&
+    source !== "homebrew"
+  ) {
+    return {
+      sentence: `Traycer CLI prereleases aren't published through ${source}. Install Traycer CLI ${requiredVersion} another way, then select Check now.`,
+      actions: [{ kind: "help", label: "Show installation help" }],
+    };
+  }
+  // npm's `latest` is stable-only; pin the published floor, including RCs.
+  const command =
+    source === "npm" && requiredVersion !== null
+      ? `npm install -g ${CLI_NPM_PACKAGE_NAME}@${requiredVersion}`
+      : PACKAGE_MANAGER_UPGRADE_COMMAND[source];
+  return describeCopyRemedy(
+    input,
+    `On ${input.hostName}, run this command to prepare the host update: ${command}. Then select Check now.`,
+    command,
     "Copy command",
   );
 }

--- a/clients/gui-app/src/components/settings/panels/host-overview-operation-card.tsx
+++ b/clients/gui-app/src/components/settings/panels/host-overview-operation-card.tsx
@@ -69,7 +69,7 @@ export function HostOverviewOperationCard(props: {
    * the ellipsis on the button is a promise, and the confirmation is what
    * re-reads live work before anything happens.
    */
-  readonly onForceRestart: () => void;
+  readonly onForceRestart: (() => void) | null;
   /**
    * The RECORDS say the install is ahead of the running host (activation
    * debt, `legacy-update-facts.ts`), and this is the page's cooperative
@@ -190,7 +190,7 @@ export function HostOverviewOperationCard(props: {
  */
 function ForceControl(props: {
   readonly onForceUpdate: (() => void) | null;
-  readonly onForceRestart: () => void;
+  readonly onForceRestart: (() => void) | null;
 }): ReactNode {
   if (props.onForceUpdate !== null) {
     return (
@@ -206,6 +206,7 @@ function ForceControl(props: {
       </Button>
     );
   }
+  if (props.onForceRestart === null) return null;
   return (
     <Button
       type="button"

--- a/clients/gui-app/src/components/settings/panels/host-overview-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/host-overview-panel.tsx
@@ -28,6 +28,7 @@ import {
 import { HostOverviewOperationCard } from "@/components/settings/panels/host-overview-operation-card";
 import { HostOverviewUpdatesRegion } from "@/components/settings/panels/host-overview-updates";
 import { useHostOverviewUpdates } from "@/components/settings/panels/host-overview-updates-state";
+import { useDesktopAppUpdates } from "@/hooks/runner/use-desktop-app-updates";
 import { useOverviewOsService } from "@/components/settings/panels/host-overview-os-service";
 import { HostOverviewAdvancedDisclosure } from "@/components/settings/panels/host-overview-advanced";
 import {
@@ -726,6 +727,7 @@ export function HostOverviewPanel(props: {
   // drain gate and the auto-update switch write through. Two instances would
   // each track their own `isPending`, so one control would stay live while the
   // other's write was still going.
+  const desktopUpdates = useDesktopAppUpdates();
   const updates = useHostOverviewUpdates({
     client,
     hostName: displayName,
@@ -736,6 +738,12 @@ export function HostOverviewPanel(props: {
     runningVersion: view.hostVersion,
     activationDebt: legacyFacts?.activationDebt ?? null,
     platformKey: host?.platform ?? null,
+    cliManifest:
+      managedInstallation(installationQuery.data)?.cliManifest ?? null,
+    isLocalMachine: host?.isLocalMachine ?? false,
+    desktopUpdate:
+      desktopUpdates.bridge === null ? null : desktopUpdates.snapshot,
+    stagedVersion: legacyFacts?.stagedWait?.stagedVersion ?? null,
     // The check reads on its own now, so this gate is load-bearing rather than
     // cosmetic: without it the page would spawn a CLI process on the host from
     // a scope that has not resolved, and cache the answer under this page's key.
@@ -1015,12 +1023,17 @@ export function HostOverviewPanel(props: {
           <HostOverviewOperationCard
             view={operationView}
             hostName={displayName}
-            onForceRestart={() => {
-              // Same route as the overflow Restart: re-ask the host about live
-              // work, then the EXISTING confirmation. This never restarts on
-              // the first click and never consumes update-force authorization.
-              setRestartConfirmOpen(true);
-            }}
+            // Restart cannot activate a stage. A floor gate must not turn a
+            // staged wait's Force update into a different, ineffective force.
+            onForceRestart={
+              (legacyFacts?.stagedWait ?? null) !== null
+                ? null
+                : () => {
+                    // Attempt parks keep the existing cooperative restart
+                    // confirmation and its fresh live-work check.
+                    setRestartConfirmOpen(true);
+                  }
+            }
             // Keyed on the FACT, not the view kind: a retained `failed`
             // marker beside real debt keeps its failure text and still gets
             // the way forward. Same confirm the header's Restart opens, so
@@ -1032,7 +1045,10 @@ export function HostOverviewPanel(props: {
                 : () => setRestartConfirmOpen(true)
             }
             onForceUpdate={
-              legacyFacts === null || legacyFacts.stagedWait === null
+              legacyFacts === null ||
+              legacyFacts.stagedWait === null ||
+              updates.stagedFloor !== null ||
+              !updates.stagedEntryKnown
                 ? null
                 : () => {
                     if (legacyFacts.stagedWait === null) return;
@@ -1055,6 +1071,8 @@ export function HostOverviewPanel(props: {
           <HostOverviewUpdatesRegion
             summary={updates.summary}
             degrade={updates.degrade}
+            desktopBridge={desktopUpdates.bridge}
+            onInstallationHelp={() => setDoctorOpen(true)}
           />
         )}
         {/* Stays OUT of Advanced, deliberately. This is the only control on the

--- a/clients/gui-app/src/components/settings/panels/host-overview-updates-state.ts
+++ b/clients/gui-app/src/components/settings/panels/host-overview-updates-state.ts
@@ -288,6 +288,19 @@ export function useHostOverviewUpdates(input: {
   // versions the failed check could not confirm - under a summary that says
   // the host could not be checked.
   const actionableManifest = checkQuery.isError ? null : manifest;
+  // A repaired refusal must not return when a later check loses its catalog.
+  // Retire it on a newer successful answer, using the same guarded render
+  // adjustment as installDiscovered; hiding the text alone keeps stale state.
+  retireForceRefusalIfRefuted({
+    refusal: forceRefusal,
+    manifest: actionableManifest,
+    checkDataUpdatedAt: checkQuery.dataUpdatedAt,
+    checkSucceeded: checkQuery.isSuccess,
+    checkIsPlaceholderData: checkQuery.isPlaceholderData,
+    platformKey: input.platformKey,
+    hostName,
+    retire: () => setForceRefusal(null),
+  });
   const failureDescription = describeUpdateFailure({
     refusal: forceRefusal,
     manifest: actionableManifest,
@@ -376,7 +389,11 @@ export function useHostOverviewUpdates(input: {
         hostName,
       });
       if (refusal !== null) {
-        setForceRefusal({ version, text: refusal });
+        setForceRefusal({
+          version,
+          text: refusal,
+          checkDataUpdatedAt: checkQuery.dataUpdatedAt,
+        });
         // No mutation means no mutation settle callback. Close synchronously
         // here or the confirmation would be stranded over the inline notice.
         onSettled();
@@ -837,6 +854,7 @@ interface CliFloor {
 interface ForceUpdateRefusal {
   readonly version: string;
   readonly text: string;
+  readonly checkDataUpdatedAt: number;
 }
 
 function deriveFloorRemedies(input: {
@@ -917,6 +935,46 @@ function describeForceUpdateRefusal(input: {
   }
   // An absent entry, failed check, or incomplete refusal cannot name a floor.
   return `Traycer couldn't verify that v${input.version} can be installed on ${input.hostName}. Select Check now and try again.`;
+}
+
+interface ForceRefusalEvidence {
+  readonly refusal: ForceUpdateRefusal | null;
+  readonly manifest: HostAvailableManifest | null;
+  readonly checkDataUpdatedAt: number;
+  readonly checkSucceeded: boolean;
+  readonly checkIsPlaceholderData: boolean;
+  readonly platformKey: string | null;
+  readonly hostName: string;
+}
+
+/**
+ * The guarded render adjustment for a Force refusal: one decision, one
+ * action, stated beside its predicate rather than inline in the hook.
+ * `retire` is the state setter; calling it conditionally during render is
+ * the same pattern the `installDiscovered` adjustment uses.
+ */
+function retireForceRefusalIfRefuted(
+  input: ForceRefusalEvidence & { readonly retire: () => void },
+): void {
+  if (checkRefutesForceRefusal(input)) input.retire();
+}
+
+function checkRefutesForceRefusal(input: ForceRefusalEvidence): boolean {
+  // A retained or placeholder catalog cannot prove a subsequent repair.
+  // The exact refused version must be cleared by a newer successful answer.
+  return (
+    input.refusal !== null &&
+    input.checkSucceeded &&
+    !input.checkIsPlaceholderData &&
+    input.manifest !== null &&
+    input.checkDataUpdatedAt > input.refusal.checkDataUpdatedAt &&
+    describeForceUpdateRefusal({
+      manifest: input.manifest,
+      version: input.refusal.version,
+      platformKey: input.platformKey,
+      hostName: input.hostName,
+    }) === null
+  );
 }
 
 function describeUpdateFailure(input: {

--- a/clients/gui-app/src/components/settings/panels/host-overview-updates-state.ts
+++ b/clients/gui-app/src/components/settings/panels/host-overview-updates-state.ts
@@ -179,7 +179,9 @@ export function useHostOverviewUpdates(input: {
   const [installFailure, setInstallFailure] = useState<CliShellFailure | null>(
     null,
   );
-  const [forceRefusal, setForceRefusal] = useState<string | null>(null);
+  const [forceRefusal, setForceRefusal] = useState<ForceUpdateRefusal | null>(
+    null,
+  );
 
   const checkQuery = useHostUpdateCheckQuery({
     client,
@@ -220,11 +222,6 @@ export function useHostOverviewUpdates(input: {
     installDegrade: input.installDegrade,
   });
   const transientFailure = installFailure ?? check.transient;
-  const failureDescription = describeUpdateFailure(
-    forceRefusal,
-    transientFailure,
-    hostName,
-  );
   // `isFetching`, not `isPending`: a forced Check now over an answer already in
   // hand leaves `isPending` false, and the button would never show it was busy.
   const checking = checkQuery.isFetching;
@@ -291,6 +288,13 @@ export function useHostOverviewUpdates(input: {
   // versions the failed check could not confirm - under a summary that says
   // the host could not be checked.
   const actionableManifest = checkQuery.isError ? null : manifest;
+  const failureDescription = describeUpdateFailure({
+    refusal: forceRefusal,
+    manifest: actionableManifest,
+    platformKey: input.platformKey,
+    failure: transientFailure,
+    hostName,
+  });
   // The best STRICTLY NEWER version this catalog offers, before the yanked and
   // platform-asset gates - what the sentence is about, where
   // `updatableVersion` below is what the button can act on.
@@ -372,7 +376,7 @@ export function useHostOverviewUpdates(input: {
         hostName,
       });
       if (refusal !== null) {
-        setForceRefusal(refusal);
+        setForceRefusal({ version, text: refusal });
         // No mutation means no mutation settle callback. Close synchronously
         // here or the confirmation would be stranded over the inline notice.
         onSettled();
@@ -830,6 +834,11 @@ interface CliFloor {
   readonly requiredCliVersion: string | null;
 }
 
+interface ForceUpdateRefusal {
+  readonly version: string;
+  readonly text: string;
+}
+
 function deriveFloorRemedies(input: {
   readonly manifest: HostAvailableManifest | null;
   readonly targetVersion: string | null;
@@ -845,8 +854,11 @@ function deriveFloorRemedies(input: {
   readonly stagedEntryKnown: boolean;
   readonly remedy: CliFloorRemedy | null;
 } {
+  // Yanked releases stay unavailable after a CLI repair, and the recovery
+  // poll ignores them. Keep this summary-only: a staged floor must still
+  // refuse Force even when the staged release has been yanked.
   const target = input.manifest?.versions.find(
-    (entry) => entry.version === input.targetVersion,
+    (entry) => entry.version === input.targetVersion && !entry.yanked,
   );
   const staged = input.manifest?.versions.find(
     (entry) => entry.version === input.stagedVersion,
@@ -907,13 +919,30 @@ function describeForceUpdateRefusal(input: {
   return `Traycer couldn't verify that v${input.version} can be installed on ${input.hostName}. Select Check now and try again.`;
 }
 
-function describeUpdateFailure(
-  refusal: string | null,
-  failure: CliShellFailure | null,
-  hostName: string,
-): string | null {
-  if (refusal !== null) return refusal;
-  return failure === null ? null : describeCliShellFailure(failure, hostName);
+function describeUpdateFailure(input: {
+  readonly refusal: ForceUpdateRefusal | null;
+  readonly manifest: HostAvailableManifest | null;
+  readonly platformKey: string | null;
+  readonly failure: CliShellFailure | null;
+  readonly hostName: string;
+}): string | null {
+  // A successful poll can repair the exact version refused at confirmation.
+  // Derive visibility from the current catalog so both failure surfaces clear
+  // with that answer, without waiting for another click to reset local state.
+  if (
+    input.refusal !== null &&
+    describeForceUpdateRefusal({
+      manifest: input.manifest,
+      version: input.refusal.version,
+      platformKey: input.platformKey,
+      hostName: input.hostName,
+    }) !== null
+  ) {
+    return input.refusal.text;
+  }
+  return input.failure === null
+    ? null
+    : describeCliShellFailure(input.failure, input.hostName);
 }
 
 function assetUnavailableReason(asset: PlatformAsset | null): string | null {

--- a/clients/gui-app/src/components/settings/panels/host-overview-updates-state.ts
+++ b/clients/gui-app/src/components/settings/panels/host-overview-updates-state.ts
@@ -323,10 +323,16 @@ export function useHostOverviewUpdates(input: {
     installedVersion,
     source: check.source,
   });
+  const summaryCandidate = selectSummaryCandidate({
+    manifest: actionableManifest,
+    installedVersion,
+    platformKey: input.platformKey,
+    source: check.source,
+  });
   const { cliFloor, stagedFloor, stagedEntryKnown, remedy } =
     deriveFloorRemedies({
       manifest: actionableManifest,
-      targetVersion,
+      summaryCandidate,
       stagedVersion: input.stagedVersion,
       platformKey: input.platformKey,
       cliManifest: input.cliManifest,
@@ -356,15 +362,7 @@ export function useHostOverviewUpdates(input: {
   // picker rows: a latest with no usable asset for this host is advertised
   // nowhere rather than installable in one surface and unavailable in the
   // other.
-  const updatableVersion =
-    cliFloor === null
-      ? offerableLatestVersion({
-          manifest: actionableManifest,
-          installedVersion,
-          platformKey: input.platformKey,
-          source: check.source,
-        })
-      : null;
+  const updatableVersion = offerableLatestVersion(summaryCandidate);
   const installingVersion = installMutation.isPending
     ? installMutation.variables.version
     : null;
@@ -567,12 +565,30 @@ function visibleVersionRows(input: {
  * explicit include: a user who asked for the broad catalog gets the broad
  * catalog's own pointer rather than a line restriction they did not request.
  */
-function offerableLatestVersion(input: {
+function offerableLatestVersion(
+  candidate: SummaryUpdateCandidate | null,
+): string | null {
+  if (candidate === null || candidate.cliFloor !== null) return null;
+  return candidate.version;
+}
+
+interface SummaryUpdateCandidate {
+  readonly version: string;
+  readonly cliFloor: CliFloor | null;
+}
+
+/**
+ * One ordered walk owns both the update and its CLI remedy. An unusable
+ * stable may leave an RC as the first repairable target; a floored stable
+ * must instead keep its priority over an already-installable lower RC.
+ * Yanked entries never become usable after a CLI repair, so skip them here.
+ */
+function selectSummaryCandidate(input: {
   readonly manifest: HostAvailableManifest | null;
   readonly installedVersion: string | null;
   readonly platformKey: string | null;
   readonly source: HostIncludePreReleasesSource | null;
-}): string | null {
+}): SummaryUpdateCandidate | null {
   const { manifest } = input;
   if (manifest === null) return null;
   for (const candidate of targetCandidates({
@@ -591,7 +607,11 @@ function offerableLatestVersion(input: {
     );
     if (entry === undefined || entry.yanked) continue;
     const asset = platformAssetFor(entry.platforms, input.platformKey);
-    if (assetUnavailableReason(asset) === null) return candidate;
+    if (assetUnavailableReason(asset) === null) {
+      return { version: candidate, cliFloor: null };
+    }
+    const cliFloor = readCliFloor(entry, input.platformKey);
+    if (cliFloor !== null) return { version: candidate, cliFloor };
   }
   return null;
 }
@@ -659,7 +679,7 @@ function targetCandidates(input: {
   );
   // EXCLUDING the matching stable, which also satisfies both predicates below
   // — it is on the line and strictly newer. Without this the stable is
-  // returned twice, and `offerableLatestVersion` pays for a second yanked and
+  // returned twice, and `selectSummaryCandidate` pays for a second yanked and
   // platform-asset probe on a candidate it already accepted or rejected.
   const laterOnLine = versions
     .filter(
@@ -859,7 +879,7 @@ interface ForceUpdateRefusal {
 
 function deriveFloorRemedies(input: {
   readonly manifest: HostAvailableManifest | null;
-  readonly targetVersion: string | null;
+  readonly summaryCandidate: SummaryUpdateCandidate | null;
   readonly stagedVersion: string | null;
   readonly platformKey: string | null;
   readonly cliManifest: StoredCliInstallManifest | null;
@@ -872,16 +892,12 @@ function deriveFloorRemedies(input: {
   readonly stagedEntryKnown: boolean;
   readonly remedy: CliFloorRemedy | null;
 } {
-  // Yanked releases stay unavailable after a CLI repair, and the recovery
-  // poll ignores them. Keep this summary-only: a staged floor must still
-  // refuse Force even when the staged release has been yanked.
-  const target = input.manifest?.versions.find(
-    (entry) => entry.version === input.targetVersion && !entry.yanked,
-  );
+  // The shared summary walk skips yanked releases, but a staged floor must
+  // still refuse Force even when the staged release has been yanked.
   const staged = input.manifest?.versions.find(
     (entry) => entry.version === input.stagedVersion,
   );
-  const cliFloor = readCliFloor(target, input.platformKey);
+  const cliFloor = input.summaryCandidate?.cliFloor ?? null;
   return {
     cliFloor,
     stagedFloor: readCliFloor(staged, input.platformKey),

--- a/clients/gui-app/src/components/settings/panels/host-overview-updates-state.ts
+++ b/clients/gui-app/src/components/settings/panels/host-overview-updates-state.ts
@@ -6,6 +6,8 @@ import {
   isStrictlyNewerHostVersion,
 } from "@traycer-clients/shared/host-version/compare-host-versions";
 import {
+  HOST_CLIENT_FLOOR_REASON_PREFIX,
+  isHostClientFloorRefusedAsset,
   isMatchingStableRelease,
   isSameReleaseLine,
 } from "@traycer-clients/shared/host-version/release-line";
@@ -14,6 +16,12 @@ import type {
   HostIncludePreReleasesSource,
   HostUpdateCheckResponseV11,
 } from "@traycer/protocol/host/maintenance/index";
+import type { StoredCliInstallManifest } from "@traycer/protocol/config/installation-records";
+import type { DesktopAppUpdateSnapshot } from "@/lib/windows/types";
+import {
+  describeCliFloorRemedy,
+  type CliFloorRemedy,
+} from "@/components/settings/panels/host-overview-cli-floor-remedy";
 import type { VersionPickerProps } from "@/components/settings/panels/host-overview-advanced";
 import type { HostVersionRow } from "@/components/settings/panels/host-version-rows";
 import { VERSION_LIST_PREVIEW } from "@/components/settings/panels/host-settings-panel-model";
@@ -101,6 +109,10 @@ export function useHostOverviewUpdates(input: {
    */
   readonly activationDebt: { readonly installedVersion: string } | null;
   readonly platformKey: string | null;
+  readonly cliManifest: StoredCliInstallManifest | null;
+  readonly isLocalMachine: boolean;
+  readonly desktopUpdate: DesktopAppUpdateSnapshot | null;
+  readonly stagedVersion: string | null;
   /** Whether this host is worth asking at all — the page owns that gate. */
   readonly enabled: boolean;
   readonly checkDegrade: OverviewDegradeReason | null;
@@ -167,6 +179,7 @@ export function useHostOverviewUpdates(input: {
   const [installFailure, setInstallFailure] = useState<CliShellFailure | null>(
     null,
   );
+  const [forceRefusal, setForceRefusal] = useState<string | null>(null);
 
   const checkQuery = useHostUpdateCheckQuery({
     client,
@@ -207,11 +220,17 @@ export function useHostOverviewUpdates(input: {
     installDegrade: input.installDegrade,
   });
   const transientFailure = installFailure ?? check.transient;
+  const failureDescription = describeUpdateFailure(
+    forceRefusal,
+    transientFailure,
+    hostName,
+  );
   // `isFetching`, not `isPending`: a forced Check now over an answer already in
   // hand leaves `isPending` false, and the button would never show it was busy.
   const checking = checkQuery.isFetching;
 
   const runCheck = (): void => {
+    setForceRefusal(null);
     void checkQuery.refetch();
   };
 
@@ -223,6 +242,7 @@ export function useHostOverviewUpdates(input: {
     // state only, like the callbacks beside it.
     onSettled: (() => void) | null,
   ): void => {
+    setForceRefusal(null);
     installMutation.mutate(
       { version, force },
       {
@@ -286,6 +306,17 @@ export function useHostOverviewUpdates(input: {
     installedVersion,
     source: check.source,
   });
+  const { cliFloor, stagedFloor, stagedEntryKnown, remedy } =
+    deriveFloorRemedies({
+      manifest: actionableManifest,
+      targetVersion,
+      stagedVersion: input.stagedVersion,
+      platformKey: input.platformKey,
+      cliManifest: input.cliManifest,
+      isLocalMachine: input.isLocalMachine,
+      desktopUpdate: input.desktopUpdate,
+      hostName,
+    });
   // Read off the resolved target rather than `manifest.latest`, which for an
   // installed-RC catalog is the WRONG pointer: `latest` tracks the stable
   // channel, so a host on `2.0.0-rc.1` sees `1.9.0` there and would be told it
@@ -308,34 +339,58 @@ export function useHostOverviewUpdates(input: {
   // picker rows: a latest with no usable asset for this host is advertised
   // nowhere rather than installable in one surface and unavailable in the
   // other.
-  const updatableVersion = offerableLatestVersion({
-    manifest: actionableManifest,
-    installedVersion,
-    platformKey: input.platformKey,
-    source: check.source,
-  });
+  const updatableVersion =
+    cliFloor === null
+      ? offerableLatestVersion({
+          manifest: actionableManifest,
+          installedVersion,
+          platformKey: input.platformKey,
+          source: check.source,
+        })
+      : null;
   const installingVersion = installMutation.isPending
     ? installMutation.variables.version
     : null;
 
   return {
     degrade,
+    cliFloor,
+    stagedFloor,
+    stagedEntryKnown,
     // The staged-wait force: the SAME dispatch as a row's Install, with
     // `force: true`, so the accepted latch, the invalidations and the
     // outcome toasts are the ones every other install on this page gets.
     // The confirmation that precedes it is the panel's (the ellipsis on
     // "Force update…" is a promise); this is only the dispatch.
-    installForce: (version, onSettled) => install(version, true, onSettled),
+    installForce: (version, onSettled) => {
+      // Re-read the exact version named by the confirmation. A catalog poll
+      // can withdraw it or project a refusal after the offer was opened.
+      const refusal = describeForceUpdateRefusal({
+        manifest: actionableManifest,
+        version,
+        platformKey: input.platformKey,
+        hostName,
+      });
+      if (refusal !== null) {
+        setForceRefusal(refusal);
+        // No mutation means no mutation settle callback. Close synchronously
+        // here or the confirmation would be stranded over the inline notice.
+        onSettled();
+        return;
+      }
+      install(version, true, onSettled);
+    },
     summary: {
       hostName,
       description: describeCheckState({
         manifest,
         checking,
-        failure: transientFailure,
+        failure: failureDescription,
         unreachable: checkQuery.isError,
         hostName,
         upToDate,
         activationDebt: input.activationDebt,
+        remedy,
         offerable: updatableVersion !== null,
         // What the BUTTON will install, when it can install anything. The two
         // differ whenever the best candidate is unusable: with a yanked
@@ -347,7 +402,8 @@ export function useHostOverviewUpdates(input: {
         strandedOnLine,
         installedVersion,
       }),
-      transientFailure,
+      failureDescription,
+      remedy,
       checking,
       // Offered only for a latest that is BOTH known and not already installed,
       // and never while the row is still reporting a failed attempt. "Update
@@ -405,7 +461,8 @@ export function useHostOverviewUpdates(input: {
 export interface HostOverviewUpdatesSummary {
   readonly hostName: string;
   readonly description: string;
-  readonly transientFailure: CliShellFailure | null;
+  readonly failureDescription: string | null;
+  readonly remedy: CliFloorRemedy | null;
   readonly checking: boolean;
   readonly updatableVersion: string | null;
   readonly installing: boolean;
@@ -418,6 +475,9 @@ export interface HostOverviewUpdatesState {
   readonly degrade: OverviewDegradeReason | null;
   readonly summary: HostOverviewUpdatesSummary;
   readonly picker: VersionPickerProps;
+  readonly cliFloor: CliFloor | null;
+  readonly stagedFloor: CliFloor | null;
+  readonly stagedEntryKnown: boolean;
   /**
    * `host.update.install {version, force: true}` — the staged-wait force.
    * `onSettled` runs once the request answers or fails, so the confirmation
@@ -766,6 +826,96 @@ function soleKeyBelongsToHost(
 type PlatformAsset =
   HostAvailableManifest["versions"][number]["platforms"][string];
 
+interface CliFloor {
+  readonly requiredCliVersion: string | null;
+}
+
+function deriveFloorRemedies(input: {
+  readonly manifest: HostAvailableManifest | null;
+  readonly targetVersion: string | null;
+  readonly stagedVersion: string | null;
+  readonly platformKey: string | null;
+  readonly cliManifest: StoredCliInstallManifest | null;
+  readonly isLocalMachine: boolean;
+  readonly desktopUpdate: DesktopAppUpdateSnapshot | null;
+  readonly hostName: string;
+}): {
+  readonly cliFloor: CliFloor | null;
+  readonly stagedFloor: CliFloor | null;
+  readonly stagedEntryKnown: boolean;
+  readonly remedy: CliFloorRemedy | null;
+} {
+  const target = input.manifest?.versions.find(
+    (entry) => entry.version === input.targetVersion,
+  );
+  const staged = input.manifest?.versions.find(
+    (entry) => entry.version === input.stagedVersion,
+  );
+  const cliFloor = readCliFloor(target, input.platformKey);
+  return {
+    cliFloor,
+    stagedFloor: readCliFloor(staged, input.platformKey),
+    stagedEntryKnown: staged !== undefined,
+    remedy:
+      cliFloor === null
+        ? null
+        : describeCliFloorRemedy({
+            isLocalMachine: input.isLocalMachine,
+            platform: input.platformKey,
+            cliSource: input.cliManifest?.source ?? null,
+            cliBinaryPath: input.cliManifest?.binaryPath ?? null,
+            cliVersion: input.cliManifest?.version ?? null,
+            requiredCliVersion: cliFloor.requiredCliVersion,
+            desktopUpdate: input.desktopUpdate,
+            hostName: input.hostName,
+          }),
+  };
+}
+
+function readCliFloor(
+  entry: HostAvailableManifest["versions"][number] | undefined,
+  platformKey: string | null,
+): CliFloor | null {
+  if (entry === undefined) return null;
+  const asset = platformAssetFor(entry.platforms, platformKey);
+  if (!isHostClientFloorRefusedAsset(asset)) return null;
+  // The version decorates the verdict; it never decides it. Older payloads
+  // can omit the field while the authored refusal still names the requirement.
+  const reasonVersion = asset?.unavailableReason
+    ?.slice(HOST_CLIENT_FLOOR_REASON_PREFIX.length)
+    .match(/^(\S+) or newer\b/)?.[1];
+  return {
+    requiredCliVersion: entry.requiredCliVersion ?? reasonVersion ?? null,
+  };
+}
+
+function describeForceUpdateRefusal(input: {
+  readonly manifest: HostAvailableManifest | null;
+  readonly version: string;
+  readonly platformKey: string | null;
+  readonly hostName: string;
+}): string | null {
+  const entry = input.manifest?.versions.find(
+    (candidate) => candidate.version === input.version,
+  );
+  const floor = readCliFloor(entry, input.platformKey);
+  if (entry !== undefined && floor === null) return null;
+  if (floor !== null && floor.requiredCliVersion !== null) {
+    return `v${input.version} needs Traycer CLI ${floor.requiredCliVersion} or newer on ${input.hostName}. Update the command-line tools first.`;
+  }
+  // An absent entry, failed check, or incomplete refusal cannot name a floor.
+  return `Traycer couldn't verify that v${input.version} can be installed on ${input.hostName}. Select Check now and try again.`;
+}
+
+function describeUpdateFailure(
+  refusal: string | null,
+  failure: CliShellFailure | null,
+  hostName: string,
+): string | null {
+  if (refusal !== null) return refusal;
+  return failure === null ? null : describeCliShellFailure(failure, hostName);
+}
+
 function assetUnavailableReason(asset: PlatformAsset | null): string | null {
   if (asset === null) return "No asset for this platform.";
   if (asset.available) return null;
@@ -917,13 +1067,14 @@ function handleInstallOutcome(input: {
 function describeCheckState(input: {
   readonly manifest: HostAvailableManifest | null;
   readonly checking: boolean;
-  readonly failure: CliShellFailure | null;
+  readonly failure: string | null;
   /** The RPC itself failed — a transport fault, not an answer from the host. */
   readonly unreachable: boolean;
   readonly hostName: string;
   readonly upToDate: boolean;
   /** The install record is ahead of the running host; see the hook's input. */
   readonly activationDebt: { readonly installedVersion: string } | null;
+  readonly remedy: CliFloorRemedy | null;
   /** `updatableVersion` resolved — the summary can actually OFFER the latest. */
   readonly offerable: boolean;
   /** The strictly-newer version this sentence is about, if there is one. */
@@ -939,7 +1090,7 @@ function describeCheckState(input: {
   // keeps the previous manifest on screen, so "vX is available." would otherwise
   // sit there unchanged while a re-check ran, or failed.
   if (input.failure !== null) {
-    return describeCliShellFailure(input.failure, input.hostName);
+    return input.failure;
   }
   // Debt outranks everything the CATALOG can say, including "checking": it is
   // a fact about this host's own disk, true whether or not the registry
@@ -951,6 +1102,9 @@ function describeCheckState(input: {
   if (input.activationDebt !== null) {
     return `v${input.activationDebt.installedVersion} is installed — restart host to finish.`;
   }
+  // Like debt, the remedy stays useful during the next check. The hook drops
+  // it when that check fails or returns a catalog that clears the refusal.
+  if (input.remedy !== null) return input.remedy.sentence;
   if (input.checking) return "Checking for updates…";
   if (input.unreachable) {
     // Deliberately NOT a toast, which is what the imperative check's `onError`

--- a/clients/gui-app/src/components/settings/panels/host-overview-updates.tsx
+++ b/clients/gui-app/src/components/settings/panels/host-overview-updates.tsx
@@ -3,11 +3,12 @@ import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 import { Button } from "@/components/ui/button";
 import { HostOverviewNotice } from "@/components/settings/panels/host-overview-status-card";
 import {
-  describeCliShellFailure,
   describeOverviewDegrade,
   type OverviewDegradeReason,
 } from "@/components/settings/panels/host-overview-model";
 import type { HostOverviewUpdatesSummary } from "@/components/settings/panels/host-overview-updates-state";
+import { CliFloorRemedyActions } from "@/components/settings/panels/host-overview-cli-floor-remedy-actions";
+import type { DesktopAppUpdatesBridge } from "@/lib/windows/types";
 import { SETTINGS_ROW_STACK } from "@/components/settings/settings-row-layout";
 import { cn } from "@/lib/utils";
 
@@ -22,6 +23,8 @@ import { cn } from "@/lib/utils";
 export function HostOverviewUpdatesRegion(props: {
   readonly summary: HostOverviewUpdatesSummary;
   readonly degrade: OverviewDegradeReason | null;
+  readonly desktopBridge: DesktopAppUpdatesBridge | null;
+  readonly onInstallationHelp: () => void;
 }): ReactNode {
   const { summary } = props;
   if (props.degrade !== null) {
@@ -60,25 +63,11 @@ export function HostOverviewUpdatesRegion(props: {
             SETTINGS_ROW_STACK.control,
           )}
         >
-          {summary.updatableVersion === null ? null : (
-            <Button
-              type="button"
-              variant="default"
-              size="sm"
-              disabled={summary.busy || summary.installing || summary.checking}
-              data-testid="host-overview-update-now"
-              onClick={summary.onUpdateLatest}
-            >
-              {summary.installing ? (
-                <AgentSpinningDots
-                  className="mr-2 size-3"
-                  testId={undefined}
-                  variant={undefined}
-                />
-              ) : null}
-              Update now
-            </Button>
-          )}
+          <OverviewUpdateControl
+            summary={summary}
+            desktopBridge={props.desktopBridge}
+            onInstallationHelp={props.onInstallationHelp}
+          />
           <Button
             type="button"
             variant="ghost"
@@ -98,11 +87,48 @@ export function HostOverviewUpdatesRegion(props: {
           </Button>
         </div>
       </div>
-      {summary.transientFailure === null ? null : (
+      {summary.failureDescription === null ? null : (
         <HostOverviewNotice testId="host-overview-update-attempt-failed">
-          {describeCliShellFailure(summary.transientFailure, summary.hostName)}
+          {summary.failureDescription}
         </HostOverviewNotice>
       )}
     </div>
+  );
+}
+
+function OverviewUpdateControl(props: {
+  readonly summary: HostOverviewUpdatesSummary;
+  readonly desktopBridge: DesktopAppUpdatesBridge | null;
+  readonly onInstallationHelp: () => void;
+}): ReactNode {
+  const { summary } = props;
+  if (summary.remedy !== null) {
+    return (
+      <CliFloorRemedyActions
+        actions={summary.remedy.actions}
+        desktopBridge={props.desktopBridge}
+        onHelp={props.onInstallationHelp}
+      />
+    );
+  }
+  if (summary.updatableVersion === null) return null;
+  return (
+    <Button
+      type="button"
+      variant="default"
+      size="sm"
+      disabled={summary.busy || summary.installing || summary.checking}
+      data-testid="host-overview-update-now"
+      onClick={summary.onUpdateLatest}
+    >
+      {summary.installing ? (
+        <AgentSpinningDots
+          className="mr-2 size-3"
+          testId={undefined}
+          variant={undefined}
+        />
+      ) : null}
+      Update now
+    </Button>
   );
 }

--- a/clients/gui-app/src/lib/host-rpc-policy/__tests__/host-method-policy-table.test.ts
+++ b/clients/gui-app/src/lib/host-rpc-policy/__tests__/host-method-policy-table.test.ts
@@ -37,6 +37,15 @@ import type {
   ConditionPollLane,
   ErasedConditionPollPolicy,
 } from "@/lib/host-rpc-policy/host-method-policy-table";
+import type {
+  HostAvailableManifest,
+  HostUpdateCheckResponseV11,
+} from "@traycer/protocol/host/maintenance/index";
+import {
+  UPDATE_CHECK_CLI_RECOVERY_POLL_LANE,
+  UPDATE_CHECK_FLOOR_RECOVERY_POLL_LANE,
+  responseHasFloorRefusedCandidate,
+} from "@/lib/host-rpc-policy/host-method-policy-table";
 
 const typedProvidersClassifier = (
   data: ResponseOfMethod<HostRpcRegistry, "providers.list"> | undefined,
@@ -51,6 +60,58 @@ const typedToErasedPolicy: ErasedConditionPollPolicy<"providers.list"> = {
   staleDataErrorLane: PROVIDERS_STALE_ERROR_POLL_LANE,
   resetLaneIds: new Set([PROVIDERS_STEADY_POLL_LANE.id]),
 };
+
+function floorManifest(options: {
+  latest: string;
+  floorVersion: string;
+  floorReason: string;
+  yanked: boolean;
+  floorSha256: string;
+}): HostAvailableManifest {
+  const { latest, floorVersion, floorReason, yanked, floorSha256 } = options;
+  const entry = (version: string, refused: boolean) => ({
+    version,
+    releasedAt: "2026-09-06T00:00:00Z",
+    releaseNotesUrl: "https://example.invalid/notes",
+    yanked: refused ? yanked : false,
+    deprecationReason: null,
+    requiredCliVersion: refused ? "1.3.0" : null,
+    platforms: {
+      "darwin-arm64": {
+        available: !refused,
+        unavailableReason: refused ? floorReason : null,
+        url: "https://example.invalid/host.tar.gz",
+        sizeBytes: 100,
+        sha256: refused ? floorSha256 : "a".repeat(64),
+        signatureUrl: "https://example.invalid/host.tar.gz.minisig",
+        signatureAlgorithm: "minisign" as const,
+        publicKeyId: "key-1",
+      },
+    },
+  });
+  const versions = [entry(latest, latest === floorVersion)];
+  if (floorVersion !== latest) {
+    versions.push(entry(floorVersion, true));
+  }
+  return {
+    schemaVersion: 1,
+    generatedAt: "2026-09-06T00:00:00Z",
+    latest,
+    versions,
+  };
+}
+
+function checkResponse(
+  manifest: HostAvailableManifest,
+  source: "stable-default" | "installed-rc",
+): HostUpdateCheckResponseV11 {
+  return {
+    outcome: "ok",
+    manifest,
+    effectiveIncludePreReleases: source === "installed-rc",
+    includePreReleasesSource: source,
+  };
+}
 
 // @ts-expect-error The phantom method field must reject a policy under another key.
 const wrongKeyPolicy: ErasedConditionPollPolicy<"agent.gui.listHarnesses"> =
@@ -184,6 +245,181 @@ describe("host method poll policy table", () => {
     const fixed = HOST_METHOD_POLL_TABLE["host.getRateLimitUsage"].poll;
     const intervalMs: number = fixed.intervalMs;
     expect(intervalMs).toBe(15 * 60 * 1_000);
+  });
+
+  describe("host.update.check CLI-floor recovery", () => {
+    const policy = HOST_METHOD_POLL_TABLE["host.update.check"].poll;
+
+    it("polls a latest candidate whose projected asset carries the authored floor reason", () => {
+      const response = checkResponse(
+        floorManifest({
+          latest: "1.3.0",
+          floorVersion: "1.3.0",
+          floorReason:
+            "Needs Traycer CLI 1.3.0 or newer (this host's CLI is 1.2.0).",
+          yanked: false,
+          floorSha256: "",
+        }),
+        "stable-default",
+      );
+      expect(responseHasFloorRefusedCandidate(response)).toBe(true);
+      expect(policy.classify(response)).toBe(
+        UPDATE_CHECK_FLOOR_RECOVERY_POLL_LANE,
+      );
+      expect(UPDATE_CHECK_FLOOR_RECOVERY_POLL_LANE.initialDelayMs).toBe(30_000);
+      expect(UPDATE_CHECK_FLOOR_RECOVERY_POLL_LANE.maxDelayMs).toBe(30_000);
+    });
+
+    it("rejects available and yanked candidates", () => {
+      const availableWithFloorReason = checkResponse(
+        {
+          ...floorManifest({
+            latest: "1.3.0",
+            floorVersion: "1.3.0",
+            floorReason:
+              "Needs Traycer CLI 1.3.0 or newer (this host's CLI is 1.2.0).",
+            yanked: false,
+            floorSha256: "c".repeat(64),
+          }),
+          versions: floorManifest({
+            latest: "1.3.0",
+            floorVersion: "1.3.0",
+            floorReason:
+              "Needs Traycer CLI 1.3.0 or newer (this host's CLI is 1.2.0).",
+            yanked: false,
+            floorSha256: "c".repeat(64),
+          }).versions.map((entry) => ({
+            ...entry,
+            platforms: {
+              "darwin-arm64": {
+                ...entry.platforms["darwin-arm64"],
+                available: true,
+                unavailableReason:
+                  "Needs Traycer CLI 1.3.0 or newer (this host's CLI is 1.2.0).",
+              },
+            },
+          })),
+        },
+        "stable-default",
+      );
+      // Removing the !asset.available predicate would classify this genuinely
+      // available asset as a floor despite its stale reason; this negative
+      // availability pin must turn RED under that concrete ablation.
+      expect(responseHasFloorRefusedCandidate(availableWithFloorReason)).toBe(
+        false,
+      );
+      expect(policy.classify(availableWithFloorReason)).toBe(false);
+      const nonFloorRefusal = checkResponse(
+        floorManifest({
+          latest: "1.3.0",
+          floorVersion: "1.3.0",
+          floorReason: "not a floor",
+          yanked: false,
+          floorSha256: "",
+        }),
+        "stable-default",
+      );
+      // Removing the authored prefix check would treat any unavailable asset
+      // as a floor; this negative available-asset pin must turn RED under that
+      // concrete classifier-ablation.
+      expect(responseHasFloorRefusedCandidate(nonFloorRefusal)).toBe(false);
+      const yanked = checkResponse(
+        floorManifest({
+          latest: "1.3.0",
+          floorVersion: "1.3.0",
+          floorReason:
+            "Needs Traycer CLI 1.3.0 or newer (this host's CLI is 1.2.0).",
+          yanked: true,
+          floorSha256: "",
+        }),
+        "stable-default",
+      );
+      // Removing the !entry.yanked predicate would poll a yanked catalog row
+      // as repairable; this negative pin must turn RED under that ablation.
+      expect(responseHasFloorRefusedCandidate(yanked)).toBe(false);
+      expect(policy.classify(yanked)).toBe(false);
+    });
+
+    it("does not mistake a withdrawn asset with a retained SHA for a CLI floor", () => {
+      const withdrawn = checkResponse(
+        floorManifest({
+          latest: "1.3.0",
+          floorVersion: "1.3.0",
+          floorReason: "platform build withdrawn",
+          yanked: false,
+          floorSha256: "b".repeat(64),
+        }),
+        "stable-default",
+      );
+      // Removing the authored-reason prefix predicate would classify this
+      // withdrawn-with-hash counterexample as a floor; this negative pin must
+      // turn RED under that concrete structural-ablation.
+      expect(responseHasFloorRefusedCandidate(withdrawn)).toBe(false);
+      expect(policy.classify(withdrawn)).toBe(false);
+    });
+
+    it("checks every non-yanked installed-RC candidate, but not ordinary nonlatest rows", () => {
+      const nonlatestFloor = checkResponse(
+        floorManifest({
+          latest: "1.2.0",
+          floorVersion: "1.3.0-rc.2",
+          floorReason:
+            "Needs Traycer CLI 1.3.0 or newer (this host's CLI is 1.2.0).",
+          yanked: false,
+          floorSha256: "",
+        }),
+        "stable-default",
+      );
+      // Removing the latest/installed-rc candidate constraint would poll this
+      // ordinary nonlatest row; this negative candidate-scope pin must turn
+      // RED under that source-predicate ablation.
+      expect(responseHasFloorRefusedCandidate(nonlatestFloor)).toBe(false);
+      // Removing the installed-rc expansion would miss this later RC refusal
+      // even though latest is clear; this negative source-expansion pin must
+      // turn RED under that concrete ablation.
+      expect(
+        responseHasFloorRefusedCandidate(
+          checkResponse(
+            floorManifest({
+              latest: "1.2.0",
+              floorVersion: "1.3.0-rc.2",
+              floorReason:
+                "Needs Traycer CLI 1.3.0 or newer (this host's CLI is 1.2.0).",
+              yanked: false,
+              floorSha256: "",
+            }),
+            "installed-rc",
+          ),
+        ),
+      ).toBe(true);
+      expect(
+        policy.classify(
+          checkResponse(
+            floorManifest({
+              latest: "1.2.0",
+              floorVersion: "1.3.0-rc.2",
+              floorReason:
+                "Needs Traycer CLI 1.3.0 or newer (this host's CLI is 1.2.0).",
+              yanked: false,
+              floorSha256: "",
+            }),
+            "installed-rc",
+          ),
+        ),
+      ).toBe(UPDATE_CHECK_FLOOR_RECOVERY_POLL_LANE);
+    });
+
+    it("preserves the existing cli-unavailable recovery lane", () => {
+      // Removing the explicit cli-unavailable arm would route this legacy
+      // response through the floor helper and lose its recovery polling;
+      // this negative lane pin must turn RED under that source-arm ablation.
+      const response: HostUpdateCheckResponseV11 = {
+        outcome: "cli-unavailable",
+      };
+      expect(policy.classify(response)).toBe(
+        UPDATE_CHECK_CLI_RECOVERY_POLL_LANE,
+      );
+    });
   });
 
   // `host.status` used to be un-polled entirely. It is now opted in

--- a/clients/gui-app/src/lib/host-rpc-policy/host-method-policy-table.ts
+++ b/clients/gui-app/src/lib/host-rpc-policy/host-method-policy-table.ts
@@ -7,6 +7,8 @@ import type {
   RpcSchedulingPolicy,
 } from "@traycer-clients/shared/host-client/rpc-scheduling-policy";
 import { hostRpcRegistry, type HostRpcRegistry } from "@traycer/protocol/host";
+import { isHostClientFloorRefusedAsset } from "@traycer-clients/shared/host-version/release-line";
+import type { HostUpdateCheckResponseV11 } from "@traycer/protocol/host/maintenance/index";
 import type {
   ProviderManagedInstallState,
   ProviderManagedVersions,
@@ -312,6 +314,27 @@ export const UPDATE_CHECK_CLI_RECOVERY_POLL_LANE: ConditionPollLane = {
   initialDelayMs: 5 * SECOND_MS,
   maxDelayMs: 60 * SECOND_MS,
 };
+/** Fixed cadence while the Overview is mounted; the repaired answer ends it. */
+export const UPDATE_CHECK_FLOOR_RECOVERY_POLL_LANE: ConditionPollLane = {
+  id: "host-update-check.floor-recovery",
+  initialDelayMs: 30 * SECOND_MS,
+  maxDelayMs: 30 * SECOND_MS,
+};
+
+export function responseHasFloorRefusedCandidate(
+  response: HostUpdateCheckResponseV11,
+): boolean {
+  if (response.outcome !== "ok") return false;
+  return response.manifest.versions.some(
+    (entry) =>
+      !entry.yanked &&
+      // A response carries no installed version. Conservatively inspect all
+      // RC candidates rather than reconstructing the Overview's same-line walk.
+      (entry.version === response.manifest.latest ||
+        response.includePreReleasesSource === "installed-rc") &&
+      Object.values(entry.platforms).some(isHostClientFloorRefusedAsset),
+  );
+}
 /**
  * The check itself failed — a transport fault, not an answer. Same recovery
  * reasoning as the lane above ("Couldn't ask …" has no retry button either),
@@ -385,8 +408,11 @@ export const HOST_METHOD_POLL_TABLE = {
     poll: defineConditionPolicy("host.update.check", {
       classify: (data) => {
         if (data === undefined) return false;
-        return data.outcome === "cli-unavailable"
-          ? UPDATE_CHECK_CLI_RECOVERY_POLL_LANE
+        if (data.outcome === "cli-unavailable") {
+          return UPDATE_CHECK_CLI_RECOVERY_POLL_LANE;
+        }
+        return responseHasFloorRefusedCandidate(data)
+          ? UPDATE_CHECK_FLOOR_RECOVERY_POLL_LANE
           : false;
       },
       initialErrorLane: UPDATE_CHECK_ERROR_POLL_LANE,

--- a/clients/shared/host-version/release-line.ts
+++ b/clients/shared/host-version/release-line.ts
@@ -35,6 +35,28 @@
 import { isValidHostVersion } from "./compare-host-versions";
 
 /**
+ * The released CLI's projected refusal is the executing CLI's verdict. A
+ * stored version can be newer after a best-effort copy into the host's tools
+ * failed, and a withdrawn platform build can retain its hash. Neither is a
+ * substitute for this authored reason on the legacy wire contract.
+ */
+export const HOST_CLIENT_FLOOR_REASON_PREFIX = "Needs Traycer CLI ";
+
+export function isHostClientFloorRefusedAsset(
+  asset: {
+    readonly available: boolean;
+    readonly unavailableReason: string | null;
+  } | null,
+): boolean {
+  return (
+    asset !== null &&
+    !asset.available &&
+    asset.unavailableReason?.startsWith(HOST_CLIENT_FLOOR_REASON_PREFIX) ===
+      true
+  );
+}
+
+/**
  * A version's `X.Y.Z` core — the identity an implicit follow is scoped to.
  *
  * Module-private, like {@link hostReleaseLine} below: no caller outside this

--- a/clients/traycer-cli/src/commands/__tests__/host-available.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/host-available.test.ts
@@ -57,6 +57,7 @@ import {
 } from "../host-available";
 import type { HostInstallRecord } from "../../manifest/host-install";
 import type { CommandContext } from "../../runner/runner";
+import { HOST_CLIENT_FLOOR_REASON_PREFIX } from "@traycer-clients/shared/host-version/release-line";
 
 const AVAILABLE_ASSET: HostPlatformAsset = {
   available: true,
@@ -127,6 +128,32 @@ describe("buildHostAvailableListing", () => {
     expect(
       listing.manifest.versions[1].platforms["darwin-arm64"]?.available,
     ).toBe(true);
+  });
+
+  it("authors the floor reason with the shared literal prefix", () => {
+    const listing = buildHostAvailableListing({
+      manifest: {
+        schemaVersion: 1,
+        generatedAt: "2026-06-22T01:00:00.000Z",
+        latest: "1.2.0",
+        versions: [
+          {
+            ...createEntry("1.2.0"),
+            requiredCliVersion: "10.0.0",
+            minimumEpoch: null,
+          },
+        ],
+      },
+      manifestUrl: "https://example.com/versions.json",
+      platformKey: "darwin-arm64",
+      includePreReleases: false,
+      includePreReleasesSource: "explicit-exclude",
+      cliVersion: "9.9.9",
+    });
+    const reason =
+      listing.manifest.versions[0].platforms["darwin-arm64"]?.unavailableReason;
+    expect(reason?.startsWith(HOST_CLIENT_FLOOR_REASON_PREFIX)).toBe(true);
+    expect(HOST_CLIENT_FLOOR_REASON_PREFIX).toBe("Needs Traycer CLI ");
   });
 
   it("hides prerelease host versions by default", () => {

--- a/clients/traycer-cli/src/commands/__tests__/host-available.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/host-available.test.ts
@@ -156,6 +156,42 @@ describe("buildHostAvailableListing", () => {
     expect(HOST_CLIENT_FLOOR_REASON_PREFIX).toBe("Needs Traycer CLI ");
   });
 
+  it("keeps a malformed required CLI floor unavailable without the repair prefix", () => {
+    const requiredCliVersion = "1.3.0; npm install -g @traycerai/cli@latest";
+    const listing = buildHostAvailableListing({
+      manifest: {
+        schemaVersion: 1,
+        generatedAt: "2026-06-22T01:00:00.000Z",
+        latest: "1.2.0",
+        versions: [
+          {
+            ...createEntry("1.2.0"),
+            requiredCliVersion,
+            minimumEpoch: null,
+          },
+        ],
+      },
+      manifestUrl: "https://example.com/versions.json",
+      platformKey: "darwin-arm64",
+      includePreReleases: false,
+      includePreReleasesSource: "explicit-exclude",
+      cliVersion: "1.2.0",
+    });
+    const asset = listing.manifest.versions[0].platforms["darwin-arm64"];
+    const reason = asset?.unavailableReason;
+    // Restoring the shared repair prefix for an unreadable floor would make
+    // the GUI offer an impossible upgrade command; these exact unreadable
+    // reason pins must turn RED under that concrete ablation.
+    // Treating floor-unreadable as a non-refusal reddens the unavailable pin.
+    expect(asset?.available).toBe(false);
+    expect
+      .soft(reason)
+      .toBe(
+        `host registry: version '1.2.0' declares requiredCliVersion ${JSON.stringify(requiredCliVersion)}, which is not a version this CLI can compare against. The manifest is wrong; do not work around it by installing a different version.`,
+      );
+    expect(reason?.startsWith(HOST_CLIENT_FLOOR_REASON_PREFIX)).toBe(false);
+  });
+
   it("hides prerelease host versions by default", () => {
     const listing = buildHostAvailableListing({
       manifest: createManifest([

--- a/clients/traycer-cli/src/commands/host-available.ts
+++ b/clients/traycer-cli/src/commands/host-available.ts
@@ -1,4 +1,5 @@
 import {
+  HOST_CLIENT_FLOOR_REASON_PREFIX,
   isCanonicalReleaseCandidate,
   isPreReleaseVersion,
 } from "@traycer-clients/shared/host-version/release-line";
@@ -305,7 +306,7 @@ function projectClientFloor(
       [platformKey]: {
         ...asset,
         available: false,
-        unavailableReason: `Needs Traycer CLI ${floor.requiredCliVersion} or newer (this host's CLI is ${cliVersion}).`,
+        unavailableReason: `${HOST_CLIENT_FLOOR_REASON_PREFIX}${floor.requiredCliVersion} or newer (this host's CLI is ${cliVersion}).`,
       },
     },
   };

--- a/clients/traycer-cli/src/commands/host-available.ts
+++ b/clients/traycer-cli/src/commands/host-available.ts
@@ -11,6 +11,7 @@ import {
 } from "../registry";
 import {
   evaluateHostClientFloor,
+  hostClientFloorRefusalMessage,
   isHostClientFloorRefusal,
 } from "../registry/client-floor";
 import { resolveCliVersion } from "../cli-version";
@@ -300,13 +301,20 @@ function projectClientFloor(
     requiredCliVersion: entry.requiredCliVersion,
   });
   if (!isHostClientFloorRefusal(floor)) return entry;
+  // Only a valid floor can be repaired by upgrading the CLI. Keep malformed
+  // registry data outside the GUI's repairable-reason prefix or it will keep
+  // asking for an upgrade that cannot fix the manifest.
+  const unavailableReason =
+    floor.kind === "floor-unreadable"
+      ? hostClientFloorRefusalMessage(floor, entry.version)
+      : `${HOST_CLIENT_FLOOR_REASON_PREFIX}${floor.requiredCliVersion} or newer (this host's CLI is ${cliVersion}).`;
   return {
     ...entry,
     platforms: {
       [platformKey]: {
         ...asset,
         available: false,
-        unavailableReason: `${HOST_CLIENT_FLOOR_REASON_PREFIX}${floor.requiredCliVersion} or newer (this host's CLI is ${cliVersion}).`,
+        unavailableReason,
       },
     },
   };

--- a/clients/traycer-cli/src/manifest/cli-manifest.ts
+++ b/clients/traycer-cli/src/manifest/cli-manifest.ts
@@ -1,5 +1,6 @@
 import { readFile, rename, writeFile } from "node:fs/promises";
 import { readStoredCliInstallManifestAtPath } from "@traycer/protocol/config/installation";
+import { PACKAGE_MANAGER_UPGRADE_COMMAND } from "@traycer/protocol/config/installation-records";
 import { ZodError } from "zod";
 import { createCliLogger } from "../logger";
 import { CLI_ERROR_CODES, cliError } from "../runner/errors";
@@ -79,22 +80,18 @@ export const PACKAGE_MANAGER_CLI_SOURCES: ReadonlySet<CliInstallSource> =
     "rpm",
   ]);
 
-// Canonical per-package-manager upgrade hint, written ONCE and shared by the
-// `cli upgrade` package-manager-owned refusal (cli-upgrade.ts) and the
-// protocol-incompatibility recovery hint (compat-recovery.ts). The desktop and
-// manual vectors are phrased differently per caller and are supplied by each
-// map, not here - so a package-manager command (e.g. the formula name) changes
-// in exactly one place instead of drifting between the two surfaces.
+// Keep the CLI's existing sentences (including the yum alternative), deriving
+// the command itself from the same table Desktop and the GUI remedy consume.
 export const PACKAGE_MANAGER_UPGRADE_HINT: Record<
   Exclude<CliInstallSource, "desktop" | "manual">,
   string
 > = {
-  homebrew: "Run 'brew upgrade traycer'.",
-  npm: "Run 'npm install -g @traycerai/cli@latest'.",
-  winget: "Run 'winget upgrade Traycer.CLI'.",
-  scoop: "Run 'scoop update traycer-cli'.",
-  apt: "Run 'sudo apt update && sudo apt install --only-upgrade traycer-cli'.",
-  rpm: "Run 'sudo dnf upgrade traycer-cli' (or 'yum upgrade').",
+  homebrew: `Run '${PACKAGE_MANAGER_UPGRADE_COMMAND.homebrew}'.`,
+  npm: `Run '${PACKAGE_MANAGER_UPGRADE_COMMAND.npm}'.`,
+  winget: `Run '${PACKAGE_MANAGER_UPGRADE_COMMAND.winget}'.`,
+  scoop: `Run '${PACKAGE_MANAGER_UPGRADE_COMMAND.scoop}'.`,
+  apt: `Run '${PACKAGE_MANAGER_UPGRADE_COMMAND.apt}'.`,
+  rpm: `Run '${PACKAGE_MANAGER_UPGRADE_COMMAND.rpm}' (or 'yum upgrade').`,
 };
 
 function currentProcessBinaryPath(): string {

--- a/protocol/src/config/installation-records.ts
+++ b/protocol/src/config/installation-records.ts
@@ -176,13 +176,25 @@ export const cliInstallSourceSchema = z.enum([
 ]);
 export type CliInstallSource = z.infer<typeof cliInstallSourceSchema>;
 
-/** One command vocabulary for CLI refusals, Desktop reconciliation and the GUI remedy. */
+export const CLI_NPM_PACKAGE_NAME = "@traycerai/cli";
+
+/**
+ * One command vocabulary for CLI refusals, Desktop reconciliation and the GUI remedy.
+ * `publish-cli-package-managers.yml` publishes npm prereleases under their own
+ * dist-tag (for example `rc`), while Homebrew's rolling formula can receive
+ * that same prerelease on manual dispatch. An npm floor remedy must therefore
+ * name its exact required version instead of the stable `latest` tag.
+ * Traycer does not publish prereleases to winget, Scoop, apt or rpm feeds:
+ * their renderers/release artifacts are not feed publishers. The GUI offers
+ * installation help for those sources under a prerelease floor; these generic
+ * upgrade commands remain available for stable floors.
+ */
 export const PACKAGE_MANAGER_UPGRADE_COMMAND: Record<
   Exclude<CliInstallSource, "desktop" | "manual">,
   string
 > = {
   homebrew: "brew upgrade traycer",
-  npm: "npm install -g @traycerai/cli@latest",
+  npm: `npm install -g ${CLI_NPM_PACKAGE_NAME}@latest`,
   winget: "winget upgrade Traycer.CLI",
   scoop: "scoop update traycer-cli",
   apt: "sudo apt update && sudo apt install --only-upgrade traycer-cli",

--- a/protocol/src/config/installation-records.ts
+++ b/protocol/src/config/installation-records.ts
@@ -176,6 +176,19 @@ export const cliInstallSourceSchema = z.enum([
 ]);
 export type CliInstallSource = z.infer<typeof cliInstallSourceSchema>;
 
+/** One command vocabulary for CLI refusals, Desktop reconciliation and the GUI remedy. */
+export const PACKAGE_MANAGER_UPGRADE_COMMAND: Record<
+  Exclude<CliInstallSource, "desktop" | "manual">,
+  string
+> = {
+  homebrew: "brew upgrade traycer",
+  npm: "npm install -g @traycerai/cli@latest",
+  winget: "winget upgrade Traycer.CLI",
+  scoop: "scoop update traycer-cli",
+  apt: "sudo apt update && sudo apt install --only-upgrade traycer-cli",
+  rpm: "sudo dnf upgrade traycer-cli",
+};
+
 export const cliPendingUpgradeSchema = z.object({
   version: z.string(),
   stagedBinaryPath: z.string(),


### PR DESCRIPTION
## Why

A 1.2.0 host whose CLI is below the manifest's `requiredCliVersion` shows "vX is available, but <host> can't install it." with the reason buried under Advanced and no way forward. Every pre-1.3.0 user hits this on the 1.3.0 update once the floor bumps (traycerai/traycer-internal#5528). Stacked on #1752 (`traycer/host-update-busy-park`).

## What

The Overview derives the floor fact from the CLI's own projected refusal (the authored "Needs Traycer CLI …" reason, now shared as `HOST_CLIENT_FLOOR_REASON_PREFIX`) and renders a remedy from one pure model, `describeCliFloorRemedy`:

- **local Desktop-installed CLI**: the header's own update states (download, progress, restart-to-install, up-to-date hint, or a manual check); never an install from a version string alone.
- **package-manager CLI**: the manager's upgrade command, from one table in the protocol (`PACKAGE_MANAGER_UPGRADE_COMMAND`) that the CLI and Desktop now derive their sentences from.
- **remote or manual CLI on Linux/macOS**: a copy of the recorded binary path as a shell token plus `cli upgrade`, so PATH does not matter.
- **Windows or unknown platform**: both commands, from a terminal outside Traycer, because the 1.2.0 `host restart` that finalizes a staged CLI dies under `taskkill /T` inside a Traycer terminal.
- **unreadable CLI manifest**: installation help.

Behaviour around it:

- The projected refusal outranks the stored CLI version (the upgrade's copy into the host's slot is best-effort), sits right after activation debt in the sentence order, and suppresses Update now. Only a non-yanked summary target can carry the floor; a yanked latest keeps the existing unavailable sentence and the same-line RC fallback stays offered.
- A staged wait whose entry is floored or absent from the catalog offers no force control. A click-time re-derivation refuses with an inline notice and settles the confirmation synchronously; the refusal is derived at render time against the current catalog, so it retires on its own once a fresh check proves the version repaired.
- `host.update.check` gains a fixed 30 s recovery poll lane while any candidate is floor-refused, so the card recovers without a click once the tools are repaired.
- No in-app terminal action: a 1.2.0 host routes ordinary terminal creates through the plain-terminal registry, which ignores `shellCommand`.

## Verification

- Narrow vitest on the five gui-app suites and the CLI `host-available` suite; a 1,152-case matrix asserts an action kind for every remedy input, with separate tests for payloads and Desktop routing.
- Executed ablations with sha-verified restores are recorded in the epic; cold review rounds and their fixes likewise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
