### PR TITLE
feat(gui): give side chats their own tile-placement row

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/dnd/root-dnd-commits.ts
+++ b/clients/gui-app/src/components/epic-canvas/dnd/root-dnd-commits.ts
@@ -482,9 +482,11 @@ function placeResolvedCanvasTile(
   // position the user dropped at. This is the same resolution the pre-intent
   // `insertNodeOnTabStrip` / `splitPaneAtEdge` did for a `node` source, only
   // spelled at the call site now that placement travels in the intent.
+  // A drop names a tab slot or an edge, never a `beside` placement - that one
+  // defers its shape to a setting, and a drop position has no shape to defer.
   const openDroppedTile = (
     viewTabId: string,
-    placement: ExplicitTilePlacement | null,
+    placement: Exclude<ExplicitTilePlacement, { kind: "beside" }> | null,
   ): boolean => {
     if (placement !== null) {
       const existing = findOpenTileInTab(viewTabId, tile);

--- a/clients/gui-app/src/components/settings/SETTINGS.md
+++ b/clients/gui-app/src/components/settings/SETTINGS.md
@@ -714,7 +714,15 @@ means the drain UI renders NOTHING - never a zero, which would offer to end
     (`conversation`) and **Browsers** (`browser`) - product nouns for what the
     user opens, not the store's category words. Browser alone adds **Picture
     in picture** (`BrowserTilePlacement`) because the other two have no PiP
-    host. Defaults content=tab, conversation=tab, browser=split;
+    host. A fourth row, **Side chats** (`sideChat`), covers the `/btw` /
+    `/side` aside: it is a plain `chat` tile, so no tile kind maps to the
+    row - the open carries it as a `beside` placement
+    (`ExplicitTilePlacement`) naming the source chat's pane, and the row
+    decides only how "beside" is drawn ("As a tab of the source chat" /
+    "In a split beside the source chat"). Its own row rather than Agents &
+    terminals because an aside is read next to its conversation whatever
+    the user chose for new agents. Defaults content=tab, conversation=tab,
+    browser=split, sideChat=split;
     `tilePlacementForCategory` resolves a category against the default. On a
     single-tile viewport (`useIsMobileViewport()`) the row gains the
     DESCRIPTION "Narrow windows show one tile at a time, so everything opens

--- a/clients/gui-app/src/components/settings/panels/__tests__/opening-behavior-panel.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/opening-behavior-panel.test.tsx
@@ -176,6 +176,7 @@ describe("<OpeningBehaviorPanel /> agent-opened tabs", () => {
         content: "tab",
         conversation: "tab",
         browser: "split",
+        sideChat: "split",
       },
     });
     render(<OpeningBehaviorPanel />);
@@ -183,6 +184,37 @@ describe("<OpeningBehaviorPanel /> agent-opened tabs", () => {
     expect(
       screen.getByRole("combobox", { name: "Agent-opened tabs" }),
     ).not.toBeNull();
+  });
+});
+
+describe("<OpeningBehaviorPanel /> side chats", () => {
+  it("renders under per-category, alongside the other per-type rows", () => {
+    render(<OpeningBehaviorPanel />);
+
+    expect(screen.getByRole("combobox", { name: "Side chats" })).not.toBeNull();
+  });
+
+  it("is absent when the default is flat rather than per-category", () => {
+    useSettingsStore.setState({
+      tilePlacement: {
+        default: "tab",
+        content: "tab",
+        conversation: "tab",
+        browser: "split",
+        sideChat: "split",
+      },
+    });
+    render(<OpeningBehaviorPanel />);
+
+    expect(screen.queryByRole("combobox", { name: "Side chats" })).toBeNull();
+  });
+
+  it("writes the side-chat placement", () => {
+    render(<OpeningBehaviorPanel />);
+
+    choose("Side chats", "As a tab of the source chat");
+
+    expect(useSettingsStore.getState().tilePlacement.sideChat).toBe("tab");
   });
 });
 

--- a/clients/gui-app/src/components/settings/panels/opening-behavior-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/opening-behavior-panel.tsx
@@ -65,6 +65,14 @@ const TILE_PLACEMENT_DEFAULT_LABELS: Record<
   ...TILE_PLACEMENT_LABELS,
   "per-category": "Per tile type",
 };
