### PR TITLE
fix(protocol): freeze the lines cli-v1.3.0 shipped; new majors for unary, new minors for streams

### DIFF
--- a/clients/traycer-cli/src/commands/agent-profile-rate-limits.ts
+++ b/clients/traycer-cli/src/commands/agent-profile-rate-limits.ts
@@ -1,7 +1,7 @@
 import { formatAgentProviderProfileRateLimitsResponse } from "@traycer/protocol/agent/agent-profile-format";
 import {
   agentGetProviderProfileRateLimitsRequestSchema,
-  agentGetProviderProfileRateLimitsResponseSchemaV5,
+  agentGetProviderProfileRateLimitsResponseSchemaV6,
 } from "@traycer/protocol/host/agent/profiles";
 import {
   callHostRpc,
@@ -44,14 +44,21 @@ export function buildAgentProfileRateLimitsCommand(opts: {
     const result = await toAgentCliError(
       callHostRpc("agent.getProviderProfileRateLimits", request),
     );
-    // The explicit v5.0 schema, not the base `...ResponseSchema` name this
-    // used to read. That name is the LIVE line's alias: identical to v5.0
-    // today, but it is redefined onto each new major as the previous one is
-    // frozen, so it only tracks canonical by coincidence of timing. Naming the
-    // version pins the contract and lets `parseCanonicalHostResponse` prove it.
+    // The explicit v6.0 schema, not the base `...ResponseSchema` name this
+    // used to read. That name is a structurally identical but DISTINCT object
+    // that is canonical for nothing, so naming the version pins the contract
+    // and lets `parseCanonicalHostResponse` prove it.
+    //
+    // This was `...V5` until `cli-v1.3.0` shipped the v5.0 line and froze it
+    // (traycerai/traycer#1808). The CLI negotiates the HEAD contract at
+    // handshake, so it has to parse against the head: pinned at the frozen
+    // v5.0 it would have strict-decoded a v6.0 response and silently dropped
+    // `antigravity` from a rate-limit read. `assertCanonicalResponseSchema` is
+    // what turned that into a red CI job instead of a wrong answer. Move this
+    // to `...V7` the same day a tag ships v6.0.
     const response = parseCanonicalHostResponse(
       "agent.getProviderProfileRateLimits",
-      agentGetProviderProfileRateLimitsResponseSchemaV5,
+      agentGetProviderProfileRateLimitsResponseSchemaV6,
       result,
     );
     return {

--- a/clients/traycer-cli/src/internal/__tests__/host-rpc.test.ts
+++ b/clients/traycer-cli/src/internal/__tests__/host-rpc.test.ts
@@ -27,6 +27,7 @@ import type { ZodType } from "zod";
 import {
   agentGetProviderProfileRateLimitsResponseSchema,
   agentGetProviderProfileRateLimitsResponseSchemaV5,
+  agentGetProviderProfileRateLimitsResponseSchemaV6,
 } from "@traycer/protocol/host/agent/profiles";
 import { worktreeListAllForHostResponseSchemaV16 } from "@traycer/protocol/host";
 import { listTerminalsResponseSchemaV23 } from "@traycer/protocol/host/terminal/unary-schemas";
@@ -451,9 +452,18 @@ describe("canonicalResponseSchemaFor", () => {
     expect(canonicalResponseSchemaFor("terminal.list")).toBe(
       listTerminalsResponseSchemaV23,
     );
+    // v6.0, not v5.0: `cli-v1.3.0` shipped the v5.0 line, so
+    // traycerai/traycer#1808 froze it against `providerRateLimitsSchemaV80`
+    // and opened v6.0 over the live union. This pin moving is the intended
+    // consequence of a freeze - what must NOT happen is the call site staying
+    // on v5.0 while this pin moves, which is why the two are asserted apart.
     expect(
       canonicalResponseSchemaFor("agent.getProviderProfileRateLimits"),
-    ).toBe(agentGetProviderProfileRateLimitsResponseSchemaV5);
+    ).toBe(agentGetProviderProfileRateLimitsResponseSchemaV6);
+    // And the line the release froze is now demonstrably NOT canonical.
+    expect(
+      canonicalResponseSchemaFor("agent.getProviderProfileRateLimits"),
+    ).not.toBe(agentGetProviderProfileRateLimitsResponseSchemaV5);
   });
 });
 
@@ -465,20 +475,30 @@ describe("parseCanonicalHostResponse", () => {
     };
     const parsed = parseCanonicalHostResponse(
       "agent.getProviderProfileRateLimits",
-      agentGetProviderProfileRateLimitsResponseSchemaV5,
+      agentGetProviderProfileRateLimitsResponseSchemaV6,
       value,
     );
     expect(parsed).toEqual(value);
   });
 
