### PR TITLE
fix(gui): open an epic on its most recently active agent, not its oldest node

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/__tests__/use-epic-route-synchronization.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/use-epic-route-synchronization.test.tsx
@@ -194,11 +194,11 @@ vi.mock("@/stores/epics/canvas/store", async (importOriginal) => {
 });
 
 vi.mock("@/lib/epic-selectors", () => ({
+  epicNodeRecency: () => ({}),
   useEpicArtifactRecords: () => testState.records,
   useEpicChatRecordListAuthoritative: () =>
     testState.chatRecordListAuthoritative,
   useEpicLastFocusedArtifactId: () => null,
-  useEpicNodeRecency: () => ({}),
   useEpicSnapshotLoaded: () => true,
   useEpicTitle: () => "",
 }));

--- a/clients/gui-app/src/components/epic-canvas/__tests__/use-epic-route-synchronization.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/use-epic-route-synchronization.test.tsx
@@ -198,6 +198,7 @@ vi.mock("@/lib/epic-selectors", () => ({
   useEpicChatRecordListAuthoritative: () =>
     testState.chatRecordListAuthoritative,
   useEpicLastFocusedArtifactId: () => null,
+  useEpicNodeRecency: () => ({}),
   useEpicSnapshotLoaded: () => true,
   useEpicTitle: () => "",
 }));

--- a/clients/gui-app/src/components/epic-canvas/hooks/use-epic-route-synchronization.ts
+++ b/clients/gui-app/src/components/epic-canvas/hooks/use-epic-route-synchronization.ts
@@ -29,6 +29,7 @@ import {
   useEpicArtifactRecords,
   useEpicChatRecordListAuthoritative,
   useEpicLastFocusedArtifactId,
+  useEpicNodeRecency,
   useEpicSnapshotLoaded,
   useEpicTitle,
 } from "@/lib/epic-selectors";
