### PR TITLE
Show imported tasks in the import wizard

### DIFF
--- a/clients/gui-app/src/components/layout/bridges/session-import-announcement-controller.tsx
+++ b/clients/gui-app/src/components/layout/bridges/session-import-announcement-controller.tsx
@@ -157,8 +157,7 @@ export function SessionImportAnnouncementController(): ReactNode {
       onClose={() => {
         setDialogOpen(false);
       }}
-      // The toast speaks for the app's active host; the dialog's own picker
-      // is where another machine gets chosen.
+      // The dialog captures the active host once when it opens.
       initialHostId={null}
     />
   );

--- a/clients/gui-app/src/components/onboarding/__tests__/onboarding-session-import-mount.test.tsx
+++ b/clients/gui-app/src/components/onboarding/__tests__/onboarding-session-import-mount.test.tsx
@@ -107,7 +107,7 @@ describe("startSessionImportRun", () => {
 
   it("forwards the submission to the mounted controller", () => {
     const start = vi.fn();
-    setSessionImportStartHandle({ start });
+    setSessionImportStartHandle({ start, attach: vi.fn() });
     const request = {
       selections: [SELECTION],
       titles: new Map([["claude:native-1", "My Session"]]),
@@ -139,7 +139,7 @@ describe("startSessionImportRun", () => {
 
   it("logs an error and does not call start when no host is bound", () => {
     const start = vi.fn();
-    setSessionImportStartHandle({ start });
+    setSessionImportStartHandle({ start, attach: vi.fn() });
     const consoleError = vi
       .spyOn(console, "error")
       .mockImplementation(() => undefined);

--- a/clients/gui-app/src/components/onboarding/onboarding-page.tsx
+++ b/clients/gui-app/src/components/onboarding/onboarding-page.tsx
@@ -666,6 +666,7 @@ function OnboardingMiniatureColumn(props: {
   readonly agentGuide: OnboardingAgentGuideState;
   readonly hostPicker: OnboardingHostPicker;
   readonly sessionImportScan: SessionImportScanHandle;
+  readonly onBeforeImportedTaskOpen: () => Promise<boolean>;
 }) {
   const { actId, addon, miniature, agentGuide, hostPicker, sessionImportScan } =
     props;
@@ -679,6 +680,7 @@ function OnboardingMiniatureColumn(props: {
       <OnboardingSessionImportStage
         scan={sessionImportScan}
         hostPicker={hostPicker}
+        onBeforeTaskOpen={props.onBeforeImportedTaskOpen}
       />
     );
   } else if (miniature.kind === "login-import") {
@@ -1557,6 +1559,18 @@ function OnboardingTour(props: {
                 agentGuide={agentGuideState}
                 hostPicker={hostPicker}
                 sessionImportScan={sessionImportScan}
+                onBeforeImportedTaskOpen={async () => {
+                  if (!(await saveAgentGuideDraft())) return false;
+                  Analytics.getInstance().track(
+                    AnalyticsEvent.OnboardingCompleted,
+                    { last_step: act.id },
+                  );
+                  consumeAnnouncement("login-import");
+                  // AppShell owns tab-navigation hydration. Finish the tour
+                  // before requesting a task tab so that hydration can run.
+                  complete();
+                  return true;
+                }}
               />
             </div>
             <OnboardingStageEdgeFade

--- a/clients/gui-app/src/components/onboarding/onboarding-session-import-stage.tsx
+++ b/clients/gui-app/src/components/onboarding/onboarding-session-import-stage.tsx
@@ -32,6 +32,7 @@ import { useStreamRuntimeBinding } from "@/lib/host/stream-runtime-context";
 export function OnboardingSessionImportStage(props: {
   readonly scan: SessionImportScanHandle;
   readonly hostPicker: OnboardingHostPicker;
+  readonly onBeforeTaskOpen: () => Promise<boolean>;
 }) {
   const { scan, hostPicker } = props;
   // Asked of the client the scan and the import would actually RUN on, not of
@@ -59,6 +60,8 @@ export function OnboardingSessionImportStage(props: {
           // "Start building" stays where it is - there is nothing for the page
           // to do when a run starts.
           onImportStarted={() => undefined}
+          onTaskOpened={() => undefined}
+          onBeforeTaskOpen={props.onBeforeTaskOpen}
           secondaryAction={null}
         />
       ) : (

--- a/clients/gui-app/src/components/session-import/__tests__/session-import-dialog.test.tsx
+++ b/clients/gui-app/src/components/session-import/__tests__/session-import-dialog.test.tsx
@@ -16,7 +16,10 @@ import type {
 } from "@/components/settings/host-scope/use-host-scope";
 import type { HostScopeStatus } from "@/components/settings/host-scope/host-scope-status";
 import type { HostScopeOption } from "@/components/settings/host-scope/host-scope-model";
-import type { StreamRuntimeBinding } from "@/lib/host/stream-runtime-context";
+import {
+  StreamRuntimeContext,
+  type StreamRuntimeBinding,
+} from "@/lib/host/stream-runtime-context";
 import type { IHostStreamClient } from "@traycer-clients/shared/host-transport/host-stream-client";
 import type { HostStreamRpcRegistry } from "@traycer/protocol/host/registry";
 import type { SessionImportScanHandle } from "@/components/session-import/use-session-import-scan";
@@ -229,18 +232,15 @@ function renderDialog(props: {
   readonly onClose: (() => void) | undefined;
 }) {
   return renderUi(
-    <SessionImportDialog
-      onClose={props.onClose ?? (() => undefined)}
-      initialHostId={props.initialHostId}
-    />,
+    <StreamRuntimeContext.Provider
+      value={streamBindingFor(hostsMock.activeHostId ?? "host-a")}
+    >
+      <SessionImportDialog
+        onClose={props.onClose ?? (() => undefined)}
+        initialHostId={props.initialHostId}
+      />
+    </StreamRuntimeContext.Provider>,
     { wrapper: WithTestQueryClient },
-  );
-}
-
-function pickHost(hostId: string): void {
-  fireEvent.click(screen.getByTestId("settings-host-switcher"));
-  fireEvent.click(
-    screen.getByTestId(`settings-host-switcher-option-${hostId}`),
   );
 }
 
@@ -267,7 +267,7 @@ describe("<SessionImportDialog />", () => {
     cleanup();
   });
 
-  it("renders the picker strip and the wizard, and scans immediately, when opened with no pick on a two-host account", () => {
+  it("renders the wizard and scans immediately without a host picker", () => {
     hostsMock.hosts = [
       { hostId: "host-a", connectable: true },
       { hostId: "host-b", connectable: true },
@@ -275,12 +275,12 @@ describe("<SessionImportDialog />", () => {
 
     renderDialog({ initialHostId: null, onClose: undefined });
 
-    expect(screen.getByTestId("session-import-host-picker-row")).not.toBeNull();
+    expect(screen.queryByTestId("session-import-host-picker-row")).toBeNull();
     expect(screen.getByTestId("session-import-wizard-stub")).not.toBeNull();
     expect(lastScanCall()).toBe(true);
   });
 
-  it("starts the scope selection on the initialHostId when it names a host other than the active one", () => {
+  it("starts the fixed scope on initialHostId when it names a host other than the active one", () => {
     hostsMock.hosts = [
       { hostId: "host-a", connectable: true },
       { hostId: "host-b", connectable: true },
@@ -290,12 +290,10 @@ describe("<SessionImportDialog />", () => {
     renderDialog({ initialHostId: "host-b", onClose: undefined });
 
     expect(hostScopeCallsMock.scopedHostIds[0]).toBe("host-b");
-    expect(screen.getByTestId("settings-host-switcher").textContent).toContain(
-      "host-b",
-    );
+    expect(screen.queryByTestId("settings-host-switcher")).toBeNull();
   });
 
-  it("withholds the wizard and shows the connecting notice for the new host while the stream still names the previous one", async () => {
+  it("withholds the wizard and shows the connecting notice while the fixed host stream catches up", async () => {
     hostsMock.hosts = [
       { hostId: "host-a", connectable: true },
       { hostId: "host-b", connectable: true },
@@ -305,10 +303,7 @@ describe("<SessionImportDialog />", () => {
     // dialog that opened following the active host with no transport of its own.
     streamOnHostMock.hostId = null;
 
-    renderDialog({ initialHostId: null, onClose: undefined });
-    expect(screen.getByTestId("session-import-wizard-stub")).not.toBeNull();
-
-    pickHost("host-b");
+    renderDialog({ initialHostId: "host-b", onClose: undefined });
 
     await waitFor(() => {
       expect(screen.getByTestId("host-scope-connecting")).not.toBeNull();
@@ -320,7 +315,7 @@ describe("<SessionImportDialog />", () => {
     expect(lastScanCall()).toBe(false);
   });
 
-  it("returns the wizard and resumes the active scan once the stream binding names the picked host", async () => {
+  it("returns the wizard and resumes the scan once the fixed host stream catches up", async () => {
     hostsMock.hosts = [
       { hostId: "host-a", connectable: true },
       { hostId: "host-b", connectable: true },
@@ -328,15 +323,16 @@ describe("<SessionImportDialog />", () => {
     hostsMock.activeHostId = "host-a";
     streamOnHostMock.hostId = null;
 
-    const view = renderDialog({ initialHostId: null, onClose: undefined });
-    pickHost("host-b");
+    const view = renderDialog({ initialHostId: "host-b", onClose: undefined });
     await waitFor(() => {
       expect(screen.getByTestId("host-scope-connecting")).not.toBeNull();
     });
 
     streamOnHostMock.hostId = "host-b";
     view.rerender(
-      <SessionImportDialog onClose={() => undefined} initialHostId={null} />,
+      <StreamRuntimeContext.Provider value={streamBindingFor("host-a")}>
+        <SessionImportDialog onClose={() => undefined} initialHostId="host-b" />
+      </StreamRuntimeContext.Provider>,
     );
 
     await waitFor(() => {
@@ -381,7 +377,7 @@ describe("<SessionImportDialog />", () => {
     expect(screen.queryByTestId("session-import-wizard-stub")).toBeNull();
   });
 
-  it('shows "<host> can\'t import sessions" and stops scanning for a ready host whose client does not support session import', async () => {
+  it('shows "<host> can\'t import sessions" and stops scanning for a ready fixed host whose client does not support session import', async () => {
     hostsMock.hosts = [
       { hostId: "host-a", connectable: true },
       { hostId: "host-b", connectable: true },
@@ -390,8 +386,7 @@ describe("<SessionImportDialog />", () => {
     streamOnHostMock.hostId = "host-b";
     scanSupportedMock.value = false;
 
-    renderDialog({ initialHostId: null, onClose: undefined });
-    pickHost("host-b");
+    renderDialog({ initialHostId: "host-b", onClose: undefined });
 
     await waitFor(() => {
       expect(
@@ -411,23 +406,23 @@ describe("<SessionImportDialog />", () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  it("passes every non-connectable host to the switcher as refused, disabling its row", () => {
+  it("captures the ambient host once when no initial host is supplied", () => {
     hostsMock.hosts = [
       { hostId: "host-a", connectable: true },
       { hostId: "host-b", connectable: false },
     ];
     hostsMock.activeHostId = "host-a";
 
-    renderDialog({ initialHostId: null, onClose: undefined });
+    const view = renderDialog({ initialHostId: null, onClose: undefined });
+    expect(hostScopeCallsMock.scopedHostIds[0]).toBe("host-a");
 
-    fireEvent.click(screen.getByTestId("settings-host-switcher"));
-    const refusedRow = screen.getByTestId(
-      "settings-host-switcher-option-host-b",
+    hostsMock.activeHostId = "host-b";
+    view.rerender(
+      <StreamRuntimeContext.Provider value={streamBindingFor("host-b")}>
+        <SessionImportDialog onClose={() => undefined} initialHostId={null} />
+      </StreamRuntimeContext.Provider>,
     );
-    expect(refusedRow.getAttribute("aria-disabled")).toBe("true");
-    const connectableRow = screen.getByTestId(
-      "settings-host-switcher-option-host-a",
-    );
-    expect(connectableRow.getAttribute("aria-disabled")).not.toBe("true");
+    expect(hostScopeCallsMock.scopedHostIds.at(-1)).toBe("host-a");
+    expect(screen.queryByTestId("settings-host-switcher")).toBeNull();
   });
 });

--- a/clients/gui-app/src/components/session-import/__tests__/session-import-model.test.ts
+++ b/clients/gui-app/src/components/session-import/__tests__/session-import-model.test.ts
@@ -931,6 +931,67 @@ describe("sessionImportWizardReducer - frame folding into view state", () => {
     expect(state.totals).toBeNull();
   });
 
+  it("pre-selects an unavailable row when it recovers, while preserving a deliberate untick", () => {
+    const deliberatelyUnticked = candidate({ nativeSessionId: "s1" });
+    const unavailable = candidate({
+      nativeSessionId: "s2",
+      state: {
+        kind: "unreadable",
+        reason: "source_unreadable",
+        detail: "temporarily unavailable",
+      },
+    });
+    const firstArrival = group(folderLocation("/repo/a"), [
+      deliberatelyUnticked,
+      unavailable,
+    ]);
+    const recovered = group(folderLocation("/repo/a"), [
+      candidate({ nativeSessionId: "s1" }),
+      candidate({ nativeSessionId: "s2" }),
+    ]);
+    const s1 = sessionImportSelectionKey("claude", "s1");
+    const s2 = sessionImportSelectionKey("claude", "s2");
+
+    const state = applyActions([
+      { kind: "scanGroupArrived", group: firstArrival },
+      { kind: "sessionToggled", selectionKey: s1 },
+      { kind: "scanRestarted", reason: "reconnect" },
+      { kind: "scanGroupArrived", group: recovered },
+    ]);
+
+    expect(state.selected.has(s1)).toBe(false);
+    expect(state.selected.has(s2)).toBe(true);
+  });
+
+  it("does not pre-select recovered rows for a harness disabled before reconnect", () => {
+    const firstArrival = group(folderLocation("/repo/a"), [
+      candidate({ harness: "codex", nativeSessionId: "s1" }),
+      candidate({
+        harness: "codex",
+        nativeSessionId: "s2",
+        state: {
+          kind: "unreadable",
+          reason: "source_unreadable",
+          detail: "temporarily unavailable",
+        },
+      }),
+    ]);
+    const recovered = group(folderLocation("/repo/a"), [
+      candidate({ harness: "codex", nativeSessionId: "s1" }),
+      candidate({ harness: "codex", nativeSessionId: "s2" }),
+    ]);
+
+    const state = applyActions([
+      { kind: "scanGroupArrived", group: firstArrival },
+      { kind: "providerScopeToggled", harness: "codex" },
+      { kind: "scanRestarted", reason: "reconnect" },
+      { kind: "scanGroupArrived", group: recovered },
+    ]);
+
+    expect(state.disabledHarnesses).toEqual(new Set(["codex"]));
+    expect(state.selected).toEqual(new Set());
+  });
+
   it("clears groups/selection/expansion/phase on a fresh scanRestarted but preserves query, disabledHarnesses, and scanWindow", () => {
     const arrivingGroup = group(folderLocation("/repo/a"), [
       candidate({ nativeSessionId: "s1" }),
@@ -1230,6 +1291,38 @@ describe("buildSessionImportView - Deleted Folders group", () => {
     expect(state.selected.has(sessionImportSelectionKey("claude", "s3"))).toBe(
       true,
     );
+  });
+
+  it("keeps recovered rows unselected when Deleted Folders stays cleared across reconnect", () => {
+    const firstArrival = group(missingLocationA, [
+      candidate({ nativeSessionId: "s1" }),
+      candidate({
+        nativeSessionId: "s2",
+        state: {
+          kind: "unreadable",
+          reason: "source_unreadable",
+          detail: "temporarily unavailable",
+        },
+      }),
+    ]);
+    const recovered = group(missingLocationA, [
+      candidate({ nativeSessionId: "s1" }),
+      candidate({ nativeSessionId: "s2" }),
+    ]);
+
+    const state = applyActions([
+      { kind: "scanGroupArrived", group: firstArrival },
+      {
+        kind: "groupSelectionSet",
+        groupKey: SESSION_IMPORT_DELETED_FOLDERS_GROUP_KEY,
+        selected: false,
+      },
+      { kind: "scanRestarted", reason: "reconnect" },
+      { kind: "scanGroupArrived", group: recovered },
+    ]);
+
+    expect(state.deletedFoldersCleared).toBe(true);
+    expect(state.selected).toEqual(new Set());
   });
 
   it("keeps deletedFoldersCleared across a reconnect restart, but resets it on a fresh one", () => {

--- a/clients/gui-app/src/components/session-import/__tests__/session-import-model.test.ts
+++ b/clients/gui-app/src/components/session-import/__tests__/session-import-model.test.ts
@@ -77,7 +77,7 @@ function applyActions(
 }
 
 describe("sessionImportWizardReducer - selection defaults as groups stream in", () => {
-  it("pre-selects every importable candidate in an arriving group, skipping already-imported and unreadable ones", () => {
+  it("pre-selects every importable candidate in an arriving group, retaining already-imported and unreadable rows", () => {
     const importableA = candidate({ nativeSessionId: "s1" });
     const importableB = candidate({ nativeSessionId: "s2" });
     const alreadyImported = candidate({
@@ -109,10 +109,10 @@ describe("sessionImportWizardReducer - selection defaults as groups stream in", 
         sessionImportSelectionKey("claude", "s2"),
       ]),
     );
-    // The already-imported row is not merely unticked - it never enters the
-    // state at all (older hosts still send it; current ones hide it).
+    // The imported row remains in state so a compatible host can reveal it;
+    // it is simply never selected.
     expect(state.groups[0]?.sessions.map((one) => one.nativeSessionId)).toEqual(
-      ["s1", "s2", "s4"],
+      ["s1", "s2", "s3", "s4"],
     );
   });
 
@@ -154,7 +154,7 @@ describe("sessionImportWizardReducer - selection defaults as groups stream in", 
     );
   });
 
-  it("is a no-op when a group with the same location kind + path arrives twice", () => {
+  it("refreshes a group with the same location while preserving its existing pick", () => {
     const first = candidate({ nativeSessionId: "s1" });
     const firstArrival = group(folderLocation("/repo/a"), [first]);
     const stateAfterFirst = sessionImportWizardReducer(
@@ -165,23 +165,28 @@ describe("sessionImportWizardReducer - selection defaults as groups stream in", 
     // A distinct object, but the same location kind + path - a re-broadcast
     // of a group the reducer has already applied.
     const secondArrival = group(folderLocation("/repo/a"), [
-      candidate({ nativeSessionId: "s1" }),
+      candidate({ nativeSessionId: "s1", title: "Updated title" }),
     ]);
     const stateAfterSecond = sessionImportWizardReducer(stateAfterFirst, {
       kind: "scanGroupArrived",
       group: secondArrival,
     });
 
-    expect(stateAfterSecond).toBe(stateAfterFirst);
+    expect(stateAfterSecond).not.toBe(stateAfterFirst);
     expect(stateAfterSecond.groups).toHaveLength(1);
+    expect(stateAfterSecond.groups[0]?.sessions[0]?.title).toBe(
+      "Updated title",
+    );
+    expect(
+      stateAfterSecond.selected.has(sessionImportSelectionKey("claude", "s1")),
+    ).toBe(true);
   });
 });
 
 describe("buildSessionImportView - disabled rows", () => {
   it("drops an arriving group that holds nothing but already-imported rows", () => {
-    // An older host still sends already_in_traycer rows; a current one hides
-    // them at the scan. Either way the wizard shows only what is new, so a
-    // group with nothing new never appears.
+    // The default view hides already_in_traycer rows. The reducer still keeps
+    // them so a supported host can reveal them with the opt-in control.
     const alreadyImported = candidate({
       nativeSessionId: "s1",
       state: { kind: "already_in_traycer", epicId: "epic-1", chatId: "chat-1" },
@@ -193,8 +198,123 @@ describe("buildSessionImportView - disabled rows", () => {
       },
     ]);
 
-    expect(state.groups).toHaveLength(0);
+    expect(state.groups).toHaveLength(1);
+    const view = buildSessionImportView(state);
+    expect(view.groups).toHaveLength(0);
+    expect(view.hiddenImportedCount).toBe(1);
+  });
+
+  it("reveals imported rows only after support is negotiated and the user opts in", () => {
+    const imported = candidate({
+      nativeSessionId: "imported",
+      state: { kind: "already_in_traycer", epicId: "epic-1", chatId: "chat-1" },
+    });
+    const fresh = candidate({ nativeSessionId: "fresh" });
+    const arrivingGroup = group(folderLocation("/repo/a"), [fresh, imported]);
+
+    let state = applyActions([
+      { kind: "scanGroupArrived", group: arrivingGroup },
+      { kind: "scanImportedSupportChanged", support: "supported" },
+    ]);
+    expect(buildSessionImportView(state).groups[0]?.rows).toHaveLength(1);
+
+    state = sessionImportWizardReducer(state, {
+      kind: "showImportedChanged",
+      showImported: true,
+    });
+    const view = buildSessionImportView(state);
+    expect(view.groups).toHaveLength(1);
+    expect(view.groups[0]?.rows.map((row) => row.selectionKey)).toEqual([
+      sessionImportSelectionKey("claude", "fresh"),
+      sessionImportSelectionKey("claude", "imported"),
+    ]);
+    expect(view.groups[0]?.rows[1]?.selectable).toBe(false);
+    expect(view.groups[0]?.totalCount).toBe(2);
+    expect(view.groups[0]?.selectableCount).toBe(1);
+    expect(view.selectedCount).toBe(1);
+  });
+
+  it("does not enable imported visibility for an unknown or unsupported scan", () => {
+    const imported = candidate({
+      nativeSessionId: "imported",
+      state: { kind: "already_in_traycer", epicId: "epic-1", chatId: "chat-1" },
+    });
+    const arrivingGroup = group(folderLocation("/repo/a"), [imported]);
+
+    let state = applyActions([
+      { kind: "scanGroupArrived", group: arrivingGroup },
+      { kind: "showImportedChanged", showImported: true },
+    ]);
+    expect(state.showImported).toBe(false);
+    expect(state.importedSupport).toBe("unknown");
+
+    state = sessionImportWizardReducer(state, {
+      kind: "scanImportedSupportChanged",
+      support: "unsupported",
+    });
+    state = sessionImportWizardReducer(state, {
+      kind: "showImportedChanged",
+      showImported: true,
+    });
+    expect(state.showImported).toBe(false);
     expect(buildSessionImportView(state).groups).toHaveLength(0);
+  });
+
+  it("keeps imported-only groups visible but never selectable, and guards the submission", () => {
+    const imported = candidate({
+      nativeSessionId: "imported-only",
+      state: { kind: "already_in_traycer", epicId: "epic-1", chatId: "chat-1" },
+    });
+    let state = applyActions([
+      {
+        kind: "scanGroupArrived",
+        group: group(folderLocation("/repo/a"), [imported]),
+      },
+      { kind: "scanImportedSupportChanged", support: "supported" },
+      { kind: "showImportedChanged", showImported: true },
+    ]);
+
+    const groupKey = sessionImportGroupKey(folderLocation("/repo/a"));
+    state = sessionImportWizardReducer(state, {
+      kind: "groupSelectionSet",
+      groupKey,
+      selected: true,
+    });
+    const view = buildSessionImportView(state);
+    expect(view.groups[0]?.rows[0]?.selectable).toBe(false);
+    expect(view.groups[0]?.rows[0]?.selected).toBe(false);
+    expect(view.groups[0]?.totalCount).toBe(1);
+    expect(view.groups[0]?.selectableCount).toBe(0);
+    expect(buildSessionImportSubmission(state).selections).toEqual([]);
+  });
+
+  it("keeps folder counts stable and preserves picks and expansion when imported visibility changes", () => {
+    const fresh = candidate({ nativeSessionId: "fresh" });
+    const imported = candidate({
+      nativeSessionId: "imported",
+      state: { kind: "already_in_traycer", epicId: "epic-1", chatId: "chat-1" },
+    });
+    const arrivingGroup = group(folderLocation("/repo/a"), [fresh, imported]);
+    const groupKey = sessionImportGroupKey(arrivingGroup.location);
+
+    let state = applyActions([
+      { kind: "scanGroupArrived", group: arrivingGroup },
+      { kind: "scanImportedSupportChanged", support: "supported" },
+      { kind: "showImportedChanged", showImported: true },
+      { kind: "groupExpansionToggled", groupKey },
+    ]);
+    expect(buildSessionImportView(state).groups[0]?.totalCount).toBe(2);
+
+    const pickedBeforeHide = new Set(state.selected);
+    expect(buildSessionImportView(state).groups[0]?.totalCount).toBe(2);
+
+    state = sessionImportWizardReducer(state, {
+      kind: "showImportedChanged",
+      showImported: false,
+    });
+    expect(buildSessionImportView(state).groups[0]?.totalCount).toBe(1);
+    expect(state.selected).toEqual(pickedBeforeHide);
+    expect(state.expandedGroups.has(groupKey)).toBe(true);
   });
 
   it("projects an unreadable row's unavailableDetail with both the reason label and the raw detail", () => {
@@ -245,6 +365,7 @@ describe("buildSessionImportView - group header counts and tri-state", () => {
 
     expect(view.groups).toHaveLength(1);
     expect(view.groups[0]?.rows).toHaveLength(1);
+    expect(view.groups[0]?.totalCount).toBe(1);
     expect(view.groups[0]?.selectableCount).toBe(2);
     expect(view.groups[0]?.selectedCount).toBe(2);
   });
@@ -1058,8 +1179,9 @@ describe("buildSessionImportView - Deleted Folders group", () => {
     expect(view.groups[0]?.rows.map((row) => row.selectionKey)).toEqual([
       sessionImportSelectionKey("claude", "s1"),
     ]);
-    // The header still counts everything in scope, search or not.
-    expect(view.groups[0]?.totalCount).toBe(2);
+    // The header count follows the visible searched rows; the selectable
+    // denominator still spans both source folders.
+    expect(view.groups[0]?.totalCount).toBe(1);
     expect(view.groups[0]?.selectableCount).toBe(2);
   });
 

--- a/clients/gui-app/src/components/session-import/__tests__/session-import-open-task-button.test.tsx
+++ b/clients/gui-app/src/components/session-import/__tests__/session-import-open-task-button.test.tsx
@@ -14,6 +14,7 @@ const harness = vi.hoisted(() => ({
   resolvedHostIds: [] as string[],
   navigate: vi.fn(),
   intents: [] as Array<Record<string, unknown>>,
+  rejectActivation: false,
   toast: vi.fn(),
 }));
 
@@ -54,8 +55,15 @@ vi.mock("@/lib/tab-navigation", () => ({
   activateTabIntent: (
     navigate: (options: Record<string, unknown>) => Promise<void>,
     intent: Record<string, unknown>,
+    options: { onRejected?: (error: Error) => void } | undefined,
   ) => {
     harness.intents.push(intent);
+    if (harness.rejectActivation) {
+      options?.onRejected?.(
+        new Error("Another task was opened before this task could open."),
+      );
+      return true;
+    }
     void navigate({}).catch(() => undefined);
     return true;
   },
@@ -101,6 +109,7 @@ beforeEach(() => {
   harness.navigate.mockReset();
   harness.navigate.mockResolvedValue(undefined);
   harness.intents.length = 0;
+  harness.rejectActivation = false;
   harness.toast.mockReset();
 });
 
@@ -162,6 +171,28 @@ describe("SessionImportOpenTaskButton", () => {
     expect(
       screen.getByRole("button", { name: "Open task: Imported task" }),
     ).toBeTruthy();
+  });
+
+  it("reports an activation rejection, clears pending state, and allows retry", async () => {
+    harness.request.mockResolvedValue({ settings: { model: "model-1" } });
+    harness.rejectActivation = true;
+    const onTaskOpened = vi.fn();
+    renderButton(onTaskOpened, null);
+    const button = () =>
+      screen.getByRole("button", { name: "Open task: Imported task" });
+
+    fireEvent.click(button());
+
+    await waitFor(() => expect(harness.toast).toHaveBeenCalledTimes(1));
+    expect(onTaskOpened).not.toHaveBeenCalled();
+    expect(button()).toHaveProperty("disabled", false);
+    expect(harness.navigate).not.toHaveBeenCalled();
+
+    harness.rejectActivation = false;
+    fireEvent.click(button());
+
+    await waitFor(() => expect(onTaskOpened).toHaveBeenCalledTimes(1));
+    expect(harness.request).toHaveBeenCalledTimes(2);
   });
 
   it("does not navigate when the caller cannot finish its pre-open work", async () => {

--- a/clients/gui-app/src/components/session-import/__tests__/session-import-open-task-button.test.tsx
+++ b/clients/gui-app/src/components/session-import/__tests__/session-import-open-task-button.test.tsx
@@ -1,0 +1,184 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const harness = vi.hoisted(() => ({
+  hostId: "stream-host",
+  request: vi.fn(),
+  resolvedHostIds: [] as string[],
+  navigate: vi.fn(),
+  intents: [] as Array<Record<string, unknown>>,
+  toast: vi.fn(),
+}));
+
+vi.mock("@/hooks/host/use-reactive-host-readiness", () => ({
+  useReactiveHostReadiness: () => ({
+    hostId: harness.hostId,
+    requestContextUserId: "user-1",
+    isReady: true,
+    hasRpcEndpoint: true,
+    canExecute: true,
+  }),
+}));
+
+vi.mock("@/lib/host", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/host")>()),
+  useHostBinding: () => ({ hostId: "ambient-host", hostClient: {} }),
+}));
+
+vi.mock("@/lib/host/binding-host-client", () => ({
+  resolveNamedHostClient: (_binding: unknown, hostId: string) => {
+    harness.resolvedHostIds.push(hostId);
+    return { request: harness.request };
+  },
+}));
+
+vi.mock("@/lib/host/stream-runtime-context", async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import("@/lib/host/stream-runtime-context")
+  >()),
+  useStreamHostId: () => harness.hostId,
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => harness.navigate,
+}));
+
+vi.mock("@/lib/tab-navigation", () => ({
+  activateTabIntent: (
+    navigate: (options: Record<string, unknown>) => Promise<void>,
+    intent: Record<string, unknown>,
+  ) => {
+    harness.intents.push(intent);
+    void navigate({}).catch(() => undefined);
+    return true;
+  },
+  resourceEpicTabIntent: (intent: Record<string, unknown>) => intent,
+}));
+
+vi.mock("@/lib/host-error-toast", () => ({
+  toastFromHostErrorWithDetail: harness.toast,
+}));
+
+import { SessionImportOpenTaskButton } from "@/components/session-import/session-import-open-task-button";
+
+function renderButton(
+  onTaskOpened: () => void,
+  onBeforeTaskOpen: (() => Promise<boolean>) | null,
+) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <SessionImportOpenTaskButton
+        target={{
+          kind: "already_in_traycer",
+          epicId: "epic-1",
+          chatId: "chat-1",
+        }}
+        title="Imported task"
+        onTaskOpened={onTaskOpened}
+        onBeforeTaskOpen={onBeforeTaskOpen}
+      />
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  harness.hostId = "stream-host";
+  harness.request.mockReset();
+  harness.resolvedHostIds.length = 0;
+  harness.navigate.mockReset();
+  harness.navigate.mockResolvedValue(undefined);
+  harness.intents.length = 0;
+  harness.toast.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("SessionImportOpenTaskButton", () => {
+  it("rechecks and opens the imported task through the stream host", async () => {
+    harness.request.mockResolvedValue({ settings: { model: "model-1" } });
+    const onTaskOpened = vi.fn();
+    renderButton(onTaskOpened, null);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open task: Imported task" }),
+    );
+
+    await waitFor(() => expect(onTaskOpened).toHaveBeenCalledTimes(1));
+    expect(harness.resolvedHostIds).toEqual(["stream-host"]);
+    expect(harness.request).toHaveBeenCalledWith("epic.getChatRunSettings", {
+      epicId: "epic-1",
+      chatId: "chat-1",
+    });
+    expect(harness.intents[0]).toMatchObject({
+      preparation: {
+        node: { type: "chat", id: "chat-1", hostId: "stream-host" },
+      },
+    });
+  });
+
+  it("keeps the wizard open and reports an unavailable task when settings are missing", async () => {
+    harness.request.mockResolvedValue({ settings: null });
+    const onTaskOpened = vi.fn();
+    renderButton(onTaskOpened, null);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open task: Imported task" }),
+    );
+
+    await waitFor(() => expect(harness.toast).toHaveBeenCalledTimes(1));
+    expect(onTaskOpened).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole("button", { name: "Open task: Imported task" }),
+    ).toBeTruthy();
+  });
+
+  it("keeps the wizard open when navigation fails", async () => {
+    harness.request.mockResolvedValue({ settings: { model: "model-1" } });
+    harness.navigate.mockRejectedValue(new Error("navigation failed"));
+    const onTaskOpened = vi.fn();
+    renderButton(onTaskOpened, null);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open task: Imported task" }),
+    );
+
+    await waitFor(() => expect(harness.toast).toHaveBeenCalledTimes(1));
+    expect(onTaskOpened).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole("button", { name: "Open task: Imported task" }),
+    ).toBeTruthy();
+  });
+
+  it("does not navigate when the caller cannot finish its pre-open work", async () => {
+    harness.request.mockResolvedValue({ settings: { model: "model-1" } });
+    const onTaskOpened = vi.fn();
+    const onBeforeTaskOpen = vi
+      .fn<() => Promise<boolean>>()
+      .mockResolvedValue(false);
+    renderButton(onTaskOpened, onBeforeTaskOpen);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open task: Imported task" }),
+    );
+
+    await waitFor(() => expect(onBeforeTaskOpen).toHaveBeenCalledTimes(1));
+    expect(harness.navigate).not.toHaveBeenCalled();
+    expect(harness.intents).toHaveLength(0);
+    expect(onTaskOpened).not.toHaveBeenCalled();
+  });
+});

--- a/clients/gui-app/src/components/session-import/__tests__/session-import-run-controller.test.tsx
+++ b/clients/gui-app/src/components/session-import/__tests__/session-import-run-controller.test.tsx
@@ -17,8 +17,10 @@ import type {
   SessionImportRunCallbacks,
   SessionImportRunClientOptions,
 } from "@traycer-clients/shared/host-transport/session-import-run-client";
+import type { IStreamClient } from "@traycer-clients/shared/host-transport/i-stream-client";
 import type { IHostStreamClient } from "@traycer-clients/shared/host-transport/host-stream-client";
 import type { HostStreamRpcRegistry } from "@traycer/protocol/host/registry";
+import type { StreamRuntimeBinding } from "@/lib/host/stream-runtime-context";
 
 /**
  * Captures every `SessionImportRunClient` the controller constructs, in
@@ -31,6 +33,7 @@ import type { HostStreamRpcRegistry } from "@traycer/protocol/host/registry";
 interface RunClientInstance {
   readonly selections: ReadonlyArray<SessionImportSelection>;
   readonly permissionMode: PermissionMode;
+  readonly wsStreamClient: IStreamClient<HostStreamRpcRegistry>;
   readonly callbacks: SessionImportRunCallbacks;
   readonly close: Mock<() => void>;
 }
@@ -49,6 +52,7 @@ vi.mock(
         runClientHarness.instances.push({
           selections: options.selections,
           permissionMode: options.permissionMode,
+          wsStreamClient: options.wsStreamClient,
           callbacks: options.callbacks,
           close: this.closeMock,
         });
@@ -61,19 +65,25 @@ vi.mock(
   }),
 );
 
-/** Stands in for the app-wide stream binding, as the wizard suite does. */
+/**
+ * Stands in for the app-wide stream binding, including the lease the real
+ * provider gives a long-lived run. A binding object stays stable until the
+ * provider swaps hosts, while each retain call gets its own release spy.
+ */
+interface StreamBindingRecord {
+  readonly binding: StreamRuntimeBinding;
+  readonly releases: Array<Mock<() => void>>;
+}
+
 interface StreamBindingHarness {
-  client: object | null;
-  hostId: string | null;
+  current: StreamBindingRecord | null;
 }
 
 const streamBinding = vi.hoisted((): StreamBindingHarness => ({
-  client: { stream: "test" },
-  hostId: "host-a",
+  current: null,
 }));
 vi.mock("@/lib/host/stream-runtime-context", () => ({
-  useWsStreamClient: () => streamBinding.client,
-  useStreamHostId: () => streamBinding.hostId,
+  useStreamRuntimeBinding: () => streamBinding.current?.binding ?? null,
 }));
 
 const invalidateQueriesMock = vi.hoisted(() => vi.fn(() => Promise.resolve()));
@@ -84,6 +94,7 @@ vi.mock("@tanstack/react-query", () => ({
 import { SessionImportRunController } from "@/components/session-import/session-import-run-controller";
 import {
   getSessionImportStartHandle,
+  type SessionImportActiveRun,
   type SessionImportRunRequest,
   type SessionImportRunTarget,
 } from "@/components/session-import/session-import-run-handle";
@@ -92,11 +103,20 @@ import {
   useSessionImportRunStore,
   type SessionImportRunState,
 } from "@/stores/session-import/session-import-run-store";
+import { sessionImportQueryKeys } from "@/lib/query-keys";
 
 const SELECTION: SessionImportSelection = {
   harness: "claude",
   nativeSessionId: "s1",
 };
+
+function activeRun(
+  runId: string,
+  done: number,
+  total: number,
+): SessionImportActiveRun {
+  return { runId, done, total };
+}
 
 function requireInstance(index: number): RunClientInstance {
   const instance = runClientHarness.instances.at(index);
@@ -134,14 +154,52 @@ function fakeWsStreamClient(): IHostStreamClient<HostStreamRpcRegistry> {
   };
 }
 
+function createStreamBinding(hostId: string): StreamBindingRecord {
+  const releases: Array<Mock<() => void>> = [];
+  const binding: StreamRuntimeBinding = {
+    wsStreamClient: fakeWsStreamClient(),
+    hostId,
+    retain: () => {
+      const release = vi.fn<() => void>();
+      releases.push(release);
+      return release;
+    },
+  };
+  return { binding, releases };
+}
+
+function currentBindingRecord(): StreamBindingRecord {
+  const current = streamBinding.current;
+  if (current === null) {
+    throw new Error("Expected a current stream binding in this test.");
+  }
+  return current;
+}
+
+function requireRelease(
+  record: StreamBindingRecord,
+  index: number,
+): Mock<() => void> {
+  const release = record.releases.at(index);
+  if (release === undefined) {
+    throw new Error(`Expected a release at index ${index}`);
+  }
+  return release;
+}
+
 /** The target every `start()` call in this suite hands the current binding under. */
 function startTarget(): SessionImportRunTarget {
-  const hostId = streamBinding.hostId;
-  if (hostId === null) {
+  return targetForBinding(currentBindingRecord().binding);
+}
+
+function targetForBinding(
+  binding: StreamRuntimeBinding,
+): SessionImportRunTarget {
+  const hostId = binding.hostId;
+  if (hostId === null)
     throw new Error("Expected a bound host id in this test.");
-  }
   return {
-    binding: { wsStreamClient: fakeWsStreamClient(), hostId, retain: null },
+    binding,
     hostId,
   };
 }
@@ -152,15 +210,14 @@ function runFor(hostId: string): SessionImportRunState {
 
 /** The store slice for the host the suite is currently bound to. */
 function currentRun(): SessionImportRunState {
-  return sessionImportRunFor(
-    useSessionImportRunStore.getState(),
-    streamBinding.hostId,
-  );
+  const hostId = currentBindingRecord().binding.hostId;
+  if (hostId === null)
+    throw new Error("Expected a bound host id in this test.");
+  return sessionImportRunFor(useSessionImportRunStore.getState(), hostId);
 }
 
 beforeEach(() => {
-  streamBinding.client = { stream: "test" };
-  streamBinding.hostId = "host-a";
+  streamBinding.current = createStreamBinding("host-a");
   runClientHarness.instances = [];
   invalidateQueriesMock.mockClear();
   useSessionImportRunStore.setState({ runs: new Map() });
@@ -188,6 +245,7 @@ describe("<SessionImportRunController />", () => {
     });
 
     expect(probe.close).toHaveBeenCalledTimes(1);
+    expect(requireRelease(currentBindingRecord(), 0)).toHaveBeenCalledTimes(1);
     expect(currentRun().status).toBe("idle");
   });
 
@@ -359,8 +417,7 @@ describe("<SessionImportRunController />", () => {
     // Runs are per host, so host-a's does not hold the question back: host-b
     // has never been asked, and a run in flight there is a fact this window
     // has no other way to learn.
-    streamBinding.client = { stream: "test-b" };
-    streamBinding.hostId = "host-b";
+    streamBinding.current = createStreamBinding("host-b");
     view.rerender(<SessionImportRunController />);
 
     expect(runClientHarness.instances).toHaveLength(2);
@@ -424,6 +481,273 @@ describe("<SessionImportRunController />", () => {
     expect(runClientHarness.instances).toHaveLength(2);
   });
 
+  it("retains an attached ambient run across a host swap and releases its lease once after completion", () => {
+    const hostABinding = currentBindingRecord();
+    const view = render(<SessionImportRunController />);
+    const hostAProbe = requireInstance(0);
+
+    expect(hostABinding.releases).toHaveLength(1);
+    const hostALease = requireRelease(hostABinding, 0);
+    expect(hostALease).not.toHaveBeenCalled();
+
+    act(() => {
+      hostAProbe.callbacks.onStarted({
+        attached: true,
+        runId: "run-a",
+        total: 1,
+      });
+    });
+
+    const hostBBinding = createStreamBinding("host-b");
+    streamBinding.current = hostBBinding;
+    view.rerender(<SessionImportRunController />);
+
+    expect(hostALease).not.toHaveBeenCalled();
+    expect(hostBBinding.releases).toHaveLength(1);
+    const hostBProbe = requireInstance(1);
+
+    act(() => {
+      hostAProbe.callbacks.onProgress({
+        runId: "run-a",
+        index: 0,
+        total: 1,
+        harness: "claude",
+        nativeSessionId: "s1",
+        outcome: { kind: "imported", epicId: "epic-a", chatId: "chat-a" },
+      });
+    });
+
+    const hostAProgress = runFor("host-a");
+    expect(hostAProgress.status).toBe("running");
+    expect(hostAProgress.outcomes.size).toBe(1);
+    expect(runFor("host-b").status).toBe("idle");
+
+    act(() => {
+      hostBProbe.callbacks.onStarted({
+        attached: true,
+        runId: "run-b",
+        total: 3,
+      });
+    });
+
+    act(() => {
+      hostAProbe.callbacks.onComplete({
+        runId: "run-a",
+        counts: { imported: 1, skippedAlreadyImported: 0, failed: 0 },
+      });
+    });
+
+    const hostAComplete = runFor("host-a");
+    expect(hostAComplete.status).toBe("complete");
+    expect(hostAComplete.runId).toBe("run-a");
+    expect(hostALease).toHaveBeenCalledTimes(1);
+    expect(hostBProbe.close).not.toHaveBeenCalled();
+
+    view.unmount();
+
+    // The completed run's release is not repeated by controller unmount. The
+    // host-B run gives back its own lease exactly once.
+    expect(hostALease).toHaveBeenCalledTimes(1);
+    expect(requireRelease(hostBBinding, 0)).toHaveBeenCalledTimes(1);
+  });
+
+  it("attaches a scoped target with its lease and keeps progress under that host", () => {
+    render(<SessionImportRunController />);
+    const scopedBinding = createStreamBinding("host-scoped");
+    const handle = getSessionImportStartHandle();
+    if (handle === null) {
+      throw new Error("Expected a session import start handle.");
+    }
+
+    act(() => {
+      handle.attach(
+        targetForBinding(scopedBinding.binding),
+        activeRun("run-scoped", 0, 1),
+      );
+    });
+
+    expect(runClientHarness.instances).toHaveLength(2);
+    expect(requireInstance(1).selections).toEqual([]);
+    expect(scopedBinding.releases).toHaveLength(1);
+    const scopedRelease = requireRelease(scopedBinding, 0);
+
+    act(() => {
+      requireInstance(1).callbacks.onStarted({
+        attached: true,
+        runId: "run-scoped",
+        total: 1,
+      });
+      requireInstance(1).callbacks.onProgress({
+        runId: "run-scoped",
+        index: 0,
+        total: 1,
+        harness: "claude",
+        nativeSessionId: "s1",
+        outcome: {
+          kind: "skipped_already_imported",
+          epicId: "epic-scoped",
+          chatId: "chat-scoped",
+        },
+      });
+    });
+
+    expect(runFor("host-scoped").status).toBe("running");
+    expect(runFor("host-scoped").outcomes.size).toBe(1);
+
+    act(() => {
+      requireInstance(1).callbacks.onComplete({
+        runId: "run-scoped",
+        counts: { imported: 0, skippedAlreadyImported: 1, failed: 0 },
+      });
+    });
+
+    expect(runFor("host-scoped").status).toBe("complete");
+    expect(scopedRelease).toHaveBeenCalledTimes(1);
+    expect(requireInstance(1).wsStreamClient).toBe(
+      scopedBinding.binding.wsStreamClient,
+    );
+  });
+
+  it("keeps the status run identity and attached state when an attach disconnects before its first frame", () => {
+    render(<SessionImportRunController />);
+    const scopedBinding = createStreamBinding("host-scoped");
+    const handle = getSessionImportStartHandle();
+    if (handle === null) {
+      throw new Error("Expected a session import start handle.");
+    }
+
+    act(() => {
+      handle.attach(
+        targetForBinding(scopedBinding.binding),
+        activeRun("run-scoped", 2, 4),
+      );
+    });
+    const attach = requireInstance(1);
+
+    const seeded = runFor("host-scoped");
+    expect(seeded.status).toBe("running");
+    expect(seeded.runId).toBe("run-scoped");
+    expect(seeded.total).toBe(4);
+    expect(seeded.attached).toBe(true);
+
+    act(() => {
+      attach.callbacks.onConnectionStatus("closed", { kind: "caller" });
+    });
+
+    const errored = runFor("host-scoped");
+    expect(errored.status).toBe("error");
+    expect(errored.runId).toBe("run-scoped");
+    expect(errored.total).toBe(4);
+    expect(errored.attached).toBe(true);
+    expect(attach.close).toHaveBeenCalledTimes(1);
+    expect(requireRelease(scopedBinding, 0)).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not duplicate an existing run when attach is called for its host", () => {
+    render(<SessionImportRunController />);
+    const probe = requireInstance(0);
+    act(() => {
+      probe.callbacks.onStarted({
+        attached: true,
+        runId: "run-1",
+        total: 1,
+      });
+    });
+    const handle = getSessionImportStartHandle();
+    if (handle === null) {
+      throw new Error("Expected a session import start handle.");
+    }
+
+    act(() => {
+      handle.attach(startTarget(), activeRun("run-1", 0, 1));
+    });
+
+    expect(runClientHarness.instances).toHaveLength(1);
+  });
+
+  it("replaces an unanswered ambient probe before an attach reports that the run has finished", () => {
+    const hostABinding = currentBindingRecord();
+    render(<SessionImportRunController />);
+    const ambientProbe = requireInstance(0);
+    const handle = getSessionImportStartHandle();
+    if (handle === null) {
+      throw new Error("Expected a session import start handle.");
+    }
+
+    act(() => {
+      handle.attach(startTarget(), activeRun("run-finished", 0, 1));
+    });
+
+    // The wizard's confirmed active status supersedes the unanswered mount
+    // probe. The replacement gets its own lease and can receive the final
+    // answer without being blocked by the stale probe in the per-host map.
+    expect(ambientProbe.close).toHaveBeenCalledTimes(1);
+    expect(requireRelease(hostABinding, 0)).toHaveBeenCalledTimes(1);
+    expect(runClientHarness.instances).toHaveLength(2);
+    const attach = requireInstance(1);
+    expect(requireRelease(hostABinding, 1)).not.toHaveBeenCalled();
+
+    act(() => {
+      attach.callbacks.onStarted({
+        attached: false,
+        runId: "run-finished",
+        total: 0,
+      });
+      attach.callbacks.onComplete({
+        runId: "run-finished",
+        counts: { imported: 1, skippedAlreadyImported: 0, failed: 0 },
+      });
+    });
+
+    const state = currentRun();
+    expect(state.status).toBe("idle");
+    expect(state.finalCounts).toBeNull();
+    expect(attach.close).toHaveBeenCalledTimes(1);
+    expect(requireRelease(hostABinding, 1)).toHaveBeenCalledTimes(1);
+    expect(invalidateQueriesMock).toHaveBeenCalledWith({
+      queryKey: sessionImportQueryKeys.status("host-a"),
+    });
+    expect(invalidateQueriesMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("resets an attach whose run finished before the empty reply and ignores its completion", () => {
+    render(<SessionImportRunController />);
+    const scopedBinding = createStreamBinding("host-scoped");
+    const handle = getSessionImportStartHandle();
+    if (handle === null) {
+      throw new Error("Expected a session import start handle.");
+    }
+
+    act(() => {
+      handle.attach(
+        targetForBinding(scopedBinding.binding),
+        activeRun("run-finished", 0, 1),
+      );
+    });
+    const attach = requireInstance(1);
+    act(() => {
+      attach.callbacks.onStarted({
+        attached: false,
+        runId: "run-finished",
+        total: 0,
+      });
+      attach.callbacks.onComplete({
+        runId: "run-finished",
+        counts: { imported: 1, skippedAlreadyImported: 0, failed: 0 },
+      });
+    });
+
+    const state = runFor("host-scoped");
+    expect(state.status).toBe("idle");
+    expect(state.finalCounts).toBeNull();
+    expect(scopedBinding.releases).toHaveLength(1);
+    expect(requireRelease(scopedBinding, 0)).toHaveBeenCalledTimes(1);
+    expect(invalidateQueriesMock).toHaveBeenCalledTimes(1);
+    expect(invalidateQueriesMock).toHaveBeenCalledWith({
+      queryKey: sessionImportQueryKeys.status("host-scoped"),
+    });
+  });
+
   it("asks again after StrictMode replays the effect, instead of treating the closed probe as answered", () => {
     render(
       <StrictMode>
@@ -436,6 +760,7 @@ describe("<SessionImportRunController />", () => {
     // notice a run already going on the host.
     expect(runClientHarness.instances).toHaveLength(2);
     expect(requireInstance(0).close).toHaveBeenCalledTimes(1);
+    expect(requireRelease(currentBindingRecord(), 0)).toHaveBeenCalledTimes(1);
     expect(requireInstance(1).close).not.toHaveBeenCalled();
     expect(requireInstance(1).selections).toEqual([]);
   });
@@ -447,5 +772,6 @@ describe("<SessionImportRunController />", () => {
     unmount();
 
     expect(probe.close).toHaveBeenCalledTimes(1);
+    expect(requireRelease(currentBindingRecord(), 0)).toHaveBeenCalledTimes(1);
   });
 });

--- a/clients/gui-app/src/components/session-import/__tests__/session-import-wizard.test.tsx
+++ b/clients/gui-app/src/components/session-import/__tests__/session-import-wizard.test.tsx
@@ -28,6 +28,7 @@ import type {
   SessionImportScanCallbacks,
   SessionImportScanClientOptions,
 } from "@traycer-clients/shared/host-transport/session-import-scan-client";
+import type { SessionImportStatusResponse } from "@traycer/protocol/host/session-import/contracts";
 import type { SessionImportRunRequest } from "@/components/session-import/session-import-run-handle";
 import type { SessionImportSurface } from "@/components/session-import/session-import-tone";
 import type { StreamRuntimeBinding } from "@/lib/host/stream-runtime-context";
@@ -64,6 +65,18 @@ const startSessionImportRunMock = vi.hoisted(() =>
     ) => void
   >(),
 );
+const attachSessionImportRunMock = vi.hoisted(() => vi.fn());
+const sessionImportCheckStatusMock = vi.hoisted(() => ({
+  data: {
+    active: null,
+    lastCompleted: null,
+  } as SessionImportStatusResponse | undefined,
+  isError: false,
+  isFetching: false,
+  isPending: false,
+  isSuccess: true,
+  refetch: vi.fn(),
+}));
 const analyticsTrackMock = vi.hoisted(() => vi.fn());
 const taskOpenedMock = vi.hoisted(() => vi.fn());
 
@@ -116,6 +129,7 @@ vi.mock("@/lib/host/stream-runtime-context", () => ({
 }));
 
 vi.mock("@/components/session-import/session-import-run-handle", () => ({
+  attachSessionImportRun: attachSessionImportRunMock,
   startSessionImportRun: startSessionImportRunMock,
 }));
 
@@ -131,6 +145,10 @@ vi.mock("@/components/session-import/session-import-open-task-button", () => ({
       Open task
     </button>
   ),
+}));
+
+vi.mock("@/hooks/session-import/use-session-import-check-status-query", () => ({
+  useSessionImportCheckStatus: () => sessionImportCheckStatusMock,
 }));
 
 vi.mock("@/lib/analytics", () => ({
@@ -354,6 +372,16 @@ beforeEach(() => {
   scanClient.updatedAfter = undefined;
   scanClient.close.mockClear();
   startSessionImportRunMock.mockClear();
+  attachSessionImportRunMock.mockClear();
+  sessionImportCheckStatusMock.data = {
+    active: null,
+    lastCompleted: null,
+  };
+  sessionImportCheckStatusMock.isError = false;
+  sessionImportCheckStatusMock.isFetching = false;
+  sessionImportCheckStatusMock.isPending = false;
+  sessionImportCheckStatusMock.isSuccess = true;
+  sessionImportCheckStatusMock.refetch.mockClear();
   analyticsTrackMock.mockClear();
   taskOpenedMock.mockClear();
   useSessionImportRunStore.setState({ runs: new Map() });
@@ -905,6 +933,115 @@ describe("<SessionImportWizard />", () => {
     expect(startSessionImportRunMock.mock.calls[0][0].selections).toEqual([
       { harness: "claude", nativeSessionId: "s1" },
     ]);
+  });
+
+  it("keeps a populated onboarding scan blocked while the status check is pending", () => {
+    sessionImportCheckStatusMock.data = undefined;
+    sessionImportCheckStatusMock.isPending = true;
+    sessionImportCheckStatusMock.isFetching = true;
+    sessionImportCheckStatusMock.isSuccess = false;
+
+    const onImportStarted = vi.fn();
+    render(
+      <TestWizard
+        surface="onboarding"
+        onImportStarted={onImportStarted}
+        secondaryAction={null}
+      />,
+    );
+    const callbacks = requireCallbacks();
+    act(() => {
+      callbacks.onGroup(
+        folderGroup({
+          path: "/repo/a",
+          sessions: [importableCandidate("claude", "s1", "Onboarding session")],
+        }),
+      );
+    });
+
+    const submit = screen.getByTestId("session-import-submit");
+    expect(submit.hasAttribute("disabled")).toBe(true);
+    fireEvent.click(submit);
+    expect(startSessionImportRunMock).not.toHaveBeenCalled();
+    expect(onImportStarted).not.toHaveBeenCalled();
+    expect(screen.getByTestId("session-import-status-spinner")).toBeTruthy();
+  });
+
+  it("attaches an active host run without submitting the scan selections", () => {
+    const activeRun = { runId: "run-active", done: 1, total: 2 };
+    sessionImportCheckStatusMock.data = {
+      active: activeRun,
+      lastCompleted: null,
+    };
+
+    const onImportStarted = vi.fn();
+    renderWizard(onImportStarted);
+    const callbacks = requireCallbacks();
+    act(() => {
+      callbacks.onGroup(
+        folderGroup({
+          path: "/repo/a",
+          sessions: [importableCandidate("claude", "s1", "Existing selection")],
+        }),
+      );
+    });
+
+    expect(attachSessionImportRunMock).toHaveBeenCalledWith(
+      expect.objectContaining({ hostId: "host-a" }),
+      activeRun,
+    );
+    const submit = screen.getByTestId("session-import-submit");
+    expect(submit.hasAttribute("disabled")).toBe(true);
+    fireEvent.click(submit);
+    expect(startSessionImportRunMock).not.toHaveBeenCalled();
+    expect(onImportStarted).not.toHaveBeenCalled();
+  });
+
+  it("allows an idle status answer to submit the populated selection", () => {
+    const onImportStarted = vi.fn();
+    renderWizard(onImportStarted);
+    const callbacks = requireCallbacks();
+    act(() => {
+      callbacks.onGroup(
+        folderGroup({
+          path: "/repo/a",
+          sessions: [importableCandidate("claude", "s1", "Idle session")],
+        }),
+      );
+    });
+
+    const submit = screen.getByTestId("session-import-submit");
+    expect(submit.hasAttribute("disabled")).toBe(false);
+    fireEvent.click(submit);
+    expect(startSessionImportRunMock).toHaveBeenCalledTimes(1);
+    expect(onImportStarted).toHaveBeenCalledTimes(1);
+  });
+
+  it("blocks on a status error and offers a retry", () => {
+    sessionImportCheckStatusMock.data = undefined;
+    sessionImportCheckStatusMock.isError = true;
+    sessionImportCheckStatusMock.isSuccess = false;
+
+    renderWizard(vi.fn());
+    const callbacks = requireCallbacks();
+    act(() => {
+      callbacks.onGroup(
+        folderGroup({
+          path: "/repo/a",
+          sessions: [importableCandidate("claude", "s1", "Retry session")],
+        }),
+      );
+    });
+
+    expect(screen.getByRole("alert").textContent).toContain(
+      "could not check whether an import is already running",
+    );
+    expect(
+      screen.getByTestId("session-import-submit").hasAttribute("disabled"),
+    ).toBe(true);
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+    expect(sessionImportCheckStatusMock.refetch).toHaveBeenCalledTimes(1);
+    expect(startSessionImportRunMock).not.toHaveBeenCalled();
   });
 
   it("shows an inline provider-failure notice without blocking groups delivered after it", () => {

--- a/clients/gui-app/src/components/session-import/__tests__/session-import-wizard.test.tsx
+++ b/clients/gui-app/src/components/session-import/__tests__/session-import-wizard.test.tsx
@@ -65,6 +65,7 @@ const startSessionImportRunMock = vi.hoisted(() =>
   >(),
 );
 const analyticsTrackMock = vi.hoisted(() => vi.fn());
+const taskOpenedMock = vi.hoisted(() => vi.fn());
 
 vi.mock(
   "@traycer-clients/shared/host-transport/session-import-scan-client",
@@ -118,6 +119,20 @@ vi.mock("@/components/session-import/session-import-run-handle", () => ({
   startSessionImportRun: startSessionImportRunMock,
 }));
 
+// Imported rows delegate their navigation to a separate host mutation. Keep
+// this suite focused on wizard wiring and selection semantics; the button's
+// destination and navigation checks belong to its own component test.
+vi.mock("@/components/session-import/session-import-open-task-button", () => ({
+  SessionImportOpenTaskButton: (props: {
+    readonly onTaskOpened: () => void;
+    readonly onBeforeTaskOpen: (() => Promise<boolean>) | null;
+  }) => (
+    <button type="button" aria-label="Open task" onClick={props.onTaskOpened}>
+      Open task
+    </button>
+  ),
+}));
+
 vi.mock("@/lib/analytics", () => ({
   Analytics: { getInstance: () => ({ track: analyticsTrackMock }) },
   AnalyticsEvent: { SessionImportStarted: "session_import_started" },
@@ -151,7 +166,14 @@ function TestWizard(props: {
       sessionImportRunFor(state, streamBinding.hostId).status === "idle",
   );
   const scan = useSessionImportScan(runIdle);
-  return <SessionImportWizard {...props} scan={scan} />;
+  return (
+    <SessionImportWizard
+      {...props}
+      scan={scan}
+      onTaskOpened={taskOpenedMock}
+      onBeforeTaskOpen={null}
+    />
+  );
 }
 
 const ZERO_TOTALS: SessionImportScanTotals = {
@@ -333,6 +355,7 @@ beforeEach(() => {
   scanClient.close.mockClear();
   startSessionImportRunMock.mockClear();
   analyticsTrackMock.mockClear();
+  taskOpenedMock.mockClear();
   useSessionImportRunStore.setState({ runs: new Map() });
 });
 
@@ -419,7 +442,7 @@ describe("<SessionImportWizard />", () => {
     });
 
     expect(screen.getByTestId("session-import-submit").textContent).toBe(
-      "Import 3 sessions",
+      "Import 3 tasks",
     );
     // The "Folder not found" pill is gone: a missing folder now renders under
     // the shared "Deleted Folders" header instead of its own per-folder pill.
@@ -539,7 +562,7 @@ describe("<SessionImportWizard />", () => {
 
     fireEvent.click(row);
     expect(screen.getByTestId("session-import-submit").textContent).toBe(
-      "Import 1 session",
+      "Import 1 task",
     );
   });
 
@@ -565,6 +588,112 @@ describe("<SessionImportWizard />", () => {
     expect(screen.getAllByTestId("session-import-row")).toHaveLength(1);
     expect(screen.queryByText("Already there")).toBeNull();
     expect(screen.queryByText("In Traycer")).toBeNull();
+  });
+
+  it("shows imported rows after a compatible scan and opens their task without selecting them", () => {
+    renderWizard(vi.fn());
+    const callbacks = requireCallbacks();
+
+    act(() => {
+      callbacks.onGroup(
+        folderGroup({
+          path: "/repo/a",
+          sessions: [
+            importableCandidate("claude", "s1", "New session"),
+            alreadyInTraycerCandidate("claude", "s2", "Already there"),
+          ],
+        }),
+      );
+      callbacks.onImportedSupport("supported");
+    });
+
+    const showImported = screen.getByTestId("session-import-show-imported");
+    expect(showImported.getAttribute("aria-disabled")).not.toBe("true");
+    fireEvent.click(showImported);
+    fireEvent.click(screen.getByTestId("session-import-group-toggle"));
+
+    const rows = screen.getAllByTestId("session-import-row");
+    expect(rows).toHaveLength(2);
+    const importedRow = rows.find((row) =>
+      row.textContent.includes("Already there"),
+    );
+    if (importedRow === undefined) {
+      throw new Error("Expected imported row to be visible");
+    }
+    expect(importedRow.getAttribute("data-selectable")).toBe("false");
+    expect(importedRow.getAttribute("role")).not.toBe("checkbox");
+    expect(screen.getByRole("button", { name: "Open task" })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Open task" }));
+    expect(taskOpenedMock).toHaveBeenCalledTimes(1);
+    expect(startSessionImportRunMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps an imported-only group visible while disabling Import", () => {
+    renderWizard(vi.fn());
+    const callbacks = requireCallbacks();
+
+    act(() => {
+      callbacks.onGroup(
+        folderGroup({
+          path: "/repo/a",
+          sessions: [
+            alreadyInTraycerCandidate("claude", "s1", "Already there"),
+          ],
+        }),
+      );
+      callbacks.onImportedSupport("supported");
+    });
+    fireEvent.click(screen.getByTestId("session-import-show-imported"));
+
+    expect(screen.getAllByTestId("session-import-group")).toHaveLength(1);
+    expect(
+      screen.getByTestId("session-import-submit").getAttribute("disabled"),
+    ).toBe("");
+    expect(screen.getByTestId("session-import-submit").textContent).toBe(
+      "Import 0 tasks",
+    );
+  });
+
+  it("preserves importable picks and expanded groups while toggling imported visibility", () => {
+    renderWizard(vi.fn());
+    const callbacks = requireCallbacks();
+
+    act(() => {
+      callbacks.onGroup(
+        folderGroup({
+          path: "/repo/a",
+          sessions: [
+            importableCandidate("claude", "s1", "New session"),
+            alreadyInTraycerCandidate("claude", "s2", "Already there"),
+          ],
+        }),
+      );
+      callbacks.onImportedSupport("supported");
+    });
+
+    const showImported = screen.getByTestId("session-import-show-imported");
+    fireEvent.click(showImported);
+    fireEvent.click(screen.getByTestId("session-import-group-toggle"));
+    expect(
+      screen
+        .getByRole("checkbox", { name: "New session" })
+        .getAttribute("aria-checked"),
+    ).toBe("true");
+
+    fireEvent.click(showImported);
+    expect(screen.queryByText("Already there")).toBeNull();
+    fireEvent.click(showImported);
+    expect(
+      screen
+        .getByTestId("session-import-group-toggle")
+        .getAttribute("aria-expanded"),
+    ).toBe("true");
+    expect(
+      screen
+        .getByRole("checkbox", { name: "New session" })
+        .getAttribute("aria-checked"),
+    ).toBe("true");
   });
 
   it("opens the scan bounded to the default window", () => {
@@ -604,7 +733,7 @@ describe("<SessionImportWizard />", () => {
 
     expect(
       screen.getByTestId("session-import-selection-count").textContent,
-    ).toBe("1 of 1 selected");
+    ).toBe("1 task selected for import");
   });
 
   it("shows the scan's own failure inline, with the groups it already delivered still on screen", () => {
@@ -655,7 +784,7 @@ describe("<SessionImportWizard />", () => {
     });
 
     expect(screen.getByTestId("session-import-submit").textContent).toBe(
-      "Import 3 sessions",
+      "Import 3 tasks",
     );
 
     const groupAKey = sessionImportGroupKey({
@@ -669,12 +798,12 @@ describe("<SessionImportWizard />", () => {
 
     fireEvent.click(groupASelect);
     expect(screen.getByTestId("session-import-submit").textContent).toBe(
-      "Import 1 session",
+      "Import 1 task",
     );
 
     fireEvent.click(groupASelect);
     expect(screen.getByTestId("session-import-submit").textContent).toBe(
-      "Import 3 sessions",
+      "Import 3 tasks",
     );
   });
 
@@ -701,7 +830,7 @@ describe("<SessionImportWizard />", () => {
 
     expect(screen.getAllByTestId("session-import-group")).toHaveLength(2);
     expect(screen.getByTestId("session-import-submit").textContent).toBe(
-      "Import 2 sessions",
+      "Import 2 tasks",
     );
 
     fireEvent.change(screen.getByTestId("session-import-search"), {
@@ -710,7 +839,7 @@ describe("<SessionImportWizard />", () => {
 
     expect(screen.getAllByTestId("session-import-group")).toHaveLength(1);
     expect(screen.getByTestId("session-import-submit").textContent).toBe(
-      "Import 2 sessions",
+      "Import 2 tasks",
     );
 
     fireEvent.change(screen.getByTestId("session-import-search"), {
@@ -770,7 +899,7 @@ describe("<SessionImportWizard />", () => {
     // provider out is scope, not amnesia about its count.
     expect(findProviderPill("codex").textContent).toContain("2");
 
-    fireEvent.click(screen.getByRole("button", { name: "Import 1 session" }));
+    fireEvent.click(screen.getByRole("button", { name: "Import 1 task" }));
 
     expect(startSessionImportRunMock).toHaveBeenCalledTimes(1);
     expect(startSessionImportRunMock.mock.calls[0][0].selections).toEqual([
@@ -855,7 +984,7 @@ describe("<SessionImportWizard />", () => {
     fireEvent.click(screen.getByRole("checkbox", { name: "Session two" }));
 
     expect(screen.getByTestId("session-import-submit").textContent).toBe(
-      "Import 1 session",
+      "Import 1 task",
     );
 
     replaceStreamClient(rerender, "host-a");
@@ -865,7 +994,7 @@ describe("<SessionImportWizard />", () => {
     // group and re-applied the pre-select-on-arrival rule would silently put
     // "Session two" back.
     expect(screen.getByTestId("session-import-submit").textContent).toBe(
-      "Import 1 session",
+      "Import 1 task",
     );
   });
 
@@ -883,7 +1012,7 @@ describe("<SessionImportWizard />", () => {
     });
 
     expect(screen.getByTestId("session-import-submit").textContent).toBe(
-      "Import 1 session",
+      "Import 1 task",
     );
 
     replaceStreamClient(rerender, "host-b");
@@ -893,7 +1022,7 @@ describe("<SessionImportWizard />", () => {
     // submit one machine's sessions to another.
     expect(screen.queryAllByTestId("session-import-group")).toHaveLength(0);
     expect(screen.getByTestId("session-import-submit").textContent).toBe(
-      "Import 0 sessions",
+      "Import 0 tasks",
     );
     expect(screen.getByTestId("session-import-scan-spinner")).toBeTruthy();
   });
@@ -1115,7 +1244,7 @@ describe("<SessionImportWizard />", () => {
     // selection without an explicit ask.
     expect(
       screen.getByTestId("session-import-selection-count").textContent,
-    ).toBe("1 of 1 selected");
+    ).toBe("1 task selected for import");
 
     fireEvent.click(screen.getByTestId("session-import-submit"));
 

--- a/clients/gui-app/src/components/session-import/session-import-dialog.tsx
+++ b/clients/gui-app/src/components/session-import/session-import-dialog.tsx
@@ -1,4 +1,4 @@
-import { use, useMemo, useState, type ReactNode } from "react";
+import { use, useState, type ReactNode } from "react";
 import {
   Dialog,
   DialogContent,
@@ -6,7 +6,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { HostSwitcher } from "@/components/settings/host-scope/host-switcher";
 import { HostScopeConnecting } from "@/components/settings/host-scope/host-scope-gate";
 import { scopedHostReadiness } from "@/components/settings/host-scope/scoped-host-readiness";
 import {
@@ -27,47 +26,24 @@ import {
 import { useSessionImportRun } from "@/stores/session-import/session-import-run-store";
 
 /**
- * The wizard as a dialog, with its own host picker. Closing it does not stop
- * an import that has already started (spec §5) - the run belongs to the
- * app-wide controller, and this dialog is only a window onto it.
- *
- * The sessions listed and the run started here belong to ONE machine, and
- * that machine is the one thing about this dialog a person may want to
- * change - the same picker the resources popover and the onboarding tour
- * head their card with. The pick lives in this dialog's own state: it is a
- * choice about this import, and must not leak into Settings' scope or outlive
- * the dialog.
- *
- * Both runtimes are re-provided, and both are needed: the scan and every run
- * started from the wizard ride the STREAM (`StreamRuntimeContext`), while the
- * wizard's unary lookups go through `HostRuntimeContext`. Swapping only one is
- * how a surface reads host B's sessions over host A's transport. They wrap
- * the body UNCONDITIONALLY (the pattern `ResourceMonitorPopover` documents):
- * mounting them only once a pick resolves would change the element type at
- * this position and remount the wizard - and drop the rows the user had
- * ticked - the instant a host was chosen.
- *
- * Safe to re-provide here because the dialog contains no composer and
- * therefore no microphone path (see `useScopedHostBinding`).
+ * The import dialog is bound to the host its entry point named for its lifetime.
+ * Both unary and stream runtimes must address that host, including while an
+ * import continues after this dialog closes.
  */
 export function SessionImportDialog(props: {
   readonly onClose: () => void;
-  /**
-   * The host the dialog opens on, when the surface that opened it names one:
-   * Settings' Host Overview passes the host its page is scoped to, so the
-   * picker agrees with the page behind it. `null` follows the app's active
-   * host, which is what the announcement toast has to offer.
-   */
+  /** Settings names its host; announcement entry captures the ambient host. */
   readonly initialHostId: string | null;
 }) {
+  const ambientStreamBinding = use(StreamRuntimeContext);
   const [scopedHostId, setScopedHostId] = useState<string | null>(
-    props.initialHostId,
+    () => props.initialHostId ?? ambientStreamBinding?.hostId ?? null,
   );
+  useRegisteredHostsPollLiveness();
   const scope = useHostScopeFor({ scopedHostId, setScopedHostId });
   const scopedBinding = useScopedHostBinding(scope);
   const ambientBinding = useHostBinding();
   const scopedStreamBinding = useScopedStreamBinding(scope);
-  const ambientStreamBinding = use(StreamRuntimeContext);
   return (
     <HostRuntimeContext.Provider value={scopedBinding ?? ambientBinding}>
       <StreamRuntimeContext.Provider
@@ -75,7 +51,7 @@ export function SessionImportDialog(props: {
       >
         <SessionImportDialogBody
           scope={scope}
-          hasExplicitPick={scopedHostId !== null}
+          hasExplicitPick
           onClose={props.onClose}
         />
       </StreamRuntimeContext.Provider>
@@ -138,12 +114,8 @@ function SessionImportDialogBody(props: {
             into Traycer as tasks.
           </DialogDescription>
         </DialogHeader>
-        {/* Bled to the dialog's edges so the picker strip, the wizard's pinned
-            header and the footer rules run the full width and the footer sits
-            flush in the corner - the dialog's chrome, not a panel floating
-            inside its padding. */}
+        {/* The pinned filters and footer share the dialog's full width. */}
         <div className="-mx-4 -mb-4 flex min-h-0 flex-1 flex-col">
-          <SessionImportHostPickerRow scope={scope} />
           {hostReady && scanSupported ? (
             <SessionImportWizard
               surface="dialog"
@@ -153,6 +125,8 @@ function SessionImportDialogBody(props: {
               // live shows the inline progress view - this closes a surface,
               // never a run.
               onImportStarted={onClose}
+              onTaskOpened={onClose}
+              onBeforeTaskOpen={null}
               secondaryAction={{ label: "Close", onSelect: onClose }}
             />
           ) : (
@@ -171,70 +145,7 @@ function SessionImportDialogBody(props: {
 }
 
 /**
- * The strip that names the machine, the way the resources popover heads its
- * card: full-bleed on purpose, so the picker's list can drop from it at
- * exactly the dialog's width.
- */
-function SessionImportHostPickerRow(props: {
-  readonly scope: HostScope;
-}): ReactNode {
-  const { scope } = props;
-  // Every host the import cannot reach, with the word its row would carry if
-  // the status column were silent. The row's own status word ("offline",
-  // "stopped") speaks first when it has one; this only makes the row inert.
-  // A refusal rather than the `pin` intent, which would gate the same rows:
-  // `pin` also drops the ACTIVE tag and the "currently viewing" mark, and this
-  // dialog has exactly the distinction those carry - following this window's
-  // host, or looking at another one - the same way the usage popover does.
-  const refusalByHostId = useMemo(
-    (): ReadonlyMap<string, string> =>
-      new Map(
-        scope.hosts
-          .filter((host) => !host.connectable)
-          .map((host) => [host.hostId, "unreachable"]),
-      ),
-    [scope.hosts],
-  );
-  // The host rows are served by a NON-polling observer; the Settings sidebar
-  // is normally what opts a window into the liveness poll. Opened from the
-  // announcement toast this dialog is the only host-list surface on screen,
-  // so it carries the same opt-in for as long as it is up.
-  useRegisteredHostsPollLiveness();
-  return (
-    // Ruled on BOTH edges: the popover's strip sits at the top of its card, but
-    // this one sits under the dialog's own title and description, so without
-    // the top rule the host name reads as a third line of the header instead
-    // of the strip that heads the list.
-    <div
-      className="flex shrink-0 items-center border-y"
-      data-testid="session-import-host-picker-row"
-    >
-      <HostSwitcher
-        hosts={scope.hosts}
-        selected={scope.host}
-        activeHostId={scope.activeHostId}
-        onSelect={scope.setHostId}
-        refusalByHostId={refusalByHostId}
-        inertExceptHostId={null}
-        // No trailing "Manage hosts" row: managing hosts is Settings' job, and
-        // this dialog may already be open on top of it. It only picks among
-        // the machines that exist.
-        action={null}
-        surface="panel-header"
-        intent="view"
-        disabled={false}
-        isLoading={scope.isLoading}
-        listsFailed={scope.listsFailed}
-        onRetryLists={scope.retryLists}
-        updateViewForHost={null}
-      />
-    </div>
-  );
-}
-
-/**
- * Why the dialog is showing nothing rather than showing another machine's
- * work under the name in the strip above it.
+ * Explain why the entry point's host cannot currently serve the wizard.
  */
 function SessionImportHostNotice(props: {
   readonly scope: HostScope;
@@ -265,8 +176,8 @@ function SessionImportHostNotice(props: {
           </p>
           <p className="text-ui-sm text-muted-foreground">
             {refusal === null
-              ? "Pick another machine above to carry on."
-              : "Update it, or pick another machine above."}
+              ? "Close this wizard and reconnect this host to carry on."
+              : "Update this host to import your work."}
           </p>
         </div>
       )}

--- a/clients/gui-app/src/components/session-import/session-import-group.tsx
+++ b/clients/gui-app/src/components/session-import/session-import-group.tsx
@@ -1,6 +1,7 @@
 import { Check, ChevronRight, Minus } from "lucide-react";
 import { HarnessIcon } from "@/components/home/pickers/harness-icon";
 import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
+import { SessionImportOpenTaskButton } from "@/components/session-import/session-import-open-task-button";
 import { cn } from "@/lib/utils";
 import { useCompactRelativeTime } from "@/lib/relative-time";
 import type {
@@ -48,32 +49,25 @@ function SessionRowTimestamp(props: {
 }) {
   const { updatedAt, tone } = props;
   const when = useCompactRelativeTime(updatedAt);
+
   return (
     <span
-      className={cn(
-        "min-w-10 shrink-0 truncate text-right text-ui-xs",
-        tone.faint,
-      )}
+      className={cn("shrink-0 text-right text-ui-xs tabular-nums", tone.faint)}
     >
       {when}
     </span>
   );
 }
 
-/**
- * One number, not a fraction: a fully picked folder reads as its count alone.
- * "All" counts what is actually submitted (the selectable rows), because
- * unavailable rows never import; an untouched or cleared folder shows
- * everything it holds.
- */
-function groupCountLabel(group: SessionImportGroupView): string {
-  if (group.selectionState === "partial") {
-    return `${group.selectedCount.toLocaleString()} of ${group.selectableCount.toLocaleString()}`;
-  }
-  if (group.selectionState === "all") {
-    return group.selectableCount.toLocaleString();
-  }
-  return group.totalCount.toLocaleString();
+/** Selection detail is available without making the folder count change meaning. */
+function groupSelectionLabel(group: SessionImportGroupView): string {
+  const count = group.selectableCount.toLocaleString();
+  const noun = group.selectableCount === 1 ? "task" : "tasks";
+  if (group.selectionState === "none")
+    return `Select ${count} available ${noun}`;
+  if (group.selectionState === "all")
+    return `All ${count} available ${noun} selected`;
+  return `${group.selectedCount.toLocaleString()} of ${count} available ${noun} selected`;
 }
 
 function SessionRow(props: {
@@ -85,9 +79,57 @@ function SessionRow(props: {
    */
   readonly showFolder: boolean;
   readonly onToggle: (selectionKey: string) => void;
+  readonly onTaskOpened: () => void;
+  readonly onBeforeTaskOpen: (() => Promise<boolean>) | null;
 }) {
-  const { row, tone, showFolder, onToggle } = props;
+  const { row, tone, showFolder, onToggle, onTaskOpened } = props;
   const { candidate } = row;
+
+  if (candidate.state.kind === "already_in_traycer") {
+    return (
+      <div
+        data-testid="session-import-row"
+        data-selectable={false}
+        className="flex w-full min-w-0 items-center gap-2.5 rounded-md px-1.5 py-1.5 text-left"
+      >
+        <span aria-hidden className="size-4 shrink-0" />
+        <HarnessIcon
+          harnessId={candidate.harness}
+          className={cn("size-3.5 opacity-75", tone.muted)}
+        />
+        <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+          <span
+            className={cn(
+              "min-w-0 truncate text-ui-sm opacity-75",
+              tone.strong,
+            )}
+          >
+            {row.title}
+          </span>
+          {showFolder ? (
+            <span className={cn("truncate text-ui-xs", tone.faint)}>
+              {row.folderPath}
+            </span>
+          ) : null}
+        </span>
+        <span
+          className={cn(
+            "shrink-0 rounded px-1.5 py-0.5 text-ui-xs bg-foreground/8",
+            tone.muted,
+          )}
+        >
+          Imported
+        </span>
+        <SessionImportOpenTaskButton
+          target={candidate.state}
+          title={row.title}
+          onTaskOpened={onTaskOpened}
+          onBeforeTaskOpen={props.onBeforeTaskOpen}
+        />
+        <SessionRowTimestamp updatedAt={candidate.updatedAt} tone={tone} />
+      </div>
+    );
+  }
 
   return (
     <TooltipWrapper
@@ -164,6 +206,8 @@ export function SessionImportGroupItem(props: {
   readonly onToggleExpanded: (groupKey: string) => void;
   readonly onSetGroupSelection: (groupKey: string, selected: boolean) => void;
   readonly onToggleSession: (selectionKey: string) => void;
+  readonly onTaskOpened: () => void;
+  readonly onBeforeTaskOpen: (() => Promise<boolean>) | null;
 }) {
   const {
     group,
@@ -186,36 +230,50 @@ export function SessionImportGroupItem(props: {
       <div
         className={cn("flex w-full min-w-0 items-center", tone.groupSurface)}
       >
-        <button
-          type="button"
-          role="checkbox"
-          aria-checked={
-            group.selectionState === "partial"
-              ? "mixed"
-              : group.selectionState === "all"
-          }
-          aria-label={`Select all work in ${group.name}`}
-          disabled={group.selectableCount === 0}
-          data-testid="session-import-group-select"
-          onClick={() =>
-            onSetGroupSelection(group.groupKey, group.selectionState !== "all")
-          }
-          // ring-inset on both header controls: the card clips at its rounded
-          // border, so an outset ring would render cut off. p-2.5 all round
-          // keeps this checkbox on the same left edge - and the same distance
-          // from what follows it - as the row checkboxes below (4px list
-          // padding + 6px row padding = the same 10px).
-          className={cn(
-            "flex shrink-0 items-center rounded-md p-2.5 outline-none focus-visible:ring-2 focus-visible:ring-ring/60 focus-visible:ring-inset",
-            group.selectableCount > 0 && tone.rowHover,
-          )}
-        >
-          <SelectionBox
-            state={group.selectionState}
-            disabled={group.selectableCount === 0}
-            tone={tone}
-          />
-        </button>
+        {group.selectableCount > 0 ? (
+          <TooltipWrapper
+            label={groupSelectionLabel(group)}
+            side="top"
+            sideOffset={undefined}
+            align={undefined}
+          >
+            <button
+              type="button"
+              role="checkbox"
+              aria-checked={
+                group.selectionState === "partial"
+                  ? "mixed"
+                  : group.selectionState === "all"
+              }
+              aria-label={`${group.name}: ${groupSelectionLabel(group)}`}
+              disabled={group.selectableCount === 0}
+              data-testid="session-import-group-select"
+              onClick={() =>
+                onSetGroupSelection(
+                  group.groupKey,
+                  group.selectionState !== "all",
+                )
+              }
+              // ring-inset on both header controls: the card clips at its rounded
+              // border, so an outset ring would render cut off. p-2.5 all round
+              // keeps this checkbox on the same left edge - and the same distance
+              // from what follows it - as the row checkboxes below (4px list
+              // padding + 6px row padding = the same 10px).
+              className={cn(
+                "flex shrink-0 items-center rounded-md p-2.5 outline-none focus-visible:ring-2 focus-visible:ring-ring/60 focus-visible:ring-inset",
+                group.selectableCount > 0 && tone.rowHover,
+              )}
+            >
+              <SelectionBox
+                state={group.selectionState}
+                disabled={group.selectableCount === 0}
+                tone={tone}
+              />
+            </button>
+          </TooltipWrapper>
+        ) : (
+          <span aria-hidden className="size-4 shrink-0 mx-2.5" />
+        )}
         <button
           type="button"
           aria-expanded={group.expanded}
@@ -249,16 +307,11 @@ export function SessionImportGroupItem(props: {
               {group.path}
             </span>
           </span>
-          {/*
-            One number, not a fraction: a folder the user has not touched is
-            fully picked, so "431 of 431" is noise on every row. The fraction
-            appears exactly when it says something - the folder is half in.
-          */}
           <span
             data-testid="session-import-group-count"
             className={cn("shrink-0 text-ui-xs tabular-nums", tone.muted)}
           >
-            {groupCountLabel(group)}
+            {group.totalCount.toLocaleString()}
           </span>
         </button>
       </div>
@@ -271,6 +324,8 @@ export function SessionImportGroupItem(props: {
               tone={tone}
               showFolder={group.missingFolder}
               onToggle={onToggleSession}
+              onTaskOpened={props.onTaskOpened}
+              onBeforeTaskOpen={props.onBeforeTaskOpen}
             />
           ))}
         </div>

--- a/clients/gui-app/src/components/session-import/session-import-model.ts
+++ b/clients/gui-app/src/components/session-import/session-import-model.ts
@@ -8,7 +8,10 @@ import type {
 } from "@traycer/protocol/host/session-import/candidate";
 import type { SessionImportScanTotals } from "@traycer/protocol/host/session-import/scan";
 import type { SessionImportOutcome } from "@traycer/protocol/host/session-import/run";
-import type { SessionImportProviderFailure } from "@traycer-clients/shared/host-transport/session-import-scan-client";
+import type {
+  SessionImportImportedSupport,
+  SessionImportProviderFailure,
+} from "@traycer-clients/shared/host-transport/session-import-scan-client";
 import {
   guiHarnessIdToProviderId,
   providerDisplayName,
@@ -134,6 +137,8 @@ export interface SessionImportWizardState {
    */
   readonly deletedFoldersCleared: boolean;
   readonly query: string;
+  readonly showImported: boolean;
+  readonly importedSupport: SessionImportImportedSupport;
   /**
    * Providers the user has switched OUT of the import. This is scope, not a
    * view filter: a harness in here is hidden from the list AND unticked, so
@@ -161,6 +166,8 @@ export const SESSION_IMPORT_INITIAL_STATE: SessionImportWizardState = {
   expandedGroups: new Set(),
   deletedFoldersCleared: false,
   query: "",
+  showImported: false,
+  importedSupport: "unknown",
   disabledHarnesses: new Set(),
   scanWindow: SESSION_IMPORT_DEFAULT_SCAN_WINDOW,
   scannedProviders: [],
@@ -182,6 +189,11 @@ export type SessionImportWizardAction =
       readonly kind: "scanStarted";
       readonly providers: ReadonlyArray<GuiHarnessId>;
     }
+  | {
+      readonly kind: "scanImportedSupportChanged";
+      readonly support: SessionImportImportedSupport;
+    }
+  | { readonly kind: "showImportedChanged"; readonly showImported: boolean }
   | { readonly kind: "scanGroupArrived"; readonly group: SessionImportGroup }
   | {
       readonly kind: "scanProviderFailed";
@@ -231,6 +243,7 @@ export function sessionImportWizardReducer(
   switch (action.kind) {
     case "scanRestarted":
     case "scanStarted":
+    case "scanImportedSupportChanged":
     case "scanGroupArrived":
     case "scanProviderFailed":
     case "scanCompleted":
@@ -259,10 +272,8 @@ function applyScanFrame(
       if (action.reason === "reconnect") {
         // The stream dropped and came back over the SAME folders, so the rows
         // the user has been ticking are the rows the host is about to re-send.
-        // Nothing below the filters is thrown away - not even the groups:
-        // re-delivered ones are ignored by the dedupe in `scanGroupArrived`,
-        // which is also what keeps a deliberate UNTICK from being undone by
-        // that case's pre-select-on-arrival rule.
+        // Keep the rows while reconnecting. Re-delivered groups refresh their
+        // states without reselecting existing rows.
         return {
           ...state,
           phase: "scanning",
@@ -280,6 +291,7 @@ function applyScanFrame(
       return {
         ...SESSION_IMPORT_INITIAL_STATE,
         query: state.query,
+        showImported: state.showImported,
         disabledHarnesses: state.disabledHarnesses,
         scanWindow: state.scanWindow,
         scannedProviders: state.scannedProviders,
@@ -288,50 +300,11 @@ function applyScanFrame(
     case "scanStarted": {
       return { ...state, scannedProviders: action.providers };
     }
+    case "scanImportedSupportChanged": {
+      return { ...state, importedSupport: action.support };
+    }
     case "scanGroupArrived": {
-      const key = sessionImportGroupKey(action.group.location);
-      if (
-        state.groups.some(
-          (group) => sessionImportGroupKey(group.location) === key,
-        )
-      ) {
-        return state;
-      }
-      // A current host hides already-imported sessions from the scan; an older
-      // one still sends them as `already_in_traycer` rows. Discard those here
-      // so both hosts produce the same wizard: only what is new to bring over.
-      const sessions = action.group.sessions.filter(
-        (candidate) => candidate.state.kind !== "already_in_traycer",
-      );
-      if (sessions.length === 0) return state;
-      const group = { ...action.group, sessions };
-      // Everything importable arrives pre-selected, missing folders included
-      // (spec §5): those still import, just without a workspace. Two
-      // exceptions: a provider the user has switched out of the import - its
-      // rows are not on screen, so ticking them would import work the user
-      // cannot see - and a missing folder landing under a Deleted Folders
-      // header the user has already cleared, which shares that header's
-      // decision rather than reopening it.
-      const preselect =
-        group.location.kind !== "missing_folder" ||
-        !state.deletedFoldersCleared;
-      const selected = new Set(state.selected);
-      for (const candidate of group.sessions) {
-        if (!preselect) break;
-        if (!isImportable(candidate)) continue;
-        if (state.disabledHarnesses.has(candidate.harness)) continue;
-        selected.add(
-          sessionImportSelectionKey(
-            candidate.harness,
-            candidate.nativeSessionId,
-          ),
-        );
-      }
-      return {
-        ...state,
-        groups: [...state.groups, group],
-        selected,
-      };
+      return applyScanGroup(state, action.group);
     }
     case "scanProviderFailed": {
       // A harness is in exactly one state per scan, so a second failure for it
@@ -358,19 +331,79 @@ function applyScanFrame(
   }
 }
 
+function applyScanGroup(
+  state: SessionImportWizardState,
+  group: SessionImportGroup,
+): SessionImportWizardState {
+  const key = sessionImportGroupKey(group.location);
+  const previous = state.groups.find(
+    (group) => sessionImportGroupKey(group.location) === key,
+  );
+  // Refresh states after reconnect without undoing a deliberate untick.
+  // A newly imported row must never retain its old selected key.
+  const previousKeys = new Set(
+    previous?.sessions.map((candidate) =>
+      sessionImportSelectionKey(candidate.harness, candidate.nativeSessionId),
+    ),
+  );
+  // Everything importable arrives pre-selected, missing folders included
+  // (spec §5): those still import, just without a workspace. Two
+  // exceptions: a provider the user has switched out of the import - its
+  // rows are not on screen, so ticking them would import work the user
+  // cannot see - and a missing folder landing under a Deleted Folders
+  // header the user has already cleared, which shares that header's
+  // decision rather than reopening it.
+  const preselect =
+    group.location.kind !== "missing_folder" || !state.deletedFoldersCleared;
+  const selected = new Set(state.selected);
+  const nextImportableKeys = new Set(
+    group.sessions
+      .filter(isImportable)
+      .map((candidate) =>
+        sessionImportSelectionKey(candidate.harness, candidate.nativeSessionId),
+      ),
+  );
+  for (const previousKey of previousKeys) {
+    if (!nextImportableKeys.has(previousKey)) selected.delete(previousKey);
+  }
+  for (const candidate of group.sessions) {
+    if (!preselect) break;
+    if (!isImportable(candidate)) continue;
+    if (state.disabledHarnesses.has(candidate.harness)) continue;
+    if (
+      previousKeys.has(
+        sessionImportSelectionKey(candidate.harness, candidate.nativeSessionId),
+      )
+    )
+      continue;
+    selected.add(
+      sessionImportSelectionKey(candidate.harness, candidate.nativeSessionId),
+    );
+  }
+  return {
+    ...state,
+    groups:
+      previous === undefined
+        ? [...state.groups, group]
+        : state.groups.map((entry) =>
+            sessionImportGroupKey(entry.location) === key ? group : entry,
+          ),
+    selected,
+  };
+}
+
 function applyUserAction(
   state: SessionImportWizardState,
   action: SessionImportUserAction,
 ): SessionImportWizardState {
   switch (action.kind) {
+    case "showImportedChanged": {
+      if (action.showImported && state.importedSupport !== "supported")
+        return state;
+      return { ...state, showImported: action.showImported };
+    }
     case "sessionToggled": {
-      const selected = new Set(state.selected);
-      if (selected.has(action.selectionKey)) {
-        selected.delete(action.selectionKey);
-      } else {
-        selected.add(action.selectionKey);
-      }
-      return { ...state, selected };
+      return toggleSessionSelection(state, action.selectionKey);
     }
     case "groupSelectionSet": {
       return applyGroupSelectionSet(state, action.groupKey, action.selected);
@@ -386,7 +419,9 @@ function applyUserAction(
     }
     case "visibleSelectionSet": {
       const selected = new Set(state.selected);
+      const eligible = eligibleSelectionKeys(state);
       for (const key of action.selectionKeys) {
+        if (!eligible.has(key)) continue;
         if (action.selected) selected.add(key);
         else selected.delete(key);
       }
@@ -404,6 +439,48 @@ function applyUserAction(
       return { ...state, scanWindow: action.window };
     }
   }
+}
+
+function toggleSessionSelection(
+  state: SessionImportWizardState,
+  selectionKey: string,
+): SessionImportWizardState {
+  if (!eligibleSelectionKeys(state).has(selectionKey)) return state;
+  const selected = new Set(state.selected);
+  if (selected.has(selectionKey)) selected.delete(selectionKey);
+  else selected.add(selectionKey);
+  return { ...state, selected };
+}
+
+function eligibleSelectionKeys(
+  state: SessionImportWizardState,
+): ReadonlySet<string> {
+  return new Set(
+    state.groups.flatMap((group) =>
+      group.sessions
+        .filter(
+          (candidate) =>
+            isImportable(candidate) &&
+            !state.disabledHarnesses.has(candidate.harness),
+        )
+        .map((candidate) =>
+          sessionImportSelectionKey(
+            candidate.harness,
+            candidate.nativeSessionId,
+          ),
+        ),
+    ),
+  );
+}
+
+function isVisibleCandidate(
+  state: SessionImportWizardState,
+  candidate: SessionImportCandidate,
+): boolean {
+  return (
+    candidate.state.kind !== "already_in_traycer" ||
+    (state.showImported && state.importedSupport === "supported")
+  );
 }
 
 function applyGroupSelectionSet(
@@ -504,7 +581,7 @@ export interface SessionImportGroupView {
   readonly missingFolder: boolean;
   readonly expanded: boolean;
   readonly rows: ReadonlyArray<SessionImportRowView>;
-  /** Everything in scope this folder holds, pickable or not. */
+  /** Rows displayed in this folder, selectable or not. */
   readonly totalCount: number;
   readonly selectableCount: number;
   readonly selectedCount: number;
@@ -525,6 +602,7 @@ export interface SessionImportWizardView {
   readonly selectableSessions: number;
   /** How many survive scope and search. */
   readonly matchedSessions: number;
+  readonly hiddenImportedCount: number;
   /** Everything ticked - search-hidden rows included - is what submits. */
   readonly selectedCount: number;
   /** Selectable rows currently on screen, for the Select all / Clear action. */
@@ -658,9 +736,18 @@ function rowView(
   );
   const title = candidateDisplayTitle(candidate);
   const state = candidate.state;
-  // `already_in_traycer` never reaches here: those rows are dropped at
-  // arrival (see `scanGroupArrived`), so the only unavailable rows are
-  // unreadable ones.
+  if (state.kind === "already_in_traycer") {
+    return {
+      selectionKey,
+      candidate,
+      title,
+      folderPath,
+      selected: false,
+      selectable: false,
+      unavailableLabel: "Imported",
+      unavailableDetail: null,
+    };
+  }
   if (state.kind === "unreadable") {
     return {
       selectionKey,
@@ -714,6 +801,7 @@ function providerViewsFor(
   for (const harness of state.disabledHarnesses) counts.set(harness, 0);
   for (const group of state.groups) {
     for (const candidate of group.sessions) {
+      if (!isVisibleCandidate(state, candidate)) continue;
       counts.set(candidate.harness, (counts.get(candidate.harness) ?? 0) + 1);
     }
   }
@@ -764,10 +852,9 @@ export function buildSessionImportView(
   let selectableSessions = 0;
   let matchedSessions = 0;
   let visibleSelectedCount = 0;
-  // Every missing folder lands here instead of in `sortable`, and becomes one
-  // rendered group after the walk. Its counts span every missing folder in
-  // scope, searched or not - the same rule as a folder header - while its
-  // rows are only the searched slice.
+  let hiddenImportedCount = 0;
+  // Missing folders share a rendered group. Selection covers their full
+  // provider scope; the displayed count covers only the matching rows.
   const deletedRows: SessionImportRowView[] = [];
   const deleted = {
     folders: 0,
@@ -779,10 +866,22 @@ export function buildSessionImportView(
 
   for (const group of state.groups) {
     const path = group.location.path;
-    totalSessions += group.sessions.length;
+    const visible = group.sessions.filter((candidate) =>
+      isVisibleCandidate(state, candidate),
+    );
+    totalSessions += visible.length;
+    hiddenImportedCount += group.sessions.filter(
+      (candidate) =>
+        !isVisibleCandidate(state, candidate) &&
+        !state.disabledHarnesses.has(candidate.harness) &&
+        matchesQuery(candidate, path, needle),
+    ).length;
 
-    const inScope = group.sessions.filter(
+    const providerScope = group.sessions.filter(
       (candidate) => !state.disabledHarnesses.has(candidate.harness),
+    );
+    const inScope = providerScope.filter((candidate) =>
+      isVisibleCandidate(state, candidate),
     );
     const selectable = inScope.filter(isImportable);
     selectableSessions += selectable.length;
@@ -808,7 +907,7 @@ export function buildSessionImportView(
     ).length;
     const latest = Math.max(
       0,
-      ...inScope.map((candidate) => candidate.updatedAt),
+      ...providerScope.map((candidate) => candidate.updatedAt),
     );
 
     if (group.location.kind === "missing_folder") {
@@ -831,13 +930,13 @@ export function buildSessionImportView(
         missingFolder: false,
         expanded: state.expandedGroups.has(groupKey),
         rows,
-        totalCount: inScope.length,
+        totalCount: rows.length,
         selectableCount: selectable.length,
         selectedCount,
         selectionState: selectionStateFor(selectable.length, selectedCount),
       },
       tier: groupSortTier(false, group.gitBacked),
-      count: inScope.length,
+      count: providerScope.length,
       latest,
     });
   }
@@ -858,7 +957,7 @@ export function buildSessionImportView(
           SESSION_IMPORT_DELETED_FOLDERS_GROUP_KEY,
         ),
         rows,
-        totalCount: deleted.inScope,
+        totalCount: rows.length,
         selectableCount: deleted.selectable,
         selectedCount: deleted.selected,
         selectionState: selectionStateFor(deleted.selectable, deleted.selected),
@@ -886,7 +985,10 @@ export function buildSessionImportView(
     totalSessions,
     selectableSessions,
     matchedSessions,
-    selectedCount: state.selected.size,
+    hiddenImportedCount,
+    selectedCount: [...eligibleSelectionKeys(state)].filter((key) =>
+      state.selected.has(key),
+    ).length,
     visibleSelectionKeys,
     visibleSelectedCount,
   };
@@ -989,6 +1091,11 @@ export function buildSessionImportSubmission(
         candidate.harness,
         candidate.nativeSessionId,
       );
+      if (
+        !isImportable(candidate) ||
+        state.disabledHarnesses.has(candidate.harness)
+      )
+        continue;
       if (!state.selected.has(key)) continue;
       selections.push({
         harness: candidate.harness,

--- a/clients/gui-app/src/components/session-import/session-import-model.ts
+++ b/clients/gui-app/src/components/session-import/session-import-model.ts
@@ -341,10 +341,14 @@ function applyScanGroup(
   );
   // Refresh states after reconnect without undoing a deliberate untick.
   // A newly imported row must never retain its old selected key.
-  const previousKeys = new Set(
-    previous?.sessions.map((candidate) =>
-      sessionImportSelectionKey(candidate.harness, candidate.nativeSessionId),
-    ),
+  // An unavailable row could not have been unticked by the user. If it
+  // becomes importable, give it the same initial selection as a new row.
+  const previousImportableKeys = new Set(
+    previous?.sessions
+      .filter(isImportable)
+      .map((candidate) =>
+        sessionImportSelectionKey(candidate.harness, candidate.nativeSessionId),
+      ),
   );
   // Everything importable arrives pre-selected, missing folders included
   // (spec §5): those still import, just without a workspace. Two
@@ -363,7 +367,7 @@ function applyScanGroup(
         sessionImportSelectionKey(candidate.harness, candidate.nativeSessionId),
       ),
   );
-  for (const previousKey of previousKeys) {
+  for (const previousKey of previousImportableKeys) {
     if (!nextImportableKeys.has(previousKey)) selected.delete(previousKey);
   }
   for (const candidate of group.sessions) {
@@ -371,7 +375,7 @@ function applyScanGroup(
     if (!isImportable(candidate)) continue;
     if (state.disabledHarnesses.has(candidate.harness)) continue;
     if (
-      previousKeys.has(
+      previousImportableKeys.has(
         sessionImportSelectionKey(candidate.harness, candidate.nativeSessionId),
       )
     )

--- a/clients/gui-app/src/components/session-import/session-import-open-task-button.tsx
+++ b/clients/gui-app/src/components/session-import/session-import-open-task-button.tsx
@@ -92,7 +92,7 @@ export function SessionImportOpenTaskButton(props: {
               },
               includeNestedFocus: true,
             }),
-            undefined,
+            { onRejected: reject },
           );
           if (!accepted)
             reject(new Error("The task could not be opened. Try again."));

--- a/clients/gui-app/src/components/session-import/session-import-open-task-button.tsx
+++ b/clients/gui-app/src/components/session-import/session-import-open-task-button.tsx
@@ -1,0 +1,141 @@
+import { ExternalLink } from "lucide-react";
+import { useNavigate } from "@tanstack/react-router";
+import type { SessionImportCandidateState } from "@traycer/protocol/host/session-import/candidate";
+import { useHostMutation } from "@/hooks/host/use-host-query";
+import { useHostBinding, type HostRpcRegistry } from "@/lib/host";
+import { resolveNamedHostClient } from "@/lib/host/binding-host-client";
+import { useStreamHostId } from "@/lib/host/stream-runtime-context";
+import { sessionImportQueryKeys } from "@/lib/query-keys";
+import { toastFromHostErrorWithDetail } from "@/lib/host-error-toast";
+import { activateTabIntent, resourceEpicTabIntent } from "@/lib/tab-navigation";
+import { Button } from "@/components/ui/button";
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
+import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
+
+type ImportedTask = Extract<
+  SessionImportCandidateState,
+  { kind: "already_in_traycer" }
+>;
+interface OpenImportedTaskVariables {
+  readonly epicId: string;
+  readonly chatId: string;
+  readonly hostId: string;
+  readonly title: string;
+}
+
+/** Recheck the destination on its source host before opening its chat tile. */
+export function SessionImportOpenTaskButton(props: {
+  readonly target: ImportedTask;
+  readonly title: string;
+  readonly onTaskOpened: () => void;
+  readonly onBeforeTaskOpen: (() => Promise<boolean>) | null;
+}) {
+  const binding = useHostBinding();
+  const hostId = useStreamHostId();
+  const navigate = useNavigate();
+  const openTask = useHostMutation<
+    HostRpcRegistry,
+    "epic.getChatRunSettings",
+    undefined,
+    OpenImportedTaskVariables
+  >({
+    client: (variables) => resolveNamedHostClient(binding, variables.hostId),
+    method: "epic.getChatRunSettings",
+    mapVariables: ({ epicId, chatId }) => ({ epicId, chatId }),
+    onResponse: (response) => {
+      // Imported chats are created with run settings. A missing tuple also
+      // covers a deleted/unavailable chat without creating an empty tab.
+      if (response.settings === null)
+        throw new Error("This imported task is no longer available.");
+    },
+    options: {
+      mutationKey: sessionImportQueryKeys.openTask(hostId),
+      onSuccess: async (_response, variables) => {
+        if (
+          props.onBeforeTaskOpen !== null &&
+          !(await props.onBeforeTaskOpen())
+        )
+          return;
+        await new Promise<void>((resolve, reject) => {
+          const accepted = activateTabIntent(
+            async (options) => {
+              try {
+                await navigate(options);
+                resolve();
+              } catch (error) {
+                const failure =
+                  error instanceof Error ? error : new Error(String(error));
+                reject(failure);
+                throw failure;
+              }
+            },
+            resourceEpicTabIntent({
+              epicId: variables.epicId,
+              tabId: null,
+              name: variables.title,
+              focus: {
+                focusedAt: undefined,
+                focusArtifactId: undefined,
+                focusThreadId: undefined,
+                migrationSource: undefined,
+              },
+              preparation: {
+                kind: "open-tile",
+                gesture: "explicit",
+                node: {
+                  type: "chat",
+                  id: variables.chatId,
+                  instanceId: crypto.randomUUID(),
+                  name: variables.title,
+                  hostId: variables.hostId,
+                },
+              },
+              includeNestedFocus: true,
+            }),
+            undefined,
+          );
+          if (!accepted)
+            reject(new Error("The task could not be opened. Try again."));
+        });
+        props.onTaskOpened();
+      },
+      onError: (error) =>
+        toastFromHostErrorWithDetail(error, "Couldn't open imported task."),
+    },
+  });
+  return (
+    <TooltipWrapper
+      label="Open task"
+      side="top"
+      sideOffset={undefined}
+      align={undefined}
+    >
+      <Button
+        variant="ghost"
+        size="icon-sm"
+        className="shrink-0"
+        disabled={hostId === null || openTask.isPending}
+        aria-label={`Open task: ${props.title}`}
+        onClick={() => {
+          if (hostId === null || openTask.isPending) return;
+          openTask.mutate({
+            epicId: props.target.epicId,
+            chatId: props.target.chatId,
+            hostId,
+            title: props.title,
+          });
+        }}
+      >
+        {openTask.isPending ? (
+          <AgentSpinningDots
+            className="text-muted-foreground"
+            testId={undefined}
+            variant={undefined}
+          />
+        ) : (
+          <ExternalLink aria-hidden className="size-3.5" />
+        )}
+      </Button>
+    </TooltipWrapper>
+  );
+}

--- a/clients/gui-app/src/components/session-import/session-import-run-controller.tsx
+++ b/clients/gui-app/src/components/session-import/session-import-run-controller.tsx
@@ -8,10 +8,7 @@ import {
   type SessionImportRunProgressPayload,
   type SessionImportRunStartedPayload,
 } from "@traycer-clients/shared/host-transport/session-import-run-client";
-import {
-  useStreamHostId,
-  useWsStreamClient,
-} from "@/lib/host/stream-runtime-context";
+import { useStreamRuntimeBinding } from "@/lib/host/stream-runtime-context";
 import { hostQueryKeys, sessionImportQueryKeys } from "@/lib/query-keys";
 import {
   progressEntryFrom,
@@ -23,6 +20,7 @@ import { useComposerRunSettingsStore } from "@/stores/composer/composer-run-sett
 import {
   getSessionImportStartHandle,
   setSessionImportStartHandle,
+  type SessionImportActiveRun,
   type SessionImportRunRequest,
   type SessionImportRunTarget,
 } from "@/components/session-import/session-import-run-handle";
@@ -68,12 +66,13 @@ function newChatPermissionModeFor(hostId: string): PermissionMode {
  */
 export function SessionImportRunController(): null {
   const queryClient = useQueryClient();
-  const ambientStreamClient = useWsStreamClient();
+  const ambientBinding = useStreamRuntimeBinding();
+  const ambientStreamClient = ambientBinding?.wsStreamClient ?? null;
   // The host the mount-time probe asks. Its name has to come off the same
   // binding as the client - a host swap between the two reads would invalidate
   // one machine's queries for a run that happened on another. See
   // `StreamRuntimeBinding.hostId`.
-  const ambientHostId = useStreamHostId();
+  const ambientHostId = ambientBinding?.hostId ?? null;
   const runsRef = useRef<Map<string, HostRun>>(new Map());
   // The stream client this window has already asked "is a run going?". One
   // question per binding: a probe that came back empty must not be asked
@@ -94,8 +93,8 @@ export function SessionImportRunController(): null {
     runsRef.current.delete(hostId);
     run.client.close();
     // Returns the transport reference this run took at subscribe. A scoped
-    // transport closes here if nothing else is reading it; the ambient one
-    // has no lease to return.
+    // transport closes here if nothing else is reading it. Ambient runs also
+    // retain their transport across a change of the window's host.
     run.release?.();
     noteClientClosed();
   }, []);
@@ -206,6 +205,55 @@ export function SessionImportRunController(): null {
     [closeRun, openRun, runCallbacks],
   );
 
+  const attach = useCallback(
+    (target: SessionImportRunTarget, run: SessionImportActiveRun): void => {
+      const hostId = target.hostId;
+      const existing = runsRef.current.get(hostId);
+      if (existing !== undefined) {
+        if (!existing.waitingProbe) return;
+        // This status-confirmed attach must own the answer. An ambient probe
+        // can find the run already finished and otherwise leave the wizard
+        // waiting on its stale active status forever.
+        closeRun(hostId);
+      }
+      // The status query already named a real run. Keep that identity even
+      // if the connection fails before the stream's first frame arrives.
+      useSessionImportRunStore.getState().applyStarted(hostId, {
+        runId: run.runId,
+        total: run.total,
+        attached: true,
+      });
+      const callbacks = runCallbacks(hostId);
+      let attached = false;
+      openRun({
+        target,
+        selections: [],
+        waitingProbe: false,
+        callbacks: {
+          ...callbacks,
+          onStarted: (payload) => {
+            attached = payload.attached;
+            if (attached) {
+              callbacks.onStarted(payload);
+              return;
+            }
+            // The run finished between the status reply and the attach.
+            // Recheck before offering selections; the empty run is no summary.
+            closeRun(hostId);
+            void queryClient.invalidateQueries({
+              queryKey: sessionImportQueryKeys.status(hostId),
+            });
+            useSessionImportRunStore.getState().reset(hostId);
+          },
+          onComplete: (payload) => {
+            if (attached) callbacks.onComplete(payload);
+          },
+        },
+      });
+    },
+    [closeRun, openRun, queryClient, runCallbacks],
+  );
+
   // Subscribing with no selections is the host's "attach to whatever is
   // running" form: a run in flight replays from the start, and an idle host
   // answers with an empty run instead. The store is touched only in the first
@@ -218,7 +266,7 @@ export function SessionImportRunController(): null {
   // new run id supersede it. A probe that finds nothing leaves the store as
   // it was.
   useEffect(() => {
-    if (ambientStreamClient === null || ambientHostId === null) return;
+    if (ambientBinding === null || ambientHostId === null) return;
     if (runsRef.current.has(ambientHostId)) return;
     if (probedStreamClientRef.current === ambientStreamClient) return;
     probedStreamClientRef.current = ambientStreamClient;
@@ -227,10 +275,8 @@ export function SessionImportRunController(): null {
     const callbacks = runCallbacks(hostId);
     let attached = false;
     const probe = openRun({
-      // The ambient binding never closes under its readers, so there is
-      // nothing to pin: `retain: null` says exactly that.
       target: {
-        binding: { wsStreamClient: ambientStreamClient, hostId, retain: null },
+        binding: ambientBinding,
         hostId,
       },
       selections: [],
@@ -274,6 +320,7 @@ export function SessionImportRunController(): null {
       }
     };
   }, [
+    ambientBinding,
     ambientHostId,
     ambientStreamClient,
     clientGeneration,
@@ -283,13 +330,13 @@ export function SessionImportRunController(): null {
   ]);
 
   useEffect(() => {
-    setSessionImportStartHandle({ start });
+    setSessionImportStartHandle({ start, attach });
     return () => {
       if (getSessionImportStartHandle()?.start === start) {
         setSessionImportStartHandle(null);
       }
     };
-  }, [start]);
+  }, [start, attach]);
 
   useEffect(
     () => () => {
@@ -303,7 +350,7 @@ export function SessionImportRunController(): null {
 
 interface HostRun {
   readonly client: SessionImportRunClient;
-  /** Returns the transport lease this run took; `null` for the ambient one. */
+  /** Returns the transport lease this run took, when the binding provides one. */
   readonly release: (() => void) | null;
   /**
    * True while this client is the mount-time probe still waiting for the

--- a/clients/gui-app/src/components/session-import/session-import-run-handle.ts
+++ b/clients/gui-app/src/components/session-import/session-import-run-handle.ts
@@ -1,4 +1,5 @@
 import type { SessionImportSelection } from "@traycer/protocol/host/session-import/candidate";
+import type { SessionImportStatusResponse } from "@traycer/protocol/host/session-import/contracts";
 import type { StreamRuntimeBinding } from "@/lib/host/stream-runtime-context";
 import { appLogger } from "@/lib/logger";
 
@@ -24,11 +25,28 @@ export interface SessionImportRunTarget {
   readonly hostId: string;
 }
 
+export type SessionImportActiveRun = NonNullable<
+  SessionImportStatusResponse["active"]
+>;
+
 interface SessionImportStartHandle {
   readonly start: (
     request: SessionImportRunRequest,
     target: SessionImportRunTarget,
   ) => void;
+  readonly attach: (
+    target: SessionImportRunTarget,
+    run: SessionImportActiveRun,
+  ) => void;
+}
+
+/** Watches the run found by the wizard's status query, without submitting selections. */
+export function attachSessionImportRun(
+  binding: StreamRuntimeBinding | null,
+  run: SessionImportActiveRun,
+): void {
+  if (binding === null || binding.hostId === null) return;
+  ref.current?.attach({ binding, hostId: binding.hostId }, run);
 }
 
 const ref: { current: SessionImportStartHandle | null } = { current: null };

--- a/clients/gui-app/src/components/session-import/session-import-wizard.tsx
+++ b/clients/gui-app/src/components/session-import/session-import-wizard.tsx
@@ -1,14 +1,17 @@
-import { useEffect, useMemo } from "react";
+import { useEffect, useId, useMemo } from "react";
 import { History, Search } from "lucide-react";
 import type { GuiHarnessId } from "@traycer/protocol/host/index";
 import type {
   SessionImportGroup,
   SessionImportSelection,
 } from "@traycer/protocol/host/session-import/candidate";
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
+import type { SessionImportImportedSupport } from "@traycer-clients/shared/host-transport/session-import-scan-client";
 import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 import { Button } from "@/components/ui/button";
 import { HarnessIcon } from "@/components/home/pickers/harness-icon";
 import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
 import {
   Select,
   SelectContent,
@@ -76,6 +79,8 @@ export function SessionImportWizard(props: {
   readonly scan: SessionImportScanHandle;
   /** Called once a run has been submitted, so the caller can move on. */
   readonly onImportStarted: () => void;
+  readonly onTaskOpened: () => void;
+  readonly onBeforeTaskOpen: (() => Promise<boolean>) | null;
   readonly secondaryAction: SessionImportSecondaryAction | null;
 }) {
   const { surface, scan, onImportStarted, secondaryAction } = props;
@@ -160,6 +165,11 @@ export function SessionImportWizard(props: {
         providers={view.providers}
         scanning={state.phase === "scanning"}
         scanWindow={state.scanWindow}
+        showImported={state.showImported}
+        importedSupport={state.importedSupport}
+        onShowImportedChange={(showImported) =>
+          dispatch({ kind: "showImportedChanged", showImported })
+        }
         onQueryChange={(query) => dispatch({ kind: "queryChanged", query })}
         onToggleProvider={(harness) =>
           dispatch({ kind: "providerScopeToggled", harness })
@@ -169,7 +179,7 @@ export function SessionImportWizard(props: {
         }
       />
 
-      {view.groups.length > 0 ? (
+      {view.groups.length > 0 && view.selectableSessions > 0 ? (
         <div className="flex shrink-0 items-center gap-1 px-4 pt-2">
           <button
             type="button"
@@ -179,7 +189,7 @@ export function SessionImportWizard(props: {
                 ? "mixed"
                 : visibleSelection === "all"
             }
-            aria-label="Select all listed work"
+            aria-label="Select all available tasks shown"
             data-testid="session-import-visible-selection"
             disabled={view.visibleSelectionKeys.length === 0}
             onClick={() =>
@@ -209,8 +219,8 @@ export function SessionImportWizard(props: {
               data-testid="session-import-selection-count"
               className={cn("text-ui-xs tabular-nums", tone.faint)}
             >
-              {view.selectedCount.toLocaleString()} of{" "}
-              {view.selectableSessions.toLocaleString()} selected
+              {view.selectedCount.toLocaleString()}{" "}
+              {view.selectedCount === 1 ? "task" : "tasks"} selected for import
             </span>
           ) : null}
         </div>
@@ -254,6 +264,8 @@ export function SessionImportWizard(props: {
             onSetGroupSelection={(groupKey, selected) =>
               dispatch({ kind: "groupSelectionSet", groupKey, selected })
             }
+            onTaskOpened={props.onTaskOpened}
+            onBeforeTaskOpen={props.onBeforeTaskOpen}
             onToggleSession={(selectionKey) =>
               dispatch({ kind: "sessionToggled", selectionKey })
             }
@@ -276,17 +288,14 @@ export function SessionImportWizard(props: {
             </span>
           </div>
         ) : null}
-        {state.phase !== "scanning" && view.groups.length === 0 ? (
-          <p
-            data-testid="session-import-empty"
-            className={cn(
-              "mx-auto max-w-[26rem] px-1 py-10 text-center text-ui-sm",
-              tone.muted,
-            )}
-          >
-            {emptyMessage(state, view)}
-          </p>
-        ) : null}
+        <SessionImportEmptyState
+          state={state}
+          view={view}
+          tone={tone}
+          onShowImported={() =>
+            dispatch({ kind: "showImportedChanged", showImported: true })
+          }
+        />
       </div>
 
       <SessionImportFooter
@@ -295,6 +304,36 @@ export function SessionImportWizard(props: {
         secondaryAction={secondaryAction}
         onSubmit={submit}
       />
+    </div>
+  );
+}
+
+function SessionImportEmptyState(props: {
+  readonly state: SessionImportWizardState;
+  readonly view: SessionImportWizardView;
+  readonly tone: SessionImportTone;
+  readonly onShowImported: () => void;
+}) {
+  const { state, view, tone, onShowImported } = props;
+  if (state.phase === "scanning" || view.groups.length > 0) return null;
+  return (
+    <div
+      data-testid="session-import-empty"
+      className={cn(
+        "mx-auto max-w-[26rem] px-1 py-10 text-center text-ui-sm",
+        tone.muted,
+      )}
+    >
+      <p>{emptyMessage(state, view)}</p>
+      {view.hiddenImportedCount > 0 && state.importedSupport === "supported" ? (
+        <Button
+          variant="link"
+          className="block mx-auto"
+          onClick={onShowImported}
+        >
+          Show imported
+        </Button>
+      ) : null}
     </div>
   );
 }
@@ -309,6 +348,9 @@ function SessionImportFilters(props: {
   readonly providers: ReadonlyArray<SessionImportProviderView>;
   readonly scanning: boolean;
   readonly scanWindow: SessionImportScanWindow;
+  readonly showImported: boolean;
+  readonly importedSupport: SessionImportImportedSupport;
+  readonly onShowImportedChange: (showImported: boolean) => void;
   readonly onQueryChange: (query: string) => void;
   readonly onToggleProvider: (harness: GuiHarnessId) => void;
   readonly onScanWindowChange: (window: SessionImportScanWindow) => void;
@@ -365,7 +407,68 @@ function SessionImportFilters(props: {
             onToggle={onToggleProvider}
           />
         ))}
+        <ImportedVisibilityToggle
+          tone={tone}
+          showImported={props.showImported}
+          support={props.importedSupport}
+          onChange={props.onShowImportedChange}
+        />
       </div>
+    </div>
+  );
+}
+
+function importedVisibilityNotice(
+  support: SessionImportImportedSupport,
+): string | null {
+  switch (support) {
+    case "unsupported":
+      return "Update this host to view imported tasks";
+    case "unknown":
+      return "Checking host support…";
+    case "supported":
+      return null;
+  }
+}
+
+function ImportedVisibilityToggle(props: {
+  readonly tone: SessionImportTone;
+  readonly showImported: boolean;
+  readonly support: SessionImportImportedSupport;
+  readonly onChange: (showImported: boolean) => void;
+}) {
+  const { tone, showImported, support, onChange } = props;
+  const switchId = useId();
+  const disabled = support !== "supported";
+  const checked = showImported && !disabled;
+  return (
+    <div
+      className={cn(
+        "ml-auto flex items-center gap-1.5 px-2 py-1 text-ui-xs",
+        disabled && "opacity-55",
+        tone.muted,
+      )}
+    >
+      <TooltipWrapper
+        label={importedVisibilityNotice(support)}
+        side="top"
+        sideOffset={undefined}
+        align={undefined}
+      >
+        <Switch
+          id={switchId}
+          checked={checked}
+          aria-label="Show imported"
+          // Keep unavailable controls focusable so the host-support tooltip
+          // is also accessible from the keyboard.
+          aria-disabled={disabled}
+          data-testid="session-import-show-imported"
+          onCheckedChange={(next) => {
+            if (!disabled) onChange(next);
+          }}
+        />
+      </TooltipWrapper>
+      <label htmlFor={switchId}>Show imported</label>
     </div>
   );
 }
@@ -470,7 +573,7 @@ function SessionImportFooter(props: {
         onClick={onSubmit}
       >
         Import {view.selectedCount}{" "}
-        {view.selectedCount === 1 ? "session" : "sessions"}
+        {view.selectedCount === 1 ? "task" : "tasks"}
       </Button>
     </div>
   );
@@ -553,6 +656,8 @@ function emptyMessage(
 ): string {
   if (state.phase === "failed")
     return "Traycer could not read your work folders.";
+  if (view.hiddenImportedCount > 0 && state.importedSupport === "supported")
+    return "All matching tasks have already been imported.";
   if (view.totalSessions === 0) {
     // A bounded scan finding nothing is not "you have no work" - the window
     // picker above can look further back, and the copy points at it.

--- a/clients/gui-app/src/components/session-import/session-import-wizard.tsx
+++ b/clients/gui-app/src/components/session-import/session-import-wizard.tsx
@@ -1,6 +1,9 @@
 import { useEffect, useId, useMemo } from "react";
+import type { UseQueryResult } from "@tanstack/react-query";
+import type { HostRpcError } from "@traycer-clients/shared/host-transport/host-messenger";
 import { History, Search } from "lucide-react";
 import type { GuiHarnessId } from "@traycer/protocol/host/index";
+import type { SessionImportStatusResponse } from "@traycer/protocol/host/session-import/contracts";
 import type {
   SessionImportGroup,
   SessionImportSelection,
@@ -40,7 +43,11 @@ import {
 } from "@/components/session-import/session-import-group";
 import { SessionImportProgress } from "@/components/session-import/session-import-progress";
 import type { SessionImportScanHandle } from "@/components/session-import/use-session-import-scan";
-import { startSessionImportRun } from "@/components/session-import/session-import-run-handle";
+import {
+  attachSessionImportRun,
+  startSessionImportRun,
+} from "@/components/session-import/session-import-run-handle";
+import { useSessionImportCheckStatus } from "@/hooks/session-import/use-session-import-check-status-query";
 import { useStreamRuntimeBinding } from "@/lib/host/stream-runtime-context";
 import {
   sessionImportTone,
@@ -92,6 +99,24 @@ export function SessionImportWizard(props: {
   const hostId = streamBinding?.hostId ?? null;
   const runStatus = useSessionImportRun(hostId).status;
   const runIdle = runStatus === "idle";
+  const statusQuery = useSessionImportCheckStatus(streamBinding, runIdle);
+  const activeRun = statusQuery.isSuccess ? statusQuery.data.active : null;
+  const canSubmit = sessionImportHostIsIdle(statusQuery);
+  const checkingStatus = !statusQuery.isError && !canSubmit;
+  // The controller only probes the app's host on its own. A wizard on any
+  // other host checks through Query first and attaches without selections.
+  // Submission stays disabled until an idle answer arrives, including when
+  // the onboarding scan was populated before this wizard mounted.
+  useEffect(() => {
+    if (!runIdle || !statusQuery.isSuccess || statusQuery.isFetching) return;
+    if (activeRun !== null) attachSessionImportRun(streamBinding, activeRun);
+  }, [
+    activeRun,
+    runIdle,
+    statusQuery.isFetching,
+    statusQuery.isSuccess,
+    streamBinding,
+  ]);
   // Meeting the wizard on any surface - the tour act, the Settings dialog,
   // the release toast's own dialog - is the announcement: the id is consumed
   // on mount so the toast never follows for a user who has already opened
@@ -134,7 +159,7 @@ export function SessionImportWizard(props: {
   const submit = (): void => {
     // A run already under way owns the screen, and the button is not rendered
     // then - this guards a click that raced the store.
-    if (!runIdle) return;
+    if (!runIdle || !canSubmit) return;
     const submission = buildSessionImportSubmission(state);
     if (submission.selections.length === 0) return;
     Analytics.getInstance().track(AnalyticsEvent.SessionImportStarted, {
@@ -298,9 +323,27 @@ export function SessionImportWizard(props: {
         />
       </div>
 
+      {statusQuery.isError ? (
+        <div role="alert" className="flex items-center gap-2 px-4 py-2">
+          <p className={cn("text-ui-xs", tone.muted)}>
+            Traycer could not check whether an import is already running.
+          </p>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={statusQuery.isFetching}
+            onClick={() => void statusQuery.refetch()}
+          >
+            Try again
+          </Button>
+        </div>
+      ) : null}
       <SessionImportFooter
         tone={tone}
         view={view}
+        canSubmit={canSubmit}
+        checkingStatus={checkingStatus}
         secondaryAction={secondaryAction}
         onSubmit={submit}
       />
@@ -336,6 +379,13 @@ function SessionImportEmptyState(props: {
       ) : null}
     </div>
   );
+}
+
+/** A pending, failed, or refetching status cannot authorize a new import. */
+function sessionImportHostIsIdle(
+  query: UseQueryResult<SessionImportStatusResponse, HostRpcError>,
+): boolean {
+  return query.isSuccess && !query.isFetching && query.data.active === null;
 }
 
 /**
@@ -544,10 +594,13 @@ function ScanWindowSelect(props: {
 function SessionImportFooter(props: {
   readonly tone: SessionImportTone;
   readonly view: SessionImportWizardView;
+  readonly canSubmit: boolean;
+  readonly checkingStatus: boolean;
   readonly secondaryAction: SessionImportSecondaryAction | null;
   readonly onSubmit: () => void;
 }) {
-  const { tone, view, secondaryAction, onSubmit } = props;
+  const { tone, view, canSubmit, checkingStatus, secondaryAction, onSubmit } =
+    props;
   return (
     <div
       className={cn(
@@ -569,9 +622,16 @@ function SessionImportFooter(props: {
         type="button"
         size="sm"
         data-testid="session-import-submit"
-        disabled={view.selectedCount === 0}
+        disabled={!canSubmit || view.selectedCount === 0}
         onClick={onSubmit}
       >
+        {checkingStatus ? (
+          <AgentSpinningDots
+            className={tone.muted}
+            testId="session-import-status-spinner"
+            variant={undefined}
+          />
+        ) : null}
         Import {view.selectedCount}{" "}
         {view.selectedCount === 1 ? "task" : "tasks"}
       </Button>

--- a/clients/gui-app/src/components/session-import/use-session-import-scan.ts
+++ b/clients/gui-app/src/components/session-import/use-session-import-scan.ts
@@ -69,6 +69,9 @@ export function useSessionImportScan(active: boolean): SessionImportScanHandle {
       updatedAfter:
         scanWindow === null ? null : Date.now() - scanWindow * DAY_IN_MS,
       callbacks: {
+        onImportedSupport: (support) => {
+          dispatch({ kind: "scanImportedSupportChanged", support });
+        },
         onStarted: (providers) => {
           // The full provider roster, before any folder lands: it is what
           // keeps the pill row present and stable for the whole scan.

--- a/clients/gui-app/src/components/settings/panels/host-import-migration-section.tsx
+++ b/clients/gui-app/src/components/settings/panels/host-import-migration-section.tsx
@@ -135,8 +135,7 @@ function SessionImportRow(props: {
           </Button>
         }
       />
-      {/* Opens on the host this row named, so the dialog's own picker agrees
-          with the page behind it; the pick can still be changed there. */}
+      {/* The dialog stays bound to the host this Settings page names. */}
       {importOpen ? (
         <SessionImportDialog
           onClose={() => setImportOpen(false)}

--- a/clients/gui-app/src/hooks/session-import/__tests__/use-session-import-check-status-query.test.tsx
+++ b/clients/gui-app/src/hooks/session-import/__tests__/use-session-import-check-status-query.test.tsx
@@ -1,0 +1,234 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { IHostStreamClient } from "@traycer-clients/shared/host-transport/host-stream-client";
+import {
+  HostClient,
+  type HostRequester,
+} from "@traycer-clients/shared/host-client/host-client";
+import {
+  mockLocalHostEntry,
+  mockRemoteHostEntry,
+} from "@traycer-clients/shared/host-client/mock/mock-host-directory";
+import { MockHostMessenger } from "@traycer-clients/shared/host-client/mock/mock-host-messenger";
+import type { ResponseOfMethod } from "@traycer-clients/shared/host-transport/host-messenger";
+import type { HostStreamRpcRegistry } from "@traycer/protocol/host/registry";
+import type { HostRpcRegistry } from "@/lib/host";
+import type { StreamRuntimeBinding } from "@/lib/host/stream-runtime-context";
+import { createRequestContextFixture } from "@traycer-clients/shared/test-fixtures/request-context";
+import { hostRpcRegistry } from "@traycer/protocol/host/index";
+import type { SessionImportStatusResponse } from "@traycer/protocol/host/session-import/contracts";
+import { sessionImportQueryKeys } from "@/lib/query-keys";
+import { useSessionImportCheckStatus } from "../use-session-import-check-status-query";
+
+type StatusResponse = ResponseOfMethod<HostRpcRegistry, "sessionImport.status">;
+
+interface RuntimeHarness {
+  client: HostRequester<HostRpcRegistry> | null;
+  hostId: string;
+}
+
+const runtime = vi.hoisted((): RuntimeHarness => ({
+  client: null,
+  hostId: "host-a",
+}));
+
+vi.mock("@/hooks/host/use-host-client-for-host-id", () => ({
+  useHostClientForHostId: () => runtime.client,
+}));
+
+vi.mock("@/hooks/host/use-reactive-host-readiness", () => ({
+  useReactiveHostReadiness: () => ({
+    hostId: runtime.hostId,
+    requestContextUserId: "test-user",
+    isReady: true,
+    hasRpcEndpoint: true,
+    canExecute: true,
+  }),
+}));
+
+function idleStatus(): SessionImportStatusResponse {
+  return { active: null, lastCompleted: null };
+}
+
+function activeStatus(runId: string): SessionImportStatusResponse {
+  return {
+    active: { runId, done: 1, total: 2 },
+    lastCompleted: null,
+  };
+}
+
+function fakeStreamClient(
+  instanceId: string,
+): IHostStreamClient<HostStreamRpcRegistry> {
+  return {
+    subscribe: () => {
+      throw new Error("stream is not exercised by this hook");
+    },
+    subscribeWithParamsProvider: () => {
+      throw new Error("stream is not exercised by this hook");
+    },
+    close: () => undefined,
+    isClosed: () => false,
+    isReady: () => true,
+    getClosedReason: () => null,
+    onClosed: () => () => undefined,
+    instanceId,
+    notifyBearerRotated: () => undefined,
+    reconnectAll: () => undefined,
+    getMethodSupport: () => "unknown",
+    subscribeMethodSupport: () => () => undefined,
+    getMethodSchemaVersion: () => null,
+    subscribeAvailabilityRecovered: () => () => undefined,
+  };
+}
+
+function binding(hostId: string, instanceId: string): StreamRuntimeBinding {
+  return { wsStreamClient: fakeStreamClient(instanceId), hostId, retain: null };
+}
+
+function createClient(
+  hostId: string,
+  response: () => StatusResponse | Promise<StatusResponse>,
+  onRequest: (hostId: string) => void,
+): HostRequester<HostRpcRegistry> {
+  const entry = {
+    ...(hostId === "host-a" ? mockLocalHostEntry : mockRemoteHostEntry),
+    hostId,
+  };
+  let requestNumber = 0;
+  const messenger = new MockHostMessenger<HostRpcRegistry>({
+    registry: hostRpcRegistry,
+    requestId: () => `status-${hostId}-${String((requestNumber += 1))}`,
+    handlers: {
+      "sessionImport.status": () => {
+        onRequest(hostId);
+        return response();
+      },
+    },
+  });
+  const client = new HostClient<HostRpcRegistry>({
+    registry: hostRpcRegistry,
+    invalidator: { invalidateHostScope: () => undefined },
+    findHostById: (requestedHostId) =>
+      requestedHostId === hostId ? entry : null,
+    messenger,
+  });
+  client.setRequestContext(
+    createRequestContextFixture({ origin: "renderer", bearerToken: "token" }),
+  );
+  return client.createRequester(entry);
+}
+
+function makeWrapper(queryClient: QueryClient) {
+  return ({ children }: { readonly children: ReactNode }): ReactNode => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe("useSessionImportCheckStatus", () => {
+  afterEach(() => {
+    cleanup();
+    runtime.client = null;
+    runtime.hostId = "host-a";
+  });
+
+  it("asks the named host again after a transport switch and ignores a cached Settings idle snapshot", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const responses: StatusResponse[] = [idleStatus()];
+    const requests: string[] = [];
+    let resolveFirst: (response: StatusResponse) => void = () => undefined;
+    const firstResponse = new Promise<StatusResponse>((resolve) => {
+      resolveFirst = resolve;
+    });
+    let requestNumber = 0;
+    runtime.client = createClient(
+      "host-a",
+      () => {
+        if (requestNumber === 0) {
+          requestNumber += 1;
+          return firstResponse;
+        }
+        const response = responses.shift();
+        if (response === undefined) {
+          throw new Error("unexpected status request");
+        }
+        return response;
+      },
+      (requestedHostId) => requests.push(requestedHostId),
+    );
+
+    // This is the Settings query's old shared key. The wizard's useId and
+    // transport instance must keep it from authorizing an idle answer here.
+    queryClient.setQueryData(
+      sessionImportQueryKeys.status("host-a"),
+      idleStatus(),
+    );
+
+    let currentBinding = binding("host-a", "stream-a");
+    const rendered = renderHook(
+      () =>
+        // The hook result remains a complete UseQueryResult, so the test
+        // observes TanStack's real pending/success transitions.
+        useSessionImportCheckStatus(currentBinding, true),
+      { wrapper: makeWrapper(queryClient) },
+    );
+
+    expect(rendered.result.current.isPending).toBe(true);
+    act(() => {
+      resolveFirst(activeStatus("run-from-host"));
+    });
+    await waitFor(() => expect(rendered.result.current.isSuccess).toBe(true));
+    expect(rendered.result.current.data?.active?.runId).toBe("run-from-host");
+
+    act(() => {
+      currentBinding = binding("host-a", "stream-b");
+      rendered.rerender();
+    });
+
+    await waitFor(() => {
+      expect(rendered.result.current.isSuccess).toBe(true);
+      expect(rendered.result.current.data?.active).toBeNull();
+    });
+    expect(requests).toEqual(["host-a", "host-a"]);
+  });
+
+  it("checks the host again when the wizard is reopened", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const requests: string[] = [];
+    runtime.client = createClient(
+      "host-a",
+      () => activeStatus("run-reopened"),
+      (requestedHostId) => requests.push(requestedHostId),
+    );
+    let currentBinding = binding("host-a", "stream-a");
+    const wrapper = makeWrapper(queryClient);
+    const first = renderHook(
+      () => useSessionImportCheckStatus(currentBinding, true),
+      { wrapper },
+    );
+    await waitFor(() => expect(first.result.current.isSuccess).toBe(true));
+    first.unmount();
+
+    // Settings may have a cached idle snapshot between visits. A reopened
+    // wizard gets a new useId and must still observe the host's active run.
+    queryClient.setQueryData(
+      sessionImportQueryKeys.status("host-a"),
+      idleStatus(),
+    );
+    currentBinding = binding("host-a", "stream-a");
+    const reopened = renderHook(
+      () => useSessionImportCheckStatus(currentBinding, true),
+      { wrapper },
+    );
+    await waitFor(() => expect(reopened.result.current.isSuccess).toBe(true));
+
+    expect(reopened.result.current.data?.active?.runId).toBe("run-reopened");
+    expect(requests).toEqual(["host-a", "host-a"]);
+  });
+});

--- a/clients/gui-app/src/hooks/session-import/use-session-import-check-status-query.ts
+++ b/clients/gui-app/src/hooks/session-import/use-session-import-check-status-query.ts
@@ -1,0 +1,27 @@
+import { useId } from "react";
+import type { UseQueryResult } from "@tanstack/react-query";
+import type { HostRpcError } from "@traycer-clients/shared/host-transport/host-messenger";
+import type { SessionImportStatusResponse } from "@traycer/protocol/host/session-import/contracts";
+import { useHostClientForHostId } from "@/hooks/host/use-host-client-for-host-id";
+import { useHostQuery } from "@/hooks/host/use-host-query";
+import type { StreamRuntimeBinding } from "@/lib/host/stream-runtime-context";
+
+/** A fresh check for each wizard opening and transport, before submission. */
+export function useSessionImportCheckStatus(
+  binding: StreamRuntimeBinding | null,
+  enabled: boolean,
+): UseQueryResult<SessionImportStatusResponse, HostRpcError> {
+  const checkId = useId();
+  const hostId = binding?.hostId ?? null;
+  const client = useHostClientForHostId(hostId);
+  return useHostQuery({
+    client: hostId === null ? null : client,
+    method: "sessionImport.status",
+    params: {},
+    // A Settings snapshot must not enable a newly opened wizard. A new
+    // transport must also answer for itself after reconnecting. These keys
+    // still live beneath status(hostId), so completion invalidates them.
+    cacheKeyIdentity: [checkId, binding?.wsStreamClient.instanceId ?? null],
+    options: { enabled, staleTime: 0, gcTime: 0, retry: false },
+  });
+}

--- a/clients/gui-app/src/lib/host/stream-runtime-context.ts
+++ b/clients/gui-app/src/lib/host/stream-runtime-context.ts
@@ -42,10 +42,10 @@ export interface StreamRuntimeBinding {
    * The returned release must be called exactly once, when the run's own need
    * for the transport ends.
    *
-   * `null` when the transport never closes under its consumers - the app-wide
-   * binding, which lives for the window. A `null` here is a promise, not an
-   * absence: it says "nothing to pin", so a caller writes `retain?.()` and is
-   * done rather than guessing which kind of binding it holds.
+   * Both scoped and app-wide transports provide a lease: the app-wide client
+   * can be replaced when the window changes hosts. `null` promises that the
+   * transport cannot close under its consumers. Providers keep this binding
+   * object stable for the lifetime of its client.
    */
   readonly retain: (() => () => void) | null;
 }

--- a/clients/gui-app/src/lib/query-keys/session-import-query-keys.ts
+++ b/clients/gui-app/src/lib/query-keys/session-import-query-keys.ts
@@ -11,6 +11,8 @@ import { hostQueryKeys } from "@/lib/query-keys/host-query-keys";
  * run they were watching finishes, without reaching for a raw array literal.
  */
 export const sessionImportQueryKeys = {
+  openTask: (hostId: string | null) =>
+    ["sessionImport.openTask", hostId] as const,
   status: (hostId: string | null): QueryKey =>
     hostQueryKeys.method<HostRpcRegistry, "sessionImport.status">(
       hostId,

--- a/clients/gui-app/src/lib/tab-navigation.ts
+++ b/clients/gui-app/src/lib/tab-navigation.ts
@@ -613,13 +613,26 @@ export class TabNavigationController {
     options: TabNavigationOptions | undefined,
   ): boolean {
     this.navigator = navigate;
-    if (!this.hydrationReady) return false;
+    if (!this.hydrationReady) {
+      options?.onRejected?.(
+        new Error("The tabs could not be paired. Try again."),
+      );
+      return false;
+    }
     const layoutBefore = currentLayout();
     const focusedRef = command.focusedRef;
     const canonical = this.canonicalIntent(intent, focusedRef);
-    if (canonical === null) return false;
+    if (canonical === null) {
+      options?.onRejected?.(
+        new Error("The tabs could not be paired. Try again."),
+      );
+      return false;
+    }
     const priorRef = backingRefOfLayout(layoutBefore);
     if (priorRef === null || !tabCommandCoordinator.pairTabs(command)) {
+      options?.onRejected?.(
+        new Error("The tabs could not be paired. Try again."),
+      );
       return false;
     }
     const replace =

--- a/clients/gui-app/src/lib/tab-navigation.ts
+++ b/clients/gui-app/src/lib/tab-navigation.ts
@@ -108,7 +108,13 @@ export interface TabNavigationLocation {
   readonly search: Readonly<Record<string, unknown>> | undefined;
 }
 
-export type TabNavigationOptions = Pick<NavigateOptions, "replace" | "search">;
+export type TabNavigationOptions = Pick<
+  NavigateOptions,
+  "replace" | "search"
+> & {
+  /** Rejected before navigate runs, including a superseded hydration queue entry. */
+  readonly onRejected?: (error: Error) => void;
+};
 
 export interface TabNavigationDiagnostics {
   readonly pendingTokenCount: number;
@@ -578,10 +584,20 @@ export class TabNavigationController {
   ): boolean {
     this.navigator = navigate;
     if (!this.hydrationReady) {
+      const superseded = this.queuedActivation;
       this.queuedActivation = { navigate, intent, options };
+      superseded?.options?.onRejected?.(
+        new Error("Another task was opened before this task could open."),
+      );
       return true;
     }
-    return this.executeActivation(navigate, intent, options);
+    const accepted = this.executeActivation(navigate, intent, options);
+    if (!accepted) {
+      options?.onRejected?.(
+        new Error("The task could not be opened. Try again."),
+      );
+    }
+    return accepted;
   }
 
   /**
@@ -784,11 +800,16 @@ export class TabNavigationController {
     const queuedActivation = this.queuedActivation;
     this.queuedActivation = null;
     if (queuedActivation !== null) {
-      this.executeActivation(
+      const accepted = this.executeActivation(
         queuedActivation.navigate,
         queuedActivation.intent,
         queuedActivation.options,
       );
+      if (!accepted) {
+        queuedActivation.options?.onRejected?.(
+          new Error("The task could not be opened. Try again."),
+        );
+      }
     }
   }
 

--- a/clients/gui-app/src/lib/tab-navigation/__tests__/navigation-envelope.test.ts
+++ b/clients/gui-app/src/lib/tab-navigation/__tests__/navigation-envelope.test.ts
@@ -21,6 +21,7 @@ import {
 } from "vitest";
 import {
   __resetTabNavigationControllerForTesting,
+  __resetTabNavigationHydrationForTesting,
   activatePreparedPairTabIntent,
   activateTabIntent,
   getTabNavigationDiagnostics,
@@ -1747,6 +1748,7 @@ describe("activateTabIntent / navigateToTabIntent seam", () => {
       systemTabs: { history: null, settings: null },
     });
     const nav = makeDeferredNavigate();
+    const onRejected = vi.fn();
 
     expect(
       activatePreparedPairTabIntent(
@@ -1759,10 +1761,11 @@ describe("activateTabIntent / navigateToTabIntent seam", () => {
           leftRatio: 0.5,
         },
         epicIntent("epic-b", b.tabId),
-        undefined,
+        { onRejected },
       ),
     ).toBe(true);
 
+    expect(onRejected).not.toHaveBeenCalled();
     expect(nav.calls[0]?.replace).not.toBe(true);
     expect(nav.envelopeAt(0).intentKind).toBe("activate-push");
     expect(focusedRefKey()).toBe(tabRefKey(b.ref));
@@ -1784,6 +1787,149 @@ describe("activateTabIntent / navigateToTabIntent seam", () => {
       index: 0,
     });
     expect(focusedRefKey()).toBe(tabRefKey(a.ref));
+  });
+
+  it("rejects prepared pairing before hydration without navigating", () => {
+    const a = openEpic("epic-a", "A");
+    const b = openEpic("epic-b", "B");
+    seedCommittedLayout({
+      version: 2,
+      items: [
+        { kind: "tab", id: tabItemId(a.ref), ref: a.ref },
+        { kind: "tab", id: tabItemId(b.ref), ref: b.ref },
+      ],
+      activeItemId: tabItemId(a.ref),
+      systemTabs: { history: null, settings: null },
+    });
+    __resetTabNavigationHydrationForTesting();
+    const nav = makeDeferredNavigate();
+    const onRejected = vi.fn();
+
+    expect(
+      activatePreparedPairTabIntent(
+        nav.asNavigate,
+        {
+          left: a.ref,
+          right: b.ref,
+          focusedRef: b.ref,
+          splitId: "split-ab",
+          leftRatio: 0.5,
+        },
+        epicIntent("epic-b", b.tabId),
+        { onRejected },
+      ),
+    ).toBe(false);
+
+    expect(onRejected).toHaveBeenCalledTimes(1);
+    expect(onRejected).toHaveBeenCalledWith(
+      new Error("The tabs could not be paired. Try again."),
+    );
+    expect(nav.calls).toHaveLength(0);
+  });
+
+  it("rejects prepared pairing when the intent cannot be canonicalized", () => {
+    const a = openEpic("epic-a", "A");
+    const b = openEpic("epic-b", "B");
+    seedCommittedLayout({
+      version: 2,
+      items: [
+        { kind: "tab", id: tabItemId(a.ref), ref: a.ref },
+        { kind: "tab", id: tabItemId(b.ref), ref: b.ref },
+      ],
+      activeItemId: tabItemId(a.ref),
+      systemTabs: { history: null, settings: null },
+    });
+    const nav = makeDeferredNavigate();
+    const onRejected = vi.fn();
+
+    expect(
+      activatePreparedPairTabIntent(
+        nav.asNavigate,
+        {
+          left: a.ref,
+          right: b.ref,
+          focusedRef: b.ref,
+          splitId: "split-ab",
+          leftRatio: 0.5,
+        },
+        newDraftTabIntent(null),
+        { onRejected },
+      ),
+    ).toBe(false);
+
+    expect(onRejected).toHaveBeenCalledTimes(1);
+    expect(onRejected).toHaveBeenCalledWith(
+      new Error("The tabs could not be paired. Try again."),
+    );
+    expect(nav.calls).toHaveLength(0);
+  });
+
+  it("rejects prepared pairing when there is no prior backing member", () => {
+    const a = openEpic("epic-a", "A");
+    const b = openEpic("epic-b", "B");
+    seedCommittedLayout({
+      version: 2,
+      items: [],
+      activeItemId: null,
+      systemTabs: { history: null, settings: null },
+    });
+    const nav = makeDeferredNavigate();
+    const onRejected = vi.fn();
+
+    expect(
+      activatePreparedPairTabIntent(
+        nav.asNavigate,
+        {
+          left: a.ref,
+          right: b.ref,
+          focusedRef: b.ref,
+          splitId: "split-ab",
+          leftRatio: 0.5,
+        },
+        epicIntent("epic-b", b.tabId),
+        { onRejected },
+      ),
+    ).toBe(false);
+
+    expect(onRejected).toHaveBeenCalledTimes(1);
+    expect(onRejected).toHaveBeenCalledWith(
+      new Error("The tabs could not be paired. Try again."),
+    );
+    expect(nav.calls).toHaveLength(0);
+  });
+
+  it("rejects prepared pairing when the pair command is refused", () => {
+    const a = openEpic("epic-a", "A");
+    const b = openEpic("epic-b", "B");
+    seedCommittedLayout({
+      version: 2,
+      items: [{ kind: "tab", id: tabItemId(a.ref), ref: a.ref }],
+      activeItemId: tabItemId(a.ref),
+      systemTabs: { history: null, settings: null },
+    });
+    const nav = makeDeferredNavigate();
+    const onRejected = vi.fn();
+
+    expect(
+      activatePreparedPairTabIntent(
+        nav.asNavigate,
+        {
+          left: a.ref,
+          right: b.ref,
+          focusedRef: b.ref,
+          splitId: "split-ab",
+          leftRatio: 0.5,
+        },
+        epicIntent("epic-b", b.tabId),
+        { onRejected },
+      ),
+    ).toBe(false);
+
+    expect(onRejected).toHaveBeenCalledTimes(1);
+    expect(onRejected).toHaveBeenCalledWith(
+      new Error("The tabs could not be paired. Try again."),
+    );
+    expect(nav.calls).toHaveLength(0);
   });
 
   it("rejected prepared pairing retains members but restores the prior owner", async () => {

--- a/clients/gui-app/src/lib/tab-navigation/__tests__/tab-navigation-adversarial.test.ts
+++ b/clients/gui-app/src/lib/tab-navigation/__tests__/tab-navigation-adversarial.test.ts
@@ -1220,6 +1220,95 @@ describe("adversarial navigation: permanent observer & hydration queue", () => {
     expect(requireSerial(nav.lastEnvelope())).toBeGreaterThan(0);
   });
 
+  it("rejects a superseded pre-hydration activation before navigating it", () => {
+    const a = openEpic("epic-a", "A");
+    const b = openEpic("epic-b", "B");
+    seedCommittedLayout({
+      version: 2,
+      items: [
+        { kind: "tab", id: tabItemId(a.ref), ref: a.ref },
+        { kind: "tab", id: tabItemId(b.ref), ref: b.ref },
+      ],
+      activeItemId: tabItemId(a.ref),
+      systemTabs: { history: null, settings: null },
+    });
+    const navA = makeDeferredNavigate();
+    const navB = makeDeferredNavigate();
+    const onARejected = vi.fn();
+    const onBRejected = vi.fn();
+
+    activateTabIntent(navA.asNavigate, epicIntent("epic-a", a.tabId), {
+      onRejected: onARejected,
+    });
+    activateTabIntent(navB.asNavigate, epicIntent("epic-b", b.tabId), {
+      onRejected: onBRejected,
+    });
+
+    expect(onARejected).toHaveBeenCalledTimes(1);
+    expect(onARejected.mock.calls[0]?.[0]).toEqual(
+      new Error("Another task was opened before this task could open."),
+    );
+    expect(navA.calls).toHaveLength(0);
+    expect(navB.calls).toHaveLength(0);
+
+    releaseHydration(navB.asNavigate);
+
+    expect(navA.calls).toHaveLength(0);
+    expect(navB.calls).toHaveLength(1);
+    expect(onBRejected).not.toHaveBeenCalled();
+    expect(navB.lastEnvelope().targetRefKey).toBe(tabRefKey(b.ref));
+  });
+
+  it("reports an invalid queued activation after hydration releases it", () => {
+    const first = openEpic("epic-phase", "Phase Epic");
+    const second = openEpic("epic-phase", "Phase Epic other tab");
+    seedCommittedLayout({
+      version: 2,
+      items: [
+        { kind: "tab", id: tabItemId(first.ref), ref: first.ref },
+        { kind: "tab", id: tabItemId(second.ref), ref: second.ref },
+      ],
+      activeItemId: tabItemId(first.ref),
+      systemTabs: { history: null, settings: null },
+    });
+    const unsubscribeRace = tabCommandCoordinator.subscribe(() => {
+      const current = useEpicCanvasStore.getState().tabsById[first.tabId];
+      if (current?.epicId === "epic-phase") {
+        resolveTabEpicIdentity(first.tabId, "epic-phase", "epic-racer");
+      }
+    });
+    onTestFinished(unsubscribeRace);
+    const nav = makeDeferredNavigate();
+    const onRejected = vi.fn();
+
+    expect(
+      activateTabIntent(
+        nav.asNavigate,
+        completeEpicMigrationIntent({
+          sourceEpicId: "epic-phase",
+          epicId: "epic-migrated",
+          tabId: first.tabId,
+          focus: {
+            focusedAt: 123,
+            focusArtifactId: undefined,
+            focusThreadId: undefined,
+            migrationSource: undefined,
+          },
+          nestedFocus: null,
+        }),
+        { replace: true, onRejected },
+      ),
+    ).toBe(true);
+    expect(nav.calls).toHaveLength(0);
+
+    releaseHydration(nav.asNavigate);
+
+    expect(onRejected).toHaveBeenCalledWith(
+      new Error("The task could not be opened. Try again."),
+    );
+    expect(nav.calls).toHaveLength(0);
+  });
+
   it("pre-hydration /draft/new creates and routes one draft only after hydration", () => {
     const nav = makeDeferredNavigate();
     const location = {
@@ -2252,6 +2341,7 @@ describe("adversarial navigation: Resource Monitor nested + Phase completion", (
     });
     onTestFinished(unsubscribeRace);
 
+    const onRejected = vi.fn();
     let result: boolean | undefined;
     expect(() => {
       result = activateTabIntent(
@@ -2268,10 +2358,13 @@ describe("adversarial navigation: Resource Monitor nested + Phase completion", (
           },
           nestedFocus: null,
         }),
-        { replace: true },
+        { replace: true, onRejected },
       );
     }).not.toThrow();
     expect(result).toBe(false);
+    expect(onRejected).toHaveBeenCalledWith(
+      new Error("The task could not be opened. Try again."),
+    );
     expect(nav.calls.length).toBe(0);
     expect(useEpicCanvasStore.getState().tabsById[first.tabId]?.epicId).toBe(
       "epic-racer",

--- a/clients/shared/host-transport/__tests__/session-import-scan-client.test.ts
+++ b/clients/shared/host-transport/__tests__/session-import-scan-client.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it, vi, type Mock } from "vitest";
+import type { SchemaVersion } from "@traycer/protocol/framework/versioned-stream-rpc";
+import { hostStreamRpcRegistry } from "@traycer/protocol/host/registry";
+import type {
+  IStreamSession,
+  ServerFrameHandler,
+  StatusChangeHandler,
+  StreamCloseReason,
+} from "../i-stream-session";
+import { SessionImportScanClient } from "../session-import-scan-client";
+import {
+  prepareStreamSubscribeRequest,
+  WsStreamClient,
+} from "../ws-stream-client";
+import { NO_TRANSPORT_EVIDENCE } from "@traycer-clients/shared/host-selection/transport-evidence";
+import { TEST_CLIENT_IDENTITY } from "@traycer-clients/shared/test-fixtures/client-identity";
+
+class StubSession implements IStreamSession {
+  private serverFrameHandler: ServerFrameHandler = () => undefined;
+  private statusChangeHandler: StatusChangeHandler = () => undefined;
+  negotiatedSchemaVersion: SchemaVersion | null = null;
+
+  readonly close = vi.fn();
+
+  sendClientFrame(): void {}
+
+  onServerFrame(handler: ServerFrameHandler): void {
+    this.serverFrameHandler = handler;
+  }
+
+  onStatusChange(handler: StatusChangeHandler): void {
+    this.statusChangeHandler = handler;
+  }
+
+  getNegotiatedSchemaVersion(): SchemaVersion | null {
+    return this.negotiatedSchemaVersion;
+  }
+
+  requestReconnect(): void {}
+
+  emitFrame(frame: Parameters<ServerFrameHandler>[0]): void {
+    this.serverFrameHandler(frame, null);
+  }
+
+  emitStatus(
+    status: Parameters<StatusChangeHandler>[0],
+    reason: StreamCloseReason | null,
+  ): void {
+    this.statusChangeHandler(status, reason);
+  }
+}
+
+function makeWsStreamClient(
+  session: IStreamSession,
+): WsStreamClient<typeof hostStreamRpcRegistry> {
+  const client = new WsStreamClient({
+    clientIdentity: TEST_CLIENT_IDENTITY,
+    registry: hostStreamRpcRegistry,
+    endpoint: () => null,
+    hostId: null,
+    bearer: () => null,
+    auth: null,
+    clock: null,
+    hostCredentialMint: null,
+    onHostCredentialState: null,
+    evidence: NO_TRANSPORT_EVIDENCE,
+    webSocketFactory: {
+      create: () => {
+        throw new Error("unexpected WebSocket creation");
+      },
+    },
+    dialTimeoutMs: 1_000,
+    openAckTimeoutMs: 1_000,
+    pingIntervalMs: 25_000,
+    pongTimeoutMs: 50_000,
+    initialBackoffMs: 10,
+    maxBackoffMs: 1_000,
+  });
+  vi.spyOn(client, "subscribe").mockReturnValue(session);
+  return client;
+}
+
+function harness(): {
+  readonly session: StubSession;
+  readonly client: SessionImportScanClient;
+  readonly onImportedSupport: Mock;
+  readonly onConnectionStatus: Mock;
+} {
+  const session = new StubSession();
+  const wsStreamClient = makeWsStreamClient(session);
+  const onImportedSupport = vi.fn();
+  const onConnectionStatus = vi.fn();
+  const client = new SessionImportScanClient({
+    wsStreamClient,
+    providers: null,
+    updatedAfter: null,
+    callbacks: {
+      onImportedSupport,
+      onStarted: vi.fn(),
+      onGroup: vi.fn(),
+      onProviderFailed: vi.fn(),
+      onComplete: vi.fn(),
+      onConnectionStatus,
+    },
+  });
+  return { session, client, onImportedSupport, onConnectionStatus };
+}
+
+describe("SessionImportScanClient imported-row compatibility", () => {
+  it.each([
+    {
+      label: "client 1.0 and host 1.0",
+      client: { major: 1, minor: 0 },
+      host: { major: 1, minor: 0 },
+      wire: { major: 1, minor: 0 },
+    },
+    {
+      label: "client 1.0 and host 1.1",
+      client: { major: 1, minor: 0 },
+      host: { major: 1, minor: 1 },
+      wire: { major: 1, minor: 0 },
+    },
+    {
+      label: "client 1.1 and host 1.0",
+      client: { major: 1, minor: 1 },
+      host: { major: 1, minor: 0 },
+      wire: { major: 1, minor: 0 },
+    },
+    {
+      label: "client 1.1 and host 1.1",
+      client: { major: 1, minor: 1 },
+      host: { major: 1, minor: 1 },
+      wire: { major: 1, minor: 1 },
+    },
+  ])(
+    "keeps the scan request payload stable for $label",
+    ({ client, host, wire }) => {
+      const params = { providers: ["claude"], updatedAfter: null };
+      const prepared = prepareStreamSubscribeRequest(
+        hostStreamRpcRegistry,
+        "sessionImport.scan",
+        client,
+        host,
+        params,
+      );
+
+      expect(prepared.onWireVersion).toEqual(wire);
+      expect(prepared.onWirePayload).toEqual(params);
+    },
+  );
+
+  it("reports unknown until negotiation, then supports scan 1.1 and resets to unknown after disconnect", () => {
+    const h = harness();
+
+    h.session.emitStatus("connecting", null);
+    expect(h.onImportedSupport).not.toHaveBeenCalled();
+
+    h.session.negotiatedSchemaVersion = { major: 1, minor: 1 };
+    h.session.emitFrame({ kind: "pong", hasBinaryPayload: false });
+    expect(h.onImportedSupport).toHaveBeenLastCalledWith("supported");
+
+    h.session.negotiatedSchemaVersion = null;
+    const reason: StreamCloseReason = { kind: "caller" };
+    h.session.emitStatus("closed", reason);
+    expect(h.onImportedSupport).toHaveBeenLastCalledWith("unknown");
+    expect(h.onConnectionStatus).toHaveBeenCalledWith("closed", reason);
+
+    h.client.close();
+  });
+
+  it("reports 1.0 as unsupported and does not confuse another minor with support", () => {
+    const h = harness();
+
+    h.session.negotiatedSchemaVersion = { major: 1, minor: 0 };
+    h.session.emitFrame({ kind: "pong", hasBinaryPayload: false });
+    expect(h.onImportedSupport).toHaveBeenLastCalledWith("unsupported");
+
+    h.session.negotiatedSchemaVersion = { major: 2, minor: 1 };
+    h.session.emitFrame({ kind: "pong", hasBinaryPayload: false });
+    expect(h.onImportedSupport).toHaveBeenLastCalledWith("unsupported");
+
+    h.client.close();
+  });
+
+  it("resets support during a reconnect and reports upgraded host support", () => {
+    const h = harness();
+
+    h.session.negotiatedSchemaVersion = { major: 1, minor: 0 };
+    h.session.emitFrame({ kind: "pong", hasBinaryPayload: false });
+    expect(h.onImportedSupport).toHaveBeenLastCalledWith("unsupported");
+
+    h.session.negotiatedSchemaVersion = null;
+    h.session.emitStatus("reconnecting", null);
+    expect(h.onImportedSupport).toHaveBeenLastCalledWith("unknown");
+
+    h.session.negotiatedSchemaVersion = { major: 1, minor: 1 };
+    h.session.emitFrame({ kind: "pong", hasBinaryPayload: false });
+    expect(h.onImportedSupport).toHaveBeenLastCalledWith("supported");
+
+    h.client.close();
+  });
+});

--- a/clients/shared/host-transport/session-import-scan-client.ts
+++ b/clients/shared/host-transport/session-import-scan-client.ts
@@ -17,6 +17,11 @@ import type {
 } from "./i-stream-session";
 import type { IStreamClient } from "./i-stream-client";
 
+export type SessionImportImportedSupport =
+  | "unknown"
+  | "supported"
+  | "unsupported";
+
 export interface SessionImportProviderFailure {
   readonly harness: GuiHarnessId;
   readonly reason: SessionImportFailureReason;
@@ -29,6 +34,7 @@ export interface SessionImportProviderFailure {
  * there is no upstream API on the wrapper.
  */
 export interface SessionImportScanCallbacks {
+  readonly onImportedSupport: (support: SessionImportImportedSupport) => void;
   readonly onStarted: (providers: ReadonlyArray<GuiHarnessId>) => void;
   readonly onGroup: (group: SessionImportGroup) => void;
   readonly onProviderFailed: (failure: SessionImportProviderFailure) => void;
@@ -61,6 +67,7 @@ export class SessionImportScanClient {
   private readonly session: IStreamSession;
   private readonly callbacks: SessionImportScanCallbacks;
   private closed: boolean;
+  private importedSupport: SessionImportImportedSupport = "unknown";
 
   constructor(options: SessionImportScanClientOptions) {
     this.callbacks = options.callbacks;
@@ -74,6 +81,7 @@ export class SessionImportScanClient {
       this.handleServerFrame(envelope, binaryPayload);
     });
     this.session.onStatusChange((status, reason) => {
+      this.updateImportedSupport();
       this.callbacks.onConnectionStatus(status, reason);
     });
   }
@@ -87,10 +95,26 @@ export class SessionImportScanClient {
     this.session.close();
   }
 
+  private updateImportedSupport(): void {
+    // Per-session negotiation works on both local and remote transports, and
+    // resets to unknown on reconnect (which may reach an upgraded host).
+    const version = this.session.getNegotiatedSchemaVersion();
+    const support: SessionImportImportedSupport =
+      version === null
+        ? "unknown"
+        : version.major === 1 && version.minor >= 1
+          ? "supported"
+          : "unsupported";
+    if (support === this.importedSupport) return;
+    this.importedSupport = support;
+    this.callbacks.onImportedSupport(support);
+  }
+
   private handleServerFrame(
     envelope: StreamFrameEnvelope,
     _binaryPayload: Uint8Array | null,
   ): void {
+    this.updateImportedSupport();
     const parsed = sessionImportScanServerFrameSchema.safeParse(envelope);
     if (!parsed.success) {
       return;

--- a/protocol/src/host/registry.ts
+++ b/protocol/src/host/registry.ts
@@ -594,7 +594,10 @@ import {
   migrationRunV10,
   phaseMigrateToEpicV10,
 } from "@traycer/protocol/host/migration/contracts";
-import { sessionImportScanV10 } from "@traycer/protocol/host/session-import/scan";
+import {
+  sessionImportScanV10,
+  sessionImportScanV11,
+} from "@traycer/protocol/host/session-import/scan";
 import { sessionImportRunV10 } from "@traycer/protocol/host/session-import/run";
 import { sessionImportStatusV10 } from "@traycer/protocol/host/session-import/contracts";
 import {
@@ -9324,10 +9327,13 @@ const HOST_STREAM_RPC_REGISTRY_OTHER_DEFINITION = {
   // nothing to fall back to and nothing lost by its absence.
   "sessionImport.scan": {
     1: {
-      latestMinor: 0,
+      latestMinor: 1,
       versions: {
         0: {
           contract: sessionImportScanV10,
+        },
+        1: {
+          contract: sessionImportScanV11,
         },
       },
     },

--- a/protocol/src/host/session-import/__tests__/session-import-contracts.test.ts
+++ b/protocol/src/host/session-import/__tests__/session-import-contracts.test.ts
@@ -3,6 +3,7 @@ import {
   sessionImportScanClientFrameSchema,
   sessionImportScanServerFrameSchema,
   sessionImportScanV10,
+  sessionImportScanV11,
 } from "@traycer/protocol/host/session-import/scan";
 import {
   sessionImportRunClientFrameSchema,
@@ -614,12 +615,14 @@ describe("sessionImport.status@1.0", () => {
  * feature the wire cannot carry, and nothing else in the suite would notice.
  */
 describe("sessionImport.* registry membership", () => {
-  it("registers both stream methods at minor 0 with a per-method degrade", () => {
+  it("registers scan at minors 0 and 1, retaining the v1.0 contract for older hosts", () => {
     const scan = hostStreamRpcRegistry["sessionImport.scan"];
     expect(scan).toBeDefined();
-    expect(scan[1].latestMinor).toBe(0);
+    expect(scan[1].latestMinor).toBe(1);
     expect(scan[1].versions[0].contract).toBe(sessionImportScanV10);
+    expect(scan[1].versions[1].contract).toBe(sessionImportScanV11);
     expect(sessionImportScanV10.schemaVersion).toEqual({ major: 1, minor: 0 });
+    expect(sessionImportScanV11.schemaVersion).toEqual({ major: 1, minor: 1 });
 
     const run = hostStreamRpcRegistry["sessionImport.run"];
     expect(run).toBeDefined();

--- a/protocol/src/host/session-import/candidate.ts
+++ b/protocol/src/host/session-import/candidate.ts
@@ -84,11 +84,10 @@ export type SessionImportUnreadableReason = z.infer<
 /**
  * Why a discovered session cannot be offered as-is.
  *
- * `already_in_traycer` is legacy: current hosts hide an already-imported
- * session from the scan entirely (the native-session index is what enforces
- * import-once, so the wizard's second visit shows only what is new). The
- * variant stays in the schema because an older host still emits it, and a
- * client must be able to parse - and then discard - those rows.
+ * `already_in_traycer` names an imported chat that still exists. Scan @1.1
+ * includes these rows for browsing; @1.0 retains its filtering behavior.
+ * The native-session index continues to enforce import-once independently
+ * of whether a client displays the row.
  *
  * `unreadable` carries the same closed reason + free-text `detail` pair the
  * run reports, so a session that fails at discovery and one that fails at

--- a/protocol/src/host/session-import/scan.ts
+++ b/protocol/src/host/session-import/scan.ts
@@ -120,3 +120,16 @@ export const sessionImportScanV10 = defineStreamRpcContract({
   serverFrameSchema: sessionImportScanServerFrameSchema,
   clientFrameSchema: sessionImportScanClientFrameSchema,
 });
+
+/**
+ * @1.1 includes live imported sessions as `already_in_traycer` candidates.
+ * The payload shapes are unchanged: the negotiated minor is the capability
+ * signal. Hosts retain @1.0 filtering and totals for older subscribers.
+ */
+export const sessionImportScanV11 = defineStreamRpcContract({
+  method: "sessionImport.scan",
+  schemaVersion: { major: 1, minor: 1 } as const,
+  openRequestSchema: sessionImportScanOpenRequestSchema,
+  serverFrameSchema: sessionImportScanServerFrameSchema,
+  clientFrameSchema: sessionImportScanClientFrameSchema,
+});


### PR DESCRIPTION
## Summary

The import wizard hides native sessions as soon as they have been imported, making them hard to find again. Add a **Show imported** switch that reveals them in their existing folders with an Imported badge and an icon-only Open task action. Imported rows cannot be selected; folder counts stay simple and selection details remain available in tooltips. Tasks that recover from an unreadable state on reconnect are preselected, while deliberate deselections and provider/folder exclusions are preserved. Timestamps align across rows and imported titles/icons are subtly dimmed.

Remove the redundant host selector and keep the wizard bound to its opening host. Opening a task verifies it still exists on that host and completes onboarding first when needed. If another activation replaces a queued task open during hydration, the earlier request is rejected so its button can leave the pending state and retry. Prepared tab-pair activations also report every rejection before navigation through the shared callback.

Before enabling Import, check the wizard's selected host for an active run using a fresh status query. Attach to existing runs without submitting selections, retain their transport across host changes, and recover if a run finishes between the status reply and attachment. These edge-case fixes are integrated from `codex/session-import-edge-cases`.

Register `sessionImport.scan@1.1` while retaining `@1.0`. The client uses the scan session's negotiated version to enable Show imported. Older hosts retain normal import behavior with an update-host tooltip on the unavailable switch; older clients continue to negotiate `@1.0`.

## Related issue

Companion host PR: https://github.com/traycerai/traycer-internal/pull/5550. Merge this PR first; the host PR pins this protocol change.

## Validation

- Targeted wizard/model/dialog/open-task, shared transport compatibility, and protocol contract tests passed.
- After the visual polish, the 30 wizard and open-task tests passed again; changed-component lint and GUI type checks passed.
- Navigation review follow-up: 53 tests passed across the controller and open-task button suites; changed-production-file React Doctor passed.
- Edge-case integration: 53 tests passed across wizard, run-controller, onboarding mount, and fresh-status-query suites. React Doctor reports three maintainability warnings (memoization and wizard complexity), with no correctness errors.
- Pairing/recovered-selection review fixes: 94 tests passed across navigation-envelope and import-model suites; changed-production-file React Doctor passed.
- User manually tested and approved the Show imported UI before the subsequent edge-case and review fixes.
- React Doctor reports existing findings outside the visual changes, including wizard complexity/manual memoization warnings.

## Checklist

- [x] Pre-commit static checks pass (affected lint, format, compile, and build)
- [ ] Separate CI test checks pass
- [x] Tests added/updated where it makes sense
- [x] Commits are signed off (`git commit -s`) per the DCO
