### PR TITLE
fix(gui-app): keep a background epic's interview card out of the composer focus registry

### DIFF
--- a/clients/gui-app/src/components/chat/composer/composer-prompt-editor.tsx
+++ b/clients/gui-app/src/components/chat/composer/composer-prompt-editor.tsx
@@ -34,6 +34,7 @@ import {
 import { normalizeComposerContentWithSelection } from "@/lib/composer/composer-content-normalizer";
 import { hasClaimableFileTransfer } from "@/lib/files/file-transfer-paths";
 import { usePaneActivationFocusIntent } from "@/components/epic-canvas/pane-activation";
+import { usePaneFocusProbe } from "@/components/epic-tabs/pane-visibility-context";
 
 import { buildComposerExtensions } from "./editor/editor-config";
 import type {
@@ -297,6 +298,9 @@ function ComposerPromptEditorImpl(props: ComposerPromptEditorProps) {
     ref,
   } = props;
   const paneActivationFocusIntent = usePaneActivationFocusIntent();
+  // The live half of `isActive` for the focus registry: a render-time flag can
+  // be one commit stale when another surface selects a composer to focus.
+  const isPaneFocusedNow = usePaneFocusProbe();
 
   // Tiptap's `useEditor` extension chain is built once (`buildComposerExtensions`
   // is memoized with empty editor deps). The plugin closure inside calls
@@ -439,8 +443,9 @@ function ComposerPromptEditorImpl(props: ComposerPromptEditorProps) {
         isEligible: () => editor.view.dom.isConnected,
       },
       isActive,
+      isPaneFocusedNow,
     );
-  }, [composerSurfaceId, editor, isActive]);
+  }, [composerSurfaceId, editor, isActive, isPaneFocusedNow]);
 
   useEffect(() => {
     if (editor === null) return;

--- a/clients/gui-app/src/components/chat/segments/pending-interview/__tests__/pending-interview-card.test.tsx
+++ b/clients/gui-app/src/components/chat/segments/pending-interview/__tests__/pending-interview-card.test.tsx
@@ -19,7 +19,14 @@ import {
   emptyDraft,
   questionIdentity,
 } from "@/components/chat/segments/pending-interview/interview-draft";
-import { focusActiveComposer } from "@/lib/composer/composer-focus-registry";
+import {
+  focusActiveComposer,
+  focusRegisteredActiveComposer,
+} from "@/lib/composer/composer-focus-registry";
+import {
+  PaneFocusProbeContext,
+  PaneSurfaceActivityContext,
+} from "@/components/epic-tabs/pane-visibility-context";
 import { setMobileApp } from "@/lib/mobile-app";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { interviewDraftKey } from "@/lib/persist";
@@ -1949,5 +1956,97 @@ describe("PendingInterviewCard keyboard navigation", () => {
     // The active-pane focus flow (and ⌘L) reaches the card through the registry.
     expect(focusActiveComposer()).toBe(true);
     expect(document.activeElement).toBe(cardEl);
+  });
+
+  // The tile flag the hosted chat body hands this card deliberately excludes
+  // top-level tab focus, so `isActive` alone is true for a card sitting in a
+  // background tab. Focus ownership is the composer's own predicate - tile
+  // active AND pane focused AND tab selected.
+  it("neither registers as active nor autofocuses while its surface is not focused", () => {
+    render(
+      <PaneSurfaceActivityContext.Provider
+        value={{ visible: true, focused: false }}
+      >
+        <TooltipProvider>
+          <PendingInterviewCard
+            chatId="chat-1"
+            blockId="unfocused-surface"
+            questions={[singleSelect("q", "Question?", ["Alpha", "Beta"])]}
+            isActive
+            isBusy={false}
+            onSubmit={vi.fn()}
+            onSkip={null}
+            onFork={null}
+          />
+        </TooltipProvider>
+      </PaneSurfaceActivityContext.Provider>,
+    );
+
+    expect(document.activeElement).not.toBe(
+      screen.getByTestId("interview-card"),
+    );
+    // A surface that becomes focused elsewhere must not be handed this card.
+    expect(focusRegisteredActiveComposer()).toBe(false);
+  });
+
+  it("does not autofocus its free-text field while its surface is not focused", async () => {
+    render(
+      <PaneSurfaceActivityContext.Provider
+        value={{ visible: true, focused: false }}
+      >
+        <TooltipProvider>
+          <PendingInterviewCard
+            chatId="chat-1"
+            blockId="unfocused-free-text"
+            questions={[singleSelect("q", "Describe it", [])]}
+            isActive
+            isBusy={false}
+            onSubmit={vi.fn()}
+            onSkip={null}
+            onFork={null}
+          />
+        </TooltipProvider>
+      </PaneSurfaceActivityContext.Provider>,
+    );
+
+    // The field focuses itself from a callback ref, one frame late.
+    await act(async () => {
+      await new Promise<void>((resolve) =>
+        window.requestAnimationFrame(() => resolve()),
+      );
+    });
+
+    expect(document.activeElement).not.toBe(
+      screen.getByLabelText("Interview answer"),
+    );
+  });
+
+  // The registration itself is a render-time value, and the surface that is
+  // becoming focused restores its own focus before a backgrounded card has
+  // re-rendered. So selection re-asks the live probe rather than trusting a
+  // claim that is one commit old.
+  it("is skipped by the registry when the live probe says its pane lost focus", () => {
+    render(
+      <PaneFocusProbeContext.Provider value={() => false}>
+        <TooltipProvider>
+          <PendingInterviewCard
+            chatId="chat-1"
+            blockId="stale-registration"
+            questions={[singleSelect("q", "Question?", ["Alpha", "Beta"])]}
+            isActive
+            isBusy={false}
+            onSubmit={vi.fn()}
+            onSkip={null}
+            onFork={null}
+          />
+        </TooltipProvider>
+      </PaneFocusProbeContext.Provider>,
+    );
+
+    const cardEl = screen.getByTestId("interview-card");
+    cardEl.blur();
+
+    expect(focusRegisteredActiveComposer()).toBe(false);
+    expect(document.activeElement).not.toBe(cardEl);
   });
 });