@@ -93,6 +94,12 @@ export function useEpicRouteSynchronization(
   const liveTitle = useEpicTitle();
   const persistedFocus = useEpicLastFocusedArtifactId();
   const records = useEpicArtifactRecords();
+  // Auto-open's recency input. It comes off the SAME epic projection as
+  // `records`, so the two are always in step: whatever agent rows this device
+  // has, it has their activity clocks, and an epic whose projection carries no
+  // agent rows yields an empty map - the resolver's "no recency available"
+  // input, which lands on the first node in tree order exactly as before.
+  const nodeRecency = useEpicNodeRecency();
   // Same-host counterpart of the cross-host cloud fallback (chat-sync-v2
   // ticket 36): `epic.listCloudChats` already excludes anything this host's
   // own registry has tombstoned, so "still cloud-known" is what tells a
@@ -385,6 +392,7 @@ export function useEpicRouteSynchronization(
       records,
       focusArtifactId ?? null,
       persistedFocus,
+      nodeRecency,
     );
     if (target === null) {
       return;
@@ -433,6 +441,7 @@ export function useEpicRouteSynchronization(
   }, [
     snapshotLoaded,
     records,
+    nodeRecency,
     focusArtifactId,
     focusedAt,
     persistedFocus,

--- a/clients/gui-app/src/components/epic-canvas/hooks/use-epic-route-synchronization.ts
+++ b/clients/gui-app/src/components/epic-canvas/hooks/use-epic-route-synchronization.ts
@@ -26,10 +26,10 @@ import {
 import { cloudRowIsViewersOwn } from "@/lib/chats/unified-chat-list";
 import { collectPanes } from "@/stores/epics/canvas/tile-tree";
 import {
+  epicNodeRecency,
   useEpicArtifactRecords,
   useEpicChatRecordListAuthoritative,
   useEpicLastFocusedArtifactId,
-  useEpicNodeRecency,
   useEpicSnapshotLoaded,
   useEpicTitle,
 } from "@/lib/epic-selectors";
@@ -94,12 +94,6 @@ export function useEpicRouteSynchronization(
   const liveTitle = useEpicTitle();
   const persistedFocus = useEpicLastFocusedArtifactId();
   const records = useEpicArtifactRecords();
-  // Auto-open's recency input. It comes off the SAME epic projection as
-  // `records`, so the two are always in step: whatever agent rows this device
-  // has, it has their activity clocks, and an epic whose projection carries no
-  // agent rows yields an empty map - the resolver's "no recency available"
-  // input, which lands on the first node in tree order exactly as before.
-  const nodeRecency = useEpicNodeRecency();
   // Same-host counterpart of the cross-host cloud fallback (chat-sync-v2
   // ticket 36): `epic.listCloudChats` already excludes anything this host's
   // own registry has tombstoned, so "still cloud-known" is what tells a
@@ -388,11 +382,20 @@ export function useEpicRouteSynchronization(
     }
 
     lastAutoOpenKey.current = key;
+    // Auto-open's recency input, read HERE rather than subscribed to. Every
+    // value in it moves on each streamed token, and this decision fires once
+    // per key - a subscription would re-render this hook at the token rate to
+    // feed a branch that has already run. The projection it reads is the same
+    // one `records` comes from, so the two are always in step: whatever agent
+    // rows this device has, it has their activity clocks, and an epic whose
+    // projection carries no agent rows yields an empty map - the resolver's
+    // "no recency available" input, which lands on the first node in tree
+    // order exactly as before.
     const target = resolveAutoOpenTarget(
       records,
       focusArtifactId ?? null,
       persistedFocus,
-      nodeRecency,
+      epicNodeRecency(handle.store.getState()),
     );
     if (target === null) {
       return;
@@ -441,7 +444,7 @@ export function useEpicRouteSynchronization(
   }, [
     snapshotLoaded,
     records,
-    nodeRecency,
+    handle,
     focusArtifactId,
     focusedAt,
     persistedFocus,

--- a/clients/gui-app/src/lib/__tests__/epic-auto-open.test.ts
+++ b/clients/gui-app/src/lib/__tests__/epic-auto-open.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
   resolveAutoOpenTarget,
+  type AutoOpenRecencyByNodeId,
   type AutoOpenRecord,
 } from "@/lib/epic-auto-open";
+
+const NO_RECENCY: AutoOpenRecencyByNodeId = {};
 
 function record(over: Partial<AutoOpenRecord>): AutoOpenRecord {
   return {
@@ -22,7 +25,7 @@ describe("resolveAutoOpenTarget", () => {
       record({ id: "tui-1", name: "Claude", type: "terminal-agent" }),
     ];
 
-    const target = resolveAutoOpenTarget(records, "tui-1", null);
+    const target = resolveAutoOpenTarget(records, "tui-1", null, NO_RECENCY);
 
     expect(target?.id).toBe("tui-1");
     expect(target?.type).toBe("terminal-agent");
@@ -31,7 +34,7 @@ describe("resolveAutoOpenTarget", () => {
   it("does not substitute another chat when an explicit focus target is gone", () => {
     const records = [record({ id: "chat-1", name: "Chat One", type: "chat" })];
 
-    const target = resolveAutoOpenTarget(records, "missing", null);
+    const target = resolveAutoOpenTarget(records, "missing", null, NO_RECENCY);
 
     expect(target).toBeNull();
   });
@@ -39,7 +42,113 @@ describe("resolveAutoOpenTarget", () => {
   it("still selects the first openable node when no focus was requested", () => {
     const records = [record({ id: "chat-1", name: "Chat One", type: "chat" })];
 
-    const target = resolveAutoOpenTarget(records, null, null);
+    const target = resolveAutoOpenTarget(records, null, null, NO_RECENCY);
+
+    expect(target?.id).toBe("chat-1");
+  });
+
+  it("lands on the most recently active chat rather than the oldest one", () => {
+    const records = [
+      record({ id: "chat-old", name: "Chat One", type: "chat" }),
+      record({ id: "chat-new", name: "Chat Two", type: "chat" }),
+    ];
+
+    const target = resolveAutoOpenTarget(records, null, null, {
+      "chat-old": 100,
+      "chat-new": 200,
+    });
+
+    expect(target?.id).toBe("chat-new");
+    expect(target?.name).toBe("Chat Two");
+  });
+
+  it("reaches a newer nested chat past a spec that heads the tree", () => {
+    const records = [
+      record({ id: "spec-1", name: "Spec", type: "spec" }),
+      record({ id: "chat-old", name: "Chat One", type: "chat" }),
+      record({
+        id: "chat-new",
+        parentId: "spec-1",
+        name: "Chat Two",
+        type: "chat",
+      }),
+    ];
+
+    const target = resolveAutoOpenTarget(records, null, null, {
+      "chat-old": 100,
+      "chat-new": 200,
+    });
+
+    expect(target?.id).toBe("chat-new");
+  });
+
+  it("falls back to tree order when no openable node carries recency", () => {
+    const records = [
+      record({ id: "chat-1", name: "Chat One", type: "chat" }),
+      record({ id: "chat-2", name: "Chat Two", type: "chat" }),
+    ];
+
+    // A recency stamp for a node that is not in the tree must not promote
+    // anything, and must not suppress the tree-first fallback either.
+    const target = resolveAutoOpenTarget(records, null, null, {
+      "chat-elsewhere": 900,
+    });
+
+    expect(target?.id).toBe("chat-1");
+  });
+
+  it("breaks a recency tie in tree order", () => {
+    const records = [
+      record({ id: "chat-1", name: "Chat One", type: "chat" }),
+      record({ id: "chat-2", name: "Chat Two", type: "chat" }),
+    ];
+
+    const target = resolveAutoOpenTarget(records, null, null, {
+      "chat-1": 500,
+      "chat-2": 500,
+    });
+
+    expect(target?.id).toBe("chat-1");
+  });
+
+  it("keeps an explicit focus target ahead of a newer chat", () => {
+    const records = [
+      record({ id: "chat-old", name: "Chat One", type: "chat" }),
+      record({ id: "chat-new", name: "Chat Two", type: "chat" }),
+    ];
+
+    const target = resolveAutoOpenTarget(records, "chat-old", null, {
+      "chat-old": 100,
+      "chat-new": 200,
+    });
+
+    expect(target?.id).toBe("chat-old");
+  });
+
+  it("keeps this device's persisted focus ahead of a newer chat", () => {
+    const records = [
+      record({ id: "chat-old", name: "Chat One", type: "chat" }),
+      record({ id: "chat-new", name: "Chat Two", type: "chat" }),
+    ];
+
+    const target = resolveAutoOpenTarget(records, null, "chat-old", {
+      "chat-old": 100,
+      "chat-new": 200,
+    });
+
+    expect(target?.id).toBe("chat-old");
+  });
+
+  it("ignores recency carried by a node that cannot be opened", () => {
+    const records = [
+      record({ id: "chat-1", name: "Chat One", type: "chat" }),
+      record({ id: "terminal-1", name: "Terminal", type: "terminal" }),
+    ];
+
+    const target = resolveAutoOpenTarget(records, null, null, {
+      "chat-1": 100,
+      "terminal-1": 900,
+    });
 
     expect(target?.id).toBe("chat-1");
   });

--- a/clients/gui-app/src/lib/__tests__/epic-selectors.test.tsx
+++ b/clients/gui-app/src/lib/__tests__/epic-selectors.test.tsx
@@ -12,6 +12,7 @@ import {
   handleHostIds,
 } from "@/lib/registries/epic-session-registry";
 import {
+  epicNodeRecency,
   epicNodeRefForNodeId,
   useEpicArtifactRecords,
   useEpicChatHarnessId,
@@ -651,3 +652,26 @@ function tuiAgent(id: string, harnessId: TuiHarnessId): TuiAgentProjection {
     terminalShellArgs: null,
   };
 }
+
+describe("epicNodeRecency", () => {
+  it("maps chats and terminal-agents to their projected updatedAt", () => {
+    const one = { ...chat("chat-1", "claude"), updatedAt: 100 };
+    const two = { ...tuiAgent("tui-1", "codex"), updatedAt: 200 };
+
+    const recency = epicNodeRecency({
+      chats: { allIds: [one.id], byId: { [one.id]: one } },
+      tuiAgents: { allIds: [two.id], byId: { [two.id]: two } },
+    });
+
+    expect(recency).toEqual({ "chat-1": 100, "tui-1": 200 });
+  });
+
+  it("answers an empty map when the projection holds no agent rows", () => {
+    const recency = epicNodeRecency({
+      chats: { allIds: [], byId: {} },
+      tuiAgents: { allIds: [], byId: {} },
+    });
+
+    expect(recency).toEqual({});
+  });
+});

--- a/clients/gui-app/src/lib/epic-auto-open.ts
+++ b/clients/gui-app/src/lib/epic-auto-open.ts
@@ -11,6 +11,17 @@ export interface AutoOpenRecord {
   readonly hostId: string;
 }
 
+/**
+ * Last-activity clock per node id, for the rows that have one.
+ *
+ * Only agent rows (chats, terminal-agents) carry activity; artifact rows
+ * (spec / ticket / story / review) are ABSENT from this map rather than mapped
+ * to `0`, because "never had an activity clock" and "last active at the epoch"
+ * must not rank alike. An empty map is the legal "no recency available for this
+ * epic" input.
+ */
+export type AutoOpenRecencyByNodeId = Readonly<Record<string, number>>;
+
 interface AutoOpenTarget {
   readonly id: string;
   readonly type:
@@ -41,10 +52,26 @@ function isAutoOpenableKind(
   );
 }
 
+/**
+ * Which node an epic lands on.
+ *
+ * The order is explicit focus, then this device's remembered focus, then the
+ * epic's most recently active agent row, then the first openable node in tree
+ * order. The third step is what a device with nothing persisted for this epic
+ * hits - a task created on one machine and opened for the first time on
+ * another - and tree order there is CREATION order, so without it the landing
+ * is the oldest node in the task rather than the one being worked in.
+ *
+ * `recencyByNodeId` is data, not a source: this resolver never reads a store,
+ * so an epic whose projection has produced no agent rows yet is expressed by
+ * passing an empty map, and the resolution degrades to the tree-first
+ * behaviour rather than waiting on anything.
+ */
 export function resolveAutoOpenTarget(
   records: ReadonlyArray<AutoOpenRecord>,
   focusArtifactId: string | null,
   persistedFocus: string | null,
+  recencyByNodeId: AutoOpenRecencyByNodeId,
 ): AutoOpenTarget | null {
   if (focusArtifactId !== null) {
     return findOpenableRecord(records, focusArtifactId);
@@ -52,6 +79,9 @@ export function resolveAutoOpenTarget(
 
   const persistedMatch = findOpenableRecord(records, persistedFocus);
   if (persistedMatch !== null) return persistedMatch;
+
+  const mostRecent = findMostRecentlyActiveInTree(records, recencyByNodeId);
+  if (mostRecent !== null) return mostRecent;
 
   return findFirstOpenableInTree(records);
 }
@@ -77,7 +107,42 @@ function findFirstOpenableInTree(
   records: ReadonlyArray<AutoOpenRecord>,
 ): AutoOpenTarget | null {
   const tree = buildEpicNodeTree(records);
-  return walkTree(tree);
+  return walkTree(tree, () => true);
+}
+
+/**
+ * The openable node carrying the epic's highest recency stamp, or `null` when
+ * no openable node has one.
+ *
+ * Resolved in two passes - find the winning stamp, then take the first node in
+ * TREE order that carries it - so nodes sharing the newest stamp resolve to
+ * the same node the tree-first fallback would have chosen. The alternative, a
+ * single pass over `records`, would break ties by the record array's own
+ * grouping (chats, then terminal-agents, then artifacts), which is not an
+ * order any surface shows.
+ */
+function findMostRecentlyActiveInTree(
+  records: ReadonlyArray<AutoOpenRecord>,
+  recencyByNodeId: AutoOpenRecencyByNodeId,
+): AutoOpenTarget | null {
+  let newestAt: number | null = null;
+  for (const record of records) {
+    if (!isOpenableEpicNodeKind(record.type)) continue;
+    if (!isAutoOpenableKind(record.type)) continue;
+    if (!Object.hasOwn(recencyByNodeId, record.id)) continue;
+    const activeAt = recencyByNodeId[record.id];
+    if (newestAt === null || activeAt > newestAt) {
+      newestAt = activeAt;
+    }
+  }
+  if (newestAt === null) return null;
+  const winningAt = newestAt;
+  return walkTree(
+    buildEpicNodeTree(records),
+    (nodeId) =>
+      Object.hasOwn(recencyByNodeId, nodeId) &&
+      recencyByNodeId[nodeId] === winningAt,
+  );
 }
 
 function walkTree(
@@ -88,10 +153,15 @@ function walkTree(
       readonly hostId: string;
     }>
   >,
+  accepts: (nodeId: string) => boolean,
 ): AutoOpenTarget | null {
   for (const node of nodes) {
     const nodeType = node.data.type;
-    if (isOpenableEpicNodeKind(nodeType) && isAutoOpenableKind(nodeType)) {
+    if (
+      isOpenableEpicNodeKind(nodeType) &&
+      isAutoOpenableKind(nodeType) &&
+      accepts(node.id)
+    ) {
       return {
         id: node.id,
         type: nodeType,
@@ -101,7 +171,7 @@ function walkTree(
     }
     const nested = node.children ?? [];
     if (nested.length === 0) continue;
-    const childMatch = walkTree(nested);
+    const childMatch = walkTree(nested, accepts);
     if (childMatch !== null) return childMatch;
   }
   return null;

--- a/clients/gui-app/src/lib/epic-selectors.ts
+++ b/clients/gui-app/src/lib/epic-selectors.ts
@@ -136,6 +136,7 @@ const EMPTY_TERMINAL_AGENT_PROJECTIONS: ReadonlyArray<TuiAgentProjection> =
   Object.freeze([]);
 const EMPTY_NODES_AS_ARTIFACTS: ReadonlyArray<ArtifactProjection> =
   Object.freeze([]);
+const EMPTY_NODE_RECENCY: Readonly<Record<string, number>> = Object.freeze({});
 const EMPTY_TREE_ID_ARRAY: readonly string[] = EMPTY_ARRAY;
 const EMPTY_TREE_ID_SET: ReadonlySet<string> = new Set<string>();
 const EMPTY_ROLE_CLAIMS: readonly RoleClaim[] = Object.freeze([]);
@@ -571,6 +572,44 @@ export function useEpicArtifactRecords(): ReadonlyArray<EpicTreeRecord> {
         records.push(recordForArtifact(s.artifacts.byId[id], fallbackHostId));
       }
       return records;
+    }),
+  );
+}
+
+/**
+ * The last-activity clock of every agent row this epic's projection holds,
+ * keyed by node id - the whole-epic counterpart of
+ * {@link useEpicNodeUpdatedAt}, and read off the same projection for the same
+ * reason: the `TreeNode` copy lags, because `CHAT_TREE_KEYS` deliberately omits
+ * `updatedAt` so touching a chat never rebuilds the tree.
+ *
+ * Artifact rows (spec / ticket / story / review) are ABSENT rather than mapped
+ * to `0`. They have no activity clock at all, and a caller ranking rows by
+ * recency must be able to tell that apart from a row last touched at the epoch.
+ *
+ * Shallow-compared over id → timestamp, so it changes at the rate the chat
+ * projections themselves do (every streamed token for a live chat). Pair it
+ * only with a subscriber that already re-renders on that churn - it is the
+ * companion of {@link useEpicArtifactRecords}, whose array churns identically.
+ * A single row wants the per-id {@link useEpicNodeUpdatedAt} instead. See
+ * RENDER_PERF_INVARIANTS.md.
+ */
+export function useEpicNodeRecency(): Readonly<Record<string, number>> {
+  const handle = useOpenEpicHandle();
+  return useStore(
+    handle.store,
+    useShallow((s): Readonly<Record<string, number>> => {
+      if (s.chats.allIds.length === 0 && s.tuiAgents.allIds.length === 0) {
+        return EMPTY_NODE_RECENCY;
+      }
+      const recency: Record<string, number> = {};
+      for (const id of s.chats.allIds) {
+        recency[id] = s.chats.byId[id].updatedAt;
+      }
+      for (const id of s.tuiAgents.allIds) {
+        recency[id] = s.tuiAgents.byId[id].updatedAt;
+      }
+      return recency;
     }),
   );
 }

--- a/clients/gui-app/src/lib/epic-selectors.ts
+++ b/clients/gui-app/src/lib/epic-selectors.ts
@@ -577,41 +577,37 @@ export function useEpicArtifactRecords(): ReadonlyArray<EpicTreeRecord> {
 }
 
 /**
- * The last-activity clock of every agent row this epic's projection holds,
- * keyed by node id - the whole-epic counterpart of
- * {@link useEpicNodeUpdatedAt}, and read off the same projection for the same
- * reason: the `TreeNode` copy lags, because `CHAT_TREE_KEYS` deliberately omits
- * `updatedAt` so touching a chat never rebuilds the tree.
+ * The last-activity clock of every agent row an epic's projection holds, keyed
+ * by node id - the whole-epic counterpart of {@link useEpicNodeUpdatedAt}, and
+ * read off the same projection for the same reason: the `TreeNode` copy lags,
+ * because `CHAT_TREE_KEYS` deliberately omits `updatedAt` so touching a chat
+ * never rebuilds the tree.
  *
  * Artifact rows (spec / ticket / story / review) are ABSENT rather than mapped
  * to `0`. They have no activity clock at all, and a caller ranking rows by
  * recency must be able to tell that apart from a row last touched at the epoch.
  *
- * Shallow-compared over id → timestamp, so it changes at the rate the chat
- * projections themselves do (every streamed token for a live chat). Pair it
- * only with a subscriber that already re-renders on that churn - it is the
- * companion of {@link useEpicArtifactRecords}, whose array churns identically.
- * A single row wants the per-id {@link useEpicNodeUpdatedAt} instead. See
- * RENDER_PERF_INVARIANTS.md.
+ * Deliberately a plain state reader and NOT a hook. Every value in it moves on
+ * each streamed token, so a subscriber would re-render at that rate; the caller
+ * that ranks rows by recency does so at a single decision point and reads the
+ * projection there instead. A row that has to RENDER its own timestamp wants
+ * the per-id {@link useEpicNodeUpdatedAt}, which stays reference-stable through
+ * unrelated churn. See RENDER_PERF_INVARIANTS.md.
  */
-export function useEpicNodeRecency(): Readonly<Record<string, number>> {
-  const handle = useOpenEpicHandle();
-  return useStore(
-    handle.store,
-    useShallow((s): Readonly<Record<string, number>> => {
-      if (s.chats.allIds.length === 0 && s.tuiAgents.allIds.length === 0) {
-        return EMPTY_NODE_RECENCY;
-      }
-      const recency: Record<string, number> = {};
-      for (const id of s.chats.allIds) {
-        recency[id] = s.chats.byId[id].updatedAt;
-      }
-      for (const id of s.tuiAgents.allIds) {
-        recency[id] = s.tuiAgents.byId[id].updatedAt;
-      }
-      return recency;
-    }),
-  );
+export function epicNodeRecency(
+  state: Pick<OpenEpicState, "chats" | "tuiAgents">,
+): Readonly<Record<string, number>> {
+  if (state.chats.allIds.length === 0 && state.tuiAgents.allIds.length === 0) {
+    return EMPTY_NODE_RECENCY;
+  }
+  const recency: Record<string, number> = {};
+  for (const id of state.chats.allIds) {
+    recency[id] = state.chats.byId[id].updatedAt;
+  }
+  for (const id of state.tuiAgents.allIds) {
+    recency[id] = state.tuiAgents.byId[id].updatedAt;
+  }
+  return recency;
 }
 
 export function useEpicHasArtifactRecords(): boolean {


### PR DESCRIPTION
## Problem

Opening a task on a device that has nothing persisted for it lands on the wrong
chat. The usual way to hit it: create the task on a desktop, then open it for
the first time on the phone.

`resolveAutoOpenTarget` resolves in three steps — an explicit `focusArtifactId`
from the URL, then the device's own `lastFocusedArtifactId` for that epic, then
a fallback that walks the artifact tree and takes the first openable node. The
persisted focus is per-device localStorage, so on a device that has never opened
the task it is empty and the fallback decides. Tree order is insertion order,
which is creation order — so the landing is the oldest node in the task, never
the one being worked in.

The tree records carry no timestamp of their own, and the epic's `updatedAt` is
epic-level, so the fallback had nothing to rank by.

## Change

Client-only, and it benefits desktop on a fresh machine as much as mobile.

Auto-open gains a step: explicit focus → the device's remembered focus → the
epic's **most recently active agent row** → the first openable node in tree
order, unchanged. Steps 1 and 2 are untouched.

- `resolveAutoOpenTarget` takes the recency map as an argument and stays pure —
  it reads no store. An epic whose projection holds no agent rows passes an
  empty map and lands exactly where it did before.
- The recency comes from `updatedAt` on the chat / terminal-agent projections
  the epic already holds (`useEpicNodeRecency`, the whole-epic counterpart of
  the existing per-row `useEpicNodeUpdatedAt`). No new wire field, and it is the
  same projection that feeds `records`, so the two are always in step: whatever
  agent rows a device has, it has their clocks.
- Rows without an activity clock (spec / ticket / story / review) are absent
  from the map rather than stamped `0`, so "no clock" cannot outrank a real one.
- A tie on the newest stamp resolves in tree order, i.e. to the same node the
  old fallback would have picked.

## Testing

- `epic-auto-open` unit tests: newest chat over an older first-in-tree chat; a
  newer chat nested under a leading spec; unavailable or unmatched recency →
  tree-first; ties → tree-first; explicit focus and persisted focus still win;
  recency on a non-openable node is ignored.
- Mutation-proofed: feeding the resolver an empty map in place of the real one
  fails the two recency tests (`2 failed | 8 passed`) — the suite cannot pass
  with the map ignored.
- `use-epic-route-synchronization` suite, `tsgo -b` for gui-app, oxlint, eslint
  on the changed files, and root `oxfmt .` in write mode with a clean tree
  after.