-  // This is the one case the type system cannot catch: `...Schema` (no
-  // version suffix) is the LIVE-line alias, redefined onto each new major as
-  // the previous one freezes. It is STRUCTURALLY IDENTICAL to `...SchemaV5`
-  // today, so it satisfies `ZodType<ResponseOfMethod<...>>` and compiles at
-  // the call site - but it is a DIFFERENT object, free to stop tracking
-  // canonical the moment a v6 line ships. Only the runtime identity check in
-  // `assertCanonicalResponseSchema` catches that drift; a type-level
-  // assertion would pass this call unchanged.
+  // This is the one case the type system cannot catch: `...Schema` (no version
+  // suffix) ranges over the same live `providerRateLimitsSchema` as the head
+  // `...SchemaV6`, so it is STRUCTURALLY IDENTICAL to canonical, satisfies
+  // `ZodType<ResponseOfMethod<...>>`, and compiles at any call site - while
+  // being a DIFFERENT object that is canonical for nothing.
+  //
+  // That is precisely the drift a freeze creates, and it is not hypothetical:
+  // `cli-v1.3.0` froze the v5.0 line and the call site in
+  // `agent-profile-rate-limits.ts` was still pinned to `...SchemaV5`, which
+  // would have strict-decoded a v6.0 response and silently dropped
+  // `antigravity`. Only the runtime identity check in
+  // `assertCanonicalResponseSchema` catches it; a type-level assertion passes
+  // both the stale pin and this call unchanged.
+  //
+  // Keeping the base alias distinct from the head is therefore deliberate -
+  // it is this test's only falsifying fixture. If a future change collapses
+  // them, this test has nothing left to prove and must be given a fresh
+  // structurally-identical object rather than deleted.
   it("throws when handed a schema that is structurally identical to canonical but not the same object (the runtime backstop)", () => {
     const value = {
       rateLimits: { provider: "codex", available: false, reason: "timeout" },

--- a/protocol/src/framework/__tests__/versioned-stream-rpc.test.ts
+++ b/protocol/src/framework/__tests__/versioned-stream-rpc.test.ts
@@ -112,7 +112,7 @@ describe("validateVersionedStreamRpcRegistry", () => {
       validateVersionedStreamRpcRegistry(hostStreamRpcRegistry);
     }).not.toThrow();
     expect(hostStreamRpcRegistry["epic.subscribe"][1].latestMinor).toBe(3);
-    expect(hostStreamRpcRegistry["chat.subscribe"][1].latestMinor).toBe(8);
+    expect(hostStreamRpcRegistry["chat.subscribe"][1].latestMinor).toBe(9);
     expect(hostStreamRpcRegistry["terminal.subscribe"][1].latestMinor).toBe(6);
     expect(hostStreamRpcRegistry["worktree.deleteByPath"][1].latestMinor).toBe(
       2,

--- a/protocol/src/host/__tests__/head-names-canonical-alias.test.ts
+++ b/protocol/src/host/__tests__/head-names-canonical-alias.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+
+import { getLatestContract } from "../../framework/versioned-rpc.js";
+import {
+  agentConfigureResponseSchema,
+  agentGetProviderProfileRateLimitsResponseSchema,
+  agentListProviderProfilesResponseSchema,
+} from "../agent/profiles.js";
+import { listGuiHarnessesResponseSchema } from "../agent/gui/unary-schemas.js";
+import { listAgentsResponseSchema } from "../agent/shared.js";
+import { getChatRunSettingsResponseSchema } from "../epic/chat-records.js";
+import { providersListResponseSchema } from "../provider-schemas.js";
+import { providersRefreshProfileStatusResponseSchema } from "../rate-limit/schemas.js";
+import { hostRpcRegistry } from "../registry.js";
+
+/**
+ * For most methods, when a release freezes a line the freeze gets its own
+ * hand-listed object and the NEW head keeps the canonical base name
+ * (`providersListResponseSchema`, `listAgentsResponseSchema`, ...). Writing the
+ * new head as a fresh `z.object` over the same fields instead leaves the base
+ * name exported, structurally identical, and backing NOTHING - so it still
+ * reads like the live line at every import site while the registry has quietly
+ * moved off it. Nothing type-errors, because the two objects infer the same
+ * type.
+ *
+ * `agent.getProviderProfileRateLimits` is EXCLUDED, and the exclusion is the
+ * interesting half. That method keeps its head in a suffixed
+ * `...ResponseSchemaV6` and deliberately leaves
+ * `agentGetProviderProfileRateLimitsResponseSchema` canonical for nothing,
+ * because that distinct-but-identical object is the only falsifying fixture
+ * `clients/traycer-cli/src/internal/__tests__/host-rpc.test.ts` has for proving
+ * the CLI's `assertCanonicalResponseSchema` backstop actually fires. Adding a
+ * row for it here would force the two objects together and silently gut that
+ * test - which is exactly the mistake this comment exists to stop the next
+ * person (and the author of this file) from repeating.
+ *
+ * FALSIFICATION RECIPE: in `agent/profiles.ts`, change `providersListV90`'s
+ * `responseSchema` from `providersListResponseSchema` to an inline
+ * `z.object({ ... })` over the same fields. The tree still compiles and every
+ * other protocol suite stays green; this file reddens on that one row.
+ * Verified against `agent.getProviderProfileRateLimits` before that row was
+ * removed: 1 failed, 7 passed - the table discriminates rather than failing
+ * wholesale.
+ *
+ * Extend the table whenever a method's head major is opened - and if the new
+ * head does NOT name its base alias, say why here rather than omitting it.
+ */
+const HEAD_NAMES_ITS_CANONICAL_ALIAS: readonly [
+  method: keyof typeof hostRpcRegistry & string,
+  aliasName: string,
+  alias: unknown,
+][] = [
+  [
+    "providers.list",
+    "providersListResponseSchema",
+    providersListResponseSchema,
+  ],
+  ["agent.list", "listAgentsResponseSchema", listAgentsResponseSchema],
+  [
+    "agent.gui.listHarnesses",
+    "listGuiHarnessesResponseSchema",
+    listGuiHarnessesResponseSchema,
+  ],
+  [
+    "agent.configure",
+    "agentConfigureResponseSchema",
+    agentConfigureResponseSchema,
+  ],
+  [
+    "agent.listProviderProfiles",
+    "agentListProviderProfilesResponseSchema",
+    agentListProviderProfilesResponseSchema,
+  ],
+  // agent.getProviderProfileRateLimits is intentionally absent - see the
+  // docblock above. Its exclusion is asserted below, not merely omitted.
+  [
+    "epic.getChatRunSettings",
+    "getChatRunSettingsResponseSchema",
+    getChatRunSettingsResponseSchema,
+  ],
+  [
+    "providers.refreshProfileStatus",
+    "providersRefreshProfileStatusResponseSchema",
+    providersRefreshProfileStatusResponseSchema,
+  ],
+];
+
+describe("the head contract names the canonical live response schema", () => {
+  it.each(HEAD_NAMES_ITS_CANONICAL_ALIAS)(
+    "%s's latest contract IS %s (identity, not shape)",
+    (method, _aliasName, alias) => {
+      const head = getLatestContract(hostRpcRegistry[method], undefined);
+      // `toBe`, not `toEqual`: an equal-but-distinct object is exactly the
+      // defect. Two schemas over the same fields are `toEqual`-identical and
+      // still leave the base name orphaned.
+      expect(head.responseSchema).toBe(alias);
+    },
+  );
+
+  it("covers every method whose head major this freeze opened, minus the one documented exclusion", () => {
+    // A row silently deleted from the table would make this file pass while
+    // checking less, so pin the count too. Raise it deliberately when a new
+    // head major is opened - never lower it to make a red row go away.
+    expect(HEAD_NAMES_ITS_CANONICAL_ALIAS).toHaveLength(7);
+    const methods = HEAD_NAMES_ITS_CANONICAL_ALIAS.map(([method]) => method);
+    expect(new Set(methods).size).toBe(methods.length);
+    for (const method of methods) {
+      expect(hostRpcRegistry[method]).toBeDefined();
+    }
+  });
+
+  it("agent.getProviderProfileRateLimits is excluded BECAUSE its head is deliberately not the base alias", () => {
+    // Asserting the exception rather than omitting it. If someone later
+    // collapses the two objects, this reddens and points at the CLI backstop
+    // test that quietly loses its fixture - instead of that test degrading to
+    // a tautology nobody notices.
+    const head = getLatestContract(
+      hostRpcRegistry["agent.getProviderProfileRateLimits"],
+      undefined,
+    );
+    expect(head.responseSchema).not.toBe(
+      agentGetProviderProfileRateLimitsResponseSchema,
+    );
+    // ...and the base alias still accepts what canonical accepts, which is
+    // what makes it a valid negative fixture rather than a shape mismatch.
+    const value = {
+      rateLimits: { provider: "codex", available: false, reason: "timeout" },
+      usageUpdatedAt: null,
+    };
+    expect(
+      agentGetProviderProfileRateLimitsResponseSchema.safeParse(value).success,
+    ).toBe(true);
+    expect(head.responseSchema.safeParse(value).success).toBe(true);
+  });
+});

--- a/protocol/src/host/__tests__/list-harnesses-enabled-compat.test.ts
+++ b/protocol/src/host/__tests__/list-harnesses-enabled-compat.test.ts
@@ -106,7 +106,7 @@ describe("frozen agent.gui.listHarnesses lines predate enabled/availabilityPendi
     // value so 2.1 callers are never fed a fabricated default.
     const downgraded = downgradeResponseAcrossMajors(
       hostRpcRegistry["agent.gui.listHarnesses"],
-      8,
+      9,
       2,
       { harnesses: [harnessRow("claude", false)] },
     );
@@ -125,7 +125,7 @@ describe("frozen agent.gui.listHarnesses lines predate enabled/availabilityPendi
   it("latest → major-1 downgrade strips both fields before the frozen 1.0 parse", () => {
     const downgraded = downgradeResponseAcrossMajors(
       hostRpcRegistry["agent.gui.listHarnesses"],
-      8,
+      9,
       1,
       { harnesses: [harnessRow("claude", false)] },
     );

--- a/protocol/src/host/__tests__/profile-eligibility-compat.test.ts
+++ b/protocol/src/host/__tests__/profile-eligibility-compat.test.ts
@@ -105,7 +105,7 @@ describe("profile eligibility protocol compatibility", () => {
     ]);
   });
 
-  it("omits disabled profiles from the v8-to-v7 older-client projection", () => {
+  it("omits disabled profiles from the v9-to-v7 older-client projection", () => {
     const current = providersListResponseSchema.parse({
       providers: [
         providerCliStateSchema.parse({
@@ -124,7 +124,7 @@ describe("profile eligibility protocol compatibility", () => {
 
     const downgraded = downgradeResponseAcrossMajors(
       hostRpcRegistry["providers.list"],
-      8,
+      9,
       7,
       current,
     );

--- a/protocol/src/host/__tests__/provider-model-providers-compat.test.ts
+++ b/protocol/src/host/__tests__/provider-model-providers-compat.test.ts
@@ -284,7 +284,7 @@ describe("the tab id can only reach a decoder that knows it", () => {
     for (const targetMajor of [1, 2, 3, 4, 5, 6] as const) {
       const downgraded = downgradeResponseAcrossMajors(
         hostRpcRegistry["providers.list"],
-        8,
+        9,
         targetMajor,
         liveResponse,
       );
@@ -324,7 +324,7 @@ describe("providers.list head line -> every older major", () => {
       ).toBeDefined();
       const downgraded = downgradeResponseAcrossMajors(
         hostRpcRegistry["providers.list"],
-        8,
+        9,
         targetMajor,
         liveResponse,
       );
@@ -343,7 +343,7 @@ describe("providers.list head line -> every older major", () => {
     // drop it wholesale and the ids survive untouched.
     const downgraded = downgradeResponseAcrossMajors(
       hostRpcRegistry["providers.list"],
-      8,
+      9,
       6,
       liveResponse,
     );
@@ -1957,7 +1957,7 @@ describe("no downgrade hop fails a whole response over one unsupported provider"
     (targetMajor) => {
       const downgraded = downgradeResponseAcrossMajors(
         hostRpcRegistry["providers.list"],
-        8,
+        9,
         targetMajor,
         { providers: [newestProvider, claudeState], native: null },
       );

--- a/protocol/src/host/__tests__/provider-native-schemas.test.ts
+++ b/protocol/src/host/__tests__/provider-native-schemas.test.ts
@@ -56,10 +56,11 @@ import {
 } from "@traycer/protocol/host/provider-schemas";
 import {
   hostRpcRegistry,
-  providersListDowngradeV8ToV1,
-  providersListDowngradeV8ToV2,
-  providersListDowngradeV8ToV3,
   providersListDowngradeV8ToV6,
+  providersListDowngradeV9ToV1,
+  providersListDowngradeV9ToV2,
+  providersListDowngradeV9ToV3,
+  providersListDowngradeV9ToV6,
   providersListUpgradeV3ToV4,
   providersListUpgradeV5ToV6,
   providersListUpgradeV6ToV7,
@@ -372,7 +373,7 @@ describe("providers.list@7.0 upgrade/downgrade bridges", () => {
       ],
       native: { ok: true, kind: "mcp", servers: [] },
     });
-    const result = providersListDowngradeV8ToV6.downgradeResponse(
+    const result = providersListDowngradeV9ToV6.downgradeResponse(
       providersListResponseSchema.parse(v70),
     );
     expect(result.ok).toBe(true);
@@ -409,7 +410,7 @@ describe("providers.list@7.0 upgrade/downgrade bridges", () => {
         },
       ],
     });
-    const result = providersListDowngradeV8ToV3.downgradeResponse(
+    const result = providersListDowngradeV9ToV3.downgradeResponse(
       providersListResponseSchema.parse(v31),
     );
     expect(result.ok).toBe(true);
@@ -434,7 +435,7 @@ describe("providers.list@7.0 upgrade/downgrade bridges", () => {
         },
       ],
     });
-    const result = providersListDowngradeV8ToV2.downgradeResponse(
+    const result = providersListDowngradeV9ToV2.downgradeResponse(
       providersListResponseSchema.parse(v31),
     );
     expect(result.ok).toBe(true);
@@ -469,7 +470,7 @@ describe("providers.list@7.0 upgrade/downgrade bridges", () => {
     const list = providersListResponseSchema.parse({
       providers: [latest],
     });
-    const listResult = providersListDowngradeV8ToV1.downgradeResponse(
+    const listResult = providersListDowngradeV9ToV1.downgradeResponse(
       providersListResponseSchema.parse(list),
     );
     expect(listResult.ok).toBe(true);

--- a/protocol/src/host/__tests__/provider-profiles-compat.test.ts
+++ b/protocol/src/host/__tests__/provider-profiles-compat.test.ts
@@ -329,13 +329,13 @@ describe("providers.list latest -> v2.0 downgrade strips profiles[]", () => {
     // them. The major is spelled out because `downgradeResponseAcrossMajors`
     // resolves it at the type level, so it cannot be read off the registry at
     // runtime - it has to be bumped by hand every time a new major opens
-    // (v5.0 and v6.0 were each frozen by a release; v7.0 is the newest line
-    // and is not released yet). The latest major also carries
+    // (v5.0, v6.0, v7.0 and v8.0 were each frozen by a release; v9.0 is the
+    // newest line and is not released yet). The latest major also carries
     // `nativeCapabilities` and `native`, which this downgrade strips alongside
     // `profiles`.
     const downgraded = downgradeResponseAcrossMajors(
       hostRpcRegistry["providers.list"],
-      8,
+      9,
       2,
       providersListResponseSchema.parse({
         providers: [stateWithProfile],
@@ -395,7 +395,7 @@ describe("providers.list v3.0 line predates profiles[]", () => {
   it("latest -> v3.0 downgrade never leaks profile identity to a v3.0 caller", () => {
     const downgraded = downgradeResponseAcrossMajors(
       hostRpcRegistry["providers.list"],
-      8,
+      9,
       3,
       providersListResponseSchema.parse({
         providers: [stateWithProfile],

--- a/protocol/src/host/__tests__/provider-registry-fields-compat.test.ts
+++ b/protocol/src/host/__tests__/provider-registry-fields-compat.test.ts
@@ -144,7 +144,7 @@ describe("cliBinaryResolved additive field (binary-absent explanation)", () => {
     for (const target of [2, 3] as const) {
       const downgraded = downgradeResponseAcrossMajors(
         hostRpcRegistry["providers.list"],
-        8,
+        9,
         target,
         providersListResponseSchema.parse({
           providers: [state],
@@ -340,7 +340,7 @@ describe("old-client behavior on the error arm", () => {
     (targetMajor) => {
       const downgraded = downgradeResponseAcrossMajors(
         hostRpcRegistry["providers.list"],
-        8,
+        9,
         targetMajor,
         providersListResponseSchema.parse({
           providers: [erroredState],
@@ -535,7 +535,7 @@ describe("providers.list latest -> v2.0/v3.0 downgrade strips the new fields", (
   it("latest -> v2.0 downgrade never leaks the new fields to a v2.0 caller", () => {
     const downgraded = downgradeResponseAcrossMajors(
       hostRpcRegistry["providers.list"],
-      8,
+      9,
       2,
       providersListResponseSchema.parse({
         providers: [stateWithRegistryFields],
@@ -554,7 +554,7 @@ describe("providers.list latest -> v2.0/v3.0 downgrade strips the new fields", (
   it("latest -> v3.0 downgrade never leaks the new fields to a v3.0 caller", () => {
     const downgraded = downgradeResponseAcrossMajors(
       hostRpcRegistry["providers.list"],
-      8,
+      9,
       3,
       providersListResponseSchema.parse({
         providers: [stateWithRegistryFields],
@@ -663,7 +663,7 @@ describe("providers.list v6.0 is frozen against the registry fields", () => {
     // an older major's table is kept for the record, not consulted.
     const downgraded = downgradeResponseAcrossMajors(
       hostRpcRegistry["providers.list"],
-      8,
+      9,
       6,
       // `native` is required here and absent from the major-6 cases above
       // because the live response shape carries it - v6.0 froze before it
@@ -707,7 +707,7 @@ describe("providers.list v5.0 is frozen against the registry fields", () => {
     // cannot reach it.
     const downgraded = downgradeResponseAcrossMajors(
       hostRpcRegistry["providers.list"],
-      8,
+      9,
       5,
       providersListResponseSchema.parse({
         providers: [stateWithRegistryFields],

--- a/protocol/src/host/__tests__/provider-schemas-v70-pins.test.ts
+++ b/protocol/src/host/__tests__/provider-schemas-v70-pins.test.ts
@@ -21,6 +21,7 @@ import {
   providersListResponseSchemaV60,
   providersListResponseSchemaV70,
   providersListResponseSchemaV70Preimage,
+  providersListResponseSchemaV80,
 } from "@traycer/protocol/host/provider-schemas";
 
 /**
@@ -30,7 +31,7 @@ import {
  *
  * `*V70Preimage` backs no contract, but remains part of the v6 -> v7 upgrade.
  * Bare `V70` exports are the released v7 contract; the live exports now back
- * v8.0 and may grow without widening v7.0.
+ * v9.0 and may grow without widening v7.0.
  */
 
 function providerState(providerId: string) {
@@ -155,27 +156,33 @@ describe("the v7-era schemas are distinct objects from the canonical live ones",
     );
   });
 
-  it("v8.0 is the head and names the canonical response; 7.0 names its freeze", () => {
-    // This assertion has now flipped four times, and the flips ARE the
+  it("v9.0 is the head and names the canonical response; 7.0 and 8.0 name their freezes", () => {
+    // This assertion has now flipped five times, and the flips ARE the
     // judgement the freeze rule exists to force. While an unreleased v8.0 sat
     // above v7.0, v7.0 was pinned; collapsing that major made v7.0 the head and
     // it tracked live again; opening a v7.1 for the auth-aware enablement
     // fields pinned v7.0 to the REAL freeze
-    // (`providersListResponseSchemaV70`); and removing those two fields removed
-    // that minor with them - they were its entire delta - so v7.0 is once again
-    // the only frozen line under a real v8.0.
+    // (`providersListResponseSchemaV70`); removing those two fields removed
+    // that minor with them - they were its entire delta - so v7.0 was once
+    // again the only frozen line under a real v8.0; and now `cli-v1.3.0` /
+    // `host-v1.3.0` shipped that v8.0 from a branch cut before Antigravity
+    // landed on `main`, so v8.0 is frozen too (at
+    // `providersListResponseSchemaV80`) and v9.0 is the new head.
     //
-    // The v7.0 PIN survived all four flips, which is the point: what freezes a
-    // line is another line opening above it, not which one. v8.0 is above it
-    // now, and 7.0 must not drift back onto live just because the line
-    // immediately above it went away.
+    // The v7.0 PIN survived all five flips, which is the point: what freezes a
+    // line is another line opening above it, not which one. v9.0 is above both
+    // 7.0 and 8.0 now, and neither may drift back onto live just because the
+    // line immediately above it went away or was itself frozen in turn.
     //
     // "A line that has STOPPED being the head still points at live" is the
     // defect being guarded, so both halves are asserted: the head names live,
-    // and the line below it does not.
+    // and every line below it does not.
     const v70 = hostRpcRegistry["providers.list"][7].versions[0].contract;
     const v80 = hostRpcRegistry["providers.list"][8].versions[0].contract;
-    expect(v80.responseSchema).toBe(providersListResponseSchema);
+    const v90 = hostRpcRegistry["providers.list"][9].versions[0].contract;
+    expect(v90.responseSchema).toBe(providersListResponseSchema);
+    expect(v80.responseSchema).toBe(providersListResponseSchemaV80);
+    expect(v80.responseSchema).not.toBe(providersListResponseSchema);
     expect(v70.responseSchema).toBe(providersListResponseSchemaV70);
     expect(v70.responseSchema).not.toBe(providersListResponseSchema);
     expect(v70.responseSchema).not.toBe(providersListResponseSchemaV70Preimage);
@@ -186,14 +193,21 @@ describe("the v7-era schemas are distinct objects from the canonical live ones",
     expect(Object.keys(hostRpcRegistry["providers.list"][7].versions)).toEqual([
       "0",
     ]);
+    // Major 8 is newly frozen behind the same shape - exactly one minor, same
+    // reasoning, so a future 8.1 has to come here and say why too.
+    expect(hostRpcRegistry["providers.list"][8].latestMinor).toBe(0);
+    expect(Object.keys(hostRpcRegistry["providers.list"][8].versions)).toEqual([
+      "0",
+    ]);
     // The REQUEST side did not move: the freezes covered only the response, so
-    // both lines still bind the live request and
+    // every line still binds the live request and
     // `providersListRequestSchemaV70` remains the hand-copy held equal to it by
     // the pin above. Request-side enum growth is advisory (a released client
     // never emits a new value), which is why it is allowed to track live here
     // while the response is not.
     expect(v70.requestSchema).toBe(providersListRequestSchema);
     expect(v80.requestSchema).toBe(providersListRequestSchema);
+    expect(v90.requestSchema).toBe(providersListRequestSchema);
     expect(v70.requestSchema).not.toBe(providersListRequestSchemaV70);
   });
 
@@ -489,7 +503,7 @@ describe("downgrade bridges v7.0 -> v6.0..v1.0 still work through the real regis
     (target) => {
       const downgraded = downgradeResponseAcrossMajors(
         hostRpcRegistry["providers.list"],
-        8,
+        9,
         target,
         providersListResponseSchema.parse({
           providers: [state],
@@ -526,7 +540,7 @@ describe("downgrade bridges v7.0 -> v6.0..v1.0 still work through the real regis
     for (const target of [6, 5, 4, 3, 2, 1] as const) {
       const downgraded = downgradeResponseAcrossMajors(
         hostRpcRegistry["providers.list"],
-        8,
+        9,
         target,
         providersListResponseSchema.parse({
           providers: [huggingfaceState],
@@ -537,6 +551,35 @@ describe("downgrade bridges v7.0 -> v6.0..v1.0 still work through the real regis
       if (!downgraded.ok) continue;
       expect(downgraded.value.providers).toHaveLength(0);
     }
+  });
+});
+
+// The new adjacent hop, one level up from the block above: v8.0 is
+// `cli-v1.3.0` / `host-v1.3.0`'s frozen line, bound at the twenty provider ids
+// that predate Antigravity. A v9.0 (head) response carrying an Antigravity
+// row must not reach a v8.0 caller - same frozen-enum-boundary shape as
+// huggingface at v6.0 above, one hop closer to head - and what survives the
+// strip must still be a valid frozen v8.0 wire.
+describe("downgrade bridge v9.0 -> v8.0 works through the real registry", () => {
+  it("antigravity never survives a downgrade past v8.0 (frozen enum boundary)", () => {
+    const antigravityState = providerCliStateSchema.parse(
+      providerState("antigravity"),
+    );
+    const downgraded = downgradeResponseAcrossMajors(
+      hostRpcRegistry["providers.list"],
+      9,
+      8,
+      providersListResponseSchema.parse({
+        providers: [antigravityState],
+        native: null,
+      }),
+    );
+    expect(downgraded.ok).toBe(true);
+    if (!downgraded.ok) return;
+    expect(downgraded.value.providers).toHaveLength(0);
+    expect(
+      providersListResponseSchemaV80.safeParse(downgraded.value).success,
+    ).toBe(true);
   });
 });
 

--- a/protocol/src/host/__tests__/provider-schemas-version-manager.test.ts
+++ b/protocol/src/host/__tests__/provider-schemas-version-manager.test.ts
@@ -115,7 +115,7 @@ describe("providers.list@7.0 carries the version manager and bridges older lines
 
     const downgraded = downgradeResponseAcrossMajors(
       hostRpcRegistry["providers.list"],
-      8,
+      9,
       6,
       response,
     );
@@ -154,7 +154,7 @@ describe("providers.list@7.0 carries the version manager and bridges older lines
     for (const target of [6, 5, 4, 3, 2, 1] as const) {
       const downgraded = downgradeResponseAcrossMajors(
         hostRpcRegistry["providers.list"],
-        8,
+        9,
         target,
         response,
       );
@@ -260,7 +260,7 @@ describe("providers.list@6.0 -> @7.0 upgrades", () => {
 
       const downgraded = downgradeResponseAcrossMajors(
         hostRpcRegistry["providers.list"],
-        8,
+        9,
         6,
         response,
       );

--- a/protocol/src/host/__tests__/released-baseline-compat.test.ts
+++ b/protocol/src/host/__tests__/released-baseline-compat.test.ts
@@ -49,12 +49,18 @@ const exceptionsPath = join(
 );
 
 describe("released baseline surface (newest release) is wire-compatible", () => {
-  it("keeps unreleased browser.screencast out of the released fixture", () => {
-    const baseline = protocolSurfaceSchema.parse(
-      JSON.parse(readFileSync(fixturePath, "utf8")),
-    );
-    expect(baseline.stream["browser.screencast"]).toBeUndefined();
-  });
+  // A `keeps unreleased browser.screencast out of the released fixture` case
+  // stood here and asserted `baseline.stream["browser.screencast"]` was
+  // undefined. It was a guard against regenerating the fixture off an
+  // UNRELEASED tree - true only while screencast was unreleased. `cli-v1.3.0` /
+  // `host-v1.3.0` ship it, so the assertion now fails on a fixture that is
+  // exactly right, and re-pointing it at the next unreleased method would just
+  // reschedule the same failure for that method's release.
+  //
+  // The property it was reaching for is already enforced where it cannot go
+  // stale: `snapshot-released-baseline.ts` renders the fixture from a released
+  // TAG, and the `protocol-compat` workflow re-derives every baseline from the
+  // immutable tag rather than from anything a PR can edit.
 
   it("live registries have no blocking findings against the committed baseline", () => {
     const theirs = protocolSurfaceSchema.parse(

--- a/protocol/src/host/__tests__/v1110-frozen-line-versioning.test.ts
+++ b/protocol/src/host/__tests__/v1110-frozen-line-versioning.test.ts
@@ -254,7 +254,7 @@ describe("providers.list request lines 1.0..6.0 <-> 7.0", () => {
     });
     const down = downgradeResponseAcrossMajors(
       providersListRegistry,
-      8,
+      9,
       6,
       canonicalResponse,
     );

--- a/protocol/src/host/agent/__tests__/profile-selection-compat.test.ts
+++ b/protocol/src/host/agent/__tests__/profile-selection-compat.test.ts
@@ -575,27 +575,32 @@ describe("optional-method capability negotiation", () => {
       split.manifest["agent.getProviderProfileRateLimits"],
     ).toBeUndefined();
     expect(split.manifest["agent.configure"]).toBeUndefined();
-    // All three now sit on the v5.0 line. Major 4 DID ship - the v1.2.0 tags
-    // (2026-08-24) carry it - so the sentence this comment used to end with
-    // ("since 4 has never shipped") stopped being true, and with it the reason
-    // these three could keep absorbing ids in place. `reasonix` opened major 5
-    // on each, with fail-closed v5->v4 bridges.
-    // `supportedMajors` is every major the line INSTALLS, so opening major 5
-    // widens it to [1..5] on all three. It is not a restatement of `major`:
+    // All three now sit on the v6.0 line, and the history is the point: major
+    // 4 shipped in the v1.2.0 tags, which ended the "4 has never shipped"
+    // reasoning that had let these absorb ids in place, and `reasonix` opened
+    // major 5. Major 5 then shipped in the 1.3.0 tags - cut from a branch that
+    // predates `antigravity` - so the SAME sentence retired again one release
+    // later, and `antigravity` opened major 6 with fail-closed v6->v5 bridges.
+    //
+    // Two releases, one mistake: a line is safe to grow in place only while it
+    // is unreleased, and "newest major" is not a synonym for that.
+    //
+    // `supportedMajors` is every major the line INSTALLS, so opening major 6
+    // widens it to [1..6] on all three. It is not a restatement of `major`:
     // `major` is the canonical one a peer picks by default, `supportedMajors`
     // is the set it can still be talked down to.
     expect(split.optionalManifest["agent.listProviderProfiles"]).toEqual({
-      major: 5,
+      major: 6,
       minor: 0,
-      supportedMajors: [1, 2, 3, 4, 5],
+      supportedMajors: [1, 2, 3, 4, 5, 6],
     });
     expect(
       split.optionalManifest["agent.getProviderProfileRateLimits"],
-    ).toEqual({ major: 5, minor: 0, supportedMajors: [1, 2, 3, 4, 5] });
+    ).toEqual({ major: 6, minor: 0, supportedMajors: [1, 2, 3, 4, 5, 6] });
     expect(split.optionalManifest["agent.configure"]).toEqual({
-      major: 5,
+      major: 6,
       minor: 0,
-      supportedMajors: [1, 2, 3, 4, 5],
+      supportedMajors: [1, 2, 3, 4, 5, 6],
     });
   });
 

--- a/protocol/src/host/agent/contracts.ts
+++ b/protocol/src/host/agent/contracts.ts
@@ -32,6 +32,7 @@ import {
   listAgentsResponseSchemaV50,
   listAgentsResponseSchemaV60,
   listAgentsResponseSchemaV70,
+  listAgentsResponseSchemaV80,
   agentSummarySchemaV10,
   agentSummarySchemaV20,
   agentSummarySchemaV30,
@@ -39,6 +40,7 @@ import {
   agentSummarySchemaV50,
   agentSummarySchemaV60,
   agentSummarySchemaV70,
+  agentSummarySchemaV80,
   sendAgentMessageRequestSchema,
   sendAgentMessageResponseSchema,
   stopAgentRequestSchema,
@@ -855,7 +857,10 @@ export const agentListV80 = defineRpcContract({
   method: "agent.list",
   schemaVersion: { major: 8, minor: 0 } as const,
   requestSchema: listAgentsRequestSchema,
-  responseSchema: listAgentsResponseSchema,
+  // Frozen: `cli-v1.3.0` / `host-v1.3.0` shipped this line without Antigravity
+  // (the release branch was cut before the id landed), so it must serve the
+  // twenty-id row those peers negotiate. v9.0 is the head line.
+  responseSchema: listAgentsResponseSchemaV80,
 });
 
 export const agentListUpgradeV7ToV8 = defineUpgradePath<
@@ -994,6 +999,172 @@ export const agentListDowngradeV8ToV1 = defineDowngradePath<
   typeof agentListV10
 >({
   from: { major: 8, minor: 0 },
+  to: { major: 1, minor: 0 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  downgradeResponse: (response) => ({
+    ok: true,
+    value: listAgentsResponseSchemaV10.parse({
+      ...response,
+      agents: response.agents.filter(
+        (agent) => agentSummarySchemaV10.safeParse(agent).success,
+      ),
+    }),
+  }),
+});
+
+// ── Major 9: the head line, where Antigravity agents ride ──────────────────
+export const agentListV90 = defineRpcContract({
+  method: "agent.list",
+  schemaVersion: { major: 9, minor: 0 } as const,
+  requestSchema: listAgentsRequestSchema,
+  responseSchema: listAgentsResponseSchema,
+});
+
+export const agentListUpgradeV8ToV9 = defineUpgradePath<
+  typeof agentListV80,
+  typeof agentListV90
+>({
+  from: { major: 8, minor: 0 },
+  to: { major: 9, minor: 0 },
+  // The request shape is identical, and a v8.0 response without Antigravity
+  // agents is a valid v9.0 response (purely additive) - both are identity.
+  upgradeRequest: (request) => request,
+  upgradeResponse: (response) => response,
+});
+
+export const agentListDowngradeV9ToV8 = defineDowngradePath<
+  typeof agentListV90,
+  typeof agentListV80
+>({
+  from: { major: 9, minor: 0 },
+  to: { major: 8, minor: 0 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  // Drop Antigravity agents so an already-shipped v8.0 client's strict decode
+  // never sees one.
+  downgradeResponse: (response) => ({
+    ok: true,
+    value: listAgentsResponseSchemaV80.parse({
+      ...response,
+      agents: response.agents.filter(
+        (agent) => agentSummarySchemaV80.safeParse(agent).success,
+      ),
+    }),
+  }),
+});
+
+export const agentListDowngradeV9ToV7 = defineDowngradePath<
+  typeof agentListV90,
+  typeof agentListV70
+>({
+  from: { major: 9, minor: 0 },
+  to: { major: 7, minor: 0 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  downgradeResponse: (response) => ({
+    ok: true,
+    value: listAgentsResponseSchemaV70.parse({
+      ...response,
+      agents: response.agents.filter(
+        (agent) => agentSummarySchemaV70.safeParse(agent).success,
+      ),
+    }),
+  }),
+});
+
+export const agentListDowngradeV9ToV6 = defineDowngradePath<
+  typeof agentListV90,
+  typeof agentListV60
+>({
+  from: { major: 9, minor: 0 },
+  to: { major: 6, minor: 0 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  downgradeResponse: (response) => ({
+    ok: true,
+    value: listAgentsResponseSchemaV60.parse({
+      ...response,
+      agents: response.agents.filter(
+        (agent) => agentSummarySchemaV60.safeParse(agent).success,
+      ),
+    }),
+  }),
+});
+
+export const agentListDowngradeV9ToV5 = defineDowngradePath<
+  typeof agentListV90,
+  typeof agentListV50
+>({
+  from: { major: 9, minor: 0 },
+  to: { major: 5, minor: 0 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  downgradeResponse: (response) => ({
+    ok: true,
+    value: listAgentsResponseSchemaV50.parse({
+      ...response,
+      agents: response.agents.filter(
+        (agent) => agentSummarySchemaV50.safeParse(agent).success,
+      ),
+    }),
+  }),
+});
+
+export const agentListDowngradeV9ToV4 = defineDowngradePath<
+  typeof agentListV90,
+  typeof agentListV40
+>({
+  from: { major: 9, minor: 0 },
+  to: { major: 4, minor: 0 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  downgradeResponse: (response) => ({
+    ok: true,
+    value: listAgentsResponseSchemaV40.parse({
+      ...response,
+      agents: response.agents.filter(
+        (agent) => agentSummarySchemaV40.safeParse(agent).success,
+      ),
+    }),
+  }),
+});
+
+export const agentListDowngradeV9ToV3 = defineDowngradePath<
+  typeof agentListV90,
+  typeof agentListV30
+>({
+  from: { major: 9, minor: 0 },
+  to: { major: 3, minor: 0 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  downgradeResponse: (response) => ({
+    ok: true,
+    value: listAgentsResponseSchemaV30.parse({
+      ...response,
+      agents: response.agents.filter(
+        (agent) => agentSummarySchemaV30.safeParse(agent).success,
+      ),
+    }),
+  }),
+});
+
+export const agentListDowngradeV9ToV2 = defineDowngradePath<
+  typeof agentListV90,
+  typeof agentListV20
+>({
+  from: { major: 9, minor: 0 },
+  to: { major: 2, minor: 0 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  downgradeResponse: (response) => ({
+    ok: true,
+    value: listAgentsResponseSchemaV20.parse({
+      ...response,
+      agents: response.agents.filter(
+        (agent) => agentSummarySchemaV20.safeParse(agent).success,
+      ),
+    }),
+  }),
+});
+
+export const agentListDowngradeV9ToV1 = defineDowngradePath<
+  typeof agentListV90,
+  typeof agentListV10
+>({
+  from: { major: 9, minor: 0 },
   to: { major: 1, minor: 0 },
   downgradeRequest: (request) => ({ ok: true, value: request }),
   downgradeResponse: (response) => ({

--- a/protocol/src/host/agent/gui/__tests__/chat-subscribe.test.ts
+++ b/protocol/src/host/agent/gui/__tests__/chat-subscribe.test.ts
@@ -15,6 +15,7 @@ import {
   chatSubscribeV16,
   chatSubscribeV17,
   chatSubscribeV18,
+  chatSubscribeV19,
   createImageResolutionUpdatedFrame,
 } from "@traycer/protocol/host/agent/gui/subscribe";
 import {
@@ -2271,18 +2272,73 @@ describe("chat.subscribe@1.6 (image generation)", () => {
 });
 
 describe("chat.subscribe registry membership", () => {
-  it("registers chat.subscribe major 1 latestMinor 8 as chatSubscribeV18", () => {
+  it("registers chat.subscribe major 1 latestMinor 9 as chatSubscribeV19", () => {
     const entry = hostStreamRpcRegistry["chat.subscribe"];
     expect(entry).toBeDefined();
-    // Registering `8` IS the switch to the windowed line: a stream minor
-    // negotiates to the highest the peers share, so this line flipping to `8`
-    // is the moment `1.8`-capable peers start exchanging windowed frames.
-    expect(entry[1].latestMinor).toBe(8);
+    // Registering `8` was the switch to the windowed line: a stream minor
+    // negotiates to the highest the peers share, so that line flipping to `8`
+    // was the moment `1.8`-capable peers started exchanging windowed frames.
+    // `9` is windowed too - it differs from `8` only in the session-anchor
+    // union reachable through `rowContext`.
+    expect(entry[1].latestMinor).toBe(9);
     expect(entry[1].versions[6].contract).toBe(chatSubscribeV16);
     expect(entry[1].versions[7].contract).toBe(chatSubscribeV17);
     expect(entry[1].versions[8].contract).toBe(chatSubscribeV18);
+    expect(entry[1].versions[9].contract).toBe(chatSubscribeV19);
     expect(chatSubscribeV17.schemaVersion).toEqual({ major: 1, minor: 7 });
     expect(chatSubscribeV18.schemaVersion).toEqual({ major: 1, minor: 8 });
+    expect(chatSubscribeV19.schemaVersion).toEqual({ major: 1, minor: 9 });
+  });
+
+  // `cli-v1.3.0` / `host-v1.3.0` shipped `@1.8`, so it is frozen at the
+  // twenty-arm session-anchor union those peers strict-decode. `@1.9` is the
+  // first minor whose `rowContext` may carry the Antigravity arm. Streams have
+  // no downgrade bridge, so the host projects the field away for a `<1.9`
+  // subscriber (`chat-session-manager.ts`'s `projectWindowedFrameForVersion`)
+  // rather than sending a frame that fails the peer's whole parse.
+  it("keeps an antigravity session anchor out of the released @1.8 frame", () => {
+    const rangeFrame = {
+      kind: "range" as const,
+      hasBinaryPayload: false as const,
+      epicId: "epic-1",
+      chatId: "chat-1",
+      range: {
+        requestId: "req-1",
+        epoch: 1,
+        fromOrdinal: 0,
+        rowIds: ["row-1"],
+        incompleteRowIds: [],
+        messages: [],
+        events: [],
+        rowContext: {
+          "row-1": {
+            sessionAnchor: {
+              harnessId: "antigravity" as const,
+              hostId: "test-host",
+              sessionId: "agy-session-1",
+              sessionWorkspaceSnapshot: {
+                workspaceKind: "session-snapshot" as const,
+                primaryWorkspace: "/repo",
+                secondaryWorkspaces: [],
+              },
+              createdAt: 1,
+              coveredUntilMessageId: null,
+              profileId: null,
+              profileLabel: null,
+            },
+          },
+        },
+        reachedStart: true,
+        reachedEnd: true,
+      },
+    };
+
+    expect(
+      chatSubscribeV18.serverFrameSchema.safeParse(rangeFrame).success,
+    ).toBe(false);
+    expect(
+      chatSubscribeV19.serverFrameSchema.safeParse(rangeFrame).success,
+    ).toBe(true);
   });
 });
 

--- a/protocol/src/host/agent/gui/__tests__/grok-versioning.test.ts
+++ b/protocol/src/host/agent/gui/__tests__/grok-versioning.test.ts
@@ -16,13 +16,14 @@ import {
   agentListDowngradeV6ToV3,
   agentListDowngradeV6ToV4,
   agentListDowngradeV6ToV5,
-  agentListDowngradeV8ToV1,
-  agentListDowngradeV8ToV2,
-  agentListDowngradeV8ToV3,
-  agentListDowngradeV8ToV4,
-  agentListDowngradeV8ToV5,
-  agentListDowngradeV8ToV6,
-  agentListDowngradeV8ToV7,
+  agentListDowngradeV9ToV1,
+  agentListDowngradeV9ToV2,
+  agentListDowngradeV9ToV3,
+  agentListDowngradeV9ToV4,
+  agentListDowngradeV9ToV5,
+  agentListDowngradeV9ToV6,
+  agentListDowngradeV9ToV7,
+  agentListDowngradeV9ToV8,
 } from "@traycer/protocol/host/agent/contracts";
 import {
   listAgentsResponseSchema,
@@ -33,6 +34,7 @@ import {
   listAgentsResponseSchemaV50,
   listAgentsResponseSchemaV60,
   listAgentsResponseSchemaV70,
+  listAgentsResponseSchemaV80,
 } from "@traycer/protocol/host/agent/shared";
 import {
   agentGuiListHarnessesDowngradeV2ToV1,
@@ -50,13 +52,14 @@ import {
   agentGuiListHarnessesDowngradeV6ToV3,
   agentGuiListHarnessesDowngradeV6ToV4,
   agentGuiListHarnessesDowngradeV6ToV5,
-  agentGuiListHarnessesDowngradeV8ToV1,
-  agentGuiListHarnessesDowngradeV8ToV2,
-  agentGuiListHarnessesDowngradeV8ToV3,
-  agentGuiListHarnessesDowngradeV8ToV4,
-  agentGuiListHarnessesDowngradeV8ToV5,
-  agentGuiListHarnessesDowngradeV8ToV6,
-  agentGuiListHarnessesDowngradeV8ToV7,
+  agentGuiListHarnessesDowngradeV9ToV1,
+  agentGuiListHarnessesDowngradeV9ToV2,
+  agentGuiListHarnessesDowngradeV9ToV3,
+  agentGuiListHarnessesDowngradeV9ToV4,
+  agentGuiListHarnessesDowngradeV9ToV5,
+  agentGuiListHarnessesDowngradeV9ToV6,
+  agentGuiListHarnessesDowngradeV9ToV7,
+  agentGuiListHarnessesDowngradeV9ToV8,
 } from "@traycer/protocol/host/agent/gui/contracts";
 import {
   guiHarnessOptionSchema,
@@ -69,6 +72,7 @@ import {
   listGuiHarnessesResponseSchemaV50,
   listGuiHarnessesResponseSchemaV60,
   listGuiHarnessesResponseSchemaV71,
+  listGuiHarnessesResponseSchemaV80,
 } from "@traycer/protocol/host/agent/gui/unary-schemas";
 import {
   PROVIDER_AUTH_STATUS_SCHEMA,
@@ -82,12 +86,13 @@ import {
   providersListResponseSchemaV50,
   providersListResponseSchemaV60,
   providersListResponseSchemaV70,
+  providersListResponseSchemaV80,
   providersSetApiKeyResponseSchemaV10,
 } from "@traycer/protocol/host/provider-schemas";
 // Importing from the registry runs `defineVersionedRpcRegistry` (full structural
 // + schema-compatibility validation) at module load, so this import alone
-// asserts the new v2.0/v3.0/v4.0/v5.0/v6.0/v7.0 lines and their upgrade/downgrade
-// bridges are well-formed.
+// asserts the new v2.0/v3.0/v4.0/v5.0/v6.0/v7.0/v8.0/v9.0 lines and their
+// upgrade/downgrade bridges are well-formed.
 import {
   providersAwaitLoginDowngradeV21ToV10,
   providersListDowngradeV2ToV1,
@@ -103,13 +108,14 @@ import {
   providersListDowngradeV6ToV3,
   providersListDowngradeV6ToV4,
   providersListDowngradeV6ToV5,
-  providersListDowngradeV8ToV1,
-  providersListDowngradeV8ToV2,
-  providersListDowngradeV8ToV3,
-  providersListDowngradeV8ToV4,
-  providersListDowngradeV8ToV5,
-  providersListDowngradeV8ToV6,
-  providersListDowngradeV8ToV7,
+  providersListDowngradeV9ToV1,
+  providersListDowngradeV9ToV2,
+  providersListDowngradeV9ToV3,
+  providersListDowngradeV9ToV4,
+  providersListDowngradeV9ToV5,
+  providersListDowngradeV9ToV6,
+  providersListDowngradeV9ToV7,
+  providersListDowngradeV9ToV8,
   providersSetApiKeyDowngradeV21ToV10,
 } from "@traycer/protocol/host/registry";
 
@@ -445,7 +451,7 @@ describe("post-v2.0 Amp non-breaking v3→v2 / v3→v1 downgrade bridges", () =>
       ],
     });
 
-    const toV3 = providersListDowngradeV8ToV3.downgradeResponse(liveResponse);
+    const toV3 = providersListDowngradeV9ToV3.downgradeResponse(liveResponse);
     expect(toV3.ok).toBe(true);
     if (!toV3.ok) return;
     expect(toV3.value.providers.map((provider) => provider.providerId)).toEqual(
@@ -455,7 +461,7 @@ describe("post-v2.0 Amp non-breaking v3→v2 / v3→v1 downgrade bridges", () =>
       providersListResponseSchemaV30.parse(toV3.value),
     ).not.toThrow();
 
-    const toV2 = providersListDowngradeV8ToV2.downgradeResponse(liveResponse);
+    const toV2 = providersListDowngradeV9ToV2.downgradeResponse(liveResponse);
     expect(toV2.ok).toBe(true);
     if (!toV2.ok) return;
     expect(toV2.value.providers.map((provider) => provider.providerId)).toEqual(
@@ -465,7 +471,7 @@ describe("post-v2.0 Amp non-breaking v3→v2 / v3→v1 downgrade bridges", () =>
       providersListResponseSchemaV20.parse(toV2.value),
     ).not.toThrow();
 
-    const toV1 = providersListDowngradeV8ToV1.downgradeResponse(liveResponse);
+    const toV1 = providersListDowngradeV9ToV1.downgradeResponse(liveResponse);
     expect(toV1.ok).toBe(true);
     if (!toV1.ok) return;
     expect(toV1.value.providers.map((provider) => provider.providerId)).toEqual(
@@ -614,14 +620,19 @@ describe("post-v3.0 Devin/Pi downgrade bridges (agent.gui.listHarnesses/agent.li
 describe("post-v6.0 Hugging Face/Reasonix/Antigravity non-breaking downgrade bridges", () => {
   // These three catalog methods each opened a new major when a release froze
   // their previous line: `huggingface` could not ride v6.0 and opened v7.0,
-  // and neither `reasonix` nor `antigravity` can ride ANY minor of major 7 -
-  // the v1.2.0 tags shipped 7.0, and `versioned-rpc.ts` refuses a minor that
-  // grows a response enum over its predecessor - so the live shape now sits
-  // on v8.0 and every older caller gets the ids it predates filtered out.
-  // Antigravity joined the live union alongside Reasonix without opening a
-  // new major, so it rides the exact same v8 -> v7 boundary.
+  // and `reasonix` could not ride ANY minor of major 7 - the v1.2.0 tags
+  // shipped 7.0, and `versioned-rpc.ts` refuses a minor that grows a response
+  // enum over its predecessor - so it opened v8.0.
+  //
+  // Antigravity did NOT join that same v8.0 the way Reasonix joined v8.0 over
+  // v7.0: `cli-v1.3.0` / `host-v1.3.0` shipped v8.0 from a branch cut BEFORE
+  // Antigravity landed on `main`, so v8.0 is now frozen at the twenty ids it
+  // actually shipped (Hugging Face and Reasonix included, Antigravity not),
+  // and Antigravity needed its own new major, v9.0 - the live shape now sits
+  // there, one hop further out, and every older caller (v8.0 included) gets
+  // the ids it predates filtered out.
   it("drops Hugging Face/Reasonix/Antigravity from agent.gui.listHarnesses for every released caller down to v1.0", () => {
-    const v8Response = listGuiHarnessesResponseSchema.parse({
+    const v9Response = listGuiHarnessesResponseSchema.parse({
       harnesses: [
         harnessOption("claude"),
         harnessOption("cursor"),
@@ -636,11 +647,33 @@ describe("post-v6.0 Hugging Face/Reasonix/Antigravity non-breaking downgrade bri
       ],
     });
 
+    // The new adjacent hop: v8.0 (`cli-v1.3.0` / `host-v1.3.0`) shipped with
+    // both Hugging Face and Reasonix, so it keeps them and loses only
+    // Antigravity, which predates it.
+    const toV8 =
+      agentGuiListHarnessesDowngradeV9ToV8.downgradeResponse(v9Response);
+    expect(toV8.ok).toBe(true);
+    if (!toV8.ok) return;
+    expect(toV8.value.harnesses.map((harness) => harness.id)).toEqual([
+      "claude",
+      "cursor",
+      "amp",
+      "devin",
+      "pi",
+      "hermes",
+      "omp",
+      "huggingface",
+      "reasonix",
+    ]);
+    expect(() =>
+      listGuiHarnessesResponseSchemaV80.parse(toV8.value),
+    ).not.toThrow();
+
     // Major 7 shipped with Hugging Face, so it keeps it and loses Reasonix
     // and Antigravity alike. The bridge lands on 7.1, major 7's latest
     // installed minor.
     const toV7 =
-      agentGuiListHarnessesDowngradeV8ToV7.downgradeResponse(v8Response);
+      agentGuiListHarnessesDowngradeV9ToV7.downgradeResponse(v9Response);
     expect(toV7.ok).toBe(true);
     if (!toV7.ok) return;
     expect(toV7.value.harnesses.map((harness) => harness.id)).toEqual([
@@ -660,7 +693,7 @@ describe("post-v6.0 Hugging Face/Reasonix/Antigravity non-breaking downgrade bri
     // v6.0 shipped with omp, so it keeps omp and loses Hugging Face,
     // Reasonix and Antigravity.
     const toV6 =
-      agentGuiListHarnessesDowngradeV8ToV6.downgradeResponse(v8Response);
+      agentGuiListHarnessesDowngradeV9ToV6.downgradeResponse(v9Response);
     expect(toV6.ok).toBe(true);
     if (!toV6.ok) return;
     expect(toV6.value.harnesses.map((harness) => harness.id)).toEqual([
@@ -677,7 +710,7 @@ describe("post-v6.0 Hugging Face/Reasonix/Antigravity non-breaking downgrade bri
     ).not.toThrow();
 
     const toV5 =
-      agentGuiListHarnessesDowngradeV8ToV5.downgradeResponse(v8Response);
+      agentGuiListHarnessesDowngradeV9ToV5.downgradeResponse(v9Response);
     expect(toV5.ok).toBe(true);
     if (!toV5.ok) return;
     expect(toV5.value.harnesses.map((harness) => harness.id)).toEqual([
@@ -693,7 +726,7 @@ describe("post-v6.0 Hugging Face/Reasonix/Antigravity non-breaking downgrade bri
     ).not.toThrow();
 
     const toV4 =
-      agentGuiListHarnessesDowngradeV8ToV4.downgradeResponse(v8Response);
+      agentGuiListHarnessesDowngradeV9ToV4.downgradeResponse(v9Response);
     expect(toV4.ok).toBe(true);
     if (!toV4.ok) return;
     expect(toV4.value.harnesses.map((harness) => harness.id)).toEqual([
@@ -708,7 +741,7 @@ describe("post-v6.0 Hugging Face/Reasonix/Antigravity non-breaking downgrade bri
     ).not.toThrow();
 
     const toV3 =
-      agentGuiListHarnessesDowngradeV8ToV3.downgradeResponse(v8Response);
+      agentGuiListHarnessesDowngradeV9ToV3.downgradeResponse(v9Response);
     expect(toV3.ok).toBe(true);
     if (!toV3.ok) return;
     expect(toV3.value.harnesses.map((harness) => harness.id)).toEqual([
@@ -721,7 +754,7 @@ describe("post-v6.0 Hugging Face/Reasonix/Antigravity non-breaking downgrade bri
     ).not.toThrow();
 
     const toV2 =
-      agentGuiListHarnessesDowngradeV8ToV2.downgradeResponse(v8Response);
+      agentGuiListHarnessesDowngradeV9ToV2.downgradeResponse(v9Response);
     expect(toV2.ok).toBe(true);
     if (!toV2.ok) return;
     expect(toV2.value.harnesses.map((harness) => harness.id)).toEqual([
@@ -733,7 +766,7 @@ describe("post-v6.0 Hugging Face/Reasonix/Antigravity non-breaking downgrade bri
     ).not.toThrow();
 
     const toV1 =
-      agentGuiListHarnessesDowngradeV8ToV1.downgradeResponse(v8Response);
+      agentGuiListHarnessesDowngradeV9ToV1.downgradeResponse(v9Response);
     expect(toV1.ok).toBe(true);
     if (!toV1.ok) return;
     expect(toV1.value.harnesses.map((harness) => harness.id)).toEqual([
@@ -746,7 +779,7 @@ describe("post-v6.0 Hugging Face/Reasonix/Antigravity non-breaking downgrade bri
   });
 
   it("drops Hugging Face/Reasonix/Antigravity agents from agent.list for every released caller down to v1.0", () => {
-    const v8Response = listAgentsResponseSchema.parse({
+    const v9Response = listAgentsResponseSchema.parse({
       caller: { agentId: "self", canSendMessages: true },
       scope: "all",
       agents: [
@@ -763,11 +796,31 @@ describe("post-v6.0 Hugging Face/Reasonix/Antigravity non-breaking downgrade bri
       ],
     });
 
+    // The new adjacent hop: v8.0 shipped with both Hugging Face and Reasonix
+    // rows, so both survive; only Antigravity, which predates v8.0, goes.
+    // `runConfig` survives too - v8.0 models it same as v7.0.
+    const toV8 = agentListDowngradeV9ToV8.downgradeResponse(v9Response);
+    expect(toV8.ok).toBe(true);
+    if (!toV8.ok) return;
+    expect(toV8.value.agents.map((agent) => agent.id)).toEqual([
+      "a-claude",
+      "a-amp",
+      "a-devin",
+      "a-pi",
+      "a-hermes",
+      "a-omp",
+      "a-hf",
+      "a-reasonix",
+      "a-null",
+    ]);
+    expect(toV8.value.agents.every((agent) => "runConfig" in agent)).toBe(true);
+    expect(() => listAgentsResponseSchemaV80.parse(toV8.value)).not.toThrow();
+
     // v7.0 shipped with Hugging Face, so that row survives; only Reasonix and
     // Antigravity go. `runConfig` survives too - it is a v7.0 field, unlike
     // every hop below, where the frozen shape predates it and the reparse
     // drops it.
-    const toV7 = agentListDowngradeV8ToV7.downgradeResponse(v8Response);
+    const toV7 = agentListDowngradeV9ToV7.downgradeResponse(v9Response);
     expect(toV7.ok).toBe(true);
     if (!toV7.ok) return;
     expect(toV7.value.agents.map((agent) => agent.id)).toEqual([
@@ -785,7 +838,7 @@ describe("post-v6.0 Hugging Face/Reasonix/Antigravity non-breaking downgrade bri
 
     // v6.0 shipped with omp, so an omp agent row survives; Hugging Face,
     // Reasonix, and Antigravity go.
-    const toV6 = agentListDowngradeV8ToV6.downgradeResponse(v8Response);
+    const toV6 = agentListDowngradeV9ToV6.downgradeResponse(v9Response);
     expect(toV6.ok).toBe(true);
     if (!toV6.ok) return;
     expect(toV6.value.agents.map((agent) => agent.id)).toEqual([
@@ -802,7 +855,7 @@ describe("post-v6.0 Hugging Face/Reasonix/Antigravity non-breaking downgrade bri
     );
     expect(() => listAgentsResponseSchemaV60.parse(toV6.value)).not.toThrow();
 
-    const toV5 = agentListDowngradeV8ToV5.downgradeResponse(v8Response);
+    const toV5 = agentListDowngradeV9ToV5.downgradeResponse(v9Response);
     expect(toV5.ok).toBe(true);
     if (!toV5.ok) return;
     expect(toV5.value.agents.map((agent) => agent.id)).toEqual([
@@ -818,7 +871,7 @@ describe("post-v6.0 Hugging Face/Reasonix/Antigravity non-breaking downgrade bri
     );
     expect(() => listAgentsResponseSchemaV50.parse(toV5.value)).not.toThrow();
 
-    const toV4 = agentListDowngradeV8ToV4.downgradeResponse(v8Response);
+    const toV4 = agentListDowngradeV9ToV4.downgradeResponse(v9Response);
     expect(toV4.ok).toBe(true);
     if (!toV4.ok) return;
     expect(toV4.value.agents.map((agent) => agent.id)).toEqual([
@@ -833,7 +886,7 @@ describe("post-v6.0 Hugging Face/Reasonix/Antigravity non-breaking downgrade bri
     );
     expect(() => listAgentsResponseSchemaV40.parse(toV4.value)).not.toThrow();
 
-    const toV3 = agentListDowngradeV8ToV3.downgradeResponse(v8Response);
+    const toV3 = agentListDowngradeV9ToV3.downgradeResponse(v9Response);
     expect(toV3.ok).toBe(true);
     if (!toV3.ok) return;
     expect(toV3.value.agents.map((agent) => agent.id)).toEqual([
@@ -846,7 +899,7 @@ describe("post-v6.0 Hugging Face/Reasonix/Antigravity non-breaking downgrade bri
     );
     expect(() => listAgentsResponseSchemaV30.parse(toV3.value)).not.toThrow();
 
-    const toV2 = agentListDowngradeV8ToV2.downgradeResponse(v8Response);
+    const toV2 = agentListDowngradeV9ToV2.downgradeResponse(v9Response);
     expect(toV2.ok).toBe(true);
     if (!toV2.ok) return;
     expect(toV2.value.agents.map((agent) => agent.id)).toEqual([
@@ -858,7 +911,7 @@ describe("post-v6.0 Hugging Face/Reasonix/Antigravity non-breaking downgrade bri
     );
     expect(() => listAgentsResponseSchemaV20.parse(toV2.value)).not.toThrow();
 
-    const toV1 = agentListDowngradeV8ToV1.downgradeResponse(v8Response);
+    const toV1 = agentListDowngradeV9ToV1.downgradeResponse(v9Response);
     expect(toV1.ok).toBe(true);
     if (!toV1.ok) return;
     expect(toV1.value.agents.map((agent) => agent.id)).toEqual([
@@ -874,9 +927,11 @@ describe("post-v6.0 Hugging Face/Reasonix/Antigravity non-breaking downgrade bri
   it("drops Hugging Face/Reasonix/Antigravity from providers.list for every released caller down to v1.0", () => {
     // `cli-v1.1.9` shipped v6.0 and `cli-v1.2.0` shipped v7.0, so none of
     // `huggingface`, `reasonix`, or `antigravity` could join the line below
-    // it. Driven from v8.0, the newest line, which carries all three because
-    // it is still unreleased.
-    const v8Response = providersListResponseSchema.parse({
+    // it. `cli-v1.3.0` then shipped v8.0 carrying `huggingface` and
+    // `reasonix` - but from a branch cut before Antigravity landed, so v8.0
+    // is now frozen too. Driven from v9.0, the newest (still unreleased)
+    // line, which is the only one that carries all three.
+    const v9Response = providersListResponseSchema.parse({
       providers: [
         providerState("cursor", "unknown"),
         providerState("amp", "unknown"),
@@ -890,10 +945,31 @@ describe("post-v6.0 Hugging Face/Reasonix/Antigravity non-breaking downgrade bri
       ],
     });
 
+    // The new adjacent hop: v8.0 shipped with both Hugging Face and Reasonix,
+    // so both survive; only Antigravity, which predates v8.0, goes.
+    const toV8 = providersListDowngradeV9ToV8.downgradeResponse(v9Response);
+    expect(toV8.ok).toBe(true);
+    if (!toV8.ok) return;
+    expect(toV8.value.providers.map((provider) => provider.providerId)).toEqual(
+      [
+        "cursor",
+        "amp",
+        "devin",
+        "pi",
+        "hermes",
+        "omp",
+        "huggingface",
+        "reasonix",
+      ],
+    );
+    expect(() =>
+      providersListResponseSchemaV80.parse(toV8.value),
+    ).not.toThrow();
+
     // Major 7 keeps Hugging Face and loses Reasonix and Antigravity alike;
     // the bridge lands on 7.0, major 7's only (and therefore latest)
     // installed minor.
-    const toV7 = providersListDowngradeV8ToV7.downgradeResponse(v8Response);
+    const toV7 = providersListDowngradeV9ToV7.downgradeResponse(v9Response);
     expect(toV7.ok).toBe(true);
     if (!toV7.ok) return;
     expect(toV7.value.providers.map((provider) => provider.providerId)).toEqual(
@@ -903,7 +979,7 @@ describe("post-v6.0 Hugging Face/Reasonix/Antigravity non-breaking downgrade bri
       providersListResponseSchemaV70.parse(toV7.value),
     ).not.toThrow();
 
-    const toV6 = providersListDowngradeV8ToV6.downgradeResponse(v8Response);
+    const toV6 = providersListDowngradeV9ToV6.downgradeResponse(v9Response);
     expect(toV6.ok).toBe(true);
     if (!toV6.ok) return;
     expect(toV6.value.providers.map((provider) => provider.providerId)).toEqual(
@@ -913,7 +989,7 @@ describe("post-v6.0 Hugging Face/Reasonix/Antigravity non-breaking downgrade bri
       providersListResponseSchemaV60.parse(toV6.value),
     ).not.toThrow();
 
-    const toV5 = providersListDowngradeV8ToV5.downgradeResponse(v8Response);
+    const toV5 = providersListDowngradeV9ToV5.downgradeResponse(v9Response);
     expect(toV5.ok).toBe(true);
     if (!toV5.ok) return;
     expect(toV5.value.providers.map((provider) => provider.providerId)).toEqual(
@@ -923,7 +999,7 @@ describe("post-v6.0 Hugging Face/Reasonix/Antigravity non-breaking downgrade bri
       providersListResponseSchemaV50.parse(toV5.value),
     ).not.toThrow();
 
-    const toV4 = providersListDowngradeV8ToV4.downgradeResponse(v8Response);
+    const toV4 = providersListDowngradeV9ToV4.downgradeResponse(v9Response);
     expect(toV4.ok).toBe(true);
     if (!toV4.ok) return;
     expect(toV4.value.providers.map((provider) => provider.providerId)).toEqual(
@@ -933,7 +1009,7 @@ describe("post-v6.0 Hugging Face/Reasonix/Antigravity non-breaking downgrade bri
       providersListResponseSchemaV40.parse(toV4.value),
     ).not.toThrow();
 
-    const toV3 = providersListDowngradeV8ToV3.downgradeResponse(v8Response);
+    const toV3 = providersListDowngradeV9ToV3.downgradeResponse(v9Response);
     expect(toV3.ok).toBe(true);
     if (!toV3.ok) return;
     expect(toV3.value.providers.map((provider) => provider.providerId)).toEqual(
@@ -943,7 +1019,7 @@ describe("post-v6.0 Hugging Face/Reasonix/Antigravity non-breaking downgrade bri
       providersListResponseSchemaV30.parse(toV3.value),
     ).not.toThrow();
 
-    const toV2 = providersListDowngradeV8ToV2.downgradeResponse(v8Response);
+    const toV2 = providersListDowngradeV9ToV2.downgradeResponse(v9Response);
     expect(toV2.ok).toBe(true);
     if (!toV2.ok) return;
     expect(toV2.value.providers.map((provider) => provider.providerId)).toEqual(
@@ -953,7 +1029,7 @@ describe("post-v6.0 Hugging Face/Reasonix/Antigravity non-breaking downgrade bri
       providersListResponseSchemaV20.parse(toV2.value),
     ).not.toThrow();
 
-    const toV1 = providersListDowngradeV8ToV1.downgradeResponse(v8Response);
+    const toV1 = providersListDowngradeV9ToV1.downgradeResponse(v9Response);
     expect(toV1.ok).toBe(true);
     if (!toV1.ok) return;
     expect(toV1.value.providers.map((provider) => provider.providerId)).toEqual(

--- a/protocol/src/host/agent/gui/contracts.ts
+++ b/protocol/src/host/agent/gui/contracts.ts
@@ -20,6 +20,7 @@ import {
   listGuiHarnessesResponseSchemaV50,
   listGuiHarnessesResponseSchemaV60,
   listGuiHarnessesResponseSchemaV71,
+  listGuiHarnessesResponseSchemaV80,
   listGuiHarnessesResponseSchemaV70,
   guiHarnessOptionSchemaV10,
   guiHarnessOptionSchemaV21,
@@ -28,6 +29,7 @@ import {
   guiHarnessOptionSchemaV50,
   guiHarnessOptionSchemaV60,
   guiHarnessOptionSchemaV71,
+  guiHarnessOptionSchemaV80,
 } from "@traycer/protocol/host/agent/gui/unary-schemas";
 import {
   chatSubscribeV10,
@@ -39,6 +41,7 @@ import {
   chatSubscribeV16,
   chatSubscribeV17,
   chatSubscribeV18,
+  chatSubscribeV19,
 } from "@traycer/protocol/host/agent/gui/subscribe";
 
 // ─── GUI-surface catalog (`agent.gui.*`) ──────────────────────────────────
@@ -526,7 +529,12 @@ export const agentGuiListHarnessesV80 = defineRpcContract({
   method: "agent.gui.listHarnesses",
   schemaVersion: { major: 8, minor: 0 } as const,
   requestSchema: listGuiHarnessesRequestSchema,
-  responseSchema: listGuiHarnessesResponseSchema,
+  // Frozen: `cli-v1.3.0` / `host-v1.3.0` shipped this line, so it must serve
+  // the twenty-id row those peers negotiate rather than the live one. Until
+  // 1.3.0 was tagged this pointed at the canonical schema, which is how
+  // Antigravity - added to the live enum after the release branch was cut -
+  // reached a line already in the field. v9.0 is the head line now.
+  responseSchema: listGuiHarnessesResponseSchemaV80,
 });
 
 export const agentGuiListHarnessesUpgradeV71ToV80 = defineUpgradePath<
@@ -661,6 +669,171 @@ export const agentGuiListHarnessesDowngradeV8ToV1 = defineDowngradePath<
   typeof agentGuiListHarnessesV10
 >({
   from: { major: 8, minor: 0 },
+  to: { major: 1, minor: 0 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  downgradeResponse: (response) => ({
+    ok: true,
+    value: listGuiHarnessesResponseSchemaV10.parse({
+      harnesses: response.harnesses.filter(
+        (harness) => guiHarnessOptionSchemaV10.safeParse(harness).success,
+      ),
+    }),
+  }),
+});
+
+// ── Major 9: the head line, where Antigravity actually rides ───────────────
+//
+// v8.0 froze above because 1.3.0 shipped it. Every bridge below is the v8
+// bridge one major up: same filter, same landing minor, one more id dropped.
+export const agentGuiListHarnessesV90 = defineRpcContract({
+  method: "agent.gui.listHarnesses",
+  schemaVersion: { major: 9, minor: 0 } as const,
+  requestSchema: listGuiHarnessesRequestSchema,
+  responseSchema: listGuiHarnessesResponseSchema,
+});
+
+export const agentGuiListHarnessesUpgradeV80ToV90 = defineUpgradePath<
+  typeof agentGuiListHarnessesV80,
+  typeof agentGuiListHarnessesV90
+>({
+  from: { major: 8, minor: 0 },
+  to: { major: 9, minor: 0 },
+  // Request shape is identical; a v8.0 response without Antigravity is a valid
+  // v9.0 response (purely additive), so both upgrades are identity.
+  upgradeRequest: (request) => request,
+  upgradeResponse: (response) => response,
+});
+
+export const agentGuiListHarnessesDowngradeV9ToV8 = defineDowngradePath<
+  typeof agentGuiListHarnessesV90,
+  typeof agentGuiListHarnessesV80
+>({
+  from: { major: 9, minor: 0 },
+  to: { major: 8, minor: 0 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  // Drop Antigravity so an already-shipped major-8 client's strict decode
+  // never sees it.
+  downgradeResponse: (response) => ({
+    ok: true,
+    value: listGuiHarnessesResponseSchemaV80.parse({
+      harnesses: response.harnesses.filter(
+        (harness) => guiHarnessOptionSchemaV80.safeParse(harness).success,
+      ),
+    }),
+  }),
+});
+
+export const agentGuiListHarnessesDowngradeV9ToV7 = defineDowngradePath<
+  typeof agentGuiListHarnessesV90,
+  typeof agentGuiListHarnessesV71
+>({
+  from: { major: 9, minor: 0 },
+  // Lands on 7.1, major 7's latest installed minor; a frozen-7.0 caller's own
+  // contract parse then strips the 7.1-only `authStatus` key.
+  to: { major: 7, minor: 1 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  downgradeResponse: (response) => ({
+    ok: true,
+    value: listGuiHarnessesResponseSchemaV71.parse({
+      harnesses: response.harnesses.filter(
+        (harness) => guiHarnessOptionSchemaV71.safeParse(harness).success,
+      ),
+    }),
+  }),
+});
+
+export const agentGuiListHarnessesDowngradeV9ToV6 = defineDowngradePath<
+  typeof agentGuiListHarnessesV90,
+  typeof agentGuiListHarnessesV60
+>({
+  from: { major: 9, minor: 0 },
+  to: { major: 6, minor: 0 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  downgradeResponse: (response) => ({
+    ok: true,
+    value: listGuiHarnessesResponseSchemaV60.parse({
+      harnesses: response.harnesses.filter(
+        (harness) => guiHarnessOptionSchemaV60.safeParse(harness).success,
+      ),
+    }),
+  }),
+});
+
+export const agentGuiListHarnessesDowngradeV9ToV5 = defineDowngradePath<
+  typeof agentGuiListHarnessesV90,
+  typeof agentGuiListHarnessesV50
+>({
+  from: { major: 9, minor: 0 },
+  to: { major: 5, minor: 0 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  downgradeResponse: (response) => ({
+    ok: true,
+    value: listGuiHarnessesResponseSchemaV50.parse({
+      harnesses: response.harnesses.filter(
+        (harness) => guiHarnessOptionSchemaV50.safeParse(harness).success,
+      ),
+    }),
+  }),
+});
+
+export const agentGuiListHarnessesDowngradeV9ToV4 = defineDowngradePath<
+  typeof agentGuiListHarnessesV90,
+  typeof agentGuiListHarnessesV40
+>({
+  from: { major: 9, minor: 0 },
+  to: { major: 4, minor: 0 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  downgradeResponse: (response) => ({
+    ok: true,
+    value: listGuiHarnessesResponseSchemaV40.parse({
+      harnesses: response.harnesses.filter(
+        (harness) => guiHarnessOptionSchemaV40.safeParse(harness).success,
+      ),
+    }),
+  }),
+});
+
+export const agentGuiListHarnessesDowngradeV9ToV3 = defineDowngradePath<
+  typeof agentGuiListHarnessesV90,
+  typeof agentGuiListHarnessesV30
+>({
+  from: { major: 9, minor: 0 },
+  to: { major: 3, minor: 0 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  downgradeResponse: (response) => ({
+    ok: true,
+    value: listGuiHarnessesResponseSchemaV30.parse({
+      harnesses: response.harnesses.filter(
+        (harness) => guiHarnessOptionSchemaV30.safeParse(harness).success,
+      ),
+    }),
+  }),
+});
+
+export const agentGuiListHarnessesDowngradeV9ToV2 = defineDowngradePath<
+  typeof agentGuiListHarnessesV90,
+  typeof agentGuiListHarnessesV21
+>({
+  from: { major: 9, minor: 0 },
+  // Lands on 2.1, major 2's latest installed minor; a frozen-2.0 caller's
+  // contract parse then strips the 2.1-only `enabled` field.
+  to: { major: 2, minor: 1 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  downgradeResponse: (response) => ({
+    ok: true,
+    value: listGuiHarnessesResponseSchemaV21.parse({
+      harnesses: response.harnesses.filter(
+        (harness) => guiHarnessOptionSchemaV21.safeParse(harness).success,
+      ),
+    }),
+  }),
+});
+
+export const agentGuiListHarnessesDowngradeV9ToV1 = defineDowngradePath<
+  typeof agentGuiListHarnessesV90,
+  typeof agentGuiListHarnessesV10
+>({
+  from: { major: 9, minor: 0 },
   to: { major: 1, minor: 0 },
   downgradeRequest: (request) => ({ ok: true, value: request }),
   downgradeResponse: (response) => ({
@@ -831,4 +1004,5 @@ export {
   chatSubscribeV16,
   chatSubscribeV17,
   chatSubscribeV18,
+  chatSubscribeV19,
 };

--- a/protocol/src/host/agent/gui/subscribe.ts
+++ b/protocol/src/host/agent/gui/subscribe.ts
@@ -114,6 +114,7 @@ import {
   chatTranscriptDerivedSchema,
   chatTranscriptWindowSchema,
 } from "@traycer/protocol/host/agent/gui/subscribe-windowed";
+import { transcriptRowContextSchemaPreAntigravity } from "@traycer/protocol/persistence/chat-transcript/row-context";
 
 const jsonContentSchema = getRecordSchema(
   commonRecordRegistry,
@@ -2819,6 +2820,45 @@ export type ChatSubscribeWindowedServerFrame = z.infer<
 >;
 
 /**
+ * Frozen windowed server frame as `cli-v1.3.0` / `host-v1.3.0` shipped `@1.8`.
+ *
+ * The only difference is the anchor union reachable through `rowContext` on
+ * the two arms that carry one: 1.3.0 was cut before Antigravity, so a released
+ * `@1.8` peer's `discriminatedUnion` has twenty arms and rejects a frame
+ * carrying the twenty-first outright - the whole frame, not the one row.
+ *
+ * Built by overriding those two arms on the live union rather than re-listing
+ * eight-plus arms, so every OTHER frame stays shared by construction and a new
+ * arm added above cannot forget this copy. `@1.9` below takes the live union.
+ */
+export const chatSubscribeWindowedServerFrameSchemaPreAntigravity =
+  z.discriminatedUnion("kind", [
+    chatSubscribeWindowedSnapshotServerFrameSchema.extend({
+      snapshot: chatWindowedSnapshotSchema.extend({
+        tail: chatTranscriptWindowSchema.extend({
+          rowContext: z
+            .record(z.string(), transcriptRowContextSchemaPreAntigravity)
+            .optional(),
+        }),
+      }),
+    }),
+    chatSubscribeSkeletonChunkServerFrameSchema,
+    chatSubscribeAccumulatedChangesServerFrameSchema,
+    chatSubscribeIndexChangedServerFrameSchema,
+    chatSubscribeRangeServerFrameSchema.extend({
+      range: chatRangeResponseSchema.extend({
+        rowContext: z
+          .record(z.string(), transcriptRowContextSchemaPreAntigravity)
+          .default({}),
+      }),
+    }),
+    chatSubscribeTurnStateChangedServerFrameSchema,
+    chatSubscribeManagedCommandsChangedServerFrameSchema,
+    chatSubscribeHeldUpdatesChangedServerFrameSchema,
+    ...chatSubscribeSharedServerFrameSchemas,
+  ]);
+
+/**
  * Ask for a span of bodies.
  *
  * Not an owner action: it carries no `clientActionId` and is never acked,
@@ -2874,6 +2914,37 @@ export type ChatSubscribeWindowedClientFrame = z.infer<
 export const chatSubscribeV18 = defineStreamRpcContract({
   method: "chat.subscribe",
   schemaVersion: { major: 1, minor: 8 } as const,
+  openRequestSchema: chatSubscribeOpenRequestSchema,
+  serverFrameSchema: chatSubscribeWindowedServerFrameSchemaPreAntigravity,
+  clientFrameSchema: chatSubscribeWindowedClientFrameSchema,
+});
+
+/**
+ * The windowed line, with the Antigravity session anchor.
+ *
+ * `@1.8` shipped in 1.3.0 and is frozen at the twenty-arm anchor union; this
+ * is the first minor whose `rowContext` may carry an Antigravity anchor. It is
+ * `@1.8` in every other respect - the windowing design, the client frames and
+ * the open request are all shared by reference.
+ *
+ * Streams have no downgrade bridge, so the host must GATE on the negotiated
+ * minor: an `@1.8` subscriber gets rows whose `sessionAnchor` is withheld
+ * rather than a frame it cannot decode. That projection is
+ * `projectWindowedFrameForVersion` in the internal repo's
+ * `traycer-host/src/domain/chat/chat-session-manager.ts`, applied at
+ * `emitWindowedFrameToSubscriber` - the same per-minor discipline
+ * `chatSubscribeClientFrameSchemaForVersion` already applies in the client
+ * direction.
+ *
+ * A SECOND, independent gate covers the harness id itself:
+ * `HARNESS_MINIMUM_CHAT_SUBSCRIBE_MINOR` refuses to serve an Antigravity CHAT
+ * below `1.9` at all. The two are not redundant - that one keys on the chat's
+ * harness, this one on an anchor that can appear on a row of a chat the peer
+ * can otherwise render.
+ */
+export const chatSubscribeV19 = defineStreamRpcContract({
+  method: "chat.subscribe",
+  schemaVersion: { major: 1, minor: 9 } as const,
   openRequestSchema: chatSubscribeOpenRequestSchema,
   serverFrameSchema: chatSubscribeWindowedServerFrameSchema,
   clientFrameSchema: chatSubscribeWindowedClientFrameSchema,

--- a/protocol/src/host/agent/gui/unary-schemas.ts
+++ b/protocol/src/host/agent/gui/unary-schemas.ts
@@ -8,6 +8,7 @@ import {
   guiHarnessIdSchemaV50,
   guiHarnessIdSchemaV60,
   guiHarnessIdSchemaV70,
+  guiHarnessIdSchemaV80,
 } from "@traycer/protocol/host/agent/shared";
 import { PROVIDER_AUTH_STATUS_SCHEMA } from "@traycer/protocol/host/provider-schemas";
 import {
@@ -412,6 +413,28 @@ export const listGuiHarnessesResponseSchemaV71 = z.object({
 });
 export type ListGuiHarnessesResponseV71 = z.infer<
   typeof listGuiHarnessesResponseSchemaV71
+>;
+
+// ── Frozen protocol-v8.0 catalog row + response ────────────────────────────
+// v8.0 shipped in `cli-v1.3.0` / `host-v1.3.0`, which was cut from a branch
+// that predates Antigravity. Until now v8.0 bound the LIVE row, on the (then
+// true) reading that it was the unreleased head line - so the id added to the
+// live enum afterwards silently widened a line already in the field.
+//
+// The BODY is `guiHarnessOptionBaseShapeV71`, not the live row: that shape is
+// byte-identical to the live body at this cut, and binding it here is what
+// keeps v8.0 from drifting the next time a field is added above - the exact
+// half-frozen row the V70 note describes. Do NOT add fields or ids here; add
+// fields to `guiHarnessOptionSchema`, which only v9.0 (the head line) binds.
+export const guiHarnessOptionSchemaV80 = z.object({
+  id: guiHarnessIdSchemaV80,
+  ...guiHarnessOptionBaseShapeV71,
+});
+export const listGuiHarnessesResponseSchemaV80 = z.object({
+  harnesses: z.array(guiHarnessOptionSchemaV80),
+});
+export type ListGuiHarnessesResponseV80 = z.infer<
+  typeof listGuiHarnessesResponseSchemaV80
 >;
 
 export type ListGuiHarnessesResponse = z.infer<

--- a/protocol/src/host/agent/profiles.ts
+++ b/protocol/src/host/agent/profiles.ts
@@ -24,6 +24,7 @@ import {
   providerIdSchemaV50,
   providerIdSchemaV60,
   providerIdSchemaV70,
+  providerIdSchemaV80,
   providerProfileRateLimitStatusSchema,
 } from "@traycer/protocol/host/provider-schemas";
 import {
@@ -35,6 +36,7 @@ import {
   providerRateLimitsSchemaV50,
   providerRateLimitsSchemaV60,
   providerRateLimitsSchemaV70,
+  providerRateLimitsSchemaV80,
 } from "@traycer/protocol/host/rate-limit/schemas";
 import {
   agentFacingHarnessIdSchema,
@@ -44,6 +46,7 @@ import {
   guiHarnessIdSchemaV50,
   guiHarnessIdSchemaV60,
   guiHarnessIdSchemaV70,
+  guiHarnessIdSchemaV80,
 } from "@traycer/protocol/host/agent/shared";
 
 // ─── `agent.listProviderProfiles@1.0` ─────────────────────────────────────
@@ -204,11 +207,120 @@ export const agentListProviderProfilesV40 = defineRpcContract({
   responseSchema: agentListProviderProfilesResponseSchemaV4,
 });
 
+/**
+ * Frozen `agent.listProviderProfiles@5.0` response, pinned to the
+ * pre-Antigravity provider id set (`providerIdSchemaV80`).
+ *
+ * This line IS released - `cli-v1.3.0` / `host-v1.3.0` shipped it, cut from a
+ * branch that predates Antigravity. Until then it pointed at the live schema,
+ * the same defect that let `omp` first try to ride v2.0, `huggingface` v3.0
+ * and `reasonix` v4.0. v6.0 now carries the live schema.
+ */
+export const agentListProviderProfilesResponseSchemaV5 = z.object({
+  providerId: providerIdSchemaV80,
+  profiles: z.array(agentProviderProfileSummarySchema),
+});
+export type AgentListProviderProfilesResponseV5 = z.infer<
+  typeof agentListProviderProfilesResponseSchemaV5
+>;
+
 export const agentListProviderProfilesV50 = defineRpcContract({
   method: "agent.listProviderProfiles",
   schemaVersion: { major: 5, minor: 0 } as const,
   requestSchema: agentListProviderProfilesRequestSchema,
+  responseSchema: agentListProviderProfilesResponseSchemaV5,
+});
+
+export const agentListProviderProfilesV60 = defineRpcContract({
+  method: "agent.listProviderProfiles",
+  schemaVersion: { major: 6, minor: 0 } as const,
+  requestSchema: agentListProviderProfilesRequestSchema,
   responseSchema: agentListProviderProfilesResponseSchema,
+});
+
+export const agentListProviderProfilesUpgradeV50ToV60 = defineUpgradePath<
+  typeof agentListProviderProfilesV50,
+  typeof agentListProviderProfilesV60
+>({
+  from: { major: 5, minor: 0 },
+  to: { major: 6, minor: 0 },
+  upgradeRequest: (request) => request,
+  upgradeResponse: (response) => response,
+});
+
+export const agentListProviderProfilesDowngradeV60ToV50 = defineDowngradePath<
+  typeof agentListProviderProfilesV60,
+  typeof agentListProviderProfilesV50
+>({
+  from: { major: 6, minor: 0 },
+  to: { major: 5, minor: 0 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  downgradeResponse: (response) => {
+    // Same fail-closed rule as the v5->v4 bridge below: this response carries
+    // exactly one provider, so there is nothing to filter and the only honest
+    // options are pass-through or refuse.
+    const parsed =
+      agentListProviderProfilesResponseSchemaV5.safeParse(response);
+    if (!parsed.success) {
+      return {
+        ok: false,
+        error: {
+          code: "DOWNGRADE_UNSUPPORTED",
+          message:
+            "Listing this provider's profiles requires a newer Traycer client.",
+        },
+      };
+    }
+    return { ok: true, value: parsed.data };
+  },
+});
+
+export const agentListProviderProfilesDowngradeV60ToV40 = defineDowngradePath<
+  typeof agentListProviderProfilesV60,
+  typeof agentListProviderProfilesV40
+>({
+  from: { major: 6, minor: 0 },
+  to: { major: 4, minor: 0 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  downgradeResponse: (response) => {
+    const parsed =
+      agentListProviderProfilesResponseSchemaV4.safeParse(response);
+    if (!parsed.success) {
+      return {
+        ok: false,
+        error: {
+          code: "DOWNGRADE_UNSUPPORTED",
+          message:
+            "Listing this provider's profiles requires a newer Traycer client.",
+        },
+      };
+    }
+    return { ok: true, value: parsed.data };
+  },
+});
+
+export const agentListProviderProfilesDowngradeV60ToV30 = defineDowngradePath<
+  typeof agentListProviderProfilesV60,
+  typeof agentListProviderProfilesV30
+>({
+  from: { major: 6, minor: 0 },
+  to: { major: 3, minor: 0 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  downgradeResponse: (response) => {
+    const parsed =
+      agentListProviderProfilesResponseSchemaV3.safeParse(response);
+    if (!parsed.success) {
+      return {
+        ok: false,
+        error: {
+          code: "DOWNGRADE_UNSUPPORTED",
+          message:
+            "Listing this provider's profiles requires a newer Traycer client.",
+        },
+      };
+    }
+    return { ok: true, value: parsed.data };
+  },
 });
 
 export const agentListProviderProfilesUpgradeV10ToV20 = defineUpgradePath<
@@ -538,6 +650,54 @@ export const agentListProviderProfilesDowngradeV50ToV10 = defineDowngradePath<
   },
 });
 
+export const agentListProviderProfilesDowngradeV60ToV20 = defineDowngradePath<
+  typeof agentListProviderProfilesV60,
+  typeof agentListProviderProfilesV20
+>({
+  from: { major: 6, minor: 0 },
+  to: { major: 2, minor: 0 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  downgradeResponse: (response) => {
+    const parsed =
+      agentListProviderProfilesResponseSchemaV2.safeParse(response);
+    if (!parsed.success) {
+      return {
+        ok: false,
+        error: {
+          code: "DOWNGRADE_UNSUPPORTED",
+          message:
+            "Listing this provider's profiles requires a newer Traycer client.",
+        },
+      };
+    }
+    return { ok: true, value: parsed.data };
+  },
+});
+
+export const agentListProviderProfilesDowngradeV60ToV10 = defineDowngradePath<
+  typeof agentListProviderProfilesV60,
+  typeof agentListProviderProfilesV10
+>({
+  from: { major: 6, minor: 0 },
+  to: { major: 1, minor: 0 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  downgradeResponse: (response) => {
+    const parsed =
+      agentListProviderProfilesResponseSchemaV1.safeParse(response);
+    if (!parsed.success) {
+      return {
+        ok: false,
+        error: {
+          code: "DOWNGRADE_UNSUPPORTED",
+          message:
+            "Listing this provider's profiles requires a newer Traycer client.",
+        },
+      };
+    }
+    return { ok: true, value: parsed.data };
+  },
+});
+
 // ─── `agent.getProviderProfileRateLimits@1.0` ─────────────────────────────
 //
 // On-demand detailed rate-limit read for one concrete profile selection
@@ -682,13 +842,14 @@ export const agentGetProviderProfileRateLimitsV40 = defineRpcContract({
   responseSchema: agentGetProviderProfileRateLimitsResponseSchemaV4,
 });
 
-// The LIVE line: ranges over `providerRateLimitsSchema` rather than a frozen
-// snapshot, because `5` is the newest major and no released peer has ever
-// negotiated it (the newest released baseline tops out at `4`). It stops being
-// the live line the moment a tag ships it - see the v4.0 block above for what
-// that costs when it is missed.
+// Frozen `@5.0`: the `1.3.0` tags shipped this line, so it ranges over
+// `providerRateLimitsSchemaV80` rather than the live union. Its comment used to
+// read "`5` is the newest major and no released peer has ever negotiated it" -
+// the sentence the v4.0 block above already records as the exact thing that
+// stops being true the moment a tag ships. It happened again here, and
+// Antigravity is the id that reached the released wire through it.
 export const agentGetProviderProfileRateLimitsResponseSchemaV5 = z.object({
-  rateLimits: providerRateLimitsSchema,
+  rateLimits: providerRateLimitsSchemaV80,
   usageUpdatedAt: z.number().nullable(),
 });
 
@@ -698,6 +859,162 @@ export const agentGetProviderProfileRateLimitsV50 = defineRpcContract({
   requestSchema: agentGetProviderProfileRateLimitsRequestSchema,
   responseSchema: agentGetProviderProfileRateLimitsResponseSchemaV5,
 });
+
+// The LIVE line. Ranges over `providerRateLimitsSchema`; the moment a tag
+// ships `6`, freeze it against a `V90` union and open `7` - do not edit this
+// comment to say the line is safe because it is newest.
+export const agentGetProviderProfileRateLimitsResponseSchemaV6 = z.object({
+  rateLimits: providerRateLimitsSchema,
+  usageUpdatedAt: z.number().nullable(),
+});
+
+export const agentGetProviderProfileRateLimitsV60 = defineRpcContract({
+  method: "agent.getProviderProfileRateLimits",
+  schemaVersion: { major: 6, minor: 0 } as const,
+  requestSchema: agentGetProviderProfileRateLimitsRequestSchema,
+  responseSchema: agentGetProviderProfileRateLimitsResponseSchemaV6,
+});
+
+export const agentGetProviderProfileRateLimitsUpgradeV50ToV60 =
+  defineUpgradePath<
+    typeof agentGetProviderProfileRateLimitsV50,
+    typeof agentGetProviderProfileRateLimitsV60
+  >({
+    from: { major: 5, minor: 0 },
+    to: { major: 6, minor: 0 },
+    // Request shape is identical - only the response's `rateLimits.provider`
+    // enum grows (antigravity).
+    upgradeRequest: (request) => request,
+    upgradeResponse: (response) => response,
+  });
+
+export const agentGetProviderProfileRateLimitsDowngradeV60ToV50 =
+  defineDowngradePath<
+    typeof agentGetProviderProfileRateLimitsV60,
+    typeof agentGetProviderProfileRateLimitsV50
+  >({
+    from: { major: 6, minor: 0 },
+    to: { major: 5, minor: 0 },
+    downgradeRequest: (request) => ({ ok: true, value: request }),
+    downgradeResponse: (response) => {
+      // One provider per response, so there is nothing to filter: pass through
+      // or refuse. The message names no provider so it stays honest as the
+      // enum grows.
+      const parsed =
+        agentGetProviderProfileRateLimitsResponseSchemaV5.safeParse(response);
+      if (!parsed.success) {
+        return {
+          ok: false,
+          error: {
+            code: "DOWNGRADE_UNSUPPORTED",
+            message:
+              "Reading this provider's rate limits requires a newer Traycer client.",
+          },
+        };
+      }
+      return { ok: true, value: parsed.data };
+    },
+  });
+
+export const agentGetProviderProfileRateLimitsDowngradeV60ToV40 =
+  defineDowngradePath<
+    typeof agentGetProviderProfileRateLimitsV60,
+    typeof agentGetProviderProfileRateLimitsV40
+  >({
+    from: { major: 6, minor: 0 },
+    to: { major: 4, minor: 0 },
+    downgradeRequest: (request) => ({ ok: true, value: request }),
+    downgradeResponse: (response) => {
+      const parsed =
+        agentGetProviderProfileRateLimitsResponseSchemaV4.safeParse(response);
+      if (!parsed.success) {
+        return {
+          ok: false,
+          error: {
+            code: "DOWNGRADE_UNSUPPORTED",
+            message:
+              "Reading this provider's rate limits requires a newer Traycer client.",
+          },
+        };
+      }
+      return { ok: true, value: parsed.data };
+    },
+  });
+
+export const agentGetProviderProfileRateLimitsDowngradeV60ToV30 =
+  defineDowngradePath<
+    typeof agentGetProviderProfileRateLimitsV60,
+    typeof agentGetProviderProfileRateLimitsV30
+  >({
+    from: { major: 6, minor: 0 },
+    to: { major: 3, minor: 0 },
+    downgradeRequest: (request) => ({ ok: true, value: request }),
+    downgradeResponse: (response) => {
+      const parsed =
+        agentGetProviderProfileRateLimitsResponseSchemaV3.safeParse(response);
+      if (!parsed.success) {
+        return {
+          ok: false,
+          error: {
+            code: "DOWNGRADE_UNSUPPORTED",
+            message:
+              "Reading this provider's rate limits requires a newer Traycer client.",
+          },
+        };
+      }
+      return { ok: true, value: parsed.data };
+    },
+  });
+
+export const agentGetProviderProfileRateLimitsDowngradeV60ToV20 =
+  defineDowngradePath<
+    typeof agentGetProviderProfileRateLimitsV60,
+    typeof agentGetProviderProfileRateLimitsV20
+  >({
+    from: { major: 6, minor: 0 },
+    to: { major: 2, minor: 0 },
+    downgradeRequest: (request) => ({ ok: true, value: request }),
+    downgradeResponse: (response) => {
+      const parsed =
+        agentGetProviderProfileRateLimitsResponseSchemaV2.safeParse(response);
+      if (!parsed.success) {
+        return {
+          ok: false,
+          error: {
+            code: "DOWNGRADE_UNSUPPORTED",
+            message:
+              "Reading this provider's rate limits requires a newer Traycer client.",
+          },
+        };
+      }
+      return { ok: true, value: parsed.data };
+    },
+  });
+
+export const agentGetProviderProfileRateLimitsDowngradeV60ToV10 =
+  defineDowngradePath<
+    typeof agentGetProviderProfileRateLimitsV60,
+    typeof agentGetProviderProfileRateLimitsV10
+  >({
+    from: { major: 6, minor: 0 },
+    to: { major: 1, minor: 0 },
+    downgradeRequest: (request) => ({ ok: true, value: request }),
+    downgradeResponse: (response) => {
+      const parsed =
+        agentGetProviderProfileRateLimitsResponseSchemaV1.safeParse(response);
+      if (!parsed.success) {
+        return {
+          ok: false,
+          error: {
+            code: "DOWNGRADE_UNSUPPORTED",
+            message:
+              "Reading this provider's rate limits requires a newer Traycer client.",
+          },
+        };
+      }
+      return { ok: true, value: parsed.data };
+    },
+  });
 
 export const agentGetProviderProfileRateLimitsUpgradeV10ToV20 =
   defineUpgradePath<
@@ -1335,11 +1652,134 @@ export const agentConfigureV40 = defineRpcContract({
   responseSchema: agentConfigureResponseSchemaV4,
 });
 
+/**
+ * Frozen `agent.configure@5.0` settings/response, pinned to the
+ * pre-Antigravity harness id set (`guiHarnessIdSchemaV80`).
+ *
+ * This line IS released - `cli-v1.3.0` / `host-v1.3.0` shipped it, cut from a
+ * branch that predates Antigravity. Until then it pointed at the live
+ * schemas, which is how the id reached it. v6.0 carries the live schemas.
+ *
+ * Only the RESPONSE is frozen; the request keeps the live enum for the reason
+ * the v4.0 freeze gives - it is a client→host slot.
+ */
+export const agentConfigureSettingsSchemaV5 = z.object({
+  harnessId: guiHarnessIdSchemaV80,
+  model: z.string().min(1),
+  profileSelection: concreteProfileSelectionSchema,
+  reasoningEffort: z.string().nullable(),
+  fastMode: z.boolean(),
+  permissionMode: permissionModeSchema,
+  agentMode: agentModeSchema,
+});
+export type AgentConfigureSettingsV5 = z.infer<
+  typeof agentConfigureSettingsSchemaV5
+>;
+
+export const agentConfigureResponseSchemaV5 = z.object({
+  settings: agentConfigureSettingsSchemaV5,
+  warnings: z.array(z.string()),
+});
+export type AgentConfigureResponseV5 = z.infer<
+  typeof agentConfigureResponseSchemaV5
+>;
+
 export const agentConfigureV50 = defineRpcContract({
   method: "agent.configure",
   schemaVersion: { major: 5, minor: 0 } as const,
   requestSchema: agentConfigureRequestSchemaV20,
+  responseSchema: agentConfigureResponseSchemaV5,
+});
+
+export const agentConfigureV60 = defineRpcContract({
+  method: "agent.configure",
+  schemaVersion: { major: 6, minor: 0 } as const,
+  requestSchema: agentConfigureRequestSchemaV20,
   responseSchema: agentConfigureResponseSchema,
+});
+
+export const agentConfigureUpgradeV50ToV60 = defineUpgradePath<
+  typeof agentConfigureV50,
+  typeof agentConfigureV60
+>({
+  from: { major: 5, minor: 0 },
+  to: { major: 6, minor: 0 },
+  // v6.0 adds no field; it only widens the response harness enum, and a v5.0
+  // response is already a valid v6.0 one.
+  upgradeRequest: (request) => request,
+  upgradeResponse: (response) => response,
+});
+
+export const agentConfigureDowngradeV60ToV50 = defineDowngradePath<
+  typeof agentConfigureV60,
+  typeof agentConfigureV50
+>({
+  from: { major: 6, minor: 0 },
+  to: { major: 5, minor: 0 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  downgradeResponse: (response) => {
+    // Fails closed for a post-v8.0 harness (antigravity) - see the v5->v4
+    // bridge below for the full reasoning. The message names no harness so it
+    // stays honest as the enum grows.
+    const parsed = agentConfigureResponseSchemaV5.safeParse(response);
+    if (!parsed.success) {
+      return {
+        ok: false,
+        error: {
+          code: "DOWNGRADE_UNSUPPORTED",
+          message:
+            "Configuring an agent on this harness requires a newer Traycer client.",
+        },
+      };
+    }
+    return { ok: true, value: parsed.data };
+  },
+});
+
+export const agentConfigureDowngradeV60ToV40 = defineDowngradePath<
+  typeof agentConfigureV60,
+  typeof agentConfigureV40
+>({
+  from: { major: 6, minor: 0 },
+  to: { major: 4, minor: 0 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  downgradeResponse: (response) => {
+    const parsed = agentConfigureResponseSchemaV4.safeParse(response);
+    if (!parsed.success) {
+      return {
+        ok: false,
+        error: {
+          code: "DOWNGRADE_UNSUPPORTED",
+          message:
+            "Configuring an agent on this harness requires a newer Traycer client.",
+        },
+      };
+    }
+    return { ok: true, value: parsed.data };
+  },
+});
+
+export const agentConfigureDowngradeV60ToV30 = defineDowngradePath<
+  typeof agentConfigureV60,
+  typeof agentConfigureV30
+>({
+  from: { major: 6, minor: 0 },
+  to: { major: 3, minor: 0 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  downgradeResponse: (response) => {
+    const parsed = agentConfigureResponseSchemaV3.safeParse(response);
+    if (!parsed.success) {
+      return {
+        ok: false,
+        error: {
+          code: "DOWNGRADE_UNSUPPORTED",
+          message:
+            "Configuring an agent on this harness requires a newer Traycer client.",
+        },
+      };
+    }
+    return { ok: true, value: parsed.data };
+  },
 });
 
 export const agentConfigureUpgradeV10ToV20 = defineUpgradePath<
@@ -1594,6 +2034,60 @@ export const agentConfigureDowngradeV50ToV30 = defineDowngradePath<
     // Fails closed for any post-v6.0 harness (huggingface, reasonix,
     // antigravity) - see the v5->v4 bridge above for the full reasoning.
     const parsed = agentConfigureResponseSchemaV3.safeParse(response);
+    if (!parsed.success) {
+      return {
+        ok: false,
+        error: {
+          code: "DOWNGRADE_UNSUPPORTED",
+          message:
+            "Configuring an agent on this harness requires a newer Traycer client.",
+        },
+      };
+    }
+    return { ok: true, value: parsed.data };
+  },
+});
+
+export const agentConfigureDowngradeV60ToV20 = defineDowngradePath<
+  typeof agentConfigureV60,
+  typeof agentConfigureV20
+>({
+  from: { major: 6, minor: 0 },
+  to: { major: 2, minor: 0 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  downgradeResponse: (response) => {
+    const parsed = agentConfigureResponseSchemaV2.safeParse(response);
+    if (!parsed.success) {
+      return {
+        ok: false,
+        error: {
+          code: "DOWNGRADE_UNSUPPORTED",
+          message:
+            "Configuring an agent on this harness requires a newer Traycer client.",
+        },
+      };
+    }
+    return { ok: true, value: parsed.data };
+  },
+});
+
+export const agentConfigureDowngradeV60ToV10 = defineDowngradePath<
+  typeof agentConfigureV60,
+  typeof agentConfigureV10
+>({
+  from: { major: 6, minor: 0 },
+  to: { major: 1, minor: 0 },
+  // Same refusal as every other bridge onto v1.0 - see the v5->v1 bridge.
+  downgradeRequest: () => ({
+    ok: false,
+    error: {
+      code: "DOWNGRADE_UNSUPPORTED",
+      message:
+        "Selecting an agent permission mode requires a newer Traycer host. Upgrade the host before configuring this agent.",
+    },
+  }),
+  downgradeResponse: (response) => {
+    const parsed = agentConfigureResponseSchemaV1.safeParse(response);
     if (!parsed.success) {
       return {
         ok: false,

--- a/protocol/src/host/agent/profiles.ts
+++ b/protocol/src/host/agent/profiles.ts
@@ -863,6 +863,16 @@ export const agentGetProviderProfileRateLimitsV50 = defineRpcContract({
 // The LIVE line. Ranges over `providerRateLimitsSchema`; the moment a tag
 // ships `6`, freeze it against a `V90` union and open `7` - do not edit this
 // comment to say the line is safe because it is newest.
+//
+// This method deliberately does NOT follow its siblings, where the head
+// contract names the un-suffixed base schema. Here the head gets its own
+// `...ResponseSchemaVN` object and the base name
+// `agentGetProviderProfileRateLimitsResponseSchema` stays a structurally
+// identical but DISTINCT object that is canonical for nothing. That is not an
+// oversight: it is the fixture
+// `clients/traycer-cli/src/internal/__tests__/host-rpc.test.ts` uses to prove
+// the CLI's `assertCanonicalResponseSchema` backstop actually fires. Collapse
+// the two and that test has nothing left to falsify with.
 export const agentGetProviderProfileRateLimitsResponseSchemaV6 = z.object({
   rateLimits: providerRateLimitsSchema,
   usageUpdatedAt: z.number().nullable(),

--- a/protocol/src/host/agent/shared.ts
+++ b/protocol/src/host/agent/shared.ts
@@ -302,6 +302,44 @@ export const guiHarnessIdSchemaV70 = harnessIdSchema.extract([
 ]);
 export type GuiHarnessIdV70 = z.infer<typeof guiHarnessIdSchemaV70>;
 
+/**
+ * Frozen harness id set as `cli-v1.3.0` / `host-v1.3.0` shipped v8.0 - i.e.
+ * everything through Reasonix, before Antigravity.
+ *
+ * v7.0's docblock above hands v8.0 the job of tracking live growth, and that
+ * was correct while v8.0 was UNRELEASED. 1.3.0 was then cut from a branch that
+ * predates Antigravity, so the tag pinned v8.0 at these twenty ids while
+ * `main` had already widened the live enum underneath it - the shipped line
+ * and the live line disagreed with nothing in between to catch it until the
+ * released-baseline gate resolved the new tag.
+ *
+ * v9.0 owns live growth now. Do NOT add new harnesses here - extend the latest
+ * `guiHarnessIdSchema`; a v9.0 bridge drops post-v8.0 ids for older callers.
+ */
+export const guiHarnessIdSchemaV80 = harnessIdSchema.extract([
+  "claude",
+  "codex",
+  "opencode",
+  "traycer",
+  "cursor",
+  "grok",
+  "qwen",
+  "kiro",
+  "droid",
+  "kimi",
+  "copilot",
+  "kilocode",
+  "openrouter",
+  "amp",
+  "devin",
+  "pi",
+  "hermes",
+  "omp",
+  "huggingface",
+  "reasonix",
+]);
+export type GuiHarnessIdV80 = z.infer<typeof guiHarnessIdSchemaV80>;
+
 export const tuiHarnessIdSchema = harnessIdSchema.extract([
   "claude",
   "codex",
@@ -966,6 +1004,23 @@ export const listAgentsResponseSchemaV70 = listAgentsResponseSchema.extend({
   agents: z.array(agentSummarySchemaV70),
 });
 export type ListAgentsResponseV70 = z.infer<typeof listAgentsResponseSchemaV70>;
+
+// ── Frozen protocol-v8.0 agent.list response (with Reasonix, pre-Antigravity)
+// This line IS released (`cli-v1.3.0` / `host-v1.3.0`), and was cut from a
+// branch that predates Antigravity - so it shipped the twenty-id set and is
+// frozen here as actually shipped. v9.0 carries Antigravity rows and v9→v8 …
+// v9→v1 bridges drop them for older callers. Do not add new harnesses here.
+//
+// Hand-frozen off `releasedAgentSummarySchema` for the same reason v7.0 is: a
+// field added to the live `agentSummarySchema` must not widen a released line.
+export const agentSummarySchemaV80 = releasedAgentSummarySchema.extend({
+  harnessId: guiHarnessIdSchemaV80.nullable(),
+  runConfig: agentRunConfigSchema.nullable().default(null),
+});
+export const listAgentsResponseSchemaV80 = listAgentsResponseSchema.extend({
+  agents: z.array(agentSummarySchemaV80),
+});
+export type ListAgentsResponseV80 = z.infer<typeof listAgentsResponseSchemaV80>;
 
 /**
  * `agent.sendMessage@1.0` - fire-and-forget enqueue from one agent to

--- a/protocol/src/host/epic/chat-records.ts
+++ b/protocol/src/host/epic/chat-records.ts
@@ -459,6 +459,67 @@ export type GetChatRunSettingsResponseV10 = z.infer<
 >;
 
 /**
+ * Frozen harness id set for `epic.getChatRunSettings@2.0`, as the `1.3.0` tags
+ * shipped it - everything through Reasonix, before Antigravity.
+ *
+ * v2.0 was opened to carry the ids v1.0 froze off, and bound the live
+ * persisted enum on the reading that it was the unreleased head. 1.3.0 was cut
+ * from a branch that predates Antigravity, so the tag froze v2.0 here while
+ * `main` widened the enum underneath it - the same trap one line down, which
+ * is the argument for pinning a released line the moment it ships rather than
+ * when the next id arrives.
+ *
+ * `.extract()` off the live persisted enum for the reason the V10 note gives:
+ * removing an id upstream then fails to compile here instead of silently
+ * narrowing a released line.
+ */
+const chatRunSettingsHarnessIdSchemaV20 = guiHarnessIdSchema.extract([
+  "claude",
+  "codex",
+  "opencode",
+  "traycer",
+  "cursor",
+  "grok",
+  "qwen",
+  "kiro",
+  "droid",
+  "kimi",
+  "copilot",
+  "kilocode",
+  "openrouter",
+  "amp",
+  "devin",
+  "pi",
+  "hermes",
+  "omp",
+  "huggingface",
+  "reasonix",
+]);
+
+/**
+ * Frozen `epic.getChatRunSettings@2.0` settings tuple. Hand-copied off
+ * `chatRunSettingsSchema` for the same reason the V10 copy is: pinning only
+ * the id over a LIVE body is a half freeze.
+ */
+export const chatRunSettingsSchemaV20 = z.object({
+  harnessId: chatRunSettingsHarnessIdSchemaV20,
+  model: z.string().min(1),
+  permissionMode: permissionModeSchema,
+  reasoningEffort: z.string().nullable(),
+  serviceTier: z.string().nullable().default(null),
+  agentMode: agentModeSchema,
+  profileId: z.string().nullable().default(null),
+});
+export type ChatRunSettingsV20 = z.infer<typeof chatRunSettingsSchemaV20>;
+
+export const getChatRunSettingsResponseSchemaV20 = z.object({
+  settings: chatRunSettingsSchemaV20.nullable(),
+});
+export type GetChatRunSettingsResponseV20 = z.infer<
+  typeof getChatRunSettingsResponseSchemaV20
+>;
+
+/**
  * `host.chatRecords.subscribe@1.0` - the record-change PUSH stream, the
  * freshness half of the read above.
  *

--- a/protocol/src/host/epic/contracts.ts
+++ b/protocol/src/host/epic/contracts.ts
@@ -146,6 +146,7 @@ import {
   getChatRunSettingsRequestSchema,
   getChatRunSettingsResponseSchema,
   getChatRunSettingsResponseSchemaV10,
+  getChatRunSettingsResponseSchemaV20,
 } from "@traycer/protocol/host/epic/chat-records";
 import {
   readChatAttachmentRequestSchema,
@@ -964,7 +965,77 @@ export const epicGetChatRunSettingsV20 = defineRpcContract({
   method: "epic.getChatRunSettings",
   schemaVersion: { major: 2, minor: 0 } as const,
   requestSchema: getChatRunSettingsRequestSchema,
+  // Frozen at the harness id set the `1.3.0` tags shipped. v2.0 was opened to
+  // carry what v1.0 froze off and then bound the live persisted enum - the
+  // same trap one line up, one release later. v3.0 is the head line.
+  responseSchema: getChatRunSettingsResponseSchemaV20,
+});
+
+export const epicGetChatRunSettingsV30 = defineRpcContract({
+  method: "epic.getChatRunSettings",
+  schemaVersion: { major: 3, minor: 0 } as const,
+  requestSchema: getChatRunSettingsRequestSchema,
   responseSchema: getChatRunSettingsResponseSchema,
+});
+
+export const epicGetChatRunSettingsUpgradeV20ToV30 = defineUpgradePath<
+  typeof epicGetChatRunSettingsV20,
+  typeof epicGetChatRunSettingsV30
+>({
+  from: { major: 2, minor: 0 },
+  to: { major: 3, minor: 0 },
+  // Request shape is identical; a v2.0 settings tuple is a valid v3.0 one
+  // (only the `harnessId` enum grows), so both upgrades are identity.
+  upgradeRequest: (request) => request,
+  upgradeResponse: (response) => response,
+});
+
+export const epicGetChatRunSettingsDowngradeV30ToV20 = defineDowngradePath<
+  typeof epicGetChatRunSettingsV30,
+  typeof epicGetChatRunSettingsV20
+>({
+  from: { major: 3, minor: 0 },
+  to: { major: 2, minor: 0 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  downgradeResponse: (response) => {
+    // Refuse rather than answering `{ settings: null }` - see the v2->v1
+    // bridge below for why that arm would be a false claim, not a degrade.
+    const parsed = getChatRunSettingsResponseSchemaV20.safeParse(response);
+    if (!parsed.success) {
+      return {
+        ok: false,
+        error: {
+          code: "DOWNGRADE_UNSUPPORTED",
+          message:
+            "Reading this chat's run settings requires a newer Traycer client.",
+        },
+      };
+    }
+    return { ok: true, value: parsed.data };
+  },
+});
+
+export const epicGetChatRunSettingsDowngradeV30ToV10 = defineDowngradePath<
+  typeof epicGetChatRunSettingsV30,
+  typeof epicGetChatRunSettingsV10
+>({
+  from: { major: 3, minor: 0 },
+  to: { major: 1, minor: 0 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  downgradeResponse: (response) => {
+    const parsed = getChatRunSettingsResponseSchemaV10.safeParse(response);
+    if (!parsed.success) {
+      return {
+        ok: false,
+        error: {
+          code: "DOWNGRADE_UNSUPPORTED",
+          message:
+            "Reading this chat's run settings requires a newer Traycer client.",
+        },
+      };
+    }
+    return { ok: true, value: parsed.data };
+  },
 });
 
 export const epicGetChatRunSettingsUpgradeV10ToV20 = defineUpgradePath<

--- a/protocol/src/host/provider-schemas.ts
+++ b/protocol/src/host/provider-schemas.ts
@@ -203,6 +203,43 @@ export const providerIdSchemaV70 = z.enum([
 ]);
 export type ProviderIdV70 = z.infer<typeof providerIdSchemaV70>;
 
+/**
+ * Frozen provider id set as `cli-v1.3.0` / `host-v1.3.0` shipped v8.0 - i.e.
+ * everything before Antigravity.
+ *
+ * v8.0's docblock above says v8.0 "owns live catalog growth". That was true
+ * only while v8.0 was UNRELEASED: 1.3.0 was cut from a branch that predates
+ * Antigravity, so the tag froze v8.0 at these twenty ids while `main` had
+ * already widened the live enum underneath it. v9.0 now owns live growth, and
+ * a v9->v8 bridge drops post-v8.0 ids for the peers that shipped with them.
+ *
+ * Do NOT add new providers here - extend the latest `providerIdSchema` and use
+ * the existing version bridges instead.
+ */
+export const providerIdSchemaV80 = z.enum([
+  "claude-code",
+  "codex",
+  "opencode",
+  "cursor",
+  "traycer",
+  "grok",
+  "qwen",
+  "kiro",
+  "droid",
+  "kimi",
+  "copilot",
+  "kilocode",
+  "openrouter",
+  "amp",
+  "devin",
+  "pi",
+  "hermes",
+  "omp",
+  "huggingface",
+  "reasonix",
+]);
+export type ProviderIdV80 = z.infer<typeof providerIdSchemaV80>;
+
 /** Human-readable provider names, shared by the host and the GUI. */
 export const PROVIDER_DISPLAY_NAMES: Record<ProviderId, string> = {
   "claude-code": "Claude Code",
@@ -2037,6 +2074,111 @@ export type ProvidersListResponseV70 = z.infer<
   typeof providersListResponseSchemaV70
 >;
 
+// ── Frozen protocol-v8.0 provider state + list response ────────────────────
+//
+// v8.0 shipped in `cli-v1.3.0` / `host-v1.3.0` and bound the LIVE schema on
+// the (then true) reading that it was the unreleased head line. Two things
+// reached it afterwards and both are host→client:
+//
+//   - `antigravity`, on `providerId` and on `managedVersions`'
+//     `sharedWithProviders` array;
+//   - `profiles[].apiKey`, added by the per-profile API-key work, which the
+//     release branch predates.
+//
+// The key set is hand-listed off `providerCliStateBaseShapeV70` (identical to
+// the live shape's keys at this cut) rather than spread from the live shape,
+// for the reason `providerCliStateBaseShapeV20`'s comment gives: a released
+// line must not absorb a field the live shape grows later.
+const providerManagedVersionsSchemaV80 = z.object({
+  autoDownload: z.boolean(),
+  pinnedVersion: z.string().nullable(),
+  updateAvailable: z.object({ version: z.string() }).nullable(),
+  // The one leaf that differs from live - same reasoning as
+  // `providerManagedVersionsSchemaV70`: this is a host→client `providerId`
+  // enum, and leaving it live let Antigravity reach a released wire.
+  sharedWithProviders: z.array(providerIdSchemaV80).catch([]),
+  totalSizeBytes: z.number().int().nonnegative().nullable(),
+  available: z.array(providerPackVersionSchema),
+});
+
+/**
+ * Frozen `providers.list@8.0` profile row: the live profile as 1.3.0 shipped
+ * it, i.e. WITHOUT `apiKey`.
+ *
+ * `apiKey` is `.catch(null).optional()`, so a v8.0 client tolerates its
+ * presence at parse time - but tolerance is not a versioning mechanism, and
+ * the gate scores an added host→client property on a released line breaking
+ * for the reason the finding states: a released peer never sends the key, so a
+ * consumer that assumes it is populated reads `undefined`. `launchCommand`
+ * stays, because it DID ship in 1.3.0.
+ */
+export const providerProfileSchemaV80 = z.object({
+  ...providerProfileShapeV70,
+  enabled: z.boolean().default(true).catch(true),
+  launchCommand: z
+    .object({
+      command: z.string(),
+      shell: z.enum(["posix", "powershell"]),
+    })
+    .nullable()
+    .catch(null)
+    .optional(),
+});
+export type ProviderProfileV80 = z.infer<typeof providerProfileSchemaV80>;
+
+const providerCliStateBaseShapeV80 = {
+  enabled: z.boolean(),
+  disabledBy: providerDisabledBySchema.nullable(),
+  selected: providerSelectionSchema,
+  candidates: z.array(providerCliCandidateSchema),
+  authPending: z.boolean(),
+  checkedAt: z.number().nullable(),
+  apiKey: providerApiKeyStateSchema,
+  terminalAgentArgs: z.string().catch(""),
+  envOverrides: z.array(providerEnvOverrideSchema).catch([]),
+  loginCapability: providerLoginCapabilitySchema.nullable().catch(null),
+  availabilityPending: z.boolean().catch(false),
+  profiles: z.array(providerProfileSchemaV80).catch([]),
+  managedInstallState: providerManagedInstallStateSchema
+    .nullable()
+    .catch(null)
+    .optional(),
+  versionVisibility: providerVersionVisibilitySchema
+    .nullable()
+    .catch(null)
+    .optional(),
+  advisory: providerAdvisorySchema.nullable().catch(null).optional(),
+  cliBinaryResolved: z.boolean().catch(true).optional(),
+  packId: z.string().nullable().catch(null).optional(),
+  managedVersions: providerManagedVersionsSchemaV80
+    .nullable()
+    .catch(null)
+    .optional(),
+  managedVersionsUnavailable: providerManagedVersionsUnavailableSchema
+    .nullable()
+    .catch(null)
+    .optional(),
+  nextRunBinary: providerNextRunBinarySchema.nullable().catch(null).optional(),
+};
+
+export const providerCliStateSchemaV80 = z.object({
+  providerId: providerIdSchemaV80,
+  ...providerCliStateBaseShapeV80,
+  auth: PROVIDER_AUTH_SCHEMA_V20,
+  nativeCapabilities: providerNativeCapabilitiesSchema.catch(
+    DEFAULT_PROVIDER_NATIVE_CAPABILITIES,
+  ),
+});
+export type ProviderCliStateV80 = z.infer<typeof providerCliStateSchemaV80>;
+
+export const providersListResponseSchemaV80 = z.object({
+  providers: z.array(providerCliStateSchemaV80),
+  native: nativeListResultSchema.nullable().default(null),
+});
+export type ProvidersListResponseV80 = z.infer<
+  typeof providersListResponseSchemaV80
+>;
+
 // THERE IS NO `providers.list@7.1`. One was opened for the auth-aware
 // enablement pair (`enablementMode` / `enablementSource`) and removed with
 // them, before either reached a tag: those two optional fields were the
@@ -3721,6 +3863,26 @@ export function downgradeProviderCliStateListToV70(
     const current = parseProviderStateWithEnabledProfiles(state);
     if (current === null) return [];
     const parsed = providerCliStateSchemaV70.safeParse(current);
+    return parsed.success ? [parsed.data] : [];
+  });
+}
+
+/**
+ * Drop post-v8.0 providers (currently `antigravity`) for an already-shipped
+ * v8.0 client, and strip `profiles[].apiKey`, which the frozen v8.0 profile
+ * does not model.
+ *
+ * Both fall out of the same reparse: `providerCliStateSchemaV80` is a plain
+ * (non-strict) object, so the added key is stripped, while an id outside the
+ * frozen enum fails the parse and the row is dropped. No `enabledProfilesOnly`
+ * pre-pass, unlike the v7.0 helper - v8.0 is the line that introduced
+ * `profiles[].enabled`, so it can carry a disabled row itself.
+ */
+export function downgradeProviderCliStateListToV80(
+  states: readonly unknown[],
+): ProviderCliStateV80[] {
+  return states.flatMap((state) => {
+    const parsed = providerCliStateSchemaV80.safeParse(state);
     return parsed.success ? [parsed.data] : [];
   });
 }

--- a/protocol/src/host/providers-changed-stream.ts
+++ b/protocol/src/host/providers-changed-stream.ts
@@ -1,5 +1,8 @@
 import { z } from "zod";
-import { providerIdSchema } from "@traycer/protocol/host/provider-schemas";
+import {
+  providerIdSchema,
+  providerIdSchemaV80,
+} from "@traycer/protocol/host/provider-schemas";
 import { defineStreamRpcContract } from "@traycer/protocol/framework/versioned-stream-rpc";
 
 export const providersChangedOpenRequestSchema = z.object({});
@@ -26,9 +29,44 @@ export const providersChangedClientFrameSchema = z.discriminatedUnion("kind", [
   }),
 ]);
 
+/**
+ * Frozen server-frame shape as `cli-v1.3.0` / `host-v1.3.0` shipped @1.0: the
+ * `changed` arm's provider id is pinned to the twenty ids those peers strict-
+ * decode.
+ *
+ * Streams carry no downgrade bridge, so a host cannot project an Antigravity
+ * notification down to this minor - it must simply not send one. That is
+ * lossless here in a way it would not be for a catalog method: the frame is a
+ * pure invalidation signal, and a peer that cannot name Antigravity has no
+ * Antigravity state to invalidate.
+ */
+export const providersChangedServerFrameSchemaPreAntigravity =
+  z.discriminatedUnion("kind", [
+    z.object({
+      kind: z.literal("changed"),
+      providerId: providerIdSchemaV80,
+      hasBinaryPayload: z.literal(false),
+    }),
+    z.object({
+      kind: z.literal("pong"),
+      hasBinaryPayload: z.literal(false),
+    }),
+  ]);
+
 export const providersChangedV10 = defineStreamRpcContract({
   method: "providers.changed",
   schemaVersion: { major: 1, minor: 0 } as const,
+  openRequestSchema: providersChangedOpenRequestSchema,
+  serverFrameSchema: providersChangedServerFrameSchemaPreAntigravity,
+  clientFrameSchema: providersChangedClientFrameSchema,
+});
+
+/**
+ * @1.1 is the first minor whose `changed` frames may name Antigravity.
+ */
+export const providersChangedV11 = defineStreamRpcContract({
+  method: "providers.changed",
+  schemaVersion: { major: 1, minor: 1 } as const,
   openRequestSchema: providersChangedOpenRequestSchema,
   serverFrameSchema: providersChangedServerFrameSchema,
   clientFrameSchema: providersChangedClientFrameSchema,

--- a/protocol/src/host/rate-limit/contracts.ts
+++ b/protocol/src/host/rate-limit/contracts.ts
@@ -9,6 +9,7 @@ import {
   providersConsumeRateLimitResetCreditResponseSchema,
   providersRefreshProfileStatusRequestSchema,
   providersRefreshProfileStatusResponseSchema,
+  providersRefreshProfileStatusResponseSchemaV10,
   rateLimitUsageRequestSchemaV10,
   rateLimitUsageRequestSchemaV11,
   rateLimitUsageRequestSchemaV12,
@@ -68,8 +69,55 @@ export const providersRefreshProfileStatusV10 = defineRpcContract({
   method: "providers.refreshProfileStatus",
   schemaVersion: { major: 1, minor: 0 } as const,
   requestSchema: providersRefreshProfileStatusRequestSchema,
+  // Frozen: the `1.3.0` tags shipped this line. The REQUEST keeps the live
+  // provider enum - a client->host slot may widen freely.
+  responseSchema: providersRefreshProfileStatusResponseSchemaV10,
+});
+
+export const providersRefreshProfileStatusV20 = defineRpcContract({
+  method: "providers.refreshProfileStatus",
+  schemaVersion: { major: 2, minor: 0 } as const,
+  requestSchema: providersRefreshProfileStatusRequestSchema,
   responseSchema: providersRefreshProfileStatusResponseSchema,
 });
+
+export const providersRefreshProfileStatusUpgradeV10ToV20 = defineUpgradePath<
+  typeof providersRefreshProfileStatusV10,
+  typeof providersRefreshProfileStatusV20
+>({
+  from: { major: 1, minor: 0 },
+  to: { major: 2, minor: 0 },
+  // Request shape identical; only the response's provider enum grows.
+  upgradeRequest: (request) => request,
+  upgradeResponse: (response) => response,
+});
+
+export const providersRefreshProfileStatusDowngradeV20ToV10 =
+  defineDowngradePath<
+    typeof providersRefreshProfileStatusV20,
+    typeof providersRefreshProfileStatusV10
+  >({
+    from: { major: 2, minor: 0 },
+    to: { major: 1, minor: 0 },
+    downgradeRequest: (request) => ({ ok: true, value: request }),
+    downgradeResponse: (response) => {
+      // One provider per response: pass through or refuse. The message names
+      // no provider so it stays honest as the enum grows.
+      const parsed =
+        providersRefreshProfileStatusResponseSchemaV10.safeParse(response);
+      if (!parsed.success) {
+        return {
+          ok: false,
+          error: {
+            code: "DOWNGRADE_UNSUPPORTED" as const,
+            message:
+              "Refreshing this provider's profile status requires a newer Traycer client.",
+          },
+        };
+      }
+      return { ok: true, value: parsed.data };
+    },
+  });
 
 export const hostGetRateLimitUsageV10 = defineRpcContract({
   method: "host.getRateLimitUsage",

--- a/protocol/src/host/rate-limit/schemas.ts
+++ b/protocol/src/host/rate-limit/schemas.ts
@@ -9,6 +9,7 @@ import {
   providerIdSchemaV50,
   providerIdSchemaV60,
   providerIdSchemaV70,
+  providerIdSchemaV80,
 } from "@traycer/protocol/host/provider-schemas";
 
 // `host.getRateLimitUsage` v1.0 request: no fields. Non-strict on purpose so a
@@ -849,6 +850,44 @@ export const providerRateLimitsSchemaV70 = z.union([
 ]);
 export type ProviderRateLimitsV70 = z.infer<typeof providerRateLimitsSchemaV70>;
 
+// Frozen pre-Antigravity unavailable arm: `provider` pinned to
+// `providerIdSchemaV80` (the id set `cli-v1.3.0` / `host-v1.3.0` shipped) so an
+// already-shipped `agent.getProviderProfileRateLimits@5.0` /
+// `providers.refreshProfileStatus@1.0` caller's strict decode never sees
+// `"antigravity"` in the `available: false` arm.
+const unavailableProviderRateLimitsSchemaV80 =
+  unavailableProviderRateLimitsSchemaV2.extend({
+    provider: providerIdSchemaV80,
+    credentialGeneration: z.string().min(1).optional(),
+  });
+
+/**
+ * Frozen provider union as the 1.3.0 tags shipped it - the live union with the
+ * `available: false` arm's `provider` pinned to `providerIdSchemaV80`.
+ *
+ * Bound by `agent.getProviderProfileRateLimits@5.0` and
+ * `providers.refreshProfileStatus@1.0`. Both lines used to range over the live
+ * union on the reading that they were the newest majors and no released peer
+ * had negotiated them - the sentence that stops being true the moment a tag
+ * ships, exactly as the v4.0 block above records. Antigravity is the first id
+ * added since 1.3.0.
+ *
+ * Every other arm is shared with the live union by reference: they carry no
+ * provider-id enum, so there is nothing for them to drift on.
+ */
+export const providerRateLimitsSchemaV80 = z.union([
+  codexRateLimitsSchema,
+  claudeCodeRateLimitsSchema,
+  openRouterRateLimitsSchema,
+  kiloCodeRateLimitsSchema,
+  grokRateLimitsSchema,
+  huggingFaceRateLimitsSchema,
+  openCodeRateLimitsSchema,
+  cursorRateLimitsSchema,
+  unavailableProviderRateLimitsSchemaV80,
+]);
+export type ProviderRateLimitsV80 = z.infer<typeof providerRateLimitsSchemaV80>;
+
 // v1.2 response = v1.0/v1.1 flat aperture fields (unchanged) + a nullable
 // provider-account snapshot, frozen at the v1 reason enum (see
 // `providerRateLimitsSchemaV1` above). Null both when the request didn't ask
@@ -946,6 +985,19 @@ export const providersRefreshProfileStatusResponseSchema = z.object({
 });
 export type ProvidersRefreshProfileStatusResponse = z.infer<
   typeof providersRefreshProfileStatusResponseSchema
+>;
+
+/**
+ * Frozen `providers.refreshProfileStatus@1.0` response: the `1.3.0` tags
+ * shipped this line, so it stops tracking the live union. Antigravity is the
+ * first id added since. v2.0 carries the live union with a fail-closed v2->v1
+ * bridge.
+ */
+export const providersRefreshProfileStatusResponseSchemaV10 = z.object({
+  providerRateLimits: providerRateLimitsSchemaV80,
+});
+export type ProvidersRefreshProfileStatusResponseV10 = z.infer<
+  typeof providersRefreshProfileStatusResponseSchemaV10
 >;
 
 /**

--- a/protocol/src/host/registry.ts
+++ b/protocol/src/host/registry.ts
@@ -52,6 +52,14 @@ import {
   agentListDowngradeV8ToV5,
   agentListDowngradeV8ToV6,
   agentListDowngradeV8ToV7,
+  agentListDowngradeV9ToV1,
+  agentListDowngradeV9ToV2,
+  agentListDowngradeV9ToV3,
+  agentListDowngradeV9ToV4,
+  agentListDowngradeV9ToV5,
+  agentListDowngradeV9ToV6,
+  agentListDowngradeV9ToV7,
+  agentListDowngradeV9ToV8,
   agentListUpgradeV1ToV2,
   agentListUpgradeV2ToV3,
   agentListUpgradeV3ToV4,
@@ -59,6 +67,7 @@ import {
   agentListUpgradeV5ToV6,
   agentListUpgradeV6ToV7,
   agentListUpgradeV7ToV8,
+  agentListUpgradeV8ToV9,
   agentListV10,
   agentListV20,
   agentListV30,
@@ -67,6 +76,7 @@ import {
   agentListV60,
   agentListV70,
   agentListV80,
+  agentListV90,
   agentSelectionGuideV10,
   agentSelectionGuideGlobalGetV10,
   agentSelectionGuideGlobalOnboardingDraftGetV10,
@@ -87,15 +97,22 @@ import {
   agentConfigureDowngradeV50ToV20,
   agentConfigureDowngradeV50ToV30,
   agentConfigureDowngradeV50ToV40,
+  agentConfigureDowngradeV60ToV10,
+  agentConfigureDowngradeV60ToV20,
+  agentConfigureDowngradeV60ToV30,
+  agentConfigureDowngradeV60ToV40,
+  agentConfigureDowngradeV60ToV50,
   agentConfigureV10,
   agentConfigureV20,
   agentConfigureV30,
   agentConfigureV40,
   agentConfigureV50,
+  agentConfigureV60,
   agentConfigureUpgradeV10ToV20,
   agentConfigureUpgradeV20ToV30,
   agentConfigureUpgradeV30ToV40,
   agentConfigureUpgradeV40ToV50,
+  agentConfigureUpgradeV50ToV60,
   agentGetProviderProfileRateLimitsDowngradeV20ToV10,
   agentGetProviderProfileRateLimitsDowngradeV30ToV10,
   agentGetProviderProfileRateLimitsDowngradeV30ToV20,
@@ -106,15 +123,22 @@ import {
   agentGetProviderProfileRateLimitsDowngradeV50ToV20,
   agentGetProviderProfileRateLimitsDowngradeV50ToV30,
   agentGetProviderProfileRateLimitsDowngradeV50ToV40,
+  agentGetProviderProfileRateLimitsDowngradeV60ToV10,
+  agentGetProviderProfileRateLimitsDowngradeV60ToV20,
+  agentGetProviderProfileRateLimitsDowngradeV60ToV30,
+  agentGetProviderProfileRateLimitsDowngradeV60ToV40,
+  agentGetProviderProfileRateLimitsDowngradeV60ToV50,
   agentGetProviderProfileRateLimitsV10,
   agentGetProviderProfileRateLimitsV20,
   agentGetProviderProfileRateLimitsV30,
   agentGetProviderProfileRateLimitsV40,
   agentGetProviderProfileRateLimitsV50,
+  agentGetProviderProfileRateLimitsV60,
   agentGetProviderProfileRateLimitsUpgradeV10ToV20,
   agentGetProviderProfileRateLimitsUpgradeV20ToV30,
   agentGetProviderProfileRateLimitsUpgradeV30ToV40,
   agentGetProviderProfileRateLimitsUpgradeV40ToV50,
+  agentGetProviderProfileRateLimitsUpgradeV50ToV60,
   agentListProviderProfilesDowngradeV20ToV10,
   agentListProviderProfilesDowngradeV30ToV10,
   agentListProviderProfilesDowngradeV30ToV20,
@@ -125,15 +149,22 @@ import {
   agentListProviderProfilesDowngradeV50ToV20,
   agentListProviderProfilesDowngradeV50ToV30,
   agentListProviderProfilesDowngradeV50ToV40,
+  agentListProviderProfilesDowngradeV60ToV10,
+  agentListProviderProfilesDowngradeV60ToV20,
+  agentListProviderProfilesDowngradeV60ToV30,
+  agentListProviderProfilesDowngradeV60ToV40,
+  agentListProviderProfilesDowngradeV60ToV50,
   agentListProviderProfilesV10,
   agentListProviderProfilesV20,
   agentListProviderProfilesV30,
   agentListProviderProfilesV40,
   agentListProviderProfilesV50,
+  agentListProviderProfilesV60,
   agentListProviderProfilesUpgradeV10ToV20,
   agentListProviderProfilesUpgradeV20ToV30,
   agentListProviderProfilesUpgradeV30ToV40,
   agentListProviderProfilesUpgradeV40ToV50,
+  agentListProviderProfilesUpgradeV50ToV60,
 } from "@traycer/protocol/host/agent/profiles";
 import {
   agentInboxAckV10,
@@ -190,6 +221,14 @@ import {
   agentGuiListHarnessesDowngradeV8ToV5,
   agentGuiListHarnessesDowngradeV8ToV6,
   agentGuiListHarnessesDowngradeV8ToV7,
+  agentGuiListHarnessesDowngradeV9ToV1,
+  agentGuiListHarnessesDowngradeV9ToV2,
+  agentGuiListHarnessesDowngradeV9ToV3,
+  agentGuiListHarnessesDowngradeV9ToV4,
+  agentGuiListHarnessesDowngradeV9ToV5,
+  agentGuiListHarnessesDowngradeV9ToV6,
+  agentGuiListHarnessesDowngradeV9ToV7,
+  agentGuiListHarnessesDowngradeV9ToV8,
   agentGuiListHarnessesUpgradeV1ToV2,
   agentGuiListHarnessesUpgradeV20ToV21,
   agentGuiListHarnessesUpgradeV2ToV3,
@@ -199,6 +238,7 @@ import {
   agentGuiListHarnessesUpgradeV6ToV7,
   agentGuiListHarnessesUpgradeV70ToV71,
   agentGuiListHarnessesUpgradeV71ToV80,
+  agentGuiListHarnessesUpgradeV80ToV90,
   agentGuiListHarnessesV10,
   agentGuiListHarnessesV20,
   agentGuiListHarnessesV21,
@@ -209,6 +249,7 @@ import {
   agentGuiListHarnessesV70,
   agentGuiListHarnessesV71,
   agentGuiListHarnessesV80,
+  agentGuiListHarnessesV90,
   agentGuiListModelsV10,
   chatSubscribeV10,
   chatSubscribeV11,
@@ -219,6 +260,7 @@ import {
   chatSubscribeV16,
   chatSubscribeV17,
   chatSubscribeV18,
+  chatSubscribeV19,
 } from "@traycer/protocol/host/agent/gui/contracts";
 import {
   agentTuiGenerateTitleV10,
@@ -358,6 +400,9 @@ import {
   hostGetRateLimitUsageDowngradeV4ToV3,
   providersConsumeRateLimitResetCreditV10,
   providersRefreshProfileStatusV10,
+  providersRefreshProfileStatusV20,
+  providersRefreshProfileStatusUpgradeV10ToV20,
+  providersRefreshProfileStatusDowngradeV20ToV10,
 } from "@traycer/protocol/host/rate-limit/contracts";
 import {
   epicBatchDeleteV10,
@@ -390,9 +435,13 @@ import {
   epicListChatRecordsV10,
   epicListChatRecordsV11,
   epicGetChatRunSettingsDowngradeV20ToV10,
+  epicGetChatRunSettingsDowngradeV30ToV10,
+  epicGetChatRunSettingsDowngradeV30ToV20,
   epicGetChatRunSettingsUpgradeV10ToV20,
+  epicGetChatRunSettingsUpgradeV20ToV30,
   epicGetChatRunSettingsV10,
   epicGetChatRunSettingsV20,
+  epicGetChatRunSettingsV30,
   epicListChatPublicationTargetsV10,
   epicListCloudChatPayloadsV10,
   epicListCloudChatsV10,
@@ -609,8 +658,12 @@ import {
 import {
   sessionImportScanV10,
   sessionImportScanV11,
+  sessionImportScanV12,
 } from "@traycer/protocol/host/session-import/scan";
-import { sessionImportRunV10 } from "@traycer/protocol/host/session-import/run";
+import {
+  sessionImportRunV10,
+  sessionImportRunV11,
+} from "@traycer/protocol/host/session-import/run";
 import { sessionImportStatusV10 } from "@traycer/protocol/host/session-import/contracts";
 import {
   worktreeDeleteBatchByPathStreamV10,
@@ -622,7 +675,10 @@ import {
   worktreeDeleteByPathStreamV12,
 } from "@traycer/protocol/host/worktree-delete-stream";
 import { worktreeChangedV10 } from "@traycer/protocol/host/worktree-changed-stream";
-import { providersChangedV10 } from "@traycer/protocol/host/providers-changed-stream";
+import {
+  providersChangedV10,
+  providersChangedV11,
+} from "@traycer/protocol/host/providers-changed-stream";
 import {
   epicCommunicationGraphSubscribeV10,
   hostCommunicationGraphCloudFeedSubscribeV10,
@@ -790,6 +846,7 @@ import {
   providersListResponseSchemaV50,
   providersListResponseSchemaV60,
   providersListResponseSchemaV70,
+  providersListResponseSchemaV80,
   isProfileEnabled,
   providersListModelProvidersRequestSchema,
   providersListModelProvidersResponseSchema,
@@ -807,6 +864,7 @@ import {
   downgradeProviderCliStateListToV50,
   downgradeProviderCliStateListToV60,
   downgradeProviderCliStateListToV70,
+  downgradeProviderCliStateListToV80,
   providersInstallPackVersionRequestSchema,
   providersInstallPackVersionResponseSchema,
   providersRemovePackVersionRequestSchema,
@@ -1943,7 +2001,31 @@ export const providersListV80 = defineRpcContract({
   method: "providers.list",
   schemaVersion: { major: 8, minor: 0 } as const,
   requestSchema: providersListRequestSchema,
+  // Frozen: `cli-v1.3.0` / `host-v1.3.0` shipped this line. It bound the live
+  // schema while it was the unreleased head, which is how `antigravity` and
+  // `profiles[].apiKey` both reached a wire already in the field. v9.0 is the
+  // head line now.
+  responseSchema: providersListResponseSchemaV80,
+});
+
+export const providersListV90 = defineRpcContract({
+  method: "providers.list",
+  schemaVersion: { major: 9, minor: 0 } as const,
+  requestSchema: providersListRequestSchema,
   responseSchema: providersListResponseSchema,
+});
+
+export const providersListUpgradeV80ToV90 = defineUpgradePath<
+  typeof providersListV80,
+  typeof providersListV90
+>({
+  from: { major: 8, minor: 0 },
+  to: { major: 9, minor: 0 },
+  // Request shape is identical. `apiKey` is deliberately NOT filled: it is
+  // `.optional()` precisely so "this host has no per-profile key method" stays
+  // distinguishable from a concrete state, and a v8.0 host IS such a host.
+  upgradeRequest: (request) => request,
+  upgradeResponse: (response) => response,
 });
 
 export const providersListUpgradeV70ToV80 = defineUpgradePath<
@@ -2310,6 +2392,168 @@ function enabledProviderProfilesOnly(
     profiles: provider.profiles.filter(isProfileEnabled),
   }));
 }
+
+export const providersListDowngradeV9ToV8 = defineDowngradePath<
+  typeof providersListV90,
+  typeof providersListV80
+>({
+  from: { major: 9, minor: 0 },
+  to: { major: 8, minor: 0 },
+  downgradeRequest: (request) => ({
+    ok: true,
+    value: providersListRequestSchema.parse(request),
+  }),
+  // Drops Antigravity rows and strips `profiles[].apiKey` - see the helper.
+  downgradeResponse: (response) => ({
+    ok: true,
+    value: providersListResponseSchemaV80.parse({
+      ...response,
+      providers: downgradeProviderCliStateListToV80(response.providers),
+    }),
+  }),
+});
+
+export const providersListDowngradeV9ToV7 = defineDowngradePath<
+  typeof providersListV90,
+  typeof providersListV70
+>({
+  from: { major: 9, minor: 0 },
+  to: { major: 7, minor: 0 },
+  downgradeRequest: (request) => ({
+    ok: true,
+    value: providersListRequestSchema.parse(request),
+  }),
+  downgradeResponse: (response) => ({
+    ok: true,
+    value: providersListResponseSchemaV70.parse({
+      ...response,
+      providers: downgradeProviderCliStateListToV70(response.providers),
+    }),
+  }),
+});
+
+export const providersListDowngradeV9ToV6 = defineDowngradePath<
+  typeof providersListV90,
+  typeof providersListV60
+>({
+  from: { major: 9, minor: 0 },
+  to: { major: 6, minor: 0 },
+  downgradeRequest: (request) => ({
+    ok: true,
+    value: providersListRequestSchemaBeforeV70.parse(request),
+  }),
+  downgradeResponse: (response) => ({
+    ok: true,
+    value: providersListResponseSchemaV60.parse({
+      providers: downgradeProviderCliStateListToV60(
+        enabledProviderProfilesOnly(response.providers),
+      ),
+    }),
+  }),
+});
+
+export const providersListDowngradeV9ToV5 = defineDowngradePath<
+  typeof providersListV90,
+  typeof providersListV50
+>({
+  from: { major: 9, minor: 0 },
+  to: { major: 5, minor: 0 },
+  downgradeRequest: (request) => ({
+    ok: true,
+    value: providersListRequestSchemaBeforeV70.parse(request),
+  }),
+  downgradeResponse: (response) => ({
+    ok: true,
+    value: providersListResponseSchemaV50.parse({
+      providers: downgradeProviderCliStateListToV50(
+        enabledProviderProfilesOnly(response.providers),
+      ),
+    }),
+  }),
+});
+
+export const providersListDowngradeV9ToV4 = defineDowngradePath<
+  typeof providersListV90,
+  typeof providersListV40
+>({
+  from: { major: 9, minor: 0 },
+  to: { major: 4, minor: 0 },
+  downgradeRequest: (request) => ({
+    ok: true,
+    value: providersListRequestSchemaBeforeV70.parse(request),
+  }),
+  downgradeResponse: (response) => ({
+    ok: true,
+    value: providersListResponseSchemaV40.parse({
+      providers: downgradeProviderCliStateListToV40(
+        enabledProviderProfilesOnly(response.providers),
+      ),
+    }),
+  }),
+});
+
+export const providersListDowngradeV9ToV3 = defineDowngradePath<
+  typeof providersListV90,
+  typeof providersListV30
+>({
+  from: { major: 9, minor: 0 },
+  to: { major: 3, minor: 0 },
+  downgradeRequest: (request) => ({
+    ok: true,
+    value: providersListRequestSchemaBeforeV70.parse(request),
+  }),
+  downgradeResponse: (response) => ({
+    ok: true,
+    value: providersListResponseSchemaV30.parse({
+      providers: downgradeProviderCliStateListToV30(
+        enabledProviderProfilesOnly(response.providers),
+      ),
+    }),
+  }),
+});
+
+export const providersListDowngradeV9ToV2 = defineDowngradePath<
+  typeof providersListV90,
+  typeof providersListV20
+>({
+  from: { major: 9, minor: 0 },
+  to: { major: 2, minor: 0 },
+  downgradeRequest: (request) => ({
+    ok: true,
+    value: providersListRequestSchemaBeforeV70.parse(request),
+  }),
+  downgradeResponse: (response) => ({
+    ok: true,
+    value: providersListResponseSchemaV20.parse({
+      providers: downgradeProviderCliStateListToV20(
+        enabledProviderProfilesOnly(response.providers),
+      ),
+    }),
+  }),
+});
+
+export const providersListDowngradeV9ToV1 = defineDowngradePath<
+  typeof providersListV90,
+  typeof providersListV10
+>({
+  from: { major: 9, minor: 0 },
+  to: { major: 1, minor: 0 },
+  downgradeRequest: (request) => ({
+    ok: true,
+    value: providersListRequestSchemaBeforeV70.parse(request),
+  }),
+  downgradeResponse: (response) => ({
+    ok: true,
+    value: providersListResponseSchemaV10.parse({
+      providers: enabledProviderProfilesOnly(response.providers).flatMap(
+        (provider) => {
+          const downgraded = downgradeProviderCliStateToV10(provider);
+          return downgraded === null ? [] : [downgraded];
+        },
+      ),
+    }),
+  }),
+});
 
 export const providersListDowngradeV8ToV7 = defineDowngradePath<
   typeof providersListV80,
@@ -4799,6 +5043,9 @@ const HOST_RPC_REGISTRY_BASE_DEFINITION = {
   },
   "providers.refreshProfileStatus": {
     degrade: { kind: "unsupported" },
+    // v1.0 is frozen at the twenty provider ids `1.3.0` shipped; v2.0 carries
+    // the live union, and its v2->v1 bridge fails closed for an id v1.0 cannot
+    // represent (one provider per response, so there is nothing to filter).
     1: {
       latestMinor: 0,
       versions: {
@@ -4808,6 +5055,19 @@ const HOST_RPC_REGISTRY_BASE_DEFINITION = {
         },
       },
       downgradePathsFromLatest: {},
+    },
+    2: {
+      latestMinor: 0,
+      versions: {
+        0: {
+          contract: providersRefreshProfileStatusV20,
+          upgradeFromPreviousVersion:
+            providersRefreshProfileStatusUpgradeV10ToV20,
+        },
+      },
+      downgradePathsFromLatest: {
+        1: providersRefreshProfileStatusDowngradeV20ToV10,
+      },
     },
   },
   "host.notifications.list": {
@@ -5284,6 +5544,25 @@ const HOST_RPC_REGISTRY_BASE_DEFINITION = {
         7: agentGuiListHarnessesDowngradeV8ToV7,
       },
     },
+    9: {
+      latestMinor: 0,
+      versions: {
+        0: {
+          contract: agentGuiListHarnessesV90,
+          upgradeFromPreviousVersion: agentGuiListHarnessesUpgradeV80ToV90,
+        },
+      },
+      downgradePathsFromLatest: {
+        1: agentGuiListHarnessesDowngradeV9ToV1,
+        2: agentGuiListHarnessesDowngradeV9ToV2,
+        3: agentGuiListHarnessesDowngradeV9ToV3,
+        4: agentGuiListHarnessesDowngradeV9ToV4,
+        5: agentGuiListHarnessesDowngradeV9ToV5,
+        6: agentGuiListHarnessesDowngradeV9ToV6,
+        7: agentGuiListHarnessesDowngradeV9ToV7,
+        8: agentGuiListHarnessesDowngradeV9ToV8,
+      },
+    },
   },
   "agent.gui.listModels": {
     1: {
@@ -5666,6 +5945,25 @@ const HOST_RPC_REGISTRY_BASE_DEFINITION = {
         5: agentListDowngradeV8ToV5,
         6: agentListDowngradeV8ToV6,
         7: agentListDowngradeV8ToV7,
+      },
+    },
+    9: {
+      latestMinor: 0,
+      versions: {
+        0: {
+          contract: agentListV90,
+          upgradeFromPreviousVersion: agentListUpgradeV8ToV9,
+        },
+      },
+      downgradePathsFromLatest: {
+        1: agentListDowngradeV9ToV1,
+        2: agentListDowngradeV9ToV2,
+        3: agentListDowngradeV9ToV3,
+        4: agentListDowngradeV9ToV4,
+        5: agentListDowngradeV9ToV5,
+        6: agentListDowngradeV9ToV6,
+        7: agentListDowngradeV9ToV7,
+        8: agentListDowngradeV9ToV8,
       },
     },
   },
@@ -7005,6 +7303,22 @@ const HOST_RPC_REGISTRY_BASE_TAIL_DEFINITION = {
         1: epicGetChatRunSettingsDowngradeV20ToV10,
       },
     },
+    // Major 3 carries the post-1.3.0 harness ids. v2.0 is frozen at the set
+    // those tags shipped: it was opened to carry what v1.0 froze off and then
+    // bound the live PERSISTED enum, so the next id reached it the same way.
+    3: {
+      latestMinor: 0,
+      versions: {
+        0: {
+          contract: epicGetChatRunSettingsV30,
+          upgradeFromPreviousVersion: epicGetChatRunSettingsUpgradeV20ToV30,
+        },
+      },
+      downgradePathsFromLatest: {
+        1: epicGetChatRunSettingsDowngradeV30ToV10,
+        2: epicGetChatRunSettingsDowngradeV30ToV20,
+      },
+    },
     degrade: { kind: "unsupported" },
   },
   // The terminal-agent record read (the TUI eviction). Optional and
@@ -7875,6 +8189,22 @@ const HOST_RPC_REGISTRY_BASE_TAIL_DEFINITION = {
         4: agentListProviderProfilesDowngradeV50ToV40,
       },
     },
+    6: {
+      latestMinor: 0,
+      versions: {
+        0: {
+          contract: agentListProviderProfilesV60,
+          upgradeFromPreviousVersion: agentListProviderProfilesUpgradeV50ToV60,
+        },
+      },
+      downgradePathsFromLatest: {
+        1: agentListProviderProfilesDowngradeV60ToV10,
+        2: agentListProviderProfilesDowngradeV60ToV20,
+        3: agentListProviderProfilesDowngradeV60ToV30,
+        4: agentListProviderProfilesDowngradeV60ToV40,
+        5: agentListProviderProfilesDowngradeV60ToV50,
+      },
+    },
   },
   "agent.getProviderProfileRateLimits": {
     degrade: { kind: "unsupported" },
@@ -7946,6 +8276,23 @@ const HOST_RPC_REGISTRY_BASE_TAIL_DEFINITION = {
         4: agentGetProviderProfileRateLimitsDowngradeV50ToV40,
       },
     },
+    6: {
+      latestMinor: 0,
+      versions: {
+        0: {
+          contract: agentGetProviderProfileRateLimitsV60,
+          upgradeFromPreviousVersion:
+            agentGetProviderProfileRateLimitsUpgradeV50ToV60,
+        },
+      },
+      downgradePathsFromLatest: {
+        1: agentGetProviderProfileRateLimitsDowngradeV60ToV10,
+        2: agentGetProviderProfileRateLimitsDowngradeV60ToV20,
+        3: agentGetProviderProfileRateLimitsDowngradeV60ToV30,
+        4: agentGetProviderProfileRateLimitsDowngradeV60ToV40,
+        5: agentGetProviderProfileRateLimitsDowngradeV60ToV50,
+      },
+    },
   },
   "agent.configure": {
     degrade: { kind: "unsupported" },
@@ -8009,6 +8356,22 @@ const HOST_RPC_REGISTRY_BASE_TAIL_DEFINITION = {
         2: agentConfigureDowngradeV50ToV20,
         3: agentConfigureDowngradeV50ToV30,
         4: agentConfigureDowngradeV50ToV40,
+      },
+    },
+    6: {
+      latestMinor: 0,
+      versions: {
+        0: {
+          contract: agentConfigureV60,
+          upgradeFromPreviousVersion: agentConfigureUpgradeV50ToV60,
+        },
+      },
+      downgradePathsFromLatest: {
+        1: agentConfigureDowngradeV60ToV10,
+        2: agentConfigureDowngradeV60ToV20,
+        3: agentConfigureDowngradeV60ToV30,
+        4: agentConfigureDowngradeV60ToV40,
+        5: agentConfigureDowngradeV60ToV50,
       },
     },
   },
@@ -8225,6 +8588,25 @@ const HOST_RPC_PROVIDERS_REGISTRY_DEFINITION = {
         5: providersListDowngradeV8ToV5,
         6: providersListDowngradeV8ToV6,
         7: providersListDowngradeV8ToV7,
+      },
+    },
+    9: {
+      latestMinor: 0,
+      versions: {
+        0: {
+          contract: providersListV90,
+          upgradeFromPreviousVersion: providersListUpgradeV80ToV90,
+        },
+      },
+      downgradePathsFromLatest: {
+        1: providersListDowngradeV9ToV1,
+        2: providersListDowngradeV9ToV2,
+        3: providersListDowngradeV9ToV3,
+        4: providersListDowngradeV9ToV4,
+        5: providersListDowngradeV9ToV5,
+        6: providersListDowngradeV9ToV6,
+        7: providersListDowngradeV9ToV7,
+        8: providersListDowngradeV9ToV8,
       },
     },
   },
@@ -9471,9 +9853,13 @@ const HOST_STREAM_RPC_REGISTRY_OTHER_DEFINITION = {
   // The reasoning lives with the contract (`./session-import/scan.ts`) and the
   // row (`./session-import/candidate.ts`); this note only keeps a reader who
   // arrives at the registry first from concluding the schemas differ.
+  //
+  // @1.2 DOES differ: @1.0/@1.1 are frozen at the twenty harness ids `1.3.0`
+  // shipped, and only @1.2 may carry an Antigravity row. Same capability-by-
+  // minor rule, one more thing to gate on.
   "sessionImport.scan": {
     1: {
-      latestMinor: 1,
+      latestMinor: 2,
       versions: {
         0: {
           contract: sessionImportScanV10,
@@ -9481,15 +9867,21 @@ const HOST_STREAM_RPC_REGISTRY_OTHER_DEFINITION = {
         1: {
           contract: sessionImportScanV11,
         },
+        2: {
+          contract: sessionImportScanV12,
+        },
       },
     },
   },
   "sessionImport.run": {
     1: {
-      latestMinor: 0,
+      latestMinor: 1,
       versions: {
         0: {
           contract: sessionImportRunV10,
+        },
+        1: {
+          contract: sessionImportRunV11,
         },
       },
     },
@@ -9540,12 +9932,19 @@ const HOST_STREAM_RPC_REGISTRY_OTHER_DEFINITION = {
       },
     },
   },
+  // @1.0 is frozen at the twenty provider ids `1.3.0` shipped; @1.1 is the
+  // first minor whose `changed` frame may name Antigravity. A host must not
+  // emit that id to a @1.0 subscriber - the frame is an invalidation signal,
+  // so withholding it costs a peer nothing it could have acted on.
   "providers.changed": {
     1: {
-      latestMinor: 0,
+      latestMinor: 1,
       versions: {
         0: {
           contract: providersChangedV10,
+        },
+        1: {
+          contract: providersChangedV11,
         },
       },
     },
@@ -9586,7 +9985,7 @@ const HOST_STREAM_RPC_REGISTRY_DEFINITION = {
   ...HOST_STREAM_RPC_REGISTRY_OTHER_DEFINITION,
   "chat.subscribe": {
     1: {
-      latestMinor: 8,
+      latestMinor: 9,
       versions: {
         0: {
           contract: chatSubscribeV10,
@@ -9614,6 +10013,13 @@ const HOST_STREAM_RPC_REGISTRY_DEFINITION = {
         },
         8: {
           contract: chatSubscribeV18,
+        },
+        // @1.8 is frozen at the twenty-arm session-anchor union 1.3.0 shipped;
+        // @1.9 is the first minor whose `rowContext` may carry an Antigravity
+        // anchor. The resolver withholds `sessionAnchor` from a <1.9
+        // subscriber rather than sending a frame it cannot decode.
+        9: {
+          contract: chatSubscribeV19,
         },
       },
     },

--- a/protocol/src/host/session-import/__tests__/session-import-contracts.test.ts
+++ b/protocol/src/host/session-import/__tests__/session-import-contracts.test.ts
@@ -4,11 +4,13 @@ import {
   sessionImportScanServerFrameSchema,
   sessionImportScanV10,
   sessionImportScanV11,
+  sessionImportScanV12,
 } from "@traycer/protocol/host/session-import/scan";
 import {
   sessionImportRunClientFrameSchema,
   sessionImportRunServerFrameSchema,
   sessionImportRunV10,
+  sessionImportRunV11,
 } from "@traycer/protocol/host/session-import/run";
 import { sessionImportStatusV10 } from "@traycer/protocol/host/session-import/contracts";
 import { sessionImportFailureReasonSchema } from "@traycer/protocol/host/session-import/candidate";
@@ -615,20 +617,68 @@ describe("sessionImport.status@1.0", () => {
  * feature the wire cannot carry, and nothing else in the suite would notice.
  */
 describe("sessionImport.* registry membership", () => {
-  it("registers scan at minors 0 and 1, retaining the v1.0 contract for older hosts", () => {
+  it("registers scan at minors 0-2, retaining the older contracts for older hosts", () => {
     const scan = hostStreamRpcRegistry["sessionImport.scan"];
     expect(scan).toBeDefined();
-    expect(scan[1].latestMinor).toBe(1);
+    expect(scan[1].latestMinor).toBe(2);
     expect(scan[1].versions[0].contract).toBe(sessionImportScanV10);
     expect(scan[1].versions[1].contract).toBe(sessionImportScanV11);
+    expect(scan[1].versions[2].contract).toBe(sessionImportScanV12);
     expect(sessionImportScanV10.schemaVersion).toEqual({ major: 1, minor: 0 });
     expect(sessionImportScanV11.schemaVersion).toEqual({ major: 1, minor: 1 });
+    expect(sessionImportScanV12.schemaVersion).toEqual({ major: 1, minor: 2 });
 
     const run = hostStreamRpcRegistry["sessionImport.run"];
     expect(run).toBeDefined();
-    expect(run[1].latestMinor).toBe(0);
+    expect(run[1].latestMinor).toBe(1);
     expect(run[1].versions[0].contract).toBe(sessionImportRunV10);
+    expect(run[1].versions[1].contract).toBe(sessionImportRunV11);
     expect(sessionImportRunV10.schemaVersion).toEqual({ major: 1, minor: 0 });
+    expect(sessionImportRunV11.schemaVersion).toEqual({ major: 1, minor: 1 });
+  });
+
+  // `@1.0`/`@1.1` are frozen at the twenty harness ids `cli-v1.3.0` shipped;
+  // only `@1.2` (scan) / `@1.1` (run) may name Antigravity. Streams carry no
+  // downgrade bridge, so the frozen server frame is the whole mechanism - a
+  // host must gate emission on the negotiated minor
+  // (`session-import-scan-stream-resolver.ts`).
+  it("keeps antigravity out of every released scan/run server frame", () => {
+    const antigravityStarted = {
+      kind: "started" as const,
+      providers: ["antigravity" as const],
+      hasBinaryPayload: false as const,
+    };
+    expect(
+      sessionImportScanV10.serverFrameSchema.safeParse(antigravityStarted)
+        .success,
+    ).toBe(false);
+    expect(
+      sessionImportScanV11.serverFrameSchema.safeParse(antigravityStarted)
+        .success,
+    ).toBe(false);
+    expect(
+      sessionImportScanV12.serverFrameSchema.safeParse(antigravityStarted)
+        .success,
+    ).toBe(true);
+
+    const antigravityProgress = {
+      kind: "progress" as const,
+      runId: "run-1",
+      index: 0,
+      total: 1,
+      harness: "antigravity" as const,
+      nativeSessionId: "s-1",
+      outcome: { kind: "imported" as const, epicId: "e-1", chatId: "c-1" },
+      hasBinaryPayload: false as const,
+    };
+    expect(
+      sessionImportRunV10.serverFrameSchema.safeParse(antigravityProgress)
+        .success,
+    ).toBe(false);
+    expect(
+      sessionImportRunV11.serverFrameSchema.safeParse(antigravityProgress)
+        .success,
+    ).toBe(true);
   });
 
   it("registers the status method as a unary that degrades unsupported", () => {

--- a/protocol/src/host/session-import/run.ts
+++ b/protocol/src/host/session-import/run.ts
@@ -45,6 +45,7 @@ import { z } from "zod";
 import { defineStreamRpcContract } from "@traycer/protocol/framework/versioned-stream-rpc";
 import {
   guiHarnessIdSchema,
+  guiHarnessIdSchemaPreAntigravity,
   permissionModeSchema,
 } from "@traycer/protocol/persistence/epic/foundation";
 import {
@@ -101,43 +102,71 @@ export type SessionImportRunCounts = z.infer<
   typeof sessionImportRunCountsSchema
 >;
 
+// The three arms that carry no harness id, shared verbatim by the live union
+// and the frozen @1.0 copy below - only the `progress` arm's enum differs
+// between them, so naming these keeps the two unions from drifting in any
+// other respect.
+const sessionImportRunStartedFrameSchema = z.object({
+  kind: z.literal("started"),
+  runId: z.string().min(1),
+  total: z.number().int().nonnegative(),
+  // False when this subscription STARTED the run, true when it attached to
+  // one already in flight (see the module doc). The wizard needs the
+  // difference: an attach ignores the `selections` it just submitted, and the
+  // `progress` frames that follow are a replay of work already done, not
+  // live progress on this client's request.
+  attached: z.boolean(),
+  hasBinaryPayload: z.literal(false),
+});
+
+const sessionImportRunCompleteFrameSchema = z.object({
+  kind: z.literal("complete"),
+  runId: z.string().min(1),
+  counts: sessionImportRunCountsSchema,
+  hasBinaryPayload: z.literal(false),
+});
+
+const sessionImportRunPongFrameSchema = z.object({
+  kind: z.literal("pong"),
+  hasBinaryPayload: z.literal(false),
+});
+
+const sessionImportRunProgressFrameSchema = z.object({
+  kind: z.literal("progress"),
+  runId: z.string().min(1),
+  index: z.number().int().nonnegative(),
+  total: z.number().int().nonnegative(),
+  harness: guiHarnessIdSchema,
+  nativeSessionId: z.string().min(1),
+  outcome: sessionImportOutcomeSchema,
+  hasBinaryPayload: z.literal(false),
+});
+
 export const sessionImportRunServerFrameSchema = z.discriminatedUnion("kind", [
-  z.object({
-    kind: z.literal("started"),
-    runId: z.string().min(1),
-    total: z.number().int().nonnegative(),
-    // False when this subscription STARTED the run, true when it attached to
-    // one already in flight (see the module doc). The wizard needs the
-    // difference: an attach ignores the `selections` it just submitted, and the
-    // `progress` frames that follow are a replay of work already done, not
-    // live progress on this client's request.
-    attached: z.boolean(),
-    hasBinaryPayload: z.literal(false),
-  }),
-  z.object({
-    kind: z.literal("progress"),
-    runId: z.string().min(1),
-    index: z.number().int().nonnegative(),
-    total: z.number().int().nonnegative(),
-    harness: guiHarnessIdSchema,
-    nativeSessionId: z.string().min(1),
-    outcome: sessionImportOutcomeSchema,
-    hasBinaryPayload: z.literal(false),
-  }),
-  z.object({
-    kind: z.literal("complete"),
-    runId: z.string().min(1),
-    counts: sessionImportRunCountsSchema,
-    hasBinaryPayload: z.literal(false),
-  }),
-  z.object({
-    kind: z.literal("pong"),
-    hasBinaryPayload: z.literal(false),
-  }),
+  sessionImportRunStartedFrameSchema,
+  sessionImportRunProgressFrameSchema,
+  sessionImportRunCompleteFrameSchema,
+  sessionImportRunPongFrameSchema,
 ]);
 export type SessionImportRunServerFrame = z.infer<
   typeof sessionImportRunServerFrameSchema
 >;
+
+/**
+ * Frozen server-frame shape as `cli-v1.3.0` / `host-v1.3.0` shipped @1.0: the
+ * `progress` arm's harness is pinned to the twenty ids those peers strict-
+ * decode. Streams carry no downgrade bridge, so a host must GATE EMISSION on
+ * the negotiated minor rather than expecting a projection to save it.
+ */
+export const sessionImportRunServerFrameSchemaPreAntigravity =
+  z.discriminatedUnion("kind", [
+    sessionImportRunStartedFrameSchema,
+    sessionImportRunProgressFrameSchema.extend({
+      harness: guiHarnessIdSchemaPreAntigravity,
+    }),
+    sessionImportRunCompleteFrameSchema,
+    sessionImportRunPongFrameSchema,
+  ]);
 
 export const sessionImportRunClientFrameSchema = z.discriminatedUnion("kind", [
   z.object({
@@ -152,6 +181,19 @@ export type SessionImportRunClientFrame = z.infer<
 export const sessionImportRunV10 = defineStreamRpcContract({
   method: "sessionImport.run",
   schemaVersion: { major: 1, minor: 0 } as const,
+  openRequestSchema: sessionImportRunOpenRequestSchema,
+  serverFrameSchema: sessionImportRunServerFrameSchemaPreAntigravity,
+  clientFrameSchema: sessionImportRunClientFrameSchema,
+});
+
+/**
+ * @1.1 is the first minor whose `progress` frames may name Antigravity. The
+ * open request already accepted the id (client->host slots may widen freely),
+ * so this minor only widens what the host is allowed to REPORT back.
+ */
+export const sessionImportRunV11 = defineStreamRpcContract({
+  method: "sessionImport.run",
+  schemaVersion: { major: 1, minor: 1 } as const,
   openRequestSchema: sessionImportRunOpenRequestSchema,
   serverFrameSchema: sessionImportRunServerFrameSchema,
   clientFrameSchema: sessionImportRunClientFrameSchema,

--- a/protocol/src/host/session-import/scan.ts
+++ b/protocol/src/host/session-import/scan.ts
@@ -34,8 +34,12 @@
  */
 import { z } from "zod";
 import { defineStreamRpcContract } from "@traycer/protocol/framework/versioned-stream-rpc";
-import { guiHarnessIdSchema } from "@traycer/protocol/persistence/epic/foundation";
 import {
+  guiHarnessIdSchema,
+  guiHarnessIdSchemaPreAntigravity,
+} from "@traycer/protocol/persistence/epic/foundation";
+import {
+  sessionImportCandidateSchema,
   sessionImportFailureReasonSchema,
   sessionImportGroupSchema,
 } from "@traycer/protocol/host/session-import/candidate";
@@ -113,11 +117,66 @@ export type SessionImportScanClientFrame = z.infer<
   typeof sessionImportScanClientFrameSchema
 >;
 
+/**
+ * Frozen server-frame shape as `cli-v1.3.0` / `host-v1.3.0` shipped @1.0 and
+ * @1.1: identical to the live union above except every harness slot is pinned
+ * to the twenty ids those peers strict-decode.
+ *
+ * Only the SERVER frame is frozen. `sessionImportScanOpenRequestSchema` stays
+ * on the live enum because it is a client->host slot - widening what a caller
+ * may ask for cannot break a released host, which simply has no reader for an
+ * id it does not know.
+ *
+ * Streams carry no downgrade bridge (`RELEASE-INVARIANT.md`: v1 stream peers
+ * reconnect on a mismatched major rather than bridging), so the freeze is the
+ * whole mechanism here - there is nothing to project a newer row through. The
+ * host must therefore GATE EMISSION on the negotiated minor and never hand an
+ * Antigravity row to a <1.2 subscriber.
+ */
+const sessionImportCandidateSchemaPreAntigravity =
+  sessionImportCandidateSchema.extend({
+    harness: guiHarnessIdSchemaPreAntigravity,
+  });
+
+const sessionImportGroupSchemaPreAntigravity = sessionImportGroupSchema.extend({
+  sessions: z.array(sessionImportCandidateSchemaPreAntigravity),
+});
+
+export const sessionImportScanServerFrameSchemaPreAntigravity =
+  z.discriminatedUnion("kind", [
+    z.object({
+      kind: z.literal("started"),
+      providers: z.array(guiHarnessIdSchemaPreAntigravity),
+      hasBinaryPayload: z.literal(false),
+    }),
+    z.object({
+      kind: z.literal("group"),
+      group: sessionImportGroupSchemaPreAntigravity,
+      hasBinaryPayload: z.literal(false),
+    }),
+    z.object({
+      kind: z.literal("providerFailed"),
+      harness: guiHarnessIdSchemaPreAntigravity,
+      reason: sessionImportFailureReasonSchema,
+      detail: z.string(),
+      hasBinaryPayload: z.literal(false),
+    }),
+    z.object({
+      kind: z.literal("complete"),
+      totals: sessionImportScanTotalsSchema,
+      hasBinaryPayload: z.literal(false),
+    }),
+    z.object({
+      kind: z.literal("pong"),
+      hasBinaryPayload: z.literal(false),
+    }),
+  ]);
+
 export const sessionImportScanV10 = defineStreamRpcContract({
   method: "sessionImport.scan",
   schemaVersion: { major: 1, minor: 0 } as const,
   openRequestSchema: sessionImportScanOpenRequestSchema,
-  serverFrameSchema: sessionImportScanServerFrameSchema,
+  serverFrameSchema: sessionImportScanServerFrameSchemaPreAntigravity,
   clientFrameSchema: sessionImportScanClientFrameSchema,
 });
 
@@ -129,6 +188,20 @@ export const sessionImportScanV10 = defineStreamRpcContract({
 export const sessionImportScanV11 = defineStreamRpcContract({
   method: "sessionImport.scan",
   schemaVersion: { major: 1, minor: 1 } as const,
+  openRequestSchema: sessionImportScanOpenRequestSchema,
+  serverFrameSchema: sessionImportScanServerFrameSchemaPreAntigravity,
+  clientFrameSchema: sessionImportScanClientFrameSchema,
+});
+
+/**
+ * @1.2 is the first minor whose frames may carry an Antigravity row. Nothing
+ * else changes: the capability signal is the negotiated minor, exactly as
+ * @1.0 -> @1.1 established, and a host must keep the id out of every frame it
+ * sends a <1.2 subscriber.
+ */
+export const sessionImportScanV12 = defineStreamRpcContract({
+  method: "sessionImport.scan",
+  schemaVersion: { major: 1, minor: 2 } as const,
   openRequestSchema: sessionImportScanOpenRequestSchema,
   serverFrameSchema: sessionImportScanServerFrameSchema,
   clientFrameSchema: sessionImportScanClientFrameSchema,

--- a/protocol/src/persistence/chat-transcript/row-context.ts
+++ b/protocol/src/persistence/chat-transcript/row-context.ts
@@ -1,6 +1,9 @@
 import { z } from "zod";
 
-import { chatSessionAnchorSchema } from "@traycer/protocol/persistence/epic/senders";
+import {
+  chatSessionAnchorSchema,
+  chatSessionAnchorSchemaPreAntigravity,
+} from "@traycer/protocol/persistence/epic/senders";
 
 /**
  * # What a row renders WITH
@@ -114,6 +117,19 @@ export const transcriptRowContextSchema = z.object({
 });
 
 export type TranscriptRowContext = z.infer<typeof transcriptRowContextSchema>;
+
+/**
+ * Frozen copy bound to the released windowed line (`chat.subscribe@1.8`).
+ *
+ * Only `sessionAnchor` differs: it takes the anchor union as 1.3.0 shipped it,
+ * without the Antigravity arm. Everything else is shared with the live schema
+ * by spreading `.shape`, so a field added above reaches both copies and only
+ * the discriminant this freeze exists to withhold stays behind.
+ */
+export const transcriptRowContextSchemaPreAntigravity =
+  transcriptRowContextSchema.extend({
+    sessionAnchor: chatSessionAnchorSchemaPreAntigravity.optional(),
+  });
 
 /** The many rows whose rendering depends on nothing around them. */
 export const EMPTY_ROW_CONTEXT: TranscriptRowContext = {};

--- a/protocol/src/persistence/epic/foundation.ts
+++ b/protocol/src/persistence/epic/foundation.ts
@@ -117,6 +117,46 @@ export type GuiHarnessIdPreReasonix = z.infer<
   typeof guiHarnessIdSchemaPreReasonix
 >;
 
+/**
+ * Frozen copy of the persisted harness enum as `cli-v1.3.0` / `host-v1.3.0`
+ * shipped it - everything before Antigravity, which first rides
+ * `chat.subscribe@1.9`, `sessionImport.scan@1.2` and `sessionImport.run@1.1`.
+ *
+ * Taken because 1.3.0 was cut from a branch that predates Antigravity while
+ * `main` had already added the id to the LIVE enum above: every stream frame
+ * that embeds this enum was therefore advertising a value the released peers
+ * strict-decode against a twenty-id set. Freezing here is what lets those
+ * released minors keep serializing exactly what they shipped with.
+ *
+ * Do NOT add new harnesses here - extend `guiHarnessIdSchema` above and gate
+ * emission on the negotiated minor (streams have no downgrade bridge).
+ */
+export const guiHarnessIdSchemaPreAntigravity = z.enum([
+  "claude",
+  "codex",
+  "opencode",
+  "traycer",
+  "cursor",
+  "grok",
+  "qwen",
+  "kiro",
+  "droid",
+  "kimi",
+  "copilot",
+  "kilocode",
+  "openrouter",
+  "amp",
+  "devin",
+  "pi",
+  "hermes",
+  "omp",
+  "huggingface",
+  "reasonix",
+]);
+export type GuiHarnessIdPreAntigravity = z.infer<
+  typeof guiHarnessIdSchemaPreAntigravity
+>;
+
 // Cursor remains a reserved compatibility value: it shipped in this persisted
 // enum before the unfinished runtime surface was withdrawn from the product.
 export const tuiHarnessIdSchema = z.enum([

--- a/protocol/src/persistence/epic/senders.ts
+++ b/protocol/src/persistence/epic/senders.ts
@@ -598,3 +598,30 @@ export const chatSessionAnchorSchemaPreReasonix = z.discriminatedUnion(
     huggingFaceChatSessionAnchorSchema,
   ],
 );
+
+/**
+ * Wire-freeze copy of the LIVE anchor union minus the Antigravity variant,
+ * bound to `chat.subscribe@1.7` and `@1.8` - the two lines `cli-v1.3.0` /
+ * `host-v1.3.0` shipped that follow the live anchor rather than the
+ * pre-Reasonix freeze above.
+ *
+ * `@1.7`'s own comment says it "admits the ids added since (`reasonix`,
+ * `antigravity`)". That was written while `@1.7`/`@1.8` were unreleased; the
+ * 1.3.0 tag was cut from a branch without Antigravity, so both lines shipped
+ * with a twenty-arm union and a released peer's `discriminatedUnion` rejects
+ * the twenty-first outright. `@1.9` is where Antigravity actually rides.
+ *
+ * Derived from the pre-Reasonix freeze plus Reasonix rather than re-listing
+ * twenty arms: the two freezes then cannot drift, and a variant added above is
+ * excluded from BOTH by construction instead of by a reviewer noticing.
+ */
+export const chatSessionAnchorSchemaPreAntigravity = z.discriminatedUnion(
+  "harnessId",
+  [
+    ...chatSessionAnchorSchemaPreReasonix.options,
+    reasonixChatSessionAnchorSchema,
+  ],
+);
+export type ChatSessionAnchorPreAntigravity = z.infer<
+  typeof chatSessionAnchorSchemaPreAntigravity
+>;


### PR DESCRIPTION
## The break

`cli-v1.3.0` was cut from `517efd28b`, which is **not** a descendant of `1139e0d33` — the commit that added the `antigravity` harness/provider id:

```
$ git merge-base --is-ancestor 1139e0d33 517efd28b   # -> no
$ git tag --contains 1139e0d33                       # -> (empty)
```

So every line that commit had grown in place shipped to users **without** the id, and the released-baseline gate reports **20 blocking findings** against the tag. That is what is currently red on `main`, and it blocks every open PR — #1804 included.

The `antigravity` change was not wrong when it was made. #1731's own body says, correctly at the time:

> No new major. `antigravity` joins the **live, unreleased** carriers only… harness-id record v8

A line is safe to grow in place only while it is unreleased, and **"newest major" is not a synonym for that**. The 1.3.0 cut retroactively withdrew that licence from eight unary majors and four stream minors at once.

## Why unary and stream get different remedies

The remedy the gate prints — *freeze the shipped line, open a new major with downgrade bridges* — is correct for **unary only**. Applying it to a stream breaks the handshake outright.

|                | unary                                                       | stream                                                                          |
| -------------- | ----------------------------------------------------------- | ------------------------------------------------------------------------------- |
| projection     | `downgradePathsFromLatest`, applied in `dispatchRpc`        | **none** — `checkStreamCompatibility` has no cross-major bridge                  |
| a MAJOR bump   | fine; bridges carry old peers                                | **fatal** — v1 peers *reconnect* on a mismatched major                           |
| the fix        | freeze major N, open N+1, add N+1→1..N bridges              | freeze the released minors' frame schema, open a new MINOR, gate emission host-side |

Both `protocol/src/host/RELEASE-INVARIANT.md` ("v1 stream clients reconnect on a mismatched major rather than bridging") and the stream registry docblock ("never [open a major] for a shipped method with a peer still in the field") state this independently.

## Unary — lines frozen, new head opened with full downgrade coverage

| method                               | frozen | new head | bridges added |
| ------------------------------------ | ------ | -------- | ------------- |
| `providers.list`                     | 8.0    | **9.0**  | 9→8…9→1       |
| `agent.list`                         | 8.0    | **9.0**  | 9→8…9→1       |
| `agent.gui.listHarnesses`            | 8.0    | **9.0**  | 9→8…9→1       |
| `agent.configure`                    | 5.0    | **6.0**  | 6→5…6→1       |
| `agent.listProviderProfiles`         | 5.0    | **6.0**  | 6→5…6→1       |
| `agent.getProviderProfileRateLimits` | 5.0    | **6.0**  | 6→5…6→1       |
| `epic.getChatRunSettings`            | 2.0    | **3.0**  | 3→2, 3→1      |
| `providers.refreshProfileStatus`     | 1.0    | **2.0**  | 2→1 (fail-closed) |

`providers.list@8.0` drops the `antigravity` provider id **and** the `apiKey` profile field — both post-date the cut. `launchCommand` stays, because that one did ship in 1.3.0.

**The frozen bodies are hand-listed, not `.extend()`ed off the live schemas.** Pinning only the id over a live body is a half-freeze, and a half-freeze is what this entire class of bug is made of.

## Streams — released frame schemas frozen, new minor opened

| method               | released minors frozen | new head |
| -------------------- | ---------------------- | -------- |
| `chat.subscribe`     | 1.7, 1.8               | **1.9**  |
| `sessionImport.scan` | 1.0, 1.1               | **1.2**  |
| `sessionImport.run`  | 1.0                    | **1.1**  |
| `providers.changed`  | 1.0                    | **1.1**  |

Because the framework does not project stream frames, a frozen schema is only half a stream fix — the host must not *send* the value. The paired emission gates are in the internal counterpart PR.

## A bug the compat gate structurally cannot see

While sweeping, probing the dumped surfaces showed `chat.subscribe@1.7` carrying 28 `antigravity` occurrences and `@1.8` carrying 36, against 0 in the 1.3.0 baseline — **with the gate silent**. `compat-exceptions.json` excepts that `**.harnessId.enum` path and names the host's `HARNESS_MINIMUM_CHAT_SUBSCRIBE_MINOR` as its compensating control. So the exception and its enforcement are one mechanism split across two repos, and only the OSS half is checked by anything. The table said `antigravity: 7`; both 1.7 and 1.8 shipped without the id. Corrected to `9` in the internal PR.

Sweeping the whole exception class: **12 of 60** exceptions touch an id path, **11 are self-enforcing** (the response echoes an id the client named in its own request, or is scoped to a harness picked from a negotiated catalog — both `listModels` methods verified to take a **required** `harnessId`), and **exactly 1** delegated to a host table. That one was the stale one.

## The `browser.screencast` test case, removed

`released-baseline-compat.test.ts` asserted that an *unreleased* method stays out of the committed fixture. That property goes stale the moment the method ships — which it now has — and it is already enforced in two places where it cannot go stale: `snapshot-released-baseline.ts` renders from a released **tag**, and `protocol-compat` re-derives from immutable tags. Replaced with a comment recording that. This was the last blocker on #1804, which can rebase and merge once this lands.

## Verification

- Compat gate: **`✓ cli-v1.3.0: compatible`** (was 20 blocking findings), `✓ cli-v1.2.0: compatible`
- `bunx vitest run` in `protocol/`: **4475 passed / 232 files**, 0 failures
- `bun run compile` across the OSS tree: clean (protocol, cli, shared, gui-app, desktop, mobile)
- 43/43 governance tests pass: `two-sided-release-invariant` (+ stream), `released-surface-compat` (+ stream), `frozen-catalog-lines`, `released-floor`
- The committed `released-baseline-surface.json` is **untouched** here, so #1804 remains the PR that syncs it.
