### PR TITLE
fix(host-update): identity is the stamp and the string at every reader - doctor's marker lock, pid.json readers, host ensure's yank check, the Overview's picker and debt mirror

### DIFF
--- a/clients/gui-app/src/components/settings/panels/__tests__/host-overview-updates.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-overview-updates.test.tsx
@@ -853,7 +853,14 @@ describe("<HostSettingsPanel /> Overview updates — version picker", () => {
         .getByRole("button", { name: "Install 1.2.0+build.2" })
         .hasAttribute("disabled"),
     ).toBe(true);
-    expect(equalRow.textContent).toContain("Already on v1.2.0+build.1");
+    // Not "already on": this host runs build.1, and the row IS another build.
+    expect(equalRow.textContent).toContain(
+      "Another build of v1.2.0+build.1 is installed.",
+    );
+    expect(equalRow.textContent).toContain(
+      "traycer host update --version 1.2.0+build.2 --allow-downgrade",
+    );
+    expect(equalRow.textContent).not.toContain("Already on");
     expect(
       within(rowFor(rows.getAllByRole("listitem"), "1.1.0"))
         .getByRole("button", { name: "Install 1.1.0" })

--- a/clients/gui-app/src/components/settings/panels/host-overview-updates-state.ts
+++ b/clients/gui-app/src/components/settings/panels/host-overview-updates-state.ts
@@ -862,7 +862,17 @@ function versionUnavailableReason(
   if (installedVersion === null || installedVersion === rowVersion) return null;
   const comparison = compareHostVersions(installedVersion, rowVersion);
   if (!comparison.comparable) return null;
-  if (comparison.ordering === "equal") return `Already on v${installedVersion}`;
+  if (comparison.ordering === "equal") {
+    // Comparable-equal but a different string: another BUILD of the installed
+    // release (`1.2.0+build.2` beside an installed `1.2.0+build.1`). The
+    // comparator is build-metadata-blind and reserved for ordering; the
+    // artifact's identity is the string, and this host is NOT on the row's
+    // version. The CLI installs such a target only as an explicit sideways
+    // move (`--allow-downgrade`), which `host.update.install` passes only on a
+    // host that knows the sideways rule - and this page cannot tell which
+    // host it has - so the row stays disabled and says how to get the build.
+    return `Another build of v${installedVersion} is installed. To install v${rowVersion} over it, run: traycer host update --version ${rowVersion} --allow-downgrade`;
+  }
   if (comparison.ordering === "greater" && !supportsDowngrade) {
     return "Update this host to a release that supports downgrades from Settings.";
   }

--- a/clients/gui-app/src/lib/host/fleet-update/__tests__/legacy-update-facts.test.ts
+++ b/clients/gui-app/src/lib/host/fleet-update/__tests__/legacy-update-facts.test.ts
@@ -150,6 +150,26 @@ describe("deriveLegacyUpdateFacts — activationDebt, no runtimeVersion (catalog
     expect(facts.activationDebt).toBeNull();
   });
 
+  it("comparator-equal but a different string (another build of the release) - debt: identity is the string, as the CLI reads it", () => {
+    const facts = deriveLegacyUpdateFacts({
+      installation: managed({ version: "1.3.0+b", runtimeVersion: null }, null),
+      runningVersion: "1.3.0+a",
+      busy: false,
+      busySessionCount: null,
+    });
+    expect(facts.activationDebt).toEqual({ installedVersion: "1.3.0+b" });
+  });
+
+  it("the same string with build metadata - no debt (control for the other-build row)", () => {
+    const facts = deriveLegacyUpdateFacts({
+      installation: managed({ version: "1.3.0+a", runtimeVersion: null }, null),
+      runningVersion: "1.3.0+a",
+      busy: false,
+      busySessionCount: null,
+    });
+    expect(facts.activationDebt).toBeNull();
+  });
+
   it("incomparable (installed is a local-file pin) - no debt", () => {
     const facts = deriveLegacyUpdateFacts({
       installation: managed(

--- a/clients/gui-app/src/lib/host/fleet-update/legacy-update-facts.ts
+++ b/clients/gui-app/src/lib/host/fleet-update/legacy-update-facts.ts
@@ -70,14 +70,18 @@ export const NO_LEGACY_UPDATE_FACTS: LegacyUpdateFacts = {
  * | `runtimeVersion` set    | equal to the stamp                              | no   |
  * | `runtimeVersion` set    | anything else (either direction, SemVer or not) | yes  |
  * | no `runtimeVersion`     | not valid SemVer (a foreign runtime)            | no   |
- * | no `runtimeVersion`     | comparable to `version` and unequal             | yes  |
- * | no `runtimeVersion`     | equal, or incomparable                          | no   |
+ * | no `runtimeVersion`     | comparable to `version` and a different string  | yes  |
+ * | no `runtimeVersion`     | the same string, or incomparable                | no   |
  * | `unmanaged` / no record | anything                                        | no   |
  *
- * The runtime-stamp domain is EQUALITY, never ordering: a staging host's stamp
- * is `staging.<epoch>.<sha>`, and a SemVer guard in front of that comparison
- * would classify every staging host as foreign. The catalog-version fallback
- * (a record with no stamp yet) keeps the CLI's release-version policy, under
+ * BOTH domains are string EQUALITY, never ordering: a staging host's stamp is
+ * `staging.<epoch>.<sha>`, and a SemVer guard in front of that comparison
+ * would classify every staging host as foreign; and in the catalog-version
+ * fallback (a record with no stamp yet) a release host publishes exactly its
+ * catalog version, so another build of the same release (`1.3.0+a` running
+ * beside a `1.3.0+b` record) is debt even though the build-metadata-blind
+ * comparator calls the pair equal - the comparator only keeps an INCOMPARABLE
+ * pair out of debt. That fallback keeps the CLI's release-version policy, under
  * which `0.0.0-dev` IS valid SemVer and a dev host beside a `1.3.0` record reads
  * as debt — the same answer the CLI gives, stated here so nobody "fixes" it on
  * one side only.
@@ -126,6 +130,12 @@ function isActivationDebt(
     return runningVersion !== installed.runtimeVersion;
   }
   if (!isValidHostVersion(runningVersion)) return false;
-  const comparison = compareHostVersions(runningVersion, installed.version);
-  return comparison.comparable && comparison.ordering !== "equal";
+  // Identity is the STRING, as the CLI's `readActivationState` reads it: a
+  // release host publishes exactly its catalog version, so a running
+  // `1.3.0+a` beside a recorded `1.3.0+b` is another build of the release,
+  // not the recorded install - debt. The comparator is build-metadata-blind
+  // and is consulted only to keep an INCOMPARABLE pair (a `local-*` pin
+  // beside a release) out of debt, never for ordering or equality.
+  if (runningVersion === installed.version) return false;
+  return compareHostVersions(runningVersion, installed.version).comparable;
 }

--- a/clients/shared/host-lock/cross-process-lock.ts
+++ b/clients/shared/host-lock/cross-process-lock.ts
@@ -637,6 +637,83 @@ export async function readLockHolder(path: string): Promise<LockHolderProbe> {
 }
 
 /**
+ * The age of a lock file by its mtime, for a READER judging whether an
+ * empty or corrupt lock is still inside {@link EMPTY_LOCK_GRACE_MS} (a holder
+ * mid-creation) or past it (a crashed holder the next acquisition
+ * age-breaks). `null` when the file cannot be stat'd. Negative when the file
+ * is dated in the future - a backward wall-clock step - and such a file is
+ * not age-breakable until its mtime plus the grace window has passed.
+ */
+export async function probeLockFileAgeMs(path: string): Promise<number | null> {
+  return lockFileAgeMs(path);
+}
+
+export { EMPTY_LOCK_GRACE_MS };
+
+/**
+ * What a READER can establish about the break-arbitration sub-lock
+ * (`<lockPath>.break`) that every stale-lock break must first take. A
+ * canonical lock that is provably stale is only RECOVERABLE if that file is
+ * free or recoverable too; a breaker that is alive, or one whose identity
+ * cannot be verified, holds the arbitration and no contender will break the
+ * stale lock behind it (`acquireBreakLock` answers busy and the contender
+ * falls back to its bounded wait).
+ *
+ * `free` covers the absent file, a crashed breaker's file (dead or recycled
+ * pid) and an empty one: `tryRecoverCrashedBreakLock` unlinks those once
+ * past {@link BREAK_LOCK_AGE_GRACE_MS}, which a contender polling inside its
+ * wait reaches on its own. `held` names the breaker when there is one. A file
+ * dated in the future is `held` with no live breaker: it is not recoverable
+ * until its mtime plus the grace window.
+ */
+export type LockBreakArbitrationProbe =
+  | { readonly kind: "free" }
+  | {
+      readonly kind: "held";
+      readonly breaker: {
+        readonly pid: number;
+        readonly startedAt: string;
+      } | null;
+      readonly cause:
+        | "breaker-live"
+        | "breaker-unverifiable"
+        | "dated-in-the-future";
+    }
+  | { readonly kind: "read-error" };
+
+export async function probeLockBreakArbitration(
+  lockPath: string,
+): Promise<LockBreakArbitrationProbe> {
+  const breakLockPath = breakLockPathFor(lockPath);
+  const read = await readLockRaw(breakLockPath);
+  if (read.kind === "absent") return { kind: "free" };
+  if (read.kind === "read-error") return { kind: "read-error" };
+  const payload = parseBreakLockPayload(read.raw);
+  const breaker =
+    payload === null
+      ? null
+      : { pid: payload.pid, startedAt: payload.startedAt };
+  if (payload !== null) {
+    const identity = verifyProcessIdentity({
+      pid: payload.pid,
+      startedAtMs: payload.processStartedAtMs,
+      startIdentity: payload.processStartIdentity,
+    });
+    if (identity === "alive-same") {
+      return { kind: "held", breaker, cause: "breaker-live" };
+    }
+    if (identity === "indeterminate") {
+      return { kind: "held", breaker, cause: "breaker-unverifiable" };
+    }
+  }
+  const ageMs = await lockFileAgeMs(breakLockPath);
+  if (ageMs !== null && ageMs < -BREAK_LOCK_AGE_GRACE_MS) {
+    return { kind: "held", breaker, cause: "dated-in-the-future" };
+  }
+  return { kind: "free" };
+}
+
+/**
  * Rewrite liveness metadata only while the canonical lock still carries the
  * expected token. This shares the stale-break arbitration lock: a contender
  * that observed a dead publisher cannot unlink/acquire between our ownership

--- a/clients/traycer-cli/src/commands/__tests__/host-status-observational.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/host-status-observational.test.ts
@@ -29,9 +29,17 @@ const mocks = vi.hoisted(() => ({
   createServiceControllerMock: vi.fn(),
 }));
 
-vi.mock("../../host/pid-metadata", () => ({
-  readHostPidMetadata: mocks.readHostPidMetadataMock,
-}));
+vi.mock("../../host/pid-metadata", async () => {
+  // Only the read is stubbed; `publishedHostProcessGone` stays real so
+  // `running` follows the (mocked) `isProcessAlive` as the command does.
+  const actual = await vi.importActual<
+    typeof import("../../host/pid-metadata")
+  >("../../host/pid-metadata");
+  return {
+    ...actual,
+    readHostPidMetadata: mocks.readHostPidMetadataMock,
+  };
+});
 
 vi.mock("../../host/bootstrap-log", () => ({
   readBootstrapMarkers: mocks.readBootstrapMarkersMock,

--- a/clients/traycer-cli/src/commands/host-status.ts
+++ b/clients/traycer-cli/src/commands/host-status.ts
@@ -6,11 +6,11 @@ import {
   type BootstrapPhase,
 } from "../host/bootstrap-log";
 import {
+  publishedHostProcessGone,
   readHostPidMetadata,
   type HostPidMetadata,
 } from "../host/pid-metadata";
 import { bootstrapLogPath } from "../store/paths";
-import { isProcessAlive } from "../store/cli-lock";
 import { makeColorizer, shouldUseColor, type Colorizer } from "../runner/ansi";
 import type { CommandFn, CommandResult } from "../runner/runner";
 import type { RuntimeContext } from "../runner/runtime";
@@ -63,12 +63,16 @@ export const hostStatusCommand: CommandFn = async (
     BOOTSTRAP_LOG_TAIL_LINES,
   );
 
+  // `running` must reflect process liveness, not merely the presence of a
+  // pid.json - a stopped/crashed host can leave a stale record behind, and a
+  // recycled pid a live-looking one; `publishedHostProcessGone` reads the
+  // record's creation stamp for the second case. (service status reads the
+  // same predicate; this keeps host status consistent and makes `host stop`
+  // observable.)
+  const running =
+    pidMetadata !== null && !publishedHostProcessGone(pidMetadata);
   const output: HostStatusOutput = {
-    // `running` must reflect process liveness, not merely the presence of a
-    // pid.json - a stopped/crashed host can leave a stale record behind.
-    // (service status already checks isProcessAlive; this keeps host
-    // status consistent and makes `host stop` observable.)
-    running: pidMetadata !== null && isProcessAlive(pidMetadata.pid),
+    running,
     pidMetadata,
     bootstrapMarkers: markers,
     bootstrapLogPath: bootstrapLogPath(ctx.runtime.environment),

--- a/clients/traycer-cli/src/commands/host-status.ts
+++ b/clients/traycer-cli/src/commands/host-status.ts
@@ -121,12 +121,16 @@ function renderHumanStatus(
     const rows: [string, string][] = [
       ["Log", tildePath(output.bootstrapLogPath)],
     ];
-    // A non-null pidMetadata with a dead pid means the host exited
-    // (e.g. after `host stop` or a crash) but its pid.json was left
-    // behind. Surface it as stale rather than silently reporting
-    // "running" off a dead record.
+    // A non-null pidMetadata in this branch means the host exited (e.g.
+    // after `host stop` or a crash) and left its pid.json behind, or the pid
+    // that record names is live and belongs to an unrelated process the OS
+    // handed the recycled number to. Surface it as stale rather than
+    // silently reporting "running" off a record that identifies no host.
     if (output.pidMetadata !== null) {
-      rows.push(["Stale pid", `${output.pidMetadata.pid} (not alive)`]);
+      rows.push([
+        "Stale pid",
+        `${output.pidMetadata.pid} (gone, or now another process)`,
+      ]);
     }
     if (last !== undefined) {
       rows.push(["Last phase", phaseLabel(last, c)]);

--- a/clients/traycer-cli/src/commands/host-update.ts
+++ b/clients/traycer-cli/src/commands/host-update.ts
@@ -1149,9 +1149,10 @@ interface ActivationDebt {
  * `activated` is the reason NOT to.
  *
  * - `no-install`: nothing to activate (the caller throws later anyway);
- * - `no-live-host`: no pid metadata, or a pid that is not alive. Before the
- *   lock this is left alone - a host that is DOWN is the service manager's
- *   problem, and `host start` re-resolves the install record on every spawn.
+ * - `no-live-host`: no pid metadata, or a record whose pid is gone - exited,
+ *   or recycled onto an unrelated process. Before the lock this is left
+ *   alone - a host that is DOWN is the service manager's problem, and
+ *   `host start` re-resolves the install record on every spawn.
  *   Under the lock, after a debt was seen, it means the host this command
  *   was about to replace is gone, which is not the same as replaced;
  * - `foreign-runtime`: a running version that is not a release version,

--- a/clients/traycer-cli/src/doctor/__tests__/engine-port-conflict.test.ts
+++ b/clients/traycer-cli/src/doctor/__tests__/engine-port-conflict.test.ts
@@ -76,13 +76,22 @@ function stageMocks(opts: {
   vi.doMock("../../host/bootstrap-log", () => ({
     readBootstrapMarkers: async () => [],
   }));
-  vi.doMock("../../host/pid-metadata", () => ({
-    readHostPidMetadata: async () => ({
-      pid: opts.hostPid,
-      version: "1.0.0",
-      websocketUrl: opts.websocketUrl,
-    }),
-  }));
+  vi.doMock("../../host/pid-metadata", async () => {
+    // Only the read is stubbed; `publishedHostProcessGone` stays real so the
+    // engine's liveness verdict follows the (mocked) `isProcessAlive` exactly
+    // as the sites under test do.
+    const actual = await vi.importActual<
+      typeof import("../../host/pid-metadata")
+    >("../../host/pid-metadata");
+    return {
+      ...actual,
+      readHostPidMetadata: async () => ({
+        pid: opts.hostPid,
+        version: "1.0.0",
+        websocketUrl: opts.websocketUrl,
+      }),
+    };
+  });
   vi.doMock("../../service", () => ({
     createServiceController: () => ({
       status: async () => ({

--- a/clients/traycer-cli/src/doctor/__tests__/engine-recent-crash.test.ts
+++ b/clients/traycer-cli/src/doctor/__tests__/engine-recent-crash.test.ts
@@ -95,6 +95,11 @@ function stageQuietHost(markers: readonly Marker[]): void {
   }));
   vi.doMock("../../store/cli-lock", () => ({
     isProcessAlive: () => false,
+    // The doctor's marker-lock probe reads through this facade too.
+    probeCliScopedFileLock: async () => ({ kind: "absent" }),
+    probeCliScopedFileLockArbitration: async () => ({ kind: "free" }),
+    cliScopedFileLockAgeMs: async () => null,
+    CLI_SCOPED_FILE_LOCK_EMPTY_GRACE_MS: 5000,
   }));
 }
 

--- a/clients/traycer-cli/src/doctor/__tests__/engine-service-stopped.test.ts
+++ b/clients/traycer-cli/src/doctor/__tests__/engine-service-stopped.test.ts
@@ -97,9 +97,17 @@ function stageServiceMocks(input: StageServiceMocksInput): void {
   // issue as the only issue in the result other than the unverified-binary
   // info (skipped because the install record's signatureKeyId is a registry
   // key).
-  vi.doMock("../../host/pid-metadata", () => ({
-    readHostPidMetadata: async () => input.pidMetadata,
-  }));
+  vi.doMock("../../host/pid-metadata", async () => {
+    // Only the read is stubbed; `publishedHostProcessGone` stays real so the
+    // engine's liveness verdict follows the (mocked) `isProcessAlive`.
+    const actual = await vi.importActual<
+      typeof import("../../host/pid-metadata")
+    >("../../host/pid-metadata");
+    return {
+      ...actual,
+      readHostPidMetadata: async () => input.pidMetadata,
+    };
+  });
   vi.doMock("../../service", () => ({
     createServiceController: () => ({
       status: async () => ({
@@ -310,6 +318,11 @@ describe("runDoctor SERVICE_STOPPED recovery routing", () => {
     });
     vi.doMock("../../store/cli-lock", () => ({
       isProcessAlive: () => false,
+      // The doctor's marker-lock probe reads through this facade too.
+      probeCliScopedFileLock: async () => ({ kind: "absent" }),
+      probeCliScopedFileLockArbitration: async () => ({ kind: "free" }),
+      cliScopedFileLockAgeMs: async () => null,
+      CLI_SCOPED_FILE_LOCK_EMPTY_GRACE_MS: 5000,
     }));
 
     const { runDoctor } = await import("../engine");

--- a/clients/traycer-cli/src/doctor/__tests__/engine-update-marker-lock.test.ts
+++ b/clients/traycer-cli/src/doctor/__tests__/engine-update-marker-lock.test.ts
@@ -1,0 +1,138 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Wiring pin: `probeUpdateMarkerLock` existing is not the same thing as
+// runDoctor consulting it. This mocks the probe module and asserts its
+// issue reaches the issue list, and that the engine hands it the marker
+// lock path of the environment it was asked about.
+
+const osHome = vi.hoisted(() => ({ current: "" }));
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:os")>();
+  return { ...actual, homedir: () => osHome.current || actual.tmpdir() };
+});
+
+const ORIGINAL_HOME = process.env.HOME;
+const ORIGINAL_USERPROFILE = process.env.USERPROFILE;
+
+let workHome: string;
+
+beforeEach(() => {
+  workHome = mkdtempSync(join(tmpdir(), "traycer-doctor-marker-lock-wiring-"));
+  osHome.current = workHome;
+  process.env.HOME = workHome;
+  process.env.USERPROFILE = workHome;
+  vi.resetModules();
+});
+
+afterEach(() => {
+  if (ORIGINAL_HOME === undefined) {
+    delete process.env.HOME;
+  } else {
+    process.env.HOME = ORIGINAL_HOME;
+  }
+  if (ORIGINAL_USERPROFILE === undefined) {
+    delete process.env.USERPROFILE;
+  } else {
+    process.env.USERPROFILE = ORIGINAL_USERPROFILE;
+  }
+  rmSync(workHome, { recursive: true, force: true });
+  vi.restoreAllMocks();
+  vi.doUnmock("../update-marker-lock");
+  vi.doUnmock("../launchd-wedge");
+  vi.doUnmock("../systemd-health");
+  vi.doUnmock("../../manifest/host-install");
+  vi.doUnmock("../../host/bootstrap-log");
+  vi.doUnmock("../../host/pid-metadata");
+  vi.doUnmock("../../service");
+});
+
+describe("runDoctor progress-marker lock wiring", () => {
+  it("surfaces the marker-lock probe's issue in the doctor result, probing the environment's lock path", async () => {
+    const hostExecutablePath = join(workHome, "bin", "host");
+    mkdirSync(join(workHome, "bin"), { recursive: true });
+    writeFileSync(hostExecutablePath, "host-bin");
+    vi.doMock("../../manifest/host-install", () => ({
+      readHostInstallRecord: () => ({
+        version: "1.4.0",
+        environment: "production",
+        executablePath: hostExecutablePath,
+        installedAt: "2026-04-01T00:00:00Z",
+        source: "registry",
+        archiveSha256: "f".repeat(64),
+        signatureKeyId: "registry:prod-2026",
+      }),
+    }));
+    vi.doMock("../../host/bootstrap-log", () => ({
+      readBootstrapMarkers: async () => [],
+    }));
+    vi.doMock("../../host/pid-metadata", () => ({
+      readHostPidMetadata: async () => null,
+    }));
+    vi.doMock("../../service", () => ({
+      createServiceController: () => ({
+        status: async () => ({
+          state: "externally-managed",
+          version: "1.4.0",
+          listenUrl: null,
+          pid: null,
+        }),
+        install: async () => undefined,
+        uninstall: async () => undefined,
+        start: async () => undefined,
+        stop: async () => undefined,
+        restart: async () => undefined,
+      }),
+      serviceLabelFor: (environment: string) => ({
+        id: `ai.traycer.host.${environment}`,
+      }),
+    }));
+    vi.doMock("../launchd-wedge", () => ({
+      createRealLaunchdPrintRunner: () => async () => {
+        throw new Error("real runner must not be invoked in this test");
+      },
+      probeMacosWedgedJob: async () => null,
+    }));
+    vi.doMock("../systemd-health", () => ({
+      createRealSystemdProbeRunner: () => async () => {
+        throw new Error("real runner must not be invoked in this test");
+      },
+      probeLinuxSystemdHealth: async () => [],
+    }));
+    const probeCalls: { lockPath: string }[] = [];
+    vi.doMock("../update-marker-lock", () => ({
+      MARKER_LOCK_RECHECK_DELAY_MS: 250,
+      probeUpdateMarkerLock: async (opts: { lockPath: string }) => {
+        probeCalls.push({ lockPath: opts.lockPath });
+        return {
+          code: "HOST_UPDATE_MARKER_LOCK_HELD",
+          severity: "warning",
+          title: "stubbed marker lock issue",
+          message: "stubbed marker lock issue",
+          fixAction: null,
+          terminalCommand: null,
+          details: { lockPath: opts.lockPath },
+        };
+      },
+    }));
+
+    const { runDoctor } = await import("../engine");
+    const { hostUpdateProgressMarkerLockPath } =
+      await import("../../store/paths");
+    const result = await runDoctor({
+      environment: "production",
+      portConflictDeps: null,
+    });
+
+    const issue = result.issues.find(
+      (i) => i.code === "HOST_UPDATE_MARKER_LOCK_HELD",
+    );
+    expect(issue).toBeDefined();
+    expect(issue?.severity).toBe("warning");
+    expect(probeCalls).toEqual([
+      { lockPath: hostUpdateProgressMarkerLockPath("production") },
+    ]);
+  });
+});

--- a/clients/traycer-cli/src/doctor/__tests__/update-marker-lock.test.ts
+++ b/clients/traycer-cli/src/doctor/__tests__/update-marker-lock.test.ts
@@ -1,0 +1,430 @@
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  unlinkSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  __acquireCliLockAtPathForTest,
+  isProcessAlive,
+  type CliLockHandle,
+} from "../../store/cli-lock";
+import { ownProcessStartIdentity } from "../../store/process-identity";
+import { DOCTOR_ISSUE_CODES } from "../issues";
+import {
+  MARKER_LOCK_RECHECK_DELAY_MS,
+  probeUpdateMarkerLock,
+} from "../update-marker-lock";
+
+// The probe against real lock files at a temp path: a lock this process
+// holds through the real facade, lock files written by hand with a holder
+// that has exited, one whose holder cannot be verified, one whose pid was
+// recycled, a hold that ends between the two reads, the break-arbitration
+// file behind a stale lock in each of its states, empty files on either
+// side of the grace window and dated in the future, and unreadable paths.
+// No `~/.traycer` is touched - the path is the probe's only input.
+
+let workDir: string;
+let lockPath: string;
+let breakPath: string;
+let held: CliLockHandle | null = null;
+
+const NO_DELAY = async (): Promise<void> => undefined;
+
+beforeEach(() => {
+  workDir = mkdtempSync(join(tmpdir(), "traycer-doctor-marker-lock-"));
+  lockPath = join(workDir, "update-progress.json.lock");
+  breakPath = `${lockPath}.break`;
+});
+
+afterEach(async () => {
+  if (held !== null) {
+    await held.release();
+    held = null;
+  }
+  // The non-writable-directory case leaves the directory 0555.
+  chmodSync(workDir, 0o755);
+  rmSync(workDir, { recursive: true, force: true });
+});
+
+// Root ignores directory write bits, and Windows has no mode bits to flip.
+const CAN_DENY_DIRECTORY_WRITE =
+  process.platform !== "win32" && process.getuid?.() !== 0;
+
+function findDeadPid(): number {
+  for (let attempt = 0; attempt < 5; attempt++) {
+    const result = spawnSync(process.execPath, ["-e", "0"]);
+    if (result.pid !== undefined && !isProcessAlive(result.pid)) {
+      return result.pid;
+    }
+  }
+  throw new Error("could not obtain a dead pid");
+}
+
+// A well-formed creation stamp of THIS platform that no process has - the
+// only way to model a recycled pid from inside one process.
+function foreignStamp(): string | null {
+  const own = ownProcessStartIdentity();
+  if (own === null) return null;
+  return `${own.slice(0, own.indexOf(":"))}:not the holder of this lock 1`;
+}
+
+function writeLock(fields: {
+  readonly pid: number;
+  readonly processStartIdentity: string | null;
+}): void {
+  writeFileSync(
+    lockPath,
+    JSON.stringify({
+      pid: fields.pid,
+      reason: "host-update-progress-marker-create",
+      startedAt: "2026-09-06T22:00:00.000Z",
+      hostname: null,
+      token: "test-token",
+      processStartedAtMs: null,
+      processStartIdentity: fields.processStartIdentity,
+    }),
+  );
+}
+
+function writeBreak(fields: {
+  readonly pid: number;
+  readonly processStartIdentity: string | null;
+}): void {
+  writeFileSync(
+    breakPath,
+    JSON.stringify({
+      pid: fields.pid,
+      startedAt: "2026-09-06T22:00:00.500Z",
+      processStartedAtMs: null,
+      processStartIdentity: fields.processStartIdentity,
+      token: "break-token",
+    }),
+  );
+}
+
+function ageFile(path: string, secondsAgo: number): void {
+  const when = new Date(Date.now() - secondsAgo * 1000);
+  utimesSync(path, when, when);
+}
+
+describe("probeUpdateMarkerLock", () => {
+  it("says nothing when there is no lock file", async () => {
+    await expect(
+      probeUpdateMarkerLock({ lockPath, delay: NO_DELAY }),
+    ).resolves.toBeNull();
+  });
+
+  it("reports a lock this process holds across both reads, and nothing once it is released", async () => {
+    held = await __acquireCliLockAtPathForTest(lockPath, {
+      reason: "host-update-progress-marker-create",
+      waitMs: 0,
+      pollIntervalMs: 10,
+    });
+    const delays: number[] = [];
+    const issue = await probeUpdateMarkerLock({
+      lockPath,
+      delay: async (ms) => {
+        delays.push(ms);
+      },
+    });
+    expect(issue?.code).toBe(DOCTOR_ISSUE_CODES.HOST_UPDATE_MARKER_LOCK_HELD);
+    expect(issue?.severity).toBe("warning");
+    expect(issue?.message).toContain(`pid ${String(process.pid)}`);
+    expect(issue?.message).toContain(lockPath);
+    expect(issue?.message).toContain("still running");
+    expect(issue?.details).toMatchObject({
+      lockPath,
+      liveness: "alive-same",
+      holder: { pid: process.pid },
+    });
+    expect(delays).toEqual([MARKER_LOCK_RECHECK_DELAY_MS]);
+
+    await held.release();
+    held = null;
+    await expect(
+      probeUpdateMarkerLock({ lockPath, delay: NO_DELAY }),
+    ).resolves.toBeNull();
+  });
+
+  it("says nothing for a holder that has exited when the arbitration is free - the next acquisition breaks it", async () => {
+    writeLock({ pid: findDeadPid(), processStartIdentity: null });
+    await expect(
+      probeUpdateMarkerLock({ lockPath, delay: NO_DELAY }),
+    ).resolves.toBeNull();
+  });
+
+  it("reports a live holder whose identity cannot be verified - the one lock no acquisition will ever break", async () => {
+    writeLock({ pid: process.pid, processStartIdentity: null });
+    const issue = await probeUpdateMarkerLock({ lockPath, delay: NO_DELAY });
+    expect(issue?.code).toBe(DOCTOR_ISSUE_CODES.HOST_UPDATE_MARKER_LOCK_HELD);
+    expect(issue?.title).toContain("unverifiable");
+    expect(issue?.message).toContain("remove the file");
+    expect(issue?.details).toMatchObject({ liveness: "indeterminate" });
+  });
+
+  it("says nothing for a live pid that is not the holder (recycled pid) when the arbitration is free", async () => {
+    const stamp = foreignStamp();
+    if (stamp === null) return;
+    writeLock({ pid: process.pid, processStartIdentity: stamp });
+    await expect(
+      probeUpdateMarkerLock({ lockPath, delay: NO_DELAY }),
+    ).resolves.toBeNull();
+  });
+
+  it("says nothing for a hold that ends between the two reads - a writer in flight", async () => {
+    writeLock({
+      pid: process.pid,
+      processStartIdentity: ownProcessStartIdentity(),
+    });
+    const issue = await probeUpdateMarkerLock({
+      lockPath,
+      delay: async () => {
+        unlinkSync(lockPath);
+      },
+    });
+    expect(issue).toBeNull();
+  });
+
+  it("says nothing for a lock re-taken by another holder between the reads", async () => {
+    const own = ownProcessStartIdentity();
+    writeLock({ pid: process.pid, processStartIdentity: own });
+    const issue = await probeUpdateMarkerLock({
+      lockPath,
+      delay: async () => {
+        writeFileSync(
+          lockPath,
+          JSON.stringify({
+            pid: process.pid,
+            reason: "host-update-progress-marker-clear",
+            startedAt: "2026-09-06T22:00:01.000Z",
+            hostname: null,
+            token: "another-token",
+            processStartedAtMs: null,
+            processStartIdentity: own,
+          }),
+        );
+      },
+    });
+    expect(issue).toBeNull();
+  });
+
+  it("says nothing for a lock that only arrives on the second read", async () => {
+    writeFileSync(lockPath, "");
+    const issue = await probeUpdateMarkerLock({
+      lockPath,
+      delay: async () => {
+        writeLock({
+          pid: process.pid,
+          processStartIdentity: ownProcessStartIdentity(),
+        });
+      },
+    });
+    expect(issue).toBeNull();
+  });
+
+  it("says nothing for a fresh empty lock file - a holder mid-create", async () => {
+    writeFileSync(lockPath, "");
+    await expect(
+      probeUpdateMarkerLock({ lockPath, delay: NO_DELAY }),
+    ).resolves.toBeNull();
+  });
+
+  it("says nothing for an empty lock file past the grace window when the arbitration is free - the next acquisition age-breaks it", async () => {
+    writeFileSync(lockPath, "");
+    ageFile(lockPath, 30);
+    await expect(
+      probeUpdateMarkerLock({ lockPath, delay: NO_DELAY }),
+    ).resolves.toBeNull();
+  });
+
+  it("reports an empty lock file dated in the future - not age-breakable until that time", async () => {
+    writeFileSync(lockPath, "");
+    ageFile(lockPath, -120);
+    const issue = await probeUpdateMarkerLock({ lockPath, delay: NO_DELAY });
+    expect(issue?.code).toBe(
+      DOCTOR_ISSUE_CODES.HOST_UPDATE_MARKER_LOCK_UNBREAKABLE,
+    );
+    expect(issue?.title).toContain("dated in the future");
+    expect(issue?.message).toContain("in the future");
+  });
+
+  describe("a stale lock behind a wedged break arbitration", () => {
+    it("reports a stale (exited-holder) lock whose break file is held by a running breaker", async () => {
+      writeLock({ pid: findDeadPid(), processStartIdentity: null });
+      writeBreak({
+        pid: process.pid,
+        processStartIdentity: ownProcessStartIdentity(),
+      });
+      const issue = await probeUpdateMarkerLock({ lockPath, delay: NO_DELAY });
+      expect(issue?.code).toBe(
+        DOCTOR_ISSUE_CODES.HOST_UPDATE_MARKER_LOCK_UNBREAKABLE,
+      );
+      expect(issue?.message).toContain(breakPath);
+      expect(issue?.message).toContain(`pid ${String(process.pid)}`);
+      expect(issue?.message).toContain("still running");
+      expect(issue?.details).toMatchObject({
+        breakPath,
+        cause: "breaker-live",
+        breaker: { pid: process.pid },
+      });
+    });
+
+    it("reports a stale lock whose break file is held by an unverifiable breaker", async () => {
+      writeLock({ pid: findDeadPid(), processStartIdentity: null });
+      writeBreak({ pid: process.pid, processStartIdentity: null });
+      const issue = await probeUpdateMarkerLock({ lockPath, delay: NO_DELAY });
+      expect(issue?.code).toBe(
+        DOCTOR_ISSUE_CODES.HOST_UPDATE_MARKER_LOCK_UNBREAKABLE,
+      );
+      expect(issue?.details).toMatchObject({ cause: "breaker-unverifiable" });
+    });
+
+    it("reports a stale (recycled-pid) lock behind a live breaker too", async () => {
+      const stamp = foreignStamp();
+      if (stamp === null) return;
+      writeLock({ pid: process.pid, processStartIdentity: stamp });
+      writeBreak({
+        pid: process.pid,
+        processStartIdentity: ownProcessStartIdentity(),
+      });
+      const issue = await probeUpdateMarkerLock({ lockPath, delay: NO_DELAY });
+      expect(issue?.code).toBe(
+        DOCTOR_ISSUE_CODES.HOST_UPDATE_MARKER_LOCK_UNBREAKABLE,
+      );
+      expect(issue?.message).toContain("belongs to another process");
+    });
+
+    it("reports an aged empty lock behind a live breaker", async () => {
+      writeFileSync(lockPath, "");
+      ageFile(lockPath, 30);
+      writeBreak({
+        pid: process.pid,
+        processStartIdentity: ownProcessStartIdentity(),
+      });
+      const issue = await probeUpdateMarkerLock({ lockPath, delay: NO_DELAY });
+      expect(issue?.code).toBe(
+        DOCTOR_ISSUE_CODES.HOST_UPDATE_MARKER_LOCK_UNBREAKABLE,
+      );
+      expect(issue?.message).toContain("empty or corrupt file");
+    });
+
+    it("says nothing when the break file was left by a crashed breaker past its grace - the next contender recovers it", async () => {
+      writeLock({ pid: findDeadPid(), processStartIdentity: null });
+      writeBreak({ pid: findDeadPid(), processStartIdentity: null });
+      ageFile(breakPath, 30);
+      await expect(
+        probeUpdateMarkerLock({ lockPath, delay: NO_DELAY }),
+      ).resolves.toBeNull();
+    });
+
+    it("says nothing when the break file was left by a crashed breaker moments ago - recovered within the contender's own wait", async () => {
+      writeLock({ pid: findDeadPid(), processStartIdentity: null });
+      writeBreak({ pid: findDeadPid(), processStartIdentity: null });
+      await expect(
+        probeUpdateMarkerLock({ lockPath, delay: NO_DELAY }),
+      ).resolves.toBeNull();
+    });
+
+    it("says nothing when the break file is empty and past its grace", async () => {
+      writeLock({ pid: findDeadPid(), processStartIdentity: null });
+      writeFileSync(breakPath, "");
+      ageFile(breakPath, 30);
+      await expect(
+        probeUpdateMarkerLock({ lockPath, delay: NO_DELAY }),
+      ).resolves.toBeNull();
+    });
+
+    it("reports a break file dated in the future", async () => {
+      writeLock({ pid: findDeadPid(), processStartIdentity: null });
+      writeBreak({ pid: findDeadPid(), processStartIdentity: null });
+      ageFile(breakPath, -120);
+      const issue = await probeUpdateMarkerLock({ lockPath, delay: NO_DELAY });
+      expect(issue?.code).toBe(
+        DOCTOR_ISSUE_CODES.HOST_UPDATE_MARKER_LOCK_UNBREAKABLE,
+      );
+      expect(issue?.details).toMatchObject({ cause: "dated-in-the-future" });
+    });
+
+    it("reports a break file that cannot be read", async () => {
+      writeLock({ pid: findDeadPid(), processStartIdentity: null });
+      mkdirSync(breakPath);
+      const issue = await probeUpdateMarkerLock({ lockPath, delay: NO_DELAY });
+      expect(issue?.code).toBe(
+        DOCTOR_ISSUE_CODES.HOST_UPDATE_MARKER_LOCK_UNREADABLE,
+      );
+      expect(issue?.title).toContain("break-arbitration");
+      expect(issue?.details).toEqual({ lockPath, breakPath });
+    });
+  });
+
+  describe.skipIf(!CAN_DENY_DIRECTORY_WRITE)(
+    "a stale lock in a directory this user cannot write",
+    () => {
+      it("reports an exited-holder lock whose directory cannot be unlinked from, even with the arbitration free", async () => {
+        writeLock({ pid: findDeadPid(), processStartIdentity: null });
+        chmodSync(workDir, 0o555);
+        const issue = await probeUpdateMarkerLock({
+          lockPath,
+          delay: NO_DELAY,
+        });
+        expect(issue?.code).toBe(
+          DOCTOR_ISSUE_CODES.HOST_UPDATE_MARKER_LOCK_UNBREAKABLE,
+        );
+        expect(issue?.title).toContain("not writable");
+        expect(issue?.message).toContain(workDir);
+        expect(issue?.details).toMatchObject({
+          cause: "directory-not-writable",
+          directory: workDir,
+        });
+      });
+
+      it("reports an aged empty lock the same way", async () => {
+        writeFileSync(lockPath, "");
+        ageFile(lockPath, 30);
+        chmodSync(workDir, 0o555);
+        const issue = await probeUpdateMarkerLock({
+          lockPath,
+          delay: NO_DELAY,
+        });
+        expect(issue?.code).toBe(
+          DOCTOR_ISSUE_CODES.HOST_UPDATE_MARKER_LOCK_UNBREAKABLE,
+        );
+        expect(issue?.details).toMatchObject({
+          cause: "directory-not-writable",
+        });
+      });
+
+      it("stays silent for a LIVE holder's directory permissions - that lock is released by its holder, not unlinked", async () => {
+        writeLock({
+          pid: process.pid,
+          processStartIdentity: ownProcessStartIdentity(),
+        });
+        chmodSync(workDir, 0o555);
+        const issue = await probeUpdateMarkerLock({
+          lockPath,
+          delay: NO_DELAY,
+        });
+        expect(issue?.code).toBe(
+          DOCTOR_ISSUE_CODES.HOST_UPDATE_MARKER_LOCK_HELD,
+        );
+      });
+    },
+  );
+
+  it("reports a lock path that exists but cannot be read", async () => {
+    mkdirSync(lockPath);
+    const issue = await probeUpdateMarkerLock({ lockPath, delay: NO_DELAY });
+    expect(issue?.code).toBe(
+      DOCTOR_ISSUE_CODES.HOST_UPDATE_MARKER_LOCK_UNREADABLE,
+    );
+    expect(issue?.details).toEqual({ lockPath, breakPath: null });
+  });
+});

--- a/clients/traycer-cli/src/doctor/__tests__/update-marker-lock.test.ts
+++ b/clients/traycer-cli/src/doctor/__tests__/update-marker-lock.test.ts
@@ -351,6 +351,29 @@ describe("probeUpdateMarkerLock", () => {
         DOCTOR_ISSUE_CODES.HOST_UPDATE_MARKER_LOCK_UNBREAKABLE,
       );
       expect(issue?.details).toMatchObject({ cause: "dated-in-the-future" });
+      expect(issue?.message).toContain("written by pid ");
+    });
+
+    it("names no breaker for a future-dated break file whose payload does not parse", async () => {
+      // The future-dated cause is decided by the file's MTIME, so it is
+      // reached with an empty or corrupt payload too - where a message that
+      // always names a breaker prints the "could not be parsed" placeholder
+      // as if it were one.
+      writeLock({ pid: findDeadPid(), processStartIdentity: null });
+      writeFileSync(breakPath, "{not json");
+      ageFile(breakPath, -120);
+      const issue = await probeUpdateMarkerLock({ lockPath, delay: NO_DELAY });
+      expect(issue?.code).toBe(
+        DOCTOR_ISSUE_CODES.HOST_UPDATE_MARKER_LOCK_UNBREAKABLE,
+      );
+      expect(issue?.details).toMatchObject({
+        cause: "dated-in-the-future",
+        breaker: null,
+      });
+      expect(issue?.message).toContain(
+        "is dated in the future and will not be recovered",
+      );
+      expect(issue?.message).not.toContain("could not be parsed");
     });
 
     it("reports a break file that cannot be read", async () => {

--- a/clients/traycer-cli/src/doctor/engine.ts
+++ b/clients/traycer-cli/src/doctor/engine.ts
@@ -17,6 +17,7 @@ import {
   hostDevIdentityPoolRoot,
   hostIdentityNeedsReauthPath,
   hostNeedsReauthPath,
+  hostUpdateProgressMarkerLockPath,
 } from "../store/paths";
 import {
   pendingUpgradeFinalisable,
@@ -33,6 +34,7 @@ import {
 } from "../host/bootstrap-log";
 import { isFatalSignal } from "../host/crash-diagnostics";
 import {
+  publishedHostProcessGone,
   readHostPidMetadata,
   type HostLayer0Record,
   type HostPidMetadata,
@@ -58,6 +60,7 @@ import {
 import { readCliFeedCompatibilityEpoch } from "../registry/cli-versions";
 import type { IncompatibilityUpgradeGuidance } from "@traycer/protocol/framework/index";
 import type { Environment } from "../runner/environment";
+import { probeUpdateMarkerLock } from "./update-marker-lock";
 import { CliError } from "../runner/errors";
 import {
   createServiceController,
@@ -73,7 +76,6 @@ import {
   createRealSystemdProbeRunner,
   probeLinuxSystemdHealth,
 } from "./systemd-health";
-import { isProcessAlive } from "../store/cli-lock";
 import {
   DOCTOR_ISSUE_CODES,
   type DoctorIssue,
@@ -265,8 +267,12 @@ export async function runDoctor(opts: RunDoctorOptions): Promise<DoctorResult> {
   // carries the repair that actually works there.
   const isExternallyManaged = serviceStatus?.state === "externally-managed";
   const pidMetadata = await readHostPidMetadata(opts.environment);
+  // Liveness AND identity: a crashed host's pid recycled onto an unrelated
+  // process is "alive" to a signal probe and would otherwise pass every
+  // pid-keyed check below as the host, including the port-conflict path's
+  // "that pid is the host, not a conflict" exclusion.
   const hostProcessAlive =
-    pidMetadata !== null && isProcessAlive(pidMetadata.pid);
+    pidMetadata !== null && !publishedHostProcessGone(pidMetadata);
   if (!hostProcessAlive && stoppedServiceIssue !== null) {
     issues.push(stoppedServiceIssue);
   }
@@ -288,7 +294,7 @@ export async function runDoctor(opts: RunDoctorOptions): Promise<DoctorResult> {
       code: DOCTOR_ISSUE_CODES.PID_METADATA_STALE,
       severity: "warning",
       title: "Stale host pid metadata",
-      message: `pid.json references pid=${pidMetadata.pid} which is no longer alive.`,
+      message: `pid.json references pid=${pidMetadata.pid} which is no longer alive, or now belongs to an unrelated process.`,
       fixAction: "host-restart",
       terminalCommand: `traycer host restart`,
       details: { pid: pidMetadata.pid, version: pidMetadata.version },
@@ -800,6 +806,19 @@ export async function runDoctor(opts: RunDoctorOptions): Promise<DoctorResult> {
     hostProcessAlive,
   );
   if (identityIssue !== null) issues.push(identityIssue);
+
+  // ---- 4e. Host update progress-marker lock ----
+  // `host update` takes a short lock beside its progress marker for every
+  // conditional write and answers `failed` for a write it could not make
+  // after a bounded wait. A holder that stays - a hung updater, or a lock
+  // whose holder cannot be verified and so is never broken - fails the
+  // marker step of every later update with nothing on disk that says why
+  // but the lock file itself. Read-only: doctor never breaks it.
+  const markerLockIssue = await probeUpdateMarkerLock({
+    lockPath: hostUpdateProgressMarkerLockPath(opts.environment),
+    delay: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+  });
+  if (markerLockIssue !== null) issues.push(markerLockIssue);
 
   // ---- 5. Windows credentials ACL ----
   // Windows ignores POSIX mode bits on the credentials file. On a

--- a/clients/traycer-cli/src/doctor/issues.ts
+++ b/clients/traycer-cli/src/doctor/issues.ts
@@ -191,6 +191,30 @@ export const DOCTOR_ISSUE_CODES = {
   // verdict for every code in this group, silence included). It is a caption
   // on the report's coverage, not a fault.
   HOST_IDENTITY_HOME_UNVERIFIED: "HOST_IDENTITY_HOME_UNVERIFIED",
+  // The lock `traycer host update` takes beside its progress marker for each
+  // conditional write (`<host home>/update-progress.json.lock`) is held past
+  // the milliseconds such a write takes, by a holder that is still running
+  // or one whose identity cannot be verified and so is never broken. Every
+  // later update then answers `failed` on its marker step after a bounded
+  // wait, with nothing on disk that says why but the lock file itself.
+  //
+  // Warning, not error: the host is not known to be broken, and a stale
+  // lock left by a holder that has EXITED is not reported at all - the next
+  // acquisition breaks it on positive evidence, so it is not a fault.
+  HOST_UPDATE_MARKER_LOCK_HELD: "HOST_UPDATE_MARKER_LOCK_HELD",
+  // The marker lock IS stale - its holder has exited or its pid was recycled,
+  // or it is an empty file past the grace window - but the next acquisition
+  // cannot break it: the break-arbitration file beside it (`<lock>.break`)
+  // is held by a breaker that is alive or cannot be verified, or is dated in
+  // the future. Every marker operation then exhausts its bounded wait for as
+  // long as that file stays. Distinct from HELD because the remedy is the
+  // OTHER file.
+  HOST_UPDATE_MARKER_LOCK_UNBREAKABLE: "HOST_UPDATE_MARKER_LOCK_UNBREAKABLE",
+  // The marker lock file exists and cannot be read (a permission or I/O
+  // error, not a missing file). Its own code because the two states have
+  // different remedies: a held lock has a holder to stop; an unreadable one
+  // has a file to inspect.
+  HOST_UPDATE_MARKER_LOCK_UNREADABLE: "HOST_UPDATE_MARKER_LOCK_UNREADABLE",
 } as const;
 
 export type DoctorIssueCode =

--- a/clients/traycer-cli/src/doctor/update-marker-lock.ts
+++ b/clients/traycer-cli/src/doctor/update-marker-lock.ts
@@ -201,12 +201,18 @@ function unbreakableIssue(
     arbitration.breaker === null
       ? "a breaker record that could not be parsed"
       : `pid ${String(arbitration.breaker.pid)} (since ${arbitration.breaker.startedAt})`;
+  // The future-dated cause is decided by the file's mtime, so it is reached
+  // with an unparseable payload too - where naming a "breaker" would print
+  // the placeholder above as if it were one. Only the two holder causes have
+  // a breaker by construction.
   const why =
     arbitration.cause === "breaker-live"
       ? `is held by ${breaker}, which is still running`
       : arbitration.cause === "breaker-unverifiable"
         ? `is held by ${breaker}, whose identity cannot be verified, so no contender will recover it`
-        : `is dated in the future (${breaker}) and will not be recovered until that time has passed`;
+        : arbitration.breaker === null
+          ? "is dated in the future and will not be recovered until that time has passed"
+          : `is dated in the future (written by ${breaker}) and will not be recovered until that time has passed`;
   return {
     code: DOCTOR_ISSUE_CODES.HOST_UPDATE_MARKER_LOCK_UNBREAKABLE,
     severity: "warning",

--- a/clients/traycer-cli/src/doctor/update-marker-lock.ts
+++ b/clients/traycer-cli/src/doctor/update-marker-lock.ts
@@ -1,0 +1,261 @@
+import { constants as fsConstants } from "node:fs";
+import { access } from "node:fs/promises";
+import { dirname } from "node:path";
+import {
+  CLI_SCOPED_FILE_LOCK_EMPTY_GRACE_MS,
+  cliScopedFileLockAgeMs,
+  probeCliScopedFileLock,
+  probeCliScopedFileLockArbitration,
+  type CliLockMetadata,
+  type CliScopedFileLockArbitration,
+} from "../store/cli-lock";
+import { DOCTOR_ISSUE_CODES, type DoctorIssue } from "./issues";
+
+// The progress-marker lock as a doctor probe. `host update` takes a short
+// cross-process lock beside `update-progress.json` around each conditional
+// write of the marker (create / replace / clear), waits a bounded time for
+// it, and answers `failed` for a write it could not make. The lock is held
+// for one write - milliseconds, never across a download or a wait - so a
+// holder that is still there on a second read is not a writer in flight:
+// it is a hung updater, or a lock whose holder cannot be verified and so is
+// never broken by the acquisition path. Either way every later update's
+// marker step fails, and the only artifact that explains it is this file.
+//
+// A STALE lock is not a fault by itself: a holder that has exited, a pid
+// that was recycled, and an empty file past its grace window are all broken
+// by the next acquisition on that evidence. What makes a stale lock a fault
+// is a break-arbitration file (`<lock>.break`) that the acquisition cannot
+// get past - a breaker that is alive or unverifiable, or a file dated in the
+// future - so the probe reads that file too before it stays silent.
+//
+// Read-only. Doctor never breaks or removes either file: the acquisition
+// path owns that, under its own arbitration, and only on positive evidence.
+
+/**
+ * How long the holder must still be there on the second read. Far above a
+ * conditional write's hold time (a rename and a `link` / `wx` create), far
+ * below the writer's own 2 s bounded wait.
+ */
+export const MARKER_LOCK_RECHECK_DELAY_MS = 250;
+
+export interface ProbeUpdateMarkerLockOptions {
+  /** `hostUpdateProgressMarkerLockPath(environment)` - the file the writer locks. */
+  readonly lockPath: string;
+  /** Injected so a test does not sleep; the engine passes a real timer. */
+  readonly delay: (ms: number) => Promise<void>;
+}
+
+/**
+ * `null` when there is nothing to say: no lock; a lock that was gone,
+ * re-taken, or only just taken by the second read (a writer in flight); an
+ * empty or corrupt file inside its grace window; or a stale lock the next
+ * acquisition will break. An issue for a holder that is still running or
+ * cannot be verified, for a stale lock whose break arbitration is wedged,
+ * and for a file that cannot be read.
+ */
+export async function probeUpdateMarkerLock(
+  opts: ProbeUpdateMarkerLockOptions,
+): Promise<DoctorIssue | null> {
+  const first = await probeCliScopedFileLock(opts.lockPath);
+  if (first.kind === "absent") return null;
+  if (first.kind === "read-error") return unreadableIssue(opts.lockPath, null);
+  await opts.delay(MARKER_LOCK_RECHECK_DELAY_MS);
+  const second = await probeCliScopedFileLock(opts.lockPath);
+  if (second.kind === "absent") return null;
+  if (second.kind === "read-error") return unreadableIssue(opts.lockPath, null);
+
+  if (second.kind === "held") {
+    // Arrived, or released and re-taken, between the reads: a moving lock.
+    if (
+      first.kind !== "held" ||
+      first.holder.pid !== second.holder.pid ||
+      first.holder.token !== second.holder.token
+    ) {
+      return null;
+    }
+    switch (second.liveness) {
+      case "alive-same":
+        return heldIssue(opts.lockPath, second.holder, "live");
+      case "indeterminate":
+        return heldIssue(opts.lockPath, second.holder, "unverifiable");
+      case "dead":
+      case "alive-different":
+        return staleLockIssue(opts.lockPath, second.holder);
+    }
+  }
+
+  // Empty or corrupt on the second read. A holder mid-creation produces
+  // exactly these bytes, so only a file past the acquisition path's grace
+  // window is stale - and one dated in the future is not age-breakable at
+  // all until that date plus the window.
+  const ageMs = await cliScopedFileLockAgeMs(opts.lockPath);
+  if (ageMs === null) return null;
+  if (ageMs < -CLI_SCOPED_FILE_LOCK_EMPTY_GRACE_MS) {
+    return futureDatedIssue(opts.lockPath, ageMs);
+  }
+  if (ageMs < CLI_SCOPED_FILE_LOCK_EMPTY_GRACE_MS) return null;
+  return staleLockIssue(opts.lockPath, null);
+}
+
+/**
+ * A stale canonical lock is silent unless the arbitration behind it is
+ * wedged - then the next acquisition cannot break it, however stale.
+ */
+async function staleLockIssue(
+  lockPath: string,
+  holder: CliLockMetadata | null,
+): Promise<DoctorIssue | null> {
+  const arbitration = await probeCliScopedFileLockArbitration(lockPath);
+  if (arbitration.kind === "read-error") {
+    return unreadableIssue(lockPath, `${lockPath}.break`);
+  }
+  if (arbitration.kind === "held") {
+    return unbreakableIssue(lockPath, holder, arbitration);
+  }
+  // A free arbitration is necessary, not sufficient: breaking a stale lock
+  // unlinks it, and taking the arbitration creates a file beside it, and
+  // neither is possible in a directory this user cannot write. The negative
+  // is asserted outright (a non-writable directory definitely cannot be
+  // unlinked from); the positive is not a promise about every sticky bit or
+  // ACL, only the absence of this one concrete cause.
+  const dir = dirname(lockPath);
+  const writable = await access(dir, fsConstants.W_OK).then(
+    () => true,
+    () => false,
+  );
+  return writable ? null : directoryNotWritableIssue(lockPath, holder, dir);
+}
+
+function directoryNotWritableIssue(
+  lockPath: string,
+  holder: CliLockMetadata | null,
+  dir: string,
+): DoctorIssue {
+  const stale =
+    holder === null
+      ? `an empty or corrupt file past the ${String(CLI_SCOPED_FILE_LOCK_EMPTY_GRACE_MS)} ms grace window`
+      : `left by ${describeHolder(holder)}, which has exited or whose pid now belongs to another process`;
+  return {
+    code: DOCTOR_ISSUE_CODES.HOST_UPDATE_MARKER_LOCK_UNBREAKABLE,
+    severity: "warning",
+    title:
+      "Host update progress-marker lock is stale but its directory is not writable",
+    message: `The host update progress-marker lock at ${lockPath} is stale (${stale}), but its directory ${dir} is not writable by this user, so no update can unlink the stale lock or create the break-arbitration file beside it. ${CONSEQUENCE} Restore write access to ${dir} for the user that runs 'traycer host update'; the stale lock is then broken by the next update on its own.`,
+    fixAction: null,
+    terminalCommand: null,
+    details: {
+      lockPath,
+      holder,
+      directory: dir,
+      cause: "directory-not-writable",
+    },
+  };
+}
+
+function describeHolder(holder: CliLockMetadata): string {
+  return `pid ${String(holder.pid)} (${holder.reason}, since ${holder.startedAt})`;
+}
+
+const CONSEQUENCE =
+  "While it stays, 'traycer host update' cannot publish, update or clear its progress marker and reports that step as failed after a short wait.";
+
+function heldIssue(
+  lockPath: string,
+  holder: CliLockMetadata,
+  liveness: "live" | "unverifiable",
+): DoctorIssue {
+  const who = describeHolder(holder);
+  const message =
+    liveness === "live"
+      ? `The host update progress-marker lock at ${lockPath} is held by ${who}, still running across two reads ${String(MARKER_LOCK_RECHECK_DELAY_MS)} ms apart; it guards one write and is normally held for milliseconds. ${CONSEQUENCE} If that process is a hung updater, stop it - the lock is released with the process.`
+      : `The host update progress-marker lock at ${lockPath} is held by ${who}, whose identity cannot be verified (no creation stamp in the lock, or a probe this platform could not answer), so no update will break it. ${CONSEQUENCE} If no updater is running, remove the file.`;
+  return {
+    code: DOCTOR_ISSUE_CODES.HOST_UPDATE_MARKER_LOCK_HELD,
+    severity: "warning",
+    title:
+      liveness === "live"
+        ? "Host update progress-marker lock is held by a running process"
+        : "Host update progress-marker lock is held by an unverifiable holder",
+    message,
+    fixAction: null,
+    terminalCommand: null,
+    details: {
+      lockPath,
+      holder,
+      liveness: liveness === "live" ? "alive-same" : "indeterminate",
+    },
+  };
+}
+
+function unbreakableIssue(
+  lockPath: string,
+  holder: CliLockMetadata | null,
+  arbitration: Extract<CliScopedFileLockArbitration, { kind: "held" }>,
+): DoctorIssue {
+  const breakPath = `${lockPath}.break`;
+  const stale =
+    holder === null
+      ? `an empty or corrupt file past the ${String(CLI_SCOPED_FILE_LOCK_EMPTY_GRACE_MS)} ms grace window`
+      : `left by ${describeHolder(holder)}, which has exited or whose pid now belongs to another process`;
+  const breaker =
+    arbitration.breaker === null
+      ? "a breaker record that could not be parsed"
+      : `pid ${String(arbitration.breaker.pid)} (since ${arbitration.breaker.startedAt})`;
+  const why =
+    arbitration.cause === "breaker-live"
+      ? `is held by ${breaker}, which is still running`
+      : arbitration.cause === "breaker-unverifiable"
+        ? `is held by ${breaker}, whose identity cannot be verified, so no contender will recover it`
+        : `is dated in the future (${breaker}) and will not be recovered until that time has passed`;
+  return {
+    code: DOCTOR_ISSUE_CODES.HOST_UPDATE_MARKER_LOCK_UNBREAKABLE,
+    severity: "warning",
+    title: "Host update progress-marker lock is stale but cannot be broken",
+    message: `The host update progress-marker lock at ${lockPath} is stale (${stale}), but the break-arbitration file beside it, ${breakPath}, ${why}. Every acquisition has to take that file before it may break a stale lock, so none can. ${CONSEQUENCE} If no updater is running, remove ${breakPath}; the stale lock is then broken by the next update on its own.`,
+    fixAction: null,
+    terminalCommand: null,
+    details: {
+      lockPath,
+      breakPath,
+      holder,
+      breaker: arbitration.breaker,
+      cause: arbitration.cause,
+    },
+  };
+}
+
+function futureDatedIssue(lockPath: string, ageMs: number): DoctorIssue {
+  const untilMs = -ageMs + CLI_SCOPED_FILE_LOCK_EMPTY_GRACE_MS;
+  return {
+    code: DOCTOR_ISSUE_CODES.HOST_UPDATE_MARKER_LOCK_UNBREAKABLE,
+    severity: "warning",
+    title: "Host update progress-marker lock is empty and dated in the future",
+    message: `The host update progress-marker lock at ${lockPath} is an empty or corrupt file whose modification time is about ${String(Math.round(-ageMs / 1000))} s in the future (the clock stepped backwards after it was written). An empty lock is broken only once it is ${String(CLI_SCOPED_FILE_LOCK_EMPTY_GRACE_MS)} ms old, so this one will not be broken for another ${String(Math.round(untilMs / 1000))} s. ${CONSEQUENCE} If no updater is running, remove the file.`,
+    fixAction: null,
+    terminalCommand: null,
+    details: { lockPath, ageMs },
+  };
+}
+
+function unreadableIssue(
+  lockPath: string,
+  breakPath: string | null,
+): DoctorIssue {
+  const file = breakPath ?? lockPath;
+  const role =
+    breakPath === null
+      ? "'traycer host update' takes this lock around each write of its progress marker; a lock it cannot read is one it cannot hold, and the marker step of every update then reports failed."
+      : `The lock at ${lockPath} is stale, and every acquisition must read this arbitration file before it may break a stale lock; one it cannot read leaves the stale lock in place, and the marker step of every update then reports failed.`;
+  return {
+    code: DOCTOR_ISSUE_CODES.HOST_UPDATE_MARKER_LOCK_UNREADABLE,
+    severity: "warning",
+    title:
+      breakPath === null
+        ? "Host update progress-marker lock cannot be read"
+        : "Host update progress-marker lock's break-arbitration file cannot be read",
+    message: `The file ${file} exists but could not be read. ${role} Check the file's permissions and ownership.`,
+    fixAction: null,
+    terminalCommand: null,
+    details: { lockPath, breakPath },
+  };
+}

--- a/clients/traycer-cli/src/host/__tests__/host-log-rotation.test.ts
+++ b/clients/traycer-cli/src/host/__tests__/host-log-rotation.test.ts
@@ -48,18 +48,25 @@ vi.mock("../../store/paths", () => ({
 // on the file). Default to "no host running"; the guard test overrides it.
 let livePid: number | null = null;
 
-vi.mock("../pid-metadata", () => ({
-  readHostPidMetadata: async () =>
-    livePid === null
-      ? null
-      : {
-          pid: livePid,
-          hostId: "host-1",
-          version: "1.0.0",
-          websocketUrl: "ws://127.0.0.1:7100/rpc",
-          startedAt: new Date(0).toISOString(),
-        },
-}));
+vi.mock("../pid-metadata", async () => {
+  // Only the read is stubbed; `publishedHostProcessGone` stays real so the
+  // guard judges `livePid` by the real liveness probe.
+  const actual =
+    await vi.importActual<typeof import("../pid-metadata")>("../pid-metadata");
+  return {
+    ...actual,
+    readHostPidMetadata: async () =>
+      livePid === null
+        ? null
+        : {
+            pid: livePid,
+            hostId: "host-1",
+            version: "1.0.0",
+            websocketUrl: "ws://127.0.0.1:7100/rpc",
+            startedAt: new Date(0).toISOString(),
+          },
+  };
+});
 
 const {
   MAX_HOST_LOG_BYTES,

--- a/clients/traycer-cli/src/host/__tests__/pid-metadata-published-gone.test.ts
+++ b/clients/traycer-cli/src/host/__tests__/pid-metadata-published-gone.test.ts
@@ -1,0 +1,102 @@
+import { spawnSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+import { isProcessAlive } from "../../store/cli-lock";
+import { ownProcessStartIdentity } from "../../store/process-identity";
+import {
+  publishedHostProcessGone,
+  type HostPidMetadata,
+} from "../pid-metadata";
+
+// `publishedHostProcessGone` against real processes: this one (alive, with
+// its own creation stamp), a reaped child (dead), and this pid under a
+// stamp no process has (the recycled-pid impostor). Every inconclusive
+// input - no stamp, a malformed one, one from another platform - keeps the
+// record, because "gone" is positive evidence only.
+
+function record(fields: {
+  readonly pid: number;
+  readonly processStartIdentity: string | null;
+}): HostPidMetadata {
+  return {
+    pid: fields.pid,
+    hostId: "host-1",
+    version: "1.0.0",
+    websocketUrl: "ws://127.0.0.1:7100/rpc",
+    startedAt: "2026-09-06T22:00:00.000Z",
+    processStartIdentity: fields.processStartIdentity,
+    layer0: null,
+    layer0Slot: null,
+  };
+}
+
+function findDeadPid(): number {
+  for (let attempt = 0; attempt < 5; attempt++) {
+    const result = spawnSync(process.execPath, ["-e", "0"]);
+    if (result.pid !== undefined && !isProcessAlive(result.pid)) {
+      return result.pid;
+    }
+  }
+  throw new Error("could not obtain a dead pid");
+}
+
+const OWN_STAMP = ownProcessStartIdentity();
+
+describe("publishedHostProcessGone", () => {
+  it("a pid that no longer runs is gone, stamp or not", () => {
+    expect(
+      publishedHostProcessGone(
+        record({ pid: findDeadPid(), processStartIdentity: null }),
+      ),
+    ).toBe(true);
+  });
+
+  it("a live pid with no stamp on record is not proven gone", () => {
+    expect(
+      publishedHostProcessGone(
+        record({ pid: process.pid, processStartIdentity: null }),
+      ),
+    ).toBe(false);
+  });
+
+  it("a live pid with a malformed stamp on record is judged by the pid alone", () => {
+    expect(
+      publishedHostProcessGone(
+        record({ pid: process.pid, processStartIdentity: "not a token" }),
+      ),
+    ).toBe(false);
+  });
+
+  describe.skipIf(OWN_STAMP === null)("with a creation stamp", () => {
+    const own = OWN_STAMP ?? "";
+    const tag = own.slice(0, own.indexOf(":"));
+
+    it("a live pid whose stamp matches the record is the publisher", () => {
+      expect(
+        publishedHostProcessGone(
+          record({ pid: process.pid, processStartIdentity: own }),
+        ),
+      ).toBe(false);
+    });
+
+    it("a live pid whose stamp differs from the record is a recycled pid - gone", () => {
+      expect(
+        publishedHostProcessGone(
+          record({
+            pid: process.pid,
+            processStartIdentity: `${tag}:not the publisher of this record 1`,
+          }),
+        ),
+      ).toBe(true);
+    });
+
+    it("a stamp from another platform compares unknown, never different", () => {
+      const foreign =
+        tag === "linux" ? "darwin:Sun Jul 6 12:00:00 2026" : "linux:boot:1";
+      expect(
+        publishedHostProcessGone(
+          record({ pid: process.pid, processStartIdentity: foreign }),
+        ),
+      ).toBe(false);
+    });
+  });
+});

--- a/clients/traycer-cli/src/host/__tests__/provision.test.ts
+++ b/clients/traycer-cli/src/host/__tests__/provision.test.ts
@@ -412,6 +412,53 @@ describe("provisionHost - Finding D: implicit-registry-minimum satisfaction", ()
     expect(commitHostInstallSourceMock).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps another build of the requested release only when the registry has not yanked it - the string is the artifact, the comparator only ranks it", async () => {
+    createServiceControllerMock.mockReturnValue(runningController());
+    readHostInstallRecordMock.mockResolvedValue(sampleRecord("2.0.0+bar"));
+    isVersionYankedMock.mockResolvedValue(false);
+
+    const kept = await provisionHost(
+      makeOpts({
+        satisfaction: {
+          kind: "implicit-registry-minimum",
+          version: "2.0.0+foo",
+        },
+      }),
+    );
+    expect(kept.action).toBe("noop");
+    expect(isVersionYankedMock).toHaveBeenCalledWith("2.0.0+bar");
+
+    isVersionYankedMock.mockReset();
+    isVersionYankedMock.mockResolvedValue(true);
+    const replaced = await provisionHost(
+      makeOpts({
+        satisfaction: {
+          kind: "implicit-registry-minimum",
+          version: "2.0.0+foo",
+        },
+      }),
+    );
+    expect(replaced.action).toBe("installed");
+    expect(commitHostInstallSourceMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats the exact requested string as satisfied without a yank lookup (control for the other-build row)", async () => {
+    createServiceControllerMock.mockReturnValue(runningController());
+    readHostInstallRecordMock.mockResolvedValue(sampleRecord("2.0.0+bar"));
+
+    const result = await provisionHost(
+      makeOpts({
+        satisfaction: {
+          kind: "implicit-registry-minimum",
+          version: "2.0.0+bar",
+        },
+      }),
+    );
+
+    expect(result.action).toBe("noop");
+    expect(isVersionYankedMock).not.toHaveBeenCalled();
+  });
+
   it("reinstalls an older install and never consults the yank list for it", async () => {
     createServiceControllerMock.mockReturnValue(runningController());
     readHostInstallRecordMock.mockResolvedValue(sampleRecord("1.6.0"));

--- a/clients/traycer-cli/src/host/busy-check.ts
+++ b/clients/traycer-cli/src/host/busy-check.ts
@@ -1,8 +1,8 @@
 import {
   isValidLocalHostWebsocketUrl,
+  publishedHostProcessGone,
   readHostPidMetadata,
 } from "./pid-metadata";
-import { isProcessAlive } from "../store/cli-lock";
 import type { Environment } from "../runner/environment";
 import { cliError, CLI_ERROR_CODES } from "../runner/errors";
 import { probeHostActivityBusy } from "@traycer-clients/shared/host-client/host-activity-probe";
@@ -53,9 +53,11 @@ async function probeHostForRestart(
   ) {
     return "no-host";
   }
-  // A stale pid.json whose process has exited is not a live host - a reinstall
-  // has nothing to lose.
-  if (!isProcessAlive(metadata.pid)) {
+  // A stale pid.json whose process has exited - or whose pid now belongs to an
+  // unrelated process - is not a live host: a reinstall has nothing to lose,
+  // and probing the dead endpoint below would read as "busy" (fail-safe) and
+  // block the repair.
+  if (publishedHostProcessGone(metadata)) {
     return "no-host";
   }
   // A live host: probe its `/activity` side-channel. Any reachable-but-

--- a/clients/traycer-cli/src/host/host-log-rotation.ts
+++ b/clients/traycer-cli/src/host/host-log-rotation.ts
@@ -3,7 +3,7 @@ import { rename, rm, stat } from "node:fs/promises";
 import type { Environment } from "../runner/environment";
 import { isErrnoException } from "../runner/errors";
 import { hostLogBackupPath, hostLogPath } from "../store/paths";
-import { readHostPidMetadata } from "./pid-metadata";
+import { publishedHostProcessGone, readHostPidMetadata } from "./pid-metadata";
 
 /**
  * Single-generation rotation for `host.log`.
@@ -171,14 +171,12 @@ async function rotate(
 async function hostIsLive(environment: Environment): Promise<boolean> {
   const metadata = await readHostPidMetadata(environment);
   if (metadata === null) return false;
-  try {
-    // Signal 0 performs the permission/existence check without delivering a
-    // signal: it throws ESRCH when no such process exists.
-    process.kill(metadata.pid, 0);
-    return true;
-  } catch {
-    return false;
-  }
+  // Liveness and identity: a stopped host's pid recycled onto an unrelated
+  // process is not a host holding this log's fd, and skipping the rotation
+  // for it would let an oversized log of a stopped host grow unbounded. A
+  // record this cannot prove gone (no stamp, a refused probe) keeps the
+  // skip - the safe direction for a live host's session.
+  return !publishedHostProcessGone(metadata);
 }
 
 /**

--- a/clients/traycer-cli/src/host/pid-metadata.ts
+++ b/clients/traycer-cli/src/host/pid-metadata.ts
@@ -1,12 +1,15 @@
 import { readFile, rm } from "node:fs/promises";
 import {
+  compareProcessStartIdentity,
   isProcessStartIdentity,
   type ProcessStartIdentity,
 } from "@traycer/protocol/host/lifecycle";
 import type { Environment } from "../runner/environment";
 import { config } from "../config";
 import { createCliLogger, errorFromUnknown } from "../logger";
+import { isProcessAlive } from "../store/cli-lock";
 import { hostPidMetadataPath } from "../store/paths";
+import { readProcessStartIdentity } from "../store/process-identity";
 
 // Mirror of the writer contract owned by the host (the external
 // Traycer Host). Read by string path so
@@ -89,6 +92,39 @@ export async function readHostPidMetadata(
 ): Promise<HostPidMetadata | null> {
   const evidence = await readHostPidMetadataEvidence(environment);
   return evidence.kind === "read" ? evidence.metadata : null;
+}
+
+/**
+ * Whether the process `pid.json` names is PROVABLY not the host that
+ * published it: the pid no longer runs, or it runs another process than the
+ * one whose creation stamp the record carries (a crashed host's pid recycled
+ * onto an unrelated process). The plain liveness check alone answered
+ * "running" for that impostor at every reader - `host status`, doctor's
+ * stale-pid verdict, every platform's `service status`, the restart busy
+ * check, RPC endpoint resolution, the cooperative shutdown and the log
+ * rotation guard - and each then acted on a dead host's endpoint as if it
+ * were live.
+ *
+ * Positive evidence only, the same reading `readActivationState` takes:
+ * a record without a stamp (written before the field), a stamp this
+ * platform cannot read back, and a probe that could not answer all keep the
+ * record - `false` here means "not proven gone", never "proven alive".
+ * `EPERM` is alive (only an existing process refuses a signal). The stamp is
+ * compared only for a live pid with a stamp on record, so an old record
+ * costs exactly the liveness syscall it always did; a stamped one adds the
+ * platform's creation-stamp read (a `ps` / PowerShell spawn on macOS and
+ * Windows), synchronous like the liveness check it extends - every caller is
+ * a one-shot CLI command or a start-path guard, not a polled status loop.
+ */
+export function publishedHostProcessGone(metadata: HostPidMetadata): boolean {
+  if (!isProcessAlive(metadata.pid)) return true;
+  if (!isProcessStartIdentity(metadata.processStartIdentity)) return false;
+  return (
+    compareProcessStartIdentity(
+      metadata.processStartIdentity,
+      readProcessStartIdentity(metadata.pid),
+    ) === "different"
+  );
 }
 
 export async function readHostPidMetadataEvidence(

--- a/clients/traycer-cli/src/host/provision.ts
+++ b/clients/traycer-cli/src/host/provision.ts
@@ -969,8 +969,19 @@ async function versionSatisfied(
   // install record we can't reason about look current.
   if (!comparison.comparable) return false;
   if (comparison.ordering === "less") return false;
-  if (comparison.ordering === "equal") return true;
-  // A newer install is normally accepted; only an explicit yank rejects it.
+  // The exact requested string is satisfied outright. Another build of the
+  // same release (`2.0.0+bar` installed, `2.0.0+foo` asked for) is a
+  // DIFFERENT artifact the comparator merely ranks equal: it is accepted the
+  // way a newer install is, unless the registry has withdrawn it - the yank
+  // check a comparator-equal shortcut used to skip.
+  if (
+    comparison.ordering === "equal" &&
+    state.version === satisfaction.version
+  ) {
+    return true;
+  }
+  // A newer install, or another build of the requested release, is normally
+  // accepted; only an explicit yank rejects it.
   return !(await yankLookup.isVersionYanked(state.version));
 }
 

--- a/clients/traycer-cli/src/host/update-progress-marker.ts
+++ b/clients/traycer-cli/src/host/update-progress-marker.ts
@@ -15,6 +15,7 @@ import {
 import { withCliScopedFileLock } from "../store/cli-lock";
 import {
   ensureHostHomeDir,
+  hostUpdateProgressMarkerLockPath,
   hostUpdateProgressMarkerPath,
 } from "../store/paths";
 
@@ -272,10 +273,6 @@ async function stageMarkerFile(
 const MARKER_LOCK_WAIT_MS = 2_000;
 const MARKER_LOCK_POLL_MS = 25;
 
-function markerLockPath(environment: Environment): string {
-  return `${hostUpdateProgressMarkerPath(environment)}.lock`;
-}
-
 /**
  * Run `fn` holding the marker lock. `null` when the lock could not be
  * held - busy past the bounded wait, or the acquisition itself failed -
@@ -291,7 +288,7 @@ async function underMarkerLock<T>(
     await ensureHostHomeDir(environment);
     const outcome = await withCliScopedFileLock(
       {
-        lockPath: markerLockPath(environment),
+        lockPath: hostUpdateProgressMarkerLockPath(environment),
         reason: `host-update-progress-marker-${operation}`,
         waitMs: MARKER_LOCK_WAIT_MS,
         pollIntervalMs: MARKER_LOCK_POLL_MS,
@@ -304,7 +301,7 @@ async function underMarkerLock<T>(
         {
           environment,
           operation,
-          lockFile: basename(markerLockPath(environment)),
+          lockFile: basename(hostUpdateProgressMarkerLockPath(environment)),
           holderPid: outcome.holder?.pid ?? null,
           holderReason: outcome.holder?.reason ?? null,
         },

--- a/clients/traycer-cli/src/internal/host-rpc.ts
+++ b/clients/traycer-cli/src/internal/host-rpc.ts
@@ -31,9 +31,9 @@ import { config } from "../config";
 import { createCliLogger, errorFromUnknown } from "../logger";
 import {
   isValidLocalHostWebsocketUrl,
+  publishedHostProcessGone,
   readHostPidMetadata,
 } from "../host/pid-metadata";
-import { isProcessAlive } from "../store/cli-lock";
 import {
   createCliCredentialsStore,
   createStoreBackedRevalidator,
@@ -301,7 +301,7 @@ export async function resolveEndpoint(): Promise<HostTransportEndpoint> {
       exitCode: 1,
     });
   }
-  if (!isProcessAlive(metadata.pid)) {
+  if (publishedHostProcessGone(metadata)) {
     logger.warn("Host RPC endpoint resolution failed; process is not alive", {
       environment: config.environment,
       hostId: metadata.hostId,

--- a/clients/traycer-cli/src/internal/host-rpc.ts
+++ b/clients/traycer-cli/src/internal/host-rpc.ts
@@ -284,11 +284,12 @@ async function requestAtEndpoint<Method extends keyof HostRpcRegistry & string>(
 export async function resolveEndpoint(): Promise<HostTransportEndpoint> {
   const logger = createCliLogger(config.environment);
   const metadata = await readHostPidMetadata(config.environment);
-  // Liveness check, not just presence: a stopped/crashed host can leave a
-  // stale pid.json behind (the same reason `host status` checks
-  // `isProcessAlive`). Catching a dead pid here is what lets `mapHostRpcError`
-  // treat a transport `RPC_ERROR` as a genuine host error rather than
-  // overloading it to mean "not running".
+  // Identity check, not just presence: a stopped/crashed host can leave a
+  // stale pid.json behind, and the pid it names can since have been handed to
+  // an unrelated process (the same reason `host status` reads
+  // `publishedHostProcessGone`). Catching that record here is what lets
+  // `mapHostRpcError` treat a transport `RPC_ERROR` as a genuine host error
+  // rather than overloading it to mean "not running".
   if (metadata === null) {
     logger.warn("Host RPC endpoint resolution failed; metadata missing", {
       environment: config.environment,
@@ -296,21 +297,24 @@ export async function resolveEndpoint(): Promise<HostTransportEndpoint> {
     throw cliError({
       code: CLI_ERROR_CODES.HOST_NOT_RUNNING,
       message:
-        "traycer: host not running - pid metadata is absent, malformed, advertises an invalid local WebSocket endpoint, or names a process that is no longer alive.",
+        "traycer: host not running - pid metadata is absent, malformed, advertises an invalid local WebSocket endpoint, or names a process that is gone (exited, or a recycled pid that now belongs to an unrelated process).",
       details: null,
       exitCode: 1,
     });
   }
   if (publishedHostProcessGone(metadata)) {
-    logger.warn("Host RPC endpoint resolution failed; process is not alive", {
-      environment: config.environment,
-      hostId: metadata.hostId,
-      pid: metadata.pid,
-    });
+    logger.warn(
+      "Host RPC endpoint resolution failed; the published process is gone (exited, or a recycled pid)",
+      {
+        environment: config.environment,
+        hostId: metadata.hostId,
+        pid: metadata.pid,
+      },
+    );
     throw cliError({
       code: CLI_ERROR_CODES.HOST_NOT_RUNNING,
       message:
-        "traycer: host not running - pid metadata is absent, malformed, advertises an invalid local WebSocket endpoint, or names a process that is no longer alive.",
+        "traycer: host not running - pid metadata is absent, malformed, advertises an invalid local WebSocket endpoint, or names a process that is gone (exited, or a recycled pid that now belongs to an unrelated process).",
       details: null,
       exitCode: 1,
     });
@@ -323,7 +327,7 @@ export async function resolveEndpoint(): Promise<HostTransportEndpoint> {
     throw cliError({
       code: CLI_ERROR_CODES.HOST_NOT_RUNNING,
       message:
-        "traycer: host not running - pid metadata is absent, malformed, advertises an invalid local WebSocket endpoint, or names a process that is no longer alive.",
+        "traycer: host not running - pid metadata is absent, malformed, advertises an invalid local WebSocket endpoint, or names a process that is gone (exited, or a recycled pid that now belongs to an unrelated process).",
       details: null,
       exitCode: 1,
     });

--- a/clients/traycer-cli/src/service/__tests__/health-probe.test.ts
+++ b/clients/traycer-cli/src/service/__tests__/health-probe.test.ts
@@ -33,6 +33,7 @@ vi.mock("../../store/cli-lock", async () => {
   };
 });
 
+import { ownProcessStartIdentity } from "../../store/process-identity";
 import { probeHostHealth } from "../health-probe";
 
 function sampleMetadata(
@@ -187,6 +188,55 @@ describe("probeHostHealth", () => {
     expect(result.healthy).toBe(false);
     expect(result.detail).toContain("did not accept a TCP connection");
   });
+});
+
+describe("probeHostHealth judges the record's process by its creation stamp", () => {
+  // The post-update caller clears its progress marker and reports success
+  // on `healthy: true`. A crashed host's pid recycled onto an unrelated
+  // process, beside some listener on the old port, must not earn that.
+  const own = ownProcessStartIdentity();
+
+  it.skipIf(own === null)(
+    "reports unhealthy for a recycled pid - alive, a listener on the old port, but not the process the record stamped - without ever checking TCP",
+    async () => {
+      mocks.isProcessAliveMock.mockReturnValue(true);
+      const tag = (own ?? "").slice(0, (own ?? "").indexOf(":"));
+      mocks.readHostPidMetadataMock.mockResolvedValue({
+        ...sampleMetadata({ pid: process.pid }),
+        processStartIdentity: `${tag}:not the host this record named 1`,
+      });
+      const checkTcpReachable = vi.fn(async () => true);
+      const result = await probeHostHealth({
+        environment: "production",
+        checkProcessAlive: null,
+        checkTcpReachable,
+        totalBudgetMs: 0,
+        retryDelayMs: 5,
+      });
+      expect(result.healthy).toBe(false);
+      expect(result.detail).toContain("belongs to another process");
+      expect(checkTcpReachable).not.toHaveBeenCalled();
+    },
+  );
+
+  it.skipIf(own === null)(
+    "reports healthy for the process the record stamped when its port answers (control)",
+    async () => {
+      mocks.isProcessAliveMock.mockReturnValue(true);
+      mocks.readHostPidMetadataMock.mockResolvedValue({
+        ...sampleMetadata({ pid: process.pid }),
+        processStartIdentity: own,
+      });
+      const result = await probeHostHealth({
+        environment: "production",
+        checkProcessAlive: null,
+        checkTcpReachable: async () => true,
+        totalBudgetMs: 0,
+        retryDelayMs: 5,
+      });
+      expect(result.healthy).toBe(true);
+    },
+  );
 });
 
 describe("probeHostHealth CS-reachability separation", () => {

--- a/clients/traycer-cli/src/service/health-probe.ts
+++ b/clients/traycer-cli/src/service/health-probe.ts
@@ -3,9 +3,10 @@ import type { Environment } from "../runner/environment";
 import { createCliLogger } from "../logger";
 import {
   isValidLocalHostWebsocketUrl,
+  publishedHostProcessGone,
   readHostPidMetadata,
+  type HostPidMetadata,
 } from "../host/pid-metadata";
-import { isProcessAlive } from "../store/cli-lock";
 
 // Bounded, purely-local health probe `commands/host-update.ts` runs after
 // the install-dir swap + service restart to decide whether the new host
@@ -33,7 +34,13 @@ export interface HealthProbeResult {
 export interface HealthProbeOptions {
   readonly environment: Environment;
   // Injectable for tests so they don't need a real process/socket.
-  // `null` uses the real local pid-liveness / loopback-TCP checks.
+  // `null` uses the real local checks: the pid's liveness AND, for a record
+  // that carries the host's creation stamp, that the live pid is still that
+  // process (`publishedHostProcessGone`) - a crashed host's pid recycled onto
+  // an unrelated process beside a listener on the old port must never read
+  // as a healthy new host, because the caller clears its progress marker
+  // and reports the update a success on this answer. A test seam sees the
+  // pid alone.
   readonly checkProcessAlive: ((pid: number) => boolean) | null;
   readonly checkTcpReachable:
     | ((host: string, port: number) => Promise<boolean>)
@@ -52,7 +59,10 @@ export async function probeHostHealth(
   opts: HealthProbeOptions,
 ): Promise<HealthProbeResult> {
   const logger = createCliLogger(opts.environment);
-  const checkProcessAlive = opts.checkProcessAlive ?? isProcessAlive;
+  const checkProcessAlive: (metadata: HostPidMetadata) => boolean =
+    opts.checkProcessAlive === null
+      ? (metadata) => !publishedHostProcessGone(metadata)
+      : liveByPidOnly(opts.checkProcessAlive);
   const checkTcpReachable = opts.checkTcpReachable ?? probeLoopbackTcp;
   const totalBudgetMs = opts.totalBudgetMs ?? DEFAULT_TOTAL_BUDGET_MS;
   const retryDelayMs = opts.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS;
@@ -88,9 +98,15 @@ export async function probeHostHealth(
   }
 }
 
+function liveByPidOnly(
+  checkPid: (pid: number) => boolean,
+): (metadata: HostPidMetadata) => boolean {
+  return (metadata) => checkPid(metadata.pid);
+}
+
 async function attemptOnce(
   environment: Environment,
-  checkProcessAlive: (pid: number) => boolean,
+  checkProcessAlive: (metadata: HostPidMetadata) => boolean,
   checkTcpReachable: (host: string, port: number) => Promise<boolean>,
 ): Promise<HealthProbeResult> {
   const metadata = await readHostPidMetadata(environment);
@@ -106,10 +122,10 @@ async function attemptOnce(
       detail: "host pid metadata advertises an invalid local websocket URL",
     };
   }
-  if (!checkProcessAlive(metadata.pid)) {
+  if (!checkProcessAlive(metadata)) {
     return {
       healthy: false,
-      detail: `host process (pid ${metadata.pid}) is not alive`,
+      detail: `host process (pid ${metadata.pid}) is not alive, or the pid now belongs to another process`,
     };
   }
   const parsed = new URL(metadata.websocketUrl);

--- a/clients/traycer-cli/src/service/platforms/__tests__/macos.test.ts
+++ b/clients/traycer-cli/src/service/platforms/__tests__/macos.test.ts
@@ -2078,6 +2078,33 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
       });
     });
 
+    it("stopForRestart forces a recycle when the published pid is gone - the child exited or lost its pid, but launchd's job may still be up", async () => {
+      // `publishedHostProcessGone` made this outcome reachable for a LIVE pid
+      // that now belongs to an unrelated process; before that a recycled pid
+      // dialled the dead endpoint and arrived here as `unreachable`, which
+      // already recycled. Either way `no-host` is a fact about the CHILD, and
+      // a plain kickstart of a job launchd still considers running is a
+      // no-op - the restart would report success having done nothing.
+      const { calls, controller } = stageDesktopManagedRunner();
+      MOCKS.requestCooperativeShutdown.mockResolvedValue({ kind: "no-host" });
+
+      await expect(
+        controller.stopForRestart(label, { force: false }),
+      ).resolves.toEqual({
+        forcedRecycle: true,
+      });
+      expect(calls.map((c) => c.args[0])).toEqual(["print"]);
+    });
+
+    it("restart of a host whose published pid is gone recycles the job with kickstart -k", async () => {
+      const { calls, controller } = stageDesktopManagedRunner();
+      MOCKS.requestCooperativeShutdown.mockResolvedValue({ kind: "no-host" });
+
+      await expect(controller.restart(label)).resolves.toBeUndefined();
+      expect(calls.map((c) => c.args[0])).toEqual(["print", "kickstart"]);
+      expect(calls[1]?.args).toEqual(["kickstart", "-k", agentTarget]);
+    });
+
     it("stopForRestart reports no forced recycle when the host really stood down", async () => {
       const { controller } = stageDesktopManagedRunner();
       MOCKS.requestCooperativeShutdown.mockResolvedValue({ kind: "stopped" });
@@ -2781,7 +2808,7 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
       [
         "no-host",
         { kind: "no-host" } as const,
-        "names a host that has already exited",
+        "names a host that is gone - exited, or a pid that now belongs to an unrelated process",
       ],
     ] as const)(
       "rejects with SERVICE_INSTALL_FAILED ('%s') and never boots out when a running Desktop-managed agent's claim can find no endpoint to ask",
@@ -3529,7 +3556,7 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
       expect(calls.some((c) => c.args[0] === "bootout")).toBe(false);
     });
 
-    it("rejects with SERVICE_INSTALL_FAILED a distinct message, and never boots out, when launchd's pid names a host that already exited (no-host)", async () => {
+    it("rejects with SERVICE_INSTALL_FAILED a distinct message, and never boots out, when launchd's pid names a host that is gone (no-host)", async () => {
       const { calls, controller } = stageStandDownRunner({ pid: 4242 });
       MOCKS.requestCooperativeShutdown.mockResolvedValue({
         kind: "no-host",
@@ -3540,7 +3567,7 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
       ).rejects.toMatchObject({
         code: CLI_ERROR_CODES.SERVICE_INSTALL_FAILED,
         message: expect.stringContaining(
-          "names a host that has already exited",
+          "names a host that is gone - exited, or a pid that now belongs to an unrelated process",
         ),
       });
       expect(calls.some((c) => c.args[0] === "bootout")).toBe(false);

--- a/clients/traycer-cli/src/service/platforms/desktop-agent-shutdown.ts
+++ b/clients/traycer-cli/src/service/platforms/desktop-agent-shutdown.ts
@@ -9,6 +9,7 @@ import {
 } from "@traycer/protocol/host/lifecycle/schemas";
 import {
   isValidLocalHostWebsocketUrl,
+  publishedHostProcessGone,
   readHostPidMetadata,
   removeHostPidMetadata,
   type HostPidMetadata,
@@ -86,7 +87,9 @@ export async function requestCooperativeShutdown(
   if (metadata === null) {
     return { kind: "no-metadata" };
   }
-  if (!isProcessAlive(metadata.pid)) {
+  // Exited, or a recycled pid: either way there is no host to claim against,
+  // and dialling the record's endpoint would only answer "unreachable".
+  if (publishedHostProcessGone(metadata)) {
     return { kind: "no-host" };
   }
   if (!isValidLocalHostWebsocketUrl(metadata.websocketUrl)) {

--- a/clients/traycer-cli/src/service/platforms/linux.ts
+++ b/clients/traycer-cli/src/service/platforms/linux.ts
@@ -4,9 +4,11 @@ import {
   verifyServiceMutationAuthority,
 } from "../mutation-authority";
 import { dirname, isAbsolute } from "node:path";
-import { readHostPidMetadata } from "../../host/pid-metadata";
+import {
+  publishedHostProcessGone,
+  readHostPidMetadata,
+} from "../../host/pid-metadata";
 import { CLI_ERROR_CODES, cliError } from "../../runner/errors";
-import { isProcessAlive } from "../../store/cli-lock";
 import { forceStopHostProcess } from "./desktop-agent-shutdown";
 import type { CliInvocation } from "../cli-binary";
 import { buildCompatibleHostStartScript } from "./host-start-script";
@@ -250,7 +252,7 @@ async function statusService(label: ServiceLabel): Promise<ServiceStatus> {
     return statusNotInstalled();
   }
   const pidMetadata = await readHostPidMetadata(label.environment);
-  if (pidMetadata !== null && isProcessAlive(pidMetadata.pid)) {
+  if (pidMetadata !== null && !publishedHostProcessGone(pidMetadata)) {
     return {
       state: "running",
       version: pidMetadata.version,

--- a/clients/traycer-cli/src/service/platforms/macos.ts
+++ b/clients/traycer-cli/src/service/platforms/macos.ts
@@ -3,6 +3,7 @@ import { chmod, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname } from "node:path";
 import {
+  publishedHostProcessGone,
   readHostPidMetadata,
   readHostPidMetadataEvidence,
 } from "../../host/pid-metadata";
@@ -1607,7 +1608,7 @@ async function statusService(
     return statusNotInstalled();
   }
   const pidMetadata = await readHostPidMetadata(label.environment);
-  if (pidMetadata !== null && isProcessAlive(pidMetadata.pid)) {
+  if (pidMetadata !== null && !publishedHostProcessGone(pidMetadata)) {
     return {
       state: "running",
       version: pidMetadata.version,

--- a/clients/traycer-cli/src/service/platforms/macos.ts
+++ b/clients/traycer-cli/src/service/platforms/macos.ts
@@ -908,11 +908,11 @@ async function standDownLiveCliLabelHost(
 // The refusal for a process under `probedLabelId` that nobody can ask (see
 // `standDownLiveCliLabelHost` and the took-over arm): `no-metadata` is a
 // host that has not published yet; `no-host` is metadata whose endpoint
-// names a process that has already exited, while launchd still reports one
-// under the label (its supervisor between children, or a supervisor whose
-// child just stood down and has not exited itself yet). After the took-over
-// arm has deregistered Desktop's agent the message says so and names the
-// re-run.
+// names a process that is gone - exited, or a pid the OS has since handed to
+// an unrelated process - while launchd still reports one under the label
+// (its supervisor between children, or a supervisor whose child just stood
+// down and has not exited itself yet). After the took-over arm has
+// deregistered Desktop's agent the message says so and names the re-run.
 function unaskableHost(
   label: ServiceLabel,
   probedLabelId: string,
@@ -924,7 +924,7 @@ function unaskableHost(
   const state =
     metadata === "no-metadata"
       ? `launchd reports ${subject} under '${probedLabelId}' that has not published a live endpoint yet, so it could not be asked to stand down; it is most likely still starting.`
-      : `launchd reports ${subject} under '${probedLabelId}', but the endpoint it published names a host that has already exited, so nothing could be asked to stand down; it is most likely between hosts (starting the next one, or exiting after the last).`;
+      : `launchd reports ${subject} under '${probedLabelId}', but the endpoint it published names a host that is gone - exited, or a pid that now belongs to an unrelated process - so nothing could be asked to stand down; it is most likely between hosts (starting the next one, or exiting after the last).`;
   const routing =
     retiredAgentLabelId === null
       ? "Retry in a moment, or run 'traycer host service uninstall' first if it never comes up."
@@ -1848,12 +1848,18 @@ async function standDownDesktopManagedHost(
     forcedRecycle:
       outcome.kind === "unreachable" ||
       outcome.kind === "hung" ||
-      // Unreadable metadata is not proof the host is gone, and a plain
-      // kickstart of a job launchd still considers running is a no-op - the
-      // restart would silently not happen. Recycling is correct in both
-      // readings: it replaces a quietly-live host, and it starts one that
-      // really had exited.
-      outcome.kind === "no-metadata",
+      // Neither of the next two says anything about the JOB, and the job is
+      // what gets kickstarted. Unreadable metadata is not proof the host is
+      // gone; `no-host` proves only that the CHILD pid.json named is gone -
+      // exited, or its pid recycled onto an unrelated process - while
+      // launchd may still be running the supervisor that spawned it. A
+      // plain kickstart of a job launchd considers running is a no-op, so
+      // the restart would silently not happen and the command would report
+      // success. Recycling is correct in every one of those readings: it
+      // replaces a quietly-live host, and it starts one that really had
+      // exited.
+      outcome.kind === "no-metadata" ||
+      outcome.kind === "no-host",
   };
 }
 

--- a/clients/traycer-cli/src/service/platforms/windows.ts
+++ b/clients/traycer-cli/src/service/platforms/windows.ts
@@ -12,6 +12,7 @@ import {
   HOST_CAPABILITY_SERVICE_LABEL,
 } from "../../host/capabilities";
 import {
+  publishedHostProcessGone,
   readHostPidMetadata,
   removeHostPidMetadata,
 } from "../../host/pid-metadata";
@@ -33,7 +34,6 @@ import {
   WINDOWS_START_SPAWN_VERIFY_MS,
 } from "@traycer/protocol/host/lifecycle-constants";
 import { CLI_ERROR_CODES, cliError } from "../../runner/errors";
-import { isProcessAlive } from "../../store/cli-lock";
 import type { CliInvocation } from "../cli-binary";
 import { escapeXml } from "../escape-xml";
 import { windowsTaskName, type ServiceLabel } from "../label";
@@ -374,7 +374,7 @@ async function statusService(label: ServiceLabel): Promise<ServiceStatus> {
     return statusNotInstalled();
   }
   const pidMetadata = await readHostPidMetadata(label.environment);
-  if (pidMetadata !== null && isProcessAlive(pidMetadata.pid)) {
+  if (pidMetadata !== null && !publishedHostProcessGone(pidMetadata)) {
     return {
       state: "running",
       version: pidMetadata.version,

--- a/clients/traycer-cli/src/store/cli-lock.ts
+++ b/clients/traycer-cli/src/store/cli-lock.ts
@@ -4,12 +4,19 @@ import { CLI_ERROR_CODES, cliError } from "../runner/errors";
 import { cliLockPath, ensureCliInstallHomeDir } from "./paths";
 import {
   acquireLock,
+  EMPTY_LOCK_GRACE_MS,
+  probeLockBreakArbitration,
+  probeLockFileAgeMs,
+  readLockHolder,
+  verifyLockHolderLiveness,
   withLock,
   type AcquireLockOptions,
+  type LockBreakArbitrationProbe,
   type LockHandle,
   type LockMetadata,
   type WithLockOutcome,
 } from "@traycer-clients/shared/host-lock/cross-process-lock";
+import type { ProcessIdentityVerdict } from "@traycer-clients/shared/host-lock/process-identity";
 
 // Re-exported for existing callers (`host/busy-check.ts`, service
 // controllers, doctor) - the liveness probe lives in
@@ -175,3 +182,69 @@ export async function withCliLock<T>(
   }
   return outcome.result;
 }
+
+/**
+ * What a READER can establish about a scoped lock file without contending
+ * for it. `absent` is the only arm that proves nobody holds the lock;
+ * `unparseable` is an empty or corrupt file, which a holder still inside
+ * its create-then-write gap also produces; `read-error` proves nothing. A
+ * `held` arm carries the holder's own liveness verdict (`alive-same` /
+ * `alive-different` / `dead` / `indeterminate`) from the same identity
+ * check the acquisition path breaks stale holders with.
+ */
+export type CliScopedFileLockProbe =
+  | { readonly kind: "absent" }
+  | {
+      readonly kind: "held";
+      readonly holder: LockMetadata;
+      readonly liveness: ProcessIdentityVerdict;
+    }
+  | { readonly kind: "unparseable" }
+  | { readonly kind: "read-error" };
+
+/**
+ * Read-only probe of a scoped lock file (`host doctor` reports a wedged
+ * progress-marker lock with it). Never acquires, never breaks, never writes:
+ * a diagnostic that took the lock to see who holds it would itself be one
+ * more holder. Through this facade for the same reason as the writer above -
+ * the shared protocol keeps a single CLI importer.
+ */
+export async function probeCliScopedFileLock(
+  lockPath: string,
+): Promise<CliScopedFileLockProbe> {
+  const probe = await readLockHolder(lockPath);
+  if (probe.kind !== "held") return probe;
+  return {
+    kind: "held",
+    holder: probe.holder,
+    liveness: verifyLockHolderLiveness(probe.holder),
+  };
+}
+
+export type CliScopedFileLockArbitration = LockBreakArbitrationProbe;
+
+/**
+ * Read-only probe of the break-arbitration file behind a scoped lock: whether
+ * a stale lock at `lockPath` can actually be broken by the next acquisition,
+ * or is wedged behind a breaker that is alive, unverifiable, or dated in the
+ * future. Same facade rule as above.
+ */
+export async function probeCliScopedFileLockArbitration(
+  lockPath: string,
+): Promise<CliScopedFileLockArbitration> {
+  return probeLockBreakArbitration(lockPath);
+}
+
+/** The lock file's age by mtime (`null` when it cannot be stat'd). */
+export async function cliScopedFileLockAgeMs(
+  lockPath: string,
+): Promise<number | null> {
+  return probeLockFileAgeMs(lockPath);
+}
+
+/**
+ * How old an empty or corrupt scoped lock file must be before an acquisition
+ * age-breaks it (a holder mid-creation writes its metadata within
+ * milliseconds; anything older has no live owner).
+ */
+export const CLI_SCOPED_FILE_LOCK_EMPTY_GRACE_MS: number = EMPTY_LOCK_GRACE_MS;

--- a/clients/traycer-cli/src/store/paths.ts
+++ b/clients/traycer-cli/src/store/paths.ts
@@ -397,6 +397,15 @@ export function hostInstallRecordPath(environment: Environment): string {
 export function hostUpdateProgressMarkerPath(environment: Environment): string {
   return join(hostHomeDir(environment), HOST_UPDATE_PROGRESS_FILENAME);
 }
+// The short cross-process lock `host update` holds around each conditional
+// write of the marker above (`host/update-progress-marker.ts`), beside the
+// file it guards. Named here so `host doctor` reads the same path the writer
+// locks.
+export function hostUpdateProgressMarkerLockPath(
+  environment: Environment,
+): string {
+  return `${hostUpdateProgressMarkerPath(environment)}.lock`;
+}
 
 export function hostDownloadCacheDir(environment: Environment): string {
   return join(hostHomeDir(environment), HOST_DOWNLOAD_CACHE_SUBDIR);


### PR DESCRIPTION
## Why

#1752 made the version STRING the artifact's identity on every CLI update arm and the process creation stamp the marker writer's identity. Outside those arms, readers still judged identity by a proxy - a pid alone, or a build-metadata-blind comparator - and one gap #1752 introduced had no diagnostic surface. Same class, one PR: every member a cold review (Codex, the reviewer that runs on these PRs) and a sweep could find, rather than a follow-up round per member.

| Surface | Before | After |
| --- | --- | --- |
| Ten `pid.json` readers (CLI) | A crashed host's pid recycled onto an unrelated process was "alive" to `isProcessAlive`. `host status` reported running with the old version and endpoint; doctor omitted `PID_METADATA_STALE` and excluded the impostor from the port-conflict report; every platform's `service status` reported running, so `host ensure`'s fast path no-op'd with the host down; the restart busy check read the dead endpoint's failed activity probe as busy and blocked the repair; RPC endpoint resolution handed out the stale endpoint instead of `HOST_NOT_RUNNING`; the cooperative shutdown dialled it; the log-rotation guard skipped an oversized stopped-host log; and the post-update health probe, with any listener on the old port, reported a vanished host healthy - on which `host update` clears its marker and reports success | `publishedHostProcessGone(metadata)` (`host/pid-metadata.ts`): gone iff the pid no longer runs or, for a live pid with a well-formed creation stamp on record, the stamp read back differs - the reading `readActivationState` already took. Positive evidence only: no stamp, a malformed or other-platform token, a stamp this platform cannot read back all keep the record. Wired at all ten sites |
| `traycer host doctor` | Nothing read the marker lock `host update` takes around each progress-marker write (`<host home>/update-progress.json.lock`, #1752 round 14). A holder that stays fails the marker step of every later update after a 2 s wait, with a WARN in the CLI log and nothing else | `HOST_UPDATE_MARKER_LOCK_HELD` for a holder still there on a second read 250 ms later that is running or cannot be verified. `HOST_UPDATE_MARKER_LOCK_UNBREAKABLE` for a lock that IS stale - exited or recycled holder, or an empty file past the 5 s grace - whose break-arbitration file (`<lock>.break`) is held by a live or unverifiable breaker or dated in the future (the acquisition path must take that file before it may break a stale lock, so none can, however stale), or whose directory this user cannot write (nothing can unlink the lock or create the arbitration file). `HOST_UPDATE_MARKER_LOCK_UNREADABLE` for either file it cannot read. Silent on what the acquisition heals on its own (an exited holder with a free arbitration, a crashed breaker's file, an empty file inside its grace, a lock released, re-taken or only arriving between the reads). Doctor never breaks a lock |
| `host ensure` (`versionSatisfied`) | The comparator-equal shortcut kept another build of the requested release (`2.0.0+bar` installed, `2.0.0+foo` asked for) without the yank check a newer install gets | The shortcut is the exact string; a different artifact at equal precedence is yank-checked like a newer one |
| Settings version picker | A comparator-equal, string-different row said "Already on v1.2.0+build.1" - comparator equality as identity, on a host that is NOT on that build | "Another build of v1.2.0+build.1 is installed. To install v1.2.0+build.2 over it, run: `traycer host update --version 1.2.0+build.2 --allow-downgrade`". Still disabled: only a host with the sideways rule passes the flag, and the page cannot tell which host it has |
| Overview activation debt (`legacy-update-facts.ts`) | Mirrors the CLI's `readActivationState`; in the catalog domain it read "comparable and comparator-unequal", so a running `1.3.0+a` beside a `1.3.0+b` record was no debt while the CLI reads debt (#1752 round 16) | Debt iff the running version is a different STRING and the pair is comparable; the comparator only keeps an incomparable pair out of debt |

## What

**CLI**
- `host/pid-metadata.ts`: `publishedHostProcessGone`. Synchronous like the liveness check it extends (`isProcessAlive` through the `store/cli-lock` re-export, so existing mocks keep their meaning; then `compareProcessStartIdentity` against `readProcessStartIdentity`); every caller is a one-shot command or a start-path guard, never a polled loop. Sites: `commands/host-status.ts`, `doctor/engine.ts` (stale-pid message extended), `service/platforms/{macos,linux,windows}.ts` `statusService`, `host/busy-check.ts`, `internal/host-rpc.ts` `resolveEndpoint`, `service/platforms/desktop-agent-shutdown.ts`, `host/host-log-rotation.ts` (which had its own bare `process.kill`), and `service/health-probe.ts` (the `checkProcessAlive: null` default; the test seam keeps its pid-only shape).
- `doctor/update-marker-lock.ts` (new) and `doctor/engine.ts` step 4e; three codes in `doctor/issues.ts` with their rationale. Read-only facades in `store/cli-lock.ts` (`probeCliScopedFileLock`, `probeCliScopedFileLockArbitration`, `cliScopedFileLockAgeMs`, the grace constant) over new read-only exports of the shared lock module, so the protocol keeps its single CLI importer (`clients/shared/__tests__/host-update-contender-architecture.test.ts` unchanged, passing). `store/paths.ts` gains `hostUpdateProgressMarkerLockPath`; the writer in `host/update-progress-marker.ts` uses it.
- `host/provision.ts`: the exact-string shortcut.

**Shared**
- `host-lock/cross-process-lock.ts`: `probeLockBreakArbitration` (free / held with cause `breaker-live` | `breaker-unverifiable` | `dated-in-the-future` / read-error, mirroring `tryRecoverCrashedBreakLock`'s rules), `probeLockFileAgeMs`, `EMPTY_LOCK_GRACE_MS` exported. Nothing in the acquisition path changes.

**GUI**
- `host-overview-updates-state.ts` `versionUnavailableReason`: the comparator-equal arm.
- `legacy-update-facts.ts` `isActivationDebt`: string identity in the catalog domain; header table reworded.

## Tests

- `doctor/__tests__/update-marker-lock.test.ts` (23): every arm against real files at a temp path - a lock this process holds through the real facade (reported, then silent after release), exited / unverifiable / recycled holders, a hold that ends, is re-taken, or only arrives between the reads, empty files fresh / aged / future-dated, the arbitration file live / unverifiable / crashed-and-aged / crashed-fresh / empty / future-dated / unreadable, and a 0555 directory (stale locks report, a live holder's still reports HELD; skipped on Windows and as root).
- `service/__tests__/health-probe.test.ts` (+2): a recycled pid beside a listener on the old port is unhealthy without a TCP check; the stamped process with its port answering is healthy.
- `doctor/__tests__/engine-update-marker-lock.test.ts` (1): wiring and the environment's lock path.
- `host/__tests__/pid-metadata-published-gone.test.ts` (6): real processes - a reaped child, this process under its own stamp, under a fabricated stamp of this platform (the recycled-pid impostor), under a malformed and an other-platform token, and without one.
- `host/__tests__/provision.test.ts` (+2): other build yank-checked and replaced when yanked; the exact string never consults the yank list.
- `host-overview-updates.test.tsx`: the row's new text, "Already on" gone. `legacy-update-facts.test.ts` (+2): other build → debt; same string with build metadata → no debt.
- Four suites that replaced `pid-metadata` or `cli-lock` wholesale now spread `importActual` (`engine-port-conflict`, `engine-service-stopped`, `engine-recent-crash`, `host-status-observational`, `host-log-rotation`).

```
traycer-cli  37 affected files   638 passed, 1 skipped
shared       host-lock + architecture   106 passed
gui-app      legacy facts + Overview    70 passed
compile (6 projects), lint (cli, shared, gui-app), format: clean
```

Cold review before the push (Codex, gpt-6-astra), three rounds: round 1 found a synchronous spawn on the host's status path and a boolean liveness that read EIO as dead (both host-side, fixed in traycerai/traycer-internal#5536), the arbitration file behind a stale lock, the nine `pid.json` readers, and the `host ensure` shortcut; round 2 found the tenth reader (the health probe), a cross-key ordering race in the host's new cache, and the non-writable-directory case; round 3 rechecked those.

## Related

traycerai/traycer-internal#5536 carries the host-side halves of the same class: the daemon's marker reader judges the writer by its creation stamp with tri-state liveness and a background probe, and `host.update.install` passes `--allow-downgrade` for another build of the installed release. Nothing deferred from this PR.