+/**
+ * A side chat is always placed relative to the chat it was asked from, so
+ * "this pane" would be ambiguous here: the options name the SOURCE chat.
+ */
+const SIDE_CHAT_PLACEMENT_LABELS: Record<TilePlacement, string> = {
+  tab: "As a tab of the source chat",
+  split: "In a split beside the source chat",
+};
 /** Only the browser category can float - the other two have no PiP host. */
 const BROWSER_TILE_PLACEMENT_LABELS: Record<BrowserTilePlacement, string> = {
   ...TILE_PLACEMENT_LABELS,
@@ -239,6 +247,22 @@ export function OpeningBehaviorPanel(): ReactNode {
                       setTilePlacement({ browser });
                     }}
                     ariaLabel="Browsers"
+                  />
+                }
+              />
+              <SettingsRow
+                label="Side chats"
+                description="Asides started with /btw or /side, placed next to the chat they were asked from."
+                control={
+                  <EnumSelect
+                    labels={SIDE_CHAT_PLACEMENT_LABELS}
+                    isValue={isTilePlacement}
+                    value={tilePlacement.sideChat}
+                    onValueChange={(sideChat) => {
+                      trackOpeningBehaviorSetting("tilePlacement");
+                      setTilePlacement({ sideChat });
+                    }}
+                    ariaLabel="Side chats"
                   />
                 }
               />