--- a/clients/gui-app/src/components/chat/segments/pending-interview/pending-interview-card.tsx
+++ b/clients/gui-app/src/components/chat/segments/pending-interview/pending-interview-card.tsx
@@ -64,6 +64,7 @@ export function PendingInterviewCard(props: PendingInterviewCardProps) {
   const shouldReduceMotion = useReducedMotion();
   const {
     containerRef,
+    focusActive,
     total,
     safeIndex,
     question,
@@ -135,7 +136,7 @@ export function PendingInterviewCard(props: PendingInterviewCardProps) {
             <QuestionPage
               question={question}
               draft={draft}
-              isActive={props.isActive}
+              focusActive={focusActive}
               disabled={props.isBusy}
               pendingOptionIndex={pendingOptionIndex}
               onToggleOption={toggleOption}

--- a/clients/gui-app/src/components/chat/segments/pending-interview/question-page.tsx
+++ b/clients/gui-app/src/components/chat/segments/pending-interview/question-page.tsx
@@ -41,8 +41,12 @@ const ANSWER_TEXTAREA_CLASS =
 interface QuestionPageProps {
   question: InterviewQuestion;
   draft: DraftAnswer;
-  // Gates auto-focus so a background pane's field never steals focus.
-  isActive: boolean;
+  // The card's own focus-ownership answer (`useInterviewCard`'s
+  // `focusActive`): the tile is active AND its pane is focused AND its tab is
+  // selected. Gates auto-focus so a field in a background pane - or in a
+  // background top-level tab, which the tile flag alone does not exclude -
+  // never steals focus.
+  focusActive: boolean;
   // True while a Submit/Skip this card sent is in flight or accepted but
   // unresolved. Natively disables every option button and text field so they
   // are neither focusable, typeable, nor exposed as actionable to assistive
@@ -60,7 +64,7 @@ export function QuestionPage(props: QuestionPageProps) {
   const {
     question,
     draft,
-    isActive,
+    focusActive,
     disabled,
     pendingOptionIndex,
     onToggleOption,
@@ -70,9 +74,10 @@ export function QuestionPage(props: QuestionPageProps) {
   } = props;
 
   // Callback ref for the free-text inputs: they appear exactly when the user
-  // chose to type, so focus belongs in them - but only when this tab is active.
-  // Memoized on isActive so the same node re-focuses when the tab becomes active
-  // (the ref re-runs) and never steals focus while inactive. The focus is
+  // chose to type, so focus belongs in them - but only when this card owns
+  // focus. Memoized on `focusActive` so the same node re-focuses when the tab
+  // becomes active (the ref re-runs) and never steals focus while the card is
+  // in a background pane or top-level tab. The focus is
   // deferred one frame for the same reason as the card itself: a pane is
   // activated on pointerdown, and the trailing mousedown's native focus would
   // otherwise steal focus before this runs (see useInterviewCard).
@@ -81,7 +86,7 @@ export function QuestionPage(props: QuestionPageProps) {
   // a tap. Tapping the field there focuses it the ordinary way.
   const focusFieldIfActive = useCallback(
     (node: HTMLInputElement | HTMLTextAreaElement | null) => {
-      if (!isActive || disabled || node === null || isMobileApp()) return;
+      if (!focusActive || disabled || node === null || isMobileApp()) return;
       const frame = window.requestAnimationFrame(() => {
         node.focus({ preventScroll: true });
       });
@@ -91,7 +96,7 @@ export function QuestionPage(props: QuestionPageProps) {
     // restores focus when a rejected action clears the busy gate: a disabled
     // field cannot take focus, and a callback ref only re-fires when its
     // identity changes, not merely when the prop it reads changes.
-    [disabled, isActive],
+    [disabled, focusActive],
   );
 
   // A question with no options is pure free-text: a single textarea that

--- a/clients/gui-app/src/components/chat/segments/pending-interview/use-interview-card.ts
+++ b/clients/gui-app/src/components/chat/segments/pending-interview/use-interview-card.ts
@@ -16,6 +16,12 @@ import {
   registerComposerFocus,
 } from "@/lib/composer/composer-focus-registry";
 import { usePaneActivationFocusIntent } from "@/components/epic-canvas/pane-activation";
+import { chatTileCatalogActivity } from "@/components/epic-canvas/renderers/chat-tile-surface-activity";
+import { useTabBodySelected } from "@/components/epic-canvas/canvas/tab-body-selected-context";
+import {
+  usePaneFocused,
+  usePaneFocusProbe,
+} from "@/components/epic-tabs/pane-visibility-context";
 import { isEditableEventTarget } from "@/lib/keybindings/editable-target";
 import {
   readInterviewDraftSnapshot,
@@ -103,6 +109,21 @@ export function useInterviewCard(args: UseInterviewCardArgs) {
   const composerSurfaceId = useId();
   const total = questions.length;
   const paneActivationFocusIntent = usePaneActivationFocusIntent();
+  // The card stands in for the Tiptap composer, so it owns focus on exactly
+  // the composer's own terms - the tile's `isActive` AND pane focus AND tab
+  // selection (`chatComposerFocused` -> `chatTileCatalogActivity`). The tile
+  // flag alone deliberately excludes top-level tab focus, so a hosted body in
+  // a BACKGROUND top-level tab still reports `isActive`, and a card trusting
+  // it registers as an active composer from behind whatever the user is
+  // actually looking at.
+  const paneFocused = usePaneFocused();
+  const tabSelected = useTabBodySelected();
+  const isPaneFocusedNow = usePaneFocusProbe();
+  const focusActive = chatTileCatalogActivity(
+    paneFocused,
+    tabSelected,
+    isActive,
+  );
 
   // The persisted row for THIS (chat, block) is the canonical draft state.
   // Subscribing (rather than reading it once) keeps duplicate live views of the
@@ -515,19 +536,23 @@ export function useInterviewCard(args: UseInterviewCardArgs) {
 
   // Auto-focus the card when active, on appear and on every question change, so
   // number keys work with zero clicks. Skipped while inactive so a pending
-  // interview in a background pane never steals focus; refocuses when the tab
-  // becomes active (isActive is a dependency). Free-text and Other inputs focus
-  // themselves via their callback ref, so the card yields to them.
+  // interview in a background pane or top-level tab never steals focus;
+  // refocuses when the tab becomes active (`focusActive` is a dependency).
+  // Free-text and Other inputs focus themselves via their callback ref, so the
+  // card yields to them.
   const wantsFieldFocus = freeTextQuestion || draft.otherSelected;
   useEffect(() => {
-    if (!isActive || wantsFieldFocus) return;
+    if (!focusActive || wantsFieldFocus) return;
     if (paneActivationFocusIntent.shouldYieldAutoFocus()) return;
     focusActiveComposer();
-  }, [safeIndex, isActive, paneActivationFocusIntent, wantsFieldFocus]);
+  }, [safeIndex, focusActive, paneActivationFocusIntent, wantsFieldFocus]);
 
   // Join the composer focus registry so the active-pane focus flow and the
   // "focus editor" shortcut reach this card - it stands in for the Tiptap
   // composer it replaced. Prefer the open text field, else the card itself.
+  // The live pane probe rides along because this registration is a render-time
+  // value: a surface that becomes focused restores focus before a backgrounded
+  // card has re-rendered, so selection has to be able to re-ask.
   useLayoutEffect(() => {
     return registerComposerFocus(
       composerSurfaceId,
@@ -543,12 +568,17 @@ export function useInterviewCard(args: UseInterviewCardArgs) {
           containerRef.current?.contains(activeElement) === true,
         isEligible: () => containerRef.current?.isConnected === true,
       },
-      isActive,
+      focusActive,
+      isPaneFocusedNow,
     );
-  }, [composerSurfaceId, isActive]);
+  }, [composerSurfaceId, focusActive, isPaneFocusedNow]);
 
   return {
     containerRef,
+    // The one focus-ownership answer for this card, for the field-level
+    // autofocus in `QuestionPage` as much as for the card itself - never a
+    // second boolean that means something slightly different.
+    focusActive,
     total,
     safeIndex,
     question,

--- a/clients/gui-app/src/components/home/__tests__/home-page.test.tsx
+++ b/clients/gui-app/src/components/home/__tests__/home-page.test.tsx
@@ -224,6 +224,7 @@ vi.mock("@/components/home/composer/landing-composer", () => ({
           isEligible: () => composer.isConnected,
         },
         activityEnabled,
+        () => true,
       );
     }, [activityEnabled, delayComposerRegistration, instanceId]);
     useEffect(() => {
@@ -911,6 +912,7 @@ describe("<HomePage />", () => {
           isEligible: () => inactiveComposer.isConnected,
         },
         false,
+        () => true,
       );
 
       const { queryClient, tree, view } =

--- a/clients/gui-app/src/components/home/terminal-panel/__tests__/landing-terminal-panel.test.tsx
+++ b/clients/gui-app/src/components/home/terminal-panel/__tests__/landing-terminal-panel.test.tsx
@@ -2324,6 +2324,7 @@ describe("<LandingTerminalPanel />", () => {
           isEligible: () => true,
         },
         true,
+        () => true,
       ),
     );
 
@@ -3034,6 +3035,7 @@ describe("<LandingTerminalPanel />", () => {
           isEligible: () => true,
         },
         true,
+        () => true,
       ),
     );
 
@@ -3491,6 +3493,7 @@ describe("<LandingTerminalPanel />", () => {
           isEligible: () => true,
         },
         true,
+        () => true,
       ),
     );
 

--- a/clients/gui-app/src/components/layout/__tests__/top-level-tab-host.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/top-level-tab-host.test.tsx
@@ -1,4 +1,6 @@
-import { useLayoutEffect, useRef, type ReactNode } from "react";
+import { use, useLayoutEffect, useRef, useState, type ReactNode } from "react";
+import type { UseNavigateResult } from "@tanstack/react-router";
+import type { InterviewQuestion } from "@traycer/protocol/persistence/epic/schemas";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   act,
@@ -44,7 +46,34 @@ import {
 import {
   publishTileSurfaceEnvironment,
   resetTileSurfaceEnvironmentRegistryForTesting,
+  type ReadyTileSurfaceEnvironment,
 } from "@/components/epic-canvas/surface-host/tile-surface-environment-registry";
+import { PendingInterviewCard } from "@/components/chat/segments/pending-interview/pending-interview-card";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import {
+  PaneFocusProbeContext,
+  PaneSurfaceActivityContext,
+  PaneVisibilityContext,
+  usePaneFocusProbe,
+  usePanePortalContainer,
+  usePaneVisible,
+} from "@/components/epic-tabs/pane-visibility-context";
+import { TabBodySelectedContext } from "@/components/epic-canvas/canvas/tab-body-selected-context";
+import {
+  PaneActivationFocusIntentContext,
+  usePaneActivationFocusIntent,
+} from "@/components/epic-canvas/pane-activation";
+import {
+  __resetTabNavigationControllerForTesting,
+  activateTabIntent,
+  navigateToTabIntent,
+} from "@/lib/tab-navigation";
+import {
+  draftTabIntent,
+  existingEpicTabIntent,
+  newDraftTabIntent,
+} from "@/lib/tab-navigation/intents";
+import { tabResolveIntent } from "@/stores/tabs/registry";
 import { resetTileSurfaceMembershipForTesting } from "@/components/epic-canvas/surface-host/tile-surface-membership";
 import { buildSyntheticTileSurfaceEnvironment } from "@/components/epic-canvas/surface-host/__tests__/synthetic-tile-surface-fixture";
 import { useSurfaceActivity } from "@/components/home/composer/surface-activity-hooks";
@@ -58,6 +87,19 @@ import { PrimaryFocusCoordinatorProvider } from "@/lib/focus/primary-focus-coord
 import { useLandingTerminalStore } from "@/stores/home/landing-terminal-store";
 
 const stableTileSurfaceHostTestState = vi.hoisted(() => ({ enabled: false }));
+
+// Two seams the hosted suites steer per test: the body a hosted record
+// renders, and an extra child the mocked Epic surface renders beside its own
+// content (the focus-snapback suite below publishes a real tile environment
+// from there, so the publish lands in the SAME commit as a tab switch).
+const hostedSurfaceBodyTestState = vi.hoisted(() => ({
+  render: null as
+    | ((environment: ReadyTileSurfaceEnvironment) => ReactNode)
+    | null,
+}));
+const epicSurfaceExtraTestState = vi.hoisted(() => ({
+  render: null as ((tabId: string) => ReactNode) | null,
+}));
 
 vi.mock("@tanstack/react-router", async (importOriginal) => {
   const actual =
@@ -93,9 +135,12 @@ vi.mock(
 vi.mock(
   "@/components/epic-canvas/surface-host/hosted-chat-surface-body",
   () => ({
-    renderHostedChatSurfaceBody: () => (
-      <div data-testid="hosted-wiring-body-stub" />
-    ),
+    renderHostedChatSurfaceBody: (environment: ReadyTileSurfaceEnvironment) =>
+      hostedSurfaceBodyTestState.render === null ? (
+        <div data-testid="hosted-wiring-body-stub" />
+      ) : (
+        hostedSurfaceBodyTestState.render(environment)
+      ),
   }),
 );
 
@@ -132,6 +177,7 @@ vi.mock("@/components/epic-tabs/epic-surface", async () => {
         />
         <input aria-label={`Primary ${props.tabId}`} ref={primaryRef} />
         <div data-testid={`blank-surface-${props.tabId}`} />
+        {epicSurfaceExtraTestState.render?.(props.tabId)}
       </div>
     );
   }
@@ -155,6 +201,7 @@ vi.mock(
 vi.mock("@/components/home/composer/landing-composer", () => ({
   LandingComposer: (props: { readonly draftId: string | null }) => {
     const active = useSurfaceActivity();
+    const isPaneFocusedNow = usePaneFocusProbe();
     const ref = useRef<HTMLButtonElement | null>(null);
     useLayoutEffect(() => {
       const element = ref.current;
@@ -167,8 +214,9 @@ vi.mock("@/components/home/composer/landing-composer", () => ({
           isEligible: () => element.isConnected,
         },
         active,
+        isPaneFocusedNow,
       );
-    }, [active, props.draftId]);
+    }, [active, isPaneFocusedNow, props.draftId]);
     return (
       <button
         ref={ref}
@@ -1163,5 +1211,293 @@ describe("TopLevelTabHost re-measures hosted geometry on a position-only placeme
     expect(recordB.style.transform).toBe("translate(0px, 0px)");
     expect(recordA.style.width).toBe("500px");
     expect(recordB.style.width).toBe("500px");
+  });
+});
+
+/**
+ * Desktop 1.3.0-rc.1 "the Start Page tab does nothing": with an Epic tab
+ * active whose hosted chat shows a pending interview card, clicking the Start
+ * Page tab silently snapped straight back to the Epic.
+ *
+ * The card registers itself in the composer focus registry with the hosted
+ * body's raw `isActive` - `tabSelected && canvasPaneActive`, which
+ * deliberately excludes top-level tab focus - so a BACKGROUND Epic tab's card
+ * stays in the registry as an active, eligible composer. When the newly
+ * focused Start Page restores focus it falls through to
+ * `focusRegisteredActiveComposer()`, picks that card, and
+ * `HTMLElement.focus()` runs synchronously - before the hosted record's own
+ * `useSyncExternalStore` re-render has made it inert. The focus bubbles to the
+ * hosted plane's `onFocusCapture`, which reads it as the user working in the
+ * Epic and re-activates that tab, superseding the draft's pending push.
+ *
+ * The publish has to happen from INSIDE the Epic surface's own commit (hence
+ * the publisher below rendered through the mocked Epic surface): a manual
+ * publish in a separate `act` moves the record's re-render out of the switch
+ * commit and erases the race the defect lives in. jsdom does not enforce
+ * `inert`, which costs nothing here - the window this pins is before `inert`
+ * is applied at all.
+ */
+describe("TopLevelTabHost: a background epic's pending interview card cannot snap a Start Page activation back", () => {
+  // The Start Page that reaches the registry is one with no restorable saved
+  // focus target - the freshly created "+" page here, and equally a retained
+  // one whose remembered element is gone. A Start Page that still has one
+  // restores it and returns before the registry is ever consulted, so the
+  // first switch below is the control and the second is the defect.
+  const CHAT_INSTANCE_ID = "interview-snapback-chat";
+  const PANE_ID = "p1";
+  const FREE_TEXT_QUESTION: InterviewQuestion = {
+    questionId: "q1",
+    question: "What should I do next?",
+    header: null,
+    options: [],
+    multiSelect: false,
+  };
+
+  /**
+   * Mirrors `TileSurfaceSlot`: republishes this tile's environment from the
+   * Epic surface's own live pane contexts, so every presentation change is
+   * published in the commit that made it.
+   */
+  function EpicInterviewTilePublisher(props: {
+    readonly viewTabId: string;
+  }): ReactNode {
+    const [base] = useState(() =>
+      buildSyntheticTileSurfaceEnvironment(CHAT_INSTANCE_ID, {}),
+    );
+    const topLevelVisible = usePaneVisible();
+    const topLevelFocused = use(PaneSurfaceActivityContext).focused;
+    const isPaneFocusedNow = usePaneFocusProbe();
+    const panePortalContainer = usePanePortalContainer();
+    const focusIntent = usePaneActivationFocusIntent();
+
+    useLayoutEffect(() => {
+      publishTileSurfaceEnvironment({
+        ...base,
+        identity: { ...base.identity, epicId: props.viewTabId },
+        placement: {
+          epicId: props.viewTabId,
+          viewTabId: props.viewTabId,
+          paneId: PANE_ID,
+          hostId: TEST_HOST_ID,
+        },
+        presentation: { topLevelVisible, topLevelFocused },
+        canvasActivity: { tabSelected: true, canvasPaneActive: true },
+        paneActivation: { focusIntent },
+        services: { ...base.services, isPaneFocusedNow, panePortalContainer },
+      });
+    }, [
+      base,
+      focusIntent,
+      isPaneFocusedNow,
+      panePortalContainer,
+      props.viewTabId,
+      topLevelFocused,
+      topLevelVisible,
+    ]);
+
+    return null;
+  }
+
+  /**
+   * The contexts `HostedChatSurfaceContextBridge` re-provides around a hosted
+   * chat, plus `HostedChatSurfaceBody`'s own `isActive` rule - the raw flag
+   * `chat-tile-lower-surfaces` hands the card.
+   */
+  function HostedInterviewCardBody(props: {
+    readonly environment: ReadyTileSurfaceEnvironment;
+  }): ReactNode {
+    const { environment } = props;
+    const tileActive =
+      environment.canvasActivity.tabSelected &&
+      environment.canvasActivity.canvasPaneActive;
+    return (
+      <PaneSurfaceActivityContext.Provider
+        value={{
+          visible: environment.presentation.topLevelVisible,
+          focused: environment.presentation.topLevelFocused,
+        }}
+      >
+        <PaneVisibilityContext.Provider
+          value={environment.presentation.topLevelVisible}
+        >
+          <PaneActivationFocusIntentContext.Provider
+            value={environment.paneActivation.focusIntent}
+          >
+            <PaneFocusProbeContext.Provider
+              value={environment.services.isPaneFocusedNow}
+            >
+              <TabBodySelectedContext.Provider
+                value={environment.canvasActivity.tabSelected}
+              >
+                <TooltipProvider>
+                  <PendingInterviewCard
+                    chatId="interview-chat"
+                    blockId="interview-block"
+                    questions={[FREE_TEXT_QUESTION]}
+                    isActive={tileActive}
+                    isBusy={false}
+                    onSubmit={() => null}
+                    onSkip={null}
+                    onFork={null}
+                  />
+                </TooltipProvider>
+              </TabBodySelectedContext.Provider>
+            </PaneFocusProbeContext.Provider>
+          </PaneActivationFocusIntentContext.Provider>
+        </PaneVisibilityContext.Provider>
+      </PaneSurfaceActivityContext.Provider>
+    );
+  }
+
+  /** Records what the controller asked the router for; never commits it. */
+  function deferredNavigate(): UseNavigateResult<string> {
+    return () => new Promise<void>(() => undefined);
+  }
+
+  function focusedRefKey(): string | null {
+    const state = useTabsStore.getState();
+    const active = state.items.find((item) => item.id === state.activeItemId);
+    if (active === undefined) return null;
+    if (active.kind === "tab") return tabRefKey(active.ref);
+    const side = active.focusedSide === "left" ? active.left : active.right;
+    return side.kind === "tab" ? tabRefKey(side.ref) : null;
+  }
+
+  async function settle(): Promise<void> {
+    await act(async () => {
+      await new Promise<void>((resolve) =>
+        window.requestAnimationFrame(() => resolve()),
+      );
+    });
+  }
+
+  beforeEach(() => {
+    window.localStorage.clear();
+    useTabsStore.setState(useTabsStore.getInitialState(), true);
+    useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
+    useLandingDraftStore.setState(useLandingDraftStore.getInitialState(), true);
+    useAuthStore.setState(useAuthStore.getInitialState(), true);
+    useLandingTerminalStore.getState().resetForTests();
+    tabCommandCoordinator.resetReconciliationForTesting();
+    resetTileSurfaceMembershipForTesting();
+    resetTileSurfaceEnvironmentRegistryForTesting();
+    resetPrimaryFocusCoordinatorForTests();
+    __resetTabNavigationControllerForTesting();
+    stableTileSurfaceHostTestState.enabled = true;
+    epicSurfaceExtraTestState.render = (tabId) => (
+      <EpicInterviewTilePublisher viewTabId={tabId} />
+    );
+    hostedSurfaceBodyTestState.render = (environment) => (
+      <HostedInterviewCardBody environment={environment} />
+    );
+  });
+
+  afterEach(() => {
+    cleanup();
+    stableTileSurfaceHostTestState.enabled = false;
+    epicSurfaceExtraTestState.render = null;
+    hostedSurfaceBodyTestState.render = null;
+    useTabsStore.setState(useTabsStore.getInitialState(), true);
+    useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
+    useLandingDraftStore.setState(useLandingDraftStore.getInitialState(), true);
+    useAuthStore.setState(useAuthStore.getInitialState(), true);
+    useLandingTerminalStore.getState().resetForTests();
+    tabCommandCoordinator.resetReconciliationForTesting();
+    resetTileSurfaceMembershipForTesting();
+    resetTileSurfaceEnvironmentRegistryForTesting();
+    resetPrimaryFocusCoordinatorForTests();
+    __resetTabNavigationControllerForTesting();
+  });
+
+  it("keeps a newly opened Start Page activated while the epic tab's interview card is still registered active", async () => {
+    seedSources([EPIC_A, DRAFT_A]);
+    useEpicCanvasStore.setState((state) => ({
+      ...state,
+      canvasByTabId: {
+        ...state.canvasByTabId,
+        [EPIC_A.id]: {
+          root: pane(PANE_ID, [CHAT_INSTANCE_ID]),
+          activePaneId: PANE_ID,
+          tilesByInstanceId: {
+            [CHAT_INSTANCE_ID]: {
+              id: CHAT_INSTANCE_ID,
+              instanceId: CHAT_INSTANCE_ID,
+              type: "chat" as const,
+              name: "Interview chat",
+              hostId: TEST_HOST_ID,
+            },
+          },
+          sizesByGroupId: {},
+        },
+      },
+    }));
+    // Start on the Start Page so its lazily loaded surface is resolved before
+    // the switch under test - in the app it has been rendered before too, and
+    // a first-ever lazy resolution would push the mount into a LATER commit
+    // than the tab switch, which is where the defect lives.
+    setSingle(DRAFT_A, [EPIC_A, DRAFT_A]);
+    const navigate = deferredNavigate();
+
+    render(
+      <PrimaryFocusCoordinatorProvider>
+        <TopLevelSurfaceActivationContext.Provider
+          value={(tab) => {
+            navigateToTabIntent(navigate, tabResolveIntent(tab), undefined);
+          }}
+        >
+          <TopLevelTabHost />
+        </TopLevelSurfaceActivationContext.Provider>
+      </PrimaryFocusCoordinatorProvider>,
+    );
+    await screen.findByRole("button", { name: `Composer ${DRAFT_A.id}` });
+
+    act(() => {
+      activateTabIntent(
+        navigate,
+        existingEpicTabIntent({
+          epicId: EPIC_A.id,
+          tabId: EPIC_A.id,
+          focus: undefined,
+        }),
+        undefined,
+      );
+    });
+    // The card is live inside the focused epic tab's hosted record, so it is
+    // registered as the active composer.
+    const answer = await screen.findByLabelText("Interview answer");
+    await settle();
+    expect(surfaceRef(EPIC_A).dataset.focused).toBe("true");
+    expect(answer.isConnected).toBe(true);
+
+    // Clicking the Start Page tab in the strip is exactly this activation.
+    act(() => {
+      activateTabIntent(navigate, draftTabIntent(DRAFT_A.id), undefined);
+    });
+    await settle();
+
+    // This one has a saved focus target of its own, so it restores that and
+    // never consults the registry - the control for the step below.
+    expect(focusedRefKey()).toBe(tabRefKey(DRAFT_A));
+    expect(surfaceRef(DRAFT_A).dataset.focused).toBe("true");
+    expect(surfaceRef(EPIC_A).dataset.focused).toBe("false");
+
+    // "+" opens a second Start Page - a surface with no saved focus target of
+    // its own, which is the shape that reaches the composer focus registry.
+    act(() => {
+      activateTabIntent(navigate, newDraftTabIntent(null), undefined);
+    });
+    await settle();
+
+    const secondDraftId = useLandingDraftStore
+      .getState()
+      .drafts.map((draft) => draft.id)
+      .find((id) => id !== DRAFT_A.id);
+    expect(secondDraftId).toBeDefined();
+    expect(document.activeElement).toBe(
+      screen.getByRole("button", { name: `Composer ${secondDraftId ?? ""}` }),
+    );
+    expect(focusedRefKey()).toBe(
+      tabRefKey({ kind: "draft", id: secondDraftId ?? "" }),
+    );
   });
 });

--- a/clients/gui-app/src/lib/composer/composer-focus-registry.ts
+++ b/clients/gui-app/src/lib/composer/composer-focus-registry.ts
@@ -1,6 +1,6 @@
 import {
   registerPrimaryFocusEndpoint,
-  requestPrimaryFocus,
+  requestPrimaryFocusIfEligible,
   type PrimaryFocusEndpoint,
   type PrimaryFocusTarget,
 } from "@/lib/focus/primary-focus-coordinator";
@@ -8,18 +8,34 @@ import {
 interface Entry {
   readonly target: PrimaryFocusTarget;
   readonly isActive: boolean;
+  readonly isSurfaceFocusedNow: () => boolean;
 }
 
 const entries = new Set<Entry>();
 
+/**
+ * Joins the composer focus registry.
+ *
+ * `isActive` is a RENDER-TIME claim, and selection can run while it is one
+ * commit stale: a surface that becomes focused restores its focus in a passive
+ * effect, which is early enough that a background surface's own re-render (and
+ * therefore its re-registration) has not happened yet. `isSurfaceFocusedNow` is
+ * the live half of the same question - `usePaneFocusProbe()`, which reads its
+ * pane's already-committed `data-pane-focused` attribute - so selection can
+ * verify the claim instead of trusting it. Registering an owner that cannot
+ * currently hold focus is not an error; being SELECTED while it cannot is,
+ * because focusing it pulls the tab it lives in back to the foreground.
+ */
 export function registerComposerFocus(
   surfaceId: string,
   endpoint: PrimaryFocusEndpoint,
   isActive: boolean,
+  isSurfaceFocusedNow: () => boolean,
 ): () => void {
   const entry: Entry = {
     target: { kind: "composer", surfaceId },
     isActive,
+    isSurfaceFocusedNow,
   };
   entries.add(entry);
   const unregister = registerPrimaryFocusEndpoint(entry.target, endpoint);
@@ -29,18 +45,29 @@ export function registerComposerFocus(
   };
 }
 
+/**
+ * An entry that claims to be active AND whose surface still holds focus right
+ * now. A stale claim is skipped outright rather than demoted to the inactive
+ * fallback below: it is not a last-resort candidate, it is an owner that has
+ * already lost the surface it was speaking for.
+ */
+function ownsFocusNow(entry: Entry): boolean {
+  return entry.isActive && entry.isSurfaceFocusedNow();
+}
+
 export function focusActiveComposer(): boolean {
   let fallback: Entry | null = null;
   for (const entry of entries) {
     if (entry.isActive) {
-      requestPrimaryFocus(entry.target);
-      return true;
+      if (ownsFocusNow(entry) && requestPrimaryFocusIfEligible(entry.target)) {
+        return true;
+      }
+      continue;
     }
     fallback = entry;
   }
   if (fallback === null) return false;
-  requestPrimaryFocus(fallback.target);
-  return true;
+  return requestPrimaryFocusIfEligible(fallback.target);
 }
 
 /**
@@ -52,9 +79,8 @@ export function focusActiveComposer(): boolean {
  */
 export function focusRegisteredActiveComposer(): boolean {
   for (const entry of entries) {
-    if (!entry.isActive) continue;
-    requestPrimaryFocus(entry.target);
-    return true;
+    if (!ownsFocusNow(entry)) continue;
+    if (requestPrimaryFocusIfEligible(entry.target)) return true;
   }
   return false;
 }

--- a/clients/gui-app/src/lib/focus/primary-focus-coordinator.ts
+++ b/clients/gui-app/src/lib/focus/primary-focus-coordinator.ts
@@ -93,6 +93,26 @@ export class PrimaryFocusCoordinator {
     return this.epoch;
   }
 
+  /**
+   * Requests focus only for a target that has a registered, currently eligible
+   * endpoint, reporting whether the request was taken up.
+   *
+   * `request` alone always parks an intent and reports an epoch, so a caller
+   * choosing BETWEEN candidates (the composer focus registry) could neither
+   * learn that its pick was unusable nor move on to the next one - it would
+   * strand an intent on a dead endpoint and report success. Eligibility is the
+   * only rejection worth reporting here: a request refused for document
+   * visibility or an in-flight pointer interaction stays parked and is
+   * fulfilled by the next `reconcile`, which is exactly the behavior a caller
+   * wants for a live endpoint.
+   */
+  requestIfEligible(target: PrimaryFocusTarget): boolean {
+    const endpoint = this.endpoints.get(targetKey(target));
+    if (endpoint === undefined || !endpoint.isEligible()) return false;
+    this.request(target);
+    return true;
+  }
+
   cancel(predicate: (target: PrimaryFocusTarget) => boolean): void {
     if (this.intent !== null && predicate(this.intent.target)) {
       this.clearIntent();
@@ -185,6 +205,12 @@ export function registerPrimaryFocusEndpoint(
 
 export function requestPrimaryFocus(target: PrimaryFocusTarget): number {
   return coordinator.request(target);
+}
+
+export function requestPrimaryFocusIfEligible(
+  target: PrimaryFocusTarget,
+): boolean {
+  return coordinator.requestIfEligible(target);
 }
 
 export function cancelPrimaryFocusIntent(


### PR DESCRIPTION
## Summary

On 1.3.0-rc.1, with an epic tab active whose chat tile shows a pending interview card (AskUserQuestion), clicking the **Start Page** tab does nothing: no highlight change, no frame of the Start Page, no error. Opening a second Start Page with **+** does not help either.

This is a second, different producer of the dead click that #1627 fixed. #1627 covered a stale route *replace* from the epic route-sync hook; the persisted route history for this report is not bare, so that mechanism is not involved.

### Mechanism

1. Hosted chat bodies compute `isActive = tabSelected && canvasPaneActive` (`hosted-chat-surface-context-bridge.tsx`). Top-level tab focus is deliberately not part of it. The chat tile passes that raw flag to `PendingInterviewCard`. The ordinary composer already derives its focus flag from tile active AND pane focused AND tab selected (`chat-composer.tsx`), which is why plain chats do not hit this.
2. The interview card registers in the composer focus registry with the raw flag and an eligibility check of "still connected", so a card in a **background** epic tab stays registered as an active, eligible composer. Its endpoint calls `HTMLElement.focus()` synchronously (Tiptap defers to rAF, which is the other half of why plain chats are safe).
3. A newly focused Start Page with no restorable saved focus target falls through to `focusRegisteredActiveComposer()`, which picks that card. The coordinator focuses it synchronously, before the hosted record's `useSyncExternalStore` re-render has made it `inert`.
4. That focus bubbles to the hosted plane's `onFocusCapture` → `activateHostedTopLevelSurface` → the epic tab is re-activated via `navigateToTabIntent`, which supersedes the draft's pending push. All inside one discrete-event commit, so nothing paints.

### Fix

Two layers, because a render-time guard alone cannot close the window (the registration is already one commit stale when selection runs):

- **Registry**: each entry carries a live ownership probe (`usePaneFocusProbe()`, which reads the pane's already-committed `data-pane-focused`). `focusActiveComposer` / `focusRegisteredActiveComposer` skip an active claim whose probe says otherwise and keep scanning, and both report `false` when the coordinator refuses the pick instead of stranding an intent on an ineligible endpoint and reporting success (new `requestPrimaryFocusIfEligible`). The inactive fallback keeps its existing meaning: a retained split partner is legitimately unfocused and is exactly what that fallback exists to reach.
- **Interview card**: registers on the composer's own predicate (`chatTileCatalogActivity`: tile active AND pane focused AND tab selected) and gates both its own autofocus and `QuestionPage`'s callback-ref field autofocus on that one flag. `ComposerPromptEditor` passes the same probe through.

Deliberately unchanged: `HostedChatSurfaceBody.isActive`, tile activation / query / find semantics, no gesture heuristics, no DOM-scoping of the landing surface's call.

### Precondition worth knowing

The registry path is reached only when the Start Page has no restorable saved focus target (`restoreLandingSurfaceFocus`): a fresh Start Page (the **+** symptom), a Start Page restored at launch and never visited, or one whose remembered element is gone. A Start Page typed in earlier this session restores its own composer and never consults the registry. The fix sits at the producer, so both entry paths are covered.

## Validation

- New repro suite in `top-level-tab-host.test.tsx` drives the real `TopLevelTabHost`, surface host, membership, environment registry, focus coordinator/registry, real `LandingDraftSurface`, and the real tab coordinator + navigation controller with a deferred router, with the tile environment published from inside the epic surface's own commit. It fails on the unfixed tree (`expected 'epic:epic-a' to be 'draft:…'`) and passes with the fix. Clicking an already-visited Start Page is kept as an explicit control (passes before and after).
- Three narrow cases beside `pending-interview-card.test.tsx`: no active registration and no autofocus while the surface is not focused (card and free-text field), and the registry skipping an owner whose live probe says its pane lost focus. All fail without the source change.
- `bun run compile`, `bun run lint` (`--max-warnings 0`), and the touched suites plus a focus-adjacent batch (primary-focus-coordinator, composer editor slot / mobile autofocus / render isolation, home-page, landing-terminal-panel, dispatch focus-editor, pane-surface-activity) are green. Browser `inert` behavior is not exercised by jsdom; the bug window is before `inert` applies, so the test does not depend on it.

Diagnosis was independently audited by a second model before implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
