### PR TITLE
fix(gui-app/mobile): disable the tab-switcher trigger until a sheet is mounted

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/__tests__/epic-mobile-header-actions.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/epic-mobile-header-actions.test.tsx
@@ -1,5 +1,6 @@
 import "../../../../__tests__/test-browser-apis";
 import {
+  act,
   cleanup,
   fireEvent,
   render,
@@ -147,11 +148,17 @@ function openEdit(testId: string): HTMLElement {
 
 describe("<EpicMobileSwitcherTrigger />", () => {
   beforeEach(() => {
-    useMobileSwitcherStore.setState({ openTabId: null });
+    useMobileSwitcherStore.setState({ openTabId: null, mountCountByTabId: {} });
   });
   afterEach(cleanup);
 
+  /** Stands in for a `MobileTabSwitcherMount` rendered somewhere on the canvas. */
+  function mountSheetFor(tabId: string): void {
+    act(() => useMobileSwitcherStore.getState().registerMount(tabId));
+  }
+
   it("opens the switcher store for its own tabId when tapped", () => {
+    mountSheetFor("tab-1");
     render(<EpicMobileSwitcherTrigger tabId="tab-1" />);
     const trigger = screen.getByTestId("mobile-epic-switcher-trigger");
     expect(trigger.getAttribute("aria-label")).toBe("Switch tab");
@@ -159,10 +166,52 @@ describe("<EpicMobileSwitcherTrigger />", () => {
     expect(useMobileSwitcherStore.getState().openTabId).toBe("tab-1");
   });
 
+  /**
+   * The loading epic: the header slot is bound for the whole pane, but the
+   * canvas branch that mounts the sheet has not been reached. A tap here used
+   * to write an open flag nothing rendered - dead on the press, and then a
+   * sheet the user never asked for once the canvas mounted.
+   */
+  it("is disabled while no sheet is mounted for its tab", () => {
+    render(<EpicMobileSwitcherTrigger tabId="tab-1" />);
+    const trigger = screen.getByTestId("mobile-epic-switcher-trigger");
+    expect(trigger.hasAttribute("disabled")).toBe(true);
+    expect(trigger.getAttribute("aria-label")).toBe("Switch tab");
+    fireEvent.click(trigger);
+    expect(useMobileSwitcherStore.getState().openTabId).toBeNull();
+  });
+
+  it("is scoped to its own tab - another tab's mount does not enable it", () => {
+    mountSheetFor("tab-2");
+    render(<EpicMobileSwitcherTrigger tabId="tab-1" />);
+    expect(
+      screen
+        .getByTestId("mobile-epic-switcher-trigger")
+        .hasAttribute("disabled"),
+    ).toBe(true);
+  });
+
+  it("enables when a sheet mounts and disables again when it goes", () => {
+    render(<EpicMobileSwitcherTrigger tabId="tab-1" />);
+    const trigger = screen.getByTestId("mobile-epic-switcher-trigger");
+    expect(trigger.hasAttribute("disabled")).toBe(true);
+    mountSheetFor("tab-1");
+    expect(trigger.hasAttribute("disabled")).toBe(false);
+    fireEvent.click(trigger);
+    expect(useMobileSwitcherStore.getState().openTabId).toBe("tab-1");
+    act(() => useMobileSwitcherStore.getState().unregisterMount("tab-1"));
+    expect(trigger.hasAttribute("disabled")).toBe(true);
+  });
+
   it("renders for a viewer role too - switching tabs is not permission-gated", () => {
     holder.role = "viewer";
+    mountSheetFor("tab-1");
     render(<EpicMobileSwitcherTrigger tabId="tab-1" />);
-    expect(screen.getByTestId("mobile-epic-switcher-trigger")).toBeTruthy();
+    expect(
+      screen
+        .getByTestId("mobile-epic-switcher-trigger")
+        .hasAttribute("disabled"),
+    ).toBe(false);
     holder.role = "owner";
   });
 });

--- a/clients/gui-app/src/components/epic-canvas/__tests__/epic-mobile-header-actions.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/epic-mobile-header-actions.test.tsx
@@ -157,10 +157,25 @@ describe("<EpicMobileSwitcherTrigger />", () => {
     act(() => useMobileSwitcherStore.getState().registerMount(tabId));
   }
 
+  /**
+   * Narrowed rather than cast, so `.disabled` below is the NATIVE button
+   * property - the one that actually decides whether a press dispatches a
+   * click. The narrowing is load-bearing on its own: an `aria-disabled` div
+   * would satisfy an attribute check while still answering the tap, which is
+   * the exact failure this control is being fixed for.
+   */
+  function switcherTrigger(): HTMLButtonElement {
+    const element = screen.getByTestId("mobile-epic-switcher-trigger");
+    if (!(element instanceof HTMLButtonElement)) {
+      throw new Error("The switcher trigger is not a native <button>");
+    }
+    return element;
+  }
+
   it("opens the switcher store for its own tabId when tapped", () => {
     mountSheetFor("tab-1");
     render(<EpicMobileSwitcherTrigger tabId="tab-1" />);
-    const trigger = screen.getByTestId("mobile-epic-switcher-trigger");
+    const trigger = switcherTrigger();
     expect(trigger.getAttribute("aria-label")).toBe("Switch tab");
     fireEvent.click(trigger);
     expect(useMobileSwitcherStore.getState().openTabId).toBe("tab-1");
@@ -174,8 +189,8 @@ describe("<EpicMobileSwitcherTrigger />", () => {
    */
   it("is disabled while no sheet is mounted for its tab", () => {
     render(<EpicMobileSwitcherTrigger tabId="tab-1" />);
-    const trigger = screen.getByTestId("mobile-epic-switcher-trigger");
-    expect(trigger.hasAttribute("disabled")).toBe(true);
+    const trigger = switcherTrigger();
+    expect(trigger.disabled).toBe(true);
     expect(trigger.getAttribute("aria-label")).toBe("Switch tab");
     fireEvent.click(trigger);
     expect(useMobileSwitcherStore.getState().openTabId).toBeNull();
@@ -184,34 +199,26 @@ describe("<EpicMobileSwitcherTrigger />", () => {
   it("is scoped to its own tab - another tab's mount does not enable it", () => {
     mountSheetFor("tab-2");
     render(<EpicMobileSwitcherTrigger tabId="tab-1" />);
-    expect(
-      screen
-        .getByTestId("mobile-epic-switcher-trigger")
-        .hasAttribute("disabled"),
-    ).toBe(true);
+    expect(switcherTrigger().disabled).toBe(true);
   });
 
   it("enables when a sheet mounts and disables again when it goes", () => {
     render(<EpicMobileSwitcherTrigger tabId="tab-1" />);
-    const trigger = screen.getByTestId("mobile-epic-switcher-trigger");
-    expect(trigger.hasAttribute("disabled")).toBe(true);
+    const trigger = switcherTrigger();
+    expect(trigger.disabled).toBe(true);
     mountSheetFor("tab-1");
-    expect(trigger.hasAttribute("disabled")).toBe(false);
+    expect(trigger.disabled).toBe(false);
     fireEvent.click(trigger);
     expect(useMobileSwitcherStore.getState().openTabId).toBe("tab-1");
     act(() => useMobileSwitcherStore.getState().unregisterMount("tab-1"));
-    expect(trigger.hasAttribute("disabled")).toBe(true);
+    expect(trigger.disabled).toBe(true);
   });
 
   it("renders for a viewer role too - switching tabs is not permission-gated", () => {
     holder.role = "viewer";
     mountSheetFor("tab-1");
     render(<EpicMobileSwitcherTrigger tabId="tab-1" />);
-    expect(
-      screen
-        .getByTestId("mobile-epic-switcher-trigger")
-        .hasAttribute("disabled"),
-    ).toBe(false);
+    expect(switcherTrigger().disabled).toBe(false);
     holder.role = "owner";
   });
 });

--- a/clients/gui-app/src/components/epic-canvas/__tests__/epic-mobile-header-actions.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/epic-mobile-header-actions.test.tsx
@@ -212,6 +212,10 @@ describe("<EpicMobileSwitcherTrigger />", () => {
     expect(useMobileSwitcherStore.getState().openTabId).toBe("tab-1");
     act(() => useMobileSwitcherStore.getState().unregisterMount("tab-1"));
     expect(trigger.disabled).toBe(true);
+    // Losing the mount re-disables the trigger without closing the sheet. The
+    // component-level form of this - a real unmount, not a direct store call -
+    // is pinned in `mobile-tab-switcher-mount.test.tsx`.
+    expect(useMobileSwitcherStore.getState().openTabId).toBe("tab-1");
   });
 
   it("renders for a viewer role too - switching tabs is not permission-gated", () => {

--- a/clients/gui-app/src/components/epic-canvas/mobile/__tests__/mobile-tab-switcher-mount.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/__tests__/mobile-tab-switcher-mount.test.tsx
@@ -1,0 +1,73 @@
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MobileTabSwitcherMount } from "@/components/epic-canvas/mobile/mobile-tab-switcher-mount";
+import { useMobileSwitcherStore } from "@/stores/epics/mobile-switcher-store";
+
+// The sheet pulls the resolved-theme context and every embedded panel body with
+// it; this file is about the mount's REGISTRATION, so stub it to a marker
+// carrying the open flag it was handed.
+vi.mock("@/components/epic-canvas/mobile/tab-switcher-sheet", () => ({
+  TabSwitcherSheet: (props: { readonly open: boolean }) => (
+    <div data-testid="sheet" data-open={props.open ? "true" : "false"} />
+  ),
+}));
+
+function mountedFor(tabId: string): boolean {
+  return (useMobileSwitcherStore.getState().mountCountByTabId[tabId] ?? 0) > 0;
+}
+
+describe("<MobileTabSwitcherMount />", () => {
+  beforeEach(() => {
+    useMobileSwitcherStore.setState({ openTabId: null, mountCountByTabId: {} });
+  });
+  afterEach(cleanup);
+
+  it("registers its tab while mounted and unregisters on unmount", () => {
+    expect(mountedFor("tab-1")).toBe(false);
+    const { unmount } = render(
+      <MobileTabSwitcherMount epicId="epic-1" tabId="tab-1" />,
+    );
+    expect(mountedFor("tab-1")).toBe(true);
+    unmount();
+    expect(mountedFor("tab-1")).toBe(false);
+  });
+
+  it("registers per tab, so one tab's mount says nothing about another's", () => {
+    render(<MobileTabSwitcherMount epicId="epic-1" tabId="tab-1" />);
+    expect(mountedFor("tab-2")).toBe(false);
+  });
+
+  /**
+   * The count, not a set: two mounts for the same tab overlap across a canvas
+   * branch swap, and the tab has to stay registered until the last one goes.
+   */
+  it("stays registered while a second mount for the same tab is alive", () => {
+    const first = render(
+      <MobileTabSwitcherMount epicId="epic-1" tabId="tab-1" />,
+    );
+    render(<MobileTabSwitcherMount epicId="epic-1" tabId="tab-1" />);
+    first.unmount();
+    expect(mountedFor("tab-1")).toBe(true);
+  });
+
+  it("renders the sheet open when the store opens its tab", () => {
+    render(<MobileTabSwitcherMount epicId="epic-1" tabId="tab-1" />);
+    expect(screen.getByTestId("sheet").getAttribute("data-open")).toBe("false");
+    act(() => useMobileSwitcherStore.getState().setOpen("tab-1", true));
+    expect(screen.getByTestId("sheet").getAttribute("data-open")).toBe("true");
+  });
+
+  /**
+   * Losing the last mount is not the user closing the sheet. Clearing the flag
+   * here would shut a sheet that is open across a branch swap; the trigger is
+   * kept honest by the registration above instead.
+   */
+  it("leaves the open flag alone when it unmounts", () => {
+    const { unmount } = render(
+      <MobileTabSwitcherMount epicId="epic-1" tabId="tab-1" />,
+    );
+    act(() => useMobileSwitcherStore.getState().setOpen("tab-1", true));
+    unmount();
+    expect(useMobileSwitcherStore.getState().openTabId).toBe("tab-1");
+  });
+});

--- a/clients/gui-app/src/components/epic-canvas/mobile/epic-mobile-header-actions.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/epic-mobile-header-actions.tsx
@@ -7,7 +7,10 @@ import {
   epicTabRightActionsKey,
   useMobileHeaderStore,
 } from "@/stores/layout/mobile-header-store";
-import { useMobileSwitcherStore } from "@/stores/epics/mobile-switcher-store";
+import {
+  useIsMobileSwitcherMounted,
+  useMobileSwitcherStore,
+} from "@/stores/epics/mobile-switcher-store";
 import { useRegisteredEpicPermissionRole } from "@/lib/epic-selectors";
 import { isEditableRole } from "@/lib/epic-permissions";
 import { useQueryClient } from "@tanstack/react-query";
@@ -31,6 +34,17 @@ import {
  * this trigger renders from the app provider stack, OUTSIDE the epic session
  * tree.
  *
+ * Disabled until a sheet is actually mounted for this tab. The header slot is
+ * bound for the whole epic PANE, but the sheet only mounts from the canvas
+ * branches that have a session and a loaded snapshot - so while the epic is
+ * still loading (header titled, body a skeleton), and on the fetch-error and
+ * repoint-failure branches, this control is on screen with nothing listening.
+ * It used to accept the tap anyway and write the open flag into the store,
+ * which read as a dead button and then popped the sheet open unasked once the
+ * canvas mounted and picked the stale flag up. Natively `disabled`, not
+ * `aria-disabled`: the tap must not reach `setOpen` at all, and the base button
+ * variant already carries the muted `disabled:opacity-50` treatment.
+ *
  * Ungated by permission: switching tabs reads, it does not mutate, so a viewer
  * gets the same trigger. The create actions inside the sheet carry their own
  * editor gate.
@@ -38,6 +52,7 @@ import {
 export function EpicMobileSwitcherTrigger(props: { readonly tabId: string }) {
   const { tabId } = props;
   const setOpen = useMobileSwitcherStore((state) => state.setOpen);
+  const mounted = useIsMobileSwitcherMounted(tabId);
   return (
     <Button
       type="button"
@@ -45,6 +60,7 @@ export function EpicMobileSwitcherTrigger(props: { readonly tabId: string }) {
       size="icon-sm"
       aria-label="Switch tab"
       data-testid="mobile-epic-switcher-trigger"
+      disabled={!mounted}
       onClick={() => setOpen(tabId, true)}
       className="shrink-0 text-muted-foreground hover:text-foreground"
     >

--- a/clients/gui-app/src/components/epic-canvas/mobile/mobile-tab-switcher-mount.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/mobile-tab-switcher-mount.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useEffect } from "react";
 import { TabSwitcherSheet } from "@/components/epic-canvas/mobile/tab-switcher-sheet";
 import {
   useIsMobileSwitcherOpen,
@@ -10,8 +10,12 @@ import {
  *
  * The sheet mounts inside the canvas tree, where the epic projection and the
  * providers its embedded panel bodies rely on are in scope, while the trigger
- * that opens it lives in the app header. Every mobile canvas state that a user
- * can reach mounts this, so the header trigger is never inert.
+ * that opens it lives in the app header. That is a strictly smaller subtree
+ * than the trigger's: the canvas branches that render a skeleton, a snapshot
+ * fetch error or a repoint failure never reach here, so the trigger is on
+ * screen in states no sheet is listening in. Registering the tab id while
+ * mounted is what lets the trigger see that and disable itself, rather than
+ * writing an open flag nothing renders.
  */
 export function MobileTabSwitcherMount(props: {
   readonly epicId: string;
@@ -20,10 +24,16 @@ export function MobileTabSwitcherMount(props: {
   const { epicId, tabId } = props;
   const open = useIsMobileSwitcherOpen(tabId);
   const setOpen = useMobileSwitcherStore((s) => s.setOpen);
+  const registerMount = useMobileSwitcherStore((s) => s.registerMount);
+  const unregisterMount = useMobileSwitcherStore((s) => s.unregisterMount);
   const handleOpenChange = useCallback(
     (next: boolean) => setOpen(tabId, next),
     [setOpen, tabId],
   );
+  useEffect(() => {
+    registerMount(tabId);
+    return () => unregisterMount(tabId);
+  }, [registerMount, tabId, unregisterMount]);
   return (
     <TabSwitcherSheet
       epicId={epicId}

--- a/clients/gui-app/src/stores/epics/mobile-switcher-store.ts
+++ b/clients/gui-app/src/stores/epics/mobile-switcher-store.ts
@@ -2,7 +2,7 @@ import { create } from "zustand";
 
 /**
  * Open state of the mobile tab-switcher sheet, keyed by the epic tab it belongs
- * to.
+ * to, alongside which tabs currently have a sheet mounted to open.
  *
  * A store rather than local view state because the two ends live on opposite
  * sides of the epic session boundary: the trigger sits in the mobile app header
@@ -10,14 +10,38 @@ import { create } from "zustand";
  * the sheet itself is mounted by the epic tile view, which is where the epic
  * projection, permission role and canvas hooks it reads are available. Keying on
  * `tabId` keeps one epic tab's sheet from opening on another.
+ *
+ * That same split is why the mount registry exists. The trigger renders from a
+ * slot that is live for the whole epic pane, while the sheet is mounted only
+ * from the canvas branches that have a session and a snapshot - so there are
+ * reachable states (a loading skeleton, a snapshot fetch error, a repoint
+ * failure card) where the trigger is on screen and no sheet is listening. The
+ * open flag alone cannot tell those apart from a mounted-but-closed sheet: it
+ * is a request, not a capability. Mounts register here so the trigger can read
+ * the capability directly and disable itself instead of writing an open that
+ * nothing renders.
  */
 interface MobileSwitcherState {
   readonly openTabId: string | null;
+  /**
+   * Live {@link MobileSwitcherState.registerMount} count per epic tab. A COUNT
+   * rather than a set of ids: the sheet is mounted from several mutually
+   * exclusive canvas branches, and moving between two of them is one commit -
+   * a set would be correct only because React happens to run every cleanup
+   * before every effect, so the tab would read as unmounted mid-swap under any
+   * other order. A count is correct either way.
+   */
+  readonly mountCountByTabId: Readonly<Record<string, number>>;
   readonly setOpen: (tabId: string, open: boolean) => void;
+  /** Declares that a switcher sheet is now rendered for this epic tab. */
+  readonly registerMount: (tabId: string) => void;
+  /** Undoes one {@link MobileSwitcherState.registerMount}. */
+  readonly unregisterMount: (tabId: string) => void;
 }
 
 export const useMobileSwitcherStore = create<MobileSwitcherState>((set) => ({
   openTabId: null,
+  mountCountByTabId: {},
   setOpen: (tabId, open) => {
     set((state) => {
       if (open) return { openTabId: tabId };
@@ -27,9 +51,43 @@ export const useMobileSwitcherStore = create<MobileSwitcherState>((set) => ({
       return { openTabId: null };
     });
   },
+  registerMount: (tabId) => {
+    set((state) => ({
+      mountCountByTabId: {
+        ...state.mountCountByTabId,
+        [tabId]: (state.mountCountByTabId[tabId] ?? 0) + 1,
+      },
+    }));
+  },
+  unregisterMount: (tabId) => {
+    set((state) => {
+      const remaining = (state.mountCountByTabId[tabId] ?? 0) - 1;
+      const next = { ...state.mountCountByTabId };
+      if (remaining > 0) next[tabId] = remaining;
+      else delete next[tabId];
+      // `openTabId` is deliberately left alone. Losing the last mount is not a
+      // user closing the sheet, and clearing here would close one that is open
+      // across a branch swap - the sheet's own create/activate rows already
+      // close it before the canvas they populate takes over. Nothing strands
+      // either: the trigger cannot write an open with no mount, and the other
+      // writer (`use-activate-comment-thread`) only fires from inside a
+      // rendered tile, which is a state that mounts the sheet.
+      return { mountCountByTabId: next };
+    });
+  },
 }));
 
 /** Whether the switcher sheet is open for this epic tab. */
 export function useIsMobileSwitcherOpen(tabId: string): boolean {
   return useMobileSwitcherStore((state) => state.openTabId === tabId);
+}
+
+/**
+ * Whether a switcher sheet is mounted for this epic tab - i.e. whether asking
+ * for it to open would put anything on screen.
+ */
+export function useIsMobileSwitcherMounted(tabId: string): boolean {
+  return useMobileSwitcherStore(
+    (state) => (state.mountCountByTabId[tabId] ?? 0) > 0,
+  );
 }


### PR DESCRIPTION
## Problem

On the mobile app, while a task is still loading — the header shows the title, the body shows the skeleton — the top-right tab-switcher button does nothing when tapped.

The two halves of the switcher live on opposite sides of the epic session boundary. `EpicMobileSwitcherTrigger` is registered into the mobile header's right-actions slot by `MobileEpicHeaderActionsBinder`, which `EpicSurface` mounts for the whole epic pane. The sheet it opens is mounted by `MobileTabSwitcherMount`, from inside the canvas tree. That is a strictly smaller subtree, and the branches that never reach it are exactly the ones with no sheet:

- `EpicShellLoadingBody` → `LoadingTileCanvas` (no session handle yet) — the reported case
- `EpicRepointFailure` (gate fallback + repoint failure)
- `TileCanvasBody` with a `snapshotFetchError` → `SnapshotErrorBanner`
- `TileCanvasBody` with the snapshot not yet loaded → `CanvasSkeleton`

In all of them the trigger accepted the tap and wrote `openTabId` into `useMobileSwitcherStore`. Nothing rendered it, so the press read as dead — and because the store keeps the flag, the sheet could then pop open unasked the moment the canvas mounted. `MobileTabSwitcherMount`'s doc comment asserted the opposite ("every mobile canvas state a user can reach mounts this, so the header trigger is never inert"); the loading state is its counter-example.

## Change

`MobileTabSwitcherMount` registers its `tabId` in the switcher store while it is mounted and unregisters on unmount. The trigger reads that through `useIsMobileSwitcherMounted(tabId)` and renders natively `disabled` when nothing is registered for its tab, so the tap cannot reach `setOpen` at all. `aria-label` is unchanged and the muted treatment is the base button variant's own `disabled:opacity-50` — no new classes, no change to the header slot's layout.

The registry is a refcount per tab, not a set of ids. The sheet is mounted from several mutually exclusive canvas branches, and moving between two of them is a single commit; a set would be correct only because React happens to run every cleanup before every effect, and would report the tab as unmounted mid-swap under any other order.

Unmounting deliberately does **not** clear `openTabId`. Losing the last mount is not the user closing the sheet, and clearing there would shut a sheet that is open across a branch swap — the sheet's own create/activate rows already close it themselves. Nothing strands as a result: the trigger can no longer write an open with no mount, and the only other writer, `useActivateCommentThread`, fires from `collab-tile-body` — inside a rendered tile, which is a state that mounts the sheet — so its mobile branch is unaffected.

Mobile-only by nature: desktop reaches its tabs through the tile canvas and has no such trigger.

## Testing

`clients/gui-app`:

- `src/components/epic-canvas/__tests__/epic-mobile-header-actions.test.tsx` — trigger disabled with no mount registered and the tap leaves `openTabId` null; another tab's mount does not enable it; enabled once a mount registers, tap opens, unmount re-disables; the viewer-role case now asserts enabled rather than merely present.
- `src/components/epic-canvas/mobile/__tests__/mobile-tab-switcher-mount.test.tsx` (new) — registers while mounted and unregisters on unmount; registration is per tab; stays registered while a second mount for the same tab is alive; the sheet still opens from the store; unmount leaves the open flag alone.

Also re-ran `mobile-epic-tile-view.test.tsx` and `tab-switcher-sheet.test.tsx` (both render the real mount). `tsgo -b`, `oxlint`, `eslint` and `oxfmt` are clean.