### PR TITLE
feat(protocol,gui-app): Received message card jumps to the sender's Sent card via the A2A receipt

### DIFF
--- a/clients/gui-app/src/components/chat/__tests__/chat-message-user-body.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/chat-message-user-body.test.tsx
@@ -24,6 +24,10 @@ import type { ChatMessage as ChatMessageModel } from "@/stores/composer/chat-sto
 import type { ChatMessageUserActions } from "@/components/chat/chat-message";
 import { useSetA2AReceivedOpen } from "@/stores/chats/a2a-open-store-context";
 import {
+  chatTranscriptJumpKey,
+  useChatTranscriptJumpStore,
+} from "@/stores/chats/chat-transcript-jump-store";
+import {
   useChatCollapsibleTileInstanceId,
   useSetChatFindForcedOpen,
 } from "@/stores/chats/chat-find-force-store-context";
@@ -112,16 +116,37 @@ function render(ui: ReactNode) {
 }
 
 vi.mock("@/lib/epic-selectors", () => ({
-  useEpicArtifact: (artifactId: string | null) =>
-    artifactId === "agent-sender-1"
-      ? {
-          id: "agent-sender-1",
-          parentId: null,
-          title: "Review Agent",
-          hostId: "host-1",
-        }
-      : null,
+  useEpicArtifact: (artifactId: string | null) => {
+    if (artifactId === "agent-sender-1") {
+      return {
+        id: "agent-sender-1",
+        parentId: null,
+        title: "Review Agent",
+        hostId: "host-1",
+      };
+    }
+    // A terminal-agent (TUI) sender: distinguished from a chat/artifact node
+    // by carrying `harnessId` - see `AgentMessageDisplayView`'s `openTarget`
+    // resolution in chat-message-user-body.tsx.
+    if (artifactId === "agent-sender-terminal") {
+      return {
+        id: "agent-sender-terminal",
+        harnessId: "claude",
+        hostId: "host-2",
+        title: "Terminal Agent",
+      };
+    }
+    return null;
+  },
   useOpenEpicId: () => "epic-1",
+}));
+
+const tileNavigationMocks = vi.hoisted(() => ({
+  openTile: vi.fn(() => null),
+}));
+
+vi.mock("@/hooks/epic/use-epic-tile-navigation", () => ({
+  useEpicTileNavigation: () => ({ openTile: tileNavigationMocks.openTile }),
 }));
 
 vi.mock("@/hooks/host/use-tab-host-client", () => ({
@@ -291,6 +316,8 @@ describe("<UserMessageBody /> agent messages", () => {
 
     composerPickerMocks.useComposerPickerItems.mockClear();
     useWorkspaceFoldersStore.setState({ byHost: {} });
+    tileNavigationMocks.openTile.mockClear();
+    useChatTranscriptJumpStore.setState({ requestsByChatId: {} });
   });
 
   it("reveals the action chip for keyboard focus", () => {
@@ -892,6 +919,47 @@ describe("<UserMessageBody /> agent messages", () => {
         .closest(".md-prose")
         ?.hasAttribute("data-quotable"),
     ).toBe(false);
+  });
+
+  it("parks a receipt jump for the sender's chat tile when the sender name is clicked", () => {
+    const message = agentMessage("Investigate this failure.");
+    render(<UserMessageBody actions={null} message={message} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Review Agent" }));
+
+    expect(tileNavigationMocks.openTile).toHaveBeenCalledTimes(1);
+    const state = useChatTranscriptJumpStore.getState();
+    const key = chatTranscriptJumpKey("host-1", "agent-sender-1");
+    expect(state.requestsByChatId[key]?.target).toEqual({
+      kind: "receipt",
+      messageId: message.id,
+    });
+  });
+
+  it("opens the tile but parks no jump when the sender resolves to a terminal agent", () => {
+    const message: ChatMessageModel = {
+      ...agentMessage("Investigate this failure."),
+      agentSenderInfo: {
+        agentId: "agent-sender-terminal",
+        senderTitle: "Terminal Agent",
+        expectReply: true,
+        responseId: "response-1",
+      },
+      agentMessage: {
+        kind: "agent",
+        content: AGENT_CONTENT,
+        fromAgentId: "agent-sender-terminal",
+        senderTitle: "Terminal Agent",
+        senderHarnessId: "claude",
+        reply: { expectsReply: true, responseId: "response-1" },
+      },
+    };
+    render(<UserMessageBody actions={null} message={message} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Terminal Agent" }));
+
+    expect(tileNavigationMocks.openTile).toHaveBeenCalledTimes(1);
+    expect(useChatTranscriptJumpStore.getState().requestsByChatId).toEqual({});
   });
 
   it("opens received A2A cards through the provider store", () => {

--- a/clients/gui-app/src/components/chat/chat-message-user-body.tsx
+++ b/clients/gui-app/src/components/chat/chat-message-user-body.tsx
@@ -56,6 +56,7 @@ import {
 } from "@/lib/composer/image-atoms";
 import { stringValue } from "@/lib/composer/tiptap-json-content";
 import { useEpicArtifact, useOpenEpicId } from "@/lib/epic-selectors";
+import { useChatTranscriptJumpStore } from "@/stores/chats/chat-transcript-jump-store";
 import { cn, formatSingleLine } from "@/lib/utils";
 import { deriveA2AReceivedCollapsibleKey } from "@/components/chat/chat-collapsible-key";
 import {
@@ -264,6 +265,7 @@ function AgentMessageDisplayView({
   const expectReply =
     agentMessage?.reply.expectsReply ?? agentSenderInfo.expectReply;
 
+  const requestJump = useChatTranscriptJumpStore((s) => s.requestJump);
   const openSenderTab = useCallback(() => {
     if (openTarget === null) return;
     openTile(
@@ -280,7 +282,26 @@ function AgentMessageDisplayView({
         "direct_ui",
       ),
     );
-  }, [agentSenderInfo.agentId, epicId, openTarget, senderName, openTile]);
+    // Mirror of the sent card's receiver link: park a jump for the sender's
+    // tile, which picks it up whether it is already mounted or is being
+    // opened by the call above. This row's own id IS the receipt the sender's
+    // harness stamped on its send block, so the landing is the exact "Sent
+    // message" card. A terminal-agent sender has no transcript, and a send
+    // persisted before receipts existed just leaves the tile open at rest.
+    if (openTarget.type !== "chat") return;
+    requestJump(openTarget.hostId, agentSenderInfo.agentId, {
+      kind: "receipt",
+      messageId,
+    });
+  }, [
+    agentSenderInfo.agentId,
+    epicId,
+    messageId,
+    openTarget,
+    openTile,
+    requestJump,
+    senderName,
+  ]);
 
   // Same shape as the sent card's header (`A2ASendToolSegment`): the sender
   // name is the only element allowed to shrink, so the direction words are

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/chat-tile-jump-locator.test.ts
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/chat-tile-jump-locator.test.ts
@@ -3,8 +3,14 @@ import type { RowSkeletonEntry } from "@traycer/protocol/persistence/chat-transc
 import {
   coldJumpOrdinal,
   hostLocatorForJumpTarget,
+  receiptAnchorBlockId,
 } from "@/components/epic-canvas/renderers/chat-tile-jump-logic";
-import type { ChatMessage } from "@/stores/composer/chat-store";
+import type {
+  ChatMessage,
+  MessageSegment,
+  SubagentSegment,
+  ToolSegment,
+} from "@/stores/composer/chat-store";
 import {
   emptyTranscriptWindow,
   type TranscriptWindow,
@@ -70,6 +76,200 @@ function renderedRow(input: {
     steerBadge: null,
   };
 }
+
+/** Only the fields either resolver reads; the rest is inert scaffolding. */
+function toolSegment(input: {
+  readonly id: string;
+  readonly agentMessageReceipt: { readonly messageId: string } | null;
+}): ToolSegment {
+  return {
+    id: input.id,
+    kind: "tool",
+    toolName: "traycer_send_message",
+    inputSummary: null,
+    inputDetail: null,
+    taskTodoItems: null,
+    error: null,
+    agentMessageSend: null,
+    managedCommand: null,
+    agentMessageReceipt:
+      input.agentMessageReceipt === null
+        ? null
+        : {
+            receiverAgentId: "receiver-1",
+            messageId: input.agentMessageReceipt.messageId,
+          },
+    isStreaming: false,
+    endState: null,
+    stopped: false,
+    progress: null,
+    backgroundOutput: null,
+    backgroundTask: null,
+    startedAt: 0,
+    durationMs: null,
+    parentId: null,
+    imageResults: [],
+  };
+}
+
+function subagentSegment(input: {
+  readonly id: string;
+  readonly children: ReadonlyArray<ToolSegment>;
+}): SubagentSegment {
+  return {
+    id: input.id,
+    kind: "subagent",
+    name: null,
+    agentType: null,
+    task: null,
+    progressUpdates: [],
+    result: null,
+    isStreaming: false,
+    endState: null,
+    stopped: false,
+    startedAt: null,
+    durationMs: null,
+    spawnToolCallId: null,
+    parentId: null,
+    workflowMeta: null,
+    children: input.children,
+  };
+}
+
+function messageWithSegments(
+  id: string,
+  segments: ReadonlyArray<MessageSegment>,
+): ChatMessage {
+  return {
+    id,
+    role: "assistant",
+    content: "",
+    segments,
+    structuredContent: null,
+    attachments: [],
+    settings: null,
+    createdAt: 1,
+    completedAt: null,
+    stopped: null,
+    persistentMessageId: null,
+    senderLabel: null,
+    assistantMeta: null,
+    statusLabel: null,
+    agentSenderInfo: null,
+    agentMessage: null,
+    runState: null,
+    sessionAnchor: null,
+    steerBadge: null,
+  };
+}
+
+describe("receiptAnchorBlockId", () => {
+  it("finds a top-level tool segment whose receipt names the message", () => {
+    const messages = [
+      messageWithSegments("m-1", [
+        toolSegment({ id: "block-1", agentMessageReceipt: null }),
+        toolSegment({
+          id: "block-2",
+          agentMessageReceipt: { messageId: "m-received" },
+        }),
+      ]),
+    ];
+
+    expect(receiptAnchorBlockId(messages, "m-received")).toBe("block-2");
+  });
+
+  it("finds a receipt nested inside a subagent card's children", () => {
+    const messages = [
+      messageWithSegments("m-1", [
+        subagentSegment({
+          id: "subagent-1",
+          children: [
+            toolSegment({
+              id: "nested-block",
+              agentMessageReceipt: { messageId: "m-received" },
+            }),
+          ],
+        }),
+      ]),
+    ];
+
+    expect(receiptAnchorBlockId(messages, "m-received")).toBe("nested-block");
+  });
+
+  it("returns null when no rendered tool segment carries the receipt", () => {
+    const messages = [
+      messageWithSegments("m-1", [
+        toolSegment({
+          id: "block-1",
+          agentMessageReceipt: { messageId: "some-other-message" },
+        }),
+      ]),
+    ];
+
+    expect(receiptAnchorBlockId(messages, "m-received")).toBeNull();
+  });
+});
+
+describe("hostLocatorForJumpTarget: a `receipt` target", () => {
+  it("asks the host when no rendered tool segment carries the receipt", () => {
+    const locator = hostLocatorForJumpTarget({
+      target: { kind: "receipt", messageId: "m-received" },
+      transcriptWindow: windowNaming(["m-1"]),
+      messages: [],
+    });
+
+    expect(locator).toEqual({ kind: "receipt", messageId: "m-received" });
+  });
+
+  it("does NOT ask once the send block carrying the receipt is rendered", () => {
+    const messages = [
+      messageWithSegments("m-1", [
+        toolSegment({
+          id: "block-1",
+          agentMessageReceipt: { messageId: "m-received" },
+        }),
+      ]),
+    ];
+
+    const locator = hostLocatorForJumpTarget({
+      target: { kind: "receipt", messageId: "m-received" },
+      transcriptWindow: windowNaming(["m-1"]),
+      messages,
+    });
+
+    expect(locator).toBeNull();
+  });
+
+  it("asks for nothing on the legacy line, which holds the whole transcript", () => {
+    const locator = hostLocatorForJumpTarget({
+      target: { kind: "receipt", messageId: "m-received" },
+      transcriptWindow: null,
+      messages: [],
+    });
+
+    expect(locator).toBeNull();
+  });
+});
+
+describe("coldJumpOrdinal: a `receipt` target", () => {
+  const window = windowNaming(["m-1", "m-2"]);
+
+  it("returns the host's answer, mirroring `block` and `sent-message`", () => {
+    expect(
+      coldJumpOrdinal(window, { kind: "receipt", messageId: "m-received" }, 1),
+    ).toBe(1);
+  });
+
+  it("stays null while the host has not answered", () => {
+    expect(
+      coldJumpOrdinal(
+        window,
+        { kind: "receipt", messageId: "m-received" },
+        null,
+      ),
+    ).toBeNull();
+  });
+});
 
 describe("hostLocatorForJumpTarget: a `message` target", () => {
   it("asks the host for an assistant record whose turn-keyed rows are cold", () => {

--- a/clients/gui-app/src/components/epic-canvas/renderers/chat-tile-jump-logic.ts
+++ b/clients/gui-app/src/components/epic-canvas/renderers/chat-tile-jump-logic.ts
@@ -156,6 +156,58 @@ export function sentMessageAnchorId(
 }
 
 /**
+ * Resolves a `receipt` transcript jump: the block id of this chat's own "Sent
+ * message" card whose `agentMessageReceipt` names the delivered message. Exact
+ * where `sentMessageAnchorId` is nearest-by-clock: the receipt is a host-minted
+ * id one delivery owns. `null` when no rendered tool segment carries it - the
+ * row is cold, or the send predates receipts.
+ */
+export function receiptAnchorBlockId(
+  messages: ReadonlyArray<ChatMessageModel>,
+  messageId: string,
+): string | null {
+  const visit = (node: BackgroundBlockSearchNode): string | null => {
+    if (
+      "kind" in node &&
+      node.kind === "tool" &&
+      node.agentMessageReceipt !== null &&
+      node.agentMessageReceipt.messageId === messageId
+    ) {
+      return node.id;
+    }
+    for (const child of backgroundBlockSearchChildren(node)) {
+      const found = visit(child);
+      if (found !== null) return found;
+    }
+    return null;
+  };
+  for (const message of messages) {
+    for (const segment of message.segments) {
+      const found = visit(segment);
+      if (found !== null) return found;
+    }
+  }
+  return null;
+}
+
+/**
+ * The block a jump LANDS ON, for the two kinds that name a card rather than a
+ * row: a `block` target names it outright, a `receipt` target resolves it via
+ * {@link receiptAnchorBlockId}. `null` for every row-landing kind, and for a
+ * receipt no rendered segment carries yet.
+ */
+export function landingBlockIdForJumpTarget(
+  messages: ReadonlyArray<ChatMessageModel>,
+  target: ChatTranscriptJumpTarget,
+): string | null {
+  if (target.kind === "block") return target.blockId;
+  if (target.kind === "receipt") {
+    return receiptAnchorBlockId(messages, target.messageId);
+  }
+  return null;
+}
+
+/**
  * The ordinal a cold jump target sits at. `null` means "nothing to ask for":
  * the legacy line, or a host-locatable target whose answer has not landed.
  *
@@ -175,6 +227,7 @@ export function coldJumpOrdinal(
     // The two whose row id needs rendered models, which a cold row has none of.
     case "block":
     case "sent-message":
+    case "receipt":
       return hostLocatedOrdinal;
     // A message id is a row id for a USER record only. An assistant record is
     // projected into turn-keyed rows and keeps its durable id off the skeleton
@@ -248,6 +301,11 @@ export function hostLocatorForJumpTarget(input: {
           messageText: target.messageText,
           timestamp: target.timestamp,
         }
+      : null;
+  }
+  if (target.kind === "receipt") {
+    return receiptAnchorBlockId(messages, target.messageId) === null
+      ? { kind: "receipt", messageId: target.messageId }
       : null;
   }
   if (target.kind === "message") {

--- a/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
@@ -148,6 +148,7 @@ import {
   coldJumpOrdinal,
   hostLocatorForJumpTarget,
   messageIdForBlock,
+  landingBlockIdForJumpTarget,
   messageIdForTranscriptTarget,
   sentMessageAnchorId,
 } from "@/components/epic-canvas/renderers/chat-tile-jump-logic";
@@ -954,6 +955,10 @@ export function ChatTileSessionView(props: ChatTileSessionViewProps) {
       requestTranscriptOrdinal(null);
       return;
     }
+    // A block or receipt target names a CARD, not a row: resolved once, up
+    // front, because the landing below scrolls to that card rather than to
+    // its owning row.
+    const landingBlockId = landingBlockIdForJumpTarget(view.messages, target);
     const resolveTargetMessageId = (): string | null => {
       if (target.kind === "message") {
         return messageIdForTranscriptTarget(view.messages, target.messageId);
@@ -987,7 +992,9 @@ export function ChatTileSessionView(props: ChatTileSessionViewProps) {
           view.messages.find((message) => message.id === firstRowId)?.id ?? null
         );
       }
-      return messageIdForBlock(view.messages, target.blockId);
+      return landingBlockId === null
+        ? null
+        : messageIdForBlock(view.messages, landingBlockId);
     };
     const messageId = resolveTargetMessageId();
     if (messageId === null) {
@@ -1000,19 +1007,19 @@ export function ChatTileSessionView(props: ChatTileSessionViewProps) {
       //
       // Only for a target whose ROW ID is derivable client-side - a user
       // message and an event anchor, whose row ids are the message id and
-      // `chatTranscriptEventRowId`. A block or a sent-message anchor is
-      // identified by walking rendered models, which a cold row has none of,
+      // `chatTranscriptEventRowId`. A block, sent-message or receipt anchor
+      // is identified by walking rendered models, which a cold row has none of,
       // and resolving those needs the host to locate the row.
       requestTranscriptOrdinal(
         coldJumpOrdinal(view.transcriptWindow, target, hostLocatedOrdinal),
       );
       return;
     }
-    if (target.kind === "block") {
+    if (landingBlockId !== null) {
       scrollToBlock(
-        target.blockId,
+        landingBlockId,
         transcriptJumpCardKind(
-          target.blockId,
+          landingBlockId,
           view.lower.backgroundItems ?? [],
         ),
       );

--- a/clients/gui-app/src/hooks/chats/use-chat-locate-row.ts
+++ b/clients/gui-app/src/hooks/chats/use-chat-locate-row.ts
@@ -7,9 +7,9 @@ import { useHostQuery } from "@/hooks/host/use-host-query";
  * The ordinal a cross-tile jump target sits at, when only the host can say.
  *
  * The client resolves some jump targets itself and reads the ordinal off the
- * skeleton it already holds. Three kinds it cannot. A `block` anchor and a
- * `sent-message` anchor are both found by walking RENDERED models, and a cold
- * row has none. A `message` anchor naming an ASSISTANT record has no row id to
+ * skeleton it already holds. Four kinds it cannot. A `block` anchor, a
+ * `sent-message` anchor and a `receipt` anchor are all found by walking
+ * RENDERED models, and a cold row has none. A `message` anchor naming an ASSISTANT record has no row id to
  * look up either way: those rows are turn-keyed, and the durable id survives
  * only as the rendered model's `persistentMessageId` - so the skeleton read
  * misses and the rendered read needs the very hydration being waited on.

--- a/clients/gui-app/src/stores/chats/chat-transcript-jump-store.ts
+++ b/clients/gui-app/src/stores/chats/chat-transcript-jump-store.ts
@@ -43,6 +43,16 @@ export type ChatTranscriptJumpTarget =
       readonly timestamp: number;
     }
   /**
+   * The SENDER-side card again, named EXACTLY from the receiver's side. The
+   * receiver knows its own delivered message id, and the sender's send block
+   * carries that id as `agentMessageReceipt.messageId` (stamped by the host
+   * at tool completion), so the "Received message" card can point at the
+   * one card that produced it with no text or clock heuristic. Misses for a
+   * send persisted before receipts existed, and then times out quietly like
+   * any absent target.
+   */
+  | { readonly kind: "receipt"; readonly messageId: string }
+  /**
    * The very start of the transcript - where this agent's life began. Used
    * by the communication graph's Created rows: a creation has no message of
    * its own to anchor on, but "the beginning" is a deterministic landing

--- a/protocol/src/host/agent/gui/subscribe-windowed.ts
+++ b/protocol/src/host/agent/gui/subscribe-windowed.ts
@@ -324,9 +324,9 @@ export {
  * Where a jump target sits in the transcript - `chat.locateRow`.
  *
  * The windowed line's other half of a cross-tile jump. A client resolves some
- * targets itself and reads the ordinal off the skeleton it holds, but `block`
- * and `sent-message` anchors are identified by walking RENDERED models, which a
- * cold row has none of - and a `message` anchor naming an ASSISTANT record has
+ * targets itself and reads the ordinal off the skeleton it holds, but `block`,
+ * `sent-message` and `receipt` anchors are identified by walking RENDERED
+ * models, which a cold row has none of - and a `message` anchor naming an ASSISTANT record has
  * no row id to read at all, because those rows are turn-keyed and keep the
  * durable id only on the rendered model. Without this the jump deadlocks rather
  * than degrading: the scroll drives hydration and the scroll is what is being

--- a/protocol/src/persistence/chat-transcript/__tests__/locate-row.test.ts
+++ b/protocol/src/persistence/chat-transcript/__tests__/locate-row.test.ts
@@ -21,10 +21,11 @@ import {
 } from "@traycer/protocol/persistence/chat-transcript/locate-row";
 
 /**
- * `locateTranscriptRowOrdinal` answers a cross-tile jump for the three target
+ * `locateTranscriptRowOrdinal` answers a cross-tile jump for the four target
  * kinds a windowed client cannot resolve on its own: a `block` (walking the
  * rendered segment tree), a `sent-message` (matching an `agentMessageSend`
- * enrichment), and a `message` naming an ASSISTANT record, whose rows are
+ * enrichment), a `receipt` (matching an `agentMessageReceipt` enrichment),
+ * and a `message` naming an ASSISTANT record, whose rows are
  * turn-keyed and therefore never named by the durable id. The invariant these
  * tests exist to pin is that the ordinal it returns is an index into the SAME
  * enumeration `buildRowSkeleton` publishes - by construction, since both are
@@ -511,6 +512,155 @@ describe("locateTranscriptRowOrdinal: sent-message targets", () => {
           messageText: "nothing matches this",
           timestamp: 60,
         },
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("locateTranscriptRowOrdinal: receipt targets", () => {
+  function sendBlock(fields: {
+    readonly blockId: string;
+    readonly timestamp: number;
+    readonly receiptMessageId: string | null;
+    readonly parentBlockId: string | null;
+  }): Record<string, unknown> {
+    return {
+      type: "tool_call",
+      blockId: fields.blockId,
+      status: "completed",
+      timestamp: fields.timestamp,
+      toolName: "SendMessage",
+      error: null,
+      parentBlockId: fields.parentBlockId,
+      agentMessageSend: {
+        receiverAgentId: "agent-recv",
+        message: "ping",
+        responseId: null,
+        expectReply: false,
+      },
+      agentMessageReceipt:
+        fields.receiptMessageId === null
+          ? null
+          : {
+              receiverAgentId: "agent-recv",
+              messageId: fields.receiptMessageId,
+            },
+    };
+  }
+
+  it("resolves to the tool_call block whose agentMessageReceipt names the delivered message", () => {
+    // Two sends of the SAME text to the SAME receiver in different turns:
+    // the text heuristic could not tell them apart without a clock, the
+    // receipt can. The target is the SECOND turn, so a "first send wins"
+    // implementation is observable.
+    const first = assistantMessageWithBlocks({
+      messageId: "m-first",
+      timestamp: 10,
+      turnId: "turn-first",
+      blocks: [
+        sendBlock({
+          blockId: "tc-first",
+          timestamp: 10,
+          receiptMessageId: "recv-msg-1",
+          parentBlockId: null,
+        }),
+      ],
+    });
+    const second = assistantMessageWithBlocks({
+      messageId: "m-second",
+      timestamp: 20,
+      turnId: "turn-second",
+      blocks: [
+        sendBlock({
+          blockId: "tc-second",
+          timestamp: 20,
+          receiptMessageId: "recv-msg-2",
+          parentBlockId: null,
+        }),
+      ],
+    });
+    const input: TranscriptRowProjectionInput = {
+      messages: [first, second],
+      events: [],
+      activeTurnId: null,
+      chatId: "chat-1",
+    };
+    const rows = projectTranscriptRows(input);
+    const skeleton = buildRowSkeleton(input, previewText);
+
+    const ordinal = locateOrThrow(rows, input.messages, {
+      kind: "receipt",
+      messageId: "recv-msg-2",
+    });
+
+    expect(skeleton[ordinal]?.rowId).toBe(assistantRowId("turn-second"));
+  });
+
+  it("finds a subagent-routed send, which is nested only when drawn", () => {
+    const turn = assistantMessageWithBlocks({
+      messageId: "m-sub",
+      timestamp: 30,
+      turnId: "turn-sub",
+      blocks: [
+        {
+          type: "tool_call",
+          blockId: "tc-task",
+          status: "completed",
+          timestamp: 30,
+          toolName: "Task",
+          error: null,
+        },
+        sendBlock({
+          blockId: "tc-nested-send",
+          timestamp: 31,
+          receiptMessageId: "recv-msg-nested",
+          parentBlockId: "tc-task",
+        }),
+      ],
+    });
+    const input: TranscriptRowProjectionInput = {
+      messages: [turn],
+      events: [],
+      activeTurnId: null,
+      chatId: "chat-1",
+    };
+    const rows = projectTranscriptRows(input);
+    const skeleton = buildRowSkeleton(input, previewText);
+
+    const ordinal = locateOrThrow(rows, input.messages, {
+      kind: "receipt",
+      messageId: "recv-msg-nested",
+    });
+
+    expect(skeleton[ordinal]?.rowId).toBe(assistantRowId("turn-sub"));
+  });
+
+  it("returns null when no block carries the receipt (a send persisted before receipts existed)", () => {
+    const turn = assistantMessageWithBlocks({
+      messageId: "m-old",
+      timestamp: 40,
+      turnId: "turn-old",
+      blocks: [
+        sendBlock({
+          blockId: "tc-old",
+          timestamp: 40,
+          receiptMessageId: null,
+          parentBlockId: null,
+        }),
+      ],
+    });
+    const input: TranscriptRowProjectionInput = {
+      messages: [turn],
+      events: [],
+      activeTurnId: null,
+      chatId: "chat-1",
+    };
+    const rows = projectTranscriptRows(input);
+
+    expect(
+      locateTranscriptRowOrdinal(
+        { rows, messages: input.messages },
+        { kind: "receipt", messageId: "recv-msg-missing" },
       ),
     ).toBeNull();
   });

--- a/protocol/src/persistence/chat-transcript/locate-row.ts
+++ b/protocol/src/persistence/chat-transcript/locate-row.ts
@@ -15,15 +15,16 @@ import type { TranscriptRowDescriptor } from "@traycer/protocol/persistence/chat
  * `chatTranscriptEventRowId` - and then reads the ordinal straight off the
  * skeleton it already holds.
  *
- * Three kinds cannot be derived that way, and they are the reason this module
+ * Four kinds cannot be derived that way, and they are the reason this module
  * exists. A `block` target is identified by walking the RENDERED segment tree,
- * and a `sent-message` target by matching an `agentMessageSend` enrichment
- * inside one - and a cold row has no rendered models at all. So the client can
+ * a `sent-message` target by matching an `agentMessageSend` enrichment inside
+ * one, and a `receipt` target by matching an `agentMessageReceipt` - and a
+ * cold row has no rendered models at all. So the client can
  * neither find the row nor learn that it exists, and waiting for it to appear
  * deadlocks: the scroll is what drives hydration and the scroll is what is
  * being held back.
  *
- * A `message` target is the third, and it fails for a different reason worth
+ * A `message` target is the fourth, and it fails for a different reason worth
  * stating separately, because "a message id is a row id" holds often enough to
  * look like a rule. It is one only for USER records. An assistant record is
  * projected into TURN-KEYED rows (`assistant:<turnKey>`, and one per slice when
@@ -76,7 +77,7 @@ import type { TranscriptRowDescriptor } from "@traycer/protocol/persistence/chat
 export const LOCATOR_MESSAGE_TEXT_MAX_CHARS = 64_000;
 
 /**
- * The three jump targets whose row a client cannot identify on its own.
+ * The four jump targets whose row a client cannot identify on its own.
  *
  * A zod schema rather than a bare type because it is also the wire shape - it
  * is re-exported by `host/agent/gui/subscribe-windowed.ts`, which is where a
@@ -101,6 +102,18 @@ export const transcriptRowLocatorSchema = z.discriminatedUnion("kind", [
     messageText: z.string().max(LOCATOR_MESSAGE_TEXT_MAX_CHARS),
     timestamp: z.number(),
   }),
+  /**
+   * The SENDER-side card of an A2A exchange, named from the RECEIVER's side.
+   * `messageId` is the received row's own id: the host mints it before
+   * delivery, the receiver's append uses it verbatim, and the sender's
+   * harness stamps it on the send's tool block as `agentMessageReceipt` at
+   * completion. So a received card can name its sender's card exactly, with
+   * no text or clock heuristic - the id is unique across the epic.
+   *
+   * Misses (`null`) for a block persisted before receipts existed; the caller
+   * degrades to the tile it already opened.
+   */
+  z.object({ kind: z.literal("receipt"), messageId: z.string() }),
   /**
    * A durable record id, for the case the client's own id-as-row-id read
    * cannot cover: an ASSISTANT record, whose rows are turn-keyed.
@@ -191,6 +204,32 @@ function sentMessageBlockId(
 }
 
 /**
+ * The `tool_call` block whose `agentMessageReceipt` names this delivered
+ * message, or `null`.
+ *
+ * Exact, not nearest: the receipt's `messageId` is a host-minted id that one
+ * delivery owns, so at most one block can legitimately carry it. First writer
+ * wins if a duplicate ever appears, matching `rowOrdinalByBlockId`. Blocks are
+ * flat on the assistant record, so a subagent-routed send (nested only when
+ * drawn) is found without walking parents.
+ */
+function receiptBlockId(
+  messages: readonly Message[],
+  messageId: string,
+): string | null {
+  for (const message of messages) {
+    if (message.role !== "assistant") continue;
+    for (const block of message.blocks) {
+      if (block.type !== "tool_call") continue;
+      if (block.agentMessageReceipt?.messageId === messageId) {
+        return block.blockId;
+      }
+    }
+  }
+  return null;
+}
+
+/**
  * The row that RENDERS this record, or `null`.
  *
  * "Renders" is the discriminating word, and it is what keeps this from being a
@@ -238,6 +277,20 @@ function rowOrdinalByMessageId(
   return found;
 }
 
+function blockIdForLocator(
+  messages: readonly Message[],
+  locator: Exclude<TranscriptRowLocator, { kind: "message" }>,
+): string | null {
+  switch (locator.kind) {
+    case "block":
+      return locator.blockId;
+    case "sent-message":
+      return sentMessageBlockId(messages, locator);
+    case "receipt":
+      return receiptBlockId(messages, locator.messageId);
+  }
+}
+
 /**
  * Where this target sits in the transcript, or `null` if nothing matches it.
  *
@@ -258,10 +311,7 @@ export function locateTranscriptRowOrdinal(
   if (locator.kind === "message") {
     return rowOrdinalByMessageId(transcript.rows, locator.messageId);
   }
-  const blockId =
-    locator.kind === "block"
-      ? locator.blockId
-      : sentMessageBlockId(transcript.messages, locator);
+  const blockId = blockIdForLocator(transcript.messages, locator);
   if (blockId === null) return null;
   return rowOrdinalByBlockId(transcript.rows).get(blockId) ?? null;
 }


### PR DESCRIPTION
## Summary

Mirror of #1709. Clicking the sender name on a "Received message · from agent" card now opens the sender's tile **and scrolls to the exact "Sent message" card** that produced it.

No new host stamping is needed: the reverse edge already exists. The received row's own message id is the `agentMessageReceipt.messageId` the sender's harness stamps on its send block at completion (internal #5471), so the receiver can name the sender's card exactly, with no text or clock heuristic.

- **protocol:** `{ kind: "receipt", messageId }` on `transcriptRowLocatorSchema`; `locateTranscriptRowOrdinal` resolves it to the flat assistant `tool_call` block carrying that receipt (subagent-routed sends included). `chat.locateRow` 1.0 is not in the released baseline, so no minor is opened.
- **gui-app:** same kind on `ChatTranscriptJumpTarget`; `receiptAnchorBlockId` walks rendered segments (nested children included); the tile lands on the card via `scrollToBlock` and asks the host only when the walk misses on the windowed line; the received card parks the jump for a chat sender and leaves a terminal-agent sender tile-only.

A send persisted before receipts existed misses and times out quietly, the same degrade as the sent card's no-receipt case. The host consumes the new locator through the protocol package; the internal side is a gitlink bump after this merges.

## Test plan

- [x] protocol `locate-row` suite: exact match across two same-text sends, nested subagent block, pre-receipt miss
- [x] `subscribe-windowed-line`, `released-baseline-compat`, `released-surface-compat` pass
- [x] gui-app `chat-tile-jump-locator`, `chat-message-user-body`, `chat-tile` suites pass
- [x] pre-commit gate (build · compile · lint · format · DCO) green
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
