### PR TITLE
fix(gui-app): keep the office hover card on a walking character

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/comm-graph/__tests__/office-agent-hover.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/comm-graph/__tests__/office-agent-hover.test.tsx
@@ -20,7 +20,9 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ReactElement } from "react";
 import { OfficeAgentHover } from "@/components/epic-canvas/comm-graph/office/office-agent-hover";
+import { followOfficeHover } from "@/components/epic-canvas/comm-graph/office/office-hover-follow";
 import { OfficeHoverSupplement } from "@/components/epic-canvas/comm-graph/office/office-hover-supplement";
+import type { OfficeHitRegion } from "@/lib/comm-graph/office/office-types";
 
 const RECT = { x: 40, y: 24, width: 16, height: 20 };
 
@@ -110,5 +112,77 @@ describe("OfficeAgentHover", () => {
     );
 
     expect(onSelect).toHaveBeenCalledWith("agent-1");
+  });
+});
+
+/**
+ * The floor is repainted every frame and a character away from its desk moves
+ * a fraction of a tile per frame. The card is placed on a pointer event, so
+ * between events it is the frame loop that has to decide whether the pointer
+ * is still on the agent and where the agent has got to - and it must do that
+ * from the pointer's position, not from whether the box is where it was.
+ * Comparing boxes closed the card on the first frame of every walk.
+ */
+describe("followOfficeHover", () => {
+  const IDENTITY = { x: 0, y: 0, zoom: 1 };
+  function walker(x: number, agentId: string): OfficeHitRegion {
+    return { agentId, rect: { x, y: 32, width: 16, height: 20 } };
+  }
+
+  it("moves the card with a walking character while the pointer stays on it", () => {
+    const anchor = { agentId: "agent-1", screenX: 48, screenY: 40 };
+    expect(
+      followOfficeHover(anchor, [walker(40, "agent-1")], IDENTITY),
+    ).toEqual({ x: 40, y: 32, width: 16, height: 20 });
+    // A fraction of a tile later - the same pointer is still inside the box,
+    // so the card is kept and re-placed over where the character now is.
+    expect(
+      followOfficeHover(anchor, [walker(40.75, "agent-1")], IDENTITY),
+    ).toEqual({ x: 40.75, y: 32, width: 16, height: 20 });
+  });
+
+  it("closes once the character has walked out from under the pointer", () => {
+    const anchor = { agentId: "agent-1", screenX: 48, screenY: 40 };
+    expect(followOfficeHover(anchor, [walker(60, "agent-1")], IDENTITY)).toBe(
+      null,
+    );
+  });
+
+  it("closes when the character leaves the floor", () => {
+    const anchor = { agentId: "agent-1", screenX: 48, screenY: 40 };
+    expect(followOfficeHover(anchor, [], IDENTITY)).toBe(null);
+  });
+
+  it("closes rather than re-targeting when another character is painted over the pointer", () => {
+    const anchor = { agentId: "agent-1", screenX: 48, screenY: 40 };
+    // Draw order: agent-2 painted last is on top, so the pointer is on it now.
+    expect(
+      followOfficeHover(
+        anchor,
+        [walker(40, "agent-1"), walker(44, "agent-2")],
+        IDENTITY,
+      ),
+    ).toBe(null);
+  });
+
+  it("re-reads the pointer through the camera, so a pan under a still pointer is a real move", () => {
+    const anchor = { agentId: "agent-1", screenX: 96, screenY: 80 };
+    const camera = { x: 16, y: 16, zoom: 2 };
+    // Sprite point (40, 32) sits inside the box; the card is placed in screen
+    // pixels through the same camera.
+    expect(followOfficeHover(anchor, [walker(40, "agent-1")], camera)).toEqual({
+      x: 96,
+      y: 80,
+      width: 32,
+      height: 40,
+    });
+    // The floor slides 40 screen pixels left under the stationary pointer,
+    // which now lands past the character's box.
+    expect(
+      followOfficeHover(anchor, [walker(40, "agent-1")], {
+        ...camera,
+        x: -24,
+      }),
+    ).toBe(null);
   });
 });

