### PR TITLE
fix(gui-app): keep a streaming turn's own row hydrated through its index echoes

### DIFF
--- a/clients/gui-app/src/stores/chats/__tests__/transcript-window.test.ts
+++ b/clients/gui-app/src/stores/chats/__tests__/transcript-window.test.ts
@@ -18,6 +18,7 @@ import {
   appendLiveRecords,
   MAX_LIVE_EVENTS,
   SPAN_MERGE_MAX_BYTES,
+  activeTurnOrdinalsOf,
   applyIndexChange,
   applyRangeResponse,
   applySkeletonChunk,
@@ -28,6 +29,7 @@ import {
   hydratedRecords,
   isActiveTurnStreamingEcho,
   mapWindowMessages,
+  rangeRecordsInstalled,
   planTranscriptHydration,
   settleWindowBytes,
   spanChargeBytes,
@@ -7479,3 +7481,68 @@ function messageWithText(message: Message, text: string): Message {
     },
   };
 }
+
+describe("what a range answer owes the active turn", () => {
+  it("counts only the ACTIVE turn's own rows as repair work", () => {
+    // A range can serve a settled row beside the streaming one. Only the
+    // streaming turn's rows are what a write staled, so only they are retired
+    // and only they are the repair a later request is charged for. Taking every
+    // ordinal the answer carried threw away the settled row's hydration and let
+    // a plain revisit to it be charged against the streaming row's budget.
+    const response = rangeResponse({
+      epoch: 1,
+      fromOrdinal: 9,
+      rowIds: [assistantRowId("t-8"), assistantRowId("t-9")],
+      messages: [
+        assistantMessage("m-9", "t-8", 9),
+        assistantMessage("m-10", "t-9", 10),
+      ],
+    });
+
+    expect(activeTurnOrdinalsOf(response, "t-9")).toEqual([10]);
+    expect(activeTurnOrdinalsOf(response, "t-8")).toEqual([9]);
+    expect(activeTurnOrdinalsOf(response, null)).toEqual([]);
+
+    // A STEER row of the same turn is NOT one of its assistant rows, so the
+    // row-id scan finds nothing here even though the answer carries the turn's
+    // records - a steer bubble's projection sources the whole turn's messages.
+    // The store reads the emptiness as "no repair can follow this answer" and
+    // keeps the drawn body rather than forfeiting it for a repair that would
+    // never be asked for.
+    const steerOnly = rangeResponse({
+      epoch: 1,
+      fromOrdinal: 11,
+      rowIds: ["steer:q-9"],
+      messages: [assistantMessage("m-10", "t-9", 10)],
+    });
+    expect(activeTurnOrdinalsOf(steerOnly, "t-9")).toEqual([]);
+  });
+
+  it("reports whether the fold installed the answer's own copies", () => {
+    // Seating an answer is not the same as its records reaching the ledger: the
+    // fold can substitute a held copy for a served one. Certifying the turn on
+    // the request's mark alone then declared the row current while the body on
+    // screen was the one the answer had been sent to replace.
+    const served = assistantMessage("m-10", "t-9", 10);
+    const response = rangeResponse({
+      epoch: 1,
+      fromOrdinal: 10,
+      // Matching the seeded skeleton: a row-id disagreement voids the index
+      // instead of seating, which is a different path entirely.
+      rowIds: ["row-10"],
+      messages: [served],
+    });
+    const seated = applyRangeResponse(
+      windowWithSkeleton(40),
+      response,
+      null,
+      null,
+    );
+
+    expect(rangeRecordsInstalled(seated, [served], "t-9")).toBe(true);
+    // A copy the fold never saw is not installed, however alike it looks.
+    expect(rangeRecordsInstalled(seated, [{ ...served }], "t-9")).toBe(false);
+    // And an answer carrying nothing of the turn cannot close its gap.
+    expect(rangeRecordsInstalled(seated, [], "t-9")).toBe(false);
+  });
+});

--- a/clients/gui-app/src/stores/chats/__tests__/windowed-session-binding.test.ts
+++ b/clients/gui-app/src/stores/chats/__tests__/windowed-session-binding.test.ts
@@ -8,13 +8,21 @@ import type {
 } from "@traycer/protocol/host/agent/gui/subscribe-windowed";
 import type { ChatStreamCallbacks } from "@traycer-clients/shared/host-transport/chat-stream-client";
 import { createImageResolutionUpdatedFrame } from "@traycer/protocol/host/agent/gui/subscribe";
-import { assistantRowId } from "@traycer/protocol/persistence/chat-transcript/row-projection";
+import {
+  assistantRowId,
+  assistantSliceRowId,
+} from "@traycer/protocol/persistence/chat-transcript/row-projection";
 import {
   createChatSessionStore,
+  MAX_PROVISIONAL_CATCH_UP_ROUNDS,
   STREAM_COMPLETION_TIMEOUT_MS,
   type ChatSessionStoreHandle,
 } from "@/stores/chats/chat-session-store";
-import { IMMEDIATE_STREAM_FLUSH_COORDINATOR } from "@/stores/chats/stream-flush-coordinator";
+import { appLogger } from "@/lib/logger";
+import {
+  IMMEDIATE_STREAM_FLUSH_COORDINATOR,
+  type StreamFlushCoordinator,
+} from "@/stores/chats/stream-flush-coordinator";
 import {
   isTailHydrated,
   spanMessages,
@@ -182,6 +190,17 @@ function raiseActiveTurn(callbacks: ChatStreamCallbacks, turnId: string): void {
   });
 }
 
