### PR TITLE
fix(desktop): finish a parked login-item registration through the CLI LaunchAgent when no host runs

### DIFF
--- a/clients/desktop/src/electron-main/app/__tests__/host-login-item.test.ts
+++ b/clients/desktop/src/electron-main/app/__tests__/host-login-item.test.ts
@@ -1409,6 +1409,46 @@ describe("readParkedRegistrationTakeover", () => {
     expect(printRunner).toHaveBeenCalledTimes(2);
   });
 
+  // `pid = 0` is launchd's idle-job marker, not a live process: the shared
+  // parser still reports it as `observed` (it is a finite number), so a
+  // reader that treated ANY observed pid as running would park every boot
+  // cycle on a job with nothing left to interrupt. Only a positive pid or an
+  // explicit `running` job state may call it live - see
+  // `probeLaunchdJobProcess` in `host-login-item.ts`.
+  it("a `pid = 0` line with no running state on the agent label is an idle job: the CLI label is probed next and the verdict is takeover", async () => {
+    getLoginItemSettings
+      .mockReturnValueOnce({ status: "not-found" }) // primary
+      .mockReturnValueOnce({ status: "not-registered" }); // legacy
+    printRunner.mockImplementation(async (target: string) =>
+      agentPrintTarget(target) === "agent"
+        ? observedPrintResult(["state = waiting", "pid = 0"])
+        : notLoadedPrintResult(),
+    );
+
+    await expect(readParkedRegistrationTakeover()).resolves.toEqual({
+      kind: "takeover",
+      status: "not-found",
+    });
+    expect(printRunner).toHaveBeenCalledTimes(2);
+  });
+
+  it("a `pid = 0` line with no running state on the CLI label (agent label absent) is an idle job, and the verdict is takeover", async () => {
+    getLoginItemSettings
+      .mockReturnValueOnce({ status: "not-found" }) // primary
+      .mockReturnValueOnce({ status: "not-registered" }); // legacy
+    printRunner.mockImplementation(async (target: string) =>
+      agentPrintTarget(target) === "agent"
+        ? notLoadedPrintResult()
+        : observedPrintResult(["state = waiting", "pid = 0"]),
+    );
+
+    await expect(readParkedRegistrationTakeover()).resolves.toEqual({
+      kind: "takeover",
+      status: "not-found",
+    });
+    expect(printRunner).toHaveBeenCalledTimes(2);
+  });
+
   it("a spawn-failed print is no-takeover/job-indeterminate", async () => {
     getLoginItemSettings
       .mockReturnValueOnce({ status: "not-found" }) // primary

--- a/clients/desktop/src/electron-main/app/__tests__/host-login-item.test.ts
+++ b/clients/desktop/src/electron-main/app/__tests__/host-login-item.test.ts
@@ -1449,6 +1449,22 @@ describe("readParkedRegistrationTakeover", () => {
     expect(printRunner).toHaveBeenCalledTimes(2);
   });
 
+  it("an exit-0 print with no recognizable job fields (indeterminate ownership) is no-takeover/job-indeterminate, not an idle job", async () => {
+    getLoginItemSettings
+      .mockReturnValueOnce({ status: "not-found" }) // primary
+      .mockReturnValueOnce({ status: "not-registered" }); // legacy
+    printRunner.mockImplementation(async () =>
+      observedPrintResult(["some unknown field = value"]),
+    );
+
+    await expect(readParkedRegistrationTakeover()).resolves.toEqual({
+      kind: "no-takeover",
+      reason: "job-indeterminate",
+    });
+    // Fails closed on the agent label's read; the CLI label is never probed.
+    expect(printRunner).toHaveBeenCalledTimes(1);
+  });
+
   it("a spawn-failed print is no-takeover/job-indeterminate", async () => {
     getLoginItemSettings
       .mockReturnValueOnce({ status: "not-found" }) // primary

--- a/clients/desktop/src/electron-main/app/__tests__/host-login-item.test.ts
+++ b/clients/desktop/src/electron-main/app/__tests__/host-login-item.test.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from "node:events";
 import electronLog from "electron-log";
+import type { ProbeCommandResult } from "@traycer-clients/shared/host-lifecycle";
 import {
   chmodSync,
   existsSync,
@@ -20,6 +21,7 @@ import {
   expect,
   it,
   vi,
+  type Mock,
 } from "vitest";
 
 // `inAppLaunchAgentPlistPath` reads `process.resourcesPath` synchronously
@@ -214,6 +216,7 @@ function makeFakeChild(): FakeChildHandle {
 const {
   registerHostLoginItem,
   readHostLoginItemStatus,
+  readParkedRegistrationTakeover,
   retireCompetingCliRegistrationAtLaunch,
   overrideAgentPrintRunnerForTests,
   runLaunchctlBootout,
@@ -1168,6 +1171,299 @@ describe("readHostLoginItemStatus", () => {
     });
 
     expect(readHostLoginItemStatus()).toBe("not-registered");
+  });
+});
+
+// `readParkedRegistrationTakeover` decides whether a parked register cycle
+// can be finished by the CLI-owned LaunchAgent (`host service install
+// --takeover`) instead of failing. Five gates, in order, every refusal
+// naming which one fired:
+//
+//   1. primary label manageable by SMAppService (not not-found/not-supported,
+//      or unreadable) -> `primary-manageable`, no further reads at all.
+//   2. legacy label IS a BTM registration (enabled/requires-approval/
+//      unreadable) -> `legacy-registered`.
+//   3. the raw CLI manifest could not be probed -> `manifest-unreadable`
+//      (present AND absent both pass this gate).
+//   4. either label has a live launchd job (a pid, or `state = running`) or
+//      an unanswerable print -> `job-running` / `job-indeterminate`.
+//   5. otherwise takeover, naming the primary status.
+//
+// The job probe is shared with the retirement gate's `runAgentPrint` seam
+// (`overrideAgentPrintRunnerForTests`) and checks HOST_AGENT_LABEL
+// (`ai.traycer.host.agent`) before CLI_HOST_LABEL (`ai.traycer.host`).
+describe("readParkedRegistrationTakeover", () => {
+  const HOST_AGENT_LABEL = "ai.traycer.host.agent";
+
+  function agentPrintTarget(target: string): "agent" | "cli" {
+    return target.endsWith(`/${HOST_AGENT_LABEL}`) ? "agent" : "cli";
+  }
+
+  function notLoadedPrintResult() {
+    return {
+      exitCode: 113,
+      stdout: "",
+      stderr: "Could not find specified service\n",
+      timedOut: false,
+      spawnFailed: false,
+      signal: null,
+    };
+  }
+
+  function observedPrintResult(fields: readonly string[]) {
+    return {
+      exitCode: 0,
+      stdout: [
+        "gui/501/some.label = {",
+        ...fields.map((field) => `\t${field}`),
+        "}",
+        "",
+      ].join("\n"),
+      stderr: "",
+      timedOut: false,
+      spawnFailed: false,
+      signal: null,
+    };
+  }
+
+  // Every test installs its own print stub (or relies on the default
+  // "not loaded" stub below) so the suite never reads the developer's real
+  // launchd domain, mirroring the `retireCompetingCliRegistrationAtLaunch`
+  // convention above.
+  let printRunner: Mock<(target: string) => Promise<ProbeCommandResult>>;
+
+  beforeEach(() => {
+    printRunner = vi.fn<(target: string) => Promise<ProbeCommandResult>>(
+      async () => notLoadedPrintResult(),
+    );
+    overrideAgentPrintRunnerForTests(printRunner);
+  });
+
+  afterEach(() => {
+    overrideAgentPrintRunnerForTests(null);
+  });
+
+  it("(not-found, not-found, manifest absent, both labels absent) is a takeover", async () => {
+    getLoginItemSettings
+      .mockReturnValueOnce({ status: "not-found" }) // primary
+      .mockReturnValueOnce({ status: "not-found" }); // legacy
+    // No `writeLegacyCliManifest()` call: manifest absent.
+
+    await expect(readParkedRegistrationTakeover()).resolves.toEqual({
+      kind: "takeover",
+      status: "not-found",
+    });
+    expect(getLoginItemSettings).toHaveBeenCalledTimes(2);
+    expect(printRunner).toHaveBeenCalledTimes(2);
+  });
+
+  it("(not-supported, not-registered, manifest present, jobs absent) is a takeover", async () => {
+    getLoginItemSettings
+      .mockReturnValueOnce({ status: "not-supported" }) // primary
+      .mockReturnValueOnce({ status: "not-registered" }); // legacy
+    writeLegacyCliManifest();
+
+    await expect(readParkedRegistrationTakeover()).resolves.toEqual({
+      kind: "takeover",
+      status: "not-supported",
+    });
+  });
+
+  // A label that IS loaded but carries neither a pid nor a `running` job
+  // state is "none" for this purpose - `runAgentPrint` returning `observed`
+  // does not by itself prove a live process.
+  it("is a takeover when a label is observed but has no pid and its job state is not running", async () => {
+    getLoginItemSettings
+      .mockReturnValueOnce({ status: "not-found" }) // primary
+      .mockReturnValueOnce({ status: "not-registered" }); // legacy
+    printRunner.mockImplementation(async () =>
+      observedPrintResult(["state = waiting", "path = /some/path"]),
+    );
+
+    await expect(readParkedRegistrationTakeover()).resolves.toEqual({
+      kind: "takeover",
+      status: "not-found",
+    });
+    expect(printRunner).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    ["not-registered", { status: "not-registered" }],
+    ["enabled", { status: "enabled" }],
+  ] as const)(
+    "primary %s is no-takeover/primary-manageable, and reads nothing else",
+    async (_label, settings) => {
+      getLoginItemSettings.mockReturnValueOnce(settings);
+
+      await expect(readParkedRegistrationTakeover()).resolves.toEqual({
+        kind: "no-takeover",
+        reason: "primary-manageable",
+      });
+      expect(getLoginItemSettings).toHaveBeenCalledTimes(1);
+      expect(printRunner).not.toHaveBeenCalled();
+    },
+  );
+
+  it("a throwing primary read is no-takeover/primary-manageable, and reads nothing else", async () => {
+    getLoginItemSettings.mockImplementationOnce(() => {
+      throw new Error("BTM database is sad");
+    });
+
+    await expect(readParkedRegistrationTakeover()).resolves.toEqual({
+      kind: "no-takeover",
+      reason: "primary-manageable",
+    });
+    expect(getLoginItemSettings).toHaveBeenCalledTimes(1);
+    expect(printRunner).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["enabled", { status: "enabled" }],
+    ["requires-approval", { status: "requires-approval" }],
+  ] as const)(
+    "(not-found, legacy %s) is no-takeover/legacy-registered, and never prints",
+    async (_label, legacySettings) => {
+      getLoginItemSettings
+        .mockReturnValueOnce({ status: "not-found" }) // primary
+        .mockReturnValueOnce(legacySettings); // legacy
+
+      await expect(readParkedRegistrationTakeover()).resolves.toEqual({
+        kind: "no-takeover",
+        reason: "legacy-registered",
+      });
+      expect(printRunner).not.toHaveBeenCalled();
+    },
+  );
+
+  it("(not-found, then a throwing legacy read) is no-takeover/legacy-registered, and never prints", async () => {
+    getLoginItemSettings
+      .mockReturnValueOnce({ status: "not-found" }) // primary
+      .mockImplementationOnce(() => {
+        throw new Error("BTM database is sad");
+      }); // legacy
+
+    await expect(readParkedRegistrationTakeover()).resolves.toEqual({
+      kind: "no-takeover",
+      reason: "legacy-registered",
+    });
+    expect(printRunner).not.toHaveBeenCalled();
+  });
+
+  // Root ignores file mode bits, so the probe would succeed and this would
+  // assert the wrong branch (same convention as the register-cycle tests
+  // above).
+  it.skipIf(process.getuid?.() === 0)(
+    "an unreadable CLI manifest directory is no-takeover/manifest-unreadable",
+    async () => {
+      getLoginItemSettings
+        .mockReturnValueOnce({ status: "not-found" }) // primary
+        .mockReturnValueOnce({ status: "not-registered" }); // legacy
+      const agentsDir = join(workHome, "Library", "LaunchAgents");
+      mkdirSync(agentsDir, { recursive: true });
+      // Drops the SEARCH (execute) bit, so `access()` on the known filename
+      // fails EACCES rather than ENOENT - the probe's unreadable branch.
+      chmodSync(agentsDir, 0o600);
+      try {
+        await expect(readParkedRegistrationTakeover()).resolves.toEqual({
+          kind: "no-takeover",
+          reason: "manifest-unreadable",
+        });
+      } finally {
+        chmodSync(agentsDir, 0o755);
+      }
+      expect(printRunner).not.toHaveBeenCalled();
+    },
+  );
+
+  it("a pid on the agent label is no-takeover/job-running, and the CLI label is never even probed", async () => {
+    getLoginItemSettings
+      .mockReturnValueOnce({ status: "not-found" }) // primary
+      .mockReturnValueOnce({ status: "not-registered" }); // legacy
+    printRunner.mockImplementation(async (target: string) =>
+      agentPrintTarget(target) === "agent"
+        ? observedPrintResult(["state = running", "pid = 123"])
+        : notLoadedPrintResult(),
+    );
+
+    await expect(readParkedRegistrationTakeover()).resolves.toEqual({
+      kind: "no-takeover",
+      reason: "job-running",
+    });
+    expect(printRunner).toHaveBeenCalledTimes(1);
+  });
+
+  it("a running job state on the CLI label (agent label absent) is no-takeover/job-running", async () => {
+    getLoginItemSettings
+      .mockReturnValueOnce({ status: "not-found" }) // primary
+      .mockReturnValueOnce({ status: "not-registered" }); // legacy
+    printRunner.mockImplementation(async (target: string) =>
+      agentPrintTarget(target) === "agent"
+        ? notLoadedPrintResult()
+        : observedPrintResult(["state = running"]),
+    );
+
+    await expect(readParkedRegistrationTakeover()).resolves.toEqual({
+      kind: "no-takeover",
+      reason: "job-running",
+    });
+    expect(printRunner).toHaveBeenCalledTimes(2);
+  });
+
+  it("a spawn-failed print is no-takeover/job-indeterminate", async () => {
+    getLoginItemSettings
+      .mockReturnValueOnce({ status: "not-found" }) // primary
+      .mockReturnValueOnce({ status: "not-registered" }); // legacy
+    printRunner.mockImplementation(async () => ({
+      exitCode: -1,
+      stdout: "",
+      stderr: "",
+      timedOut: false,
+      spawnFailed: true,
+      signal: null,
+    }));
+
+    await expect(readParkedRegistrationTakeover()).resolves.toEqual({
+      kind: "no-takeover",
+      reason: "job-indeterminate",
+    });
+  });
+
+  it("a timed-out print is no-takeover/job-indeterminate", async () => {
+    getLoginItemSettings
+      .mockReturnValueOnce({ status: "not-found" }) // primary
+      .mockReturnValueOnce({ status: "not-registered" }); // legacy
+    printRunner.mockImplementation(async () => ({
+      exitCode: -1,
+      stdout: "",
+      stderr: "",
+      timedOut: true,
+      spawnFailed: false,
+      signal: null,
+    }));
+
+    await expect(readParkedRegistrationTakeover()).resolves.toEqual({
+      kind: "no-takeover",
+      reason: "job-indeterminate",
+    });
+  });
+
+  it("a non-zero exit whose output is not a not-found message is no-takeover/job-indeterminate", async () => {
+    getLoginItemSettings
+      .mockReturnValueOnce({ status: "not-found" }) // primary
+      .mockReturnValueOnce({ status: "not-registered" }); // legacy
+    printRunner.mockImplementation(async () => ({
+      exitCode: 1,
+      stdout: "",
+      stderr: "some unrecognized launchctl failure\n",
+      timedOut: false,
+      spawnFailed: false,
+      signal: null,
+    }));
+
+    await expect(readParkedRegistrationTakeover()).resolves.toEqual({
+      kind: "no-takeover",
+      reason: "job-indeterminate",
+    });
   });
 });
 

--- a/clients/desktop/src/electron-main/app/host-login-item.ts
+++ b/clients/desktop/src/electron-main/app/host-login-item.ts
@@ -236,7 +236,11 @@ export function readHostLoginItemStatus(): HostLoginItemStatus {
  *     own takeover treats missing metadata as a reason to boot the job out
  *     underneath a host it could not ask. A job that is loaded but has no
  *     process is fine: the install re-registers and kickstarts it, which is
- *     the start this exists to perform.
+ *     the start this exists to perform. This read is a snapshot, not a
+ *     lock: a job that starts between it and the CLI taking its contender
+ *     lock is caught THERE - `takeoverDesktopRegistration` asks a live
+ *     CLI-label process to stand down before its reload and refuses one
+ *     that has no endpoint to ask yet.
  */
 export type ParkedRegistrationTakeover =
   | {

--- a/clients/desktop/src/electron-main/app/host-login-item.ts
+++ b/clients/desktop/src/electron-main/app/host-login-item.ts
@@ -228,19 +228,21 @@ export function readHostLoginItemStatus(): HostLoginItemStatus {
  *   - `manifest-unreadable`: `~/Library/LaunchAgents/<cli-label>.plist` could
  *     not be probed - the same input the entry guard refuses on.
  *   - `job-running` / `job-indeterminate`: launchd reports a live process
- *     under either label, or could not be asked. This is the down-host proof
- *     the callers' `prePid === null` is NOT: that is a structural read of
- *     `pid.json`, and a host in its first seconds after a `KeepAlive` respawn
- *     (or one whose metadata tore) has none - while the takeover's install
- *     boots a loaded CLI label out with no cooperative claim, and the CLI's
- *     own takeover treats missing metadata as a reason to boot the job out
- *     underneath a host it could not ask. A job that is loaded but has no
- *     process is fine: the install re-registers and kickstarts it, which is
+ *     (a positive `pid`, or `state = running`) under either label, or could
+ *     not be asked. This is the down-host proof the callers'
+ *     `prePid === null` is NOT: that is a structural read of `pid.json`, and
+ *     a host in its first seconds after a `KeepAlive` respawn (or one whose
+ *     metadata tore) has none - while the takeover's install boots a loaded
+ *     CLI label out with no cooperative claim, and the CLI's own takeover
+ *     treats missing metadata as a reason to boot the job out underneath a
+ *     host it could not ask. A job that is loaded but has no process is
+ *     fine: the CLI unloads it under its lock and re-registers it, which is
  *     the start this exists to perform. This read is a snapshot, not a
  *     lock: a job that starts between it and the CLI taking its contender
  *     lock is caught THERE - `takeoverDesktopRegistration` asks a live
- *     CLI-label process to stand down before its reload and refuses one
- *     that has no endpoint to ask yet.
+ *     CLI-label process to stand down before its reload, refuses one that
+ *     has no endpoint to ask yet, and unloads an idle one itself so launchd
+ *     cannot start it under the install.
  */
 export type ParkedRegistrationTakeover =
   | {
@@ -305,8 +307,13 @@ async function probeLaunchdJobProcess(
   if (probe.kind === "absent") return "none";
   if (probe.kind === "indeterminate") return "job-indeterminate";
   const { pid, jobState } = probe.runState;
+  // `pid = 0` is launchd's idle job, not a process: the shared parser keeps
+  // every finite number as observed, and the CLI's ownership classifier and
+  // `wedge.ts` both read only a positive pid as live. Reading 0 as running
+  // would park this boot cycle, and every retry after it, on a job that has
+  // nothing to interrupt.
   if (
-    pid.kind === "observed" ||
+    (pid.kind === "observed" && pid.value > 0) ||
     (jobState.kind === "observed" && jobState.value.toLowerCase() === "running")
   ) {
     return "job-running";

--- a/clients/desktop/src/electron-main/app/host-login-item.ts
+++ b/clients/desktop/src/electron-main/app/host-login-item.ts
@@ -306,6 +306,12 @@ async function probeLaunchdJobProcess(
   const probe = classifyLaunchctlPrintResult(result, null, labelId);
   if (probe.kind === "absent") return "none";
   if (probe.kind === "indeterminate") return "job-indeterminate";
+  // An exit-0 answer with no recognizable job fields (truncated output, a
+  // changed format) is `observed` with an indeterminate OWNERSHIP, and its
+  // run state is then empty by construction, not because the job is idle.
+  // Reading that as "no process" would let unreadable evidence authorize
+  // the takeover (Codex, traycer#1761); it fails closed like a non-answer.
+  if (probe.ownership.kind === "indeterminate") return "job-indeterminate";
   const { pid, jobState } = probe.runState;
   // `pid = 0` is launchd's idle job, not a process: the shared parser keeps
   // every finite number as observed, and the CLI's ownership classifier and

--- a/clients/desktop/src/electron-main/app/host-login-item.ts
+++ b/clients/desktop/src/electron-main/app/host-login-item.ts
@@ -96,8 +96,11 @@ export function withHostLoginItemRegistrationLock<Result>(
  * - `requires-approval` - registered but disabled by the user in System
  *   Settings → Login Items. launchd refuses to spawn until they re-enable.
  * - `not-registered` - SMAppService has no record of this plist.
- * - `not-found` - the in-bundle plist filename isn't where SMAppService
- *   looks. A packaging bug; never expected at runtime.
+ * - `not-found` - SMAppService cannot see the in-bundle plist. A packaging
+ *   bug in a signed build, but also the steady answer for an ad-hoc-signed
+ *   build (no Team ID for BTM to key the item on) and, per the 2026-07-28
+ *   RCA, for a byte-correct plist whose BTM record is keyed to a previous
+ *   build - in both cases for the life of the process. Not a transient.
  * - `not-supported` - running on a platform/build where SMAppService is
  *   unavailable. Caller MUST gate with `hostManagesHostLoginItem()`.
  */
@@ -182,6 +185,129 @@ export async function hostManagesHostLoginItem(): Promise<boolean> {
  */
 export function readHostLoginItemStatus(): HostLoginItemStatus {
   return readLoginItemStatus(HOST_SERVICE_NAME);
+}
+
+/**
+ * Whether a register cycle that PARKED can be finished by the CLI-owned
+ * LaunchAgent (`host service install --takeover`) instead of failing.
+ *
+ * `takeover` names the one parked state that is unrestorable because there is
+ * nothing to restore: SMAppService cannot see the in-bundle agent plist at all
+ * (`not-found` - an ad-hoc-signed build, or a BTM record keyed to a previous
+ * build - or `not-supported`). No register cycle in this process will ever
+ * put a login item there, so re-running the cycle cannot start a host. On
+ * 2026-09-06 that stranded a machine: `host uninstall` had removed the CLI
+ * registration the host had always run under, the reinstalled app parked on
+ * `not-found`, and every boot retry failed "no host is running to restart"
+ * until a person ran `host service install` by hand. That command is what
+ * the takeover runs, so the desktop can run it itself.
+ *
+ * `not-registered` is deliberately NOT in that set, although
+ * `HostController.isCliTakeoverRecoverableStatus` admits it after a cycle
+ * RAN: a cycle that ends `not-registered` has already booted the old agent
+ * out, so leaving it there strands the machine, and `not-registered` is the
+ * one status the register poll treats as potentially transient (cold-BTM
+ * commit lag). A park booted nothing out, and a fresh read cannot say which
+ * of the guard's three inputs refused - so only the two statuses that are
+ * terminal for the life of the process admit the takeover.
+ *
+ * Four refusals, all read HERE after the park, never from the snapshot the
+ * guard refused on, and every unreadable answer refuses:
+ *
+ *   - `primary-manageable`: the primary status is one SMAppService can still
+ *     act on; the park was about something else.
+ *   - `legacy-registered`: the legacy label reads `enabled` or
+ *     `requires-approval` - a BTM record under the very label the raw plist
+ *     would use, which is the collision the park exists to avoid. Honest
+ *     limit: on an ad-hoc build BOTH labels read `not-found` whatever BTM
+ *     holds, so this is a bound, not a proof; the residual (a BTM record from
+ *     an older signed build under the CLI label, unloaded) is the accepted
+ *     edge `installService` documents on its loaded-state probe, and the
+ *     `register-failed` path already takes the takeover with no legacy check
+ *     at all.
+ *   - `manifest-unreadable`: `~/Library/LaunchAgents/<cli-label>.plist` could
+ *     not be probed - the same input the entry guard refuses on.
+ *   - `job-running` / `job-indeterminate`: launchd reports a live process
+ *     under either label, or could not be asked. This is the down-host proof
+ *     the callers' `prePid === null` is NOT: that is a structural read of
+ *     `pid.json`, and a host in its first seconds after a `KeepAlive` respawn
+ *     (or one whose metadata tore) has none - while the takeover's install
+ *     boots a loaded CLI label out with no cooperative claim, and the CLI's
+ *     own takeover treats missing metadata as a reason to boot the job out
+ *     underneath a host it could not ask. A job that is loaded but has no
+ *     process is fine: the install re-registers and kickstarts it, which is
+ *     the start this exists to perform.
+ */
+export type ParkedRegistrationTakeover =
+  | {
+      readonly kind: "takeover";
+      readonly status: "not-found" | "not-supported";
+    }
+  | {
+      readonly kind: "no-takeover";
+      readonly reason:
+        | "primary-manageable"
+        | "legacy-registered"
+        | "manifest-unreadable"
+        | "job-running"
+        | "job-indeterminate";
+    };
+
+export async function readParkedRegistrationTakeover(): Promise<ParkedRegistrationTakeover> {
+  const primary = readLoginItemStatusEvidence(HOST_SERVICE_NAME);
+  if (
+    primary.kind !== "read" ||
+    (primary.status !== "not-found" && primary.status !== "not-supported")
+  ) {
+    return { kind: "no-takeover", reason: "primary-manageable" };
+  }
+  const legacy = readLoginItemStatusEvidence(LEGACY_HOST_SERVICE_NAME);
+  if (
+    legacy.kind !== "read" ||
+    legacy.status === "enabled" ||
+    legacy.status === "requires-approval"
+  ) {
+    return { kind: "no-takeover", reason: "legacy-registered" };
+  }
+  const manifest = await probeCliLabelManifest(
+    userLaunchAgentPlistPath(CLI_HOST_LABEL),
+  );
+  if (manifest.kind === "unreadable") {
+    return { kind: "no-takeover", reason: "manifest-unreadable" };
+  }
+  for (const labelId of [HOST_AGENT_LABEL, CLI_HOST_LABEL]) {
+    const job = await probeLaunchdJobProcess(labelId);
+    if (job !== "none") return { kind: "no-takeover", reason: job };
+  }
+  return { kind: "takeover", status: primary.status };
+}
+
+/**
+ * Whether launchd holds a live process under `labelId`. `job-indeterminate`
+ * when launchd could not be asked (no uid, spawn failure, timeout,
+ * permission, unrecognized output); the caller fails closed on it.
+ */
+async function probeLaunchdJobProcess(
+  labelId: string,
+): Promise<"none" | "job-running" | "job-indeterminate"> {
+  if (typeof process.getuid !== "function") return "job-indeterminate";
+  let result: ProbeCommandResult;
+  try {
+    result = await runAgentPrint(`gui/${process.getuid()}/${labelId}`);
+  } catch {
+    return "job-indeterminate";
+  }
+  const probe = classifyLaunchctlPrintResult(result, null, labelId);
+  if (probe.kind === "absent") return "none";
+  if (probe.kind === "indeterminate") return "job-indeterminate";
+  const { pid, jobState } = probe.runState;
+  if (
+    pid.kind === "observed" ||
+    (jobState.kind === "observed" && jobState.value.toLowerCase() === "running")
+  ) {
+    return "job-running";
+  }
+  return "none";
 }
 
 function readLoginItemStatus(serviceName: string): HostLoginItemStatus {

--- a/clients/desktop/src/electron-main/host/__tests__/host-controller.test.ts
+++ b/clients/desktop/src/electron-main/host/__tests__/host-controller.test.ts
@@ -88,6 +88,10 @@ vi.mock("../../app/host-login-item", () => ({
   ),
   hasUnappliedPendingLoginItemRevision: vi.fn(async () => false),
   readHostLoginItemStatus: vi.fn(() => "enabled"),
+  readParkedRegistrationTakeover: vi.fn(async () => ({
+    kind: "no-takeover",
+    reason: "primary-manageable",
+  })),
 }));
 
 vi.mock("../host-readiness", async (importOriginal) => {
@@ -247,6 +251,7 @@ import {
   hasUnappliedPendingLoginItemRevision,
   hostManagesHostLoginItem,
   readHostLoginItemStatus,
+  readParkedRegistrationTakeover,
   registerHostLoginItem,
   unregisterHostLoginItemGuarded,
 } from "../../app/host-login-item";
@@ -324,6 +329,10 @@ beforeEach(() => {
   });
   vi.mocked(hasUnappliedPendingLoginItemRevision).mockResolvedValue(false);
   vi.mocked(readHostLoginItemStatus).mockReturnValue("enabled");
+  vi.mocked(readParkedRegistrationTakeover).mockResolvedValue({
+    kind: "no-takeover",
+    reason: "primary-manageable",
+  });
   vi.mocked(registerHostLoginItem).mockResolvedValue("enabled");
   vi.mocked(unregisterHostLoginItemGuarded).mockResolvedValue(true);
   vi.mocked(probeHostActivityBusy).mockResolvedValue(false);
@@ -3379,7 +3388,7 @@ describe("platform matrix", () => {
       expect(readyOrder).toBeGreaterThan(restartOrder);
     });
 
-    it("with no running host and a login item that is not enabled, fails immediately naming the parked registration and never spawns a restart", async () => {
+    it("with no running host and a login item that is not enabled, and no takeover is possible, fails immediately naming the parked registration and never spawns a restart", async () => {
       vi.mocked(hostManagesHostLoginItem).mockResolvedValue(true);
       const controller = newController("production");
       writeInstallRecord("production", {
@@ -3390,6 +3399,14 @@ describe("platform matrix", () => {
       // `null` and there is nothing to restart onto.
       vi.mocked(registerHostLoginItem).mockResolvedValue("parked");
       vi.mocked(readHostLoginItemStatus).mockReturnValue("not-found");
+      // The legacy label holds a BTM record, so a raw LaunchAgent may not be
+      // installed beside it - `readParkedRegistrationTakeover` reports
+      // `no-takeover` (reason `legacy-registered`) even though the primary
+      // status alone looks takeover-eligible.
+      vi.mocked(readParkedRegistrationTakeover).mockResolvedValue({
+        kind: "no-takeover",
+        reason: "legacy-registered",
+      });
       vi.mocked(streamBundledTraycerCliJson).mockResolvedValue({ data: {} });
 
       const outcome = await controller.installVersion("1.8.0", false);
@@ -3398,13 +3415,217 @@ describe("platform matrix", () => {
       if (outcome.kind === "failed") {
         expect(outcome.message).toContain("no host is running to restart");
       }
+      expect(readParkedRegistrationTakeover).toHaveBeenCalled();
       const restartCallIndex = vi
         .mocked(streamBundledTraycerCliJson)
         .mock.calls.findIndex(
           ([opts]) => Array.isArray(opts.args) && opts.args[1] === "restart",
         );
       expect(restartCallIndex).toBe(-1);
+      const serviceInstallCallIndex = vi
+        .mocked(streamBundledTraycerCliJson)
+        .mock.calls.findIndex(
+          ([opts]) =>
+            Array.isArray(opts.args) &&
+            opts.args[0] === "host" &&
+            opts.args[1] === "service" &&
+            opts.args[2] === "install",
+        );
+      expect(serviceInstallCallIndex).toBe(-1);
       expect(waitForHostReady).not.toHaveBeenCalled();
+    });
+
+    // Contrasts with the immediately-preceding test: when the legacy label
+    // ALSO carries no registration, `readParkedRegistrationTakeover` reports
+    // `takeover` and the down-host park is finished through the CLI-owned
+    // LaunchAgent instead of failing outright (2026-09-06 field RCA: this is
+    // the exact state `host uninstall` followed by a reinstall leaves an
+    // ad-hoc-signed build in).
+    it("with no running host and no registration SMAppService can ever manage, finishes the park through the CLI-owned LaunchAgent takeover", async () => {
+      vi.mocked(hostManagesHostLoginItem).mockResolvedValue(true);
+      const controller = newController("production");
+      writeInstallRecord("production", {
+        version: "1.7.0",
+        runtimeVersion: "1.7.0",
+      });
+      // No `writePidMetadata` call: no running host, so `prePid` resolves
+      // `null`.
+      vi.mocked(registerHostLoginItem).mockResolvedValue("parked");
+      vi.mocked(readHostLoginItemStatus).mockReturnValue("not-found");
+      vi.mocked(readParkedRegistrationTakeover).mockResolvedValue({
+        kind: "takeover",
+        status: "not-found",
+      });
+      // The recovered host must publish the runtime the committed install
+      // expects - the beforeEach default (1.0.0) would rightly be rejected.
+      vi.mocked(waitForHostReady).mockResolvedValue({
+        ready: true,
+        version: "1.7.0",
+        pid: 1,
+        startedAt: "2026-01-01T00:00:00.000Z",
+        reason: "ready",
+      });
+
+      const outcome = await controller.installVersion("1.8.0", false);
+
+      expect(outcome.kind).toBe("ok");
+      const takeoverCalls = vi
+        .mocked(streamBundledTraycerCliJson)
+        .mock.calls.filter(
+          ([opts]) =>
+            Array.isArray(opts.args) && opts.args.includes("--takeover"),
+        );
+      expect(takeoverCalls).toHaveLength(1);
+      expect(takeoverCalls[0][0].args).toEqual([
+        "host",
+        "service",
+        "install",
+        "--takeover",
+      ]);
+      const restartCallIndex = vi
+        .mocked(streamBundledTraycerCliJson)
+        .mock.calls.findIndex(
+          ([opts]) => Array.isArray(opts.args) && opts.args[1] === "restart",
+        );
+      expect(restartCallIndex).toBe(-1);
+
+      // Call-order proof, mirroring the sibling test above: `waitForHostReady`
+      // must run strictly AFTER the takeover spawn, never before it.
+      const takeoverCallIndex = vi
+        .mocked(streamBundledTraycerCliJson)
+        .mock.calls.findIndex(
+          ([opts]) =>
+            Array.isArray(opts.args) && opts.args.includes("--takeover"),
+        );
+      const takeoverOrder = vi.mocked(streamBundledTraycerCliJson).mock
+        .invocationCallOrder[takeoverCallIndex];
+      const readyOrder =
+        vi.mocked(waitForHostReady).mock.invocationCallOrder[0];
+      expect(readyOrder).toBeGreaterThan(takeoverOrder);
+    });
+
+    // The takeover fallback is down-host-only: with a host RUNNING under the
+    // CLI label, the cooperative `host restart` is the right route even when
+    // no registration SMAppService can ever manage - restarting makes the
+    // shutdown claim a busy host can deny, whereas the takeover's install
+    // boots the label out with no claim at all.
+    it("with a RUNNING host, never takes over even when no registration SMAppService can manage - restarts through the CLI instead", async () => {
+      vi.mocked(hostManagesHostLoginItem).mockResolvedValue(true);
+      const controller = newController("production");
+      writeInstallRecord("production", {
+        version: "1.7.0",
+        runtimeVersion: "1.7.0",
+      });
+      writePidMetadata("production", { version: "1.7.0", pid: process.pid });
+      vi.mocked(registerHostLoginItem).mockResolvedValue("parked");
+      vi.mocked(readHostLoginItemStatus).mockReturnValue("not-found");
+      vi.mocked(readParkedRegistrationTakeover).mockResolvedValue({
+        kind: "takeover",
+        status: "not-found",
+      });
+      vi.mocked(streamBundledTraycerCliJson).mockResolvedValue({ data: {} });
+      vi.mocked(waitForHostReady).mockResolvedValue({
+        ready: true,
+        version: "1.7.0",
+        pid: process.pid,
+        startedAt: "2026-01-01T00:00:00.000Z",
+        reason: "ready",
+      });
+
+      const outcome = await controller.installVersion("1.8.0", false);
+
+      expect(outcome.kind).toBe("ok");
+      const restartCallIndex = vi
+        .mocked(streamBundledTraycerCliJson)
+        .mock.calls.findIndex(
+          ([opts]) =>
+            Array.isArray(opts.args) &&
+            opts.args[0] === "host" &&
+            opts.args[1] === "restart",
+        );
+      expect(restartCallIndex).toBeGreaterThanOrEqual(0);
+      expect(
+        vi.mocked(streamBundledTraycerCliJson).mock.calls[restartCallIndex][0]
+          .args,
+      ).toEqual(["host", "restart", "--if-idle", "--defer-if-parked"]);
+      const takeoverCallIndex = vi
+        .mocked(streamBundledTraycerCliJson)
+        .mock.calls.findIndex(
+          ([opts]) =>
+            Array.isArray(opts.args) && opts.args.includes("--takeover"),
+        );
+      expect(takeoverCallIndex).toBe(-1);
+    });
+
+    // The takeover call itself can fail (e.g. the fallback CLI install
+    // throws) - that must surface as the takeover's own failure, never as
+    // the generic "no host is running to restart" message the down-host
+    // no-takeover case reports.
+    it("with no running host and a takeover verdict, a failing CLI takeover surfaces its own failure rather than the generic no-restart message", async () => {
+      vi.mocked(hostManagesHostLoginItem).mockResolvedValue(true);
+      const controller = newController("production");
+      writeInstallRecord("production", {
+        version: "1.7.0",
+        runtimeVersion: "1.7.0",
+      });
+      // No `writePidMetadata` call: no running host.
+      vi.mocked(registerHostLoginItem).mockResolvedValue("parked");
+      vi.mocked(readHostLoginItemStatus).mockReturnValue("not-found");
+      vi.mocked(readParkedRegistrationTakeover).mockResolvedValue({
+        kind: "takeover",
+        status: "not-found",
+      });
+      vi.mocked(streamBundledTraycerCliJson).mockRejectedValue(
+        new Error("takeover exploded"),
+      );
+
+      const outcome = await controller.installVersion("1.8.0", false);
+
+      expect(outcome.kind).not.toBe("ok");
+      if (outcome.kind === "failed" || outcome.kind === "deferred") {
+        expect(outcome.message).not.toContain("no host is running to restart");
+      }
+    });
+
+    // `takeOverParkedRegistrationIfDown` deliberately does not thread
+    // `force`: `host service install` has no force flag and the takeover is
+    // cooperative by construction, so a `busy` refusal from the CLI (a host
+    // appeared between the verdict and the CLI's own probe) must not be
+    // reported as `busy` - that outcome advertises a Force affordance, and
+    // Force would just re-run the same forceless command against the same
+    // host. It is remapped to `deferred` instead, with no continuation.
+    it("with no running host and a takeover verdict, an E_HOST_BUSY from the CLI takeover is reported deferred, never busy", async () => {
+      vi.mocked(hostManagesHostLoginItem).mockResolvedValue(true);
+      const controller = newController("production");
+      writeInstallRecord("production", {
+        version: "1.7.0",
+        runtimeVersion: "1.7.0",
+      });
+      // No `writePidMetadata` call: no running host.
+      vi.mocked(registerHostLoginItem).mockResolvedValue("parked");
+      vi.mocked(readHostLoginItemStatus).mockReturnValue("not-found");
+      vi.mocked(readParkedRegistrationTakeover).mockResolvedValue({
+        kind: "takeover",
+        status: "not-found",
+      });
+      // Only the TAKEOVER spawn (`--takeover`) must reject with the busy
+      // error - the preceding bytes-only `host install` call (packaged-macOS
+      // installVersion's first streamed command) must still succeed, or the
+      // takeover/park cycle is never reached at all.
+      vi.mocked(streamBundledTraycerCliJson).mockImplementation(
+        async (options) =>
+          options.args.includes("--takeover")
+            ? Promise.reject(new TraycerCliError("E_HOST_BUSY", "host busy"))
+            : { data: {} },
+      );
+
+      const outcome = await controller.installVersion("1.8.0", false);
+
+      expect(outcome.kind).toBe("deferred");
+      expect(outcome.kind).not.toBe("busy");
+      if (outcome.kind === "deferred") {
+        expect(outcome.message).toContain("work in progress");
+      }
     });
 
     // An enabled login item is not "down" in the way the failure branch
@@ -3666,6 +3887,52 @@ describe("platform matrix", () => {
         expect(outcome.message).toContain("status=not-found");
       }
       expect(streamBundledTraycerCliJson).not.toHaveBeenCalled();
+    });
+
+    // Contrasts with the test immediately above: with NO running host and a
+    // takeover verdict, `registerService`'s promise ("registered") can still
+    // be kept - the CLI-owned LaunchAgent becomes the only registration this
+    // machine can have, which is exactly what installing it accomplishes.
+    it("registerService: a park over a NOT-FOUND login item with NO running host and a takeover verdict succeeds via the CLI takeover", async () => {
+      vi.mocked(hostManagesHostLoginItem).mockResolvedValue(true);
+      const controller = newController("production");
+      writeInstallRecord("production", {
+        version: "1.7.0",
+        runtimeVersion: "1.7.0",
+      });
+      // No `writePidMetadata` call: no running host.
+      vi.mocked(registerHostLoginItem).mockResolvedValue("parked");
+      vi.mocked(readHostLoginItemStatus).mockReturnValue("not-found");
+      vi.mocked(readParkedRegistrationTakeover).mockResolvedValue({
+        kind: "takeover",
+        status: "not-found",
+      });
+      // The recovered host must publish the runtime the committed install
+      // expects - the beforeEach default (1.0.0) would rightly be rejected.
+      vi.mocked(waitForHostReady).mockResolvedValue({
+        ready: true,
+        version: "1.7.0",
+        pid: 1,
+        startedAt: "2026-01-01T00:00:00.000Z",
+        reason: "ready",
+      });
+
+      const outcome = await controller.registerService({ kind: "background" });
+
+      expect(outcome).toEqual({ kind: "ok", value: { registered: true } });
+      const takeoverCalls = vi
+        .mocked(streamBundledTraycerCliJson)
+        .mock.calls.filter(
+          ([opts]) =>
+            Array.isArray(opts.args) && opts.args.includes("--takeover"),
+        );
+      expect(takeoverCalls).toHaveLength(1);
+      expect(takeoverCalls[0][0].args).toEqual([
+        "host",
+        "service",
+        "install",
+        "--takeover",
+      ]);
     });
   });
 
@@ -7564,6 +7831,45 @@ describe("F3: routeForceRestartContinuation via respawn", () => {
       // spawned argv no longer contained `--attempt-adoption` at all
       // (`flagIndex` was `-1`). Reverted before committing anything;
       // `host-controller.ts` was never touched.
+    });
+
+    // Sibling of the test above, for the OTHER `needs-takeover` producer:
+    // `registerActuator`'s `parked` arm (not `register-failed`). With no
+    // running host and `readParkedRegistrationTakeover` reporting `takeover`,
+    // the continuation finishes the park through the same minted-adoption CLI
+    // takeover rather than reporting the generic "could not be re-registered
+    // right now" deferral.
+    it("a parked registration with no running host and a takeover verdict shells --takeover with --attempt-adoption <nonce>", async () => {
+      eligibleDesktopCohort();
+      stageCliWithVerification({ outcome: "complete" });
+      const controller = stagePackagedMacRestartWorldHostDown();
+      writeOwnedSmAppServiceSubstrate();
+      await seedParkedActivationAttempt("2.0.0");
+      // Drives `runMacActivationStepWithCapability` to `phase: "parked"`
+      // with `prePid === null` (no running host, per
+      // `stagePackagedMacRestartWorldHostDown`).
+      vi.mocked(registerHostLoginItem).mockResolvedValueOnce("parked");
+      vi.mocked(readHostLoginItemStatus).mockReturnValue("not-found");
+      vi.mocked(readParkedRegistrationTakeover).mockResolvedValue({
+        kind: "takeover",
+        status: "not-found",
+      });
+
+      const outcome = await controller.respawn({ kind: "background" });
+
+      expect(outcome).toEqual({ kind: "ok", value: { activated: true } });
+      const argv = takeoverCallArgv();
+      expect(argv).toBeDefined();
+      // Match the first four: adoption args may be appended after them.
+      expect(argv?.slice(0, 4)).toEqual([
+        "host",
+        "service",
+        "install",
+        "--takeover",
+      ]);
+      const flagIndex = argv?.indexOf("--attempt-adoption") ?? -1;
+      expect(flagIndex).toBeGreaterThanOrEqual(0);
+      expect(argv?.[flagIndex + 1]).toMatch(UUID_PATTERN);
     });
 
     // Ruling (round 5, F3): terminal-with-diagnostics is correct for a

--- a/clients/desktop/src/electron-main/host/host-controller.ts
+++ b/clients/desktop/src/electron-main/host/host-controller.ts
@@ -9,7 +9,9 @@ import {
   hasUnappliedPendingLoginItemRevision,
   hostManagesHostLoginItem,
   readHostLoginItemStatus,
+  readParkedRegistrationTakeover,
   type HostLoginItemStatus,
+  type ParkedRegistrationTakeover,
   type RegisterHostLoginItemResult,
 } from "../app/host-login-item";
 import { resolveBundledCliPath } from "../cli/cli-discovery";
@@ -719,6 +721,9 @@ type LockedMacActivationStep =
    * restart itself through the CLI (`host restart`, cooperative claim →
    * commit → kickstart); the supervisor it relaunches re-resolves the install
    * record on spawn, which is the activation this cycle set out to perform.
+   * With NO host running and a park SMAppService can never resolve, the
+   * CLI-owned LaunchAgent takes the registration over instead
+   * (`takeOverParkedRegistrationIfDown`).
    */
   | {
       readonly phase: "parked";
@@ -1522,8 +1527,11 @@ export class HostController {
   // definitively failed to register the LaunchAgent (as opposed to
   // `requires-approval`, which means it IS registered and only needs the
   // user's own toggle) - the CLI's raw-LaunchAgent takeover can recover from
-  // exactly these. Single source of truth for the three call sites below so
-  // a future `HostLoginItemStatus` member can't drift between them.
+  // exactly these. Single source of truth for every post-cycle call site
+  // below, so a future `HostLoginItemStatus` member can't drift between them.
+  // The PARKED path uses the narrower `readParkedRegistrationTakeover`
+  // instead (no bootout happened, so `not-registered` is not admitted); a new
+  // member has to be placed in both, and that predicate's doc says how.
   private isCliTakeoverRecoverableStatus(
     status: RegisterHostLoginItemResult,
   ): status is "not-registered" | "not-found" | "not-supported" {
@@ -1536,7 +1544,11 @@ export class HostController {
 
   // Last-rung recovery for a macOS register cycle whose SMAppService calls
   // failed (`not-found` / `not-registered` / `not-supported`) AFTER the
-  // cycle's own bootout already tore down the loaded agent. Field RCA
+  // cycle's own bootout already tore down the loaded agent - and, since the
+  // 2026-09-06 incident, for a cycle that PARKED on a status SMAppService can
+  // never resolve while no host runs (`takeOverParkedRegistrationIfDown`;
+  // there nothing was booted out, and the CLI stops a still-loaded agent
+  // cooperatively before retiring it). Field RCA
   // (2026-07-28): SMAppService can answer `not-found` for a byte-correct
   // in-bundle plist for the remainder of the app process's life (the BTM
   // record's identity keyed to a previous build), so re-running the same
@@ -1988,8 +2000,12 @@ export class HostController {
    * started through the same CLI cycle (its relaunch half kickstarts the
    * registered agent, which needs no live pid); `requires-approval` fails
    * with the System Settings guidance, since nothing but the user can
-   * re-enable it; anything else fails immediately naming the parked
-   * registration, not with a two-minute timeout that names the wrong cause.
+   * re-enable it; a park SMAppService can never resolve (`not-found` /
+   * `not-supported` with nothing registered under the legacy label either)
+   * is finished by the CLI-owned LaunchAgent, exactly as a register cycle
+   * that FAILED with that status is; anything else fails immediately naming
+   * the parked registration, not with a two-minute timeout that names the
+   * wrong cause.
    */
   private async activateAroundParkedRegistration(
     step: Extract<LockedMacActivationStep, { phase: "parked" }>,
@@ -2011,6 +2027,11 @@ export class HostController {
         return this.failedAfterServiceCycle(approvalRequiredMessage());
       }
       if (loginItemStatus !== "enabled") {
+        const takeover = await this.takeOverParkedRegistrationIfDown(
+          step.prePid,
+          step.expectedRuntimeVersion,
+        );
+        if (takeover !== null) return takeover;
         log.warn(
           "[host-controller] login-item registration parked with no running host to restart",
           { loginItemStatus },
@@ -2055,6 +2076,151 @@ export class HostController {
         : ["host", "restart", "--if-idle", "--defer-if-parked"],
       step.prePid,
     );
+  }
+
+  /**
+   * The parked-cycle takeover verdict shared by every consumer of `parked`:
+   * `null` unless NO host is running and `readParkedRegistrationTakeover`
+   * says the CLI-owned LaunchAgent may finish the registration.
+   *
+   * `prePid === null` alone is not "no host": it is a structural read of
+   * `pid.json`, absent for a host in its first seconds after a `KeepAlive`
+   * respawn or one whose metadata tore. The verdict's own launchd probe
+   * supplies the positive half (no live process under either label), and it
+   * is read HERE, at the decision, not from the snapshot captured before the
+   * register cycle queued.
+   */
+  private async parkedTakeoverVerdict(
+    prePid: number | null,
+  ): Promise<Extract<ParkedRegistrationTakeover, { kind: "takeover" }> | null> {
+    if (prePid !== null) return null;
+    const verdict = await readParkedRegistrationTakeover();
+    if (verdict.kind !== "takeover") {
+      log.info(
+        "[host-controller] parked login-item registration is not one the CLI-owned LaunchAgent may finish",
+        { reason: verdict.reason },
+      );
+      return null;
+    }
+    return verdict;
+  }
+
+  /**
+   * The takeover arm of a parked register cycle, shared by every consumer of
+   * `parked` that finds NO host running: `null` when the park is not one the
+   * CLI-owned LaunchAgent may finish, otherwise the takeover's outcome.
+   *
+   * A park attempted nothing, so the machine is exactly as the caller found
+   * it: bytes committed, no host, and - when `parkedTakeoverVerdict` admits it
+   * - no registration SMAppService can ever manage from this process and no
+   * live process under either label. Nothing on the machine will start this
+   * host. This is the state `host uninstall` followed by a reinstall leaves
+   * an ad-hoc-signed build in (2026-09-06: every boot retry parked here,
+   * failed "no host is running to restart", and waited fifty minutes for a
+   * person to run `host service install`). The recovery is the one a
+   * register cycle that FAILED with this status already uses: `host service
+   * install --takeover`, which with nothing loaded is a plain install of the
+   * CLI-owned LaunchAgent. Unlike that path, nothing was booted out first,
+   * so a still-loaded (idle) desktop agent is stopped cooperatively and
+   * retired by the CLI - a larger action than a plain install, and the right
+   * one for an agent SMAppService can no longer see.
+   *
+   * Down-host only, by design. With a host RUNNING under the CLI label the
+   * callers' cooperative `host restart` is the right route: it makes the
+   * shutdown claim and a busy host refuses it, whereas the takeover's install
+   * boots that label out with no claim at all. A running host with NO
+   * registration anywhere (a hand-run `host start`) is not this method's
+   * case either: the restart fails to relaunch, the next boot retry finds the
+   * host down, and lands here.
+   *
+   * `force` is deliberately not threaded in: `host service install` has no
+   * force and the takeover is cooperative by construction. So a `busy`
+   * refusal (a host appeared between the verdict and the CLI's own probe) is
+   * reported `deferred`, not `busy`: the busy outcome advertises a Force
+   * affordance, and Force would re-run this same forceless command against
+   * the same host - a loop with a live button on it. The next boot retry
+   * re-derives the verdict from live evidence instead.
+   */
+  private async takeOverParkedRegistrationIfDown(
+    prePid: number | null,
+    expectedRuntimeVersion: string | null,
+  ): Promise<MutationOutcome<{ readonly activated: boolean }> | null> {
+    const takeover = await this.parkedTakeoverVerdict(prePid);
+    if (takeover === null) return null;
+    log.warn(
+      "[host-controller] login-item registration parked with no running host and no registration SMAppService can manage - finishing it through the CLI-owned LaunchAgent",
+      { loginItemStatus: takeover.status },
+    );
+    const recovery = await this.recoverRegistrationViaCliTakeover({
+      adoptionArgs: [],
+      failedStatus: takeover.status,
+      prePid: null,
+      expectedRuntimeVersion,
+    });
+    if (recovery.recovered) {
+      return { kind: "ok", value: { activated: true } };
+    }
+    return recovery.outcome.kind === "busy"
+      ? { kind: "deferred", message: recovery.outcome.message }
+      : recovery.outcome;
+  }
+
+  /**
+   * The F3 continuation's takeover, as a thunk the executor runs OUTSIDE its
+   * actuator span (the takeover child takes the cli-lock itself, so running
+   * it inline would block the parent on its own child). One body for the two
+   * states that need it - a register cycle that failed with a recoverable
+   * status, and a park with no host that SMAppService can never resolve - so
+   * the adoption minting and its failure reporting cannot drift between them.
+   */
+  private mintedTakeoverContinuation(
+    capability: UpdateMutationCapability,
+    args: {
+      readonly failedStatus: HostLoginItemStatus;
+      readonly prePid: number | null;
+      readonly expectedRuntimeVersion: string | null;
+    },
+  ): () => Promise<DesktopActivationCycleOutcome> {
+    return async (): Promise<DesktopActivationCycleOutcome> => {
+      const recovery = await withMintedAdoption(
+        capability,
+        this.layout,
+        (adoptionArgs) =>
+          this.recoverRegistrationViaCliTakeover({
+            failedStatus: args.failedStatus,
+            prePid: args.prePid,
+            expectedRuntimeVersion: args.expectedRuntimeVersion,
+            adoptionArgs,
+          }),
+      ).catch((err: unknown) => {
+        const cause = err instanceof Error ? err.message : String(err);
+        log.warn("[host-controller] takeover adoption could not be minted", {
+          cause,
+        });
+        return { mintFailure: cause };
+      });
+      if ("mintFailure" in recovery) {
+        // Carry the REAL cause. This used to return the generic lock-busy
+        // message, which `terminalize` then wrote to disk as the failure's
+        // `cause` - so a local proof-write I/O error was permanently recorded
+        // as lock contention, which is not merely vague but actively wrong
+        // for whoever reads that diagnostic later.
+        //
+        // Same invariant as the takeover-diagnostics ruling earlier in this
+        // ticket: classification may normalize the failure CATEGORY, but it
+        // must never replace caller-only discriminating evidence.
+        return {
+          kind: "failed",
+          message: `adoption proof could not be minted: ${recovery.mintFailure}`,
+        };
+      }
+      return recovery.recovered
+        ? { kind: "activated" }
+        : {
+            kind: "deferred",
+            message: describeTakeoverRefusal(recovery.outcome),
+          };
+    };
   }
 
   private async runLockedMacActivationCycleOnce(
@@ -3721,15 +3887,28 @@ export class HostController {
           if (registration.status === "parked") {
             // A park attempted NOTHING, so the login item is exactly what it
             // was before this call. This method's promise is "registered",
-            // and only an item that already reads `enabled` can keep it - a
-            // `requires-approval` or unreadable item is the user's (or
-            // `traycer host doctor`'s) to fix, and restarting the running
-            // host would cost it its connections without registering a
-            // thing. The status is read HERE, not taken from the snapshot the
-            // guard refused on: the guard also parks on the LEGACY label and
-            // the manifest, so the primary item can be enabled under a park.
+            // and two states can keep it: an item that already reads
+            // `enabled`, and - with nothing running - an item SMAppService can
+            // never manage, where the CLI-owned LaunchAgent is the only
+            // registration this machine can have and installing it is what a
+            // person would do next. A `requires-approval` or unreadable item
+            // is the user's (or `traycer host doctor`'s) to fix, and
+            // restarting the running host would cost it its connections
+            // without registering a thing. The status is read HERE, not taken
+            // from the snapshot the guard refused on: the guard also parks on
+            // the LEGACY label and the manifest, so the primary item can be
+            // enabled under a park.
             const loginItemStatus = readHostLoginItemStatus();
             if (loginItemStatus !== "enabled") {
+              const takeover = await this.takeOverParkedRegistrationIfDown(
+                registration.prePid,
+                registration.expectedRuntimeVersion,
+              );
+              if (takeover !== null) {
+                return takeover.kind === "ok"
+                  ? { kind: "ok", value: { registered: true } }
+                  : takeover;
+              }
               return {
                 kind: "failed",
                 message:
@@ -4100,9 +4279,31 @@ export class HostController {
           if (step.phase === "registered") return { kind: "activated" };
           if (step.phase === "parked") {
             // The executor segment holds the actuator lock and the parked
-            // fallback spawns the CLI, so it cannot run inline. Report it as
-            // deferred: the record stays where it is and the next
-            // continuation (or an explicit Restart) performs the activation.
+            // fallback spawns the CLI, so it cannot run inline. A park with NO
+            // host running that SMAppService can never resolve is finished
+            // outside the lock by the same takeover a failed register uses
+            // (the down-host rule of `takeOverParkedRegistrationIfDown`);
+            // every other park is reported deferred: the record stays where
+            // it is and the next continuation (or an explicit Restart)
+            // performs the activation.
+            const takeover = await this.parkedTakeoverVerdict(step.prePid);
+            if (takeover !== null) {
+              log.warn(
+                "[host-controller] login-item registration parked with no running host and no registration SMAppService can manage - finishing the continuation through the CLI-owned LaunchAgent",
+                { loginItemStatus: takeover.status },
+              );
+              return {
+                kind: "needs-takeover",
+                recoverOutsideLock: this.mintedTakeoverContinuation(
+                  capability,
+                  {
+                    failedStatus: takeover.status,
+                    prePid: null,
+                    expectedRuntimeVersion: step.expectedRuntimeVersion,
+                  },
+                ),
+              };
+            }
             return {
               kind: "deferred",
               message:
@@ -4117,51 +4318,14 @@ export class HostController {
             if (this.isCliTakeoverRecoverableStatus(step.status)) {
               return {
                 kind: "needs-takeover",
-                recoverOutsideLock:
-                  async (): Promise<DesktopActivationCycleOutcome> => {
-                    const recovery = await withMintedAdoption(
-                      capability,
-                      this.layout,
-                      (adoptionArgs) =>
-                        this.recoverRegistrationViaCliTakeover({
-                          failedStatus: step.status,
-                          prePid: step.prePid,
-                          expectedRuntimeVersion: step.expectedRuntimeVersion,
-                          adoptionArgs,
-                        }),
-                    ).catch((err: unknown) => {
-                      const cause =
-                        err instanceof Error ? err.message : String(err);
-                      log.warn(
-                        "[host-controller] takeover adoption could not be minted",
-                        { cause },
-                      );
-                      return { mintFailure: cause };
-                    });
-                    if ("mintFailure" in recovery) {
-                      // Carry the REAL cause. This used to return the generic
-                      // lock-busy message, which `terminalize` then wrote to disk
-                      // as the failure's `cause` - so a local proof-write I/O
-                      // error was permanently recorded as lock contention, which
-                      // is not merely vague but actively wrong for whoever reads
-                      // that diagnostic later.
-                      //
-                      // Same invariant as the takeover-diagnostics ruling earlier
-                      // in this ticket: classification may normalize the failure
-                      // CATEGORY, but it must never replace caller-only
-                      // discriminating evidence.
-                      return {
-                        kind: "failed",
-                        message: `adoption proof could not be minted: ${recovery.mintFailure}`,
-                      };
-                    }
-                    return recovery.recovered
-                      ? { kind: "activated" }
-                      : {
-                          kind: "deferred",
-                          message: describeTakeoverRefusal(recovery.outcome),
-                        };
+                recoverOutsideLock: this.mintedTakeoverContinuation(
+                  capability,
+                  {
+                    failedStatus: step.status,
+                    prePid: step.prePid,
+                    expectedRuntimeVersion: step.expectedRuntimeVersion,
                   },
+                ),
               };
             }
             // Carries the login-item status rather than a message. Keep the

--- a/clients/traycer-cli/src/commands/__tests__/service-install.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/service-install.test.ts
@@ -361,4 +361,33 @@ describe("buildServiceInstallCommand", () => {
       takeover: { kind: "cli-host-stopped", cooperativeStop: "stopped" },
     });
   });
+
+  it("--takeover surfaces a cli-host-stopped/no-host outcome (no Desktop agent, and the CLI-label job was loaded with no running host) in both the human line and the JSON payload", async () => {
+    // `standDownLiveCliLabelHost` (macos.ts) resolves this kind when the
+    // CLI label is loaded as `cli-or-other` with `pid === null` - a clean
+    // prior exit or the throttle window before a respawn - so it is
+    // unloaded outright rather than asked to stand down.
+    const takeoverDesktopRegistrationMock = vi.fn().mockResolvedValue({
+      kind: "cli-host-stopped",
+      cooperativeStop: "no-host",
+    });
+    mocks.createServiceControllerMock.mockReturnValue({
+      install: vi.fn().mockResolvedValue(undefined),
+      takeoverDesktopRegistration: takeoverDesktopRegistrationMock,
+      hostStartAdoptionLabel: vi.fn(async (label) => label.id),
+    });
+    mocks.runSignInPreflightMock.mockResolvedValue(signedInPreflight());
+    mocks.maybeProvisionCredentialMock.mockResolvedValue(null);
+
+    const command = buildServiceInstallCommand(baseArgs({ takeover: true }));
+    const result = await command(fakeCtx());
+
+    expect(takeoverDesktopRegistrationMock).toHaveBeenCalledTimes(1);
+    expect(result.human ?? "").toContain(
+      "the job already loaded under this label had no host running and was unloaded before the reload",
+    );
+    expect(result.data).toMatchObject({
+      takeover: { kind: "cli-host-stopped", cooperativeStop: "no-host" },
+    });
+  });
 });

--- a/clients/traycer-cli/src/commands/__tests__/service-install.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/service-install.test.ts
@@ -329,4 +329,36 @@ describe("buildServiceInstallCommand", () => {
       "host credential not provisioned (the host did not adopt it in time)",
     );
   });
+
+  it("--takeover surfaces a cli-host-stopped outcome (no Desktop agent, but a live CLI-label host stood down before the reload) in both the human line and the JSON payload", async () => {
+    // `standDownLiveCliLabelHost` (macos.ts) resolves this kind when
+    // `probeDesktopAgentOwnership` finds no Desktop SMAppService agent but
+    // the CLI label itself was loaded with a live pid - the KeepAlive-
+    // respawn race the guard exists to close. `controller.takeoverDesktopRegistration`
+    // is exercised through `takeoverDesktopRegistrationWithAttempt`
+    // (`../host/update-mutation`), which is real in this suite; only the
+    // controller itself is a mock, same as every other test in this file.
+    const takeoverDesktopRegistrationMock = vi.fn().mockResolvedValue({
+      kind: "cli-host-stopped",
+      cooperativeStop: "stopped",
+    });
+    mocks.createServiceControllerMock.mockReturnValue({
+      install: vi.fn().mockResolvedValue(undefined),
+      takeoverDesktopRegistration: takeoverDesktopRegistrationMock,
+      hostStartAdoptionLabel: vi.fn(async (label) => label.id),
+    });
+    mocks.runSignInPreflightMock.mockResolvedValue(signedInPreflight());
+    mocks.maybeProvisionCredentialMock.mockResolvedValue(null);
+
+    const command = buildServiceInstallCommand(baseArgs({ takeover: true }));
+    const result = await command(fakeCtx());
+
+    expect(takeoverDesktopRegistrationMock).toHaveBeenCalledTimes(1);
+    expect(result.human ?? "").toContain(
+      "the host already running under this label stood down cooperatively before the reload",
+    );
+    expect(result.data).toMatchObject({
+      takeover: { kind: "cli-host-stopped", cooperativeStop: "stopped" },
+    });
+  });
 });

--- a/clients/traycer-cli/src/commands/service-install.ts
+++ b/clients/traycer-cli/src/commands/service-install.ts
@@ -174,7 +174,7 @@ export function buildServiceInstallCommand(
       takeover !== null && takeover.kind === "took-over"
         ? `service '${label.id}' registered (environment=${label.environment}); host management taken over from Traycer Desktop (agent '${takeover.agentLabelId}' deregistered, host ${takeover.cooperativeStop === "stopped" ? "stopped cooperatively" : takeover.cooperativeStop === "no-host" ? "was not running" : "was unreachable and booted out"})`
         : takeover !== null && takeover.kind === "cli-host-stopped"
-          ? `service '${label.id}' registered (environment=${label.environment}); the host already running under this label ${takeover.cooperativeStop === "stopped" ? "stood down cooperatively before the reload" : "was unreachable and booted out"}`
+          ? `service '${label.id}' registered (environment=${label.environment}); ${takeover.cooperativeStop === "no-host" ? "the job already loaded under this label had no host running and was unloaded before the reload" : `the host already running under this label ${takeover.cooperativeStop === "stopped" ? "stood down cooperatively before the reload" : "was unreachable and booted out"}`}`
           : `service '${label.id}' registered (environment=${label.environment})`;
     // Restate the unauthenticated warning on the terminal line - the
     // pre-flight's copy printed before the registration output and may

--- a/clients/traycer-cli/src/commands/service-install.ts
+++ b/clients/traycer-cli/src/commands/service-install.ts
@@ -173,7 +173,9 @@ export function buildServiceInstallCommand(
     let human =
       takeover !== null && takeover.kind === "took-over"
         ? `service '${label.id}' registered (environment=${label.environment}); host management taken over from Traycer Desktop (agent '${takeover.agentLabelId}' deregistered, host ${takeover.cooperativeStop === "stopped" ? "stopped cooperatively" : takeover.cooperativeStop === "no-host" ? "was not running" : "was unreachable and booted out"})`
-        : `service '${label.id}' registered (environment=${label.environment})`;
+        : takeover !== null && takeover.kind === "cli-host-stopped"
+          ? `service '${label.id}' registered (environment=${label.environment}); the host already running under this label ${takeover.cooperativeStop === "stopped" ? "stood down cooperatively before the reload" : "was unreachable and booted out"}`
+          : `service '${label.id}' registered (environment=${label.environment})`;
     // Restate the unauthenticated warning on the terminal line - the
     // pre-flight's copy printed before the registration output and may
     // have scrolled away.

--- a/clients/traycer-cli/src/host/__tests__/pid-metadata-evidence.test.ts
+++ b/clients/traycer-cli/src/host/__tests__/pid-metadata-evidence.test.ts
@@ -1,0 +1,93 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// `readHostPidMetadataEvidence` keeps an absent record apart from one that
+// exists and cannot be read. The takeover's published-host gate refuses on
+// the second and proceeds on the first, so the split is what this file pins;
+// `readHostPidMetadata` must keep folding both into `null` for every
+// discovery caller. The record path is redirected to a scratch directory so
+// the real `~/.traycer` is never read.
+const PATHS = vi.hoisted(() => ({ recordPath: "" }));
+vi.mock("../../store/paths", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../store/paths")>();
+  return {
+    ...actual,
+    hostPidMetadataPath: () => PATHS.recordPath,
+  };
+});
+
+import {
+  readHostPidMetadata,
+  readHostPidMetadataEvidence,
+} from "../pid-metadata";
+
+const VALID_RECORD = {
+  pid: 4242,
+  hostId: "host-1",
+  version: "1.2.3",
+  websocketUrl: "ws://127.0.0.1:7100/rpc",
+  startedAt: "2026-09-06T00:00:00.000Z",
+};
+
+describe("readHostPidMetadataEvidence", () => {
+  let dir = "";
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "traycer-pid-metadata-"));
+    PATHS.recordPath = join(dir, "pid.json");
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("reads a missing record as absent, and readHostPidMetadata as null", async () => {
+    await expect(readHostPidMetadataEvidence("staging")).resolves.toEqual({
+      kind: "absent",
+    });
+    await expect(readHostPidMetadata("staging")).resolves.toBeNull();
+  });
+
+  it("reads a torn or non-JSON record as unreadable, not absent", async () => {
+    await writeFile(PATHS.recordPath, '{"pid": 42', "utf8");
+    await expect(readHostPidMetadataEvidence("staging")).resolves.toEqual({
+      kind: "unreadable",
+      cause: "not valid JSON",
+    });
+    // Discovery callers keep the fold: unreadable is still `null` for them.
+    await expect(readHostPidMetadata("staging")).resolves.toBeNull();
+  });
+
+  it("reads a JSON scalar and a record missing required fields as unreadable with distinct causes", async () => {
+    await writeFile(PATHS.recordPath, "42", "utf8");
+    await expect(readHostPidMetadataEvidence("staging")).resolves.toEqual({
+      kind: "unreadable",
+      cause: "not a JSON object",
+    });
+    await writeFile(
+      PATHS.recordPath,
+      JSON.stringify({ pid: 4242, hostId: "host-1" }),
+      "utf8",
+    );
+    await expect(readHostPidMetadataEvidence("staging")).resolves.toEqual({
+      kind: "unreadable",
+      cause: "malformed record (required fields missing)",
+    });
+  });
+
+  it("reads a valid record as read, with the same projection readHostPidMetadata returns", async () => {
+    await writeFile(PATHS.recordPath, JSON.stringify(VALID_RECORD), "utf8");
+    const evidence = await readHostPidMetadataEvidence("staging");
+    expect(evidence.kind).toBe("read");
+    if (evidence.kind !== "read") throw new Error("expected a read record");
+    expect(evidence.metadata).toMatchObject({
+      ...VALID_RECORD,
+      processStartIdentity: null,
+      layer0: null,
+      layer0Slot: null,
+    });
+    await expect(readHostPidMetadata("staging")).resolves.toEqual(
+      evidence.metadata,
+    );
+  });
+});

--- a/clients/traycer-cli/src/host/pid-metadata.ts
+++ b/clients/traycer-cli/src/host/pid-metadata.ts
@@ -73,23 +73,41 @@ export type HostLayer0Record =
     }
   | { readonly status: "unrecognized"; readonly raw: string };
 
+/**
+ * The pid.json read with absence kept apart from failure. `readHostPidMetadata`
+ * folds both into `null`, which is right for discovery ("no host to talk to
+ * either way") and wrong for a gate that must fail closed: a torn or
+ * momentarily unreadable record is not evidence that no host is running.
+ */
+export type HostPidMetadataEvidence =
+  | { readonly kind: "absent" }
+  | { readonly kind: "unreadable"; readonly cause: string }
+  | { readonly kind: "read"; readonly metadata: HostPidMetadata };
+
 export async function readHostPidMetadata(
   environment: Environment | undefined,
 ): Promise<HostPidMetadata | null> {
+  const evidence = await readHostPidMetadataEvidence(environment);
+  return evidence.kind === "read" ? evidence.metadata : null;
+}
+
+export async function readHostPidMetadataEvidence(
+  environment: Environment | undefined,
+): Promise<HostPidMetadataEvidence> {
   const logEnvironment = environment ?? config.environment;
   const logger = createCliLogger(logEnvironment);
   let raw: string;
   try {
     raw = await readFile(hostPidMetadataPath(environment), "utf8");
   } catch (err) {
-    if (readErrorCode(err) !== "ENOENT") {
-      logger.debug("Host pid metadata read failed", {
-        environment: logEnvironment,
-        errorName: errorFromUnknown(err).name,
-        errorCode: readErrorCode(err),
-      });
-    }
-    return null;
+    const code = readErrorCode(err);
+    if (code === "ENOENT") return { kind: "absent" };
+    logger.debug("Host pid metadata read failed", {
+      environment: logEnvironment,
+      errorName: errorFromUnknown(err).name,
+      errorCode: code,
+    });
+    return { kind: "unreadable", cause: `read failed (${code ?? "unknown"})` };
   }
   let parsed: unknown;
   try {
@@ -100,13 +118,13 @@ export async function readHostPidMetadata(
       errorName: errorFromUnknown(err).name,
       errorMessage: errorFromUnknown(err).message,
     });
-    return null;
+    return { kind: "unreadable", cause: "not valid JSON" };
   }
   if (parsed === null || typeof parsed !== "object") {
     logger.warn("Host pid metadata rejected non-object payload", {
       environment: logEnvironment,
     });
-    return null;
+    return { kind: "unreadable", cause: "not a JSON object" };
   }
   const obj = parsed as Record<string, unknown>;
   if (
@@ -124,7 +142,10 @@ export async function readHostPidMetadata(
       hasWebsocketUrl: typeof obj.websocketUrl === "string",
       hasStartedAt: typeof obj.startedAt === "string",
     });
-    return null;
+    return {
+      kind: "unreadable",
+      cause: "malformed record (required fields missing)",
+    };
   }
   logger.debug("Host pid metadata read completed", {
     environment: logEnvironment,
@@ -133,18 +154,21 @@ export async function readHostPidMetadata(
     version: obj.version,
   });
   return {
-    pid: obj.pid,
-    hostId: obj.hostId,
-    version: obj.version,
-    websocketUrl: obj.websocketUrl,
-    startedAt: obj.startedAt,
-    processStartIdentity: isProcessStartIdentity(obj.processStartIdentity)
-      ? obj.processStartIdentity
-      : null,
-    layer0: decodeLayer0Record(obj.layer0),
-    // Same decoder, same fail-open-on-shape contract. An old record simply
-    // has no such key and decodes to `null`.
-    layer0Slot: decodeLayer0Record(obj.layer0Slot),
+    kind: "read",
+    metadata: {
+      pid: obj.pid,
+      hostId: obj.hostId,
+      version: obj.version,
+      websocketUrl: obj.websocketUrl,
+      startedAt: obj.startedAt,
+      processStartIdentity: isProcessStartIdentity(obj.processStartIdentity)
+        ? obj.processStartIdentity
+        : null,
+      layer0: decodeLayer0Record(obj.layer0),
+      // Same decoder, same fail-open-on-shape contract. An old record simply
+      // has no such key and decodes to `null`.
+      layer0Slot: decodeLayer0Record(obj.layer0Slot),
+    },
   };
 }
 

--- a/clients/traycer-cli/src/service/index.ts
+++ b/clients/traycer-cli/src/service/index.ts
@@ -130,10 +130,14 @@ export type DesktopRegistrationTakeover =
       readonly kind: "took-over";
       readonly agentLabelId: string;
       // How the running host was handled: "stopped" through its own
-      // lifecycle RPCs, "no-host" when nothing was running,
-      // "skipped-unreachable" when the host could not be asked (it is the
-      // broken part - the takeover IS the recovery) and the job was booted
-      // out underneath it.
+      // lifecycle RPCs; "no-host" when nothing was running to ask (the
+      // claim answered `no-host` or `no-metadata` with the agent idle - no
+      // process under the label, so there was nothing to interrupt whatever
+      // the metadata said - or the process seen under the CLI label at the
+      // probe had exited before its stand-down could ask it); "skipped-unreachable" when the host could not be asked
+      // (it is the broken part - the takeover IS the recovery) and the job
+      // was booted out underneath it. A running agent process that could
+      // not be asked is refused, never proceeded past.
       readonly cooperativeStop: "stopped" | "no-host" | "skipped-unreachable";
     }
   // No Desktop agent to retire, but the CLI label itself was loaded - a job

--- a/clients/traycer-cli/src/service/index.ts
+++ b/clients/traycer-cli/src/service/index.ts
@@ -136,6 +136,18 @@ export type DesktopRegistrationTakeover =
       // out underneath it.
       readonly cooperativeStop: "stopped" | "no-host" | "skipped-unreachable";
     }
+  // No Desktop agent to retire, but the CLI label itself was loaded with a
+  // live process - a host this install's own reload would otherwise bootout
+  // with no cooperative claim (a KeepAlive respawn that started after the
+  // caller's probe). It was asked to stand down first, on the same terms as
+  // a Desktop-managed host.
+  // "stopped" through its own lifecycle RPCs, or "skipped-unreachable" when
+  // a published endpoint could not be asked (the reload boots it out). A
+  // process with no live endpoint is refused, never proceeded past.
+  | {
+      readonly kind: "cli-host-stopped";
+      readonly cooperativeStop: "stopped" | "skipped-unreachable";
+    }
   | { readonly kind: "not-applicable" };
 
 // Carried from `stopForRestart` to `relaunchAfterRestart` so the relaunch

--- a/clients/traycer-cli/src/service/index.ts
+++ b/clients/traycer-cli/src/service/index.ts
@@ -136,17 +136,21 @@ export type DesktopRegistrationTakeover =
       // out underneath it.
       readonly cooperativeStop: "stopped" | "no-host" | "skipped-unreachable";
     }
-  // No Desktop agent to retire, but the CLI label itself was loaded with a
-  // live process - a host this install's own reload would otherwise bootout
-  // with no cooperative claim (a KeepAlive respawn that started after the
-  // caller's probe). It was asked to stand down first, on the same terms as
-  // a Desktop-managed host.
-  // "stopped" through its own lifecycle RPCs, or "skipped-unreachable" when
-  // a published endpoint could not be asked (the reload boots it out). A
-  // process with no live endpoint is refused, never proceeded past.
+  // No Desktop agent to retire, but the CLI label itself was loaded - a job
+  // this install's own reload would otherwise bootout with no cooperative
+  // claim (a KeepAlive respawn that started after the caller's probe, or an
+  // idle job launchd could start while the install writes its files). The
+  // takeover unloaded it under its own lock first, and waited for it.
+  // "stopped": a live process stood down through its own lifecycle RPCs;
+  // "skipped-unreachable": a published endpoint could not be asked (the
+  // job was booted out underneath it); "no-host": launchd reported no
+  // process under the job, so no claim was made (the `took-over` arm's
+  // "no-host" is the claim's own answer - metadata naming a host that has
+  // exited; here nothing was there to name one). A process with no live
+  // endpoint is refused, never proceeded past.
   | {
       readonly kind: "cli-host-stopped";
-      readonly cooperativeStop: "stopped" | "skipped-unreachable";
+      readonly cooperativeStop: "stopped" | "skipped-unreachable" | "no-host";
     }
   | { readonly kind: "not-applicable" };
 

--- a/clients/traycer-cli/src/service/platforms/__tests__/macos.test.ts
+++ b/clients/traycer-cli/src/service/platforms/__tests__/macos.test.ts
@@ -2111,15 +2111,29 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
       "/Applications/Traycer.app/Contents/Library/LaunchAgents/ai.traycer.host.agent.plist";
     const agentTarget = `gui/${process.getuid?.() ?? 0}/${label.id}.agent`;
 
+    // `cliLabelLoadedAsCliOrOther`, when set, stages the CLI label as a
+    // raw `~/Library/LaunchAgents/<label>.plist` load (`cli-or-other`, NOT
+    // an in-bundle SMAppService path, and with NO pid - the idle-job case)
+    // rather than the plain owned/not-loaded pair `cliLabelOwned` controls.
+    // Three non-`.agent` prints matter here: the FIRST (the initial
+    // `cliProbe`) and the SECOND (the fresh re-probe `takeoverDesktopRegistration`
+    // runs after the agent is retired) both answer loaded; the THIRD (the
+    // post-bootout re-probe `unloadCliLabelJob` runs) answers per
+    // `afterBootout` - "absent" is launchd's not-found output, "still-loaded"
+    // repeats the loaded answer.
     function stageTakeoverRunner(input: {
       cliLabelOwned: boolean;
       agentLoadedAfterBootout: boolean;
+      cliLabelLoadedAsCliOrOther?: {
+        afterBootout: "absent" | "still-loaded";
+      };
     }): {
       calls: RecordedCall[];
       controller: ServiceController;
     } {
       const calls: RecordedCall[] = [];
       let agentPrints = 0;
+      let cliLabelPrints = 0;
       const runner: ProcessRunner = async (command, args) => {
         calls.push({ command, args });
         if (args[0] === "print") {
@@ -2134,6 +2148,24 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
                   stderr: "Could not find specified service\n",
                   exitCode: 113,
                 };
+          }
+          cliLabelPrints += 1;
+          if (input.cliLabelLoadedAsCliOrOther !== undefined) {
+            const cliOrOther = input.cliLabelLoadedAsCliOrOther;
+            const loadedResult = {
+              stdout: `\tpath = /Users/me/Library/LaunchAgents/${label.id}.plist\n\ttype = LaunchAgent\n`,
+              stderr: "",
+              exitCode: 0,
+            };
+            const notFoundResult = {
+              stdout: "",
+              stderr: "Could not find specified service\n",
+              exitCode: 113,
+            };
+            if (cliLabelPrints <= 2) return loadedResult;
+            return cliOrOther.afterBootout === "still-loaded"
+              ? loadedResult
+              : notFoundResult;
           }
           return input.cliLabelOwned
             ? {
@@ -2177,6 +2209,7 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
         "print",
         "print",
         "bootout",
+        "print",
         "print",
       ]);
       expect(calls[2]?.args).toEqual(["bootout", "--wait", agentTarget]);
@@ -2225,6 +2258,7 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
         "print",
         "print",
         "bootout",
+        "print",
         "print",
       ]);
       expect(MOCKS.cliLoggerWarn).toHaveBeenCalledWith(
@@ -2294,7 +2328,10 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
         message: expect.stringContaining("traycer host service uninstall"),
       });
       expect(MOCKS.requestCooperativeShutdown).not.toHaveBeenCalled();
-      expect(calls.map((c) => c.args[0])).toEqual(["print"]);
+      // The agent is probed FIRST (it reads loaded/smappservice here too,
+      // via `smAgentPath`) and only THEN the CLI label, whose smappservice
+      // read is what trips the refusal.
+      expect(calls.map((c) => c.args[0])).toEqual(["print", "print"]);
     });
 
     it("reports not-applicable when Desktop owns nothing", async () => {
@@ -2381,6 +2418,287 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
         expect(bootout?.args).toEqual(["bootout", "--wait", agentTarget]);
       },
     );
+
+    // A dual-registered machine: Desktop's agent AND the raw CLI-label
+    // plist are both loaded. `takeoverDesktopRegistration` boots out the
+    // agent first (the claim above went through `pid.json`), then - under
+    // the same lock - also unloads the CLI label so launchd cannot start
+    // it while `installService` writes its files underneath this takeover.
+    const cliTarget = `gui/${process.getuid?.() ?? 0}/${label.id}`;
+
+    it("also unloads a CLI-label job loaded beside Desktop's agent, with --wait and a positive re-probe", async () => {
+      // The FIRST cli print is `standDownLiveCliLabelHost`'s no-agent probe
+      // above (a `cliProbe` reading loaded-idle also short-circuits that
+      // check, since only a positive pid trips it); the takeover then reads
+      // the CLI label a SECOND time, fresh, after the agent is retired -
+      // that fresh read is what this test is pinning.
+      const { calls, controller } = stageTakeoverRunner({
+        cliLabelOwned: false,
+        agentLoadedAfterBootout: false,
+        cliLabelLoadedAsCliOrOther: { afterBootout: "absent" },
+      });
+      MOCKS.requestCooperativeShutdown.mockResolvedValue({ kind: "stopped" });
+
+      await expect(
+        controller.takeoverDesktopRegistration(label),
+      ).resolves.toEqual({
+        kind: "took-over",
+        agentLabelId: `${label.id}.agent`,
+        cooperativeStop: "stopped",
+      });
+      expect(calls.map((c) => c.args[0])).toEqual([
+        "print",
+        "print",
+        "bootout",
+        "print",
+        "print",
+        "bootout",
+        "print",
+      ]);
+      expect(calls[5]?.args).toEqual(["bootout", "--wait", cliTarget]);
+      expect(calls[6]?.args[1]).toEqual(cliTarget);
+      // `standDownLiveCliLabelHost`'s pid-null branch logs the same generic
+      // message whether or not an agent was just retired - there is no
+      // agent-specific copy any more, so this pins the message it does log.
+      expect(MOCKS.cliLoggerInfo).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "the CLI label is loaded with no running process",
+        ),
+        expect.objectContaining({ label: label.id }),
+      );
+    });
+
+    it("rejects with SERVICE_INSTALL_FAILED ('did not take effect') when the CLI-label job loaded beside Desktop's agent does not unload", async () => {
+      const { controller } = stageTakeoverRunner({
+        cliLabelOwned: false,
+        agentLoadedAfterBootout: false,
+        cliLabelLoadedAsCliOrOther: { afterBootout: "still-loaded" },
+      });
+      MOCKS.requestCooperativeShutdown.mockResolvedValue({ kind: "stopped" });
+
+      // Re-assert against the SAME already-settled promise (not a fresh
+      // call): `stageTakeoverRunner`'s print counters are shared, mutable
+      // state, and a second invocation would keep incrementing them into a
+      // completely different scenario rather than repeating this one.
+      const takeover = controller.takeoverDesktopRegistration(label);
+      await expect(takeover).rejects.toMatchObject({
+        code: CLI_ERROR_CODES.SERVICE_INSTALL_FAILED,
+        message: expect.stringContaining(
+          "did not take effect (the job is still loaded)",
+        ),
+      });
+      await expect(takeover).rejects.toMatchObject({
+        message: expect.stringContaining("is already deregistered"),
+      });
+    });
+
+    it("rejects before any bootout when the CLI label has a live pid beside the agent and the claim finds no endpoint (pre-check)", async () => {
+      const calls: RecordedCall[] = [];
+      const runner: ProcessRunner = async (command, args) => {
+        calls.push({ command, args });
+        if (args[0] === "print") {
+          if (args[1]?.endsWith(".agent") === true) {
+            return {
+              stdout: `path = ${smAgentPath}\n`,
+              stderr: "",
+              exitCode: 0,
+            };
+          }
+          return {
+            stdout: `\tpath = /Users/me/Library/LaunchAgents/${label.id}.plist\n\ttype = LaunchAgent\n\tpid = 4242\n`,
+            stderr: "",
+            exitCode: 0,
+          };
+        }
+        return buildSuccessResult();
+      };
+      MOCKS.requestCooperativeShutdown.mockResolvedValue({
+        kind: "no-metadata",
+      });
+
+      const takeover =
+        createMacosController(runner).takeoverDesktopRegistration(label);
+      await expect(takeover).rejects.toMatchObject({
+        code: CLI_ERROR_CODES.SERVICE_INSTALL_FAILED,
+        message: expect.stringContaining(
+          "has not published a live endpoint yet",
+        ),
+      });
+      await expect(takeover).rejects.toMatchObject({
+        message: expect.not.stringContaining("already deregistered"),
+      });
+      expect(calls.some((c) => c.args[0] === "bootout")).toBe(false);
+    });
+
+    // `agentBootout` shared by the two tests below: `bootout --wait`
+    // resolving a NON-ZERO exit is what the runner reports for its own
+    // timeout (`tolerateNonZeroExit` turns a hang into exit -1) - the
+    // process-alive check below is gated on exactly that, since after a
+    // clean exit 0 the pid launchd reported can already have been recycled.
+    function stageAgentAliveAfterBootoutRunner(input: {
+      bootoutExitCode: number;
+    }): ProcessRunner {
+      let agentPrints = 0;
+      return async (command, args) => {
+        if (args[0] === "print") {
+          if (args[1]?.endsWith(".agent") === true) {
+            agentPrints += 1;
+            // First probe establishes Desktop ownership with a live pid; the
+            // verification probe after `bootout --wait` reads the label
+            // gone - the process (checked separately via `isProcessAlive`)
+            // is what has not actually exited.
+            return agentPrints === 1
+              ? {
+                  stdout: `path = ${smAgentPath}\n\tpid = 777\n`,
+                  stderr: "",
+                  exitCode: 0,
+                }
+              : {
+                  stdout: "",
+                  stderr: "Could not find specified service\n",
+                  exitCode: 113,
+                };
+          }
+          return {
+            stdout: "",
+            stderr: "Could not find specified service\n",
+            exitCode: 113,
+          };
+        }
+        if (args[0] === "bootout") {
+          return { stdout: "", stderr: "", exitCode: input.bootoutExitCode };
+        }
+        return buildSuccessResult();
+      };
+    }
+
+    it("rejects with SERVICE_INSTALL_FAILED ('is still running after the wait') when the agent's process survives the bootout wait", async () => {
+      const runner = stageAgentAliveAfterBootoutRunner({ bootoutExitCode: -1 });
+      MOCKS.requestCooperativeShutdown.mockResolvedValue({
+        kind: "unreachable",
+        cause: "x",
+      });
+      MOCKS.isProcessAlive.mockImplementation((pid: number) => pid === 777);
+
+      await expect(
+        createMacosController(runner).takeoverDesktopRegistration(label),
+      ).rejects.toMatchObject({
+        code: CLI_ERROR_CODES.SERVICE_INSTALL_FAILED,
+        message: expect.stringContaining("is still running after the wait"),
+        details: expect.objectContaining({
+          agentLabel: `${label.id}.agent`,
+          pid: 777,
+          verification: "process-alive",
+        }),
+      });
+    });
+
+    it("does not refuse the takeover when the agent's bootout exits cleanly even though `isProcessAlive` reports the reported pid alive (a recycled pid)", async () => {
+      const runner = stageAgentAliveAfterBootoutRunner({ bootoutExitCode: 0 });
+      MOCKS.requestCooperativeShutdown.mockResolvedValue({
+        kind: "unreachable",
+        cause: "x",
+      });
+      MOCKS.isProcessAlive.mockImplementation((pid: number) => pid === 777);
+
+      await expect(
+        createMacosController(runner).takeoverDesktopRegistration(label),
+      ).resolves.toMatchObject({ kind: "took-over" });
+    });
+
+    // Staging for the two pins below: the CLI label is absent on the FIRST
+    // print (so the initial `standDownLiveCliLabelHost(..., null)` call from
+    // the no-agent branch never fires here - the agent IS loaded), but
+    // loaded with a live pid on the SECOND, fresh print the takeover runs
+    // after retiring the agent. That live pid means a real cooperative claim
+    // is made (a SECOND `requestCooperativeShutdown` call), unlike the
+    // idle-job case above.
+    function stageCliAbsentThenLoadedRunner(input: {
+      cliVerifyAfterBootout: "absent" | "still-loaded";
+    }): {
+      calls: RecordedCall[];
+      controller: ServiceController;
+    } {
+      const calls: RecordedCall[] = [];
+      let agentPrints = 0;
+      let cliPrints = 0;
+      const loadedWithPid = {
+        stdout: `\tpath = /Users/me/Library/LaunchAgents/${label.id}.plist\n\ttype = LaunchAgent\n\tpid = 4242\n`,
+        stderr: "",
+        exitCode: 0,
+      };
+      const notFound = {
+        stdout: "",
+        stderr: "Could not find specified service\n",
+        exitCode: 113,
+      };
+      const runner: ProcessRunner = async (command, args) => {
+        calls.push({ command, args });
+        if (args[0] === "print") {
+          if (args[1]?.endsWith(".agent") === true) {
+            agentPrints += 1;
+            return agentPrints === 1
+              ? { stdout: `path = ${smAgentPath}\n`, stderr: "", exitCode: 0 }
+              : notFound;
+          }
+          cliPrints += 1;
+          if (cliPrints === 1) return notFound;
+          if (cliPrints === 2) return loadedWithPid;
+          return input.cliVerifyAfterBootout === "still-loaded"
+            ? loadedWithPid
+            : notFound;
+        }
+        return buildSuccessResult();
+      };
+      return { calls, controller: createMacosController(runner) };
+    }
+
+    it("rejects when the CLI label appears with a live pid after the agent is retired and the fresh claim finds no endpoint", async () => {
+      const { calls, controller } = stageCliAbsentThenLoadedRunner({
+        cliVerifyAfterBootout: "absent",
+      });
+      MOCKS.requestCooperativeShutdown
+        .mockResolvedValueOnce({ kind: "stopped" })
+        .mockResolvedValueOnce({ kind: "no-metadata" });
+
+      await expect(
+        controller.takeoverDesktopRegistration(label),
+      ).rejects.toMatchObject({
+        code: CLI_ERROR_CODES.SERVICE_INSTALL_FAILED,
+        message: expect.stringContaining(
+          "is already deregistered; re-run the command in a moment",
+        ),
+      });
+      expect(MOCKS.requestCooperativeShutdown).toHaveBeenCalledTimes(2);
+      expect(calls.some((c) => c.args[0] === "bootout")).toBe(true);
+    });
+
+    it("also unloads a CLI-label job that appears with a live pid after the agent is retired, once the fresh claim succeeds", async () => {
+      const { calls, controller } = stageCliAbsentThenLoadedRunner({
+        cliVerifyAfterBootout: "absent",
+      });
+      MOCKS.requestCooperativeShutdown
+        .mockResolvedValueOnce({ kind: "stopped" })
+        .mockResolvedValueOnce({ kind: "stopped" });
+
+      await expect(
+        controller.takeoverDesktopRegistration(label),
+      ).resolves.toEqual({
+        kind: "took-over",
+        agentLabelId: `${label.id}.agent`,
+        cooperativeStop: "stopped",
+      });
+      expect(calls.map((c) => c.args[0])).toEqual([
+        "print",
+        "print",
+        "bootout",
+        "print",
+        "print",
+        "bootout",
+        "print",
+      ]);
+      expect(MOCKS.requestCooperativeShutdown).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe("takeoverDesktopRegistration - standing down a live CLI-label host", () => {
@@ -2400,6 +2718,7 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
     function stageStandDownRunner(input: {
       pid: number | null;
       postBootout?: "absent" | "still-loaded" | "spawn-failure";
+      bootoutExitCode?: number;
     }): {
       calls: RecordedCall[];
       controller: ServiceController;
@@ -2442,6 +2761,13 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
             exitCode: 113,
           };
         }
+        if (args[0] === "bootout") {
+          return {
+            stdout: "",
+            stderr: "",
+            exitCode: input.bootoutExitCode ?? 0,
+          };
+        }
         return buildSuccessResult();
       };
       return { calls, controller: createMacosController(runner) };
@@ -2477,7 +2803,7 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
       expect(calls.some((c) => c.args[0] === "bootout")).toBe(false);
     });
 
-    it("rejects with SERVICE_INSTALL_FAILED the same way, and never boots out, when launchd's pid names a host that already exited (no-host)", async () => {
+    it("rejects with SERVICE_INSTALL_FAILED a distinct message, and never boots out, when launchd's pid names a host that already exited (no-host)", async () => {
       const { calls, controller } = stageStandDownRunner({ pid: 4242 });
       MOCKS.requestCooperativeShutdown.mockResolvedValue({
         kind: "no-host",
@@ -2488,7 +2814,7 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
       ).rejects.toMatchObject({
         code: CLI_ERROR_CODES.SERVICE_INSTALL_FAILED,
         message: expect.stringContaining(
-          "has not published a live endpoint yet",
+          "names a host that has already exited",
         ),
       });
       expect(calls.some((c) => c.args[0] === "bootout")).toBe(false);
@@ -2545,6 +2871,82 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
       expect(calls.some((c) => c.args[0] === "bootout")).toBe(true);
     });
 
+    it("resolves cli-host-stopped/skipped-unreachable and warns when the live CLI-label host is hung, after booting it out and verifying it is gone", async () => {
+      const { calls, controller } = stageStandDownRunner({ pid: 4242 });
+      MOCKS.requestCooperativeShutdown.mockResolvedValue({
+        kind: "hung",
+        pid: 4242,
+      });
+
+      await expect(
+        controller.takeoverDesktopRegistration(label),
+      ).resolves.toEqual({
+        kind: "cli-host-stopped",
+        cooperativeStop: "skipped-unreachable",
+      });
+      expect(MOCKS.cliLoggerWarn).toHaveBeenCalledWith(
+        expect.stringContaining("could not be stopped cooperatively"),
+        expect.objectContaining({
+          cause: "pid 4242 outlived the shutdown grace",
+        }),
+      );
+      const bootout = calls.find((c) => c.args[0] === "bootout");
+      expect(bootout?.args).toEqual([
+        "bootout",
+        "--wait",
+        `gui/${process.getuid?.() ?? 0}/${label.id}`,
+      ]);
+      const prints = calls.filter(
+        (c) => c.args[0] === "print" && c.args[1]?.endsWith(".agent") !== true,
+      );
+      expect(prints).toHaveLength(2);
+    });
+
+    it("rejects with SERVICE_INSTALL_FAILED ('is still running after the wait') when a hung live CLI-label host's process survives the bootout wait", async () => {
+      // The liveness refusal fires only when `bootout --wait` itself did
+      // NOT exit cleanly (the runner-timeout case) - stage that explicitly.
+      const { calls, controller } = stageStandDownRunner({
+        pid: 4242,
+        bootoutExitCode: -1,
+      });
+      MOCKS.requestCooperativeShutdown.mockResolvedValue({
+        kind: "hung",
+        pid: 4242,
+      });
+      MOCKS.isProcessAlive.mockImplementation((pid: number) => pid === 4242);
+
+      await expect(
+        controller.takeoverDesktopRegistration(label),
+      ).rejects.toMatchObject({
+        code: CLI_ERROR_CODES.SERVICE_INSTALL_FAILED,
+        message: expect.stringContaining("is still running after the wait"),
+        details: expect.objectContaining({
+          pid: 4242,
+          verification: "process-alive",
+        }),
+      });
+      expect(calls.some((c) => c.args[0] === "bootout")).toBe(true);
+    });
+
+    it("does not refuse the takeover when the CLI-label bootout exits cleanly even though `isProcessAlive` reports the reported pid alive (a recycled pid)", async () => {
+      const { controller } = stageStandDownRunner({
+        pid: 4242,
+        bootoutExitCode: 0,
+      });
+      MOCKS.requestCooperativeShutdown.mockResolvedValue({
+        kind: "hung",
+        pid: 4242,
+      });
+      MOCKS.isProcessAlive.mockImplementation((pid: number) => pid === 4242);
+
+      await expect(
+        controller.takeoverDesktopRegistration(label),
+      ).resolves.toEqual({
+        kind: "cli-host-stopped",
+        cooperativeStop: "skipped-unreachable",
+      });
+    });
+
     it("rejects with SERVICE_INSTALL_FAILED ('did not take effect') when the post-bootout probe still finds the CLI-label job loaded", async () => {
       const { controller } = stageStandDownRunner({
         pid: 4242,
@@ -2580,12 +2982,46 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
       });
     });
 
-    it("reports not-applicable and never calls requestCooperativeShutdown when the CLI label is loaded but has no live pid", async () => {
-      const { controller } = stageStandDownRunner({ pid: null });
+    it("resolves cli-host-stopped/no-host, logs, and unloads the job when the CLI label is loaded but has no live pid, never calling requestCooperativeShutdown", async () => {
+      const { calls, controller } = stageStandDownRunner({ pid: null });
 
       await expect(
         controller.takeoverDesktopRegistration(label),
-      ).resolves.toEqual({ kind: "not-applicable" });
+      ).resolves.toEqual({
+        kind: "cli-host-stopped",
+        cooperativeStop: "no-host",
+      });
+      expect(MOCKS.requestCooperativeShutdown).not.toHaveBeenCalled();
+      expect(MOCKS.cliLoggerInfo).toHaveBeenCalledWith(
+        expect.stringContaining("loaded with no running process"),
+        expect.objectContaining({ label: label.id }),
+      );
+      const bootout = calls.find((c) => c.args[0] === "bootout");
+      expect(bootout?.args).toEqual([
+        "bootout",
+        "--wait",
+        `gui/${process.getuid?.() ?? 0}/${label.id}`,
+      ]);
+      const prints = calls.filter(
+        (c) => c.args[0] === "print" && c.args[1]?.endsWith(".agent") !== true,
+      );
+      expect(prints).toHaveLength(2);
+    });
+
+    it("rejects with SERVICE_INSTALL_FAILED ('did not take effect') when the CLI label has no live pid and the post-bootout probe still finds it loaded", async () => {
+      const { controller } = stageStandDownRunner({
+        pid: null,
+        postBootout: "still-loaded",
+      });
+
+      await expect(
+        controller.takeoverDesktopRegistration(label),
+      ).rejects.toMatchObject({
+        code: CLI_ERROR_CODES.SERVICE_INSTALL_FAILED,
+        message: expect.stringContaining(
+          "did not take effect (the job is still loaded)",
+        ),
+      });
       expect(MOCKS.requestCooperativeShutdown).not.toHaveBeenCalled();
     });
 
@@ -2606,10 +3042,20 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
     // must abort the takeover rather than fall through to "not applicable"
     // and let `installService`'s later plain bootout run with no claim.
     it("rejects when the CLI-label print exits non-zero with unrelated output, naming the CLI label and never touching cooperative shutdown or launchd", async () => {
+      // The agent is probed FIRST now; it must read cleanly (not-loaded)
+      // here so the indeterminate CLI-label read - not the agent read - is
+      // what this test pins.
       const calls: RecordedCall[] = [];
       const runner: ProcessRunner = async (command, args) => {
         calls.push({ command, args });
         if (args[0] === "print") {
+          if (args[1]?.endsWith(".agent") === true) {
+            return {
+              stdout: "",
+              stderr: "Could not find specified service\n",
+              exitCode: 113,
+            };
+          }
           return {
             stdout: "",
             stderr: "launchctl: some unrecognized internal error\n",
@@ -2631,12 +3077,15 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
       });
       expect(MOCKS.requestCooperativeShutdown).not.toHaveBeenCalled();
       expect(calls.some((c) => c.args[0] === "bootout")).toBe(false);
-      // Only the CLI-label probe should have run; an indeterminate CLI-label
-      // read must abort before the `.agent` probe is even attempted.
-      expect(calls.map((c) => c.args[0])).toEqual(["print"]);
+      // The agent probe runs first and reads cleanly; only then does the
+      // indeterminate CLI-label read abort the takeover.
+      expect(calls.map((c) => c.args[0])).toEqual(["print", "print"]);
     });
 
-    it("rejects when the CLI label is absent but the .agent print fails to spawn, naming the agent label and never touching cooperative shutdown or launchd", async () => {
+    it("rejects when the .agent print fails to spawn, naming the agent label, before the CLI label is ever probed", async () => {
+      // The agent is probed FIRST, so a failure there aborts the takeover
+      // before the CLI label is read at all - unlike the sibling test
+      // above, there is no second print to stage.
       const calls: RecordedCall[] = [];
       const runner: ProcessRunner = async (command, args) => {
         calls.push({ command, args });
@@ -2665,7 +3114,56 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
       });
       expect(MOCKS.requestCooperativeShutdown).not.toHaveBeenCalled();
       expect(calls.some((c) => c.args[0] === "bootout")).toBe(false);
-      expect(calls.map((c) => c.args[0])).toEqual(["print", "print"]);
+      expect(calls.map((c) => c.args[0])).toEqual(["print"]);
+    });
+
+    it("rejects when the fresh CLI probe after the agent's retirement fails to spawn, naming both the CLI label and the already-deregistered agent", async () => {
+      const agentPlistPath =
+        "/Applications/Traycer.app/Contents/Library/LaunchAgents/ai.traycer.host.agent.plist";
+      let agentPrints = 0;
+      let cliPrints = 0;
+      const runner: ProcessRunner = async (command, args) => {
+        if (args[0] === "print") {
+          if (args[1]?.endsWith(".agent") === true) {
+            agentPrints += 1;
+            return agentPrints === 1
+              ? {
+                  stdout: `path = ${agentPlistPath}\n`,
+                  stderr: "",
+                  exitCode: 0,
+                }
+              : {
+                  stdout: "",
+                  stderr: "Could not find specified service\n",
+                  exitCode: 113,
+                };
+          }
+          cliPrints += 1;
+          if (cliPrints === 1) {
+            return {
+              stdout: "",
+              stderr: "Could not find specified service\n",
+              exitCode: 113,
+            };
+          }
+          throw new Error("launchctl could not be spawned");
+        }
+        return buildSuccessResult();
+      };
+      MOCKS.requestCooperativeShutdown.mockResolvedValue({ kind: "stopped" });
+
+      const takeover =
+        createMacosController(runner).takeoverDesktopRegistration(label);
+      await expect(takeover).rejects.toMatchObject({
+        code: CLI_ERROR_CODES.SERVICE_INSTALL_FAILED,
+        message: expect.stringContaining(
+          `could not read launchd's state for '${label.id}'`,
+        ),
+        details: expect.objectContaining({ agentLabel: `${label.id}.agent` }),
+      });
+      await expect(takeover).rejects.toMatchObject({
+        message: expect.stringContaining("is already deregistered"),
+      });
     });
   });
 

--- a/clients/traycer-cli/src/service/platforms/__tests__/macos.test.ts
+++ b/clients/traycer-cli/src/service/platforms/__tests__/macos.test.ts
@@ -52,6 +52,7 @@ const execFileAsync = promisify(execFile);
 
 const MOCKS = vi.hoisted(() => ({
   readHostPidMetadata: vi.fn(),
+  readHostPidMetadataEvidence: vi.fn(),
   isProcessAlive: vi.fn(),
   cliLoggerWarn: vi.fn(),
   cliLoggerInfo: vi.fn(),
@@ -105,6 +106,7 @@ const HOST_PID_METADATA = {
 
 vi.mock("../../../host/pid-metadata", () => ({
   readHostPidMetadata: MOCKS.readHostPidMetadata,
+  readHostPidMetadataEvidence: MOCKS.readHostPidMetadataEvidence,
 }));
 
 vi.mock("../../../store/cli-lock", async (importOriginal) => {
@@ -463,6 +465,8 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
     createdPlistPath = null;
     MOCKS.readHostPidMetadata.mockReset();
     MOCKS.readHostPidMetadata.mockResolvedValue(null);
+    MOCKS.readHostPidMetadataEvidence.mockReset();
+    MOCKS.readHostPidMetadataEvidence.mockResolvedValue({ kind: "absent" });
     MOCKS.isProcessAlive.mockReset();
     MOCKS.isProcessAlive.mockReturnValue(false);
     MOCKS.readProcessStartIdentity.mockReset();
@@ -2476,13 +2480,16 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
           exitCode: 113,
         };
       };
-      MOCKS.readHostPidMetadata.mockResolvedValue({
-        pid: 9001,
-        hostId: "hand-run-host",
-        version: "1.2.3",
-        websocketUrl: "ws://127.0.0.1:9001/rpc",
-        startedAt: "2026-07-12T00:00:00.000Z",
-        processStartIdentity: null,
+      MOCKS.readHostPidMetadataEvidence.mockResolvedValue({
+        kind: "read",
+        metadata: {
+          pid: 9001,
+          hostId: "hand-run-host",
+          version: "1.2.3",
+          websocketUrl: "ws://127.0.0.1:9001/rpc",
+          startedAt: "2026-07-12T00:00:00.000Z",
+          processStartIdentity: null,
+        },
       });
       MOCKS.getPublishedProcessIdentityVerdict.mockResolvedValue("current");
 
@@ -2506,13 +2513,16 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
         stderr: "Could not find specified service\n",
         exitCode: 113,
       });
-      MOCKS.readHostPidMetadata.mockResolvedValue({
-        pid: 9001,
-        hostId: "hand-run-host",
-        version: "1.2.3",
-        websocketUrl: "ws://127.0.0.1:9001/rpc",
-        startedAt: "2026-07-12T00:00:00.000Z",
-        processStartIdentity: null,
+      MOCKS.readHostPidMetadataEvidence.mockResolvedValue({
+        kind: "read",
+        metadata: {
+          pid: 9001,
+          hostId: "hand-run-host",
+          version: "1.2.3",
+          websocketUrl: "ws://127.0.0.1:9001/rpc",
+          startedAt: "2026-07-12T00:00:00.000Z",
+          processStartIdentity: null,
+        },
       });
       MOCKS.getPublishedProcessIdentityVerdict.mockResolvedValue("mismatch");
 
@@ -2535,13 +2545,16 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
         stderr: "Could not find specified service\n",
         exitCode: 113,
       });
-      MOCKS.readHostPidMetadata.mockResolvedValue({
-        pid: 9001,
-        hostId: "hand-run-host",
-        version: "1.2.3",
-        websocketUrl: "ws://127.0.0.1:9001/rpc",
-        startedAt: "2026-07-12T00:00:00.000Z",
-        processStartIdentity: null,
+      MOCKS.readHostPidMetadataEvidence.mockResolvedValue({
+        kind: "read",
+        metadata: {
+          pid: 9001,
+          hostId: "hand-run-host",
+          version: "1.2.3",
+          websocketUrl: "ws://127.0.0.1:9001/rpc",
+          startedAt: "2026-07-12T00:00:00.000Z",
+          processStartIdentity: null,
+        },
       });
       MOCKS.getPublishedProcessIdentityVerdict.mockResolvedValue(
         "indeterminate",
@@ -2573,13 +2586,16 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
         stderr: "Could not find specified service\n",
         exitCode: 113,
       });
-      MOCKS.readHostPidMetadata.mockResolvedValue({
-        pid: 9001,
-        hostId: "hand-run-host",
-        version: "1.2.3",
-        websocketUrl: "ws://127.0.0.1:9001/rpc",
-        startedAt: "2026-07-12T00:00:00.000Z",
-        processStartIdentity: null,
+      MOCKS.readHostPidMetadataEvidence.mockResolvedValue({
+        kind: "read",
+        metadata: {
+          pid: 9001,
+          hostId: "hand-run-host",
+          version: "1.2.3",
+          websocketUrl: "ws://127.0.0.1:9001/rpc",
+          startedAt: "2026-07-12T00:00:00.000Z",
+          processStartIdentity: null,
+        },
       });
       MOCKS.getPublishedProcessIdentityVerdict.mockResolvedValue(
         "indeterminate",
@@ -2615,13 +2631,16 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
         stderr: "Could not find specified service\n",
         exitCode: 113,
       });
-      MOCKS.readHostPidMetadata.mockResolvedValue({
-        pid: 9001,
-        hostId: "hand-run-host",
-        version: "1.2.3",
-        websocketUrl: "ws://127.0.0.1:9001/rpc",
-        startedAt: "2026-07-12T00:00:00.000Z",
-        processStartIdentity: "darwin:1699999999.123456",
+      MOCKS.readHostPidMetadataEvidence.mockResolvedValue({
+        kind: "read",
+        metadata: {
+          pid: 9001,
+          hostId: "hand-run-host",
+          version: "1.2.3",
+          websocketUrl: "ws://127.0.0.1:9001/rpc",
+          startedAt: "2026-07-12T00:00:00.000Z",
+          processStartIdentity: "darwin:1699999999.123456",
+        },
       });
       MOCKS.getPublishedProcessIdentityVerdict.mockResolvedValue(
         "indeterminate",
@@ -2642,6 +2661,39 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
         }),
       });
       expect(MOCKS.probeHostHealth).not.toHaveBeenCalled();
+    });
+
+    // A torn or momentarily unreadable pid.json must fail CLOSED, not be
+    // folded into "no host" the way `readHostPidMetadata` folds it for
+    // discovery callers - the record's absence and its unreadability read
+    // identically through that API, and letting the gate pass on "no
+    // evidence" is exactly the hostless-bootstrap-beside-a-corpse this
+    // command exists to prevent.
+    it("rejects with SERVICE_INSTALL_FAILED ('could not be read') when the published record is unreadable (no-agent arm)", async () => {
+      const calls: RecordedCall[] = [];
+      const notLoadedRunner: ProcessRunner = async (command, args) => {
+        calls.push({ command, args });
+        return {
+          stdout: "",
+          stderr: "Could not find specified service\n",
+          exitCode: 113,
+        };
+      };
+      MOCKS.readHostPidMetadataEvidence.mockResolvedValue({
+        kind: "unreadable",
+        cause: "not valid JSON",
+      });
+
+      await expect(
+        createMacosController(notLoadedRunner).takeoverDesktopRegistration(
+          label,
+        ),
+      ).rejects.toMatchObject({
+        code: CLI_ERROR_CODES.SERVICE_INSTALL_FAILED,
+        message: expect.stringContaining("could not be read (not valid JSON)"),
+        details: expect.objectContaining({ cause: "not valid JSON" }),
+      });
+      expect(calls.some((c) => c.args[0] === "bootout")).toBe(false);
     });
 
     it("fails closed when the bootout does not take effect", async () => {
@@ -3275,13 +3327,16 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
         agentRunning: true,
       });
       MOCKS.requestCooperativeShutdown.mockResolvedValue({ kind: "stopped" });
-      MOCKS.readHostPidMetadata.mockResolvedValue({
-        pid: 9001,
-        hostId: "hand-run-host",
-        version: "1.2.3",
-        websocketUrl: "ws://127.0.0.1:9001/rpc",
-        startedAt: "2026-07-12T00:00:00.000Z",
-        processStartIdentity: null,
+      MOCKS.readHostPidMetadataEvidence.mockResolvedValue({
+        kind: "read",
+        metadata: {
+          pid: 9001,
+          hostId: "hand-run-host",
+          version: "1.2.3",
+          websocketUrl: "ws://127.0.0.1:9001/rpc",
+          startedAt: "2026-07-12T00:00:00.000Z",
+          processStartIdentity: null,
+        },
       });
       MOCKS.getPublishedProcessIdentityVerdict.mockResolvedValue("dead");
 
@@ -3306,13 +3361,16 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
         agentRunning: true,
       });
       MOCKS.requestCooperativeShutdown.mockResolvedValue({ kind: "stopped" });
-      MOCKS.readHostPidMetadata.mockResolvedValue({
-        pid: 9001,
-        hostId: "hand-run-host",
-        version: "1.2.3",
-        websocketUrl: "ws://127.0.0.1:9001/rpc",
-        startedAt: "2026-07-12T00:00:00.000Z",
-        processStartIdentity: null,
+      MOCKS.readHostPidMetadataEvidence.mockResolvedValue({
+        kind: "read",
+        metadata: {
+          pid: 9001,
+          hostId: "hand-run-host",
+          version: "1.2.3",
+          websocketUrl: "ws://127.0.0.1:9001/rpc",
+          startedAt: "2026-07-12T00:00:00.000Z",
+          processStartIdentity: null,
+        },
       });
       MOCKS.getPublishedProcessIdentityVerdict.mockResolvedValue("current");
 
@@ -3321,6 +3379,36 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
       ).rejects.toMatchObject({
         code: CLI_ERROR_CODES.SERVICE_INSTALL_FAILED,
         message: expect.stringContaining("a host is still running (pid 9001"),
+      });
+      expect(MOCKS.cliLoggerInfo).not.toHaveBeenCalledWith(
+        expect.stringContaining("the CLI now owns host registration"),
+        expect.anything(),
+      );
+    });
+
+    // The took-over variant: the gate fires AFTER the agent is retired, so
+    // the routing tail must name it, exactly like every other refusal this
+    // arm can issue post-retirement.
+    it("rejects with SERVICE_INSTALL_FAILED ('could not be read') when the published record is unreadable (took-over arm), naming the retired agent", async () => {
+      const { controller } = stageTakeoverRunner({
+        cliLabelOwned: false,
+        agentLoadedAfterBootout: false,
+        agentRunning: true,
+      });
+      MOCKS.requestCooperativeShutdown.mockResolvedValue({ kind: "stopped" });
+      MOCKS.readHostPidMetadataEvidence.mockResolvedValue({
+        kind: "unreadable",
+        cause: "not valid JSON",
+      });
+
+      const takeover = controller.takeoverDesktopRegistration(label);
+      await expect(takeover).rejects.toMatchObject({
+        code: CLI_ERROR_CODES.SERVICE_INSTALL_FAILED,
+        message: expect.stringContaining("could not be read (not valid JSON)"),
+        details: expect.objectContaining({ cause: "not valid JSON" }),
+      });
+      await expect(takeover).rejects.toMatchObject({
+        message: expect.stringContaining("is already deregistered"),
       });
       expect(MOCKS.cliLoggerInfo).not.toHaveBeenCalledWith(
         expect.stringContaining("the CLI now owns host registration"),

--- a/clients/traycer-cli/src/service/platforms/__tests__/macos.test.ts
+++ b/clients/traycer-cli/src/service/platforms/__tests__/macos.test.ts
@@ -3220,6 +3220,44 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
     // exit) is `indeterminate` - and an indeterminate read of EITHER label
     // must abort the takeover rather than fall through to "not applicable"
     // and let `installService`'s later plain bootout run with no claim.
+    it("rejects when the CLI-label print exits 0 with no recognizable job fields (indeterminate ownership), instead of reading it as an idle cli-or-other job and unloading it with no claim", async () => {
+      const calls: RecordedCall[] = [];
+      const runner: ProcessRunner = async (command, args) => {
+        calls.push({ command, args });
+        if (args[0] === "print") {
+          if (args[1]?.endsWith(".agent") === true) {
+            return {
+              stdout: "",
+              stderr: "Could not find specified service\n",
+              exitCode: 113,
+            };
+          }
+          return {
+            stdout: "some unknown field = value\n",
+            stderr: "",
+            exitCode: 0,
+          };
+        }
+        return buildSuccessResult();
+      };
+      const controller = createMacosController(runner);
+
+      await expect(
+        controller.takeoverDesktopRegistration(label),
+      ).rejects.toMatchObject({
+        code: CLI_ERROR_CODES.SERVICE_INSTALL_FAILED,
+        message: expect.stringContaining(
+          `could not read launchd's state for '${label.id}'`,
+        ),
+        details: expect.objectContaining({
+          probedLabel: label.id,
+          cause: "unrecognized-format",
+        }),
+      });
+      expect(MOCKS.requestCooperativeShutdown).not.toHaveBeenCalled();
+      expect(calls.some((c) => c.args[0] === "bootout")).toBe(false);
+    });
+
     it("rejects when the CLI-label print exits non-zero with unrelated output, naming the CLI label and never touching cooperative shutdown or launchd", async () => {
       // The agent is probed FIRST now; it must read cleanly (not-loaded)
       // here so the indeterminate CLI-label read - not the agent read - is

--- a/clients/traycer-cli/src/service/platforms/__tests__/macos.test.ts
+++ b/clients/traycer-cli/src/service/platforms/__tests__/macos.test.ts
@@ -2391,11 +2391,21 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
     // tripping the pre-split refusal) with an optional live `pid` -
     // the KeepAlive-respawn race `standDownLiveCliLabelHost` exists to
     // close.
-    function stageStandDownRunner(input: { pid: number | null }): {
+    //
+    // `postBootout` controls the SECOND non-`.agent` print (the positive
+    // re-probe after `bootout --wait`, mirroring `agentLoadedAfterBootout`
+    // in `stageTakeoverRunner` above): "absent" (default) answers with
+    // launchd's not-found output, "still-loaded" repeats the loaded
+    // answer, and "spawn-failure" throws so the probe reads indeterminate.
+    function stageStandDownRunner(input: {
+      pid: number | null;
+      postBootout?: "absent" | "still-loaded" | "spawn-failure";
+    }): {
       calls: RecordedCall[];
       controller: ServiceController;
     } {
       const calls: RecordedCall[] = [];
+      let cliLabelPrints = 0;
       const runner: ProcessRunner = async (command, args) => {
         calls.push({ command, args });
         if (args[0] === "print") {
@@ -2406,11 +2416,30 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
               exitCode: 113,
             };
           }
-          const pidLine = input.pid === null ? "" : `\tpid = ${input.pid}\n`;
+          cliLabelPrints += 1;
+          if (cliLabelPrints === 1) {
+            const pidLine = input.pid === null ? "" : `\tpid = ${input.pid}\n`;
+            return {
+              stdout: `\tpath = /Users/me/Library/LaunchAgents/${label.id}.plist\n\ttype = LaunchAgent\n${pidLine}`,
+              stderr: "",
+              exitCode: 0,
+            };
+          }
+          const postBootout = input.postBootout ?? "absent";
+          if (postBootout === "still-loaded") {
+            return {
+              stdout: `\tpath = /Users/me/Library/LaunchAgents/${label.id}.plist\n\ttype = LaunchAgent\n`,
+              stderr: "",
+              exitCode: 0,
+            };
+          }
+          if (postBootout === "spawn-failure") {
+            throw new Error("launchctl could not be spawned");
+          }
           return {
-            stdout: `\tpath = /Users/me/Library/LaunchAgents/${label.id}.plist\n\ttype = LaunchAgent\n${pidLine}`,
-            stderr: "",
-            exitCode: 0,
+            stdout: "",
+            stderr: "Could not find specified service\n",
+            exitCode: 113,
           };
         }
         return buildSuccessResult();
@@ -2465,8 +2494,8 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
       expect(calls.some((c) => c.args[0] === "bootout")).toBe(false);
     });
 
-    it("resolves cli-host-stopped/stopped and logs the stand-down when the live CLI-label host stops cooperatively", async () => {
-      const { controller } = stageStandDownRunner({ pid: 4242 });
+    it("resolves cli-host-stopped/stopped and logs the stand-down when the live CLI-label host stops cooperatively, after booting it out and verifying it is gone", async () => {
+      const { calls, controller } = stageStandDownRunner({ pid: 4242 });
       MOCKS.requestCooperativeShutdown.mockResolvedValue({ kind: "stopped" });
 
       await expect(
@@ -2484,10 +2513,20 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
         expect.stringContaining("stood down before the reload"),
         expect.objectContaining({ label: label.id, pid: 4242 }),
       );
+      const bootout = calls.find((c) => c.args[0] === "bootout");
+      expect(bootout?.args).toEqual([
+        "bootout",
+        "--wait",
+        `gui/${process.getuid?.() ?? 0}/${label.id}`,
+      ]);
+      const prints = calls.filter(
+        (c) => c.args[0] === "print" && c.args[1]?.endsWith(".agent") !== true,
+      );
+      expect(prints).toHaveLength(2);
     });
 
-    it("resolves cli-host-stopped/skipped-unreachable and warns when the live CLI-label host cannot be stopped cooperatively", async () => {
-      const { controller } = stageStandDownRunner({ pid: 4242 });
+    it("resolves cli-host-stopped/skipped-unreachable and warns when the live CLI-label host cannot be stopped cooperatively, after booting it out and verifying it is gone", async () => {
+      const { calls, controller } = stageStandDownRunner({ pid: 4242 });
       MOCKS.requestCooperativeShutdown.mockResolvedValue({
         kind: "unreachable",
         cause: "boom",
@@ -2503,6 +2542,42 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
         expect.stringContaining("could not be stopped cooperatively"),
         expect.objectContaining({ cause: "boom" }),
       );
+      expect(calls.some((c) => c.args[0] === "bootout")).toBe(true);
+    });
+
+    it("rejects with SERVICE_INSTALL_FAILED ('did not take effect') when the post-bootout probe still finds the CLI-label job loaded", async () => {
+      const { controller } = stageStandDownRunner({
+        pid: 4242,
+        postBootout: "still-loaded",
+      });
+      MOCKS.requestCooperativeShutdown.mockResolvedValue({ kind: "stopped" });
+
+      await expect(
+        controller.takeoverDesktopRegistration(label),
+      ).rejects.toMatchObject({
+        code: CLI_ERROR_CODES.SERVICE_INSTALL_FAILED,
+        message: expect.stringContaining(
+          "did not take effect (the job is still loaded)",
+        ),
+      });
+    });
+
+    it("rejects with SERVICE_INSTALL_FAILED ('could not confirm') when the post-bootout probe fails to spawn", async () => {
+      const { controller } = stageStandDownRunner({
+        pid: 4242,
+        postBootout: "spawn-failure",
+      });
+      MOCKS.requestCooperativeShutdown.mockResolvedValue({
+        kind: "unreachable",
+        cause: "boom",
+      });
+
+      await expect(
+        controller.takeoverDesktopRegistration(label),
+      ).rejects.toMatchObject({
+        code: CLI_ERROR_CODES.SERVICE_INSTALL_FAILED,
+        message: expect.stringContaining("could not confirm"),
+      });
     });
 
     it("reports not-applicable and never calls requestCooperativeShutdown when the CLI label is loaded but has no live pid", async () => {
@@ -2521,6 +2596,77 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
     // at `not-loaded` (not `cli-or-other`), so `standDownLiveCliLabelHost`
     // short-circuits to `not-applicable` without calling
     // `requestCooperativeShutdown`. No separate test added here.
+  });
+
+  describe("takeoverDesktopRegistration - indeterminate label probes fail closed", () => {
+    // `probeLabelForTakeover` is three-state: a positive not-found answer is
+    // `absent`, a positive loaded answer is `loaded`, and everything else
+    // (spawn failure, timeout, permission text, an unrecognized non-zero
+    // exit) is `indeterminate` - and an indeterminate read of EITHER label
+    // must abort the takeover rather than fall through to "not applicable"
+    // and let `installService`'s later plain bootout run with no claim.
+    it("rejects when the CLI-label print exits non-zero with unrelated output, naming the CLI label and never touching cooperative shutdown or launchd", async () => {
+      const calls: RecordedCall[] = [];
+      const runner: ProcessRunner = async (command, args) => {
+        calls.push({ command, args });
+        if (args[0] === "print") {
+          return {
+            stdout: "",
+            stderr: "launchctl: some unrecognized internal error\n",
+            exitCode: 1,
+          };
+        }
+        return buildSuccessResult();
+      };
+      const controller = createMacosController(runner);
+
+      await expect(
+        controller.takeoverDesktopRegistration(label),
+      ).rejects.toMatchObject({
+        code: CLI_ERROR_CODES.SERVICE_INSTALL_FAILED,
+        message: expect.stringContaining(
+          `could not read launchd's state for '${label.id}'`,
+        ),
+        details: expect.objectContaining({ probedLabel: label.id }),
+      });
+      expect(MOCKS.requestCooperativeShutdown).not.toHaveBeenCalled();
+      expect(calls.some((c) => c.args[0] === "bootout")).toBe(false);
+      // Only the CLI-label probe should have run; an indeterminate CLI-label
+      // read must abort before the `.agent` probe is even attempted.
+      expect(calls.map((c) => c.args[0])).toEqual(["print"]);
+    });
+
+    it("rejects when the CLI label is absent but the .agent print fails to spawn, naming the agent label and never touching cooperative shutdown or launchd", async () => {
+      const calls: RecordedCall[] = [];
+      const runner: ProcessRunner = async (command, args) => {
+        calls.push({ command, args });
+        if (args[0] === "print") {
+          if (args[1]?.endsWith(".agent") === true) {
+            throw new Error("launchctl could not be spawned");
+          }
+          return {
+            stdout: "",
+            stderr: "Could not find specified service\n",
+            exitCode: 113,
+          };
+        }
+        return buildSuccessResult();
+      };
+      const controller = createMacosController(runner);
+
+      await expect(
+        controller.takeoverDesktopRegistration(label),
+      ).rejects.toMatchObject({
+        code: CLI_ERROR_CODES.SERVICE_INSTALL_FAILED,
+        message: expect.stringContaining(
+          `could not read launchd's state for '${label.id}.agent'`,
+        ),
+        details: expect.objectContaining({ probedLabel: `${label.id}.agent` }),
+      });
+      expect(MOCKS.requestCooperativeShutdown).not.toHaveBeenCalled();
+      expect(calls.some((c) => c.args[0] === "bootout")).toBe(false);
+      expect(calls.map((c) => c.args[0])).toEqual(["print", "print"]);
+    });
   });
 
   it("stop/start/restart proceed normally when the agent probe reads not-loaded (CLI-managed machine)", async () => {

--- a/clients/traycer-cli/src/service/platforms/__tests__/macos.test.ts
+++ b/clients/traycer-cli/src/service/platforms/__tests__/macos.test.ts
@@ -2606,6 +2606,58 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
       ).resolves.toMatchObject({ kind: "took-over" });
     });
 
+    it("rejects with SERVICE_INSTALL_FAILED ('the wait did not end with its exit') when the agent's state is running but has no pid to verify after the bootout wait", async () => {
+      let agentPrints = 0;
+      const runner: ProcessRunner = async (command, args) => {
+        if (args[0] === "print") {
+          if (args[1]?.endsWith(".agent") === true) {
+            agentPrints += 1;
+            // launchd reports the job running (no pid printed) - the same
+            // reading the desktop's parked-registration probe makes. The
+            // verification print after bootout reads absent; only the
+            // process itself (which cannot be checked without a pid) may
+            // still be alive.
+            return agentPrints === 1
+              ? {
+                  stdout: `path = ${smAgentPath}\n\tstate = running\n`,
+                  stderr: "",
+                  exitCode: 0,
+                }
+              : {
+                  stdout: "",
+                  stderr: "Could not find specified service\n",
+                  exitCode: 113,
+                };
+          }
+          return {
+            stdout: "",
+            stderr: "Could not find specified service\n",
+            exitCode: 113,
+          };
+        }
+        if (args[0] === "bootout") {
+          return { stdout: "", stderr: "", exitCode: -1 };
+        }
+        return buildSuccessResult();
+      };
+      MOCKS.requestCooperativeShutdown.mockResolvedValue({
+        kind: "unreachable",
+        cause: "x",
+      });
+
+      await expect(
+        createMacosController(runner).takeoverDesktopRegistration(label),
+      ).rejects.toMatchObject({
+        code: CLI_ERROR_CODES.SERVICE_INSTALL_FAILED,
+        message: expect.stringContaining("the wait did not end with its exit"),
+        details: expect.objectContaining({
+          agentLabel: `${label.id}.agent`,
+          pid: null,
+          verification: "process-unverified",
+        }),
+      });
+    });
+
     // Staging for the two pins below: the CLI label is absent on the FIRST
     // print (so the initial `standDownLiveCliLabelHost(..., null)` call from
     // the no-agent branch never fires here - the agent IS loaded), but
@@ -2719,6 +2771,12 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
       pid: number | null;
       postBootout?: "absent" | "still-loaded" | "spawn-failure";
       bootoutExitCode?: number;
+      // A `state = <value>` line on the FIRST cli-label print - "running"
+      // (case-insensitive per `probeLabelForTakeover`) makes the job
+      // `running` with no pid to check; anything else (e.g. "waiting")
+      // exercises the idle path with an explicit non-running state instead
+      // of no state line at all.
+      stateLine?: "running" | "waiting";
     }): {
       calls: RecordedCall[];
       controller: ServiceController;
@@ -2738,8 +2796,12 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
           cliLabelPrints += 1;
           if (cliLabelPrints === 1) {
             const pidLine = input.pid === null ? "" : `\tpid = ${input.pid}\n`;
+            const stateLine =
+              input.stateLine === undefined
+                ? ""
+                : `\tstate = ${input.stateLine}\n`;
             return {
-              stdout: `\tpath = /Users/me/Library/LaunchAgents/${label.id}.plist\n\ttype = LaunchAgent\n${pidLine}`,
+              stdout: `\tpath = /Users/me/Library/LaunchAgents/${label.id}.plist\n\ttype = LaunchAgent\n${stateLine}${pidLine}`,
               stderr: "",
               exitCode: 0,
             };
@@ -3023,6 +3085,123 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
         ),
       });
       expect(MOCKS.requestCooperativeShutdown).not.toHaveBeenCalled();
+    });
+
+    // `state = running` with NO pid still counts as `running` per
+    // `probeLabelForTakeover` - the job is asked to stand down just like a
+    // pid-bearing one, and only the post-bootout liveness check has nothing
+    // to key on (see the `process-unverified` pin below).
+    it("resolves cli-host-stopped/stopped and asks a running, pidless CLI-label job to stand down (state = running, no pid)", async () => {
+      const { calls, controller } = stageStandDownRunner({
+        pid: null,
+        stateLine: "running",
+      });
+      MOCKS.requestCooperativeShutdown.mockResolvedValue({ kind: "stopped" });
+
+      await expect(
+        controller.takeoverDesktopRegistration(label),
+      ).resolves.toEqual({
+        kind: "cli-host-stopped",
+        cooperativeStop: "stopped",
+      });
+      expect(MOCKS.requestCooperativeShutdown).toHaveBeenCalledWith(
+        label.environment,
+        "takeover",
+        "shutdown",
+      );
+      expect(MOCKS.cliLoggerInfo).toHaveBeenCalledWith(
+        expect.stringContaining("stood down before the reload"),
+        expect.objectContaining({ label: label.id, pid: null }),
+      );
+      const bootout = calls.find((c) => c.args[0] === "bootout");
+      expect(bootout?.args).toEqual([
+        "bootout",
+        "--wait",
+        `gui/${process.getuid?.() ?? 0}/${label.id}`,
+      ]);
+    });
+
+    it("rejects with SERVICE_INSTALL_FAILED naming 'a running job' when a running, pidless CLI-label job has not published a live endpoint yet (no-metadata)", async () => {
+      const { calls, controller } = stageStandDownRunner({
+        pid: null,
+        stateLine: "running",
+      });
+      MOCKS.requestCooperativeShutdown.mockResolvedValue({
+        kind: "no-metadata",
+      });
+
+      const takeover = controller.takeoverDesktopRegistration(label);
+      await expect(takeover).rejects.toMatchObject({
+        code: CLI_ERROR_CODES.SERVICE_INSTALL_FAILED,
+        message: expect.stringContaining("a running job under"),
+      });
+      await expect(takeover).rejects.toMatchObject({
+        message: expect.stringContaining(
+          "has not published a live endpoint yet",
+        ),
+      });
+      expect(calls.some((c) => c.args[0] === "bootout")).toBe(false);
+    });
+
+    it("rejects with SERVICE_INSTALL_FAILED ('the wait did not end with its exit') when a running, pidless CLI-label job's bootout does not confirm exit", async () => {
+      const { controller } = stageStandDownRunner({
+        pid: null,
+        stateLine: "running",
+        bootoutExitCode: -1,
+      });
+      MOCKS.requestCooperativeShutdown.mockResolvedValue({
+        kind: "unreachable",
+        cause: "x",
+      });
+
+      await expect(
+        controller.takeoverDesktopRegistration(label),
+      ).rejects.toMatchObject({
+        code: CLI_ERROR_CODES.SERVICE_INSTALL_FAILED,
+        message: expect.stringContaining("the wait did not end with its exit"),
+        details: expect.objectContaining({
+          verification: "process-unverified",
+          pid: null,
+        }),
+      });
+    });
+
+    it("does not refuse a running, pidless CLI-label job whose host ANSWERED the claim with stopped, even when the bootout wait exits non-zero (the stale running flag is not evidence after an answer)", async () => {
+      const { calls, controller } = stageStandDownRunner({
+        pid: null,
+        stateLine: "running",
+        bootoutExitCode: -1,
+      });
+      MOCKS.requestCooperativeShutdown.mockResolvedValue({ kind: "stopped" });
+
+      await expect(
+        controller.takeoverDesktopRegistration(label),
+      ).resolves.toEqual({
+        kind: "cli-host-stopped",
+        cooperativeStop: "stopped",
+      });
+      expect(calls.some((c) => c.args[0] === "bootout")).toBe(true);
+    });
+
+    it("resolves cli-host-stopped/no-host via the idle unload path (no claim) when the CLI-label job's state is explicitly not running (state = waiting, no pid)", async () => {
+      const { calls, controller } = stageStandDownRunner({
+        pid: null,
+        stateLine: "waiting",
+      });
+
+      await expect(
+        controller.takeoverDesktopRegistration(label),
+      ).resolves.toEqual({
+        kind: "cli-host-stopped",
+        cooperativeStop: "no-host",
+      });
+      expect(MOCKS.requestCooperativeShutdown).not.toHaveBeenCalled();
+      const bootout = calls.find((c) => c.args[0] === "bootout");
+      expect(bootout?.args).toEqual([
+        "bootout",
+        "--wait",
+        `gui/${process.getuid?.() ?? 0}/${label.id}`,
+      ]);
     });
 
     // The CLI label not loaded at all (exit 113 on both probes) is already

--- a/clients/traycer-cli/src/service/platforms/__tests__/macos.test.ts
+++ b/clients/traycer-cli/src/service/platforms/__tests__/macos.test.ts
@@ -1425,6 +1425,67 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
     expect(classifyLaunchdPrintOutput(printOutput)).toEqual({
       kind: "cli-or-other",
       path: "/Users/me/Library/LaunchAgents/ai.traycer.host.plist",
+      pid: null,
+    });
+  });
+
+  it("classifies a raw CLI-bootstrapped LaunchAgent with a live pid as cli-or-other with that pid", () => {
+    const printOutput = [
+      "gui/501/ai.traycer.host = {",
+      "\tactive count = 1",
+      "\tpath = /Users/me/Library/LaunchAgents/ai.traycer.host.plist",
+      "\ttype = LaunchAgent",
+      "\tstate = running",
+      "\tpid = 4242",
+      "",
+      "\tprogram = /Users/me/.traycer/cli/bin/traycer",
+      "\targuments = {",
+      "\t\t/Users/me/.traycer/cli/bin/traycer",
+      "\t\thost",
+      "\t\tstart",
+      "\t}",
+      "}",
+      "",
+    ].join("\n");
+
+    expect(classifyLaunchdPrintOutput(printOutput)).toEqual({
+      kind: "cli-or-other",
+      path: "/Users/me/Library/LaunchAgents/ai.traycer.host.plist",
+      pid: 4242,
+    });
+  });
+
+  it("treats a zero or non-numeric pid field as no live process", () => {
+    const printOutputZero = [
+      "gui/501/ai.traycer.host = {",
+      "\tpath = /Users/me/Library/LaunchAgents/ai.traycer.host.plist",
+      "\ttype = LaunchAgent",
+      "\tpid = 0",
+      "\tprogram = /Users/me/.traycer/cli/bin/traycer",
+      "}",
+      "",
+    ].join("\n");
+
+    expect(classifyLaunchdPrintOutput(printOutputZero)).toEqual({
+      kind: "cli-or-other",
+      path: "/Users/me/Library/LaunchAgents/ai.traycer.host.plist",
+      pid: null,
+    });
+
+    const printOutputNonNumeric = [
+      "gui/501/ai.traycer.host = {",
+      "\tpath = /Users/me/Library/LaunchAgents/ai.traycer.host.plist",
+      "\ttype = LaunchAgent",
+      "\tpid = (null)",
+      "\tprogram = /Users/me/.traycer/cli/bin/traycer",
+      "}",
+      "",
+    ].join("\n");
+
+    expect(classifyLaunchdPrintOutput(printOutputNonNumeric)).toEqual({
+      kind: "cli-or-other",
+      path: "/Users/me/Library/LaunchAgents/ai.traycer.host.plist",
+      pid: null,
     });
   });
 
@@ -2320,6 +2381,146 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
         expect(bootout?.args).toEqual(["bootout", "--wait", agentTarget]);
       },
     );
+  });
+
+  describe("takeoverDesktopRegistration - standing down a live CLI-label host", () => {
+    // No Desktop SMAppService agent is loaded (the `.agent` probe reads
+    // not-loaded, exit 113), but the CLI label itself is loaded from a
+    // raw `~/Library/LaunchAgents/<label>.plist` path (NOT an in-bundle
+    // SMAppService path, so this stays `cli-or-other` rather than
+    // tripping the pre-split refusal) with an optional live `pid` -
+    // the KeepAlive-respawn race `standDownLiveCliLabelHost` exists to
+    // close.
+    function stageStandDownRunner(input: { pid: number | null }): {
+      calls: RecordedCall[];
+      controller: ServiceController;
+    } {
+      const calls: RecordedCall[] = [];
+      const runner: ProcessRunner = async (command, args) => {
+        calls.push({ command, args });
+        if (args[0] === "print") {
+          if (args[1]?.endsWith(".agent") === true) {
+            return {
+              stdout: "",
+              stderr: "Could not find specified service\n",
+              exitCode: 113,
+            };
+          }
+          const pidLine = input.pid === null ? "" : `\tpid = ${input.pid}\n`;
+          return {
+            stdout: `\tpath = /Users/me/Library/LaunchAgents/${label.id}.plist\n\ttype = LaunchAgent\n${pidLine}`,
+            stderr: "",
+            exitCode: 0,
+          };
+        }
+        return buildSuccessResult();
+      };
+      return { calls, controller: createMacosController(runner) };
+    }
+
+    it("rejects with HOST_BUSY and never boots out when the live CLI-label host denies the shutdown claim", async () => {
+      const { calls, controller } = stageStandDownRunner({ pid: 4242 });
+      MOCKS.requestCooperativeShutdown.mockResolvedValue({ kind: "busy" });
+
+      await expect(
+        controller.takeoverDesktopRegistration(label),
+      ).rejects.toMatchObject({
+        code: CLI_ERROR_CODES.HOST_BUSY,
+        message: expect.stringContaining("denied the shutdown claim"),
+      });
+      expect(calls.some((c) => c.args[0] === "bootout")).toBe(false);
+    });
+
+    it("rejects with SERVICE_INSTALL_FAILED and never boots out when the live CLI-label host has not published a live endpoint yet (no-metadata)", async () => {
+      const { calls, controller } = stageStandDownRunner({ pid: 4242 });
+      MOCKS.requestCooperativeShutdown.mockResolvedValue({
+        kind: "no-metadata",
+      });
+
+      await expect(
+        controller.takeoverDesktopRegistration(label),
+      ).rejects.toMatchObject({
+        code: CLI_ERROR_CODES.SERVICE_INSTALL_FAILED,
+        message: expect.stringContaining(
+          "has not published a live endpoint yet",
+        ),
+      });
+      expect(calls.some((c) => c.args[0] === "bootout")).toBe(false);
+    });
+
+    it("rejects with SERVICE_INSTALL_FAILED the same way, and never boots out, when launchd's pid names a host that already exited (no-host)", async () => {
+      const { calls, controller } = stageStandDownRunner({ pid: 4242 });
+      MOCKS.requestCooperativeShutdown.mockResolvedValue({
+        kind: "no-host",
+      });
+
+      await expect(
+        controller.takeoverDesktopRegistration(label),
+      ).rejects.toMatchObject({
+        code: CLI_ERROR_CODES.SERVICE_INSTALL_FAILED,
+        message: expect.stringContaining(
+          "has not published a live endpoint yet",
+        ),
+      });
+      expect(calls.some((c) => c.args[0] === "bootout")).toBe(false);
+    });
+
+    it("resolves cli-host-stopped/stopped and logs the stand-down when the live CLI-label host stops cooperatively", async () => {
+      const { controller } = stageStandDownRunner({ pid: 4242 });
+      MOCKS.requestCooperativeShutdown.mockResolvedValue({ kind: "stopped" });
+
+      await expect(
+        controller.takeoverDesktopRegistration(label),
+      ).resolves.toEqual({
+        kind: "cli-host-stopped",
+        cooperativeStop: "stopped",
+      });
+      expect(MOCKS.requestCooperativeShutdown).toHaveBeenCalledWith(
+        label.environment,
+        "takeover",
+        "shutdown",
+      );
+      expect(MOCKS.cliLoggerInfo).toHaveBeenCalledWith(
+        expect.stringContaining("stood down before the reload"),
+        expect.objectContaining({ label: label.id, pid: 4242 }),
+      );
+    });
+
+    it("resolves cli-host-stopped/skipped-unreachable and warns when the live CLI-label host cannot be stopped cooperatively", async () => {
+      const { controller } = stageStandDownRunner({ pid: 4242 });
+      MOCKS.requestCooperativeShutdown.mockResolvedValue({
+        kind: "unreachable",
+        cause: "boom",
+      });
+
+      await expect(
+        controller.takeoverDesktopRegistration(label),
+      ).resolves.toEqual({
+        kind: "cli-host-stopped",
+        cooperativeStop: "skipped-unreachable",
+      });
+      expect(MOCKS.cliLoggerWarn).toHaveBeenCalledWith(
+        expect.stringContaining("could not be stopped cooperatively"),
+        expect.objectContaining({ cause: "boom" }),
+      );
+    });
+
+    it("reports not-applicable and never calls requestCooperativeShutdown when the CLI label is loaded but has no live pid", async () => {
+      const { controller } = stageStandDownRunner({ pid: null });
+
+      await expect(
+        controller.takeoverDesktopRegistration(label),
+      ).resolves.toEqual({ kind: "not-applicable" });
+      expect(MOCKS.requestCooperativeShutdown).not.toHaveBeenCalled();
+    });
+
+    // The CLI label not loaded at all (exit 113 on both probes) is already
+    // covered above by "reports not-applicable when Desktop owns nothing"
+    // in the `takeoverDesktopRegistration` describe block - that runner
+    // makes every `print` call return exit 113, which puts `cliOwnership`
+    // at `not-loaded` (not `cli-or-other`), so `standDownLiveCliLabelHost`
+    // short-circuits to `not-applicable` without calling
+    // `requestCooperativeShutdown`. No separate test added here.
   });
 
   it("stop/start/restart proceed normally when the agent probe reads not-loaded (CLI-managed machine)", async () => {

--- a/clients/traycer-cli/src/service/platforms/__tests__/macos.test.ts
+++ b/clients/traycer-cli/src/service/platforms/__tests__/macos.test.ts
@@ -57,6 +57,9 @@ const MOCKS = vi.hoisted(() => ({
   cliLoggerInfo: vi.fn(),
   requestCooperativeShutdown: vi.fn(),
   forceStopHostProcess: vi.fn(),
+  readProcessStartIdentity: vi.fn(),
+  getPublishedProcessIdentityVerdict: vi.fn(),
+  probeHostHealth: vi.fn(),
 }));
 
 // The cooperative-shutdown RPC flow and the forced-kill path each have their
@@ -109,6 +112,31 @@ vi.mock("../../../store/cli-lock", async (importOriginal) => {
     await importOriginal<typeof import("../../../store/cli-lock")>();
   return { ...actual, isProcessAlive: MOCKS.isProcessAlive };
 });
+
+// `probeLabelForTakeover` reads a live pid's start identity, and
+// `processMayLiveOn` asks whether launchd's process is still the one it
+// published - both live in `store/process-identity`. Stubbed the same way
+// as `cli-lock` above so the takeover tests control the recycled-pid
+// evidence directly instead of reading the real OS process table.
+vi.mock("../../../store/process-identity", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../../store/process-identity")>();
+  return {
+    ...actual,
+    readProcessStartIdentity: MOCKS.readProcessStartIdentity,
+    getPublishedProcessIdentityVerdict:
+      MOCKS.getPublishedProcessIdentityVerdict,
+  };
+});
+
+// `refuseIfPublishedHostAlive` dials `probeHostHealth` once for an
+// `indeterminate` verdict whose record predates identity tracking, to tell
+// a still-running hand-run host apart from a stale record left behind by
+// one long gone. Stubbed so the takeover tests control that dial directly
+// instead of opening a real loopback socket.
+vi.mock("../../health-probe", () => ({
+  probeHostHealth: MOCKS.probeHostHealth,
+}));
 
 // Test isolation: `serviceManifestPath` normally resolves to the REAL
 // `~/Library/LaunchAgents/<label>.plist` (via `os.homedir()`, which ignores
@@ -437,6 +465,15 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
     MOCKS.readHostPidMetadata.mockResolvedValue(null);
     MOCKS.isProcessAlive.mockReset();
     MOCKS.isProcessAlive.mockReturnValue(false);
+    MOCKS.readProcessStartIdentity.mockReset();
+    MOCKS.readProcessStartIdentity.mockReturnValue(null);
+    MOCKS.getPublishedProcessIdentityVerdict.mockReset();
+    MOCKS.getPublishedProcessIdentityVerdict.mockResolvedValue("indeterminate");
+    MOCKS.probeHostHealth.mockReset();
+    MOCKS.probeHostHealth.mockResolvedValue({
+      healthy: false,
+      detail: "no host",
+    });
     MOCKS.cliLoggerWarn.mockReset();
     MOCKS.cliLoggerInfo.mockReset();
     MOCKS.requestCooperativeShutdown.mockReset();
@@ -2121,9 +2158,15 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
     // post-bootout re-probe `unloadCliLabelJob` runs) answers per
     // `afterBootout` - "absent" is launchd's not-found output, "still-loaded"
     // repeats the loaded answer.
+    // `agentRunning` puts a `\tpid = 777\n` line on the FIRST agent print -
+    // the only one `agentProbe` is read from - so `agentProbe.running` is
+    // true and the took-over arm actually makes a cooperative claim. Idle
+    // (false) is the default shape most fixtures used before the claim was
+    // conditioned on it: `path = ...` alone, no pid or state line.
     function stageTakeoverRunner(input: {
       cliLabelOwned: boolean;
       agentLoadedAfterBootout: boolean;
+      agentRunning: boolean;
       cliLabelLoadedAsCliOrOther?: {
         afterBootout: "absent" | "still-loaded";
       };
@@ -2141,8 +2184,14 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
             agentPrints += 1;
             const loaded =
               agentPrints === 1 ? true : input.agentLoadedAfterBootout;
+            const pidLine =
+              agentPrints === 1 && input.agentRunning ? "\tpid = 777\n" : "";
             return loaded
-              ? { stdout: `path = ${smAgentPath}\n`, stderr: "", exitCode: 0 }
+              ? {
+                  stdout: `path = ${smAgentPath}\n${pidLine}`,
+                  stderr: "",
+                  exitCode: 0,
+                }
               : {
                   stdout: "",
                   stderr: "Could not find specified service\n",
@@ -2188,6 +2237,7 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
       const { calls, controller } = stageTakeoverRunner({
         cliLabelOwned: false,
         agentLoadedAfterBootout: false,
+        agentRunning: true,
       });
       MOCKS.requestCooperativeShutdown.mockResolvedValue({ kind: "stopped" });
 
@@ -2225,6 +2275,7 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
       const { calls, controller } = stageTakeoverRunner({
         cliLabelOwned: false,
         agentLoadedAfterBootout: true,
+        agentRunning: true,
       });
       MOCKS.requestCooperativeShutdown.mockResolvedValue({ kind: "busy" });
 
@@ -2241,6 +2292,7 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
       const { calls, controller } = stageTakeoverRunner({
         cliLabelOwned: false,
         agentLoadedAfterBootout: false,
+        agentRunning: true,
       });
       MOCKS.requestCooperativeShutdown.mockResolvedValue({
         kind: "unreachable",
@@ -2319,6 +2371,9 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
       const { calls, controller } = stageTakeoverRunner({
         cliLabelOwned: true,
         agentLoadedAfterBootout: true,
+        // Irrelevant here: the pre-split refusal fires on the CLI label's
+        // own probe, before the agent's `running` flag is ever read.
+        agentRunning: false,
       });
 
       await expect(
@@ -2334,10 +2389,58 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
       expect(calls.map((c) => c.args[0])).toEqual(["print", "print"]);
     });
 
+    // A job loaded under the AGENT label that Desktop itself never
+    // registered - a raw `~/Library/LaunchAgents/<label>.agent.plist`,
+    // `cli-or-other` ownership rather than an in-bundle SMAppService path.
+    // This command only manages Desktop's own registration, so it refuses
+    // rather than bootstrap the CLI label beside a job nobody asked to
+    // stand down. Idle here (no pid, no `running` claim to make) - the
+    // refusal fires on ownership alone, before any liveness is read.
+    it("rejects with SERVICE_INSTALL_FAILED ('is not Traycer Desktop's registration') when the agent label is loaded idle but not by Desktop", async () => {
+      const loadedPath = `/Users/me/Library/LaunchAgents/${label.id}.agent.plist`;
+      const calls: RecordedCall[] = [];
+      const runner: ProcessRunner = async (command, args) => {
+        calls.push({ command, args });
+        if (args[0] === "print") {
+          if (args[1]?.endsWith(".agent") === true) {
+            return {
+              stdout: `\tpath = ${loadedPath}\n\ttype = LaunchAgent\n`,
+              stderr: "",
+              exitCode: 0,
+            };
+          }
+          return {
+            stdout: "",
+            stderr: "Could not find specified service\n",
+            exitCode: 113,
+          };
+        }
+        return buildSuccessResult();
+      };
+
+      await expect(
+        createMacosController(runner).takeoverDesktopRegistration(label),
+      ).rejects.toMatchObject({
+        code: CLI_ERROR_CODES.SERVICE_INSTALL_FAILED,
+        message: expect.stringContaining(
+          "is not Traycer Desktop's registration",
+        ),
+        details: expect.objectContaining({
+          agentLabel: `${label.id}.agent`,
+          loadedPath,
+        }),
+      });
+      expect(MOCKS.requestCooperativeShutdown).not.toHaveBeenCalled();
+      expect(calls.some((c) => c.args[0] === "bootout")).toBe(false);
+    });
+
     it("reports not-applicable when Desktop owns nothing", async () => {
       const { calls, controller } = stageTakeoverRunner({
         cliLabelOwned: false,
         agentLoadedAfterBootout: true,
+        // Irrelevant: this runner and controller are discarded below in
+        // favour of `notLoadedRunner`.
+        agentRunning: false,
       });
       // Agent print must read not-loaded on the FIRST probe for this case.
       calls.length = 0;
@@ -2359,12 +2462,201 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
       void controller;
     });
 
+    // Rule 3, no-agent arm: `refuseIfPublishedHostAlive` runs even when
+    // Desktop owns nothing and the CLI label itself is absent - a hand-run
+    // host can still be the one `pid.json` names, and nothing under either
+    // label ever asked it to stand down.
+    it("rejects with SERVICE_INSTALL_FAILED ('a host is still running') when Desktop owns nothing but a published endpoint's identity verdict is 'current'", async () => {
+      const calls: RecordedCall[] = [];
+      const notLoadedRunner: ProcessRunner = async (command, args) => {
+        calls.push({ command, args });
+        return {
+          stdout: "",
+          stderr: "Could not find specified service\n",
+          exitCode: 113,
+        };
+      };
+      MOCKS.readHostPidMetadata.mockResolvedValue({
+        pid: 9001,
+        hostId: "hand-run-host",
+        version: "1.2.3",
+        websocketUrl: "ws://127.0.0.1:9001/rpc",
+        startedAt: "2026-07-12T00:00:00.000Z",
+        processStartIdentity: null,
+      });
+      MOCKS.getPublishedProcessIdentityVerdict.mockResolvedValue("current");
+
+      await expect(
+        createMacosController(notLoadedRunner).takeoverDesktopRegistration(
+          label,
+        ),
+      ).rejects.toMatchObject({
+        code: CLI_ERROR_CODES.SERVICE_INSTALL_FAILED,
+        message: expect.stringContaining(
+          "a host is still running (pid 9001, per its published endpoint)",
+        ),
+        details: expect.objectContaining({ pid: 9001, verdict: "current" }),
+      });
+      expect(calls.some((c) => c.args[0] === "bootout")).toBe(false);
+    });
+
+    it("resolves not-applicable when Desktop owns nothing and a published endpoint's identity verdict is 'mismatch'", async () => {
+      const notLoadedRunner: ProcessRunner = async () => ({
+        stdout: "",
+        stderr: "Could not find specified service\n",
+        exitCode: 113,
+      });
+      MOCKS.readHostPidMetadata.mockResolvedValue({
+        pid: 9001,
+        hostId: "hand-run-host",
+        version: "1.2.3",
+        websocketUrl: "ws://127.0.0.1:9001/rpc",
+        startedAt: "2026-07-12T00:00:00.000Z",
+        processStartIdentity: null,
+      });
+      MOCKS.getPublishedProcessIdentityVerdict.mockResolvedValue("mismatch");
+
+      await expect(
+        createMacosController(notLoadedRunner).takeoverDesktopRegistration(
+          label,
+        ),
+      ).resolves.toEqual({ kind: "not-applicable" });
+    });
+
+    // An "indeterminate" verdict on a record that predates identity
+    // tracking (`processStartIdentity === null`) cannot be told apart from
+    // a host still running by the verdict alone, so `refuseIfPublishedHostAlive`
+    // dials the endpoint once via `probeHostHealth`. Nothing answering means
+    // the record is stale (most likely a host that crashed without
+    // cleaning up `pid.json`), and the reload proceeds under a warning.
+    it("resolves not-applicable and warns 'treating the record as stale' when an indeterminate, identity-less record's endpoint answers unhealthy", async () => {
+      const notLoadedRunner: ProcessRunner = async () => ({
+        stdout: "",
+        stderr: "Could not find specified service\n",
+        exitCode: 113,
+      });
+      MOCKS.readHostPidMetadata.mockResolvedValue({
+        pid: 9001,
+        hostId: "hand-run-host",
+        version: "1.2.3",
+        websocketUrl: "ws://127.0.0.1:9001/rpc",
+        startedAt: "2026-07-12T00:00:00.000Z",
+        processStartIdentity: null,
+      });
+      MOCKS.getPublishedProcessIdentityVerdict.mockResolvedValue(
+        "indeterminate",
+      );
+      MOCKS.probeHostHealth.mockResolvedValue({
+        healthy: false,
+        detail: "no host loopback port reachable",
+      });
+
+      await expect(
+        createMacosController(notLoadedRunner).takeoverDesktopRegistration(
+          label,
+        ),
+      ).resolves.toEqual({ kind: "not-applicable" });
+      expect(MOCKS.probeHostHealth).toHaveBeenCalledTimes(1);
+      expect(MOCKS.cliLoggerWarn).toHaveBeenCalledWith(
+        expect.stringContaining("treating the record as stale"),
+        expect.objectContaining({ pid: 9001 }),
+      );
+    });
+
+    // The opposite dial result: something DOES answer on the endpoint the
+    // record advertises, so it is a host, whatever its identity record
+    // says - refused with wording distinct from the "current" branch, since
+    // there is no process-identity match here, only a live TCP answer.
+    it("rejects with SERVICE_INSTALL_FAILED ('a host answered on the endpoint') when an indeterminate, identity-less record's endpoint answers healthy", async () => {
+      const notLoadedRunner: ProcessRunner = async () => ({
+        stdout: "",
+        stderr: "Could not find specified service\n",
+        exitCode: 113,
+      });
+      MOCKS.readHostPidMetadata.mockResolvedValue({
+        pid: 9001,
+        hostId: "hand-run-host",
+        version: "1.2.3",
+        websocketUrl: "ws://127.0.0.1:9001/rpc",
+        startedAt: "2026-07-12T00:00:00.000Z",
+        processStartIdentity: null,
+      });
+      MOCKS.getPublishedProcessIdentityVerdict.mockResolvedValue(
+        "indeterminate",
+      );
+      MOCKS.probeHostHealth.mockResolvedValue({
+        healthy: true,
+        detail: "process alive and loopback port reachable",
+      });
+
+      await expect(
+        createMacosController(notLoadedRunner).takeoverDesktopRegistration(
+          label,
+        ),
+      ).rejects.toMatchObject({
+        code: CLI_ERROR_CODES.SERVICE_INSTALL_FAILED,
+        message: expect.stringContaining(
+          "a host answered on the endpoint the published host record",
+        ),
+        details: expect.objectContaining({
+          pid: 9001,
+          verdict: "indeterminate",
+        }),
+      });
+    });
+
+    // With a NON-null `processStartIdentity`, an "indeterminate" verdict is
+    // a probe fault (the recorded stamp could not be compared), not a
+    // record that predates identity tracking - so it refuses like
+    // "current", with its OWN wording, and never dials `probeHostHealth`.
+    it("rejects with SERVICE_INSTALL_FAILED ('its process identity could not be read') and never dials the endpoint when the record HAS a process identity", async () => {
+      const notLoadedRunner: ProcessRunner = async () => ({
+        stdout: "",
+        stderr: "Could not find specified service\n",
+        exitCode: 113,
+      });
+      MOCKS.readHostPidMetadata.mockResolvedValue({
+        pid: 9001,
+        hostId: "hand-run-host",
+        version: "1.2.3",
+        websocketUrl: "ws://127.0.0.1:9001/rpc",
+        startedAt: "2026-07-12T00:00:00.000Z",
+        processStartIdentity: "darwin:1699999999.123456",
+      });
+      MOCKS.getPublishedProcessIdentityVerdict.mockResolvedValue(
+        "indeterminate",
+      );
+
+      await expect(
+        createMacosController(notLoadedRunner).takeoverDesktopRegistration(
+          label,
+        ),
+      ).rejects.toMatchObject({
+        code: CLI_ERROR_CODES.SERVICE_INSTALL_FAILED,
+        message: expect.stringContaining(
+          "its process identity could not be read",
+        ),
+        details: expect.objectContaining({
+          pid: 9001,
+          verdict: "indeterminate",
+        }),
+      });
+      expect(MOCKS.probeHostHealth).not.toHaveBeenCalled();
+    });
+
     it("fails closed when the bootout does not take effect", async () => {
       const { calls, controller } = stageTakeoverRunner({
         cliLabelOwned: false,
         agentLoadedAfterBootout: true,
+        agentRunning: true,
       });
-      MOCKS.requestCooperativeShutdown.mockResolvedValue({ kind: "no-host" });
+      // `no-metadata`/`no-host` with a running agent now refuse OUTRIGHT
+      // (before any bootout), so this "did not take effect" pin needs an
+      // outcome that still proceeds to the bootout - `hung` does.
+      MOCKS.requestCooperativeShutdown.mockResolvedValue({
+        kind: "hung",
+        pid: 777,
+      });
 
       await expect(
         controller.takeoverDesktopRegistration(label),
@@ -2397,16 +2689,20 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
      * still alive" - a single row over `stopped` would pass while every
      * dangerous arm regressed.
      */
+    // `no-metadata`/`no-host` dropped from this table: with a running
+    // agent those two now refuse OUTRIGHT (pinned separately below) instead
+    // of proceeding to the bootout, so a row here would have asserted the
+    // pre-change behaviour.
     it.each([
       ["unreachable", { kind: "unreachable", cause: "dial failed" }],
       ["hung", { kind: "hung", pid: 4242 }],
-      ["no-metadata", { kind: "no-metadata" }],
     ] as const)(
       "waits for the evicted host to exit before install can race it (%s)",
       async (_name, outcome) => {
         const { calls, controller } = stageTakeoverRunner({
           cliLabelOwned: false,
           agentLoadedAfterBootout: false,
+          agentRunning: true,
         });
         MOCKS.requestCooperativeShutdown.mockResolvedValue(outcome);
 
@@ -2418,6 +2714,74 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
         expect(bootout?.args).toEqual(["bootout", "--wait", agentTarget]);
       },
     );
+
+    // A running agent process that nobody could ask - `unaskableHost`, the
+    // same refusal the CLI-label stand-down uses. `agentProbe.running` gates
+    // it: the claim went through `pid.json`, and a fresh host in its first
+    // seconds (no-metadata) or between children (no-host) gets no bootout
+    // at all here, unlike `unreachable`/`hung` above.
+    it.each([
+      [
+        "no-metadata",
+        { kind: "no-metadata" } as const,
+        "has not published a live endpoint yet",
+      ],
+      [
+        "no-host",
+        { kind: "no-host" } as const,
+        "names a host that has already exited",
+      ],
+    ] as const)(
+      "rejects with SERVICE_INSTALL_FAILED ('%s') and never boots out when a running Desktop-managed agent's claim can find no endpoint to ask",
+      async (metadataKind, outcome, messageFragment) => {
+        const { calls, controller } = stageTakeoverRunner({
+          cliLabelOwned: false,
+          agentLoadedAfterBootout: false,
+          agentRunning: true,
+        });
+        MOCKS.requestCooperativeShutdown.mockResolvedValue(outcome);
+
+        await expect(
+          controller.takeoverDesktopRegistration(label),
+        ).rejects.toMatchObject({
+          code: CLI_ERROR_CODES.SERVICE_INSTALL_FAILED,
+          message: expect.stringContaining(messageFragment),
+          details: expect.objectContaining({
+            probedLabel: `${label.id}.agent`,
+            metadata: metadataKind,
+          }),
+        });
+        expect(calls.some((c) => c.args[0] === "bootout")).toBe(false);
+      },
+    );
+
+    // The mirror case: an IDLE agent (no process for the claim to have
+    // reached in the first place) gets the SAME `no-metadata`/`no-host`
+    // answer, but `agentProbe.running` is false, so the refusal above never
+    // fires - there was nothing to ask, and the agent is booted out exactly
+    // as it would be for any other non-`busy` outcome. No degradation
+    // warning either: that only logs for `unreachable`/`hung`.
+    it("boots out an idle agent and resolves cooperativeStop 'no-host' when the claim answers no-metadata, with no warning logged", async () => {
+      const { calls, controller } = stageTakeoverRunner({
+        cliLabelOwned: false,
+        agentLoadedAfterBootout: false,
+        agentRunning: false,
+      });
+      MOCKS.requestCooperativeShutdown.mockResolvedValue({
+        kind: "no-metadata",
+      });
+
+      await expect(
+        controller.takeoverDesktopRegistration(label),
+      ).resolves.toEqual({
+        kind: "took-over",
+        agentLabelId: `${label.id}.agent`,
+        cooperativeStop: "no-host",
+      });
+      const bootout = calls.find((c) => c.args[0] === "bootout");
+      expect(bootout?.args).toEqual(["bootout", "--wait", agentTarget]);
+      expect(MOCKS.cliLoggerWarn).not.toHaveBeenCalled();
+    });
 
     // A dual-registered machine: Desktop's agent AND the raw CLI-label
     // plist are both loaded. `takeoverDesktopRegistration` boots out the
@@ -2435,6 +2799,7 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
       const { calls, controller } = stageTakeoverRunner({
         cliLabelOwned: false,
         agentLoadedAfterBootout: false,
+        agentRunning: true,
         cliLabelLoadedAsCliOrOther: { afterBootout: "absent" },
       });
       MOCKS.requestCooperativeShutdown.mockResolvedValue({ kind: "stopped" });
@@ -2457,6 +2822,10 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
       ]);
       expect(calls[5]?.args).toEqual(["bootout", "--wait", cliTarget]);
       expect(calls[6]?.args[1]).toEqual(cliTarget);
+      // The CLI label was idle (no pid) both times it was read, so its
+      // stand-down never itself asks for a claim - only the agent's claim
+      // above was made.
+      expect(MOCKS.requestCooperativeShutdown).toHaveBeenCalledTimes(1);
       // `standDownLiveCliLabelHost`'s pid-null branch logs the same generic
       // message whether or not an agent was just retired - there is no
       // agent-specific copy any more, so this pins the message it does log.
@@ -2472,6 +2841,7 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
       const { controller } = stageTakeoverRunner({
         cliLabelOwned: false,
         agentLoadedAfterBootout: false,
+        agentRunning: true,
         cliLabelLoadedAsCliOrOther: { afterBootout: "still-loaded" },
       });
       MOCKS.requestCooperativeShutdown.mockResolvedValue({ kind: "stopped" });
@@ -2492,14 +2862,108 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
       });
     });
 
-    it("rejects before any bootout when the CLI label has a live pid beside the agent and the claim finds no endpoint (pre-check)", async () => {
+    // Rule 2: the claim is skipped ONLY when the CLI label is the one
+    // holding a process. An idle agent with the CLI label absent is not
+    // that case - `pid.json` could still name a hand-run host, so the claim
+    // is made here even though the agent itself reports no process.
+    it("still makes the cooperative claim for an idle agent when the CLI label is absent, because a hand-run host must be asked", async () => {
+      const { calls, controller } = stageTakeoverRunner({
+        cliLabelOwned: false,
+        agentLoadedAfterBootout: false,
+        agentRunning: false,
+      });
+      MOCKS.requestCooperativeShutdown.mockResolvedValue({ kind: "no-host" });
+
+      await expect(
+        controller.takeoverDesktopRegistration(label),
+      ).resolves.toEqual({
+        kind: "took-over",
+        agentLabelId: `${label.id}.agent`,
+        cooperativeStop: "no-host",
+      });
+      expect(MOCKS.requestCooperativeShutdown).toHaveBeenCalledTimes(1);
+      const bootout = calls.find((c) => c.args[0] === "bootout");
+      expect(bootout?.args).toEqual(["bootout", "--wait", agentTarget]);
+    });
+
+    // The other half of rule 2: an idle agent beside a CLI label that DOES
+    // hold a process. Here the first claim IS skipped - the CLI label is
+    // the one with the process, so the stand-down asks it afterwards, with
+    // a claim that reaches only that host. The agent is still booted out
+    // unconditionally (idle, so its own liveness check is trivially "no");
+    // the CLI label is then re-read fresh and its own stand-down makes the
+    // ONLY cooperative claim in this run, and that claim's answer -
+    // "stopped" - is what the overall result reports.
+    it("skips the first claim for an idle agent when the CLI label holds the process, and reports the stand-down's claim as the outcome", async () => {
+      const calls: RecordedCall[] = [];
+      let agentPrints = 0;
+      let cliPrints = 0;
+      const cliLoadedPidResult = {
+        stdout: `\tpath = /Users/me/Library/LaunchAgents/${label.id}.plist\n\ttype = LaunchAgent\n\tpid = 4242\n`,
+        stderr: "",
+        exitCode: 0,
+      };
+      const notFoundResult = {
+        stdout: "",
+        stderr: "Could not find specified service\n",
+        exitCode: 113,
+      };
+      const runner: ProcessRunner = async (command, args) => {
+        calls.push({ command, args });
+        if (args[0] === "print") {
+          if (args[1]?.endsWith(".agent") === true) {
+            agentPrints += 1;
+            // First probe: idle SMAppService agent (no pid, no state
+            // line). Second probe (post-bootout verify): gone.
+            return agentPrints === 1
+              ? { stdout: `path = ${smAgentPath}\n`, stderr: "", exitCode: 0 }
+              : notFoundResult;
+          }
+          cliPrints += 1;
+          // Both reads before the CLI-label bootout - the initial
+          // `cliProbe` (decides `claimHere`) and the fresh re-probe after
+          // the agent is retired - see the same running process; the third
+          // (post-bootout verify) answers absent.
+          return cliPrints <= 2 ? cliLoadedPidResult : notFoundResult;
+        }
+        return buildSuccessResult();
+      };
+      MOCKS.requestCooperativeShutdown.mockResolvedValue({ kind: "stopped" });
+
+      await expect(
+        createMacosController(runner).takeoverDesktopRegistration(label),
+      ).resolves.toEqual({
+        kind: "took-over",
+        agentLabelId: `${label.id}.agent`,
+        cooperativeStop: "stopped",
+      });
+      expect(MOCKS.requestCooperativeShutdown).toHaveBeenCalledTimes(1);
+      expect(calls.map((c) => c.args[0])).toEqual([
+        "print",
+        "print",
+        "bootout",
+        "print",
+        "print",
+        "bootout",
+        "print",
+      ]);
+      expect(calls[2]?.args).toEqual(["bootout", "--wait", agentTarget]);
+      expect(calls[5]?.args).toEqual(["bootout", "--wait", cliTarget]);
+    });
+
+    // Replaces an older "pre-check" pin: with the dual-live refusal below
+    // added, a live pid on the CLI label beside a running agent is caught by
+    // THAT guard instead, before any claim is even considered - there is no
+    // longer a distinct "claim finds no endpoint" pre-check to pin on its
+    // own.
+    it("rejects with SERVICE_INSTALL_FAILED ('two hosts on one machine') before any claim or bootout when both the agent and the CLI label report a running process", async () => {
       const calls: RecordedCall[] = [];
       const runner: ProcessRunner = async (command, args) => {
         calls.push({ command, args });
         if (args[0] === "print") {
           if (args[1]?.endsWith(".agent") === true) {
             return {
-              stdout: `path = ${smAgentPath}\n`,
+              stdout: `path = ${smAgentPath}\n\tpid = 777\n`,
               stderr: "",
               exitCode: 0,
             };
@@ -2512,21 +2976,62 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
         }
         return buildSuccessResult();
       };
-      MOCKS.requestCooperativeShutdown.mockResolvedValue({
-        kind: "no-metadata",
-      });
 
-      const takeover =
-        createMacosController(runner).takeoverDesktopRegistration(label);
-      await expect(takeover).rejects.toMatchObject({
+      await expect(
+        createMacosController(runner).takeoverDesktopRegistration(label),
+      ).rejects.toMatchObject({
         code: CLI_ERROR_CODES.SERVICE_INSTALL_FAILED,
-        message: expect.stringContaining(
-          "has not published a live endpoint yet",
-        ),
+        message: expect.stringContaining("two hosts on one machine"),
+        details: expect.objectContaining({
+          agentLabel: `${label.id}.agent`,
+          agentPid: 777,
+          cliPid: 4242,
+        }),
       });
-      await expect(takeover).rejects.toMatchObject({
-        message: expect.not.stringContaining("already deregistered"),
+      expect(MOCKS.requestCooperativeShutdown).not.toHaveBeenCalled();
+      expect(calls.some((c) => c.args[0] === "bootout")).toBe(false);
+    });
+
+    // Rule 1 is keyed on both probes' `running`, WHATEVER owns the agent
+    // label - not only the SMAppService took-over arm. A pre-split-style
+    // machine where the agent label itself was loaded as a raw
+    // `~/Library/LaunchAgents/<label>.agent.plist` (`cli-or-other`
+    // ownership, not an in-bundle SMAppService path) with a live process
+    // beside a running CLI label is refused by the SAME dual-live guard,
+    // before the no-agent early return ever reads `agentProbe.ownership`.
+    it("rejects with SERVICE_INSTALL_FAILED ('two hosts on one machine') when the agent label is loaded cli-or-other (not SMAppService) and both labels report a running process", async () => {
+      const calls: RecordedCall[] = [];
+      const runner: ProcessRunner = async (command, args) => {
+        calls.push({ command, args });
+        if (args[0] === "print") {
+          if (args[1]?.endsWith(".agent") === true) {
+            return {
+              stdout: `\tpath = /Users/me/Library/LaunchAgents/${label.id}.agent.plist\n\ttype = LaunchAgent\n\tpid = 777\n`,
+              stderr: "",
+              exitCode: 0,
+            };
+          }
+          return {
+            stdout: `\tpath = /Users/me/Library/LaunchAgents/${label.id}.plist\n\ttype = LaunchAgent\n\tpid = 4242\n`,
+            stderr: "",
+            exitCode: 0,
+          };
+        }
+        return buildSuccessResult();
+      };
+
+      await expect(
+        createMacosController(runner).takeoverDesktopRegistration(label),
+      ).rejects.toMatchObject({
+        code: CLI_ERROR_CODES.SERVICE_INSTALL_FAILED,
+        message: expect.stringContaining("two hosts on one machine"),
+        details: expect.objectContaining({
+          agentLabel: `${label.id}.agent`,
+          agentPid: 777,
+          cliPid: 4242,
+        }),
       });
+      expect(MOCKS.requestCooperativeShutdown).not.toHaveBeenCalled();
       expect(calls.some((c) => c.args[0] === "bootout")).toBe(false);
     });
 
@@ -2658,13 +3163,16 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
       });
     });
 
-    // Staging for the two pins below: the CLI label is absent on the FIRST
-    // print (so the initial `standDownLiveCliLabelHost(..., null)` call from
-    // the no-agent branch never fires here - the agent IS loaded), but
-    // loaded with a live pid on the SECOND, fresh print the takeover runs
-    // after retiring the agent. That live pid means a real cooperative claim
-    // is made (a SECOND `requestCooperativeShutdown` call), unlike the
-    // idle-job case above.
+    // Staging for the two pins below: the agent is running (a live pid on
+    // its FIRST print) so the took-over arm's own claim actually fires - a
+    // claim is only made when the agent reports a process now. The CLI
+    // label is absent on the FIRST print (so the initial
+    // `standDownLiveCliLabelHost(..., null)` call from the no-agent branch
+    // never fires here - the dual-live guard also stays clear, since the CLI
+    // label has no process yet when the agent's claim is made), but loaded
+    // with a live pid on the SECOND, fresh print the takeover runs after
+    // retiring the agent. That live pid means a real, SECOND cooperative
+    // claim is made for the CLI label's own stand-down.
     function stageCliAbsentThenLoadedRunner(input: {
       cliVerifyAfterBootout: "absent" | "still-loaded";
     }): {
@@ -2690,7 +3198,11 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
           if (args[1]?.endsWith(".agent") === true) {
             agentPrints += 1;
             return agentPrints === 1
-              ? { stdout: `path = ${smAgentPath}\n`, stderr: "", exitCode: 0 }
+              ? {
+                  stdout: `path = ${smAgentPath}\n\tpid = 777\n`,
+                  stderr: "",
+                  exitCode: 0,
+                }
               : notFound;
           }
           cliPrints += 1;
@@ -2750,6 +3262,70 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
         "print",
       ]);
       expect(MOCKS.requestCooperativeShutdown).toHaveBeenCalledTimes(2);
+    });
+
+    // Rule 3, took-over arm: `refuseIfPublishedHostAlive` runs after the
+    // agent is retired and the CLI label's own stand-down has resolved. A
+    // "dead" verdict on a leftover `pid.json` is proof the process is gone,
+    // so the takeover still succeeds.
+    it("still resolves took-over when a published endpoint's identity verdict is 'dead'", async () => {
+      const { controller } = stageTakeoverRunner({
+        cliLabelOwned: false,
+        agentLoadedAfterBootout: false,
+        agentRunning: true,
+      });
+      MOCKS.requestCooperativeShutdown.mockResolvedValue({ kind: "stopped" });
+      MOCKS.readHostPidMetadata.mockResolvedValue({
+        pid: 9001,
+        hostId: "hand-run-host",
+        version: "1.2.3",
+        websocketUrl: "ws://127.0.0.1:9001/rpc",
+        startedAt: "2026-07-12T00:00:00.000Z",
+        processStartIdentity: null,
+      });
+      MOCKS.getPublishedProcessIdentityVerdict.mockResolvedValue("dead");
+
+      await expect(
+        controller.takeoverDesktopRegistration(label),
+      ).resolves.toEqual({
+        kind: "took-over",
+        agentLabelId: `${label.id}.agent`,
+        cooperativeStop: "stopped",
+      });
+    });
+
+    // The gate now runs BEFORE the "CLI now owns host registration" audit
+    // line - a took-over arm refused at `refuseIfPublishedHostAlive` must
+    // never have logged that line, or a support thread would show the
+    // ownership hand-off succeeding right above the error that says it
+    // didn't.
+    it("does not log 'the CLI now owns host registration' when the gate refuses the takeover (verdict 'current')", async () => {
+      const { controller } = stageTakeoverRunner({
+        cliLabelOwned: false,
+        agentLoadedAfterBootout: false,
+        agentRunning: true,
+      });
+      MOCKS.requestCooperativeShutdown.mockResolvedValue({ kind: "stopped" });
+      MOCKS.readHostPidMetadata.mockResolvedValue({
+        pid: 9001,
+        hostId: "hand-run-host",
+        version: "1.2.3",
+        websocketUrl: "ws://127.0.0.1:9001/rpc",
+        startedAt: "2026-07-12T00:00:00.000Z",
+        processStartIdentity: null,
+      });
+      MOCKS.getPublishedProcessIdentityVerdict.mockResolvedValue("current");
+
+      await expect(
+        controller.takeoverDesktopRegistration(label),
+      ).rejects.toMatchObject({
+        code: CLI_ERROR_CODES.SERVICE_INSTALL_FAILED,
+        message: expect.stringContaining("a host is still running (pid 9001"),
+      });
+      expect(MOCKS.cliLoggerInfo).not.toHaveBeenCalledWith(
+        expect.stringContaining("the CLI now owns host registration"),
+        expect.anything(),
+      );
     });
   });
 
@@ -3009,6 +3585,53 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
       });
     });
 
+    // The "recycled pid" control above passes because the identity verdict
+    // defaults to "indeterminate", which still falls back to the bootout
+    // exit code. A "current" verdict is stronger evidence than any exit code
+    // or cooperative answer: it is the SAME process the probe read, so it
+    // refuses even after the host answered `stopped` and even with a clean
+    // bootout exit.
+    it("rejects with SERVICE_INSTALL_FAILED ('is still running after the wait') when the published identity verdict is 'current', regardless of a clean bootout exit or a stopped answer", async () => {
+      const { controller } = stageStandDownRunner({
+        pid: 4242,
+        bootoutExitCode: 0,
+      });
+      MOCKS.requestCooperativeShutdown.mockResolvedValue({ kind: "stopped" });
+      MOCKS.isProcessAlive.mockImplementation((pid: number) => pid === 4242);
+      MOCKS.getPublishedProcessIdentityVerdict.mockResolvedValue("current");
+
+      await expect(
+        controller.takeoverDesktopRegistration(label),
+      ).rejects.toMatchObject({
+        code: CLI_ERROR_CODES.SERVICE_INSTALL_FAILED,
+        message: expect.stringContaining("is still running after the wait"),
+        details: expect.objectContaining({
+          pid: 4242,
+          verification: "process-alive",
+        }),
+      });
+    });
+
+    // The opposite evidence: a "mismatch" verdict means the alive pid is NOT
+    // the process launchd reported (it was recycled) - conclusive enough to
+    // resolve even though the bootout wait itself did not end cleanly.
+    it("resolves cli-host-stopped/stopped when the published identity verdict is 'mismatch', even though the bootout wait exits non-zero", async () => {
+      const { controller } = stageStandDownRunner({
+        pid: 4242,
+        bootoutExitCode: -1,
+      });
+      MOCKS.requestCooperativeShutdown.mockResolvedValue({ kind: "stopped" });
+      MOCKS.isProcessAlive.mockImplementation((pid: number) => pid === 4242);
+      MOCKS.getPublishedProcessIdentityVerdict.mockResolvedValue("mismatch");
+
+      await expect(
+        controller.takeoverDesktopRegistration(label),
+      ).resolves.toEqual({
+        kind: "cli-host-stopped",
+        cooperativeStop: "stopped",
+      });
+    });
+
     it("rejects with SERVICE_INSTALL_FAILED ('did not take effect') when the post-bootout probe still finds the CLI-label job loaded", async () => {
       const { controller } = stageStandDownRunner({
         pid: 4242,
@@ -3166,7 +3789,14 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
       });
     });
 
-    it("does not refuse a running, pidless CLI-label job whose host ANSWERED the claim with stopped, even when the bootout wait exits non-zero (the stale running flag is not evidence after an answer)", async () => {
+    // `processMayLiveOn` is never cleared by a cooperative `stopped` answer:
+    // the claim goes through `pid.json`, which need not name THIS label's
+    // process, so evidence about the process itself - not the claim's own
+    // outcome - decides whether the bootout wait proved it gone. A pidless
+    // running job has nothing to check the kernel with, so launchd's own
+    // exit is the only tiebreak: non-zero (the runner-timeout shape) still
+    // refuses even after a `stopped` answer.
+    it("rejects with SERVICE_INSTALL_FAILED ('the wait did not end with its exit') for a running, pidless CLI-label job even when the host ANSWERED the claim with stopped, because the bootout wait exits non-zero", async () => {
       const { calls, controller } = stageStandDownRunner({
         pid: null,
         stateLine: "running",
@@ -3176,11 +3806,31 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
 
       await expect(
         controller.takeoverDesktopRegistration(label),
+      ).rejects.toMatchObject({
+        code: CLI_ERROR_CODES.SERVICE_INSTALL_FAILED,
+        message: expect.stringContaining("the wait did not end with its exit"),
+        details: expect.objectContaining({
+          verification: "process-unverified",
+          pid: null,
+        }),
+      });
+      expect(calls.some((c) => c.args[0] === "bootout")).toBe(true);
+    });
+
+    it("resolves cli-host-stopped/stopped for a running, pidless CLI-label job that ANSWERED the claim with stopped, when the bootout wait exits cleanly (0)", async () => {
+      const { controller } = stageStandDownRunner({
+        pid: null,
+        stateLine: "running",
+        bootoutExitCode: 0,
+      });
+      MOCKS.requestCooperativeShutdown.mockResolvedValue({ kind: "stopped" });
+
+      await expect(
+        controller.takeoverDesktopRegistration(label),
       ).resolves.toEqual({
         kind: "cli-host-stopped",
         cooperativeStop: "stopped",
       });
-      expect(calls.some((c) => c.args[0] === "bootout")).toBe(true);
     });
 
     it("resolves cli-host-stopped/no-host via the idle unload path (no claim) when the CLI-label job's state is explicitly not running (state = waiting, no pid)", async () => {

--- a/clients/traycer-cli/src/service/platforms/macos.ts
+++ b/clients/traycer-cli/src/service/platforms/macos.ts
@@ -3,9 +3,15 @@ import { chmod, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname } from "node:path";
 import { readHostPidMetadata } from "../../host/pid-metadata";
+import { hostPidMetadataPath } from "../../store/paths";
+import { probeHostHealth } from "../health-probe";
 import { createCliLogger } from "../../logger";
 import { CLI_ERROR_CODES, cliError } from "../../runner/errors";
 import { isProcessAlive } from "../../store/cli-lock";
+import {
+  getPublishedProcessIdentityVerdict,
+  readProcessStartIdentity,
+} from "../../store/process-identity";
 import type { CliInvocation } from "../cli-binary";
 import { HOST_V8_FLAGS } from "../host-node-options";
 import { escapeXml } from "../escape-xml";
@@ -29,7 +35,9 @@ import {
 // fields only, `^\t?` anchor) replaces the any-depth variant that used to
 // live here, so a nested `path` inside `endpoints = { ... }` can never
 // masquerade as the job's plist path.
+import type { ProcessStartIdentity } from "@traycer/protocol/host/lifecycle";
 import {
+  type CooperativeShutdownOutcome,
   forceStopHostProcess,
   requestCooperativeShutdown,
 } from "./desktop-agent-shutdown";
@@ -147,6 +155,50 @@ export function createMacosController(
 // register cycle (an app relaunch may re-register its agent); the info log
 // says so, because "my host went back to the app" is otherwise
 // undiagnosable from the shell.
+//
+// The whole decision, by the two labels' `launchctl print` evidence
+// (`probeLabelForTakeover`: absent | indeterminate | loaded{ownership,
+// running, pid}). Two invariants hold in every cell: no process is booted
+// out without a cooperative claim made while ITS label held the machine's
+// only process - the claim follows `pid.json`, so the residual is a host
+// run by hand outside launchd racing a label's host, itself the dual-host
+// state, and a process launchd starts between a probe and the bootout that
+// follows it, microseconds old - and no replacement is registered while a
+// process of the evicted job, or a host `pid.json` names, may be alive.
+//
+//   agent label            CLI label              action
+//   ---------------------  ---------------------  ---------------------------
+//   indeterminate          any                    refuse (unreadable)
+//   any                    indeterminate          refuse (unreadable)
+//   any                    smappservice           refuse (pre-split label)
+//   running                running                refuse (two hosts)
+//   loaded, not Desktop's  any                    refuse (foreign agent job)
+//   absent                 absent                 not-applicable
+//   absent                 idle                   unload, no claim
+//   absent                 running                claim -> busy/no-metadata/
+//                                                 no-host refuse; stopped/
+//                                                 unreachable/hung unload
+//   smappservice           running                no claim here; unload the
+//                                                 agent (idle); the CLI
+//                                                 label's stand-down asks
+//   smappservice running   absent | idle          claim (reaches only the
+//                                                 agent's host, or a hand-
+//                                                 run one) -> busy/
+//                                                 no-metadata/no-host
+//                                                 refuse; else bootout
+//   smappservice idle      absent | idle          claim (for a hand-run host
+//                                                 only) -> busy refuses;
+//                                                 else unload the agent
+//
+// Every "unload"/"bootout" is `bootout --wait`, a positive label re-probe,
+// and `processMayLiveOn` against the process's creation stamp; any of the
+// three failing refuses, naming the retired agent when there is one. After
+// the agent is gone the CLI label is read again and takes the CLI-label
+// rows above with its own claim, which by then can reach only its host.
+// Both arms end in `refuseIfPublishedHostAlive`: a host `pid.json` still
+// names alive - under neither label - refuses the registration. Only then
+// does `installService` run, reading the CLI label as `not-loaded`; its
+// bare bootout never runs on a takeover.
 async function takeoverDesktopRegistration(
   label: ServiceLabel,
   run: ProcessRunner,
@@ -190,24 +242,93 @@ async function takeoverDesktopRegistration(
   ) {
     throw preSplitCliLabelRefusal(label, cliProbe.ownership.path, null);
   }
+  // The cooperative claim is machine-wide: `requestCooperativeShutdown`
+  // follows `pid.json`, and nothing in it names a launchd label. Its answer
+  // is therefore evidence about ONE process, and every arm below must know
+  // which. Three rules make that so by construction:
+  //   1. Both labels reporting a process is refused outright, whatever owns
+  //      them. That is two hosts racing over the same stores, the
+  //      dual-registration state `retireCompetingRegistration` / `host
+  //      doctor` repair; a claim made there stops one of them and says
+  //      nothing about the other, which was then booted out unasked (Codex,
+  //      traycer#1761, round 6). After this rule at most ONE label has a
+  //      process, and every claim below can reach only that label's host -
+  //      or a host run by hand outside launchd (rule 3).
+  //   2. In the took-over arm the claim before the agent's bootout is
+  //      skipped when the CLI label is the one with a process: that host is
+  //      asked by the stand-down after the agent is gone, with a claim that
+  //      reaches only it, instead of being asked here, stopped, and then
+  //      refused by a second claim that finds its metadata gone. In every
+  //      other case the claim is made even for an idle agent, because a
+  //      hand-run host may be what `pid.json` names and it must be asked.
+  //   3. Nothing is registered while `pid.json` still names a live process
+  //      (`refuseIfPublishedHostAlive`, at the end of both arms). A host the
+  //      claims could not stop and the bootouts could not reach - one run by
+  //      hand, or an unreachable one whose supervisor is not under either
+  //      label - would otherwise be the incumbent the replacement declines
+  //      to, and `KeepAlive{SuccessfulExit: false}` leaves the machine
+  //      hostless.
   if (
-    agentProbe.kind !== "loaded" ||
-    agentProbe.ownership.kind !== "smappservice"
+    agentProbe.kind === "loaded" &&
+    agentProbe.running &&
+    cliProbe.kind === "loaded" &&
+    cliProbe.running
   ) {
-    return await standDownLiveCliLabelHost(label, cliProbe, run, null);
+    throw cliError({
+      code: CLI_ERROR_CODES.SERVICE_INSTALL_FAILED,
+      message: `service install --takeover: launchd reports a running process under both '${agentLabelId}' and '${label.id}' - two hosts on one machine. A cooperative stop cannot tell which one it reached, so the takeover was stopped rather than interrupt a host it never asked. Run 'traycer host doctor' to repair the dual registration, or 'traycer host service uninstall', then re-run this command.`,
+      details: {
+        label: label.id,
+        agentLabel: agentLabelId,
+        agentPid: agentProbe.pid,
+        cliPid: cliProbe.pid,
+      },
+      exitCode: 1,
+    });
+  }
+  if (agentProbe.kind === "absent") {
+    const standDown = await standDownLiveCliLabelHost(
+      label,
+      cliProbe,
+      run,
+      null,
+    );
+    await refuseIfPublishedHostAlive(label, null);
+    return standDown;
+  }
+  // A job under the agent label that Desktop did not register (a raw
+  // `~/Library/LaunchAgents/<label>.agent.plist`) is nothing this command
+  // manages: idle, launchd could start it beside the CLI label it is about
+  // to register; running, its host was never asked. Refused either way.
+  if (agentProbe.ownership.kind !== "smappservice") {
+    throw cliError({
+      code: CLI_ERROR_CODES.SERVICE_INSTALL_FAILED,
+      message: `service install --takeover: launchd has '${agentLabelId}' loaded from ${agentProbe.ownership.path ?? "an unknown path"}, which is not Traycer Desktop's registration; this command does not manage that job and will not register the CLI label beside it. Unload it (launchctl bootout gui/<uid>/${agentLabelId}) and re-run this command.`,
+      details: {
+        label: label.id,
+        agentLabel: agentLabelId,
+        loadedPath: agentProbe.ownership.path,
+        pid: agentProbe.pid,
+      },
+      exitCode: 1,
+    });
   }
   const desktopAgent: DesktopAgentOwnership = {
     agentLabelId,
     loadedPath: agentProbe.ownership.path,
   };
   // The CLI is taking this label over; Desktop's registration is retired, not
-  // relaunched. Nothing is coming back under this identity.
-  const outcome = await requestCooperativeShutdown(
-    label.environment,
-    "takeover",
-    "shutdown",
-  );
-  if (outcome.kind === "busy") {
+  // relaunched. Nothing is coming back under this identity. Rule 2: with the
+  // CLI label holding the only process, the stand-down below makes the claim.
+  const claimHere = !(cliProbe.kind === "loaded" && cliProbe.running);
+  const outcome: CooperativeShutdownOutcome | null = claimHere
+    ? await requestCooperativeShutdown(
+        label.environment,
+        "takeover",
+        "shutdown",
+      )
+    : null;
+  if (outcome !== null && outcome.kind === "busy") {
     throw cliError({
       code: CLI_ERROR_CODES.HOST_BUSY,
       message:
@@ -216,25 +337,30 @@ async function takeoverDesktopRegistration(
       exitCode: 1,
     });
   }
-  // A live process under the CLI label that has no endpoint to ask is
-  // refused BEFORE the agent is touched, on the terms the stand-down below
-  // refuses it after: `no-metadata` and `no-host` mean no claim was made at
-  // all. The agent arm boots ITS job out on that evidence because the
-  // Desktop-managed host is what this command retires; the CLI-label process
-  // is not, and interrupting it in its first seconds is the round-1 bug on
-  // the sibling path. Refusing here leaves nothing half done.
+  // A running agent process that nobody could ask - no metadata yet, or
+  // metadata naming a child that has exited while the supervisor lives - is
+  // refused on the same terms the stand-down refuses it for the CLI label:
+  // a host in its first seconds, or between children; the window closes on
+  // its own and the next run asks it. With the agent IDLE the same answers
+  // mean there was nothing to ask (the claim was for a hand-run host, and
+  // none is there), and the unload below has no process to interrupt.
   if (
-    (outcome.kind === "no-metadata" || outcome.kind === "no-host") &&
-    cliProbe.kind === "loaded" &&
-    cliProbe.running
+    outcome !== null &&
+    agentProbe.running &&
+    (outcome.kind === "no-metadata" || outcome.kind === "no-host")
   ) {
-    throw unaskableCliLabelHost(label, cliProbe.pid, outcome.kind, null);
+    throw unaskableHost(
+      label,
+      desktopAgent.agentLabelId,
+      agentProbe.pid,
+      outcome.kind,
+      null,
+    );
   }
   const logger = createCliLogger(label.environment);
   if (
-    outcome.kind === "unreachable" ||
-    outcome.kind === "hung" ||
-    outcome.kind === "no-metadata"
+    outcome !== null &&
+    (outcome.kind === "unreachable" || outcome.kind === "hung")
   ) {
     logger.warn(
       "Takeover: the Desktop-managed host could not be stopped cooperatively; booting the job out underneath it.",
@@ -244,9 +370,7 @@ async function takeoverDesktopRegistration(
         cause:
           outcome.kind === "unreachable"
             ? outcome.cause
-            : outcome.kind === "hung"
-              ? `pid ${outcome.pid} outlived the shutdown grace`
-              : "pid metadata is missing or unreadable, so no endpoint could be asked",
+            : `pid ${outcome.pid} outlived the shutdown grace`,
       },
     );
   }
@@ -255,9 +379,10 @@ async function takeoverDesktopRegistration(
   // `retireCompetingRegistration` (see the note there): a bare bootout
   // returns when launchd ACCEPTS the request, not when the process is gone.
   //
-  // This line is reached precisely in the states where the old host is known
-  // to still be running - `unreachable`, `hung`, `no-metadata`; only the
-  // `stopped` arm above waited for exit - and the evicted host publishes
+  // This line is reached with the old host possibly still running -
+  // `unreachable` and `hung` never waited for exit; the claim skipped under
+  // rule 2, or answered `no-metadata`/`no-host` for an idle agent, may leave
+  // a supervisor between children - and the evicted host publishes
   // `pid.json` until the very end of its teardown. `service install` calls
   // `controller.install` immediately after this returns, and that host's
   // first act is `findLiveIncumbentHost`. Without the barrier it reads the
@@ -313,17 +438,11 @@ async function takeoverDesktopRegistration(
   // the timeout as exit -1), and a `hung` host is by definition still alive
   // at that point, still publishing `pid.json`. Registering the CLI label on
   // the label evidence alone is the hostless bootstrap-beside-a-corpse this
-  // barrier exists to prevent, so the pid launchd reported is checked too -
-  // only when the wait did not end with launchd's own success, because after
-  // a clean exit 0 the process is reaped and a pid read before the claim can
-  // already have been recycled (see `unloadCliLabelJob`).
-  if (
-    agentBootout.exitCode !== 0 &&
-    processMayLiveOn({
-      pid: agentProbe.pid,
-      running: agentProbe.running && outcome.kind !== "stopped",
-    })
-  ) {
+  // barrier exists to prevent, so the process launchd reported is checked
+  // too - against its own creation stamp, so neither a `stopped` answer that
+  // may have come from another host nor a recycled pid decides it (see
+  // `processMayLiveOn`).
+  if (await processMayLiveOn(agentProbe, agentBootout.exitCode)) {
     throw cliError({
       code: CLI_ERROR_CODES.SERVICE_INSTALL_FAILED,
       message: `service install --takeover: launchctl bootout unloaded '${desktopAgent.agentLabelId}', but ${agentProbe.pid !== null ? `its process (pid ${agentProbe.pid}) is still running after the wait` : "launchd had reported it running with no pid to check and the wait did not end with its exit"}, so the takeover was stopped rather than start a replacement beside it. Re-run the command once it has exited, or use the Traycer app to remove the host, or run 'traycer host service uninstall'.`,
@@ -339,14 +458,12 @@ async function takeoverDesktopRegistration(
   }
   // The CLI label is read AGAIN, not from `cliProbe`: that snapshot predates
   // the whole claim and the agent's bootout wait (a minute at the limit), and
-  // a job loaded since - a dual-registered machine's CLI label, or a
-  // throttled `KeepAlive` respawn of one - would otherwise be left for the
-  // install's bare bootout. The fresh read goes through the same stand-down
-  // as the no-agent arm, with a fresh claim: the claim above went to whatever
-  // `pid.json` named, which need not be this label's process. The one false
-  // refusal that leaves is a supervisor still winding down after its child
-  // stood down through that claim (`no-metadata`, a few hundred milliseconds
-  // wide); its message says the agent is already gone and a re-run finishes.
+  // a job loaded since - a throttled `KeepAlive` respawn of an idle CLI label
+  // - would otherwise be left for the install's bare bootout. The fresh read
+  // goes through the same stand-down as the no-agent arm, with its own claim:
+  // either the CLI label held the machine's only process and no claim was
+  // made above (rule 2), or it held none and a process here is new; in both
+  // cases the stand-down's claim can reach only it.
   const cliAfterAgent = await probeLabelForTakeover(
     `${guiTarget}/${label.id}`,
     run,
@@ -375,6 +492,7 @@ async function takeoverDesktopRegistration(
     run,
     desktopAgent.agentLabelId,
   );
+  await refuseIfPublishedHostAlive(label, desktopAgent.agentLabelId);
   logger.info(
     "Takeover: booted out Traycer Desktop's SMAppService agent; the CLI now owns host registration. Launching the Desktop app again may re-register its agent - uninstall or update the app to make the takeover permanent.",
     {
@@ -390,13 +508,90 @@ async function takeoverDesktopRegistration(
   return {
     kind: "took-over",
     agentLabelId: desktopAgent.agentLabelId,
+    // With the claim deferred to the CLI label's stand-down (rule 2), that
+    // stand-down's answer is the machine's cooperative outcome.
     cooperativeStop:
-      outcome.kind === "stopped"
-        ? "stopped"
-        : outcome.kind === "no-host"
-          ? "no-host"
-          : "skipped-unreachable",
+      outcome === null
+        ? cliStandDown.kind === "cli-host-stopped"
+          ? cliStandDown.cooperativeStop
+          : "no-host"
+        : outcome.kind === "stopped"
+          ? "stopped"
+          : outcome.kind === "no-host" || outcome.kind === "no-metadata"
+            ? "no-host"
+            : "skipped-unreachable",
   };
+}
+
+// Rule 3 of `takeoverDesktopRegistration`: the positive gate before the
+// caller registers the CLI label. Every bootout above is judged against the
+// process launchd reported, but a host `pid.json` names need not be under
+// either label - started by hand, or a child whose supervisor already
+// exited - and a replacement bootstrapped beside it declines to it as the
+// incumbent, exits 0, and `KeepAlive{SuccessfulExit: false}` leaves the
+// machine hostless. A process proven gone (dead, or the pid recycled) lets
+// the registration run; an alive one refuses; one that cannot be judged
+// refuses too, except that a record with no identity to judge BY is settled
+// by dialling the endpoint it advertises (see below).
+async function refuseIfPublishedHostAlive(
+  label: ServiceLabel,
+  retiredAgentLabelId: string | null,
+): Promise<void> {
+  const metadata = await readHostPidMetadata(label.environment);
+  if (metadata === null) return;
+  const verdict = await getPublishedProcessIdentityVerdict(
+    metadata.pid,
+    metadata.processStartIdentity,
+  );
+  if (verdict === "dead" || verdict === "mismatch") return;
+  // `indeterminate` with a record that predates identity tracking
+  // (`processStartIdentity === null`, which every field record before the
+  // field shipped is) means a live pid the record cannot vouch for: the old
+  // host still running, or a record it left behind whose pid another process
+  // now holds. Refusing outright would strand exactly the hostless machine
+  // this command recovers (macOS `uninstall` does not remove the record), so
+  // the endpoint the record advertises is dialled once: a host that answers
+  // is a host, and refuses; nothing answering means the record is stale and
+  // the reload proceeds under a warning. With a stamp to compare, an
+  // `indeterminate` is a probe fault and refuses like `current`.
+  if (verdict === "indeterminate" && metadata.processStartIdentity === null) {
+    const health = await probeHostHealth({
+      environment: label.environment,
+      checkProcessAlive: null,
+      checkTcpReachable: null,
+      totalBudgetMs: 0,
+      retryDelayMs: 0,
+    });
+    if (!health.healthy) {
+      createCliLogger(label.environment).warn(
+        "Takeover: the published host record names a live pid with no process identity to compare and nothing answers on its endpoint; treating the record as stale and proceeding.",
+        {
+          label: label.id,
+          pid: metadata.pid,
+          record: hostPidMetadataPath(label.environment),
+          detail: health.detail,
+        },
+      );
+      return;
+    }
+  }
+  const state =
+    verdict === "current"
+      ? `a host is still running (pid ${metadata.pid}, per its published endpoint) after the takeover retired the launchd registration; it is not under a label this command booted out - most likely started by hand - so the reload was stopped rather than register a replacement that would decline to it and leave the machine hostless. Stop it with 'traycer host stop', then re-run this command.`
+      : metadata.processStartIdentity === null
+        ? `a host answered on the endpoint the published host record ${hostPidMetadataPath(label.environment)} advertises (pid ${metadata.pid}; the record carries no process identity), so the reload was stopped rather than register a replacement beside it. Stop it with 'traycer host stop', then re-run this command.`
+        : `the published host record names pid ${metadata.pid} and its process identity could not be read, so the reload was stopped rather than register a replacement beside a host that may still be running. Re-run the command; if it persists, stop the host with 'traycer host stop' first.`;
+  throw cliError({
+    code: CLI_ERROR_CODES.SERVICE_INSTALL_FAILED,
+    message: `service install --takeover: ${state} ${takeoverRerunRouting(retiredAgentLabelId)}`,
+    details: {
+      label: label.id,
+      pid: metadata.pid,
+      verdict,
+      agentLabel: retiredAgentLabelId,
+    },
+    exitCode: 1,
+  });
 }
 
 type TakeoverLabelProbe =
@@ -418,6 +613,13 @@ type TakeoverLabelProbe =
       // liveness check after the bootout has nothing to key on, and it fails
       // closed on the wait's timeout instead.
       readonly running: boolean;
+      // The kernel's creation stamp for `pid` at probe time (null without a
+      // pid, or when it could not be read). Read synchronously (`ps`, 3 s
+      // cap) at most once per loaded label per takeover. After a bootout it tells a
+      // process that is STILL the one launchd reported from a recycled pid,
+      // which `isProcessAlive` alone cannot; the takeover's liveness check
+      // after every bootout keys on it.
+      readonly startIdentity: ProcessStartIdentity | null;
     };
 
 // Three-state `launchctl print` for the takeover's two labels: `absent` only
@@ -481,24 +683,46 @@ async function probeLabelForTakeover(
       livePid !== null ||
       (jobState.kind === "observed" &&
         jobState.value.toLowerCase() === "running"),
+    startIdentity: livePid === null ? null : readProcessStartIdentity(livePid),
   };
 }
 
 // The process evidence a takeover bootout is checked against afterwards.
 type TakeoverJobProcess = Pick<
   Extract<TakeoverLabelProbe, { kind: "loaded" }>,
-  "pid" | "running"
+  "pid" | "running" | "startIdentity"
 >;
 
-// After a `bootout --wait` that did NOT end with launchd's exit 0: may the
-// job's process live on? Only if launchd had reported one - and the caller
-// clears `running` once the host ANSWERED the claim with `stopped`, since
-// then it has exited and neither a recycled pid nor a stale flag is evidence.
-// With a pid, ask the kernel; without one, a running job cannot be checked
-// and the answer is yes.
-function processMayLiveOn(job: TakeoverJobProcess): boolean {
+// After a `bootout --wait`: may the job's process live on? The evidence is
+// what launchd reported at probe time and is never cleared by a cooperative
+// answer - the claim goes through `pid.json`, which need not name THIS
+// label's process (Codex, traycer#1761, round 6) - so the question is
+// settled against the process itself:
+//   - no process reported: no.
+//   - a pid the kernel says is dead: no.
+//   - a pid alive whose creation stamp still matches the one read at probe
+//     time: yes, whatever launchctl's exit was (`getPublishedProcessIdentity
+//     Verdict` is the tree's recycled-pid detector).
+//   - a pid alive with a DIFFERENT stamp: no - the pid was recycled after the
+//     process exited (a `stopped` host's teardown can take that long).
+//   - no stamp to compare (`indeterminate`), or `state = running` with no pid
+//     printed: launchd's own exit is the tiebreak - its 0 means it reaped
+//     the process, anything else (the runner's timeout resolves as -1) means
+//     it may still be killing it.
+async function processMayLiveOn(
+  job: TakeoverJobProcess,
+  bootoutExitCode: number,
+): Promise<boolean> {
   if (!job.running) return false;
-  return job.pid !== null ? isProcessAlive(job.pid) : true;
+  if (job.pid === null) return bootoutExitCode !== 0;
+  if (!isProcessAlive(job.pid)) return false;
+  const verdict = await getPublishedProcessIdentityVerdict(
+    job.pid,
+    job.startIdentity,
+  );
+  if (verdict === "current") return true;
+  if (verdict === "dead" || verdict === "mismatch") return false;
+  return bootoutExitCode !== 0;
 }
 
 function preSplitCliLabelRefusal(
@@ -553,7 +777,7 @@ function takeoverProbeIndeterminate(
 // traycer#1761). Under this lock, a live process is asked to stand down on
 // the same terms as a Desktop-managed host: a busy denial ABORTS, a stopped
 // host proceeds, an unreachable one is booted out underneath because it is
-// the broken part - and, unlike that arm, a host nobody can ask is refused:
+// the broken part - and a host nobody can ask is refused:
 //
 // `no-metadata` and `no-host` while launchd reports a process (a positive
 // pid, or `state = running` with none printed) both REFUSE instead of
@@ -626,7 +850,13 @@ async function standDownLiveCliLabelHost(
     });
   }
   if (outcome.kind === "no-metadata" || outcome.kind === "no-host") {
-    throw unaskableCliLabelHost(label, pid, outcome.kind, retiredAgentLabelId);
+    throw unaskableHost(
+      label,
+      label.id,
+      pid,
+      outcome.kind,
+      retiredAgentLabelId,
+    );
   }
   if (outcome.kind === "unreachable" || outcome.kind === "hung") {
     logger.warn(
@@ -646,12 +876,7 @@ async function standDownLiveCliLabelHost(
       { label: label.id, pid, outcome: outcome.kind },
     );
   }
-  await unloadCliLabelJob(
-    label,
-    { pid, running: outcome.kind !== "stopped" },
-    run,
-    retiredAgentLabelId,
-  );
+  await unloadCliLabelJob(label, cliProbe, run, retiredAgentLabelId);
   return {
     kind: "cli-host-stopped",
     cooperativeStop:
@@ -659,15 +884,17 @@ async function standDownLiveCliLabelHost(
   };
 }
 
-// The refusal for a CLI-label process that nobody can ask (see
-// `standDownLiveCliLabelHost`): `no-metadata` is a host that has not
-// published yet; `no-host` is metadata whose endpoint names a process that
-// has already exited, while launchd still reports one under the label (its
-// supervisor between children, or a supervisor whose child just stood down
-// and has not exited itself yet). After the took-over arm has deregistered
-// Desktop's agent the message says so and names the re-run.
-function unaskableCliLabelHost(
+// The refusal for a process under `probedLabelId` that nobody can ask (see
+// `standDownLiveCliLabelHost` and the took-over arm): `no-metadata` is a
+// host that has not published yet; `no-host` is metadata whose endpoint
+// names a process that has already exited, while launchd still reports one
+// under the label (its supervisor between children, or a supervisor whose
+// child just stood down and has not exited itself yet). After the took-over
+// arm has deregistered Desktop's agent the message says so and names the
+// re-run.
+function unaskableHost(
   label: ServiceLabel,
+  probedLabelId: string,
   pid: number | null,
   metadata: "no-metadata" | "no-host",
   retiredAgentLabelId: string | null,
@@ -675,8 +902,8 @@ function unaskableCliLabelHost(
   const subject = pid === null ? "a running job" : `a process (pid ${pid})`;
   const state =
     metadata === "no-metadata"
-      ? `launchd reports ${subject} under '${label.id}' that has not published a live endpoint yet, so it could not be asked to stand down; it is most likely still starting.`
-      : `launchd reports ${subject} under '${label.id}', but the endpoint it published names a host that has already exited, so nothing could be asked to stand down; it is most likely between hosts (starting the next one, or exiting after the last).`;
+      ? `launchd reports ${subject} under '${probedLabelId}' that has not published a live endpoint yet, so it could not be asked to stand down; it is most likely still starting.`
+      : `launchd reports ${subject} under '${probedLabelId}', but the endpoint it published names a host that has already exited, so nothing could be asked to stand down; it is most likely between hosts (starting the next one, or exiting after the last).`;
   const routing =
     retiredAgentLabelId === null
       ? "Retry in a moment, or run 'traycer host service uninstall' first if it never comes up."
@@ -686,6 +913,7 @@ function unaskableCliLabelHost(
     message: `service install --takeover: ${state} ${routing}`,
     details: {
       label: label.id,
+      probedLabel: probedLabelId,
       pid,
       metadata,
       agentLabel: retiredAgentLabelId,
@@ -707,13 +935,12 @@ function unaskableCliLabelHost(
 // close that: `bootout --wait` also returns at the runner's timeout
 // (`tolerateNonZeroExit` resolves it as exit -1), which under `hung` is the
 // expected exit, and launchd can have dropped the label while the process
-// it is still killing lives on. So when the wait did NOT end with launchd's
-// own success - only then: after a clean exit 0 the process is reaped, and a
-// pid read before the claim can have been recycled by the time a
-// `stopped` host's teardown is over, which `isProcessAlive` would report as
-// alive - the process launchd reported is checked too: by pid when there
-// was one, and taken as still possible when launchd said `running` without
-// printing one. The caller clears `running` after a `stopped` answer.
+// it is still killing lives on. So the process launchd reported is checked
+// too, against its own creation stamp (`processMayLiveOn`): the same
+// process still alive refuses whatever launchctl's exit was, a pid recycled
+// after a `stopped` host's teardown does not, and only an unreadable stamp
+// (or `state = running` with no pid printed) falls back to launchctl's exit
+// as the tiebreak - its 0 means it reaped the process.
 async function unloadCliLabelJob(
   label: ServiceLabel,
   job: TakeoverJobProcess,
@@ -730,7 +957,7 @@ async function unloadCliLabelJob(
   });
   const postBootout = await verifyAgentBootedOut(serviceTarget, run);
   const verification =
-    postBootout === "absent" && bootout.exitCode !== 0 && processMayLiveOn(job)
+    postBootout === "absent" && (await processMayLiveOn(job, bootout.exitCode))
       ? pid !== null
         ? "process-alive"
         : "process-unverified"

--- a/clients/traycer-cli/src/service/platforms/macos.ts
+++ b/clients/traycer-cli/src/service/platforms/macos.ts
@@ -2,7 +2,10 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import { chmod, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname } from "node:path";
-import { readHostPidMetadata } from "../../host/pid-metadata";
+import {
+  readHostPidMetadata,
+  readHostPidMetadataEvidence,
+} from "../../host/pid-metadata";
 import { hostPidMetadataPath } from "../../store/paths";
 import { probeHostHealth } from "../health-probe";
 import { createCliLogger } from "../../logger";
@@ -532,13 +535,30 @@ async function takeoverDesktopRegistration(
 // machine hostless. A process proven gone (dead, or the pid recycled) lets
 // the registration run; an alive one refuses; one that cannot be judged
 // refuses too, except that a record with no identity to judge BY is settled
-// by dialling the endpoint it advertises (see below).
+// by dialling the endpoint it advertises (see below). The record is read
+// with absence kept apart from failure: `readHostPidMetadata` folds a torn
+// or unreadable file into `null`, and here that would let the one gate a
+// hand-run host has pass on no evidence (Codex, traycer#1761, round 7).
 async function refuseIfPublishedHostAlive(
   label: ServiceLabel,
   retiredAgentLabelId: string | null,
 ): Promise<void> {
-  const metadata = await readHostPidMetadata(label.environment);
-  if (metadata === null) return;
+  const record = await readHostPidMetadataEvidence(label.environment);
+  if (record.kind === "absent") return;
+  if (record.kind === "unreadable") {
+    throw cliError({
+      code: CLI_ERROR_CODES.SERVICE_INSTALL_FAILED,
+      message: `service install --takeover: the published host record ${hostPidMetadataPath(label.environment)} could not be read (${record.cause}), so whether a host is still running could not be judged and the reload was stopped rather than register a replacement beside one. Re-run the command; if it persists and no Traycer host is running, remove that record first. ${takeoverRerunRouting(retiredAgentLabelId)}`,
+      details: {
+        label: label.id,
+        record: hostPidMetadataPath(label.environment),
+        cause: record.cause,
+        agentLabel: retiredAgentLabelId,
+      },
+      exitCode: 1,
+    });
+  }
+  const { metadata } = record;
   const verdict = await getPublishedProcessIdentityVerdict(
     metadata.pid,
     metadata.processStartIdentity,

--- a/clients/traycer-cli/src/service/platforms/macos.ts
+++ b/clients/traycer-cli/src/service/platforms/macos.ts
@@ -461,6 +461,14 @@ async function probeLabelForTakeover(
   if (probe.kind === "indeterminate") {
     return { kind: "indeterminate", cause: probe.cause };
   }
+  // An exit-0 answer with no recognizable job fields (truncated output, a
+  // changed format) is `observed` with an indeterminate OWNERSHIP; the
+  // CLI-local classifier below would read it as `cli-or-other` with no pid
+  // and the stand-down would unload it with no claim (Codex, traycer#1761).
+  // Same fail-closed verdict as a non-answer, naming the cause.
+  if (probe.ownership.kind === "indeterminate") {
+    return { kind: "indeterminate", cause: probe.ownership.cause };
+  }
   const ownership = classifyLaunchdPrintOutput(probe.raw);
   if (ownership.kind === "not-loaded") return { kind: "absent" };
   const { pid, jobState } = probe.runState;

--- a/clients/traycer-cli/src/service/platforms/macos.ts
+++ b/clients/traycer-cli/src/service/platforms/macos.ts
@@ -167,7 +167,9 @@ async function takeoverDesktopRegistration(
     });
   }
   const desktopAgent = await probeDesktopAgentOwnership(label, run);
-  if (desktopAgent === null) return { kind: "not-applicable" };
+  if (desktopAgent === null) {
+    return await standDownLiveCliLabelHost(label, cliOwnership);
+  }
   // The CLI is taking this label over; Desktop's registration is retired, not
   // relaunched. Nothing is coming back under this identity.
   const outcome = await requestCooperativeShutdown(
@@ -275,6 +277,85 @@ async function takeoverDesktopRegistration(
         : outcome.kind === "no-host"
           ? "no-host"
           : "skipped-unreachable",
+  };
+}
+
+// The takeover with NO Desktop agent to retire. Its caller (`installService`)
+// boots out a loaded CLI label with a plain `launchctl bootout` and no
+// cooperative claim - fine for a job with no process, and exactly wrong for
+// a host that started between the caller's own probe and this lock: the
+// Desktop's parked-registration fallback admits the takeover only after it
+// has seen no live process under the label, but a throttled `KeepAlive`
+// respawn can start in that gap (Codex, traycer#1761). Under this lock, a
+// live process is asked to stand down on the same terms as a Desktop-managed
+// host: a busy denial ABORTS, a stopped or dead host proceeds, and an
+// unreachable one is booted out underneath because it is the broken part.
+//
+// `no-metadata` and `no-host` with a live launchd pid both REFUSE instead of
+// proceeding. launchd's pid is the supervisor; `pid.json` names its host
+// child. A supervisor that is alive while the metadata is absent, or names a
+// child that is gone, is a host in its first seconds (fresh start, or a
+// respawn after the old child exited and before the new one published) -
+// there is no endpoint to ask yet, and booting it out now is the very
+// interruption this guard exists to prevent. The window closes on its own;
+// the caller retries. Only a host that answered - stood down, or is
+// provably unreachable behind a published endpoint - lets the reload run.
+async function standDownLiveCliLabelHost(
+  label: ServiceLabel,
+  cliOwnership: LaunchdOwnership,
+): Promise<DesktopRegistrationTakeover> {
+  if (cliOwnership.kind !== "cli-or-other" || cliOwnership.pid === null) {
+    return { kind: "not-applicable" };
+  }
+  const outcome = await requestCooperativeShutdown(
+    label.environment,
+    "takeover",
+    "shutdown",
+  );
+  if (outcome.kind === "busy") {
+    throw cliError({
+      code: CLI_ERROR_CODES.HOST_BUSY,
+      message:
+        "service install --takeover: the host running under the CLI label has work in progress and denied the shutdown claim; retry once the work completes.",
+      details: { label: label.id, pid: cliOwnership.pid },
+      exitCode: 1,
+    });
+  }
+  if (outcome.kind === "no-metadata" || outcome.kind === "no-host") {
+    throw cliError({
+      code: CLI_ERROR_CODES.SERVICE_INSTALL_FAILED,
+      message: `service install --takeover: launchd reports a process (pid ${cliOwnership.pid}) under '${label.id}' that has not published a live endpoint yet, so it could not be asked to stand down; it is most likely still starting. Retry in a moment, or run 'traycer host service uninstall' first if it never comes up.`,
+      details: {
+        label: label.id,
+        pid: cliOwnership.pid,
+        metadata: outcome.kind,
+      },
+      exitCode: 1,
+    });
+  }
+  const logger = createCliLogger(label.environment);
+  if (outcome.kind === "unreachable" || outcome.kind === "hung") {
+    logger.warn(
+      "Takeover: the host running under the CLI label could not be stopped cooperatively; the reload will boot the job out underneath it.",
+      {
+        label: label.id,
+        pid: cliOwnership.pid,
+        cause:
+          outcome.kind === "unreachable"
+            ? outcome.cause
+            : `pid ${outcome.pid} outlived the shutdown grace`,
+      },
+    );
+  } else {
+    logger.info(
+      "Takeover: the host running under the CLI label stood down before the reload.",
+      { label: label.id, pid: cliOwnership.pid, outcome: outcome.kind },
+    );
+  }
+  return {
+    kind: "cli-host-stopped",
+    cooperativeStop:
+      outcome.kind === "stopped" ? "stopped" : "skipped-unreachable",
   };
 }
 
@@ -617,7 +698,14 @@ async function reloadRegisteredService(
 type LaunchdOwnership =
   | { readonly kind: "not-loaded" }
   | { readonly kind: "smappservice"; readonly path: string }
-  | { readonly kind: "cli-or-other"; readonly path: string | null };
+  | {
+      readonly kind: "cli-or-other";
+      readonly path: string | null;
+      // launchd's `pid` for the job, or null when the job is loaded but has
+      // no running process (a clean exit under `KeepAlive{SuccessfulExit:
+      // false}`, or the throttle window between crashes).
+      readonly pid: number | null;
+    };
 
 // Probe launchd for who currently owns this label. `launchctl print`
 // exits 0 when loaded; non-zero means not loaded. Tolerate non-zero so a
@@ -686,7 +774,14 @@ function classifyLaunchdPrintOutput(printOutput: string): LaunchdOwnership {
   if (isServiceManagement) {
     return { kind: "smappservice", path: path ?? SMAPPSERVICE_PATH_UNKNOWN };
   }
-  return { kind: "cli-or-other", path };
+  const pidField = fields.get("pid");
+  const pid =
+    pidField === undefined ? Number.NaN : Number.parseInt(pidField, 10);
+  return {
+    kind: "cli-or-other",
+    path,
+    pid: Number.isInteger(pid) && pid > 0 ? pid : null,
+  };
 }
 
 // launchctl returns "Service is already loaded" / "Bootstrap failed:

--- a/clients/traycer-cli/src/service/platforms/macos.ts
+++ b/clients/traycer-cli/src/service/platforms/macos.ts
@@ -226,7 +226,7 @@ async function takeoverDesktopRegistration(
   if (
     (outcome.kind === "no-metadata" || outcome.kind === "no-host") &&
     cliProbe.kind === "loaded" &&
-    cliProbe.pid !== null
+    cliProbe.running
   ) {
     throw unaskableCliLabelHost(label, cliProbe.pid, outcome.kind, null);
   }
@@ -319,17 +319,20 @@ async function takeoverDesktopRegistration(
   // already have been recycled (see `unloadCliLabelJob`).
   if (
     agentBootout.exitCode !== 0 &&
-    agentProbe.pid !== null &&
-    isProcessAlive(agentProbe.pid)
+    processMayLiveOn({
+      pid: agentProbe.pid,
+      running: agentProbe.running && outcome.kind !== "stopped",
+    })
   ) {
     throw cliError({
       code: CLI_ERROR_CODES.SERVICE_INSTALL_FAILED,
-      message: `service install --takeover: launchctl bootout unloaded '${desktopAgent.agentLabelId}', but its process (pid ${agentProbe.pid}) is still running after the wait, so the takeover was stopped rather than start a replacement beside it. Re-run the command once it has exited, or use the Traycer app to remove the host, or run 'traycer host service uninstall'.`,
+      message: `service install --takeover: launchctl bootout unloaded '${desktopAgent.agentLabelId}', but ${agentProbe.pid !== null ? `its process (pid ${agentProbe.pid}) is still running after the wait` : "launchd had reported it running with no pid to check and the wait did not end with its exit"}, so the takeover was stopped rather than start a replacement beside it. Re-run the command once it has exited, or use the Traycer app to remove the host, or run 'traycer host service uninstall'.`,
       details: {
         label: label.id,
         agentLabel: desktopAgent.agentLabelId,
         pid: agentProbe.pid,
-        verification: "process-alive",
+        verification:
+          agentProbe.pid !== null ? "process-alive" : "process-unverified",
       },
       exitCode: 1,
     });
@@ -406,6 +409,15 @@ type TakeoverLabelProbe =
       // carries one only for `cli-or-other`), so a bootout of either label is
       // checked against the PROCESS afterwards, not only the label.
       readonly pid: number | null;
+      // Whether launchd reports a process under the job: a positive pid, or
+      // `state = running` with no pid field printed - the same reading the
+      // desktop's parked-registration probe makes (Codex, traycer#1761); an
+      // exact match, like that probe, because no live bytes show a
+      // decorated form (`wedge.ts` documents the same rule for its tokens). A
+      // running job with no pid is still asked to stand down; only the
+      // liveness check after the bootout has nothing to key on, and it fails
+      // closed on the wait's timeout instead.
+      readonly running: boolean;
     };
 
 // Three-state `launchctl print` for the takeover's two labels: `absent` only
@@ -451,12 +463,34 @@ async function probeLabelForTakeover(
   }
   const ownership = classifyLaunchdPrintOutput(probe.raw);
   if (ownership.kind === "not-loaded") return { kind: "absent" };
-  const { pid } = probe.runState;
+  const { pid, jobState } = probe.runState;
+  const livePid = pid.kind === "observed" && pid.value > 0 ? pid.value : null;
   return {
     kind: "loaded",
     ownership,
-    pid: pid.kind === "observed" && pid.value > 0 ? pid.value : null,
+    pid: livePid,
+    running:
+      livePid !== null ||
+      (jobState.kind === "observed" &&
+        jobState.value.toLowerCase() === "running"),
   };
+}
+
+// The process evidence a takeover bootout is checked against afterwards.
+type TakeoverJobProcess = Pick<
+  Extract<TakeoverLabelProbe, { kind: "loaded" }>,
+  "pid" | "running"
+>;
+
+// After a `bootout --wait` that did NOT end with launchd's exit 0: may the
+// job's process live on? Only if launchd had reported one - and the caller
+// clears `running` once the host ANSWERED the claim with `stopped`, since
+// then it has exited and neither a recycled pid nor a stale flag is evidence.
+// With a pid, ask the kernel; without one, a running job cannot be checked
+// and the answer is yes.
+function processMayLiveOn(job: TakeoverJobProcess): boolean {
+  if (!job.running) return false;
+  return job.pid !== null ? isProcessAlive(job.pid) : true;
 }
 
 function preSplitCliLabelRefusal(
@@ -513,7 +547,8 @@ function takeoverProbeIndeterminate(
 // host proceeds, an unreachable one is booted out underneath because it is
 // the broken part - and, unlike that arm, a host nobody can ask is refused:
 //
-// `no-metadata` and `no-host` with a live launchd pid both REFUSE instead of
+// `no-metadata` and `no-host` while launchd reports a process (a positive
+// pid, or `state = running` with none printed) both REFUSE instead of
 // proceeding. launchd's pid is the supervisor; `pid.json` names its host
 // child. A supervisor that is alive while the metadata is absent, or names a
 // child that is gone, is a host in its first seconds (fresh start, or a
@@ -561,12 +596,12 @@ async function standDownLiveCliLabelHost(
   }
   const { pid } = cliProbe;
   const logger = createCliLogger(label.environment);
-  if (pid === null) {
+  if (!cliProbe.running) {
     logger.info(
       "Takeover: the CLI label is loaded with no running process; unloading it before the reload so launchd cannot start it underneath the install.",
       { label: label.id, path: cliProbe.ownership.path },
     );
-    await unloadCliLabelJob(label, null, run, retiredAgentLabelId);
+    await unloadCliLabelJob(label, cliProbe, run, retiredAgentLabelId);
     return { kind: "cli-host-stopped", cooperativeStop: "no-host" };
   }
   const outcome = await requestCooperativeShutdown(
@@ -603,7 +638,12 @@ async function standDownLiveCliLabelHost(
       { label: label.id, pid, outcome: outcome.kind },
     );
   }
-  await unloadCliLabelJob(label, pid, run, retiredAgentLabelId);
+  await unloadCliLabelJob(
+    label,
+    { pid, running: outcome.kind !== "stopped" },
+    run,
+    retiredAgentLabelId,
+  );
   return {
     kind: "cli-host-stopped",
     cooperativeStop:
@@ -620,14 +660,15 @@ async function standDownLiveCliLabelHost(
 // Desktop's agent the message says so and names the re-run.
 function unaskableCliLabelHost(
   label: ServiceLabel,
-  pid: number,
+  pid: number | null,
   metadata: "no-metadata" | "no-host",
   retiredAgentLabelId: string | null,
 ): Error {
+  const subject = pid === null ? "a running job" : `a process (pid ${pid})`;
   const state =
     metadata === "no-metadata"
-      ? `launchd reports a process (pid ${pid}) under '${label.id}' that has not published a live endpoint yet, so it could not be asked to stand down; it is most likely still starting.`
-      : `launchd reports a process (pid ${pid}) under '${label.id}', but the endpoint it published names a host that has already exited, so nothing could be asked to stand down; it is most likely between hosts (starting the next one, or exiting after the last).`;
+      ? `launchd reports ${subject} under '${label.id}' that has not published a live endpoint yet, so it could not be asked to stand down; it is most likely still starting.`
+      : `launchd reports ${subject} under '${label.id}', but the endpoint it published names a host that has already exited, so nothing could be asked to stand down; it is most likely between hosts (starting the next one, or exiting after the last).`;
   const routing =
     retiredAgentLabelId === null
       ? "Retry in a moment, or run 'traycer host service uninstall' first if it never comes up."
@@ -662,13 +703,16 @@ function unaskableCliLabelHost(
 // own success - only then: after a clean exit 0 the process is reaped, and a
 // pid read before the claim can have been recycled by the time a
 // `stopped` host's teardown is over, which `isProcessAlive` would report as
-// alive - the `pid` the caller knew is checked too.
+// alive - the process launchd reported is checked too: by pid when there
+// was one, and taken as still possible when launchd said `running` without
+// printing one. The caller clears `running` after a `stopped` answer.
 async function unloadCliLabelJob(
   label: ServiceLabel,
-  pid: number | null,
+  job: TakeoverJobProcess,
   run: ProcessRunner,
   retiredAgentLabelId: string | null,
 ): Promise<void> {
+  const { pid } = job;
   const serviceTarget = `${guiDomain()}/${label.id}`;
   const bootout = await run("launchctl", ["bootout", "--wait", serviceTarget], {
     env: undefined,
@@ -678,11 +722,10 @@ async function unloadCliLabelJob(
   });
   const postBootout = await verifyAgentBootedOut(serviceTarget, run);
   const verification =
-    postBootout === "absent" &&
-    bootout.exitCode !== 0 &&
-    pid !== null &&
-    isProcessAlive(pid)
-      ? "process-alive"
+    postBootout === "absent" && bootout.exitCode !== 0 && processMayLiveOn(job)
+      ? pid !== null
+        ? "process-alive"
+        : "process-unverified"
       : postBootout;
   if (verification === "absent") return;
   const routing = takeoverRerunRouting(retiredAgentLabelId);
@@ -691,7 +734,9 @@ async function unloadCliLabelJob(
       ? `launchctl bootout of '${label.id}' did not take effect (the job is still loaded), so the reload was stopped rather than start a replacement beside the old host.`
       : verification === "process-alive"
         ? `launchctl bootout unloaded '${label.id}', but its process (pid ${pid}) is still running after the wait, so the reload was stopped rather than start a replacement beside it.`
-        : `could not confirm that '${label.id}' was booted out (launchctl did not answer), so the reload was stopped rather than risk running two hosts.`;
+        : verification === "process-unverified"
+          ? `launchctl bootout unloaded '${label.id}', but launchd had reported the job running with no pid to check and the wait did not end with its exit, so the reload was stopped rather than start a replacement beside a process that may still be running.`
+          : `could not confirm that '${label.id}' was booted out (launchctl did not answer), so the reload was stopped rather than risk running two hosts.`;
   throw cliError({
     code: CLI_ERROR_CODES.SERVICE_INSTALL_FAILED,
     message: `service install --takeover: ${what} ${routing}`,

--- a/clients/traycer-cli/src/service/platforms/macos.ts
+++ b/clients/traycer-cli/src/service/platforms/macos.ts
@@ -152,24 +152,52 @@ async function takeoverDesktopRegistration(
   run: ProcessRunner,
 ): Promise<DesktopRegistrationTakeover> {
   const guiTarget = guiDomain();
+  // Both probes fail CLOSED here, unlike the advisory ownership probes the
+  // stop/restart paths use. Those collapse a non-zero or thrown `launchctl
+  // print` into "not loaded" because for an ownership question an unreadable
+  // label is safely "not ours". For a takeover the safe direction is the
+  // opposite: a label read as absent by a transient fault skips the
+  // cooperative stop below, and `installService`'s later probe then finds
+  // the loaded job and boots it out with no claim (Codex, traycer#1761).
+  const cliProbe = await probeLabelForTakeover(`${guiTarget}/${label.id}`, run);
+  if (cliProbe.kind === "indeterminate") {
+    throw takeoverProbeIndeterminate(label, label.id, cliProbe.cause);
+  }
   // Pre-split machines: the CLI label itself is Desktop's SMAppService
   // registration. Booting THAT out corrupts the BTM state the app manages.
-  const cliOwnership = await inspectLaunchdOwnership(
-    `${guiTarget}/${label.id}`,
-    run,
-  ).catch((): LaunchdOwnership => ({ kind: "not-loaded" }));
-  if (cliOwnership.kind === "smappservice") {
+  if (
+    cliProbe.kind === "loaded" &&
+    cliProbe.ownership.kind === "smappservice"
+  ) {
     throw cliError({
       code: CLI_ERROR_CODES.SERVICE_INSTALL_FAILED,
-      message: `service install --takeover: label '${label.id}' is Desktop's own SMAppService registration (pre-label-split machine, loaded from ${cliOwnership.path}); takeover cannot bootout this label without corrupting the login-item state the app manages. Run 'traycer host service uninstall', then re-run 'traycer host service install'.`,
-      details: { label: label.id, loadedPath: cliOwnership.path },
+      message: `service install --takeover: label '${label.id}' is Desktop's own SMAppService registration (pre-label-split machine, loaded from ${cliProbe.ownership.path}); takeover cannot bootout this label without corrupting the login-item state the app manages. Run 'traycer host service uninstall', then re-run 'traycer host service install'.`,
+      details: { label: label.id, loadedPath: cliProbe.ownership.path },
       exitCode: 1,
     });
   }
-  const desktopAgent = await probeDesktopAgentOwnership(label, run);
-  if (desktopAgent === null) {
-    return await standDownLiveCliLabelHost(label, cliOwnership);
+  const agentLabelId = smAppServiceAgentLabelId(label);
+  const agentProbe = await probeLabelForTakeover(
+    `${guiTarget}/${agentLabelId}`,
+    run,
+  );
+  if (agentProbe.kind === "indeterminate") {
+    throw takeoverProbeIndeterminate(label, agentLabelId, agentProbe.cause);
   }
+  if (
+    agentProbe.kind !== "loaded" ||
+    agentProbe.ownership.kind !== "smappservice"
+  ) {
+    return await standDownLiveCliLabelHost(
+      label,
+      cliProbe.kind === "loaded" ? cliProbe.ownership : { kind: "not-loaded" },
+      run,
+    );
+  }
+  const desktopAgent: DesktopAgentOwnership = {
+    agentLabelId,
+    loadedPath: agentProbe.ownership.path,
+  };
   // The CLI is taking this label over; Desktop's registration is retired, not
   // relaunched. Nothing is coming back under this identity.
   const outcome = await requestCooperativeShutdown(
@@ -280,6 +308,73 @@ async function takeoverDesktopRegistration(
   };
 }
 
+type TakeoverLabelProbe =
+  | { readonly kind: "absent" }
+  | { readonly kind: "indeterminate"; readonly cause: string }
+  | {
+      readonly kind: "loaded";
+      readonly ownership: Exclude<LaunchdOwnership, { kind: "not-loaded" }>;
+    };
+
+// Three-state `launchctl print` for the takeover's two labels: `absent` only
+// on launchctl's own not-found answer, `indeterminate` for everything that
+// is not an answer (spawn failure, timeout, permission, unrecognized
+// output), `loaded` with the same ownership classification the advisory
+// probes use. A revoked mutation capability still rethrows, as everywhere.
+async function probeLabelForTakeover(
+  target: string,
+  run: ProcessRunner,
+): Promise<TakeoverLabelProbe> {
+  let result: ProbeCommandResult;
+  try {
+    const value = await run("launchctl", ["print", target], {
+      env: undefined,
+      cwd: undefined,
+      timeoutMs: 10_000,
+      tolerateNonZeroExit: true,
+    });
+    result = {
+      exitCode: value.exitCode,
+      stdout: value.stdout,
+      stderr: value.stderr,
+      timedOut: false,
+      spawnFailed: false,
+      signal: null,
+    };
+  } catch (cause) {
+    if (isServiceMutationAuthorityError(cause)) throw cause;
+    result = {
+      exitCode: -1,
+      stdout: "",
+      stderr: "",
+      timedOut: false,
+      spawnFailed: true,
+      signal: null,
+    };
+  }
+  const probe = classifyLaunchctlPrintResult(result, null, null);
+  if (probe.kind === "absent") return { kind: "absent" };
+  if (probe.kind === "indeterminate") {
+    return { kind: "indeterminate", cause: probe.cause };
+  }
+  const ownership = classifyLaunchdPrintOutput(probe.raw);
+  if (ownership.kind === "not-loaded") return { kind: "absent" };
+  return { kind: "loaded", ownership };
+}
+
+function takeoverProbeIndeterminate(
+  label: ServiceLabel,
+  probedLabelId: string,
+  cause: string,
+): Error {
+  return cliError({
+    code: CLI_ERROR_CODES.SERVICE_INSTALL_FAILED,
+    message: `service install --takeover: could not read launchd's state for '${probedLabelId}' (${cause}), so the takeover was stopped rather than reload a job it could not see. Re-run the command, or run 'traycer host service uninstall' first.`,
+    details: { label: label.id, probedLabel: probedLabelId, cause },
+    exitCode: 1,
+  });
+}
+
 // The takeover with NO Desktop agent to retire. Its caller (`installService`)
 // boots out a loaded CLI label with a plain `launchctl bootout` and no
 // cooperative claim - fine for a job with no process, and exactly wrong for
@@ -300,9 +395,20 @@ async function takeoverDesktopRegistration(
 // interruption this guard exists to prevent. The window closes on its own;
 // the caller retries. Only a host that answered - stood down, or is
 // provably unreachable behind a published endpoint - lets the reload run.
+//
+// And it runs only once the job is provably GONE: the same `bootout --wait`
+// barrier and positive re-probe the Desktop-agent arm uses. A cooperative
+// stop waits for the host child, not the supervisor launchd runs, and an
+// unreachable host was never asked at all; `installService`'s own bootout
+// does not wait, so without the barrier it can bootstrap the replacement
+// while the incumbent is still tearing down and still publishing `pid.json`
+// - the replacement's `findLiveIncumbentHost` then reads the corpse as live,
+// declines, exits 0, and `KeepAlive{SuccessfulExit: false}` leaves the
+// machine hostless (CodeRabbit, traycer#1761).
 async function standDownLiveCliLabelHost(
   label: ServiceLabel,
   cliOwnership: LaunchdOwnership,
+  run: ProcessRunner,
 ): Promise<DesktopRegistrationTakeover> {
   if (cliOwnership.kind !== "cli-or-other" || cliOwnership.pid === null) {
     return { kind: "not-applicable" };
@@ -351,6 +457,29 @@ async function standDownLiveCliLabelHost(
       "Takeover: the host running under the CLI label stood down before the reload.",
       { label: label.id, pid: cliOwnership.pid, outcome: outcome.kind },
     );
+  }
+  const serviceTarget = `${guiDomain()}/${label.id}`;
+  await run("launchctl", ["bootout", "--wait", serviceTarget], {
+    env: undefined,
+    cwd: undefined,
+    timeoutMs: STOP_EXIT_TIMEOUT_MS,
+    tolerateNonZeroExit: true,
+  });
+  const postBootout = await verifyAgentBootedOut(serviceTarget, run);
+  if (postBootout !== "absent") {
+    throw cliError({
+      code: CLI_ERROR_CODES.SERVICE_INSTALL_FAILED,
+      message:
+        postBootout === "still-loaded"
+          ? `service install --takeover: launchctl bootout of '${label.id}' did not take effect (the job is still loaded), so the reload was stopped rather than start a replacement beside the old host. Re-run the command, or run 'traycer host service uninstall' first.`
+          : `service install --takeover: could not confirm that '${label.id}' was booted out (launchctl did not answer), so the reload was stopped rather than risk running two hosts. Re-run the command, or run 'traycer host service uninstall' first.`,
+      details: {
+        label: label.id,
+        pid: cliOwnership.pid,
+        verification: postBootout,
+      },
+      exitCode: 1,
+    });
   }
   return {
     kind: "cli-host-stopped",

--- a/clients/traycer-cli/src/service/platforms/macos.ts
+++ b/clients/traycer-cli/src/service/platforms/macos.ts
@@ -159,9 +159,28 @@ async function takeoverDesktopRegistration(
   // opposite: a label read as absent by a transient fault skips the
   // cooperative stop below, and `installService`'s later probe then finds
   // the loaded job and boots it out with no claim (Codex, traycer#1761).
+  //
+  // The agent is probed FIRST so that the CLI-label read is the freshest
+  // evidence the no-agent arm acts on: `standDownLiveCliLabelHost` decides
+  // from it, and a job that becomes loaded during an earlier probe would
+  // otherwise be missed (the took-over arm re-reads the label after the
+  // agent's bootout for the same reason).
+  const agentLabelId = smAppServiceAgentLabelId(label);
+  const agentProbe = await probeLabelForTakeover(
+    `${guiTarget}/${agentLabelId}`,
+    run,
+  );
+  if (agentProbe.kind === "indeterminate") {
+    throw takeoverProbeIndeterminate(
+      label,
+      agentLabelId,
+      agentProbe.cause,
+      null,
+    );
+  }
   const cliProbe = await probeLabelForTakeover(`${guiTarget}/${label.id}`, run);
   if (cliProbe.kind === "indeterminate") {
-    throw takeoverProbeIndeterminate(label, label.id, cliProbe.cause);
+    throw takeoverProbeIndeterminate(label, label.id, cliProbe.cause, null);
   }
   // Pre-split machines: the CLI label itself is Desktop's SMAppService
   // registration. Booting THAT out corrupts the BTM state the app manages.
@@ -169,30 +188,13 @@ async function takeoverDesktopRegistration(
     cliProbe.kind === "loaded" &&
     cliProbe.ownership.kind === "smappservice"
   ) {
-    throw cliError({
-      code: CLI_ERROR_CODES.SERVICE_INSTALL_FAILED,
-      message: `service install --takeover: label '${label.id}' is Desktop's own SMAppService registration (pre-label-split machine, loaded from ${cliProbe.ownership.path}); takeover cannot bootout this label without corrupting the login-item state the app manages. Run 'traycer host service uninstall', then re-run 'traycer host service install'.`,
-      details: { label: label.id, loadedPath: cliProbe.ownership.path },
-      exitCode: 1,
-    });
-  }
-  const agentLabelId = smAppServiceAgentLabelId(label);
-  const agentProbe = await probeLabelForTakeover(
-    `${guiTarget}/${agentLabelId}`,
-    run,
-  );
-  if (agentProbe.kind === "indeterminate") {
-    throw takeoverProbeIndeterminate(label, agentLabelId, agentProbe.cause);
+    throw preSplitCliLabelRefusal(label, cliProbe.ownership.path, null);
   }
   if (
     agentProbe.kind !== "loaded" ||
     agentProbe.ownership.kind !== "smappservice"
   ) {
-    return await standDownLiveCliLabelHost(
-      label,
-      cliProbe.kind === "loaded" ? cliProbe.ownership : { kind: "not-loaded" },
-      run,
-    );
+    return await standDownLiveCliLabelHost(label, cliProbe, run, null);
   }
   const desktopAgent: DesktopAgentOwnership = {
     agentLabelId,
@@ -213,6 +215,20 @@ async function takeoverDesktopRegistration(
       details: { label: label.id, agentLabel: desktopAgent.agentLabelId },
       exitCode: 1,
     });
+  }
+  // A live process under the CLI label that has no endpoint to ask is
+  // refused BEFORE the agent is touched, on the terms the stand-down below
+  // refuses it after: `no-metadata` and `no-host` mean no claim was made at
+  // all. The agent arm boots ITS job out on that evidence because the
+  // Desktop-managed host is what this command retires; the CLI-label process
+  // is not, and interrupting it in its first seconds is the round-1 bug on
+  // the sibling path. Refusing here leaves nothing half done.
+  if (
+    (outcome.kind === "no-metadata" || outcome.kind === "no-host") &&
+    cliProbe.kind === "loaded" &&
+    cliProbe.pid !== null
+  ) {
+    throw unaskableCliLabelHost(label, cliProbe.pid, outcome.kind, null);
   }
   const logger = createCliLogger(label.environment);
   if (
@@ -256,12 +272,16 @@ async function takeoverDesktopRegistration(
   // `tolerateNonZeroExit` stays `true`, unlike the retirement path, because
   // that positive probe is the gate here - a benign "no such process" exit
   // must reach it rather than abort a takeover that in fact succeeded.
-  await run("launchctl", ["bootout", "--wait", agentTarget], {
-    env: undefined,
-    cwd: undefined,
-    timeoutMs: STOP_EXIT_TIMEOUT_MS,
-    tolerateNonZeroExit: true,
-  });
+  const agentBootout = await run(
+    "launchctl",
+    ["bootout", "--wait", agentTarget],
+    {
+      env: undefined,
+      cwd: undefined,
+      timeoutMs: STOP_EXIT_TIMEOUT_MS,
+      tolerateNonZeroExit: true,
+    },
+  );
   // Verification must be POSITIVE. `inspectLaunchdOwnership` collapses every
   // non-zero exit - and its caller every thrown error - into `not-loaded`,
   // so an EPERM, a timeout, or a launchctl that could not spawn would all
@@ -288,12 +308,80 @@ async function takeoverDesktopRegistration(
       exitCode: 1,
     });
   }
+  // The label is gone; the PROCESS may not be. `bootout --wait` returns at
+  // the runner's timeout as well as at exit (`tolerateNonZeroExit` resolves
+  // the timeout as exit -1), and a `hung` host is by definition still alive
+  // at that point, still publishing `pid.json`. Registering the CLI label on
+  // the label evidence alone is the hostless bootstrap-beside-a-corpse this
+  // barrier exists to prevent, so the pid launchd reported is checked too -
+  // only when the wait did not end with launchd's own success, because after
+  // a clean exit 0 the process is reaped and a pid read before the claim can
+  // already have been recycled (see `unloadCliLabelJob`).
+  if (
+    agentBootout.exitCode !== 0 &&
+    agentProbe.pid !== null &&
+    isProcessAlive(agentProbe.pid)
+  ) {
+    throw cliError({
+      code: CLI_ERROR_CODES.SERVICE_INSTALL_FAILED,
+      message: `service install --takeover: launchctl bootout unloaded '${desktopAgent.agentLabelId}', but its process (pid ${agentProbe.pid}) is still running after the wait, so the takeover was stopped rather than start a replacement beside it. Re-run the command once it has exited, or use the Traycer app to remove the host, or run 'traycer host service uninstall'.`,
+      details: {
+        label: label.id,
+        agentLabel: desktopAgent.agentLabelId,
+        pid: agentProbe.pid,
+        verification: "process-alive",
+      },
+      exitCode: 1,
+    });
+  }
+  // The CLI label is read AGAIN, not from `cliProbe`: that snapshot predates
+  // the whole claim and the agent's bootout wait (a minute at the limit), and
+  // a job loaded since - a dual-registered machine's CLI label, or a
+  // throttled `KeepAlive` respawn of one - would otherwise be left for the
+  // install's bare bootout. The fresh read goes through the same stand-down
+  // as the no-agent arm, with a fresh claim: the claim above went to whatever
+  // `pid.json` named, which need not be this label's process. The one false
+  // refusal that leaves is a supervisor still winding down after its child
+  // stood down through that claim (`no-metadata`, a few hundred milliseconds
+  // wide); its message says the agent is already gone and a re-run finishes.
+  const cliAfterAgent = await probeLabelForTakeover(
+    `${guiTarget}/${label.id}`,
+    run,
+  );
+  if (cliAfterAgent.kind === "indeterminate") {
+    throw takeoverProbeIndeterminate(
+      label,
+      label.id,
+      cliAfterAgent.cause,
+      desktopAgent.agentLabelId,
+    );
+  }
+  if (
+    cliAfterAgent.kind === "loaded" &&
+    cliAfterAgent.ownership.kind === "smappservice"
+  ) {
+    throw preSplitCliLabelRefusal(
+      label,
+      cliAfterAgent.ownership.path,
+      desktopAgent.agentLabelId,
+    );
+  }
+  const cliStandDown = await standDownLiveCliLabelHost(
+    label,
+    cliAfterAgent,
+    run,
+    desktopAgent.agentLabelId,
+  );
   logger.info(
     "Takeover: booted out Traycer Desktop's SMAppService agent; the CLI now owns host registration. Launching the Desktop app again may re-register its agent - uninstall or update the app to make the takeover permanent.",
     {
       label: label.id,
       agentLabel: desktopAgent.agentLabelId,
       loadedPath: desktopAgent.loadedPath,
+      cliLabel:
+        cliStandDown.kind === "cli-host-stopped"
+          ? `unloaded (${cliStandDown.cooperativeStop})`
+          : "not loaded",
     },
   );
   return {
@@ -314,6 +402,10 @@ type TakeoverLabelProbe =
   | {
       readonly kind: "loaded";
       readonly ownership: Exclude<LaunchdOwnership, { kind: "not-loaded" }>;
+      // launchd's pid for the job whatever its ownership (`LaunchdOwnership`
+      // carries one only for `cli-or-other`), so a bootout of either label is
+      // checked against the PROCESS afterwards, not only the label.
+      readonly pid: number | null;
     };
 
 // Three-state `launchctl print` for the takeover's two labels: `absent` only
@@ -359,32 +451,67 @@ async function probeLabelForTakeover(
   }
   const ownership = classifyLaunchdPrintOutput(probe.raw);
   if (ownership.kind === "not-loaded") return { kind: "absent" };
-  return { kind: "loaded", ownership };
+  const { pid } = probe.runState;
+  return {
+    kind: "loaded",
+    ownership,
+    pid: pid.kind === "observed" && pid.value > 0 ? pid.value : null,
+  };
+}
+
+function preSplitCliLabelRefusal(
+  label: ServiceLabel,
+  loadedPath: string,
+  retiredAgentLabelId: string | null,
+): Error {
+  return cliError({
+    code: CLI_ERROR_CODES.SERVICE_INSTALL_FAILED,
+    message: `service install --takeover: label '${label.id}' is Desktop's own SMAppService registration (pre-label-split machine, loaded from ${loadedPath}); takeover cannot bootout this label without corrupting the login-item state the app manages.${retiredAgentLabelId === null ? "" : ` Traycer Desktop's agent '${retiredAgentLabelId}' is already deregistered.`} Run 'traycer host service uninstall', then re-run 'traycer host service install'.`,
+    details: { label: label.id, loadedPath, agentLabel: retiredAgentLabelId },
+    exitCode: 1,
+  });
+}
+
+// Routing tail for every refusal the takeover can issue AFTER it has
+// deregistered Desktop's agent: at that point the machine's only remaining
+// registration is the one being refused, and the re-run that finishes the
+// takeover has to be spelled out.
+function takeoverRerunRouting(retiredAgentLabelId: string | null): string {
+  return retiredAgentLabelId === null
+    ? "Re-run the command, or run 'traycer host service uninstall' first."
+    : `Traycer Desktop's agent '${retiredAgentLabelId}' is already deregistered; re-run the command to finish the takeover, or run 'traycer host service uninstall' first.`;
 }
 
 function takeoverProbeIndeterminate(
   label: ServiceLabel,
   probedLabelId: string,
   cause: string,
+  retiredAgentLabelId: string | null,
 ): Error {
   return cliError({
     code: CLI_ERROR_CODES.SERVICE_INSTALL_FAILED,
-    message: `service install --takeover: could not read launchd's state for '${probedLabelId}' (${cause}), so the takeover was stopped rather than reload a job it could not see. Re-run the command, or run 'traycer host service uninstall' first.`,
-    details: { label: label.id, probedLabel: probedLabelId, cause },
+    message: `service install --takeover: could not read launchd's state for '${probedLabelId}' (${cause}), so the takeover was stopped rather than reload a job it could not see. ${takeoverRerunRouting(retiredAgentLabelId)}`,
+    details: {
+      label: label.id,
+      probedLabel: probedLabelId,
+      cause,
+      agentLabel: retiredAgentLabelId,
+    },
     exitCode: 1,
   });
 }
 
-// The takeover with NO Desktop agent to retire. Its caller (`installService`)
-// boots out a loaded CLI label with a plain `launchctl bootout` and no
-// cooperative claim - fine for a job with no process, and exactly wrong for
-// a host that started between the caller's own probe and this lock: the
-// Desktop's parked-registration fallback admits the takeover only after it
-// has seen no live process under the label, but a throttled `KeepAlive`
-// respawn can start in that gap (Codex, traycer#1761). Under this lock, a
-// live process is asked to stand down on the same terms as a Desktop-managed
-// host: a busy denial ABORTS, a stopped or dead host proceeds, and an
-// unreachable one is booted out underneath because it is the broken part.
+// The takeover's handling of the CLI label itself, under the CLI's lock.
+// Its caller (`installService`) boots out a loaded CLI label with a plain
+// `launchctl bootout` and no cooperative claim - fine for a job with no
+// process, and exactly wrong for a host that started between the caller's
+// own probe and this lock: the Desktop's parked-registration fallback admits
+// the takeover only after it has seen no live process under the label, but
+// a throttled `KeepAlive` respawn can start in that gap (Codex,
+// traycer#1761). Under this lock, a live process is asked to stand down on
+// the same terms as a Desktop-managed host: a busy denial ABORTS, a stopped
+// host proceeds, an unreachable one is booted out underneath because it is
+// the broken part - and, unlike that arm, a host nobody can ask is refused:
 //
 // `no-metadata` and `no-host` with a live launchd pid both REFUSE instead of
 // proceeding. launchd's pid is the supervisor; `pid.json` names its host
@@ -396,22 +523,51 @@ function takeoverProbeIndeterminate(
 // the caller retries. Only a host that answered - stood down, or is
 // provably unreachable behind a published endpoint - lets the reload run.
 //
-// And it runs only once the job is provably GONE: the same `bootout --wait`
-// barrier and positive re-probe the Desktop-agent arm uses. A cooperative
-// stop waits for the host child, not the supervisor launchd runs, and an
-// unreachable host was never asked at all; `installService`'s own bootout
-// does not wait, so without the barrier it can bootstrap the replacement
-// while the incumbent is still tearing down and still publishing `pid.json`
-// - the replacement's `findLiveIncumbentHost` then reads the corpse as live,
-// declines, exits 0, and `KeepAlive{SuccessfulExit: false}` leaves the
-// machine hostless (CodeRabbit, traycer#1761).
+// A job that is loaded with NO process is not left for the caller either.
+// It is either idle for good (a clean exit: `traycer host stop`, or a child
+// that declined to an incumbent, which `KeepAlive{SuccessfulExit: false}`
+// never respawns) or inside launchd's throttle window before a respawn, and
+// the two cannot be told apart from `launchctl print`. Left loaded, the
+// throttled one can start while `installService` writes its launcher and
+// manifest, after which the install's bare bootout interrupts a host that
+// was never asked (Codex, traycer#1761, round 3). So the job is unloaded
+// HERE, under this lock, through `unloadCliLabelJob`: once it is verified
+// gone nothing can start under the label - launchd does not spawn an
+// unloaded job, another CLI is excluded by the contender lock, and a
+// Desktop SMAppService load of this label is the pre-split refusal the
+// install re-checks - and the install's own probe then reads it as
+// `not-loaded` and skips its bootout. What remains is the gap between
+// launchd answering the probe and the `bootout --wait` reaching it,
+// normally microseconds; a process launchd starts inside it is terminated
+// by that bootout without a claim, at an age where it has no client and no
+// work to lose.
+//
+// `retiredAgentLabelId` names Desktop's agent when the took-over arm calls
+// this after deregistering it; the refusals then say so, because at that
+// point the machine's only registration is the one being refused and the
+// re-run that finishes the takeover must be spelled out. Both callers refuse
+// an SMAppService-owned CLI label before calling.
 async function standDownLiveCliLabelHost(
   label: ServiceLabel,
-  cliOwnership: LaunchdOwnership,
+  cliProbe: Exclude<TakeoverLabelProbe, { kind: "indeterminate" }>,
   run: ProcessRunner,
+  retiredAgentLabelId: string | null,
 ): Promise<DesktopRegistrationTakeover> {
-  if (cliOwnership.kind !== "cli-or-other" || cliOwnership.pid === null) {
+  if (
+    cliProbe.kind !== "loaded" ||
+    cliProbe.ownership.kind !== "cli-or-other"
+  ) {
     return { kind: "not-applicable" };
+  }
+  const { pid } = cliProbe;
+  const logger = createCliLogger(label.environment);
+  if (pid === null) {
+    logger.info(
+      "Takeover: the CLI label is loaded with no running process; unloading it before the reload so launchd cannot start it underneath the install.",
+      { label: label.id, path: cliProbe.ownership.path },
+    );
+    await unloadCliLabelJob(label, null, run, retiredAgentLabelId);
+    return { kind: "cli-host-stopped", cooperativeStop: "no-host" };
   }
   const outcome = await requestCooperativeShutdown(
     label.environment,
@@ -421,31 +577,20 @@ async function standDownLiveCliLabelHost(
   if (outcome.kind === "busy") {
     throw cliError({
       code: CLI_ERROR_CODES.HOST_BUSY,
-      message:
-        "service install --takeover: the host running under the CLI label has work in progress and denied the shutdown claim; retry once the work completes.",
-      details: { label: label.id, pid: cliOwnership.pid },
+      message: `service install --takeover: the host running under the CLI label has work in progress and denied the shutdown claim; retry once the work completes.${retiredAgentLabelId === null ? "" : ` Traycer Desktop's agent '${retiredAgentLabelId}' is already deregistered; the re-run finishes the takeover.`}`,
+      details: { label: label.id, pid, agentLabel: retiredAgentLabelId },
       exitCode: 1,
     });
   }
   if (outcome.kind === "no-metadata" || outcome.kind === "no-host") {
-    throw cliError({
-      code: CLI_ERROR_CODES.SERVICE_INSTALL_FAILED,
-      message: `service install --takeover: launchd reports a process (pid ${cliOwnership.pid}) under '${label.id}' that has not published a live endpoint yet, so it could not be asked to stand down; it is most likely still starting. Retry in a moment, or run 'traycer host service uninstall' first if it never comes up.`,
-      details: {
-        label: label.id,
-        pid: cliOwnership.pid,
-        metadata: outcome.kind,
-      },
-      exitCode: 1,
-    });
+    throw unaskableCliLabelHost(label, pid, outcome.kind, retiredAgentLabelId);
   }
-  const logger = createCliLogger(label.environment);
   if (outcome.kind === "unreachable" || outcome.kind === "hung") {
     logger.warn(
       "Takeover: the host running under the CLI label could not be stopped cooperatively; the reload will boot the job out underneath it.",
       {
         label: label.id,
-        pid: cliOwnership.pid,
+        pid,
         cause:
           outcome.kind === "unreachable"
             ? outcome.cause
@@ -455,37 +600,109 @@ async function standDownLiveCliLabelHost(
   } else {
     logger.info(
       "Takeover: the host running under the CLI label stood down before the reload.",
-      { label: label.id, pid: cliOwnership.pid, outcome: outcome.kind },
+      { label: label.id, pid, outcome: outcome.kind },
     );
   }
+  await unloadCliLabelJob(label, pid, run, retiredAgentLabelId);
+  return {
+    kind: "cli-host-stopped",
+    cooperativeStop:
+      outcome.kind === "stopped" ? "stopped" : "skipped-unreachable",
+  };
+}
+
+// The refusal for a CLI-label process that nobody can ask (see
+// `standDownLiveCliLabelHost`): `no-metadata` is a host that has not
+// published yet; `no-host` is metadata whose endpoint names a process that
+// has already exited, while launchd still reports one under the label (its
+// supervisor between children, or a supervisor whose child just stood down
+// and has not exited itself yet). After the took-over arm has deregistered
+// Desktop's agent the message says so and names the re-run.
+function unaskableCliLabelHost(
+  label: ServiceLabel,
+  pid: number,
+  metadata: "no-metadata" | "no-host",
+  retiredAgentLabelId: string | null,
+): Error {
+  const state =
+    metadata === "no-metadata"
+      ? `launchd reports a process (pid ${pid}) under '${label.id}' that has not published a live endpoint yet, so it could not be asked to stand down; it is most likely still starting.`
+      : `launchd reports a process (pid ${pid}) under '${label.id}', but the endpoint it published names a host that has already exited, so nothing could be asked to stand down; it is most likely between hosts (starting the next one, or exiting after the last).`;
+  const routing =
+    retiredAgentLabelId === null
+      ? "Retry in a moment, or run 'traycer host service uninstall' first if it never comes up."
+      : `Traycer Desktop's agent '${retiredAgentLabelId}' is already deregistered; re-run the command in a moment to finish the takeover, or run 'traycer host service uninstall' first if it never comes up.`;
+  return cliError({
+    code: CLI_ERROR_CODES.SERVICE_INSTALL_FAILED,
+    message: `service install --takeover: ${state} ${routing}`,
+    details: {
+      label: label.id,
+      pid,
+      metadata,
+      agentLabel: retiredAgentLabelId,
+    },
+    exitCode: 1,
+  });
+}
+
+// Unload the CLI label under the takeover's lock, and prove it: the same
+// `bootout --wait` barrier and positive re-probe the Desktop-agent arm uses,
+// plus a liveness check of the process launchd reported. A cooperative stop
+// waits for the host child, not the supervisor launchd runs, and an
+// unreachable host was never asked at all; `installService`'s own bootout
+// does not wait, so without the barrier it can bootstrap the replacement
+// while the incumbent is still tearing down and still publishing `pid.json`
+// - the replacement's `findLiveIncumbentHost` then reads the corpse as live,
+// declines, exits 0, and `KeepAlive{SuccessfulExit: false}` leaves the
+// machine hostless (CodeRabbit, traycer#1761). The label probe alone cannot
+// close that: `bootout --wait` also returns at the runner's timeout
+// (`tolerateNonZeroExit` resolves it as exit -1), which under `hung` is the
+// expected exit, and launchd can have dropped the label while the process
+// it is still killing lives on. So when the wait did NOT end with launchd's
+// own success - only then: after a clean exit 0 the process is reaped, and a
+// pid read before the claim can have been recycled by the time a
+// `stopped` host's teardown is over, which `isProcessAlive` would report as
+// alive - the `pid` the caller knew is checked too.
+async function unloadCliLabelJob(
+  label: ServiceLabel,
+  pid: number | null,
+  run: ProcessRunner,
+  retiredAgentLabelId: string | null,
+): Promise<void> {
   const serviceTarget = `${guiDomain()}/${label.id}`;
-  await run("launchctl", ["bootout", "--wait", serviceTarget], {
+  const bootout = await run("launchctl", ["bootout", "--wait", serviceTarget], {
     env: undefined,
     cwd: undefined,
     timeoutMs: STOP_EXIT_TIMEOUT_MS,
     tolerateNonZeroExit: true,
   });
   const postBootout = await verifyAgentBootedOut(serviceTarget, run);
-  if (postBootout !== "absent") {
-    throw cliError({
-      code: CLI_ERROR_CODES.SERVICE_INSTALL_FAILED,
-      message:
-        postBootout === "still-loaded"
-          ? `service install --takeover: launchctl bootout of '${label.id}' did not take effect (the job is still loaded), so the reload was stopped rather than start a replacement beside the old host. Re-run the command, or run 'traycer host service uninstall' first.`
-          : `service install --takeover: could not confirm that '${label.id}' was booted out (launchctl did not answer), so the reload was stopped rather than risk running two hosts. Re-run the command, or run 'traycer host service uninstall' first.`,
-      details: {
-        label: label.id,
-        pid: cliOwnership.pid,
-        verification: postBootout,
-      },
-      exitCode: 1,
-    });
-  }
-  return {
-    kind: "cli-host-stopped",
-    cooperativeStop:
-      outcome.kind === "stopped" ? "stopped" : "skipped-unreachable",
-  };
+  const verification =
+    postBootout === "absent" &&
+    bootout.exitCode !== 0 &&
+    pid !== null &&
+    isProcessAlive(pid)
+      ? "process-alive"
+      : postBootout;
+  if (verification === "absent") return;
+  const routing = takeoverRerunRouting(retiredAgentLabelId);
+  const what =
+    verification === "still-loaded"
+      ? `launchctl bootout of '${label.id}' did not take effect (the job is still loaded), so the reload was stopped rather than start a replacement beside the old host.`
+      : verification === "process-alive"
+        ? `launchctl bootout unloaded '${label.id}', but its process (pid ${pid}) is still running after the wait, so the reload was stopped rather than start a replacement beside it.`
+        : `could not confirm that '${label.id}' was booted out (launchctl did not answer), so the reload was stopped rather than risk running two hosts.`;
+  throw cliError({
+    code: CLI_ERROR_CODES.SERVICE_INSTALL_FAILED,
+    message: `service install --takeover: ${what} ${routing}`,
+    details: {
+      label: label.id,
+      pid,
+      verification,
+      agentLabel: retiredAgentLabelId,
+    },
+    exitCode: 1,
+  });
 }
 
 async function installService(


### PR DESCRIPTION
## Summary

### Why

Reinstalling the Traycer Staging app on 2026-09-06 left the machine with no host for fifty minutes. `traycer host uninstall` had removed the CLI-owned LaunchAgent the staging host had always run under; the new app installed the new host bytes and then tried to register its in-bundle login item. SMAppService answers `not-found` for that item on this build (it is ad-hoc signed, so BTM has no Team ID to key the item on; the 2026-07-28 RCA showed the same answer for a byte-correct plist whose BTM record is keyed to a previous build, for the life of the process). `registerHostLoginItem`'s entry guard treats `not-found` as a prior state it cannot restore and parks. With no host running, `activateAroundParkedRegistration` then fails at once with "no host is running to restart - run `traycer host doctor`", the boot loop retries every 30-120 s, and every retry parks the same way. The CLI takeover that exists for exactly this state (`recoverRegistrationViaCliTakeover`, from the 2026-07-28 RCA) was reachable only from a register cycle that *returned* `not-found` after its bootout, never from one that parked before calling SMAppService. `host doctor` named the fix (`SERVICE_NOT_REGISTERED` → `traycer host service install`), and running it by hand is what brought the host back.

### What

- `host-login-item.ts`: new `readParkedRegistrationTakeover()`. After a park it answers whether the CLI-owned LaunchAgent may finish the registration. `takeover` only when the PRIMARY label reads `not-found`/`not-supported` (nothing this process can ever register) and none of four refusals hold: the LEGACY label reads `enabled`/`requires-approval` (a BTM record under the very label the raw plist would use; on an ad-hoc build both labels read `not-found` whatever BTM holds, so this is a bound, not a proof, and the doc says so), the CLI manifest is unreadable (the entry guard's own input), or launchd reports a live process under either label or cannot be asked. That last probe is the positive down-host evidence `prePid === null` is not: `pid.json` is a structural read, absent for a host in its first seconds after a `KeepAlive` respawn, while the CLI's install boots a loaded label out with no cooperative claim. `not-registered` is deliberately excluded from the admitting set (a park booted nothing out, and that is the one status the register poll treats as transient); the doc comment argues it. The `not-found` doc line no longer calls it "a packaging bug; never expected at runtime".
- `host-controller.ts`: `parkedTakeoverVerdict(prePid)` (no host per `pid.json` AND the verdict above) and `takeOverParkedRegistrationIfDown(prePid, expectedRuntimeVersion)`: run the same `host service install --takeover` recovery a failed register uses (with nothing loaded it is a plain install of the CLI LaunchAgent). `force` is not threaded in - the command has no force and the takeover is cooperative by construction - so a `busy` refusal is reported `deferred`, not `busy`, because the busy outcome advertises a Force affordance that would re-run the same forceless command. Used by every consumer of `parked`:
  - `activateAroundParkedRegistration` (the boot / activation cycle, the path in the incident) - before the "no host is running to restart" failure.
  - `registerService`'s parked branch - before the "could not be re-registered (status=…)" failure; success reports `registered: true`.
  - the F3 force-restart continuation - a down-host takeover-recoverable park now returns `needs-takeover` with the same outside-the-lock thunk the `register-failed` phase uses (factored into `mintedTakeoverContinuation` so the two cannot drift); every other park stays `deferred`.
- Down-host only, on purpose. With a host RUNNING under the CLI label the existing cooperative `host restart --if-idle` stays the route: it makes the shutdown claim and a busy host refuses it, whereas the takeover's `service install` boots the label out with no claim. A running host with no registration anywhere (a hand-run `host start`) converges through the same rule: the restart cannot relaunch, the next boot retry finds the host down, and takes the takeover.
- `clients/traycer-cli` (`macos.ts`, Codex P1 on round 1): the desktop's launchd probe is a snapshot, and a loaded-but-idle CLI-label job (a throttled `KeepAlive` respawn) can start between it and the CLI taking its contender lock; `installService` would then boot that job out with a plain `launchctl bootout` and no claim. `takeoverDesktopRegistration` now closes that under the CLI's lock: with no Desktop agent to retire, a CLI-label job that launchd reports WITH a live pid is asked to stand down through the same cooperative claim a Desktop-managed host gets (`busy` aborts with `E_HOST_BUSY`; `stopped` proceeds; an unreachable published endpoint is booted out as the broken part), and a process that has no live endpoint to ask yet (`no-metadata`, or `no-host` from stale metadata naming a dead child while the supervisor lives) is refused with a retry hint, because that is what a host looks like in its first seconds. `LaunchdOwnership.cli-or-other` carries launchd's `pid`; the new `cli-host-stopped` outcome is reported on the human line. Round 2 (CodeRabbit + Codex): the stand-down now ends with the same `bootout --wait` barrier and positive re-probe the Desktop-agent arm uses, so `installService` never bootstraps a replacement beside a supervisor still publishing `pid.json`; and both takeover probes are three-state (`probeLabelForTakeover`), refusing the takeover when `launchctl print` did not answer instead of reading the fault as "not loaded" and skipping the claim. Round 3 (Codex): a CLI-label job loaded with NO process is no longer handed to the install either - an idle job and a throttled `KeepAlive` respawn look the same to `launchctl print`, and the throttled one could start while the install wrote its files and then meet the install's bare bootout. The takeover unloads it itself, under its lock, through the same `bootout --wait` + re-probe (`unloadCliLabelJob`), so the install's probe reads `not-loaded` and nothing can start under the label in between. `cli-host-stopped` gained `cooperativeStop: "no-host"`. The took-over arm (Desktop's agent retired) had left a CLI label loaded beside the agent to the same bare bootout: it now re-probes the CLI label AFTER the agent is gone (its first probe predates the whole claim and bootout wait) and routes the fresh read through the same stand-down with a fresh claim; a CLI-label process with no endpoint to ask while the claim came back `no-metadata`/`no-host` is refused before the agent is touched, and refusals issued after the agent is deregistered say so. Cold review on the round: `bootout --wait` also returns at the runner's timeout, which under a `hung` host is the expected exit, and a label-only re-probe can read absent while launchd is still killing the process - so both takeover probes carry launchd's pid and every takeover bootout checks `isProcessAlive` after the label verify, refusing on a live read (only when the wait did not end with launchd's exit 0: after a clean exit the process is reaped and a pid read before the claim can have been recycled). The agent label is probed before the CLI label so the no-agent arm acts on the fresher read. Round 4 (Codex): a job `launchctl print` reports as `state = running` with no `pid` field is a running host, as the desktop probe already reads it; the takeover probe carries `running`, such a job is asked to stand down like a pid-bearing one, and the post-bootout liveness check it cannot make fails closed (`process-unverified`) on a timed-out wait. Round 5 (Codex): an exit-0 `launchctl print` with no recognizable job fields is `observed` with an indeterminate ownership and an empty run state by construction; both takeover probes (desktop verdict, CLI `probeLabelForTakeover`) now fail closed on it instead of reading it as an idle job. Round 6 (Codex) fixed the predicate the earlier rounds had been fixing one cell at a time: the cooperative claim follows `pid.json` and is not bound to a launchd label, so its answer is evidence about one process the arm could not name. The took-over arm now makes the subject unambiguous by construction - a process under BOTH labels, whatever owns them, is refused before any claim (two hosts on one machine; `host doctor` repairs it); the claim before the agent's bootout is skipped only when the CLI label is the one with a process (the stand-down asks that host afterwards, with a claim that reaches only it) and is made in every other case, idle agent included, because a hand-run host may be what `pid.json` names; nothing is registered while `pid.json` still names a live process (`refuseIfPublishedHostAlive` at the end of both arms, on the process identity verdict; a pre-identity record naming a live pid is settled by dialling its endpoint once, so a stale record left by an old host cannot strand the machine); a running agent process no claim could reach (`no-metadata`, or `no-host` with the supervisor between children) is refused as the stand-down refuses it for the CLI label instead of being booted out silently; a job loaded under the agent label that is not Desktop's registration is refused rather than left beside the CLI label; and no answer clears liveness evidence: every takeover bootout is judged against the process itself, comparing the creation stamp read at probe time (`getPublishedProcessIdentityVerdict`), so the same process still alive refuses whatever launchctl's exit was and a recycled pid does not. The decision matrix is written above `takeoverDesktopRegistration`. Round 7 (Codex): that gate read `pid.json` through `readHostPidMetadata`, which folds a torn or unreadable record into the same `null` as an absent one; new `readHostPidMetadataEvidence` keeps the two apart (`readHostPidMetadata` delegates to it, no other reader changes) and the gate refuses an unreadable record naming its path and cause.
- `host-login-item.ts` (Codex, round 3): the launchd job probe reads only a POSITIVE `pid` as a running job; `launchctl print` reports `pid = 0` for an idle one and the shared parser keeps every finite number, so a zero pid would have parked every boot retry. Same rule `classifyLaunchdPrintOutput` and `wedge.ts` already apply.
- Considered and rejected: returning the primary status from `registerHostLoginItem` instead of `parked` when SMAppService cannot see the plist. One site, but it would route the running-host cases and the opportunistic pending-revision refresh through the non-cooperative takeover as well.

### Not in this PR

The uninstall side needs no change: `host uninstall` deregistered the service as asked, and the host it could not stop cooperatively exited on the later SIGTERM. The gap was entirely on the reinstall's registration.

## Related issue

None. Field incident on the staging app, 2026-09-06 (host offline after reinstall; recovered by hand with `traycer host service install`).

## Validation

- `host-controller.test.ts`: 220/220. New pins: the down-host takeover at the activation cycle (spawns exactly `host service install --takeover`, no `host restart`, readiness waited AFTER the spawn); a RUNNING host still takes the cooperative restart and never the takeover; a takeover failure surfaces its own message, not "no host is running to restart"; an `E_HOST_BUSY` from the takeover is reported `deferred`, never `busy`; `registerService` with no host and a takeover verdict reports `registered: true`; the F3 continuation shells `--takeover` with `--attempt-adoption <nonce>` from a parked step. The pre-existing "not enabled, no host" failure test is now the explicit no-takeover case (legacy label holds a BTM record).
- `macos.test.ts` / `service-install.test.ts` (rounds 1-3): the stand-down under every cooperative outcome (busy, no-metadata, no-host, stopped, unreachable, hung), the post-bootout still-loaded and unanswered probes, the idle-job unload (`no-process`, no shutdown claim, `bootout --wait` + re-probe, still-loaded refusal), the took-over arm unloading a CLI label loaded beside the agent, indeterminate probes on both labels, and the human lines.
- `host-login-item.test.ts`: 76/76. 15 new verdict tests over the real `getLoginItemSettings`, manifest and `launchctl print` seams: both takeover shapes, a loaded-but-idle job, every refusal reason (`primary-manageable` with no further reads, `legacy-registered` with no print, `manifest-unreadable`, `job-running` from a pid on the agent label and from `state = running` on the CLI label, `job-indeterminate` from spawn failure, timeout and an unrecognised non-zero exit).
- `bun run compile` clean; pre-commit (build, compile, lint, format) passed on the commit.
- Cold review before the push (round 1 on the first draft): one HIGH - `prePid === null` is a structural `pid.json` read, not proof of no host, and the CLI's install boots a loaded label out without a claim - fixed with the launchd process probe; the force/busy loop, the legacy-check overclaim, three stale comments and the `not-registered` rationale were fixed as reported. Lock discipline at all three sites, the launch-time retirement and the pending-revision refresh were verified not to undo the takeover.
- Field: the machine this happened on was recovered by hand with the same command the takeover runs (`traycer host service install`), and the host came up in seconds.

## Checklist

- [x] Pre-commit static checks pass (`pre-commit run --all-files` for an explicit full-repo run)
- [ ] Separate CI test checks pass
- [x] Tests added/updated where it makes sense
- [x] Commits are signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#developer-certificate-of-origin-dco)
