### PR TITLE
fix(cli): an absent /proc/self/cgroup refuses the stop instead of reading as "not inside the host unit"

### DIFF
--- a/clients/traycer-cli/README.md
+++ b/clients/traycer-cli/README.md
@@ -149,10 +149,12 @@ Every way that can fail leaves the host running and reports
 
 - `systemd-run` is missing, or starts and then exits before the command does -
   there is no systemd user manager, or the transient scope was refused;
-- the CLI cannot read its own `/proc/self/cgroup`. An absent file (a container,
-  or WSL without systemd) means nothing can kill the command and it simply runs;
-  a file that exists but cannot be read says nothing either way, and is treated
-  as a failed check rather than permission to proceed;
+- the CLI cannot read its own `/proc/self/cgroup`. Any read failure, absence
+  included, means the CLI cannot establish which cgroup it is in, and it refuses
+  the stop rather than proceeding: a mount namespace can hide procfs from a
+  process that is still inside the host's unit and can still reach the user
+  manager. The message says `absent` when that is what was seen, so a sandbox is
+  recognisable as the cause;
 - an argument contains `$`. systemd 258 expands variables in scope arguments by
   default, and the option to turn that off does not exist before systemd 254, so
   a path such as `--from '/tmp/${BUILD}/host.tar.gz'` is refused instead of being

