### PR TITLE
fix(gui-app): comm-graph transport empty state, Live toggle, office cursor chip

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/comm-graph/__tests__/comm-graph-office-canvas.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/comm-graph/__tests__/comm-graph-office-canvas.test.tsx
@@ -40,6 +40,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ReactNode } from "react";
 import { CommGraphOfficeCanvas } from "@/components/epic-canvas/comm-graph/office/comm-graph-office-canvas";
+import { useCommGraphTimelineStore } from "@/stores/epics/comm-graph-timeline-store";
 import {
   commGraphPairId,
   type CommGraphAgentNode,
@@ -88,6 +89,7 @@ interface OfficeRenderOptions {
   readonly events: ReadonlyArray<CommGraphEvent>;
   readonly pulse: CommGraphPulse | null;
   readonly pulseKey: string | null;
+  readonly playing?: boolean;
 }
 
 const STATIC_OFFICE: OfficeRenderOptions = {
@@ -109,7 +111,7 @@ function officeElement(
       events={options.events}
       hosts={[]}
       initialHistoryCaughtUp={false}
-      playing={false}
+      playing={options.playing ?? false}
       pulse={options.pulse}
       pulseKey={options.pulseKey}
       modeToggle={null}
@@ -241,6 +243,7 @@ afterEach(() => {
   cleanup();
   registerFindAdapterMock.mockClear();
   vi.restoreAllMocks();
+  useCommGraphTimelineStore.setState({ stateByEpicId: {} });
 });
 
 /**
@@ -453,5 +456,44 @@ describe("CommGraphOfficeCanvas", () => {
     expect(screen.getByTestId("comm-graph-office-zoom-in")).toBeDefined();
     expect(screen.getByTestId("comm-graph-office-zoom-out")).toBeDefined();
     expect(screen.getByTestId("comm-graph-office-fit")).toBeDefined();
+  });
+
+  it("shows no cursor chip when there is no cursor", () => {
+    renderOffice(new Set([ORCHESTRATOR.id, REVIEWER.id]));
+
+    expect(screen.queryByTestId("comm-graph-office-cursor-chip")).toBeNull();
+  });
+
+  it("shows a Paused chip once the epic's cursor is set", () => {
+    renderOffice(new Set([ORCHESTRATOR.id, REVIEWER.id]));
+
+    act(() => {
+      useCommGraphTimelineStore
+        .getState()
+        .setCursor("epic-1", { timestamp: 1_000, hostId: "host-1", id: 1 });
+    });
+
+    const chip = screen.getByTestId("comm-graph-office-cursor-chip");
+    expect(chip.textContent).toMatch(/^Paused at/);
+  });
+
+  it("shows a Replaying chip when the cursor is set and playback is running", () => {
+    render(
+      withQueryClient(
+        officeElement(new Set([ORCHESTRATOR.id, REVIEWER.id]), {
+          ...STATIC_OFFICE,
+          playing: true,
+        }),
+      ),
+    );
+
+    act(() => {
+      useCommGraphTimelineStore
+        .getState()
+        .setCursor("epic-1", { timestamp: 1_000, hostId: "host-1", id: 1 });
+    });
+
+    const chip = screen.getByTestId("comm-graph-office-cursor-chip");
+    expect(chip.textContent).toMatch(/^Replaying/);
   });
 });

--- a/clients/gui-app/src/components/epic-canvas/comm-graph/__tests__/comm-graph-open-button.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/comm-graph/__tests__/comm-graph-open-button.test.tsx
@@ -32,9 +32,7 @@ describe("CommGraphOpenButton", () => {
       <CommGraphOpenButton epicId={EPIC_ID} disabled={false} className="" />,
     );
 
-    fireEvent.click(
-      screen.getByRole("button", { name: "Open communication graph" }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: "Agent office" }));
 
     expect(tileNavigationMocks.openTile).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -66,7 +64,7 @@ describe("CommGraphOpenButton", () => {
     );
 
     const button = screen.getByRole("button", {
-      name: "Open communication graph",
+      name: "Agent office",
     });
     fireEvent.click(button);
     fireEvent.click(button);
@@ -96,9 +94,7 @@ describe("CommGraphOpenButton", () => {
   it("does not open while the panel is collapsed", () => {
     render(<CommGraphOpenButton epicId={EPIC_ID} disabled className="" />);
 
-    fireEvent.click(
-      screen.getByRole("button", { name: "Open communication graph" }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: "Agent office" }));
 
     expect(tileNavigationMocks.openTile).not.toHaveBeenCalled();
   });
@@ -114,9 +110,7 @@ describe("CommGraphOpenMenuItem", () => {
       </DropdownMenu>,
     );
 
-    fireEvent.click(
-      screen.getByRole("menuitem", { name: "Open communication graph" }),
-    );
+    fireEvent.click(screen.getByRole("menuitem", { name: "Agent office" }));
 
     expect(tileNavigationMocks.openTile).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/clients/gui-app/src/components/epic-canvas/comm-graph/__tests__/comm-graph-timeline.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/comm-graph/__tests__/comm-graph-timeline.test.tsx
@@ -1503,6 +1503,70 @@ describe("comm-graph transport", () => {
     expect(
       screen.getByTestId("comm-graph-transport-play").hasAttribute("disabled"),
     ).toBe(true);
+    // No live badge, no elapsed fill, and the empty track says so in words.
+    const empty = screen.getByTestId("comm-graph-transport-empty");
+    expect(empty.textContent).toBe("No events yet");
+    expect(screen.queryByTestId("comm-graph-transport-follow-live")).toBeNull();
+    expect(screen.queryByTestId("comm-graph-transport-elapsed")).toBeNull();
+  });
+
+  it("toggles Live: pressing it goes live, pressing it again returns to the saved position", async () => {
+    await renderWithEvents(3);
+    const track = screen.getByTestId("comm-graph-transport-track");
+    fireEvent.keyDown(track, { key: "Home" });
+    await waitFor(() => {
+      expect(following()).toBe("false");
+    });
+
+    fireEvent.click(screen.getByTestId("comm-graph-transport-follow-live"));
+    await waitFor(() => {
+      expect(following()).toBe("true");
+    });
+    expect(
+      screen
+        .getByTestId("comm-graph-transport-follow-live")
+        .getAttribute("data-can-return"),
+    ).toBe("true");
+
+    fireEvent.click(screen.getByTestId("comm-graph-transport-follow-live"));
+    await waitFor(() => {
+      expect(following()).toBe("false");
+    });
+    expect(track.getAttribute("aria-valuenow")).toBe("0");
+  });
+
+  it("stays live, with nothing to return to, when Live is pressed while live", async () => {
+    await renderWithEvents(3);
+    expect(following()).toBe("true");
+
+    fireEvent.click(screen.getByTestId("comm-graph-transport-follow-live"));
+
+    expect(following()).toBe("true");
+    expect(
+      screen
+        .getByTestId("comm-graph-transport-follow-live")
+        .getAttribute("data-can-return"),
+    ).toBe("false");
+  });
+
+  it("does not erase the saved return position when Live is pressed while already live", async () => {
+    await renderWithEvents(3);
+    const track = screen.getByTestId("comm-graph-transport-track");
+    fireEvent.keyDown(track, { key: "Home" });
+    fireEvent.keyDown(track, { key: "ArrowRight" });
+    await waitFor(() => {
+      expect(track.getAttribute("aria-valuenow")).toBe("1");
+    });
+
+    fireEvent.click(screen.getByTestId("comm-graph-transport-follow-live"));
+    await waitFor(() => {
+      expect(following()).toBe("true");
+    });
+    fireEvent.click(screen.getByTestId("comm-graph-transport-follow-live"));
+
+    await waitFor(() => {
+      expect(track.getAttribute("aria-valuenow")).toBe("1");
+    });
   });
 
   /**

--- a/clients/gui-app/src/components/epic-canvas/comm-graph/comm-graph-open-button.tsx
+++ b/clients/gui-app/src/components/epic-canvas/comm-graph/comm-graph-open-button.tsx
@@ -12,7 +12,7 @@
  * the content id (the graph's persisted viewport) would otherwise be written by
  * two tabs at once, so panning one would move the other.
  */
-import { Waypoints } from "lucide-react";
+import { Building2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
@@ -34,13 +34,13 @@ export function CommGraphOpenButton(props: CommGraphOpenButtonProps) {
       type="button"
       variant="ghost"
       size="icon-sm"
-      aria-label="Open communication graph"
+      aria-label="Agent office"
       data-testid="epic-sidebar-open-comm-graph"
       disabled={disabled}
       onClick={openGraph}
       className={cn("text-muted-foreground hover:text-foreground", className)}
     >
-      <Waypoints className="size-4" />
+      <Building2 className="size-4" />
     </Button>
   );
 }
@@ -57,8 +57,8 @@ export function CommGraphOpenMenuItem(props: {
       onSelect={openGraph}
       data-testid="epic-sidebar-more-open-comm-graph"
     >
-      <Waypoints className="size-4" />
-      Open communication graph
+      <Building2 className="size-4" />
+      Agent office
     </DropdownMenuItem>
   );
 }

--- a/clients/gui-app/src/components/epic-canvas/comm-graph/comm-graph-tile-icon.tsx
+++ b/clients/gui-app/src/components/epic-canvas/comm-graph/comm-graph-tile-icon.tsx
@@ -1,4 +1,4 @@
-import { NetworkIcon } from "lucide-react";
+import { Building2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 /**
@@ -8,7 +8,7 @@ import { cn } from "@/lib/utils";
  */
 export function CommGraphTileIcon(props: { readonly className: string }) {
   return (
-    <NetworkIcon
+    <Building2
       className={cn("shrink-0 text-muted-foreground", props.className)}
     />
   );

--- a/clients/gui-app/src/components/epic-canvas/comm-graph/comm-graph-transport-bar.tsx
+++ b/clients/gui-app/src/components/epic-canvas/comm-graph/comm-graph-transport-bar.tsx
@@ -132,31 +132,14 @@ export function CommGraphTransportBar(props: CommGraphTransportBarProps) {
         onSeekToFraction={seekToFraction}
       />
 
-      <Button
-        type="button"
-        size="xs"
-        variant="ghost"
-        aria-pressed={transport.following}
-        data-testid="comm-graph-transport-follow-live"
-        data-following={transport.following ? "true" : "false"}
-        onClick={transport.followLive}
-        className={cn(
-          "shrink-0",
-          transport.following
-            ? "bg-primary/5 text-primary"
-            : "text-muted-foreground",
-        )}
-      >
-        <LivePulse
-          size="xs"
-          tone={transport.following ? "active" : "idle"}
-          ariaLabel={
-            transport.following ? "Following live" : "Detached from live"
-          }
-          className={undefined}
-        />
-        {transport.following ? "Live" : "Follow live"}
-      </Button>
+      {/*
+        WITH NOTHING CAPTURED THERE IS NO LIVE BADGE either: "Live" next to an
+        empty track reads as a feed that is stuck, when the truth is that there
+        has been nothing to feed. The track itself says so.
+      */}
+      {events.length === 0 ? null : (
+        <CommGraphFollowLiveButton transport={transport} />
+      )}
     </div>
   );
 }
@@ -236,37 +219,27 @@ function CommGraphTransportTrack(props: {
     [events, transport],
   );
 
+  // After the hooks, so the two renderings share one hook order.
+  if (!hasEvents)
+    return <CommGraphEmptyTrack following={transport.following} />;
+
   return (
-    /*
-      WITH NOTHING CAPTURED THERE IS NO SLIDER, not a slider that reports
-      nonsense. An empty epic has no positions to be at, so declaring
-      `min=0 max=0 valuenow=-1` would put a focusable control in the tab order
-      that announces a value outside its own range and moves nowhere when
-      driven. The empty track is inert scenery instead, matching the play
-      button, which is already disabled.
-    */
     <div
       ref={trackRef}
-      role={hasEvents ? "slider" : undefined}
-      tabIndex={hasEvents ? 0 : undefined}
-      aria-label={hasEvents ? "Event timeline" : undefined}
-      aria-disabled={hasEvents ? undefined : true}
-      aria-valuemin={hasEvents ? 0 : undefined}
-      aria-valuemax={hasEvents ? events.length - 1 : undefined}
-      aria-valuenow={hasEvents ? transport.cursorIndex : undefined}
-      aria-valuetext={hasEvents ? trackValueText(transport) : undefined}
+      role="slider"
+      tabIndex={0}
+      aria-label="Event timeline"
+      aria-valuemin={0}
+      aria-valuemax={events.length - 1}
+      aria-valuenow={transport.cursorIndex}
+      aria-valuetext={trackValueText(transport)}
       data-testid="comm-graph-transport-track"
       data-following={transport.following ? "true" : "false"}
-      data-empty={hasEvents ? "false" : "true"}
-      className={cn(
-        "relative h-6 min-w-0 flex-1 rounded-sm bg-muted/40",
-        hasEvents
-          ? "cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
-          : "cursor-default opacity-60",
-      )}
-      onPointerDown={hasEvents ? handlePointerDown : undefined}
-      onPointerMove={hasEvents ? handlePointerMove : undefined}
-      onKeyDown={hasEvents ? handleKeyDown : undefined}
+      data-empty="false"
+      className="relative h-6 min-w-0 flex-1 cursor-pointer rounded-sm bg-muted/40 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onKeyDown={handleKeyDown}
     >
       {/* Elapsed fill: everything the graph is currently showing. */}
       <div
@@ -297,15 +270,94 @@ function CommGraphTransportTrack(props: {
           />
         </TooltipWrapper>
       ))}
-      {!hasEvents ? null : (
-        <div
-          aria-hidden
-          data-testid="comm-graph-transport-playhead"
-          className="absolute inset-y-0 w-0.5 -translate-x-1/2 rounded-full bg-primary"
-          style={{ left: `${playhead * 100}%` }}
-        />
-      )}
+      <div
+        aria-hidden
+        data-testid="comm-graph-transport-playhead"
+        className="absolute inset-y-0 w-0.5 -translate-x-1/2 rounded-full bg-primary"
+        style={{ left: `${playhead * 100}%` }}
+      />
     </div>
+  );
+}
+
+/**
+ * WITH NOTHING CAPTURED THERE IS NO SLIDER, not a slider that reports
+ * nonsense. An empty epic has no positions to be at, so declaring
+ * `min=0 max=0 valuenow=-1` would put a focusable control in the tab order
+ * that announces a value outside its own range and moves nowhere when driven.
+ *
+ * The empty track SAYS it is empty instead. A blank bar beside a disabled play
+ * button reads as a control that is broken; a word in its place reads as a log
+ * that has nothing in it yet - which is the only thing that is true. Short and
+ * literal: created rows are events too, so this is not "no messages".
+ */
+function CommGraphEmptyTrack(props: { readonly following: boolean }) {
+  return (
+    <div
+      aria-disabled
+      data-testid="comm-graph-transport-track"
+      data-following={props.following ? "true" : "false"}
+      data-empty="true"
+      className="relative flex h-6 min-w-0 flex-1 cursor-default items-center justify-center rounded-sm bg-muted/40"
+    >
+      <span
+        data-testid="comm-graph-transport-empty"
+        className="text-ui-xs text-muted-foreground"
+      >
+        No events yet
+      </span>
+    </div>
+  );
+}
+
+/**
+ * The Live badge. A TOGGLE, not a one-way door: pressed while detached it
+ * re-attaches and remembers where you were; pressed again while live it takes
+ * you back there. With nothing to go back to it is a plain "Live".
+ */
+function CommGraphFollowLiveButton(props: {
+  readonly transport: CommGraphTransport;
+}) {
+  const { transport } = props;
+  const canReturn = transport.following && transport.returnCursor !== null;
+  const button = (
+    <Button
+      type="button"
+      size="xs"
+      variant="ghost"
+      aria-pressed={transport.following}
+      data-testid="comm-graph-transport-follow-live"
+      data-following={transport.following ? "true" : "false"}
+      data-can-return={canReturn ? "true" : "false"}
+      onClick={canReturn ? transport.returnToReplay : transport.followLive}
+      className={cn(
+        "shrink-0",
+        transport.following
+          ? "bg-primary/5 text-primary"
+          : "text-muted-foreground",
+      )}
+    >
+      <LivePulse
+        size="xs"
+        tone={transport.following ? "active" : "idle"}
+        ariaLabel={
+          transport.following ? "Following live" : "Detached from live"
+        }
+        className={undefined}
+      />
+      {transport.following ? "Live" : "Follow live"}
+    </Button>
+  );
+  if (!canReturn) return button;
+  return (
+    <TooltipWrapper
+      label="Back to replay position"
+      side="top"
+      sideOffset={4}
+      align="center"
+    >
+      {button}
+    </TooltipWrapper>
   );
 }
 

--- a/clients/gui-app/src/components/epic-canvas/comm-graph/office/comm-graph-office-canvas.tsx
+++ b/clients/gui-app/src/components/epic-canvas/comm-graph/office/comm-graph-office-canvas.tsx
@@ -1338,6 +1338,25 @@ function usePrefersReducedMotion(): boolean {
   return reduced;
 }
 
+/** The moment a detached floor is showing; nothing while live. */
+function OfficeCursorChip(props: {
+  readonly cursorMs: number | null;
+  readonly playing: boolean;
+}) {
+  if (props.cursorMs === null) return null;
+  return (
+    <div
+      data-testid="comm-graph-office-cursor-chip"
+      className="absolute top-2 left-2 z-10 rounded-md border border-border bg-popover px-1.5 py-0.5 text-ui-xs text-popover-foreground tabular-nums shadow-xs"
+    >
+      <span className="text-muted-foreground">
+        {props.playing ? "Replaying " : "Paused at "}
+      </span>
+      {new Date(props.cursorMs).toLocaleTimeString()}
+    </div>
+  );
+}
+
 export type CommGraphOfficeCanvasProps = CommGraphCanvasProps;
 
 export function CommGraphOfficeCanvas(props: CommGraphOfficeCanvasProps) {
@@ -2284,6 +2303,14 @@ export function CommGraphOfficeCanvas(props: CommGraphOfficeCanvasProps) {
           aria-label="Office view of the communication graph"
         />
         {modeToggle}
+        {/*
+          A detached cursor has to be VISIBLE on the floor. Scrubbing back
+          changes little here - the same people sit at the same desks, only
+          their screens go dark and later arrivals vanish - so without a sign
+          the past reads as a live floor that stopped moving. The chip names
+          the moment being shown; the transport bar below owns moving it.
+        */}
+        <OfficeCursorChip cursorMs={cursorMs} playing={playing} />
         {hoverCard === null || hoveredAgent === null ? null : (
           <OfficeAgentHover
             epicId={epicId}

--- a/clients/gui-app/src/components/epic-canvas/comm-graph/office/comm-graph-office-canvas.tsx
+++ b/clients/gui-app/src/components/epic-canvas/comm-graph/office/comm-graph-office-canvas.tsx
@@ -1347,7 +1347,9 @@ function OfficeCursorChip(props: {
   return (
     <div
       data-testid="comm-graph-office-cursor-chip"
-      className="absolute top-2 left-2 z-10 rounded-md border border-border bg-popover px-1.5 py-0.5 text-ui-xs text-popover-foreground tabular-nums shadow-xs"
+      // Read-only: it must not take the pan or the click a person aims at the
+      // floor underneath it.
+      className="pointer-events-none absolute top-2 left-2 z-10 rounded-md border border-border bg-popover px-1.5 py-0.5 text-ui-xs text-popover-foreground tabular-nums shadow-xs"
     >
       <span className="text-muted-foreground">
         {props.playing ? "Replaying " : "Paused at "}

--- a/clients/gui-app/src/components/epic-canvas/comm-graph/use-comm-graph-transport.ts
+++ b/clients/gui-app/src/components/epic-canvas/comm-graph/use-comm-graph-transport.ts
@@ -32,6 +32,7 @@ import {
   readCommGraphTimelineEpicState,
   useCommGraphCursor,
   useCommGraphPlaying,
+  useCommGraphReturnCursor,
   useCommGraphSpeed,
   useCommGraphTimelineStore,
 } from "@/stores/epics/comm-graph-timeline-store";
@@ -57,7 +58,16 @@ export interface CommGraphTransport {
   readonly cursorIndex: number;
   readonly togglePlay: () => void;
   readonly cycleSpeed: () => void;
+  /** Re-attach to live, remembering where the cursor was for `returnToReplay`. */
   readonly followLive: () => void;
+  /**
+   * The replay position `followLive` left, or `null` when there is none to go
+   * back to. Live with a return position is what makes the Live button a
+   * toggle rather than a one-way door.
+   */
+  readonly returnCursor: CommGraphTimeCursor | null;
+  /** Detach again onto `returnCursor`; a no-op when there is none. */
+  readonly returnToReplay: () => void;
   /**
    * Seek the cursor onto a row. Detaching is a CONSEQUENCE of landing on a row
    * that is not the newest, not a separate action - which is what keeps "scrub
@@ -76,6 +86,7 @@ export function useCommGraphTransport(
   const cursor = useCommGraphCursor(epicId);
   const playing = useCommGraphPlaying(epicId);
   const speed = useCommGraphSpeed(epicId);
+  const returnCursor = useCommGraphReturnCursor(epicId);
 
   // The playback timer must not restart every time a live frame lands, so the
   // array it reads is reached through a ref and kept out of the effect's
@@ -116,8 +127,23 @@ export function useCommGraphTransport(
 
   const followLive = useCallback(() => {
     const store = useCommGraphTimelineStore.getState();
+    const current = readCommGraphTimelineEpicState(epicId).cursor;
+    // Remember only a real detachment: pressing Live while already live must
+    // not erase the position a previous press saved.
+    if (current !== null) store.setReturnCursor(epicId, current);
     store.setPlaying(epicId, false);
     store.setCursor(epicId, null);
+  }, [epicId]);
+
+  const returnToReplay = useCallback(() => {
+    const store = useCommGraphTimelineStore.getState();
+    const target = readCommGraphTimelineEpicState(epicId).returnCursor;
+    if (target === null) return;
+    // Through `seekToEvent`'s rule rather than a raw set: the remembered row
+    // may have BECOME the newest row (nothing arrived since), and landing
+    // there is live, not a detachment.
+    if (commGraphCursorAtEnd(eventsRef.current, target)) return;
+    store.setCursor(epicId, target);
   }, [epicId]);
 
   const cycleSpeed = useCallback(() => {
@@ -191,6 +217,8 @@ export function useCommGraphTransport(
     togglePlay,
     cycleSpeed,
     followLive,
+    returnCursor,
+    returnToReplay,
     seekToEvent,
     stepForward,
     stepBackward,

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-selection-mode.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-selection-mode.test.tsx
@@ -1772,7 +1772,7 @@ describe("epic sidebar selection mode", () => {
     render(<EpicLeftPanelHost epicId={EPIC_ID} tabId={TAB_ID} side="left" />);
 
     expect(
-      screen.getByRole("menuitem", { name: "Open communication graph" }),
+      screen.getByRole("menuitem", { name: "Agent office" }),
     ).not.toBeNull();
   });
 

--- a/clients/gui-app/src/lib/comm-graph/__tests__/comm-graph-cloud-subscription.test.ts
+++ b/clients/gui-app/src/lib/comm-graph/__tests__/comm-graph-cloud-subscription.test.ts
@@ -595,6 +595,7 @@ describe("CommGraphCloudSubscriptionManager", () => {
     expect(readCommGraphTimelineEpicState("epic-1")).toEqual({
       cursor: null,
       playing: false,
+      returnCursor: null,
       speed: 1,
     });
 

--- a/clients/gui-app/src/lib/commands/__tests__/open.source.test.ts
+++ b/clients/gui-app/src/lib/commands/__tests__/open.source.test.ts
@@ -52,7 +52,7 @@ describe("openSource", () => {
       "Files",
       "Diff",
       "Text search",
-      "Communication graph",
+      "Agent office",
     ]);
     for (const item of items) {
       expect(item.group).toBe("open");

--- a/clients/gui-app/src/lib/commands/sources/open/comm-graph-leaf.ts
+++ b/clients/gui-app/src/lib/commands/sources/open/comm-graph-leaf.ts
@@ -19,15 +19,17 @@ import type { CommandContext, CommandItem } from "@/lib/commands/types";
 export function commGraphOpenerItem(ctx: CommandContext): CommandItem {
   return openerActionLeaf({
     id: "open:comm-graph",
-    label: "Communication graph",
+    label: "Agent office",
     keywords: [
-      "communication",
       "graph",
+      "communication",
       "comms",
       "agents",
       "messages",
       "a2a",
       "timeline",
+      "office",
+      "team",
     ],
     run: () => {
       const epicId = ctx.activeEpicId;

--- a/clients/gui-app/src/stores/epics/canvas/__tests__/comm-graph-tile-schema.test.ts
+++ b/clients/gui-app/src/stores/epics/canvas/__tests__/comm-graph-tile-schema.test.ts
@@ -51,7 +51,7 @@ describe("comm-graph tile schema", () => {
       id: commGraphTileId(EPIC_ID),
       instanceId: "inst-1",
       type: "comm-graph",
-      name: "Communication graph",
+      name: "Agent office",
       hostId: UNKNOWN_HOST_PLACEHOLDER,
       epicId: EPIC_ID,
       view: { x: 4, y: 5, zoom: 2 },
@@ -69,7 +69,7 @@ describe("comm-graph tile schema", () => {
       id: commGraphTileId(EPIC_ID),
       instanceId: "inst-1",
       type: "comm-graph",
-      name: "Communication graph",
+      name: "Agent office",
       hostId: UNKNOWN_HOST_PLACEHOLDER,
       epicId: EPIC_ID,
       view: { x: 0, y: 0, zoom: 1, mode: "isometric" },
@@ -86,7 +86,7 @@ describe("comm-graph tile schema", () => {
       id: commGraphTileId(EPIC_ID),
       instanceId: "inst-1",
       type: "comm-graph",
-      name: "Communication graph",
+      name: "Agent office",
       hostId: UNKNOWN_HOST_PLACEHOLDER,
       epicId: EPIC_ID,
       view: { x: 0, y: 0, zoom: 1, mode: "office" },
@@ -101,7 +101,7 @@ describe("comm-graph tile schema", () => {
       id: commGraphTileId(EPIC_ID),
       instanceId: "inst-1",
       type: "comm-graph",
-      name: "Communication graph",
+      name: "Agent office",
       hostId: UNKNOWN_HOST_PLACEHOLDER,
       epicId: EPIC_ID,
       view: { x: 0, y: 0, zoom: 1, mode: "graph" },
@@ -111,12 +111,31 @@ describe("comm-graph tile schema", () => {
     expect(parsed.view.mode).toBe("graph");
   });
 
+  it("renames a tile saved under the old copy on load, by kind not by name", () => {
+    const parsed = parseTileRef({
+      id: commGraphTileId(EPIC_ID),
+      instanceId: "inst-1",
+      type: "comm-graph",
+      name: "Communication graph",
+      hostId: UNKNOWN_HOST_PLACEHOLDER,
+      epicId: EPIC_ID,
+      view: { x: 0, y: 0, zoom: 1, mode: "office" },
+    });
+    expect(parsed?.type).toBe("comm-graph");
+    if (parsed === null || parsed.type !== "comm-graph") return;
+    // Matched on tile kind, not on the persisted name - a comm-graph tile
+    // saved under any prior name always renders under the current one.
+    expect(parsed.name).toBe("Agent office");
+    // The saved office/graph view mode is untouched by the rename.
+    expect(parsed.view.mode).toBe("office");
+  });
+
   it("recomputes the id on rehydrate rather than trusting the persisted one", () => {
     const parsed = parseTileRef({
       id: "stale-random-uuid",
       instanceId: "inst-1",
       type: "comm-graph",
-      name: "Communication graph",
+      name: "Agent office",
       hostId: UNKNOWN_HOST_PLACEHOLDER,
       epicId: EPIC_ID,
       view: { x: 0, y: 0, zoom: 1 },
@@ -129,7 +148,7 @@ describe("comm-graph tile schema", () => {
       parseTileRef({
         instanceId: "inst-1",
         type: "comm-graph",
-        name: "Communication graph",
+        name: "Agent office",
         hostId: UNKNOWN_HOST_PLACEHOLDER,
         view: { x: 0, y: 0, zoom: 1 },
       }),
@@ -141,7 +160,7 @@ describe("comm-graph tile schema", () => {
       id: commGraphTileId(EPIC_ID),
       instanceId: "inst-1",
       type: "comm-graph",
-      name: "Communication graph",
+      name: "Agent office",
       hostId: UNKNOWN_HOST_PLACEHOLDER,
       epicId: EPIC_ID,
       // A zero zoom would render an unrecoverable blank canvas.

--- a/clients/gui-app/src/stores/epics/canvas/tile-schema/comm-graph-tile.ts
+++ b/clients/gui-app/src/stores/epics/canvas/tile-schema/comm-graph-tile.ts
@@ -18,7 +18,7 @@ import type { CommGraphTileRef, CommGraphTileViewState } from "../types";
 import type { TileSchema } from "./index";
 import { readTileInstanceId } from "./instance-id";
 
-export const COMM_GRAPH_TILE_NAME = "Communication graph";
+export const COMM_GRAPH_TILE_NAME = "Agent office";
 
 /**
  * Neutral starting viewport; the canvas fits the graph on first layout.
@@ -127,7 +127,10 @@ function parseCommGraphTileRef(value: unknown): CommGraphTileRef | null {
     id: commGraphTileId(value.epicId),
     instanceId: readTileInstanceId(value.instanceId),
     type: TILE_KIND_COMM_GRAPH,
-    name: typeof value.name === "string" ? value.name : COMM_GRAPH_TILE_NAME,
+    // Rename previously saved tiles on load: match on tile kind, not on the
+    // persisted name, so a comm-graph tile saved under the old "Communication
+    // graph" copy picks up the current name unconditionally.
+    name: COMM_GRAPH_TILE_NAME,
     hostId:
       typeof value.hostId === "string" && value.hostId.length > 0
         ? value.hostId

--- a/clients/gui-app/src/stores/epics/comm-graph-timeline-store.ts
+++ b/clients/gui-app/src/stores/epics/comm-graph-timeline-store.ts
@@ -38,12 +38,20 @@ export interface CommGraphTimelineEpicState {
   readonly cursor: CommGraphTimeCursor | null;
   readonly playing: boolean;
   readonly speed: number;
+  /**
+   * Where the cursor sat when "Live" was last pressed, so the same button can
+   * take the person back. Only meaningful while `cursor` is `null`; a manual
+   * seek replaces it the next time Live is pressed. Never cleared by an
+   * arriving row - the position it names is a row, and rows are not removed.
+   */
+  readonly returnCursor: CommGraphTimeCursor | null;
 }
 
 const DEFAULT_EPIC_STATE: CommGraphTimelineEpicState = {
   cursor: null,
   playing: false,
   speed: DEFAULT_SPEED,
+  returnCursor: null,
 };
 
 interface CommGraphTimelineStore {
@@ -55,6 +63,10 @@ interface CommGraphTimelineStore {
     cursor: CommGraphTimeCursor | null,
   ) => void;
   readonly setPlaying: (epicId: string, playing: boolean) => void;
+  readonly setReturnCursor: (
+    epicId: string,
+    returnCursor: CommGraphTimeCursor | null,
+  ) => void;
   readonly cycleSpeed: (epicId: string) => void;
 }
 
@@ -97,6 +109,13 @@ export const useCommGraphTimelineStore = create<CommGraphTimelineStore>(
           current.playing === playing ? null : { ...current, playing },
         ),
 
+      setReturnCursor: (epicId, returnCursor) =>
+        patch(epicId, (current) =>
+          current.returnCursor === returnCursor
+            ? null
+            : { ...current, returnCursor },
+        ),
+
       cycleSpeed: (epicId) =>
         patch(epicId, (current) => {
           const index = COMM_GRAPH_PLAYBACK_SPEEDS.indexOf(current.speed);
@@ -122,6 +141,14 @@ export function useCommGraphPlaying(epicId: string): boolean {
 
 export function useCommGraphSpeed(epicId: string): number {
   return useCommGraphTimelineStore((s) => readEpicState(s, epicId).speed);
+}
+
+export function useCommGraphReturnCursor(
+  epicId: string,
+): CommGraphTimeCursor | null {
+  return useCommGraphTimelineStore(
+    (s) => readEpicState(s, epicId).returnCursor,
+  );
 }
 
 /** Imperative read for callbacks that must not subscribe (playback ticks). */


### PR DESCRIPTION
## Problem

Three things made the communication-graph transport read as broken on an epic whose agents are running but have exchanged no messages (see the paired internal fix, which also explains why GUI-created chats had no graph rows at all):

- An epic with no captured events showed a blank track beside a disabled play button and a lit **Live** badge, which reads as a stuck feed rather than an empty log.
- **Live** was a one-way door: pressing it dropped the replay position, so checking the present and coming back meant finding the spot on the track again.
- In Office mode a detached cursor was almost invisible: the same people sit at the same desks, only screens go dark and later arrivals vanish, so the past read as a live floor that stopped moving.

## Fix

- Empty log: the track is replaced by a muted "No events yet", play stays disabled, and the Live badge is hidden (`CommGraphEmptyTrack`). No slider role is declared, as before.
- Live is a toggle: pressing it while detached re-attaches and stores the position in the per-epic timeline store (`returnCursor`); pressing it again while live returns there (`returnToReplay`), with a tooltip saying so. Pressing it while live with nothing saved is a no-op, and pressing it while already live never erases a saved position. A saved row that has since become the newest row is treated as live, by the same rule `seekToEvent` uses.
- Office mode shows a "Paused at <time>" / "Replaying <time>" chip (top-left) while the cursor is detached.

## Verification

- `comm-graph-timeline.test.tsx`: empty state (text, no Live badge, no elapsed fill, play disabled); Live toggle round trip; Live with nothing to return to; Live pressed twice does not erase the saved position.
- `comm-graph-office-canvas.test.tsx`: no chip while live; "Paused at" chip once the store cursor is set; "Replaying" chip when playing.
- Existing comm-graph suites (timeline, office canvas, tile, transport math) pass: 81 tests before the new cases, 60 in the two touched files after.

Pairs with traycerai/traycer-internal (host records an `agent_created` row from `epic.createChat`).