--- a/clients/gui-app/src/components/epic-canvas/comm-graph/office/comm-graph-office-canvas.tsx
+++ b/clients/gui-app/src/components/epic-canvas/comm-graph/office/comm-graph-office-canvas.tsx
@@ -57,6 +57,11 @@ import { CommGraphAgentDetailSurface } from "@/components/epic-canvas/comm-graph
 import { CommGraphThreadPanel } from "@/components/epic-canvas/comm-graph/comm-graph-thread-panel";
 import { OFFICE_ENVELOPE_TINTS } from "@/components/epic-canvas/comm-graph/office/office-envelope-tints";
 import { OfficeAgentHover } from "@/components/epic-canvas/comm-graph/office/office-agent-hover";
+import {
+  followOfficeHover,
+  hitRegionFor,
+  type OfficeHoverAnchor,
+} from "@/components/epic-canvas/comm-graph/office/office-hover-follow";
 import { OfficeHoverSupplement } from "@/components/epic-canvas/comm-graph/office/office-hover-supplement";
 import { OfficeLegend } from "@/components/epic-canvas/comm-graph/office/office-legend";
 import {
@@ -174,8 +179,8 @@ type OfficeSelectedDetail =
 
 /**
  * The hovered character and where its card should sit, in container-relative
- * screen pixels. Recomputed on pointer move rather than per frame: the camera
- * does not move under a stationary pointer, and a drag clears the hover.
+ * screen pixels. Set on pointer move, and moved by the frame loop only while
+ * the character under the pointer is itself moving.
  */
 interface OfficeHoverTarget {
   readonly agentId: string;
@@ -183,47 +188,13 @@ interface OfficeHoverTarget {
   readonly rect: OfficeRect;
 }
 
-/**
- * What the open hover card was measured against, so the frame loop can tell
- * when that measurement has stopped being true without a pointer event.
- *
- * The card's screen rect is computed on a pointermove and never again, but the
- * thing it points at keeps moving: the character walks off to lunch, or an
- * auto-pan slides the whole floor under a stationary cursor. Either leaves the
- * trigger anchored over empty floor. Both are a change in exactly these five
- * numbers, which is what makes them the thing to remember.
- */
-interface HoverAnchor {
-  readonly agentId: string;
-  /** The hit region's box in sprite space, as it was when the pointer landed. */
-  readonly rect: OfficeRect;
-  readonly cameraX: number;
-  readonly cameraY: number;
-  readonly zoom: number;
-}
-
-function sameRect(a: OfficeRect, b: OfficeRect): boolean {
+function sameRect(a: OfficeRect, b: OfficeRect | null): boolean {
   return (
-    a.x === b.x && a.y === b.y && a.width === b.width && a.height === b.height
-  );
-}
-
-/** Whether the hovered box is still exactly where the card was measured. */
-function hoverAnchorHolds(
-  anchor: HoverAnchor,
-  regions: ReadonlyArray<OfficeHitRegion>,
-  camera: OfficeCamera,
-): boolean {
-  if (
-    camera.x !== anchor.cameraX ||
-    camera.y !== anchor.cameraY ||
-    camera.zoom !== anchor.zoom
-  ) {
-    return false;
-  }
-  return regions.some(
-    (region) =>
-      region.agentId === anchor.agentId && sameRect(region.rect, anchor.rect),
+    b !== null &&
+    a.x === b.x &&
+    a.y === b.y &&
+    a.width === b.width &&
+    a.height === b.height
   );
 }
 
@@ -573,26 +544,6 @@ function spriteBoundsFor(
   }
   if (left === Number.POSITIVE_INFINITY) return null;
   return { x: left, y: top, width: right - left, height: bottom - top };
-}
-
-function hitRegionFor(
-  regions: ReadonlyArray<OfficeHitRegion>,
-  point: OfficePoint,
-): OfficeHitRegion | null {
-  // Last match wins: `hitRegions` follows the frame's own draw order, so the
-  // character painted on top of another is the one the pointer is over.
-  let found: OfficeHitRegion | null = null;
-  for (const region of regions) {
-    if (
-      point.x >= region.rect.x &&
-      point.x <= region.rect.x + region.rect.width &&
-      point.y >= region.rect.y &&
-      point.y <= region.rect.y + region.rect.height
-    ) {
-      found = region;
-    }
-  }
-  return found;
 }
 
 /**
@@ -1403,7 +1354,11 @@ export function CommGraphOfficeCanvas(props: CommGraphOfficeCanvasProps) {
     floor: { width: 0, height: 0 },
     viewport: { width: 0, height: 0 },
   });
-  const hoverAnchorRef = useRef<HoverAnchor | null>(null);
+  // The open hover's subject and the pointer's last position; `null` while no
+  // card is open. The frame loop re-resolves it against every frame.
+  const hoverAnchorRef = useRef<OfficeHoverAnchor | null>(null);
+  /** The box the card was last placed at, so a frame that moved nothing is free. */
+  const hoverRectRef = useRef<OfficeRect | null>(null);
   // A pan asked for outside the frame loop. Handlers and the Find adapter have
   // no frame clock, so they name the destination and the loop starts it.
   const dragRef = useRef<DragState | null>(null);
@@ -1891,21 +1846,28 @@ export function CommGraphOfficeCanvas(props: CommGraphOfficeCanvasProps) {
       applyAutoFit(frame.size, viewport);
       requestPlaybackPan(frame.focus, viewport);
       advanceCamera(now, viewport);
-      // The hover card's rect was measured on the last pointermove, and what
-      // it points at can move without the pointer moving at all: the cursor
-      // scrubs to a time before that agent existed, the agent walks off to
-      // the cafeteria, or an auto-pan slides the floor under the cursor.
-      // Holding the card open would leave it anchored to empty floor. Checked
-      // AFTER the camera has moved for this frame, so a pan is caught on the
-      // frame it happens rather than the one after.
+      // What the hover card points at can move without the pointer moving at
+      // all: the agent walks off to the cafeteria, an auto-pan slides the
+      // floor under the cursor, or the cursor scrubs to a time before that
+      // agent existed. So the pointer's last position is hit-tested against
+      // THIS frame: while it still lands on the hovered agent the card follows
+      // the character, and once it does not the card closes rather than being
+      // left anchored to empty floor. Checked AFTER the camera has moved for
+      // this frame, so a pan is caught on the frame it happens rather than
+      // the one after.
       const anchor = hoverAnchorRef.current;
-      if (
-        anchor !== null &&
-        !hoverAnchorHolds(anchor, frame.hitRegions, camera)
-      ) {
-        hoverAnchorRef.current = null;
-        runtime.setHoveredAgentId(null);
-        setHoverCard(null);
+      if (anchor !== null) {
+        const rect = followOfficeHover(anchor, frame.hitRegions, camera);
+        if (rect === null) {
+          hoverAnchorRef.current = null;
+          hoverRectRef.current = null;
+          runtime.setHoveredAgentId(null);
+          setHoverCard(null);
+        } else if (!sameRect(rect, hoverRectRef.current)) {
+          // React state, so only a box that actually moved is worth a render.
+          hoverRectRef.current = rect;
+          setHoverCard({ agentId: anchor.agentId, rect });
+        }
       }
 
       // Repainted only when the floor's version, the theme or its size moves;
@@ -1991,18 +1953,28 @@ export function CommGraphOfficeCanvas(props: CommGraphOfficeCanvasProps) {
     };
   }, [applyCanvasSize, readScene, resolvedTheme, runtime]);
 
-  const toSpritePoint = useCallback(
+  /** A client position in container screen pixels. */
+  const toScreenPoint = useCallback(
     (clientX: number, clientY: number): OfficePoint | null => {
       const container = containerRef.current;
       if (container === null) return null;
       const rect = container.getBoundingClientRect();
+      return { x: clientX - rect.left, y: clientY - rect.top };
+    },
+    [],
+  );
+
+  const toSpritePoint = useCallback(
+    (clientX: number, clientY: number): OfficePoint | null => {
+      const screen = toScreenPoint(clientX, clientY);
+      if (screen === null) return null;
       const camera = runtime.getCamera();
       return {
-        x: (clientX - rect.left - camera.x) / camera.zoom,
-        y: (clientY - rect.top - camera.y) / camera.zoom,
+        x: (screen.x - camera.x) / camera.zoom,
+        y: (screen.y - camera.y) / camera.zoom,
       };
     },
-    [runtime],
+    [runtime, toScreenPoint],
   );
 
   // Shared by the canvas and the hover trigger that sits over a character: a
@@ -2054,42 +2026,61 @@ export function CommGraphOfficeCanvas(props: CommGraphOfficeCanvasProps) {
       const region =
         point === null ? null : hitRegionFor(runtime.getHitRegions(), point);
       const camera = runtime.getCamera();
+      const screen = toScreenPoint(event.clientX, event.clientY);
       // Mirrored for the DRAW, which needs it to keep an away agent's name tag
       // while the pointer is on it; the card itself is React state.
       runtime.setHoveredAgentId(region === null ? null : region.agentId);
-      hoverAnchorRef.current =
+      const rect =
         region === null
           ? null
           : {
-              agentId: region.agentId,
-              rect: region.rect,
-              cameraX: camera.x,
-              cameraY: camera.y,
-              zoom: camera.zoom,
+              x: region.rect.x * camera.zoom + camera.x,
+              y: region.rect.y * camera.zoom + camera.y,
+              width: region.rect.width * camera.zoom,
+              height: region.rect.height * camera.zoom,
             };
-      setHoverCard(
-        region === null
+      hoverAnchorRef.current =
+        region === null || screen === null
           ? null
-          : {
-              agentId: region.agentId,
-              rect: {
-                x: region.rect.x * camera.zoom + camera.x,
-                y: region.rect.y * camera.zoom + camera.y,
-                width: region.rect.width * camera.zoom,
-                height: region.rect.height * camera.zoom,
-              },
-            },
+          : { agentId: region.agentId, screenX: screen.x, screenY: screen.y };
+      hoverRectRef.current = rect;
+      setHoverCard(
+        region === null || rect === null
+          ? null
+          : { agentId: region.agentId, rect },
       );
       // An envelope is clickable too, so it earns the same cursor even where
       // it is flying over open floor with no desk under it.
       event.currentTarget.style.cursor =
         region === null && !overEnvelope ? "default" : "pointer";
     },
-    [readScene, runtime, toSpritePoint],
+    [readScene, runtime, toScreenPoint, toSpritePoint],
+  );
+
+  // On the CONTAINER, because the hover trigger is laid over the character and
+  // takes the pointer from the canvas while it is there. A move inside the
+  // trigger never reaches the canvas handler, but the frame loop still needs
+  // the pointer's true position to decide whether a walking character is
+  // still under it - so the anchor is kept current from whichever element
+  // has the pointer.
+  const trackHoverPointer = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      const anchor = hoverAnchorRef.current;
+      if (anchor === null) return;
+      const screen = toScreenPoint(event.clientX, event.clientY);
+      if (screen === null) return;
+      hoverAnchorRef.current = {
+        agentId: anchor.agentId,
+        screenX: screen.x,
+        screenY: screen.y,
+      };
+    },
+    [toScreenPoint],
   );
 
   const clearHover = useCallback(() => {
     hoverAnchorRef.current = null;
+    hoverRectRef.current = null;
     runtime.setHoveredAgentId(null);
     setHoverCard(null);
   }, [runtime]);
@@ -2284,6 +2275,7 @@ export function CommGraphOfficeCanvas(props: CommGraphOfficeCanvasProps) {
         ref={containerRef}
         className="relative h-full min-h-0 w-full min-w-0 flex-1 overflow-hidden"
         data-testid="comm-graph-office-canvas"
+        onPointerMove={trackHoverPointer}
       >
         <canvas
           ref={canvasRef}

--- a/clients/gui-app/src/components/epic-canvas/comm-graph/office/office-hover-follow.ts
+++ b/clients/gui-app/src/components/epic-canvas/comm-graph/office/office-hover-follow.ts
@@ -1,0 +1,85 @@
+/**
+ * How the office floor's hover card keeps up with a moving character.
+ *
+ * The floor is one `<canvas>` repainted every frame, and a character away from
+ * its desk moves a fraction of a tile per frame. The card is placed on a
+ * pointer event, so between events it is the frame loop that has to decide
+ * whether the pointer is still on the agent and where the agent has got to.
+ * Kept out of the component file so the card itself stays a pure component.
+ */
+import type {
+  OfficeHitRegion,
+  OfficePoint,
+  OfficeRect,
+} from "@/lib/comm-graph/office/office-types";
+
+/** The floor's camera, as the hover needs it: a screen offset and a scale. */
+export interface OfficeHoverCamera {
+  readonly x: number;
+  readonly y: number;
+  readonly zoom: number;
+}
+
+/**
+ * The open hover's subject and the pointer's last position over the floor, in
+ * container screen pixels.
+ *
+ * The pointer is remembered rather than the character's box: the box is what
+ * MOVES between pointer events - the character walks off to lunch, an
+ * auto-pan slides the floor under a stationary cursor - so a box measured once
+ * stops being true within a frame of either. The pointer only changes when
+ * the pointer moves, and a hit test at it against the frame just built answers
+ * both "is the cursor still on this agent" and "where is the agent now".
+ */
+export interface OfficeHoverAnchor {
+  readonly agentId: string;
+  readonly screenX: number;
+  readonly screenY: number;
+}
+
+export function hitRegionFor(
+  regions: ReadonlyArray<OfficeHitRegion>,
+  point: OfficePoint,
+): OfficeHitRegion | null {
+  // Last match wins: `hitRegions` follows the frame's own draw order, so the
+  // character painted on top of another is the one the pointer is over.
+  let found: OfficeHitRegion | null = null;
+  for (const region of regions) {
+    if (
+      point.x >= region.rect.x &&
+      point.x <= region.rect.x + region.rect.width &&
+      point.y >= region.rect.y &&
+      point.y <= region.rect.y + region.rect.height
+    ) {
+      found = region;
+    }
+  }
+  return found;
+}
+
+/**
+ * Where the open hover's trigger belongs on THIS frame, in container screen
+ * pixels - or `null` once the pointer's last position no longer lands on the
+ * hovered agent, because the character walked out from under it, the floor
+ * panned, or another character was painted over it.
+ *
+ * A moving character keeps its card as long as the cursor stays on it, and
+ * the card moves with it; a card is never left anchored to empty floor.
+ */
+export function followOfficeHover(
+  anchor: OfficeHoverAnchor,
+  regions: ReadonlyArray<OfficeHitRegion>,
+  camera: OfficeHoverCamera,
+): OfficeRect | null {
+  const region = hitRegionFor(regions, {
+    x: (anchor.screenX - camera.x) / camera.zoom,
+    y: (anchor.screenY - camera.y) / camera.zoom,
+  });
+  if (region === null || region.agentId !== anchor.agentId) return null;
+  return {
+    x: region.rect.x * camera.zoom + camera.x,
+    y: region.rect.y * camera.zoom + camera.y,
+    width: region.rect.width * camera.zoom,
+    height: region.rect.height * camera.zoom,
+  };
+}


### PR DESCRIPTION
## Problem

In the office view, hovering a character who is away from their desk opened the agent card and closed it again on the very next frame. Moving the mouse over the character re-opened it, so it read as flicker.

The frame loop tore the hover down unless the character's hit box was **pixel-identical** to the box measured on the last `pointermove` (`hoverAnchorHolds`). A walking character gets a fractional `col`/`row` increment every tick, so the rect differed every frame and the check failed immediately. Seated agents were unaffected because their box is stable.

## Fix

- The frame loop now re-hit-tests the **pointer's last position** against the frame it just built (`followOfficeHover`). While it still lands on the hovered agent the card **follows the character**; once it does not (the agent walked out from under the cursor, the floor panned, another character was painted over it, or the agent left the floor) the card closes as before.
- The pointer position is tracked on the container, not only the canvas: the hover trigger sits over the character and takes the pointer from the canvas while it is there, so moves inside the trigger would otherwise leave the anchor stale.
- The card is only re-set when the box actually moved, so a stationary character costs no renders.
- The pure follow logic and the hit test moved to `office-hover-follow.ts` (kept out of the component file for fast refresh) and are covered directly in `office-agent-hover.test.tsx`: follow a walking character, close when it walks out from under the pointer, close when it leaves the floor, close when another character is painted over it, and re-read the pointer through the camera on a pan.

## Verification

- `bun run vitest run` on `office-agent-hover.test.tsx`, `comm-graph-office-canvas.test.tsx`, `office-overlays.test.tsx`: 29 passed.
- gui-app `compile`, `oxlint --deny-warnings`, `eslint --max-warnings 0`, and `oxfmt --check .` clean; pre-commit passed on the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