--- a/clients/traycer-cli/src/host/__tests__/cgroup-relocation.test.ts
+++ b/clients/traycer-cli/src/host/__tests__/cgroup-relocation.test.ts
@@ -26,9 +26,9 @@ vi.mock("../../logger", () => ({
 const mocks = vi.hoisted(() => ({
   platform: "linux" as NodeJS.Platform,
   // A string is the file's contents. `null` fails the read with ENOENT (no
-  // `/proc/self/cgroup`, the supported absence case); an object names the errno
-  // to fail with instead, which is how the "unreadable, so unanswerable" cases
-  // are driven.
+  // `/proc/self/cgroup`); an object names the errno to fail with instead.
+  // Both are "unreadable, so unanswerable": absence refuses like any other
+  // failure.
   cgroup: null as string | null | { readonly errno: string },
   packaged: false,
   // Recorded fd-3 writes from `acknowledgeRelocationEntry`.
@@ -883,22 +883,33 @@ describe("relocateOutOfHostCgroupIfNeeded", () => {
     });
     expect(spawnMocks.recorded).toHaveLength(0);
 
-    // Ablation: in `readHostUnitCgroup`, replace the `isMissingCgroupFile`
-    // branch with a blanket `return null` → this test fails: EACCES resolves
+    // Ablation: in `readHostUnitCgroup`, replace the `throw cliError(...)` in
+    // the catch with `return null` → this test fails: EACCES resolves
     // `not-needed` and the command runs in the cgroup that is about to kill it.
   });
 
-  it("treats an ABSENT /proc/self/cgroup (ENOENT, ENOTDIR) as not inside a host unit", async () => {
-    // Containers, WSL without systemd, a kernel with no cgroup filesystem:
-    // there is no cgroup that can kill us, which is a real answer and not a
-    // failed check.
+  it("REFUSES an ABSENT /proc/self/cgroup (ENOENT, ENOTDIR) - absence says where we cannot look, not where we are", async () => {
+    // Codex on #1755 (post-merge): a mount namespace may hide procfs, or just
+    // this file, while the process is still in the cgroup it was born in and
+    // still reaches the user manager through `$XDG_RUNTIME_DIR`. "Not inside"
+    // there is the stop that kills its issuer. Membership is unknown; refuse.
     for (const errno of ["ENOENT", "ENOTDIR"]) {
       mocks.cgroup = { errno };
       await expect(
         relocateOutOfHostCgroupIfNeeded("host update", {}),
-      ).resolves.toEqual({ kind: "not-needed" });
+      ).rejects.toMatchObject({
+        code: "E_SERVICE_CONTROL_FAILED",
+        message: expect.stringContaining("/proc/self/cgroup is absent"),
+        details: { path: "/proc/self/cgroup", absent: true },
+      });
     }
     expect(spawnMocks.recorded).toHaveLength(0);
+
+    // Ablation: in `readHostUnitCgroup`, add `if (absent) return null;` right
+    // after `const absent = isAbsentPath(cause);` (the pre-#1755-follow-up
+    // behaviour) → this test fails: both errnos resolve `not-needed` and the
+    // command runs inside the cgroup its own stop is about to kill, while the
+    // EACCES test above stays green.
   });
 
   // The four commands whose reachability now depends on the parsed options,
@@ -1152,9 +1163,16 @@ describe("assertNotInsideHostUnit", () => {
     });
   });
 
-  it("resolves when /proc/self/cgroup is ABSENT (ENOENT) - nothing there can kill us", async () => {
+  it("REFUSES when /proc/self/cgroup is ABSENT (ENOENT) - the second line closes the hidden-procfs hole too", async () => {
+    // The guard shares `readHostUnitCgroup` with relocation, so a hidden
+    // cgroup file that slipped past relocation (or a CLI that never ran
+    // through `withRunner`, like `host maintenance-lease`) is refused here
+    // as well.
     mocks.cgroup = { errno: "ENOENT" };
-    await expect(assertNotInsideHostUnit()).resolves.toBeUndefined();
+    await expect(assertNotInsideHostUnit()).rejects.toMatchObject({
+      code: "E_SERVICE_CONTROL_FAILED",
+      details: { path: "/proc/self/cgroup", absent: true },
+    });
   });
 
   it("resolves on darwin even inside a host unit cgroup", async () => {

--- a/clients/traycer-cli/src/host/cgroup-relocation.ts
+++ b/clients/traycer-cli/src/host/cgroup-relocation.ts
@@ -189,9 +189,10 @@ export type CgroupRelocation =
  *
  * `completed` means the child ran the whole command and this process must exit
  * with its code without running anything itself. `not-needed` means nothing was
- * moved and the caller runs the command in place - which covers every machine
- * where nothing can kill us for issuing a stop: a host started by hand, WSL
- * without systemd, a container, and every non-Linux platform.
+ * moved and the caller runs the command in place: a readable cgroup that places
+ * this process outside any host unit (a host started by hand, a shell of the
+ * user's own), every non-Linux platform, a command or option form that never
+ * reaches a stop, and the relocated child itself.
  *
  * Throws `SERVICE_CONTROL_FAILED` when the move was needed and could not be
  * made - including when membership itself could not be established. It
@@ -344,41 +345,59 @@ export function findHostUnitCgroup(contents: string): HostUnitCgroup | null {
 /**
  * Read our own cgroup membership, or refuse to answer.
  *
- * ABSENCE is an answer: no `/proc/self/cgroup` (ENOENT) and no `/proc` at all
- * (ENOTDIR) mean there is no cgroup that can kill us - a container, WSL without
- * systemd, a kernel without the filesystem mounted - and "not inside a host
- * unit" is exactly right there.
+ * Every read failure is a FAILED CHECK, not a negative answer - ABSENCE
+ * included. An absent `/proc/self/cgroup` (ENOENT, or ENOTDIR when `/proc` is
+ * not a directory) says where this process cannot look, not where it is: a
+ * mount namespace may hide procfs, or just this file (a sandboxed agent, a
+ * wrapping unit's `TemporaryFileSystem=` or `InaccessiblePaths=`), while the
+ * process still belongs to the cgroup it was born in and still reaches the
+ * user manager through `$XDG_RUNTIME_DIR/systemd/private`, which needs no
+ * procfs. Answering "not inside" there is exactly the stop that kills its
+ * issuer (Codex on #1755, post-merge). A kernel built without cgroups omits the
+ * file too, and refusing there costs nothing: the service registration this
+ * guard protects is systemd-only, and systemd needs cgroups. No independent
+ * marker rescues the case either: `sd_booted()`'s `/run/systemd/system/` is
+ * namespace-local as well, and `TemporaryFileSystem=` hides it while leaving
+ * `/run/user/<uid>` bound, so its absence proves nothing about the manager the
+ * stop would reach.
  *
- * Every OTHER read failure is a FAILED CHECK, not a negative answer. EACCES,
- * EMFILE and EIO say nothing about membership, and the earlier blanket catch
- * turned each of them into permission to stop: relocation would be skipped, the
- * guard would pass, intent would be written, and the stop would kill the process
- * issuing it. So they refuse instead, with the errno recorded at DEBUG.
+ * EACCES, EMFILE and EIO say nothing about membership either, and the earlier
+ * blanket catch turned each of them into permission to stop: relocation would
+ * be skipped, the guard would pass, intent would be written, and the stop
+ * would kill the process issuing it. So every failure refuses, with the errno
+ * recorded at DEBUG and absence named in the message because it is the case a
+ * person can recognise (a sandbox) rather than a permission to fix.
  */
 async function readHostUnitCgroup(): Promise<HostUnitCgroup | null> {
   let contents: string;
   try {
     contents = await readFile(PROC_SELF_CGROUP, "utf8");
   } catch (cause) {
-    if (isMissingCgroupFile(cause)) return null;
+    const absent = isAbsentPath(cause);
     createCliLogger(config.environment).debug(
       "Failed to read the cgroup this process belongs to",
-      { path: PROC_SELF_CGROUP, cause: errorFromUnknown(cause).message },
+      {
+        path: PROC_SELF_CGROUP,
+        absent,
+        cause: errorFromUnknown(cause).message,
+      },
     );
     throw cliError({
       code: CLI_ERROR_CODES.SERVICE_CONTROL_FAILED,
       message:
-        `could not read ${PROC_SELF_CGROUP}, so this command cannot tell whether ` +
-        "stopping the Traycer host would also kill it. " +
-        "Run it again from a shell outside the Traycer host.",
-      details: { path: PROC_SELF_CGROUP },
+        (absent
+          ? `${PROC_SELF_CGROUP} is absent in this environment`
+          : `could not read ${PROC_SELF_CGROUP}`) +
+        ", so this command cannot tell whether stopping the Traycer host " +
+        "would also kill it. Run it again from a shell outside the Traycer host.",
+      details: { path: PROC_SELF_CGROUP, absent },
       exitCode: 1,
     });
   }
   return findHostUnitCgroup(contents);
 }
 
-function isMissingCgroupFile(cause: unknown): boolean {
+function isAbsentPath(cause: unknown): boolean {
   if (!isErrnoException(cause)) return false;
   return cause.code === "ENOENT" || cause.code === "ENOTDIR";
 }

--- a/clients/traycer-cli/src/service/__tests__/stop-intent-cgroup-guard.test.ts
+++ b/clients/traycer-cli/src/service/__tests__/stop-intent-cgroup-guard.test.ts
@@ -481,36 +481,66 @@ describe("withStopIntent - Linux cgroup self-protection guard", () => {
     expect(ran).toBe(false);
 
     // Ablation: in `readHostUnitCgroup` (host/cgroup-relocation.ts), replace
-    // the `isMissingCgroupFile` branch with a blanket `return null` → this
-    // test fails on the first route: the guard resolves, intent is written,
-    // and the stop proceeds from inside a cgroup nobody could rule out.
+    // the `throw cliError(...)` in the catch with `return null` → this test
+    // fails on the first route: the guard resolves, intent is written, and
+    // the stop proceeds from inside a cgroup nobody could rule out.
   });
 
-  // An ABSENT cgroup file is a different machine and a real answer: no cgroup
-  // exists that could kill us, so all five proceed.
-  it("proceeds on all five routes when /proc/self/cgroup is absent (ENOENT)", async () => {
+  // An ABSENT cgroup file says where the process cannot look, not where it is
+  // (Codex on #1755, post-merge: a namespace may hide procfs while the process
+  // is still in whatever cgroup it was born in). Membership is unknown, so
+  // every route refuses before announcing anything - exactly like EACCES
+  // above, with `absent: true` distinguishing the case.
+  it("refuses on all five routes when /proc/self/cgroup is absent (ENOENT)", async () => {
     mocks.cgroup = { errno: "ENOENT" };
-    let installRan = false;
+    let ran = false;
     const controller = withStopIntent(
       baseController({
         install: async () => {
-          installRan = true;
+          ran = true;
         },
-        stop: async () => undefined,
-        stopForRestart: async () => ({ forcedRecycle: false }),
-        uninstall: async () => undefined,
-        restart: async () => undefined,
+        stop: async () => {
+          ran = true;
+        },
+        stopForRestart: async () => {
+          ran = true;
+          return { forcedRecycle: false };
+        },
+        uninstall: async () => {
+          ran = true;
+        },
+        restart: async () => {
+          ran = true;
+        },
       }),
     );
 
-    await controller.stop(label, { force: false });
-    await controller.stopForRestart(label, { force: false });
-    await controller.uninstall({ label });
-    await controller.restart(label);
-    await controller.install(installOptions);
+    await expect(
+      controller.stop(label, { force: false }),
+    ).rejects.toMatchObject({
+      code: "E_SERVICE_CONTROL_FAILED",
+      details: { path: "/proc/self/cgroup", absent: true },
+    });
+    await expect(
+      controller.stopForRestart(label, { force: false }),
+    ).rejects.toMatchObject({ code: "E_SERVICE_CONTROL_FAILED" });
+    await expect(controller.uninstall({ label })).rejects.toMatchObject({
+      code: "E_SERVICE_CONTROL_FAILED",
+    });
+    await expect(controller.restart(label)).rejects.toMatchObject({
+      code: "E_SERVICE_CONTROL_FAILED",
+    });
+    await expect(controller.install(installOptions)).rejects.toMatchObject({
+      code: "E_SERVICE_CONTROL_FAILED",
+    });
 
-    expect(mocks.writes).toEqual(["stop", "restart", "uninstall", "restart"]);
-    expect(installRan).toBe(true);
+    expect(mocks.writes).toEqual([]);
+    expect(mocks.clears).toEqual([]);
+    expect(ran).toBe(false);
+
+    // Ablation: in `readHostUnitCgroup`, add `if (absent) return null;` after
+    // `const absent = isAbsentPath(cause);` → this test fails on the first
+    // route exactly like the EACCES test above, which stays green.
   });
 
   // Ablation (run once per method, one at a time - five separate ablations):


### PR DESCRIPTION
## Why

Follow-up to #1755, from Codex's post-merge review (https://github.com/traycerai/traycer/pull/1755#discussion_r3944482905). `readHostUnitCgroup` treated ENOENT/ENOTDIR on `/proc/self/cgroup` as proof that no cgroup can kill the CLI. An absent file says where the process cannot look, not where it is: a mount namespace can hide procfs, or just that file (a sandboxed agent, a wrapping unit's `TemporaryFileSystem=` or `InaccessiblePaths=`), while the process is still in the host unit's cgroup and still reaches the user manager through `$XDG_RUNTIME_DIR`, which needs no procfs. Both the relocation and the second-line guard were off exactly where `systemctl --user stop` would kill the process issuing it.

## What

- Absence now refuses like every other read failure: `E_SERVICE_CONTROL_FAILED`, exit 1, `details: { path, absent: true }`, message `/proc/self/cgroup is absent in this environment, so this command cannot tell whether stopping the Traycer host would also kill it. Run it again from a shell outside the Traycer host.` Machines where the file is readable are untouched.
- Considered and rejected in cold review: consulting `sd_booted()`'s `/run/systemd/system/` to let absence through when systemd is not booted. That marker is namespace-local too (`TemporaryFileSystem=` hides it while `/run/user/<uid>` stays bound), so its absence proves nothing about the manager the stop would reach. Refusing on a kernel without cgroups costs nothing: the Linux service registration this protects is systemd-only, and systemd needs cgroups.
- README and the relocation summary no longer promise the old pass-through.

## Verification

- `cgroup-relocation.test.ts`, `stop-intent-cgroup-guard.test.ts`, `cli-with-runner-relocation.test.ts`: 69/69. The "absent → proceeds" pins became "absent → refuses" (relocation for both errnos with no spawn, `assertNotInsideHostUnit`, all five stop-intent routes with nothing written).
- Ablation recorded in each test: re-adding `if (absent) return null;` reddens exactly the three absence pins while the EACCES pins stay green.
- Cold review before the push: round 1 found the marker approach unsound (P2), round 2 on the refuse-unconditionally version is 0 P1 / 0 P2 with two doc nits, both folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