+function completeActiveTurn(callbacks: ChatStreamCallbacks): void {
+  callbacks.onTurnStateChanged({
+    kind: "turnStateChanged",
+    hasBinaryPayload: false,
+    epicId: EPIC_ID,
+    chatId: CHAT_ID,
+    runStatus: "idle",
+    activeTurn: null,
+  });
+}
+
 function blockOf(
   message: Message | undefined,
   blockId: string,
@@ -239,7 +258,49 @@ interface WindowedHarness {
   providerAuthNudgeCount(): number;
 }
 
+/**
+ * A harness whose stream deltas are NOT applied at the moment they arrive.
+ *
+ * The real coordinator coalesces: a delta frame is buffered on receipt and
+ * folded on a later tick. `IMMEDIATE_STREAM_FLUSH_COORDINATOR` collapses that
+ * interval to nothing, which is what most of these tests want - but it is also
+ * an interval a range answer can land inside, and a body seated there is
+ * folding into a window that has not yet absorbed the writes the client already
+ * holds. `flushDeltas()` is that tick, under the test's control.
+ */
+interface DeferredFlushHarness extends WindowedHarness {
+  readonly flushDeltas: () => void;
+}
+
+function createDeferredFlushHarness(): DeferredFlushHarness {
+  let pendingFlush: (() => void) | null = null;
+  const harness = createHarnessWith({
+    register: (input) => {
+      pendingFlush = input.flush;
+      return {
+        requestFlush: () => {},
+        setVisible: () => {},
+        unregister: () => {
+          pendingFlush = null;
+        },
+      };
+    },
+  });
+  return {
+    ...harness,
+    flushDeltas: () => {
+      if (pendingFlush !== null) pendingFlush();
+    },
+  };
+}
+
 function createWindowedHarness(): WindowedHarness {
+  return createHarnessWith(IMMEDIATE_STREAM_FLUSH_COORDINATOR);
+}
+
+function createHarnessWith(
+  streamFlushCoordinator: StreamFlushCoordinator,
+): WindowedHarness {
   const rangeRequests: ChatLoadRangeRequest[] = [];
   let resnapshots = 0;
   let providerAuthNudges = 0;
@@ -254,7 +315,7 @@ function createWindowedHarness(): WindowedHarness {
     onProviderAuthError: () => {
       providerAuthNudges += 1;
     },
-    streamFlushCoordinator: IMMEDIATE_STREAM_FLUSH_COORDINATOR,
+    streamFlushCoordinator,
     streamClientFactory: (_epicId, _chatId, nextCallbacks) => {
       callbacks = nextCallbacks;
       return {
@@ -1769,12 +1830,132 @@ describe("the active turn's streaming echo does not starve in-flight hydration",
     }
   });
 
-  it("a streaming echo still supersedes when the turn's record is not held", () => {
-    // The cold-row boundary of the exemption: a copy the window does not
-    // hold is not being rewritten - its deltas are dropped - so an answer
-    // generated before them carries blocks the client can never recover.
-    // Accepting it would seat the older body permanently; it must be
-    // discarded and re-asked exactly as before the exemption existed.
+  /** A text block, so an answer's body is distinguishable from its successor's. */
+  function textBlock(blockId: string, text: string): AssistantBlocks[number] {
+    return {
+      type: "text",
+      blockId,
+      status: "streaming",
+      timestamp: 1,
+      text,
+      providerNotice: null,
+    };
+  }
+
+  /**
+   * The streaming turn's body as of some point in the turn, carrying the host's
+   * write counter for that slice.
+   *
+   * The counter is what a settled record's substitution rules read, and it is
+   * the ordinary shape the host serves - so these bodies exercise the versioned
+   * path. It is NOT what decides whether a catch-up is owed: that is the
+   * request's own write mark, which is why the versionless bodies below recover
+   * their content just the same. See `versionlessTurnBody`.
+   */
+  function turnBodyAt(text: string, blocksVersion: number): Message {
+    const base = assistantWithBlocks("assistant-10", 10, "t-9", [
+      textBlock("b-1", text),
+    ]);
+    return base.role === "assistant" ? { ...base, blocksVersion } : base;
+  }
+
+  /**
+   * The streaming turn's body with NO `blocksVersion`, which the wire schema
+   * still allows and delta writers preserve.
+   */
+  function versionlessTurnBody(text: string): Message {
+    return assistantWithBlocks("assistant-10", 10, "t-9", [
+      textBlock("b-1", text),
+    ]);
+  }
+
+  /** One `text.delta` from the host, appended to the turn's text block. */
+  function streamTextDelta(harness: WindowedHarness, delta: string): void {
+    harness.callbacks().onBlockDelta({
+      kind: "blockDelta",
+      hasBinaryPayload: false,
+      epicId: EPIC_ID,
+      chatId: CHAT_ID,
+      event: { type: "text.delta", blockId: "b-1", timestamp: 5, delta },
+    });
+  }
+
+  /** The text the store is currently publishing for the streaming turn. */
+  function publishedTurnText(harness: WindowedHarness): string | undefined {
+    const message = harness.handle.store
+      .getState()
+      .messages.find((candidate) => candidate.messageId === "assistant-10");
+    const block = blockOf(message, "b-1");
+    return block?.type === "text" ? block.text : undefined;
+  }
+
+  /**
+   * A skeleton whose ordinals 10-12 are ONE steered turn - two assistant slices
+   * with the steer bubble between them - so an echo can name one slice while a
+   * request is in flight for the other.
+   */
+  function splitTurnSkeleton(): Parameters<
+    ChatStreamCallbacks["onSkeletonChunk"]
+  >[0] {
+    const rowIds = new Map([
+      [10, assistantSliceRowId("t-9", 0, true)],
+      [11, "steer:q-9"],
+      [12, assistantSliceRowId("t-9", 1, true)],
+    ]);
+    return {
+      kind: "skeletonChunk",
+      hasBinaryPayload: false,
+      epicId: EPIC_ID,
+      chatId: CHAT_ID,
+      chunk: {
+        epoch: 1,
+        fromOrdinal: 0,
+        entries: Array.from({ length: 40 }, (_unused, ordinal) => ({
+          rowId: rowIds.get(ordinal) ?? `row-${ordinal}`,
+          createdAt: ordinal,
+          role: "user" as const,
+          byteLength: 64,
+          bodyDigest: `d${ordinal}`,
+        })),
+        isFinal: true,
+      },
+    };
+  }
+
+  /** One per-approval `updated` echo of the streaming row, at `revision`. */
+  function streamingRowEcho(revision: number): IndexChangedFrame {
+    return indexChangedFrame({
+      epoch: 1,
+      rowCount: 40,
+      indexRevision: revision,
+      changes: [
+        {
+          type: "updated",
+          entries: [
+            {
+              ordinal: 10,
+              entry: {
+                rowId: assistantRowId("t-9"),
+                createdAt: 10,
+                role: "assistant",
+                byteLength: 4096 * revision,
+                bodyDigest: `d10-approval-${revision}`,
+              },
+            },
+          ],
+        },
+      ],
+    });
+  }
+
+  it("a storm of streaming echoes against an UNHELD turn seats the row, catches it up, and then leaves it alone", () => {
+    // The loop that left a tool-heavy turn's own row as a placeholder for the
+    // life of the turn. The window holds no copy of the streaming turn (the
+    // tail below does not carry it), the viewport asks for its row, and the
+    // host echoes the row's index entry once per approval while the answer is
+    // in flight. Before the fix each echo superseded the request, the answer
+    // was discarded, the re-plan asked again and the next echo caught that
+    // one too.
     const harness = createWindowedHarness();
     try {
       seatedTail(harness);
@@ -1783,8 +1964,1448 @@ describe("the active turn's streaming echo does not starve in-flight hydration",
       harness.handle.store
         .getState()
         .reportVisibleTranscriptRange({ fromOrdinal: 10, toOrdinal: 11 });
-      const requestId = harness.lastRangeRequestId();
+      const firstRequestId = harness.lastRangeRequestId();
+      expect(harness.rangeRequests).toHaveLength(1);
 
+      // Five approvals land while the first answer is on the wire. None of
+      // them may supersede it, and none may mint a request of its own.
+      for (let revision = 1; revision <= 5; revision += 1) {
+        harness.callbacks().onIndexChanged(streamingRowEcho(revision));
+      }
+      expect(harness.rangeRequests).toHaveLength(1);
+
+      // The body the host sliced BEFORE those five writes - what a pre-echo
+      // answer necessarily carries.
+      harness.callbacks().onRange(
+        rangeFrame({
+          requestId: firstRequestId,
+          epoch: 1,
+          fromOrdinal: 10,
+          rowIds: [assistantRowId("t-9")],
+          messages: [turnBodyAt("before the approvals", 1)],
+        }),
+      );
+
+      // The answer SEATED - it was not discarded - so the row draws instead of
+      // going back to a placeholder. But it predates writes this client
+      // dropped, so its span is retired to the stale tier (still rendering the
+      // body it carried) and exactly one catch-up request goes out.
+      const afterFirst = harness.handle.store.getState().transcriptWindow;
+      expect(afterFirst.spans.some((span) => span.fromOrdinal === 10)).toBe(
+        false,
+      );
+      expect(
+        afterFirst.staleSpans.some((span) => span.fromOrdinal === 10),
+      ).toBe(true);
+      expect(publishedTurnText(harness)).toBe("before the approvals");
+      expect(harness.rangeRequests).toHaveLength(2);
+      const catchUpRequestId = harness.lastRangeRequestId();
+      expect(catchUpRequestId).not.toBe(firstRequestId);
+      expect(harness.rangeRequests[1]?.fromOrdinal).toBe(10);
+
+      // More approvals while the CATCH-UP is in flight. The host may well have
+      // sliced after them - the client cannot tell - so this is not "the answer
+      // is missing them", it is "the answer has not ESTABLISHED that it covers
+      // them". A body seated around a gap goes on missing the write whatever
+      // lands on it afterwards, so the conservative reading is the only safe
+      // one: seat it, and ask once more across a quiet interval.
+      for (let revision = 6; revision <= 8; revision += 1) {
+        harness.callbacks().onIndexChanged(streamingRowEcho(revision));
+      }
+      expect(harness.rangeRequests).toHaveLength(2);
+
+      harness.callbacks().onRange(
+        rangeFrame({
+          requestId: catchUpRequestId,
+          epoch: 1,
+          fromOrdinal: 10,
+          rowIds: [assistantRowId("t-9")],
+          messages: [turnBodyAt("after the approvals", 2)],
+        }),
+      );
+      expect(publishedTurnText(harness)).toBe("after the approvals");
+      expect(harness.rangeRequests).toHaveLength(3);
+      const finalRequestId = harness.lastRangeRequestId();
+
+      // This one is asked and answered across a quiet stream: no write happened
+      // between it going out and coming back, so it carries every write up to
+      // its slice and the client has applied every write since. That is the
+      // whole of the turn, and it is what ends the obligation.
+      harness.callbacks().onRange(
+        rangeFrame({
+          requestId: finalRequestId,
+          epoch: 1,
+          fromOrdinal: 10,
+          rowIds: [assistantRowId("t-9")],
+          messages: [turnBodyAt("all of the approvals", 3)],
+        }),
+      );
+
+      // Final: a further storm of echoes neither retires it nor asks again.
+      const afterCatchUp = harness.handle.store.getState().transcriptWindow;
+      expect(afterCatchUp.spans.some((span) => span.fromOrdinal === 10)).toBe(
+        true,
+      );
+      expect(publishedTurnText(harness)).toBe("all of the approvals");
+      for (let revision = 9; revision <= 14; revision += 1) {
+        harness.callbacks().onIndexChanged(streamingRowEcho(revision));
+      }
+      const settled = harness.handle.store.getState().transcriptWindow;
+      expect(settled.spans.some((span) => span.fromOrdinal === 10)).toBe(true);
+      expect(publishedTurnText(harness)).toBe("all of the approvals");
+      expect(harness.rangeRequests).toHaveLength(3);
+    } finally {
+      harness.handle.dispose();
+    }
+  });
+
+  it("a second pre-echo answer cannot discharge the catch-up the first one owed", () => {
+    // The dedup slot hides the catch-up when several requests for the same
+    // range are outstanding. A is sent, the viewport moves away and back so B
+    // and C follow, then the echo lands. A seats and asks for a catch-up - but
+    // C already names that range, so the planner suppresses it. C's answer is
+    // just as old as A's, and an obligation keyed on the ordinal would read as
+    // discharged the moment A consumed it, leaving the pre-echo body on screen
+    // with nothing outstanding. The mark is on the REQUEST, so C owes the
+    // catch-up too, and the request that finally settles the row is one sent
+    // after the dropped write.
+    const harness = createWindowedHarness();
+    try {
+      seatedTail(harness);
+      raiseActiveTurn(harness.callbacks(), "t-9");
+      const store = harness.handle.store.getState();
+
+      store.reportVisibleTranscriptRange({ fromOrdinal: 10, toOrdinal: 11 });
+      const requestA = harness.lastRangeRequestId();
+      store.reportVisibleTranscriptRange({ fromOrdinal: 12, toOrdinal: 13 });
+      store.reportVisibleTranscriptRange({ fromOrdinal: 10, toOrdinal: 11 });
+      const requestC = harness.lastRangeRequestId();
+      expect(harness.rangeRequests).toHaveLength(3);
+      expect(requestC).not.toBe(requestA);
+
+      harness.callbacks().onIndexChanged(streamingRowEcho(1));
+
+      harness.callbacks().onRange(
+        rangeFrame({
+          requestId: requestA,
+          epoch: 1,
+          fromOrdinal: 10,
+          rowIds: [assistantRowId("t-9")],
+          messages: [turnBodyAt("A: before the write", 1)],
+        }),
+      );
+      // A's catch-up is suppressed by C's dedup slot - the state the ordinal
+      // debt could not see.
+      expect(harness.rangeRequests).toHaveLength(3);
+
+      harness.callbacks().onRange(
+        rangeFrame({
+          requestId: requestC,
+          epoch: 1,
+          fromOrdinal: 10,
+          rowIds: [assistantRowId("t-9")],
+          messages: [turnBodyAt("C: also before the write", 1)],
+        }),
+      );
+
+      // C is pre-echo too, so it owes the same catch-up - and its own arrival
+      // freed the slot, so this one is actually sent.
+      expect(harness.rangeRequests).toHaveLength(4);
+      const catchUpRequestId = harness.lastRangeRequestId();
+      expect(harness.rangeRequests[3]?.fromOrdinal).toBe(10);
+
+      harness.callbacks().onRange(
+        rangeFrame({
+          requestId: catchUpRequestId,
+          epoch: 1,
+          fromOrdinal: 10,
+          rowIds: [assistantRowId("t-9")],
+          messages: [turnBodyAt("after the write", 2)],
+        }),
+      );
+
+      expect(publishedTurnText(harness)).toBe("after the write");
+      const window = harness.handle.store.getState().transcriptWindow;
+      expect(window.spans.some((span) => span.fromOrdinal === 10)).toBe(true);
+      expect(harness.rangeRequests).toHaveLength(4);
+    } finally {
+      harness.handle.dispose();
+    }
+  });
+
+  it("an echo naming a SIBLING slice still catches up the answer carrying the turn's records", () => {
+    // A turn's records are shared by every row it produces, so an answer for
+    // slice 0 carries exactly the record slice 1 renders from. An echo naming
+    // only slice 1 therefore stales a body being served under an ordinal it
+    // never mentioned - which an obligation keyed on the echoed ordinal misses
+    // entirely, because ordinal 12 is neither visible nor requested.
+    const harness = createWindowedHarness();
+    try {
+      seatedTail(harness);
+      harness.callbacks().onSkeletonChunk(splitTurnSkeleton());
+      raiseActiveTurn(harness.callbacks(), "t-9");
+
+      harness.handle.store
+        .getState()
+        .reportVisibleTranscriptRange({ fromOrdinal: 10, toOrdinal: 11 });
+      const sliceRequestId = harness.lastRangeRequestId();
+      expect(harness.rangeRequests).toHaveLength(1);
+
+      // Echoes the OTHER slice of the same turn.
+      harness.callbacks().onIndexChanged(
+        indexChangedFrame({
+          epoch: 1,
+          rowCount: 40,
+          indexRevision: 1,
+          changes: [
+            {
+              type: "updated",
+              entries: [
+                {
+                  ordinal: 12,
+                  entry: {
+                    rowId: assistantSliceRowId("t-9", 1, true),
+                    createdAt: 12,
+                    role: "assistant",
+                    byteLength: 8192,
+                    bodyDigest: "d12-echo",
+                  },
+                },
+              ],
+            },
+          ],
+        }),
+      );
+
+      harness.callbacks().onRange(
+        rangeFrame({
+          requestId: sliceRequestId,
+          epoch: 1,
+          fromOrdinal: 10,
+          rowIds: [assistantSliceRowId("t-9", 0, true)],
+          messages: [turnBodyAt("slice body before the sibling write", 1)],
+        }),
+      );
+
+      // The catch-up is owed by the ANSWER, which carried the turn's records,
+      // not by the ordinal the echo happened to name.
+      expect(harness.rangeRequests).toHaveLength(2);
+      expect(harness.rangeRequests[1]?.fromOrdinal).toBe(10);
+    } finally {
+      harness.handle.dispose();
+    }
+  });
+
+  it("an answer that seats no body leaves the catch-up owed for the row's next answer", () => {
+    // A row can come back listed in `incompleteRowIds`: the host served the row
+    // id but withheld its records, so nothing seats. Spending the obligation
+    // there retires it against a body that never arrived, and the row's real
+    // answer - which can be just as old - then seats permanently. Nothing is
+    // consumed here, so the next answer is judged on its own provenance.
+    const info = vi.spyOn(appLogger, "info").mockImplementation(() => {});
+    const harness = createWindowedHarness();
+    try {
+      seatedTail(harness);
+      raiseActiveTurn(harness.callbacks(), "t-9");
+
+      harness.handle.store
+        .getState()
+        .reportVisibleTranscriptRange({ fromOrdinal: 10, toOrdinal: 11 });
+      const firstRequestId = harness.lastRangeRequestId();
+      harness.callbacks().onIndexChanged(streamingRowEcho(1));
+
+      const incomplete = rangeFrame({
+        requestId: firstRequestId,
+        epoch: 1,
+        fromOrdinal: 10,
+        rowIds: [assistantRowId("t-9")],
+        messages: [turnBodyAt("withheld", 1)],
+      });
+      harness.callbacks().onRange({
+        ...incomplete,
+        range: {
+          ...incomplete.range,
+          incompleteRowIds: [assistantRowId("t-9")],
+        },
+      });
+
+      // Nothing seated, so nothing is retired and no catch-up is claimed.
+      const afterIncomplete = harness.handle.store.getState().transcriptWindow;
+      expect(
+        afterIncomplete.spans.some((span) => span.fromOrdinal === 10),
+      ).toBe(false);
+      expect(
+        afterIncomplete.staleSpans.some((span) => span.fromOrdinal === 10),
+      ).toBe(false);
+      // And the log says so. A re-ask logged against an answer that seated
+      // nothing reads, to whoever is debugging this next, as a body corrected
+      // when none was ever drawn.
+      expect(info).not.toHaveBeenCalledWith(
+        expect.stringContaining("predates a dropped write"),
+        expect.anything(),
+      );
+
+      // The row becomes servable again and is re-requested.
+      harness.callbacks().onIndexChanged(streamingRowEcho(2));
+      const retryRequestId = harness.lastRangeRequestId();
+      expect(retryRequestId).not.toBe(firstRequestId);
+
+      // A further echo WHILE that retry is in flight, with the turn still
+      // unheld - the interleaving the whole mark exists for. An obligation
+      // keyed on the echoed ordinal was already spent by the answer that seated
+      // nothing, so the retry's own staleness went unnoticed and its body
+      // seated for good.
+      harness.callbacks().onIndexChanged(streamingRowEcho(3));
+
+      harness.callbacks().onRange(
+        rangeFrame({
+          requestId: retryRequestId,
+          epoch: 1,
+          fromOrdinal: 10,
+          rowIds: [assistantRowId("t-9")],
+          messages: [turnBodyAt("stale", 2)],
+        }),
+      );
+
+      // Sliced before that second echo, so it seats provisionally and is asked
+      // for again rather than standing as the turn's body.
+      const thirdRequestId = harness.lastRangeRequestId();
+      expect(thirdRequestId).not.toBe(retryRequestId);
+
+      harness.callbacks().onRange(
+        rangeFrame({
+          requestId: thirdRequestId,
+          epoch: 1,
+          fromOrdinal: 10,
+          rowIds: [assistantRowId("t-9")],
+          messages: [turnBodyAt("current", 3)],
+        }),
+      );
+
+      expect(publishedTurnText(harness)).toBe("current");
+      const settled = harness.handle.store.getState().transcriptWindow;
+      expect(settled.spans.some((span) => span.fromOrdinal === 10)).toBe(true);
+    } finally {
+      info.mockRestore();
+      harness.handle.dispose();
+    }
+  });
+
+  it("a pre-echo answer carrying no record of the streaming turn is left alone", () => {
+    // The bound on the catch-up. A dropped write stales the turn it was written
+    // for and nothing else, so scrollback fetched in the same window is current
+    // - re-asking for it would spend a round trip per echo on rows the write
+    // could not have touched.
+    const harness = createWindowedHarness();
+    try {
+      seatedTail(harness);
+      raiseActiveTurn(harness.callbacks(), "t-9");
+
+      harness.handle.store
+        .getState()
+        .reportVisibleTranscriptRange({ fromOrdinal: 4, toOrdinal: 5 });
+      const scrollbackRequestId = harness.lastRangeRequestId();
+      harness.callbacks().onIndexChanged(streamingRowEcho(1));
+
+      harness.callbacks().onRange(
+        rangeFrame({
+          requestId: scrollbackRequestId,
+          epoch: 1,
+          fromOrdinal: 4,
+          rowIds: ["row-4"],
+          messages: [userMessage("m-4", 4)],
+        }),
+      );
+
+      const window = harness.handle.store.getState().transcriptWindow;
+      expect(window.spans.some((span) => span.fromOrdinal === 4)).toBe(true);
+      expect(harness.rangeRequests).toHaveLength(1);
+    } finally {
+      harness.handle.dispose();
+    }
+  });
+
+  it("recovers a write that a delta overtook the catch-up answer for", () => {
+    // The provisionally seated body is TORN, and that is the whole difficulty.
+    // The catch-up carries the write the client dropped; the deltas that landed
+    // on the provisional body while the catch-up flew carry writes the catch-up
+    // predates. Neither copy is a superset of the other, so a rule that just
+    // picks one loses text either way - the answer is to notice that the seat
+    // was overtaken and ask once more, for a slice taken after both writes.
+    const harness = createWindowedHarness();
+    try {
+      seatedTail(harness);
+      raiseActiveTurn(harness.callbacks(), "t-9");
+
+      harness.handle.store
+        .getState()
+        .reportVisibleTranscriptRange({ fromOrdinal: 10, toOrdinal: 11 });
+      const firstRequestId = harness.lastRangeRequestId();
+
+      // Dropped: nothing holds the turn, so this write has nowhere to land.
+      streamTextDelta(harness, " missed");
+      harness.callbacks().onIndexChanged(streamingRowEcho(1));
+
+      // Sliced before that write, so it seats provisionally and owes a catch-up.
+      harness.callbacks().onRange(
+        rangeFrame({
+          requestId: firstRequestId,
+          epoch: 1,
+          fromOrdinal: 10,
+          rowIds: [assistantRowId("t-9")],
+          messages: [turnBodyAt("before", 1)],
+        }),
+      );
+      const catchUpRequestId = harness.lastRangeRequestId();
+      expect(catchUpRequestId).not.toBe(firstRequestId);
+
+      // This one is NOT dropped - the provisional body absorbs it - but it
+      // overtakes the catch-up already in flight, so the answer coming back
+      // cannot contain it.
+      streamTextDelta(harness, " later");
+      expect(publishedTurnText(harness)).toBe("before later");
+      harness.callbacks().onIndexChanged(streamingRowEcho(2));
+
+      harness.callbacks().onRange(
+        rangeFrame({
+          requestId: catchUpRequestId,
+          epoch: 1,
+          fromOrdinal: 10,
+          rowIds: [assistantRowId("t-9")],
+          messages: [turnBodyAt("before missed", 2)],
+        }),
+      );
+
+      // Equal versions, and the client's counter is its own: it counts the
+      // writes this client applied, from a base already behind the host, so a
+      // tie proves nothing. Certifying the answer here on its request's mark
+      // published `before later` and left ` missed` gone for the turn.
+      const secondCatchUpId = harness.lastRangeRequestId();
+      expect(secondCatchUpId).not.toBe(catchUpRequestId);
+
+      harness.callbacks().onRange(
+        rangeFrame({
+          requestId: secondCatchUpId,
+          epoch: 1,
+          fromOrdinal: 10,
+          rowIds: [assistantRowId("t-9")],
+          messages: [turnBodyAt("before missed later", 3)],
+        }),
+      );
+
+      expect(publishedTurnText(harness)).toBe("before missed later");
+      // Settled: a slice nothing overtook seats fresh and is asked for no more.
+      const settled = harness.handle.store.getState().transcriptWindow;
+      expect(settled.spans.some((span) => span.fromOrdinal === 10)).toBe(true);
+      expect(harness.lastRangeRequestId()).toBe(secondCatchUpId);
+    } finally {
+      harness.handle.dispose();
+    }
+  });
+
+  it("seats a catch-up over a provisional body that carries no version", () => {
+    // `blocksVersion` is optional on the wire and delta writers preserve its
+    // absence, so the catch-up and the body it repairs can both arrive without
+    // one. The held-copy preference cannot prove the provisional body older and
+    // used to keep it - pinning the incomplete text with no gap left to
+    // re-request. A body the client itself flagged as short of the host has no
+    // claim on the stream's authority, so the serve seats.
+    const harness = createWindowedHarness();
+    try {
+      seatedTail(harness);
+      raiseActiveTurn(harness.callbacks(), "t-9");
+
+      harness.handle.store
+        .getState()
+        .reportVisibleTranscriptRange({ fromOrdinal: 10, toOrdinal: 11 });
+      const firstRequestId = harness.lastRangeRequestId();
+
+      streamTextDelta(harness, " missed");
+      harness.callbacks().onIndexChanged(streamingRowEcho(1));
+
+      harness.callbacks().onRange(
+        rangeFrame({
+          requestId: firstRequestId,
+          epoch: 1,
+          fromOrdinal: 10,
+          rowIds: [assistantRowId("t-9")],
+          messages: [versionlessTurnBody("before")],
+        }),
+      );
+      const catchUpRequestId = harness.lastRangeRequestId();
+      expect(catchUpRequestId).not.toBe(firstRequestId);
+
+      // Nothing overtakes this one, so it is the whole truth as of its slice.
+      harness.callbacks().onRange(
+        rangeFrame({
+          requestId: catchUpRequestId,
+          epoch: 1,
+          fromOrdinal: 10,
+          rowIds: [assistantRowId("t-9")],
+          messages: [versionlessTurnBody("before missed")],
+        }),
+      );
+
+      expect(publishedTurnText(harness)).toBe("before missed");
+      // And it is final: an install discharges the obligation, so no third
+      // request goes out.
+      expect(harness.lastRangeRequestId()).toBe(catchUpRequestId);
+      const settled = harness.handle.store.getState().transcriptWindow;
+      expect(settled.spans.some((span) => span.fromOrdinal === 10)).toBe(true);
+    } finally {
+      harness.handle.dispose();
+    }
+  });
+
+  it("leaves a COMPLETE row alone when the same answer withholds the streaming turn", () => {
+    // A mixed answer: one settled row served whole, the active turn's row listed
+    // incomplete. The fold withholds the whole turn's records, so nothing of it
+    // seats - but the raw answer still carries them, and reading the raw records
+    // retired every ordinal the answer served. That threw away the settled row's
+    // valid hydration and re-asked for it, to chase a body the fold had already
+    // refused. What seats is what decides.
+    const info = vi.spyOn(appLogger, "info").mockImplementation(() => {});
+    const harness = createWindowedHarness();
+    try {
+      seatedTail(harness);
+      raiseActiveTurn(harness.callbacks(), "t-9");
+
+      harness.handle.store
+        .getState()
+        .reportVisibleTranscriptRange({ fromOrdinal: 9, toOrdinal: 11 });
+      const requestId = harness.lastRangeRequestId();
+      harness.callbacks().onIndexChanged(streamingRowEcho(1));
+
+      const mixed = rangeFrame({
+        requestId,
+        epoch: 1,
+        fromOrdinal: 9,
+        rowIds: [assistantRowId("t-8"), assistantRowId("t-9")],
+        messages: [
+          assistantWithBlocks("assistant-9", 9, "t-8", [
+            textBlock("b-8", "settled"),
+          ]),
+          turnBodyAt("withheld", 1),
+        ],
+      });
+      harness.callbacks().onRange({
+        ...mixed,
+        range: { ...mixed.range, incompleteRowIds: [assistantRowId("t-9")] },
+      });
+
+      // The settled row seated and stays FRESH: no catch-up was owed for it,
+      // and none of the streaming turn seated to owe one.
+      const seated = harness.handle.store.getState().transcriptWindow;
+      expect(seated.spans.some((span) => span.fromOrdinal === 9)).toBe(true);
+      expect(seated.staleSpans.some((span) => span.fromOrdinal === 9)).toBe(
+        false,
+      );
+      // And nothing claims a catch-up it did not perform.
+      expect(info).not.toHaveBeenCalledWith(
+        expect.stringContaining("predates a dropped write"),
+        expect.anything(),
+      );
+      // Nothing is re-requested at all. The withheld row is marked unavailable,
+      // which the planner skips, and the settled row is hydrated - so the
+      // correct amount of traffic here is none. Retiring the served ordinals
+      // asked for the settled row again, wire-inclusive [9,9], purely to
+      // re-fetch a body that had not changed.
+      expect(harness.lastRangeRequestId()).toBe(requestId);
+    } finally {
+      info.mockRestore();
+      harness.handle.dispose();
+    }
+  });
+
+  it("stops asking once the stream has overtaken every catch-up", () => {
+    // The bound. Each catch-up is answered with a slice the next delta
+    // immediately overtakes, which is a live possibility on a fast turn. Asking
+    // again is right up to a point; a request per round trip for the length of
+    // the turn is not, so the client keeps what it has and lets the completion
+    // rebase - which re-seats the turn from the host - finish the repair.
+    const harness = createWindowedHarness();
+    try {
+      seatedTail(harness);
+      raiseActiveTurn(harness.callbacks(), "t-9");
+
+      harness.handle.store
+        .getState()
+        .reportVisibleTranscriptRange({ fromOrdinal: 10, toOrdinal: 11 });
+      let requestId = harness.lastRangeRequestId();
+      streamTextDelta(harness, " missed");
+      harness.callbacks().onIndexChanged(streamingRowEcho(1));
+
+      const requestIds = new Set<string>([requestId]);
+      for (let round = 1; round <= 8; round += 1) {
+        harness.callbacks().onRange(
+          rangeFrame({
+            requestId,
+            epoch: 1,
+            fromOrdinal: 10,
+            rowIds: [assistantRowId("t-9")],
+            messages: [turnBodyAt(`slice-${round}`, round)],
+          }),
+        );
+        const next = harness.lastRangeRequestId();
+        if (next === requestId) break;
+        requestId = next;
+        requestIds.add(next);
+        // Every catch-up is overtaken the moment it is asked for.
+        streamTextDelta(harness, `-${round}`);
+        harness.callbacks().onIndexChanged(streamingRowEcho(round + 1));
+      }
+
+      // The first request plus MAX_PROVISIONAL_CATCH_UP_ROUNDS catch-ups, and
+      // then it stops - not one per delta for the rest of the turn.
+      expect(requestIds.size).toBe(MAX_PROVISIONAL_CATCH_UP_ROUNDS + 1);
+      const settled = harness.handle.store.getState().transcriptWindow;
+      expect(settled.spans.some((span) => span.fromOrdinal === 10)).toBe(true);
+    } finally {
+      harness.handle.dispose();
+    }
+  });
+
+  it("charges the repair budget for catch-ups SENT, not for demotions the dedup slot suppresses", () => {
+    // Several requests can be outstanding for the same row at once - ordinary
+    // scrolling does it - and every one of their answers predates the write. The
+    // first demotion asks for a re-plan and gets nothing, because the dedup slot
+    // still names a request covering those rows; so do the second and third.
+    // Charging the budget at the demotion spent all three rounds on suppressed
+    // re-plans and then announced that the client was giving up, having asked
+    // the host exactly nothing. The budget is for requests that reach the wire.
+    const harness = createWindowedHarness();
+    try {
+      seatedTail(harness);
+      raiseActiveTurn(harness.callbacks(), "t-9");
+
+      // Seven outstanding requests, under the ledger's cap of eight; four of
+      // them for row 10, and the last one owns the dedup slot.
+      const rowTenRequestIds: string[] = [];
+      for (const ordinal of [10, 12, 10, 13, 10, 14, 10]) {
+        harness.handle.store.getState().reportVisibleTranscriptRange({
+          fromOrdinal: ordinal,
+          toOrdinal: ordinal + 1,
+        });
+        if (ordinal === 10) rowTenRequestIds.push(harness.lastRangeRequestId());
+      }
+      expect(harness.rangeRequests).toHaveLength(7);
+      expect(rowTenRequestIds).toHaveLength(4);
+
+      // One write, dropped while the turn is unheld. The stream then goes
+      // quiet, so a single corrective request would be answered with the truth.
+      streamTextDelta(harness, " missed");
+      harness.callbacks().onIndexChanged(streamingRowEcho(1));
+
+      // All four row-10 answers were sliced before that write. Oldest first.
+      for (const requestId of rowTenRequestIds) {
+        harness.callbacks().onRange(
+          rangeFrame({
+            requestId,
+            epoch: 1,
+            fromOrdinal: 10,
+            rowIds: [assistantRowId("t-9")],
+            messages: [turnBodyAt("before", 1)],
+          }),
+        );
+      }
+
+      // Exactly one of those four demotions could actually send, and it did.
+      expect(harness.rangeRequests).toHaveLength(8);
+      const catchUpRequestId = harness.lastRangeRequestId();
+      expect(rowTenRequestIds).not.toContain(catchUpRequestId);
+
+      harness.callbacks().onRange(
+        rangeFrame({
+          requestId: catchUpRequestId,
+          epoch: 1,
+          fromOrdinal: 10,
+          rowIds: [assistantRowId("t-9")],
+          messages: [turnBodyAt("before missed", 2)],
+        }),
+      );
+
+      expect(publishedTurnText(harness)).toBe("before missed");
+    } finally {
+      harness.handle.dispose();
+    }
+  });
+
+  it("one answer installing a body does not discharge what another still owes", () => {
+    // Two answers for the same row are in flight, both sliced before a write
+    // that overtakes them. The first installs its body; a rule that asked "has
+    // the held body changed since the last seat" then read the second answer as
+    // current, because the first had just reset that baseline - and discharged
+    // the obligation with the write still missing. Each request carries its own
+    // mark, so what one answer does to the body cannot answer for another.
+    const harness = createWindowedHarness();
+    try {
+      seatedTail(harness);
+      raiseActiveTurn(harness.callbacks(), "t-9");
+
+      harness.handle.store
+        .getState()
+        .reportVisibleTranscriptRange({ fromOrdinal: 10, toOrdinal: 11 });
+      const firstRequestId = harness.lastRangeRequestId();
+      streamTextDelta(harness, " missed");
+      harness.callbacks().onIndexChanged(streamingRowEcho(1));
+
+      harness.callbacks().onRange(
+        rangeFrame({
+          requestId: firstRequestId,
+          epoch: 1,
+          fromOrdinal: 10,
+          rowIds: [assistantRowId("t-9")],
+          messages: [turnBodyAt("before", 1)],
+        }),
+      );
+      const b = harness.lastRangeRequestId();
+
+      // Scroll away and back: a second request for the same row, which takes
+      // the dedup slot and will suppress the re-plan B's own answer asks for.
+      harness.handle.store
+        .getState()
+        .reportVisibleTranscriptRange({ fromOrdinal: 12, toOrdinal: 13 });
+      harness.handle.store
+        .getState()
+        .reportVisibleTranscriptRange({ fromOrdinal: 10, toOrdinal: 11 });
+      const d = harness.lastRangeRequestId();
+      expect(d).not.toBe(b);
+
+      // A write overtakes both of them.
+      streamTextDelta(harness, " later");
+      harness.callbacks().onIndexChanged(streamingRowEcho(2));
+
+      const sentBefore = harness.rangeRequests.length;
+      harness.callbacks().onRange(
+        rangeFrame({
+          requestId: b,
+          epoch: 1,
+          fromOrdinal: 10,
+          rowIds: [assistantRowId("t-9")],
+          messages: [turnBodyAt("before missed", 2)],
+        }),
+      );
+      // B's demotion is suppressed by D's outstanding request, so nothing is
+      // sent and nothing is charged.
+      expect(harness.rangeRequests).toHaveLength(sentBefore);
+
+      harness.callbacks().onRange(
+        rangeFrame({
+          requestId: d,
+          epoch: 1,
+          fromOrdinal: 10,
+          rowIds: [assistantRowId("t-9")],
+          messages: [turnBodyAt("before missed", 2)],
+        }),
+      );
+      // D predates ` later` just as B did, so it owes the repair it cannot make.
+      const repairId = harness.lastRangeRequestId();
+      expect(repairId).not.toBe(d);
+
+      harness.callbacks().onRange(
+        rangeFrame({
+          requestId: repairId,
+          epoch: 1,
+          fromOrdinal: 10,
+          rowIds: [assistantRowId("t-9")],
+          messages: [turnBodyAt("before missed later", 3)],
+        }),
+      );
+
+      expect(publishedTurnText(harness)).toBe("before missed later");
+    } finally {
+      harness.handle.dispose();
+    }
+  });
+
+  it("recovers an overtaking write when NO body carries a version", () => {
+    // The two supported shapes at once: the host omits `blocksVersion`, and a
+    // write overtakes the catch-up. A change detector reading that optional
+    // field saw every copy as version zero, so the overtaking write was
+    // invisible and the already-rendered text was overwritten and forgotten.
+    // The request's own mark needs no field on the record.
+    const harness = createWindowedHarness();
+    try {
+      seatedTail(harness);
+      raiseActiveTurn(harness.callbacks(), "t-9");
+
+      harness.handle.store
+        .getState()
+        .reportVisibleTranscriptRange({ fromOrdinal: 10, toOrdinal: 11 });
+      const firstRequestId = harness.lastRangeRequestId();
+      streamTextDelta(harness, " missed");
+      harness.callbacks().onIndexChanged(streamingRowEcho(1));
+
+      harness.callbacks().onRange(
+        rangeFrame({
+          requestId: firstRequestId,
+          epoch: 1,
+          fromOrdinal: 10,
+          rowIds: [assistantRowId("t-9")],
+          messages: [versionlessTurnBody("before")],
+        }),
+      );
+      const catchUpRequestId = harness.lastRangeRequestId();
+
+      streamTextDelta(harness, " later");
+      expect(publishedTurnText(harness)).toBe("before later");
+      harness.callbacks().onIndexChanged(streamingRowEcho(2));
+
+      harness.callbacks().onRange(
+        rangeFrame({
+          requestId: catchUpRequestId,
+          epoch: 1,
+          fromOrdinal: 10,
+          rowIds: [assistantRowId("t-9")],
+          messages: [versionlessTurnBody("before missed")],
+        }),
+      );
+      const secondCatchUpId = harness.lastRangeRequestId();
+      expect(secondCatchUpId).not.toBe(catchUpRequestId);
+
+      harness.callbacks().onRange(
+        rangeFrame({
+          requestId: secondCatchUpId,
+          epoch: 1,
+          fromOrdinal: 10,
+          rowIds: [assistantRowId("t-9")],
+          messages: [versionlessTurnBody("before missed later")],
+        }),
+      );
+
+      expect(publishedTurnText(harness)).toBe("before missed later");
+    } finally {
+      harness.handle.dispose();
+    }
+  });
+
+  it("a late answer from the exhausted episode does not restart the budget", () => {
+    // The cap has to be a per-turn total, so the record of having spent it
+    // outlives the episode. Forgetting it at the cap let an answer that had been
+    // in flight the whole time arrive afterwards, find a fresh budget, and start
+    // the rounds over - with no new write, eviction, boundary or turn change to
+    // justify it.
+    const harness = createWindowedHarness();
+    try {
+      seatedTail(harness);
+      raiseActiveTurn(harness.callbacks(), "t-9");
+
+      harness.handle.store
+        .getState()
+        .reportVisibleTranscriptRange({ fromOrdinal: 10, toOrdinal: 11 });
+      const stragglerId = harness.lastRangeRequestId();
+      // A second request for the same row, which is the one the episode below
+      // runs on; the first is left in flight throughout.
+      harness.handle.store
+        .getState()
+        .reportVisibleTranscriptRange({ fromOrdinal: 12, toOrdinal: 13 });
+      harness.handle.store
+        .getState()
+        .reportVisibleTranscriptRange({ fromOrdinal: 10, toOrdinal: 11 });
+      let requestId = harness.lastRangeRequestId();
+
+      streamTextDelta(harness, " missed");
+      harness.callbacks().onIndexChanged(streamingRowEcho(1));
+
+      // Burn the budget: every catch-up is overtaken as soon as it is sent.
+      for (let round = 1; round <= 6; round += 1) {
+        harness.callbacks().onRange(
+          rangeFrame({
+            requestId,
+            epoch: 1,
+            fromOrdinal: 10,
+            rowIds: [assistantRowId("t-9")],
+            messages: [turnBodyAt(`slice-${round}`, round)],
+          }),
+        );
+        const next = harness.lastRangeRequestId();
+        if (next === requestId) break;
+        requestId = next;
+        streamTextDelta(harness, `-${round}`);
+        harness.callbacks().onIndexChanged(streamingRowEcho(round + 1));
+      }
+      const exhausted = harness.rangeRequests.length;
+
+      // The straggler: still eligible, still older than the write, arriving
+      // after the client already gave up.
+      harness.callbacks().onRange(
+        rangeFrame({
+          requestId: stragglerId,
+          epoch: 1,
+          fromOrdinal: 10,
+          rowIds: [assistantRowId("t-9")],
+          messages: [turnBodyAt("straggler", 1)],
+        }),
+      );
+
+      expect(harness.rangeRequests).toHaveLength(exhausted);
+    } finally {
+      harness.handle.dispose();
+    }
+  });
+
+  it("a NEW turn gets its own repair budget", () => {
+    // The exhaustion is the previous turn's, and it must not be charged to the
+    // next one. `turnId` guarded which body the obligation was about but not the
+    // rounds beside it, so a turn raised before any authority movement inherited
+    // an exhausted budget and gave up before asking even once.
+    const harness = createWindowedHarness();
+    try {
+      seatedTail(harness);
+      raiseActiveTurn(harness.callbacks(), "t-9");
+
+      harness.handle.store
+        .getState()
+        .reportVisibleTranscriptRange({ fromOrdinal: 10, toOrdinal: 11 });
+      let requestId = harness.lastRangeRequestId();
+      streamTextDelta(harness, " missed");
+      harness.callbacks().onIndexChanged(streamingRowEcho(1));
+
+      // Spend the whole budget WITHOUT tripping the cap: three catch-ups are
+      // sent, each overtaken as soon as it goes out, and the third is left
+      // outstanding. That leaves the previous turn's record at its limit and
+      // still live, which is the state the next turn must not inherit.
+      for (
+        let round = 1;
+        round <= MAX_PROVISIONAL_CATCH_UP_ROUNDS;
+        round += 1
+      ) {
+        harness.callbacks().onRange(
+          rangeFrame({
+            requestId,
+            epoch: 1,
+            fromOrdinal: 10,
+            rowIds: [assistantRowId("t-9")],
+            messages: [turnBodyAt(`slice-${round}`, round)],
+          }),
+        );
+        const next = harness.lastRangeRequestId();
+        expect(next).not.toBe(requestId);
+        requestId = next;
+        streamTextDelta(harness, `-${round}`);
+        harness.callbacks().onIndexChanged(streamingRowEcho(round + 1));
+      }
+      const afterExhaustion = harness.rangeRequests.length;
+
+      // The turn completes and the next one starts, with no authority boundary
+      // between them - so nothing has re-seated the window and the spent budget
+      // is still the only record of the previous episode.
+      completeActiveTurn(harness.callbacks());
+      raiseActiveTurn(harness.callbacks(), "t-10");
+      harness.handle.store
+        .getState()
+        .reportVisibleTranscriptRange({ fromOrdinal: 12, toOrdinal: 13 });
+      const nextTurnRequestId = harness.lastRangeRequestId();
+      // The write reaches the client only as an index echo, with nothing of the
+      // new turn held - so it is dropped, exactly as the first turn's was.
+      harness.callbacks().onIndexChanged(
+        indexChangedFrame({
+          epoch: 1,
+          rowCount: 40,
+          indexRevision: 5,
+          changes: [
+            {
+              type: "updated",
+              entries: [
+                {
+                  ordinal: 12,
+                  entry: {
+                    rowId: assistantRowId("t-10"),
+                    createdAt: 12,
+                    role: "assistant",
+                    byteLength: 4096,
+                    bodyDigest: "d12-echo",
+                  },
+                },
+              ],
+            },
+          ],
+        }),
+      );
+
+      harness.callbacks().onRange(
+        rangeFrame({
+          requestId: nextTurnRequestId,
+          epoch: 1,
+          fromOrdinal: 12,
+          rowIds: [assistantRowId("t-10")],
+          messages: [
+            assistantWithBlocks("assistant-12", 12, "t-10", [
+              textBlock("b-12", "stale"),
+            ]),
+          ],
+        }),
+      );
+
+      // The new turn asks for its first catch-up rather than inheriting a spent
+      // budget and giving up.
+      expect(harness.rangeRequests.length).toBeGreaterThan(afterExhaustion + 1);
+    } finally {
+      harness.handle.dispose();
+    }
+  });
+
+  it("does not apply a buffered write twice onto a catch-up that already carries it", () => {
+    // The gap between a delta ARRIVING and a delta being APPLIED. The stream
+    // coordinator coalesces, so a frame sits in the buffer for a tick; a range
+    // answer landing inside that tick folds into a window that has not absorbed
+    // it yet. Everywhere else that is harmless, because the active arm keeps the
+    // held copy and the buffered write lands on it a moment later - but the
+    // repair path hands the served body the seat, and the host may have sliced
+    // that body AFTER the very write still sitting in the buffer. Applying it
+    // then writes the same text a second time.
+    const harness = createDeferredFlushHarness();
+    try {
+      seatedTail(harness);
+      raiseActiveTurn(harness.callbacks(), "t-9");
+
+      harness.handle.store
+        .getState()
+        .reportVisibleTranscriptRange({ fromOrdinal: 10, toOrdinal: 11 });
+      const firstRequestId = harness.lastRangeRequestId();
+
+      streamTextDelta(harness, " missed");
+      harness.flushDeltas();
+      harness.callbacks().onIndexChanged(streamingRowEcho(1));
+
+      harness.callbacks().onRange(
+        rangeFrame({
+          requestId: firstRequestId,
+          epoch: 1,
+          fromOrdinal: 10,
+          rowIds: [assistantRowId("t-9")],
+          messages: [turnBodyAt("before", 1)],
+        }),
+      );
+      const catchUpRequestId = harness.lastRangeRequestId();
+      expect(catchUpRequestId).not.toBe(firstRequestId);
+
+      // Received but deliberately NOT flushed: this write is in the buffer for
+      // the rest of the sequence, and the host has it.
+      streamTextDelta(harness, " later");
+      harness.callbacks().onIndexChanged(streamingRowEcho(2));
+
+      harness.callbacks().onRange(
+        rangeFrame({
+          requestId: catchUpRequestId,
+          epoch: 1,
+          fromOrdinal: 10,
+          rowIds: [assistantRowId("t-9")],
+          messages: [turnBodyAt("before missed", 2)],
+        }),
+      );
+      const repairId = harness.lastRangeRequestId();
+      expect(repairId).not.toBe(catchUpRequestId);
+
+      // The host slices this one after ` later`, so the served body already
+      // contains the write the client is still holding in its buffer.
+      harness.callbacks().onRange(
+        rangeFrame({
+          requestId: repairId,
+          epoch: 1,
+          fromOrdinal: 10,
+          rowIds: [assistantRowId("t-9")],
+          messages: [turnBodyAt("before missed later", 3)],
+        }),
+      );
+
+      // The buffer's tick finally runs. Whatever it holds must not re-append
+      // text the seated body already carries.
+      harness.flushDeltas();
+
+      expect(publishedTurnText(harness)).toBe("before missed later");
+    } finally {
+      harness.handle.dispose();
+    }
+  });
+
+  it("scrolling through history does not spend the streaming row's repair budget", () => {
+    // The reader scrolls away between a demotion and its re-plan, so the request
+    // the planner mints next is for scrollback - which owes nothing and repairs
+    // nothing. Charging the budget for those spent it on history: by the time
+    // the reader came back to the streaming row there were no rounds left, and a
+    // write that overtook its answer went unrepaired. Only a request covering
+    // the rows the demotion opened is a repair.
+    const harness = createWindowedHarness();
+    try {
+      seatedTail(harness);
+      raiseActiveTurn(harness.callbacks(), "t-9");
+
+      // Three row-10 requests outstanding, each followed by a history request
+      // that takes the dedup slot.
+      const rowTenRequestIds: string[] = [];
+      let historyOrdinal = 14;
+      for (let pass = 0; pass < 3; pass += 1) {
+        harness.handle.store
+          .getState()
+          .reportVisibleTranscriptRange({ fromOrdinal: 10, toOrdinal: 11 });
+        rowTenRequestIds.push(harness.lastRangeRequestId());
+        historyOrdinal += 1;
+        harness.handle.store.getState().reportVisibleTranscriptRange({
+          fromOrdinal: historyOrdinal,
+          toOrdinal: historyOrdinal + 1,
+        });
+      }
+
+      streamTextDelta(harness, " missed");
+      harness.callbacks().onIndexChanged(streamingRowEcho(1));
+
+      // Each row-10 answer demotes while the reader is in history, so its
+      // re-plan is deduplicated and the NEXT request minted is scrollback.
+      for (const requestId of rowTenRequestIds) {
+        harness.callbacks().onRange(
+          rangeFrame({
+            requestId,
+            epoch: 1,
+            fromOrdinal: 10,
+            rowIds: [assistantRowId("t-9")],
+            messages: [turnBodyAt("before", 1)],
+          }),
+        );
+        historyOrdinal += 1;
+        harness.handle.store.getState().reportVisibleTranscriptRange({
+          fromOrdinal: historyOrdinal,
+          toOrdinal: historyOrdinal + 1,
+        });
+      }
+
+      // Back to the streaming row, where a write overtakes the answer.
+      harness.handle.store
+        .getState()
+        .reportVisibleTranscriptRange({ fromOrdinal: 10, toOrdinal: 11 });
+      const returnRequestId = harness.lastRangeRequestId();
+      streamTextDelta(harness, " later");
+      harness.callbacks().onIndexChanged(streamingRowEcho(2));
+
+      harness.callbacks().onRange(
+        rangeFrame({
+          requestId: returnRequestId,
+          epoch: 1,
+          fromOrdinal: 10,
+          rowIds: [assistantRowId("t-9")],
+          messages: [turnBodyAt("before missed", 2)],
+        }),
+      );
+
+      // Rounds are still available, so the repair goes out and recovers.
+      const repairId = harness.lastRangeRequestId();
+      expect(repairId).not.toBe(returnRequestId);
+      harness.callbacks().onRange(
+        rangeFrame({
+          requestId: repairId,
+          epoch: 1,
+          fromOrdinal: 10,
+          rowIds: [assistantRowId("t-9")],
+          messages: [turnBodyAt("before missed later", 3)],
+        }),
+      );
+
+      expect(publishedTurnText(harness)).toBe("before missed later");
+    } finally {
+      harness.handle.dispose();
+    }
+  });
+
+  it("protects the drawn body from an old answer once no repair can follow", () => {
+    // Forfeiting the held copy's authority buys a repair: the served body may be
+    // older than what is drawn, and the catch-up afterwards is what makes that
+    // acceptable. Past the cap no catch-up comes, so an answer still in flight
+    // from before the write would replace the best body the client has with a
+    // worse one and nothing would put it back.
+    const harness = createWindowedHarness();
+    try {
+      seatedTail(harness);
+      raiseActiveTurn(harness.callbacks(), "t-9");
+
+      harness.handle.store
+        .getState()
+        .reportVisibleTranscriptRange({ fromOrdinal: 10, toOrdinal: 11 });
+      const stragglerId = harness.lastRangeRequestId();
+      harness.handle.store
+        .getState()
+        .reportVisibleTranscriptRange({ fromOrdinal: 12, toOrdinal: 13 });
+      harness.handle.store
+        .getState()
+        .reportVisibleTranscriptRange({ fromOrdinal: 10, toOrdinal: 11 });
+      let requestId = harness.lastRangeRequestId();
+
+      streamTextDelta(harness, " missed");
+      harness.callbacks().onIndexChanged(streamingRowEcho(1));
+
+      // Every catch-up is overtaken, so the budget runs out. Versionless
+      // throughout: nothing on the records can order these copies.
+      for (let round = 1; round <= 6; round += 1) {
+        harness.callbacks().onRange(
+          rangeFrame({
+            requestId,
+            epoch: 1,
+            fromOrdinal: 10,
+            rowIds: [assistantRowId("t-9")],
+            messages: [versionlessTurnBody(`slice-${round}`)],
+          }),
+        );
+        const next = harness.lastRangeRequestId();
+        if (next === requestId) break;
+        requestId = next;
+        streamTextDelta(harness, ` later-${round}`);
+        harness.callbacks().onIndexChanged(streamingRowEcho(round + 1));
+      }
+      const exhaustedText = publishedTurnText(harness);
+      const exhaustedRequests = harness.rangeRequests.length;
+
+      // The straggler, sliced before any of it.
+      harness.callbacks().onRange(
+        rangeFrame({
+          requestId: stragglerId,
+          epoch: 1,
+          fromOrdinal: 10,
+          rowIds: [assistantRowId("t-9")],
+          messages: [versionlessTurnBody("before")],
+        }),
+      );
+
+      // The drawn body is not rolled backward, and nothing restarts the rounds.
+      expect(publishedTurnText(harness)).toBe(exhaustedText);
+      expect(harness.rangeRequests).toHaveLength(exhaustedRequests);
+    } finally {
+      harness.handle.dispose();
+    }
+  });
+
+  it("an event the reducer rejects for another turn is not a write to this one", () => {
+    // The mark is evidence about the STREAMING turn's body. A late
+    // `usage.updated` from a previous turn is rejected by the reducer and
+    // changes nothing, so counting it as a write retired a catch-up answer that
+    // was current and spent a round asking the host to re-send an unchanged
+    // body.
+    const harness = createWindowedHarness();
+    try {
+      seatedTail(harness);
+      raiseActiveTurn(harness.callbacks(), "t-9");
+
+      harness.handle.store
+        .getState()
+        .reportVisibleTranscriptRange({ fromOrdinal: 10, toOrdinal: 11 });
+      const firstRequestId = harness.lastRangeRequestId();
+      streamTextDelta(harness, " missed");
+      harness.callbacks().onIndexChanged(streamingRowEcho(1));
+
+      harness.callbacks().onRange(
+        rangeFrame({
+          requestId: firstRequestId,
+          epoch: 1,
+          fromOrdinal: 10,
+          rowIds: [assistantRowId("t-9")],
+          messages: [turnBodyAt("before", 1)],
+        }),
+      );
+      const catchUpRequestId = harness.lastRangeRequestId();
+      expect(catchUpRequestId).not.toBe(firstRequestId);
+
+      // Valid frame, previous turn, rejected by the reducer.
+      harness.callbacks().onBlockDelta({
+        kind: "blockDelta",
+        hasBinaryPayload: false,
+        epicId: EPIC_ID,
+        chatId: CHAT_ID,
+        event: {
+          type: "usage.updated",
+          blockId: "usage-t-8",
+          turnId: "t-8",
+          timestamp: 6,
+          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+        },
+      });
+
+      harness.callbacks().onRange(
+        rangeFrame({
+          requestId: catchUpRequestId,
+          epoch: 1,
+          fromOrdinal: 10,
+          rowIds: [assistantRowId("t-9")],
+          messages: [turnBodyAt("before missed", 2)],
+        }),
+      );
+
+      // The stream was quiet, so this answer is final: no third request.
+      expect(publishedTurnText(harness)).toBe("before missed");
+      expect(harness.lastRangeRequestId()).toBe(catchUpRequestId);
+    } finally {
+      harness.handle.dispose();
+    }
+  });
+
+  it("installs the LAST authorised repair's own answer", () => {
+    // The boundary between "may I authorise another repair" and "is this answer
+    // the repair I authorised". Rounds are charged when a request is sent, so by
+    // the time the third one's answer arrives the budget already reads as spent.
+    // Asking the budget question there rejected the very body that repair went
+    // out to fetch and certified the torn copy in its place - the whole episode
+    // spending three round trips and then discarding the answer that closed it.
+    const harness = createWindowedHarness();
+    try {
+      seatedTail(harness);
+      raiseActiveTurn(harness.callbacks(), "t-9");
+
+      harness.handle.store
+        .getState()
+        .reportVisibleTranscriptRange({ fromOrdinal: 10, toOrdinal: 11 });
+      const firstRequestId = harness.lastRangeRequestId();
+      streamTextDelta(harness, " missed");
+      harness.callbacks().onIndexChanged(streamingRowEcho(1));
+
+      // A seats `before` and asks for B.
+      harness.callbacks().onRange(
+        rangeFrame({
+          requestId: firstRequestId,
+          epoch: 1,
+          fromOrdinal: 10,
+          rowIds: [assistantRowId("t-9")],
+          messages: [versionlessTurnBody("before")],
+        }),
+      );
+
+      // Two overtaken repairs, which spend the first two rounds.
+      const overtaken = [
+        { delta: " later-1", slice: "before missed" },
+        { delta: " later-2", slice: "before missed later-1" },
+      ];
+      let requestId = harness.lastRangeRequestId();
+      overtaken.forEach((step, index) => {
+        streamTextDelta(harness, step.delta);
+        harness.callbacks().onIndexChanged(streamingRowEcho(index + 2));
+        harness.callbacks().onRange(
+          rangeFrame({
+            requestId,
+            epoch: 1,
+            fromOrdinal: 10,
+            rowIds: [assistantRowId("t-9")],
+            messages: [versionlessTurnBody(step.slice)],
+          }),
+        );
+        const next = harness.lastRangeRequestId();
+        expect(next).not.toBe(requestId);
+        requestId = next;
+      });
+
+      // The third and last permitted repair, asked and answered across a quiet
+      // stream, carrying everything.
+      harness.callbacks().onRange(
+        rangeFrame({
+          requestId,
+          epoch: 1,
+          fromOrdinal: 10,
+          rowIds: [assistantRowId("t-9")],
+          messages: [versionlessTurnBody("before missed later-1 later-2")],
+        }),
+      );
+
+      expect(publishedTurnText(harness)).toBe("before missed later-1 later-2");
+      // And it settled: no fourth request, and the row is fresh.
+      expect(harness.lastRangeRequestId()).toBe(requestId);
+      const settled = harness.handle.store.getState().transcriptWindow;
+      expect(settled.spans.some((span) => span.fromOrdinal === 10)).toBe(true);
+    } finally {
+      harness.handle.dispose();
+    }
+  });
+
+  it("reconciles SEVERAL writes buffered across a whole repair episode", () => {
+    // The flush seam again, widened: two writes sit in the coordinator's buffer
+    // across an entire repair round rather than one across a single seat. The
+    // drain has to apply both before the fold, the version comparison has to see
+    // the body they produced, and the episode still has to converge on the full
+    // text - not on the catch-up's older slice, and not on it twice.
+    const harness = createDeferredFlushHarness();
+    try {
+      seatedTail(harness);
+      raiseActiveTurn(harness.callbacks(), "t-9");
+
+      harness.handle.store
+        .getState()
+        .reportVisibleTranscriptRange({ fromOrdinal: 10, toOrdinal: 11 });
+      const firstRequestId = harness.lastRangeRequestId();
+
+      // Dropped: flushed while nothing holds the turn.
+      streamTextDelta(harness, " missed");
+      harness.flushDeltas();
+      harness.callbacks().onIndexChanged(streamingRowEcho(1));
+
+      harness.callbacks().onRange(
+        rangeFrame({
+          requestId: firstRequestId,
+          epoch: 1,
+          fromOrdinal: 10,
+          rowIds: [assistantRowId("t-9")],
+          messages: [turnBodyAt("before", 1)],
+        }),
+      );
+      const catchUpRequestId = harness.lastRangeRequestId();
+      expect(catchUpRequestId).not.toBe(firstRequestId);
+
+      // Two writes the client has but has not applied, spanning the catch-up.
+      streamTextDelta(harness, " later-1");
+      harness.callbacks().onIndexChanged(streamingRowEcho(2));
+      streamTextDelta(harness, " later-2");
+      harness.callbacks().onIndexChanged(streamingRowEcho(3));
+
+      harness.callbacks().onRange(
+        rangeFrame({
+          requestId: catchUpRequestId,
+          epoch: 1,
+          fromOrdinal: 10,
+          rowIds: [assistantRowId("t-9")],
+          messages: [turnBodyAt("before missed", 2)],
+        }),
+      );
+
+      // The drain applied both buffered writes before the seat, so the drawn
+      // body carries them and the older slice does not displace it.
+      expect(publishedTurnText(harness)).toBe("before later-1 later-2");
+      const repairId = harness.lastRangeRequestId();
+      expect(repairId).not.toBe(catchUpRequestId);
+
+      // The quiet repair carries everything the host has.
+      harness.callbacks().onRange(
+        rangeFrame({
+          requestId: repairId,
+          epoch: 1,
+          fromOrdinal: 10,
+          rowIds: [assistantRowId("t-9")],
+          messages: [turnBodyAt("before missed later-1 later-2", 4)],
+        }),
+      );
+      harness.flushDeltas();
+
+      expect(publishedTurnText(harness)).toBe("before missed later-1 later-2");
+      expect(harness.lastRangeRequestId()).toBe(repairId);
+    } finally {
+      harness.handle.dispose();
+    }
+  });
+
+  it("does not roll the drawn body back for an answer that can queue no repair", () => {
+    // A STEER row of the streaming turn carries the whole turn's records - its
+    // projection sources the turn's messages - so an answer serving only that
+    // row passes the records test. But it is not one of the turn's ASSISTANT
+    // rows, so it yields no ordinal to retire: the demotion never happens, no
+    // repair is queued, and nothing is logged. Forfeiting the held copy's
+    // authority there installed an older served body over the drawn one with no
+    // gap left to re-request it - silently, and only for versionless bodies.
+    // No repair possible means no forfeit.
+    const harness = createWindowedHarness();
+    try {
+      seatedTail(harness);
+      harness.callbacks().onSkeletonChunk(splitTurnSkeleton());
+      raiseActiveTurn(harness.callbacks(), "t-9");
+
+      harness.handle.store
+        .getState()
+        .reportVisibleTranscriptRange({ fromOrdinal: 10, toOrdinal: 11 });
+      const firstRequestId = harness.lastRangeRequestId();
+      streamTextDelta(harness, " missed");
+      // Named with the SLICE's row id: a bare `assistant:` id would contradict
+      // this skeleton and void the index instead of echoing.
       harness.callbacks().onIndexChanged(
         indexChangedFrame({
           epoch: 1,
@@ -1797,11 +3418,11 @@ describe("the active turn's streaming echo does not starve in-flight hydration",
                 {
                   ordinal: 10,
                   entry: {
-                    rowId: assistantRowId("t-9"),
+                    rowId: assistantSliceRowId("t-9", 0, true),
                     createdAt: 10,
                     role: "assistant",
                     byteLength: 4096,
-                    bodyDigest: "d10-cold",
+                    bodyDigest: "d10-echo",
                   },
                 },
               ],
@@ -1810,6 +3431,64 @@ describe("the active turn's streaming echo does not starve in-flight hydration",
         }),
       );
 
+      // The turn is unsound and its body is drawn from the stream.
+      harness.callbacks().onRange(
+        rangeFrame({
+          requestId: firstRequestId,
+          epoch: 1,
+          fromOrdinal: 10,
+          rowIds: [assistantSliceRowId("t-9", 0, true)],
+          messages: [versionlessTurnBody("before")],
+        }),
+      );
+      streamTextDelta(harness, " later");
+      const drawn = publishedTurnText(harness);
+      expect(drawn).toBe("before later");
+      const requestsBefore = harness.rangeRequests.length;
+
+      // An answer for the steer row alone, carrying an older copy of the turn.
+      harness.callbacks().onRange(
+        rangeFrame({
+          requestId: harness.lastRangeRequestId(),
+          epoch: 1,
+          fromOrdinal: 11,
+          rowIds: ["steer:q-9"],
+          messages: [versionlessTurnBody("before missed")],
+        }),
+      );
+
+      // The drawn body survives. Rolling it back would be a regression against
+      // base, and the branch that did it queued nothing to put it right.
+      expect(publishedTurnText(harness)).toBe(drawn);
+      // The steer answer creates no obligation of its own: the only request
+      // minted after it is the re-ask for ordinal 10, the turn's own row, whose
+      // repair was owed before this answer and which this answer did not serve.
+      expect(harness.rangeRequests.length).toBe(requestsBefore + 1);
+      const reAsk = harness.rangeRequests.at(-1);
+      expect(reAsk?.fromOrdinal).toBe(10);
+      expect(reAsk?.toOrdinal).toBe(10);
+    } finally {
+      harness.handle.dispose();
+    }
+  });
+
+  it("a streaming echo against a HELD turn owes no refresh", () => {
+    // The refresh exists only for the unheld seat. When the tail already
+    // holds the turn, the deltas rewrote that copy in place, so the answer is
+    // current and seats once with nothing further asked.
+    const harness = createWindowedHarness();
+    try {
+      seatedTailHoldingTurn(harness, "t-9");
+      raiseActiveTurn(harness.callbacks(), "t-9");
+
+      harness.handle.store
+        .getState()
+        .reportVisibleTranscriptRange({ fromOrdinal: 10, toOrdinal: 11 });
+      const requestId = harness.lastRangeRequestId();
+
+      for (let revision = 1; revision <= 3; revision += 1) {
+        harness.callbacks().onIndexChanged(streamingRowEcho(revision));
+      }
       harness.callbacks().onRange(
         rangeFrame({
           requestId,
@@ -1821,9 +3500,96 @@ describe("the active turn's streaming echo does not starve in-flight hydration",
       );
 
       const window = harness.handle.store.getState().transcriptWindow;
-      expect(window.spans.some((span) => span.fromOrdinal === 10)).toBe(false);
-      expect(harness.rangeRequests.length).toBeGreaterThan(1);
+      expect(window.spans.some((span) => span.fromOrdinal === 10)).toBe(true);
+      expect(harness.rangeRequests).toHaveLength(1);
     } finally {
+      harness.handle.dispose();
+    }
+  });
+
+  it("logs every discarded range answer", () => {
+    // A discarded answer has no other trace on screen or in the desktop log;
+    // the placeholder it would have filled looks like one nothing has asked
+    // for yet. The warning is the only way the loop above is diagnosable
+    // from outside.
+    const warn = vi.spyOn(appLogger, "warn").mockImplementation(() => {});
+    const harness = createWindowedHarness();
+    try {
+      seatedTail(harness);
+      raiseActiveTurn(harness.callbacks(), "t-9");
+
+      harness.handle.store
+        .getState()
+        .reportVisibleTranscriptRange({ fromOrdinal: 10, toOrdinal: 11 });
+      const requestId = harness.lastRangeRequestId();
+
+      // A different turn's row: not an echo, so the in-flight request is
+      // superseded and its answer must be discarded - and logged.
+      harness.callbacks().onIndexChanged(
+        indexChangedFrame({
+          epoch: 1,
+          rowCount: 40,
+          indexRevision: 1,
+          changes: [
+            {
+              type: "updated",
+              entries: [
+                {
+                  ordinal: 10,
+                  entry: {
+                    rowId: assistantRowId("other-turn"),
+                    createdAt: 10,
+                    role: "assistant",
+                    byteLength: 4096,
+                    bodyDigest: "d10-other",
+                  },
+                },
+              ],
+            },
+          ],
+        }),
+      );
+      harness.callbacks().onRange(
+        rangeFrame({
+          requestId,
+          epoch: 1,
+          fromOrdinal: 10,
+          rowIds: [assistantRowId("other-turn")],
+          messages: [assistantWithBlocks("assistant-10", 10, "other-turn", [])],
+        }),
+      );
+
+      expect(warn).toHaveBeenCalledWith(
+        "[transcript] discarded a range answer as stale",
+        expect.objectContaining({
+          chatId: CHAT_ID,
+          requestId,
+          epoch: 1,
+          fromOrdinal: 10,
+          rows: 1,
+          awaited: true,
+        }),
+      );
+
+      // An answer framed against an epoch this window has left never seats
+      // either, and is logged under its own reason.
+      warn.mockClear();
+      const lateRequestId = harness.lastRangeRequestId();
+      harness.callbacks().onRange(
+        rangeFrame({
+          requestId: lateRequestId,
+          epoch: 0,
+          fromOrdinal: 10,
+          rowIds: [assistantRowId("other-turn")],
+          messages: [assistantWithBlocks("assistant-10", 10, "other-turn", [])],
+        }),
+      );
+      expect(warn).toHaveBeenCalledWith(
+        "[transcript] discarded a range answer unseated",
+        expect.objectContaining({ requestId: lateRequestId, windowEpoch: 1 }),
+      );
+    } finally {
+      warn.mockRestore();
       harness.handle.dispose();
     }
   });

--- a/clients/gui-app/src/stores/chats/chat-session-store.ts
+++ b/clients/gui-app/src/stores/chats/chat-session-store.ts
@@ -65,7 +65,11 @@ import {
   isTailHydrated,
   mapWindowMessages,
   planTranscriptHydration,
+  activeTurnOrdinalsOf,
+  rangeRecordsInstalled,
+  rangeSeatsActiveTurn,
   recordSharingOrdinals,
+  refreshSeatedRows,
   streamWindowMessage,
   touchTranscriptRange,
   transcriptWindowChargedBytes,
@@ -112,6 +116,7 @@ import {
   type WorktreeStagingKey,
 } from "@/stores/worktree/worktree-intent-staging-store";
 import { transientLiveAssistantMessageId } from "@/lib/chat/transient-live-assistant-message-id";
+import { appLogger } from "@/lib/logger";
 import type {
   ChatStreamCallbacks,
   ChatStreamClient,
@@ -1313,6 +1318,38 @@ export const STREAM_COMPLETION_TIMEOUT_MS = 45_000;
  */
 export const MAX_WATCHDOG_RESTREAMS_PER_EPOCH = 3;
 
+/**
+ * How many catch-ups one provisionally seated body may ask for.
+ *
+ * A catch-up is answered with a slice, and a slice taken while the turn is still
+ * writing can be overtaken before it lands: the client then holds a body with
+ * the later writes and the answer carries the earlier one, and no merge of the
+ * two is sound. Asking again is the repair - the next slice is taken later - but
+ * a stream that keeps overtaking would make that a request per round trip for
+ * the length of the turn. Past the cap the client keeps what it has and stops
+ * asking; the turn's completion rebase re-seats the row from the host, so the
+ * cap costs a delayed repair rather than a permanent one.
+ */
+export const MAX_PROVISIONAL_CATCH_UP_ROUNDS = 3;
+
+/**
+ * Is this stream event evidence that the host wrote to the STREAMING turn?
+ *
+ * Read by the write mark, so it errs towards yes: over-counting costs a request,
+ * under-counting can certify an answer that is short of the host. The one thing
+ * it rules out is an event the reducer itself will reject as another turn's - a
+ * late `usage.updated` from the previous turn, say (see `applyBlockDelta`) -
+ * which changes nothing about the active body and so is no evidence at all.
+ */
+function countsAsActiveTurnWrite(
+  event: RuntimeEvent,
+  activeTurnId: string | null,
+): boolean {
+  if (activeTurnId === null) return false;
+  if (!("turnId" in event) || typeof event.turnId !== "string") return true;
+  return event.turnId === activeTurnId;
+}
+
 const EMPTY_QUEUE: ChatQueueState = { status: "idle", items: [] };
 
 function chatRunSettingsEqual(a: ChatRunSettings, b: ChatRunSettings): boolean {
@@ -2202,7 +2239,11 @@ export function createChatSessionStoreWithNotificationDependencies(
       //
       // Nothing here bounds the buffer, and that is the existing contract: it
       // is drained by the flush coordinator's tick on every non-deferred beat,
-      // and a deferral resolves on the very next range response.
+      // and a deferral resolves on the next range response that hydrates the
+      // tail. On a live chat the streaming row IS the tail, so a catch-up
+      // demotion of that row can re-open the deferral for one more answer;
+      // that is bounded by `MAX_PROVISIONAL_CATCH_UP_ROUNDS`, and the repair
+      // seat drains this buffer itself before it looks at the served body.
       if (deferredWindowedSnapshot !== null) return;
       const batch = bufferedDeltas;
       bufferedDeltas = [];
@@ -2858,6 +2899,126 @@ export function createChatSessionStoreWithNotificationDependencies(
       readonly range: OrdinalRange;
     } | null = null;
 
+    /**
+     * How many writes to the streaming turn this client has seen, from any
+     * source: block deltas it applied, block deltas it had nowhere to put, and
+     * accepted index echoes reporting a write the host made.
+     *
+     * Monotonic, never decremented, and deliberately NOT a count of outstanding
+     * work. Its whole purpose is to date a `range` answer against the writes it
+     * MAY be missing. A request records the value it was sent under
+     * ({@link hydrationRequestMarks}); the host slices its answer at some point
+     * after that, which may be before or after any given write. So the mark
+     * answers one question, in one direction only, and that is the whole of what
+     * is needed here:
+     *
+     *   sentUnderMark === activeTurnWriteMark  =>  no write was observed
+     *   between this request going out and its answer arriving, so what it
+     *   carries plus what the client has applied since is the whole of the turn.
+     *
+     * The converse does NOT hold: a write observed in that interval may still be
+     * in the answer, because the host may have sliced after it. Nothing here
+     * claims otherwise - an observed write means coverage is not ESTABLISHED,
+     * which is why the response is to ask again rather than to discard anything.
+     * The clock also sees only what reaches this client's callbacks, never every
+     * write the host made.
+     *
+     * Counting EVERY write, rather than only the ones the client dropped, is
+     * what makes that implication hold - and it is the correction a cold review
+     * forced twice. An earlier version compared the held copy's
+     * `blocksVersion` before and after the fold to spot a write that overtook a
+     * catch-up. That reading is a per-SEAT baseline, so one answer installing a
+     * body reset it and the next answer read "unchanged" and discharged the
+     * obligation while the write was still missing; and `blocksVersion` is
+     * optional on the wire, so where the host omits it every reading
+     * normalised to the same number and no overtaking write was ever visible.
+     * A mark carried by each REQUEST has neither problem: it is per-answer
+     * provenance rather than shared state, and it does not depend on a field
+     * the schema lets the host leave out.
+     */
+    let activeTurnWriteMark = 0;
+
+    /**
+     * The mark each outstanding range request was sent under.
+     *
+     * Retired when its answer arrives, whatever became of it, so this tracks
+     * the ledger's open ranges rather than accumulating. The bulk clears sit
+     * beside the ledger's own (`authorityBoundary`, `dropAll`), because a
+     * request those abandon is one no answer will ever retire.
+     */
+    const hydrationRequestMarks = new Map<string, number>();
+
+    /** The mark a request was sent under, retired from the map. */
+    const takeHydrationRequestMark = (
+      requestId: string,
+    ): number | undefined => {
+      const mark = hydrationRequestMarks.get(requestId);
+      hydrationRequestMarks.delete(requestId);
+      return mark;
+    };
+
+    /**
+     * The streaming turn whose held body is UNSOUND, with the repair budget
+     * spent on it so far.
+     *
+     * Unsound means the client's copy is not what the host would serve: either
+     * nothing is held, or a write arrived with no body to apply it to and the
+     * body seated afterwards is torn around the gap. It is set when such a write
+     * is dropped and cleared only by an answer that provably closes the gap -
+     * one whose request saw no write between going out and coming back.
+     *
+     * `rounds` counts catch-up requests actually SENT for this turn, charged at
+     * the mint in {@link requestPlannedHydration} rather than at the demotion
+     * that asks for one. The two differ: a demotion whose re-plan is suppressed
+     * by an outstanding request for the same rows sends nothing, and charging it
+     * let a queue of old answers spend the whole budget without a single
+     * corrective request reaching the host.
+     *
+     * Kept for the turn once exhausted, which is why `rounds` lives here rather
+     * than beside the obligation it bounds: forgetting the record at the cap let
+     * a late answer that predated the write start the budget over, and the cap
+     * has to be a per-turn total. Keyed by `turnId` for the opposite reason - a
+     * NEXT turn must not inherit an exhausted budget and give up before asking
+     * once.
+     */
+    let catchUpBudget: {
+      readonly turnId: string;
+      /** The held body is known to be short of the host. */
+      readonly unsound: boolean;
+      /** Catch-up requests sent for this turn. */
+      readonly rounds: number;
+    } | null = null;
+
+    /**
+     * The ordinals a demotion retired, waiting for the re-plan to turn them
+     * back into a request.
+     *
+     * The ORDINALS and not a bare flag, because the next request the planner
+     * mints need not be the repair: the reader can scroll away between the
+     * demotion and the re-plan, and the requests that follow are then for
+     * scrollback that owes nothing. Charging the budget for those spent it on
+     * history and left the streaming row with no rounds when the reader came
+     * back to it. A round is charged only by a request that covers the rows the
+     * demotion opened.
+     */
+    let pendingCatchUp: {
+      readonly turnId: string;
+      readonly ordinals: readonly number[];
+    } | null = null;
+
+    const forgetCatchUpBudget = (): void => {
+      catchUpBudget = null;
+      pendingCatchUp = null;
+    };
+
+    /** The budget for `turnId`, fresh when the turn is new. */
+    const budgetForTurn = (
+      turnId: string,
+    ): { readonly unsound: boolean; readonly rounds: number } =>
+      catchUpBudget?.turnId === turnId
+        ? catchUpBudget
+        : { unsound: false, rounds: 0 };
+
     let resnapshotRequestTimer: number | null = null;
 
     const clearResnapshotRequestTimer = (): void => {
@@ -3256,6 +3417,36 @@ export function createChatSessionStoreWithNotificationDependencies(
         epoch: transcriptWindow.epoch,
         range: next,
       });
+      // The repair budget is charged HERE, at the mint, and not at the demotion
+      // that asks for one. A demotion is a request to re-plan, not a request on
+      // the wire: when an outstanding request already covers the same rows the
+      // re-plan is deduplicated and nothing is sent. Charging the demotion let a
+      // queue of answers older than the write spend the whole budget while the
+      // dedup slot suppressed every send - the client then warned that it was
+      // giving up after three rounds having asked the host exactly nothing.
+      // Owned by the turn that asked for it, as well as by the rows: a demotion
+      // whose re-plan never went out can outlive its turn, and without the turn
+      // check the NEXT turn's first request over those same rows was charged as
+      // that turn's first repair before it had asked for anything.
+      const repairs =
+        pendingCatchUp !== null &&
+        pendingCatchUp.turnId === catchUpBudget?.turnId &&
+        pendingCatchUp.ordinals.some(
+          (ordinal) => ordinal >= next.fromOrdinal && ordinal < next.toOrdinal,
+        );
+      // Dated on the way out: what this answer can be missing is decided by the
+      // writes already made when it was asked for, never by what the window
+      // happens to hold when it lands.
+      hydrationRequestMarks.set(requestId, activeTurnWriteMark);
+      if (repairs) {
+        pendingCatchUp = null;
+        if (catchUpBudget !== null) {
+          catchUpBudget = {
+            ...catchUpBudget,
+            rounds: catchUpBudget.rounds + 1,
+          };
+        }
+      }
       hydrationRequestTimer = window.setTimeout(() => {
         hydrationRequestTimer = null;
         // Only the request this timeout was armed for. Anything else already
@@ -3297,6 +3488,17 @@ export function createChatSessionStoreWithNotificationDependencies(
       // no path lets one member's response discharge another's obligation.
       // The ledger evicted enough to fit this one back under the cap.
       if (capEvicted.length > 0) {
+        // The marks go with the entries, always. `takeHydrationRequestMark`
+        // retires a mark when its answer ARRIVES, and for these ids no answer
+        // ever will be accepted - the ledger dropped them, so the response path
+        // refuses them exactly as it refuses an unrecorded id. Leaving the marks
+        // behind grew the map without bound on any stream that keeps losing
+        // requests or answers: the 30-second timeout re-asks, each re-ask can
+        // evict at the cap, and none of it is visible to the ledger's own byte
+        // accounting because these entries sit outside it.
+        for (const entry of capEvicted) {
+          hydrationRequestMarks.delete(entry.requestId);
+        }
         const evictedFrom = Math.min(
           ...capEvicted.map((entry) => entry.range.fromOrdinal),
         );
@@ -3309,6 +3511,10 @@ export function createChatSessionStoreWithNotificationDependencies(
           epoch: transcriptWindow.epoch,
           range: { fromOrdinal: evictedFrom, toOrdinal: evictedTo },
         });
+        // Dated like any other request. It replaces the evicted entries'
+        // obligations, and it inherits nothing from them: it is sent NOW, so
+        // what it can contain is what the current mark says.
+        hydrationRequestMarks.set(widerRequestId, activeTurnWriteMark);
         client.requestTranscriptRange({
           requestId: widerRequestId,
           epoch: transcriptWindow.epoch,
@@ -3394,6 +3600,301 @@ export function createChatSessionStoreWithNotificationDependencies(
         fromOrdinal: response.fromOrdinal,
         servedCount: response.rowIds.length,
       });
+
+    /**
+     * What every log line about a range answer names.
+     *
+     * Every discarded answer is logged, at the one level the desktop log keeps
+     * for the renderer. A range that never seats has no other trace: the
+     * placeholder it would have filled looks exactly like one nothing has asked
+     * for yet, and the loop this store shipped twice - every answer thrown
+     * away, every discard minting one more request - was invisible from
+     * outside until a screenshot arrived.
+     */
+    const rangeAnswerLogFields = (
+      response: ChatRangeResponse,
+    ): {
+      readonly epicId: string;
+      readonly chatId: string;
+      readonly requestId: string;
+      readonly epoch: number;
+      readonly fromOrdinal: number;
+      readonly rows: number;
+      readonly activeTurnId: string | null;
+    } => ({
+      epicId: options.epicId,
+      chatId: options.chatId,
+      requestId: response.requestId,
+      epoch: response.epoch,
+      fromOrdinal: response.fromOrdinal,
+      rows: response.rowIds.length,
+      activeTurnId: get().activeTurn?.turnId ?? null,
+    });
+
+    /**
+     * May this answer install over a body the client knows is unsound?
+     *
+     * Every condition here is about there being a REPAIR behind the forfeit.
+     * Handing the served body the seat is only acceptable because something
+     * comes after it to correct what it in turn is missing; where nothing can,
+     * the ordinary held-copy preference is what protects the drawn body, and
+     * that is also exactly what base does.
+     */
+    const mayRepairUnsoundBody = (input: {
+      readonly budget: {
+        readonly unsound: boolean;
+        readonly rounds: number;
+      } | null;
+      readonly turnOrdinals: readonly number[];
+      readonly markIsCurrent: boolean;
+      readonly deferred: boolean;
+    }): boolean => {
+      const { budget } = input;
+      if (budget === null || !budget.unsound) return false;
+      // Nothing of the turn's OWN rows to retire means no repair can follow, so
+      // a forfeit here is just a worse body installed with no gap left to
+      // re-request it. A STEER row is the case that matters: it carries the
+      // whole turn's records, so the answer passes the records test, but it is
+      // not one of the turn's assistant rows - it yields no ordinal,
+      // `refreshSeatedRows` moves nothing, and the demotion never happens.
+      if (input.turnOrdinals.length === 0) return false;
+      // While a windowed snapshot waits for its tail the coalescing buffer
+      // cannot be drained, so seating a served body over the held one would
+      // install it against a window that has not absorbed the writes the client
+      // already holds - the double-apply, by another route.
+      if (input.deferred) return false;
+      // Either this answer is itself the whole truth, or another repair can
+      // still follow it.
+      return (
+        input.markIsCurrent || budget.rounds < MAX_PROVISIONAL_CATCH_UP_ROUNDS
+      );
+    };
+
+    /**
+     * Seat one non-stale `range` answer, logging the two ways the fold can
+     * still refuse it, and re-ask for a body that predates a dropped write.
+     */
+    const seatRangeAnswer = (
+      response: ChatRangeResponse,
+      /**
+       * The write mark this answer's request was sent under, or `undefined` for
+       * a request nothing recorded - a cap-evicted or boundary-abandoned id,
+       * whose answer the ledger has already refused.
+       */
+      sentUnderMark: number | undefined,
+    ): TranscriptWindow => {
+      const activeTurnIdBeforeFlush = get().activeTurn?.turnId ?? null;
+      // Forfeiting the held copy's authority is only ever worth it because a
+      // repair is in play: the served body may be older than what is on screen,
+      // and what makes that acceptable is either that THIS answer is the repair,
+      // or that one can still follow it. An old answer arriving once neither
+      // holds would replace the best body the client has with a worse one and
+      // nothing would put it back, so past that point the ordinary held-copy
+      // preference protects what is drawn - while the exhausted budget is still
+      // retained, so nothing restarts the rounds.
+      //
+      // The first disjunct is not redundant, and leaving it out broke the LAST
+      // repair of every episode. Rounds are charged when a request is SENT, so
+      // by the time the third one's own answer arrives the budget already reads
+      // as spent; asking "may I authorise another" there rejected the very body
+      // that repair had been authorised to fetch and certified the torn copy in
+      // its place. Asking instead whether THIS answer saw no write in flight
+      // gets that case right, and is strictly better than a "was this the
+      // repair" stamp would be: an authorised repair that a write DID overtake
+      // is not preferred either, so the newer text on screen survives it.
+      const markIsCurrent =
+        sentUnderMark !== undefined && sentUnderMark === activeTurnWriteMark;
+      // The rows this answer could retire, decided before the seat because the
+      // forfeit below depends on it.
+      const turnOrdinals = activeTurnOrdinalsOf(
+        response,
+        activeTurnIdBeforeFlush,
+      );
+      const repairsUnsoundBody = mayRepairUnsoundBody({
+        budget:
+          activeTurnIdBeforeFlush === null
+            ? null
+            : budgetForTurn(activeTurnIdBeforeFlush),
+        turnOrdinals,
+        markIsCurrent,
+        deferred: deferredWindowedSnapshot !== null,
+      });
+      if (repairsUnsoundBody) {
+        // Drain the coalescing buffer BEFORE seating, so the window this answer
+        // folds into is what the client has actually received rather than what
+        // the flush coordinator has got round to applying.
+        //
+        // Everywhere else the two can differ harmlessly, because the active
+        // arm keeps the held copy and the buffered delta lands on it a tick
+        // later. This path is the exception: it hands the served body the seat,
+        // and a delta still sitting in the buffer is then applied on top of a
+        // body the host had ALREADY applied it to - the same text twice. The
+        // mark cannot see that either, since it counts a write when the frame
+        // arrives and the buffer is exactly the gap between arriving and being
+        // applied.
+        //
+        // The deferred-snapshot state is excluded by the gate above rather than
+        // here: that is the one state `applyBufferedDeltas` refuses to drain in
+        // (there is no seated row for a delta to attach to yet, and forcing it
+        // would discard the batch), so taking the repair arm there would seat a
+        // served body with the buffer still full - the same double-apply by
+        // another route.
+        applyBufferedDeltas();
+      }
+      const before = get().transcriptWindow;
+      const activeTurnId = get().activeTurn?.turnId ?? null;
+      const seated = applyRangeResponse(
+        before,
+        response,
+        // An UNSOUND body forfeits the active turn's held-copy authority: it is
+        // one this client knows is not what the host would serve, so the premise
+        // that the held copy has every write - the whole basis of the active arm
+        // - is false for it, and letting it stand would have that body
+        // substitute away the catch-up sent to repair it. `activeTurnId` is the
+        // only thing that selects that arm, so passing `null` is how the fold is
+        // told. Under the settled arm the served copy seats unless the held one
+        // is demonstrably ahead, which is the right default for a record the
+        // client has already established is incomplete.
+        repairsUnsoundBody ? null : activeTurnId,
+        imageWitnesses,
+      );
+      if (seated === before) {
+        // The fold returns its input by identity on an epoch mismatch or an
+        // empty answer - neither seats a row.
+        appLogger.warn("[transcript] discarded a range answer unseated", {
+          ...rangeAnswerLogFields(response),
+          windowEpoch: before.epoch,
+        });
+        return seated;
+      }
+      if (!before.invalidated && seated.invalidated) {
+        appLogger.warn(
+          "[transcript] discarded a range answer that contradicted the skeleton; index voided",
+          rangeAnswerLogFields(response),
+        );
+        return seated;
+      }
+      return settleActiveTurnCatchUp({
+        response,
+        seated,
+        activeTurnId,
+        markIsCurrent,
+        turnOrdinals,
+      });
+    };
+
+    /**
+     * Decide what the answer just seated leaves owed for the streaming turn:
+     * nothing, or another catch-up.
+     *
+     * Split out of {@link seatRangeAnswer} for the complexity budget, and the
+     * split falls where the two halves genuinely differ - above is "did this
+     * answer seat at all", here is "is what it seated the whole of the turn".
+     */
+    const settleActiveTurnCatchUp = (input: {
+      readonly response: ChatRangeResponse;
+      readonly seated: TranscriptWindow;
+      readonly activeTurnId: string | null;
+      /** No write was observed between this answer's request and its arrival. */
+      readonly markIsCurrent: boolean;
+      /** The active turn's own rows among the ones this answer served. */
+      readonly turnOrdinals: readonly number[];
+    }): TranscriptWindow => {
+      const { response, seated, activeTurnId, markIsCurrent, turnOrdinals } =
+        input;
+      // The turn's RECORDS are what a write staled, so records are what this
+      // asks about. Scrollback from the same era is current and must not be
+      // re-fetched; a sibling row of the turn is stale even though the echo
+      // named a different ordinal. And "seats" rather than "carries": a row the
+      // host declared incomplete takes its whole turn out of the fold, so an
+      // answer that carries the turn and withholds it has installed nothing -
+      // reading the raw records there retired a COMPLETE historical row served
+      // in the same answer and asked for it again, discarding valid hydration
+      // to chase a body that never seated.
+      if (activeTurnId === null) return seated;
+      if (!rangeSeatsActiveTurn(response, activeTurnId)) return seated;
+      const budget = budgetForTurn(activeTurnId);
+      // Nothing is owed for a turn whose held copy is sound: the deltas have
+      // been landing on it, so it is already what the host would serve, and the
+      // active arm of the fold kept it over this answer for exactly that reason.
+      if (!budget.unsound) return seated;
+      // Closing the gap takes BOTH halves, and each rules out a different way
+      // of being wrong.
+      //
+      // The mark answers "did any write happen between this request going out
+      // and its answer coming back". If none did, the answer carries every
+      // write up to its slice and the client has applied every write since, so
+      // together they are the turn. It is per-ANSWER provenance, which is what
+      // makes it hold when several answers are outstanding at once: a shared
+      // "has the body changed since the last seat" baseline cannot, because the
+      // first answer to install resets it and the next then reads "unchanged"
+      // and discharges the obligation with the write still missing.
+      //
+      // But a mark describes the ANSWER, and the answer is not necessarily what
+      // the window ended up holding - the fold can substitute a held copy for
+      // the served one. Certifying on the mark alone then declared the row
+      // current while the body on screen was the torn one this answer had been
+      // sent to replace. So the records have to have actually landed.
+      const closesTheGap =
+        markIsCurrent &&
+        rangeRecordsInstalled(seated, response.messages, activeTurnId);
+      if (closesTheGap) {
+        catchUpBudget = { ...budget, turnId: activeTurnId, unsound: false };
+        // And the demotion that never became a request is cancelled with it.
+        // Left standing, the next request to cover these rows - a plain
+        // re-visit, once the turn is sound again - would be charged as a repair
+        // for a turn that no longer owes one.
+        pendingCatchUp = null;
+        return seated;
+      }
+      if (budget.rounds >= MAX_PROVISIONAL_CATCH_UP_ROUNDS) {
+        // Writes have overtaken every catch-up actually sent. Keep what is on
+        // screen and stop: the completion rebase re-seats the turn from the
+        // host, and a request per round trip for the rest of a long turn is a
+        // worse failure than a body that repairs late.
+        //
+        // The exhausted budget is KEPT, not forgotten. Dropping it let a late
+        // answer - one that predated the write and had been in flight through
+        // the whole episode - find a fresh budget and start the rounds over,
+        // which is the cap failing to be a cap.
+        appLogger.warn(
+          "[transcript] giving up on catching a streaming row up; leaving it to the completion rebase",
+          { ...rangeAnswerLogFields(response), rounds: budget.rounds },
+        );
+        pendingCatchUp = null;
+        return seated;
+      }
+      // The ACTIVE TURN's rows only, widened to the turn inside
+      // `refreshSeatedRows`: a slice and its steer siblings share the records
+      // that went stale, so retiring one without the others would leave the
+      // same trailing body drawn under a neighbouring ordinal. A settled row
+      // served in the same answer is not retired and is not repair work -
+      // taking every ordinal the answer happened to carry threw away a complete
+      // historical row's hydration, and then let a later visit to that row be
+      // charged against the streaming row's repair budget. The seat stays
+      // rendered - the stale tier still draws - and the gap it opens is what
+      // the planner turns back into a request.
+      const refreshed = refreshSeatedRows(seated, turnOrdinals);
+      if (refreshed === seated) return seated;
+      // Asking for the re-plan, not charging for it. The budget moves only if
+      // this turns into a request on the wire - see the mint in
+      // `requestPlannedHydration`.
+      catchUpBudget = { ...budget, turnId: activeTurnId };
+      pendingCatchUp = { turnId: activeTurnId, ordinals: turnOrdinals };
+      appLogger.info(
+        "[transcript] re-asking for a range answer that predates a write",
+        {
+          ...rangeAnswerLogFields(response),
+          // Which half of the gap test refused it: `false` means a write was
+          // observed while it was in flight, `true` means the fold kept a held
+          // copy over the one it served.
+          markIsCurrent,
+          activeTurnWriteMark,
+          rounds: budget.rounds,
+        },
+      );
+      return refreshed;
+    };
 
     /** {@link ChatSessionState.reportVisibleTranscriptRange}'s implementation;
      *  hoisted beside the planner it drives rather than defined inline in the
@@ -3808,6 +4309,10 @@ export function createChatSessionStoreWithNotificationDependencies(
       // The whole ledger drops with the window - ranges, recovery entries
       // and summary trust alike.
       recovery.dropAll();
+      hydrationRequestMarks.clear();
+      // The window itself is going: whatever body was seated in it is not
+      // there to repair any more.
+      forgetCatchUpBudget();
       clearResnapshotRequestTimer();
       forgetDeferredWindowedSnapshot();
       // The buffer belongs to the windowed line too. Left behind, the flag
@@ -4018,6 +4523,16 @@ export function createChatSessionStoreWithNotificationDependencies(
             epoch: window.epoch,
             announcesRebuild: frame.snapshot.indexRevision === null,
           });
+          // The marks go with the entries they date: the boundary subsumes
+          // every open range, so no answer will retire them individually.
+          hydrationRequestMarks.clear();
+          // And so does the obligation they carried, budget included. An
+          // authoritative snapshot re-seats the turn's body from the host,
+          // which IS the repair the catch-up was asking for - carrying the
+          // obligation across would retire the row the boundary just made
+          // current, and carrying an exhausted budget across would deny the
+          // next episode the rounds it is entitled to.
+          forgetCatchUpBudget();
           imageWitnesses.invalidateAll();
         }
         if (window.skeletonComplete) {
@@ -4148,46 +4663,43 @@ export function createChatSessionStoreWithNotificationDependencies(
         // anyway is a starvation loop on a chat dominated by one long turn -
         // every answer arrives after the next echo and hydration never lands.
         //
-        // But ONLY while the turn's record is actually HELD. A copy the
-        // window does not hold is not being rewritten - its deltas are
-        // dropped - so an answer generated before them carries blocks the
-        // client can never recover, and it must be superseded and re-asked
-        // exactly as before. The holds scan is gated on there being an
-        // outstanding request at all, so it never runs on the bare per-token
-        // path.
+        // The exemption is NOT gated on the client holding a copy of the
+        // turn, and it used to be. That gate read as the conservative half of
+        // the choice and was the loop's own trigger: the state in which the
+        // window holds no copy - the live record retired by a seated span,
+        // that span then dropped or its answer discarded - is precisely the
+        // state every later echo then re-created. Each echo superseded the
+        // request in flight for the row, the discarded answer re-planned a
+        // new one, and the next echo (one per approval on a tool-heavy turn,
+        // sixty-odd on the turn that surfaced this) caught that one too. The
+        // row stayed a placeholder for the life of the turn and, with nothing
+        // backing it, the turn's live copy was not drawn either - only the
+        // status chip. The completion rebase was the first thing that seated
+        // it.
         //
-        // KNOWN GAP, deliberately not patched here: holding a copy is not the
-        // same as that copy being CURRENT with this echo, which is what the
-        // premise above actually needs. A write dropped while its row was
-        // unheld leaves the client behind, and a range sliced before it then
-        // seats a copy at the same older `blocksVersion` - so the seat's
-        // held-versus-served comparison reads a tie rather than both trailing
-        // the host, and the row is hydrated so no gap is left to repair it.
+        // What the gate was protecting is real and is handled differently: a
+        // copy the window does not hold is not being rewritten - its deltas
+        // are dropped - so an answer sliced before those deltas seats a body
+        // that trails the host, and a hydrated row is never re-asked for. So
+        // the seat is allowed, and the row is marked UNSOUND instead
+        // (`catchUpBudget`, read in `onRange`): the client's copy is not what
+        // the host would serve, and stays so until an answer provably closes
+        // the gap. That puts a trailing body on screen for a round trip rather
+        // than no body for the whole turn.
         //
-        // A latch cleared on the supersede this branch performs does NOT close
-        // it: `supersedeInFlightHydration` marks only requests whose ordinals
-        // intersect the change, so an append-only frame discharges the latch
-        // having covered nothing. Clearing only once nothing is outstanding
-        // fails the other way - each supersede re-plans a fresh request, so
-        // the set never empties and the exemption is disabled for the rest of
-        // the turn, which is the starvation this exemption exists to prevent.
-        // The per-request provenance lives on the recovery ledger's range
-        // entries now, and their honest ends are what retire the wedge: an
-        // answer closes its entry, an authority boundary subsumes it, the cap
-        // replaces it with a wider request - an entry can no longer sit open
-        // for the life of a turn with nothing owed against it. The residual
-        // this gate cannot see (a write dropped while its row was unheld,
-        // leaving held and served tied at the same stale version) is narrowed
-        // by the image witness store - which records writes even for unheld
-        // rows - and what remains rides the `updated` index entry, exactly as
-        // the settled-arm comparison documents.
-        const streamingEcho =
-          isActiveTurnStreamingEcho(frame.changes, activeTurnId) &&
-          (!recovery.hasOpenRanges() ||
-            holdsActiveTurnAssistantMessage(
-              get().transcriptWindow,
-              activeTurnId,
-            ));
+        // The holds scan is gated on there being an outstanding request at
+        // all, so it never runs on the bare per-token path.
+        const streamingEcho = isActiveTurnStreamingEcho(
+          frame.changes,
+          activeTurnId,
+        );
+        const echoWhileUnheld =
+          streamingEcho &&
+          recovery.hasOpenRanges() &&
+          !holdsActiveTurnAssistantMessage(
+            get().transcriptWindow,
+            activeTurnId,
+          );
         // Folded FIRST, but not published yet - the two orderings this has to
         // satisfy pull in opposite directions and this is what satisfies both.
         //
@@ -4220,6 +4732,26 @@ export function createChatSessionStoreWithNotificationDependencies(
             changes: frame.changes,
           });
         }
+        if (streamingEcho && window !== beforeFold && activeTurnId !== null) {
+          // Same acceptance gate as the supersede: a frame the window rejected
+          // reports no write. An accepted one reports a write the host made,
+          // and every write moves the mark whether or not this client had a
+          // body to put it in - that is what lets a request's own mark decide
+          // whether its answer could have contained it.
+          activeTurnWriteMark += 1;
+          if (echoWhileUnheld) {
+            // And this write had nowhere to land, so the copy the client ends
+            // up with is torn around it. What the echo NAMED is deliberately
+            // not recorded - the write staled the turn's records, which every
+            // row of that turn shares, so an obligation keyed on the echoed
+            // ordinal misses the sibling rows carrying the same stale copy.
+            catchUpBudget = {
+              turnId: activeTurnId,
+              unsound: true,
+              rounds: budgetForTurn(activeTurnId).rounds,
+            };
+          }
+        }
         publishWindowedTranscript(window, null);
         // Covers the `reindexed` case too: `requestPlannedHydration` sends a
         // `resnapshot` rather than a range when the window is invalidated.
@@ -4236,6 +4768,10 @@ export function createChatSessionStoreWithNotificationDependencies(
         }
         const tracked = inFlightHydrationRequest;
         const stale = rangeResponseIsStale(frame.range);
+        // Retired here rather than beside the seat, so an answer that never
+        // reaches the seat - stale, or refused by the fold - does not leave its
+        // mark behind for a request id that will never be answered again.
+        const sentUnderMark = takeHydrationRequestMark(frame.range.requestId);
         // This request is answered: it can neither be superseded nor seat
         // anything again, whichever way the staleness check just went.
         recovery.closeRange(frame.range.requestId);
@@ -4254,6 +4790,14 @@ export function createChatSessionStoreWithNotificationDependencies(
           clearInFlightHydration();
         }
         if (stale) {
+          appLogger.warn("[transcript] discarded a range answer as stale", {
+            ...rangeAnswerLogFields(frame.range),
+            // Whether the dedup slot still named this request. `false` is the
+            // late-answer shape (the timeout re-asked, or a re-plan replaced
+            // it); `true` is an answer superseded by an index change while it
+            // was the one being waited for.
+            awaited: tracked?.requestId === frame.range.requestId,
+          });
           // Seat nothing. The ordinals stay unhydrated, so the re-plan below
           // asks for them again - which is the whole point: a discarded
           // response costs a round trip, a seated stale one costs a row that
@@ -4262,12 +4806,7 @@ export function createChatSessionStoreWithNotificationDependencies(
           return;
         }
         const window = evictTranscriptWindowToBudget(
-          applyRangeResponse(
-            get().transcriptWindow,
-            frame.range,
-            get().activeTurn?.turnId ?? null,
-            imageWitnesses,
-          ),
+          seatRangeAnswer(frame.range, sentUnderMark),
           TRANSCRIPT_WINDOW_MAX_BYTES,
           // What the reader is looking at is never evicted - see the
           // function's own doc for the oversized-row re-fetch loop this
@@ -5007,6 +5546,25 @@ export function createChatSessionStoreWithNotificationDependencies(
             turnId: frame.event.turnId,
             observedAt,
           });
+        }
+        // A block delta is the most direct evidence of a write to the streaming
+        // turn this client ever gets - it needs no index echo to follow it and
+        // no `blocksVersion` to be present. Counted here, before the fold that
+        // may or may not find a body to apply it to, because the mark asks what
+        // the HOST did while the request was in the air, not what this client
+        // could do with it. An echo for the same write counts again; the mark is
+        // a monotonic clock, so double-counting one write costs nothing.
+        //
+        // Except for an event the reducer will reject as belonging to a
+        // different turn - a late `usage.updated` from the previous turn on
+        // OpenCode's SSE ordering, say (see `applyBlockDelta`'s own check). That
+        // is not a write to the streaming turn's body at all, and counting it
+        // retired a perfectly current catch-up answer and spent a round asking
+        // the host to re-send a body that had not changed.
+        if (
+          countsAsActiveTurnWrite(frame.event, get().activeTurn?.turnId ?? null)
+        ) {
+          activeTurnWriteMark += 1;
         }
         bufferedDeltas.push(frame.event);
         lease.requestFlush();
@@ -6681,6 +7239,8 @@ export function createChatSessionStoreWithNotificationDependencies(
         clearBufferedDeltas();
         clearInFlightHydration();
         recovery.dropAll();
+        hydrationRequestMarks.clear();
+        forgetCatchUpBudget();
         clearResnapshotRequestTimer();
         clearStreamCompletionWatchdog();
         legacyTranscriptAdapter.detach("disposed");

--- a/clients/gui-app/src/stores/chats/transcript-window.ts
+++ b/clients/gui-app/src/stores/chats/transcript-window.ts
@@ -4159,24 +4159,30 @@ export function applyIndexChange(
  * sibling slice holding the same turn's records is the case where it is not.
  * See {@link recordSharingOrdinals}.
  *
- * ## Why the echo test alone, when the store also asks whether the copy is HELD
+ * ## The echo test alone, on both halves of the decision
  *
- * The store gates its half of this decision - whether to supersede in-flight
- * hydration - on {@link holdsActiveTurnAssistantMessage} as well, because an
- * unheld copy is not being rewritten by the deltas and an answer generated
- * before them carries blocks the client can never recover. That conjunct is
- * absent here, and the two still agree, for a reason worth stating rather than
- * rediscovering: this half is a NO-OP whenever the conjunct would differ.
- * {@link dropSpansForUpdatedOrdinals} drops by ordinal containment, every
- * ordinal it is given names an `assistant:` row of the active turn (the entry
- * test in {@link isActiveTurnStreamingEcho}, widened along the same axis by
- * {@link recordSharingOrdinals}), and a span covering such an ordinal was
- * served the records backing it - so "no span holds the turn's assistant
- * message" already implies "no span contains one of these ordinals", and there
- * is nothing for the skip to keep. Adding the scan here would buy no
- * behavioural change and would put an O(records held) walk on the per-token
- * path, which is exactly what the store's own `outstandingHydrationRequests`
- * gate exists to avoid.
+ * The store's half - whether to supersede in-flight hydration - asks exactly
+ * this same question and nothing more. It once carried a second conjunct,
+ * {@link holdsActiveTurnAssistantMessage}, on the reasoning that an unheld copy
+ * is not being rewritten so an answer generated before those deltas must be
+ * discarded. That conjunct was the starvation loop it was meant to prevent:
+ * unheld is precisely the state each supersede re-created, so every echo of a
+ * long turn discarded the answer for its own row and the row never hydrated.
+ * The store now supersedes on the echo test alone and repairs the trailing body
+ * a different way - see `chat-session-store`'s dropped-write mark, which asks
+ * whether the ANSWER predates a write this client dropped rather than whether a
+ * copy happens to be held at fold time.
+ *
+ * Holding is still what decides whether such a write was dropped at all, so the
+ * scan survives in the store on that path. It is deliberately absent HERE, and
+ * would be a no-op if added: {@link dropSpansForUpdatedOrdinals} drops by
+ * ordinal containment, every ordinal it is given names an `assistant:` row of
+ * the active turn (the entry test in {@link isActiveTurnStreamingEcho}, widened
+ * along the same axis by {@link recordSharingOrdinals}), and a span covering
+ * such an ordinal was served the records backing it - so "no span holds the
+ * turn's assistant message" already implies "no span contains one of these
+ * ordinals". Adding the scan would buy no behavioural change and would put an
+ * O(records held) walk on the per-token path.
  */
 function reconcileUpdatedBodies(
   window: TranscriptWindow,
@@ -4192,6 +4198,39 @@ function reconcileUpdatedBodies(
   return dropSpansForUpdatedOrdinals(
     window,
     recordSharingOrdinals(window, invalidated),
+  );
+}
+
+/**
+ * Retire the fresh spans holding `ordinals` into the stale tier so the planner
+ * asks for those rows once more - the catch-up behind the streaming-echo
+ * exemption.
+ *
+ * The exemption lets a `range` answer for the active turn's row seat even when
+ * the client held no copy of that turn while the answer was in flight. Such an
+ * answer was sliced BEFORE writes this client dropped (dropped because nothing
+ * held the row to apply them to), so the body it seats can trail the host by
+ * exactly those blocks - and nothing re-asks for a row that is hydrated. So the
+ * store retires the span here: the body stays renderable from the stale tier,
+ * the ordinal reads as a gap again, and the request the planner then sends is
+ * sliced after every write the first one missed.
+ *
+ * Which answers get this treatment is the store's decision and rests on the
+ * ANSWER's provenance, never on what happens to be held when it lands - see the
+ * dropped-write mark in `chat-session-store`. Seating is also what ends the
+ * condition: once any span or the ledger holds the turn's records, later deltas
+ * are applied rather than dropped, so no further write goes missing.
+ *
+ * The same transition a non-echo `updated` performs - deliberately, so this
+ * introduces no second way for a span to leave the fresh tier.
+ */
+export function refreshSeatedRows(
+  window: TranscriptWindow,
+  ordinals: readonly number[],
+): TranscriptWindow {
+  return dropSpansForUpdatedOrdinals(
+    window,
+    recordSharingOrdinals(window, ordinals),
   );
 }
 
@@ -4320,11 +4359,14 @@ function heldMessageCopy(
  * Does the window hold the active turn's assistant message ANYWHERE - live,
  * fresh span, or stale span?
  *
- * The precondition for skipping the in-flight supersede on a streaming echo:
- * the skip is sound because the delta stream rewrites the held copy in place,
- * and a copy that is not held is not being rewritten - deltas for it are
- * dropped, so an answer generated before them carries blocks the client can
- * never recover and MUST be discarded and re-asked.
+ * Not a precondition for the streaming-echo exemption - that gate was the
+ * starvation loop and is gone. What this answers now is whether a delta the
+ * echo reports was APPLIED or DROPPED: the stream rewrites a held copy in
+ * place, while a write for a row nothing holds has nowhere to land. So the
+ * store reads it to decide whether a dropped write happened at all, and an
+ * answer sliced before one owes a catch-up (see `chat-session-store`'s
+ * dropped-write mark). Because it counts the stale tier too, one seat is enough
+ * to end the condition - a demoted body still receives the deltas that follow.
  *
  * O(records the window holds); the caller gates it on there being an
  * outstanding request at all, so it never runs on the bare per-token path.
@@ -4334,15 +4376,117 @@ export function holdsActiveTurnAssistantMessage(
   activeTurnId: string | null,
 ): boolean {
   if (activeTurnId === null) return false;
-  const matches = (message: Message): boolean =>
-    message.role === "assistant" && assistantTurnKey(message) === activeTurnId;
-  if (window.liveMessages.some(matches)) return true;
+  if (window.liveMessages.some(assistantMessageOfTurn(activeTurnId))) {
+    return true;
+  }
   // The ledger IS the span tiers' holdings, fresh and stale alike.
   for (const entry of window.records.messages.values()) {
-    if (matches(entry.record)) return true;
+    if (assistantMessageOfTurn(activeTurnId)(entry.record)) return true;
   }
   return false;
 }
+
+/**
+ * Will this range answer SEAT the active turn's own assistant records?
+ *
+ * The question the store asks of an answer that predates a dropped write, and
+ * it is about RECORDS rather than ordinals deliberately. A dropped write can
+ * only have staled the turn it was written for, so a scrollback answer from the
+ * same era is current and must not be re-fetched. Conversely a turn's records
+ * are shared by every row it produces - its slices and the steer bubbles
+ * between them - so an answer serving any one of those rows carries the stale
+ * copy even when the echo named a different ordinal. Matching on the records
+ * catches both, where matching on the echoed ordinal catches neither.
+ *
+ * "Will seat" and not "carries", because {@link applyRangeResponse} can WITHHOLD
+ * the very records the raw answer carries: a row the host declared incomplete
+ * takes its whole turn's records out of the fold, so an answer that carries the
+ * turn and lists one of its rows in `incompleteRowIds` seats none of it. Reading
+ * `response.messages` alone there let a mixed answer - one historical row served
+ * complete beside an incomplete active row - retire the COMPLETE row and re-ask
+ * for it, discarding valid hydration to chase a body the fold had already
+ * refused. So the withholding rule is applied here, exactly as the fold applies
+ * it, before the records are looked at.
+ */
+export function rangeSeatsActiveTurn(
+  response: ChatRangeResponse,
+  activeTurnId: string | null,
+): boolean {
+  if (activeTurnId === null) return false;
+  // The fold collects the TURN KEYS of every withheld row and filters by turn,
+  // so one incomplete row of the active turn withholds all of it - including
+  // the copy a sibling row in the same answer would otherwise have seated.
+  for (const rowId of incompleteRowIdsToWithhold(response.incompleteRowIds)) {
+    if (assistantRowTurnKey(rowId) === activeTurnId) return false;
+  }
+  return response.messages.some(assistantMessageOfTurn(activeTurnId));
+}
+
+/**
+ * The ordinals this answer served for the ACTIVE turn's own rows.
+ *
+ * A range can serve a settled row and the streaming row in one answer. Only the
+ * streaming turn's rows are what a write staled, so only they are retired and
+ * only they are what a repair request is for - retiring every ordinal the answer
+ * happened to carry threw away a complete historical row's hydration, and
+ * recording every ordinal as repair work let a later visit to that historical
+ * row be charged against the streaming row's repair budget.
+ *
+ * Sibling slices need no special handling: {@link refreshSeatedRows} widens
+ * whatever it is given along the turn's shared records.
+ *
+ * This reads the answer's row ids, not what the fold will seat, so it also
+ * counts a row the fold withholds. That is safe only because withholding is
+ * per turn and wholesale: an answer that withholds any row of the active turn
+ * fails {@link rangeSeatsActiveTurn}, and nothing downstream of that gate
+ * reads these ordinals.
+ */
+export function activeTurnOrdinalsOf(
+  response: ChatRangeResponse,
+  activeTurnId: string | null,
+): readonly number[] {
+  if (activeTurnId === null) return [];
+  const ordinals: number[] = [];
+  response.rowIds.forEach((rowId, offset) => {
+    if (assistantRowTurnKey(rowId) === activeTurnId) {
+      ordinals.push(response.fromOrdinal + offset);
+    }
+  });
+  return ordinals;
+}
+
+/**
+ * Did the fold actually INSTALL this answer's copies of the active turn?
+ *
+ * Seating an answer is not the same as its records reaching the ledger:
+ * {@link preferFresherHeldMessages} can substitute a held copy for a served one,
+ * and then the window holds the body that was already there. A request's mark
+ * dates what the answer could contain and cannot see that - so certifying the
+ * turn on the mark alone declared the row current while the copy on screen was
+ * the torn one the answer had been sent to replace.
+ *
+ * Identity is the exact test, and it is available because the seat stores the
+ * message objects it was handed by reference (`seatLedgerRecords`); a
+ * substituted copy is a different object.
+ */
+export function rangeRecordsInstalled(
+  window: TranscriptWindow,
+  messages: readonly Message[],
+  activeTurnId: string | null,
+): boolean {
+  if (activeTurnId === null) return false;
+  const served = messages.filter(assistantMessageOfTurn(activeTurnId));
+  if (served.length === 0) return false;
+  return served.every(
+    (message) =>
+      window.records.messages.get(message.messageId)?.record === message,
+  );
+}
+
+const assistantMessageOfTurn =
+  (turnId: string) =>
+  (message: Message): boolean =>
+    message.role === "assistant" && assistantTurnKey(message) === turnId;
 
 /**
  * While a turn streams, the held copy of its assistant message outranks any
@@ -4382,6 +4526,23 @@ export function holdsActiveTurnAssistantMessage(
  * {@link hydratedRecords} renders rather than the first one found - see
  * {@link heldMessageCopy}. Comparing the served body against some OTHER held
  * copy decides the seat on a record the reader is not looking at.
+ *
+ * ## The arm is chosen by the CALLER, and a provisional body forfeits it
+ *
+ * `activeTurnId` is the only thing that selects the active arm, and the store
+ * passes `null` for it deliberately when the held copy is one IT seated
+ * provisionally - a body it accepted knowing the answer predated a write the
+ * client dropped (see `chat-session-store`'s provisional-seat ledger). The
+ * active arm's premise is that the held copy has every delta applied; for that
+ * body the client itself recorded that it does not, so the premise is false and
+ * the arm must not run. Under the settled arm the catch-up's copy seats unless
+ * the held one is demonstrably ahead, which is the correct default for a record
+ * whose incompleteness the client has already established.
+ *
+ * Without that, a catch-up requested precisely to repair the provisional body
+ * was substituted away by the body it was sent to replace, and the row went on
+ * rendering content the client knew to be short of the host with no gap left to
+ * re-request it.
  */
 function preferFresherHeldMessages(
   window: TranscriptWindow,


### PR DESCRIPTION
## Summary

A long tool-heavy turn on a windowed chat left **its own row as a placeholder for the whole turn**. The host emits an `indexChanged` `updated` for the streaming row on every broadcast (62 on the turn that surfaced this). Each echo superseded the in-flight `loadRange` for that row, discarded its answer on arrival, and re-planned straight into the next echo. The exemption meant to prevent this was gated on the client *holding a copy of the turn*, which is exactly the state each supersede destroyed, so once a seated span retired the live record and that span was dropped, the gate was off for the rest of the turn.

The commit message carries the full design; in short:

- The streaming-echo test alone decides the supersede (`onIndexChanged`).
- What the old gate protected (an answer sliced before writes the client dropped) is repaired by **dating the answer**: each request records the turn's write mark it was sent under, and `sentUnderMark === activeTurnWriteMark` is exactly "no write happened while this answer was in flight".
- A body seated around a gap forfeits the held-copy preference so the catch-up can install, but **only when a repair can follow** (`mayRepairUnsoundBody`): a retirable assistant row of the turn, no deferred snapshot, and a current mark or budget left. Otherwise base behaviour applies.
- Repair is bounded by `MAX_PROVISIONAL_CATCH_UP_ROUNDS = 3`, charged at request mint, kept per turn.
- Every discarded range answer, catch-up and give-up is logged at warn.

Healthy-path behaviour (no echo while a range is open for the streaming row) is a strict no-op relative to base.

## Intended for the release RC

This is meant to be cherry-picked into the current RC. No commit on `main` since the fork point touches `clients/gui-app/src/stores/chats/`; the branch is rebased onto `main` and the pick applies clean.

## Review

Seven cold-review rounds by independent agents. Rounds 1 to 6 each found real defects in earlier revisions of the fix (content loss, duplication, drawn text rolling backward); every one was pinned by a test and confirmed by ablation against the superseded revision. Round 7 re-ran all 30 preserved probes from earlier rounds against the final revision with nothing reintroduced, enumerated every exit of the catch-up settlement for a forfeit without a repair and found none reachable, and returned **GO** with no P1/P2. The remaining nits from that round (a load-bearing comment, a vacuous assertion, a doc sentence) are folded in here.

## Verification

- `clients/gui-app`: 67 windowed-binding + 182 transcript-window tests; 3068 across `src/stores/chats`, `src/stores/replica-memory`, `src/components/chat`, all passing on the rebased commit.
- Full `gui-app` suite passed on the previous revision and is re-running on this commit before merge.
- pre-commit (build, compile, lint, format, DCO) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
