### PR TITLE
gui-app: Home tab with a cross-task focus view (behind a setting)

### DIFF
--- a/clients/gui-app/src/components/home-focus/__tests__/home-focus-view.test.tsx
+++ b/clients/gui-app/src/components/home-focus/__tests__/home-focus-view.test.tsx
@@ -1,0 +1,991 @@
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { HostDirectoryEntry } from "@traycer-clients/shared/host-client/host-directory";
+import { HomeFocusView } from "@/components/home-focus/home-focus-view";
+import type {
+  FocusAgentRow,
+  FocusBackgroundRow,
+  FocusModel,
+  FocusPromptRow,
+  FocusTaskRow,
+} from "@/lib/home-focus/focus-model";
+import type { MergedNotificationRow } from "@/stores/notifications/merged-notifications";
+
+const modelMock = vi.hoisted(() => ({ value: null as FocusModel | null }));
+vi.mock("@/hooks/home-focus/use-focus-model", () => ({
+  useFocusModel: () => modelMock.value,
+}));
+
+const actionsMock = vi.hoisted(() => ({
+  openPrompt: vi.fn(),
+  openAgent: vi.fn(),
+  openTask: vi.fn(),
+  openBackground: vi.fn(),
+  stopAgent: vi.fn(),
+  stopManagedCommand: vi.fn(),
+  stopping: new Set<string>(),
+}));
+vi.mock("@/hooks/home-focus/use-focus-actions", () => ({
+  useFocusActions: () => actionsMock,
+}));
+
+const navigateMock = vi.hoisted(() => vi.fn());
+vi.mock("@tanstack/react-router", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@tanstack/react-router")>()),
+  useNavigate: () => navigateMock,
+}));
+
+const tabNavigationMock = vi.hoisted(() => ({ navigateToTabIntent: vi.fn() }));
+vi.mock("@/lib/tab-navigation", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/tab-navigation")>()),
+  navigateToTabIntent: tabNavigationMock.navigateToTabIntent,
+}));
+
+const localHostMock = vi.hoisted(() => ({
+  value: null as HostDirectoryEntry | null,
+}));
+vi.mock("@/hooks/host/use-reactive-local-host-entry", () => ({
+  useReactiveLocalHostEntry: () => localHostMock.value,
+}));
+
+const hostDirectoryEntryMock = vi.hoisted(() => ({
+  value: null as HostDirectoryEntry | null,
+}));
+vi.mock("@/hooks/host/use-host-directory-entry", () => ({
+  useHostDirectoryEntry: () => hostDirectoryEntryMock.value,
+}));
+
+let idSeq = 0;
+function nextId(prefix: string): string {
+  idSeq += 1;
+  return `${prefix}-${idSeq}`;
+}
+
+function activationRow(
+  overrides: Partial<MergedNotificationRow>,
+): MergedNotificationRow {
+  const feedId = overrides.feedId ?? nextId("activation");
+  return {
+    feedId,
+    source: "host",
+    sourceId: feedId,
+    createdAt: Date.now(),
+    readAt: null,
+    title: "Approve: run bun test",
+    body: "The agent wants to run a command.",
+    payload: null,
+    hostKind: "approval.requested",
+    appLocalKind: null,
+    globalEntry: null,
+    severity: "needs_action",
+    outcome: null,
+    resolvedAt: null,
+    sourceRef: null,
+    originHostId: null,
+    providerPackAttribution: null,
+    category: "task",
+    ...overrides,
+  };
+}
+
+function promptRow(overrides: Partial<FocusPromptRow>): FocusPromptRow {
+  const key = overrides.key ?? nextId("prompt");
+  return {
+    key,
+    kind: "approval",
+    epicId: "epic-1",
+    chatId: "chat-1",
+    taskTitle: "Task title",
+    title: "Approve: run bun test",
+    body: "The agent wants to run a command.",
+    createdAt: Date.now(),
+    originHostId: null,
+    activation: activationRow({ feedId: key }),
+    ...overrides,
+  };
+}
+
+// `title` defaults to `null` on purpose: that is what a cold epic reports, and
+// a fixture defaulting to the literal string "agent" would make the row's
+// `?? "agent"` fallback untestable by accident.
+function agentRow(overrides: Partial<FocusAgentRow>): FocusAgentRow {
+  return {
+    agentId: overrides.agentId ?? nextId("agent"),
+    title: null,
+    surface: "chat",
+    tier: "turn",
+    parentId: null,
+    hostId: null,
+    ...overrides,
+  };
+}
+
+function taskRow(overrides: Partial<FocusTaskRow>): FocusTaskRow {
+  return {
+    epicId: overrides.epicId ?? nextId("epic"),
+    taskTitle: "Task title",
+    mountedHere: true,
+    agents: [agentRow({})],
+    needsYou: false,
+    stoppable: true,
+    ...overrides,
+  };
+}
+
+function backgroundRow(
+  overrides: Partial<FocusBackgroundRow>,
+): FocusBackgroundRow {
+  const key = overrides.key ?? nextId("background");
+  return {
+    key,
+    epicId: "epic-1",
+    chatId: "chat-1",
+    taskTitle: "Task title",
+    label: "dev server",
+    kind: "managed-command",
+    startedAtMs: Date.now(),
+    stoppable: true,
+    ...overrides,
+  };
+}
+
+function model(overrides: Partial<FocusModel>): FocusModel {
+  return {
+    prompts: [],
+    tasks: [],
+    background: [],
+    coverage: {
+      activity: "live",
+      notifications: "cloud",
+      backgroundIsMountedOnly: true,
+    },
+    badgeCount: 0,
+    ...overrides,
+  };
+}
+
+function hostEntry(overrides: Partial<HostDirectoryEntry>): HostDirectoryEntry {
+  return {
+    hostId: overrides.hostId ?? nextId("host"),
+    label: "Host",
+    kind: "local",
+    websocketUrl: null,
+    version: null,
+    transportDialability: "dialable",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  actionsMock.openPrompt.mockReset();
+  actionsMock.openAgent.mockReset();
+  actionsMock.openTask.mockReset();
+  actionsMock.openBackground.mockReset();
+  actionsMock.stopAgent.mockReset();
+  actionsMock.stopManagedCommand.mockReset();
+  actionsMock.stopping.clear();
+  navigateMock.mockReset();
+  tabNavigationMock.navigateToTabIntent.mockReset();
+  localHostMock.value = null;
+  hostDirectoryEntryMock.value = null;
+  modelMock.value = null;
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("<HomeFocusView /> section presence", () => {
+  it("renders all three sections when every list is populated", () => {
+    modelMock.value = model({
+      prompts: [promptRow({})],
+      tasks: [taskRow({})],
+      background: [backgroundRow({})],
+      badgeCount: 1,
+    });
+    render(<HomeFocusView />);
+    expect(screen.getByTestId("home-focus-section-prompts")).toBeDefined();
+    expect(screen.getByTestId("home-focus-section-tasks")).toBeDefined();
+    expect(screen.getByTestId("home-focus-section-background")).toBeDefined();
+    expect(screen.queryByTestId("home-focus-empty")).toBeNull();
+  });
+
+  it("omits the prompts section when there are no prompts, keeping the others", () => {
+    modelMock.value = model({
+      prompts: [],
+      tasks: [taskRow({})],
+      background: [backgroundRow({})],
+      badgeCount: 0,
+    });
+    render(<HomeFocusView />);
+    expect(screen.queryByTestId("home-focus-section-prompts")).toBeNull();
+    expect(screen.getByTestId("home-focus-section-tasks")).toBeDefined();
+    expect(screen.getByTestId("home-focus-section-background")).toBeDefined();
+  });
+
+  it("renders only the empty state when all three lists are empty", () => {
+    modelMock.value = model({});
+    render(<HomeFocusView />);
+    expect(screen.getByTestId("home-focus-empty")).toBeDefined();
+    expect(screen.queryByTestId("home-focus-section-prompts")).toBeNull();
+    expect(screen.queryByTestId("home-focus-section-tasks")).toBeNull();
+    expect(screen.queryByTestId("home-focus-section-background")).toBeNull();
+  });
+});
+
+describe("<HomeFocusView /> section headers", () => {
+  it("reads 'Needs you · 2' for two prompts", () => {
+    modelMock.value = model({
+      prompts: [promptRow({}), promptRow({})],
+      badgeCount: 2,
+    });
+    render(<HomeFocusView />);
+    const heading = within(
+      screen.getByTestId("home-focus-section-prompts"),
+    ).getByRole("heading", { level: 2 });
+    expect(heading.textContent).toContain("Needs you · 2");
+  });
+
+  it("reads 'Running · 3 tasks' for three tasks", () => {
+    modelMock.value = model({
+      tasks: [taskRow({}), taskRow({}), taskRow({})],
+    });
+    render(<HomeFocusView />);
+    const heading = within(
+      screen.getByTestId("home-focus-section-tasks"),
+    ).getByRole("heading", { level: 2 });
+    expect(heading.textContent).toContain("Running · 3 tasks");
+  });
+
+  it("reads 'Running · 1 task' (singular) for one task", () => {
+    modelMock.value = model({ tasks: [taskRow({})] });
+    render(<HomeFocusView />);
+    const heading = within(
+      screen.getByTestId("home-focus-section-tasks"),
+    ).getByRole("heading", { level: 2 });
+    expect(heading.textContent).toContain("Running · 1 task");
+    expect(heading.textContent).not.toContain("1 tasks");
+  });
+
+  it("reads 'Background · 2' with the fixed caption", () => {
+    modelMock.value = model({
+      background: [backgroundRow({}), backgroundRow({})],
+    });
+    render(<HomeFocusView />);
+    const heading = within(
+      screen.getByTestId("home-focus-section-background"),
+    ).getByRole("heading", { level: 2 });
+    expect(heading.textContent).toContain("Background · 2");
+    expect(
+      screen.getByTestId("home-focus-section-background-caption").textContent,
+    ).toBe("Only tasks open in this window");
+  });
+});
+
+describe("<HomeFocusView /> row ordering", () => {
+  it("renders prompt rows in the model's array order", () => {
+    modelMock.value = model({
+      prompts: [
+        promptRow({ title: "First prompt" }),
+        promptRow({ title: "Second prompt" }),
+        promptRow({ title: "Third prompt" }),
+      ],
+      badgeCount: 3,
+    });
+    render(<HomeFocusView />);
+    const rows = screen.getAllByTestId("home-focus-prompt-row");
+    expect(rows.map((row) => row.textContent)).toEqual([
+      expect.stringContaining("First prompt"),
+      expect.stringContaining("Second prompt"),
+      expect.stringContaining("Third prompt"),
+    ]);
+  });
+
+  it("renders task rows in the model's array order", () => {
+    modelMock.value = model({
+      tasks: [
+        taskRow({ taskTitle: "Alpha task" }),
+        taskRow({ taskTitle: "Beta task" }),
+        taskRow({ taskTitle: "Gamma task" }),
+      ],
+    });
+    render(<HomeFocusView />);
+    const rows = screen.getAllByTestId("home-focus-task-row");
+    expect(rows.map((row) => row.textContent)).toEqual([
+      expect.stringContaining("Alpha task"),
+      expect.stringContaining("Beta task"),
+      expect.stringContaining("Gamma task"),
+    ]);
+  });
+});
+
+describe("<HomeFocusView /> prompt row actions", () => {
+  it("calls openPrompt with the exact row from the body button and the explicit Open button", () => {
+    const row = promptRow({});
+    modelMock.value = model({ prompts: [row], badgeCount: 1 });
+    render(<HomeFocusView />);
+
+    fireEvent.click(screen.getByTestId("home-focus-prompt-open-body"));
+    expect(actionsMock.openPrompt).toHaveBeenCalledTimes(1);
+    expect(actionsMock.openPrompt).toHaveBeenNthCalledWith(1, row);
+
+    fireEvent.click(screen.getByTestId("home-focus-prompt-open"));
+    expect(actionsMock.openPrompt).toHaveBeenCalledTimes(2);
+    expect(actionsMock.openPrompt).toHaveBeenNthCalledWith(2, row);
+  });
+});
+
+describe("<HomeFocusView /> open actions", () => {
+  it("opens the task from the task row's body and its Open button", () => {
+    modelMock.value = model({ tasks: [taskRow({ epicId: "epic-open" })] });
+    render(<HomeFocusView />);
+
+    fireEvent.click(screen.getByTestId("home-focus-task-open-body"));
+    fireEvent.click(screen.getByTestId("home-focus-task-open"));
+    expect(actionsMock.openTask).toHaveBeenCalledTimes(2);
+    expect(actionsMock.openTask).toHaveBeenNthCalledWith(1, "epic-open");
+    expect(actionsMock.openTask).toHaveBeenNthCalledWith(2, "epic-open");
+  });
+
+  it("opens the owning chat from a background row's body and Open button", () => {
+    const row = backgroundRow({
+      epicId: "epic-background",
+      chatId: "chat-background",
+    });
+    modelMock.value = model({ background: [row] });
+    render(<HomeFocusView />);
+
+    fireEvent.click(screen.getByTestId("home-focus-background-open-body"));
+    fireEvent.click(screen.getByTestId("home-focus-background-open"));
+    expect(actionsMock.openBackground).toHaveBeenCalledTimes(2);
+    expect(actionsMock.openBackground).toHaveBeenNthCalledWith(1, row);
+    expect(actionsMock.openBackground).toHaveBeenNthCalledWith(2, row);
+    // The chat is the target, so the row never falls back to its task.
+    expect(actionsMock.openTask).not.toHaveBeenCalled();
+  });
+});
+
+describe("<HomeFocusView /> task row stop controls", () => {
+  it("stops a single agent directly, cascading, with no confirmation dialog", () => {
+    const row = taskRow({
+      epicId: "epic-solo",
+      agents: [agentRow({ agentId: "agent-solo" })],
+    });
+    modelMock.value = model({ tasks: [row] });
+    render(<HomeFocusView />);
+
+    expect(screen.queryByTestId("home-focus-task-stop-all")).toBeNull();
+    fireEvent.click(screen.getByTestId("home-focus-task-stop"));
+
+    expect(actionsMock.stopAgent).toHaveBeenCalledTimes(1);
+    expect(actionsMock.stopAgent).toHaveBeenCalledWith({
+      epicId: "epic-solo",
+      agentId: "agent-solo",
+      hostId: null,
+      cascade: true,
+    });
+    expect(screen.queryByTestId("home-focus-stop-all-dialog")).toBeNull();
+  });
+
+  it("stops only the ROOT once when the task lists a parent and its children", () => {
+    const agents = [
+      agentRow({
+        agentId: "root",
+        title: "impl",
+        parentId: null,
+        hostId: "host-tree",
+      }),
+      agentRow({ agentId: "child-a", title: "reviewer", parentId: "root" }),
+      agentRow({ agentId: "child-b", title: "docs", parentId: "root" }),
+    ];
+    modelMock.value = model({
+      tasks: [taskRow({ epicId: "epic-tree", agents })],
+    });
+    render(<HomeFocusView />);
+
+    fireEvent.click(screen.getByTestId("home-focus-task-stop-all"));
+    // The dialog still names everything that goes down, not just the root.
+    const dialog = screen.getByTestId("home-focus-stop-all-dialog");
+    for (const agent of agents) {
+      expect(within(dialog).getByText(agent.title ?? "agent")).toBeDefined();
+    }
+
+    fireEvent.click(screen.getByTestId("home-focus-stop-all-confirm"));
+    expect(actionsMock.stopAgent).toHaveBeenCalledTimes(1);
+    expect(actionsMock.stopAgent).toHaveBeenCalledWith({
+      epicId: "epic-tree",
+      agentId: "root",
+      hostId: "host-tree",
+      cascade: true,
+    });
+  });
+
+  it("stops each independent root once when a parent is not itself listed", () => {
+    const agents = [
+      agentRow({ agentId: "root-a", title: "impl", parentId: null }),
+      // Parented by an agent that is not running, so it is a root here.
+      agentRow({ agentId: "root-b", title: "docs", parentId: "not-listed" }),
+      agentRow({ agentId: "child", title: "reviewer", parentId: "root-a" }),
+    ];
+    modelMock.value = model({
+      tasks: [taskRow({ epicId: "epic-forest", agents })],
+    });
+    render(<HomeFocusView />);
+
+    fireEvent.click(screen.getByTestId("home-focus-task-stop-all"));
+    fireEvent.click(screen.getByTestId("home-focus-stop-all-confirm"));
+
+    expect(actionsMock.stopAgent).toHaveBeenCalledTimes(2);
+    expect(actionsMock.stopAgent).toHaveBeenCalledWith({
+      epicId: "epic-forest",
+      agentId: "root-a",
+      hostId: null,
+      cascade: true,
+    });
+    expect(actionsMock.stopAgent).toHaveBeenCalledWith({
+      epicId: "epic-forest",
+      agentId: "root-b",
+      hostId: null,
+      cascade: true,
+    });
+  });
+
+  it("stopping several agents goes through a confirmation dialog listing every agent", () => {
+    const agents = [
+      agentRow({ agentId: "agent-a", title: "impl" }),
+      agentRow({ agentId: "agent-b", title: "reviewer" }),
+      agentRow({ agentId: "agent-c", title: "docs" }),
+    ];
+    const row = taskRow({ epicId: "epic-multi", agents });
+    modelMock.value = model({ tasks: [row] });
+    render(<HomeFocusView />);
+
+    expect(screen.queryByTestId("home-focus-task-stop")).toBeNull();
+    fireEvent.click(screen.getByTestId("home-focus-task-stop-all"));
+
+    const dialog = screen.getByTestId("home-focus-stop-all-dialog");
+    expect(dialog).toBeDefined();
+    for (const agent of agents) {
+      expect(within(dialog).getByText(agent.title ?? "agent")).toBeDefined();
+    }
+
+    fireEvent.click(screen.getByTestId("home-focus-stop-all-confirm"));
+    expect(actionsMock.stopAgent).toHaveBeenCalledTimes(3);
+    for (const agent of agents) {
+      expect(actionsMock.stopAgent).toHaveBeenCalledWith({
+        epicId: "epic-multi",
+        agentId: agent.agentId,
+        hostId: agent.hostId,
+        cascade: true,
+      });
+    }
+  });
+
+  it("cancelling the stop-all dialog closes it and calls nothing", () => {
+    const agents = [
+      agentRow({ agentId: "agent-a", title: "impl" }),
+      agentRow({ agentId: "agent-b", title: "reviewer" }),
+    ];
+    const row = taskRow({ epicId: "epic-multi", agents });
+    modelMock.value = model({ tasks: [row] });
+    render(<HomeFocusView />);
+
+    fireEvent.click(screen.getByTestId("home-focus-task-stop-all"));
+    expect(screen.getByTestId("home-focus-stop-all-dialog")).toBeDefined();
+
+    fireEvent.click(screen.getByTestId("home-focus-stop-all-cancel"));
+    expect(screen.queryByTestId("home-focus-stop-all-dialog")).toBeNull();
+    expect(actionsMock.stopAgent).not.toHaveBeenCalled();
+  });
+});
+
+describe("<HomeFocusView /> task row agent presentation", () => {
+  it("shows cold-agent summary with no chips when the task is not mounted here", () => {
+    const row = taskRow({
+      mountedHere: false,
+      agents: [agentRow({}), agentRow({})],
+    });
+    modelMock.value = model({ tasks: [row] });
+    render(<HomeFocusView />);
+
+    const cold = screen.getByTestId("home-focus-cold-agents");
+    expect(cold.textContent).toContain("2 agents");
+    expect(cold.textContent).toContain("not open in this window");
+    expect(screen.queryByTestId("home-focus-agent-chip")).toBeNull();
+  });
+
+  it("shows one chip per agent when mounted, and clicking a chip opens the agent", () => {
+    const agents = [
+      agentRow({ agentId: "agent-x", title: "impl", tier: "turn" }),
+      agentRow({ agentId: "agent-y", title: "reviewer", tier: "background" }),
+    ];
+    const row = taskRow({
+      epicId: "epic-mounted",
+      mountedHere: true,
+      agents,
+    });
+    modelMock.value = model({ tasks: [row] });
+    render(<HomeFocusView />);
+
+    const chips = screen.getAllByTestId("home-focus-agent-chip");
+    expect(chips).toHaveLength(2);
+    expect(chips[0].textContent).toContain("impl");
+    expect(chips[0].textContent).toContain("turn");
+    expect(chips[1].textContent).toContain("reviewer");
+    expect(chips[1].textContent).toContain("background");
+
+    fireEvent.click(chips[0]);
+    expect(actionsMock.openAgent).toHaveBeenCalledWith(
+      "epic-mounted",
+      "agent-x",
+    );
+  });
+
+  it("falls back to 'agent' for a chip whose title is null", () => {
+    modelMock.value = model({
+      tasks: [
+        taskRow({
+          mountedHere: true,
+          agents: [agentRow({ agentId: "agent-nameless", title: null })],
+        }),
+      ],
+    });
+    render(<HomeFocusView />);
+    expect(screen.getByTestId("home-focus-agent-chip").textContent).toContain(
+      "agent",
+    );
+  });
+});
+
+describe("<HomeFocusView /> task row stop availability", () => {
+  it("disables Stop with a reason when the task is not stoppable", () => {
+    modelMock.value = model({
+      tasks: [
+        taskRow({
+          stoppable: false,
+          agents: [agentRow({ agentId: "agent-remote" })],
+        }),
+      ],
+    });
+    render(<HomeFocusView />);
+
+    const stop = screen.getByTestId("home-focus-task-stop");
+    expect(stop.hasAttribute("disabled")).toBe(true);
+    fireEvent.click(stop);
+    expect(actionsMock.stopAgent).not.toHaveBeenCalled();
+    // The reason rides the accessible name, not only the hover tooltip.
+    expect(stop.getAttribute("aria-label")).toContain("Runs on another device");
+  });
+
+  it("disables Stop while that agent's stop is in flight", () => {
+    actionsMock.stopping.add("agent-busy");
+    modelMock.value = model({
+      tasks: [taskRow({ agents: [agentRow({ agentId: "agent-busy" })] })],
+    });
+    render(<HomeFocusView />);
+
+    const stop = screen.getByTestId("home-focus-task-stop");
+    expect(stop.hasAttribute("disabled")).toBe(true);
+    fireEvent.click(stop);
+    expect(actionsMock.stopAgent).not.toHaveBeenCalled();
+  });
+
+  it("disables Stop all while a root it would call is in flight", () => {
+    actionsMock.stopping.add("root");
+    modelMock.value = model({
+      tasks: [
+        taskRow({
+          agents: [
+            agentRow({ agentId: "root", parentId: null }),
+            agentRow({ agentId: "other-root", parentId: null }),
+          ],
+        }),
+      ],
+    });
+    render(<HomeFocusView />);
+
+    const stopAll = screen.getByTestId("home-focus-task-stop-all");
+    expect(stopAll.hasAttribute("disabled")).toBe(true);
+    fireEvent.click(stopAll);
+    expect(screen.queryByTestId("home-focus-stop-all-dialog")).toBeNull();
+  });
+
+  it("leaves Stop all enabled when only a DESCENDANT it never calls is in flight", () => {
+    actionsMock.stopping.add("child");
+    modelMock.value = model({
+      tasks: [
+        taskRow({
+          agents: [
+            agentRow({ agentId: "root", parentId: null }),
+            agentRow({ agentId: "child", parentId: "root" }),
+          ],
+        }),
+      ],
+    });
+    render(<HomeFocusView />);
+    expect(
+      screen.getByTestId("home-focus-task-stop-all").hasAttribute("disabled"),
+    ).toBe(false);
+  });
+});
+
+describe("<HomeFocusView /> row structure", () => {
+  it.each([
+    ["home-focus-prompt-open-body", "home-focus-prompt-open"],
+    ["home-focus-task-open-body", "home-focus-task-stop"],
+    ["home-focus-background-open-body", "home-focus-background-stop"],
+  ])(
+    "keeps %s's trailing control a sibling, not a descendant",
+    (body, control) => {
+      modelMock.value = model({
+        prompts: [promptRow({})],
+        tasks: [taskRow({})],
+        background: [backgroundRow({})],
+        badgeCount: 1,
+      });
+      render(<HomeFocusView />);
+
+      const bodyEl = screen.getByTestId(body);
+      expect(bodyEl.tagName).toBe("BUTTON");
+      expect(bodyEl.contains(screen.getByTestId(control))).toBe(false);
+    },
+  );
+});
+
+describe("<HomeFocusView /> prompt glyphs", () => {
+  it.each([
+    ["approval", "text-warning-foreground"],
+    ["interview", "text-warning-foreground"],
+    ["browser", "text-warning-foreground"],
+  ] as const)("renders a glyph for a %s prompt", (kind, toneClass) => {
+    modelMock.value = model({
+      prompts: [promptRow({ kind })],
+      badgeCount: 1,
+    });
+    render(<HomeFocusView />);
+    const glyph = screen.getByTestId("home-focus-prompt-glyph");
+    expect(glyph.getAttribute("class")).toContain(toneClass);
+  });
+
+  it("gives approval and interview prompts different glyphs", () => {
+    modelMock.value = model({
+      prompts: [
+        promptRow({ kind: "approval" }),
+        promptRow({ kind: "interview" }),
+        promptRow({ kind: "browser" }),
+      ],
+      badgeCount: 3,
+    });
+    render(<HomeFocusView />);
+    const shapes = screen
+      .getAllByTestId("home-focus-prompt-glyph")
+      .map((glyph) => glyph.innerHTML);
+    expect(new Set(shapes).size).toBe(3);
+  });
+});
+
+describe("<HomeFocusView /> task attention", () => {
+  it("renders the attention glyph when needsYou is true", () => {
+    modelMock.value = model({ tasks: [taskRow({ needsYou: true })] });
+    render(<HomeFocusView />);
+    expect(screen.getByTestId("home-focus-task-attention")).toBeDefined();
+  });
+
+  it("does not render the attention glyph when needsYou is false", () => {
+    modelMock.value = model({ tasks: [taskRow({ needsYou: false })] });
+    render(<HomeFocusView />);
+    expect(screen.queryByTestId("home-focus-task-attention")).toBeNull();
+  });
+});
+
+describe("<HomeFocusView /> empty state", () => {
+  it("navigates to a new draft from 'Start a new task'", () => {
+    modelMock.value = model({});
+    render(<HomeFocusView />);
+
+    fireEvent.click(screen.getByTestId("home-focus-empty-new-task"));
+    expect(tabNavigationMock.navigateToTabIntent).toHaveBeenCalledWith(
+      navigateMock,
+      { kind: "new-draft", settings: null },
+      undefined,
+    );
+  });
+
+  it("navigates to history from 'Open History'", () => {
+    modelMock.value = model({});
+    render(<HomeFocusView />);
+
+    fireEvent.click(screen.getByTestId("home-focus-empty-history"));
+    expect(tabNavigationMock.navigateToTabIntent).toHaveBeenCalledWith(
+      navigateMock,
+      { kind: "history" },
+      undefined,
+    );
+  });
+});
+
+describe("<HomeFocusView /> coverage notices", () => {
+  it.each(["disconnected", "reconnecting"] as const)(
+    "renders the activity notice when coverage.activity is %s",
+    (activity) => {
+      modelMock.value = model({
+        tasks: [taskRow({})],
+        coverage: {
+          activity,
+          notifications: "cloud",
+          backgroundIsMountedOnly: true,
+        },
+      });
+      render(<HomeFocusView />);
+      const notice = screen.getByTestId("home-focus-activity-notice");
+      expect(notice).toBeDefined();
+      expect(notice.getAttribute("data-activity")).toBe(activity);
+    },
+  );
+
+  it.each(["live", "unknown"] as const)(
+    "does not render the activity notice when coverage.activity is %s",
+    (activity) => {
+      modelMock.value = model({
+        tasks: [taskRow({})],
+        coverage: {
+          activity,
+          notifications: "cloud",
+          backgroundIsMountedOnly: true,
+        },
+      });
+      render(<HomeFocusView />);
+      expect(screen.queryByTestId("home-focus-activity-notice")).toBeNull();
+    },
+  );
+
+  it("shows the 'this host only' caption in the Needs-you header when notifications are local", () => {
+    modelMock.value = model({
+      prompts: [promptRow({})],
+      badgeCount: 1,
+      coverage: {
+        activity: "live",
+        notifications: "local",
+        backgroundIsMountedOnly: true,
+      },
+    });
+    render(<HomeFocusView />);
+    expect(
+      screen.getByTestId("home-focus-section-prompts-caption").textContent,
+    ).toBe("this host only");
+  });
+
+  it("omits the caption in the Needs-you header when notifications are cloud", () => {
+    modelMock.value = model({
+      prompts: [promptRow({})],
+      badgeCount: 1,
+      coverage: {
+        activity: "live",
+        notifications: "cloud",
+        backgroundIsMountedOnly: true,
+      },
+    });
+    render(<HomeFocusView />);
+    expect(
+      screen.queryByTestId("home-focus-section-prompts-caption"),
+    ).toBeNull();
+  });
+});
+
+describe("<HomeFocusView /> badge parity", () => {
+  it("badgeCount equals the number of rendered prompt rows", () => {
+    const prompts = [promptRow({}), promptRow({}), promptRow({})];
+    modelMock.value = model({ prompts, badgeCount: prompts.length });
+    render(<HomeFocusView />);
+    expect(screen.getAllByTestId("home-focus-prompt-row")).toHaveLength(
+      modelMock.value.badgeCount,
+    );
+  });
+});
+
+describe("<HomeFocusView /> relative time ticking", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("repaints the same DOM node from 'Just now' to '1m ago' on the shared clock tick", () => {
+    vi.useFakeTimers();
+    const base = Date.now();
+    const row = promptRow({ createdAt: base - 30_000 });
+    modelMock.value = model({ prompts: [row], badgeCount: 1 });
+    render(<HomeFocusView />);
+
+    const timeNode = screen.getByTestId("home-focus-relative-time");
+    expect(timeNode.textContent).toBe("Just now");
+
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+
+    const timeNodeAfter = screen.getByTestId("home-focus-relative-time");
+    expect(timeNodeAfter).toBe(timeNode);
+    expect(timeNodeAfter.textContent).toBe("1m ago");
+  });
+});
+
+describe("<HomeFocusView /> live model updates without remount", () => {
+  it("reuses the same task row DOM node when the model updates in place", () => {
+    const initialTask = taskRow({
+      epicId: "epic-stable",
+      agents: [agentRow({ agentId: "agent-1" })],
+    });
+    modelMock.value = model({ tasks: [initialTask] });
+    const { rerender } = render(<HomeFocusView />);
+
+    const rowBefore = screen.getByTestId("home-focus-task-row");
+
+    const updatedTask = taskRow({
+      epicId: "epic-stable",
+      agents: [
+        agentRow({ agentId: "agent-1" }),
+        agentRow({ agentId: "agent-2" }),
+      ],
+    });
+    modelMock.value = model({ tasks: [updatedTask] });
+    rerender(<HomeFocusView />);
+
+    const rowAfter = screen.getByTestId("home-focus-task-row");
+    expect(rowAfter).toBe(rowBefore);
+    expect(screen.getAllByTestId("home-focus-agent-chip")).toHaveLength(2);
+  });
+});
+
+describe("<HomeFocusView /> background rows", () => {
+  it("renders the label and elapsed running duration", () => {
+    const startedAtMs = Date.now() - 41 * 60_000;
+    modelMock.value = model({
+      background: [backgroundRow({ label: "dev server", startedAtMs })],
+    });
+    render(<HomeFocusView />);
+    expect(
+      screen.getByTestId("home-focus-background-row").textContent,
+    ).toContain("dev server");
+    expect(screen.getByTestId("home-focus-running-duration").textContent).toBe(
+      "running 41m",
+    );
+  });
+
+  it("shows a stop button when stoppable and calls stopManagedCommand with the row", () => {
+    const row = backgroundRow({ stoppable: true });
+    modelMock.value = model({ background: [row] });
+    render(<HomeFocusView />);
+
+    fireEvent.click(screen.getByTestId("home-focus-background-stop"));
+    expect(actionsMock.stopManagedCommand).toHaveBeenCalledWith(row);
+  });
+
+  it("renders a disabled stop with a reason when the job is not stoppable", () => {
+    modelMock.value = model({
+      background: [backgroundRow({ stoppable: false })],
+    });
+    render(<HomeFocusView />);
+
+    const stop = screen.getByTestId("home-focus-background-stop");
+    expect(stop.hasAttribute("disabled")).toBe(true);
+    fireEvent.click(stop);
+    expect(actionsMock.stopManagedCommand).not.toHaveBeenCalled();
+    expect(stop.getAttribute("aria-label")).toContain("Runs on another device");
+  });
+
+  it("disables the stop while this job's stop is in flight", () => {
+    const row = backgroundRow({ stoppable: true });
+    actionsMock.stopping.add(row.key);
+    modelMock.value = model({ background: [row] });
+    render(<HomeFocusView />);
+
+    const stop = screen.getByTestId("home-focus-background-stop");
+    expect(stop.hasAttribute("disabled")).toBe(true);
+    fireEvent.click(stop);
+    expect(actionsMock.stopManagedCommand).not.toHaveBeenCalled();
+  });
+
+  it("renders no duration for a background item with no start time", () => {
+    modelMock.value = model({
+      background: [
+        backgroundRow({ kind: "background-item", startedAtMs: null }),
+      ],
+    });
+    render(<HomeFocusView />);
+    expect(screen.queryByTestId("home-focus-running-duration")).toBeNull();
+  });
+
+  it("reads 'just started' under a minute rather than 'running now'", () => {
+    modelMock.value = model({
+      background: [backgroundRow({ startedAtMs: Date.now() - 5_000 })],
+    });
+    render(<HomeFocusView />);
+    expect(screen.getByTestId("home-focus-running-duration").textContent).toBe(
+      "just started",
+    );
+  });
+});
+
+describe("<HomeFocusView /> untitled task", () => {
+  it("renders 'Untitled task' when taskTitle is null", () => {
+    modelMock.value = model({ tasks: [taskRow({ taskTitle: null })] });
+    render(<HomeFocusView />);
+    expect(screen.getByTestId("home-focus-task-row").textContent).toContain(
+      "Untitled task",
+    );
+  });
+});
+
+describe("<HomeFocusView /> origin host chip", () => {
+  it("shows the origin host's label when it differs from the local host", () => {
+    localHostMock.value = hostEntry({ hostId: "host-local" });
+    hostDirectoryEntryMock.value = hostEntry({
+      hostId: "host-remote",
+      label: "Remote Box",
+    });
+    const row = promptRow({ originHostId: "host-remote" });
+    modelMock.value = model({ prompts: [row], badgeCount: 1 });
+    render(<HomeFocusView />);
+    expect(screen.getByTestId("home-focus-origin-host").textContent).toBe(
+      "Remote Box",
+    );
+  });
+
+  it("hides the chip when the origin host is the local host", () => {
+    localHostMock.value = hostEntry({ hostId: "host-local" });
+    hostDirectoryEntryMock.value = hostEntry({ hostId: "host-local" });
+    const row = promptRow({ originHostId: "host-local" });
+    modelMock.value = model({ prompts: [row], badgeCount: 1 });
+    render(<HomeFocusView />);
+    expect(screen.queryByTestId("home-focus-origin-host")).toBeNull();
+  });
+
+  it("hides the chip on a build with no local host, even with an origin host", () => {
+    localHostMock.value = null;
+    hostDirectoryEntryMock.value = hostEntry({
+      hostId: "host-remote",
+      label: "Remote Box",
+    });
+    const row = promptRow({ originHostId: "host-remote" });
+    modelMock.value = model({ prompts: [row], badgeCount: 1 });
+    render(<HomeFocusView />);
+    expect(screen.queryByTestId("home-focus-origin-host")).toBeNull();
+  });
+
+  it("falls back to 'another host' when the directory does not know the origin", () => {
+    localHostMock.value = hostEntry({ hostId: "host-local" });
+    hostDirectoryEntryMock.value = null;
+    const row = promptRow({ originHostId: "host-unknown" });
+    modelMock.value = model({ prompts: [row], badgeCount: 1 });
+    render(<HomeFocusView />);
+    expect(screen.getByTestId("home-focus-origin-host").textContent).toBe(
+      "another host",
+    );
+  });
+});

--- a/clients/gui-app/src/components/home-focus/__tests__/home-focus-view.test.tsx
+++ b/clients/gui-app/src/components/home-focus/__tests__/home-focus-view.test.tsx
@@ -6,6 +6,7 @@ import {
   screen,
   within,
 } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { HostDirectoryEntry } from "@traycer-clients/shared/host-client/host-directory";
 import { HomeFocusView } from "@/components/home-focus/home-focus-view";
@@ -169,6 +170,15 @@ function model(overrides: Partial<FocusModel>): FocusModel {
     badgeCount: 0,
     ...overrides,
   };
+}
+
+/** The element a row's tooltip is anchored to: `FocusStopButton` wraps its
+ * button in a span, because a disabled button fires no pointer events of its
+ * own. */
+function tooltipTriggerOf(control: HTMLElement): HTMLElement {
+  const trigger = control.parentElement;
+  if (trigger === null) throw new Error("control has no tooltip trigger");
+  return trigger;
 }
 
 function hostEntry(overrides: Partial<HostDirectoryEntry>): HostDirectoryEntry {
@@ -886,7 +896,7 @@ describe("<HomeFocusView /> background rows", () => {
     expect(actionsMock.stopManagedCommand).toHaveBeenCalledWith(row);
   });
 
-  it("renders a disabled stop with a reason when the job is not stoppable", () => {
+  it("renders a disabled stop naming the unreachable host when a managed command's host is unknown", () => {
     modelMock.value = model({
       background: [backgroundRow({ stoppable: false })],
     });
@@ -897,6 +907,37 @@ describe("<HomeFocusView /> background rows", () => {
     fireEvent.click(stop);
     expect(actionsMock.stopManagedCommand).not.toHaveBeenCalled();
     expect(stop.getAttribute("aria-label")).toContain("Runs on another device");
+  });
+
+  // The shape `buildFocusBackground` actually produces: EVERY background item
+  // is `stoppable: false`, because its stop is a `chat.subscribe` action on a
+  // warm session rather than a unary RPC - which says nothing about which
+  // machine it runs on. A single-host install has no other device to blame.
+  it("sends a background item's disabled stop to the chat rather than to another device", async () => {
+    const user = userEvent.setup();
+    modelMock.value = model({
+      background: [
+        backgroundRow({
+          kind: "background-item",
+          label: "bun run dev",
+          startedAtMs: null,
+          stoppable: false,
+        }),
+      ],
+    });
+    render(<HomeFocusView />);
+
+    const stop = screen.getByTestId("home-focus-background-stop");
+    expect(stop.hasAttribute("disabled")).toBe(true);
+    // The accessible name, which is the only place a reader who cannot hover a
+    // disabled button hears the reason at all.
+    expect(stop.getAttribute("aria-label")).toBe(
+      "Stop bun run dev. Stop this from the chat",
+    );
+
+    // And the same sentence in the tooltip, for everyone else.
+    await user.hover(tooltipTriggerOf(stop));
+    expect(await screen.findByText("Stop this from the chat")).toBeTruthy();
   });
 
   it("disables the stop while this job's stop is in flight", () => {

--- a/clients/gui-app/src/components/home-focus/__tests__/use-home-badge-count.test.tsx
+++ b/clients/gui-app/src/components/home-focus/__tests__/use-home-badge-count.test.tsx
@@ -1,0 +1,64 @@
+import { cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { MergedNotificationRow } from "@/stores/notifications/merged-notifications";
+import { countPendingPromptRows } from "@/lib/home-focus/focus-prompts";
+import {
+  makeApprovalPayload,
+  makeMergedNotificationRow,
+} from "@/lib/home-focus/__tests__/fixtures";
+import { useHomeBadgeCount } from "@/components/home-focus/use-home-badge-count";
+
+/**
+ * Regression guard for the always-on-join fix: `useHomeBadgeCount` must be
+ * cheap enough to mount for the life of the window, so it reads
+ * `useMergedNotificationRows` directly rather than joining through
+ * `useFocusModel`. Mocking ONLY that one store here - no activity store, no
+ * chat-session/open-epic registry, no host query - is the test itself: if the
+ * hook regressed back to calling `useFocusModel()`, this file would need every
+ * mock `use-focus-model.test.tsx` needs and would fail to render without them.
+ */
+const { notificationRowsMock } = vi.hoisted(() => ({
+  notificationRowsMock: vi.fn<() => ReadonlyArray<MergedNotificationRow>>(
+    () => [],
+  ),
+}));
+
+vi.mock("@/stores/notifications/merged-notifications", () => ({
+  useMergedNotificationRows: notificationRowsMock,
+}));
+
+afterEach(() => {
+  cleanup();
+  notificationRowsMock.mockReturnValue([]);
+});
+
+describe("useHomeBadgeCount", () => {
+  it("equals countPendingPromptRows(rows) while depending on nothing but the merged-notifications store", () => {
+    const eligible = makeMergedNotificationRow({
+      feedId: "host:approval-1",
+      hostKind: "approval.requested",
+      severity: "needs_action",
+      payload: makeApprovalPayload("epic-1", "chat-1"),
+    });
+    const ineligible = makeMergedNotificationRow({
+      feedId: "host:stopped-1",
+      hostKind: "agent.stopped",
+      severity: "failure",
+    });
+    const rows = [eligible, ineligible];
+    notificationRowsMock.mockReturnValue(rows);
+
+    const { result } = renderHook(() => useHomeBadgeCount());
+
+    expect(result.current).toBe(countPendingPromptRows(rows));
+    expect(result.current).toBe(1);
+  });
+
+  it("is 0 for an empty feed", () => {
+    notificationRowsMock.mockReturnValue([]);
+
+    const { result } = renderHook(() => useHomeBadgeCount());
+
+    expect(result.current).toBe(0);
+  });
+});

--- a/clients/gui-app/src/components/home-focus/home-focus-rows.tsx
+++ b/clients/gui-app/src/components/home-focus/home-focus-rows.tsx
@@ -1,0 +1,666 @@
+/**
+ * The three row shapes Home renders: a pending prompt, a task with its running
+ * agents, and a background job.
+ *
+ * They share the History list's row language (`epics-list-panel`'s row card) so
+ * a task reads the same here as it does in History: one rounded card, `p-3`
+ * density, `text-ui-sm`, the title in `font-medium text-foreground`.
+ *
+ * Every row's primary control is a real `<button>` spanning the row's body
+ * rather than a click handler on the `<li>`, so the row is reachable by Tab and
+ * Enter opens it with no key handling of our own. Trailing controls are
+ * SIBLINGS of that button, never nested inside it.
+ */
+import { useState, type ReactNode } from "react";
+import { Globe, Layers, Square, Terminal } from "lucide-react";
+import {
+  APPROVAL_TONE,
+  INTERVIEW_TONE,
+  type IndicatorTone,
+} from "@/components/notifications/notification-indicator-tones";
+import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
+import { Button } from "@/components/ui/button";
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { useHostDirectoryEntry } from "@/hooks/host/use-host-directory-entry";
+import { useReactiveLocalHostEntry } from "@/hooks/host/use-reactive-local-host-entry";
+import {
+  formatCompactRelativeTime,
+  useRelativeTimestamp,
+  useSampledNow,
+} from "@/lib/relative-time";
+import { cn } from "@/lib/utils";
+import type {
+  FocusAgentRow,
+  FocusBackgroundRow,
+  FocusPromptKind,
+  FocusPromptRow,
+  FocusTaskRow,
+} from "@/lib/home-focus/focus-model";
+
+/**
+ * What a row can do, declared structurally rather than imported from the
+ * actions hook. The hook's module is the model lane's to own, so naming its
+ * return type here would couple two lanes' file contents; structural matching
+ * costs nothing and lets that lane name its own type whatever it likes.
+ */
+export interface HomeFocusRowActions {
+  readonly openPrompt: (row: FocusPromptRow) => void;
+  readonly openAgent: (epicId: string, agentId: string) => void;
+  readonly openTask: (epicId: string) => void;
+  /** The job's own chat, not just its task - a background row names a shell in
+   * one conversation, and landing on the task would make the user find it. */
+  readonly openBackground: (row: FocusBackgroundRow) => void;
+  /** One object, carrying the agent's own host: the stop has to be routed to
+   * the machine the agent runs on, not to whichever host this window is on. */
+  readonly stopAgent: (input: {
+    readonly epicId: string;
+    readonly agentId: string;
+    readonly hostId: string | null;
+    readonly cascade: boolean;
+  }) => void;
+  readonly stopManagedCommand: (row: FocusBackgroundRow) => void;
+  /** Agent ids and `FocusBackgroundRow.key`s with an in-flight stop. */
+  readonly stopping: ReadonlySet<string>;
+}
+
+const UNTITLED_TASK = "Untitled task";
+
+/** What a row whose stop cannot be routed says instead of offering one. */
+const UNREACHABLE_STOP_REASON = "Runs on another device";
+
+// `active:press-scrim pointer-coarse:touch-chrome` for the same reason the
+// History row card carries them: the row is a plain container, not a `Button`,
+// so it opts into the shared press scrim itself. Without it a tap on touch -
+// where `hover:` never fires - leaves the row inert for the whole open round
+// trip, and Home is a phone surface too.
+const ROW_CLASS =
+  "group/focus-row relative flex min-w-0 items-center gap-3 rounded-md p-3 text-ui-sm transition-colors hover:bg-accent/40 has-[:focus-visible]:bg-accent/40 active:press-scrim pointer-coarse:touch-chrome";
+
+/** The row's edge-to-edge open control. Stretched over the whole card by the
+ * absolute overlay so a click anywhere that is not another control opens the
+ * row, while the button itself stays an ordinary inline flex child for layout
+ * and for the accessible name. */
+const ROW_BODY_CLASS =
+  "flex min-w-0 flex-1 items-center gap-2 rounded-sm text-left outline-none before:absolute before:inset-0 before:rounded-md before:content-[''] focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:ring-inset";
+
+const TASK_TITLE_CLASS = "shrink-0 truncate font-medium text-foreground";
+
+function taskTitleOf(title: string | null): string {
+  return title ?? UNTITLED_TASK;
+}
+
+/** The tone registry entry a prompt kind reads as. Browser hand-offs have no
+ * tone of their own - they are a needs-action row whose subject is the browser,
+ * so they borrow the approval color and keep the globe as their glyph, exactly
+ * as the notification feed renders them.
+ *
+ * Mapped here rather than through `notificationFeedTone`, which resolves from a
+ * whole `MergedNotificationRow` and returns `null` for the browser kind. If the
+ * registry ever grows a browser tone, this mapping is what has to move. */
+function promptTone(kind: FocusPromptKind): IndicatorTone {
+  if (kind === "interview") return INTERVIEW_TONE;
+  return APPROVAL_TONE;
+}
+
+function PromptGlyph(props: { readonly kind: FocusPromptKind }): ReactNode {
+  const tone = promptTone(props.kind);
+  const Icon = props.kind === "browser" ? Globe : tone.Icon;
+  return (
+    <Icon
+      aria-hidden
+      className={cn("size-4 shrink-0", tone.className)}
+      data-testid="home-focus-prompt-glyph"
+    />
+  );
+}
+
+/** The attention glyph a task carries when something in it is waiting on the
+ * user - the same registry the History rows and the tab strip read, so a task
+ * that wants attention looks the same wherever it is listed. */
+function TaskAttentionGlyph(): ReactNode {
+  const Icon = APPROVAL_TONE.Icon;
+  return (
+    <Icon
+      aria-label="Needs your attention"
+      role="img"
+      className={cn("size-4 shrink-0", APPROVAL_TONE.className)}
+      data-testid="home-focus-task-attention"
+    />
+  );
+}
+
+/** Isolated leaf so the shared 60s clock repaints the label and not the row
+ * around it (same reason `NotificationTimestamp` is its own component). */
+function FocusRelativeTime(props: { readonly createdAt: number }): ReactNode {
+  const label = useRelativeTimestamp(props.createdAt);
+  return (
+    <span
+      className="shrink-0 text-ui-xs text-muted-foreground"
+      data-testid="home-focus-relative-time"
+    >
+      {label}
+    </span>
+  );
+}
+
+/** Elapsed time for a background job, on the same shared clock. "just started"
+ * rather than "running now", which reads as a state rather than a duration. */
+function FocusRunningDuration(props: {
+  readonly startedAtMs: number;
+}): ReactNode {
+  const now = useSampledNow();
+  const elapsed = formatCompactRelativeTime(props.startedAtMs, now);
+  return (
+    <span
+      className="shrink-0 text-ui-xs text-muted-foreground"
+      data-testid="home-focus-running-duration"
+    >
+      {elapsed === "now" ? "just started" : `running ${elapsed}`}
+    </span>
+  );
+}
+
+/**
+ * Names the machine a prompt came from, and only when that is not THIS
+ * machine - on a single-host install the chip never renders.
+ *
+ * Compared against the local host rather than the app-wide effective one, the
+ * same call `notification-row` makes for pack attribution: an origin-bound
+ * prompt has to be acted on where it was raised, so "not the machine you are
+ * sitting at" is the fact worth a chip. It also keeps this row out of the
+ * app-wide host-read layer, which Home is not part of. A build with no local
+ * host (the browser client) can't tell the two apart and shows nothing rather
+ * than chipping every row.
+ */
+function OriginHostChip(props: {
+  readonly originHostId: string | null;
+}): ReactNode {
+  const localHost = useReactiveLocalHostEntry();
+  const entry = useHostDirectoryEntry(props.originHostId);
+  if (props.originHostId === null) return null;
+  if (localHost === null) return null;
+  if (props.originHostId === localHost.hostId) return null;
+  return (
+    <span
+      className="shrink-0 rounded-sm bg-foreground/8 px-1.5 py-0.5 text-ui-xs text-muted-foreground"
+      data-testid="home-focus-origin-host"
+    >
+      {entry === null ? "another host" : entry.label}
+    </span>
+  );
+}
+
+export function HomeFocusPromptRow(props: {
+  readonly row: FocusPromptRow;
+  readonly actions: HomeFocusRowActions;
+}): ReactNode {
+  const { row, actions } = props;
+  const open = (): void => actions.openPrompt(row);
+  return (
+    <li className={ROW_CLASS} data-testid="home-focus-prompt-row">
+      <button
+        type="button"
+        onClick={open}
+        className={ROW_BODY_CLASS}
+        data-testid="home-focus-prompt-open-body"
+      >
+        <PromptGlyph kind={row.kind} />
+        <span className={TASK_TITLE_CLASS}>{taskTitleOf(row.taskTitle)}</span>
+        <span className="min-w-0 flex-1 truncate text-muted-foreground">
+          <span className="text-foreground">{row.title}</span>
+          {row.body === "" ? null : <span> — {row.body}</span>}
+        </span>
+        <OriginHostChip originHostId={row.originHostId} />
+        <FocusRelativeTime createdAt={row.createdAt} />
+      </button>
+      <RowActions>
+        {/* Every row's trailing control says "Open"; the label is what tells
+            a screen reader which one it landed on. */}
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          aria-label={`Open ${row.title}`}
+          onClick={open}
+          data-testid="home-focus-prompt-open"
+        >
+          Open
+        </Button>
+      </RowActions>
+    </li>
+  );
+}
+
+/**
+ * Trailing control cluster. `relative` lifts it above the body button's
+ * stretched hit area so its own clicks land on it.
+ *
+ * That is an invariant, not a detail: the overlay is a positioned box early in
+ * tree order, so ANY interactive element placed after the body button without
+ * a position of its own paints under it and stops being clickable, silently.
+ * Every control in a row belongs either here or inside a positioned wrapper of
+ * its own (`AgentChip`).
+ */
+function RowActions(props: { readonly children: ReactNode }): ReactNode {
+  return (
+    <div className="relative flex shrink-0 items-center gap-1.5">
+      {props.children}
+    </div>
+  );
+}
+
+/**
+ * The one stop control every row uses.
+ *
+ * Follows the house pending contract (`gui-app/CLAUDE.md`, Backend calls) and
+ * the reference `AgentStopButton`: disabled while the stop is in flight, the
+ * label unchanged, an inline spinner beside it. A stop that cannot be routed
+ * renders disabled with a reason rather than vanishing, so the row still
+ * accounts for work it cannot end from here. The `<span>` wrapper is what
+ * carries the tooltip - a disabled button fires no pointer events.
+ *
+ * The reason also joins the accessible NAME rather than living only in the
+ * tooltip. A Radix tooltip mounts on hover, so on the one control that can
+ * never be hovered into usefulness - a disabled one - it is exactly the reader
+ * who cannot hover that would be left with an unexplained dead button.
+ */
+function FocusStopButton(props: {
+  readonly label: string;
+  readonly ariaLabel: string;
+  readonly reason: string | null;
+  readonly disabled: boolean;
+  readonly pending: boolean;
+  readonly onClick: () => void;
+  readonly testId: string;
+}): ReactNode {
+  return (
+    <TooltipWrapper
+      label={props.reason}
+      side="top"
+      sideOffset={undefined}
+      align={undefined}
+    >
+      <span className="inline-flex">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          aria-label={
+            props.reason === null
+              ? props.ariaLabel
+              : `${props.ariaLabel}. ${props.reason}`
+          }
+          disabled={props.disabled}
+          onClick={props.onClick}
+          data-testid={props.testId}
+        >
+          {/* The spinner REPLACES a resting glyph rather than appearing beside
+              the label, so the button keeps its width the moment a stop starts
+              and the row's trailing cluster does not jump. Same shape as
+              `StopButtonShell`. */}
+          {props.pending ? (
+            <AgentSpinningDots
+              className="size-3"
+              testId={undefined}
+              variant={undefined}
+            />
+          ) : (
+            <Square aria-hidden className="size-3" />
+          )}
+          {props.label}
+        </Button>
+      </span>
+    </TooltipWrapper>
+  );
+}
+
+/**
+ * The agents "Stop all" actually calls: every listed agent that no OTHER
+ * listed agent parents.
+ *
+ * `FocusTaskRow.agents` is flat - parents and children alike - and each stop
+ * cascades, so calling once per listed agent would issue N RPCs where the
+ * first already tore the whole subtree down, and the rest would address agents
+ * the host had just stopped (up to N-1 spurious "Couldn't stop agent." toasts
+ * after a stop that fully succeeded). `parentId === null` means "root OR
+ * unknown", so an agent whose parentage we cannot see is still stopped - the
+ * safe direction.
+ */
+function stopAllRoots(
+  agents: ReadonlyArray<FocusAgentRow>,
+): ReadonlyArray<FocusAgentRow> {
+  const listed = new Set(agents.map((agent) => agent.agentId));
+  return agents.filter(
+    (agent) => agent.parentId === null || !listed.has(agent.parentId),
+  );
+}
+
+function ActivityDot(props: {
+  readonly tier: FocusAgentRow["tier"];
+}): ReactNode {
+  return (
+    <span
+      aria-hidden
+      data-testid="home-focus-activity-dot"
+      data-tier={props.tier}
+      className={cn(
+        "size-2 shrink-0 rounded-full",
+        props.tier === "turn" ? "bg-primary" : "bg-muted-foreground",
+      )}
+    />
+  );
+}
+
+function agentDisplayName(agent: FocusAgentRow): string {
+  return agent.title ?? "agent";
+}
+
+/** A task's tier at a glance: any agent taking a turn makes the task a turn. */
+function taskTier(agents: ReadonlyArray<FocusAgentRow>): FocusAgentRow["tier"] {
+  return agents.some((agent) => agent.tier === "turn") ? "turn" : "background";
+}
+
+function AgentChip(props: {
+  readonly epicId: string;
+  readonly agent: FocusAgentRow;
+  readonly actions: HomeFocusRowActions;
+}): ReactNode {
+  const { epicId, agent, actions } = props;
+  const name = agentDisplayName(agent);
+  return (
+    <button
+      type="button"
+      onClick={() => actions.openAgent(epicId, agent.agentId)}
+      className="relative flex min-w-0 shrink-0 items-center gap-1.5 rounded-sm px-1.5 py-0.5 outline-none hover:bg-foreground/8 focus-visible:ring-2 focus-visible:ring-ring/50"
+      data-testid="home-focus-agent-chip"
+      data-agent-id={agent.agentId}
+    >
+      <ActivityDot tier={agent.tier} />
+      {agent.surface === "terminal-agent" ? (
+        <Terminal
+          aria-hidden
+          className="size-3 shrink-0 text-muted-foreground"
+        />
+      ) : null}
+      <span className="truncate text-foreground">{name}</span>
+      <span className="shrink-0 text-ui-xs text-muted-foreground">
+        {agent.tier}
+      </span>
+    </button>
+  );
+}
+
+/** What a cold task can say about itself: a count and a tier, with no names,
+ * because agent titles only exist for epics mounted in this window. */
+function ColdTaskAgents(props: {
+  readonly agents: ReadonlyArray<FocusAgentRow>;
+}): ReactNode {
+  const count = props.agents.length;
+  const tier = taskTier(props.agents);
+  return (
+    <span
+      className="flex min-w-0 items-center gap-1.5"
+      data-testid="home-focus-cold-agents"
+    >
+      <ActivityDot tier={tier} />
+      <span className="shrink-0 text-foreground">
+        {count === 1 ? "1 agent" : `${count} agents`}
+      </span>
+      <span className="truncate text-ui-xs text-muted-foreground">
+        {tier} · not open in this window
+      </span>
+    </span>
+  );
+}
+
+export function HomeFocusTaskRow(props: {
+  readonly row: FocusTaskRow;
+  readonly actions: HomeFocusRowActions;
+}): ReactNode {
+  const { row, actions } = props;
+  const [confirmingStopAll, setConfirmingStopAll] = useState<boolean>(false);
+  const title = taskTitleOf(row.taskTitle);
+  return (
+    <li className={ROW_CLASS} data-testid="home-focus-task-row">
+      <button
+        type="button"
+        onClick={() => actions.openTask(row.epicId)}
+        className={cn(ROW_BODY_CLASS, "flex-initial")}
+        data-testid="home-focus-task-open-body"
+      >
+        {row.needsYou ? (
+          <TaskAttentionGlyph />
+        ) : (
+          <Layers
+            aria-hidden
+            className="size-4 shrink-0 text-muted-foreground"
+          />
+        )}
+        <span className={TASK_TITLE_CLASS}>{title}</span>
+      </button>
+      {/* Deliberately NOT `relative`: the body button's stretched overlay must
+          stay above this container so a click on the row's blank space opens
+          the task, while each chip's own `relative` lifts it back above the
+          overlay. */}
+      <div className="flex min-w-0 flex-1 flex-wrap items-center gap-x-2 gap-y-1">
+        {row.mountedHere ? (
+          row.agents.map((agent) => (
+            <AgentChip
+              key={agent.agentId}
+              epicId={row.epicId}
+              agent={agent}
+              actions={actions}
+            />
+          ))
+        ) : (
+          <ColdTaskAgents agents={row.agents} />
+        )}
+      </div>
+      <RowActions>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          aria-label={`Open ${title}`}
+          onClick={() => actions.openTask(row.epicId)}
+          data-testid="home-focus-task-open"
+        >
+          Open
+        </Button>
+        <TaskStopControl
+          row={row}
+          actions={actions}
+          onRequestStopAll={() => setConfirmingStopAll(true)}
+        />
+      </RowActions>
+      <StopAllDialog
+        row={row}
+        open={confirmingStopAll}
+        onOpenChange={setConfirmingStopAll}
+        onConfirm={() => {
+          setConfirmingStopAll(false);
+          for (const agent of stopAllRoots(row.agents)) {
+            actions.stopAgent({
+              epicId: row.epicId,
+              agentId: agent.agentId,
+              hostId: agent.hostId,
+              cascade: true,
+            });
+          }
+        }}
+      />
+    </li>
+  );
+}
+
+/**
+ * One running agent stops directly; several stop through a confirmation.
+ *
+ * The asymmetry is about the dialog, not the blast radius: every stop cascades
+ * (`cascade: true`), the way every other stop in the app does, so a user who
+ * learned the gesture in chat gets the same behaviour here. What the second
+ * form adds is a list - "Stop all" reaches subtrees the row does not name, and
+ * the confirmation is where they are named.
+ */
+function TaskStopControl(props: {
+  readonly row: FocusTaskRow;
+  readonly actions: HomeFocusRowActions;
+  readonly onRequestStopAll: () => void;
+}): ReactNode {
+  const { row, actions } = props;
+  const title = taskTitleOf(row.taskTitle);
+  if (row.agents.length === 0) return null;
+  const reason = row.stoppable ? null : UNREACHABLE_STOP_REASON;
+  const only = row.agents.length === 1 ? row.agents[0] : undefined;
+  if (only !== undefined) {
+    const pending = actions.stopping.has(only.agentId);
+    return (
+      <FocusStopButton
+        label="Stop"
+        ariaLabel={`Stop ${agentDisplayName(only)} in ${title}`}
+        reason={reason}
+        disabled={pending || !row.stoppable}
+        pending={pending}
+        onClick={() =>
+          actions.stopAgent({
+            epicId: row.epicId,
+            agentId: only.agentId,
+            hostId: only.hostId,
+            cascade: true,
+          })
+        }
+        testId="home-focus-task-stop"
+      />
+    );
+  }
+  // Gated on the roots, because those are the calls this button issues.
+  const pending = stopAllRoots(row.agents).some((agent) =>
+    actions.stopping.has(agent.agentId),
+  );
+  return (
+    <FocusStopButton
+      label="Stop all"
+      ariaLabel={`Stop all agents in ${title}`}
+      reason={reason}
+      disabled={pending || !row.stoppable}
+      pending={pending}
+      onClick={props.onRequestStopAll}
+      testId="home-focus-task-stop-all"
+    />
+  );
+}
+
+function StopAllDialog(props: {
+  readonly row: FocusTaskRow;
+  readonly open: boolean;
+  readonly onOpenChange: (open: boolean) => void;
+  readonly onConfirm: () => void;
+}): ReactNode {
+  const { row } = props;
+  const title = taskTitleOf(row.taskTitle);
+  return (
+    <Dialog open={props.open} onOpenChange={props.onOpenChange}>
+      <DialogContent
+        showCloseButton={false}
+        data-testid="home-focus-stop-all-dialog"
+      >
+        <DialogHeader>
+          <DialogTitle>Stop all agents in {title}?</DialogTitle>
+          <DialogDescription>
+            This stops the agents below and anything they started.
+          </DialogDescription>
+        </DialogHeader>
+        <ul
+          className="flex flex-col gap-1 text-ui-sm text-foreground"
+          data-testid="home-focus-stop-all-list"
+        >
+          {row.agents.map((agent) => (
+            <li key={agent.agentId} className="flex items-center gap-2">
+              <ActivityDot tier={agent.tier} />
+              <span className="truncate">{agentDisplayName(agent)}</span>
+              <span className="shrink-0 text-ui-xs text-muted-foreground">
+                {agent.tier}
+              </span>
+            </li>
+          ))}
+        </ul>
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={() => props.onOpenChange(false)}
+            data-testid="home-focus-stop-all-cancel"
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            variant="destructive"
+            onClick={props.onConfirm}
+            data-testid="home-focus-stop-all-confirm"
+          >
+            Stop all
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export function HomeFocusBackgroundRow(props: {
+  readonly row: FocusBackgroundRow;
+  readonly actions: HomeFocusRowActions;
+}): ReactNode {
+  const { row, actions } = props;
+  return (
+    <li className={ROW_CLASS} data-testid="home-focus-background-row">
+      <button
+        type="button"
+        onClick={() => actions.openBackground(row)}
+        className={ROW_BODY_CLASS}
+        data-testid="home-focus-background-open-body"
+      >
+        <Terminal
+          aria-hidden
+          className="size-4 shrink-0 text-muted-foreground"
+        />
+        <span className={TASK_TITLE_CLASS}>{taskTitleOf(row.taskTitle)}</span>
+        <span className="min-w-0 flex-1 truncate text-foreground">
+          {row.label}
+        </span>
+        {row.startedAtMs === null ? null : (
+          <FocusRunningDuration startedAtMs={row.startedAtMs} />
+        )}
+      </button>
+      <RowActions>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          aria-label={`Open ${row.label}`}
+          onClick={() => actions.openBackground(row)}
+          data-testid="home-focus-background-open"
+        >
+          Open
+        </Button>
+        <FocusStopButton
+          label="Stop"
+          ariaLabel={`Stop ${row.label}`}
+          reason={row.stoppable ? null : UNREACHABLE_STOP_REASON}
+          disabled={actions.stopping.has(row.key) || !row.stoppable}
+          pending={actions.stopping.has(row.key)}
+          onClick={() => actions.stopManagedCommand(row)}
+          testId="home-focus-background-stop"
+        />
+      </RowActions>
+    </li>
+  );
+}

--- a/clients/gui-app/src/components/home-focus/home-focus-rows.tsx
+++ b/clients/gui-app/src/components/home-focus/home-focus-rows.tsx
@@ -46,10 +46,12 @@ import type {
 } from "@/lib/home-focus/focus-model";
 
 /**
- * What a row can do, declared structurally rather than imported from the
- * actions hook. The hook's module is the model lane's to own, so naming its
- * return type here would couple two lanes' file contents; structural matching
- * costs nothing and lets that lane name its own type whatever it likes.
+ * What a row can do, declared structurally rather than imported from
+ * `use-focus-actions`. A row depends on the SHAPE of the actions, not on the
+ * hook that builds them, so this module pulls in no hook, no router and no
+ * query client and a test can render a row with a plain object. Drift is still
+ * caught: `home-focus-view` assigns the real `FocusActions` to this type, so a
+ * member that stops matching is a type error at that assignment.
  */
 export interface HomeFocusRowActions {
   readonly openPrompt: (row: FocusPromptRow) => void;
@@ -73,8 +75,25 @@ export interface HomeFocusRowActions {
 
 const UNTITLED_TASK = "Untitled task";
 
-/** What a row whose stop cannot be routed says instead of offering one. */
+/** What a row whose stop cannot be ROUTED says instead of offering one: the
+ * machine it runs on is not one this window can dial. */
 const UNREACHABLE_STOP_REASON = "Runs on another device";
+
+/** A background item's stop is a `chat.subscribe` action on a warm session
+ * rather than a unary RPC (`focus-background.ts`), so it exists in the job's own
+ * chat and nowhere else - which is where this sends the user, not to another
+ * machine. */
+const BACKGROUND_ITEM_STOP_REASON = "Stop this from the chat";
+
+/** Why a background row's stop is disabled, which is never the same question
+ * for the two planes the section lists: a managed command is unstoppable only
+ * when its host is unknown, a background item always. */
+function backgroundStopReason(row: FocusBackgroundRow): string | null {
+  if (row.stoppable) return null;
+  return row.kind === "background-item"
+    ? BACKGROUND_ITEM_STOP_REASON
+    : UNREACHABLE_STOP_REASON;
+}
 
 // `active:press-scrim pointer-coarse:touch-chrome` for the same reason the
 // History row card carries them: the row is a plain container, not a `Button`,
@@ -654,7 +673,7 @@ export function HomeFocusBackgroundRow(props: {
         <FocusStopButton
           label="Stop"
           ariaLabel={`Stop ${row.label}`}
-          reason={row.stoppable ? null : UNREACHABLE_STOP_REASON}
+          reason={backgroundStopReason(row)}
           disabled={actions.stopping.has(row.key) || !row.stoppable}
           pending={actions.stopping.has(row.key)}
           onClick={() => actions.stopManagedCommand(row)}

--- a/clients/gui-app/src/components/home-focus/home-focus-view.tsx
+++ b/clients/gui-app/src/components/home-focus/home-focus-view.tsx
@@ -1,22 +1,235 @@
-import type { ReactNode } from "react";
+/**
+ * The Home tab's surface: everything happening across every task on the host,
+ * with whatever wants the user first.
+ *
+ * Sections are omitted when they hold nothing rather than rendered empty, so
+ * the page shrinks to what is true right now, and the empty state only appears
+ * when all three are empty. Ordering is the model's - this file renders, it
+ * does not sort.
+ *
+ * Live updates arrive as new model values on the same mounted tree: rows carry
+ * stable keys (a prompt's feed id, a task's epic id, a background job's key),
+ * so a store change repaints rows instead of remounting them, and the relative
+ * timestamps subscribe to the app's shared 60s clock inside their own leaves
+ * rather than holding a timer here.
+ */
+import { type ReactNode } from "react";
+import { useNavigate } from "@tanstack/react-router";
+import { Button } from "@/components/ui/button";
+import {
+  HomeFocusBackgroundRow,
+  HomeFocusPromptRow,
+  HomeFocusTaskRow,
+  type HomeFocusRowActions,
+} from "@/components/home-focus/home-focus-rows";
+import { useFocusActions } from "@/hooks/home-focus/use-focus-actions";
+import { useFocusModel } from "@/hooks/home-focus/use-focus-model";
+import { openNewEpicIntent } from "@/lib/commands/actions/new-epic";
+import { navigateToTabIntent } from "@/lib/tab-navigation";
+import { historyTabIntent } from "@/lib/tab-navigation/intents";
+import type { FocusModel } from "@/lib/home-focus/focus-model";
+
+const BACKGROUND_CAPTION = "Only tasks open in this window";
+const NOTIFICATIONS_LOCAL_CAPTION = "this host only";
+const ACTIVITY_NOTICE = "Activity from other hosts may be missing";
+
+export function HomeFocusView(): ReactNode {
+  const model = useFocusModel();
+  const actions: HomeFocusRowActions = useFocusActions();
+  const isEmpty =
+    model.prompts.length === 0 &&
+    model.tasks.length === 0 &&
+    model.background.length === 0;
+  return (
+    // One landmark for the whole page - the inner groups are plain containers
+    // with `h2` headings so a screen reader gets a heading outline rather than
+    // three more regions to step through.
+    <section
+      aria-label="Home"
+      data-testid="home-focus-view"
+      className="h-full w-full overflow-y-auto"
+    >
+      {/* `pb-safe-bottom-gutter`, not `pb-6`: the page scrolls to its own end,
+          so the last row has to clear the home indicator on a phone and still
+          keep a real gutter on a desktop where every inset is zero. */}
+      <div className="mx-auto flex w-full max-w-3xl flex-col gap-2 px-4 pt-6 pb-safe-bottom-gutter">
+        <ActivityCoverageNotice activity={model.coverage.activity} />
+        {isEmpty ? (
+          <HomeFocusEmptyState />
+        ) : (
+          <>
+            <PromptsSection model={model} actions={actions} />
+            <TasksSection model={model} actions={actions} />
+            <BackgroundSection model={model} actions={actions} />
+          </>
+        )}
+      </div>
+    </section>
+  );
+}
 
 /**
- * The Home tab's body: everything happening right now across every task.
- *
- * Only the empty state exists so far - the sections (Needs you, Running,
- * Background) land with the cross-task focus model. The export name and the
- * prop-free signature are the contract `TopLevelTabHost` mounts, so they stay
- * fixed while the body fills in.
+ * Says the page may be incomplete, and only when it may be. `unknown` is not a
+ * warning: it is what a client that has never heard from the activity plane
+ * reports at startup, and a notice on every cold open would train the user to
+ * ignore the one that matters.
  */
-export function HomeFocusView(): ReactNode {
+function ActivityCoverageNotice(props: {
+  readonly activity: FocusModel["coverage"]["activity"];
+}): ReactNode {
+  const degraded =
+    props.activity === "reconnecting" || props.activity === "disconnected";
+  // The live region is mounted whether or not it has anything to say: a region
+  // inserted together with its first content is announced far less reliably
+  // than one already in the tree when the text appears. `display: contents`
+  // keeps that permanence free of layout - an empty box would otherwise take a
+  // slot in the page's `gap-2` column and push the first section down.
+  return (
+    <div role="status" aria-live="polite" className="contents">
+      {degraded ? (
+        <p
+          data-testid="home-focus-activity-notice"
+          data-activity={props.activity}
+          className="rounded-md bg-foreground/5 px-3 py-2 text-ui-xs text-muted-foreground"
+        >
+          {ACTIVITY_NOTICE}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+function HomeFocusSection(props: {
+  readonly title: string;
+  readonly count: string;
+  readonly caption: string | null;
+  readonly testId: string;
+  readonly children: ReactNode;
+}): ReactNode {
+  return (
+    <div data-testid={props.testId} className="flex flex-col gap-1">
+      {/* The caption is a SIBLING of the heading, not inside it: a screen
+          reader's heading outline should read "Background · 2", not
+          "Background · 2 Only tasks open in this window". */}
+      <div className="flex flex-wrap items-baseline gap-x-2 px-3 pt-4 pb-1 text-ui-xs text-muted-foreground">
+        <h2 className="tracking-[0.08em] uppercase">
+          {props.title} · {props.count}
+        </h2>
+        {props.caption === null ? null : (
+          <p data-testid={`${props.testId}-caption`}>{props.caption}</p>
+        )}
+      </div>
+      <ul className="flex flex-col">{props.children}</ul>
+    </div>
+  );
+}
+
+function PromptsSection(props: {
+  readonly model: FocusModel;
+  readonly actions: HomeFocusRowActions;
+}): ReactNode {
+  const { prompts } = props.model;
+  if (prompts.length === 0) return null;
+  return (
+    <HomeFocusSection
+      title="Needs you"
+      count={String(prompts.length)}
+      caption={
+        props.model.coverage.notifications === "local"
+          ? NOTIFICATIONS_LOCAL_CAPTION
+          : null
+      }
+      testId="home-focus-section-prompts"
+    >
+      {prompts.map((row) => (
+        <HomeFocusPromptRow key={row.key} row={row} actions={props.actions} />
+      ))}
+    </HomeFocusSection>
+  );
+}
+
+function TasksSection(props: {
+  readonly model: FocusModel;
+  readonly actions: HomeFocusRowActions;
+}): ReactNode {
+  const { tasks } = props.model;
+  if (tasks.length === 0) return null;
+  return (
+    <HomeFocusSection
+      title="Running"
+      count={tasks.length === 1 ? "1 task" : `${tasks.length} tasks`}
+      caption={null}
+      testId="home-focus-section-tasks"
+    >
+      {tasks.map((row) => (
+        <HomeFocusTaskRow key={row.epicId} row={row} actions={props.actions} />
+      ))}
+    </HomeFocusSection>
+  );
+}
+
+function BackgroundSection(props: {
+  readonly model: FocusModel;
+  readonly actions: HomeFocusRowActions;
+}): ReactNode {
+  const { background } = props.model;
+  if (background.length === 0) return null;
+  return (
+    <HomeFocusSection
+      title="Background"
+      count={String(background.length)}
+      caption={BACKGROUND_CAPTION}
+      testId="home-focus-section-background"
+    >
+      {background.map((row) => (
+        <HomeFocusBackgroundRow
+          key={row.key}
+          row={row}
+          actions={props.actions}
+        />
+      ))}
+    </HomeFocusSection>
+  );
+}
+
+/**
+ * Nothing is running and nothing is pending. Home has no composer (that is
+ * Start New's job), so the two ways out are links to the two surfaces that do
+ * have one.
+ */
+function HomeFocusEmptyState(): ReactNode {
+  const navigate = useNavigate();
   return (
     <div
-      data-testid="home-focus-view"
-      className="flex min-h-0 w-full flex-1 items-center justify-center p-6"
+      data-testid="home-focus-empty"
+      className="flex flex-col items-center justify-center gap-2 py-[min(4rem,12vh)] text-center text-ui-sm text-muted-foreground"
     >
-      <p className="max-w-prose text-center text-ui-sm text-muted-foreground">
-        Nothing needs you. Start a new task or open a recent one.
-      </p>
+      <p className="font-medium text-foreground">Nothing needs you.</p>
+      <p>Start a new task or open a recent one.</p>
+      <div className="flex flex-wrap items-center justify-center gap-2">
+        <Button
+          type="button"
+          variant="link"
+          size="sm"
+          onClick={() => {
+            navigateToTabIntent(navigate, openNewEpicIntent(), undefined);
+          }}
+          data-testid="home-focus-empty-new-task"
+        >
+          Start a new task
+        </Button>
+        <Button
+          type="button"
+          variant="link"
+          size="sm"
+          onClick={() => {
+            navigateToTabIntent(navigate, historyTabIntent(), undefined);
+          }}
+          data-testid="home-focus-empty-history"
+        >
+          Open History
+        </Button>
+      </div>
     </div>
   );
 }

--- a/clients/gui-app/src/components/home-focus/home-focus-view.tsx
+++ b/clients/gui-app/src/components/home-focus/home-focus-view.tsx
@@ -1,0 +1,22 @@
+import type { ReactNode } from "react";
+
+/**
+ * The Home tab's body: everything happening right now across every task.
+ *
+ * Only the empty state exists so far - the sections (Needs you, Running,
+ * Background) land with the cross-task focus model. The export name and the
+ * prop-free signature are the contract `TopLevelTabHost` mounts, so they stay
+ * fixed while the body fills in.
+ */
+export function HomeFocusView(): ReactNode {
+  return (
+    <div
+      data-testid="home-focus-view"
+      className="flex min-h-0 w-full flex-1 items-center justify-center p-6"
+    >
+      <p className="max-w-prose text-center text-ui-sm text-muted-foreground">
+        Nothing needs you. Start a new task or open a recent one.
+      </p>
+    </div>
+  );
+}

--- a/clients/gui-app/src/components/home-focus/home-focus-view.tsx
+++ b/clients/gui-app/src/components/home-focus/home-focus-view.tsx
@@ -31,7 +31,10 @@ import type { FocusModel } from "@/lib/home-focus/focus-model";
 
 const BACKGROUND_CAPTION = "Only tasks open in this window";
 const NOTIFICATIONS_LOCAL_CAPTION = "this host only";
-const ACTIVITY_NOTICE = "Activity from other hosts may be missing";
+// Deliberately does not name other hosts: `disconnected` is also what THIS
+// client's own activity stream reports when it is closed, and then the Running
+// section can be empty outright rather than merely partial.
+const ACTIVITY_NOTICE = "Some activity may be missing";
 
 export function HomeFocusView(): ReactNode {
   const model = useFocusModel();

--- a/clients/gui-app/src/components/home-focus/use-home-badge-count.ts
+++ b/clients/gui-app/src/components/home-focus/use-home-badge-count.ts
@@ -10,12 +10,14 @@ import { useMergedNotificationRows } from "@/stores/notifications/merged-notific
  *
  * It deliberately does NOT call `useFocusModel()`, even though that would read
  * better. The badge lives in the tab strip, which is mounted for the life of
- * the window (Home is always present), so a model here would keep
- * the entire cross-task join running while Home is closed: subscriptions to the
- * activity store, the chat-session registry, the open-epic registry and every
- * mounted epic's Y.Doc, plus two RPC families keyed on an epic set that moves
- * whenever any task on the account starts or stops. The notification rows this
- * reads are already subscribed by the bell.
+ * the window (Home is always present), so a model here would keep the entire
+ * cross-task join running whether or not Home is ever opened: subscriptions to
+ * the activity store, the chat-session registry, the open-epic registry and
+ * every mounted epic's Y.Doc, plus two RPC families keyed on an epic set that
+ * moves whenever any task on the account starts or stops. The Home surface
+ * itself only mounts once the user opens it (`TopLevelTabHost`), so a model
+ * here would be the one thing charging a window that never does. The
+ * notification rows this reads are already subscribed by the bell.
  *
  * NOT the bell's count. The bell's attention tier also carries unread failures,
  * which are history rather than a question; this counts only what is waiting on

--- a/clients/gui-app/src/components/home-focus/use-home-badge-count.ts
+++ b/clients/gui-app/src/components/home-focus/use-home-badge-count.ts
@@ -1,0 +1,26 @@
+import { countPendingPromptRows } from "@/lib/home-focus/focus-prompts";
+import { useMergedNotificationRows } from "@/stores/notifications/merged-notifications";
+
+/**
+ * The count on the Home tab: unresolved, unread prompts across every task.
+ *
+ * Counted through `countPendingPromptRows`, the same selector
+ * `buildFocusPrompts` maps its rows from, so this is provably `badgeCount` and
+ * not a second derivation that could drift from the "Needs you" section.
+ *
+ * It deliberately does NOT call `useFocusModel()`, even though that would read
+ * better. The badge lives in the tab strip, which is mounted for the life of
+ * the window (Home is always present), so a model here would keep
+ * the entire cross-task join running while Home is closed: subscriptions to the
+ * activity store, the chat-session registry, the open-epic registry and every
+ * mounted epic's Y.Doc, plus two RPC families keyed on an epic set that moves
+ * whenever any task on the account starts or stops. The notification rows this
+ * reads are already subscribed by the bell.
+ *
+ * NOT the bell's count. The bell's attention tier also carries unread failures,
+ * which are history rather than a question; this counts only what is waiting on
+ * an answer.
+ */
+export function useHomeBadgeCount(): number {
+  return countPendingPromptRows(useMergedNotificationRows());
+}

--- a/clients/gui-app/src/components/layout/__tests__/app-shell-lifecycle-bridges.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/app-shell-lifecycle-bridges.test.tsx
@@ -94,6 +94,14 @@ vi.mock("@/components/home/terminal-panel/landing-terminal-host", () => ({
   LandingTerminalHost: () => <div data-testid="landing-terminal-host" />,
 }));
 
+// Lazily loaded by the "history" tab kind's descriptor; stubbed the same way
+// `top-level-tab-host.test.tsx` stubs it, so a real History tab can be seeded
+// here without pulling its full router-backed surface into this
+// provider-light shell test.
+vi.mock("@/components/epics/history-surface", () => ({
+  HistorySurface: () => <div data-testid="history-surface-body" />,
+}));
+
 import { AppShell } from "@/components/layout/app-shell";
 import {
   hostRpcRegistry,
@@ -101,6 +109,7 @@ import {
   type HostRpcRegistry,
 } from "@/lib/host";
 import { RunnerHostProvider } from "@/providers/runner-host-provider";
+import { useTabsStore } from "@/stores/tabs/store";
 
 function renderAppShell(): QueryClient {
   const queryClient = new QueryClient({
@@ -163,7 +172,11 @@ describe("<AppShell />", () => {
         { userId: "user-1", username: "test-user" },
         [],
       );
-    useSettingsStore.setState({ showGlobalResourceMonitor: true });
+    useSettingsStore.setState({
+      showGlobalResourceMonitor: true,
+      homeTabEnabled: false,
+    });
+    useTabsStore.setState(useTabsStore.getInitialState(), true);
   });
 
   afterEach(() => {
@@ -172,7 +185,11 @@ describe("<AppShell />", () => {
     queryClient = undefined;
     delete windowHost.runnerHost;
     useAuthStore.getState().setSignedOut();
-    useSettingsStore.setState({ showGlobalResourceMonitor: true });
+    useSettingsStore.setState({
+      showGlobalResourceMonitor: true,
+      homeTabEnabled: false,
+    });
+    useTabsStore.setState(useTabsStore.getInitialState(), true);
   });
 
   it("renders the signed-in app shell around routed children", async () => {
@@ -243,5 +260,94 @@ describe("<AppShell />", () => {
     await screen.findByTestId("app-shell-child");
 
     expect(screen.queryByTestId("resource-monitor-header-button")).toBeNull();
+  });
+
+  // `TopLevelTabHost` mounts the whole time - `AppShell` renders it directly,
+  // not through the routed `children` this suite otherwise stubs out - so the
+  // Home surface's mount/visibility contract can be exercised through a real
+  // signed-in shell render exactly like every other assertion in this file.
+  describe("Home tab surface", () => {
+    function homeSurface(): HTMLElement {
+      return screen.getByTestId("top-level-surface-home-home");
+    }
+
+    it("mounts the Home surface when the flag is on", async () => {
+      useSettingsStore.setState({ homeTabEnabled: true });
+
+      queryClient = renderAppShell();
+      await screen.findByTestId("app-shell-child");
+
+      expect(homeSurface()).not.toBeNull();
+    });
+
+    it("shows the Home surface as visible when Home is the active tab", async () => {
+      useSettingsStore.setState({ homeTabEnabled: true });
+      // `activeItemId: null` is the tabs store's own default (no tabs open
+      // yet), which is exactly what "Home is active" means while the flag is
+      // on - see `layoutHomeIsActive` in `stores/tabs/store.ts`. Set it
+      // explicitly so the test does not depend on that default staying
+      // unchanged.
+      useTabsStore.setState((state) => ({ ...state, activeItemId: null }));
+
+      queryClient = renderAppShell();
+      await screen.findByTestId("app-shell-child");
+
+      const surface = await screen.findByTestId("home-focus-view");
+      expect(surface).not.toBeNull();
+      expect(homeSurface().dataset.visible).toBe("true");
+      expect(homeSurface().getAttribute("aria-hidden")).toBe("false");
+    });
+
+    it("keeps the Home surface mounted but hidden while a real other tab is active", async () => {
+      useSettingsStore.setState({ homeTabEnabled: true });
+      // A real, non-Home strip tab - seeded the way `top-level-tab-host.test.tsx`
+      // seeds a History tab (its own surface stubbed above, since this
+      // provider-light shell has no router for the real one to run under).
+      useTabsStore.setState((state) => ({
+        ...state,
+        items: [
+          {
+            kind: "tab",
+            id: "tab:history:history",
+            ref: { kind: "history", id: "history" },
+          },
+        ],
+        activeItemId: "tab:history:history",
+        stripOrder: [{ kind: "history", id: "history" }],
+        systemTabs: {
+          history: {
+            id: "history",
+            kind: "history",
+            name: "History",
+            lastPath: null,
+          },
+          settings: null,
+        },
+      }));
+
+      queryClient = renderAppShell();
+      await screen.findByTestId("app-shell-child");
+
+      // The other tab is the one actually visible...
+      const historySurface = await screen.findByTestId(
+        "top-level-surface-history-history",
+      );
+      expect(historySurface.dataset.visible).toBe("true");
+
+      // ...but Home stays in the DOM rather than unmounting - the whole point
+      // of hosting it outside the MRU cap - it is just hidden.
+      expect(homeSurface()).not.toBeNull();
+      expect(homeSurface().dataset.visible).toBe("false");
+      expect(homeSurface().getAttribute("aria-hidden")).toBe("true");
+    });
+
+    it("does not mount the Home surface when the flag is off", async () => {
+      useSettingsStore.setState({ homeTabEnabled: false });
+
+      queryClient = renderAppShell();
+      await screen.findByTestId("app-shell-child");
+
+      expect(screen.queryByTestId("top-level-surface-home-home")).toBeNull();
+    });
   });
 });

--- a/clients/gui-app/src/components/layout/__tests__/app-shell-lifecycle-bridges.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/app-shell-lifecycle-bridges.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { cleanup, render, screen } from "@testing-library/react";
+import { act, cleanup, render, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MockHostMessenger } from "@traycer-clients/shared/host-client/mock/mock-host-messenger";
 import { MockRunnerHost } from "@traycer-clients/shared/host-client/mock/mock-runner-host";
@@ -271,7 +271,7 @@ describe("<AppShell />", () => {
       return screen.getByTestId("top-level-surface-home-home");
     }
 
-    it("mounts the Home surface when the flag is on", async () => {
+    it("mounts the Home surface when the flag is on and Home holds the selection", async () => {
       useSettingsStore.setState({ homeTabEnabled: true });
 
       queryClient = renderAppShell();
@@ -298,11 +298,13 @@ describe("<AppShell />", () => {
       expect(homeSurface().getAttribute("aria-hidden")).toBe("false");
     });
 
-    it("keeps the Home surface mounted but hidden while a real other tab is active", async () => {
+    it("keeps the Home surface mounted but hidden once it has been opened and a real other tab takes over", async () => {
       useSettingsStore.setState({ homeTabEnabled: true });
       // A real, non-Home strip tab - seeded the way `top-level-tab-host.test.tsx`
       // seeds a History tab (its own surface stubbed above, since this
       // provider-light shell has no router for the real one to run under).
+      // Home holds the selection first, because the surface latches its mount
+      // on that first activation: this is a window that HAS opened Home.
       useTabsStore.setState((state) => ({
         ...state,
         items: [
@@ -312,7 +314,7 @@ describe("<AppShell />", () => {
             ref: { kind: "history", id: "history" },
           },
         ],
-        activeItemId: "tab:history:history",
+        activeItemId: null,
         stripOrder: [{ kind: "history", id: "history" }],
         systemTabs: {
           history: {
@@ -327,6 +329,14 @@ describe("<AppShell />", () => {
 
       queryClient = renderAppShell();
       await screen.findByTestId("app-shell-child");
+      expect(homeSurface()).not.toBeNull();
+
+      act(() => {
+        useTabsStore.setState((state) => ({
+          ...state,
+          activeItemId: "tab:history:history",
+        }));
+      });
 
       // The other tab is the one actually visible...
       const historySurface = await screen.findByTestId(

--- a/clients/gui-app/src/components/layout/__tests__/home-surface-mount-latch.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/home-surface-mount-latch.test.tsx
@@ -1,0 +1,147 @@
+/**
+ * When the Home surface is allowed to run, and when it is not.
+ *
+ * The surface is the head of the whole cross-task join - task-context and
+ * indicator RPCs keyed on an epic set that moves whenever anything on the
+ * account starts or stops, a projection re-encode per Y.Doc notification, a
+ * subscription per warm chat - so mounting it costs the same whether it is
+ * visible or hidden behind `display: none`. Two facts have to hold together:
+ * a window that never opens Home pays none of that, and a window that HAS
+ * opened it keeps the surface warm for the rest of the session rather than
+ * paying a cold rebuild on every visit.
+ *
+ * Asserted through the real component and the real stores, with the model and
+ * actions hooks faked - a call to `useFocusModel` IS the cost being measured,
+ * so counting the calls is the honest test.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import type { NavigateOptions } from "@tanstack/react-router";
+import { TopLevelTabHost } from "@/components/layout/top-level-tab-host";
+import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import { useLandingDraftStore } from "@/stores/home/landing-draft-store";
+import { useSettingsStore } from "@/stores/settings/settings-store";
+import { emptyTabStripLayout } from "@/stores/tabs/layout";
+import { useTabsStore } from "@/stores/tabs/store";
+import { __resetTabNavigationControllerForTesting } from "@/lib/tab-navigation";
+import {
+  __resetTabSyncCoordinatorForTesting,
+  installTabSyncCoordinator,
+} from "@/lib/tab-sync/tab-sync-coordinator";
+
+const focusModel = vi.hoisted(() => ({ calls: 0 }));
+vi.mock("@/hooks/home-focus/use-focus-model", async () => {
+  const { EMPTY_FOCUS_MODEL: empty } =
+    await import("@/lib/home-focus/build-focus-model");
+  return {
+    useFocusModel: () => {
+      focusModel.calls += 1;
+      return empty;
+    },
+  };
+});
+
+vi.mock("@/hooks/home-focus/use-focus-actions", () => ({
+  useFocusActions: () => ({
+    openPrompt: vi.fn(),
+    openAgent: vi.fn(),
+    openTask: vi.fn(),
+    openBackground: vi.fn(),
+    stopAgent: vi.fn(),
+    stopManagedCommand: vi.fn(),
+    stopping: new Set<string>(),
+  }),
+}));
+
+vi.mock("@tanstack/react-router", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@tanstack/react-router")>();
+  return {
+    ...actual,
+    useNavigate: () => (_options: NavigateOptions) => Promise.resolve(),
+  };
+});
+
+vi.mock("@/components/epic-tabs/phase-migration-controller-host", () => ({
+  PhaseMigrationControllerHost: () => null,
+}));
+
+vi.mock(
+  "@/components/epic-canvas/surface-host/stable-tile-surface-host-switch",
+  () => ({ STABLE_TILE_SURFACE_HOST_ENABLED: false }),
+);
+
+const HOME_SURFACE = "top-level-surface-home-home";
+
+function resetStores(): void {
+  useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
+  useLandingDraftStore.setState({ drafts: [], activeDraftId: null });
+  useTabsStore.setState({ ...emptyTabStripLayout(), stripOrder: [] });
+  useSettingsStore.setState({ homeTabEnabled: true });
+  focusModel.calls = 0;
+}
+
+/** Home holds the selection as `activeItemId === null`; any other id is a task
+ * tab, which is "switched away from Home". */
+function selectItem(activeItemId: string | null): void {
+  act(() => {
+    useTabsStore.setState({ activeItemId });
+  });
+}
+
+describe("the Home surface's mount", () => {
+  beforeEach(async () => {
+    resetStores();
+    __resetTabSyncCoordinatorForTesting();
+    __resetTabNavigationControllerForTesting();
+    installTabSyncCoordinator({ readyPromise: Promise.resolve() });
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+
+  afterEach(() => {
+    cleanup();
+    resetStores();
+  });
+
+  it("runs nothing in a window that has the tab on but never opens it", async () => {
+    selectItem("tab:epic:working");
+    render(<TopLevelTabHost />);
+
+    // The surface's chunk resolves in a microtask, so flushing one is what
+    // makes this a real absence rather than a race with the lazy import.
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(screen.queryByTestId(HOME_SURFACE)).toBeNull();
+    expect(screen.queryByTestId("home-focus-view")).toBeNull();
+    expect(focusModel.calls).toBe(0);
+  });
+
+  it("stays mounted after the first visit, including once the user switches away", async () => {
+    selectItem("tab:epic:working");
+    render(<TopLevelTabHost />);
+
+    selectItem(null);
+    // The surface itself is behind a `lazy()`, so the model starts running a
+    // chunk load after the mount appears, not with it.
+    expect(await screen.findByTestId("home-focus-view")).toBeDefined();
+    expect(focusModel.calls).toBeGreaterThan(0);
+
+    selectItem("tab:epic:working");
+    const hidden = screen.getByTestId(HOME_SURFACE);
+    expect(hidden.getAttribute("data-visible")).toBe("false");
+  });
+
+  it("unmounts when the tab is turned off", async () => {
+    render(<TopLevelTabHost />);
+    await waitFor(() => {
+      expect(screen.getByTestId(HOME_SURFACE)).toBeDefined();
+    });
+
+    act(() => {
+      useSettingsStore.setState({ homeTabEnabled: false });
+    });
+    expect(screen.queryByTestId(HOME_SURFACE)).toBeNull();
+  });
+});

--- a/clients/gui-app/src/components/layout/__tests__/home-tab-disabled-fallback.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/home-tab-disabled-fallback.test.tsx
@@ -1,0 +1,131 @@
+/**
+ * Turning the Home tab off while Home holds the selection must land somewhere,
+ * and must land there IDEMPOTENTLY.
+ *
+ * `activeItemId === null` means Home only while the flag is on; the moment it
+ * goes off, that selection names nothing and the window would render an empty
+ * content area. Start New is where it goes - the other surface reachable with
+ * no task open, and what `/` resolved to before Home existed.
+ *
+ * The idempotence is the part worth pinning. A user who toggles the setting
+ * off, misses Home, toggles it back on and then off again is doing something
+ * ordinary, and a fallback that mints a fresh draft per flip leaves a trail of
+ * Start New tabs they never asked for. The sibling stepped-landing resolver
+ * names the existing draft explicitly for exactly this reason; this asserts the
+ * fallback does the same.
+ *
+ * Drives the real component, coordinator and stores. Only the router commit
+ * boundary is faked: the draft is created by the coordinator before `navigate`
+ * is ever called, so the store is the honest place to assert.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, render } from "@testing-library/react";
+import type { NavigateOptions } from "@tanstack/react-router";
+import { TopLevelTabHost } from "@/components/layout/top-level-tab-host";
+import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import { useLandingDraftStore } from "@/stores/home/landing-draft-store";
+import { useSettingsStore } from "@/stores/settings/settings-store";
+import { emptyTabStripLayout } from "@/stores/tabs/layout";
+import { useTabsStore } from "@/stores/tabs/store";
+import { __resetTabNavigationControllerForTesting } from "@/lib/tab-navigation";
+import {
+  __resetTabSyncCoordinatorForTesting,
+  installTabSyncCoordinator,
+} from "@/lib/tab-sync/tab-sync-coordinator";
+
+const navigated = vi.hoisted(() => ({ options: [] as NavigateOptions[] }));
+
+vi.mock("@tanstack/react-router", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@tanstack/react-router")>();
+  return {
+    ...actual,
+    useNavigate: () => (options: NavigateOptions) => {
+      navigated.options.push(options);
+      return Promise.resolve();
+    },
+  };
+});
+
+vi.mock("@/components/epic-tabs/phase-migration-controller-host", () => ({
+  PhaseMigrationControllerHost: () => null,
+}));
+
+vi.mock(
+  "@/components/epic-canvas/surface-host/stable-tile-surface-host-switch",
+  () => ({ STABLE_TILE_SURFACE_HOST_ENABLED: false }),
+);
+
+function resetStores(): void {
+  useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
+  useLandingDraftStore.setState({ drafts: [], activeDraftId: null });
+  useTabsStore.setState({ ...emptyTabStripLayout(), stripOrder: [] });
+  useSettingsStore.setState({ homeTabEnabled: false });
+  navigated.options = [];
+}
+
+function setHomeTabEnabled(enabled: boolean): void {
+  act(() => {
+    useSettingsStore.setState({ homeTabEnabled: enabled });
+  });
+}
+
+describe("turning the Home tab off while Home is active", () => {
+  beforeEach(async () => {
+    resetStores();
+    __resetTabSyncCoordinatorForTesting();
+    __resetTabNavigationControllerForTesting();
+    installTabSyncCoordinator({ readyPromise: Promise.resolve() });
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+
+  afterEach(() => {
+    cleanup();
+    resetStores();
+  });
+
+  it("reuses the one Start New page across repeated off/on/off flips", () => {
+    setHomeTabEnabled(true);
+    render(<TopLevelTabHost />);
+    expect(useTabsStore.getState().activeItemId).toBeNull();
+
+    setHomeTabEnabled(false);
+    expect(useLandingDraftStore.getState().drafts).toHaveLength(1);
+    const firstDraftId = useLandingDraftStore.getState().drafts[0]?.id;
+    expect(firstDraftId).toBeDefined();
+
+    // Back to Home, then off again - the flip the naive fallback stacks a
+    // second Start New tab on.
+    setHomeTabEnabled(true);
+    act(() => {
+      useTabsStore.setState({ activeItemId: null });
+    });
+    setHomeTabEnabled(false);
+
+    expect(useLandingDraftStore.getState().drafts).toHaveLength(1);
+    expect(useLandingDraftStore.getState().drafts[0]?.id).toBe(firstDraftId);
+  });
+
+  it("leaves a window that never had Home alone", () => {
+    render(<TopLevelTabHost />);
+
+    // Flag off from the start with an empty strip: the ordinary pre-Home empty
+    // state, which must mint nothing and navigate nowhere.
+    expect(useLandingDraftStore.getState().drafts).toHaveLength(0);
+    expect(navigated.options).toHaveLength(0);
+  });
+
+  it("leaves a real tab's selection alone when the flag goes off", () => {
+    setHomeTabEnabled(true);
+    render(<TopLevelTabHost />);
+    act(() => {
+      useTabsStore.setState({ activeItemId: "tab:epic:kept" });
+    });
+
+    setHomeTabEnabled(false);
+
+    expect(useLandingDraftStore.getState().drafts).toHaveLength(0);
+    expect(useTabsStore.getState().activeItemId).toBe("tab:epic:kept");
+  });
+});

--- a/clients/gui-app/src/components/layout/dialogs/desktop/report-issue-dialog.tsx
+++ b/clients/gui-app/src/components/layout/dialogs/desktop/report-issue-dialog.tsx
@@ -107,6 +107,7 @@ const ROUTE_TEMPLATE_LABELS: Readonly<
   "/epics/$epicId/$tabId": "Epic tab",
   "/draft/new": "New chat draft",
   "/draft/$draftId": "Chat draft",
+  "/home": "Home",
   "/onboarding": "Onboarding",
   "/settings": "Settings",
   "/settings/": "Settings",

--- a/clients/gui-app/src/components/layout/header/mobile-app-header.tsx
+++ b/clients/gui-app/src/components/layout/header/mobile-app-header.tsx
@@ -168,11 +168,13 @@ function MobileHeaderTitleSlot(props: MobileHeaderTitleSlotProps): ReactNode {
 type MobileHeaderSurface =
   | { readonly kind: "epic"; readonly tabId: string }
   | { readonly kind: "history" }
+  | { readonly kind: "home" }
   | { readonly kind: "settings"; readonly path: string | null }
   | { readonly kind: "composer" };
 
 const COMPOSER_SURFACE: MobileHeaderSurface = { kind: "composer" };
 const HISTORY_SURFACE: MobileHeaderSurface = { kind: "history" };
+const HOME_SURFACE: MobileHeaderSurface = { kind: "home" };
 
 /**
  * Resolves the presented surface from the tab layout that renders it, NOT from
@@ -188,15 +190,27 @@ const HISTORY_SURFACE: MobileHeaderSurface = { kind: "history" };
  * screen - for an epic, for History and for Settings alike.
  */
 function useMobileHeaderSurface(): MobileHeaderSurface {
+  const homeTabEnabled = useSettingsStore((state) => state.homeTabEnabled);
   return useTabsStore(
     useShallow((state): MobileHeaderSurface => {
       const focused = selectHostFocusedRef(state);
-      if (focused === null) return COMPOSER_SURFACE;
+      // Home is the one presented surface with no focused ref to resolve: it
+      // holds the selection as `activeItemId === null`, which reads here as "no
+      // ref" exactly like an empty layout does.
+      if (focused === null) {
+        return homeTabEnabled && state.activeItemId === null
+          ? HOME_SURFACE
+          : COMPOSER_SURFACE;
+      }
       switch (focused.kind) {
         case "epic":
           return { kind: "epic", tabId: focused.id };
         case "history":
           return HISTORY_SURFACE;
+        // Unreachable: Home is never a strip ref, so `selectHostFocusedRef`
+        // cannot answer with one. Present for the exhaustive switch.
+        case "home":
+          return HOME_SURFACE;
         case "settings":
           return {
             kind: "settings",
@@ -265,6 +279,7 @@ function useMobileHeaderTitle(
   if (surface.kind === "epic") return firstResolvedTitle(liveTitle, tabName);
   if (surface.kind === "settings") return "Settings";
   if (surface.kind === "history") return "History";
+  if (surface.kind === "home") return "Home";
   // Titles name a place you navigated TO. The composer surfaces - landing and
   // drafts - are where you already are, and each one opens with a hero greeting
   // that carries the page, so "Traycer" and "New task" were both labelling the

--- a/clients/gui-app/src/components/layout/shell/__tests__/mobile-nav-home.test.tsx
+++ b/clients/gui-app/src/components/layout/shell/__tests__/mobile-nav-home.test.tsx
@@ -1,0 +1,229 @@
+import "../../../../../__tests__/test-browser-apis";
+
+/**
+ * The mobile drawer's Home row is the phone's ONLY way back to the always-
+ * available Home surface: the desktop tab strip, its route guard and its
+ * keybinding chord are all hidden on the phone shell, so this row is the sole
+ * entry point there. It exists only while the `homeTabEnabled` settings flag
+ * is on, and it must sit ABOVE "New task" - the drawer's one filled, primary
+ * action - so a thumb reaching for the drawer's first row lands on returning
+ * home before it lands on starting something new. A tap must both close the
+ * drawer AND actually select Home in the shared tab layout (`activeItemId`
+ * clears to `null` while every open item is preserved) - closing the drawer
+ * while leaving the previously active tab still selected underneath it would
+ * be a silent no-op dressed up as navigation.
+ *
+ * This is a SEPARATE file rather than an extension of
+ * `mobile-nav-drawer.test.tsx` because that file's shared, file-wide
+ * `vi.mock("@/lib/tab-navigation", ...)` only stubs `draftTabIntent` /
+ * `navigateToTabIntent` - names the component no longer imports. It is inert
+ * today only because nothing in that file ever clicks "New task" or "Home";
+ * exercising the Home tap for real needs the actual `activateTabIntent` ->
+ * `tabCommandCoordinator.activateTab` -> `useTabsStore` pipeline, which
+ * reusing that stale mock would silently break. `@tanstack/react-router`'s
+ * `useNavigate` is swapped for a capturing stub here instead of using a real
+ * router destination, since the store mutation this suite cares about is
+ * committed by `tabCommandCoordinator.activateTab` BEFORE
+ * `TabNavigationController` ever calls `navigate(...)` (see
+ * `executeActivation` in `src/lib/tab-navigation.ts`), and the shared
+ * `TestRouterProvider` only defines a root route - too thin to resolve a real
+ * Home destination.
+ */
+
+import type { UseNavigateResult } from "@tanstack/react-router";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { domMax, LazyMotion } from "motion/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TestRouterProvider } from "../../../../__tests__/with-test-router";
+import { MobileNavDrawer } from "@/components/layout/shell/mobile-nav-drawer";
+import { setMobileApp } from "@/lib/mobile-app";
+import * as TabNav from "@/lib/tab-navigation";
+import { existingEpicTabIntent } from "@/lib/tab-navigation/intents";
+import { installTabSyncCoordinator } from "@/lib/tab-sync/tab-sync-coordinator";
+import { useAuthStore } from "@/stores/auth/auth-store";
+import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import { emptyTabStripLayout, tabItemId } from "@/stores/tabs/layout";
+import { useMobileNavStore } from "@/stores/layout/mobile-nav-store";
+import { useSettingsStore } from "@/stores/settings/settings-store";
+import { useTabsStore } from "@/stores/tabs/store";
+
+// One-time, real reconciliation install - mirrors `tab-navigation.test.ts`,
+// the only other suite that drives `activateTabIntent` against real stores.
+installTabSyncCoordinator({ readyPromise: Promise.resolve() });
+
+const navigateMock = vi.hoisted(() => vi.fn(() => Promise.resolve()));
+
+// `vi.fn(() => Promise.resolve())` already satisfies the navigate signature, so
+// this names the seam rather than casting to it.
+function asNavigate(mock: typeof navigateMock): UseNavigateResult<string> {
+  return mock;
+}
+
+// The store mutation under test is committed before `navigate()` runs, so a
+// capturing stub is enough - real route resolution is exercised elsewhere
+// (`tab-navigation.test.ts`). Every other export (the in-memory router
+// primitives `TestRouterProvider` itself builds on) stays real.
+vi.mock("@tanstack/react-router", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@tanstack/react-router")>();
+  return { ...actual, useNavigate: () => asNavigate(navigateMock) };
+});
+
+vi.mock("@/hooks/epic/use-epic-activity-status", () => ({
+  useEpicActivityStatus: () => "idle",
+}));
+
+vi.mock("@/hooks/notifications/use-notification-indicators-query", () => ({
+  useNotificationIndicators: () => ({ epics: {}, chats: {} }),
+}));
+
+const openLink = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/links/open-link", () => ({ useOpenLink: () => openLink }));
+
+const trackMock = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/analytics", () => ({
+  AnalyticsEvent: {
+    SettingsOpened: "SettingsOpened",
+    SubscriptionManagementOpened: "SubscriptionManagementOpened",
+    SignOutRequested: "SignOutRequested",
+  },
+  Analytics: { getInstance: () => ({ track: trackMock }) },
+}));
+
+vi.mock("@/lib/host", () => ({
+  useAuthService: () => ({ signOut: () => Promise.resolve() }),
+}));
+
+vi.mock("@/providers/use-runner-host", () => ({
+  useRunnerHost: () => ({
+    authnBaseUrl: "https://authn.test",
+    signInUrl: "https://platform.test/sign-in",
+  }),
+}));
+
+vi.mock("@/stores/tabs/use-system-tab-modal", () => ({
+  useSystemTabModalActions: () => ({
+    openSettings: () => undefined,
+    openHistory: () => undefined,
+  }),
+}));
+
+// Never invoked by these tests (nothing here clicks "New task"), but the
+// component imports it unconditionally, so it needs a stub that matches the
+// CURRENT export name - unlike `mobile-nav-drawer.test.tsx`'s stale
+// `openNewEpicDraft` stub, which the component stopped importing.
+vi.mock("@/lib/commands/actions/new-epic", () => ({
+  openNewEpicIntent: () => ({ kind: "new-draft", settings: null }),
+}));
+
+vi.mock("@/hooks/home/use-history-query", () => ({
+  useHistoryQuery: () => ({
+    data: { items: [], totalCount: 0 },
+    isPending: false,
+    isFetching: false,
+    error: null,
+    refetch: () => Promise.resolve(),
+    fetchNextPage: () => undefined,
+    hasNextPage: false,
+    isFetchingNextPage: false,
+  }),
+}));
+
+/**
+ * Mirrors `mobile-nav-drawer.test.tsx`'s `renderDrawer`: `LazyMotion` is what
+ * the installed-app panel needs to exist at all, and `TestRouterProvider`
+ * gives `useNavigate` / `useRouterState` a real (if root-only) router.
+ */
+function renderDrawer(): void {
+  render(
+    <LazyMotion features={domMax}>
+      <TestRouterProvider>
+        <MobileNavDrawer />
+      </TestRouterProvider>
+    </LazyMotion>,
+  );
+}
+
+describe("MobileNavDrawer Home row", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    navigateMock.mockClear();
+    openLink.mockClear();
+    trackMock.mockClear();
+    useMobileNavStore.setState({ open: true });
+    useAuthStore.setState({
+      profile: {
+        userId: "u1",
+        userName: "devansh",
+        email: "devansh@traycer.ai",
+        avatarUrl: null,
+      },
+    });
+    useSettingsStore.setState({ homeTabEnabled: false });
+    useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
+    useTabsStore.setState({ ...emptyTabStripLayout(), stripOrder: [] });
+    TabNav.__resetTabNavigationControllerForTesting();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+    useMobileNavStore.setState({ open: false });
+    useAuthStore.setState({ profile: null });
+    // Reset LAST, and to the disabled default: a leaked `true` here would
+    // silently turn the Home row on for every other suite that renders the
+    // drawer after this file runs in the same worker.
+    useSettingsStore.setState({ homeTabEnabled: false });
+    useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
+    useTabsStore.setState({ ...emptyTabStripLayout(), stripOrder: [] });
+    setMobileApp(false);
+  });
+
+  it("renders above New task when the Home tab is enabled", async () => {
+    useSettingsStore.setState({ homeTabEnabled: true });
+    renderDrawer();
+
+    const home = await screen.findByTestId("mobile-nav-home");
+    const newTask = screen.getByTestId("mobile-nav-new-task");
+
+    // `DOCUMENT_POSITION_FOLLOWING` on the result means "newTask comes after
+    // home" - i.e. Home precedes New task in DOM order, not just visually.
+    expect(
+      home.compareDocumentPosition(newTask) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it("is absent from the drawer when the Home tab is disabled", async () => {
+    useSettingsStore.setState({ homeTabEnabled: false });
+    renderDrawer();
+    await screen.findByTestId("mobile-nav-new-task");
+
+    expect(screen.queryByTestId("mobile-nav-home")).toBeNull();
+  });
+
+  it("closes the drawer and selects Home, preserving the open tab", async () => {
+    useSettingsStore.setState({ homeTabEnabled: true });
+    // Seed a real, already-active epic tab through the same activation seam
+    // the component uses, so the click has a concrete prior selection to
+    // clear rather than starting from an already-empty layout.
+    const tabId = useEpicCanvasStore.getState().openEpicTab("epic-1", "Alpha");
+    TabNav.activateTabIntent(
+      asNavigate(navigateMock),
+      existingEpicTabIntent({ epicId: "epic-1", tabId, focus: undefined }),
+      undefined,
+    );
+    expect(useTabsStore.getState().activeItemId).toBe(
+      tabItemId({ kind: "epic", id: tabId }),
+    );
+    expect(useTabsStore.getState().items.length).toBe(1);
+
+    renderDrawer();
+    fireEvent.click(await screen.findByTestId("mobile-nav-home"));
+
+    expect(useMobileNavStore.getState().open).toBe(false);
+    // Home is a selection, not a placement: it clears the active item without
+    // dropping it from the layout.
+    expect(useTabsStore.getState().activeItemId).toBeNull();
+    expect(useTabsStore.getState().items.length).toBe(1);
+  });
+});

--- a/clients/gui-app/src/components/layout/shell/mobile-nav-drawer.tsx
+++ b/clients/gui-app/src/components/layout/shell/mobile-nav-drawer.tsx
@@ -1,6 +1,12 @@
 import { type ReactNode, useMemo, useState } from "react";
 import { useNavigate, useRouterState } from "@tanstack/react-router";
-import { LogOut, Pin, Settings, SquareArrowOutUpRight } from "lucide-react";
+import {
+  House,
+  LogOut,
+  Pin,
+  Settings,
+  SquareArrowOutUpRight,
+} from "lucide-react";
 import { SignOutConfirmDialog } from "@/components/auth/sign-out-confirm-dialog";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
@@ -22,8 +28,10 @@ import { openNewEpicIntent } from "@/lib/commands/actions/new-epic";
 import { openEpicFromList } from "@/lib/commands/actions/open-epic-from-list";
 import {
   activateTabIntent,
+  homeTabIntent,
   openPhaseMigrationIntent,
 } from "@/lib/tab-navigation";
+import { useSettingsStore } from "@/stores/settings/settings-store";
 import { cn } from "@/lib/utils";
 import { epicDisplayTitle } from "@/lib/display-title";
 import { useAmbientHistorySearchState } from "@/hooks/home/use-history-search-state";
@@ -62,6 +70,7 @@ export function MobileNavDrawer(): ReactNode {
   const runnerHost = useRunnerHost();
   const openLink = useOpenLink();
   const [signOutOpen, setSignOutOpen] = useState(false);
+  const homeTabEnabled = useSettingsStore((state) => state.homeTabEnabled);
   // Immutable after boot, so a plain read is stable for this component's
   // whole life - no resize can flip it the way the viewport hook flips.
   const installedApp = isMobileApp();
@@ -72,6 +81,10 @@ export function MobileNavDrawer(): ReactNode {
   const handleNewTask = () => {
     close();
     activateTabIntent(navigate, openNewEpicIntent(), undefined);
+  };
+  const handleHome = () => {
+    close();
+    activateTabIntent(navigate, homeTabIntent(), undefined);
   };
   const handleSettings = () => {
     close();
@@ -157,6 +170,22 @@ export function MobileNavDrawer(): ReactNode {
       {/* "New task" sits outside the scroll container so it stays pinned
             while the recent-task list below it scrolls. */}
       <nav className="flex min-h-0 flex-1 flex-col p-2">
+        {/* Above "New task": on the phone this row is the whole tab strip's
+            job - the one way back to what is happening across every task. It
+            stays a flat ghost row so the create action keeps the drawer's only
+            resting fill. */}
+        {homeTabEnabled ? (
+          <Button
+            type="button"
+            variant="ghost"
+            className={cn(ROW_CLASS, "mb-1 shrink-0")}
+            data-testid="mobile-nav-home"
+            onClick={handleHome}
+          >
+            <House className="size-4" />
+            <span className="flex-1 text-left">Home</span>
+          </Button>
+        ) : null}
         <Button
           type="button"
           variant="default"

--- a/clients/gui-app/src/components/layout/tabs/__tests__/tab-strip-home-item.test.tsx
+++ b/clients/gui-app/src/components/layout/tabs/__tests__/tab-strip-home-item.test.tsx
@@ -1,0 +1,150 @@
+/**
+ * `TabStripHomeItem` borrows `TabItem`'s tab silhouette but is deliberately
+ * NOT a `TabItem` (`tab-strip-item.tsx`): Home has no strip ref, so it must
+ * carry none of the affordances that depend on one - a drag source, a drop
+ * slot, or the `data-tab-index` digit slot the Alt-digit chords index into.
+ * If Home ever grew a `data-tab-index`, `useHeaderTabs()` (which does not
+ * include Home) would disagree with the strip about which control "digit 1"
+ * names, and the Alt+1 chord would silently point at the wrong control.
+ *
+ * This file locks the control's own contract in isolation - role, selection,
+ * activation, badge formatting, and the precise absence of the dnd/index
+ * attributes `TabItem` sets on its own DOM node. Assertions use plain DOM
+ * reads (`getAttribute` / `hasAttribute`) rather than `jest-dom` matchers:
+ * this suite has no global `jest-dom` setup, and no other test under
+ * `tabs/__tests__/` imports it per-file either.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { TabStripHomeItem } from "@/components/layout/tabs/tab-strip-home-item";
+
+afterEach(() => {
+  cleanup();
+});
+
+function renderHomeItem(
+  isActive: boolean,
+  onActivate: () => void,
+  badgeCount: number,
+): void {
+  render(
+    <TooltipProvider>
+      <TabStripHomeItem
+        isActive={isActive}
+        onActivate={onActivate}
+        badgeCount={badgeCount}
+      />
+    </TooltipProvider>,
+  );
+}
+
+describe("<TabStripHomeItem />", () => {
+  it("renders as a tab with the plain Home label at rest", () => {
+    renderHomeItem(false, vi.fn(), 0);
+
+    const tab = screen.getByTestId("tab-home");
+    expect(tab.getAttribute("role")).toBe("tab");
+    expect(tab.getAttribute("aria-label")).toBe("Home");
+  });
+
+  it("follows the isActive prop through aria-selected", () => {
+    const { unmount } = render(
+      <TooltipProvider>
+        <TabStripHomeItem isActive onActivate={vi.fn()} badgeCount={0} />
+      </TooltipProvider>,
+    );
+    expect(screen.getByTestId("tab-home").getAttribute("aria-selected")).toBe(
+      "true",
+    );
+    unmount();
+
+    render(
+      <TooltipProvider>
+        <TabStripHomeItem
+          isActive={false}
+          onActivate={vi.fn()}
+          badgeCount={0}
+        />
+      </TooltipProvider>,
+    );
+    expect(screen.getByTestId("tab-home").getAttribute("aria-selected")).toBe(
+      "false",
+    );
+  });
+
+  it("fires onActivate when clicked", () => {
+    const onActivate = vi.fn();
+    renderHomeItem(false, onActivate, 0);
+
+    fireEvent.click(screen.getByTestId("tab-home"));
+
+    expect(onActivate).toHaveBeenCalledTimes(1);
+  });
+
+  it("carries no data-tab-index - the digit slot TabItem sets and Home must not", () => {
+    renderHomeItem(true, vi.fn(), 0);
+
+    expect(screen.getByTestId("tab-home").hasAttribute("data-tab-index")).toBe(
+      false,
+    );
+  });
+
+  it("is not a dnd draggable/droppable node like an ordinary TabItem", () => {
+    renderHomeItem(false, vi.fn(), 0);
+
+    const tab = screen.getByTestId("tab-home");
+    // `TabItem`'s own control node (`tab-strip-item.tsx`) sets
+    // `data-tab-index` for every real strip tab, and its `HeaderTabMotionFrame`
+    // wrapper (mounted around every real tab via `includeMotionFrame`) sets
+    // `data-strip-item-id` / `data-strip-item-mergeable` for the reorder
+    // model. Home renders neither: it is not wrapped in a motion frame and
+    // never registers with `useDraggable`/`useDroppable`, so none of these
+    // three should be present. No HTML5 `draggable` attribute either - the
+    // strip's dnd-kit source uses pointer sensors, so absence of a literal
+    // `draggable` attribute is not itself distinguishing (TabItem doesn't set
+    // one either), but it is still asserted here as a direct contract check.
+    expect(tab.hasAttribute("draggable")).toBe(false);
+    expect(tab.hasAttribute("data-tab-index")).toBe(false);
+    expect(tab.hasAttribute("data-strip-item-id")).toBe(false);
+    expect(tab.hasAttribute("data-strip-item-mergeable")).toBe(false);
+  });
+
+  it("keeps [-webkit-app-region:no-drag] so the window drag region skips the control", () => {
+    renderHomeItem(false, vi.fn(), 0);
+
+    expect(screen.getByTestId("tab-home").className).toContain(
+      "[-webkit-app-region:no-drag]",
+    );
+  });
+
+  it("hides the badge at zero - a permanent '0' would be decoration, not signal", () => {
+    renderHomeItem(false, vi.fn(), 0);
+
+    expect(screen.queryByTestId("tab-home-badge")).toBeNull();
+    expect(screen.getByTestId("tab-home").getAttribute("aria-label")).toBe(
+      "Home",
+    );
+  });
+
+  it("shows the exact count under the 99 threshold", () => {
+    renderHomeItem(false, vi.fn(), 3);
+
+    const badge = screen.getByTestId("tab-home-badge");
+    expect(badge.textContent).toBe("3");
+    expect(badge.hasAttribute("aria-hidden")).toBe(true);
+    expect(screen.getByTestId("tab-home").getAttribute("aria-label")).toBe(
+      "Home, 3 waiting on you",
+    );
+  });
+
+  it("clamps to 99+ once the count passes the threshold", () => {
+    renderHomeItem(false, vi.fn(), 150);
+
+    const badge = screen.getByTestId("tab-home-badge");
+    expect(badge.textContent).toBe("99+");
+    expect(screen.getByTestId("tab-home").getAttribute("aria-label")).toBe(
+      "Home, 99+ waiting on you",
+    );
+  });
+});

--- a/clients/gui-app/src/components/layout/tabs/__tests__/tab-strip-home-placement.test.tsx
+++ b/clients/gui-app/src/components/layout/tabs/__tests__/tab-strip-home-placement.test.tsx
@@ -1,0 +1,231 @@
+/**
+ * Home is structural, not a strip item: `TabStrip` (`tab-strip.tsx`) renders
+ * it as a fixed sibling BEFORE the scrollable `header-tab-strip-scroll`
+ * container, outside the `LayoutGroup` whose reorder animations belong to
+ * draggable strip items, and it is never present in `items` / `stripOrder`.
+ * That placement is what this file locks down against the real `TabStrip`
+ * component (not a stand-in), covering:
+ *
+ *  - Home renders as the first child of the `role="tablist"` element and is
+ *    never a descendant of the scrollable strip.
+ *  - the empty-strip early return (`if (!homeTabEnabled && allTabs.length
+ *    === 0 && isLandingPage) return null`) still fires with the flag off,
+ *    but Home being on means there is always something to render even with
+ *    zero task tabs open on the landing route - the one control that gets a
+ *    user back to Home must not disappear exactly when it is the only
+ *    surface left.
+ *  - with the flag off, no `tab-home` node exists anywhere, regression-
+ *    proofing the pre-existing (flag-independent) behavior.
+ *  - Home never consumes a `data-tab-index` digit slot: two ordinary strip
+ *    tabs still read `data-tab-index` 0 and 1 with Home enabled, because the
+ *    Alt-digit chords index `useHeaderTabs()`, which does not include Home.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  RouterProvider,
+} from "@tanstack/react-router";
+import { TabStrip } from "@/components/layout/tabs/tab-strip";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import { useLandingDraftStore } from "@/stores/home/landing-draft-store";
+import { useTabsStore } from "@/stores/tabs/store";
+import { tabItemId } from "@/stores/tabs/layout";
+import type { TabRef } from "@/stores/tabs/types";
+import { useSettingsStore } from "@/stores/settings/settings-store";
+import { installTabSyncCoordinator } from "@/lib/tab-sync/tab-sync-coordinator";
+
+vi.mock("@/hooks/notifications/use-host-notification-indicators-query", () => ({
+  useHostNotificationIndicators: () => ({
+    data: { epics: {}, chats: {} },
+    isPending: false,
+    isFetching: false,
+    error: null,
+    refetch: () => Promise.resolve(),
+  }),
+}));
+
+vi.mock("@/hooks/epic/use-epic-task-pinned-states-query", () => ({
+  useEpicTaskPinnedStates: () => new Map<string, boolean>(),
+}));
+
+vi.mock("@/hooks/epic/use-epic-set-pinned-mutation", () => ({
+  useEpicSetPinned: () => ({ mutate: vi.fn() }),
+  usePendingSetPinnedEpicIds: () => new Set<string>(),
+}));
+
+// Reconciliation install is owned by `WindowsBridgeProvider` in production;
+// this router-only harness skips that provider, so install once here - the
+// same thing `tab-strip.test.tsx` does for the same reason.
+installTabSyncCoordinator({ readyPromise: Promise.resolve() });
+
+let queryClient: QueryClient;
+
+function openEpicFixture(id: string, name: string): void {
+  useEpicCanvasStore.getState().seedEpic(id, { tabId: id, name }, []);
+}
+
+function openDraftFixture(id: string): void {
+  useLandingDraftStore.getState().createDraftWithId(id, null);
+}
+
+function resetStores(): void {
+  useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
+  useLandingDraftStore.setState({ drafts: [], activeDraftId: null });
+  useTabsStore.setState(useTabsStore.getInitialState(), true);
+}
+
+function buildRouter(initialPath: string) {
+  const rootRoute = createRootRoute({
+    component: () => (
+      <QueryClientProvider client={queryClient}>
+        <TooltipProvider>
+          <TabStrip />
+        </TooltipProvider>
+      </QueryClientProvider>
+    ),
+  });
+  const indexRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/",
+    component: () => <div data-testid="landing-route-body" />,
+  });
+  const epicTabRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/epics/$epicId/$tabId",
+    validateSearch: (
+      search: Record<string, unknown>,
+    ): { focusedAt: number | undefined } => ({
+      focusedAt:
+        typeof search.focusedAt === "number" ? search.focusedAt : undefined,
+    }),
+    component: () => <div data-testid="epic-tab-body" />,
+  });
+  const routeTree = rootRoute.addChildren([indexRoute, epicTabRoute]);
+  return createRouter({
+    routeTree,
+    history: createMemoryHistory({ initialEntries: [initialPath] }),
+  });
+}
+
+/** Router matching runs a microtask/timer chain even with no loader. */
+async function flushRouter(): Promise<void> {
+  for (let i = 0; i < 5; i++) {
+    await Promise.resolve();
+  }
+  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+}
+
+describe("<TabStrip /> - Home placement", () => {
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+    useSettingsStore.setState({ homeTabEnabled: false });
+    resetStores();
+  });
+
+  afterEach(() => {
+    cleanup();
+    queryClient.clear();
+    useSettingsStore.setState({ homeTabEnabled: false });
+    resetStores();
+  });
+
+  it("renders Home as the tablist's first child, outside the scrollable strip, when the flag is on", async () => {
+    useSettingsStore.setState({ homeTabEnabled: true });
+    openEpicFixture("e-a", "Alpha");
+    const refA: TabRef = { kind: "epic", id: "e-a" };
+    useTabsStore.setState({
+      version: 2,
+      items: [{ kind: "tab", id: tabItemId(refA), ref: refA }],
+      activeItemId: tabItemId(refA),
+      stripOrder: [refA],
+      systemTabs: { history: null, settings: null },
+    });
+    const router = buildRouter("/epics/e-a/e-a");
+    render(<RouterProvider router={router} />);
+
+    const homeTab = await screen.findByTestId("tab-home");
+    const tablist = screen.getByTestId("tab-strip");
+    expect(tablist.getAttribute("role")).toBe("tablist");
+    expect(tablist.children[0]).toBe(homeTab);
+
+    const scrollContainer = screen.getByTestId("header-tab-strip-scroll");
+    expect(scrollContainer.contains(homeTab)).toBe(false);
+    expect(within(scrollContainer).queryByTestId("tab-home")).toBeNull();
+  });
+
+  it("still renders on the landing route with zero tabs when the flag is on", async () => {
+    useSettingsStore.setState({ homeTabEnabled: true });
+    const router = buildRouter("/");
+    render(<RouterProvider router={router} />);
+
+    // The empty strip used to be nothing at all on the landing route; with
+    // Home fixed and on, there is always something to render.
+    expect(await screen.findByTestId("tab-strip")).not.toBeNull();
+    expect(screen.getByTestId("tab-home")).not.toBeNull();
+  });
+
+  it("renders nothing on the landing route with zero tabs when the flag is off, and shows no Home control anywhere", async () => {
+    const router = buildRouter("/");
+    render(<RouterProvider router={router} />);
+    await flushRouter();
+
+    expect(screen.queryByTestId("tab-strip")).toBeNull();
+    expect(screen.queryByTestId("tab-home")).toBeNull();
+  });
+
+  it("shows no Home control when the flag is off even with real tabs open", async () => {
+    openEpicFixture("e-a", "Alpha");
+    const refA: TabRef = { kind: "epic", id: "e-a" };
+    useTabsStore.setState({
+      version: 2,
+      items: [{ kind: "tab", id: tabItemId(refA), ref: refA }],
+      activeItemId: tabItemId(refA),
+      stripOrder: [refA],
+      systemTabs: { history: null, settings: null },
+    });
+    const router = buildRouter("/epics/e-a/e-a");
+    render(<RouterProvider router={router} />);
+
+    expect(await screen.findByTestId("tab-epic-e-a")).not.toBeNull();
+    expect(screen.queryByTestId("tab-home")).toBeNull();
+  });
+
+  it("keeps ordinary strip tabs at data-tab-index 0 and 1 - Home consumes no digit slot", async () => {
+    useSettingsStore.setState({ homeTabEnabled: true });
+    openEpicFixture("e-a", "Alpha");
+    openDraftFixture("draft-1");
+    const refEpic: TabRef = { kind: "epic", id: "e-a" };
+    const refDraft: TabRef = { kind: "draft", id: "draft-1" };
+    useTabsStore.setState({
+      version: 2,
+      items: [
+        { kind: "tab", id: tabItemId(refEpic), ref: refEpic },
+        { kind: "tab", id: tabItemId(refDraft), ref: refDraft },
+      ],
+      activeItemId: tabItemId(refEpic),
+      stripOrder: [refEpic, refDraft],
+      systemTabs: { history: null, settings: null },
+    });
+    const router = buildRouter("/epics/e-a/e-a");
+    render(<RouterProvider router={router} />);
+
+    const epicTab = await screen.findByTestId("tab-epic-e-a");
+    const draftTab = screen.getByTestId("tab-draft-draft-1");
+    expect(epicTab.getAttribute("data-tab-index")).toBe("0");
+    expect(draftTab.getAttribute("data-tab-index")).toBe("1");
+    expect(screen.getByTestId("tab-home").hasAttribute("data-tab-index")).toBe(
+      false,
+    );
+  });
+});

--- a/clients/gui-app/src/components/layout/tabs/__tests__/tab-strip-home-placement.test.tsx
+++ b/clients/gui-app/src/components/layout/tabs/__tests__/tab-strip-home-placement.test.tsx
@@ -38,6 +38,7 @@ import { useTabsStore } from "@/stores/tabs/store";
 import { tabItemId } from "@/stores/tabs/layout";
 import type { TabRef } from "@/stores/tabs/types";
 import { useSettingsStore } from "@/stores/settings/settings-store";
+import { WindowsBridgeContext } from "@/providers/windows-bridge-context";
 import { installTabSyncCoordinator } from "@/lib/tab-sync/tab-sync-coordinator";
 
 vi.mock("@/hooks/notifications/use-host-notification-indicators-query", () => ({
@@ -227,5 +228,45 @@ describe("<TabStrip /> - Home placement", () => {
     expect(screen.getByTestId("tab-home").hasAttribute("data-tab-index")).toBe(
       false,
     );
+  });
+});
+
+/**
+ * Before the windows bridge hydrates, the strip is a skeleton. Home is a fixed
+ * tab rather than a persisted ref, so nothing in `stripOrder` accounts for it -
+ * and a skeleton that leaves its slot out drops the whole strip one tab's width
+ * to the left, then snaps it back the instant hydration lands.
+ */
+describe("<TabStrip /> - pre-hydration skeleton", () => {
+  function renderSkeleton(): void {
+    render(
+      <WindowsBridgeContext.Provider
+        value={{ bridge: null, hasHydrated: false }}
+      >
+        <TabStrip />
+      </WindowsBridgeContext.Provider>,
+    );
+  }
+
+  beforeEach(() => {
+    useSettingsStore.setState({ homeTabEnabled: false });
+    resetStores();
+  });
+
+  afterEach(() => {
+    cleanup();
+    useSettingsStore.setState({ homeTabEnabled: false });
+    resetStores();
+  });
+
+  it("reserves the Home slot when the flag is on", () => {
+    useSettingsStore.setState({ homeTabEnabled: true });
+    renderSkeleton();
+    expect(screen.getByTestId("tab-strip-skeleton-home")).not.toBeNull();
+  });
+
+  it("reserves nothing when the flag is off", () => {
+    renderSkeleton();
+    expect(screen.queryByTestId("tab-strip-skeleton-home")).toBeNull();
   });
 });

--- a/clients/gui-app/src/components/layout/tabs/tab-strip-home-item.tsx
+++ b/clients/gui-app/src/components/layout/tabs/tab-strip-home-item.tsx
@@ -1,0 +1,95 @@
+import { type ReactNode } from "react";
+import { House } from "lucide-react";
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
+import { TabChrome } from "@/components/layout/tabs/tab-strip-item";
+import { cn } from "@/lib/utils";
+
+const HOME_TAB_LABEL = "Home";
+const MAX_BADGE_COUNT = 99;
+
+interface TabStripHomeItemProps {
+  readonly isActive: boolean;
+  readonly onActivate: () => void;
+  /** Unresolved prompts waiting on the user; `0` renders no badge. */
+  readonly badgeCount: number;
+}
+
+/**
+ * The fixed Home tab at the left edge of the strip.
+ *
+ * Deliberately not a `TabItem`: Home has no strip ref, so every affordance that
+ * component carries - drag source, drop slot, context menu, close button,
+ * `data-tab-index` digit badge - is one Home must not have. What it does share
+ * is the silhouette, so it borrows `TabChrome` rather than growing a second set
+ * of tab-shaped tokens. No `data-tab-index` in particular: the Alt-digit chords
+ * index `useHeaderTabs()`, which Home is not in, so `alt+1` still names the
+ * first task tab.
+ */
+export function TabStripHomeItem(props: TabStripHomeItemProps): ReactNode {
+  const { isActive, onActivate, badgeCount } = props;
+
+  return (
+    <TooltipWrapper
+      label={HOME_TAB_LABEL}
+      side="bottom"
+      sideOffset={undefined}
+      align={undefined}
+    >
+      <button
+        type="button"
+        role="tab"
+        aria-selected={isActive}
+        // The count rides the button's own label: an `aria-label` replaces the
+        // element's whole subtree for assistive tech, so a label on the badge
+        // itself would never be announced. Plain "Home" whenever there is
+        // nothing waiting, which is the resting state.
+        aria-label={homeAccessibleLabel(badgeCount)}
+        data-testid="tab-home"
+        data-tab-kind="home"
+        onClick={onActivate}
+        className={cn(
+          "group/tab relative flex h-10 w-11 shrink-0 cursor-pointer items-center justify-center transition-colors duration-300 ease-spring [-webkit-app-region:no-drag]",
+          isActive
+            ? "z-10 text-foreground"
+            : "text-muted-foreground hover:text-foreground",
+        )}
+      >
+        <TabChrome isActive={isActive} />
+        <House className="relative z-20 size-4" />
+        <HomeBadge count={badgeCount} />
+      </button>
+    </TooltipWrapper>
+  );
+}
+
+/**
+ * How many prompts are waiting on the user, across every task. Absent at zero:
+ * a badge reading "0" is a permanent decoration, not a signal.
+ */
+function HomeBadge(props: { readonly count: number }): ReactNode {
+  if (props.count <= 0) return null;
+  return (
+    // Same badge the notifications bell wears, and for the same reason: both
+    // count things waiting on the user, so they should not read as two
+    // different signals. Only the offsets differ - the bell hangs its badge
+    // outside a free-standing icon button, while this one has to stay inside
+    // the tab's own silhouette.
+    <span
+      aria-hidden
+      data-testid="tab-home-badge"
+      className="absolute right-1 top-1 z-20 flex h-4 min-w-4 items-center justify-center rounded-md bg-destructive px-1 text-overline font-semibold leading-none text-destructive-foreground tabular-nums shadow-sm ring-2 ring-background"
+    >
+      {badgeLabel(props.count)}
+    </span>
+  );
+}
+
+function badgeLabel(count: number): string {
+  return count > MAX_BADGE_COUNT ? `${MAX_BADGE_COUNT}+` : String(count);
+}
+
+function homeAccessibleLabel(count: number): string {
+  return count > 0
+    ? `${HOME_TAB_LABEL}, ${badgeLabel(count)} waiting on you`
+    : HOME_TAB_LABEL;
+}

--- a/clients/gui-app/src/components/layout/tabs/tab-strip-skeleton.tsx
+++ b/clients/gui-app/src/components/layout/tabs/tab-strip-skeleton.tsx
@@ -17,9 +17,16 @@ import { cn } from "@/lib/utils";
 
 interface TabStripSkeletonProps {
   readonly count: number;
+  /** Whether the fixed Home tab will be there after hydration. Its slot is
+   * reserved here so the whole strip does not slide right by a tab's width the
+   * moment the bridge hydrates. */
+  readonly reserveHome: boolean;
 }
 
-export function TabStripSkeleton({ count }: TabStripSkeletonProps) {
+export function TabStripSkeleton({
+  count,
+  reserveHome,
+}: TabStripSkeletonProps) {
   return (
     <div
       data-testid="tab-strip-skeleton"
@@ -30,6 +37,12 @@ export function TabStripSkeleton({ count }: TabStripSkeletonProps) {
         "[-webkit-app-region:drag]",
       )}
     >
+      {reserveHome ? (
+        <Skeleton
+          data-testid="tab-strip-skeleton-home"
+          className="h-7 w-11 shrink-0 rounded-md [-webkit-app-region:no-drag]"
+        />
+      ) : null}
       {Array.from({ length: count }, (_, index) => (
         <Skeleton
           key={index}

--- a/clients/gui-app/src/components/layout/tabs/tab-strip.tsx
+++ b/clients/gui-app/src/components/layout/tabs/tab-strip.tsx
@@ -41,10 +41,13 @@ import { openNewEpicIntent } from "@/lib/commands/actions/new-epic";
 import { registerDynamicActionHandler } from "@/lib/keybindings/dispatch";
 import { TabStripSkeleton } from "@/components/layout/tabs/tab-strip-skeleton";
 import { useWindowsBridgeHydrated } from "@/providers/windows-bridge-context";
-import { navigateToTabIntent } from "@/lib/tab-navigation";
+import { homeTabIntent, navigateToTabIntent } from "@/lib/tab-navigation";
 import { TabItem } from "@/components/layout/tabs/tab-strip-item";
 import { SplitTabItem } from "@/components/layout/tabs/split-tab-item";
 import { TabStripNewButton } from "@/components/layout/tabs/tab-strip-new-button";
+import { TabStripHomeItem } from "@/components/layout/tabs/tab-strip-home-item";
+import { useHomeBadgeCount } from "@/components/home-focus/use-home-badge-count";
+import { useSettingsStore } from "@/stores/settings/settings-store";
 import { useHorizontalWheelScroll } from "@/hooks/use-horizontal-wheel-scroll";
 import { useNotificationIndicators } from "@/hooks/notifications/use-notification-indicators-query";
 import { NotificationIndicatorsProvider } from "@/components/notifications/notification-indicators-provider";
@@ -82,6 +85,11 @@ function TabStripBody() {
   const modalActive = useAnySystemOverlayActive();
   const handleWheel = useHorizontalWheelScroll();
   const activeItemId = useTabsStore((state) => state.activeItemId);
+  const homeTabEnabled = useSettingsStore((state) => state.homeTabEnabled);
+  // `activeItemId === null` over a populated strip means Home holds the
+  // selection; over an empty one it means the same thing, since Home is the
+  // only surface left to hold it.
+  const homeIsActive = homeTabEnabled && activeItemId === null;
   const activePathname = useRouterState({
     select: (s) => s.location.pathname,
   });
@@ -155,6 +163,10 @@ function TabStripBody() {
 
   const handleNewTab = useCallback(() => {
     navigateToTabIntent(navigate, openNewEpicIntent(), undefined);
+  }, [navigate]);
+
+  const handleHomeTab = useCallback(() => {
+    navigateToTabIntent(navigate, homeTabIntent(), undefined);
   }, [navigate]);
 
   const handleDuplicateTab = useCallback(
@@ -269,7 +281,11 @@ function TabStripBody() {
     });
   }, [closeActiveStripTab, closeModal, modalActive]);
 
-  if (allTabs.length === 0 && isLandingPage) {
+  // The empty strip used to be nothing at all on the landing route. Home is a
+  // fixed tab, so with it on there is always something to render and the strip
+  // must not collapse - otherwise the one control that gets the user back to
+  // Home disappears exactly when it is the only surface open.
+  if (!homeTabEnabled && allTabs.length === 0 && isLandingPage) {
     return null;
   }
 
@@ -283,6 +299,12 @@ function TabStripBody() {
         data-testid="tab-strip"
         className="relative flex min-w-0 flex-1 items-end"
       >
+        {/* Outside the scrollable list and before it: Home is fixed, so it must
+            not scroll away with the task tabs, and it must not sit inside the
+            `LayoutGroup` whose reorder animations belong to draggable items. */}
+        {homeTabEnabled ? (
+          <HomeStripSlot isActive={homeIsActive} onActivate={handleHomeTab} />
+        ) : null}
         <div className="relative flex min-w-0 max-w-full flex-[0_1_auto] items-end">
           <LayoutGroup id="header-tabs">
             <div
@@ -329,6 +351,24 @@ function TabStripBody() {
         <UnsyncedEpicMoveDialog flow={openInNewWindowFlow.epicFlow} />
       </div>
     </NotificationIndicatorsProvider>
+  );
+}
+
+/**
+ * Owns the badge subscription so a change to the cross-task prompt count
+ * re-renders the Home control alone, not the whole strip body.
+ */
+function HomeStripSlot(props: {
+  readonly isActive: boolean;
+  readonly onActivate: () => void;
+}): ReactNode {
+  const badgeCount = useHomeBadgeCount();
+  return (
+    <TabStripHomeItem
+      isActive={props.isActive}
+      onActivate={props.onActivate}
+      badgeCount={badgeCount}
+    />
   );
 }
 

--- a/clients/gui-app/src/components/layout/tabs/tab-strip.tsx
+++ b/clients/gui-app/src/components/layout/tabs/tab-strip.tsx
@@ -68,8 +68,14 @@ import { useEpicTaskPinnedStates } from "@/hooks/epic/use-epic-task-pinned-state
 export function TabStrip() {
   const hasHydrated = useWindowsBridgeHydrated();
   const persistedStripCount = useTabsStore((s) => s.stripOrder.length);
+  const homeTabEnabled = useSettingsStore((state) => state.homeTabEnabled);
   if (!hasHydrated) {
-    return <TabStripSkeleton count={persistedStripCount} />;
+    return (
+      <TabStripSkeleton
+        count={persistedStripCount}
+        reserveHome={homeTabEnabled}
+      />
+    );
   }
   return <TabStripBody />;
 }

--- a/clients/gui-app/src/components/layout/tabs/use-neighbor-tab-picker.ts
+++ b/clients/gui-app/src/components/layout/tabs/use-neighbor-tab-picker.ts
@@ -1,7 +1,8 @@
 import { useCallback, useMemo } from "react";
 import { useNavigate, useRouter } from "@tanstack/react-router";
 import { LANDING_ROUTE } from "@/lib/routes";
-import { navigateToTabIntent } from "@/lib/tab-navigation";
+import { homeTabIntent, navigateToTabIntent } from "@/lib/tab-navigation";
+import { isHomeTabEnabled } from "@/stores/settings/settings-store";
 import { tabActivationHistory, tabRefKey } from "@/stores/tabs/layout";
 import { pickNeighborAfterRemovingTabs } from "@/stores/tabs/neighbor";
 import { readTabStripLayout } from "@/stores/tabs/store";
@@ -50,6 +51,13 @@ export function useNeighborTabPicker(): NeighborTabPicker {
     (captured: CapturedNeighbor) => {
       if (!captured.wasActive) return;
       if (captured.neighbor === null) {
+        // Closing the last tab lands on Home rather than on the landing route:
+        // `/` redirects there anyway once Home is on, and going straight to the
+        // intent keeps the activation and the URL in one commit.
+        if (isHomeTabEnabled()) {
+          navigateToTabIntent(navigate, homeTabIntent(), undefined);
+          return;
+        }
         void navigate(LANDING_ROUTE);
         return;
       }

--- a/clients/gui-app/src/components/layout/top-level-tab-host.tsx
+++ b/clients/gui-app/src/components/layout/top-level-tab-host.tsx
@@ -99,6 +99,18 @@ export function TopLevelTabHost() {
   // Home holds the selection as `activeItemId === null`, so it is the one
   // surface whose visibility is not a question about `items`.
   const homeIsActive = homeTabEnabled && activeItemId === null;
+  // Home mounts on its FIRST activation and stays mounted from then on. Its
+  // surface reads live cross-task streams - running agents, pending prompts,
+  // every mounted epic's projection - so it has to be warm the moment the user
+  // comes back to it, which is why it is never unmounted once opened. But a
+  // window that never opens Home should pay none of that, and mounting on the
+  // flag alone charged every window for the life of the session. The latch is
+  // adjusted during render rather than in an effect - the same pattern
+  // `useMountedSurfaceKeys` uses below - so the activating render is the one
+  // that mounts, with no empty frame in between.
+  const [homeHasBeenActive, setHomeHasBeenActive] = useState(false);
+  if (homeIsActive && !homeHasBeenActive) setHomeHasBeenActive(true);
+  const homeIsMounted = homeTabEnabled && homeHasBeenActive;
   useHomeTabDisabledFallback(homeTabEnabled, activeItemId);
   const hostBoundsRef = useRef<HTMLDivElement | null>(null);
   const [previewRatio, setPreviewRatio] = useState<number | null>(null);
@@ -187,7 +199,7 @@ export function TopLevelTabHost() {
       data-testid="top-level-tab-host"
     >
       <PhaseMigrationControllerHost />
-      {homeTabEnabled ? (
+      {homeIsMounted ? (
         <TopLevelSurfaceMount
           mount={homeMount}
           activateSurface={activateSurface}
@@ -412,13 +424,14 @@ function useHomeTabDisabledFallback(
 /**
  * The MRU keep-alive set, and the one surface deliberately left out of it.
  *
- * Home is mounted unconditionally by `TopLevelTabHost` instead of competing for
- * a slot here. Two reasons: it reads live cross-task streams (running agents,
- * pending prompts) whose whole value is being warm the moment the user looks at
- * them, so an eviction after a few tab switches would defeat the surface's
- * purpose; and it has no strip ref, so there is no key for it to occupy a slot
- * with in the first place - `availableRefKeys` derives from `items`, which Home
- * is never in. It therefore cannot displace a task surface from the cap.
+ * Home is mounted by `TopLevelTabHost` itself - latched on its first activation
+ * and kept for the rest of the session - instead of competing for a slot here.
+ * Two reasons: it reads live cross-task streams (running agents, pending
+ * prompts) whose whole value is being warm the moment the user looks at them,
+ * so an eviction after a few tab switches would defeat the surface's purpose;
+ * and it has no strip ref, so there is no key for it to occupy a slot with in
+ * the first place - `availableRefKeys` derives from `items`, which Home is
+ * never in. It therefore cannot displace a task surface from the cap.
  */
 function useMountedSurfaceKeys(
   availableRefKeys: ReadonlyArray<string>,

--- a/clients/gui-app/src/components/layout/top-level-tab-host.tsx
+++ b/clients/gui-app/src/components/layout/top-level-tab-host.tsx
@@ -1,6 +1,7 @@
 import {
   Suspense,
   useCallback,
+  useEffect,
   useLayoutEffect,
   useMemo,
   useRef,
@@ -12,6 +13,7 @@ import {
   type ReactNode,
 } from "react";
 import { useDroppable } from "@dnd-kit/core";
+import { useNavigate } from "@tanstack/react-router";
 import { useShallow } from "zustand/react/shallow";
 import { cn } from "@/lib/utils";
 import {
@@ -25,6 +27,11 @@ import {
 import { tabSurfaceDescriptor } from "@/stores/tabs/registry";
 import { useHeaderTabs } from "@/stores/tabs/use-header-tabs";
 import { useTabsStore } from "@/stores/tabs/store";
+import { useSettingsStore } from "@/stores/settings/settings-store";
+import { homeHeaderTab } from "@/stores/tabs/kinds/home";
+import { openNewEpicIntent } from "@/lib/commands/actions/new-epic";
+import { draftTabIntent, navigateToTabIntent } from "@/lib/tab-navigation";
+import { newestLandingDraftId } from "@/stores/home/landing-draft-store";
 import { tabCommandCoordinator } from "@/stores/tabs/tab-command-coordinator";
 import {
   getTabStructuralLockRevision,
@@ -88,6 +95,11 @@ export function TopLevelTabHost() {
     })),
   );
   const headerTabs = useHeaderTabs();
+  const homeTabEnabled = useSettingsStore((state) => state.homeTabEnabled);
+  // Home holds the selection as `activeItemId === null`, so it is the one
+  // surface whose visibility is not a question about `items`.
+  const homeIsActive = homeTabEnabled && activeItemId === null;
+  useHomeTabDisabledFallback(homeTabEnabled, activeItemId);
   const hostBoundsRef = useRef<HTMLDivElement | null>(null);
   const [previewRatio, setPreviewRatio] = useState<number | null>(null);
   const activeItem = items.find((item) => item.id === activeItemId) ?? null;
@@ -122,6 +134,14 @@ export function TopLevelTabHost() {
     [renderedActiveItem, tabsByRefKey],
   );
   const mountedRefKeys = useMountedSurfaceKeys(availableRefKeys, activeRefKeys);
+  const homeMount = useMemo<MountedTopLevelSurface>(
+    () => ({
+      tab: homeHeaderTab(),
+      placement: homeIsActive ? { kind: "single" } : { kind: "hidden" },
+      activity: { visible: homeIsActive, focused: homeIsActive },
+    }),
+    [homeIsActive],
+  );
   const activateSurface = useTopLevelSurfaceActivator();
   const mounts = mountedRefKeys.flatMap((key) => {
     const tab = tabsByRefKey.get(key);
@@ -167,6 +187,12 @@ export function TopLevelTabHost() {
       data-testid="top-level-tab-host"
     >
       <PhaseMigrationControllerHost />
+      {homeTabEnabled ? (
+        <TopLevelSurfaceMount
+          mount={homeMount}
+          activateSurface={activateSurface}
+        />
+      ) : null}
       {mounts.map((mount) => (
         <TopLevelSurfaceMount
           key={tabRefKey(mount.tab)}
@@ -347,6 +373,53 @@ function TopLevelSurfaceMount(props: {
   );
 }
 
+/**
+ * Turning the Home tab off while Home is the selected surface would leave the
+ * window with `activeItemId === null` and nothing rendering it. Start New is
+ * where that selection goes: it is the other surface reachable with no task
+ * open, and it is what `/` resolved to before Home existed.
+ *
+ * Keyed on the FLIP, not on the flag's value: an app that boots with Home off
+ * and an empty strip is the ordinary pre-Home empty state and must be left
+ * exactly alone.
+ *
+ * IDEMPOTENT, and for the same reason `resolveSteppedLanding`'s draft arm is:
+ * the existing Start New page is named explicitly, so toggling the setting off,
+ * on, and off again re-selects the one draft instead of stacking a fresh tab
+ * per flip. Only a window that has never had one mints.
+ */
+function useHomeTabDisabledFallback(
+  enabled: boolean,
+  activeItemId: string | null,
+): void {
+  const navigate = useNavigate();
+  const previouslyEnabledRef = useRef(enabled);
+  useEffect(() => {
+    const previouslyEnabled = previouslyEnabledRef.current;
+    previouslyEnabledRef.current = enabled;
+    if (enabled || !previouslyEnabled || activeItemId !== null) return;
+    const existingDraftId = newestLandingDraftId();
+    navigateToTabIntent(
+      navigate,
+      existingDraftId === null
+        ? openNewEpicIntent()
+        : draftTabIntent(existingDraftId),
+      undefined,
+    );
+  }, [activeItemId, enabled, navigate]);
+}
+
+/**
+ * The MRU keep-alive set, and the one surface deliberately left out of it.
+ *
+ * Home is mounted unconditionally by `TopLevelTabHost` instead of competing for
+ * a slot here. Two reasons: it reads live cross-task streams (running agents,
+ * pending prompts) whose whole value is being warm the moment the user looks at
+ * them, so an eviction after a few tab switches would defeat the surface's
+ * purpose; and it has no strip ref, so there is no key for it to occupy a slot
+ * with in the first place - `availableRefKeys` derives from `items`, which Home
+ * is never in. It therefore cannot displace a task surface from the cap.
+ */
 function useMountedSurfaceKeys(
   availableRefKeys: ReadonlyArray<string>,
   activeRefKeys: ReadonlyArray<string>,
@@ -497,6 +570,8 @@ function TabSurface(props: { readonly tab: HeaderTab }): ReactNode {
       return tabSurfaceDescriptor("history").render(props.tab);
     case "settings":
       return tabSurfaceDescriptor("settings").render(props.tab);
+    case "home":
+      return tabSurfaceDescriptor("home").render(props.tab);
   }
 }
 

--- a/clients/gui-app/src/components/settings/panels/__tests__/general-settings-panel.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/general-settings-panel.test.tsx
@@ -18,6 +18,7 @@ import {
   type Mock,
 } from "vitest";
 import { GeneralSettingsPanel } from "@/components/settings/panels/general-settings-panel";
+import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 import { modLabel } from "@/lib/keybindings/platform";
 import { clearAllPersistedStores } from "@/lib/persist";
 import { useAuthStore } from "@/stores/auth/auth-store";
@@ -270,6 +271,7 @@ describe("GeneralSettingsPanel", () => {
       showNavigatorResourceStats: false,
       pinContextUsageBreakdown: false,
       quoteReplyEnabled: true,
+      homeTabEnabled: false,
       linkOpen: {
         default: "in-app",
         markdown: "in-app",
@@ -287,6 +289,7 @@ describe("GeneralSettingsPanel", () => {
     useAuthStore.getState().setSignedOut();
     useLocalSnapshotClearStore.setState({ clearedAtByScope: {} });
     useOnboardingStore.setState({ completedAt: null, step: 0 });
+    useSettingsStore.setState({ homeTabEnabled: false });
     delete (globalThis as { runnerHost?: unknown }).runnerHost;
   });
 
@@ -377,6 +380,74 @@ describe("GeneralSettingsPanel", () => {
     fireEvent.click(toggle);
 
     expect(useSettingsStore.getState().pinContextUsageBreakdown).toBe(true);
+  });
+
+  // The Layout group holds the fixed Home tab switch behind
+  // `homeTabEnabled`, off by default. Mirrors the surrounding switch-row
+  // tests: the control reflects store state on render, and reflects it again
+  // after the store value changes underneath it.
+  it("reflects the Home tab store value under the Layout group", () => {
+    renderPanel();
+
+    expect(screen.getByText("Layout")).toBeTruthy();
+    expect(useSettingsStore.getState().homeTabEnabled).toBe(false);
+    expect(
+      screen
+        .getByRole("switch", { name: "Home tab" })
+        .getAttribute("aria-checked"),
+    ).toBe("false");
+
+    cleanup();
+    useSettingsStore.setState({ homeTabEnabled: true });
+    renderPanel();
+
+    expect(
+      screen
+        .getByRole("switch", { name: "Home tab" })
+        .getAttribute("aria-checked"),
+    ).toBe("true");
+  });
+
+  // Established elsewhere in the codebase (e.g.
+  // `components/report-issue/__tests__/report-issue-action-analytics.test.tsx`)
+  // as the way to observe a real `setting_changed` call: spy on the real
+  // `Analytics.getInstance().track`, which still runs the sanitizer in test
+  // mode even though PostHog capture itself is disabled. Nothing in this file
+  // tracked `setting_changed` before this row, so there was no in-file
+  // assertion shape to mirror; this follows the codebase-wide one instead of
+  // inventing a new one.
+  it("toggles the Home tab setting and tracks setting_changed for it", () => {
+    const track = vi.spyOn(Analytics.getInstance(), "track");
+    renderPanel();
+
+    expect(useSettingsStore.getState().homeTabEnabled).toBe(false);
+    const toggle = screen.getByRole("switch", { name: "Home tab" });
+
+    fireEvent.click(toggle);
+
+    expect(useSettingsStore.getState().homeTabEnabled).toBe(true);
+    const settingChangedCalls = track.mock.calls
+      .filter((call) => call[0] === AnalyticsEvent.SettingChanged)
+      .map((call) => call[1]);
+    expect(settingChangedCalls).toEqual([
+      { source: "direct_ui", section: "general", setting: "homeTabEnabled" },
+    ]);
+  });
+
+  // Exercises the real allowlist path a `setting_changed` call for
+  // `homeTabEnabled` travels through: `Analytics.getInstance().track` runs
+  // `sanitizeAnalyticsProperties`, which validates `setting` against the
+  // runtime `ANALYTICS_SETTINGS` set unconditionally (even with PostHog
+  // capture disabled in test mode) and reports back through the boolean
+  // return. This calls the real consuming function rather than reaching into
+  // `ANALYTICS_SETTINGS` directly.
+  it("passes homeTabEnabled through the setting_changed allowlist", () => {
+    const accepted = Analytics.getInstance().track(
+      AnalyticsEvent.SettingChanged,
+      { source: "direct_ui", section: "general", setting: "homeTabEnabled" },
+    );
+
+    expect(accepted).toBe(true);
   });
 
   it("renders resource display rows and toggles their settings", () => {

--- a/clients/gui-app/src/components/settings/panels/__tests__/keybindings-settings-panel.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/keybindings-settings-panel.test.tsx
@@ -11,6 +11,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { KeybindingsSettingsPanel } from "@/components/settings/panels/keybindings-settings-panel";
 import { getDefaultBindings } from "@/lib/keybindings/actions";
 import { useKeybindingStore } from "@/stores/settings/keybinding-store";
+import { useSettingsStore } from "@/stores/settings/settings-store";
 import { GLOBAL_SHORTCUT_DEFAULT_CHORDS } from "@traycer-clients/shared/keybindings/global-shortcuts";
 import type {
   DesktopGlobalShortcutsBridge,
@@ -71,6 +72,41 @@ function makeBridge(
     onChange: vi.fn(() => ({ dispose: () => undefined })),
   };
 }
+
+/**
+ * A row here is a promise that its chord does something, and it is bindable -
+ * so an action whose handler is gated on a setting must not be listed while
+ * that setting is off, or the user can assign a chord to nothing. Same rule the
+ * command palette applies to the same action.
+ */
+describe("KeybindingsSettingsPanel - flag-gated actions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    platformMock.isMac = false;
+    useKeybindingStore.setState({ bindings: getDefaultBindings() });
+    useSettingsStore.setState({ homeTabEnabled: false });
+    summonHotkeyMock.current = { bridge: null, status: null };
+  });
+
+  afterEach(() => {
+    cleanup();
+    useSettingsStore.setState({ homeTabEnabled: false });
+  });
+
+  it("omits Go to Home while the Home tab is off", () => {
+    renderPanel();
+
+    expect(screen.queryByText("Go to Home")).toBeNull();
+  });
+
+  it("lists Go to Home once the Home tab is on", () => {
+    useSettingsStore.setState({ homeTabEnabled: true });
+
+    renderPanel();
+
+    expect(screen.getByText("Go to Home")).not.toBeNull();
+  });
+});
 
 describe("KeybindingsSettingsPanel - Global shortcuts (T2)", () => {
   beforeEach(() => {

--- a/clients/gui-app/src/components/settings/panels/general-settings-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/general-settings-panel.tsx
@@ -65,6 +65,8 @@ export function GeneralSettingsPanel() {
   const setSteerOnModEnterEnabled = useSettingsStore(
     (s) => s.setSteerOnModEnterEnabled,
   );
+  const homeTabEnabled = useSettingsStore((s) => s.homeTabEnabled);
+  const setHomeTabEnabled = useSettingsStore((s) => s.setHomeTabEnabled);
   const compact = useSettingsDensity() === "compact";
   const featureSettings = useRunnerFeatureSettingsQuery();
   const setAgentRoles = useRunnerAgentRolesSet();
@@ -162,6 +164,30 @@ export function GeneralSettingsPanel() {
                   setShowNavigatorResourceStats(value);
                 }}
                 aria-label="Show navigator resource stats"
+              />
+            }
+          />
+        </SettingsGroup>
+
+        {/* Layout lives here only until the app grows a page of its own for
+            it; the row moves there wholesale, store key and all. */}
+        <SettingsGroup
+          title="Layout"
+          tone="default"
+          dataTestId={undefined}
+          fill={false}
+        >
+          <SettingsRow
+            label="Home tab"
+            description="Show a fixed Home tab with everything running across your tasks."
+            control={
+              <Switch
+                checked={homeTabEnabled}
+                onCheckedChange={(value) => {
+                  trackGeneralSetting("homeTabEnabled");
+                  setHomeTabEnabled(value);
+                }}
+                aria-label="Home tab"
               />
             }
           />

--- a/clients/gui-app/src/components/settings/panels/keybindings-settings-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/keybindings-settings-panel.tsx
@@ -13,6 +13,7 @@ import {
 import { formatModifierChordForDisplay } from "@/lib/keybindings/chord";
 import { findConflict } from "@/lib/keybindings/conflicts";
 import { useKeybindingStore } from "@/stores/settings/keybinding-store";
+import { useSettingsStore } from "@/stores/settings/settings-store";
 import { Kbd } from "@/components/ui/kbd";
 import { useSummonHotkey } from "@/hooks/runner/use-summon-hotkey";
 import { GLOBAL_SHORTCUT_DEFAULT_CHORDS } from "@traycer-clients/shared/keybindings/global-shortcuts";
@@ -43,8 +44,15 @@ export function KeybindingsSettingsPanel() {
   const clearBinding = useKeybindingStore((s) => s.clearBinding);
   const resetAll = useKeybindingStore((s) => s.resetAll);
 
+  const homeTabEnabled = useSettingsStore((s) => s.homeTabEnabled);
+  // A row here is a promise that the chord does something. `app.home.open`
+  // dispatches to nothing while the Home tab is off, so it would be a bindable
+  // row for a surface this build has not got - the same reason the command
+  // palette omits it.
   const primaryActionIds = ACTION_IDS.filter(
-    (id) => !SUB_LEADER_ACTION_SET.has(id),
+    (id) =>
+      !SUB_LEADER_ACTION_SET.has(id) &&
+      (homeTabEnabled || id !== "app.home.open"),
   );
 
   // Lifted (rather than owned by `SummonHotkeyRow`) so the "Reset all to

--- a/clients/gui-app/src/hooks/home-focus/__tests__/use-focus-actions.test.tsx
+++ b/clients/gui-app/src/hooks/home-focus/__tests__/use-focus-actions.test.tsx
@@ -1,0 +1,392 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { FocusBackgroundRow } from "@/lib/home-focus/focus-model";
+import type { NotificationActivationOutcome } from "@/hooks/notifications/use-notification-activation";
+import type { FocusStopAgentInput } from "@/hooks/home-focus/use-focus-actions";
+import type { ManagedCommandLifecycleVariables } from "@/hooks/managed-command/use-managed-command-lifecycle-mutations";
+import {
+  makeApprovalPayload,
+  makeFocusBackgroundChat,
+  makeManagedCommand,
+  makeMergedNotificationRow,
+  makeRunningBackgroundItem,
+} from "@/lib/home-focus/__tests__/fixtures";
+import { buildFocusBackground } from "@/lib/home-focus/focus-background";
+import { useFocusActions } from "@/hooks/home-focus/use-focus-actions";
+
+const {
+  navigateMock,
+  routeNotificationForHostMock,
+  activateMock,
+  markAsReadMock,
+  stopAgentMutateMock,
+  stopManagedCommandMutateMock,
+} = vi.hoisted(() => ({
+  navigateMock: vi.fn(),
+  routeNotificationForHostMock: vi.fn(() => true),
+  activateMock: vi.fn(),
+  markAsReadMock: vi.fn(),
+  // Typed against the exact two-argument shape `useFocusActions` calls -
+  // `mutate(variables, { onSettled })` - never optional: every real call site
+  // in the hook passes both.
+  stopAgentMutateMock: vi.fn(
+    (_variables: FocusStopAgentInput, _options: { onSettled: () => void }) =>
+      undefined,
+  ),
+  stopManagedCommandMutateMock: vi.fn(
+    (
+      _variables: ManagedCommandLifecycleVariables,
+      _options: { onSettled: () => void },
+    ) => undefined,
+  ),
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => navigateMock,
+}));
+
+vi.mock("@/lib/notifications", () => ({
+  routeNotificationForHost: routeNotificationForHostMock,
+}));
+
+vi.mock("@/hooks/notifications/use-notification-activation", () => ({
+  useNotificationActivation: () => ({ activate: activateMock }),
+}));
+
+vi.mock("@/stores/notifications/merged-notifications", () => ({
+  useMergedNotificationsActions: () => ({
+    markAsRead: markAsReadMock,
+    clear: vi.fn(),
+    clearAll: vi.fn(),
+    markAllAsRead: vi.fn(),
+    markEntityAsRead: vi.fn(),
+    loadMoreHost: vi.fn(),
+    canLoadMoreHost: false,
+    isLoadingMoreHost: false,
+    hasHostLoadError: false,
+    loadMoreAttention: vi.fn(),
+    canLoadMoreAttention: false,
+    isLoadingMoreAttention: false,
+    hasAttentionLoadError: false,
+    loadMoreUnreadRecent: vi.fn(),
+    canLoadMoreUnreadRecent: false,
+    isLoadingMoreUnreadRecent: false,
+    hasUnreadRecentLoadError: false,
+  }),
+}));
+
+vi.mock("@/hooks/home-focus/use-focus-stop-agent-mutation", () => ({
+  useFocusStopAgent: () => ({ mutate: stopAgentMutateMock }),
+}));
+
+vi.mock("@/hooks/host/use-effective-host-id", () => ({
+  useEffectiveHostId: () => "effective-host-1",
+}));
+
+vi.mock(
+  "@/hooks/managed-command/use-managed-command-lifecycle-mutations",
+  () => ({
+    useManagedCommandStop: () => ({ mutate: stopManagedCommandMutateMock }),
+  }),
+);
+
+beforeEach(() => {
+  navigateMock.mockClear();
+  routeNotificationForHostMock.mockClear();
+  activateMock.mockClear();
+  markAsReadMock.mockClear();
+  stopAgentMutateMock.mockClear();
+  stopManagedCommandMutateMock.mockClear();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+function renderActions() {
+  return renderHook(() => useFocusActions()).result;
+}
+
+/** A managed-command row built through the real builder, so its `key`
+ * carries a genuine parseable address rather than a hand-typed literal. */
+function managedCommandRow(
+  overrides: Partial<{ hostId: string | null; commandId: string }>,
+): FocusBackgroundRow {
+  const chat = makeFocusBackgroundChat({
+    epicId: "epic-1",
+    chatId: "chat-1",
+    hostId: overrides.hostId === undefined ? "host-1" : overrides.hostId,
+    managedCommands: [
+      makeManagedCommand({ id: overrides.commandId ?? "cmd-1" }),
+    ],
+  });
+  const [row] = buildFocusBackground([chat], []);
+  return row;
+}
+
+function backgroundItemRow(): FocusBackgroundRow {
+  const chat = makeFocusBackgroundChat({
+    epicId: "epic-2",
+    chatId: "chat-2",
+    backgroundItems: [
+      makeRunningBackgroundItem({ taskId: "task-1", title: "Subagent" }),
+    ],
+  });
+  const [row] = buildFocusBackground([chat], []);
+  return row;
+}
+
+describe("useFocusActions", () => {
+  describe("stopAgent", () => {
+    it("calls the focus-stop mutate with exactly the input object as its first argument", () => {
+      const result = renderActions();
+
+      act(() => {
+        result.current.stopAgent({
+          hostId: "host-b",
+          epicId: "epic-1",
+          agentId: "agent-1",
+          cascade: true,
+        });
+      });
+
+      expect(stopAgentMutateMock).toHaveBeenCalledExactlyOnceWith(
+        {
+          hostId: "host-b",
+          epicId: "epic-1",
+          agentId: "agent-1",
+          cascade: true,
+        },
+        expect.anything(),
+      );
+    });
+
+    it("sends hostId: null through unchanged when null is passed", () => {
+      const result = renderActions();
+
+      act(() => {
+        result.current.stopAgent({
+          hostId: null,
+          epicId: "epic-1",
+          agentId: "agent-1",
+          cascade: false,
+        });
+      });
+
+      expect(stopAgentMutateMock).toHaveBeenCalledExactlyOnceWith(
+        { hostId: null, epicId: "epic-1", agentId: "agent-1", cascade: false },
+        expect.anything(),
+      );
+    });
+  });
+
+  describe("stopManagedCommand", () => {
+    it("calls the managed-command mutate with {hostId, epicId, commandId} parsed from the row key", () => {
+      const row = managedCommandRow({ hostId: "host-1", commandId: "cmd-1" });
+      const result = renderActions();
+
+      act(() => {
+        result.current.stopManagedCommand(row);
+      });
+
+      expect(stopManagedCommandMutateMock).toHaveBeenCalledExactlyOnceWith(
+        { hostId: "host-1", epicId: "epic-1", commandId: "cmd-1" },
+        expect.anything(),
+      );
+    });
+
+    it("is a no-op for a stoppable: false row", () => {
+      const row = managedCommandRow({ hostId: null });
+      expect(row.stoppable).toBe(false);
+      const result = renderActions();
+
+      result.current.stopManagedCommand(row);
+
+      expect(stopManagedCommandMutateMock).not.toHaveBeenCalled();
+    });
+
+    it("is a no-op for a background-item row", () => {
+      const row = backgroundItemRow();
+      expect(row.kind).toBe("background-item");
+      const result = renderActions();
+
+      result.current.stopManagedCommand(row);
+
+      expect(stopManagedCommandMutateMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("stopping", () => {
+    it("starts empty, contains the agent id between stopAgent(...) and the settle, and empties again once it settles - whether the mutation succeeded or failed", () => {
+      const result = renderActions();
+      expect(result.current.stopping.size).toBe(0);
+
+      act(() => {
+        result.current.stopAgent({
+          hostId: "host-b",
+          epicId: "epic-1",
+          agentId: "agent-1",
+          cascade: true,
+        });
+      });
+
+      expect(result.current.stopping.has("agent-1")).toBe(true);
+
+      const [, options] = stopAgentMutateMock.mock.calls[0];
+      // `onSettled` is the ONLY callback `useFocusActions` passes - react-query
+      // fires it identically on success and on failure, so invoking it here is
+      // evidence that `stopping` clears in BOTH cases, not just the happy path.
+      act(() => {
+        options.onSettled();
+      });
+
+      expect(result.current.stopping.has("agent-1")).toBe(false);
+    });
+
+    it("tracks a managed-command stop keyed by the ROW KEY - FocusBackgroundRow exposes no command id, so the key is what a renderer looks itself up by", () => {
+      const row = managedCommandRow({ hostId: "host-1", commandId: "cmd-1" });
+      const result = renderActions();
+      expect(result.current.stopping.size).toBe(0);
+
+      act(() => {
+        result.current.stopManagedCommand(row);
+      });
+
+      expect(result.current.stopping.has(row.key)).toBe(true);
+      // Confirms it is the KEY, not the parsed command id, that is tracked.
+      expect(row.key).not.toBe("cmd-1");
+
+      const [, options] = stopManagedCommandMutateMock.mock.calls[0];
+      // Same as the agent case: `onSettled` fires identically on success and
+      // failure, so this is evidence `stopping` clears in both cases.
+      act(() => {
+        options.onSettled();
+      });
+
+      expect(result.current.stopping.has(row.key)).toBe(false);
+    });
+  });
+
+  it("openAgent(epicId, agentId) routes with a {kind: chat, epicId, chatId: agentId} payload, chatId equal to the agent id", () => {
+    const result = renderActions();
+
+    result.current.openAgent("epic-1", "agent-1");
+
+    expect(routeNotificationForHostMock).toHaveBeenCalledExactlyOnceWith(
+      navigateMock,
+      { kind: "chat", epicId: "epic-1", chatId: "agent-1" },
+      expect.any(Number),
+      { originHostId: null, effectiveHostId: "effective-host-1" },
+    );
+  });
+
+  it("openTask(epicId) routes with a {kind: epic, epicId} payload", () => {
+    const result = renderActions();
+
+    result.current.openTask("epic-1");
+
+    expect(routeNotificationForHostMock).toHaveBeenCalledExactlyOnceWith(
+      navigateMock,
+      { kind: "epic", epicId: "epic-1" },
+      expect.any(Number),
+      { originHostId: null, effectiveHostId: "effective-host-1" },
+    );
+  });
+
+  describe("openBackground", () => {
+    it("routes to the owning chat with {kind: chat, epicId: row.epicId, chatId: row.chatId} for a managed-command row", () => {
+      const row = managedCommandRow({});
+      const result = renderActions();
+
+      result.current.openBackground(row);
+
+      expect(routeNotificationForHostMock).toHaveBeenCalledExactlyOnceWith(
+        navigateMock,
+        { kind: "chat", epicId: row.epicId, chatId: row.chatId },
+        expect.any(Number),
+        { originHostId: null, effectiveHostId: "effective-host-1" },
+      );
+    });
+
+    it("routes to the owning chat for a background-item row too - it does not depend on stoppable", () => {
+      const row = backgroundItemRow();
+      expect(row.stoppable).toBe(false);
+      const result = renderActions();
+
+      result.current.openBackground(row);
+
+      expect(routeNotificationForHostMock).toHaveBeenCalledExactlyOnceWith(
+        navigateMock,
+        { kind: "chat", epicId: row.epicId, chatId: row.chatId },
+        expect.any(Number),
+        { originHostId: null, effectiveHostId: "effective-host-1" },
+      );
+    });
+  });
+
+  describe("openPrompt", () => {
+    it("calls activate with the row's payload/feedId/originHostId", () => {
+      const payload = makeApprovalPayload("epic-1", "chat-1");
+      const activation = makeMergedNotificationRow({
+        feedId: "host:approval-1",
+        hostKind: "approval.requested",
+        severity: "needs_action",
+        originHostId: "origin-host-1",
+        payload,
+      });
+      const result = renderActions();
+
+      result.current.openPrompt({
+        key: activation.feedId,
+        kind: "approval",
+        epicId: "epic-1",
+        chatId: "chat-1",
+        taskTitle: null,
+        title: activation.title,
+        body: activation.body,
+        createdAt: activation.createdAt,
+        originHostId: activation.originHostId,
+        activation,
+      });
+
+      expect(activateMock).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({
+          payload,
+          feedId: "host:approval-1",
+          originHostId: "origin-host-1",
+          // `expect.any` is an `any`-typed matcher; type it as the value it
+          // stands in for so the object literal stays free of unsafe `any`.
+          receivedAt: expect.any(Number) as number,
+          onResult: expect.any(Function) as (
+            outcome: NotificationActivationOutcome,
+          ) => void,
+        }),
+      );
+    });
+
+    it("is a no-op when row.activation.payload is null", () => {
+      const activation = makeMergedNotificationRow({
+        feedId: "host:approval-1",
+        hostKind: "approval.requested",
+        severity: "needs_action",
+        payload: null,
+      });
+      const result = renderActions();
+
+      result.current.openPrompt({
+        key: activation.feedId,
+        kind: "approval",
+        epicId: null,
+        chatId: null,
+        taskTitle: null,
+        title: activation.title,
+        body: activation.body,
+        createdAt: activation.createdAt,
+        originHostId: activation.originHostId,
+        activation,
+      });
+
+      expect(activateMock).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/clients/gui-app/src/hooks/home-focus/__tests__/use-focus-model.test.tsx
+++ b/clients/gui-app/src/hooks/home-focus/__tests__/use-focus-model.test.tsx
@@ -1,0 +1,224 @@
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { HOST_NOTIFICATIONS_INDICATOR_BATCH_CAP } from "@traycer/protocol/host/notifications/contracts";
+import {
+  __resetAgentActivityStoreForTests,
+  __setAgentActivityPlaneAnsweringForTests,
+  __setAgentActivityStateForTests,
+} from "@/stores/agent-activity-store";
+import type { MergedNotificationRow } from "@/stores/notifications/merged-notifications";
+import type { UseNotificationIndicatorsArgs } from "@/hooks/notifications/use-notification-indicators-query";
+import { useHomeBadgeCount } from "@/components/home-focus/use-home-badge-count";
+import { useFocusModel } from "@/hooks/home-focus/use-focus-model";
+import {
+  makeApprovalPayload,
+  makeMergedNotificationRow,
+} from "@/lib/home-focus/__tests__/fixtures";
+
+/**
+ * Everything the hook joins from OTHER stores/queries is mocked to a fixed,
+ * referentially-stable answer, so the suite can drive the one live piece
+ * (`useAgentActivityStore`, the real store + its test helpers) and observe
+ * the model react - without a host runtime.
+ *
+ * `notificationRowsMock` is the one exception: the badge-equivalence case
+ * needs a real prompt row on the feed, so it is a controllable `vi.fn`
+ * reset to an empty array between tests.
+ */
+const { notificationRowsMock, notificationIndicatorsMock } = vi.hoisted(() => ({
+  notificationRowsMock: vi.fn<() => ReadonlyArray<MergedNotificationRow>>(
+    () => [],
+  ),
+  notificationIndicatorsMock: vi.fn((_args: UseNotificationIndicatorsArgs) => ({
+    epics: {},
+    chats: {},
+  })),
+}));
+
+vi.mock("@/stores/notifications/merged-notifications", () => ({
+  useMergedNotificationRows: notificationRowsMock,
+}));
+
+vi.mock("@/lib/notifications/notification-feed-mode", () => ({
+  useNotificationFeedMode: () => "local",
+}));
+
+vi.mock("@/hooks/epic/use-epic-get-task-contexts-query", () => ({
+  useEpicGetTaskContexts: () => ({
+    tasksById: new Map(),
+    isFetching: false,
+    error: null,
+  }),
+}));
+
+vi.mock("@/hooks/notifications/use-notification-indicators-query", () => ({
+  useNotificationIndicators: notificationIndicatorsMock,
+}));
+
+vi.mock("@/hooks/home-focus/use-warm-chat-background", () => ({
+  useWarmChatBackground: () => [],
+}));
+
+vi.mock("@/hooks/home-focus/use-mounted-epic-projection", () => ({
+  useMountedEpicProjection: () => ({
+    mountedEpicIds: new Set<string>(),
+    liveTitles: new Map<string, string>(),
+    agentIdentities: new Map(),
+  }),
+}));
+
+// `useFocusModel` also resolves `coldEpicHostIds`/`activeHostId`/
+// `reachableHostIds` for the task-level `stoppable` field. Neither hook is
+// exercised by this suite's assertions (those live in
+// `focus-tasks.test.ts`/`build-focus-model.test.ts`), so both are pinned to a
+// fixed, dependency-free answer rather than wiring up a QueryClient +
+// host-directory just to satisfy `useConnectableHostIds`.
+vi.mock("@/hooks/host/use-effective-host-id", () => ({
+  useEffectiveHostId: () => null,
+}));
+
+vi.mock("@/hooks/host/use-connectable-host-ids", () => ({
+  useConnectableHostIds: () => ({ hostIds: [], resolved: true }),
+}));
+
+vi.mock("@/stores/auth/auth-store", () => ({
+  useAuthStore: function useAuthStoreMock<T>(
+    selector: (state: {
+      contextMetadata: { userId: string; username: string } | null;
+    }) => T,
+  ): T {
+    return selector({
+      contextMetadata: { userId: "user-1", username: "user" },
+    });
+  },
+}));
+
+beforeEach(() => {
+  notificationRowsMock.mockReturnValue([]);
+  notificationIndicatorsMock.mockClear();
+  __resetAgentActivityStoreForTests();
+});
+
+afterEach(() => {
+  cleanup();
+  __resetAgentActivityStoreForTests();
+});
+
+describe("useFocusModel", () => {
+  it("reflects an activity-store change without remounting the hook", () => {
+    const { result } = renderHook(() => useFocusModel());
+    expect(result.current.tasks).toHaveLength(0);
+
+    act(() => {
+      __setAgentActivityPlaneAnsweringForTests();
+      __setAgentActivityStateForTests(
+        { "epic-1": { working: ["agent-1"], turn: [] } },
+        "local",
+        "connected",
+      );
+    });
+
+    expect(result.current.tasks).toHaveLength(1);
+    expect(result.current.tasks[0]?.epicId).toBe("epic-1");
+  });
+
+  it("decodes multiple epics each holding multiple working agents without cross-epic misattribution - the multi-separator regression guard", () => {
+    // The blocker this guards: an earlier single-separator encoding nested an
+    // agent-id list inside a group list using the SAME separator, so an epic
+    // with two working agents (a root plus a subagent - the most ordinary
+    // state Home has) either threw inside the decoding `useMemo` or handed one
+    // epic's second agent to a neighboring group. Two epics, two agents each,
+    // is exactly the shape that broke.
+    const { result } = renderHook(() => useFocusModel());
+
+    act(() => {
+      __setAgentActivityPlaneAnsweringForTests();
+      __setAgentActivityStateForTests(
+        {
+          "epic-1": { working: ["agent-1a", "agent-1b"], turn: ["agent-1a"] },
+          "epic-2": { working: ["agent-2a", "agent-2b"], turn: [] },
+        },
+        "local",
+        "connected",
+      );
+    });
+
+    expect(result.current.tasks).toHaveLength(2);
+    const tasksByEpic = new Map(
+      result.current.tasks.map((task) => [task.epicId, task]),
+    );
+    const epic1AgentIds = tasksByEpic
+      .get("epic-1")
+      ?.agents.map((agent) => agent.agentId)
+      .sort();
+    const epic2AgentIds = tasksByEpic
+      .get("epic-2")
+      ?.agents.map((agent) => agent.agentId)
+      .sort();
+
+    expect(epic1AgentIds).toEqual(["agent-1a", "agent-1b"]);
+    expect(epic2AgentIds).toEqual(["agent-2a", "agent-2b"]);
+    // No cross-epic contamination in either direction.
+    expect(epic1AgentIds).not.toContain("agent-2a");
+    expect(epic1AgentIds).not.toContain("agent-2b");
+    expect(epic2AgentIds).not.toContain("agent-1a");
+    expect(epic2AgentIds).not.toContain("agent-1b");
+  });
+
+  it("keeps the same model object across a re-render that changes nothing", () => {
+    const { result, rerender } = renderHook(() => useFocusModel());
+    const first = result.current;
+
+    rerender();
+
+    expect(result.current).toBe(first);
+  });
+
+  it("caps indicatorEpicIds at HOST_NOTIFICATIONS_INDICATOR_BATCH_CAP sorted ids, from a >500-epic activity fixture", () => {
+    const epicCount = HOST_NOTIFICATIONS_INDICATOR_BATCH_CAP + 37;
+    const byEpic: Record<string, { working: string[]; turn: string[] }> = {};
+    const epicIds: string[] = [];
+    for (let index = 0; index < epicCount; index += 1) {
+      // Zero-padded so byte-ascending string sort matches numeric order,
+      // which is what makes the expected slice easy to state.
+      const epicId = `epic-${String(index).padStart(6, "0")}`;
+      epicIds.push(epicId);
+      byEpic[epicId] = { working: [`${epicId}-agent`], turn: [] };
+    }
+
+    const { result } = renderHook(() => useFocusModel());
+    act(() => {
+      __setAgentActivityPlaneAnsweringForTests();
+      __setAgentActivityStateForTests(byEpic, "local", "connected");
+    });
+
+    expect(result.current.tasks).toHaveLength(epicCount);
+    expect(notificationIndicatorsMock).toHaveBeenCalled();
+
+    const lastArgs = notificationIndicatorsMock.mock.calls.at(-1)?.[0];
+    const expectedIds = [...epicIds]
+      .sort()
+      .slice(0, HOST_NOTIFICATIONS_INDICATOR_BATCH_CAP);
+
+    expect(lastArgs?.epicIds).toHaveLength(
+      HOST_NOTIFICATIONS_INDICATOR_BATCH_CAP,
+    );
+    expect(lastArgs?.epicIds).toEqual(expectedIds);
+  });
+
+  it("useHomeBadgeCount() equals useFocusModel().badgeCount", () => {
+    const approvalRow = makeMergedNotificationRow({
+      feedId: "host:approval-1",
+      hostKind: "approval.requested",
+      severity: "needs_action",
+      payload: makeApprovalPayload("epic-1", "chat-1"),
+    });
+    notificationRowsMock.mockReturnValue([approvalRow]);
+
+    const model = renderHook(() => useFocusModel());
+    const badge = renderHook(() => useHomeBadgeCount());
+
+    expect(model.result.current.badgeCount).toBe(1);
+    expect(badge.result.current).toBe(model.result.current.badgeCount);
+  });
+});

--- a/clients/gui-app/src/hooks/home-focus/__tests__/use-focus-stop-agent-mutation.test.tsx
+++ b/clients/gui-app/src/hooks/home-focus/__tests__/use-focus-stop-agent-mutation.test.tsx
@@ -1,0 +1,237 @@
+import type { ReactNode } from "react";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type MockInstance,
+} from "vitest";
+import { HostClient } from "@traycer-clients/shared/host-client/host-client";
+import type { HostDirectoryEntry } from "@traycer-clients/shared/host-client/host-directory";
+import {
+  mockLocalHostEntry,
+  mockRemoteHostEntry,
+} from "@traycer-clients/shared/host-client/mock/mock-host-directory";
+import { MockHostMessenger } from "@traycer-clients/shared/host-client/mock/mock-host-messenger";
+import { createRequestContextFixture } from "@traycer-clients/shared/test-fixtures/request-context";
+import type { RequestOfMethod } from "@traycer-clients/shared/host-transport/host-messenger";
+import { hostRpcRegistry, type HostRpcRegistry } from "@/lib/host";
+import { hostQueryKeys } from "@/lib/query-keys";
+import { useFocusStopAgent } from "@/hooks/home-focus/use-focus-stop-agent-mutation";
+
+type StopAgentRequest = RequestOfMethod<HostRpcRegistry, "agent.stop">;
+
+/**
+ * `useFocusStopAgent` resolves a per-call client from the host directory
+ * rather than binding one client for the whole hook (Home lists every task on
+ * the account, so two rows can name different machines). It is exercised
+ * against a REAL `HostClient` wired to a `MockHostMessenger`, the same shape
+ * `use-managed-command-stop-all.test.tsx` uses for the identical
+ * per-call-transient-client pattern - real `.request()`/`.getActiveHostId()`
+ * behavior, zero hand-stubbed methods.
+ */
+const { findByIdMock } = vi.hoisted(() => ({
+  findByIdMock: vi.fn<(hostId: string) => HostDirectoryEntry | null>(
+    () => null,
+  ),
+}));
+
+vi.mock("@/lib/host", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/host")>();
+  return {
+    ...actual,
+    useHostClient: () => hostClient,
+    useHostDirectory: () => ({ findById: findByIdMock }),
+  };
+});
+
+const hostA: HostDirectoryEntry = { ...mockLocalHostEntry, hostId: "host-a" };
+const hostB: HostDirectoryEntry = { ...mockRemoteHostEntry, hostId: "host-b" };
+
+const agentStopRequests: StopAgentRequest[] = [];
+let agentStopResponse: Promise<{ stoppedAgentIds: string[] }> = Promise.resolve(
+  { stoppedAgentIds: [] },
+);
+
+let hostClient: HostClient<HostRpcRegistry>;
+let queryClient: QueryClient;
+let invalidateQueries: MockInstance<QueryClient["invalidateQueries"]>;
+
+function wrapper(props: { readonly children: ReactNode }): ReactNode {
+  return (
+    <QueryClientProvider client={queryClient}>
+      {props.children}
+    </QueryClientProvider>
+  );
+}
+
+function buildSpine(): HostClient<HostRpcRegistry> {
+  const spine = new HostClient<HostRpcRegistry>({
+    registry: hostRpcRegistry,
+    invalidator: { invalidateHostScope: () => undefined },
+    findHostById: (hostId) => {
+      if (hostId === hostA.hostId) return hostA;
+      if (hostId === hostB.hostId) return hostB;
+      return null;
+    },
+    messenger: new MockHostMessenger<HostRpcRegistry>({
+      registry: hostRpcRegistry,
+      requestId: () => "focus-stop-agent-request",
+      handlers: {
+        "agent.stop": (params) => {
+          agentStopRequests.push(params);
+          return agentStopResponse;
+        },
+      },
+    }),
+  });
+  spine.setRequestContext(
+    createRequestContextFixture({
+      origin: "renderer",
+      bearerToken: "focus-stop-agent-token",
+    }),
+  );
+  return spine;
+}
+
+let spine: HostClient<HostRpcRegistry>;
+
+beforeEach(() => {
+  findByIdMock.mockReset();
+  findByIdMock.mockReturnValue(null);
+  agentStopRequests.length = 0;
+  agentStopResponse = Promise.resolve({ stoppedAgentIds: ["agent-1"] });
+  queryClient = new QueryClient({
+    defaultOptions: { mutations: { retry: false } },
+  });
+  invalidateQueries = vi.spyOn(queryClient, "invalidateQueries");
+  spine = buildSpine();
+  hostClient = spine.createRequester(hostA);
+});
+
+afterEach(() => {
+  cleanup();
+  hostClient.dispose();
+});
+
+describe("useFocusStopAgent", () => {
+  it("a named hostId consults the directory and dials that entry's client - the invalidation targets the NAMED host", async () => {
+    findByIdMock.mockReturnValue(hostB);
+    const { result } = renderHook(() => useFocusStopAgent(), { wrapper });
+
+    act(() => {
+      result.current.mutate({
+        hostId: "host-b",
+        epicId: "epic-1",
+        agentId: "agent-1",
+        cascade: false,
+      });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(findByIdMock).toHaveBeenCalledWith("host-b");
+    expect(agentStopRequests).toEqual([
+      { epicId: "epic-1", agentId: "agent-1", cascade: false },
+    ]);
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: hostQueryKeys.methodScope("host-b", "agent.list"),
+    });
+  });
+
+  it("hostId: null uses the following client without ever consulting the directory", async () => {
+    const { result } = renderHook(() => useFocusStopAgent(), { wrapper });
+
+    act(() => {
+      result.current.mutate({
+        hostId: null,
+        epicId: "epic-1",
+        agentId: "agent-1",
+        cascade: true,
+      });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(findByIdMock).not.toHaveBeenCalled();
+    expect(agentStopRequests).toEqual([
+      { epicId: "epic-1", agentId: "agent-1", cascade: true },
+    ]);
+    // `followingClient.getActiveHostId()` is "host-a" - the following client's
+    // own bound host - since `variables.hostId` was null.
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: hostQueryKeys.methodScope("host-a", "agent.list"),
+    });
+  });
+
+  it("a named hostId the directory cannot resolve rejects rather than silently falling back to the following client", async () => {
+    findByIdMock.mockReturnValue(null);
+    const { result } = renderHook(() => useFocusStopAgent(), { wrapper });
+
+    act(() => {
+      result.current.mutate({
+        hostId: "host-missing",
+        epicId: "epic-1",
+        agentId: "agent-1",
+        cascade: false,
+      });
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    // Had it fallen back to the following client (bound to host-a), this
+    // would have succeeded and sent a request - it must do neither.
+    expect(agentStopRequests).toEqual([]);
+    expect(invalidateQueries).not.toHaveBeenCalled();
+  });
+
+  it("invalidates the host captured at SEND time, not the one live when the mutation settles", async () => {
+    let resolvePromise: (value: { stoppedAgentIds: string[] }) => void = () =>
+      undefined;
+    agentStopResponse = new Promise((resolve) => {
+      resolvePromise = resolve;
+    });
+
+    const { result, rerender } = renderHook(() => useFocusStopAgent(), {
+      wrapper,
+    });
+
+    // hostId: null - `onMutate` captures `followingClient.getActiveHostId()`,
+    // which is "host-a" at this instant.
+    act(() => {
+      result.current.mutate({
+        hostId: null,
+        epicId: "epic-1",
+        agentId: "agent-1",
+        cascade: false,
+      });
+    });
+    await waitFor(() => expect(agentStopRequests).toHaveLength(1));
+
+    // The window re-points to a DIFFERENT host while the stop is still in
+    // flight - the same host-swap race `use-host-notifications-set-config-
+    // mutation.test.tsx` drives for the identical invariant.
+    act(() => {
+      hostClient = spine.createRequester(hostB);
+    });
+    rerender();
+
+    await act(async () => {
+      resolvePromise({ stoppedAgentIds: ["agent-1"] });
+      await agentStopResponse;
+    });
+
+    await waitFor(() => {
+      expect(invalidateQueries).toHaveBeenCalledWith({
+        queryKey: hostQueryKeys.methodScope("host-a", "agent.list"),
+      });
+    });
+    expect(invalidateQueries).not.toHaveBeenCalledWith({
+      queryKey: hostQueryKeys.methodScope("host-b", "agent.list"),
+    });
+  });
+});

--- a/clients/gui-app/src/hooks/home-focus/__tests__/use-mounted-epic-projection.test.tsx
+++ b/clients/gui-app/src/hooks/home-focus/__tests__/use-mounted-epic-projection.test.tsx
@@ -1,0 +1,303 @@
+import { useMemo, useState } from "react";
+import { act, cleanup, render, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type {
+  ChatProjection,
+  TuiAgentProjection,
+} from "@/stores/epics/open-epic/types";
+import type { EpicStreamClientFactory } from "@/stores/epics/open-epic/store";
+import {
+  openStoreForTest,
+  type OpenedStoreForTest,
+} from "@/stores/epics/open-epic/test-support/open-store-for-test";
+import { __getOpenEpicRegistryForTests } from "@/lib/registries/epic-session-registry";
+import { focusAgentKey } from "@/lib/home-focus/focus-tasks";
+import {
+  useMountedEpicProjection,
+  type MountedEpicRef,
+} from "@/hooks/home-focus/use-mounted-epic-projection";
+
+/**
+ * `useMountedEpicProjection` reads the REAL open-epic registry - the shape
+ * `useRegisteredEpicLiveAgents` already uses (`epic-selectors.test.tsx`) - so
+ * it is exercised against a real in-process runtime worker via
+ * `openStoreForTest`, never a mock of the hook under test.
+ */
+const fakeStreamClientFactory: EpicStreamClientFactory = () => ({
+  applyUpdate: () => undefined,
+  awareness: () => undefined,
+  applyArtifactRoomUpdate: () => undefined,
+  artifactRoomAwareness: () => undefined,
+  retryMigration: () => undefined,
+  close: () => undefined,
+});
+
+function chatProjection(
+  id: string,
+  overrides: Partial<ChatProjection>,
+): ChatProjection {
+  return {
+    id,
+    title: "Chat",
+    parentId: null,
+    createdAt: 0,
+    updatedAt: 0,
+    userId: null,
+    hostId: "host-a",
+    isTitleEditedByUser: false,
+    docResident: false,
+    archivedAt: null,
+    settings: null,
+    ...overrides,
+  };
+}
+
+function tuiAgentProjection(
+  id: string,
+  overrides: Partial<TuiAgentProjection>,
+): TuiAgentProjection {
+  return {
+    id,
+    docResident: false,
+    origin: "registry",
+    harnessId: "codex",
+    title: "Codex",
+    parentId: null,
+    createdAt: 0,
+    updatedAt: 0,
+    userId: null,
+    hostId: "host-a",
+    workspaceFolders: [],
+    workspaceMode: undefined,
+    model: null,
+    reasoningEffort: null,
+    agentMode: "regular",
+    profileId: null,
+    archivedAt: null,
+    harnessSessionId: null,
+    terminalAgentArgs: null,
+    terminalShellCommand: null,
+    terminalShellArgs: null,
+    ...overrides,
+  };
+}
+
+const handles: OpenedStoreForTest[] = [];
+
+function openEpic(epicId: string): OpenedStoreForTest {
+  const handle = openStoreForTest({
+    epicId,
+    userId: null,
+    factories: {
+      streamClientFactory: fakeStreamClientFactory,
+      laneSelection: null,
+    },
+    writeCommand: null,
+  });
+  handles.push(handle);
+  return handle;
+}
+
+afterEach(() => {
+  cleanup();
+  __getOpenEpicRegistryForTests().disposeAll();
+  for (const handle of handles) handle.dispose();
+  handles.length = 0;
+  vi.restoreAllMocks();
+});
+
+describe("useMountedEpicProjection", () => {
+  it("leaves an unmounted epic out of mountedEpicIds, with its agents unresolved", () => {
+    const refs: ReadonlyArray<MountedEpicRef> = [
+      { epicId: "epic-unmounted", agentIds: ["agent-1"] },
+    ];
+
+    const { result } = renderHook(() => useMountedEpicProjection(refs));
+
+    expect(result.current.mountedEpicIds.has("epic-unmounted")).toBe(false);
+    expect(result.current.liveTitles.has("epic-unmounted")).toBe(false);
+    expect(result.current.agentIdentities.size).toBe(0);
+  });
+
+  it("resolves title, parentId, surface and hostId for a mounted epic's agents", () => {
+    const registry = __getOpenEpicRegistryForTests();
+    const handle = openEpic("epic-mounted");
+    handle.store.setState({
+      epic: { title: "My Epic", updatedAt: 1 },
+      chats: {
+        allIds: ["agent-1"],
+        byId: {
+          "agent-1": chatProjection("agent-1", {
+            title: "Agent One",
+            parentId: "parent-1",
+            hostId: "host-known",
+          }),
+        },
+      },
+    });
+    act(() => {
+      registry.acquire("epic-mounted", () => handle);
+    });
+
+    const refs: ReadonlyArray<MountedEpicRef> = [
+      { epicId: "epic-mounted", agentIds: ["agent-1"] },
+    ];
+    const { result } = renderHook(() => useMountedEpicProjection(refs));
+
+    expect(result.current.mountedEpicIds.has("epic-mounted")).toBe(true);
+    expect(result.current.liveTitles.get("epic-mounted")).toBe("My Epic");
+    expect(
+      result.current.agentIdentities.get(
+        focusAgentKey("epic-mounted", "agent-1"),
+      ),
+    ).toEqual({
+      surface: "chat",
+      title: "Agent One",
+      parentId: "parent-1",
+      hostId: "host-known",
+    });
+  });
+
+  it("resolves a terminal-agent's identity the same way", () => {
+    const registry = __getOpenEpicRegistryForTests();
+    const handle = openEpic("epic-mounted");
+    handle.store.setState({
+      tuiAgents: {
+        allIds: ["tui-1"],
+        byId: {
+          "tui-1": tuiAgentProjection("tui-1", {
+            title: "Codex Agent",
+            parentId: null,
+            hostId: "host-tui",
+          }),
+        },
+      },
+    });
+    act(() => {
+      registry.acquire("epic-mounted", () => handle);
+    });
+
+    const refs: ReadonlyArray<MountedEpicRef> = [
+      { epicId: "epic-mounted", agentIds: ["tui-1"] },
+    ];
+    const { result } = renderHook(() => useMountedEpicProjection(refs));
+
+    expect(
+      result.current.agentIdentities.get(
+        focusAgentKey("epic-mounted", "tui-1"),
+      ),
+    ).toEqual({
+      surface: "terminal-agent",
+      title: "Codex Agent",
+      parentId: null,
+      hostId: "host-tui",
+    });
+  });
+
+  it("keeps the SAME encoded projection across an unrelated store notification", () => {
+    const registry = __getOpenEpicRegistryForTests();
+    const handle = openEpic("epic-mounted");
+    handle.store.setState({
+      epic: { title: "My Epic", updatedAt: 1 },
+      chats: {
+        allIds: ["agent-1"],
+        byId: { "agent-1": chatProjection("agent-1", {}) },
+      },
+    });
+    act(() => {
+      registry.acquire("epic-mounted", () => handle);
+    });
+
+    const refs: ReadonlyArray<MountedEpicRef> = [
+      { epicId: "epic-mounted", agentIds: ["agent-1"] },
+    ];
+    const { result } = renderHook(() => useMountedEpicProjection(refs));
+    const first = result.current;
+
+    // An unrelated field change on the SAME store - the projection's own
+    // snapshot only encodes the epic title plus the referenced agents'
+    // identities, so a change elsewhere must not mint a new object.
+    act(() => {
+      handle.store.setState({
+        artifacts: { byId: {}, allIds: [] },
+      });
+    });
+
+    expect(result.current).toBe(first);
+  });
+
+  it("subscribes to the handle on mount and unsubscribes on unmount", () => {
+    const registry = __getOpenEpicRegistryForTests();
+    const handle = openEpic("epic-mounted");
+    handle.store.setState({ chats: { allIds: [], byId: {} } });
+    act(() => {
+      registry.acquire("epic-mounted", () => handle);
+    });
+
+    const originalSubscribe = handle.store.subscribe.bind(handle.store);
+    let capturedUnsubscribe: (() => void) | null = null;
+    vi.spyOn(handle.store, "subscribe").mockImplementation((listener) => {
+      const real = originalSubscribe(listener);
+      const wrapped = vi.fn(real);
+      capturedUnsubscribe = wrapped;
+      return wrapped;
+    });
+
+    const refs: ReadonlyArray<MountedEpicRef> = [
+      { epicId: "epic-mounted", agentIds: [] },
+    ];
+    const { unmount } = renderHook(() => useMountedEpicProjection(refs));
+
+    expect(capturedUnsubscribe).not.toBeNull();
+    unmount();
+    expect(capturedUnsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps a fixed hook count as the ref set grows and shrinks - no React hook-order warning", () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {
+      /* silence expected-clean output; assertions below check it directly */
+    });
+    const registry = __getOpenEpicRegistryForTests();
+    const handleA = openEpic("epic-a");
+    handleA.store.setState({ chats: { allIds: [], byId: {} } });
+    act(() => {
+      registry.acquire("epic-a", () => handleA);
+    });
+
+    function Probe(props: {
+      readonly refs: ReadonlyArray<MountedEpicRef>;
+    }): null {
+      const [tick, setTick] = useState(0);
+      const projection = useMountedEpicProjection(props.refs);
+      const summary = useMemo(
+        () => `${tick}:${projection.mountedEpicIds.size}`,
+        [tick, projection.mountedEpicIds.size],
+      );
+      void setTick;
+      void summary;
+      return null;
+    }
+
+    const { rerender } = render(
+      <Probe refs={[{ epicId: "epic-a", agentIds: [] }]} />,
+    );
+
+    rerender(
+      <Probe
+        refs={[
+          { epicId: "epic-a", agentIds: [] },
+          { epicId: "epic-b", agentIds: ["agent-x"] },
+        ]}
+      />,
+    );
+    rerender(<Probe refs={[]} />);
+    rerender(<Probe refs={[{ epicId: "epic-a", agentIds: [] }]} />);
+
+    const hookOrderWarning = consoleError.mock.calls.some((call) =>
+      call.some(
+        (arg) => typeof arg === "string" && arg.includes("Rendered more"),
+      ),
+    );
+    expect(hookOrderWarning).toBe(false);
+  });
+});

--- a/clients/gui-app/src/hooks/home-focus/__tests__/use-warm-chat-background.test.tsx
+++ b/clients/gui-app/src/hooks/home-focus/__tests__/use-warm-chat-background.test.tsx
@@ -1,0 +1,236 @@
+import { useMemo, useState } from "react";
+import { act, cleanup, render, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { BackgroundItem } from "@traycer/protocol/host/agent/gui/subscribe";
+import type { ManagedCommand } from "@traycer/protocol/host/managed-command/unary-schemas";
+import { useWarmChatBackground } from "@/hooks/home-focus/use-warm-chat-background";
+import {
+  __getChatSessionRegistryForTests,
+  disposeAllChatSessions,
+} from "@/lib/registries/chat-session-registry";
+import {
+  createChatSessionStore,
+  type ChatSessionStoreHandle,
+} from "@/stores/chats/chat-session-store";
+import { IMMEDIATE_STREAM_FLUSH_COORDINATOR } from "@/stores/chats/stream-flush-coordinator";
+import { CHAT_STORE_TEST_ENVIRONMENT } from "@/stores/chats/test-support/chat-store-test-environment";
+import {
+  makeManagedCommand,
+  makeWakeupBackgroundItem,
+} from "@/lib/home-focus/__tests__/fixtures";
+
+/**
+ * `useWarmChatBackground` reads the REAL chat-session registry - the only
+ * client-side source for a warm chat's shells/background work - so it is
+ * exercised against a real registry + real zustand session stores, the same
+ * shape `use-epic-activity-status.test.tsx` uses for the identical registry.
+ * No mock of the hook under test.
+ */
+const EPIC_ID = "epic-warm-1";
+const HOST_ID = "host-warm-1";
+
+function registerChatSession(
+  chatId: string,
+  overrides: {
+    readonly managedCommands?: readonly ManagedCommand[];
+    readonly backgroundItems?: readonly BackgroundItem[];
+  },
+): ChatSessionStoreHandle {
+  const handle = __getChatSessionRegistryForTests().acquire(
+    {
+      epicId: EPIC_ID,
+      chatId,
+      hostId: HOST_ID,
+      scopeKey: "warm-chat-background-test-scope",
+    },
+    () =>
+      createChatSessionStore({
+        environment: CHAT_STORE_TEST_ENVIRONMENT,
+        hostId: HOST_ID,
+        epicId: EPIC_ID,
+        chatId,
+        userId: null,
+        onAuthError: null,
+        onProviderAuthError: null,
+        streamFlushCoordinator: IMMEDIATE_STREAM_FLUSH_COORDINATOR,
+        streamClientFactory: () => ({
+          sendAction: () => undefined,
+          sameTurnSteeringProtocolSupported: () => true,
+          requestTranscriptRange: () => undefined,
+          requestResnapshot: () => undefined,
+          close: () => undefined,
+        }),
+      }),
+  );
+  handle.store.setState({
+    managedCommands: [...(overrides.managedCommands ?? [])],
+    backgroundItems: [...(overrides.backgroundItems ?? [])],
+  });
+  return handle;
+}
+
+function runningCommand(id: string): ManagedCommand {
+  return makeManagedCommand({
+    id,
+    status: { state: "running", pid: 1, startedAtMs: 0 },
+  });
+}
+
+afterEach(() => {
+  cleanup();
+  disposeAllChatSessions();
+  vi.restoreAllMocks();
+});
+
+describe("useWarmChatBackground", () => {
+  it("produces no entry for a chat whose only background items are wakeups", () => {
+    registerChatSession("chat-wakeup", {
+      backgroundItems: [
+        makeWakeupBackgroundItem({
+          taskId: "task-1",
+          title: "Scheduled wake",
+          scheduledFor: 1_000,
+        }),
+      ],
+    });
+
+    const { result } = renderHook(() => useWarmChatBackground());
+
+    expect(result.current).toHaveLength(0);
+  });
+
+  it("returns the SAME array reference across an unrelated registry notification", () => {
+    registerChatSession("chat-a", {
+      managedCommands: [runningCommand("cmd-a")],
+    });
+
+    const { result } = renderHook(() => useWarmChatBackground());
+    const first = result.current;
+    expect(first).toHaveLength(1);
+
+    // An unrelated registry membership change - a second chat that
+    // contributes nothing to the warm-background output (empty commands and
+    // items), registered here purely to fire the registry's own `subscribe`
+    // notification independent of any handle-level change.
+    act(() => {
+      registerChatSession("chat-b", {});
+    });
+
+    expect(result.current).toBe(first);
+  });
+
+  it("mints a new array when a chat's content actually changes", () => {
+    const handle = registerChatSession("chat-a", {
+      managedCommands: [runningCommand("cmd-a")],
+    });
+
+    const { result } = renderHook(() => useWarmChatBackground());
+    const first = result.current;
+    expect(first).toHaveLength(1);
+    expect(first[0]?.managedCommands).toHaveLength(1);
+
+    act(() => {
+      handle.store.setState({
+        managedCommands: [runningCommand("cmd-a"), runningCommand("cmd-b")],
+      });
+    });
+
+    expect(result.current).not.toBe(first);
+    expect(result.current[0]?.managedCommands).toHaveLength(2);
+  });
+
+  it("tears down both the registry subscription and the per-handle subscription on unmount", () => {
+    const handle = registerChatSession("chat-a", {
+      managedCommands: [runningCommand("cmd-a")],
+    });
+    const registry = __getChatSessionRegistryForTests();
+
+    const originalRegistrySubscribe = registry.subscribe.bind(registry);
+    let capturedRegistryUnsubscribe: (() => void) | null = null;
+    vi.spyOn(registry, "subscribe").mockImplementation((listener) => {
+      const real = originalRegistrySubscribe(listener);
+      const wrapped = vi.fn(real);
+      capturedRegistryUnsubscribe = wrapped;
+      return wrapped;
+    });
+
+    const originalHandleSubscribe = handle.store.subscribe.bind(handle.store);
+    let capturedHandleUnsubscribe: (() => void) | null = null;
+    vi.spyOn(handle.store, "subscribe").mockImplementation((listener) => {
+      const real = originalHandleSubscribe(listener);
+      const wrapped = vi.fn(real);
+      capturedHandleUnsubscribe = wrapped;
+      return wrapped;
+    });
+
+    const { unmount } = renderHook(() => useWarmChatBackground());
+    expect(capturedRegistryUnsubscribe).not.toBeNull();
+    expect(capturedHandleUnsubscribe).not.toBeNull();
+
+    unmount();
+
+    expect(capturedRegistryUnsubscribe).toHaveBeenCalledTimes(1);
+    expect(capturedHandleUnsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps a fixed hook count as the warm set grows and shrinks - no React hook-order warning", () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {
+      /* silence expected-clean output; assertions below check it directly */
+    });
+
+    function Probe(): null {
+      // A fixed budget of OTHER hooks alongside the one under test - if
+      // `useWarmChatBackground` ever called a hook per warm chat, this
+      // component's total hook count would change between renders and React
+      // would log the "Rendered more/fewer hooks" error to `console.error`.
+      const [tick, setTick] = useState(0);
+      const warmChats = useWarmChatBackground();
+      const summary = useMemo(
+        () => `${tick}:${warmChats.length}`,
+        [tick, warmChats.length],
+      );
+      void setTick;
+      void summary;
+      return null;
+    }
+
+    const { rerender } = render(<Probe />);
+
+    let chat1Handle: ChatSessionStoreHandle | null = null;
+    act(() => {
+      chat1Handle = registerChatSession("chat-1", {
+        managedCommands: [runningCommand("c1")],
+      });
+    });
+    rerender(<Probe />);
+
+    act(() => {
+      registerChatSession("chat-2", {
+        managedCommands: [runningCommand("c2")],
+      });
+      registerChatSession("chat-3", {
+        managedCommands: [runningCommand("c3")],
+      });
+    });
+    rerender(<Probe />);
+
+    act(() => {
+      if (chat1Handle !== null) {
+        __getChatSessionRegistryForTests().releaseHandle(
+          EPIC_ID,
+          "chat-1",
+          HOST_ID,
+          chat1Handle,
+        );
+      }
+    });
+    rerender(<Probe />);
+
+    const hookOrderWarning = consoleError.mock.calls.some((call) =>
+      call.some(
+        (arg) => typeof arg === "string" && arg.includes("Rendered more"),
+      ),
+    );
+    expect(hookOrderWarning).toBe(false);
+  });
+});

--- a/clients/gui-app/src/hooks/home-focus/use-focus-actions.ts
+++ b/clients/gui-app/src/hooks/home-focus/use-focus-actions.ts
@@ -1,0 +1,236 @@
+import { useCallback, useMemo, useState } from "react";
+import { useNavigate } from "@tanstack/react-router";
+import {
+  useFocusStopAgent,
+  type FocusStopAgentInput,
+} from "@/hooks/home-focus/use-focus-stop-agent-mutation";
+import { useEffectiveHostId } from "@/hooks/host/use-effective-host-id";
+import { useManagedCommandStop } from "@/hooks/managed-command/use-managed-command-lifecycle-mutations";
+import { useNotificationActivation } from "@/hooks/notifications/use-notification-activation";
+import { routeNotificationForHost } from "@/lib/notifications";
+import { activationResultHandler } from "@/lib/notifications/notification-activation-result";
+import { useMergedNotificationsActions } from "@/stores/notifications/merged-notifications";
+import { parseManagedCommandRowKey } from "@/lib/home-focus/focus-background";
+import type {
+  FocusBackgroundRow,
+  FocusPromptRow,
+} from "@/lib/home-focus/focus-model";
+
+export interface FocusActions {
+  /**
+   * Opens the chat (or browser session) a prompt is waiting in, and
+   * acknowledges the row on success.
+   *
+   * CLICK-THROUGH, not decide-in-place, and that is a discovery rather than a
+   * preference: approving, denying and answering are methods on a
+   * warm `chat.subscribe` session, so there is no unary RPC this cross-task
+   * surface could call. An origin-bound prompt whose host this window is not
+   * addressing still NAVIGATES, but settles as `"failure"` and stays unread -
+   * the existing refusal in `useNotificationActivation`, which exists so a
+   * prompt is never credited to a host that never showed it.
+   */
+  readonly openPrompt: (row: FocusPromptRow) => void;
+  /** Focuses the agent's tile where one is already open, else opens the task's
+   * tab focused on it. */
+  readonly openAgent: (epicId: string, agentId: string) => void;
+  /**
+   * Opens the CHAT a background row belongs to - the shell's owner, not the
+   * shell. There is no cross-task route to a managed-command output tile, and
+   * the chat is where the row's other capabilities live anyway (a background
+   * item's stop is an action on that chat's warm session, which is why
+   * `stoppable` is false for one here).
+   */
+  readonly openBackground: (row: FocusBackgroundRow) => void;
+  readonly openTask: (epicId: string) => void;
+  /**
+   * `agent.stop`, sent to the AGENT's host (`FocusAgentRow.hostId`) rather than
+   * to whichever host this window addresses; `null` follows the window.
+   *
+   * `cascade` also stops the subtree the agent delegated to - callers pass
+   * `true` and issue one call per ROOT, because a cascade already covers every
+   * descendant and a second call for a child would race its own parent's
+   * teardown. Unary and epic-addressed, so it works for any task on the
+   * account, opened in this window or not.
+   *
+   * ASYMMETRY WORTH KNOWING: this does NOT check `FocusTaskRow.stoppable`, while
+   * {@link FocusActions.stopManagedCommand} does check the row's own flag. The
+   * flag is a property of the TASK (every one of its agents is reachable) and
+   * this takes a single agent, so enforcing it here would refuse a reachable
+   * agent because a sibling on a sleeping host is not. Gating the control is
+   * the view's job; this sends what it is told to send.
+   */
+  readonly stopAgent: (input: FocusStopAgentInput) => void;
+  /**
+   * `managedCommand.stop`, pinned to the command's own host. A row with
+   * `stoppable: false` is refused here rather than sent and failed: a
+   * background item has no unary stop at all, and a command whose host the
+   * registry cannot name has nowhere to send one.
+   */
+  readonly stopManagedCommand: (row: FocusBackgroundRow) => void;
+  /**
+   * Ids with a stop currently in flight, so a row can disable its own button
+   * without the view holding pending state per row.
+   *
+   * Keyed by whatever the ROW can name itself with: an agent contributes its
+   * `agentId`, a background row its `key`. The key rather than the command id
+   * because `FocusBackgroundRow` exposes no command id - the key IS its
+   * address, and a renderer holding a row can look itself up without parsing
+   * anything. An id leaves the set when the RPC settles, success or failure: a
+   * failed stop is not still running.
+   */
+  readonly stopping: ReadonlySet<string>;
+}
+
+export type { FocusStopAgentInput };
+
+const EMPTY_STOPPING: ReadonlySet<string> = new Set<string>();
+
+/**
+ * Every action the focus view can take, and deliberately no more.
+ *
+ * Navigation goes through `routeNotificationForHost` rather than assembling tab
+ * intents here. That function already IS the recipe the ticket names - reuse an
+ * open tile's tab and focus it, fall back to opening the epic's tab focused on
+ * the artifact - and routing through it keeps Home's "Open" behaving exactly
+ * like the bell's, including the closed-tile revival path and the host-bound
+ * tile matching. Reimplementing it would also mean calling a canvas
+ * `prepare*FocusTarget` action directly, which the tile-open boundary rules ban
+ * for good reason.
+ */
+export function useFocusActions(): FocusActions {
+  const navigate = useNavigate();
+  const effectiveHostId = useEffectiveHostId();
+  const { activate } = useNotificationActivation();
+  const notificationActions = useMergedNotificationsActions();
+  const markAsRead = notificationActions.markAsRead;
+  const stopAgentMutation = useFocusStopAgent();
+  const stopManagedCommandMutation = useManagedCommandStop();
+  const { mutate: stopAgentMutate } = stopAgentMutation;
+  const { mutate: stopManagedCommandMutate } = stopManagedCommandMutation;
+
+  // In-flight stops, tracked here rather than read off the mutations: one
+  // mutation observer serves every row, so `isPending` would light every Stop
+  // button on the page the moment any one of them was pressed.
+  const [stopping, setStopping] = useState<ReadonlySet<string>>(EMPTY_STOPPING);
+  const beginStopping = useCallback((id: string) => {
+    setStopping((current) => new Set(current).add(id));
+  }, []);
+  const endStopping = useCallback((id: string) => {
+    setStopping((current) => {
+      if (!current.has(id)) return current;
+      const next = new Set(current);
+      next.delete(id);
+      return next.size === 0 ? EMPTY_STOPPING : next;
+    });
+  }, []);
+
+  const openPrompt = useCallback(
+    (row: FocusPromptRow) => {
+      const payload = row.activation.payload;
+      if (payload === null) return;
+      activate({
+        payload,
+        receivedAt: Date.now(),
+        feedId: row.activation.feedId,
+        originHostId: row.activation.originHostId,
+        onResult: activationResultHandler({
+          row: row.activation,
+          feedId: row.activation.feedId,
+          surface: "home",
+          markAsRead,
+          onSuccess: null,
+        }),
+      });
+    },
+    [activate, markAsRead],
+  );
+
+  const openChat = useCallback(
+    (epicId: string, chatId: string) => {
+      routeNotificationForHost(
+        navigate,
+        { kind: "chat", epicId, chatId },
+        Date.now(),
+        // No origin host: the activity union names an agent, not the machine it
+        // runs on, so any tile holding that id is the right one to focus. A
+        // prompt is the case that DOES need an origin, and it goes through
+        // `openPrompt`.
+        { originHostId: null, effectiveHostId },
+      );
+    },
+    [navigate, effectiveHostId],
+  );
+
+  const openAgent = useCallback(
+    (epicId: string, agentId: string) => {
+      openChat(epicId, agentId);
+    },
+    [openChat],
+  );
+
+  const openBackground = useCallback(
+    (row: FocusBackgroundRow) => {
+      openChat(row.epicId, row.chatId);
+    },
+    [openChat],
+  );
+
+  const openTask = useCallback(
+    (epicId: string) => {
+      routeNotificationForHost(navigate, { kind: "epic", epicId }, Date.now(), {
+        originHostId: null,
+        effectiveHostId,
+      });
+    },
+    [navigate, effectiveHostId],
+  );
+
+  const stopAgent = useCallback(
+    (input: FocusStopAgentInput) => {
+      beginStopping(input.agentId);
+      stopAgentMutate(input, {
+        onSettled: () => endStopping(input.agentId),
+      });
+    },
+    [stopAgentMutate, beginStopping, endStopping],
+  );
+
+  const stopManagedCommand = useCallback(
+    (row: FocusBackgroundRow) => {
+      if (!row.stoppable) return;
+      const target = parseManagedCommandRowKey(row.key);
+      if (target === null) return;
+      beginStopping(row.key);
+      stopManagedCommandMutate(
+        {
+          hostId: target.hostId,
+          epicId: target.epicId,
+          commandId: target.commandId,
+        },
+        { onSettled: () => endStopping(row.key) },
+      );
+    },
+    [stopManagedCommandMutate, beginStopping, endStopping],
+  );
+
+  return useMemo(
+    () => ({
+      openPrompt,
+      openAgent,
+      openBackground,
+      openTask,
+      stopAgent,
+      stopManagedCommand,
+      stopping,
+    }),
+    [
+      openPrompt,
+      openAgent,
+      openBackground,
+      openTask,
+      stopAgent,
+      stopManagedCommand,
+      stopping,
+    ],
+  );
+}

--- a/clients/gui-app/src/hooks/home-focus/use-focus-actions.ts
+++ b/clients/gui-app/src/hooks/home-focus/use-focus-actions.ts
@@ -89,8 +89,8 @@ const EMPTY_STOPPING: ReadonlySet<string> = new Set<string>();
  * Every action the focus view can take, and deliberately no more.
  *
  * Navigation goes through `routeNotificationForHost` rather than assembling tab
- * intents here. That function already IS the recipe the ticket names - reuse an
- * open tile's tab and focus it, fall back to opening the epic's tab focused on
+ * intents here. That function is the bell's own Open path - reuse an open
+ * tile's tab and focus it, fall back to opening the epic's tab focused on
  * the artifact - and routing through it keeps Home's "Open" behaving exactly
  * like the bell's, including the closed-tile revival path and the host-bound
  * tile matching. Reimplementing it would also mean calling a canvas

--- a/clients/gui-app/src/hooks/home-focus/use-focus-model.ts
+++ b/clients/gui-app/src/hooks/home-focus/use-focus-model.ts
@@ -57,8 +57,8 @@ const focusModelCache = new WeakMap<object, FocusModel>();
  * Which means a title here can be BEHIND for a task not open in this window,
  * and ABSENT for a brand-new task the cloud index has not published yet -
  * `null`, not a placeholder. Rendering an id is honest; inventing "Untitled" as
- * if it were the task's name is not. The ticket named `useHistoryQuery` for
- * this; that hook resolves a SEARCH PAGE (with debouncing, local fuzzy ranking
+ * if it were the task's name is not. Not `useHistoryQuery`, the app's other
+ * title reader: it resolves a SEARCH PAGE (with debouncing, local fuzzy ranking
  * and worktree probes) and would answer for the epics that happen to be on the
  * current page rather than the epics that are actually running.
  * `useEpicGetTaskContexts` is the by-id primitive `useHistoryQuery` itself uses

--- a/clients/gui-app/src/hooks/home-focus/use-focus-model.ts
+++ b/clients/gui-app/src/hooks/home-focus/use-focus-model.ts
@@ -1,0 +1,351 @@
+import { useMemo, useState } from "react";
+import { HOST_NOTIFICATIONS_INDICATOR_BATCH_CAP } from "@traycer/protocol/host/notifications/contracts";
+import type { ListTaskLight } from "@traycer/protocol/host/epic/unary-schemas";
+import { useAgentActivityStore } from "@/stores/agent-activity-store";
+import { useAuthStore } from "@/stores/auth/auth-store";
+import { useConnectableHostIds } from "@/hooks/host/use-connectable-host-ids";
+import { useEffectiveHostId } from "@/hooks/host/use-effective-host-id";
+import { useEpicGetTaskContexts } from "@/hooks/epic/use-epic-get-task-contexts-query";
+import { useNotificationFeedMode } from "@/lib/notifications/notification-feed-mode";
+import { useNotificationIndicators } from "@/hooks/notifications/use-notification-indicators-query";
+import { useMergedNotificationRows } from "@/stores/notifications/merged-notifications";
+import {
+  buildFocusModel,
+  EMPTY_FOCUS_MODEL,
+} from "@/lib/home-focus/build-focus-model";
+import { compareAscending } from "@/lib/home-focus/focus-identity";
+import type { FocusModel } from "@/lib/home-focus/focus-model";
+import { pendingPromptEpicIds } from "@/lib/home-focus/focus-prompts";
+import type { FocusBackgroundChat } from "@/lib/home-focus/focus-background";
+import {
+  useMountedEpicProjection,
+  type MountedEpicRef,
+} from "@/hooks/home-focus/use-mounted-epic-projection";
+import { useWarmChatBackground } from "@/hooks/home-focus/use-warm-chat-background";
+
+/**
+ * Per-hook-instance memory of the last model built, so an unchanged section
+ * keeps its row objects across a rebuild triggered by a different section.
+ * Keyed by a token the hook owns, so two Home surfaces in one window do not
+ * share (and reset) each other's baseline, and the entry dies with the token.
+ */
+const focusModelCache = new WeakMap<object, FocusModel>();
+
+/**
+ * The Home focus view's whole data contract, joined from the stores this client
+ * already runs. No RPC of its own beyond two batched reads (task titles by id,
+ * and the host's per-epic indicator flags), and no protocol change.
+ *
+ * ## Hook-count stability
+ *
+ * The number of tasks and warm chats changes as agents start, tiles open and
+ * the session cap evicts - so nothing here may call a hook per row. Every
+ * dynamic set is read through ONE subscription that publishes a value-comparable
+ * snapshot: `useMountedEpicProjection` for names and parentage,
+ * `useWarmChatBackground` for shells and background items,
+ * `useEpicGetTaskContexts` for titles (which batches ids into cap-sized
+ * requests inside a single `useHostQueries`).
+ *
+ * ## Task titles and their staleness
+ *
+ * Two sources, in this precedence:
+ *
+ * 1. A MOUNTED epic's live Y.Doc title, which is what the tab strip shows and
+ *    updates the instant someone renames the task.
+ * 2. The cloud task index (`epic.getTaskContexts`, five-minute stale window).
+ *
+ * Which means a title here can be BEHIND for a task not open in this window,
+ * and ABSENT for a brand-new task the cloud index has not published yet -
+ * `null`, not a placeholder. Rendering an id is honest; inventing "Untitled" as
+ * if it were the task's name is not. The ticket named `useHistoryQuery` for
+ * this; that hook resolves a SEARCH PAGE (with debouncing, local fuzzy ranking
+ * and worktree probes) and would answer for the epics that happen to be on the
+ * current page rather than the epics that are actually running.
+ * `useEpicGetTaskContexts` is the by-id primitive `useHistoryQuery` itself uses
+ * for exactly this, and it is documented as the presentation-only title reader.
+ *
+ * ## The indicator batch cap
+ *
+ * `host.notifications.indicatorState` is capped at
+ * `HOST_NOTIFICATIONS_INDICATOR_BATCH_CAP` ids per request, and the query hook
+ * pages beyond it by issuing MORE requests. This surface asks about at most one
+ * page: an install with more than 500 simultaneously-running tasks would
+ * otherwise fan out an unbounded number of RPCs to decorate rows nobody can
+ * read. Epics past the cap still resolve `needsYou` from a loaded prompt row -
+ * they lose only the host's flags for a prompt this client has not paged in.
+ * The ids are sorted before slicing so the covered set is stable rather than
+ * re-drawn on every frame.
+ */
+export function useFocusModel(): FocusModel {
+  const byEpic = useAgentActivityStore((state) => state.byEpic);
+  const connectionStatus = useAgentActivityStore(
+    (state) => state.connectionStatus,
+  );
+  const cloudSyncStatus = useAgentActivityStore(
+    (state) => state.cloudSyncStatus,
+  );
+  const stateFrameSeenThisEpoch = useAgentActivityStore(
+    (state) => state.stateFrameSeenThisEpoch,
+  );
+  const notificationRows = useMergedNotificationRows();
+  const feedMode = useNotificationFeedMode();
+  const userId = useAuthStore((state) => state.contextMetadata?.userId ?? null);
+  const warmChats = useWarmChatBackground();
+  const activeHostId = useEffectiveHostId();
+  const connectableHosts = useConnectableHostIds();
+
+  // Every derived id list is memoized on a JOINED KEY rather than on the store
+  // value it came from, and that indirection is the point: `notificationRows`
+  // is re-minted on any notification frame and `byEpic` on any activity frame,
+  // so memoizing directly on them re-mints an equal-content array several times
+  // a minute - which re-subscribes the projection, re-keys the task-context
+  // query and re-encodes the whole snapshot for no change at all. A string is
+  // cheap to build and compares by value, so the arrays below keep their
+  // identity for as long as their CONTENTS do.
+  const activeEpicIdsKey = useMemo(
+    () => joinIds(workingEpicIds(byEpic)),
+    [byEpic],
+  );
+  const promptEpicIdsKey = useMemo(
+    () => joinIds(pendingPromptEpicIds(notificationRows)),
+    [notificationRows],
+  );
+  const warmEpicIdsKey = useMemo(
+    () => joinIds(new Set(warmChats.map((chat) => chat.epicId))),
+    [warmChats],
+  );
+  // Titles are needed for every epic the page can name: the running tasks, the
+  // tasks a prompt points at, and the tasks whose warm chats contribute
+  // background rows.
+  const titleEpicIds = useMemo(
+    () => unionIds([activeEpicIdsKey, promptEpicIdsKey, warmEpicIdsKey]),
+    [activeEpicIdsKey, promptEpicIdsKey, warmEpicIdsKey],
+  );
+  const indicatorEpicIds = useMemo(
+    () =>
+      unionIds([activeEpicIdsKey, promptEpicIdsKey]).slice(
+        0,
+        HOST_NOTIFICATIONS_INDICATOR_BATCH_CAP,
+      ),
+    [activeEpicIdsKey, promptEpicIdsKey],
+  );
+  const agentRefsKey = useMemo(
+    () =>
+      titleEpicIds
+        .map((epicId) =>
+          [epicId, joinIds(byEpic.get(epicId)?.working ?? EMPTY_ID_SET)].join(
+            ID_GROUP_SEPARATOR,
+          ),
+        )
+        .join(ID_GROUP_LIST_SEPARATOR),
+    [titleEpicIds, byEpic],
+  );
+  const agentRefs = useMemo<ReadonlyArray<MountedEpicRef>>(
+    () => decodeAgentRefs(agentRefsKey),
+    [agentRefsKey],
+  );
+
+  const taskContexts = useEpicGetTaskContexts(titleEpicIds, userId);
+  const projection = useMountedEpicProjection(agentRefs);
+  // Epic ids only, so the app-wide active host is the right one to ask: an Epic
+  // is a shared cloud entity, not a host-owned record.
+  const indicators = useNotificationIndicators({
+    hostId: null,
+    epicIds: indicatorEpicIds,
+    chatIds: [],
+    enabled: indicatorEpicIds.length > 0,
+  });
+
+  const taskTitles = useMemo(
+    () => mergeTaskTitles(taskContexts.tasksById, projection.liveTitles),
+    [taskContexts.tasksById, projection.liveTitles],
+  );
+  const coldEpicHostIds = useMemo(
+    () => singleHostTaskIds(taskContexts.tasksById),
+    [taskContexts.tasksById],
+  );
+  const reachableHostIds = useMemo(
+    () => new Set(connectableHosts.hostIds),
+    [connectableHosts.hostIds],
+  );
+  const backgroundChats = useMemo<ReadonlyArray<FocusBackgroundChat>>(
+    () =>
+      warmChats.map((chat) => ({
+        ...chat,
+        taskTitle: taskTitles.get(chat.epicId) ?? null,
+      })),
+    [warmChats, taskTitles],
+  );
+
+  // The previous model, so the builders can hand back their own unchanged rows
+  // rather than rebuilding every section whenever one of them moves. `useMemo`
+  // alone cannot do this - it has no access to what it produced last time.
+  //
+  // Held in a module WeakMap keyed by a per-instance token, the same shape
+  // `useStableChatTimelineRows` uses and for the same reason: reading a ref
+  // during render is what `react-hooks/refs` forbids. The entry is published
+  // from render, so a discarded render can advance it - which is harmless here
+  // because the builders are idempotent (rebuilding from identical inputs
+  // against a previous that already equals the result returns that same
+  // result), and nothing downstream reasons about what was last COMMITTED.
+  const [cacheKey] = useState<object>(() => ({}));
+  const model = useMemo(() => {
+    const previous = focusModelCache.get(cacheKey) ?? EMPTY_FOCUS_MODEL;
+    const next = buildFocusModel(
+      {
+        notificationRows,
+        tasks: {
+          byEpic,
+          taskTitles,
+          mountedEpicIds: projection.mountedEpicIds,
+          agentIdentities: projection.agentIdentities,
+          indicatorEpics: indicators.epics,
+          coldEpicHostIds,
+          activeHostId,
+          reachableHostIds,
+        },
+        backgroundChats,
+        activity: {
+          connectionStatus,
+          cloudSyncStatus,
+          stateFrameSeenThisEpoch,
+          connectableHostCount: connectableHosts.hostIds.length,
+          connectableHostsResolved: connectableHosts.resolved,
+        },
+        feedMode,
+      },
+      previous,
+    );
+    focusModelCache.set(cacheKey, next);
+    return next;
+  }, [
+    cacheKey,
+    notificationRows,
+    byEpic,
+    taskTitles,
+    projection.mountedEpicIds,
+    projection.agentIdentities,
+    indicators.epics,
+    backgroundChats,
+    coldEpicHostIds,
+    activeHostId,
+    reachableHostIds,
+    connectionStatus,
+    cloudSyncStatus,
+    stateFrameSeenThisEpoch,
+    connectableHosts.hostIds.length,
+    connectableHosts.resolved,
+    feedMode,
+  ]);
+  return model;
+}
+
+function workingEpicIds(
+  byEpic: ReadonlyMap<string, { readonly working: ReadonlySet<string> }>,
+): ReadonlySet<string> {
+  const epicIds = new Set<string>();
+  for (const [epicId, activity] of byEpic) {
+    if (activity.working.size > 0) epicIds.add(epicId);
+  }
+  return epicIds;
+}
+
+const EMPTY_ID_SET: ReadonlySet<string> = new Set<string>();
+const EMPTY_IDS: ReadonlyArray<string> = [];
+/**
+ * THREE separators, one per nesting level, and they must stay distinct.
+ *
+ * An earlier version reused the id-list separator for the group list, so a
+ * single epic with two working agents - a root plus one subagent, the most
+ * ordinary state Home has - encoded to `epic<GROUP>a1<LIST>a2` and split back
+ * into two GROUPS, leaving the second without an id list at all. Nesting one
+ * delimited list inside another delimited list needs a delimiter the inner one
+ * cannot contain, which is why the outer level gets its own code point and is
+ * split first.
+ */
+const ID_LIST_SEPARATOR = "\u0000";
+const ID_GROUP_SEPARATOR = "\u0001";
+const ID_GROUP_LIST_SEPARATOR = "\u0002";
+
+/** Byte-order ascending, so every derived id list is stable frame to frame and
+ * the indicator slice always covers the same epics. Joined on a NUL, which no
+ * id can carry. */
+function joinIds(ids: ReadonlySet<string>): string {
+  return Array.from(ids).sort(compareAscending).join(ID_LIST_SEPARATOR);
+}
+
+function splitIds(key: string): ReadonlyArray<string> {
+  return key.length === 0 ? EMPTY_IDS : key.split(ID_LIST_SEPARATOR);
+}
+
+/** The sorted union of several joined keys. */
+function unionIds(keys: ReadonlyArray<string>): ReadonlyArray<string> {
+  const ids = new Set(keys.flatMap((key) => splitIds(key)));
+  return ids.size === 0 ? EMPTY_IDS : Array.from(ids).sort(compareAscending);
+}
+
+/**
+ * Inverse of the `agentRefsKey` encoding: one group per epic, each
+ * `<epicId><GROUP><joined agent ids>`, groups separated by `<GROUP_LIST>`.
+ *
+ * Split on the OUTERMOST separator first, then cut each group at its first
+ * group separator rather than destructuring the split - a group that somehow
+ * carries no separator yields an epic with no agents instead of an exception
+ * inside a `useMemo`, which React surfaces as the whole page failing.
+ */
+function decodeAgentRefs(key: string): ReadonlyArray<MountedEpicRef> {
+  if (key.length === 0) return EMPTY_AGENT_REFS;
+  return key.split(ID_GROUP_LIST_SEPARATOR).map((group) => {
+    const separatorIndex = group.indexOf(ID_GROUP_SEPARATOR);
+    if (separatorIndex < 0) return { epicId: group, agentIds: EMPTY_IDS };
+    return {
+      epicId: group.slice(0, separatorIndex),
+      agentIds: splitIds(group.slice(separatorIndex + 1)),
+    };
+  });
+}
+
+const EMPTY_AGENT_REFS: ReadonlyArray<MountedEpicRef> = [];
+
+/**
+ * Cloud-index titles, displaced by the live projection's title wherever this
+ * window has the epic open. An empty title is dropped rather than stored: the
+ * cloud index keeps an epic's RAW title, and "" there means untitled, not
+ * named "".
+ */
+function mergeTaskTitles(
+  tasksById: ReadonlyMap<string, ListTaskLight>,
+  liveTitles: ReadonlyMap<string, string>,
+): ReadonlyMap<string, string> {
+  const titles = new Map<string, string>();
+  for (const [epicId, task] of tasksById) {
+    const title = task.epic?.light?.title ?? task.phase?.light?.title ?? "";
+    if (title.length > 0) titles.set(epicId, title);
+  }
+  for (const [epicId, title] of liveTitles) titles.set(epicId, title);
+  return titles;
+}
+
+/**
+ * Epic id → the one host that owns this task's chats, and only when the cloud
+ * index names EXACTLY one.
+ *
+ * `chatHostIds` is "the hosts owning the signed-in user's own live chats in
+ * this task", and `undefined` (a peer too old to report it) is not `[]`. Two or
+ * more hosts is unusable here: nothing in it says WHICH host a given agent id
+ * belongs to, and a wrong guess aims a stop at a machine that never ran the
+ * agent. One host is the case worth resolving - it is also the overwhelmingly
+ * common one - and it is what lets a task nobody has opened in this window
+ * still show as stoppable.
+ */
+function singleHostTaskIds(
+  tasksById: ReadonlyMap<string, ListTaskLight>,
+): ReadonlyMap<string, string> {
+  const hostIds = new Map<string, string>();
+  for (const [epicId, task] of tasksById) {
+    const chatHostIds = task.chatHostIds ?? [];
+    if (chatHostIds.length !== 1) continue;
+    hostIds.set(epicId, chatHostIds[0]);
+  }
+  return hostIds;
+}

--- a/clients/gui-app/src/hooks/home-focus/use-focus-stop-agent-mutation.ts
+++ b/clients/gui-app/src/hooks/home-focus/use-focus-stop-agent-mutation.ts
@@ -1,0 +1,133 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import type { UseMutationResult } from "@tanstack/react-query";
+import {
+  HostRpcError,
+  withHostRpcErrorBoundary,
+} from "@traycer-clients/shared/host-transport/host-messenger";
+import type { ResponseOfMethod } from "@traycer-clients/shared/host-transport/host-messenger";
+import type { HostClient } from "@traycer-clients/shared/host-client/host-client";
+import type { HostDirectoryEntry } from "@traycer-clients/shared/host-client/host-directory";
+import {
+  useHostClient,
+  useHostDirectory,
+  type HostRpcRegistry,
+} from "@/lib/host";
+import { buildDialableHostClient } from "@/hooks/host/use-host-client-for";
+import {
+  hostClientUnavailableError,
+  withHostMutationLifecycleBoundary,
+} from "@/hooks/host/use-host-query";
+import { toastFromHostError } from "@/lib/host-error-toast";
+import { agentMutationKeys, hostQueryKeys } from "@/lib/query-keys";
+
+/** What `onMutate` captured at SEND time. The host a response is filed against
+ * must be the one the request went out on, never the one the client happens to
+ * address when it lands. */
+interface FocusStopAgentContext {
+  readonly hostId: string | null;
+}
+
+export interface FocusStopAgentInput {
+  /** The agent's own host, or `null` to send on whichever host this window is
+   * addressing. */
+  readonly hostId: string | null;
+  readonly epicId: string;
+  readonly agentId: string;
+  readonly cascade: boolean;
+}
+
+/**
+ * `agent.stop`, aimed at the AGENT's host rather than at whichever host the
+ * window happens to be addressing.
+ *
+ * `useAgentStop` is the app's ordinary stop and rides `useHostScopedMutation`,
+ * which resolves one client for the whole hook. That is right for a surface
+ * inside a task - everything on it belongs to one host - and wrong here: Home
+ * lists every task on the account, so two rows on the same page can name
+ * different machines, and a hook-level client would send one of them to a host
+ * that has never heard of that agent.
+ *
+ * So the client is resolved per call from the host directory, the same shape
+ * `useManagedCommandStop` uses for exactly the same reason. `null` follows the
+ * window's own client, which is what an agent with no recorded host gets.
+ *
+ * On success the host's `agent.list` cache is dropped - a stop changes which
+ * agents are running - scoped to the host captured in `onMutate`, so a host
+ * switch mid-flight cannot invalidate the wrong machine's cache.
+ */
+export function useFocusStopAgent(): UseMutationResult<
+  ResponseOfMethod<HostRpcRegistry, "agent.stop">,
+  HostRpcError,
+  FocusStopAgentInput,
+  // `| undefined` because TanStack types the context as absent until `onMutate`
+  // has run - a callback firing before it (an `onError` from the boundary
+  // itself) legitimately has none.
+  FocusStopAgentContext | undefined
+> {
+  const followingClient = useHostClient();
+  const directory = useHostDirectory();
+  const queryClient = useQueryClient();
+
+  return useMutation(
+    withHostMutationLifecycleBoundary("agent.stop", {
+      mutationKey: agentMutationKeys.stop(),
+      mutationFn: (variables: FocusStopAgentInput) =>
+        withHostRpcErrorBoundary("agent.stop", () => {
+          // `null` follows this window's own client - that is what an agent
+          // with no recorded host gets, and what the row's `stoppable` already
+          // promised.
+          const client =
+            variables.hostId === null
+              ? followingClient
+              : transientClientForEntry(
+                  followingClient,
+                  directory.findById(variables.hostId),
+                );
+          if (client === null) {
+            return Promise.reject(hostClientUnavailableError("agent.stop"));
+          }
+          return client.request("agent.stop", {
+            epicId: variables.epicId,
+            agentId: variables.agentId,
+            cascade: variables.cascade,
+          });
+        }),
+      // Read at SEND time, not at settle time. For a `null`-host agent the
+      // request goes out on whatever host the window addresses THEN, and the
+      // user can activate another host in Settings while it is in flight -
+      // which would otherwise drop `agent.list` for the new host and leave the
+      // one that actually stopped the agent listing it as running. This is the
+      // host-swap rule in gui-app AGENTS.md, and what `useHostScopedMutation`
+      // does for every other host mutation in the app.
+      onMutate: (variables: FocusStopAgentInput): FocusStopAgentContext => ({
+        hostId: variables.hostId ?? followingClient.getActiveHostId() ?? null,
+      }),
+      onSuccess: (
+        _data,
+        _variables: FocusStopAgentInput,
+        context: FocusStopAgentContext | undefined,
+      ) => {
+        const hostId = context?.hostId ?? null;
+        if (hostId === null) return;
+        void queryClient.invalidateQueries({
+          queryKey: hostQueryKeys.methodScope(hostId, "agent.list"),
+        });
+      },
+      onError: (error: HostRpcError) =>
+        toastFromHostError(error, "Couldn't stop agent."),
+    }),
+  );
+}
+
+/**
+ * A named host resolves to a transient client dialed at that directory row.
+ * Both "no such host in the directory" and "that host is not reachable"
+ * collapse to `null`, because the caller answers them the same way - the
+ * `hostClientUnavailableError` rejection.
+ */
+function transientClientForEntry(
+  defaultClient: HostClient<HostRpcRegistry>,
+  entry: HostDirectoryEntry | null,
+): HostClient<HostRpcRegistry> | null {
+  return entry === null ? null : buildDialableHostClient(defaultClient, entry);
+}

--- a/clients/gui-app/src/hooks/home-focus/use-mounted-epic-projection.ts
+++ b/clients/gui-app/src/hooks/home-focus/use-mounted-epic-projection.ts
@@ -1,0 +1,173 @@
+import { useMemo, useSyncExternalStore } from "react";
+import { getOpenEpicRegistry } from "@/lib/registries/epic-session-registry";
+import type { OpenEpicSessionRegistry } from "@/stores/epics/open-epic/session-registry";
+import type { OpenEpicStoreHandle } from "@/stores/epics/open-epic/store";
+import { liveEpicTitleFromHandle } from "@/lib/epic-selectors";
+import {
+  focusAgentKey,
+  type FocusAgentIdentity,
+} from "@/lib/home-focus/focus-tasks";
+
+export interface MountedEpicRef {
+  readonly epicId: string;
+  /** The working agent ids to resolve in that epic. Ids the epic's projection
+   * does not know are simply unresolved. */
+  readonly agentIds: ReadonlyArray<string>;
+}
+
+export interface MountedEpicProjection {
+  /** Epics with a live Y.Doc projection in THIS window. */
+  readonly mountedEpicIds: ReadonlySet<string>;
+  /** Epic id → live title, for mounted epics that have one. */
+  readonly liveTitles: ReadonlyMap<string, string>;
+  /** {@link focusAgentKey} → identity, for mounted epics only. */
+  readonly agentIdentities: ReadonlyMap<string, FocusAgentIdentity>;
+}
+
+const EMPTY_PROJECTION: MountedEpicProjection = {
+  mountedEpicIds: new Set<string>(),
+  liveTitles: new Map<string, string>(),
+  agentIdentities: new Map<string, FocusAgentIdentity>(),
+};
+
+/**
+ * Names, parentage and mounted-ness for a DYNAMIC set of epics and agents,
+ * read from this window's open-epic projections.
+ *
+ * ONE subscription for the whole set, not a hook per epic, and that is a
+ * correctness requirement rather than an optimization: Home's epic list is the
+ * activity union, whose size changes as agents start and stop, so a loop of
+ * per-epic hooks would change React's hook count between renders. The shape is
+ * the one `useRegisteredEpicLiveAgents` already uses for the same reason -
+ * subscribe once to the registry and to every currently referenced handle, and
+ * publish an ENCODED snapshot so `useSyncExternalStore` compares by value. The
+ * registry and every epic store notify on changes that touch none of these
+ * fields; a fresh object per notification would re-render the whole page each
+ * time.
+ *
+ * A mounted epic's title is its live Y.Doc title, which is why it is kept apart
+ * from the cloud-indexed titles the caller merges it into: a rename shows here
+ * immediately, while the cloud index is a cache.
+ */
+export function useMountedEpicProjection(
+  refs: ReadonlyArray<MountedEpicRef>,
+): MountedEpicProjection {
+  const registry = getOpenEpicRegistry();
+  const encoded = useSyncExternalStore(
+    (listener) => {
+      const unsubscribeByHandle = new Map<OpenEpicStoreHandle, () => void>();
+      const reconcileHandleSubscriptions = (): void => {
+        const currentHandles = new Set<OpenEpicStoreHandle>();
+        for (const ref of refs) {
+          const handle = registry.peek(ref.epicId);
+          if (handle === null || currentHandles.has(handle)) continue;
+          currentHandles.add(handle);
+          if (!unsubscribeByHandle.has(handle)) {
+            unsubscribeByHandle.set(handle, handle.store.subscribe(listener));
+          }
+        }
+        for (const [handle, unsubscribe] of unsubscribeByHandle) {
+          if (currentHandles.has(handle)) continue;
+          unsubscribe();
+          unsubscribeByHandle.delete(handle);
+        }
+      };
+      reconcileHandleSubscriptions();
+      const unsubscribeRegistry = registry.subscribe(() => {
+        reconcileHandleSubscriptions();
+        listener();
+      });
+      return () => {
+        unsubscribeRegistry();
+        for (const unsubscribe of unsubscribeByHandle.values()) unsubscribe();
+      };
+    },
+    () => projectionSnapshot(registry, refs),
+    () => EMPTY_SNAPSHOT,
+  );
+  return useMemo(() => decodeProjection(encoded, refs), [encoded, refs]);
+}
+
+const EMPTY_SNAPSHOT = "[]";
+
+/**
+ * Per-ref tuples of `[title, [[kind, title, parentId, hostId] | null, ...]]`,
+ * or `null`
+ * for an epic this window has not mounted. JSON rather than a structural
+ * comparator because `useSyncExternalStore` compares snapshots with `===` and
+ * this is the cheapest value identity that survives it.
+ */
+function projectionSnapshot(
+  registry: OpenEpicSessionRegistry,
+  refs: ReadonlyArray<MountedEpicRef>,
+): string {
+  return JSON.stringify(
+    refs.map((ref) => {
+      const handle = registry.peek(ref.epicId);
+      if (handle === null) return null;
+      return [
+        liveEpicTitleFromHandle(handle),
+        ref.agentIds.map((agentId) => liveAgentIdentity(handle, agentId)),
+      ];
+    }),
+  );
+}
+
+function liveAgentIdentity(
+  handle: OpenEpicStoreHandle,
+  agentId: string,
+): readonly [string, string, string | null, string | null] | null {
+  const state = handle.store.getState();
+  if (Object.hasOwn(state.chats.byId, agentId)) {
+    const chat = state.chats.byId[agentId];
+    return ["chat", chat.title, chat.parentId, chat.hostId];
+  }
+  if (Object.hasOwn(state.tuiAgents.byId, agentId)) {
+    const agent = state.tuiAgents.byId[agentId];
+    return ["terminal-agent", agent.title, agent.parentId, agent.hostId];
+  }
+  return null;
+}
+
+function decodeProjection(
+  encoded: string,
+  refs: ReadonlyArray<MountedEpicRef>,
+): MountedEpicProjection {
+  const decoded: unknown = JSON.parse(encoded);
+  if (!Array.isArray(decoded)) return EMPTY_PROJECTION;
+  const mountedEpicIds = new Set<string>();
+  const liveTitles = new Map<string, string>();
+  const agentIdentities = new Map<string, FocusAgentIdentity>();
+  refs.forEach((ref, index) => {
+    const entry: unknown = decoded[index];
+    if (!Array.isArray(entry)) return;
+    mountedEpicIds.add(ref.epicId);
+    const title: unknown = entry[0];
+    if (typeof title === "string" && title.length > 0) {
+      liveTitles.set(ref.epicId, title);
+    }
+    const agents: unknown = entry[1];
+    if (!Array.isArray(agents)) return;
+    ref.agentIds.forEach((agentId, agentIndex) => {
+      const identity = decodeAgentIdentity(agents[agentIndex]);
+      if (identity === null) return;
+      agentIdentities.set(focusAgentKey(ref.epicId, agentId), identity);
+    });
+  });
+  return { mountedEpicIds, liveTitles, agentIdentities };
+}
+
+function decodeAgentIdentity(entry: unknown): FocusAgentIdentity | null {
+  if (!Array.isArray(entry)) return null;
+  const surface: unknown = entry[0];
+  const title: unknown = entry[1];
+  const parentId: unknown = entry[2];
+  const hostId: unknown = entry[3];
+  if (surface !== "chat" && surface !== "terminal-agent") return null;
+  return {
+    surface,
+    title: typeof title === "string" && title.length > 0 ? title : null,
+    parentId: typeof parentId === "string" ? parentId : null,
+    hostId: typeof hostId === "string" && hostId.length > 0 ? hostId : null,
+  };
+}

--- a/clients/gui-app/src/hooks/home-focus/use-warm-chat-background.ts
+++ b/clients/gui-app/src/hooks/home-focus/use-warm-chat-background.ts
@@ -1,0 +1,168 @@
+import { useMemo, useSyncExternalStore } from "react";
+import type { BackgroundItem } from "@traycer/protocol/host/agent/gui/subscribe";
+import type { ManagedCommand } from "@traycer/protocol/host/managed-command/unary-schemas";
+import { isRunningBackgroundRoot } from "@/lib/home-focus/focus-background";
+import {
+  getChatSessionHandleHostId,
+  getChatSessionRegistry,
+} from "@/lib/registries/chat-session-registry";
+import { reconcileStoreSubscriptions } from "@/lib/registries/reconcile-store-subscriptions";
+import type { ChatSessionStoreHandle } from "@/stores/chats/chat-session-store";
+
+/** One warm chat session's live background work, before task titles are
+ * attached. */
+export interface WarmChatBackground {
+  readonly epicId: string;
+  readonly chatId: string;
+  readonly hostId: string | null;
+  readonly managedCommands: ReadonlyArray<ManagedCommand>;
+  readonly backgroundItems: ReadonlyArray<BackgroundItem>;
+}
+
+const EMPTY_WARM_CHATS: ReadonlyArray<WarmChatBackground> = [];
+
+/**
+ * Every warm chat session in this window, with its running managed commands and
+ * its live background items.
+ *
+ * MOUNTED ONLY, and irreducibly so: both lists ride the chat's own
+ * `chat.subscribe` stream, so a shell in a chat this window has never opened is
+ * invisible to the client whatever it asks. That is the documented v1 gap
+ * behind the section's caption, and the host follow-up (folding managed
+ * commands into a host-scoped stream) is what closes it.
+ *
+ * One subscription for the whole registry rather than a hook per chat: the warm
+ * set changes as tiles open, close and get evicted by the session cap, so any
+ * per-chat hook loop would change React's hook count between renders. The
+ * per-handle subscriptions are reconciled through the same
+ * `reconcileStoreSubscriptions` helper the agent-activity monitor uses.
+ *
+ * The published snapshot is REPLACED only when its content changes, never
+ * rebuilt per read: `useSyncExternalStore` compares snapshots with `===`, and
+ * the arrays inside a chat store keep their identity between frames (the host
+ * sends each set whole), so a per-read rebuild would look like a change on
+ * every unrelated store notification and re-render the page.
+ */
+export function useWarmChatBackground(): ReadonlyArray<WarmChatBackground> {
+  const source = useMemo(() => createWarmChatBackgroundSource(), []);
+  return useSyncExternalStore(
+    source.subscribe,
+    source.read,
+    () => EMPTY_WARM_CHATS,
+  );
+}
+
+interface WarmChatBackgroundSource {
+  readonly subscribe: (listener: () => void) => () => void;
+  /** Returns the SAME array until its content changes, which is what lets
+   * `useSyncExternalStore` compare snapshots with `===`. */
+  readonly read: () => ReadonlyArray<WarmChatBackground>;
+}
+
+function createWarmChatBackgroundSource(): WarmChatBackgroundSource {
+  let published = EMPTY_WARM_CHATS;
+  let unsubscribeRegistry: (() => void) | null = null;
+  const listeners = new Set<() => void>();
+  const handleSubscriptions = new Map<ChatSessionStoreHandle, () => void>();
+
+  const refresh = (): void => {
+    const next = readWarmChatBackground();
+    if (sameWarmChatBackground(next, published)) return;
+    published = next;
+    for (const listener of listeners) listener();
+  };
+
+  const resync = (): void => {
+    reconcileStoreSubscriptions(
+      getChatSessionRegistry().listHandles(),
+      handleSubscriptions,
+      (handle) =>
+        handle.store.subscribe((state, previousState) => {
+          if (
+            state.managedCommands === previousState.managedCommands &&
+            state.backgroundItems === previousState.backgroundItems
+          ) {
+            return;
+          }
+          refresh();
+        }),
+    );
+    refresh();
+  };
+
+  return {
+    subscribe: (listener) => {
+      listeners.add(listener);
+      if (listeners.size === 1) {
+        unsubscribeRegistry = getChatSessionRegistry().subscribe(resync);
+        resync();
+      }
+      return () => {
+        listeners.delete(listener);
+        if (listeners.size > 0) return;
+        unsubscribeRegistry?.();
+        unsubscribeRegistry = null;
+        for (const unsubscribe of handleSubscriptions.values()) unsubscribe();
+        handleSubscriptions.clear();
+      };
+    },
+    read: () => published,
+  };
+}
+
+function readWarmChatBackground(): ReadonlyArray<WarmChatBackground> {
+  const chats = getChatSessionRegistry()
+    .listHandles()
+    .map((handle): WarmChatBackground => {
+      const state = handle.store.getState();
+      return {
+        epicId: handle.epicId,
+        chatId: handle.chatId,
+        hostId: getChatSessionHandleHostId(handle),
+        managedCommands: state.managedCommands.filter(
+          (command) => command.status.state === "running",
+        ),
+        // Filtered at READ time with the same predicate the builder uses, so a
+        // chat whose only background items are scheduled wakeups contributes
+        // nothing here AND never reaches the caller's title batch. Filtering on
+        // the raw length instead put such a chat's epic into the
+        // `epic.getTaskContexts` request for rows it can never produce.
+        backgroundItems: (state.backgroundItems ?? []).filter(
+          isRunningBackgroundRoot,
+        ),
+      };
+    })
+    .filter(
+      (chat) =>
+        chat.managedCommands.length > 0 || chat.backgroundItems.length > 0,
+    );
+  return chats.length === 0 ? EMPTY_WARM_CHATS : chats;
+}
+
+/**
+ * Content comparison down to the two arrays, which are compared by LENGTH and
+ * element identity rather than deeply: the host replaces each set whole, so an
+ * element that changed is a new object, and an element that did not is the same
+ * one.
+ */
+function sameWarmChatBackground(
+  a: ReadonlyArray<WarmChatBackground>,
+  b: ReadonlyArray<WarmChatBackground>,
+): boolean {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  return a.every((chat, index) => {
+    const prior = b[index];
+    return (
+      chat.epicId === prior.epicId &&
+      chat.chatId === prior.chatId &&
+      chat.hostId === prior.hostId &&
+      sameElements(chat.managedCommands, prior.managedCommands) &&
+      sameElements(chat.backgroundItems, prior.backgroundItems)
+    );
+  });
+}
+
+function sameElements<T>(a: ReadonlyArray<T>, b: ReadonlyArray<T>): boolean {
+  return a.length === b.length && a.every((item, index) => item === b[index]);
+}

--- a/clients/gui-app/src/lib/analytics.ts
+++ b/clients/gui-app/src/lib/analytics.ts
@@ -266,6 +266,7 @@ export type AnalyticsSetting =
   | "defaultSelection"
   | "defaultServiceTier"
   | "diffViewerPreferences"
+  | "homeTabEnabled"
   | "linkOpen"
   | "pinContextUsageBreakdown"
   | "pointerCursors"
@@ -1136,6 +1137,7 @@ const ANALYTICS_SETTINGS = new Set<string>([
   "defaultSelection",
   "defaultServiceTier",
   "diffViewerPreferences",
+  "homeTabEnabled",
   "linkOpen",
   "pinContextUsageBreakdown",
   "pointerCursors",

--- a/clients/gui-app/src/lib/analytics.ts
+++ b/clients/gui-app/src/lib/analytics.ts
@@ -158,7 +158,11 @@ export type AnalyticsNotificationFilter =
 
 export type AnalyticsNotificationSection = "attention" | "recent";
 
-export type AnalyticsNotificationSurface = "center" | "toast" | "native";
+export type AnalyticsNotificationSurface =
+  | "center"
+  | "toast"
+  | "native"
+  | "home";
 
 export type AnalyticsNotificationAcknowledgmentSource =
   | "explicit_action"

--- a/clients/gui-app/src/lib/commands/__tests__/actions.source.test.tsx
+++ b/clients/gui-app/src/lib/commands/__tests__/actions.source.test.tsx
@@ -4,6 +4,7 @@ import { actionsSource } from "@/lib/commands/sources/actions.source";
 import type { CommandContext, CommandItem } from "@/lib/commands/types";
 import { ACTION_META, getDefaultBindings } from "@/lib/keybindings/actions";
 import { useKeybindingStore } from "@/stores/settings/keybinding-store";
+import { useSettingsStore } from "@/stores/settings/settings-store";
 
 function ctx(): CommandContext {
   return {
@@ -44,11 +45,13 @@ describe("actionsSource", () => {
   beforeEach(() => {
     window.localStorage.clear();
     useKeybindingStore.setState({ bindings: getDefaultBindings() });
+    useSettingsStore.setState({ homeTabEnabled: false });
   });
 
   afterEach(() => {
     cleanup();
     useKeybindingStore.setState({ bindings: getDefaultBindings() });
+    useSettingsStore.setState({ homeTabEnabled: false });
   });
 
   it("emits one item per chord-kind action and skips digit-kind ones", () => {
@@ -90,5 +93,28 @@ describe("actionsSource", () => {
       (row) => row.id === "action:app.settings.open",
     );
     expect(item?.shortcut).toBeNull();
+  });
+
+  // `isPaletteEligible` (actions.source.ts) special-cases app.home.open: its
+  // dispatch handler no-ops while the Home tab is off, so a palette row that
+  // does nothing would be worse than no row. Locks down both sides of that
+  // gate so the row can't reappear stale while the setting is off, or stay
+  // missing once it's on.
+  describe("app.home.open row (gated on the homeTabEnabled setting)", () => {
+    it("omits the row while the Home tab is off", () => {
+      useSettingsStore.setState({ homeTabEnabled: false });
+      const ids = captureItems().map((item) => item.id);
+      expect(ids).not.toContain("action:app.home.open");
+    });
+
+    it("includes the row, with its live shortcut, once the Home tab is on", () => {
+      useSettingsStore.setState({ homeTabEnabled: true });
+      const item = captureItems().find(
+        (row) => row.id === "action:app.home.open",
+      );
+      expect(item).toBeDefined();
+      expect(item?.label).toBe("Go to Home");
+      expect(item?.shortcut).toBe("mod+shift+h");
+    });
   });
 });

--- a/clients/gui-app/src/lib/commands/sources/actions.source.ts
+++ b/clients/gui-app/src/lib/commands/sources/actions.source.ts
@@ -13,7 +13,8 @@
  *   - `app.palette.open` (the opener itself would loop);
  *   - `composer.dictation.toggle` (no `dispatchAction` handler - it's a
  *     press-and-hold action owned by a capture-phase hook, so a palette
- *     entry would be inert; toggling it is the mic button's job).
+ *     entry would be inert; toggling it is the mic button's job);
+ *   - `app.home.open` while the Home tab setting is off.
  */
 import { useMemo } from "react";
 import {
@@ -23,26 +24,31 @@ import {
   type ActionMeta,
 } from "@/lib/keybindings/actions";
 import { useKeybindingStore } from "@/stores/settings/keybinding-store";
+import { useSettingsStore } from "@/stores/settings/settings-store";
 import type { CommandItem, ReactCommandSource } from "@/lib/commands/types";
 
 export const actionsSource: ReactCommandSource = {
   id: "actions",
   useItems: () => {
     const bindings = useKeybindingStore((state) => state.bindings);
+    const homeTabEnabled = useSettingsStore((state) => state.homeTabEnabled);
     return useMemo<ReadonlyArray<CommandItem>>(() => {
       const items: Array<CommandItem> = [];
       for (const id of ACTION_IDS) {
         const meta = ACTION_META[id];
-        if (!isPaletteEligible(meta)) continue;
+        if (!isPaletteEligible(meta, homeTabEnabled)) continue;
         items.push(buildActionItem(meta, bindings[id] ?? null));
       }
       return items;
-    }, [bindings]);
+    }, [bindings, homeTabEnabled]);
   },
 };
 
-function isPaletteEligible(meta: ActionMeta): boolean {
+function isPaletteEligible(meta: ActionMeta, homeTabEnabled: boolean): boolean {
   if (meta.kind !== "chord") return false;
+  // Its handler no-ops while the Home tab is off, and a palette row that does
+  // nothing is worse than no row.
+  if (meta.id === "app.home.open" && !homeTabEnabled) return false;
   if (meta.id === "app.palette.open") return false;
   // No dispatchAction handler; handled by the capture-phase dictation hook.
   if (meta.id === "composer.dictation.toggle") return false;

--- a/clients/gui-app/src/lib/home-focus/__tests__/build-focus-model.test.ts
+++ b/clients/gui-app/src/lib/home-focus/__tests__/build-focus-model.test.ts
@@ -1,0 +1,352 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildFocusModel,
+  EMPTY_FOCUS_MODEL,
+  focusActivityCoverage,
+  type BuildFocusModelInput,
+  type FocusActivityHealth,
+} from "@/lib/home-focus/build-focus-model";
+import {
+  makeApprovalPayload,
+  makeEpicAgentActivity,
+  makeMergedNotificationRow,
+} from "@/lib/home-focus/__tests__/fixtures";
+
+function baseModelInput(
+  overrides: Partial<BuildFocusModelInput>,
+): BuildFocusModelInput {
+  return {
+    notificationRows: [],
+    tasks: {
+      byEpic: new Map(),
+      taskTitles: new Map(),
+      mountedEpicIds: new Set(),
+      agentIdentities: new Map(),
+      indicatorEpics: {},
+      coldEpicHostIds: new Map(),
+      activeHostId: null,
+      reachableHostIds: new Set(),
+    },
+    backgroundChats: [],
+    activity: {
+      connectionStatus: "open",
+      cloudSyncStatus: null,
+      stateFrameSeenThisEpoch: true,
+      connectableHostCount: 1,
+      connectableHostsResolved: true,
+    },
+    feedMode: "local",
+    ...overrides,
+  };
+}
+
+function health(overrides: Partial<FocusActivityHealth>): FocusActivityHealth {
+  return {
+    connectionStatus: "open",
+    cloudSyncStatus: null,
+    stateFrameSeenThisEpoch: true,
+    connectableHostCount: 1,
+    connectableHostsResolved: true,
+    ...overrides,
+  };
+}
+
+describe("buildFocusModel", () => {
+  it("badgeCount equals prompts.length", () => {
+    const approvalRow = makeMergedNotificationRow({
+      feedId: "host:approval-1",
+      hostKind: "approval.requested",
+      severity: "needs_action",
+      payload: makeApprovalPayload("epic-1", "chat-1"),
+    });
+    const input = baseModelInput({ notificationRows: [approvalRow] });
+
+    const model = buildFocusModel(input, EMPTY_FOCUS_MODEL);
+
+    expect(model.badgeCount).toBe(model.prompts.length);
+    expect(model.badgeCount).toBe(1);
+  });
+
+  it("gives needsYou: true to a task that only a prompt names, when it also has running agents", () => {
+    const approvalRow = makeMergedNotificationRow({
+      feedId: "host:approval-1",
+      hostKind: "approval.requested",
+      severity: "needs_action",
+      payload: makeApprovalPayload("epic-1", "chat-1"),
+    });
+    const input = baseModelInput({
+      notificationRows: [approvalRow],
+      tasks: {
+        byEpic: new Map([["epic-1", makeEpicAgentActivity(["agent-1"], [])]]),
+        taskTitles: new Map(),
+        mountedEpicIds: new Set(),
+        agentIdentities: new Map(),
+        // Deliberately NOT covering epic-1: the host's indicator batch is
+        // silent, so only the prompt row can supply needsYou.
+        indicatorEpics: {},
+        coldEpicHostIds: new Map(),
+        activeHostId: null,
+        reachableHostIds: new Set(),
+      },
+    });
+
+    const model = buildFocusModel(input, EMPTY_FOCUS_MODEL);
+
+    expect(model.tasks).toHaveLength(1);
+    expect(model.tasks[0]).toMatchObject({ epicId: "epic-1", needsYou: true });
+  });
+
+  it("threads coldEpicHostIds/activeHostId/reachableHostIds through to tasks[0].stoppable", () => {
+    const input = baseModelInput({
+      tasks: {
+        byEpic: new Map([["epic-1", makeEpicAgentActivity(["agent-1"], [])]]),
+        taskTitles: new Map(),
+        mountedEpicIds: new Set(),
+        agentIdentities: new Map(),
+        indicatorEpics: {},
+        // The agent's host resolves through the cold-epic guess (no mounted
+        // identity), and that host is neither the active host nor reachable -
+        // so the task must read stoppable: false end to end.
+        coldEpicHostIds: new Map([["epic-1", "host-unreachable"]]),
+        activeHostId: "host-active",
+        reachableHostIds: new Set(["host-reachable"]),
+      },
+    });
+
+    const model = buildFocusModel(input, EMPTY_FOCUS_MODEL);
+
+    expect(model.tasks[0]?.agents[0]?.hostId).toBe("host-unreachable");
+    expect(model.tasks[0]?.stoppable).toBe(false);
+  });
+
+  describe("focusActivityCoverage", () => {
+    it("closed -> disconnected", () => {
+      expect(
+        focusActivityCoverage(health({ connectionStatus: "closed" })),
+      ).toBe("disconnected");
+    });
+
+    it("connecting -> reconnecting", () => {
+      expect(
+        focusActivityCoverage(health({ connectionStatus: "connecting" })),
+      ).toBe("reconnecting");
+    });
+
+    it("reconnecting -> reconnecting", () => {
+      expect(
+        focusActivityCoverage(health({ connectionStatus: "reconnecting" })),
+      ).toBe("reconnecting");
+    });
+
+    it("open without a state frame this epoch -> unknown", () => {
+      expect(
+        focusActivityCoverage(
+          health({ connectionStatus: "open", stateFrameSeenThisEpoch: false }),
+        ),
+      ).toBe("unknown");
+    });
+
+    it("open + frame + cloudSyncStatus null -> live", () => {
+      expect(
+        focusActivityCoverage(
+          health({
+            connectionStatus: "open",
+            stateFrameSeenThisEpoch: true,
+            cloudSyncStatus: null,
+          }),
+        ),
+      ).toBe("live");
+    });
+
+    it("open + frame + cloudSyncStatus connected -> live", () => {
+      expect(
+        focusActivityCoverage(
+          health({
+            connectionStatus: "open",
+            stateFrameSeenThisEpoch: true,
+            cloudSyncStatus: "connected",
+          }),
+        ),
+      ).toBe("live");
+    });
+
+    it("open + frame + cloudSyncStatus reconnecting -> reconnecting", () => {
+      expect(
+        focusActivityCoverage(
+          health({
+            connectionStatus: "open",
+            stateFrameSeenThisEpoch: true,
+            cloudSyncStatus: "reconnecting",
+          }),
+        ),
+      ).toBe("reconnecting");
+    });
+
+    it("open + frame + cloudSyncStatus disconnected -> disconnected", () => {
+      expect(
+        focusActivityCoverage(
+          health({
+            connectionStatus: "open",
+            stateFrameSeenThisEpoch: true,
+            cloudSyncStatus: "disconnected",
+          }),
+        ),
+      ).toBe("disconnected");
+    });
+
+    it("RESOLVED + connectableHostCount 1 + cloudSyncStatus null -> live (a single-host install has nothing else to look at)", () => {
+      expect(
+        focusActivityCoverage(
+          health({
+            connectionStatus: "open",
+            stateFrameSeenThisEpoch: true,
+            cloudSyncStatus: null,
+            connectableHostCount: 1,
+            connectableHostsResolved: true,
+          }),
+        ),
+      ).toBe("live");
+    });
+
+    it("resolved + connectableHostCount 2 -> unknown (a narrow union is now an incomplete one)", () => {
+      expect(
+        focusActivityCoverage(
+          health({
+            connectionStatus: "open",
+            stateFrameSeenThisEpoch: true,
+            cloudSyncStatus: null,
+            connectableHostCount: 2,
+            connectableHostsResolved: true,
+          }),
+        ),
+      ).toBe("unknown");
+    });
+
+    it("UNRESOLVED directory + cloudSyncStatus null + connectableHostCount 0 -> unknown (a loading directory reports zero hosts, indistinguishable from a single-host install by count alone)", () => {
+      expect(
+        focusActivityCoverage(
+          health({
+            connectionStatus: "open",
+            stateFrameSeenThisEpoch: true,
+            cloudSyncStatus: null,
+            connectableHostCount: 0,
+            connectableHostsResolved: false,
+          }),
+        ),
+      ).toBe("unknown");
+    });
+
+    it("unresolved directory + connectableHostCount 1 -> unknown (the count cannot be trusted before the directory answers)", () => {
+      expect(
+        focusActivityCoverage(
+          health({
+            connectionStatus: "open",
+            stateFrameSeenThisEpoch: true,
+            cloudSyncStatus: null,
+            connectableHostCount: 1,
+            connectableHostsResolved: false,
+          }),
+        ),
+      ).toBe("unknown");
+    });
+
+    it("cloudSyncStatus connected + UNRESOLVED directory -> live (a connected stamp spans the fleet regardless of what the directory knows)", () => {
+      expect(
+        focusActivityCoverage(
+          health({
+            connectionStatus: "open",
+            stateFrameSeenThisEpoch: true,
+            cloudSyncStatus: "connected",
+            connectableHostCount: 0,
+            connectableHostsResolved: false,
+          }),
+        ),
+      ).toBe("live");
+    });
+
+    it("open + frame + cloudSyncStatus connected + connectableHostCount 5 -> live (a fleet-wide union proves itself regardless of host count)", () => {
+      expect(
+        focusActivityCoverage(
+          health({
+            connectionStatus: "open",
+            stateFrameSeenThisEpoch: true,
+            cloudSyncStatus: "connected",
+            connectableHostCount: 5,
+          }),
+        ),
+      ).toBe("live");
+    });
+
+    it("closed still wins over the new arm regardless of connectableHostCount", () => {
+      expect(
+        focusActivityCoverage(
+          health({ connectionStatus: "closed", connectableHostCount: 5 }),
+        ),
+      ).toBe("disconnected");
+    });
+
+    it("reconnecting connectionStatus still wins over the new arm regardless of connectableHostCount", () => {
+      expect(
+        focusActivityCoverage(
+          health({ connectionStatus: "reconnecting", connectableHostCount: 5 }),
+        ),
+      ).toBe("reconnecting");
+    });
+
+    it("no state frame this epoch still wins over the new arm regardless of connectableHostCount", () => {
+      expect(
+        focusActivityCoverage(
+          health({
+            connectionStatus: "open",
+            stateFrameSeenThisEpoch: false,
+            connectableHostCount: 5,
+          }),
+        ),
+      ).toBe("unknown");
+    });
+  });
+
+  it("coverage.notifications follows feed mode", () => {
+    const cloudModel = buildFocusModel(
+      baseModelInput({ feedMode: "cloud" }),
+      EMPTY_FOCUS_MODEL,
+    );
+    const localModel = buildFocusModel(
+      baseModelInput({ feedMode: "local" }),
+      EMPTY_FOCUS_MODEL,
+    );
+    const upgradeModel = buildFocusModel(
+      baseModelInput({ feedMode: "upgrade-required" }),
+      EMPTY_FOCUS_MODEL,
+    );
+
+    expect(cloudModel.coverage.notifications).toBe("cloud");
+    expect(localModel.coverage.notifications).toBe("local");
+    expect(upgradeModel.coverage.notifications).toBe("local");
+  });
+
+  it("coverage.backgroundIsMountedOnly is the literal true", () => {
+    const model = buildFocusModel(baseModelInput({}), EMPTY_FOCUS_MODEL);
+    expect(model.coverage.backgroundIsMountedOnly).toBe(true);
+  });
+
+  it("returns the SAME model object when rebuilt from identical inputs", () => {
+    const input = baseModelInput({
+      tasks: {
+        byEpic: new Map([["epic-1", makeEpicAgentActivity(["agent-1"], [])]]),
+        taskTitles: new Map(),
+        mountedEpicIds: new Set(),
+        agentIdentities: new Map(),
+        indicatorEpics: {},
+        coldEpicHostIds: new Map(),
+        activeHostId: null,
+        reachableHostIds: new Set(),
+      },
+    });
+
+    const first = buildFocusModel(input, EMPTY_FOCUS_MODEL);
+    const second = buildFocusModel(input, first);
+
+    expect(second).toBe(first);
+  });
+});

--- a/clients/gui-app/src/lib/home-focus/__tests__/fixtures.ts
+++ b/clients/gui-app/src/lib/home-focus/__tests__/fixtures.ts
@@ -1,0 +1,186 @@
+import type { BackgroundItem } from "@traycer/protocol/host/agent/gui/subscribe";
+import type { ManagedCommand } from "@traycer/protocol/host/managed-command/unary-schemas";
+import type { HostNotificationsIndicatorState } from "@traycer/protocol/host/notifications/contracts";
+import { categoryForNotificationSource } from "@/lib/notifications/notification-category";
+import type {
+  ApprovalNotificationPayload,
+  BrowserSessionNotificationPayload,
+  InterviewNotificationPayload,
+} from "@/lib/notifications/payload";
+import type {
+  MergedNotificationRow,
+  MergedNotificationSource,
+} from "@/stores/notifications/merged-notifications";
+import type { EpicAgentActivity } from "@/lib/agent-activity";
+import type { FocusAgentIdentity } from "@/lib/home-focus/focus-tasks";
+import type { FocusBackgroundChat } from "@/lib/home-focus/focus-background";
+
+/**
+ * Small typed factories for the home-focus test suites, mirroring the
+ * `Partial<T> & Pick<T, ...>` shape `notification-lifecycle.test.ts` already
+ * uses for its own row fixture: every field defaults to an innocuous value so
+ * a test only names what it is actually asserting on, and `overrides` always
+ * wins because it spreads last.
+ */
+
+export function makeMergedNotificationRow(
+  overrides: Partial<MergedNotificationRow> &
+    Pick<MergedNotificationRow, "feedId">,
+): MergedNotificationRow {
+  const source: MergedNotificationSource = overrides.source ?? "host";
+  return {
+    source,
+    sourceId: overrides.feedId,
+    createdAt: 0,
+    readAt: null,
+    title: "Notification",
+    body: "Body",
+    payload: null,
+    agentSurface: null,
+    hostKind: null,
+    appLocalKind: null,
+    globalEntry: null,
+    severity: "info",
+    outcome: null,
+    resolvedAt: null,
+    sourceRef: null,
+    originHostId: null,
+    providerPackAttribution: null,
+    category: categoryForNotificationSource(source),
+    ...overrides,
+  };
+}
+
+export function makeApprovalPayload(
+  epicId: string | undefined,
+  chatId: string | undefined,
+): ApprovalNotificationPayload {
+  return {
+    kind: "approval",
+    epicId,
+    chatId,
+    approvalId: undefined,
+    sessionId: undefined,
+    artifactId: undefined,
+  };
+}
+
+export function makeInterviewPayload(
+  epicId: string,
+  chatId: string,
+): InterviewNotificationPayload {
+  return { kind: "interview", epicId, chatId, interviewBlockId: undefined };
+}
+
+export function makeBrowserSessionPayload(
+  epicId: string,
+  sessionId: string,
+  tabId: string,
+): BrowserSessionNotificationPayload {
+  return { kind: "browserSession", epicId, sessionId, tabId };
+}
+
+export function makeEpicAgentActivity(
+  working: ReadonlyArray<string>,
+  turn: ReadonlyArray<string>,
+): EpicAgentActivity {
+  return { working: new Set(working), turn: new Set(turn) };
+}
+
+export function makeFocusAgentIdentity(
+  overrides: Partial<FocusAgentIdentity> & Pick<FocusAgentIdentity, "surface">,
+): FocusAgentIdentity {
+  return {
+    title: null,
+    parentId: null,
+    hostId: null,
+    ...overrides,
+  };
+}
+
+export function makeIndicatorFlags(
+  overrides: Partial<HostNotificationsIndicatorState>,
+): HostNotificationsIndicatorState {
+  return {
+    pendingApproval: false,
+    pendingInterview: false,
+    unreadFailure: false,
+    unreadDone: false,
+    pendingFork: false,
+    ...overrides,
+  };
+}
+
+export function makeManagedCommand(
+  overrides: Partial<ManagedCommand> & Pick<ManagedCommand, "id">,
+): ManagedCommand {
+  return {
+    monitoring: false,
+    description: "Command",
+    command: null,
+    cwd: null,
+    cadence: null,
+    status: { state: "running", pid: 1, startedAtMs: 0 },
+    relaunchOnHostRestart: true,
+    chatId: "chat-1",
+    createdAtMs: 0,
+    updatedAtMs: 0,
+    ...overrides,
+  };
+}
+
+interface RunningBackgroundItemOverrides {
+  readonly taskId: string;
+  readonly title?: string;
+  readonly blockId?: string;
+  readonly parentTaskId?: string | null;
+  readonly kind?: "subagent" | "monitor";
+}
+
+/** A running, non-wakeup background item - the only kind a "root" test needs
+ * to distinguish from `wakeup`. */
+export function makeRunningBackgroundItem(
+  overrides: RunningBackgroundItemOverrides,
+): BackgroundItem {
+  return {
+    kind: overrides.kind ?? "subagent",
+    taskId: overrides.taskId,
+    title: overrides.title ?? "Subagent",
+    blockId: overrides.blockId ?? overrides.taskId,
+    parentTaskId: overrides.parentTaskId ?? null,
+    scheduledFor: null,
+  };
+}
+
+interface WakeupBackgroundItemOverrides {
+  readonly taskId: string;
+  readonly title?: string;
+  readonly scheduledFor: number;
+  readonly parentTaskId?: string | null;
+}
+
+export function makeWakeupBackgroundItem(
+  overrides: WakeupBackgroundItemOverrides,
+): BackgroundItem {
+  return {
+    kind: "wakeup",
+    taskId: overrides.taskId,
+    title: overrides.title ?? "Wakeup",
+    blockId: overrides.taskId,
+    parentTaskId: overrides.parentTaskId ?? null,
+    scheduledFor: overrides.scheduledFor,
+  };
+}
+
+export function makeFocusBackgroundChat(
+  overrides: Partial<FocusBackgroundChat> &
+    Pick<FocusBackgroundChat, "epicId" | "chatId">,
+): FocusBackgroundChat {
+  return {
+    hostId: "host-1",
+    taskTitle: null,
+    managedCommands: [],
+    backgroundItems: [],
+    ...overrides,
+  };
+}

--- a/clients/gui-app/src/lib/home-focus/__tests__/focus-background.test.ts
+++ b/clients/gui-app/src/lib/home-focus/__tests__/focus-background.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildFocusBackground,
+  parseManagedCommandRowKey,
+} from "@/lib/home-focus/focus-background";
+import {
+  makeFocusBackgroundChat,
+  makeManagedCommand,
+  makeRunningBackgroundItem,
+  makeWakeupBackgroundItem,
+} from "@/lib/home-focus/__tests__/fixtures";
+
+describe("buildFocusBackground", () => {
+  it("turns a running managed command into a managed-command row with startedAtMs, label and stoppable from hostId", () => {
+    const chatWithHost = makeFocusBackgroundChat({
+      epicId: "epic-1",
+      chatId: "chat-1",
+      hostId: "host-1",
+      managedCommands: [
+        makeManagedCommand({
+          id: "cmd-1",
+          description: "deploy watcher",
+          status: { state: "running", pid: 42, startedAtMs: 12_345 },
+        }),
+      ],
+    });
+    const chatWithoutHost = makeFocusBackgroundChat({
+      epicId: "epic-2",
+      chatId: "chat-2",
+      hostId: null,
+      managedCommands: [
+        makeManagedCommand({
+          id: "cmd-2",
+          description: "build watcher",
+          status: { state: "running", pid: 43, startedAtMs: 99_999 },
+        }),
+      ],
+    });
+
+    const rows = buildFocusBackground([chatWithHost, chatWithoutHost], []);
+    const byEpic = new Map(rows.map((row) => [row.epicId, row]));
+
+    expect(byEpic.get("epic-1")).toMatchObject({
+      kind: "managed-command",
+      label: "deploy watcher",
+      startedAtMs: 12_345,
+      stoppable: true,
+    });
+    expect(byEpic.get("epic-2")).toMatchObject({
+      kind: "managed-command",
+      label: "build watcher",
+      startedAtMs: 99_999,
+      stoppable: false,
+    });
+  });
+
+  it("only surfaces root, non-wakeup background items; every one is unstoppable with no startedAtMs", () => {
+    const chat = makeFocusBackgroundChat({
+      epicId: "epic-1",
+      chatId: "chat-1",
+      backgroundItems: [
+        makeRunningBackgroundItem({ taskId: "task-root", title: "Subagent" }),
+        makeRunningBackgroundItem({
+          taskId: "task-child",
+          title: "Nested",
+          parentTaskId: "task-root",
+        }),
+        makeWakeupBackgroundItem({
+          taskId: "task-wakeup",
+          title: "Scheduled wake",
+          scheduledFor: 999,
+        }),
+      ],
+    });
+
+    const rows = buildFocusBackground([chat], []);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      kind: "background-item",
+      label: "Subagent",
+      startedAtMs: null,
+      stoppable: false,
+    });
+  });
+
+  it("orders rows by epic asc, then chat asc, then managed-command before background-item, then key asc", () => {
+    const chatB = makeFocusBackgroundChat({
+      epicId: "epic-b",
+      chatId: "chat-1",
+      hostId: "host-1",
+      managedCommands: [makeManagedCommand({ id: "cmd-b" })],
+    });
+    const chatAChat2 = makeFocusBackgroundChat({
+      epicId: "epic-a",
+      chatId: "chat-2",
+      hostId: "host-1",
+      backgroundItems: [
+        makeRunningBackgroundItem({ taskId: "task-a2", title: "A2" }),
+      ],
+    });
+    const chatAChat1BackgroundItem = makeFocusBackgroundChat({
+      epicId: "epic-a",
+      chatId: "chat-1",
+      backgroundItems: [
+        makeRunningBackgroundItem({ taskId: "task-a1", title: "A1 item" }),
+      ],
+    });
+    const chatAChat1ManagedCommand = makeFocusBackgroundChat({
+      epicId: "epic-a",
+      chatId: "chat-1",
+      hostId: "host-1",
+      // Two commands in the same epic/chat to exercise the final "key asc"
+      // tie-break: their keys differ only by commandId.
+      managedCommands: [
+        makeManagedCommand({ id: "cmd-z" }),
+        makeManagedCommand({ id: "cmd-a" }),
+      ],
+    });
+
+    const rows = buildFocusBackground(
+      [chatB, chatAChat2, chatAChat1BackgroundItem, chatAChat1ManagedCommand],
+      [],
+    );
+
+    expect(
+      rows.map((row) => ({
+        epicId: row.epicId,
+        chatId: row.chatId,
+        kind: row.kind,
+      })),
+    ).toEqual([
+      { epicId: "epic-a", chatId: "chat-1", kind: "managed-command" },
+      { epicId: "epic-a", chatId: "chat-1", kind: "managed-command" },
+      { epicId: "epic-a", chatId: "chat-1", kind: "background-item" },
+      { epicId: "epic-a", chatId: "chat-2", kind: "background-item" },
+      { epicId: "epic-b", chatId: "chat-1", kind: "managed-command" },
+    ]);
+    // The two epic-a/chat-1 managed-command rows tie on epic, chat and kind;
+    // the key (which embeds commandId last) breaks the tie ascending.
+    const epicAManagedCommandKeys = rows
+      .filter(
+        (row) => row.epicId === "epic-a" && row.kind === "managed-command",
+      )
+      .map((row) => row.key);
+    expect(epicAManagedCommandKeys).toEqual(
+      [...epicAManagedCommandKeys].sort(),
+    );
+  });
+
+  describe("identity stability", () => {
+    it("returns the same array reference when rebuilt from unchanged content", () => {
+      const chat = makeFocusBackgroundChat({
+        epicId: "epic-1",
+        chatId: "chat-1",
+        hostId: "host-1",
+        managedCommands: [makeManagedCommand({ id: "cmd-1" })],
+      });
+
+      const first = buildFocusBackground([chat], []);
+      const second = buildFocusBackground([chat], first);
+
+      expect(second).toBe(first);
+    });
+  });
+});
+
+describe("parseManagedCommandRowKey", () => {
+  it("round-trips a managed-command row's key back to {hostId, epicId, commandId}", () => {
+    const chat = makeFocusBackgroundChat({
+      epicId: "epic-1",
+      chatId: "chat-1",
+      hostId: "host-1",
+      managedCommands: [makeManagedCommand({ id: "cmd-1" })],
+    });
+
+    const [row] = buildFocusBackground([chat], []);
+
+    expect(parseManagedCommandRowKey(row.key)).toEqual({
+      hostId: "host-1",
+      epicId: "epic-1",
+      commandId: "cmd-1",
+    });
+  });
+
+  it("returns null for a background-item row's key", () => {
+    const chat = makeFocusBackgroundChat({
+      epicId: "epic-1",
+      chatId: "chat-1",
+      backgroundItems: [
+        makeRunningBackgroundItem({ taskId: "task-1", title: "Subagent" }),
+      ],
+    });
+
+    const [row] = buildFocusBackground([chat], []);
+
+    expect(parseManagedCommandRowKey(row.key)).toBeNull();
+  });
+
+  it("returns null for a managed-command row built with hostId: null", () => {
+    const chat = makeFocusBackgroundChat({
+      epicId: "epic-1",
+      chatId: "chat-1",
+      hostId: null,
+      managedCommands: [makeManagedCommand({ id: "cmd-1" })],
+    });
+
+    const [row] = buildFocusBackground([chat], []);
+
+    expect(parseManagedCommandRowKey(row.key)).toBeNull();
+  });
+});

--- a/clients/gui-app/src/lib/home-focus/__tests__/focus-prompts.test.ts
+++ b/clients/gui-app/src/lib/home-focus/__tests__/focus-prompts.test.ts
@@ -1,0 +1,362 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildFocusPrompts,
+  countPendingPromptRows,
+  focusPromptEpicIds,
+  pendingPromptEpicIds,
+} from "@/lib/home-focus/focus-prompts";
+import {
+  makeApprovalPayload,
+  makeBrowserSessionPayload,
+  makeInterviewPayload,
+  makeMergedNotificationRow,
+} from "@/lib/home-focus/__tests__/fixtures";
+
+describe("buildFocusPrompts", () => {
+  it("only promotes rows whose hostKind is a pending-prompt kind; an agent.stopped failure row is excluded", () => {
+    const approvalRow = makeMergedNotificationRow({
+      feedId: "host:approval-1",
+      hostKind: "approval.requested",
+      severity: "needs_action",
+      payload: makeApprovalPayload("epic-1", "chat-1"),
+    });
+    const interviewRow = makeMergedNotificationRow({
+      feedId: "host:interview-1",
+      hostKind: "interview.requested",
+      severity: "needs_action",
+      payload: makeInterviewPayload("epic-2", "chat-2"),
+    });
+    const browserRow = makeMergedNotificationRow({
+      feedId: "host:browser-1",
+      hostKind: "browser.human.needed",
+      severity: "needs_action",
+      payload: makeBrowserSessionPayload("epic-3", "session-1", "tab-1"),
+    });
+    const agentStoppedRow = makeMergedNotificationRow({
+      feedId: "host:stopped-1",
+      hostKind: "agent.stopped",
+      severity: "failure",
+    });
+
+    const prompts = buildFocusPrompts(
+      [approvalRow, interviewRow, browserRow, agentStoppedRow],
+      new Map(),
+      [],
+    );
+
+    expect(prompts.map((prompt) => prompt.key).sort()).toEqual([
+      "host:approval-1",
+      "host:browser-1",
+      "host:interview-1",
+    ]);
+  });
+
+  it("excludes a row with resolvedAt !== null", () => {
+    const resolved = makeMergedNotificationRow({
+      feedId: "host:approval-resolved",
+      hostKind: "approval.requested",
+      severity: "needs_action",
+      resolvedAt: 123,
+      readAt: null,
+      payload: makeApprovalPayload("epic-1", "chat-1"),
+    });
+
+    expect(buildFocusPrompts([resolved], new Map(), [])).toHaveLength(0);
+  });
+
+  it("excludes a row with readAt !== null (the lifecycle classifier reads it as recent)", () => {
+    const read = makeMergedNotificationRow({
+      feedId: "host:approval-read",
+      hostKind: "approval.requested",
+      severity: "needs_action",
+      resolvedAt: null,
+      readAt: 50,
+      payload: makeApprovalPayload("epic-1", "chat-1"),
+    });
+
+    expect(buildFocusPrompts([read], new Map(), [])).toHaveLength(0);
+  });
+
+  it("orders blocking before failure, newest createdAt first within a tier, ascending feedId as the tie-break", () => {
+    const blockingOld = makeMergedNotificationRow({
+      feedId: "host:blocking-old",
+      hostKind: "approval.requested",
+      severity: "needs_action",
+      createdAt: 10,
+      payload: makeApprovalPayload("epic-1", "chat-1"),
+    });
+    const blockingNew = makeMergedNotificationRow({
+      feedId: "host:blocking-new",
+      hostKind: "interview.requested",
+      severity: "needs_action",
+      createdAt: 500,
+      payload: makeInterviewPayload("epic-2", "chat-2"),
+    });
+    const blockingTieA = makeMergedNotificationRow({
+      feedId: "host:tie-aaa",
+      hostKind: "approval.requested",
+      severity: "needs_action",
+      createdAt: 500,
+      payload: makeApprovalPayload("epic-3", "chat-3"),
+    });
+    const blockingTieB = makeMergedNotificationRow({
+      feedId: "host:tie-zzz",
+      hostKind: "approval.requested",
+      severity: "needs_action",
+      createdAt: 500,
+      payload: makeApprovalPayload("epic-4", "chat-4"),
+    });
+    // Deliberately a "failure"-severity row on a pending-prompt hostKind: the
+    // ordering rule is about the attention TIER the classifier assigns, and
+    // only `needs_action`/unread `failure` rows ever reach the candidate set.
+    const failureNewest = makeMergedNotificationRow({
+      feedId: "host:failure-newest",
+      hostKind: "browser.human.needed",
+      severity: "failure",
+      createdAt: 100_000,
+      payload: makeBrowserSessionPayload("epic-5", "session-1", "tab-1"),
+    });
+
+    const prompts = buildFocusPrompts(
+      [failureNewest, blockingOld, blockingTieB, blockingNew, blockingTieA],
+      new Map(),
+      [],
+    );
+
+    expect(prompts.map((prompt) => prompt.key)).toEqual([
+      "host:blocking-new",
+      "host:tie-aaa",
+      "host:tie-zzz",
+      "host:blocking-old",
+      "host:failure-newest",
+    ]);
+  });
+
+  it("maps kind and target ids from the payload for all three host kinds", () => {
+    const approvalRow = makeMergedNotificationRow({
+      feedId: "host:approval",
+      hostKind: "approval.requested",
+      severity: "needs_action",
+      payload: makeApprovalPayload("epic-1", "chat-1"),
+    });
+    const interviewRow = makeMergedNotificationRow({
+      feedId: "host:interview",
+      hostKind: "interview.requested",
+      severity: "needs_action",
+      payload: makeInterviewPayload("epic-2", "chat-2"),
+    });
+    const browserRow = makeMergedNotificationRow({
+      feedId: "host:browser",
+      hostKind: "browser.human.needed",
+      severity: "needs_action",
+      payload: makeBrowserSessionPayload("epic-3", "session-1", "tab-1"),
+    });
+    const nullPayloadRow = makeMergedNotificationRow({
+      feedId: "host:null-payload",
+      hostKind: "approval.requested",
+      severity: "needs_action",
+      payload: null,
+    });
+
+    const prompts = buildFocusPrompts(
+      [approvalRow, interviewRow, browserRow, nullPayloadRow],
+      new Map(),
+      [],
+    );
+    const byKey = new Map(prompts.map((prompt) => [prompt.key, prompt]));
+
+    expect(byKey.get("host:approval")).toMatchObject({
+      kind: "approval",
+      epicId: "epic-1",
+      chatId: "chat-1",
+    });
+    expect(byKey.get("host:interview")).toMatchObject({
+      kind: "interview",
+      epicId: "epic-2",
+      chatId: "chat-2",
+    });
+    expect(byKey.get("host:browser")).toMatchObject({
+      kind: "browser",
+      epicId: "epic-3",
+      chatId: null,
+    });
+    expect(byKey.get("host:null-payload")).toMatchObject({
+      kind: "approval",
+      epicId: null,
+      chatId: null,
+    });
+  });
+
+  it("looks up taskTitle from the passed map, null when absent", () => {
+    const withTitle = makeMergedNotificationRow({
+      feedId: "host:a",
+      hostKind: "approval.requested",
+      severity: "needs_action",
+      payload: makeApprovalPayload("epic-1", "chat-1"),
+    });
+    const withoutTitle = makeMergedNotificationRow({
+      feedId: "host:b",
+      hostKind: "approval.requested",
+      severity: "needs_action",
+      payload: makeApprovalPayload("epic-2", "chat-2"),
+    });
+    const titles = new Map([["epic-1", "Epic One"]]);
+
+    const prompts = buildFocusPrompts([withTitle, withoutTitle], titles, []);
+    const byKey = new Map(prompts.map((prompt) => [prompt.key, prompt]));
+
+    expect(byKey.get("host:a")?.taskTitle).toBe("Epic One");
+    expect(byKey.get("host:b")?.taskTitle).toBeNull();
+  });
+
+  it("keeps activation as the original MergedNotificationRow object", () => {
+    const row = makeMergedNotificationRow({
+      feedId: "host:a",
+      hostKind: "approval.requested",
+      severity: "needs_action",
+      payload: makeApprovalPayload("epic-1", "chat-1"),
+    });
+
+    const [prompt] = buildFocusPrompts([row], new Map(), []);
+
+    expect(prompt.activation).toBe(row);
+  });
+
+  it("returns the same array reference when rebuilt from unchanged content", () => {
+    const row = makeMergedNotificationRow({
+      feedId: "host:a",
+      hostKind: "approval.requested",
+      severity: "needs_action",
+      payload: makeApprovalPayload("epic-1", "chat-1"),
+    });
+
+    const first = buildFocusPrompts([row], new Map(), []);
+    const second = buildFocusPrompts([row], new Map(), first);
+
+    expect(second).toBe(first);
+  });
+
+  describe("row identity uses feedId, not activation reference", () => {
+    it("reuses the previous row - and its ORIGINAL activation - when rebuilt from a fresh array of content-equal rows", () => {
+      const original = makeMergedNotificationRow({
+        feedId: "host:a",
+        hostKind: "approval.requested",
+        severity: "needs_action",
+        title: "Approve the plan",
+        body: "Body text",
+        createdAt: 42,
+        payload: makeApprovalPayload("epic-1", "chat-1"),
+      });
+      const first = buildFocusPrompts([original], new Map(), []);
+
+      // A FRESH object, same feedId/title/body/createdAt - the store re-mints
+      // rows like this on any unrelated notification frame.
+      const freshEqual = makeMergedNotificationRow({
+        feedId: "host:a",
+        hostKind: "approval.requested",
+        severity: "needs_action",
+        title: "Approve the plan",
+        body: "Body text",
+        createdAt: 42,
+        payload: makeApprovalPayload("epic-1", "chat-1"),
+      });
+      expect(freshEqual).not.toBe(original);
+
+      const second = buildFocusPrompts([freshEqual], new Map(), first);
+
+      expect(second).toBe(first);
+      expect(second[0]?.activation).toBe(original);
+      expect(second[0]?.activation).not.toBe(freshEqual);
+    });
+
+    it("mints a new row when a genuine content change (a new title) lands under the same feedId", () => {
+      const original = makeMergedNotificationRow({
+        feedId: "host:a",
+        hostKind: "approval.requested",
+        severity: "needs_action",
+        title: "Approve the plan",
+        payload: makeApprovalPayload("epic-1", "chat-1"),
+      });
+      const first = buildFocusPrompts([original], new Map(), []);
+
+      const retitled = makeMergedNotificationRow({
+        feedId: "host:a",
+        hostKind: "approval.requested",
+        severity: "needs_action",
+        title: "Approve the REVISED plan",
+        payload: makeApprovalPayload("epic-1", "chat-1"),
+      });
+      const second = buildFocusPrompts([retitled], new Map(), first);
+
+      expect(second).not.toBe(first);
+      expect(second[0]?.title).toBe("Approve the REVISED plan");
+      expect(second[0]?.activation).toBe(retitled);
+    });
+  });
+
+  it("countPendingPromptRows(rows) equals buildFocusPrompts(rows, new Map(), []).length across a mixed fixture", () => {
+    const eligible = makeMergedNotificationRow({
+      feedId: "host:approval-1",
+      hostKind: "approval.requested",
+      severity: "needs_action",
+      payload: makeApprovalPayload("epic-1", "chat-1"),
+    });
+    const wrongKind = makeMergedNotificationRow({
+      feedId: "host:stopped-1",
+      hostKind: "agent.stopped",
+      severity: "failure",
+    });
+    const resolved = makeMergedNotificationRow({
+      feedId: "host:approval-resolved",
+      hostKind: "approval.requested",
+      severity: "needs_action",
+      resolvedAt: 999,
+      payload: makeApprovalPayload("epic-2", "chat-2"),
+    });
+    const alreadyRead = makeMergedNotificationRow({
+      feedId: "host:approval-read",
+      hostKind: "approval.requested",
+      severity: "needs_action",
+      readAt: 10,
+      payload: makeApprovalPayload("epic-3", "chat-3"),
+    });
+    const anotherEligible = makeMergedNotificationRow({
+      feedId: "host:browser-1",
+      hostKind: "browser.human.needed",
+      severity: "needs_action",
+      payload: makeBrowserSessionPayload("epic-4", "session-1", "tab-1"),
+    });
+    const rows = [eligible, wrongKind, resolved, alreadyRead, anotherEligible];
+
+    expect(countPendingPromptRows(rows)).toBe(
+      buildFocusPrompts(rows, new Map(), []).length,
+    );
+    expect(countPendingPromptRows(rows)).toBe(2);
+  });
+
+  it("pendingPromptEpicIds agrees with focusPromptEpicIds(buildFocusPrompts(...))", () => {
+    const approvalRow = makeMergedNotificationRow({
+      feedId: "host:approval-1",
+      hostKind: "approval.requested",
+      severity: "needs_action",
+      payload: makeApprovalPayload("epic-1", "chat-1"),
+    });
+    const interviewRow = makeMergedNotificationRow({
+      feedId: "host:interview-1",
+      hostKind: "interview.requested",
+      severity: "needs_action",
+      payload: makeInterviewPayload("epic-2", "chat-2"),
+    });
+    const agentStoppedRow = makeMergedNotificationRow({
+      feedId: "host:stopped-1",
+      hostKind: "agent.stopped",
+      severity: "failure",
+    });
+    const rows = [approvalRow, interviewRow, agentStoppedRow];
+
+    const prompts = buildFocusPrompts(rows, new Map(), []);
+
+    expect(pendingPromptEpicIds(rows)).toEqual(focusPromptEpicIds(prompts));
+    expect(pendingPromptEpicIds(rows)).toEqual(new Set(["epic-1", "epic-2"]));
+  });
+});

--- a/clients/gui-app/src/lib/home-focus/__tests__/focus-tasks.test.ts
+++ b/clients/gui-app/src/lib/home-focus/__tests__/focus-tasks.test.ts
@@ -1,0 +1,412 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildFocusTasks,
+  focusAgentKey,
+  type FocusTasksInput,
+} from "@/lib/home-focus/focus-tasks";
+import {
+  makeEpicAgentActivity,
+  makeFocusAgentIdentity,
+  makeIndicatorFlags,
+} from "@/lib/home-focus/__tests__/fixtures";
+
+function baseInput(overrides: Partial<FocusTasksInput>): FocusTasksInput {
+  return {
+    byEpic: new Map(),
+    taskTitles: new Map(),
+    mountedEpicIds: new Set(),
+    agentIdentities: new Map(),
+    indicatorEpics: {},
+    promptEpicIds: new Set(),
+    coldEpicHostIds: new Map(),
+    activeHostId: null,
+    reachableHostIds: new Set(),
+    ...overrides,
+  };
+}
+
+describe("buildFocusTasks", () => {
+  it("omits an epic whose working set is empty", () => {
+    const input = baseInput({
+      byEpic: new Map([["epic-1", makeEpicAgentActivity([], [])]]),
+    });
+
+    expect(buildFocusTasks(input, [])).toHaveLength(0);
+  });
+
+  describe("needsYou precedence", () => {
+    it("is true when the epic is in promptEpicIds", () => {
+      const input = baseInput({
+        byEpic: new Map([["epic-1", makeEpicAgentActivity(["agent-1"], [])]]),
+        promptEpicIds: new Set(["epic-1"]),
+        indicatorEpics: {},
+      });
+
+      const [task] = buildFocusTasks(input, []);
+      expect(task.needsYou).toBe(true);
+    });
+
+    it("is true when the indicator flags say pendingApproval or pendingInterview", () => {
+      const approvalInput = baseInput({
+        byEpic: new Map([["epic-1", makeEpicAgentActivity(["agent-1"], [])]]),
+        indicatorEpics: {
+          "epic-1": makeIndicatorFlags({ pendingApproval: true }),
+        },
+      });
+      const interviewInput = baseInput({
+        byEpic: new Map([["epic-2", makeEpicAgentActivity(["agent-1"], [])]]),
+        indicatorEpics: {
+          "epic-2": makeIndicatorFlags({ pendingInterview: true }),
+        },
+      });
+
+      expect(buildFocusTasks(approvalInput, [])[0]?.needsYou).toBe(true);
+      expect(buildFocusTasks(interviewInput, [])[0]?.needsYou).toBe(true);
+    });
+
+    it("is false, not throwing, when the epic is absent from the indicator batch and has no prompt row", () => {
+      const input = baseInput({
+        byEpic: new Map([["epic-1", makeEpicAgentActivity(["agent-1"], [])]]),
+        indicatorEpics: {},
+        promptEpicIds: new Set(),
+      });
+
+      const [task] = buildFocusTasks(input, []);
+      expect(task.needsYou).toBe(false);
+    });
+  });
+
+  it("orders tasks by needsYou first, then most agents in the turn tier, then most agents overall, then epic id ascending", () => {
+    const input = baseInput({
+      byEpic: new Map([
+        // Needs-you loser on agent counts, but wins overall on needsYou.
+        ["epic-needs-you", makeEpicAgentActivity(["a1"], [])],
+        // Two epics tied on needsYou=false; "epic-b" has more turn agents.
+        [
+          "epic-more-turn",
+          makeEpicAgentActivity(["a1", "a2", "a3"], ["a1", "a2"]),
+        ],
+        ["epic-fewer-turn", makeEpicAgentActivity(["a1", "a2"], ["a1"])],
+        // Tied on turn-agent count (0) and total-agent count (1) with
+        // "epic-fewer-turn-2" below; epic id ascending breaks the tie.
+        ["epic-z-tiebreak", makeEpicAgentActivity(["a1"], [])],
+        ["epic-a-tiebreak", makeEpicAgentActivity(["a1"], [])],
+      ]),
+      promptEpicIds: new Set(["epic-needs-you"]),
+    });
+
+    const tasks = buildFocusTasks(input, []);
+
+    expect(tasks.map((task) => task.epicId)).toEqual([
+      "epic-needs-you",
+      "epic-more-turn",
+      "epic-fewer-turn",
+      "epic-a-tiebreak",
+      "epic-z-tiebreak",
+    ]);
+  });
+
+  it("orders agents within a task: turn before background, named before unnamed, then title ascending, then agentId ascending", () => {
+    const input = baseInput({
+      byEpic: new Map([
+        [
+          "epic-1",
+          makeEpicAgentActivity(
+            ["bg-unnamed", "bg-named-b", "turn-unnamed", "turn-named-a"],
+            ["turn-unnamed", "turn-named-a"],
+          ),
+        ],
+      ]),
+      mountedEpicIds: new Set(["epic-1"]),
+      agentIdentities: new Map([
+        [
+          focusAgentKey("epic-1", "turn-named-a"),
+          makeFocusAgentIdentity({ surface: "chat", title: "Alpha" }),
+        ],
+        [
+          focusAgentKey("epic-1", "bg-named-b"),
+          makeFocusAgentIdentity({ surface: "chat", title: "Beta" }),
+        ],
+        // "turn-unnamed" and "bg-unnamed" deliberately have no identity entry.
+      ]),
+    });
+
+    const [task] = buildFocusTasks(input, []);
+
+    expect(task.agents.map((agent) => agent.agentId)).toEqual([
+      "turn-named-a",
+      "turn-unnamed",
+      "bg-named-b",
+      "bg-unnamed",
+    ]);
+  });
+
+  it("marks an unmounted epic's agents fully null, while its title still comes from the titles map", () => {
+    const input = baseInput({
+      byEpic: new Map([["epic-1", makeEpicAgentActivity(["agent-1"], [])]]),
+      taskTitles: new Map([["epic-1", "Task One"]]),
+      mountedEpicIds: new Set(),
+      // No agentIdentities entry: an unmounted epic's agents are never
+      // resolved by the real caller, which only populates identities for
+      // mounted epics.
+      agentIdentities: new Map(),
+    });
+
+    const [task] = buildFocusTasks(input, []);
+
+    expect(task.mountedHere).toBe(false);
+    expect(task.taskTitle).toBe("Task One");
+    expect(task.agents[0]).toMatchObject({
+      agentId: "agent-1",
+      title: null,
+      surface: null,
+      parentId: null,
+    });
+  });
+
+  it("resolves a mounted epic's agent identities through focusAgentKey", () => {
+    const input = baseInput({
+      byEpic: new Map([["epic-1", makeEpicAgentActivity(["agent-1"], [])]]),
+      mountedEpicIds: new Set(["epic-1"]),
+      agentIdentities: new Map([
+        [
+          focusAgentKey("epic-1", "agent-1"),
+          makeFocusAgentIdentity({
+            surface: "terminal-agent",
+            title: "Terminal Agent",
+            parentId: "parent-1",
+          }),
+        ],
+      ]),
+    });
+
+    const [task] = buildFocusTasks(input, []);
+
+    expect(task.mountedHere).toBe(true);
+    expect(task.agents[0]).toMatchObject({
+      agentId: "agent-1",
+      title: "Terminal Agent",
+      surface: "terminal-agent",
+      parentId: "parent-1",
+    });
+  });
+
+  describe("agent hostId resolution", () => {
+    it("uses the resolved identity's hostId when mounted, INCLUDING null (a legacy chat) - it must not fall through to the cold-epic guess", () => {
+      const input = baseInput({
+        byEpic: new Map([["epic-1", makeEpicAgentActivity(["agent-1"], [])]]),
+        mountedEpicIds: new Set(["epic-1"]),
+        agentIdentities: new Map([
+          [
+            focusAgentKey("epic-1", "agent-1"),
+            makeFocusAgentIdentity({ surface: "chat", hostId: null }),
+          ],
+        ]),
+        // A cold-epic guess is available too, but the resolved identity - even
+        // though its own hostId is null - must win over it.
+        coldEpicHostIds: new Map([["epic-1", "cold-host-should-not-show"]]),
+      });
+
+      const [task] = buildFocusTasks(input, []);
+
+      expect(task.agents[0]?.hostId).toBeNull();
+    });
+
+    it("uses the resolved identity's hostId when it names a real host", () => {
+      const input = baseInput({
+        byEpic: new Map([["epic-1", makeEpicAgentActivity(["agent-1"], [])]]),
+        mountedEpicIds: new Set(["epic-1"]),
+        agentIdentities: new Map([
+          [
+            focusAgentKey("epic-1", "agent-1"),
+            makeFocusAgentIdentity({ surface: "chat", hostId: "host-known" }),
+          ],
+        ]),
+      });
+
+      const [task] = buildFocusTasks(input, []);
+
+      expect(task.agents[0]?.hostId).toBe("host-known");
+    });
+
+    it("falls back to the cold-epic guess when the agent is absent from agentIdentities", () => {
+      const input = baseInput({
+        byEpic: new Map([["epic-1", makeEpicAgentActivity(["agent-1"], [])]]),
+        agentIdentities: new Map(),
+        coldEpicHostIds: new Map([["epic-1", "cold-host-1"]]),
+      });
+
+      const [task] = buildFocusTasks(input, []);
+
+      expect(task.agents[0]?.hostId).toBe("cold-host-1");
+    });
+
+    it("is null when the epic is in neither agentIdentities nor coldEpicHostIds", () => {
+      const input = baseInput({
+        byEpic: new Map([["epic-1", makeEpicAgentActivity(["agent-1"], [])]]),
+        agentIdentities: new Map(),
+        coldEpicHostIds: new Map(),
+      });
+
+      const [task] = buildFocusTasks(input, []);
+
+      expect(task.agents[0]?.hostId).toBeNull();
+    });
+  });
+
+  describe("task stoppable", () => {
+    it("is false for a COLD epic's null-host agent - unmounted, absent from coldEpicHostIds, unresolved in agentIdentities", () => {
+      const input = baseInput({
+        byEpic: new Map([["epic-1", makeEpicAgentActivity(["agent-1"], [])]]),
+        mountedEpicIds: new Set(),
+        coldEpicHostIds: new Map(),
+        agentIdentities: new Map(),
+        activeHostId: "host-active",
+      });
+
+      const [task] = buildFocusTasks(input, []);
+
+      expect(task.agents[0]?.hostId).toBeNull();
+      // Nothing resolved this agent, so a `null` host is a REFUSAL to guess,
+      // not evidence the active host is where it lives - `agent.stop` would
+      // resolve the subtree from shared cloud storage and let the wrong host
+      // report an empty `stoppedAgentIds` while the real agent kept running.
+      expect(task.stoppable).toBe(false);
+    });
+
+    it("is true for a MOUNTED epic's null-host agent - the projection resolved it and recorded no host (a legacy chat)", () => {
+      const input = baseInput({
+        byEpic: new Map([["epic-1", makeEpicAgentActivity(["agent-1"], [])]]),
+        mountedEpicIds: new Set(["epic-1"]),
+        agentIdentities: new Map([
+          [
+            focusAgentKey("epic-1", "agent-1"),
+            makeFocusAgentIdentity({ surface: "chat", hostId: null }),
+          ],
+        ]),
+        activeHostId: "host-active",
+      });
+
+      const [task] = buildFocusTasks(input, []);
+
+      expect(task.agents[0]?.hostId).toBeNull();
+      // This window is already talking to that epic's host (it resolved the
+      // agent's identity), so the active-host guess is honest here.
+      expect(task.stoppable).toBe(true);
+    });
+
+    it("is true when the agent's host equals activeHostId", () => {
+      const input = baseInput({
+        byEpic: new Map([["epic-1", makeEpicAgentActivity(["agent-1"], [])]]),
+        coldEpicHostIds: new Map([["epic-1", "host-active"]]),
+        activeHostId: "host-active",
+      });
+
+      const [task] = buildFocusTasks(input, []);
+
+      expect(task.agents[0]?.hostId).toBe("host-active");
+      expect(task.stoppable).toBe(true);
+    });
+
+    it("is true when the agent's host is in reachableHostIds (and is not the active host)", () => {
+      const input = baseInput({
+        byEpic: new Map([["epic-1", makeEpicAgentActivity(["agent-1"], [])]]),
+        coldEpicHostIds: new Map([["epic-1", "host-reachable"]]),
+        activeHostId: "host-active",
+        reachableHostIds: new Set(["host-reachable"]),
+      });
+
+      const [task] = buildFocusTasks(input, []);
+
+      expect(task.stoppable).toBe(true);
+    });
+
+    it("is false when the agent's host is neither the active host nor reachable", () => {
+      const input = baseInput({
+        byEpic: new Map([["epic-1", makeEpicAgentActivity(["agent-1"], [])]]),
+        coldEpicHostIds: new Map([["epic-1", "host-unreachable"]]),
+        activeHostId: "host-active",
+        reachableHostIds: new Set(["host-reachable"]),
+      });
+
+      const [task] = buildFocusTasks(input, []);
+
+      expect(task.stoppable).toBe(false);
+    });
+
+    it("is false for a MIXED task - one stoppable agent plus one unreachable agent - because it is an every, not a some", () => {
+      const input = baseInput({
+        byEpic: new Map([
+          [
+            "epic-1",
+            makeEpicAgentActivity(["agent-stoppable", "agent-stuck"], []),
+          ],
+        ]),
+        mountedEpicIds: new Set(["epic-1"]),
+        agentIdentities: new Map([
+          [
+            focusAgentKey("epic-1", "agent-stoppable"),
+            makeFocusAgentIdentity({ surface: "chat", hostId: "host-active" }),
+          ],
+          [
+            focusAgentKey("epic-1", "agent-stuck"),
+            makeFocusAgentIdentity({
+              surface: "chat",
+              hostId: "host-unreachable",
+            }),
+          ],
+        ]),
+        activeHostId: "host-active",
+        reachableHostIds: new Set(),
+      });
+
+      const [task] = buildFocusTasks(input, []);
+
+      expect(task.stoppable).toBe(false);
+    });
+  });
+
+  describe("identity stability", () => {
+    it("returns the same array reference when rebuilt from unchanged content", () => {
+      const input = baseInput({
+        byEpic: new Map([["epic-1", makeEpicAgentActivity(["agent-1"], [])]]),
+      });
+
+      const first = buildFocusTasks(input, []);
+      const second = buildFocusTasks(input, first);
+
+      expect(second).toBe(first);
+    });
+
+    it("leaves an unrelated task's row identical when only a sibling task changes", () => {
+      const unrelatedActivity = makeEpicAgentActivity(["agent-1"], []);
+      const before = baseInput({
+        byEpic: new Map([
+          ["epic-unrelated", unrelatedActivity],
+          ["epic-changing", makeEpicAgentActivity(["agent-1"], [])],
+        ]),
+      });
+      const firstResult = buildFocusTasks(before, []);
+      const unrelatedRowBefore = firstResult.find(
+        (task) => task.epicId === "epic-unrelated",
+      );
+      expect(unrelatedRowBefore).toBeDefined();
+
+      const after = baseInput({
+        byEpic: new Map([
+          ["epic-unrelated", unrelatedActivity],
+          [
+            "epic-changing",
+            makeEpicAgentActivity(["agent-1", "agent-2"], ["agent-2"]),
+          ],
+        ]),
+      });
+      const secondResult = buildFocusTasks(after, firstResult);
+      const unrelatedRowAfter = secondResult.find(
+        (task) => task.epicId === "epic-unrelated",
+      );
+
+      expect(unrelatedRowAfter).toBe(unrelatedRowBefore);
+    });
+  });
+});

--- a/clients/gui-app/src/lib/home-focus/build-focus-model.ts
+++ b/clients/gui-app/src/lib/home-focus/build-focus-model.ts
@@ -23,9 +23,9 @@ import {
 import { shallowEqualRow } from "@/lib/home-focus/focus-identity";
 
 /**
- * What `FocusModel` (`focus-model.ts`) means. The contract file is kept to the
- * interface block alone so the view lane's copy of it merges byte-identical,
- * so the reasoning behind those fields lives here.
+ * What `FocusModel` (`focus-model.ts`) means. That file is kept to the
+ * interface block alone so it reads as a contract at a glance, which is why the
+ * reasoning behind its fields lives here instead.
  *
  * The model is everything happening right now across every task on the host,
  * with the things that need the user first.
@@ -39,7 +39,9 @@ import { shallowEqualRow } from "@/lib/home-focus/focus-identity";
  * - `background` covers only tasks whose chats are warm in THIS window, because
  *   the only client-side source for a shell or a sub-agent is a live
  *   `chat.subscribe` session. `coverage.backgroundIsMountedOnly` is the literal
- *   `true` rather than a boolean so a renderer cannot forget to caption it.
+ *   `true` rather than a boolean, which puts that limit in the TYPE: a source
+ *   that ever covers unmounted tasks cannot be widened into this field without
+ *   failing to compile here, where the caption's premise is decided.
  *
  * What is missing is missing for a reason, not by omission: there are no agent
  * start timestamps on the activity plane (so no elapsed time), and a received

--- a/clients/gui-app/src/lib/home-focus/build-focus-model.ts
+++ b/clients/gui-app/src/lib/home-focus/build-focus-model.ts
@@ -1,0 +1,201 @@
+import type { StreamConnectionStatus } from "@traycer-clients/shared/host-transport/i-stream-session";
+import type { AgentActivityCloudSyncStatus } from "@traycer/protocol/host/agent/activity";
+import type { NotificationFeedMode } from "@/lib/notifications/notification-feed-mode";
+import type { MergedNotificationRow } from "@/stores/notifications/merged-notifications";
+import {
+  buildFocusBackground,
+  type FocusBackgroundChat,
+} from "@/lib/home-focus/focus-background";
+import type {
+  FocusBackgroundRow,
+  FocusModel,
+  FocusPromptRow,
+  FocusTaskRow,
+} from "@/lib/home-focus/focus-model";
+import {
+  buildFocusPrompts,
+  focusPromptEpicIds,
+} from "@/lib/home-focus/focus-prompts";
+import {
+  buildFocusTasks,
+  type FocusTasksInput,
+} from "@/lib/home-focus/focus-tasks";
+import { shallowEqualRow } from "@/lib/home-focus/focus-identity";
+
+/**
+ * What `FocusModel` (`focus-model.ts`) means. The contract file is kept to the
+ * interface block alone so the view lane's copy of it merges byte-identical,
+ * so the reasoning behind those fields lives here.
+ *
+ * The model is everything happening right now across every task on the host,
+ * with the things that need the user first.
+ *
+ * Read as three independent projections that happen to share a page, because
+ * their COVERAGE differs and the difference is user-visible:
+ *
+ * - `prompts` and `tasks` cover every task the host knows about, opened in this
+ *   window or not - the agent-activity stream is per-user and the notification
+ *   feed is per-host (per-account in cloud mode).
+ * - `background` covers only tasks whose chats are warm in THIS window, because
+ *   the only client-side source for a shell or a sub-agent is a live
+ *   `chat.subscribe` session. `coverage.backgroundIsMountedOnly` is the literal
+ *   `true` rather than a boolean so a renderer cannot forget to caption it.
+ *
+ * What is missing is missing for a reason, not by omission: there are no agent
+ * start timestamps on the activity plane (so no elapsed time), and a received
+ * A2A message awaiting a reply has neither a notification kind nor a live
+ * index, so it cannot be a prompt row here.
+ *
+ * Every field is derived; nothing in this module owns state. The builders in
+ * this directory are pure and deterministic, and reuse the previous model's
+ * rows whenever their content is unchanged, so a store frame that changes
+ * nothing re-renders nothing.
+ *
+ * {@link EMPTY_FOCUS_MODEL} below is that model's zero: the baseline a first
+ * build reconciles against. Its `activity: "unknown"` is deliberate - no claim
+ * has been made yet, and reading silence as an outage is the mistake the
+ * activity store's own attestation marker exists to prevent. Note that an idle
+ * app only keeps returning it BY IDENTITY while that stays true: the first
+ * `state` frame moves `coverage.activity` off `"unknown"`, which mints a new
+ * coverage object and therefore a new model, once.
+ */
+export const EMPTY_FOCUS_MODEL: FocusModel = Object.freeze({
+  prompts: Object.freeze<FocusPromptRow[]>([]),
+  tasks: Object.freeze<FocusTaskRow[]>([]),
+  background: Object.freeze<FocusBackgroundRow[]>([]),
+  coverage: Object.freeze({
+    activity: "unknown",
+    notifications: "local",
+    backgroundIsMountedOnly: true,
+  }),
+  badgeCount: 0,
+});
+
+export interface FocusActivityHealth {
+  readonly connectionStatus: StreamConnectionStatus;
+  readonly cloudSyncStatus: AgentActivityCloudSyncStatus | null;
+  readonly stateFrameSeenThisEpoch: boolean;
+  /** How many hosts this client can currently dial (`useConnectableHostIds`).
+   * More than one is what makes a host-local union incomplete rather than
+   * merely narrow. */
+  readonly connectableHostCount: number;
+  /** Whether that count is an ANSWER yet. A directory still loading reports
+   * zero hosts, which is indistinguishable from a single-host install by the
+   * count alone - and the two want opposite verdicts. */
+  readonly connectableHostsResolved: boolean;
+}
+
+export interface BuildFocusModelInput {
+  /** Every merged notification row, unfiltered. The prompt builder does its own
+   * lifecycle classification so its ordering is testable without a store. */
+  readonly notificationRows: ReadonlyArray<MergedNotificationRow>;
+  readonly tasks: Omit<FocusTasksInput, "promptEpicIds">;
+  readonly backgroundChats: ReadonlyArray<FocusBackgroundChat>;
+  readonly activity: FocusActivityHealth;
+  readonly feedMode: NotificationFeedMode;
+}
+
+/**
+ * The whole model in one pure pass, reusing `previous`'s rows wherever content
+ * is unchanged so an unrelated store frame produces no new references at all.
+ *
+ * Prompts are built first because the task rows read their epic ids: a task
+ * whose prompt row is loaded reads `needsYou` even when the host's indicator
+ * batch did not cover it.
+ */
+export function buildFocusModel(
+  input: BuildFocusModelInput,
+  previous: FocusModel,
+): FocusModel {
+  const prompts = buildFocusPrompts(
+    input.notificationRows,
+    input.tasks.taskTitles,
+    previous.prompts,
+  );
+  const tasks = buildFocusTasks(
+    { ...input.tasks, promptEpicIds: focusPromptEpicIds(prompts) },
+    previous.tasks,
+  );
+  const background = buildFocusBackground(
+    input.backgroundChats,
+    previous.background,
+  );
+  const coverage = {
+    activity: focusActivityCoverage(input.activity),
+    notifications: focusNotificationCoverage(input.feedMode),
+    backgroundIsMountedOnly: true,
+  } as const;
+  const next: FocusModel = {
+    prompts,
+    tasks,
+    background,
+    coverage: shallowEqualRow(coverage, previous.coverage)
+      ? previous.coverage
+      : coverage,
+    badgeCount: prompts.length,
+  };
+  return shallowEqualRow(next, previous) ? previous : next;
+}
+
+/**
+ * How far the "Running" section can be trusted right now, read off the activity
+ * store's own health fields rather than re-derived from `byEpic`.
+ *
+ * The store splits this question in two on purpose, and BOTH halves are load
+ * bearing here.
+ *
+ * The first is `agentActivityPlaneAnswers`: an open socket, this epoch's own
+ * `state` frame, and a cloud stamp that is not itself degraded. All three,
+ * because `servedBy` and `byEpic` survive a stream replacement AND an in-place
+ * reconnect, so an open socket alone can be showing the previous connection's
+ * union.
+ *
+ * The second is `agentActivityPlaneSpansFleet`, and it is the one this section
+ * actually turns on. The Running list claims to cover EVERY task on the
+ * account, so a union that reaches only the serving host is not a narrow-but-
+ * true answer here - it is a short list under a caption that says the list is
+ * complete. Only a `connected` cloud stamp proves the union reached other
+ * machines; `null` is NO CLAIM (a host with no cloud link, or one on the `@1.0`
+ * minor that predates the field), never proof of the negative.
+ *
+ * So a narrow union reads `"unknown"` - but only once the client knows there IS
+ * somewhere else to look. A single-host install has nothing beyond its own
+ * host, its narrow union is therefore complete, and it keeps reading `"live"`;
+ * downgrading it would make every install without a cloud link look blind,
+ * which is exactly what the store's own doc warns against.
+ *
+ * Until the directory has ANSWERED, the fleet's shape is not known either, and
+ * an unanswered directory reports zero hosts - which the count alone cannot
+ * tell apart from a single-host install. So the loading window also reads
+ * `"unknown"`: the honest value while the client cannot say whether anything
+ * is missing, and the one that cannot flash a false "complete" caption before
+ * settling.
+ */
+export function focusActivityCoverage(
+  health: FocusActivityHealth,
+): FocusModel["coverage"]["activity"] {
+  if (health.connectionStatus === "closed") return "disconnected";
+  if (health.connectionStatus !== "open") return "reconnecting";
+  if (!health.stateFrameSeenThisEpoch) return "unknown";
+  if (health.cloudSyncStatus === "reconnecting") return "reconnecting";
+  if (health.cloudSyncStatus === "disconnected") return "disconnected";
+  if (
+    health.cloudSyncStatus !== "connected" &&
+    (!health.connectableHostsResolved || health.connectableHostCount > 1)
+  ) {
+    return "unknown";
+  }
+  return "live";
+}
+
+/**
+ * `upgrade-required` is a mode the notification hook cannot currently return,
+ * but the type still names it. It maps to `"local"` rather than widening the
+ * contract: a host that cannot serve the cloud feed is answering from whatever
+ * it has locally, which is exactly what "local" tells the reader.
+ */
+function focusNotificationCoverage(
+  feedMode: NotificationFeedMode,
+): FocusModel["coverage"]["notifications"] {
+  return feedMode === "cloud" ? "cloud" : "local";
+}

--- a/clients/gui-app/src/lib/home-focus/focus-background.ts
+++ b/clients/gui-app/src/lib/home-focus/focus-background.ts
@@ -1,0 +1,181 @@
+import type { BackgroundItem } from "@traycer/protocol/host/agent/gui/subscribe";
+import type { ManagedCommand } from "@traycer/protocol/host/managed-command/unary-schemas";
+import {
+  compareAscending,
+  shallowEqualRow,
+  stabilizeRows,
+} from "@/lib/home-focus/focus-identity";
+import type { FocusBackgroundRow } from "@/lib/home-focus/focus-model";
+
+/**
+ * One warm chat session's contribution to the Background section. Assembled by
+ * the hook from the chat session registry, which is the ONLY client-side source
+ * for either list: both ride that chat's own `chat.subscribe` stream, so a chat
+ * this window has never opened contributes nothing and cannot be made to.
+ */
+export interface FocusBackgroundChat {
+  readonly epicId: string;
+  readonly chatId: string;
+  /** The host the session is bound to. `null` for a handle whose host the
+   * registry cannot name, which makes its managed commands unaddressable and
+   * therefore unstoppable. */
+  readonly hostId: string | null;
+  readonly taskTitle: string | null;
+  /** Running commands only - the caller filters, because "running" is a
+   * property of the live status rather than of the row. */
+  readonly managedCommands: ReadonlyArray<ManagedCommand>;
+  readonly backgroundItems: ReadonlyArray<BackgroundItem>;
+}
+
+const BACKGROUND_KIND_ORDER: Readonly<
+  Record<FocusBackgroundRow["kind"], number>
+> = {
+  "managed-command": 0,
+  "background-item": 1,
+};
+
+/**
+ * The "Background" section: durable shells and in-turn background work, for the
+ * tasks open in this window only.
+ *
+ * TWO PLANES, deliberately not merged. A managed command is a durable shell the
+ * host owns across turns and restarts; a background item is a node of the turn
+ * that is running right now. They can describe the same shell and they are
+ * still different objects with different lifetimes, so the section lists both
+ * and labels each - collapsing them would need an identity relation neither
+ * plane publishes.
+ *
+ * `startedAtMs` is populated for managed commands only, because only their
+ * `running` status carries one. Background items have no start timestamp on the
+ * wire, which is the same gap that keeps elapsed time off the agent rows.
+ *
+ * `stoppable`:
+ * - A managed command is stoppable whenever its host is known.
+ *   `managedCommand.stop` is a UNARY RPC pinned to the command's own host
+ *   (`useManagedCommandStop`), so the stop does not need the chat session that
+ *   revealed the command - only the id and the machine.
+ * - A background item is NOT stoppable from here. Its stop is a `chat.subscribe`
+ *   ACTION on a warm session (`ChatSessionState.stopBackgroundItem`), which is
+ *   a chat-scoped capability rather than a cross-task one; the row still opens
+ *   the chat, where the action lives. This is the same "no unary decision RPC"
+ *   shape that makes approvals click-through rather than inline.
+ *
+ * ORDERING groups a task's rows together and is total: epic, then chat, then
+ * plane, then key. Not "newest first" - a background list that re-sorts itself
+ * whenever a shell prints is harder to read than one that stays put, and
+ * neither plane reports a start time for every row anyway.
+ */
+export function buildFocusBackground(
+  chats: ReadonlyArray<FocusBackgroundChat>,
+  previous: ReadonlyArray<FocusBackgroundRow>,
+): ReadonlyArray<FocusBackgroundRow> {
+  const rows = chats.flatMap((chat) => [
+    ...chat.managedCommands.map((command): FocusBackgroundRow => ({
+      key: managedCommandRowKey(chat, command.id),
+      epicId: chat.epicId,
+      chatId: chat.chatId,
+      taskTitle: chat.taskTitle,
+      label: command.description,
+      kind: "managed-command",
+      startedAtMs:
+        command.status.state === "running" ? command.status.startedAtMs : null,
+      stoppable: chat.hostId !== null,
+    })),
+    ...chat.backgroundItems
+      .filter(isRunningBackgroundRoot)
+      .map((item): FocusBackgroundRow => ({
+        key: backgroundItemRowKey(chat, item.taskId),
+        epicId: chat.epicId,
+        chatId: chat.chatId,
+        taskTitle: chat.taskTitle,
+        label: item.title,
+        kind: "background-item",
+        startedAtMs: null,
+        stoppable: false,
+      })),
+  ]);
+  rows.sort(compareFocusBackground);
+  return stabilizeRows(rows, previous, shallowEqualRow);
+}
+
+/**
+ * Root items only, and never a `wakeup`.
+ *
+ * Roots because the nested items are that root's own tree - the chat's
+ * Background panel renders them as children, and Home has one line per piece of
+ * work, not one per node. A `wakeup` is excluded because it is a SCHEDULE, not
+ * something running: it is due at `scheduledFor` and nothing is happening in
+ * the meantime, so counting it here would overstate what is live.
+ */
+export function isRunningBackgroundRoot(item: BackgroundItem): boolean {
+  return item.parentTaskId === null && item.kind !== "wakeup";
+}
+
+/**
+ * A managed-command row's key is also its ADDRESS: `managedCommand.stop` needs
+ * the host, the epic and the command id, and `FocusBackgroundRow` carries none
+ * of the three separately - the contract the view codes against is one flat row
+ * with one opaque key. Composed and parsed in this one module, on a NUL
+ * separator no id can contain, so the two halves cannot drift; an empty host
+ * segment is the unaddressable case, which is exactly when `stoppable` is
+ * false.
+ */
+const MANAGED_COMMAND_KEY_PREFIX = "managed-command";
+const FOCUS_KEY_SEPARATOR = "\u0000";
+
+function managedCommandRowKey(
+  chat: FocusBackgroundChat,
+  commandId: string,
+): string {
+  return [
+    MANAGED_COMMAND_KEY_PREFIX,
+    chat.hostId ?? "",
+    chat.epicId,
+    commandId,
+  ].join(FOCUS_KEY_SEPARATOR);
+}
+
+export interface ManagedCommandRowTarget {
+  readonly hostId: string;
+  readonly epicId: string;
+  readonly commandId: string;
+}
+
+/** `null` for any key that is not an addressable managed command - a
+ * background-item row, or a command whose host was unknown when the row was
+ * built. */
+export function parseManagedCommandRowKey(
+  key: string,
+): ManagedCommandRowTarget | null {
+  const segments = key.split(FOCUS_KEY_SEPARATOR);
+  if (segments.length !== 4) return null;
+  const [prefix, hostId, epicId, commandId] = segments;
+  if (prefix !== MANAGED_COMMAND_KEY_PREFIX) return null;
+  if (hostId.length === 0 || epicId.length === 0 || commandId.length === 0) {
+    return null;
+  }
+  return { hostId, epicId, commandId };
+}
+
+function backgroundItemRowKey(
+  chat: FocusBackgroundChat,
+  taskId: string,
+): string {
+  return ["background-item", chat.epicId, chat.chatId, taskId].join(
+    FOCUS_KEY_SEPARATOR,
+  );
+}
+
+function compareFocusBackground(
+  a: FocusBackgroundRow,
+  b: FocusBackgroundRow,
+): number {
+  const epicDelta = compareAscending(a.epicId, b.epicId);
+  if (epicDelta !== 0) return epicDelta;
+  const chatDelta = compareAscending(a.chatId, b.chatId);
+  if (chatDelta !== 0) return chatDelta;
+  const kindDelta =
+    BACKGROUND_KIND_ORDER[a.kind] - BACKGROUND_KIND_ORDER[b.kind];
+  if (kindDelta !== 0) return kindDelta;
+  return compareAscending(a.key, b.key);
+}

--- a/clients/gui-app/src/lib/home-focus/focus-identity.ts
+++ b/clients/gui-app/src/lib/home-focus/focus-identity.ts
@@ -1,0 +1,69 @@
+/**
+ * Identity preservation for the focus builders, the same contract
+ * `reconcileAgentActivityByEpic` keeps for the activity store: a rebuild whose
+ * CONTENT matches the previous rebuild returns the previous objects, so a store
+ * frame that changes nothing produces no new references and nothing re-renders.
+ *
+ * Kept generic and structural rather than per-row, because every focus row is a
+ * flat readonly record over primitives plus at most one nested array - which is
+ * exactly what a shallow comparison decides correctly, and exactly what a
+ * hand-written per-row comparator would get wrong the first time a field is
+ * added.
+ */
+
+/**
+ * `next`, with every element that shallow-equals its positional counterpart in
+ * `previous` replaced by that counterpart - and the `previous` array itself
+ * when every element matched.
+ *
+ * Positional rather than keyed on purpose: these arrays are ordered by a
+ * deterministic comparator, so an unchanged list is unchanged in place, and a
+ * list whose ORDER moved is a genuinely different rendering.
+ */
+export function stabilizeRows<T extends object>(
+  next: ReadonlyArray<T>,
+  previous: ReadonlyArray<T>,
+  equal: (a: T, b: T) => boolean,
+): ReadonlyArray<T> {
+  let changed = next.length !== previous.length;
+  const rows = next.map((row, index) => {
+    // Bounds-checked by index rather than by an `undefined` test: index access
+    // is typed as present here, so only the length can say whether it is.
+    if (index < previous.length && equal(row, previous[index])) {
+      return previous[index];
+    }
+    changed = true;
+    return row;
+  });
+  return changed ? rows : previous;
+}
+
+/**
+ * Shallow record equality, with arrays and nested objects compared by
+ * reference. Row builders run their nested arrays through
+ * {@link stabilizeRows} first, so a reference match there is a content match
+ * here - which is what lets a parent row keep its identity when only a sibling
+ * task's agents moved.
+ */
+export function shallowEqualRow<T extends object>(a: T, b: T): boolean {
+  if (a === b) return true;
+  const left = Object.entries(a);
+  const right = new Map(Object.entries(b));
+  if (left.length !== right.size) return false;
+  for (const [key, value] of left) {
+    if (!right.has(key)) return false;
+    if (right.get(key) !== value) return false;
+  }
+  return true;
+}
+
+/**
+ * Byte-order ascending, never locale-sensitive, so ordering cannot drift by ICU
+ * version or system locale - the same rule the notification feed's
+ * `compareFeedIdAscending` keeps.
+ */
+export function compareAscending(a: string, b: string): number {
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+}

--- a/clients/gui-app/src/lib/home-focus/focus-model.ts
+++ b/clients/gui-app/src/lib/home-focus/focus-model.ts
@@ -1,0 +1,52 @@
+import type { MergedNotificationRow } from "@/stores/notifications/merged-notifications";
+
+export type FocusPromptKind = "approval" | "interview" | "browser";
+export interface FocusPromptRow {
+  readonly key: string; // notification feedId
+  readonly kind: FocusPromptKind;
+  readonly epicId: string | null;
+  readonly chatId: string | null;
+  readonly taskTitle: string | null; // from history query or mounted epic; null if unknown
+  readonly title: string; // notification title
+  readonly body: string;
+  readonly createdAt: number;
+  readonly originHostId: string | null;
+  readonly activation: MergedNotificationRow; // handed to useNotificationActivation
+}
+export interface FocusAgentRow {
+  readonly agentId: string;
+  readonly title: string | null; // null when the epic is not mounted here
+  readonly surface: "chat" | "terminal-agent" | null;
+  readonly tier: "turn" | "background";
+  readonly parentId: string | null; // null when unknown
+  readonly hostId: string | null; // the agent's host when known
+}
+export interface FocusTaskRow {
+  readonly epicId: string;
+  readonly taskTitle: string | null;
+  readonly mountedHere: boolean; // agent names + background available
+  readonly agents: ReadonlyArray<FocusAgentRow>; // running only, turn first
+  readonly needsYou: boolean; // indicator flags or a prompt row for this epic
+  readonly stoppable: boolean; // every running agent's host is active or reachable
+}
+export interface FocusBackgroundRow {
+  readonly key: string;
+  readonly epicId: string;
+  readonly chatId: string;
+  readonly taskTitle: string | null;
+  readonly label: string; // managed command description or background item title
+  readonly kind: "managed-command" | "background-item";
+  readonly startedAtMs: number | null; // managed commands only
+  readonly stoppable: boolean;
+}
+export interface FocusModel {
+  readonly prompts: ReadonlyArray<FocusPromptRow>; // attention order (blocking first, newest first)
+  readonly tasks: ReadonlyArray<FocusTaskRow>; // tasks with ≥1 running agent; needsYou first, then most agents in turn
+  readonly background: ReadonlyArray<FocusBackgroundRow>;
+  readonly coverage: {
+    readonly activity: "live" | "reconnecting" | "disconnected" | "unknown";
+    readonly notifications: "local" | "cloud";
+    readonly backgroundIsMountedOnly: true;
+  };
+  readonly badgeCount: number; // prompts.length
+}

--- a/clients/gui-app/src/lib/home-focus/focus-prompts.ts
+++ b/clients/gui-app/src/lib/home-focus/focus-prompts.ts
@@ -1,0 +1,218 @@
+import { HOST_NOTIFICATION_PENDING_PROMPT_KINDS } from "@traycer/protocol/host/notifications/host-notifications";
+import {
+  classifyNotificationLifecycle,
+  compareAttentionOrder,
+  type NotificationAttentionTier,
+} from "@/lib/notifications/notification-lifecycle";
+import type { MergedNotificationRow } from "@/stores/notifications/merged-notifications";
+import {
+  shallowEqualRow,
+  stabilizeRows,
+} from "@/lib/home-focus/focus-identity";
+import type {
+  FocusPromptKind,
+  FocusPromptRow,
+} from "@/lib/home-focus/focus-model";
+
+/**
+ * The three things a task can be waiting on a human for, and the only three the
+ * client can currently see across tasks. Mirrors
+ * `HOST_NOTIFICATION_PENDING_PROMPT_KINDS`, which is the list the pending-prompt
+ * glyph and the host's own indicator SQL both read - so a kind added there and
+ * not here degrades to "no Home row", never to a mis-labelled one.
+ */
+const PROMPT_KIND_BY_HOST_KIND: Readonly<Record<string, FocusPromptKind>> = {
+  "approval.requested": "approval",
+  "interview.requested": "interview",
+  "browser.human.needed": "browser",
+};
+
+/**
+ * The "Needs you" section: unresolved, unread prompts across every task on the
+ * notification feed, in the bell's own attention order.
+ *
+ * THREE conditions, and all three are load-bearing (the badge
+ * counts exactly these rows):
+ *
+ * 1. The row's kind is a pending-prompt kind. A failure row is attention too,
+ *    but it is history, not a question.
+ * 2. `resolvedAt === null`. A prompt answered from the chat stays in the feed
+ *    with its answer recorded; it is not waiting on anyone.
+ * 3. The lifecycle classifier puts it in `attention`, which for a
+ *    `needs_action` row means UNREAD. A prompt whose row the user has already
+ *    acknowledged is not what Home is for.
+ *
+ * Ordering is `compareAttentionOrder` - blocking tier first, newest first
+ * within a tier, `feedId` ascending as the deterministic tie-break. The
+ * provider-pack local-first re-order the bell applies is deliberately not
+ * repeated: it discriminates pack-store events, which are never a prompt kind,
+ * so applying it here could only be a no-op with a second ordering rule to keep
+ * in step.
+ *
+ * `taskTitle` is resolved by the caller and looked up per row rather than
+ * carried on the notification, because a cloud row's own title is the epic's
+ * title AT THE TIME THE ROW WAS WRITTEN.
+ */
+export function buildFocusPrompts(
+  rows: ReadonlyArray<MergedNotificationRow>,
+  taskTitles: ReadonlyMap<string, string>,
+  previous: ReadonlyArray<FocusPromptRow>,
+): ReadonlyArray<FocusPromptRow> {
+  const candidates = selectPromptCandidates(rows);
+  candidates.sort((a, b) =>
+    compareAttentionOrder(
+      { tier: a.tier, createdAt: a.row.createdAt, feedId: a.row.feedId },
+      { tier: b.tier, createdAt: b.row.createdAt, feedId: b.row.feedId },
+    ),
+  );
+  const next = candidates.map(({ row, kind }): FocusPromptRow => {
+    const target = promptTarget(row);
+    return {
+      key: row.feedId,
+      kind,
+      epicId: target.epicId,
+      chatId: target.chatId,
+      taskTitle:
+        target.epicId === null ? null : (taskTitles.get(target.epicId) ?? null),
+      title: row.title,
+      body: row.body,
+      createdAt: row.createdAt,
+      originHostId: row.originHostId,
+      activation: row,
+    };
+  });
+  return stabilizeRows(next, previous, sameFocusPromptRow);
+}
+
+/**
+ * Row equality for {@link buildFocusPrompts}, and the ONE place a focus row is
+ * not compared with the generic shallow comparator.
+ *
+ * `activation` holds a whole `MergedNotificationRow`, and that store re-mints
+ * every row object on any notification frame - a row marked read elsewhere, an
+ * unrelated agent finishing. Comparing it by reference would therefore give
+ * every prompt a new identity several times a minute, in the one section that
+ * is non-empty precisely when the badge is non-zero.
+ *
+ * Comparing by `feedId` instead is safe for the one thing `activation` is used
+ * for. The activation handler wants the occurrence AS IT WAS WHEN SHOWN
+ * (`notification-activation-result.ts` keeps the captured row for exactly that
+ * reason), and an equal-content earlier object with the same feed id IS that.
+ * Every field this row derives FROM the notification - title, body,
+ * `createdAt`, `originHostId` - is compared normally, so content drift under a
+ * stable feed id still mints a new row.
+ *
+ * Exhaustive BY CONSTRUCTION rather than by a maintained field list: pulling
+ * `activation` off with a rest destructure means a field added to
+ * `FocusPromptRow` lands in `scalarsA`/`scalarsB` and is compared without
+ * anyone remembering to come here. That is the property a hand-written `&&`
+ * chain silently loses the first time the contract grows.
+ */
+function sameFocusPromptRow(a: FocusPromptRow, b: FocusPromptRow): boolean {
+  const { activation: activationA, ...scalarsA } = a;
+  const { activation: activationB, ...scalarsB } = b;
+  return (
+    activationA.feedId === activationB.feedId &&
+    shallowEqualRow(scalarsA, scalarsB)
+  );
+}
+
+/**
+ * The badge's number, without building a model.
+ *
+ * `badgeCount === prompts.length` by construction - {@link buildFocusPrompts}
+ * maps its candidates one-to-one with no post-filter - so counting the
+ * candidates through the SAME selector is provably the same number rather than
+ * a second derivation that could drift. That is what lets the Home tab's badge,
+ * which is mounted for the life of the window, avoid running the whole
+ * cross-task join while Home is closed.
+ */
+export function countPendingPromptRows(
+  rows: ReadonlyArray<MergedNotificationRow>,
+): number {
+  return selectPromptCandidates(rows).length;
+}
+
+/** Epic ids a prompt row points at - the set the task rows read to decide
+ * `needsYou` without re-walking the feed. */
+export function focusPromptEpicIds(
+  prompts: ReadonlyArray<FocusPromptRow>,
+): ReadonlySet<string> {
+  const epicIds = new Set<string>();
+  for (const prompt of prompts) {
+    if (prompt.epicId !== null) epicIds.add(prompt.epicId);
+  }
+  return epicIds;
+}
+
+/**
+ * The same epic ids, straight from the raw feed - what the hook needs BEFORE it
+ * can build a prompt row, because a task whose only presence on this page is a
+ * waiting prompt still needs its title fetched.
+ */
+export function pendingPromptEpicIds(
+  rows: ReadonlyArray<MergedNotificationRow>,
+): ReadonlySet<string> {
+  const epicIds = new Set<string>();
+  for (const candidate of selectPromptCandidates(rows)) {
+    const epicId = promptTarget(candidate.row).epicId;
+    if (epicId !== null) epicIds.add(epicId);
+  }
+  return epicIds;
+}
+
+interface PromptCandidate {
+  readonly row: MergedNotificationRow;
+  readonly kind: FocusPromptKind;
+  readonly tier: NotificationAttentionTier;
+}
+
+function selectPromptCandidates(
+  rows: ReadonlyArray<MergedNotificationRow>,
+): PromptCandidate[] {
+  return rows.flatMap((row): PromptCandidate[] => {
+    const kind = focusPromptKind(row);
+    if (kind === null) return [];
+    if (row.resolvedAt !== null) return [];
+    const classification = classifyNotificationLifecycle(row);
+    if (classification.section !== "attention") return [];
+    return [{ row, kind, tier: classification.tier }];
+  });
+}
+
+function focusPromptKind(row: MergedNotificationRow): FocusPromptKind | null {
+  const hostKind = row.hostKind;
+  if (hostKind === null) return null;
+  if (!HOST_NOTIFICATION_PENDING_PROMPT_KINDS.includes(hostKind)) return null;
+  return PROMPT_KIND_BY_HOST_KIND[hostKind] ?? null;
+}
+
+/**
+ * Where the prompt lives, read from the NAVIGATION payload rather than the
+ * row's raw fields: the payload is the second-stage semantic parse, so a row
+ * from a newer host whose payload this build cannot understand answers `null`
+ * here and renders without a task attribution instead of guessing one.
+ *
+ * A browser prompt names a session rather than a chat, so its `chatId` is
+ * `null` - the row still opens (the activation payload carries the session and
+ * tab), it just has no chat to attribute.
+ */
+function promptTarget(row: MergedNotificationRow): {
+  readonly epicId: string | null;
+  readonly chatId: string | null;
+} {
+  const payload = row.payload;
+  if (payload === null) return { epicId: null, chatId: null };
+  if (payload.kind === "approval") {
+    // An approval payload's ids are optional on the wire; absent stays absent
+    // rather than becoming an empty-string id nothing can open.
+    return { epicId: payload.epicId ?? null, chatId: payload.chatId ?? null };
+  }
+  if (payload.kind === "interview") {
+    return { epicId: payload.epicId, chatId: payload.chatId };
+  }
+  if (payload.kind === "browserSession") {
+    return { epicId: payload.epicId, chatId: null };
+  }
+  return { epicId: null, chatId: null };
+}

--- a/clients/gui-app/src/lib/home-focus/focus-tasks.ts
+++ b/clients/gui-app/src/lib/home-focus/focus-tasks.ts
@@ -1,0 +1,244 @@
+import type { HostNotificationsIndicatorStateResponse } from "@traycer/protocol/host/notifications/contracts";
+import {
+  agentActivityTiers,
+  type EpicAgentActivity,
+} from "@/lib/agent-activity";
+import {
+  compareAscending,
+  shallowEqualRow,
+  stabilizeRows,
+} from "@/lib/home-focus/focus-identity";
+import type { FocusAgentRow, FocusTaskRow } from "@/lib/home-focus/focus-model";
+
+/**
+ * What this window's live projection knows about one working agent. `null`
+ * everywhere for an agent in a task no tile in this window has open - the
+ * activity stream carries ids and tiers for every task on the host, and names
+ * for none of them.
+ */
+export interface FocusAgentIdentity {
+  readonly title: string | null;
+  readonly surface: "chat" | "terminal-agent";
+  readonly parentId: string | null;
+  /** The projection's recorded host. `null` for a legacy chat that predates
+   * the field. */
+  readonly hostId: string | null;
+}
+
+export interface FocusTasksInput {
+  /** The activity store's per-user union: every task on the host, opened here
+   * or not. */
+  readonly byEpic: ReadonlyMap<string, EpicAgentActivity>;
+  /** Epic id → best-available task title. Absent means "no title known", which
+   * is not the same as an untitled task. */
+  readonly taskTitles: ReadonlyMap<string, string>;
+  /** Epics with a live projection in this window. */
+  readonly mountedEpicIds: ReadonlySet<string>;
+  /** `${epicId}\0${agentId}` → identity, for mounted epics only. */
+  readonly agentIdentities: ReadonlyMap<string, FocusAgentIdentity>;
+  /** The host's per-epic indicator flags, as returned by
+   * `host.notifications.indicatorState`. Epics the batch did not cover are
+   * simply absent. */
+  readonly indicatorEpics: HostNotificationsIndicatorStateResponse["epics"];
+  /** Epics with at least one unresolved prompt row. */
+  readonly promptEpicIds: ReadonlySet<string>;
+  /**
+   * Epic id → the single host that owns this task's chats, for COLD epics.
+   *
+   * Populated only when the cloud index names EXACTLY ONE host: with two or
+   * more there is no way to say which of them a given agent id belongs to, and
+   * guessing would send a stop to the wrong machine. Absent is `null`, which is
+   * how an unmounted agent's `hostId` honestly reads.
+   */
+  readonly coldEpicHostIds: ReadonlyMap<string, string>;
+  /** The host this window addresses, which is where a `null`-host agent's stop
+   * would be sent. */
+  readonly activeHostId: string | null;
+  /** Hosts this client can dial right now (`useConnectableHostIds`). */
+  readonly reachableHostIds: ReadonlySet<string>;
+}
+
+const AGENT_TIER_ORDER: Readonly<Record<"turn" | "background", number>> = {
+  turn: 0,
+  background: 1,
+};
+
+/**
+ * The "Running" section: one row per task with at least one working agent.
+ *
+ * A task with no working agent is not here at all - Home is about what is
+ * happening now, and "Finished recently" was kept out of the first version. That also
+ * means the list is driven entirely by the activity union, so a task whose
+ * prompt is waiting but whose agents have all stopped appears in "Needs you"
+ * and nowhere else, which is the correct reading of both sections.
+ *
+ * ORDERING - tasks needing the user first, then the task with the most agents
+ * mid-turn, then the most agents overall, then epic id ascending. The last term
+ * is not cosmetic: without a total order the list re-shuffles between two
+ * equally-ranked tasks on every unrelated frame.
+ *
+ * `mountedHere` is the honest caption for a row's own gaps rather than a filter:
+ * an unmounted task's agents are rendered by id, and its background work is not
+ * rendered at all.
+ */
+export function buildFocusTasks(
+  input: FocusTasksInput,
+  previous: ReadonlyArray<FocusTaskRow>,
+): ReadonlyArray<FocusTaskRow> {
+  const previousAgentsByEpicId = new Map(
+    previous.map((task) => [task.epicId, task.agents]),
+  );
+  const rows = Array.from(input.byEpic.entries()).flatMap(
+    ([epicId, activity]): FocusTaskRow[] => {
+      if (activity.working.size === 0) return [];
+      const agents = buildFocusAgents(
+        epicId,
+        activity,
+        input,
+        previousAgentsByEpicId.get(epicId) ?? [],
+      );
+      return [
+        {
+          epicId,
+          taskTitle: input.taskTitles.get(epicId) ?? null,
+          mountedHere: input.mountedEpicIds.has(epicId),
+          agents,
+          needsYou: taskNeedsYou(epicId, input),
+          stoppable: agents.every((agent) =>
+            agentIsStoppable(agent, epicId, input),
+          ),
+        },
+      ];
+    },
+  );
+  rows.sort(compareFocusTasks);
+  return stabilizeRows(rows, previous, shallowEqualRow);
+}
+
+/**
+ * A task needs the user when the host's own indicator flags say a prompt is
+ * pending on it, OR when a prompt row in this client's feed points at it.
+ *
+ * Both, because neither alone covers the page. The indicator RPC answers about
+ * ONE host's SQLite and only for the epics the batch covered; the feed answers
+ * for whatever the client has actually loaded. A task outside the indicator
+ * batch with a loaded prompt row still reads correctly, and so does a task
+ * whose prompt row has not been paged in.
+ */
+function taskNeedsYou(epicId: string, input: FocusTasksInput): boolean {
+  if (input.promptEpicIds.has(epicId)) return true;
+  if (!Object.hasOwn(input.indicatorEpics, epicId)) return false;
+  const flags = input.indicatorEpics[epicId];
+  return flags.pendingApproval || flags.pendingInterview;
+}
+
+/**
+ * Running agents for one task, turn tier first.
+ *
+ * Within a tier the order is title-then-id, both byte-ascending, so a task's
+ * agent list is stable frame to frame and identical between two windows. An
+ * agent with no known name sorts after every named one rather than under an
+ * empty string, because "the epic is not mounted here" is a property of this
+ * window, not of the agent.
+ */
+function buildFocusAgents(
+  epicId: string,
+  activity: EpicAgentActivity,
+  input: FocusTasksInput,
+  previous: ReadonlyArray<FocusAgentRow>,
+): ReadonlyArray<FocusAgentRow> {
+  const tiers = agentActivityTiers(activity);
+  const coldHostId = input.coldEpicHostIds.get(epicId) ?? null;
+  const rows = Array.from(tiers.entries()).map(
+    ([agentId, tier]): FocusAgentRow => {
+      const identity = input.agentIdentities.get(
+        focusAgentKey(epicId, agentId),
+      );
+      return {
+        agentId,
+        title: identity?.title ?? null,
+        surface: identity?.surface ?? null,
+        tier,
+        parentId: identity?.parentId ?? null,
+        // A resolved identity is the authority even when its own host is
+        // `null` (a legacy chat that predates the field): the projection has
+        // SEEN this agent, so falling through to the task-level guess would
+        // overwrite a known absence with an inference.
+        hostId: identity === undefined ? coldHostId : identity.hostId,
+      };
+    },
+  );
+  rows.sort(compareFocusAgents);
+  return stabilizeRows(rows, previous, shallowEqualRow);
+}
+
+/**
+ * Whether a stop aimed at this agent would reach the machine it is running on.
+ *
+ * A NAMED host has to be one this client can currently dial - a task on a
+ * machine that is asleep or unreachable is honestly not stoppable from here,
+ * and the row says so instead of failing after the click.
+ *
+ * A `null` host splits in two, and the split is the whole point. `null` means
+ * the stop goes to the ACTIVE host, so it is only honest when the active host
+ * is in fact where the agent lives:
+ *
+ * - The projection RESOLVED this agent and recorded no host - a legacy chat
+ *   predating the field. This window is already talking to that epic's host, so
+ *   the active host is right and the row stays actionable rather than being
+ *   greyed out on a technicality.
+ * - Nothing resolved it: the epic is cold and {@link FocusTasksInput.coldEpicHostIds}
+ *   declined to name a host, because the cloud index listed two of them (or
+ *   none). That refusal is deliberate - nothing in `chatHostIds` says WHICH
+ *   host a given agent id belongs to - and it must not be undone here by
+ *   quietly aiming at the active host instead. A Stop that promises to reach a
+ *   machine the model could not name is worse than a disabled one: `agent.stop`
+ *   resolves the subtree from shared cloud storage, so the wrong host finds the
+ *   agent and then tears down through ITS OWN session managers, reporting an
+ *   empty `stoppedAgentIds` while the real agent keeps running.
+ */
+function agentIsStoppable(
+  agent: FocusAgentRow,
+  epicId: string,
+  input: FocusTasksInput,
+): boolean {
+  if (agent.hostId !== null) {
+    return (
+      agent.hostId === input.activeHostId ||
+      input.reachableHostIds.has(agent.hostId)
+    );
+  }
+  return input.agentIdentities.has(focusAgentKey(epicId, agent.agentId));
+}
+
+/** The `agentIdentities` key. An epic id and an agent id are both opaque
+ * strings, so they are joined on a NUL - the same separator `workspaceKey`
+ * uses, and the one byte neither id can carry. Written as an escape so the
+ * source stays plain ASCII. */
+export function focusAgentKey(epicId: string, agentId: string): string {
+  return `${epicId}\u0000${agentId}`;
+}
+
+function compareFocusTasks(a: FocusTaskRow, b: FocusTaskRow): number {
+  if (a.needsYou !== b.needsYou) return a.needsYou ? -1 : 1;
+  const turnDelta = countTurnAgents(b) - countTurnAgents(a);
+  if (turnDelta !== 0) return turnDelta;
+  const agentDelta = b.agents.length - a.agents.length;
+  if (agentDelta !== 0) return agentDelta;
+  return compareAscending(a.epicId, b.epicId);
+}
+
+function countTurnAgents(task: FocusTaskRow): number {
+  return task.agents.filter((agent) => agent.tier === "turn").length;
+}
+
+function compareFocusAgents(a: FocusAgentRow, b: FocusAgentRow): number {
+  const tierDelta = AGENT_TIER_ORDER[a.tier] - AGENT_TIER_ORDER[b.tier];
+  if (tierDelta !== 0) return tierDelta;
+  const aUnnamed = a.title === null;
+  const bUnnamed = b.title === null;
+  if (aUnnamed !== bUnnamed) return aUnnamed ? 1 : -1;
+  const titleDelta = compareAscending(a.title ?? "", b.title ?? "");
+  if (titleDelta !== 0) return titleDelta;
+  return compareAscending(a.agentId, b.agentId);
+}

--- a/clients/gui-app/src/lib/keybindings/__tests__/home-action.test.ts
+++ b/clients/gui-app/src/lib/keybindings/__tests__/home-action.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Locks down the `app.home.open` keybinding action end to end:
+ *
+ *  - its `ACTION_META` registration (label, category, default chord) and
+ *    that the chord doesn't collide with any other action's default chord -
+ *    a silent collision would mean one of the two chords never fires;
+ *  - `dispatchAction` gates on the `homeTabEnabled` settings flag exactly as
+ *    documented in `dispatch.ts` - returning `false` and touching nothing
+ *    while the flag is off, so the provider leaves the chord unhandled
+ *    instead of swallowing a keypress for a surface this build hasn't got;
+ *  - `closeActiveEpic` (the handler behind `epic.close`) falls back to
+ *    `router.navigateHome()` when closing the only open Epic tab leaves no
+ *    next tab to focus - the one place `app.home.open`'s target is reached
+ *    from a path other than the chord itself.
+ *
+ * Router-stub and canvas-store fixture patterns follow
+ * `dispatch-focus-editor.test.ts` and `blank-tab.test.ts` in this directory.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  dispatchAction,
+  type KeybindingRouter,
+} from "@/lib/keybindings/dispatch";
+import {
+  ACTION_IDS,
+  ACTION_META,
+  getDefaultBindings,
+  resolveActionDefaultChord,
+} from "@/lib/keybindings/actions";
+import { findConflict } from "@/lib/keybindings/conflicts";
+import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import {
+  resetTabsStoreForTest,
+  seedActiveEpicTabInTabsStore,
+} from "@/stores/tabs/test-support/tabs-store-fixtures";
+import { useSettingsStore } from "@/stores/settings/settings-store";
+
+const SEED_EPIC_ID = "epic-home-action";
+
+/** Mirrors the router stubs in `dispatch-focus-editor.test.ts` / `blank-tab.test.ts`. */
+function routerForTab(
+  tabId: string,
+  homeCalls: { count: number },
+): KeybindingRouter {
+  return {
+    getPathname: () => `/epics/${SEED_EPIC_ID}/${tabId}`,
+    navigateHome: () => {
+      homeCalls.count += 1;
+    },
+    navigateSettings: () => undefined,
+    navigateToEpic: () => undefined,
+    navigateToEpicTab: () => undefined,
+    navigateToEpicList: () => undefined,
+    navigateSettingsSection: () => undefined,
+    navigateToTabIntent: () => undefined,
+    goBack: () => undefined,
+    goForward: () => undefined,
+    isHistoryNavAvailable: () => false,
+    canGoBack: () => false,
+    canGoForward: () => false,
+  };
+}
+
+/** A router with no epic-tab context, for the flag-gated dispatch tests. */
+function plainRouter(homeCalls: { count: number }): KeybindingRouter {
+  return {
+    getPathname: () => "/",
+    navigateHome: () => {
+      homeCalls.count += 1;
+    },
+    navigateSettings: () => undefined,
+    navigateToEpic: () => undefined,
+    navigateToEpicTab: () => undefined,
+    navigateToEpicList: () => undefined,
+    navigateSettingsSection: () => undefined,
+    navigateToTabIntent: () => undefined,
+    goBack: () => undefined,
+    goForward: () => undefined,
+    isHistoryNavAvailable: () => false,
+    canGoBack: () => false,
+    canGoForward: () => false,
+  };
+}
+
+beforeEach(() => {
+  useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
+  resetTabsStoreForTest();
+  useSettingsStore.setState({ homeTabEnabled: false });
+});
+
+afterEach(() => {
+  useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
+  resetTabsStoreForTest();
+  useSettingsStore.setState({ homeTabEnabled: false });
+});
+
+describe("ACTION_META['app.home.open']", () => {
+  it("registers a chord action labeled 'Go to Home' in the app category with the mod+shift+h default", () => {
+    const meta = ACTION_META["app.home.open"];
+    expect(meta.kind).toBe("chord");
+    expect(meta.label).toBe("Go to Home");
+    expect(meta.category).toBe("app");
+    expect(resolveActionDefaultChord(meta)).toBe("mod+shift+h");
+  });
+
+  it("doesn't collide with any other action's default chord", () => {
+    const bindings = getDefaultBindings();
+    const candidate = bindings["app.home.open"];
+    expect(candidate).not.toBeNull();
+    if (candidate === null) return;
+    const result = findConflict(bindings, "app.home.open", candidate, []);
+    expect(result).toBeNull();
+  });
+
+  it("no other action's default chord collides with app.home.open's default, checked from every direction", () => {
+    // Belt-and-braces over the single check above: walk every OTHER
+    // chord-kind action's own default and confirm none of them resolve to
+    // app.home.open's chord either - `findConflict` is symmetric in
+    // practice, but this doesn't rely on that.
+    const bindings = getDefaultBindings();
+    const homeChord = bindings["app.home.open"];
+    for (const id of ACTION_IDS) {
+      if (id === "app.home.open") continue;
+      const meta = ACTION_META[id];
+      if (meta.kind !== "chord") continue;
+      const chord = bindings[id];
+      if (chord === null) continue;
+      expect(chord).not.toBe(homeChord);
+    }
+  });
+});
+
+describe("dispatchAction('app.home.open', router)", () => {
+  it("calls navigateHome and returns true when homeTabEnabled is on", () => {
+    useSettingsStore.setState({ homeTabEnabled: true });
+    const homeCalls = { count: 0 };
+    const result = dispatchAction("app.home.open", plainRouter(homeCalls));
+    expect(result).toBe(true);
+    expect(homeCalls.count).toBe(1);
+  });
+
+  it("returns false and calls nothing when homeTabEnabled is off", () => {
+    useSettingsStore.setState({ homeTabEnabled: false });
+    const homeCalls = { count: 0 };
+    const result = dispatchAction("app.home.open", plainRouter(homeCalls));
+    expect(result).toBe(false);
+    expect(homeCalls.count).toBe(0);
+  });
+});
+
+describe("closeActiveEpic (epic.close) falling back to Home", () => {
+  it("returns false when no epic tab is open", () => {
+    const homeCalls = { count: 0 };
+    const result = dispatchAction("epic.close", plainRouter(homeCalls));
+    expect(result).toBe(false);
+    expect(homeCalls.count).toBe(0);
+  });
+
+  it("calls navigateHome when closing the only open epic tab leaves no next tab to focus", () => {
+    const store = useEpicCanvasStore.getState();
+    const tabId = store.openEpicTab(SEED_EPIC_ID, "Epic");
+    seedActiveEpicTabInTabsStore(tabId);
+
+    const homeCalls = { count: 0 };
+    const result = dispatchAction("epic.close", routerForTab(tabId, homeCalls));
+
+    expect(result).toBe(true);
+    expect(useEpicCanvasStore.getState().activeTabId).toBeNull();
+    expect(homeCalls.count).toBe(1);
+  });
+
+  it("navigates to the next epic tab instead of Home when one remains", () => {
+    const store = useEpicCanvasStore.getState();
+    const firstTabId = store.openEpicTab(SEED_EPIC_ID, "Epic One");
+    store.openEpicTab(SEED_EPIC_ID, "Epic Two");
+    seedActiveEpicTabInTabsStore(firstTabId);
+
+    const homeCalls = { count: 0 };
+    let navigatedTabId: string | null = null;
+    const router: KeybindingRouter = {
+      ...routerForTab(firstTabId, homeCalls),
+      navigateToEpicTab: (tab) => {
+        navigatedTabId = tab.tabId;
+      },
+    };
+
+    const result = dispatchAction("epic.close", router);
+
+    expect(result).toBe(true);
+    expect(homeCalls.count).toBe(0);
+    expect(navigatedTabId).not.toBeNull();
+  });
+});

--- a/clients/gui-app/src/lib/keybindings/actions.ts
+++ b/clients/gui-app/src/lib/keybindings/actions.ts
@@ -52,6 +52,7 @@ export const ACTION_IDS = [
   "app.rate-limits.open",
   "app.notifications.open",
   "app.history.open",
+  "app.home.open",
   "app.settings.open",
   "app.settings.section.byDigit",
   "app.palette.open",
@@ -539,6 +540,20 @@ export const ACTION_META: Readonly<Record<ActionId, ActionMeta>> = {
     defaultChord: "mod+y",
     secondaryChord: undefined,
     terminalPolicy: "shell",
+    secondaryTerminalPolicy: undefined,
+  },
+  "app.home.open": {
+    id: "app.home.open",
+    label: "Go to Home",
+    description:
+      "Show the Home tab: everything running, and everything waiting on you, across every task.",
+    category: "app",
+    kind: "chord",
+    // Free across this map and not a native-menu accelerator on any platform,
+    // in the same mod+shift family as the other global surface openers.
+    defaultChord: "mod+shift+h",
+    secondaryChord: undefined,
+    terminalPolicy: "app",
     secondaryTerminalPolicy: undefined,
   },
   "app.settings.open": {

--- a/clients/gui-app/src/lib/keybindings/dispatch.ts
+++ b/clients/gui-app/src/lib/keybindings/dispatch.ts
@@ -13,6 +13,7 @@ import { focusActiveComposer } from "@/lib/composer/composer-focus-registry";
 import { tabMatchesPath, tabResolveIntent } from "@/stores/tabs/registry";
 import { selectHostFocusedRef } from "@/stores/tabs/selectors";
 import { useTabsStore } from "@/stores/tabs/store";
+import { isHomeTabEnabled } from "@/stores/settings/settings-store";
 import type { TabActivationIntent } from "@/lib/tab-navigation/intents";
 import type {
   NavigateNestedFocus,
@@ -405,6 +406,13 @@ const STATIC_HANDLERS: Readonly<Partial<Record<ActionId, StaticHandler>>> = {
   },
   "app.history.open": (r) => {
     r.navigateToEpicList();
+    return true;
+  },
+  // Reports `false` while the Home tab is off, so the provider leaves the chord
+  // unhandled rather than swallowing it for a surface this build has not got.
+  "app.home.open": (r) => {
+    if (!isHomeTabEnabled()) return false;
+    r.navigateHome();
     return true;
   },
   "app.settings.open": (r) => {

--- a/clients/gui-app/src/lib/keybindings/router-adapter.ts
+++ b/clients/gui-app/src/lib/keybindings/router-adapter.ts
@@ -21,9 +21,11 @@ import { historyNavChromeAvailable } from "@/lib/history-navigation/use-history-
 import { LANDING_ROUTE } from "@/lib/routes";
 import {
   existingEpicTabIntent,
+  homeTabIntent,
   navigateToTabIntent,
   openOrFocusEpicIntent,
 } from "@/lib/tab-navigation";
+import { isHomeTabEnabled } from "@/stores/settings/settings-store";
 import {
   navigateNestedFocus,
   navigateNestedFocusToPrimaryEditor,
@@ -51,7 +53,14 @@ export function routerAdapterFor(
 ): KeybindingRouter {
   return {
     getPathname: () => router.state.location.pathname,
+    // "Home" means the Home tab once it exists, and the landing route before
+    // that. Both callers - the Go to Home chord and the last-Epic close - want
+    // whichever of the two this build actually has.
     navigateHome: () => {
+      if (isHomeTabEnabled()) {
+        navigateToTabIntent(router.navigate, homeTabIntent(), undefined);
+        return;
+      }
       void router.navigate(LANDING_ROUTE);
     },
     navigateSettings: () => {

--- a/clients/gui-app/src/lib/tab-navigation.ts
+++ b/clients/gui-app/src/lib/tab-navigation.ts
@@ -17,6 +17,7 @@ import {
   existingEpicTabIntent,
   existingEpicTabIntentWithNestedFocus,
   historyTabIntent,
+  homeTabIntent,
   openEpicTabIntent,
   settingsTabIntent,
   type EpicPostResolvePreparation,
@@ -42,6 +43,8 @@ import {
   useLandingDraftStore,
 } from "@/stores/home/landing-draft-store";
 import { tabRouteOptions } from "@/stores/tabs/registry";
+import { HOME_TAB_REF, isHomePath } from "@/stores/tabs/kinds/home";
+import { isHomeTabEnabled } from "@/stores/settings/settings-store";
 import {
   tabCommandCoordinator,
   type CoordinatedTabActivation,
@@ -66,6 +69,7 @@ export {
   existingEpicTabIntent,
   existingEpicTabIntentWithNestedFocus,
   historyTabIntent,
+  homeTabIntent,
   newDraftTabIntent,
   openEpicFromListIntent,
   openExactEpicTabIntent,
@@ -286,7 +290,24 @@ function intentRef(intent: TabNavigationIntent): TabRef {
       return { kind: "history", id: "history" };
     case "settings":
       return { kind: "settings", id: "settings" };
+    case "home":
+      return HOME_TAB_REF;
   }
+}
+
+/**
+ * Home's ref when Home is the active surface, `null` otherwise.
+ *
+ * Home holds `activeItemId === null`, which the item lookups below read as "no
+ * active item" and answer with `null` - the same answer they give an empty
+ * strip. Every seam that resolves the CURRENT surface (route backing, focus,
+ * re-activation) therefore has to consult this first, or a repair issued while
+ * Home is up would aim at `/` instead of at `/home`.
+ */
+function homeRefOfLayout(layout: PersistedTabStripLayout): TabRef | null {
+  return layout.activeItemId === null && isHomeTabEnabled()
+    ? HOME_TAB_REF
+    : null;
 }
 
 function refsEqual(left: TabRef | null, right: TabRef): boolean {
@@ -305,6 +326,8 @@ function currentLayout(): PersistedTabStripLayout {
 }
 
 function backingRefOfLayout(layout: PersistedTabStripLayout): TabRef | null {
+  const home = homeRefOfLayout(layout);
+  if (home !== null) return home;
   const active = layout.items.find((item) => item.id === layout.activeItemId);
   if (active === undefined) return null;
   if (active.kind === "tab") return active.ref;
@@ -320,6 +343,8 @@ function backingRefOfLayout(layout: PersistedTabStripLayout): TabRef | null {
  * not a no-op.
  */
 function focusedRefOfLayout(layout: PersistedTabStripLayout): TabRef | null {
+  const home = homeRefOfLayout(layout);
+  if (home !== null) return home;
   const active = layout.items.find((item) => item.id === layout.activeItemId);
   if (active === undefined) return null;
   if (active.kind === "tab") return active.ref;
@@ -331,6 +356,7 @@ function activeItemContainsRef(
   layout: PersistedTabStripLayout,
   ref: TabRef,
 ): boolean {
+  if (ref.kind === "home") return homeRefOfLayout(layout) !== null;
   const active = layout.items.find((item) => item.id === layout.activeItemId);
   if (active === undefined) return false;
   if (active.kind === "tab") return refsEqual(active.ref, ref);
@@ -400,6 +426,13 @@ function routedTabTarget(pathname: string): RoutedTabTarget | null {
   if (isHistoryPath(pathname)) {
     return { ref: { kind: "history", id: "history" }, epicId: null };
   }
+  // Gated on the flag, so with Home off `/home` is an unroutable path that
+  // corrects back to whatever the strip is showing - the same treatment any
+  // other unknown route gets. The route guard redirects it first; this is the
+  // backstop for a location that reaches the resolver another way.
+  if (isHomePath(pathname) && isHomeTabEnabled()) {
+    return { ref: HOME_TAB_REF, epicId: null };
+  }
   return null;
 }
 
@@ -431,6 +464,7 @@ function intentForRef(
     return exists ? draftTabIntent(ref.id) : null;
   }
   if (ref.kind === "history") return historyTabIntent();
+  if (ref.kind === "home") return homeTabIntent();
   return settingsTabIntent(settingsSectionFromPath(pathname));
 }
 
@@ -487,6 +521,8 @@ function refIsMaterialized(ref: TabRef): boolean {
       .getState()
       .drafts.some((draft) => draft.id === ref.id);
   }
+  // Home has no source record to materialize: the flag is the whole condition.
+  if (ref.kind === "home") return isHomeTabEnabled();
   return useTabsStore.getState().systemTabs[ref.kind] !== null;
 }
 
@@ -985,6 +1021,7 @@ export class TabNavigationController {
     if (intent.kind === "history" || intent.kind === "settings") {
       return systemActivationTarget(intent);
     }
+    if (intent.kind === "home") return { kind: "home" };
     return { kind: "ref", ref: intentRef(intent) };
   }
 
@@ -1510,7 +1547,7 @@ export class TabNavigationController {
     const routed = routedTabTarget(location.pathname);
     if (routed === null) {
       if (isLandingPath(location.pathname)) {
-        if (historyStep) this.resolveSteppedLanding();
+        if (historyStep) this.resolveSteppedLanding(location, navigate);
         return;
       }
       this.issueLandingCorrection(location, navigate);
@@ -1533,7 +1570,28 @@ export class TabNavigationController {
       case "history":
       case "settings":
         this.resolveExternalSystem(location, ref.kind, navigate);
+        return;
+      case "home":
+        this.resolveExternalHome(location, navigate);
     }
+  }
+
+  /**
+   * `/home` arrived from outside this controller (a deep link, a restored
+   * location, a back step). Activating is a no-op when Home already holds the
+   * selection, and `activateExternalTarget` swallows the coordinator's
+   * re-entrancy refusal the same way every other arm here does.
+   */
+  private resolveExternalHome(
+    location: TabNavigationLocation,
+    navigate: NavigateFn,
+  ): void {
+    const activation = this.activateExternalTarget({ kind: "home" });
+    if (activation === null) {
+      this.issueLandingCorrection(location, navigate);
+      return;
+    }
+    this.rememberRoute(HOME_TAB_REF, homeTabIntent(), location.search);
   }
 
   /**
@@ -1719,7 +1777,42 @@ export class TabNavigationController {
    * the one Home instead of stacking a new draft per press; only a session that
    * has never had one mints, through the same activation `/draft/new` runs.
    */
-  private resolveSteppedLanding(): void {
+  private resolveSteppedLanding(
+    location: TabNavigationLocation,
+    navigate: NavigateFn,
+  ): void {
+    // With the Home tab on, `/` IS Home, so a step back onto the landing selects
+    // Home rather than minting a draft - otherwise every back press to `/` would
+    // leave a new Start Page behind.
+    //
+    // The URL then has to follow, which the draft arm never needed: `/` and the
+    // landing draft surface are the same place, while `/` and `/home` are not.
+    // Leaving the two disagreeing would render Home under a `/` URL, and
+    // `isProjectionCoherent` - which requires `/home` whenever Home holds the
+    // selection - would refuse to schedule ANY desktop layout write until the
+    // next navigation that lands on something else. That is not an exotic
+    // state: the phone shell boots its WebView at `/` and keeps it as the first
+    // history entry, so the system back gesture from Home lands here every
+    // time. A `replace` correction, the same shape `resolveDraftEntry` issues,
+    // swaps that entry for `/home` and leaves the next back doing exactly what
+    // it did before (exiting).
+    if (isHomeTabEnabled()) {
+      if (this.activateExternalTarget({ kind: "home" }) === null) return;
+      const intent = homeTabIntent();
+      this.rememberRoute(HOME_TAB_REF, intent, location.search);
+      this.issueCorrection(navigate, {
+        navigation: {
+          destination: destinationForRef(HOME_TAB_REF),
+          intent,
+          ref: HOME_TAB_REF,
+          options: { ...tabRouteOptions(intent), replace: true },
+        },
+        kind: "external-replace",
+        attempt: 0,
+        correctionKey: locationIdentity(location),
+      });
+      return;
+    }
     this.activateExternalTarget({
       kind: "draft",
       draftId: newestLandingDraftId(),

--- a/clients/gui-app/src/lib/tab-navigation/__tests__/external-resolution-backing-correction.test.ts
+++ b/clients/gui-app/src/lib/tab-navigation/__tests__/external-resolution-backing-correction.test.ts
@@ -40,6 +40,7 @@ import {
   type TabNavigationLocation,
 } from "@/lib/tab-navigation";
 import { hasRestoredTabs } from "@/lib/has-restored-tabs";
+import { useSettingsStore } from "@/stores/settings/settings-store";
 import { draftPathname, epicPathname } from "@/lib/routes";
 import {
   __resetTabSyncCoordinatorForTesting,
@@ -245,6 +246,7 @@ function resetStores(): void {
   });
   useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
   useLandingDraftStore.setState({ drafts: [], activeDraftId: null });
+  useSettingsStore.setState({ homeTabEnabled: false });
   __resetTabSyncCoordinatorForTesting();
   __resetTabNavigationControllerForTesting();
 }
@@ -559,6 +561,7 @@ function pathnameForDestination(
   if (kind === "draft") return draftPathname(id);
   if (kind === "history") return "/epics";
   if (kind === "settings") return "/settings/general";
+  if (kind === "home") return "/home";
   const tab = useEpicCanvasStore.getState().tabsById[id];
   expect(tab, `no canvas tab for ${destination.refKey}`).toBeDefined();
   if (tab === undefined) throw new Error("unreachable");
@@ -724,5 +727,76 @@ describe("closing the Settings overlay over a populated strip", () => {
     history.back();
 
     expect(useLandingDraftStore.getState().drafts).toHaveLength(1);
+  });
+});
+
+/**
+ * The same stepped-landing resolver, with the Home tab on.
+ *
+ * `/` is Home's route once the redirect exists, so a back-step onto the landing
+ * has to select Home instead of minting a Start Page - and then the URL has to
+ * follow. Leaving it on `/` renders Home under a route that names something
+ * else, and `isProjectionCoherent` (which requires `/home` whenever Home holds
+ * the selection) then refuses to schedule any desktop layout write until the
+ * next navigation lands elsewhere. Not an exotic path: the phone shell boots
+ * its WebView at `/` and keeps it as the first history entry, so the system
+ * back gesture from Home arrives here every time.
+ */
+describe("stepping back onto the landing with the Home tab on", () => {
+  beforeEach(async () => {
+    resetStores();
+    useSettingsStore.setState({ homeTabEnabled: true });
+    installTabSyncCoordinator({ readyPromise: Promise.resolve() });
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    resetStores();
+  });
+
+  it("selects Home, corrects the URL to /home, and mints no draft", () => {
+    const a = openEpic("epic-a", "A");
+    seedCommittedLayout({
+      version: 2,
+      items: [{ kind: "tab", id: tabItemId(a.ref), ref: a.ref }],
+      activeItemId: tabItemId(a.ref),
+      systemTabs: { history: null, settings: null },
+    });
+    const history = makeAppliedHistory();
+    // The boot entry the phone shell leaves behind, then the tab the user
+    // actually opened on top of it.
+    history.push("/", undefined);
+    history.push(a.pathname, undefined);
+
+    history.back();
+
+    expect(useTabsStore.getState().activeItemId).toBeNull();
+    expect(history.currentPathname()).toBe("/home");
+    expect(useLandingDraftStore.getState().drafts).toHaveLength(0);
+    // The epic tab is still there - Home is a selection, not a placement.
+    expect(flattenLayoutRefs(useTabsStore.getState())).toEqual([a.ref]);
+  });
+
+  it("mints the landing draft instead when the Home tab is off", () => {
+    useSettingsStore.setState({ homeTabEnabled: false });
+    const a = openEpic("epic-a", "A");
+    seedCommittedLayout({
+      version: 2,
+      items: [{ kind: "tab", id: tabItemId(a.ref), ref: a.ref }],
+      activeItemId: tabItemId(a.ref),
+      systemTabs: { history: null, settings: null },
+    });
+    const history = makeAppliedHistory();
+    history.push("/", undefined);
+    history.push(a.pathname, undefined);
+
+    history.back();
+
+    // Pre-Home behaviour, unchanged: the landing IS the draft surface, so the
+    // step activates one and the URL stays where the step left it.
+    expect(useLandingDraftStore.getState().drafts).toHaveLength(1);
+    expect(history.currentPathname()).toBe("/");
   });
 });

--- a/clients/gui-app/src/lib/tab-navigation/intents.ts
+++ b/clients/gui-app/src/lib/tab-navigation/intents.ts
@@ -54,7 +54,8 @@ export type TabNavigationIntent =
     }
   | { readonly kind: "draft"; readonly draftId: string }
   | { readonly kind: "history" }
-  | { readonly kind: "settings"; readonly section: SettingsSectionId };
+  | { readonly kind: "settings"; readonly section: SettingsSectionId }
+  | { readonly kind: "home" };
 
 /**
  * Requests that need source resolution are deliberately distinct from canonical
@@ -271,6 +272,13 @@ export function historyTabIntent(): Extract<
   { kind: "history" }
 > {
   return { kind: "history" };
+}
+
+export function homeTabIntent(): Extract<
+  TabNavigationIntent,
+  { kind: "home" }
+> {
+  return { kind: "home" };
 }
 
 export function settingsTabIntent(

--- a/clients/gui-app/src/providers/__tests__/keybinding-provider.test.ts
+++ b/clients/gui-app/src/providers/__tests__/keybinding-provider.test.ts
@@ -129,6 +129,9 @@ function buildRouter(initialPath: string): MockRouter {
       } else if (intent.kind === "history") {
         calls.push({ kind: "epic", epicId: null, sectionId: null });
         pathname = "/epics";
+      } else if (intent.kind === "home") {
+        calls.push({ kind: "home", epicId: null, sectionId: null });
+        pathname = "/home";
       } else {
         calls.push({
           kind: "section",

--- a/clients/gui-app/src/routeTree.gen.ts
+++ b/clients/gui-app/src/routeTree.gen.ts
@@ -11,6 +11,7 @@
 import { Route as rootRouteImport } from "./routes/__root";
 import { Route as IndexRouteImport } from "./routes/index";
 import { Route as EpicsRouteImport } from "./routes/epics";
+import { Route as HomeRouteImport } from "./routes/home";
 import { Route as OnboardingRouteImport } from "./routes/onboarding";
 import { Route as SettingsRouteImport } from "./routes/settings";
 import { Route as DraftDraftIdRouteImport } from "./routes/draft.$draftId";
@@ -44,6 +45,11 @@ const IndexRoute = IndexRouteImport.update({
 const EpicsRoute = EpicsRouteImport.update({
   id: "/epics",
   path: "/epics",
+  getParentRoute: () => rootRouteImport,
+} as any);
+const HomeRoute = HomeRouteImport.update({
+  id: "/home",
+  path: "/home",
   getParentRoute: () => rootRouteImport,
 } as any);
 const OnboardingRoute = OnboardingRouteImport.update({
@@ -171,6 +177,7 @@ const EpicsEpicIdTabIdRoute = EpicsEpicIdTabIdRouteImport.update({
 export interface FileRoutesByFullPath {
   "/": typeof IndexRoute;
   "/epics": typeof EpicsRouteWithChildren;
+  "/home": typeof HomeRoute;
   "/onboarding": typeof OnboardingRoute;
   "/settings": typeof SettingsRouteWithChildren;
   "/draft/$draftId": typeof DraftDraftIdRoute;
@@ -198,6 +205,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   "/": typeof IndexRoute;
+  "/home": typeof HomeRoute;
   "/onboarding": typeof OnboardingRoute;
   "/draft/$draftId": typeof DraftDraftIdRoute;
   "/draft/new": typeof DraftNewRoute;
@@ -226,6 +234,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport;
   "/": typeof IndexRoute;
   "/epics": typeof EpicsRouteWithChildren;
+  "/home": typeof HomeRoute;
   "/onboarding": typeof OnboardingRoute;
   "/settings": typeof SettingsRouteWithChildren;
   "/draft/$draftId": typeof DraftDraftIdRoute;
@@ -256,6 +265,7 @@ export interface FileRouteTypes {
   fullPaths:
     | "/"
     | "/epics"
+    | "/home"
     | "/onboarding"
     | "/settings"
     | "/draft/$draftId"
@@ -283,6 +293,7 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo;
   to:
     | "/"
+    | "/home"
     | "/onboarding"
     | "/draft/$draftId"
     | "/draft/new"
@@ -310,6 +321,7 @@ export interface FileRouteTypes {
     | "__root__"
     | "/"
     | "/epics"
+    | "/home"
     | "/onboarding"
     | "/settings"
     | "/draft/$draftId"
@@ -339,6 +351,7 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute;
   EpicsRoute: typeof EpicsRouteWithChildren;
+  HomeRoute: typeof HomeRoute;
   OnboardingRoute: typeof OnboardingRoute;
   SettingsRoute: typeof SettingsRouteWithChildren;
   DraftDraftIdRoute: typeof DraftDraftIdRoute;
@@ -359,6 +372,13 @@ declare module "@tanstack/react-router" {
       path: "/epics";
       fullPath: "/epics";
       preLoaderRoute: typeof EpicsRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/home": {
+      id: "/home";
+      path: "/home";
+      fullPath: "/home";
+      preLoaderRoute: typeof HomeRouteImport;
       parentRoute: typeof rootRouteImport;
     };
     "/onboarding": {
@@ -593,6 +613,7 @@ const SettingsRouteWithChildren = SettingsRoute._addFileChildren(
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   EpicsRoute: EpicsRouteWithChildren,
+  HomeRoute: HomeRoute,
   OnboardingRoute: OnboardingRoute,
   SettingsRoute: SettingsRouteWithChildren,
   DraftDraftIdRoute: DraftDraftIdRoute,

--- a/clients/gui-app/src/routes/home-route-components.tsx
+++ b/clients/gui-app/src/routes/home-route-components.tsx
@@ -1,0 +1,10 @@
+import type { ReactNode } from "react";
+
+/**
+ * Route adapter for `/home`. The Home surface is mounted for the whole session
+ * by `TopLevelTabHost`, outside the retention cap, so the route body itself has
+ * nothing to render - the same shape as the `/epics` layout adapter.
+ */
+export function HomeRoute(): ReactNode {
+  return null;
+}

--- a/clients/gui-app/src/routes/home.tsx
+++ b/clients/gui-app/src/routes/home.tsx
@@ -1,0 +1,17 @@
+import { createFileRoute, redirect } from "@tanstack/react-router";
+import { requireSignedIn } from "@/lib/router-auth";
+import { isHomeTabEnabled } from "@/stores/settings/settings-store";
+import { HomeRoute } from "./home-route-components";
+
+export const Route = createFileRoute("/home")({
+  beforeLoad: ({ context }) => {
+    requireSignedIn(context);
+    // With the Home tab off there is no Home surface, so `/home` is not a place
+    // this build can land on. A stale link or a restored location goes back to
+    // `/`, which resolves to whatever this window is actually showing.
+    if (!isHomeTabEnabled()) {
+      redirect({ to: "/", replace: true, throw: true });
+    }
+  },
+  component: HomeRoute,
+});

--- a/clients/gui-app/src/routes/index.tsx
+++ b/clients/gui-app/src/routes/index.tsx
@@ -1,9 +1,11 @@
 import { createFileRoute, redirect } from "@tanstack/react-router";
 import { RootLandingPage } from "@/components/layout/root-landing-page";
 import { hasRestoredTabs } from "@/lib/has-restored-tabs";
+import { isHomeTabEnabled } from "@/stores/settings/settings-store";
 
 export const Route = createFileRoute("/")({
-  // Sends a signed-in user with no restored tabs to a fresh draft. In Electron
+  // Sends a signed-in user with no restored tabs onward - to Home where the
+  // Home tab is on, and to a fresh draft otherwise. In Electron
   // the stores this reads are only authoritative after the windows-bridge
   // snapshot has hydrated; `beforeLoad` runs on preload and cannot await that,
   // so a stale-empty read here may over-redirect to `/draft/new`. That is safe:
@@ -12,6 +14,15 @@ export const Route = createFileRoute("/")({
   beforeLoad: ({ context }) => {
     if (context.getAuthSnapshot().status !== "signed-in") return;
     if (hasRestoredTabs()) return;
+    // With the Home tab on, a window with nothing restored opens on Home rather
+    // than on a freshly minted draft. Still behind `hasRestoredTabs()`, and for
+    // the reason that guard has always existed: the phone shell boots its
+    // WebView at `/` with a full layout restored behind it, so a redirect that
+    // fired there would land on Home every relaunch and throw away the tab the
+    // user actually left open.
+    if (isHomeTabEnabled()) {
+      redirect({ to: "/home", replace: true, throw: true });
+    }
     redirect({ to: "/draft/new", replace: true, throw: true });
   },
   component: RootLandingPage,

--- a/clients/gui-app/src/stores/layout/mobile-header-right-actions.ts
+++ b/clients/gui-app/src/stores/layout/mobile-header-right-actions.ts
@@ -34,8 +34,11 @@ export function resolveMobileHeaderRightActionsKey(
       return landingTerminalRightActionsKey(focused.id);
     case "epic":
       return epicTabRightActionsKey(focused.id);
+    // Home is never a strip ref, so it cannot be the focused one; it also
+    // presents nothing of its own, which is the same answer either way.
     case "history":
     case "settings":
+    case "home":
       return null;
   }
 }

--- a/clients/gui-app/src/stores/notifications/merged-notifications.ts
+++ b/clients/gui-app/src/stores/notifications/merged-notifications.ts
@@ -231,7 +231,7 @@ export function mergedUnreadCount(input: {
 /** Every merged row, newest-first across the active feed plus renderer-local
  * failures - the shared base the id/Attention/Recent projections all derive
  * from without recomputing their own source subscriptions. */
-function useMergedNotificationRows(): ReadonlyArray<MergedNotificationRow> {
+export function useMergedNotificationRows(): ReadonlyArray<MergedNotificationRow> {
   const feedMode = useNotificationFeedMode();
   const activeHostId = useAddressableHostId();
   const hostIds = useHostNotificationIds();

--- a/clients/gui-app/src/stores/settings/settings-store.ts
+++ b/clients/gui-app/src/stores/settings/settings-store.ts
@@ -227,6 +227,12 @@ export interface SettingsState {
   workspaceFileWordWrap: boolean | null;
   /** App-wide audible cues selected for each notification event type. */
   notificationChimeSounds: NotificationChimeSoundsByEvent;
+  /**
+   * The fixed Home tab and its focus view. Opt-in while the view is still
+   * filling out: with this off the strip, the routes, the chord and the mobile
+   * drawer behave exactly as they did before Home existed.
+   */
+  homeTabEnabled: boolean;
   setTheme: (theme: ThemeMode) => void;
   setThemePreset: (preset: ThemePreset) => void;
   setComposerMode: (mode: ComposerMode) => void;
@@ -265,6 +271,7 @@ export interface SettingsState {
     eventType: NotificationChimeEventType,
     value: NotificationChimeSound,
   ) => void;
+  setHomeTabEnabled: (value: boolean) => void;
 }
 
 type PersistedSettingsState = Pick<
@@ -305,6 +312,7 @@ type PersistedSettingsState = Pick<
   | "diffViewerPreferences"
   | "workspaceFileWordWrap"
   | "notificationChimeSounds"
+  | "homeTabEnabled"
 >;
 
 type SetFn = (
@@ -379,6 +387,7 @@ function partializeSettingsState(state: SettingsState): PersistedSettingsState {
     diffViewerPreferences: state.diffViewerPreferences,
     workspaceFileWordWrap: state.workspaceFileWordWrap,
     notificationChimeSounds: state.notificationChimeSounds,
+    homeTabEnabled: state.homeTabEnabled,
   };
 }
 
@@ -421,6 +430,7 @@ export const useSettingsStore = create<SettingsState>()(
       diffViewerPreferences: DEFAULT_DIFF_VIEWER_PREFERENCES,
       workspaceFileWordWrap: null,
       notificationChimeSounds: DEFAULT_NOTIFICATION_CHIME_SOUNDS,
+      homeTabEnabled: false,
       setTheme: makeSetter(set, "theme"),
       setThemePreset: makeSetter(set, "themePreset"),
       setComposerMode: makeSetter(set, "composerMode"),
@@ -534,6 +544,7 @@ export const useSettingsStore = create<SettingsState>()(
               },
         );
       },
+      setHomeTabEnabled: makeSetter(set, "homeTabEnabled"),
     }),
     {
       ...basePersistOptions(persistKey(STORE_KEYS.settings)),
@@ -588,11 +599,28 @@ export const useSettingsStore = create<SettingsState>()(
             persisted.notificationChimeSounds,
             persisted.notificationChimeSound,
           ),
+          // Narrowed rather than merged verbatim, for the same reason
+          // `workspaceFileWordWrap` is: this flag gates a tab kind, a route
+          // guard and a chord, so a truthy non-boolean rehydrating as-is would
+          // switch Home on for a user who never asked for it.
+          homeTabEnabled:
+            typeof merged.homeTabEnabled === "boolean"
+              ? merged.homeTabEnabled
+              : false,
         };
       },
     },
   ),
 );
+
+/**
+ * Non-hook read of the Home-tab flag, for the framework-free seams that gate on
+ * it (route guards, the tab command coordinator, the navigation controller and
+ * the keybinding dispatcher). Components read `homeTabEnabled` reactively.
+ */
+export function isHomeTabEnabled(): boolean {
+  return useSettingsStore.getState().homeTabEnabled;
+}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);

--- a/clients/gui-app/src/stores/tabs/__tests__/desktop-tabs-persistence.test.ts
+++ b/clients/gui-app/src/stores/tabs/__tests__/desktop-tabs-persistence.test.ts
@@ -23,6 +23,7 @@ import {
 } from "@/stores/tabs/layout";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 import { useLandingDraftStore } from "@/stores/home/landing-draft-store";
+import { useSettingsStore } from "@/stores/settings/settings-store";
 import { useTabsStore } from "@/stores/tabs/store";
 import { tabCommandCoordinator } from "@/stores/tabs/tab-command-coordinator";
 import { getTabSplitCompatibility } from "@/stores/tabs/tab-split-compatibility";
@@ -89,7 +90,55 @@ function resetStores(): void {
   useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
   useLandingDraftStore.setState({ drafts: [], activeDraftId: null });
   useTabsStore.setState({ ...emptyTabStripLayout(), stripOrder: [] });
+  useSettingsStore.setState({ homeTabEnabled: false });
   tabCommandCoordinator.resetReconciliationForTesting();
+}
+
+/**
+ * A snapshot with two epic tabs whose layout selection is Home's - a null
+ * `activeItemId` over a populated strip, which only means Home while the flag
+ * is on and means "unset" while it is off.
+ */
+function homeSelectedSnapshot(
+  tabA: string,
+  tabB: string,
+  activeRoute: string,
+): DesktopPerWindowSnapshot {
+  return {
+    ...emptySnapshot(),
+    revision: 11,
+    epicTabs: [
+      { id: tabA, epicId: "epic-a", name: "Alpha" },
+      { id: tabB, epicId: "epic-b", name: "Beta" },
+    ],
+    activeTabId: null,
+    tabStripLayout: {
+      version: 2,
+      items: [
+        {
+          kind: "tab",
+          id: tabItemId({ kind: "epic", id: tabA }),
+          ref: { kind: "epic", id: tabA },
+        },
+        {
+          kind: "tab",
+          id: tabItemId({ kind: "epic", id: tabB }),
+          ref: { kind: "epic", id: tabB },
+        },
+      ],
+      activeItemId: null,
+      systemTabs: { history: null, settings: null },
+    },
+    activeRoute,
+  };
+}
+
+function openTwoEpicTabs(): { readonly tabA: string; readonly tabB: string } {
+  const canvas = useEpicCanvasStore.getState();
+  return {
+    tabA: canvas.openEpicTabWithId("tab-a", "epic-a", "Alpha"),
+    tabB: canvas.openEpicTabWithId("tab-b", "epic-b", "Beta"),
+  };
 }
 
 beforeEach(() => {
@@ -413,6 +462,85 @@ describe("desktop tabs persistence", () => {
       id: "split-a",
       focusedSide: "right",
       routeBackingSide: "left",
+    });
+  });
+
+  /**
+   * The desktop snapshot is the only path where a Home selection has to survive
+   * a round trip through code that knows nothing about it: `repairLayout`
+   * resolves a null active id to the first item, and every ref-keyed lookup in
+   * this module answers `null` for a surface with no ref. Four private helpers
+   * carry Home across that boundary, so the only way any of them can regress is
+   * silently - hence both halves of the flag for each.
+   */
+  describe("Home selection across the desktop snapshot", () => {
+    it("restores a Home-selected snapshot with the null selection, both tabs, and the /home route", () => {
+      useSettingsStore.setState({ homeTabEnabled: true });
+      const { tabA, tabB } = openTwoEpicTabs();
+
+      const hydration = hydrateDesktopTabs(
+        homeSelectedSnapshot(tabA, tabB, "/home"),
+        true,
+        null,
+      );
+
+      expect(useTabsStore.getState().activeItemId).toBeNull();
+      expect(flattenLayoutRefs(useTabsStore.getState())).toEqual([
+        { kind: "epic", id: tabA },
+        { kind: "epic", id: tabB },
+      ]);
+      expect(hydration.route).toBe("/home");
+    });
+
+    it("restores the same snapshot onto the first tab with the flag off", () => {
+      const { tabA, tabB } = openTwoEpicTabs();
+
+      const hydration = hydrateDesktopTabs(
+        homeSelectedSnapshot(tabA, tabB, "/home"),
+        true,
+        null,
+      );
+
+      // The byte-identical-when-off half: `repairLayout`'s own fallback stands,
+      // and `routeRef("/home")` names nothing, so the route follows the layout.
+      expect(useTabsStore.getState().activeItemId).toBe(
+        tabItemId({ kind: "epic", id: tabA }),
+      );
+      expect(flattenLayoutRefs(useTabsStore.getState())).toEqual([
+        { kind: "epic", id: tabA },
+        { kind: "epic", id: tabB },
+      ]);
+      expect(hydration.route).toBe("/epics/epic-a/tab-a");
+    });
+
+    it("schedules a layout write while Home is active only once the route agrees", async () => {
+      useSettingsStore.setState({ homeTabEnabled: true });
+      const { tabA, tabB } = openTwoEpicTabs();
+      useTabsStore.getState().setStripOrder([
+        { kind: "epic", id: tabA },
+        { kind: "epic", id: tabB },
+      ]);
+      const updates: DesktopPerWindowStatePatch[] = [];
+      installDesktopTabsPersistence(acknowledgedBridge(updates), 0);
+
+      // Home selected, but the URL still says `/` - the state a back-step onto
+      // the landing route used to leave behind. Incoherent, so nothing is
+      // written, and a layout change made here would be lost on quit.
+      updateDesktopTabsActiveRoute("/");
+      expect(
+        tabCommandCoordinator.activateTab({ kind: "home" }),
+      ).not.toBeNull();
+      await vi.advanceTimersByTimeAsync(100);
+      expect(updates).toHaveLength(0);
+
+      updateDesktopTabsActiveRoute("/home");
+      await flushDesktopTabsPersistence();
+
+      expect(updates).toHaveLength(1);
+      expect(updates[0]).toMatchObject({
+        activeRoute: "/home",
+        tabStripLayout: { activeItemId: null },
+      });
     });
   });
 });

--- a/clients/gui-app/src/stores/tabs/__tests__/home-active-selection.test.ts
+++ b/clients/gui-app/src/stores/tabs/__tests__/home-active-selection.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Locks down "Home is active" == `activeItemId === null`.
+ *
+ * That state only means Home while `homeTabEnabled` is on - with the flag
+ * off, a populated strip must never legitimately sit on a null selection, so
+ * every commit boundary (`committedLayout`, `repairLayout`,
+ * `migrateTabsPersistedState`) has to keep resolving null back to the first
+ * item exactly as it did before Home existed. Getting this wrong either stops
+ * Home from working (flag on) or strands a real user's strip with nothing
+ * selected (flag off) - so both sides of the flag are exercised for every
+ * commit path below, not just the "happy" one.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import { useLandingDraftStore } from "@/stores/home/landing-draft-store";
+import { useSettingsStore } from "@/stores/settings/settings-store";
+import {
+  emptyTabStripLayout,
+  flattenLayoutRefs,
+  type PersistedTabStripLayout,
+} from "@/stores/tabs/layout";
+import { isRegisteredTabKind } from "@/stores/tabs/registry";
+import {
+  layoutHomeIsActive,
+  migrateTabsPersistedState,
+  readTabStripLayout,
+  useTabsStore,
+} from "@/stores/tabs/store";
+import { tabCommandCoordinator } from "@/stores/tabs/tab-command-coordinator";
+import {
+  __resetTabSyncCoordinatorForTesting,
+  installTabSyncCoordinator,
+} from "@/lib/tab-sync/tab-sync-coordinator";
+import type { TabRef } from "@/stores/tabs/types";
+
+function resetStores(): void {
+  useTabsStore.setState({
+    ...emptyTabStripLayout(),
+    stripOrder: [],
+  });
+  useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
+  useLandingDraftStore.setState({ drafts: [], activeDraftId: null });
+  useSettingsStore.setState({ homeTabEnabled: false });
+  __resetTabSyncCoordinatorForTesting();
+}
+
+describe("home active selection", () => {
+  beforeEach(async () => {
+    resetStores();
+    installTabSyncCoordinator({ readyPromise: Promise.resolve() });
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+
+  afterEach(() => {
+    resetStores();
+  });
+
+  it("flag ON: a null activeItemId survives repair() and stripOrder still lists the items", () => {
+    useSettingsStore.setState({ homeTabEnabled: true });
+    const epicRef: TabRef = { kind: "epic", id: "epic-a" };
+    useTabsStore.setState({
+      version: 2,
+      items: [{ kind: "tab", id: "tab:epic:epic-a", ref: epicRef }],
+      activeItemId: null,
+      systemTabs: { history: null, settings: null },
+      activationHistory: [],
+      stripOrder: [epicRef],
+    });
+
+    useTabsStore.getState().repair();
+
+    const state = useTabsStore.getState();
+    expect(state.activeItemId).toBeNull();
+    expect(state.stripOrder).toEqual([epicRef]);
+    expect(layoutHomeIsActive(readTabStripLayout())).toBe(true);
+  });
+
+  it("flag OFF: the same null-activeItemId seed resolves to the first item after repair() - byte-identical to pre-Home behavior", () => {
+    useSettingsStore.setState({ homeTabEnabled: false });
+    const epicRef: TabRef = { kind: "epic", id: "epic-a" };
+    useTabsStore.setState({
+      version: 2,
+      items: [{ kind: "tab", id: "tab:epic:epic-a", ref: epicRef }],
+      activeItemId: null,
+      systemTabs: { history: null, settings: null },
+      activationHistory: [],
+      stripOrder: [epicRef],
+    });
+
+    useTabsStore.getState().repair();
+
+    const state = useTabsStore.getState();
+    expect(state.activeItemId).toBe("tab:epic:epic-a");
+    expect(layoutHomeIsActive(readTabStripLayout())).toBe(false);
+  });
+
+  it("flag ON: activateTab({ kind: 'home' }) selects Home, leaves items untouched, and clears the epic canvas's active id", () => {
+    useSettingsStore.setState({ homeTabEnabled: true });
+    const activation = tabCommandCoordinator.activateTab({
+      kind: "epic",
+      epicId: "epic-a",
+      tabId: null,
+      name: "A",
+    });
+    expect(activation).not.toBeNull();
+    const itemsBeforeHome = useTabsStore.getState().items;
+    expect(useEpicCanvasStore.getState().activeTabId).not.toBeNull();
+
+    const homeActivation = tabCommandCoordinator.activateTab({ kind: "home" });
+
+    expect(homeActivation).not.toBeNull();
+    expect(homeActivation?.ref).toEqual({ kind: "home", id: "home" });
+    expect(useTabsStore.getState().activeItemId).toBeNull();
+    expect(useTabsStore.getState().items).toEqual(itemsBeforeHome);
+    expect(useEpicCanvasStore.getState().activeTabId).toBeNull();
+  });
+
+  it("flag ON: activateTab({ kind: 'home' }) clears the landing draft store's active draft id", () => {
+    useSettingsStore.setState({ homeTabEnabled: true });
+    const activation = tabCommandCoordinator.activateTab({
+      kind: "draft",
+      draftId: null,
+      settings: null,
+      create: true,
+    });
+    expect(activation).not.toBeNull();
+    expect(useLandingDraftStore.getState().activeDraftId).not.toBeNull();
+
+    const homeActivation = tabCommandCoordinator.activateTab({ kind: "home" });
+
+    expect(homeActivation?.ref).toEqual({ kind: "home", id: "home" });
+    expect(useTabsStore.getState().activeItemId).toBeNull();
+    expect(useLandingDraftStore.getState().activeDraftId).toBeNull();
+  });
+
+  it("flag OFF: activateTab({ kind: 'home' }) returns null and leaves the layout unchanged", () => {
+    useSettingsStore.setState({ homeTabEnabled: false });
+    tabCommandCoordinator.activateTab({
+      kind: "epic",
+      epicId: "epic-a",
+      tabId: null,
+      name: "A",
+    });
+    const before: PersistedTabStripLayout = readTabStripLayout();
+
+    const homeActivation = tabCommandCoordinator.activateTab({ kind: "home" });
+
+    expect(homeActivation).toBeNull();
+    expect(readTabStripLayout()).toEqual(before);
+  });
+
+  it("opening a real tab after Home was active re-selects that tab", () => {
+    useSettingsStore.setState({ homeTabEnabled: true });
+    const activation = tabCommandCoordinator.activateTab({
+      kind: "epic",
+      epicId: "epic-a",
+      tabId: null,
+      name: "A",
+    });
+    expect(activation).not.toBeNull();
+    if (activation === null) return;
+
+    tabCommandCoordinator.activateTab({ kind: "home" });
+    expect(useTabsStore.getState().activeItemId).toBeNull();
+
+    const reopened = tabCommandCoordinator.activateTab({
+      kind: "ref",
+      ref: activation.ref,
+    });
+
+    expect(reopened).not.toBeNull();
+    expect(useTabsStore.getState().activeItemId).not.toBeNull();
+    expect(flattenLayoutRefs(readTabStripLayout())).toContainEqual(
+      activation.ref,
+    );
+  });
+
+  it("migrateTabsPersistedState keeps a null activeItemId when the flag is on", () => {
+    useSettingsStore.setState({ homeTabEnabled: true });
+    const persisted = {
+      items: [
+        {
+          kind: "tab",
+          id: "tab:epic:epic-a",
+          ref: { kind: "epic", id: "epic-a" },
+        },
+      ],
+      activeItemId: null,
+      systemTabs: { history: null, settings: null },
+    };
+
+    const migrated = migrateTabsPersistedState(persisted);
+
+    expect(migrated.activeItemId).toBeNull();
+    expect(migrated.items).toHaveLength(1);
+  });
+
+  it("migrateTabsPersistedState resolves the same payload to the first item when the flag is off", () => {
+    useSettingsStore.setState({ homeTabEnabled: false });
+    const persisted = {
+      items: [
+        {
+          kind: "tab",
+          id: "tab:epic:epic-a",
+          ref: { kind: "epic", id: "epic-a" },
+        },
+      ],
+      activeItemId: null,
+      systemTabs: { history: null, settings: null },
+    };
+
+    const migrated = migrateTabsPersistedState(persisted);
+
+    expect(migrated.activeItemId).toBe("tab:epic:epic-a");
+  });
+
+  it("isRegisteredTabKind still resolves ordinary kinds (sanity check on the guard used throughout)", () => {
+    expect(isRegisteredTabKind("epic")).toBe(true);
+    expect(isRegisteredTabKind("home")).toBe(true);
+    expect(isRegisteredTabKind("not-a-kind")).toBe(false);
+  });
+});

--- a/clients/gui-app/src/stores/tabs/__tests__/home-kind.test.ts
+++ b/clients/gui-app/src/stores/tabs/__tests__/home-kind.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Locks down the Home tab kind's registry dispatch: every per-concern
+ * function (`tabSurfaceDescriptor`, `tabDuplicate`, `tabRequestClose`,
+ * `tabRequiresCloseConfirm`, `tabEpicId`, `tabResolveIntent`,
+ * `tabRouteOptions`, `tabMatchesPath`) must handle `home` without throwing,
+ * and must answer with the fixed, singleton shape the design calls for -
+ * Home cannot be duplicated, closed, or split, and it owns no epic.
+ *
+ * Also locks down the two structural refusals that keep Home out of the
+ * ordinary strip machinery even though it is a registered kind:
+ * `repairLayout` drops a `home` strip item, and `migrateTabsPersistedState`
+ * refuses to materialize one from a persisted payload. A regression in
+ * either would let a hand-edited or corrupted payload put a second,
+ * closable "Home" into the strip.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  isRegisteredTabKind,
+  tabDuplicate,
+  tabEpicId,
+  tabMatchesPath,
+  tabRequestClose,
+  tabRequiresCloseConfirm,
+  tabResolveIntent,
+  tabRouteOptions,
+  tabSurfaceDescriptor,
+} from "@/stores/tabs/registry";
+import { homeHeaderTab, HOME_TAB_REF } from "@/stores/tabs/kinds/home";
+import { homeTabIntent } from "@/lib/tab-navigation/intents";
+import {
+  emptySystemTabs,
+  emptyTabStripLayout,
+  repairLayout,
+  type PersistedTabStripLayout,
+} from "@/stores/tabs/layout";
+import { migrateTabsPersistedState, useTabsStore } from "@/stores/tabs/store";
+import type { TabRef } from "@/stores/tabs/types";
+
+describe("home tab kind - registry dispatch", () => {
+  it("is registered", () => {
+    expect(isRegisteredTabKind("home")).toBe(true);
+  });
+
+  it("declares an ineligible-for-split, non-duplicable surface", () => {
+    const surface = tabSurfaceDescriptor("home");
+    expect(surface.splitEligibility).toBe("ineligible");
+    expect(surface.duplication).toBe("forbidden");
+  });
+
+  it("tabDuplicate refuses to duplicate Home", () => {
+    expect(tabDuplicate(homeHeaderTab())).toBeNull();
+  });
+
+  it("tabRequestClose does not throw and leaves the tabs store untouched", () => {
+    expect(() => tabRequestClose(homeHeaderTab())).not.toThrow();
+  });
+
+  it("tabRequiresCloseConfirm is false", () => {
+    expect(tabRequiresCloseConfirm(homeHeaderTab())).toBe(false);
+  });
+
+  it("tabEpicId is null", () => {
+    expect(tabEpicId(homeHeaderTab())).toBeNull();
+  });
+
+  it("tabResolveIntent resolves the home intent", () => {
+    expect(tabResolveIntent(homeHeaderTab())).toEqual({ kind: "home" });
+  });
+
+  it("tabRouteOptions for the home intent navigates to /home", () => {
+    expect(tabRouteOptions(homeTabIntent())).toEqual({ to: "/home" });
+  });
+
+  it("tabMatchesPath matches /home and /home/ only", () => {
+    const tab = homeHeaderTab();
+    expect(tabMatchesPath(tab, "/home")).toBe(true);
+    expect(tabMatchesPath(tab, "/home/")).toBe(true);
+    expect(tabMatchesPath(tab, "/")).toBe(false);
+    expect(tabMatchesPath(tab, "/epics")).toBe(false);
+  });
+});
+
+describe("home tab kind - structural refusals", () => {
+  it("repairLayout drops a home strip item from items", () => {
+    const layout: PersistedTabStripLayout = {
+      version: 2,
+      items: [{ kind: "tab", id: "tab:home:home", ref: HOME_TAB_REF }],
+      activeItemId: "tab:home:home",
+      systemTabs: emptySystemTabs(),
+      activationHistory: [],
+    };
+    const repaired = repairLayout(layout, isRegisteredTabKind);
+    expect(repaired.items).toEqual([]);
+    expect(repaired.activeItemId).toBeNull();
+  });
+
+  it("migrateTabsPersistedState drops a home item from a persisted payload", () => {
+    const persisted = {
+      items: [{ kind: "tab", id: "tab:home:home", ref: HOME_TAB_REF }],
+      activeItemId: "tab:home:home",
+      systemTabs: { history: null, settings: null },
+    };
+    const migrated = migrateTabsPersistedState(persisted);
+    expect(migrated.items).toEqual([]);
+  });
+
+  it("useTabsStore.pair() refuses to pair Home with a real tab (canSplitRef)", () => {
+    const epicRef: TabRef = { kind: "epic", id: "epic-a" };
+    useTabsStore.setState({
+      ...emptyTabStripLayout(),
+      items: [{ kind: "tab", id: "tab:epic:epic-a", ref: epicRef }],
+      activeItemId: "tab:epic:epic-a",
+      stripOrder: [epicRef],
+    });
+    const before = useTabsStore.getState().items;
+
+    useTabsStore.getState().pair({
+      left: epicRef,
+      right: HOME_TAB_REF,
+      splitId: "split-home-refused",
+      leftRatio: 0.5,
+    });
+
+    // `pairLayoutRefs` guards on `canSplitRef` for BOTH sides before it ever
+    // touches the layout, and the store's `canSplitRef` composes
+    // `tabSurfaceDescriptor("home").splitEligibility === "ineligible"` -
+    // exercised here through the real store action rather than reached for
+    // directly, since the store's `canSplitRef` closure is private.
+    expect(useTabsStore.getState().items).toEqual(before);
+    useTabsStore.setState(emptyTabStripLayout());
+  });
+});
+
+describe("home tab kind - build()", () => {
+  it("homeHeaderTab returns a stable identity across calls", () => {
+    expect(homeHeaderTab()).toBe(homeHeaderTab());
+  });
+
+  it("homeHeaderTab cannot be duplicated or opened in a new window", () => {
+    const tab = homeHeaderTab();
+    expect(tab.canDuplicate).toBe(false);
+    expect(tab.canOpenInNewWindow).toBe(false);
+    expect(tab.kind).toBe("home");
+    expect(tab.id).toBe("home");
+  });
+});

--- a/clients/gui-app/src/stores/tabs/__tests__/layout-authority.test.ts
+++ b/clients/gui-app/src/stores/tabs/__tests__/layout-authority.test.ts
@@ -45,6 +45,7 @@ import { epicTabModule } from "@/stores/tabs/kinds/epic";
 import { draftTabModule } from "@/stores/tabs/kinds/draft";
 import { historyTabModule } from "@/stores/tabs/kinds/history";
 import { settingsTabModule } from "@/stores/tabs/kinds/settings";
+import { homeTabModule } from "@/stores/tabs/kinds/home";
 import {
   EMPTY_LANDING_DRAFT_CONTENT,
   emptyLandingDraftWorkspaceSnapshot,
@@ -242,6 +243,7 @@ describe("TAB_KINDS surface exhaustiveness", () => {
       "draft",
       "epic",
       "history",
+      "home",
       "settings",
     ];
     expect(Object.keys(TAB_KINDS).length).toBe(expectedKinds.length);
@@ -255,6 +257,7 @@ describe("TAB_KINDS surface exhaustiveness", () => {
     expectTypeOf(TAB_KINDS).toHaveProperty("draft");
     expectTypeOf(TAB_KINDS).toHaveProperty("history");
     expectTypeOf(TAB_KINDS).toHaveProperty("settings");
+    expectTypeOf(TAB_KINDS).toHaveProperty("home");
 
     expectTypeOf(tabSurfaceDescriptor("epic")).toEqualTypeOf<
       TabSurfaceDescriptor<"epic">
@@ -267,6 +270,9 @@ describe("TAB_KINDS surface exhaustiveness", () => {
     >();
     expectTypeOf(tabSurfaceDescriptor("settings")).toEqualTypeOf<
       TabSurfaceDescriptor<"settings">
+    >();
+    expectTypeOf(tabSurfaceDescriptor("home")).toEqualTypeOf<
+      TabSurfaceDescriptor<"home">
     >();
 
     expectTypeOf(TAB_KINDS.epic.descriptor.surface).toExtend<
@@ -281,12 +287,16 @@ describe("TAB_KINDS surface exhaustiveness", () => {
     expectTypeOf(TAB_KINDS.settings.descriptor.surface).toExtend<
       TabSurfaceDescriptor<"settings">
     >();
+    expectTypeOf(TAB_KINDS.home.descriptor.surface).toExtend<
+      TabSurfaceDescriptor<"home">
+    >();
 
     const headerKinds: ReadonlyArray<HeaderTabKind> = [
       "epic",
       "draft",
       "history",
       "settings",
+      "home",
     ];
     headerKinds.forEach((kind) => {
       const surface = tabSurfaceDescriptor(kind);
@@ -337,6 +347,13 @@ describe("TAB_KINDS surface exhaustiveness", () => {
         tab: settingsTabModule.build(SETTINGS_SOURCE),
         surface: settingsTabModule.descriptor.surface,
         expectedNewWindow: "copy",
+      },
+      // The only kind that answers `none`: Home is fixed to its window, so
+      // both halves of the capability pair have to say so.
+      {
+        tab: homeTabModule.build(null),
+        surface: homeTabModule.descriptor.surface,
+        expectedNewWindow: "none",
       },
     ];
 

--- a/clients/gui-app/src/stores/tabs/desktop-tabs-persistence.ts
+++ b/clients/gui-app/src/stores/tabs/desktop-tabs-persistence.ts
@@ -21,11 +21,13 @@ import {
 } from "@/stores/tabs/layout";
 import {
   discardLegacyTabsSourceActiveSelection,
+  layoutHomeIsActive,
   migrateTabsPersistedState,
   setTabsLocalPersistenceEnabled,
   useTabsStore,
 } from "@/stores/tabs/store";
 import { isRegisteredTabKind } from "@/stores/tabs/registry";
+import { homeRoutePath, isHomePath } from "@/stores/tabs/kinds/home";
 import { setTabSplitCompatibility } from "@/stores/tabs/tab-split-compatibility";
 import { tabCommandCoordinator } from "@/stores/tabs/tab-command-coordinator";
 import { tabSourceRefs } from "@/stores/tabs/source-refs";
@@ -342,6 +344,11 @@ function isProjectionCoherent(
   layout: PersistedTabStripLayout,
 ): boolean {
   if (route === null) return false;
+  // Home holds the selection with no item and no ref, so every ref-backed
+  // check below would call it incoherent - and an incoherent projection is
+  // never scheduled, which would silently stop persisting layout changes for
+  // as long as Home is the surface on screen.
+  if (layoutHomeIsActive(layout)) return isHomePath(routePath(route) ?? "");
   const ref = routeRef(routePath(route));
   if (ref === null)
     return layout.items.length === 0 && routePath(route) === "/";
@@ -387,7 +394,13 @@ function sanitizeDesktopLayout(
       !sourceKeys.has(refKey(ref)),
   );
   const withoutMissing = missing.reduce(removeMissingRef, persisted);
-  return repairLayout(withoutMissing, isRegisteredTabKind);
+  const repaired = repairLayout(withoutMissing, isRegisteredTabKind);
+  // Same distinction `committedLayout` draws: a null active id is a snapshot
+  // that never carried one for `repairLayout`, and a snapshot that was sitting
+  // on Home for us.
+  return layoutHomeIsActive(withoutMissing)
+    ? { ...repaired, activeItemId: null }
+    : repaired;
 }
 
 function removeMissingRef(
@@ -411,12 +424,27 @@ function removeMissingRef(
       ? []
       : [{ kind: "tab", id: tabItemId(survivor), ref: survivor }];
   });
-  const activeItemId = items.some(
-    (candidate) => candidate.id === layout.activeItemId,
-  )
-    ? layout.activeItemId
-    : (items.at(0)?.id ?? null);
-  return { ...layout, items, activeItemId };
+  return {
+    ...layout,
+    items,
+    activeItemId: survivingActiveItemId(layout, items),
+  };
+}
+
+/**
+ * The active item after a removal. Home keeps its null selection - it names no
+ * item, so the membership test below would read it as a stale id and hand the
+ * selection to whichever task tab happens to sit first.
+ */
+function survivingActiveItemId(
+  layout: PersistedTabStripLayout,
+  items: ReadonlyArray<StripItem>,
+): string | null {
+  if (layoutHomeIsActive(layout)) return null;
+  if (items.some((candidate) => candidate.id === layout.activeItemId)) {
+    return layout.activeItemId;
+  }
+  return items.at(0)?.id ?? null;
 }
 
 function legacyDesktopLayout(
@@ -494,6 +522,10 @@ function restoreRoute(
   layout: PersistedTabStripLayout,
   activeRoute: string | null,
 ): string {
+  // Ahead of the persisted route: Home names no item and no ref, so none of the
+  // lookups below can recover it, and a snapshot left on Home would restore
+  // onto whichever task tab happens to sit first in the strip.
+  if (layoutHomeIsActive(layout)) return homeRoutePath();
   const active = activeRoute === null ? null : routeRef(routePath(activeRoute));
   if (
     active !== null &&
@@ -549,6 +581,9 @@ function routeForRef(layout: PersistedTabStripLayout, ref: TabRef): string {
       : `/epics/${encodeURIComponent(tab.epicId)}/${encodeURIComponent(tab.tabId)}`;
   }
   if (ref.kind === "draft") return `/draft/${encodeURIComponent(ref.id)}`;
+  // A `home` ref never reaches here: it is not a layout ref (`validRef` refuses
+  // one) and not a source ref, so nothing this module walks can produce it.
+  if (ref.kind === "home") return "/";
   const lastPath = layout.systemTabs[ref.kind]?.lastPath ?? null;
   if (
     lastPath !== null &&

--- a/clients/gui-app/src/stores/tabs/kinds/home.tsx
+++ b/clients/gui-app/src/stores/tabs/kinds/home.tsx
@@ -1,0 +1,95 @@
+import { createElement, lazy } from "react";
+import { House } from "lucide-react";
+import { useLandingDraftStore } from "@/stores/home/landing-draft-store";
+import { homeTabIntent } from "@/lib/tab-navigation/intents";
+import type { HeaderTab, TabKindModule, TabRef } from "@/stores/tabs/types";
+
+const HOME_TAB_LABEL = "Home";
+const HOME_ROUTE = "/home";
+
+/**
+ * Home's ref, for the seams that are ref-addressed (navigation destinations,
+ * activation results, the mobile header's surface resolution).
+ *
+ * It is deliberately NOT a layout ref: Home is never an entry in `items`, never
+ * a `systemTab`, and never a source ref, so `repairLayout` rejects it (see
+ * `validRef`) and `stripOrder` can never contain it. "Home is active" is
+ * `activeItemId === null` in a layout whose Home tab is enabled - one state, not
+ * a second item competing with the strip.
+ */
+export const HOME_TAB_REF: TabRef = { kind: "home", id: "home" };
+
+const homeSurface = lazy(() =>
+  import("@/components/home-focus/home-focus-view").then((module) => ({
+    default: module.HomeFocusView,
+  })),
+);
+
+/**
+ * One record for the whole app rather than one per `build()` call: Home has no
+ * source store to key a memo cache on, and the strip and the surface host both
+ * compare it by identity.
+ */
+const HOME_HEADER_TAB: Extract<HeaderTab, { kind: "home" }> = {
+  kind: "home",
+  id: "home",
+  route: HOME_ROUTE,
+  name: HOME_TAB_LABEL,
+  icon: House,
+  canDuplicate: false,
+  canOpenInNewWindow: false,
+};
+
+/**
+ * Module for `kind: "home"` tabs. A fixed singleton: it cannot be closed,
+ * duplicated, moved, split, or opened in another window, so every behavior
+ * below is either a refusal or the one route it owns.
+ */
+export const homeTabModule: TabKindModule<"home", null> = {
+  kind: "home",
+  build: () => HOME_HEADER_TAB,
+  descriptor: {
+    kind: "home",
+    surface: {
+      render: () => createElement(homeSurface),
+      canonicalRoute: (tab) => tab.route,
+      splitEligibility: "ineligible",
+      duplication: "forbidden",
+      singleton: "per-window",
+      newWindow: "none",
+      readinessScope: "none",
+      durableState: { owner: "tabs-store", eviction: "reconstruct" },
+    },
+    duplicate: () => null,
+    resolveIntent: () => homeTabIntent(),
+    routeOptions: () => ({ to: HOME_ROUTE }),
+    // Belt-and-braces: the activating transaction's own compatibility
+    // projection already nulls `activeDraftId` whenever the focused ref is
+    // null, which Home's always is. Kept so the kind states its own
+    // post-condition rather than inheriting one, matching `history`.
+    activate: () => {
+      useLandingDraftStore.getState().clearActiveDraft();
+    },
+    // Refuses. Home is the surface every close lands ON; a close that could
+    // remove it would leave the strip with nothing to fall back to.
+    requestClose: () => undefined,
+    requiresCloseConfirm: () => false,
+    // Never offered - `canOpenInNewWindow` is false on the record above - so
+    // this exists only to satisfy the exhaustive dispatch.
+    openInNewWindow: () => undefined,
+    matchesPath: (_tab, pathname) => isHomePath(pathname),
+  },
+};
+
+/** The single Home `HeaderTab`, for consumers that render it structurally. */
+export function homeHeaderTab(): Extract<HeaderTab, { kind: "home" }> {
+  return HOME_HEADER_TAB;
+}
+
+export function homeRoutePath(): string {
+  return HOME_ROUTE;
+}
+
+export function isHomePath(pathname: string): boolean {
+  return pathname === HOME_ROUTE || pathname === `${HOME_ROUTE}/`;
+}

--- a/clients/gui-app/src/stores/tabs/layout.ts
+++ b/clients/gui-app/src/stores/tabs/layout.ts
@@ -760,6 +760,11 @@ function validRef(ref: TabRef, isKnownTabKind: IsKnownTabKind): boolean {
   if (!isKnownTabKind(ref.kind) || ref.id.length === 0) return false;
   if (ref.kind === "history") return ref.id === "history";
   if (ref.kind === "settings") return ref.id === "settings";
+  // Home is a registered kind but never a strip item: it has no source record,
+  // is not persisted, and is rendered structurally beside the strip. Refusing
+  // it here is what keeps a persisted or hand-edited payload from materializing
+  // one as an ordinary, closable, draggable tab.
+  if (ref.kind === "home") return false;
   return true;
 }
 

--- a/clients/gui-app/src/stores/tabs/registry.ts
+++ b/clients/gui-app/src/stores/tabs/registry.ts
@@ -3,6 +3,7 @@ import { epicTabModule } from "@/stores/tabs/kinds/epic";
 import { draftTabModule } from "@/stores/tabs/kinds/draft";
 import { historyTabModule } from "@/stores/tabs/kinds/history";
 import { settingsTabModule } from "@/stores/tabs/kinds/settings";
+import { homeTabModule } from "@/stores/tabs/kinds/home";
 import type { TabNavigationIntent } from "@/lib/tab-navigation/intents";
 import type {
   HeaderTab,
@@ -23,12 +24,20 @@ import type {
  * All kind-dispatched behaviors (close, duplicate, navigate) go through the
  * per-concern dispatch functions exported below. Switches are centralized here
  * - consumers call `tabRequestClose(tab)`, `tabDuplicate(tab)`, etc.
+ *
+ * `home` is registered like every other kind so it dispatches through the same
+ * seams, but it is the one kind with no strip presence: it is never in `items`,
+ * `systemTabs` or `stripOrder`, and `validRef` in `layout.ts` refuses a `home`
+ * ref outright. Registration here is what makes `isRegisteredTabKind("home")`
+ * true, so that refusal is the thing keeping a hand-edited payload from
+ * injecting a second Home into the strip.
  */
 export const TAB_KINDS = {
   epic: epicTabModule,
   draft: draftTabModule,
   history: historyTabModule,
   settings: settingsTabModule,
+  home: homeTabModule,
 } as const;
 
 /**
@@ -69,19 +78,24 @@ export function tabSurfaceDescriptor(
   kind: "settings",
 ): TabSurfaceDescriptor<"settings">;
 export function tabSurfaceDescriptor(
-  kind: HeaderTabKind,
-):
-  | TabSurfaceDescriptor<"epic">
-  | TabSurfaceDescriptor<"draft">
-  | TabSurfaceDescriptor<"history">
-  | TabSurfaceDescriptor<"settings">;
+  kind: "home",
+): TabSurfaceDescriptor<"home">;
 export function tabSurfaceDescriptor(
   kind: HeaderTabKind,
 ):
   | TabSurfaceDescriptor<"epic">
   | TabSurfaceDescriptor<"draft">
   | TabSurfaceDescriptor<"history">
-  | TabSurfaceDescriptor<"settings"> {
+  | TabSurfaceDescriptor<"settings">
+  | TabSurfaceDescriptor<"home">;
+export function tabSurfaceDescriptor(
+  kind: HeaderTabKind,
+):
+  | TabSurfaceDescriptor<"epic">
+  | TabSurfaceDescriptor<"draft">
+  | TabSurfaceDescriptor<"history">
+  | TabSurfaceDescriptor<"settings">
+  | TabSurfaceDescriptor<"home"> {
   switch (kind) {
     case "epic":
       return TAB_KINDS.epic.descriptor.surface;
@@ -91,6 +105,8 @@ export function tabSurfaceDescriptor(
       return TAB_KINDS.history.descriptor.surface;
     case "settings":
       return TAB_KINDS.settings.descriptor.surface;
+    case "home":
+      return TAB_KINDS.home.descriptor.surface;
   }
 }
 
@@ -112,6 +128,8 @@ export function tabRequestClose(tab: HeaderTab): void {
       return TAB_KINDS.history.descriptor.requestClose(tab);
     case "settings":
       return TAB_KINDS.settings.descriptor.requestClose(tab);
+    case "home":
+      return TAB_KINDS.home.descriptor.requestClose(tab);
   }
 }
 
@@ -129,6 +147,8 @@ export function tabDuplicate(tab: HeaderTab): TabNavigationIntent | null {
       return TAB_KINDS.history.descriptor.duplicate(tab);
     case "settings":
       return TAB_KINDS.settings.descriptor.duplicate(tab);
+    case "home":
+      return TAB_KINDS.home.descriptor.duplicate(tab);
   }
 }
 
@@ -146,6 +166,8 @@ export function tabResolveIntent(tab: HeaderTab): TabNavigationIntent {
       return TAB_KINDS.history.descriptor.resolveIntent(tab);
     case "settings":
       return TAB_KINDS.settings.descriptor.resolveIntent(tab);
+    case "home":
+      return TAB_KINDS.home.descriptor.resolveIntent(tab);
   }
 }
 
@@ -163,6 +185,8 @@ export function tabRouteOptions(intent: TabNavigationIntent): NavigateOptions {
       return TAB_KINDS.history.descriptor.routeOptions(intent);
     case "settings":
       return TAB_KINDS.settings.descriptor.routeOptions(intent);
+    case "home":
+      return TAB_KINDS.home.descriptor.routeOptions(intent);
   }
 }
 
@@ -180,6 +204,8 @@ export function tabActivate(intent: TabNavigationIntent): void {
       return TAB_KINDS.history.descriptor.activate(intent);
     case "settings":
       return TAB_KINDS.settings.descriptor.activate(intent);
+    case "home":
+      return TAB_KINDS.home.descriptor.activate(intent);
   }
 }
 
@@ -199,6 +225,8 @@ export function tabRequiresCloseConfirm(tab: HeaderTab): boolean {
       return TAB_KINDS.history.descriptor.requiresCloseConfirm(tab);
     case "settings":
       return TAB_KINDS.settings.descriptor.requiresCloseConfirm(tab);
+    case "home":
+      return TAB_KINDS.home.descriptor.requiresCloseConfirm(tab);
   }
 }
 
@@ -214,6 +242,7 @@ export function tabEpicId(tab: HeaderTab): string | null {
     case "draft":
     case "history":
     case "settings":
+    case "home":
       return null;
   }
 }
@@ -241,6 +270,8 @@ export function tabOpenInNewWindow(
       return TAB_KINDS.history.descriptor.openInNewWindow(tab, deps);
     case "settings":
       return TAB_KINDS.settings.descriptor.openInNewWindow(tab, deps);
+    case "home":
+      return TAB_KINDS.home.descriptor.openInNewWindow(tab, deps);
   }
 }
 
@@ -259,5 +290,7 @@ export function tabMatchesPath(tab: HeaderTab, pathname: string): boolean {
       return TAB_KINDS.history.descriptor.matchesPath(tab, pathname);
     case "settings":
       return TAB_KINDS.settings.descriptor.matchesPath(tab, pathname);
+    case "home":
+      return TAB_KINDS.home.descriptor.matchesPath(tab, pathname);
   }
 }

--- a/clients/gui-app/src/stores/tabs/store.ts
+++ b/clients/gui-app/src/stores/tabs/store.ts
@@ -42,6 +42,7 @@ import {
   type SystemTabs,
 } from "@/stores/tabs/layout";
 import type { SystemTab, TabRef } from "@/stores/tabs/types";
+import { isHomeTabEnabled } from "@/stores/settings/settings-store";
 import { canMutateTabSplits } from "@/stores/tabs/tab-split-compatibility";
 import { isTabStructurallyLocked } from "@/stores/tabs/tab-structural-lock";
 
@@ -170,11 +171,47 @@ function itemContainsStructurallyLockedRef(item: StripItem): boolean {
 }
 
 function committedLayout(layout: PersistedTabStripLayout): CommittedTabsLayout {
-  const repaired = repairLayout(layout, isRegisteredTabKind);
+  const repaired = withHomeActivePreserved(
+    layout,
+    repairLayout(layout, isRegisteredTabKind),
+  );
   return {
     ...repaired,
     stripOrder: flattenLayoutRefs(repaired),
   };
+}
+
+/**
+ * `true` when this layout's `activeItemId: null` means "the Home tab is
+ * active", rather than "the strip is empty and nothing is selected".
+ *
+ * The two states are the same value and are told apart by the flag alone: with
+ * Home off, a populated strip always has an active item and `repairLayout`
+ * restores that invariant after every commit. Home is what makes null a
+ * selection a populated strip can legitimately hold.
+ */
+export function layoutHomeIsActive(layout: PersistedTabStripLayout): boolean {
+  return layout.activeItemId === null && isHomeTabEnabled();
+}
+
+/**
+ * Re-applies a deliberate Home selection that `repairLayout` resolved away.
+ *
+ * `repairLayout` is pure and knows nothing about Home, so it reads a null
+ * active id as "unset" and falls back to the first item - correct before Home
+ * existed, and still correct for a persisted payload that simply never carried
+ * one. Only the source layout can say which of the two it meant, so the
+ * distinction is drawn here, at the commit boundary, rather than by teaching
+ * the reducer a flag.
+ */
+function withHomeActivePreserved(
+  source: PersistedTabStripLayout,
+  repaired: PersistedTabStripLayout,
+): PersistedTabStripLayout {
+  if (repaired.activeItemId === null || !layoutHomeIsActive(source)) {
+    return repaired;
+  }
+  return { ...repaired, activeItemId: null };
 }
 
 function layoutFromState(state: TabsStoreState): PersistedTabStripLayout {
@@ -314,6 +351,9 @@ function parseTabRef(value: unknown): ReadonlyArray<TabRef> {
   if (!isRegisteredTabKind(value.kind) || value.id.length === 0) return [];
   if (value.kind === "history" && value.id !== "history") return [];
   if (value.kind === "settings" && value.id !== "settings") return [];
+  // Home is never persisted as a strip ref; `repairLayout` would drop one
+  // anyway, but refusing it here keeps the parsed layout honest.
+  if (value.kind === "home") return [];
   return [{ kind: value.kind, id: value.id }];
 }
 

--- a/clients/gui-app/src/stores/tabs/tab-command-coordinator.ts
+++ b/clients/gui-app/src/stores/tabs/tab-command-coordinator.ts
@@ -19,8 +19,11 @@ import {
 } from "@/stores/tabs/registry";
 import {
   consumeLegacyTabsSourceActiveSelection,
+  layoutHomeIsActive,
   useTabsStore,
 } from "@/stores/tabs/store";
+import { isHomeTabEnabled } from "@/stores/settings/settings-store";
+import { HOME_TAB_REF } from "@/stores/tabs/kinds/home";
 import {
   createEmptySplit,
   createLayoutItem,
@@ -155,7 +158,13 @@ export type CoordinatedTabActivationTarget =
       readonly systemKind: "history" | "settings";
       readonly name: string;
       readonly lastPath: string;
-    };
+    }
+  /**
+   * The fixed Home tab. It owns no strip item, so activating it is purely a
+   * selection move: `activeItemId` goes to null and every source-backed active
+   * id is cleared by the transaction's own compatibility projection.
+   */
+  | { readonly kind: "home" };
 
 export interface CoordinatedTabSelection {
   readonly items: ReadonlyArray<StripItem>;
@@ -314,6 +323,9 @@ function sourceHasRef(ref: TabRef): boolean {
       .getState()
       .drafts.some((draft) => draft.id === ref.id);
   }
+  // Home owns no source record and no strip item, so it is never a placement
+  // this reconciles - `resolveHomeActivation` is its only entry point.
+  if (ref.kind === "home") return false;
   return currentLayout().systemTabs[ref.kind] !== null;
 }
 
@@ -330,6 +342,24 @@ function canFillSplitRef(ref: TabRef): boolean {
     !isTabStructurallyLocked(ref) &&
     tabSurfaceDescriptor(ref.kind).splitEligibility === "eligible"
   );
+}
+
+/**
+ * `repairLayout`, with a deliberate Home selection carried through it.
+ *
+ * The reducer is pure and reads a null active id as "unset", falling back to
+ * the first item; only the layout being repaired can say whether that null was
+ * an absent selection or Home holding one. Same distinction `committedLayout`
+ * draws at the store's commit boundary, applied to the two places this module
+ * repairs a layout without going through it.
+ */
+function repairedLayoutPreservingHome(
+  layout: PersistedTabStripLayout,
+): PersistedTabStripLayout {
+  const repaired = repairLayout(layout, isRegisteredTabKind);
+  return layoutHomeIsActive(layout)
+    ? { ...repaired, activeItemId: null }
+    : repaired;
 }
 
 function focusedRef(layout: PersistedTabStripLayout): TabRef | null {
@@ -373,6 +403,12 @@ function restoreCoordinatedSelection(
   layout: PersistedTabStripLayout,
   selection: CoordinatedTabSelection,
 ): PersistedTabStripLayout | null {
+  // A rejected navigation that STARTED on Home has to land back on Home. Its
+  // prior selection names no item, so the item lookup below can never recover
+  // it; the selection itself is the whole state to restore.
+  if (selection.activeItemId === null) {
+    return isHomeTabEnabled() ? { ...layout, activeItemId: null } : null;
+  }
   const priorItem = layout.items.find(
     (item) => item.id === selection.activeItemId,
   );
@@ -980,7 +1016,27 @@ export class TabCommandCoordinator {
         return this.resolveMigratedEpicActivation(target, layout);
       case "ref":
         return this.resolveRefActivation(target.ref, layout);
+      case "home":
+        return this.resolveHomeActivation(layout);
     }
+  }
+
+  /**
+   * Home is a selection, not a placement: nothing is created, nothing is
+   * reserved, and the layout keeps every item it had. Refused outright while
+   * the Home tab is off, so a stale intent cannot strand the window on a
+   * selection with no surface behind it.
+   */
+  private resolveHomeActivation(
+    layout: PersistedTabStripLayout,
+  ): ResolvedCoordinatedActivation | null {
+    if (!isHomeTabEnabled()) return null;
+    return {
+      ref: HOME_TAB_REF,
+      layout: { ...layout, activeItemId: null },
+      reservedAdditions: [],
+      applySources: () => undefined,
+    };
   }
 
   private resolveSystemActivation(
@@ -1169,6 +1225,7 @@ export class TabCommandCoordinator {
         useLandingDraftStore.getState().setActiveDraft(ref.id);
       });
     }
+    if (ref.kind === "home") return this.resolveHomeActivation(layout);
     if (layout.systemTabs[ref.kind] === null) return null;
     return this.activationForRef(layout, ref, () => undefined);
   }
@@ -1440,9 +1497,8 @@ export class TabCommandCoordinator {
         ref.kind !== "settings" &&
         !sourceKeys.has(tabRefKey(ref)),
     );
-    const repaired = repairLayout(
+    const repaired = repairedLayoutPreservingHome(
       missing.reduce(removeLayoutRef, layout),
-      isRegisteredTabKind,
     );
     const currentKeys = new Set(flattenLayoutRefs(current).map(tabRefKey));
     const reservedAdditions = flattenLayoutRefs(repaired).filter(
@@ -1699,7 +1755,7 @@ export class TabCommandCoordinator {
       return null;
     } catch (error) {
       const primary = transactionError(error);
-      const repaired = repairLayout(currentLayout(), isRegisteredTabKind);
+      const repaired = repairedLayoutPreservingHome(currentLayout());
       const fallbackFailure = this.replaceLayoutWithoutPersistence(repaired);
       this.diagnostics = {
         ...this.diagnostics,

--- a/clients/gui-app/src/stores/tabs/types.ts
+++ b/clients/gui-app/src/stores/tabs/types.ts
@@ -101,6 +101,22 @@ export type HeaderTab =
       readonly canDuplicate: boolean;
       readonly canOpenInNewWindow: boolean;
       readonly lastPath: string | null;
+    }
+  /**
+   * The fixed Home tab. Unlike every other variant this one is NOT projected
+   * from a strip ref - it has no source record and never appears in `items`,
+   * `systemTabs` or `stripOrder`. The strip renders it structurally and the
+   * surface host mounts it unconditionally; the variant exists so Home flows
+   * through the same registry dispatch, intents and route options as the rest.
+   */
+  | {
+      readonly kind: "home";
+      readonly id: "home";
+      readonly route: string;
+      readonly name: string;
+      readonly icon: TabIcon | null;
+      readonly canDuplicate: boolean;
+      readonly canOpenInNewWindow: boolean;
     };
 
 export interface TabContextMenuCtx {


### PR DESCRIPTION
## What

A fixed **Home** tab at the left of the top-level tab strip, behind a new Settings ▸ General switch (**default off**; with it off the app is unchanged). Home shows a **focus view** across every task on the host:

- **Needs you** — unresolved approval / question / browser prompts, in the bell's attention order, click-through to the chat.
- **Running** — every task with a working agent (all tasks the host knows, including ones not open in this window), agents with turn / background tier, **Open**, **Stop** / **Stop all** (one `agent.stop` per root, cascade).
- **Background** — managed commands and background items from chats open in this window, with elapsed time and Stop.

Start New (`+`, `/draft/new`) is unchanged. Three stacked commits: the model (pure builders + hooks + actions), the tab (kind, strip placement, routing, `app.home.open`, mobile drawer, flag), the view.

## Notes for review

- Home is never a strip item: `activeItemId === null` means "Home is active" while the flag is on; it is excluded from digit chords, DnD, splits and close.
- The model never fetches beyond existing subscriptions; ephemeral providers' stop calls route to the agent's own host, and a cold task whose host cannot be named is not stoppable from Home.
- Client-only phase. Inline approve / answer / reply, elapsed time for agents, and background jobs for tasks not open in this window need host work (listed in the epic brief as phase 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)