--- a/clients/gui-app/src/lib/canvas/tile-open/__tests__/resolve-tile-open.test.ts
+++ b/clients/gui-app/src/lib/canvas/tile-open/__tests__/resolve-tile-open.test.ts
@@ -117,6 +117,7 @@ const DEFAULT_SETTINGS: TilePlacementSettings = {
   content: "tab",
   conversation: "tab",
   browser: "split",
+  sideChat: "split",
 };
 
 function resolve(input: {
@@ -436,6 +437,7 @@ describe("setting and modifiers", () => {
     content: "tab",
     conversation: "tab",
     browser: "tab",
+    sideChat: "tab",
   };
 
   it("honors a flat (non-per-category) default", () => {
@@ -525,6 +527,7 @@ describe("single-tile viewport", () => {
         content: "tab",
         conversation: "tab",
         browser: "pip",
+        sideChat: "split",
       },
       canvas: SINGLE_PANE_CANVAS,
       singleTileViewport: true,
@@ -539,6 +542,7 @@ describe("pip", () => {
     content: "tab",
     conversation: "tab",
     browser: "pip",
+    sideChat: "split",
   };
 
   it("floats a browser tile", () => {
@@ -589,6 +593,7 @@ describe("category affinity", () => {
     content: "tab",
     conversation: "split",
     browser: "split",
+    sideChat: "split",
   };
 
   it("groups into the pane whose same-category tile is most recent", () => {
@@ -701,6 +706,7 @@ describe("empty panes", () => {
     content: "split",
     conversation: "split",
     browser: "split",
+    sideChat: "split",
   };
 
   /** p1 (active) holds a spec; p2 was opened and never filled. */
@@ -793,6 +799,232 @@ describe("empty panes", () => {
       kind: "split",
       tabId: TAB_ID,
       paneId: "p1",
+      edge: "right",
+      mode: "permanent",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// `beside` placement (side chats): a `/btw` names the pane its source chat
+// lives in; the "Side chats" row decides tab-versus-split. Category
+// affinity and empty-pane filling do NOT apply - the whole point of naming
+// the pane is that the tile lands next to it.
+// ---------------------------------------------------------------------------
+
+describe("beside placement", () => {
+  // p1 (active) holds CHAT_A; p2 (NOT active) holds SPEC_A - the named pane
+  // for these cases, so a wrong answer that lands in the active pane instead
+  // is caught rather than accidentally matching.
+  const TWO_PANE_CANVAS = canvasOf({
+    root: group("g1", "horizontal", [
+      pane("p1", [CHAT_A.instanceId]),
+      pane("p2", [SPEC_A.instanceId]),
+    ]),
+    activePaneId: "p1",
+    tiles: [CHAT_A, SPEC_A],
+  });
+
+  function besideIntent(
+    paneId: string,
+    overrides: Partial<TileOpenIntent> = {},
+  ): TileOpenIntent {
+    return {
+      ...BASE_INTENT,
+      node: CHAT_C,
+      placement: { kind: "beside", paneId, category: "side-chat" },
+      ...overrides,
+    };
+  }
+
+  it("splits to the right of the NAMED pane on the split row", () => {
+    expect(
+      resolve({
+        intent: besideIntent("p2"),
+        settings: { ...DEFAULT_SETTINGS, sideChat: "split" },
+        canvas: TWO_PANE_CANVAS,
+        singleTileViewport: false,
+      }),
+    ).toEqual({
+      kind: "split",
+      tabId: TAB_ID,
+      paneId: "p2",
+      edge: "right",
+      mode: "permanent",
+    });
+  });
+
+  it("opens as a tab of the NAMED pane on the tab row", () => {
+    expect(
+      resolve({
+        intent: besideIntent("p2"),
+        settings: { ...DEFAULT_SETTINGS, sideChat: "tab" },
+        canvas: TWO_PANE_CANVAS,
+        singleTileViewport: false,
+      }),
+    ).toEqual({
+      kind: "open-in-pane",
+      tabId: TAB_ID,
+      paneId: "p2",
+      mode: "permanent",
+      index: null,
+    });
+  });
+
+  it("alt inverts split -> tab", () => {
+    expect(
+      resolve({
+        intent: besideIntent("p2", {
+          modifiers: { ...NO_MODS, alt: true },
+        }),
+        settings: { ...DEFAULT_SETTINGS, sideChat: "split" },
+        canvas: TWO_PANE_CANVAS,
+        singleTileViewport: false,
+      }),
+    ).toEqual({
+      kind: "open-in-pane",
+      tabId: TAB_ID,
+      paneId: "p2",
+      mode: "permanent",
+      index: null,
+    });
+  });
+
+  it("alt inverts tab -> split", () => {
+    expect(
+      resolve({
+        intent: besideIntent("p2", {
+          modifiers: { ...NO_MODS, alt: true },
+        }),
+        settings: { ...DEFAULT_SETTINGS, sideChat: "tab" },
+        canvas: TWO_PANE_CANVAS,
+        singleTileViewport: false,
+      }),
+    ).toEqual({
+      kind: "split",
+      tabId: TAB_ID,
+      paneId: "p2",
+      edge: "right",
+      mode: "permanent",
+    });
+  });
+
+  it("shift forces a split even on the tab row", () => {
+    expect(
+      resolve({
+        intent: besideIntent("p2", {
+          modifiers: { ...NO_MODS, shift: true },
+        }),
+        settings: { ...DEFAULT_SETTINGS, sideChat: "tab" },
+        canvas: TWO_PANE_CANVAS,
+        singleTileViewport: false,
+      }),
+    ).toEqual({
+      kind: "split",
+      tabId: TAB_ID,
+      paneId: "p2",
+      edge: "right",
+      mode: "permanent",
+    });
+  });
+
+  it("clamps to the named pane on a single-tile viewport", () => {
+    expect(
+      resolve({
+        intent: besideIntent("p2"),
+        settings: { ...DEFAULT_SETTINGS, sideChat: "split" },
+        canvas: TWO_PANE_CANVAS,
+        singleTileViewport: true,
+      }),
+    ).toEqual({
+      kind: "open-in-pane",
+      tabId: TAB_ID,
+      paneId: "p2",
+      mode: "permanent",
+      index: null,
+    });
+  });
+
+  it("a flat (non-per-category) default wins over the row", () => {
+    const FLAT_TAB: TilePlacementSettings = {
+      default: "tab",
+      content: "tab",
+      conversation: "tab",
+      browser: "tab",
+      sideChat: "split",
+    };
+    expect(
+      resolve({
+        intent: besideIntent("p2"),
+        settings: FLAT_TAB,
+        canvas: TWO_PANE_CANVAS,
+        singleTileViewport: false,
+      }),
+    ).toEqual({
+      kind: "open-in-pane",
+      tabId: TAB_ID,
+      paneId: "p2",
+      mode: "permanent",
+      index: null,
+    });
+  });
+
+  describe("named pane not on the canvas", () => {
+    it("falls through to the configured split, right of the active pane", () => {
+      expect(
+        resolve({
+          intent: besideIntent("gone"),
+          settings: { ...DEFAULT_SETTINGS, sideChat: "split" },
+          canvas: SINGLE_PANE_CANVAS,
+          singleTileViewport: false,
+        }),
+      ).toEqual({
+        kind: "split",
+        tabId: TAB_ID,
+        paneId: "p1",
+        edge: "right",
+        mode: "permanent",
+      });
+    });
+
+    it("falls through to the configured tab, in the active pane", () => {
+      expect(
+        resolve({
+          intent: besideIntent("gone"),
+          settings: { ...DEFAULT_SETTINGS, sideChat: "tab" },
+          canvas: SINGLE_PANE_CANVAS,
+          singleTileViewport: false,
+        }),
+      ).toEqual({
+        kind: "open-in-pane",
+        tabId: TAB_ID,
+        paneId: "p1",
+        mode: "permanent",
+        index: null,
+      });
+    });
+  });
+
+  it("does not fill an existing empty pane - splits right of the named (occupied) pane instead", () => {
+    const canvas = canvasOf({
+      root: group("g1", "horizontal", [
+        pane("p1", []),
+        pane("p2", [SPEC_A.instanceId]),
+      ]),
+      activePaneId: "p1",
+      tiles: [SPEC_A],
+    });
+    expect(
+      resolve({
+        intent: besideIntent("p2"),
+        settings: { ...DEFAULT_SETTINGS, sideChat: "split" },
+        canvas,
+        singleTileViewport: false,
+      }),
+    ).toEqual({
+      kind: "split",
+      tabId: TAB_ID,
+      paneId: "p2",
       edge: "right",
       mode: "permanent",
     });

--- a/clients/gui-app/src/lib/canvas/tile-open/intent.ts
+++ b/clients/gui-app/src/lib/canvas/tile-open/intent.ts
@@ -24,12 +24,34 @@ export interface TileOpenModifiers {
   readonly middle: boolean;
 }
 
-/** Placement is configured per category, never per tile kind (C2, C3). */
+/**
+ * The category a tile KIND places under (C2, C3). Placement is configured per
+ * category, never per tile kind, and every tile on the canvas belongs to
+ * exactly one of these - they are what category affinity (C5) groups by.
+ */
 export type TileCategory = "content" | "conversation" | "browser";
+
+/**
+ * A category an OPEN places under that no tile kind maps to: the tile is a
+ * plain `chat`, but the open was a `/btw` side chat, and "where does an aside
+ * land relative to its conversation" is a different question from "where
+ * does a new agent land". Carried on the placement (`beside`), never derived
+ * from the node, so an open that is not an aside can never claim its row.
+ */
+export type AnchoredTileCategory = "side-chat";
+
+/** Everything the tile placement setting has a row for. */
+export type TilePlacementCategory = TileCategory | AnchoredTileCategory;
 
 /**
  * A placement the caller already decided: a drop position, a PaneOpener's own
  * pane, an Electron popup's originating pane. Overrides the setting (C7).
+ *
+ * `beside` is the half-decided case: the caller names the pane the open is
+ * relative to and the category whose setting row applies, and the setting
+ * still decides tab-versus-split - a tab in that pane, or a split to its
+ * right. A side chat is read next to the conversation it was asked from
+ * whichever the user picked; the row only says how "next to" is drawn.
  */
 export type ExplicitTilePlacement =
   | {
@@ -41,6 +63,11 @@ export type ExplicitTilePlacement =
       readonly kind: "split";
       readonly paneId: string;
       readonly edge: EdgeDropPosition;
+    }
+  | {
+      readonly kind: "beside";
+      readonly paneId: string;
+      readonly category: AnchoredTileCategory;
     };
 
 /** Which epic canvas to open into: a header tab, or the epic behind one. */

--- a/clients/gui-app/src/lib/canvas/tile-open/resolve-tile-open.ts
+++ b/clients/gui-app/src/lib/canvas/tile-open/resolve-tile-open.ts
@@ -17,12 +17,12 @@ import {
 import {
   tileCategoryOf,
   type ExplicitTilePlacement,
-  type TileCategory,
   type TileOpenGesture,
   type TileOpenIntent,
   type TileOpenMode,
   type TileOpenModifiers,
   type TileOpenPlan,
+  type TilePlacementCategory,
 } from "./intent";
 
 const NO_MODIFIERS: TileOpenModifiers = {
@@ -46,7 +46,7 @@ function resolveMode(
  * placements it names, not "whatever is configured". */
 function resolvePlacement(
   settings: TilePlacementSettings,
-  category: TileCategory,
+  category: TilePlacementCategory,
   modifiers: TileOpenModifiers,
 ): BrowserTilePlacement {
   const configured = tilePlacementForCategory(settings, category);
@@ -65,7 +65,7 @@ function resolvePlacement(
 function categoryRecency(
   canvas: EpicCanvasState,
   pane: TilePane,
-  category: TileCategory,
+  category: TilePlacementCategory,
 ): number | null {
   let best: number | null = null;
   for (const instanceId of pane.tabInstanceIds) {
@@ -89,7 +89,7 @@ function categoryRecency(
  */
 function affinityPaneId(
   canvas: EpicCanvasState,
-  category: TileCategory,
+  category: TilePlacementCategory,
 ): string | null {
   let bestId: string | null = null;
   let bestRank = 0;
@@ -145,7 +145,7 @@ function anchorPaneId(canvas: EpicCanvasState): string | null {
  */
 function resolveExplicitPlan(
   tabId: string,
-  placement: ExplicitTilePlacement,
+  placement: Exclude<ExplicitTilePlacement, { kind: "beside" }>,
   mode: TileOpenMode,
   singleTileViewport: boolean,
 ): TileOpenPlan {
@@ -176,11 +176,65 @@ function resolveExplicitPlan(
   };
 }
 
+type BesidePlacement = Extract<ExplicitTilePlacement, { kind: "beside" }>;
+
+/**
+ * The `beside` placement to honour, or `null` when there is none or its pane
+ * is gone (closed before a forked chat projected). A gone pane still places
+ * under the placement's own row - unanchored, the way a side chat asked from
+ * a chat that is not on this canvas does.
+ */
+function anchoredBeside(
+  placement: ExplicitTilePlacement | null,
+  canvas: EpicCanvasState,
+): BesidePlacement | null {
+  if (placement === null || placement.kind !== "beside") return null;
+  if (canvas.root === null) return null;
+  return findPaneById(canvas.root, placement.paneId) === null
+    ? null
+    : placement;
+}
+
+/**
+ * A `beside` placement decided the pane but not the shape: its category's
+ * setting row (plus the same modifiers as any configured open) says whether
+ * the tile becomes a tab of that pane or a split to its right. Category
+ * grouping (C5) and empty-pane filling deliberately do NOT apply - the whole
+ * point of naming the pane is that the tile lands next to it, not in
+ * whichever pane last showed something similar.
+ */
+function resolveBesidePlan(args: {
+  readonly settings: TilePlacementSettings;
+  readonly placement: BesidePlacement;
+  readonly modifiers: TileOpenModifiers;
+  readonly tabId: string;
+  readonly mode: TileOpenMode;
+  readonly singleTileViewport: boolean;
+}): TileOpenPlan {
+  const { mode, tabId } = args;
+  const { paneId } = args.placement;
+  const configured = resolvePlacement(
+    args.settings,
+    args.placement.category,
+    args.modifiers,
+  );
+  if (
+    configured === "tab" ||
+    mode === "background" ||
+    args.singleTileViewport
+  ) {
+    return { kind: "open-in-pane", tabId, paneId, mode, index: null };
+  }
+  // `pip` cannot be configured for an anchored category (its row is a plain
+  // `TilePlacement`), so anything that is not `tab` is a split.
+  return { kind: "split", tabId, paneId, edge: "right", mode };
+}
+
 /** Steps 4b-7: the configured placement, once no caller has overridden it. */
 function resolveConfiguredPlan(args: {
   readonly canvas: EpicCanvasState;
   readonly settings: TilePlacementSettings;
-  readonly category: TileCategory;
+  readonly category: TilePlacementCategory;
   readonly modifiers: TileOpenModifiers;
   readonly tabId: string;
   readonly mode: "preview" | "permanent";
@@ -250,7 +304,11 @@ export function resolveTileOpen(input: {
       : input.resolveTargetTabForEpic(intent.target.epicId);
 
   const modifiers = intent.modifiers ?? NO_MODIFIERS;
-  const category = tileCategoryOf(intent.node);
+  const beside = anchoredBeside(intent.placement, canvas);
+  const category: TilePlacementCategory =
+    intent.placement?.kind === "beside"
+      ? intent.placement.category
+      : tileCategoryOf(intent.node);
 
   // 2. Mode (C4). Needed before dedupe: a permanent hit on the pane's preview
   // promotes it.
@@ -276,8 +334,19 @@ export function resolveTileOpen(input: {
     }
   }
 
-  // 4a. Explicit placement wins over the setting (C7).
-  if (intent.placement !== null) {
+  // 4a. Explicit placement wins over the setting (C7); a `beside` placement
+  // wins on the pane and defers to its row on the shape.
+  if (beside !== null) {
+    return resolveBesidePlan({
+      settings,
+      placement: beside,
+      modifiers,
+      tabId,
+      mode,
+      singleTileViewport,
+    });
+  }
+  if (intent.placement !== null && intent.placement.kind !== "beside") {
     return resolveExplicitPlan(
       tabId,
       intent.placement,

--- a/clients/gui-app/src/lib/commands/actions/__tests__/start-side-chat.test.ts
+++ b/clients/gui-app/src/lib/commands/actions/__tests__/start-side-chat.test.ts
@@ -169,7 +169,11 @@ describe("startSideChat", () => {
         baseArgs({
           createChat: recorder.createChat,
           worktreeIntent: WORKTREE_INTENT,
-          placement: { kind: "split", paneId: "pane-1", edge: "right" },
+          placement: {
+            kind: "beside",
+            paneId: "pane-1",
+            category: "side-chat",
+          },
         }),
       );
 
@@ -197,9 +201,9 @@ describe("startSideChat", () => {
       expect(handoff).not.toBeNull();
       expect(handoff?.status).toBe("pending");
       expect(handoff?.placement).toEqual({
-        kind: "split",
+        kind: "beside",
         paneId: "pane-1",
-        edge: "right",
+        category: "side-chat",
       });
       expect(handoff?.messageId).toBe(request.initialMessage?.messageId);
       expect(handoff?.clientActionId).toBe(
@@ -375,7 +379,7 @@ describe("sideChatPlacementForTile", () => {
     setMobileApp(false);
   });
 
-  it("splits to the right of the pane holding the source chat's tile", () => {
+  it("names the pane holding the source chat's tile as a beside placement", () => {
     useEpicCanvasStore
       .getState()
       .seedEpic(EPIC_ID, { tabId: TAB_ID, name: "Epic" }, []);
@@ -392,9 +396,9 @@ describe("sideChatPlacementForTile", () => {
 
     const placement = sideChatPlacementForTile(TAB_ID, SOURCE_CHAT_ID);
     expect(placement).toEqual({
-      kind: "split",
+      kind: "beside",
       paneId,
-      edge: "right",
+      category: "side-chat",
     });
   });
 

--- a/clients/gui-app/src/lib/commands/actions/start-side-chat.ts
+++ b/clients/gui-app/src/lib/commands/actions/start-side-chat.ts
@@ -241,13 +241,14 @@ function openIntentForPlacement(
 }
 
 /**
- * Where a side chat asked from `sourceChatId`'s tile lands: split to the RIGHT
- * of the pane showing that tile, so the source keeps streaming in view - a
- * side chat is read beside its conversation, not instead of it. Returns `null`
- * - "use the configured conversation placement" - when the source is not on
- * this tab's canvas (or on a phone, which shows one tile at a time), and the
- * handoff degrades the same way on its own if the pane closes before the fork
- * projects.
+ * Where a side chat asked from `sourceChatId`'s tile lands: BESIDE the pane
+ * showing that tile, so the source keeps streaming in view - a side chat is
+ * read beside its conversation, not instead of it. The "Side chats" placement
+ * row decides how "beside" is drawn (a split to the pane's right, or a tab of
+ * that pane); this only names the pane. Returns `null` - "place under the
+ * Side chats row, unanchored" - when the source is not on this tab's canvas
+ * (or on a phone, which shows one tile at a time), and the handoff degrades
+ * the same way on its own if the pane closes before the fork projects.
  */
 export function sideChatPlacementForTile(
   tabId: string,
@@ -262,5 +263,5 @@ export function sideChatPlacementForTile(
     ),
   );
   if (pane === undefined) return null;
-  return { kind: "split", paneId: pane.id, edge: "right" };
+  return { kind: "beside", paneId: pane.id, category: "side-chat" };
 }

--- a/clients/gui-app/src/stores/epics/__tests__/initial-chat-handoff-store.test.ts
+++ b/clients/gui-app/src/stores/epics/__tests__/initial-chat-handoff-store.test.ts
@@ -157,6 +157,42 @@ describe("v1 -> v2 persisted-key migration", () => {
     });
   });
 
+  it("keeps a persisted beside placement for the side-chat category intact", () => {
+    const migrated = migrateInitialChatHandoffState({
+      handoffs: {
+        [V1_KEY]: {
+          ...V1_RECORD,
+          placement: {
+            kind: "beside",
+            paneId: "pane-1",
+            category: "side-chat",
+          },
+        },
+      },
+    });
+
+    expect(migrated.handoffs[initialChatHandoffKey(SCOPE)].placement).toEqual({
+      kind: "beside",
+      paneId: "pane-1",
+      category: "side-chat",
+    });
+  });
+
+  it("drops a beside placement carrying a foreign category", () => {
+    const migrated = migrateInitialChatHandoffState({
+      handoffs: {
+        [V1_KEY]: {
+          ...V1_RECORD,
+          placement: { kind: "beside", paneId: "pane-1", category: "browser" },
+        },
+      },
+    });
+
+    expect(
+      migrated.handoffs[initialChatHandoffKey(SCOPE)].placement,
+    ).toBeNull();
+  });
+
   it("drops a record whose status is outside the union rather than stranding it", () => {
     const migrated = migrateInitialChatHandoffState({
       handoffs: {

--- a/clients/gui-app/src/stores/epics/initial-chat-handoff-store.ts
+++ b/clients/gui-app/src/stores/epics/initial-chat-handoff-store.ts
@@ -175,6 +175,9 @@ function readPersistedPlacement(value: unknown): ExplicitTilePlacement | null {
   if (value.kind === "split" && isEdgeDropPosition(value.edge)) {
     return { kind: "split", paneId: value.paneId, edge: value.edge };
   }
+  if (value.kind === "beside" && value.category === "side-chat") {
+    return { kind: "beside", paneId: value.paneId, category: "side-chat" };
+  }
   return null;
 }
 

--- a/clients/gui-app/src/stores/settings/__tests__/settings-store.test.ts
+++ b/clients/gui-app/src/stores/settings/__tests__/settings-store.test.ts
@@ -464,10 +464,12 @@ describe("useSettingsStore", () => {
       content: "tab",
       conversation: "tab",
       browser: "split",
+      sideChat: "split",
     });
     const placement = useSettingsStore.getState().tilePlacement;
     expect(tilePlacementForCategory(placement, "content")).toBe("tab");
     expect(tilePlacementForCategory(placement, "browser")).toBe("split");
+    expect(tilePlacementForCategory(placement, "side-chat")).toBe("split");
   });
 
   it("lets an explicit default override the per-kind and per-category rows", () => {
@@ -488,8 +490,23 @@ describe("useSettingsStore", () => {
           content: "tab",
           conversation: "tab",
           browser: "pip",
+          sideChat: "tab",
         },
         "browser",
+      ),
+    ).toBe("split");
+    // A flat default answers for the side-chat row too - it is not exempt
+    // from "default" the way `pip` is exempt from `alt`.
+    expect(
+      tilePlacementForCategory(
+        {
+          default: "split",
+          content: "tab",
+          conversation: "tab",
+          browser: "pip",
+          sideChat: "tab",
+        },
+        "side-chat",
       ),
     ).toBe("split");
   });
@@ -515,6 +532,39 @@ describe("useSettingsStore", () => {
       ...DEFAULT_TILE_PLACEMENT_SETTINGS,
       browser: "pip",
     });
+  });
+
+  it("fills a missing sideChat row on a pre-row persisted blob with the default", async () => {
+    await rehydrateFrom({
+      tilePlacement: {
+        default: "per-category",
+        content: "tab",
+        conversation: "tab",
+        browser: "split",
+      },
+    });
+
+    expect(useSettingsStore.getState().tilePlacement).toEqual({
+      default: "per-category",
+      content: "tab",
+      conversation: "tab",
+      browser: "split",
+      sideChat: "split",
+    });
+  });
+
+  it("repairs an invalid persisted sideChat value to the default", async () => {
+    await rehydrateFrom({
+      tilePlacement: {
+        default: "per-category",
+        content: "tab",
+        conversation: "tab",
+        browser: "split",
+        sideChat: "pip",
+      },
+    });
+
+    expect(useSettingsStore.getState().tilePlacement.sideChat).toBe("split");
   });
 
   it("defaults agent tab surfacing to off", () => {

--- a/clients/gui-app/src/stores/settings/settings-store.ts
+++ b/clients/gui-app/src/stores/settings/settings-store.ts
@@ -35,6 +35,7 @@ import {
   type NotificationChimeSoundsByEvent,
 } from "@/lib/notifications/notification-chime";
 import type { DefaultOpenTarget } from "@/lib/editor/editor-menu-catalog";
+import type { TilePlacementCategory } from "@/lib/canvas/tile-open/intent";
 
 export type ThemeMode = "system" | "light" | "dark";
 export type EpicNodeIconColorMode = "byType" | "none";
@@ -56,6 +57,14 @@ export interface TilePlacementSettings {
   content: TilePlacement;
   conversation: TilePlacement;
   browser: BrowserTilePlacement;
+  /**
+   * A `/btw` side chat, which is always placed relative to the chat it was
+   * asked from: `split` opens it to that pane's right, `tab` as a tab of that
+   * pane. Its own row rather than `conversation` because the aside is read
+   * BESIDE its conversation - a user who tabs every new agent still wants
+   * the aside next to the chat it is about.
+   */
+  sideChat: TilePlacement;
 }
 /**
  * Whether a tab the AGENT opens via its browser REPL (`openTab`) reaches the
@@ -79,6 +88,7 @@ export const DEFAULT_TILE_PLACEMENT_SETTINGS: TilePlacementSettings = {
   content: "tab",
   conversation: "tab",
   browser: "split",
+  sideChat: "split",
 };
 const DEFAULT_AGENT_TAB_SURFACING: AgentTabSurfacing = "off";
 export type MinimapSide = "left" | "right";
@@ -667,14 +677,27 @@ export function linkOpenModeForKind(
   return settings.default === "per-kind" ? settings[kind] : settings.default;
 }
 
+/** The setting row each placement category reads. Spelled out because the
+ * category words are the resolver's and the keys are the store's; a total
+ * record keeps the two in step when either side grows. */
+const TILE_PLACEMENT_KEY_BY_CATEGORY: Record<
+  TilePlacementCategory,
+  Exclude<keyof TilePlacementSettings, "default">
+> = {
+  content: "content",
+  conversation: "conversation",
+  browser: "browser",
+  "side-chat": "sideChat",
+};
+
 /** Same shape for tiles: the global default wins unless it defers per
  * category. Only `browser` can answer `pip`. */
 export function tilePlacementForCategory(
   settings: TilePlacementSettings,
-  category: "content" | "conversation" | "browser",
+  category: TilePlacementCategory,
 ): BrowserTilePlacement {
   return settings.default === "per-category"
-    ? settings[category]
+    ? settings[TILE_PLACEMENT_KEY_BY_CATEGORY[category]]
     : settings.default;
 }
 
@@ -752,6 +775,11 @@ function resolvePersistedTilePlacement(
     browser: isBrowserTilePlacement(stored.browser)
       ? stored.browser
       : DEFAULT_TILE_PLACEMENT_SETTINGS.browser,
+    // Newer than the other rows: a blob written before it existed takes the
+    // default, which is the split-beside-the-source the feature always did.
+    sideChat: isTilePlacement(stored.sideChat)
+      ? stored.sideChat
+      : DEFAULT_TILE_PLACEMENT_SETTINGS.sideChat,
   };
 }
 


### PR DESCRIPTION
## Why

A `/btw` or `/side` aside was always split to the right of the chat it was asked from, bypassing Settings > Opening behavior entirely. Folding it into the existing "Agents & terminals" row would cover the parent chat under that row's default (`tab`), which defeats the point of an aside: it is read *beside* its conversation.

## What

- **Settings**: new **Side chats** row under Tile placement (`tilePlacement.sideChat`, default `split`). Options: "As a tab of the source chat" / "In a split beside the source chat". The flat global default still overrides it like the other rows. A persisted blob from before the row existed rehydrates to `split`.
- **Intent**: `ExplicitTilePlacement` gains a `beside` variant carrying the source chat's pane and the `side-chat` category. The category rides on the open, not the tile kind, so an ordinary chat open can never claim the row.
- **Resolver**: a `beside` placement whose pane is on the canvas resolves through the Side chats row: `split` becomes a split right of that pane, `tab` a tab of that pane. Shift/alt still apply. Category affinity and empty-pane filling are skipped on purpose. If the pane is gone it falls through to the row's unanchored placement.
- **Side chat action**: `sideChatPlacementForTile` returns the `beside` placement instead of a hardcoded split. Mobile and parent-off-canvas fallbacks unchanged.
- **Handoff store**: accepts the `beside` shape on rehydrate; rejects a foreign category.
- **DnD**: the drop path's placement parameter is narrowed to tab/split, since a drop never produces `beside`.
- `SETTINGS.md` documents the row and why it is separate.

## Tests

Resolver cases for every `beside` branch, settings-store default and migration, the panel row, the handoff-store migration, and the side-chat action expectations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

