### PR TITLE
fix(cli): terminate Windows host processes through an identity-checked handle, not by pid

### DIFF
--- a/clients/desktop/src/electron-main/host/__tests__/host-controller.test.ts
+++ b/clients/desktop/src/electron-main/host/__tests__/host-controller.test.ts
@@ -4009,8 +4009,8 @@ describe("platform matrix", () => {
 
   it("deregisterService streams `host service uninstall` on non-macOS rather than running it under the flat JSON timeout", async () => {
     // On Windows the uninstall stops the host through the bounded
-    // scan-then-kill loop, whose worst case is several 30 s scans plus
-    // `schtasks /End` and `taskkill` before `/Delete`. The run path's flat
+    // scan-then-kill loop, whose worst case is several 30 s scans and kill
+    // scripts plus `schtasks /End` before `/Delete`. The run path's flat
     // 45 s budget would SIGKILL the CLI mid-loop and leave the host
     // half-stopped with its task still registered; the streaming path's idle
     // timeout (re-armed by output, ten minutes) is what `host restart`

--- a/clients/desktop/src/electron-main/host/host-controller.ts
+++ b/clients/desktop/src/electron-main/host/host-controller.ts
@@ -137,8 +137,8 @@ import {
 // Deliberately shared by `host service install` too, not a tighter
 // per-command bound: that command's legitimately SILENT windows stack -
 // a 30s cli-lock wait, a 32s cooperative host stop (SHUTDOWN_FORCE_EXIT_MS
-// + margin), and on win32 an install/replace sequence whose schtasks/
-// taskkill subprocess timeouts alone sum past 100s with no NDJSON between
+// + margin), and on win32 an install/replace sequence whose schtasks and
+// PowerShell scan-and-kill subprocess timeouts alone sum past 100s with no NDJSON between
 // them - so any bound tight enough to feel responsive risks SIGKILLing a
 // slow-but-live registration mid-critical-section, the torn-record class
 // the A8 comment above exists to prevent. Slow detection of a rare wedge
@@ -4030,8 +4030,8 @@ export class HostController {
         }
         // Streamed, not run: on Windows `host service uninstall` stops the
         // host through the bounded scan-then-kill loop, whose worst case is
-        // several 30 s scans plus `schtasks /End` and `taskkill` before the
-        // confirming scan and `schtasks /Delete`
+        // several 30 s scans and kill scripts plus `schtasks /End` before
+        // the confirming scan and `schtasks /Delete`
         // (`WINDOWS_RESTART_SEQUENCE_TIMEOUT_MS` in the protocol's
         // lifecycle constants). The run path's flat 45 s budget could SIGKILL
         // the CLI after a kill pass and before `/Delete`, leaving the host

--- a/clients/traycer-cli/README.md
+++ b/clients/traycer-cli/README.md
@@ -168,7 +168,10 @@ In each case, run the command again from a shell outside Traycer.
 On Windows there is no re-exec. The host's processes are terminated
 individually, and the CLI running the command, its children, and the shell that
 launched it are excluded from that set - terminating the host's whole tree would
-take them down with it.
+take them down with it. Each process is terminated through a handle whose
+creation time is first checked against the scan that selected it, so a process
+id that Windows has since handed to something unrelated is skipped rather than
+killed.
 
 macOS needs neither: stopping the host's launchd job does not touch the CLI.
 

--- a/clients/traycer-cli/src/commands/host-uninstall.ts
+++ b/clients/traycer-cli/src/commands/host-uninstall.ts
@@ -75,8 +75,8 @@ export interface RunHostUninstallDeps {
   /**
    * The host process this environment last published, read BEFORE the
    * teardown - because the teardown destroys it. On Windows the uninstall
-   * removes pid metadata even when its `taskkill` calls failed, so a probe
-   * that runs afterwards has nothing left to look at.
+   * removes pid metadata once its confirming process scan finds the slot
+   * empty, so a probe that runs afterwards has nothing left to look at.
    */
   readPublishedHost(environment: Environment): Promise<PublishedHost | null>;
   /**
@@ -248,9 +248,10 @@ async function runHostUninstallWithActuators(
   let retainedAfterAll: ServiceStatus | null = null;
   let registrationClear = false;
   // Captured FIRST, before anything is torn down. The teardown destroys this
-  // evidence: on Windows `uninstallService` removes pid metadata even when its
-  // `taskkill` calls failed or timed out, so a probe that runs afterwards is
-  // guaranteed to find nothing and would read a surviving host as gone.
+  // evidence: on Windows `uninstallService` removes pid metadata once its
+  // confirming process scan finds the slot empty, so a probe that runs
+  // afterwards is guaranteed to find nothing and would read a surviving host
+  // as gone.
   //
   // Only `--all` needs the pre-teardown capture; the default path tears
   // nothing down and reads at the boundary instead, so reading here too was

--- a/clients/traycer-cli/src/host/pid-metadata.ts
+++ b/clients/traycer-cli/src/host/pid-metadata.ts
@@ -209,8 +209,8 @@ export function decodeLayer0Record(value: unknown): HostLayer0Record | null {
  * Purge the published pid metadata on the host's behalf.
  *
  * The writer contract says the HOST removes pid.json on graceful shutdown -
- * but a Windows stop is a `taskkill /T /F`, which never lets the host's
- * shutdown handler run, so the file survives every deliberate stop there.
+ * but a Windows stop is a forced `TerminateProcess`, which never lets the
+ * host's shutdown handler run, so the file survives every deliberate stop there.
  * That matters because "pid.json present but endpoint dead" is the signal
  * clients read as *the host died unexpectedly* (the desktop's health
  * watchdog auto-respawns on it); a deliberately stopped host must leave no

--- a/clients/traycer-cli/src/host/stop-intent.ts
+++ b/clients/traycer-cli/src/host/stop-intent.ts
@@ -26,9 +26,9 @@ export type { StopIntent, StopIntentReason };
  *
  * ### Why intent has to be STATED, not inferred
  *
- * Exit shape cannot answer this. On Windows `taskkill /T /F` gives the killed
- * process exit code 1, which is byte-identical to a host that genuinely crashed
- * with exit 1. On POSIX the supervisor forwards SIGTERM itself, so the child's
+ * Exit shape cannot answer this. On Windows a forced `TerminateProcess` gives
+ * the killed process a nonzero exit code that is byte-identical to a host that
+ * genuinely crashed with it. On POSIX the supervisor forwards SIGTERM itself, so the child's
  * death during a stop wears the same signal as any other signal death. Every
  * heuristic here is a coin flip on whether we fight the user.
  *
@@ -65,7 +65,7 @@ export const STOP_INTENT_STALE_MS = 300_000;
  * because "the worst case is one unwanted relaunch, which the supervisor's own
  * budget and incumbent re-check then contain". That is false, and the
  * containment argument is what made it sound safe. If the write fails on
- * win32, `/End` and `taskkill` still run, the orphaned supervisor is never
+ * win32, `/End` and the kill still run, the orphaned supervisor is never
  * signalled and sees no intent, so it reads the killed child's nonzero exit as
  * a crash and relaunches. A replacement that then stays healthy resets the
  * budget and IS the incumbent - so neither mechanism stops it, and `host stop`

--- a/clients/traycer-cli/src/installer/install.ts
+++ b/clients/traycer-cli/src/installer/install.ts
@@ -1050,10 +1050,12 @@ export const SWAP_RENAME_DELAYS_MS: readonly number[] = [
 ];
 
 // Wall-clock ceiling for one swap rename INCLUDING its re-kill hooks. The
-// schedule above sums to ~24s of sleeps, but each Windows re-kill pass can
-// legitimately spend a 10s WMI scan plus a 30s taskkill on a degraded
-// machine - seven such passes would keep the service down and the
-// environment cli-lock held for ~5 minutes. Healthy re-kills run in a
+// schedule above sums to ~24s of sleeps, but each Windows re-kill pass is a
+// bounded scan-then-kill loop whose every PowerShell step carries a 30s
+// ceiling (`WINDOWS_RESTART_SEQUENCE_TIMEOUT_MS` derives the worst case), so
+// one pass can legitimately spend minutes on a degraded machine - seven
+// such passes would keep the service down and the environment cli-lock
+// held far longer than that. Healthy re-kills run in a
 // couple of seconds, so this ceiling never truncates the schedule where
 // the retries can actually work; it only stops the pathological machines
 // from wedging every other host mutation while they fail.

--- a/clients/traycer-cli/src/installer/rename-retry.ts
+++ b/clients/traycer-cli/src/installer/rename-retry.ts
@@ -36,10 +36,11 @@ const DEFAULT_DELAYS_MS: readonly number[] = [50, 100, 200, 400, 800, 1000];
 //
 // `maxTotalMs` is a wall-clock ceiling across ALL attempts, hooks, and
 // backoff sleeps. The schedule alone does not bound the retry when the
-// hook is slow - the Windows re-kill can spend a 10s WMI scan plus a 30s
-// taskkill per pass on a degraded machine, stretching a ~24s schedule
-// into minutes while the caller holds the cli-lock with the service
-// stopped. Once the ceiling is exceeded, the next retryable failure is
+// hook is slow - the Windows re-kill is a bounded scan-then-kill loop
+// whose every PowerShell step carries a 30s ceiling, so one pass on a
+// degraded machine can stretch a ~24s schedule into minutes while the
+// caller holds the cli-lock with the service stopped. Once the ceiling is
+// exceeded, the next retryable failure is
 // thrown as final. Null bounds the retry by the schedule alone.
 export interface RenameRetryPlan {
   readonly delaysMs: readonly number[];

--- a/clients/traycer-cli/src/service/__tests__/install-lifecycle.test.ts
+++ b/clients/traycer-cli/src/service/__tests__/install-lifecycle.test.ts
@@ -57,8 +57,8 @@ vi.mock("../platforms/macos", () => ({
   readRegisteredCliInvocation: mocks.readRegisteredCliInvocationMock,
 }));
 
-// The Windows swap-lock recovery functions shell out to schtasks /
-// powershell / taskkill - stub the module so the wiring tests can assert
+// The Windows swap-lock recovery functions shell out to schtasks and
+// powershell - stub the module so the wiring tests can assert
 // the lifecycle hands the label through without touching the OS.
 vi.mock("../platforms/windows", async () => {
   // The REAL clock helper, re-exported through the mock: the wiring test

--- a/clients/traycer-cli/src/service/platforms/__tests__/windows.test.ts
+++ b/clients/traycer-cli/src/service/platforms/__tests__/windows.test.ts
@@ -16,6 +16,7 @@ import {
   parseWindowsProcessTableJson,
   setWindowsStartEvidenceDepsForTests,
   setWindowsTaskInstallDepsForTests,
+  WINDOWS_KILL_TARGETS_PER_SCRIPT,
   type ProcessRunner,
   type WindowsControllerDeps,
   type WindowsKillMemory,
@@ -26,7 +27,10 @@ import {
   type WindowsTaskInstallDeps,
 } from "../windows";
 import { serviceLabelFor } from "../../label";
-import { WINDOWS_KILL_CONVERGENCE_ROUNDS } from "@traycer/protocol/host/lifecycle-constants";
+import {
+  WINDOWS_KILL_CONVERGENCE_ROUNDS,
+  WINDOWS_PROCESS_KILL_TIMEOUT_MS,
+} from "@traycer/protocol/host/lifecycle-constants";
 import { ProcessRunError, type RunResult } from "../../process-runner";
 import type { SpawnEvidenceBaseline } from "../../../host/spawn-evidence";
 import { CLI_ERROR_CODES } from "../../../runner/errors";
@@ -202,8 +206,9 @@ function scanCalls(calls: readonly RecordedCall[]): RecordedCall[] {
   return calls.filter((call) => isScanCall(call.command, call.args));
 }
 
-// One entry per kill invocation - which is one per round - holding that
-// round's targets in issue order.
+// One entry per kill script - one per round, unless the round carried more
+// than `WINDOWS_KILL_TARGETS_PER_SCRIPT` targets and issued several in a row -
+// holding that script's targets in issue order.
 function killRounds(calls: readonly RecordedCall[]): WindowsKillTarget[][] {
   return calls
     .filter((call) => isKillCall(call.command, call.args))
@@ -2684,6 +2689,90 @@ describe("handle-bound kill script", () => {
     expect(caught).toBe(authorityError);
     expect(scanCalls(calls)).toHaveLength(1);
     expect(mocks.removeHostPidMetadata).not.toHaveBeenCalled();
+  });
+
+  it("a round with more targets than one script carries issues several scripts, in order, and still converges", async () => {
+    // Codex P2 on #1762: the script rides `powershell.exe`'s command line,
+    // which `CreateProcessW` caps at 32,767 characters; a single script over
+    // 500-600 targets could not start at all, and every kill pass would
+    // silently become a no-op. 600 slot processes here: three scripts of
+    // 250, 250 and 100, in the round's order (all depth 0, so by pid).
+    const rows: TableRowInput[] = Array.from({ length: 600 }, (_, index) => ({
+      processId: 1000 + index,
+      parentProcessId: 1,
+      slot: true,
+    }));
+    const { runner, calls } = convergingTableRunner(rows);
+    const controller = createWindowsController(runner, noTimingDeps);
+
+    await controller.stop(serviceLabelFor("staging"), { force: false });
+
+    const scripts = killRounds(calls);
+    expect(scripts.map((script) => script.length)).toEqual([
+      WINDOWS_KILL_TARGETS_PER_SCRIPT,
+      WINDOWS_KILL_TARGETS_PER_SCRIPT,
+      600 - 2 * WINDOWS_KILL_TARGETS_PER_SCRIPT,
+    ]);
+    expect(killedPids(calls)).toEqual(rows.map((row) => row.processId));
+    // One round: a scan, the three scripts, the confirming scan.
+    expect(scanCalls(calls)).toHaveLength(2);
+  });
+
+  it("a round that runs out of time issues no further script: the unsent targets are next round's, and the confirming scan still decides", async () => {
+    // The chunks share ONE deadline, so the restart budget's one-kill-bound
+    // per round holds however many scripts a slot needs. Every script here
+    // "takes" the whole budget, so each round sends exactly one script and
+    // the 600 targets drain across the three kill passes - convergence, not
+    // a widened round.
+    let clock = 0;
+    const monotonic = vi
+      .spyOn(performance, "now")
+      .mockImplementation(() => clock);
+    try {
+      const rows: TableRowInput[] = Array.from({ length: 600 }, (_, index) => ({
+        processId: 1000 + index,
+        parentProcessId: 1,
+        slot: true,
+      }));
+      const calls: RecordedCall[] = [];
+      let live = rows;
+      const runner: ProcessRunner = async (command, args) => {
+        calls.push({ command, args });
+        if (isScanCall(command, args)) return success(tableJson(live));
+        if (isKillCall(command, args)) {
+          const killed = new Set(
+            killTargetsOf(args).map((target) => target.processId),
+          );
+          live = live.filter((row) => !killed.has(row.processId));
+          clock += WINDOWS_PROCESS_KILL_TIMEOUT_MS + 1;
+        }
+        return success("");
+      };
+      const controller = createWindowsController(runner, noTimingDeps);
+
+      await controller.stop(serviceLabelFor("staging"), { force: false });
+
+      expect(killRounds(calls).map((script) => script.length)).toEqual([
+        WINDOWS_KILL_TARGETS_PER_SCRIPT,
+        WINDOWS_KILL_TARGETS_PER_SCRIPT,
+        600 - 2 * WINDOWS_KILL_TARGETS_PER_SCRIPT,
+      ]);
+      // Three rounds, each one script, plus the confirming scan.
+      expect(scanCalls(calls)).toHaveLength(4);
+      expect(live).toEqual([]);
+    } finally {
+      monotonic.mockRestore();
+    }
+  });
+
+  it("a script over the maximum number of worst-case targets stays under half the command-line cap", () => {
+    const script = buildWindowsHandleBoundKillScript(
+      Array.from({ length: WINDOWS_KILL_TARGETS_PER_SCRIPT }, () => ({
+        processId: 4_294_967_295,
+        created: Number.MAX_SAFE_INTEGER,
+      })),
+    );
+    expect(script.length).toBeLessThan(32_767 / 2);
   });
 
   it("parses the kill script's outcome report, bare single object included, and rejects any other shape", () => {

--- a/clients/traycer-cli/src/service/platforms/__tests__/windows.test.ts
+++ b/clients/traycer-cli/src/service/platforms/__tests__/windows.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   buildScheduledTaskXml,
+  buildWindowsHandleBoundKillScript,
   buildWindowsSlotProcessDetailScanScript,
   buildWindowsSlotProcessTableScanScript,
   computeWindowsHostKillSet,
@@ -10,6 +11,7 @@ import {
   killLingeringSlotProcesses,
   orderWindowsKillsDescendantsFirst,
   parseSchtasksLastRunResult,
+  parseWindowsKillOutcomeJson,
   parseWindowsProcessDetailJson,
   parseWindowsProcessTableJson,
   setWindowsStartEvidenceDepsForTests,
@@ -17,6 +19,7 @@ import {
   type ProcessRunner,
   type WindowsControllerDeps,
   type WindowsKillMemory,
+  type WindowsKillTarget,
   type WindowsKillVictim,
   type WindowsProcessTableRow,
   type WindowsStartEvidenceDeps,
@@ -161,16 +164,70 @@ function tableJson(rows: readonly TableRowInput[]): string {
   );
 }
 
+// Both halves of a kill round are `powershell.exe` invocations: the table scan
+// (`Get-CimInstance Win32_Process`) and the handle-bound kill
+// (`GetProcessById`). The fakes below tell them apart by the script they
+// carry, which is also the only way a fixture can know which pids a round
+// decided to kill - the kill script's target literal is the argv.
+function isScanCall(command: string, args: readonly string[]): boolean {
+  return (
+    command === "powershell.exe" &&
+    args.some((arg) => arg.includes("Get-CimInstance Win32_Process"))
+  );
+}
+
+function isKillCall(command: string, args: readonly string[]): boolean {
+  return (
+    command === "powershell.exe" &&
+    args.some((arg) => arg.includes("GetProcessById"))
+  );
+}
+
+// The targets one kill invocation carries, in the order the script walks
+// them. Read back out of the target literal `buildHandleBoundKillScript`
+// emits (`@{ ProcessId = <pid>; Created = <micros> }` per target).
+function killTargetsOf(args: readonly string[]): WindowsKillTarget[] {
+  const script = args.find((arg) => arg.includes("GetProcessById")) ?? "";
+  const targets: WindowsKillTarget[] = [];
+  for (const match of script.matchAll(/ProcessId = (\d+); Created = (\d+)/g)) {
+    targets.push({
+      processId: Number(match[1]),
+      created: Number(match[2]),
+    });
+  }
+  return targets;
+}
+
+function scanCalls(calls: readonly RecordedCall[]): RecordedCall[] {
+  return calls.filter((call) => isScanCall(call.command, call.args));
+}
+
+// One entry per kill invocation - which is one per round - holding that
+// round's targets in issue order.
+function killRounds(calls: readonly RecordedCall[]): WindowsKillTarget[][] {
+  return calls
+    .filter((call) => isKillCall(call.command, call.args))
+    .map((call) => killTargetsOf(call.args));
+}
+
+// Every pid a stop issued a kill for, across rounds, in issue order. The
+// shape most pins in this file reason about.
+function killedPids(calls: readonly RecordedCall[]): number[] {
+  return killRounds(calls).flatMap((round) =>
+    round.map((target) => target.processId),
+  );
+}
+
 // A fake scan-then-kill runner that CONVERGES the way the real scan does. A
 // real scan verifies by exe path/command line, not by remembering what an
-// earlier round saw, so a process this round's `taskkill` actually reached is
+// earlier round saw, so a process this round's kill actually reached is
 // simply ABSENT from the next snapshot - it isn't "seen and skipped", it's
 // gone. `killHostProcessTree`'s bounded convergence loop (Codex round 2 on
 // #1755: the old single-pass scan left anything spawned after the snapshot
 // untouched) rescans after every kill, so a fixture that keeps returning one
 // constant table makes every pid look like a survivor and gets re-killed
 // `WINDOWS_KILL_CONVERGENCE_ROUNDS` times instead of once. This tracks which
-// pids a `taskkill` call has fired for and drops those rows from every later
+// pids a kill script has been handed and drops those rows from every later
 // snapshot, so a fixture built for the old one-pass code keeps its original
 // meaning under the new loop.
 function convergingTableRunner(rows: readonly TableRowInput[]): {
@@ -181,10 +238,12 @@ function convergingTableRunner(rows: readonly TableRowInput[]): {
   let live = rows;
   const runner: ProcessRunner = async (command, args) => {
     calls.push({ command, args });
-    if (command === "powershell.exe") return success(tableJson(live));
-    if (command === "taskkill") {
-      const killedPid = Number(args[2]);
-      live = live.filter((row) => row.processId !== killedPid);
+    if (isScanCall(command, args)) return success(tableJson(live));
+    if (isKillCall(command, args)) {
+      const killed = new Set(
+        killTargetsOf(args).map((target) => target.processId),
+      );
+      live = live.filter((row) => !killed.has(row.processId));
     }
     return success("");
   };
@@ -569,12 +628,10 @@ describe("Windows service stale host cleanup", () => {
       noTimingDeps,
     );
 
-    expect(
-      calls
-        .filter((call) => call.command === "taskkill")
-        .map((call) => call.args),
-    ).toEqual([["/F", "/PID", "401"]]);
-    expect(calls.every((call) => !call.args.includes("/T"))).toBe(true);
+    expect(killedPids(calls)).toEqual([401]);
+    // Never a pid-only kill: no `taskkill` at all, `/T` or otherwise. The
+    // handle-bound script is the only thing that terminates a process.
+    expect(calls.some((call) => call.command === "taskkill")).toBe(false);
   });
 
   it("kills slot-scanned processes when pid metadata is missing", async () => {
@@ -591,14 +648,7 @@ describe("Windows service stale host cleanup", () => {
       args: ["/End", "/TN", "\\Traycer\\Host-Staging"],
     });
     expect(calls.some((call) => call.command === "powershell.exe")).toBe(true);
-    expect(
-      calls
-        .filter((call) => call.command === "taskkill")
-        .map((call) => call.args),
-    ).toEqual([
-      ["/F", "/PID", "401"],
-      ["/F", "/PID", "402"],
-    ]);
+    expect(killedPids(calls)).toEqual([401, 402]);
   });
 
   it("kills exactly the scan-verified pids when the scan covers the recorded pid", async () => {
@@ -617,11 +667,7 @@ describe("Windows service stale host cleanup", () => {
 
     await controller.stop(serviceLabelFor("staging"), { force: false });
 
-    expect(
-      calls
-        .filter((call) => call.command === "taskkill")
-        .map((call) => call.args[2]),
-    ).toEqual(["401", "402"]);
+    expect(killedPids(calls)).toEqual([401, 402]);
   });
 
   it("does not kill the recorded pid when the scan verifies it no longer matches the host", async () => {
@@ -643,11 +689,7 @@ describe("Windows service stale host cleanup", () => {
 
     await controller.stop(serviceLabelFor("staging"), { force: false });
 
-    expect(
-      calls
-        .filter((call) => call.command === "taskkill")
-        .map((call) => call.args[2]),
-    ).toEqual(["402"]);
+    expect(killedPids(calls)).toEqual([402]);
   });
 
   it("purges pid metadata on uninstall like it does on stop", async () => {
@@ -730,7 +772,7 @@ describe("killHostProcessTree convergence loop", () => {
     let scanCount = 0;
     const runner: ProcessRunner = async (command, args) => {
       calls.push({ command, args });
-      if (command === "powershell.exe") {
+      if (isScanCall(command, args)) {
         const response = responses[scanCount] ?? { kind: "table", rows: [] };
         scanCount += 1;
         if (response.kind === "throw") throw new Error("spawn failed");
@@ -767,18 +809,8 @@ describe("killHostProcessTree convergence loop", () => {
     // The kill set is asserted FIRST on purpose: it is the finding's own
     // symptom, so a regression here reports "403 was never killed" rather
     // than an arithmetic complaint about how many times we scanned.
-    expect(
-      calls
-        .filter((call) => call.command === "taskkill")
-        .map((call) => call.args),
-    ).toEqual([
-      ["/F", "/PID", "401"],
-      ["/F", "/PID", "402"],
-      ["/F", "/PID", "403"],
-    ]);
-    expect(
-      calls.filter((call) => call.command === "powershell.exe"),
-    ).toHaveLength(3);
+    expect(killedPids(calls)).toEqual([401, 402, 403]);
+    expect(scanCalls(calls)).toHaveLength(3);
 
     // Ablation (§C): in `killHostProcessTree`, change the loop bound from
     // `round <= WINDOWS_KILL_CONVERGENCE_ROUNDS` to `round <= 1` (a single
@@ -798,7 +830,7 @@ describe("killHostProcessTree convergence loop", () => {
     const calls: RecordedCall[] = [];
     const runner: ProcessRunner = async (command, args) => {
       calls.push({ command, args });
-      if (command === "powershell.exe") {
+      if (isScanCall(command, args)) {
         const pid = 800 + scanCount;
         scanCount += 1;
         return success(
@@ -819,15 +851,11 @@ describe("killHostProcessTree convergence loop", () => {
       details: { survivingPids: [800 + WINDOWS_KILL_CONVERGENCE_ROUNDS] },
     });
 
-    expect(
-      calls.filter((call) => call.command === "powershell.exe"),
-    ).toHaveLength(WINDOWS_KILL_CONVERGENCE_ROUNDS + 1);
-    const taskkillPids = calls
-      .filter((call) => call.command === "taskkill")
-      .map((call) => call.args[2]);
-    expect(taskkillPids).toEqual(
-      Array.from({ length: WINDOWS_KILL_CONVERGENCE_ROUNDS }, (_, index) =>
-        String(800 + index),
+    expect(scanCalls(calls)).toHaveLength(WINDOWS_KILL_CONVERGENCE_ROUNDS + 1);
+    expect(killedPids(calls)).toEqual(
+      Array.from(
+        { length: WINDOWS_KILL_CONVERGENCE_ROUNDS },
+        (_, index) => 800 + index,
       ),
     );
 
@@ -840,16 +868,16 @@ describe("killHostProcessTree convergence loop", () => {
 
   it("a lingering already-killed pid exhausts the bound - the same never-dying pid every round, not a fresh spawn", async () => {
     // The OTHER honest-failure path the function comment's caveat names:
-    // `taskkill /F` is `TerminateProcess`, asynchronous, so a confirming scan
-    // can briefly still list a pid a previous round already killed. The
-    // bound absorbs ONE such round; this pushes that to its limit - the
-    // scan returns the exact SAME pid every round (as if `taskkill` never
-    // actually reaped it), never a fresh spawn - and the loop still refuses
-    // rather than grinding forever or quietly reporting success.
+    // `TerminateProcess` is asynchronous, so a confirming scan can briefly
+    // still list a pid a previous round already killed. The bound absorbs
+    // ONE such round; this pushes that to its limit - the scan returns the
+    // exact SAME pid every round (as if the kill never actually reaped it),
+    // never a fresh spawn - and the loop still refuses rather than grinding
+    // forever or quietly reporting success.
     const calls: RecordedCall[] = [];
     const runner: ProcessRunner = async (command, args) => {
       calls.push({ command, args });
-      if (command === "powershell.exe") {
+      if (isScanCall(command, args)) {
         return success(
           tableJson([{ processId: 900, parentProcessId: 1, slot: true }]),
         );
@@ -865,15 +893,11 @@ describe("killHostProcessTree convergence loop", () => {
       details: { survivingPids: [900] },
     });
 
-    expect(
-      calls.filter((call) => call.command === "powershell.exe"),
-    ).toHaveLength(WINDOWS_KILL_CONVERGENCE_ROUNDS + 1);
-    // taskkill fired every round, not skipped just because it is the "same"
+    expect(scanCalls(calls)).toHaveLength(WINDOWS_KILL_CONVERGENCE_ROUNDS + 1);
+    // The kill fired every round, not skipped just because it is the "same"
     // pid as last time - the loop has no way to know that without a scan
     // proving it, and a scan proving it IS what this test denies it.
-    expect(calls.filter((call) => call.command === "taskkill")).toHaveLength(
-      WINDOWS_KILL_CONVERGENCE_ROUNDS,
-    );
+    expect(killRounds(calls)).toHaveLength(WINDOWS_KILL_CONVERGENCE_ROUNDS);
   });
 
   it("refuses before killing anything when the scan is unavailable - the round-0 case of the general rule", async () => {
@@ -893,10 +917,8 @@ describe("killHostProcessTree convergence loop", () => {
       controller.stop(serviceLabelFor("staging"), { force: false }),
     ).rejects.toMatchObject({ code: "E_SERVICE_CONTROL_FAILED" });
 
-    expect(
-      calls.filter((call) => call.command === "powershell.exe"),
-    ).toHaveLength(1);
-    expect(calls.filter((call) => call.command === "taskkill")).toHaveLength(0);
+    expect(scanCalls(calls)).toHaveLength(1);
+    expect(killRounds(calls)).toHaveLength(0);
     expect(mocks.readHostPidMetadata).not.toHaveBeenCalled();
 
     // Ablation (§ablation table, row 2): in `killHostProcessTree`, change
@@ -927,16 +949,10 @@ describe("killHostProcessTree convergence loop", () => {
       controller.stop(serviceLabelFor("staging"), { force: false }),
     ).rejects.toMatchObject({ code: "E_SERVICE_CONTROL_FAILED" });
 
-    expect(
-      calls.filter((call) => call.command === "powershell.exe"),
-    ).toHaveLength(2);
+    expect(scanCalls(calls)).toHaveLength(2);
     // Round 0's kill still happened - the refusal is about round 1's scan,
     // not a reason to have skipped work already done.
-    expect(
-      calls
-        .filter((call) => call.command === "taskkill")
-        .map((call) => call.args),
-    ).toEqual([["/F", "/PID", "901"]]);
+    expect(killedPids(calls)).toEqual([901]);
     expect(mocks.readHostPidMetadata).not.toHaveBeenCalled();
 
     // Ablation (§ablation table, row 2): the same `scanned === null` `throw`
@@ -951,8 +967,8 @@ describe("killHostProcessTree convergence loop", () => {
     //   R0: host 100 (born 1000, slot) and its validated child 555 (born
     //       1500, a shell or provider binary whose own path matches nothing).
     //       Both are killed, 555 first.
-    //   R1: 100 is gone. 555 is STILL listed - `taskkill /F` is
-    //       `TerminateProcess`, asynchronous, and the loop's own comment names
+    //   R1: 100 is gone. 555 is STILL listed - `TerminateProcess` is
+    //       asynchronous, and the loop's own comment names
     //       this case - and its edge now arrives as `parentProcessId` 0: the
     //       parent that would have vouched for it is dead. Its own path
     //       matches nothing. Without `priorVictims` carrying 100's window
@@ -992,18 +1008,8 @@ describe("killHostProcessTree convergence loop", () => {
 
     await controller.stop(serviceLabelFor("staging"), { force: false });
 
-    expect(
-      calls.filter((call) => call.command === "powershell.exe"),
-    ).toHaveLength(3);
-    expect(
-      calls
-        .filter((call) => call.command === "taskkill")
-        .map((call) => call.args),
-    ).toEqual([
-      ["/F", "/PID", "555"],
-      ["/F", "/PID", "100"],
-      ["/F", "/PID", "555"],
-    ]);
+    expect(scanCalls(calls)).toHaveLength(3);
+    expect(killedPids(calls)).toEqual([555, 100, 555]);
 
     // Ablation (§ablation table): in `classifyCarryOverClaim`, replace the
     // body with `return "none";` → this test reddens alongside the direct
@@ -1117,18 +1123,8 @@ describe("killHostProcessTree convergence loop", () => {
       }
     }
 
-    expect(
-      calls.filter((call) => call.command === "powershell.exe"),
-    ).toHaveLength(4);
-    expect(
-      calls
-        .filter((call) => call.command === "taskkill")
-        .map((call) => call.args),
-    ).toEqual([
-      ["/F", "/PID", "100"],
-      ["/F", "/PID", "555"],
-      ["/F", "/PID", "888"],
-    ]);
+    expect(scanCalls(calls)).toHaveLength(4);
+    expect(killedPids(calls)).toEqual([100, 555, 888]);
 
     // Ablation: in `killHostProcessTree`, keep only the latest round's
     // victims - `priorVictims.clear()` just before the recording loop at the
@@ -1202,20 +1198,8 @@ describe("killHostProcessTree convergence loop", () => {
 
     await controller.stop(serviceLabelFor("staging"), { force: false });
 
-    expect(
-      calls.filter((call) => call.command === "powershell.exe"),
-    ).toHaveLength(4);
-    expect(
-      calls
-        .filter((call) => call.command === "taskkill")
-        .map((call) => call.args),
-    ).toEqual([
-      ["/F", "/PID", "555"],
-      ["/F", "/PID", "100"],
-      ["/F", "/PID", "100"],
-      ["/F", "/PID", "555"],
-      ["/F", "/PID", "555"],
-    ]);
+    expect(scanCalls(calls)).toHaveLength(4);
+    expect(killedPids(calls)).toEqual([555, 100, 100, 555, 555]);
 
     // Ablation: in `rememberIncarnation`, replace the push with an overwrite
     // (`memory.set(pid, [incarnation])` on both arms) → this test reddens:
@@ -1246,11 +1230,7 @@ describe("killHostProcessTree convergence loop", () => {
 
     await controller.stop(serviceLabelFor("staging"), { force: false });
 
-    expect(
-      calls
-        .filter((call) => call.command === "taskkill")
-        .map((call) => call.args[2]),
-    ).toEqual(["160", "150", "100"]);
+    expect(killedPids(calls)).toEqual([160, 150, 100]);
 
     // Ablation (§ablation table): in `orderWindowsKillsDescendantsFirst`,
     // change the body to `return pids;` (issue order unchanged) → run and
@@ -1300,11 +1280,7 @@ describe("killHostProcessTree convergence loop", () => {
       controller.stop(serviceLabelFor("staging"), { force: false }),
     ).resolves.toBeUndefined();
 
-    expect(
-      calls
-        .filter((call) => call.command === "taskkill")
-        .map((call) => call.args[2]),
-    ).toEqual(["100"]);
+    expect(killedPids(calls)).toEqual([100]);
 
     // Ablation (§ablation table): change `created < victim.created` to
     // `return "unattributed"` in `classifyAgainstVictim` → this test
@@ -1329,7 +1305,7 @@ describe("killHostProcessTree convergence loop", () => {
     let scanCount = 0;
     const runner: ProcessRunner = async (command, args) => {
       calls.push({ command, args });
-      if (command === "powershell.exe") {
+      if (isScanCall(command, args)) {
         scanCount += 1;
         if (scanCount === 1) {
           const stdout = tableJson([
@@ -1370,11 +1346,7 @@ describe("killHostProcessTree convergence loop", () => {
     // Round 0 killed 100 using the sample taken BEFORE its scan (2000): 777
     // was born at 3000, after that sample, so round 1 refuses it rather
     // than silently killing or silently sparing it.
-    expect(
-      calls
-        .filter((call) => call.command === "taskkill")
-        .map((call) => call.args[2]),
-    ).toEqual(["100"]);
+    expect(killedPids(calls)).toEqual([100]);
 
     // Ablation (§ablation table): in `killHostProcessTree`, move the
     // `deps.now()` sample to AFTER `scanSlotProcessTable` returns → this
@@ -1392,7 +1364,7 @@ describe("killHostProcessTree convergence loop", () => {
   it("a repeated victim's seenAliveAt advances across rounds, widening what a later orphan can be attributed to", async () => {
     // Chronology (samples 2000, 4000, 6000, 8000):
     //   R0 (sample 2000): 100 (born 1000, slot). Killed.
-    //   R1 (sample 4000): 100 is STILL listed (`taskkill /F` is
+    //   R1 (sample 4000): 100 is STILL listed (`TerminateProcess` is
     //       asynchronous - the loop's own comment names this exact case) and
     //       has meanwhile spawned 555 (born 3000, validated child). Both are
     //       killed, 555 first. 100's window now extends to 4000.
@@ -1448,16 +1420,7 @@ describe("killHostProcessTree convergence loop", () => {
 
     await controller.stop(serviceLabelFor("staging"), { force: false });
 
-    expect(
-      calls
-        .filter((call) => call.command === "taskkill")
-        .map((call) => call.args),
-    ).toEqual([
-      ["/F", "/PID", "100"],
-      ["/F", "/PID", "555"],
-      ["/F", "/PID", "100"],
-      ["/F", "/PID", "555"],
-    ]);
+    expect(killedPids(calls)).toEqual([100, 555, 100, 555]);
 
     // Ablation: in `rememberIncarnation`, skip the push when an entry already
     // exists (first incarnation only) → this test reddens: 100's only window
@@ -1535,14 +1498,7 @@ describe("killHostProcessTree convergence loop", () => {
 
     // 200 (an ordinary slot match) was killed even though 777 (undecided)
     // sat alongside it in the very same round's scan.
-    expect(
-      calls
-        .filter((call) => call.command === "taskkill")
-        .map((call) => call.args),
-    ).toEqual([
-      ["/F", "/PID", "100"],
-      ["/F", "/PID", "200"],
-    ]);
+    expect(killedPids(calls)).toEqual([100, 200]);
 
     // Ablation (§ablation table): in `killHostProcessTree`, return `kill`
     // only (drop the `unattributed.length > 0` throw) → this test's
@@ -1622,17 +1578,8 @@ describe("killHostProcessTree convergence loop", () => {
       details: { unattributedPids: [888] },
     });
 
-    expect(
-      calls.filter((call) => call.command === "powershell.exe"),
-    ).toHaveLength(3);
-    expect(
-      calls
-        .filter((call) => call.command === "taskkill")
-        .map((call) => call.args),
-    ).toEqual([
-      ["/F", "/PID", "100"],
-      ["/F", "/PID", "200"],
-    ]);
+    expect(scanCalls(calls)).toHaveLength(3);
+    expect(killedPids(calls)).toEqual([100, 200]);
 
     // Ablation (§ablation table): in `killHostProcessTree`, drop the
     // `priorSuspects` recording loop (record victims only) → this test
@@ -1728,15 +1675,7 @@ describe("killHostProcessTree convergence loop", () => {
       details: { unattributedPids: [888] },
     });
 
-    expect(
-      calls
-        .filter((call) => call.command === "taskkill")
-        .map((call) => call.args),
-    ).toEqual([
-      ["/F", "/PID", "100"],
-      ["/F", "/PID", "200"],
-      ["/F", "/PID", "777"],
-    ]);
+    expect(killedPids(calls)).toEqual([100, 200, 777]);
 
     // Ablation: in `classifyCarryOverClaim`, return the FIRST verdict instead
     // of the strongest (`return classifyAgainstVictim(...)` inside the
@@ -1821,17 +1760,8 @@ describe("killHostProcessTree convergence loop", () => {
 
     await controller.stop(serviceLabelFor("staging"), { force: false });
 
-    expect(
-      calls.filter((call) => call.command === "powershell.exe"),
-    ).toHaveLength(3);
-    expect(
-      calls
-        .filter((call) => call.command === "taskkill")
-        .map((call) => call.args),
-    ).toEqual([
-      ["/F", "/PID", "100"],
-      ["/F", "/PID", "200"],
-    ]);
+    expect(scanCalls(calls)).toHaveLength(3);
+    expect(killedPids(calls)).toEqual([100, 200]);
   });
 
   it("round-6 P2: a spared shell's uncertainty outlives the shell - its children still refuse the stop after it exits", async () => {
@@ -1941,17 +1871,8 @@ describe("killHostProcessTree convergence loop", () => {
       }
     }
 
-    expect(
-      calls.filter((call) => call.command === "powershell.exe"),
-    ).toHaveLength(3);
-    expect(
-      calls
-        .filter((call) => call.command === "taskkill")
-        .map((call) => call.args),
-    ).toEqual([
-      ["/F", "/PID", "100"],
-      ["/F", "/PID", "200"],
-    ]);
+    expect(scanCalls(calls)).toHaveLength(3);
+    expect(killedPids(calls)).toEqual([100, 200]);
 
     // Ablation: in `killHostProcessTree`, record suspects from `unattributed`
     // instead of `undecided` → this test reddens: round 2 remembers 888 but
@@ -2101,20 +2022,12 @@ describe("killHostProcessTree convergence loop", () => {
       }
     }
 
-    expect(
-      calls.filter((call) => call.command === "powershell.exe"),
-    ).toHaveLength(3);
-    expect(
-      calls
-        .filter((call) => call.command === "taskkill")
-        .map((call) => call.args),
-    ).toEqual([
+    expect(scanCalls(calls)).toHaveLength(3);
+    expect(killedPids(calls)).toEqual([
       // R0: both slot rows have zeroed edges (depth 0), so pid order.
-      ["/F", "/PID", "100"],
-      ["/F", "/PID", "200"],
+      100, 200,
       // R1: 888 (depth 2) before the lingering 100.
-      ["/F", "/PID", "888"],
-      ["/F", "/PID", "100"],
+      888, 100,
     ]);
 
     // Ablation: in `killHostProcessTree`, drop the `protectedAncestors`
@@ -2248,18 +2161,8 @@ describe("killHostProcessTree convergence loop", () => {
       }
     }
 
-    expect(
-      calls.filter((call) => call.command === "powershell.exe"),
-    ).toHaveLength(4);
-    expect(
-      calls
-        .filter((call) => call.command === "taskkill")
-        .map((call) => call.args),
-    ).toEqual([
-      ["/F", "/PID", "100"],
-      ["/F", "/PID", "888"],
-      ["/F", "/PID", "888"],
-    ]);
+    expect(scanCalls(calls)).toHaveLength(4);
+    expect(killedPids(calls)).toEqual([100, 888, 888]);
 
     // Ablation: in `killHostProcessTree`, drop the `protectedAncestors`
     // recording loop → this test reddens: round 2 finds three orphans
@@ -2347,17 +2250,8 @@ describe("killHostProcessTree convergence loop", () => {
       }
     }
 
-    expect(
-      calls.filter((call) => call.command === "powershell.exe"),
-    ).toHaveLength(3);
-    expect(
-      calls
-        .filter((call) => call.command === "taskkill")
-        .map((call) => call.args),
-    ).toEqual([
-      ["/F", "/PID", "100"],
-      ["/F", "/PID", "100"],
-    ]);
+    expect(scanCalls(calls)).toHaveLength(3);
+    expect(killedPids(calls)).toEqual([100, 100]);
 
     // Ablation: in `computeWindowsHostKillSet`, drop `!cliBranch.has(pid)`
     // from the `undecided` filter → this test reddens: round 1 remembers
@@ -2483,21 +2377,12 @@ describe("killHostProcessTree convergence loop", () => {
       }
     }
 
-    expect(
-      calls.filter((call) => call.command === "powershell.exe"),
-    ).toHaveLength(3);
-    expect(
-      calls
-        .filter((call) => call.command === "taskkill")
-        .map((call) => call.args),
-    ).toEqual([
-      ["/F", "/PID", "100"],
-      ["/F", "/PID", "888"],
-    ]);
+    expect(scanCalls(calls)).toHaveLength(3);
+    expect(killedPids(calls)).toEqual([100, 888]);
 
     // Ablation: in `killHostProcessTree`, drop the `priorProtected`
     // recording (or in `computeWindowsHostKillSet` the identity lookup) →
-    // this test reddens: round 1 issues `taskkill /F /PID 700` as well -
+    // this test reddens: round 1 kills 700 as well -
     // the shell this CLI is running in - after 888 (descendants first).
   });
 
@@ -2603,7 +2488,226 @@ describe("killHostProcessTree convergence loop", () => {
 // both directly and through `controller.stop`, because the direct unit tests
 // alone would not catch a wiring bug that hands the wrong pid in as `cliPid`
 // (`process.pid`, not PowerShell's own `$PID` inside the scan script).
-describe("computeWindowsHostKillSet and the taskkill self-protection it drives", () => {
+// The kill is a PowerShell script over (pid, creation time) pairs, not a
+// `taskkill` per pid (post-merge P1 on #1755): the scan proves a row is the
+// host's by pid AND creation time, but a pid-only kill re-resolves the integer
+// at kill time, so a victim that exits between the snapshot and the kill and
+// has its pid reused hands the kill to a stranger the carry-over never saw.
+// The script opens a handle (which pins the pid), reads the creation time
+// through it, and terminates through it only on a match. PowerShell itself
+// cannot run here, so these pin the script's TEXT and the loop's use of it;
+// the live Windows run is what proves the two creation-time sources agree.
+describe("handle-bound kill script", () => {
+  beforeEach(() => {
+    mocks.readHostPidMetadata.mockReset();
+    mocks.readHostPidMetadata.mockResolvedValue(null);
+    mocks.removeHostPidMetadata.mockReset();
+    mocks.removeHostPidMetadata.mockResolvedValue(undefined);
+  });
+
+  it("carries every target as (pid, creation micros) in issue order, opens the handle before reading StartTime, and kills through it only within 1 µs of the scan's creation time", () => {
+    const script = buildWindowsHandleBoundKillScript([
+      { processId: 400, created: 1_700_000_000_000_400 },
+      { processId: 100, created: 1_700_000_000_000_100 },
+    ]);
+    expect(script).toContain("$ErrorActionPreference = 'Stop'");
+    // Integers only, no exponent, no quoting - and in the caller's order.
+    const first = script.indexOf("ProcessId = 400; Created = 1700000000000400");
+    const second = script.indexOf(
+      "ProcessId = 100; Created = 1700000000000100",
+    );
+    expect(first).toBeGreaterThan(-1);
+    expect(second).toBeGreaterThan(first);
+    // The handle is opened BEFORE the identity is read, and the kill goes
+    // through the same object afterwards - that ordering is the mechanism.
+    const handleAt = script.indexOf("$null = $process.Handle");
+    const startAt = script.indexOf("$process.StartTime");
+    const killAt = script.indexOf("$process.Kill()");
+    expect(handleAt).toBeGreaterThan(-1);
+    expect(startAt).toBeGreaterThan(handleAt);
+    expect(killAt).toBeGreaterThan(startAt);
+    expect(script).toContain(
+      "if ([math]::Abs($started - [long]$target.Created) -le 1) {",
+    );
+    // Nothing in the script re-resolves a pid at kill time.
+    expect(script).not.toMatch(/taskkill|Stop-Process/i);
+    // The handle is released whatever happened.
+    expect(script).toContain("if ($null -ne $process) { $process.Dispose() }");
+  });
+
+  it("normalises StartTime like the scan normalises CreationDate (UTC, Unix epoch, microseconds) but floors with integer arithmetic, and tolerates 1 µs", () => {
+    const epoch = ".ToUniversalTime() - [datetime]'1970-01-01').Ticks";
+    const scan = buildWindowsSlotProcessTableScanScript(
+      "C:\\Users\\me\\.traycer\\host",
+    );
+    const kill = buildWindowsHandleBoundKillScript([
+      { processId: 1, created: 1 },
+    ]);
+    // Same epoch, same UTC normalisation on both sides.
+    expect(scan).toContain(`($_.CreationDate${epoch} / 10)`);
+    expect(kill).toContain(`($process.StartTime${epoch}`);
+    // But NOT the scan's `/ 10` (cold review P1 on the first draft): the
+    // scan's ticks are multiples of 10 (CIM carries microseconds) so its
+    // division is exact, while StartTime keeps the FILETIME's 100 ns digit
+    // and PowerShell's non-exact `[long]` division goes through `[double]`,
+    // which past 2^53 rounds `...9` up to `...10` and lands the floor one
+    // microsecond high. Falsification on Windows PowerShell 5.1:
+    // `[long][math]::Floor([long]17870000000000019 / 10)` prints
+    // `1787000000000002`. Integer arithmetic throughout instead:
+    expect(kill).toContain("$started = [long](($ticks - ($ticks % 10)) / 10)");
+    expect(kill).not.toContain("Ticks / 10");
+    // And a 1 µs tolerance for WMI rounding rather than truncating its last
+    // digit; no stranger is born within a microsecond of the victim's birth.
+    expect(kill).toContain(
+      "if ([math]::Abs($started - [long]$target.Created) -le 1) {",
+    );
+  });
+
+  it("a target whose age is 0 - or anything that is not a safe non-negative integer - is emitted as Created = 0, which the script never kills", () => {
+    const script = buildWindowsHandleBoundKillScript([
+      { processId: 7, created: 0 },
+      { processId: 8, created: -5 },
+      { processId: 9, created: Number.MAX_SAFE_INTEGER + 2 },
+      { processId: 10, created: 1.5 },
+    ]);
+    for (const pid of [7, 8, 9, 10]) {
+      expect(script).toContain(`ProcessId = ${pid}; Created = 0`);
+    }
+    // The guard that makes 0 mean "no identity, no kill".
+    expect(script).toContain("if ([long]$target.Created -gt 0) {");
+  });
+
+  it("one kill invocation per round, carrying that round's whole kill set with the ages from that round's scan, descendants first", async () => {
+    const calls: RecordedCall[] = [];
+    let scanCount = 0;
+    const runner: ProcessRunner = async (command, args) => {
+      calls.push({ command, args });
+      if (isScanCall(command, args)) {
+        scanCount += 1;
+        if (scanCount === 1) {
+          return success(
+            tableJson([
+              { processId: 100, parentProcessId: 1, created: 1000, slot: true },
+              {
+                processId: 555,
+                parentProcessId: 100,
+                created: 3000,
+                slot: false,
+              },
+            ]),
+          );
+        }
+        if (scanCount === 2) {
+          return success(
+            tableJson([
+              { processId: 777, parentProcessId: 1, created: 5000, slot: true },
+            ]),
+          );
+        }
+        return success(tableJson([]));
+      }
+      return success("");
+    };
+    const controller = createWindowsController(runner, noTimingDeps);
+
+    await controller.stop(serviceLabelFor("staging"), { force: false });
+
+    expect(killRounds(calls)).toEqual([
+      // R0: 555 (child) before 100 (host), each with the age its row had.
+      [
+        { processId: 555, created: 3000 },
+        { processId: 100, created: 1000 },
+      ],
+      // R1: the late spawn, in its own invocation.
+      [{ processId: 777, created: 5000 }],
+    ]);
+    expect(scanCalls(calls)).toHaveLength(3);
+    expect(calls.some((call) => call.command === "taskkill")).toBe(false);
+
+    // Ablation: in `killHostProcessTree`, hand `killProcessIdentities` a
+    // `created` of 0 for every target (drop the `created.get(pid)` lookup) →
+    // this test reddens: both rounds carry `Created = 0`, which the script
+    // would never kill.
+  });
+
+  it("a kill invocation that fails does not end the round: the confirming scan still runs and is what decides", async () => {
+    const calls: RecordedCall[] = [];
+    let scanCount = 0;
+    const runner: ProcessRunner = async (command, args) => {
+      calls.push({ command, args });
+      if (isScanCall(command, args)) {
+        scanCount += 1;
+        return success(
+          scanCount === 1
+            ? tableJson([{ processId: 100, parentProcessId: 1, slot: true }])
+            : tableJson([]),
+        );
+      }
+      if (isKillCall(command, args)) throw new Error("powershell timed out");
+      return success("");
+    };
+    const controller = createWindowsController(runner, noTimingDeps);
+
+    await expect(
+      controller.stop(serviceLabelFor("staging"), { force: false }),
+    ).resolves.toBeUndefined();
+
+    expect(killRounds(calls)).toHaveLength(1);
+    expect(scanCalls(calls)).toHaveLength(2);
+    expect(mocks.removeHostPidMetadata).toHaveBeenCalledWith("staging");
+  });
+
+  it("an authority loss during the kill is the one failure that propagates, before any further scan", async () => {
+    const authorityError = new ServiceMutationAuthorityError(
+      new Error("maintenance lease revoked"),
+    );
+    const calls: RecordedCall[] = [];
+    const runner: ProcessRunner = async (command, args) => {
+      calls.push({ command, args });
+      if (isScanCall(command, args)) {
+        return success(
+          tableJson([{ processId: 100, parentProcessId: 1, slot: true }]),
+        );
+      }
+      if (isKillCall(command, args)) throw authorityError;
+      return success("");
+    };
+    const controller = createWindowsController(runner, noTimingDeps);
+
+    let caught: unknown = null;
+    try {
+      await controller.stop(serviceLabelFor("staging"), { force: false });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBe(authorityError);
+    expect(scanCalls(calls)).toHaveLength(1);
+    expect(mocks.removeHostPidMetadata).not.toHaveBeenCalled();
+  });
+
+  it("parses the kill script's outcome report, bare single object included, and rejects any other shape", () => {
+    expect(
+      parseWindowsKillOutcomeJson(
+        '[{"ProcessId":100,"Outcome":"killed"},{"ProcessId":555,"Outcome":"reused"}]',
+      ),
+    ).toEqual([
+      { processId: 100, outcome: "killed" },
+      { processId: 555, outcome: "reused" },
+    ]);
+    expect(
+      parseWindowsKillOutcomeJson('{"ProcessId":100,"Outcome":"gone"}'),
+    ).toEqual([{ processId: 100, outcome: "gone" }]);
+    expect(parseWindowsKillOutcomeJson("")).toBeNull();
+    expect(parseWindowsKillOutcomeJson("not json")).toBeNull();
+    expect(
+      parseWindowsKillOutcomeJson('[{"ProcessId":"100","Outcome":"killed"}]'),
+    ).toBeNull();
+    expect(parseWindowsKillOutcomeJson('[{"ProcessId":100}]')).toBeNull();
+  });
+});
+
+describe("computeWindowsHostKillSet and the kill self-protection it drives", () => {
   beforeEach(() => {
     mocks.readHostPidMetadata.mockReset();
     mocks.readHostPidMetadata.mockResolvedValue(null);
@@ -2639,26 +2743,23 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
       }
     }
 
-    const taskkillArgs = calls
-      .filter((call) => call.command === "taskkill")
-      .map((call) => call.args);
+    const killed = killedPids(calls);
     // Deepest-first (`orderWindowsKillsDescendantsFirst`): 400 hangs off 100,
     // so it is issued first. The KILL SET is unchanged from before that
     // ordering existed - both pids, nothing more, nothing less - only the
-    // argv order changed.
-    expect(taskkillArgs).toEqual([
-      ["/F", "/PID", "400"],
-      ["/F", "/PID", "100"],
-    ]);
-    expect(taskkillArgs.every((args) => !args.includes("/T"))).toBe(true);
-    // The scan ANSWERED, so the pid.json fallback must not be consulted at
-    // all. Before pid 0 was accepted, the idle row failed the whole parse and
-    // every stop silently degraded to that fallback.
+    // issue order changed.
+    expect(killed).toEqual([400, 100]);
+    // And never through a pid-only `taskkill`, tree or otherwise.
+    expect(calls.some((call) => call.command === "taskkill")).toBe(false);
+    // The scan ANSWERED, so pid metadata is never read as a kill source.
+    // Before pid 0 was accepted, the idle row failed the whole parse and
+    // every stop silently degraded to the pid.json fallback that existed
+    // then; the fallback is gone, and this pins that nothing reads it back.
     expect(mocks.readHostPidMetadata).not.toHaveBeenCalled();
 
     // Ablation: in `isProcessTableId`, require `value > 0` again → this test
-    // fails: the idle row rejects the table, `findSlotProcessIds` returns
-    // null, the fallback is read, and the kill set collapses to nothing.
+    // fails: the idle row rejects the table, the scan parses to null, and
+    // the stop refuses before killing anything.
   });
 
   it("terminal-run: a non-slot shell ancestor between the host and the CLI is spared", async () => {
@@ -2688,19 +2789,14 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
       }
     }
 
-    const taskkillArgs = calls
-      .filter((call) => call.command === "taskkill")
-      .map((call) => call.args);
+    const killed = killedPids(calls);
     // Deepest-first, same reasoning as the host-spawned test above: 400 hangs
     // off 100, so it is issued first. The kill SET is unchanged.
-    expect(taskkillArgs).toEqual([
-      ["/F", "/PID", "400"],
-      ["/F", "/PID", "100"],
-    ]);
+    expect(killed).toEqual([400, 100]);
     // 50 (a non-slot ancestor of the CLI) is spared, and never appears.
-    expect(taskkillArgs.some((args) => args[2] === "50")).toBe(false);
+    expect(killed.includes(50)).toBe(false);
     // Nor does pid 0, which is in the table and in nobody's kill set.
-    expect(taskkillArgs.some((args) => args[2] === "0")).toBe(false);
+    expect(killed.includes(0)).toBe(false);
     expect(mocks.readHostPidMetadata).not.toHaveBeenCalled();
   });
 
@@ -2732,7 +2828,7 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
     // in `killHostProcessTree`): this test calls the algebra directly and
     // would not see it. The host-spawned integration test above is the one
     // that catches a wrong pid being threaded in, because it drives
-    // `controller.stop` and asserts the taskkill argv.
+    // `controller.stop` and asserts the kill script's targets.
   });
 
   it("a stale parent id the scan could not verify (arriving as 0) does not make a stranger a victim", () => {
@@ -3270,7 +3366,7 @@ describe("computeWindowsHostKillSet and the taskkill self-protection it drives",
     // that happens to be a former victim's pid, recycled).
     describe("shapes the ordinary walk decides, not the carry-over", () => {
       it("a lingering victim (still occupying its own pid) is killed through the ordinary walk", () => {
-        // `taskkill /F` is asynchronous: the confirming scan can briefly
+        // `TerminateProcess` is asynchronous: the confirming scan can briefly
         // still list the exact pid a previous round already killed. 100 IS
         // the victim, still there, and it is ALSO a genuine slot match
         // (`slot: true`) - so it is killed as an ordinary slot-descendant

--- a/clients/traycer-cli/src/service/platforms/windows.ts
+++ b/clients/traycer-cli/src/service/platforms/windows.ts
@@ -24,13 +24,13 @@ import {
 } from "../../host/spawn-evidence";
 import {
   WINDOWS_KILL_CONVERGENCE_ROUNDS,
+  WINDOWS_PROCESS_KILL_TIMEOUT_MS,
   WINDOWS_PROCESS_SCAN_TIMEOUT_MS,
   WINDOWS_SCHTASKS_END_TIMEOUT_MS,
   WINDOWS_SCHTASKS_QUERY_TIMEOUT_MS,
   WINDOWS_SCHTASKS_RUN_TIMEOUT_MS,
   WINDOWS_START_SPAWN_POLL_MS,
   WINDOWS_START_SPAWN_VERIFY_MS,
-  WINDOWS_TASKKILL_TIMEOUT_MS,
 } from "@traycer/protocol/host/lifecycle-constants";
 import { CLI_ERROR_CODES, cliError } from "../../runner/errors";
 import { isProcessAlive } from "../../store/cli-lock";
@@ -52,7 +52,7 @@ import type {
 // prompting for UAC.
 
 // Pluggable runner shape kept consistent with macOS so tests can exercise the
-// controller without touching schtasks/taskkill.
+// controller without touching schtasks or the PowerShell scan and kill.
 export type ProcessRunner = typeof runCommand;
 
 /**
@@ -103,8 +103,8 @@ export function createWindowsController(
     // No Desktop/SMAppService split on Windows, so the restart halves are the
     // stop and start `host restart` already performed - the named seam exists
     // so the command has one shape on every platform. `forcedRecycle` is
-    // never set: `stopService` taskkills and waits, so nothing survives to
-    // need a recycle.
+    // never set: `stopService` kills the tree and waits, so nothing survives
+    // to need a recycle.
     stopForRestart: async (label) => {
       await stopService(label, run, deps);
       return { forcedRecycle: false };
@@ -423,39 +423,59 @@ async function stopService(
 // trade: a stop that cannot be verified leaves the tree whole for the next
 // attempt instead of half torn down.
 //
-// NEVER `/T`. This CLI is routinely a CHILD of the host it is stopping - a
-// maintenance RPC, the reconciler, or a person's command in a Traycer-hosted
-// terminal - and `taskkill /T` walks down from the host and kills it mid-update:
-// the host is gone, the updater is gone, and nothing finishes the swap. The
-// scan computes which pids to kill (`computeWindowsHostKillSet`) and each one is
-// killed individually, deepest first (`orderWindowsKillsDescendantsFirst`) so a
-// child is issued its kill before the parent whose death would orphan it. That
-// ordering is a courtesy, not a mechanism - the kills are issued concurrently,
-// and what actually catches a process spawned mid-kill is the victim carry-over
-// below. `taskkill /F` on a parent leaves its children running, the VBS launcher
+// NEVER a tree kill (`taskkill /T`). This CLI is routinely a CHILD of the host
+// it is stopping - a maintenance RPC, the reconciler, or a person's command in
+// a Traycer-hosted terminal - and a tree kill walks down from the host and
+// kills it mid-update: the host is gone, the updater is gone, and nothing
+// finishes the swap. The scan computes which pids to kill
+// (`computeWindowsHostKillSet`) and each one is killed individually, deepest
+// first (`orderWindowsKillsDescendantsFirst`) so a child is issued its kill
+// before the parent whose death would orphan it. That ordering is a courtesy,
+// not a mechanism - a process spawned after the snapshot is in no ordering of
+// this list, and what actually catches it is the victim carry-over below.
+// `TerminateProcess` on a parent leaves its children running, the VBS launcher
 // re-runs the host only on exit 75 (the refreshed-slot signal) and never after a
 // kill, and the CLI-side supervisor is already silenced by the stop intent
 // written before any of this.
 //
-// Not `/T` also means nothing sweeps up what is spawned DURING the kill. The
-// scan is a snapshot, so a child the host or one of its agents starts after
-// `Get-CimInstance` materializes the table is in no round's kill set; killing
-// its parent orphans it, and the caller goes on to delete the pid metadata
-// while it still holds the install dir open. So this rescans and kills again
-// until a scan comes back empty. Each round kills exactly what THAT round's
-// scan returned - the scan verifies by exe path/command line, so a pid Windows
-// recycled between rounds is simply not in it.
+// Killed by IDENTITY, not by pid. The scan proves a row is the host's by its
+// pid AND its creation time, but a pid is only a name: a victim can exit on its
+// own between the snapshot and the kill - an agent does the moment the pipe to
+// its just-killed host closes - and Windows hands pids out again eagerly.
+// `taskkill /F /PID` re-resolves the integer at kill time,
+// so in that window it terminates whatever now wears the number: a process the
+// scan never saw, which the carry-over cannot protect because it only reasons
+// about rows that were in a snapshot. `killProcessIdentities` therefore hands
+// each round's victims to ONE PowerShell script that opens a handle to the pid,
+// checks the creation time through that handle against the one the scan
+// recorded, and terminates through the same handle. An open handle keeps the
+// process object - and with it the pid - alive, so the process the check
+// passed is the process the kill reaches. A mismatch is a reused pid and is
+// skipped; the next scan lists whatever is really there. A victim whose
+// creation time the scan could not read (0) is skipped for the same reason -
+// there is no identity to check - and surfaces as a survivor if it persists;
+// no live slot process is known to lack one (pid 0 and System have none, and
+// neither is ever in a kill set).
+//
+// Not a tree kill also means nothing sweeps up what is spawned DURING the
+// kill. The scan is a snapshot, so a child the host or one of its agents
+// starts after `Get-CimInstance` materializes the table is in no round's kill
+// set; killing its parent orphans it, and the caller goes on to delete the pid
+// metadata while it still holds the install dir open. So this rescans and
+// kills again until a scan comes back empty. Each round kills exactly what
+// THAT round's scan returned - the scan verifies by exe path/command line, so
+// a pid Windows recycled between rounds is simply not in it.
 //
 // `WINDOWS_KILL_CONVERGENCE_ROUNDS` counts KILL passes, so the loop scans one
 // more time than it kills: the last scan is always a confirming one, and an
 // empty scan is the ONLY way out that reports success.
 //
-// Known and deliberately not mechanised: `taskkill /F` is `TerminateProcess`,
-// which is asynchronous - the confirming scan can briefly still list a pid the
-// previous round killed. The bound absorbs one such round (that pid is gone by
-// the next scan and the loop converges normally). If the live Windows run shows
-// this flaking, the lever is a short settle before the re-scan, NOT a wider
-// bound: more rounds would only spend more time re-killing the same pids.
+// Known and deliberately not mechanised: `TerminateProcess` is asynchronous -
+// the confirming scan can briefly still list a pid the previous round killed.
+// The bound absorbs one such round (that pid is gone by the next scan and the
+// loop converges normally). If the live Windows run shows this flaking, the
+// lever is a short settle before the re-scan, NOT a wider bound: more rounds
+// would only spend more time re-killing the same pids.
 async function killHostProcessTree(
   label: ServiceLabel,
   run: ProcessRunner,
@@ -609,19 +629,33 @@ async function killHostProcessTree(
         exitCode: 1,
       });
     }
-    await killProcessIds(orderWindowsKillsDescendantsFirst(pids, table), run);
+    // The ages from the snapshot the kill set was computed from. They serve
+    // twice: as the identity each kill is checked against, and as what the
+    // memory below records. A row is always in the table it was selected
+    // from, so the fallback age is unreachable; 0 is the value the kill
+    // refuses to act on and the next round refuses to link anything to, which
+    // is the right way for it to be wrong.
+    const created = new Map(table.map((row) => [row.processId, row.created]));
+    await killProcessIdentities(
+      orderWindowsKillsDescendantsFirst(pids, table).map((pid) => ({
+        processId: pid,
+        created: created.get(pid) ?? 0,
+      })),
+      label,
+      run,
+    );
     // Remembered AFTER the kill, from the snapshot the kill was computed from,
-    // so each victim's age is the one it had while it was alive. A row is
-    // always in the table it was selected from, so the fallback age is
-    // unreachable; 0 is the value the next round refuses to link anything to,
-    // which is the right way for it to be wrong.
+    // so each victim's age is the one it had while it was alive. Remembered
+    // whether or not the kill reached it: a victim that exited on its own
+    // before its kill, or whose pid a stranger had already taken, was still
+    // placed in the host's tree by the scan that saw it alive at
+    // `seenAliveAt`, and the children born inside that window are the host's.
     //
     // A pid killed again in a later round gets a second entry with that
     // round's `seenAliveAt`, and the wider window is the honest bound: its
     // scan saw the pid alive too, so the interval in which the pid was
     // demonstrably still the victim's genuinely extends to there. The earlier
     // entry stays; nothing it proved has become false.
-    const created = new Map(table.map((row) => [row.processId, row.created]));
     for (const pid of pids) {
       rememberIncarnation(priorVictims, pid, {
         created: created.get(pid) ?? 0,
@@ -681,22 +715,243 @@ function rememberIncarnation<T>(
   }
 }
 
-async function killProcessIds(
-  pids: readonly number[],
+// One process the round decided to kill: the pid the scan listed and the
+// creation time it listed beside it, in the scan's epoch microseconds. The pair
+// is the identity; the pid alone is not (see the header of
+// `killHostProcessTree`).
+export interface WindowsKillTarget {
+  readonly processId: number;
+  readonly created: number;
+}
+
+// The kill script's report on one target. Diagnostic only: the loop never acts
+// on it, because the next scan is the only evidence of what is still running.
+// `reused` is the case this mechanism exists for - the pid the scan selected
+// now belongs to a process born at a different time - and `unverifiable` is a
+// target whose creation time the scan could not read, which is never killed.
+export interface WindowsKillOutcome {
+  readonly processId: number;
+  readonly outcome: string;
+}
+
+// One PowerShell invocation for the whole round, in the caller's order. The
+// script is what turns a pid into an identity: it never terminates a process
+// whose creation time it did not just read through the very handle it then
+// terminates through. Failures are swallowed for the same reason the outcomes
+// are diagnostic - a kill that did not land shows up in the confirming scan as
+// a survivor, and the round bound turns that into a refusal that names it. The
+// authority error is the one exception, as everywhere in this module.
+async function killProcessIdentities(
+  targets: readonly WindowsKillTarget[],
+  label: ServiceLabel,
   run: ProcessRunner,
 ): Promise<void> {
-  await Promise.all(
-    pids.map((pid) =>
-      run("taskkill", ["/F", "/PID", String(pid)], {
+  try {
+    const result = await run(
+      "powershell.exe",
+      [
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        buildHandleBoundKillScript(targets),
+      ],
+      {
         env: undefined,
         cwd: undefined,
-        timeoutMs: WINDOWS_TASKKILL_TIMEOUT_MS,
+        timeoutMs: WINDOWS_PROCESS_KILL_TIMEOUT_MS,
         tolerateNonZeroExit: true,
-      }).catch((cause) => {
-        if (isServiceMutationAuthorityError(cause)) throw cause;
-      }),
-    ),
-  );
+      },
+    );
+    const outcomes = parseKillOutcomeJson(result.stdout);
+    const logger = createCliLogger(label.environment);
+    if (outcomes === null) {
+      // The script did not report, so nothing is known about what it did.
+      // The confirming scan still decides, but the exit code and stderr
+      // belong in a support report, which DEBUG does not reach: our own
+      // script's stderr is PowerShell's wording plus pids, no user data. (A
+      // timeout, a missing `powershell.exe` and a signal all resolve as
+      // exit -1 with empty stderr under `tolerateNonZeroExit`, the runner's
+      // contract; the scan shares that blind spot.)
+      logger.warn("Windows host kill round produced no readable report", {
+        targets: targets.length,
+        exitCode: result.exitCode,
+        stderr: result.stderr.trim().slice(0, 500),
+      });
+      return;
+    }
+    const rendered = outcomes.map(
+      (outcome) => `${outcome.processId}=${outcome.outcome}`,
+    );
+    const unreached = outcomes.filter(
+      (outcome) => outcome.outcome !== "killed" && outcome.outcome !== "gone",
+    );
+    if (unreached.length > 0) {
+      // A target the kill did not reach and that may still be alive: a
+      // reused pid (the case this exists for, and rare), no identity to
+      // check, or a refused handle. EVERY target `reused` is the signature
+      // of the two creation-time sources disagreeing, which the live Windows
+      // run exists to rule out - and the one thing the survivor refusal the
+      // user sees cannot tell them.
+      logger.warn("Windows host kill round left targets unreached", {
+        targets: targets.length,
+        outcomes: rendered,
+      });
+    } else {
+      logger.debug("Windows host kill round completed", {
+        targets: targets.length,
+        outcomes: rendered,
+      });
+    }
+  } catch (cause) {
+    if (isServiceMutationAuthorityError(cause)) throw cause;
+    createCliLogger(label.environment).debug(
+      "Windows host kill round did not complete; the next scan decides",
+      { targets: targets.length, cause: describeCause(cause) },
+    );
+  }
+}
+
+/**
+ * The handle-bound kill, as a Windows PowerShell 5.1 script over `targets`.
+ *
+ * Per target, in order: `GetProcessById` (throws when nothing wears the pid),
+ * then `.Handle`, which opens a process handle and caches it on the object.
+ * From that line on the kernel keeps the process object alive for as long as
+ * the handle is open, so the pid cannot be reused underneath us, and every
+ * later member call on the object - `StartTime`, `Kill` - goes through that
+ * same cached handle rather than re-resolving the pid. `StartTime` is then
+ * normalised the way the table scan normalises `CreationDate`
+ * (`ROW_CREATION_SCRIPT_LINES`): UTC, ticks since the Unix epoch, truncated to
+ * microseconds. Both come from the kernel's creation FILETIME, so for one and
+ * the same process they agree to the microsecond. A match is the scan's
+ * process and is killed; anything else is skipped and reported, and the
+ * confirming scan says what that pid really is now.
+ *
+ * NOT the scan's `Ticks / 10` though. The scan's ticks are multiples of 10 by
+ * construction - CIM carries `CreationDate` as a DMTF datetime with six
+ * fractional digits - so its division is exact and PowerShell keeps it a
+ * `[long]`. `StartTime` keeps the FILETIME's 100 ns digit, and PowerShell's
+ * `/` on a non-exact `[long]` quotient goes through `[double]`, whose
+ * precision past 2^53 (ticks since 1970 passed that in 1998, and pass 2^54
+ * in January 2027, where it halves again) is 2 ticks: a `...9` rounds up to
+ * `...10`, the floor lands one microsecond high, and an
+ * exact comparison refuses to kill the host - every stop, for as long as that
+ * host lives, with nothing above DEBUG to say why. Falsification, on Windows
+ * PowerShell 5.1: `[long][math]::Floor([long]17870000000000019 / 10)` prints
+ * `1787000000000002`. `($t - ($t % 10)) / 10` is integer arithmetic
+ * throughout. The comparison then allows a difference of 1 µs, which absorbs
+ * WMI rounding rather than truncating its last digit; it admits no stranger,
+ * because a reused pid is born after the victim exited, which is after the
+ * scan that saw the victim alive - never within a microsecond of the
+ * victim's own birth.
+ *
+ * `.Handle` asks for full access to the process. Same-user processes at the
+ * same integrity level grant it, which is every process the host and its
+ * agents are; the case that refuses it - an elevated host from an unelevated
+ * CLI - refuses `PROCESS_TERMINATE` too, so nothing `taskkill /F` could have
+ * ended is out of reach here. A refusal is reported as `failed`, and the
+ * survivor shows up in the confirming scan like any other.
+ *
+ * Every statement inside the `try` is a .NET member access, and those throw
+ * terminating errors whatever `$ErrorActionPreference` says; the setting is
+ * there so nothing outside the `try` can half-succeed silently either.
+ * PowerShell wraps a member's exception - `MethodInvocationException` for a
+ * method, `GetValueInvocationException` for a property getter such as
+ * `.Handle` - and both derive from `RuntimeException`, which is what the
+ * catch unwraps so the report names the real cause (`ArgumentException` is
+ * "not running").
+ *
+ * The literal holds only integers this module produced (`WindowsKillTarget`
+ * from the scan's own JSON), never text, so there is nothing to quote and no
+ * argument-injection surface.
+ */
+function buildHandleBoundKillScript(
+  targets: readonly WindowsKillTarget[],
+): string {
+  const literal = targets
+    .map(
+      (target) =>
+        `  @{ ProcessId = ${killTargetInteger(target.processId)}; Created = ${killTargetInteger(target.created)} }`,
+    )
+    .join(",\n");
+  return [
+    "$ErrorActionPreference = 'Stop'",
+    "$targets = @(",
+    literal,
+    ")",
+    "$results = foreach ($target in $targets) {",
+    "  $process = $null",
+    "  $outcome = 'unverifiable'",
+    "  try {",
+    "    if ([long]$target.Created -gt 0) {",
+    "      $process = [System.Diagnostics.Process]::GetProcessById([int]$target.ProcessId)",
+    "      $null = $process.Handle",
+    "      $ticks = ($process.StartTime.ToUniversalTime() - [datetime]'1970-01-01').Ticks",
+    "      $started = [long](($ticks - ($ticks % 10)) / 10)",
+    "      if ([math]::Abs($started - [long]$target.Created) -le 1) {",
+    "        $process.Kill()",
+    "        $outcome = 'killed'",
+    "      } else {",
+    "        $outcome = 'reused'",
+    "      }",
+    "    }",
+    "  } catch {",
+    "    $reason = $_.Exception",
+    "    if ($reason -is [System.Management.Automation.RuntimeException] -and $null -ne $reason.InnerException) {",
+    "      $reason = $reason.InnerException",
+    "    }",
+    "    if ($reason -is [System.ArgumentException]) { $outcome = 'gone' }",
+    "    else { $outcome = 'failed: ' + $reason.GetType().Name }",
+    "  } finally {",
+    "    if ($null -ne $process) { $process.Dispose() }",
+    "  }",
+    "  [pscustomobject]@{ ProcessId = [int]$target.ProcessId; Outcome = $outcome }",
+    "}",
+    "@($results) | ConvertTo-Json -Compress",
+  ].join("\n");
+}
+
+// A value that is not a safe non-negative integer is emitted as 0, which the
+// script treats as "no identity" and never kills. Unreachable from the scan
+// parser, which only admits such integers; this is the script's own guarantee
+// that its literal is integers whatever it is handed.
+function killTargetInteger(value: number): string {
+  return Number.isSafeInteger(value) && value >= 0 ? String(value) : "0";
+}
+
+/**
+ * Parse the kill script's report, or `null` if it is not the shape this module
+ * asked for. Same single-row leniency as the table parser: Windows PowerShell
+ * 5.1 emits a bare object for one target.
+ */
+function parseKillOutcomeJson(
+  stdout: string,
+): readonly WindowsKillOutcome[] | null {
+  const trimmed = stdout.trim();
+  if (trimmed.length === 0) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+  const entries = Array.isArray(parsed) ? parsed : [parsed];
+  const outcomes: WindowsKillOutcome[] = [];
+  for (const entry of entries) {
+    if (entry === null || typeof entry !== "object") return null;
+    const record = entry as Record<string, unknown>;
+    const processId = record.ProcessId;
+    const outcome = record.Outcome;
+    if (
+      typeof processId !== "number" ||
+      !Number.isSafeInteger(processId) ||
+      typeof outcome !== "string"
+    ) {
+      return null;
+    }
+    outcomes.push({ processId, outcome });
+  }
+  return outcomes;
 }
 
 async function startService(
@@ -1155,10 +1410,12 @@ export interface WindowsProcessTableRow {
  * All-or-nothing on purpose. A partially-parsed table produces a kill set built
  * from a partial ancestry, and a missing edge there does not read as an error -
  * it reads as "this process has no parent", which spares nothing and kills a
- * branch that should have been spared. `null` sends the caller to the pid.json
- * fallback, which is weaker but honest about what it knows. Empty output is
- * `null` for the same reason: a real Win32_Process scan is never empty, so
- * nothing on stdout means the scan did not run.
+ * branch that should have been spared. `null` makes `killHostProcessTree`
+ * refuse: before its first kill it refuses to start, after one it refuses to
+ * report the tree down. There is no weaker path to fall back to - the
+ * pid.json `taskkill` that used to be one was removed for being unverified.
+ * Empty output is `null` for the same reason: a real Win32_Process scan is
+ * never empty, so nothing on stdout means the scan did not run.
  */
 function parseProcessTableJson(
   stdout: string,
@@ -1626,14 +1883,15 @@ function classifyAgainstSuspect(
 }
 
 /**
- * The same kill set, ordered so a process is issued its `taskkill` before its
+ * The same kill set, ordered so a process is issued its kill before its
  * ancestors are. Cheap, and it shrinks the window in which a parent is already
- * gone while its child is not yet reaped.
+ * gone while its child is not yet reaped: the kill script walks the list in
+ * this order, one `TerminateProcess` after another.
  *
  * It does NOT replace the victim carry-over, and must not be mistaken for it:
- * the kills are issued concurrently, so this orders their ISSUE and nothing
- * more, and a process spawned after the snapshot is not in this list at all at
- * any ordering. The carry-over is what actually catches that one, a round later.
+ * this orders the ISSUE of the kills and nothing more, and a process spawned
+ * after the snapshot is not in this list at all at any ordering. The
+ * carry-over is what actually catches that one, a round later.
  */
 export function orderWindowsKillsDescendantsFirst(
   pids: readonly number[],
@@ -2133,6 +2391,8 @@ export {
   buildHiddenHostLauncher as buildWindowsHiddenHostLauncher,
   buildSlotProcessTableScanScript as buildWindowsSlotProcessTableScanScript,
   buildSlotProcessDetailScanScript as buildWindowsSlotProcessDetailScanScript,
+  buildHandleBoundKillScript as buildWindowsHandleBoundKillScript,
   parseProcessTableJson as parseWindowsProcessTableJson,
   parseProcessDetailJson as parseWindowsProcessDetailJson,
+  parseKillOutcomeJson as parseWindowsKillOutcomeJson,
 };

--- a/clients/traycer-cli/src/service/platforms/windows.ts
+++ b/clients/traycer-cli/src/service/platforms/windows.ts
@@ -734,15 +734,68 @@ export interface WindowsKillOutcome {
   readonly outcome: string;
 }
 
-// One PowerShell invocation for the whole round, in the caller's order. The
-// script is what turns a pid into an identity: it never terminates a process
-// whose creation time it did not just read through the very handle it then
-// terminates through. Failures are swallowed for the same reason the outcomes
-// are diagnostic - a kill that did not land shows up in the confirming scan as
-// a survivor, and the round bound turns that into a refusal that names it. The
-// authority error is the one exception, as everywhere in this module.
+// How many targets one kill script carries. The script travels on
+// `powershell.exe`'s command line, which `CreateProcessW` caps at 32,767
+// characters, and the previous per-pid `taskkill` had no aggregate limit to
+// inherit. Measured on the script text: a target costs 59 characters with
+// its separator at a ten-digit pid and a sixteen-digit age, the fixed body
+// is 1,126, so 250 targets are 15,874 - under half the cap, with the
+// `powershell.exe -NoProfile -NonInteractive -Command` prefix and Node's
+// quoting adding some 50 more. Every realistic round is one script; a slot
+// with more processes than this issues several, in order, under the round's
+// single deadline (`killProcessIdentities`). Codex P2 on #1762.
+export const WINDOWS_KILL_TARGETS_PER_SCRIPT = 250;
+
+// The whole round's kill, in the caller's order: one PowerShell script per
+// `WINDOWS_KILL_TARGETS_PER_SCRIPT` targets, all under ONE deadline of
+// `WINDOWS_PROCESS_KILL_TIMEOUT_MS`. The restart budget models a round as one
+// kill bound, and chunking must not widen it, so a script that no longer fits
+// the remaining time is not started: its targets are simply next round's,
+// where a fresh scan re-selects whatever is still there, and the round bound
+// turns what never converges into the refusal that names it. The deadline is
+// measured on the monotonic clock, not `Date.now()`: a wall-clock step during
+// the round would either stretch the budget or starve the later scripts.
+//
+// The script is what turns a pid into an identity: it never terminates a
+// process whose creation time it did not just read through the very handle it
+// then terminates through. Failures are swallowed for the same reason the
+// outcomes are diagnostic - a kill that did not land shows up in the
+// confirming scan as a survivor, and the round bound turns that into a
+// refusal that names it. The authority error is the one exception, as
+// everywhere in this module.
 async function killProcessIdentities(
   targets: readonly WindowsKillTarget[],
+  label: ServiceLabel,
+  run: ProcessRunner,
+): Promise<void> {
+  const startedAt = performance.now();
+  for (
+    let start = 0;
+    start < targets.length;
+    start += WINDOWS_KILL_TARGETS_PER_SCRIPT
+  ) {
+    const remainingMs = Math.floor(
+      WINDOWS_PROCESS_KILL_TIMEOUT_MS - (performance.now() - startedAt),
+    );
+    if (remainingMs <= 0) {
+      createCliLogger(label.environment).warn(
+        "Windows host kill round ran out of time; the targets not yet sent wait for the next scan",
+        { targets: targets.length, unsent: targets.length - start },
+      );
+      return;
+    }
+    await runHandleBoundKillScript(
+      targets.slice(start, start + WINDOWS_KILL_TARGETS_PER_SCRIPT),
+      remainingMs,
+      label,
+      run,
+    );
+  }
+}
+
+async function runHandleBoundKillScript(
+  targets: readonly WindowsKillTarget[],
+  timeoutMs: number,
   label: ServiceLabel,
   run: ProcessRunner,
 ): Promise<void> {
@@ -758,7 +811,7 @@ async function killProcessIdentities(
       {
         env: undefined,
         cwd: undefined,
-        timeoutMs: WINDOWS_PROCESS_KILL_TIMEOUT_MS,
+        timeoutMs,
         tolerateNonZeroExit: true,
       },
     );

--- a/protocol/src/host/lifecycle-constants.ts
+++ b/protocol/src/host/lifecycle-constants.ts
@@ -55,12 +55,14 @@ export const WINDOWS_SCHTASKS_END_TIMEOUT_MS = 30_000;
  */
 export const WINDOWS_PROCESS_SCAN_TIMEOUT_MS = 30_000;
 /**
- * Bound on ONE kill round: a single PowerShell script that terminates every
- * pid the preceding scan selected, each through a handle whose creation time
- * it first checks against the scan's. It pays the same emulated-PowerShell
- * startup the scan does - the reason it is one script per round and not one
- * per pid - and then microseconds per `TerminateProcess`, so the scan's
- * ceiling is the right one here too.
+ * Bound on ONE kill round, however many PowerShell scripts it takes: the
+ * round terminates every pid the preceding scan selected, each through a
+ * handle whose creation time it first checks against the scan's, in scripts
+ * of at most `WINDOWS_KILL_TARGETS_PER_SCRIPT` targets (one for any realistic
+ * round) that share this single deadline. A script pays the same
+ * emulated-PowerShell startup the scan does - the reason it carries the round
+ * and not one pid - and then microseconds per `TerminateProcess`, so the
+ * scan's ceiling is the right one here too.
  */
 export const WINDOWS_PROCESS_KILL_TIMEOUT_MS = 30_000;
 export const WINDOWS_SCHTASKS_RUN_TIMEOUT_MS = 30_000;

--- a/protocol/src/host/lifecycle-constants.ts
+++ b/protocol/src/host/lifecycle-constants.ts
@@ -33,8 +33,8 @@ export const STOP_EXIT_GRACE_MARGIN_MS = 2_000;
  * single graceful-stop signal like launchd SIGTERM - `restart` runs a
  * sequence of independently-capped steps: `schtasks /End`, then up to
  * `WINDOWS_KILL_CONVERGENCE_ROUNDS` PowerShell process-tree scans each
- * followed by `taskkill` on the pids that scan returns plus one final
- * confirming scan, then `schtasks /Run`,
+ * followed by one PowerShell kill script over the pids that scan returns,
+ * plus one final confirming scan, then `schtasks /Run`,
  * post-`/Run` spawn-evidence verification, and (on verification failure) a
  * Last Run Result query.
  * Exported here (not left as local literals in `windows.ts`) so the outer
@@ -54,7 +54,15 @@ export const WINDOWS_SCHTASKS_END_TIMEOUT_MS = 30_000;
  * this timeout, is what keeps a non-converging host from grinding.
  */
 export const WINDOWS_PROCESS_SCAN_TIMEOUT_MS = 30_000;
-export const WINDOWS_TASKKILL_TIMEOUT_MS = 30_000;
+/**
+ * Bound on ONE kill round: a single PowerShell script that terminates every
+ * pid the preceding scan selected, each through a handle whose creation time
+ * it first checks against the scan's. It pays the same emulated-PowerShell
+ * startup the scan does - the reason it is one script per round and not one
+ * per pid - and then microseconds per `TerminateProcess`, so the scan's
+ * ceiling is the right one here too.
+ */
+export const WINDOWS_PROCESS_KILL_TIMEOUT_MS = 30_000;
 export const WINDOWS_SCHTASKS_RUN_TIMEOUT_MS = 30_000;
 export const WINDOWS_SCHTASKS_QUERY_TIMEOUT_MS = 10_000;
 
@@ -102,12 +110,12 @@ export const WINDOWS_RESTART_SEQUENCE_TIMEOUT_MS =
   WINDOWS_SCHTASKS_END_TIMEOUT_MS +
   // The kill step is a bounded scan-then-kill loop, not a single pass, so its
   // worst case scales with the round bound. Leaving this as one scan + one
-  // taskkill would understate the sequence and let the caller's SIGKILL land
+  // kill would understate the sequence and let the caller's SIGKILL land
   // mid-restart - the exact failure the outer budget below exists to prevent.
   // Scans and kills are counted separately because the loop confirms with a
   // final scan it does not kill from: N+1 scans, N kills.
   (WINDOWS_KILL_CONVERGENCE_ROUNDS + 1) * WINDOWS_PROCESS_SCAN_TIMEOUT_MS +
-  WINDOWS_KILL_CONVERGENCE_ROUNDS * WINDOWS_TASKKILL_TIMEOUT_MS +
+  WINDOWS_KILL_CONVERGENCE_ROUNDS * WINDOWS_PROCESS_KILL_TIMEOUT_MS +
   WINDOWS_SCHTASKS_RUN_TIMEOUT_MS +
   WINDOWS_START_SPAWN_VERIFY_MS +
   WINDOWS_SCHTASKS_QUERY_TIMEOUT_MS;


### PR DESCRIPTION
Follow-up to #1755, closing the P1 from its post-merge review (https://github.com/traycerai/traycer/pull/1755#issuecomment-5562039646).

## The hole

`killHostProcessTree` selects victims from a `Get-CimInstance Win32_Process` snapshot that verifies each row by pid **and** creation time. The kill itself was `taskkill /F /PID <pid>`, which re-resolves the integer at kill time. A victim can exit on its own between the snapshot and the kill - an agent does the moment the pipe to its just-killed host closes - and Windows hands pids out again eagerly, so in that window the kill terminated whatever now wore the number: a process the scan never saw. The victim carry-over cannot protect it, because it only reasons about rows that were in a snapshot. Pre-existing: the old `/T` path and the pid.json taskkill had the same exposure.

## The fix

Each round hands its whole kill set, descendants first, to **one** Windows PowerShell 5.1 script (`buildHandleBoundKillScript`). Per target:

1. `[System.Diagnostics.Process]::GetProcessById(pid)` - throws when nothing wears the pid.
2. `$null = $process.Handle` - opens a process handle and caches it on the object. While it is open the kernel keeps the process object, and with it the pid, alive; every later member call goes through the cached handle rather than re-resolving the pid.
3. `StartTime`, normalised the way the scan normalises `CreationDate` (UTC, ticks since the Unix epoch, truncated to microseconds) and compared with the age the scan recorded for that pid, allowing 1 µs for WMI rounding its last digit.
4. `.Kill()` through the same handle only on a match. A mismatch is a reused pid and is skipped (`reused`); a target the scan could read no creation time for is never killed (`unverifiable`); the confirming scan says what is really there.

The flooring is integer arithmetic on purpose, not the scan's `Ticks / 10`: the scan's ticks are multiples of 10 (CIM carries microseconds) so its division is exact, but `StartTime` keeps the FILETIME's 100 ns digit and PowerShell's non-exact `[long]` division goes through `[double]`, which past 2^53 rounds `...9` up and lands the floor one microsecond high (`[long][math]::Floor([long]17870000000000019 / 10)` prints `1787000000000002` on Windows PowerShell 5.1). The first draft had that bug and would have refused to stop some live hosts; the cold review caught it before the push.

Outcomes come back per target (`pid=killed|reused|gone|unverifiable|failed: <type>`). A round whose every target was killed or already gone logs them at DEBUG; a round that left a target unreached, or produced no readable report, logs at WARN with the outcomes (or exit code and bounded stderr), so the signature of the two creation-time sources disagreeing reaches a support report. The loop's semantics are unchanged: the confirming scan is the only evidence of what is still running, a script failure is swallowed (authority loss excepted), and the round bound turns a survivor into the existing refusal that names it.

`WINDOWS_TASKKILL_TIMEOUT_MS` → `WINDOWS_PROCESS_KILL_TIMEOUT_MS` (same 30 s; the script pays the same emulated-PowerShell startup the scan does, which is why it carries the round rather than one pid). The restart budget derivation follows the rename.

The script rides `powershell.exe`'s command line, which `CreateProcessW` caps at 32,767 characters (Codex P2), so a round carries at most `WINDOWS_KILL_TARGETS_PER_SCRIPT` (250) targets per script - under half the cap at worst-case digit counts - and a slot with more processes issues several scripts in order under the round's **single** 30 s deadline, so the budget is not widened; a script that no longer fits the remaining time is not started and its targets are next round's.

Also swept: prose that still described the removed pid.json taskkill fallback (`parseProcessTableJson`, the Windows test's host-spawned pin), `taskkill /T` (stop-intent, pid-metadata), a 10 s scan (install swap ceilings), the desktop host controller's two budget comments, and the README's Windows paragraph.

## Tests

The Windows suite's fake runners now tell the scan and the kill apart by the script each carries and read a round's targets out of the kill script's literal, so every existing kill-set, order and per-round pin survives with the same meaning. New pins: the script text (target literal in issue order, `.Handle` before `StartTime` before `Kill()`, the scan's epoch and UTC normalisation with integer flooring and the 1 µs tolerance, unverifiable ages emitted as `Created = 0`), one invocation per round carrying that round's ages (ablation-verified: dropping the age lookup reddens exactly this test), a failing kill not ending the round, an authority loss propagating, and the outcome parser.

## What only a live run settles

PowerShell cannot run in the unit suite. The fix relies on WMI's `CreationDate` and .NET's `Process.StartTime` describing the same instant once both are in UTC and truncated to microseconds; both derive from the kernel's creation FILETIME, so they should agree within the tolerance. If they do not (a timezone-kind disagreement would be hours, every time), the code fails closed: every kill is skipped and the stop reports "still running after 3 kill rounds", which is safe but would break every Windows stop. **The Windows VM run is the merge gate for this PR**, not a nicety, and it has to be on a machine whose clock is not UTC. The proof is a `Windows host kill round completed` DEBUG line with `killed` outcomes on a live host; the failure signature is a `Windows host kill round left targets unreached` WARN line with `reused` on every target.
