### PR TITLE
fix(shared,ci): full host.status@1.4 baseline-smoke body; gate the transport smoke against the working tree (1.3.0)

### DIFF
--- a/.github/workflows/protocol-compat.yml
+++ b/.github/workflows/protocol-compat.yml
@@ -145,7 +145,18 @@ jobs:
             args+=(--baseline "$pair")
           done < /tmp/baseline-args.txt
           bun run protocol/scripts/compat/check-protocol-compat.ts --mine /tmp/working-tree.json "${args[@]}"
-      - name: Drive the real client transports against the released manifests
+      - name: Add this tree's own surface as the working-tree baseline for the transport smoke
+        # The released set only ever asks the transports for what a RELEASED
+        # peer negotiates, so a test fixture that lags this tree's own latest
+        # minor is invisible until this tree becomes a release tag - which the
+        # stable release does mid-run, after the rc gate on the same commit
+        # passed (cli-v1.3.0: host.status@1.4 reddened the stable desktop gate
+        # minutes after rc.5 went green). Feeding the working tree in as a
+        # baseline makes every PR negotiate the latest minor here. It is added
+        # AFTER the surface-compat check above, which takes its baselines from
+        # the explicit argument list, not from this directory.
+        run: cp /tmp/working-tree.json /tmp/surfaces/working-tree.json
+      - name: Drive the real client transports against the released manifests and the working tree
         env:
           PROTOCOL_BASELINE_SURFACES_DIR: /tmp/surfaces
         run: |

--- a/clients/shared/host-transport/__tests__/released-baseline-handshake.test.ts
+++ b/clients/shared/host-transport/__tests__/released-baseline-handshake.test.ts
@@ -482,6 +482,15 @@ describe.skipIf(baselines.length === 0)(
           // Serving a superset body is sound because the line is additive and
           // `z.object` is non-strict: extra keys are stripped at the negotiated
           // version, missing ones are not invented.
+          //
+          // This body must be valid at the LATEST installed minor, not merely
+          // the highest minor a released baseline negotiates. The gate feeds
+          // this tree's own surface in as the `working-tree` baseline, so the
+          // latest minor is always exercised here - before it becomes a
+          // release tag. The 1.4 stable cut (cli-v1.3.0) found this stub two
+          // minors stale: nothing released negotiated above 1.2 until the
+          // stable cli tag itself did, mid-release, and the rc gate that ran
+          // minutes earlier on the same commit could not see it.
           const served = {
             ready: true,
             hostVersion: "0.0.0-smoke",
@@ -490,6 +499,11 @@ describe.skipIf(baselines.length === 0)(
             busySessionCount: null,
             updateProgress: null,
             busyBreakdown: null,
+            // @1.3
+            updateOperation: null,
+            updateTransaction: null,
+            // @1.4
+            storeFormats: null,
           };
 
           // SELF-CHECKING FIXTURE. Without this, the next released minor a


### PR DESCRIPTION
## Why

The 1.3.0 stable cut failed at `desktop / Protocol compatibility gate` (traycer-internal run 34293499486) on the same commit rc.5 had passed:

> the stub response is not valid at the negotiated host.status@1.4; extend `served` with that minor's fields

The released-baseline handshake smoke only negotiates what a **released** peer advertises. cli-v1.2.0 advertises host.status@1.2, so 1.3 and 1.4 were never exercised. The stable run published `cli-v1.3.0` (1.4) *before* the desktop gate resolved baselines, so that gate was the first to negotiate 1.4. rc tags are excluded from the baseline set, so rc.5 could not have seen it.

## What

- `served` now carries the 1.3 fields (`updateOperation`, `updateTransaction`) and the 1.4 field (`storeFormats`), all `null` (absent evidence, never a fabricated capability). The existing `toMatchObject` already expected those as null after upgrade.
- `protocol-compat.yml` copies this tree's own dumped surface into the surfaces directory as the `working-tree` baseline before the transport smoke. Every PR now negotiates the latest installed minor here, before it becomes a release tag. Added after the surface-compat check, which takes its baselines from an explicit argument list rather than the directory. The internal gate action gets the same step (rc gates included) in the paired traycer-internal PR.

## Falsification

Locally, with a surfaces dir of `working-tree.json` + `cli-v1.2.0.json`:
- old stub: `× WsRpcClient completes the unary handshake against working-tree` with the 1.4 message above; cli-v1.2.0 rows pass (1 failed | 9 passed).
- new stub: 10 passed.
- host-side `released-baseline-open-frame.test.ts` with the same dir: 2 passed (the host acknowledges the working-tree client manifest).

Guarded file `.github/workflows/protocol-compat.yml` changed: this **adds** a baseline, it relaxes nothing. Label `protocol-compat-override` applied for the tripwire.

Base is `release-v1.3.0` (the 1.3.0 line rc.5 was cut from). Same change to `main`: see the sibling PR.