### PR TITLE
fix(gui-app): search artifacts by their path, not only title and body

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-artifact-search.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-artifact-search.tsx
@@ -582,9 +582,13 @@ const ArtifactSearchResultRow = memo(function ArtifactSearchResultRow(
     : FileText;
   const title = displayTitle(hit.title, hit.kind);
   // The RPC breadcrumb includes the artifact's own folder slug last; drop it so
-  // only the ancestor trail shows (the title already names the artifact). These
-  // are folder slugs relative to the artifact root - never host-absolute paths.
-  const ancestors = hit.breadcrumb.slice(0, -1);
+  // only the ancestor trail shows (the title already names the artifact) -
+  // unless the path is what matched, in which case the full slug chain IS the
+  // evidence for the hit and must stay visible. These are folder slugs relative
+  // to the artifact root - never host-absolute paths.
+  const ancestors = hit.sources.includes("path")
+    ? hit.breadcrumb
+    : hit.breadcrumb.slice(0, -1);
   const showStatusDot =
     hit.status !== null && Object.hasOwn(STATUS_DOT_CLASSES, hit.status);
 

--- a/clients/gui-app/src/hooks/epic/__tests__/use-epic-search-artifacts-query.test.tsx
+++ b/clients/gui-app/src/hooks/epic/__tests__/use-epic-search-artifacts-query.test.tsx
@@ -33,7 +33,7 @@ vi.mock("@/hooks/host/use-host-query", () => ({
 }));
 
 describe("useEpicSearchArtifacts", () => {
-  it("searches artifact titles and bodies without matching mirror-relative paths", () => {
+  it("searches artifact titles, logical paths, and bodies", () => {
     const args: UseEpicSearchArtifactsArgs = {
       client: null,
       epicId: "epic-1",
@@ -49,7 +49,7 @@ describe("useEpicSearchArtifacts", () => {
     expect(capturedQuery.current?.method).toBe("epic.searchArtifacts");
     expect(capturedQuery.current?.params.fields).toEqual({
       title: true,
-      path: false,
+      path: true,
       body: true,
     });
   });

--- a/clients/gui-app/src/hooks/epic/use-epic-search-artifacts-query.ts
+++ b/clients/gui-app/src/hooks/epic/use-epic-search-artifacts-query.ts
@@ -11,10 +11,15 @@ import { useHostQuery } from "@/hooks/host/use-host-query";
 
 const EPIC_SEARCH_ARTIFACTS_LIMIT = 50;
 
-/** Artifact search covers user-visible content, not mirror-relative paths. */
+/**
+ * Titles, logical artifact paths, and bodies. Paths are searched because agents
+ * routinely print an artifact's slug chain (`tickets/sweep-dialog-discovery`)
+ * and users paste that back to find it; the host ranks the logical path, never
+ * the physical `index.md` mirror layout.
+ */
 const ARTIFACT_SEARCH_FIELDS = Object.freeze({
   title: true,
-  path: false,
+  path: true,
   body: true,
 });
 


### PR DESCRIPTION
## Summary

Artifact search asked the host for titles and bodies only — `path: false` was hardcoded in the request, so the host never ranked paths at all.

That is the one surface agents hand people. A model prints an artifact's slug chain, the user pastes it back into the search box, and nothing comes up unless those words happen to also sit in a title or a body. Reported from live staging: searching `sweep-dialog-discovery` returned only the *parent* artifact that mentions it in prose, never the artifact whose slug it is.

- request the path surface alongside title and body
- keep a path hit legible: the result row dropped the artifact's own slug so only the ancestor trail showed, which would leave a path-only hit with no visible reason for appearing. When the path is what matched, the full slug chain stays on screen as the evidence for the hit.

The host ranks the *logical* artifact path rather than the physical `index.md` mirror layout, so this does not turn a query like `index` into a match on every artifact. That half is the paired internal PR; see the compatibility note below.

## Compatibility

`epic.searchArtifacts` already carries the `path` field — no protocol change, no version bump. Against a host that predates the paired change, this ranks the raw mirror path, so a query like `index` over-matches until that host ships. Titles and bodies are unaffected either way.

## Verification

- `clients/gui-app`: `src/hooks/epic/__tests__/use-epic-search-artifacts-query.test.tsx` + `src/components/epic-canvas/sidebar/__tests__` — 47 files, 539 tests, all passing
- `pre-commit`: build · compile · lint · format (nx affected) — passed
