### PR TITLE
fix(cli): Windows host stop no longer kills the updater that issued it

### DIFF
--- a/clients/traycer-cli/src/service/platforms/__tests__/windows.test.ts
+++ b/clients/traycer-cli/src/service/platforms/__tests__/windows.test.ts
@@ -154,6 +154,9 @@ describe("Windows service stale host cleanup", () => {
     // links guarded by creation order (pid reuse turns a dead parent's id
     // into an unrelated process's).
     expect(script).toContain("ParentProcessId");
+    expect(script).toContain(
+      "if ($null -eq $parent.CreationDate -or $null -eq $p.CreationDate) { continue }",
+    );
     expect(script).toContain("$parent.CreationDate -gt $p.CreationDate");
     // This process and everything under it (the scan, the taskkills) is
     // spared - the daemon spawns `host update` as its own child, so the CLI

--- a/clients/traycer-cli/src/service/platforms/__tests__/windows.test.ts
+++ b/clients/traycer-cli/src/service/platforms/__tests__/windows.test.ts
@@ -358,6 +358,46 @@ describe("Windows service stale host cleanup", () => {
     );
   });
 
+  it("grants an adoptable lifetime only to a kill that reported success", async () => {
+    // 401's taskkill says "not found" (the process left on its own - its pid
+    // may already be a stranger's), 402's runner rejects outright, 403's
+    // succeeds. Only 403 may vouch for orphans in the next pass; all three
+    // stay off the target list so the loop still ends.
+    const calls: RecordedCall[] = [];
+    let scan = 0;
+    const runner: ProcessRunner = async (command, args) => {
+      calls.push({ command, args });
+      if (command === "powershell.exe") {
+        scan += 1;
+        return success(
+          '[{"ProcessId":401,"CreationMs":100},{"ProcessId":402,"CreationMs":100},{"ProcessId":403,"CreationMs":100}]',
+        );
+      }
+      if (args[2] === "401") {
+        return { stdout: "", stderr: "not found", exitCode: 128 };
+      }
+      if (args[2] === "402") throw new Error("taskkill spawn failed");
+      return success("SUCCESS");
+    };
+    const controller = createWindowsController(runner);
+
+    await controller.stop(serviceLabelFor("staging"), { force: false });
+
+    const scans = calls.filter((call) => call.command === "powershell.exe");
+    expect(scans).toHaveLength(2);
+    const second = scans[1]?.args.at(-1) ?? "";
+    expect(second).not.toContain("$killed[401]");
+    expect(second).not.toContain("$killed[402]");
+    expect(second).toMatch(
+      /\$killed\[403\] = @\{ born = \[long\]100; died = \[long\]\d+ \}/,
+    );
+    expect(
+      calls
+        .filter((call) => call.command === "taskkill")
+        .map((call) => call.args[2]),
+    ).toEqual(["401", "402", "403"]);
+  });
+
   it("bounds the follow-up passes even when every pass finds something new", async () => {
     const calls: RecordedCall[] = [];
     let scan = 0;

--- a/clients/traycer-cli/src/service/platforms/__tests__/windows.test.ts
+++ b/clients/traycer-cli/src/service/platforms/__tests__/windows.test.ts
@@ -156,9 +156,9 @@ describe("Windows service stale host cleanup", () => {
     expect(script).toContain("$spared = @{ $PID = $true }");
     expect(script).toContain("& $expand @(1234)");
     expect(script).toContain("-not $spared.ContainsKey([int]$_)");
-    expect(script.trim().endsWith("@($victims) | ConvertTo-Json -Compress")).toBe(
-      true,
-    );
+    expect(
+      script.trim().endsWith("@($victims) | ConvertTo-Json -Compress"),
+    ).toBe(true);
   });
 
   it("parses PowerShell process detail JSON in both array and single-object shape", () => {

--- a/clients/traycer-cli/src/service/platforms/__tests__/windows.test.ts
+++ b/clients/traycer-cli/src/service/platforms/__tests__/windows.test.ts
@@ -12,6 +12,7 @@ import {
   parseWindowsProcessIdJson,
   setWindowsStartEvidenceDepsForTests,
   setWindowsTaskInstallDepsForTests,
+  WINDOWS_SLOT_PROCESS_SCAN_FILTER_LINE_COUNT,
   type ProcessRunner,
   type WindowsStartEvidenceDeps,
   type WindowsTaskInstallDeps,
@@ -128,11 +129,35 @@ describe("Windows service stale host cleanup", () => {
       "c:\\users\\traycer dev\\.traycer\\host\\install\\",
     );
     expect(detail).toContain("Select-Object ProcessId, Name, ExecutablePath");
-    // Everything but the projection line is byte-identical to the pid scan
-    // - the filter must never drift between the kill and the diagnostic.
+    // Everything up to the projection is byte-identical to the pid scan - the
+    // filter must never drift between the kill and the diagnostic.
     const pidScan = buildWindowsSlotProcessScanScript(options);
-    expect(detail.split("\n").slice(0, -1)).toEqual(
-      pidScan.split("\n").slice(0, -1),
+    const filter = WINDOWS_SLOT_PROCESS_SCAN_FILTER_LINE_COUNT;
+    expect(detail.split("\n").slice(0, filter)).toEqual(
+      pidScan.split("\n").slice(0, filter),
+    );
+    expect(detail.split("\n")).toHaveLength(filter + 1);
+    expect(pidScan.split("\n").length).toBeGreaterThan(filter + 1);
+  });
+
+  it("expands the pid scan into the host tree minus this CLI's own subtree", () => {
+    const script = buildWindowsSlotProcessScanScript({
+      hostHome: "C:\\Users\\Traycer Dev\\.traycer\\host",
+      currentPid: 1234,
+    });
+    // The tree is walked from the one snapshot the filter took, over parent
+    // links guarded by creation order (pid reuse turns a dead parent's id
+    // into an unrelated process's).
+    expect(script).toContain("ParentProcessId");
+    expect(script).toContain("$parent.CreationDate -gt $p.CreationDate");
+    // This process and everything under it (the scan, the taskkills) is
+    // spared - the daemon spawns `host update` as its own child, so the CLI
+    // is routinely inside the very tree it is stopping.
+    expect(script).toContain("$spared = @{ $PID = $true }");
+    expect(script).toContain("& $expand @(1234)");
+    expect(script).toContain("-not $spared.ContainsKey([int]$_)");
+    expect(script.trim().endsWith("@($victims) | ConvertTo-Json -Compress")).toBe(
+      true,
     );
   });
 
@@ -208,7 +233,7 @@ describe("Windows service stale host cleanup", () => {
       calls
         .filter((call) => call.command === "taskkill")
         .map((call) => call.args),
-    ).toEqual([["/T", "/F", "/PID", "401"]]);
+    ).toEqual([["/F", "/PID", "401"]]);
   });
 
   it("kills slot-scanned processes when pid metadata is missing", async () => {
@@ -231,8 +256,8 @@ describe("Windows service stale host cleanup", () => {
         .filter((call) => call.command === "taskkill")
         .map((call) => call.args),
     ).toEqual([
-      ["/T", "/F", "/PID", "401"],
-      ["/T", "/F", "/PID", "402"],
+      ["/F", "/PID", "401"],
+      ["/F", "/PID", "402"],
     ]);
   });
 
@@ -256,8 +281,11 @@ describe("Windows service stale host cleanup", () => {
     expect(
       calls
         .filter((call) => call.command === "taskkill")
-        .map((call) => call.args[3]),
-    ).toEqual(["401", "402"]);
+        .map((call) => call.args),
+    ).toEqual([
+      ["/F", "/PID", "401"],
+      ["/F", "/PID", "402"],
+    ]);
   });
 
   it("does not kill the recorded pid when the scan verifies it no longer matches the host", async () => {
@@ -282,8 +310,8 @@ describe("Windows service stale host cleanup", () => {
     expect(
       calls
         .filter((call) => call.command === "taskkill")
-        .map((call) => call.args[3]),
-    ).toEqual(["402"]);
+        .map((call) => call.args),
+    ).toEqual([["/F", "/PID", "402"]]);
   });
 
   it("falls back to the recorded pid when the slot scan cannot run", async () => {
@@ -304,11 +332,39 @@ describe("Windows service stale host cleanup", () => {
 
     await controller.stop(serviceLabelFor("staging"), { force: false });
 
+    // Unverified, so the tree flag stays: the fallback cannot enumerate.
     expect(
       calls
         .filter((call) => call.command === "taskkill")
-        .map((call) => call.args[3]),
-    ).toEqual(["401"]);
+        .map((call) => call.args),
+    ).toEqual([["/T", "/F", "/PID", "401"]]);
+  });
+
+  it("never tree-kills its own parent on the unverified fallback", async () => {
+    // The daemon spawns this CLI as its child; when the scan is unavailable
+    // and pid.json names that daemon, `/T` would take the CLI down with it.
+    mocks.readHostPidMetadata.mockResolvedValue({
+      pid: process.ppid,
+      hostId: "host-test",
+      version: "1.0.0",
+      websocketUrl: "ws://127.0.0.1:54321/rpc",
+      startedAt: "2026-01-01T00:00:00.000Z",
+    });
+    const calls: RecordedCall[] = [];
+    const runner: ProcessRunner = async (command, args) => {
+      calls.push({ command, args });
+      if (command === "powershell.exe") throw new Error("spawn failed");
+      return success("");
+    };
+    const controller = createWindowsController(runner);
+
+    await controller.stop(serviceLabelFor("staging"), { force: false });
+
+    expect(
+      calls
+        .filter((call) => call.command === "taskkill")
+        .map((call) => call.args),
+    ).toEqual([["/F", "/PID", String(process.ppid)]]);
   });
 
   it("purges pid metadata on uninstall like it does on stop", async () => {

--- a/clients/traycer-cli/src/service/platforms/__tests__/windows.test.ts
+++ b/clients/traycer-cli/src/service/platforms/__tests__/windows.test.ts
@@ -172,14 +172,18 @@ describe("Windows service stale host cleanup", () => {
       hostHome: "C:\\Users\\Traycer Dev\\.traycer\\host",
       currentPid: 1234,
       killed: [
-        { pid: 401, creationMs: 1788000000000 },
-        { pid: 402, creationMs: null },
+        { pid: 401, creationMs: 1788000000000, killedAtMs: 1788000005000 },
+        { pid: 402, creationMs: null, killedAtMs: 1788000005000 },
       ],
     });
-    expect(script).toContain("$killed[401] = [long]1788000000000");
-    expect(script).toContain("$killed[402] = $null");
+    expect(script).toContain(
+      "$killed[401] = @{ born = [long]1788000000000; died = [long]1788000005000 }",
+    );
+    // A killed parent with no creation stamp cannot vouch for anyone.
+    expect(script).not.toContain("$killed[402]");
     // Recorded parent among the killed, that pid gone (present = reused),
-    // never this CLI's own pid, and born no earlier than the parent.
+    // never this CLI's own pid, a known birth, and born inside the parent's
+    // lifetime - a pid handed on after the kill vouches for nothing.
     expect(script).toContain(
       "if (-not $killed.ContainsKey($parentId)) { return $false }",
     );
@@ -189,7 +193,10 @@ describe("Windows service stale host cleanup", () => {
     expect(script).toContain(
       "if ($excluded -contains [int]$_.ProcessId) { return $false }",
     );
-    expect(script).toContain("($born -ge $killed[$parentId])");
+    expect(script).toContain("if ($null -eq $born) { return $false }");
+    expect(script).toContain(
+      "($born -ge $life.born) -and ($born -le $life.died)",
+    );
     expect(script).toContain(
       "+ @($orphans | ForEach-Object { [int]$_.ProcessId })",
     );
@@ -312,8 +319,9 @@ describe("Windows service stale host cleanup", () => {
     // and ended the loop - no third scan.
     const scans = calls.filter((call) => call.command === "powershell.exe");
     expect(scans).toHaveLength(2);
-    expect(scans[1]?.args.at(-1)).toContain("$killed[401] = $null");
-    expect(scans[1]?.args.at(-1)).toContain("$killed[402] = $null");
+    // Bare-pid scan output carries no stamps, so nothing is vouched for.
+    expect(scans[1]?.args.at(-1)).toContain("$killed = @{}");
+    expect(scans[1]?.args.at(-1)).not.toContain("$killed[401]");
   });
 
   it("reaps a child that appeared after the first snapshot through the follow-up pass", async () => {
@@ -342,8 +350,12 @@ describe("Windows service stale host cleanup", () => {
     ]);
     const scans = calls.filter((call) => call.command === "powershell.exe");
     expect(scans).toHaveLength(3);
-    expect(scans[1]?.args.at(-1)).toContain("$killed[401] = [long]100");
-    expect(scans[2]?.args.at(-1)).toContain("$killed[777] = [long]150");
+    expect(scans[1]?.args.at(-1)).toMatch(
+      /\$killed\[401\] = @\{ born = \[long\]100; died = \[long\]\d+ \}/,
+    );
+    expect(scans[2]?.args.at(-1)).toMatch(
+      /\$killed\[777\] = @\{ born = \[long\]150; died = \[long\]\d+ \}/,
+    );
   });
 
   it("bounds the follow-up passes even when every pass finds something new", async () => {

--- a/clients/traycer-cli/src/service/platforms/__tests__/windows.test.ts
+++ b/clients/traycer-cli/src/service/platforms/__tests__/windows.test.ts
@@ -10,6 +10,7 @@ import {
   parseSchtasksLastRunResult,
   parseWindowsProcessDetailJson,
   parseWindowsProcessIdJson,
+  parseWindowsProcessKillSetJson,
   setWindowsStartEvidenceDepsForTests,
   setWindowsTaskInstallDepsForTests,
   WINDOWS_SLOT_PROCESS_SCAN_FILTER_LINE_COUNT,
@@ -101,6 +102,7 @@ describe("Windows service stale host cleanup", () => {
     const script = buildWindowsSlotProcessScanScript({
       hostHome: "C:\\Users\\Traycer Dev\\.traycer\\host\\staging",
       currentPid: 1234,
+      killed: [],
     });
     expect(script).toContain("$excluded = @(1234, $PID)");
     expect(script).toContain(".traycer\\host\\staging\\install\\");
@@ -111,6 +113,7 @@ describe("Windows service stale host cleanup", () => {
     const script = buildWindowsSlotProcessScanScript({
       hostHome: "C:\\Users\\Traycer Dev\\.traycer\\host",
       currentPid: 1234,
+      killed: [],
     });
     expect(script).toContain(
       "c:\\users\\traycer dev\\.traycer\\host\\install\\",
@@ -122,6 +125,7 @@ describe("Windows service stale host cleanup", () => {
     const options = {
       hostHome: "C:\\Users\\Traycer Dev\\.traycer\\host",
       currentPid: 1234,
+      killed: [],
     };
     const detail = buildWindowsSlotProcessDetailScanScript(options);
     expect(detail).toContain("$excluded = @(1234, $PID)");
@@ -144,6 +148,7 @@ describe("Windows service stale host cleanup", () => {
     const script = buildWindowsSlotProcessScanScript({
       hostHome: "C:\\Users\\Traycer Dev\\.traycer\\host",
       currentPid: 1234,
+      killed: [],
     });
     // The tree is walked from the one snapshot the filter took, over parent
     // links guarded by creation order (pid reuse turns a dead parent's id
@@ -156,9 +161,53 @@ describe("Windows service stale host cleanup", () => {
     expect(script).toContain("$spared = @{ $PID = $true }");
     expect(script).toContain("& $expand @(1234)");
     expect(script).toContain("-not $spared.ContainsKey([int]$_)");
+    expect(script).toContain(
+      "[pscustomobject]@{ ProcessId = $_; CreationMs = (& $stamp $byId[$_]) }",
+    );
+    expect(script.trim().endsWith("| ConvertTo-Json -Compress")).toBe(true);
+  });
+
+  it("adopts orphans of pids an earlier pass killed, guarded by presence and creation order", () => {
+    const script = buildWindowsSlotProcessScanScript({
+      hostHome: "C:\\Users\\Traycer Dev\\.traycer\\host",
+      currentPid: 1234,
+      killed: [
+        { pid: 401, creationMs: 1788000000000 },
+        { pid: 402, creationMs: null },
+      ],
+    });
+    expect(script).toContain("$killed[401] = [long]1788000000000");
+    expect(script).toContain("$killed[402] = $null");
+    // Recorded parent among the killed, that pid gone (present = reused),
+    // never this CLI's own pid, and born no earlier than the parent.
+    expect(script).toContain(
+      "if (-not $killed.ContainsKey($parentId)) { return $false }",
+    );
+    expect(script).toContain(
+      "if ($byId.ContainsKey($parentId)) { return $false }",
+    );
+    expect(script).toContain(
+      "if ($excluded -contains [int]$_.ProcessId) { return $false }",
+    );
+    expect(script).toContain("($born -ge $killed[$parentId])");
+    expect(script).toContain(
+      "+ @($orphans | ForEach-Object { [int]$_.ProcessId })",
+    );
+  });
+
+  it("parses the kill-set object shape and bare pids alike, collapsing duplicates", () => {
     expect(
-      script.trim().endsWith("@($victims) | ConvertTo-Json -Compress"),
-    ).toBe(true);
+      parseWindowsProcessKillSetJson(
+        '[{"ProcessId":401,"CreationMs":1788000000000},{"ProcessId":402,"CreationMs":null},401,{"Name":"no-pid"}]',
+      ),
+    ).toEqual([
+      { pid: 401, creationMs: 1788000000000 },
+      { pid: 402, creationMs: null },
+    ]);
+    expect(
+      parseWindowsProcessKillSetJson('{"ProcessId":7,"CreationMs":9}'),
+    ).toEqual([{ pid: 7, creationMs: 9 }]);
+    expect(parseWindowsProcessKillSetJson("")).toEqual([]);
   });
 
   it("parses PowerShell process detail JSON in both array and single-object shape", () => {
@@ -259,6 +308,65 @@ describe("Windows service stale host cleanup", () => {
       ["/F", "/PID", "401"],
       ["/F", "/PID", "402"],
     ]);
+    // A second pass ran, was told what the first killed, found nothing new
+    // and ended the loop - no third scan.
+    const scans = calls.filter((call) => call.command === "powershell.exe");
+    expect(scans).toHaveLength(2);
+    expect(scans[1]?.args.at(-1)).toContain("$killed[401] = $null");
+    expect(scans[1]?.args.at(-1)).toContain("$killed[402] = $null");
+  });
+
+  it("reaps a child that appeared after the first snapshot through the follow-up pass", async () => {
+    // Pass 1 sees the host; between its snapshot and the kill the host forks
+    // a worker. Pass 2, told the host's pid and stamp, adopts the orphan.
+    const calls: RecordedCall[] = [];
+    let scan = 0;
+    const runner: ProcessRunner = async (command, args) => {
+      calls.push({ command, args });
+      if (command !== "powershell.exe") return success("");
+      scan += 1;
+      if (scan === 1) return success('[{"ProcessId":401,"CreationMs":100}]');
+      return success('[{"ProcessId":777,"CreationMs":150}]');
+    };
+    const controller = createWindowsController(runner);
+
+    await controller.stop(serviceLabelFor("staging"), { force: false });
+
+    expect(
+      calls
+        .filter((call) => call.command === "taskkill")
+        .map((call) => call.args),
+    ).toEqual([
+      ["/F", "/PID", "401"],
+      ["/F", "/PID", "777"],
+    ]);
+    const scans = calls.filter((call) => call.command === "powershell.exe");
+    expect(scans).toHaveLength(3);
+    expect(scans[1]?.args.at(-1)).toContain("$killed[401] = [long]100");
+    expect(scans[2]?.args.at(-1)).toContain("$killed[777] = [long]150");
+  });
+
+  it("bounds the follow-up passes even when every pass finds something new", async () => {
+    const calls: RecordedCall[] = [];
+    let scan = 0;
+    const runner: ProcessRunner = async (command, args) => {
+      calls.push({ command, args });
+      if (command !== "powershell.exe") return success("");
+      scan += 1;
+      return success(`[${String(1000 + scan)}]`);
+    };
+    const controller = createWindowsController(runner);
+
+    await controller.stop(serviceLabelFor("staging"), { force: false });
+
+    expect(
+      calls.filter((call) => call.command === "powershell.exe"),
+    ).toHaveLength(3);
+    expect(
+      calls
+        .filter((call) => call.command === "taskkill")
+        .map((call) => call.args[2]),
+    ).toEqual(["1001", "1002", "1003"]);
   });
 
   it("kills exactly the scan-verified pids when the scan covers the recorded pid", async () => {

--- a/clients/traycer-cli/src/service/platforms/windows.ts
+++ b/clients/traycer-cli/src/service/platforms/windows.ts
@@ -759,11 +759,16 @@ interface SlotProcessScanOptions {
 // it is stopping (the daemon spawns `host update` as its child). See
 // `killHostProcessTree`.
 //
-// Parent links are trusted only when the parent started no later than the
-// child: `ParentProcessId` is a bare number, and once the real parent has
-// exited Windows can hand its pid to an unrelated process that then reads as
-// the orphan's parent. `taskkill /T` walks that link blindly; the creation
-// order check refuses it. Cycles from the same reuse are closed by the
+// Parent links are trusted only when BOTH creation stamps are readable and
+// the parent started no later than the child: `ParentProcessId` is a bare
+// number, and once the real parent has exited Windows can hand its pid to an
+// unrelated process that then reads as the orphan's parent. `taskkill /T`
+// walks that link blindly; the creation order check refuses it. A link with
+// an unreadable stamp on either end is refused too - the same fail-closed
+// policy the orphan adoption below applies - at the cost of a child whose
+// stamp the scan could not read (`SilentlyContinue` hides the failure);
+// such a process is one the scan could barely see, and killing on a guess
+// is the wrong side to err on. Cycles from the same reuse are closed by the
 // visited set.
 function buildSlotProcessScanScript(options: SlotProcessScanOptions): string {
   return buildSlotProcessScanScriptWithProjection(options, [
@@ -801,7 +806,8 @@ function buildSlotProcessScanScript(options: SlotProcessScanOptions): string {
     "  $parentId = [int]$p.ParentProcessId",
     "  $parent = $byId[$parentId]",
     "  if ($null -eq $parent) { continue }",
-    "  if ($null -ne $parent.CreationDate -and $null -ne $p.CreationDate -and $parent.CreationDate -gt $p.CreationDate) { continue }",
+    "  if ($null -eq $parent.CreationDate -or $null -eq $p.CreationDate) { continue }",
+    "  if ($parent.CreationDate -gt $p.CreationDate) { continue }",
     "  if (-not $children.ContainsKey($parentId)) { $children[$parentId] = New-Object System.Collections.ArrayList }",
     "  [void]$children[$parentId].Add([int]$p.ProcessId)",
     "}",
@@ -840,15 +846,27 @@ function buildSlotProcessDetailScanScript(
   ]);
 }
 
-// The lines shared by every scan: the snapshot and the slot filter. Exported
-// (as a count) so the suite can pin that the kill and the diagnostic never
-// drift apart on what they call a host process.
-export const WINDOWS_SLOT_PROCESS_SCAN_FILTER_LINE_COUNT = 19;
-
 function buildSlotProcessScanScriptWithProjection(
   options: SlotProcessScanOptions,
   projection: readonly string[],
 ): string {
+  return [...slotProcessScanFilterLines(options), ...projection].join("\n");
+}
+
+// The lines shared by every scan: the snapshot and the slot filter. The count
+// is exported, derived from the lines themselves, so the suite can pin that
+// the kill and the diagnostic never drift apart on what they call a host
+// process.
+export const WINDOWS_SLOT_PROCESS_SCAN_FILTER_LINE_COUNT =
+  slotProcessScanFilterLines({
+    hostHome: "",
+    currentPid: 0,
+    killed: [],
+  }).length;
+
+function slotProcessScanFilterLines(
+  options: SlotProcessScanOptions,
+): readonly string[] {
   const hostPaths = powershellStringArray(
     slotHostProcessPaths(options.hostHome),
   );
@@ -872,8 +890,7 @@ function buildSlotProcessScanScriptWithProjection(
     "    $hostMatch",
     "  }",
     "}",
-    ...projection,
-  ].join("\n");
+  ];
 }
 
 function slotHostProcessPaths(hostHome: string): readonly string[] {

--- a/clients/traycer-cli/src/service/platforms/windows.ts
+++ b/clients/traycer-cli/src/service/platforms/windows.ts
@@ -395,35 +395,81 @@ async function stopService(
 // tree MINUS the process performing it - which is the only tree a stop can
 // ever have meant. Each survivor is then killed on its own, without `/T`.
 //
+// The tree keeps moving while it is being taken: a worker the host forks
+// between the snapshot and the kill is in no scan, and once its parent is
+// dead it matches nothing by path and hangs off a pid nobody is walking. (An
+// old `/T` could still find it, enumerating at kill time.) So the kill runs
+// in bounded PASSES: every pass hands the scan the pids it has already killed
+// and their creation stamps, and the scan adopts as further roots the
+// processes whose recorded parent is one of those - provided that parent pid
+// is no longer present (a present one is a reused pid, and its children are
+// nobody's business) and the child was born no earlier than the parent it
+// claims. The loop ends the first time a pass finds nothing new, or at the
+// pass bound; the updater exclusion holds throughout.
+//
 // The raw recorded pid is used only when the scan itself is unavailable: a
 // host that died without cleanup leaves pid.json behind, and Windows may have
 // recycled that pid for an unrelated process an unverified kill would take
 // down. That path cannot enumerate, so it keeps `/T` - except when the
 // recorded pid is this process's own parent, the one shape in which `/T` is
 // known to be suicide.
+const WINDOWS_KILL_TREE_MAX_PASSES = 3;
+
 async function killHostProcessTree(
   label: ServiceLabel,
   run: ProcessRunner,
 ): Promise<void> {
-  const scannedPids = await findSlotProcessIds(label, run);
-  const pidMetadata =
-    scannedPids === null ? await readHostPidMetadata(label.environment) : null;
-  const fallbackPids = pidMetadata === null ? [] : [pidMetadata.pid];
-  const pids = uniqueProcessIds(scannedPids ?? fallbackPids);
-  const treeFlag = (pid: number): readonly string[] =>
-    scannedPids === null && pid !== process.ppid ? ["/T"] : [];
-  await Promise.all(
-    pids.map((pid) =>
-      run("taskkill", [...treeFlag(pid), "/F", "/PID", String(pid)], {
-        env: undefined,
-        cwd: undefined,
-        timeoutMs: WINDOWS_TASKKILL_TIMEOUT_MS,
-        tolerateNonZeroExit: true,
-      }).catch((cause) => {
-        if (isServiceMutationAuthorityError(cause)) throw cause;
-      }),
-    ),
-  );
+  const killed = new Map<number, number | null>();
+  for (let pass = 0; pass < WINDOWS_KILL_TREE_MAX_PASSES; pass += 1) {
+    const scanned = await findSlotProcesses(
+      label,
+      run,
+      killedProcesses(killed),
+    );
+    if (scanned === null) {
+      if (pass === 0) await killRecordedPidUnverified(label, run);
+      return;
+    }
+    const fresh = scanned.filter((entry) => !killed.has(entry.pid));
+    if (fresh.length === 0) return;
+    for (const entry of fresh) killed.set(entry.pid, entry.creationMs);
+    await Promise.all(
+      fresh.map((entry) =>
+        run("taskkill", ["/F", "/PID", String(entry.pid)], {
+          env: undefined,
+          cwd: undefined,
+          timeoutMs: WINDOWS_TASKKILL_TIMEOUT_MS,
+          tolerateNonZeroExit: true,
+        }).catch((cause) => {
+          if (isServiceMutationAuthorityError(cause)) throw cause;
+        }),
+      ),
+    );
+  }
+}
+
+function killedProcesses(
+  killed: ReadonlyMap<number, number | null>,
+): readonly KilledProcess[] {
+  return Array.from(killed, ([pid, creationMs]) => ({ pid, creationMs }));
+}
+
+async function killRecordedPidUnverified(
+  label: ServiceLabel,
+  run: ProcessRunner,
+): Promise<void> {
+  const pidMetadata = await readHostPidMetadata(label.environment);
+  if (pidMetadata === null || !isKillableProcessId(pidMetadata.pid)) return;
+  const pid = pidMetadata.pid;
+  const treeFlag = pid === process.ppid ? [] : ["/T"];
+  await run("taskkill", [...treeFlag, "/F", "/PID", String(pid)], {
+    env: undefined,
+    cwd: undefined,
+    timeoutMs: WINDOWS_TASKKILL_TIMEOUT_MS,
+    tolerateNonZeroExit: true,
+  }).catch((cause) => {
+    if (isServiceMutationAuthorityError(cause)) throw cause;
+  });
 }
 
 async function startService(
@@ -626,10 +672,11 @@ function describeCause(cause: unknown): string {
 // Returns null (rather than an empty list) when the scan could not run at
 // all, so the caller can distinguish "verified: nothing to kill" from
 // "unknown: PowerShell unavailable".
-async function findSlotProcessIds(
+async function findSlotProcesses(
   label: ServiceLabel,
   run: ProcessRunner,
-): Promise<readonly number[] | null> {
+  killed: readonly KilledProcess[],
+): Promise<readonly SlotProcessToKill[] | null> {
   try {
     const result = await run(
       "powershell.exe",
@@ -640,6 +687,7 @@ async function findSlotProcessIds(
         buildSlotProcessScanScript({
           hostHome: hostHomeDir(label.environment),
           currentPid: process.pid,
+          killed,
         }),
       ],
       {
@@ -649,16 +697,31 @@ async function findSlotProcessIds(
         tolerateNonZeroExit: true,
       },
     );
-    return parseProcessIdJson(result.stdout);
+    return parseProcessKillSetJson(result.stdout);
   } catch (cause) {
     if (isServiceMutationAuthorityError(cause)) throw cause;
     return null;
   }
 }
 
+/** A process an earlier pass killed: its pid and the creation stamp it had. */
+export interface KilledProcess {
+  readonly pid: number;
+  /** `CreationDate` as epoch milliseconds, or `null` when the scan had none. */
+  readonly creationMs: number | null;
+}
+
+/** A process the scan says to kill, with the stamp a later pass adopts by. */
+export interface SlotProcessToKill {
+  readonly pid: number;
+  readonly creationMs: number | null;
+}
+
 interface SlotProcessScanOptions {
   readonly hostHome: string;
   readonly currentPid: number;
+  /** Pids killed by earlier passes; the scan adopts their orphans as roots. */
+  readonly killed: readonly KilledProcess[];
 }
 
 // The kill set: every slot-matching process AND its descendants, minus this
@@ -678,6 +741,23 @@ function buildSlotProcessScanScript(options: SlotProcessScanOptions): string {
   return buildSlotProcessScanScriptWithProjection(options, [
     "$byId = @{}",
     "foreach ($p in $all) { $byId[[int]$p.ProcessId] = $p }",
+    "$stamp = { param($p) if ($null -eq $p -or $null -eq $p.CreationDate) { $null } else { [long](($p.CreationDate.ToUniversalTime() - [datetime]'1970-01-01').TotalMilliseconds) } }",
+    "$killed = @{}",
+    ...options.killed.map(
+      (entry) =>
+        `$killed[${String(entry.pid)}] = ${entry.creationMs === null ? "$null" : `[long]${String(entry.creationMs)}`}`,
+    ),
+    // Orphans of an earlier pass: their recorded parent is a pid we killed,
+    // that pid is not present now (present = reused, unrelated), and they
+    // were born no earlier than the parent they name.
+    "$orphans = $all | Where-Object {",
+    "  $parentId = [int]$_.ParentProcessId",
+    "  if (-not $killed.ContainsKey($parentId)) { return $false }",
+    "  if ($byId.ContainsKey($parentId)) { return $false }",
+    "  if ($excluded -contains [int]$_.ProcessId) { return $false }",
+    "  $born = & $stamp $_",
+    "  ($null -eq $killed[$parentId]) -or ($null -eq $born) -or ($born -ge $killed[$parentId])",
+    "}",
     "$children = @{}",
     "foreach ($p in $all) {",
     "  $parentId = [int]$p.ParentProcessId",
@@ -703,9 +783,9 @@ function buildSlotProcessScanScript(options: SlotProcessScanOptions): string {
     "}",
     `$spared = @{ $PID = $true }`,
     `foreach ($id in (& $expand @(${options.currentPid}))) { $spared[[int]$id] = $true }`,
-    "$roots = @($matches | ForEach-Object { [int]$_.ProcessId })",
+    "$roots = @($matches | ForEach-Object { [int]$_.ProcessId }) + @($orphans | ForEach-Object { [int]$_.ProcessId })",
     "$victims = @(& $expand $roots) | Where-Object { -not $spared.ContainsKey([int]$_) } | ForEach-Object { [int]$_ }",
-    "@($victims) | ConvertTo-Json -Compress",
+    "@($victims | ForEach-Object { [pscustomobject]@{ ProcessId = $_; CreationMs = (& $stamp $byId[$_]) } }) | ConvertTo-Json -Compress",
   ]);
 }
 
@@ -784,6 +864,14 @@ function powershellStringArray(values: readonly string[]): string {
 }
 
 function parseProcessIdJson(stdout: string): readonly number[] {
+  return parseProcessKillSetJson(stdout).map((entry) => entry.pid);
+}
+
+// Accepts both the kill-set shape (`{ProcessId, CreationMs}` objects) and
+// bare pids, in array or single-value form - Windows PowerShell 5.1 emits a
+// bare value for a single element even under `@(...)`. Duplicates collapse to
+// the first occurrence.
+function parseProcessKillSetJson(stdout: string): readonly SlotProcessToKill[] {
   const trimmed = stdout.trim();
   if (trimmed.length === 0) return [];
   let parsed: unknown;
@@ -794,11 +882,30 @@ function parseProcessIdJson(stdout: string): readonly number[] {
     return [];
   }
   const values = Array.isArray(parsed) ? parsed : [parsed];
-  return values.filter(isKillableProcessId);
+  const seen = new Set<number>();
+  const entries: SlotProcessToKill[] = [];
+  for (const value of values) {
+    const entry = parseKillSetEntry(value);
+    if (entry === null || seen.has(entry.pid)) continue;
+    seen.add(entry.pid);
+    entries.push(entry);
+  }
+  return entries;
 }
 
-function uniqueProcessIds(values: readonly number[]): readonly number[] {
-  return Array.from(new Set(values.filter(isKillableProcessId)));
+function parseKillSetEntry(value: unknown): SlotProcessToKill | null {
+  if (isKillableProcessId(value)) return { pid: value, creationMs: null };
+  if (typeof value !== "object" || value === null) return null;
+  const record = value as Record<string, unknown>;
+  if (!isKillableProcessId(record.ProcessId)) return null;
+  const stamp = record.CreationMs;
+  return {
+    pid: record.ProcessId,
+    creationMs:
+      typeof stamp === "number" && Number.isSafeInteger(stamp) && stamp > 0
+        ? stamp
+        : null,
+  };
 }
 
 // A slot-matching process reported by the detail scan. Field names mirror
@@ -876,6 +983,7 @@ export async function describeSlotLockHolders(
         buildSlotProcessDetailScanScript({
           hostHome: hostHomeDir(label.environment),
           currentPid: process.pid,
+          killed: [],
         }),
       ],
       {
@@ -1210,5 +1318,6 @@ export {
   buildSlotProcessScanScript as buildWindowsSlotProcessScanScript,
   buildSlotProcessDetailScanScript as buildWindowsSlotProcessDetailScanScript,
   parseProcessIdJson as parseWindowsProcessIdJson,
+  parseProcessKillSetJson as parseWindowsProcessKillSetJson,
   parseProcessDetailJson as parseWindowsProcessDetailJson,
 };

--- a/clients/traycer-cli/src/service/platforms/windows.ts
+++ b/clients/traycer-cli/src/service/platforms/windows.ts
@@ -379,10 +379,28 @@ async function stopService(
 // (worse) its CWD stays open inside the install dir, so the next install-swap
 // rename fails with EBUSY. Kill the processes a slot-scoped scan verifies by
 // exe path/command line - that covers the recorded pid.json host too, when it
-// is genuinely still the host. The raw recorded pid is used only when the scan
-// itself is unavailable: a host that died without cleanup leaves pid.json
-// behind, and Windows may have recycled that pid for an unrelated process an
-// unverified `taskkill /T /F` would take down.
+// is genuinely still the host - AND their descendants, which the scan expands
+// itself (see `buildSlotProcessScanScript`) rather than leaving to
+// `taskkill /T`.
+//
+// The difference is whether this CLI survives its own stop. The host daemon
+// spawns `traycer host update` / `traycer host service uninstall` as ITS
+// child (`detached` on win32 opens no gap in the parent chain), so a
+// `taskkill /T` rooted at the host walks straight into the updater that
+// issued it: the update died mid-`beforeSwap` every time, between stopping
+// the old host and swapping the new one in, leaving an `updating` progress
+// marker nobody would ever clear and the old install still in place. The
+// scan's expansion subtracts this process and everything under it (the
+// PowerShell running the scan, the taskkills below), so the kill is the host
+// tree MINUS the process performing it - which is the only tree a stop can
+// ever have meant. Each survivor is then killed on its own, without `/T`.
+//
+// The raw recorded pid is used only when the scan itself is unavailable: a
+// host that died without cleanup leaves pid.json behind, and Windows may have
+// recycled that pid for an unrelated process an unverified kill would take
+// down. That path cannot enumerate, so it keeps `/T` - except when the
+// recorded pid is this process's own parent, the one shape in which `/T` is
+// known to be suicide.
 async function killHostProcessTree(
   label: ServiceLabel,
   run: ProcessRunner,
@@ -392,9 +410,11 @@ async function killHostProcessTree(
     scannedPids === null ? await readHostPidMetadata(label.environment) : null;
   const fallbackPids = pidMetadata === null ? [] : [pidMetadata.pid];
   const pids = uniqueProcessIds(scannedPids ?? fallbackPids);
+  const treeFlag = (pid: number): readonly string[] =>
+    scannedPids === null && pid !== process.ppid ? ["/T"] : [];
   await Promise.all(
     pids.map((pid) =>
-      run("taskkill", ["/T", "/F", "/PID", String(pid)], {
+      run("taskkill", [...treeFlag(pid), "/F", "/PID", String(pid)], {
         env: undefined,
         cwd: undefined,
         timeoutMs: WINDOWS_TASKKILL_TIMEOUT_MS,
@@ -641,28 +661,75 @@ interface SlotProcessScanOptions {
   readonly currentPid: number;
 }
 
+// The kill set: every slot-matching process AND its descendants, minus this
+// CLI's own subtree. Expanded here, from the one `Win32_Process` snapshot the
+// filter already took, instead of by `taskkill /T` per root - `/T` cannot be
+// told to spare anything, and this CLI is routinely a descendant of the host
+// it is stopping (the daemon spawns `host update` as its child). See
+// `killHostProcessTree`.
+//
+// Parent links are trusted only when the parent started no later than the
+// child: `ParentProcessId` is a bare number, and once the real parent has
+// exited Windows can hand its pid to an unrelated process that then reads as
+// the orphan's parent. `taskkill /T` walks that link blindly; the creation
+// order check refuses it. Cycles from the same reuse are closed by the
+// visited set.
 function buildSlotProcessScanScript(options: SlotProcessScanOptions): string {
-  return buildSlotProcessScanScriptWithProjection(
-    options,
-    "@($matches | Select-Object -ExpandProperty ProcessId) | ConvertTo-Json -Compress",
-  );
+  return buildSlotProcessScanScriptWithProjection(options, [
+    "$byId = @{}",
+    "foreach ($p in $all) { $byId[[int]$p.ProcessId] = $p }",
+    "$children = @{}",
+    "foreach ($p in $all) {",
+    "  $parentId = [int]$p.ParentProcessId",
+    "  $parent = $byId[$parentId]",
+    "  if ($null -eq $parent) { continue }",
+    "  if ($null -ne $parent.CreationDate -and $null -ne $p.CreationDate -and $parent.CreationDate -gt $p.CreationDate) { continue }",
+    "  if (-not $children.ContainsKey($parentId)) { $children[$parentId] = New-Object System.Collections.ArrayList }",
+    "  [void]$children[$parentId].Add([int]$p.ProcessId)",
+    "}",
+    "$expand = {",
+    "  param($roots)",
+    "  $seen = @{}",
+    "  $queue = New-Object System.Collections.ArrayList",
+    "  foreach ($root in $roots) { [void]$queue.Add([int]$root) }",
+    "  while ($queue.Count -gt 0) {",
+    "    $id = [int]$queue[0]",
+    "    $queue.RemoveAt(0)",
+    "    if ($seen.ContainsKey($id)) { continue }",
+    "    $seen[$id] = $true",
+    "    if ($children.ContainsKey($id)) { foreach ($child in $children[$id]) { [void]$queue.Add($child) } }",
+    "  }",
+    "  @($seen.Keys)",
+    "}",
+    `$spared = @{ $PID = $true }`,
+    `foreach ($id in (& $expand @(${options.currentPid}))) { $spared[[int]$id] = $true }`,
+    "$roots = @($matches | ForEach-Object { [int]$_.ProcessId })",
+    "$victims = @(& $expand $roots) | Where-Object { -not $spared.ContainsKey([int]$_) } | ForEach-Object { [int]$_ }",
+    "@($victims) | ConvertTo-Json -Compress",
+  ]);
 }
 
 // Same filter as the pid scan, projecting name + executable path as well so
 // the install swap's EBUSY error can NAME the processes still matching the
-// slot instead of surfacing a bare errno.
+// slot instead of surfacing a bare errno. Direct matches only: this names the
+// handle holders the swap rename tripped over, and their children are not
+// what holds the rename.
 function buildSlotProcessDetailScanScript(
   options: SlotProcessScanOptions,
 ): string {
-  return buildSlotProcessScanScriptWithProjection(
-    options,
+  return buildSlotProcessScanScriptWithProjection(options, [
     "@($matches | Select-Object ProcessId, Name, ExecutablePath) | ConvertTo-Json -Compress",
-  );
+  ]);
 }
+
+// The lines shared by every scan: the snapshot and the slot filter. Exported
+// (as a count) so the suite can pin that the kill and the diagnostic never
+// drift apart on what they call a host process.
+export const WINDOWS_SLOT_PROCESS_SCAN_FILTER_LINE_COUNT = 19;
 
 function buildSlotProcessScanScriptWithProjection(
   options: SlotProcessScanOptions,
-  projection: string,
+  projection: readonly string[],
 ): string {
   const hostPaths = powershellStringArray(
     slotHostProcessPaths(options.hostHome),
@@ -671,7 +738,8 @@ function buildSlotProcessScanScriptWithProjection(
     "$ErrorActionPreference = 'SilentlyContinue'",
     `$excluded = @(${options.currentPid}, $PID)`,
     `$hostPaths = @(${hostPaths})`,
-    "$matches = Get-CimInstance Win32_Process | Where-Object {",
+    "$all = @(Get-CimInstance Win32_Process | Select-Object ProcessId, ParentProcessId, CreationDate, Name, ExecutablePath, CommandLine)",
+    "$matches = $all | Where-Object {",
     "  $pidValue = [int]$_.ProcessId",
     "  if ($excluded -contains $pidValue) {",
     "    $false",
@@ -686,7 +754,7 @@ function buildSlotProcessScanScriptWithProjection(
     "    $hostMatch",
     "  }",
     "}",
-    projection,
+    ...projection,
   ].join("\n");
 }
 

--- a/clients/traycer-cli/src/service/platforms/windows.ts
+++ b/clients/traycer-cli/src/service/platforms/windows.ts
@@ -423,6 +423,14 @@ async function killHostProcessTree(
   label: ServiceLabel,
   run: ProcessRunner,
 ): Promise<void> {
+  // Two histories, deliberately apart. `attempted` is every pid a pass has
+  // aimed at, and only bounds the loop. `killed` is the subset whose taskkill
+  // REPORTED success, and is the only history the next scan may adopt
+  // orphans from: a "not found" (the process left on its own, and the pid may
+  // already be someone else's), a timeout or a runner failure prove nothing
+  // about when - or whether - that process died, and a lifetime granted on
+  // them would let a stranger's child pass as the host's orphan.
+  const attempted = new Set<number>();
   const killed = new Map<number, KilledProcess>();
   for (let pass = 0; pass < WINDOWS_KILL_TREE_MAX_PASSES; pass += 1) {
     const scanned = await findSlotProcesses(
@@ -434,20 +442,28 @@ async function killHostProcessTree(
       if (pass === 0) await killRecordedPidUnverified(label, run);
       return;
     }
-    const fresh = scanned.filter((entry) => !killed.has(entry.pid));
+    const fresh = scanned.filter((entry) => !attempted.has(entry.pid));
     if (fresh.length === 0) return;
+    for (const entry of fresh) attempted.add(entry.pid);
     await Promise.all(
       fresh.map(async (entry) => {
-        await run("taskkill", ["/F", "/PID", String(entry.pid)], {
-          env: undefined,
-          cwd: undefined,
-          timeoutMs: WINDOWS_TASKKILL_TIMEOUT_MS,
-          tolerateNonZeroExit: true,
-        }).catch((cause) => {
+        const result = await run(
+          "taskkill",
+          ["/F", "/PID", String(entry.pid)],
+          {
+            env: undefined,
+            cwd: undefined,
+            timeoutMs: WINDOWS_TASKKILL_TIMEOUT_MS,
+            tolerateNonZeroExit: true,
+          },
+        ).catch((cause) => {
           if (isServiceMutationAuthorityError(cause)) throw cause;
+          return null;
         });
-        // Stamped AFTER the kill returns: nothing this process was the parent
-        // of can have been born later than this, so it bounds its orphans.
+        if (result === null || result.exitCode !== 0) return;
+        // Stamped AFTER a successful kill returns: nothing this process was
+        // the parent of can have been born later than this, so it bounds
+        // its orphans.
         killed.set(entry.pid, {
           pid: entry.pid,
           creationMs: entry.creationMs,

--- a/clients/traycer-cli/src/service/platforms/windows.ts
+++ b/clients/traycer-cli/src/service/platforms/windows.ts
@@ -400,12 +400,16 @@ async function stopService(
 // dead it matches nothing by path and hangs off a pid nobody is walking. (An
 // old `/T` could still find it, enumerating at kill time.) So the kill runs
 // in bounded PASSES: every pass hands the scan the pids it has already killed
-// and their creation stamps, and the scan adopts as further roots the
-// processes whose recorded parent is one of those - provided that parent pid
-// is no longer present (a present one is a reused pid, and its children are
-// nobody's business) and the child was born no earlier than the parent it
-// claims. The loop ends the first time a pass finds nothing new, or at the
-// pass bound; the updater exclusion holds throughout.
+// with the LIFETIME each had - its creation stamp and the moment its kill
+// returned - and the scan adopts as further roots the processes whose recorded
+// parent is one of those, provided that parent pid is no longer present (a
+// present one is a reused pid, and its children are nobody's business) and
+// the child was born INSIDE that lifetime. The upper bound is what makes
+// absence safe: a pid handed to an unrelated launcher between passes, which
+// started something and exited, is absent too - but everything it started
+// was born after the kill, and is refused. A process with no creation stamp
+// is never adopted on inference. The loop ends the first time a pass finds
+// nothing new, or at the pass bound; the updater exclusion holds throughout.
 //
 // The raw recorded pid is used only when the scan itself is unavailable: a
 // host that died without cleanup leaves pid.json behind, and Windows may have
@@ -419,7 +423,7 @@ async function killHostProcessTree(
   label: ServiceLabel,
   run: ProcessRunner,
 ): Promise<void> {
-  const killed = new Map<number, number | null>();
+  const killed = new Map<number, KilledProcess>();
   for (let pass = 0; pass < WINDOWS_KILL_TREE_MAX_PASSES; pass += 1) {
     const scanned = await findSlotProcesses(
       label,
@@ -432,26 +436,32 @@ async function killHostProcessTree(
     }
     const fresh = scanned.filter((entry) => !killed.has(entry.pid));
     if (fresh.length === 0) return;
-    for (const entry of fresh) killed.set(entry.pid, entry.creationMs);
     await Promise.all(
-      fresh.map((entry) =>
-        run("taskkill", ["/F", "/PID", String(entry.pid)], {
+      fresh.map(async (entry) => {
+        await run("taskkill", ["/F", "/PID", String(entry.pid)], {
           env: undefined,
           cwd: undefined,
           timeoutMs: WINDOWS_TASKKILL_TIMEOUT_MS,
           tolerateNonZeroExit: true,
         }).catch((cause) => {
           if (isServiceMutationAuthorityError(cause)) throw cause;
-        }),
-      ),
+        });
+        // Stamped AFTER the kill returns: nothing this process was the parent
+        // of can have been born later than this, so it bounds its orphans.
+        killed.set(entry.pid, {
+          pid: entry.pid,
+          creationMs: entry.creationMs,
+          killedAtMs: Date.now(),
+        });
+      }),
     );
   }
 }
 
 function killedProcesses(
-  killed: ReadonlyMap<number, number | null>,
+  killed: ReadonlyMap<number, KilledProcess>,
 ): readonly KilledProcess[] {
-  return Array.from(killed, ([pid, creationMs]) => ({ pid, creationMs }));
+  return Array.from(killed.values());
 }
 
 async function killRecordedPidUnverified(
@@ -704,11 +714,13 @@ async function findSlotProcesses(
   }
 }
 
-/** A process an earlier pass killed: its pid and the creation stamp it had. */
+/** A process an earlier pass killed, with the lifetime its orphans must fit. */
 export interface KilledProcess {
   readonly pid: number;
   /** `CreationDate` as epoch milliseconds, or `null` when the scan had none. */
   readonly creationMs: number | null;
+  /** Epoch milliseconds when its `taskkill` returned. */
+  readonly killedAtMs: number;
 }
 
 /** A process the scan says to kill, with the stamp a later pass adopts by. */
@@ -743,20 +755,30 @@ function buildSlotProcessScanScript(options: SlotProcessScanOptions): string {
     "foreach ($p in $all) { $byId[[int]$p.ProcessId] = $p }",
     "$stamp = { param($p) if ($null -eq $p -or $null -eq $p.CreationDate) { $null } else { [long](($p.CreationDate.ToUniversalTime() - [datetime]'1970-01-01').TotalMilliseconds) } }",
     "$killed = @{}",
-    ...options.killed.map(
-      (entry) =>
-        `$killed[${String(entry.pid)}] = ${entry.creationMs === null ? "$null" : `[long]${String(entry.creationMs)}`}`,
-    ),
+    // Only a parent with a known creation stamp can vouch for orphans: the
+    // lifetime window needs both ends, and an unknown stamp must never turn
+    // into an inferred kill.
+    ...options.killed
+      .filter((entry) => entry.creationMs !== null)
+      .map(
+        (entry) =>
+          `$killed[${String(entry.pid)}] = @{ born = [long]${String(entry.creationMs)}; died = [long]${String(entry.killedAtMs)} }`,
+      ),
     // Orphans of an earlier pass: their recorded parent is a pid we killed,
     // that pid is not present now (present = reused, unrelated), and they
-    // were born no earlier than the parent they name.
+    // were born inside that parent's lifetime - after its creation and no
+    // later than its kill. A child of whatever the pid was handed to next
+    // was born after the kill and is refused; a child with no stamp is
+    // refused too.
     "$orphans = $all | Where-Object {",
     "  $parentId = [int]$_.ParentProcessId",
     "  if (-not $killed.ContainsKey($parentId)) { return $false }",
     "  if ($byId.ContainsKey($parentId)) { return $false }",
     "  if ($excluded -contains [int]$_.ProcessId) { return $false }",
     "  $born = & $stamp $_",
-    "  ($null -eq $killed[$parentId]) -or ($null -eq $born) -or ($born -ge $killed[$parentId])",
+    "  if ($null -eq $born) { return $false }",
+    "  $life = $killed[$parentId]",
+    "  ($born -ge $life.born) -and ($born -le $life.died)",
     "}",
     "$children = @{}",
     "foreach ($p in $all) {",


### PR DESCRIPTION
## Problem

On Windows the host daemon spawns `traycer host update` (and `host service uninstall`) as its own child; `detached` does not change the parent link on win32. The stop those commands run before swapping was `taskkill /T /F` rooted at the host, which walks parent links straight into the updater that issued it. Every GUI-driven host update on Windows died between stopping the old host and swapping the new one in, leaving an `updating` progress marker nobody would clear and the old install still running (seen updating 1.2.0 → 1.3.0-rc.3: `cli.log` stops after "Host install running lifecycle before swap", `install/` untouched, `staged/` promoted).

## Fix

- The PowerShell slot scan expands each matched host process into its descendant tree from the one `Win32_Process` snapshot it already takes, subtracts this CLI's pid and everything under it, and each survivor is killed individually without `/T`. Parent links are trusted only when the parent started no later than the child (pid reuse guard `/T` never had).
- The kill runs in up to three passes. Each pass hands the scan the pids it killed and their creation stamps (epoch ms), and the scan adopts as further roots processes whose recorded parent is one of those, when that pid is no longer present and the child was born no earlier than the parent it names. This reaps a worker forked between the snapshot and the kill, which the old `/T` could still find at kill time.
- The pid.json fallback (scan unavailable) keeps `/T`, except when the recorded pid is this process's own parent.

## Verification

- `windows.test.ts` covers the script shape, the kill-set parser, the follow-up pass, the pass bound, and the fallback.
- Live on Windows 11 / PowerShell 5.1 with the CLI as a child of a WMI-created fake host: pass 1 selects the host, its worker and conhosts but not the CLI or the CLI's children; after killing only the host, pass 2 adopts the orphaned worker; a killed stamp newer than the worker's birth refuses adoption.

Companion host-side change (orphan launcher + legacy marker aging) lands in traycer-internal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
