### PR TITLE
fix(gui): make an interview option's details reachable on touch

### DIFF
--- a/clients/gui-app/src/components/chat/segments/__tests__/interview-segment.test.tsx
+++ b/clients/gui-app/src/components/chat/segments/__tests__/interview-segment.test.tsx
@@ -829,6 +829,75 @@ describe("InterviewSegment", () => {
     expect(screen.getAllByText("Beta details")).toHaveLength(1);
   });
 
+  // A detail the user expanded by hand and the one search pins are the same
+  // text rendered by two owners. Pinning must not show it twice, and the
+  // pinned `?` has no toggle to close a duplicate; clearing the pin hands the
+  // row's own expansion back.
+  it("yields a hand-expanded detail to the search pin and restores it when the pin clears", () => {
+    const blockId = "interview-details";
+    const view = (targetUnitId: string | null) => (
+      <InterviewTestProviders>
+        <FindForceController
+          blockId={blockId}
+          forcedOpen
+          targetUnitId={targetUnitId}
+        />
+        <InterviewSegment
+          blockId={blockId}
+          status="completed"
+          questions={[
+            {
+              questionId: "q1",
+              question: "Which scope?",
+              header: null,
+              options: [
+                { label: "Alpha", description: null, preview: null },
+                { label: "Beta", description: "Beta details", preview: null },
+              ],
+              multiSelect: false,
+              allowsCustomAnswer: null,
+            },
+          ]}
+          answers={[]}
+          draftAnswers={[]}
+          outcome="answered"
+          settlement={null}
+          error={null}
+          delivery={null}
+          forkedWithoutAnswer={false}
+          interviewDeliveryRetry={null}
+          forkAction={null}
+        />
+      </InterviewTestProviders>
+    );
+    const { rerender } = render(view(null));
+
+    fireEvent.click(screen.getByRole("button", { name: "Beta details" }));
+    expect(
+      screen.getAllByRole("note", { name: "Option details" }),
+    ).toHaveLength(1);
+
+    rerender(
+      view(`interview:${blockId}:question:0:option-description:option:1`),
+    );
+    const pinned = screen.getAllByRole("note", { name: "Option details" });
+    expect(pinned).toHaveLength(1);
+    const describedBy = screen
+      .getByRole("button", { name: "Beta details" })
+      .getAttribute("aria-describedby");
+    expect(document.getElementById(describedBy ?? "")).toBe(pinned[0]);
+
+    rerender(view(null));
+    expect(
+      screen.getAllByRole("note", { name: "Option details" }),
+    ).toHaveLength(1);
+    expect(
+      screen
+        .getByRole("button", { name: "Beta details" })
+        .getAttribute("aria-expanded"),
+    ).toBe("true");
+  });
+
   it("scopes pinned option detail ids to each mounted card view", () => {
     const blockId = "interview-details";
     const card = (tileInstanceId: string) => (

--- a/clients/gui-app/src/components/chat/segments/__tests__/interview-segment.test.tsx
+++ b/clients/gui-app/src/components/chat/segments/__tests__/interview-segment.test.tsx
@@ -289,6 +289,13 @@ describe("InterviewSegment", () => {
     expect(screen.queryByRole("button", { name: "Beta" })).toBeNull();
     expect(screen.getByRole("button", { name: "Beta details" })).toBeTruthy();
 
+    // The historical/resolved card's `?` (`StaticOptionRow`) is the same
+    // disclosure affordance as the live card's: clicking it reveals the
+    // option's description inline, below the row.
+    expect(screen.queryByText("Beta details")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Beta details" }));
+    expect(screen.getByText("Beta details")).toBeTruthy();
+
     fireEvent.click(screen.getByRole("button", { name: "Next question" }));
 
     expect(screen.getByText("Rollout")).toBeTruthy();

--- a/clients/gui-app/src/components/chat/segments/interview-visuals.tsx
+++ b/clients/gui-app/src/components/chat/segments/interview-visuals.tsx
@@ -5,7 +5,7 @@ import {
   CircleHelp,
   Pencil,
 } from "lucide-react";
-import { useId, type ReactNode } from "react";
+import { useCallback, useId, useState, type ReactNode } from "react";
 import type {
   InterviewQuestion,
   InterviewQuestionOption,
@@ -123,29 +123,67 @@ export function InterviewQuestionPager(props: {
   );
 }
 
+export interface InterviewOptionDetailsDisclosure {
+  readonly regionId: string;
+  readonly expanded: boolean;
+  readonly toggle: () => void;
+}
+
+/**
+ * Per-option disclosure state for the `?` affordance, owned by whichever row
+ * component renders it.
+ *
+ * A Radix tooltip is hover/focus-only BY CONSTRUCTION, so a finger could never
+ * reach these strings: the trigger's `pointerMove` returns early on
+ * `pointerType === "touch"` - the only open-from-pointer path there is - and
+ * the tap's own `pointerdown` sets the flag that suppresses the focus
+ * fallback. The `?` had no `onClick` either, so on a phone it was a dead hole
+ * in the row that swallowed the tap without selecting the option (it sits at
+ * `z-20` over the row's own `absolute inset-0` toggle).
+ *
+ * So the `?` doubles as a disclosure. This is deliberately NOT gated on
+ * `useCoarsePointer()`: hover still previews on a fine pointer, and a click
+ * pins the same text inline under the row where it survives a scroll - which
+ * is an improvement on a mouse too, and one branch less to keep true.
+ */
+export function useInterviewOptionDetailsDisclosure(): InterviewOptionDetailsDisclosure {
+  const regionId = useId();
+  const [expanded, setExpanded] = useState(false);
+  const toggle = useCallback(() => setExpanded((open) => !open), []);
+  return { regionId, expanded, toggle };
+}
+
+// Hit-slop only - the `?` stays visually 20px while its tap target grows to
+// 32px. Deliberately short of the 44px guideline: the row's own select target
+// is underneath and the next option is 6px away, so a 44px box would steal
+// taps from the two things a finger is far more likely to be aiming at.
+const DETAILS_BUTTON_CLASS =
+  "relative inline-flex size-5 shrink-0 items-center justify-center rounded-sm text-muted-foreground transition-colors after:absolute after:-inset-1.5 after:content-[''] hover:bg-foreground/8 hover:text-foreground focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/40";
+
 export function InterviewOptionDetailsButton(props: {
   readonly label: string;
   readonly option: InterviewQuestionOption;
   readonly className: string | null;
   /** Inline search-pinned detail owns the accessible description. */
   readonly pinnedDetailRegionId: string | null;
+  readonly disclosure: InterviewOptionDetailsDisclosure;
 }) {
   const details = optionDetails(props.option);
   if (details.length === 0) return null;
-  const button = (
-    <button
-      type="button"
-      aria-label={`${props.label} details`}
-      aria-describedby={props.pinnedDetailRegionId ?? undefined}
-      className={cn(
-        "inline-flex size-5 shrink-0 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-foreground/8 hover:text-foreground focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/40",
-        props.className,
-      )}
-    >
-      <CircleHelp className="size-3.5" aria-hidden />
-    </button>
-  );
-  if (props.pinnedDetailRegionId !== null) return button;
+  // Search pinned the detail open above us: it is already on screen and owns
+  // the accessible description, so there is nothing here to disclose.
+  if (props.pinnedDetailRegionId !== null) {
+    return (
+      <button
+        type="button"
+        aria-label={`${props.label} details`}
+        aria-describedby={props.pinnedDetailRegionId}
+        className={cn(DETAILS_BUTTON_CLASS, props.className)}
+      >
+        <CircleHelp className="size-3.5" aria-hidden />
+      </button>
+    );
+  }
   return (
     <TooltipWrapper
       label={<OptionDetailsTooltip details={details} />}
@@ -153,8 +191,39 @@ export function InterviewOptionDetailsButton(props: {
       sideOffset={6}
       align="center"
     >
-      {button}
+      <button
+        type="button"
+        aria-label={`${props.label} details`}
+        aria-expanded={props.disclosure.expanded}
+        aria-controls={
+          props.disclosure.expanded ? props.disclosure.regionId : undefined
+        }
+        onClick={props.disclosure.toggle}
+        className={cn(DETAILS_BUTTON_CLASS, props.className)}
+      >
+        <CircleHelp className="size-3.5" aria-hidden />
+      </button>
     </TooltipWrapper>
+  );
+}
+
+/**
+ * The disclosed half of the `?`, rendered by the row UNDER its own row box so
+ * the text wraps at full width instead of inside the row's flex line.
+ */
+export function InterviewOptionDetailsRegion(props: {
+  readonly option: InterviewQuestionOption;
+  readonly disclosure: InterviewOptionDetailsDisclosure;
+}) {
+  const details = optionDetails(props.option);
+  if (!props.disclosure.expanded || details.length === 0) return null;
+  return (
+    <InlineOptionDetails
+      details={details}
+      descriptionFindUnitId={null}
+      previewFindUnitId={null}
+      regionId={props.disclosure.regionId}
+    />
   );
 }
 
@@ -241,36 +310,46 @@ function StaticOptionRow(props: {
   readonly pinnedDetailRegionId: string | null;
   readonly children: ReactNode;
 }) {
+  const disclosure = useInterviewOptionDetailsDisclosure();
   return (
-    <div
-      className={cn(
-        "flex w-full items-center gap-2 rounded-md border border-transparent bg-foreground/3 px-2 py-1.5",
-        props.selected
-          ? "border-border bg-foreground/6 text-foreground shadow-sm"
-          : "text-muted-foreground",
-      )}
-    >
-      {/* Historical option labels intentionally wrap while live rows truncate for review readability. */}
-      <span
-        data-chat-find-unit={props.labelFindUnitId ?? undefined}
-        className="min-w-0 flex-1 break-words font-medium text-foreground/90"
+    <div className="flex w-full flex-col gap-1.5">
+      <div
+        className={cn(
+          "flex w-full items-center gap-2 rounded-md border border-transparent bg-foreground/3 px-2 py-1.5",
+          props.selected
+            ? "border-border bg-foreground/6 text-foreground shadow-sm"
+            : "text-muted-foreground",
+        )}
       >
-        {props.label}
-      </span>
+        {/* Historical option labels intentionally wrap while live rows truncate for review readability. */}
+        <span
+          data-chat-find-unit={props.labelFindUnitId ?? undefined}
+          className="min-w-0 flex-1 break-words font-medium text-foreground/90"
+        >
+          {props.label}
+        </span>
+        {props.option === null ? null : (
+          <InterviewOptionDetailsButton
+            label={props.label}
+            option={props.option}
+            className={null}
+            pinnedDetailRegionId={props.pinnedDetailRegionId}
+            disclosure={disclosure}
+          />
+        )}
+        {props.children}
+        <OptionBadge
+          index={props.index}
+          selected={props.selected}
+          custom={props.custom}
+        />
+      </div>
       {props.option === null ? null : (
-        <InterviewOptionDetailsButton
-          label={props.label}
+        <InterviewOptionDetailsRegion
           option={props.option}
-          className={null}
-          pinnedDetailRegionId={props.pinnedDetailRegionId}
+          disclosure={disclosure}
         />
       )}
-      {props.children}
-      <OptionBadge
-        index={props.index}
-        selected={props.selected}
-        custom={props.custom}
-      />
     </div>
   );
 }

--- a/clients/gui-app/src/components/chat/segments/interview-visuals.tsx
+++ b/clients/gui-app/src/components/chat/segments/interview-visuals.tsx
@@ -5,12 +5,16 @@ import {
   CircleHelp,
   Pencil,
 } from "lucide-react";
-import { useCallback, useId, useState, type ReactNode } from "react";
+import { useId, type ReactNode } from "react";
 import type {
   InterviewQuestion,
   InterviewQuestionOption,
 } from "@traycer/protocol/persistence/epic/schemas";
 import { questionAllowsCustomAnswer } from "@/components/chat/segments/interview-custom-answer";
+import {
+  useInterviewOptionDetailsDisclosure,
+  type InterviewOptionDetailsDisclosure,
+} from "@/components/chat/segments/use-interview-option-details-disclosure";
 import { Button } from "@/components/ui/button";
 import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 import { cn } from "@/lib/utils";
@@ -121,36 +125,6 @@ export function InterviewQuestionPager(props: {
       </Button>
     </div>
   );
-}
-
-export interface InterviewOptionDetailsDisclosure {
-  readonly regionId: string;
-  readonly expanded: boolean;
-  readonly toggle: () => void;
-}
-
-/**
- * Per-option disclosure state for the `?` affordance, owned by whichever row
- * component renders it.
- *
- * A Radix tooltip is hover/focus-only BY CONSTRUCTION, so a finger could never
- * reach these strings: the trigger's `pointerMove` returns early on
- * `pointerType === "touch"` - the only open-from-pointer path there is - and
- * the tap's own `pointerdown` sets the flag that suppresses the focus
- * fallback. The `?` had no `onClick` either, so on a phone it was a dead hole
- * in the row that swallowed the tap without selecting the option (it sits at
- * `z-20` over the row's own `absolute inset-0` toggle).
- *
- * So the `?` doubles as a disclosure. This is deliberately NOT gated on
- * `useCoarsePointer()`: hover still previews on a fine pointer, and a click
- * pins the same text inline under the row where it survives a scroll - which
- * is an improvement on a mouse too, and one branch less to keep true.
- */
-export function useInterviewOptionDetailsDisclosure(): InterviewOptionDetailsDisclosure {
-  const regionId = useId();
-  const [expanded, setExpanded] = useState(false);
-  const toggle = useCallback(() => setExpanded((open) => !open), []);
-  return { regionId, expanded, toggle };
 }
 
 // Hit-slop only - the `?` stays visually 20px while its tap target grows to

--- a/clients/gui-app/src/components/chat/segments/interview-visuals.tsx
+++ b/clients/gui-app/src/components/chat/segments/interview-visuals.tsx
@@ -318,7 +318,10 @@ function StaticOptionRow(props: {
           custom={props.custom}
         />
       </div>
-      {props.option === null ? null : (
+      {/* Search pins this option's details open in the parent, and the pinned
+          button has no toggle - so a region the user expanded first must
+          yield to it, or both render. It returns when the pin clears. */}
+      {props.option === null || props.pinnedDetailRegionId !== null ? null : (
         <InterviewOptionDetailsRegion
           option={props.option}
           disclosure={disclosure}

--- a/clients/gui-app/src/components/chat/segments/pending-interview/__tests__/pending-interview-card.test.tsx
+++ b/clients/gui-app/src/components/chat/segments/pending-interview/__tests__/pending-interview-card.test.tsx
@@ -2549,76 +2549,65 @@ describe("PendingInterviewCard keyboard navigation", () => {
     expect(document.activeElement).not.toBe(cardEl);
   });
 
+  // Deliberately NOT the shape of the `?`'s accessible name (`Beta details`):
+  // the disclosure assertions must prove they found the REVEALED text, and a
+  // description that reads the same as the trigger's label cannot distinguish
+  // the two if a query ever starts matching accessible names.
+  const BETA_DESCRIPTION = "Beta explains the scope";
+
+  function renderDetailsCard() {
+    renderCard(
+      [
+        {
+          questionId: "q1",
+          question: "Pick one",
+          header: null,
+          options: [
+            { label: "Alpha", description: null, preview: null },
+            { label: "Beta", description: BETA_DESCRIPTION, preview: null },
+          ],
+          multiSelect: false,
+          allowsCustomAnswer: null,
+        },
+      ],
+      vi.fn(),
+      null,
+    );
+    return screen.getByRole("button", { name: "Beta details" });
+  }
+
+  // Drives the exact sequence Radix's own trigger sees from a finger, so the
+  // assertion fails against the pre-fix trigger and passes only because
+  // `onClick` now toggles the disclosure independently of the tooltip.
+  function tapWithFinger(element: HTMLElement) {
+    fireEvent.pointerMove(element, { pointerType: "touch" });
+    fireEvent.pointerDown(element, { pointerType: "touch" });
+    fireEvent.pointerUp(element, { pointerType: "touch" });
+    fireEvent.click(element);
+  }
+
   // Radix Tooltip is hover/focus-only by construction: the trigger's
   // `onPointerMove` returns early for `pointerType === "touch"`, and the
   // tap's own `pointerdown` sets the flag that suppresses the focus
   // fallback. Before the fix the `?` had no `onClick`, so a finger could
-  // never reach these strings at all - this drives the exact touch sequence
-  // Radix's own trigger sees (`pointerMove` touch, `pointerDown`,
-  // `pointerUp`, then the browser's synthesized `click`) so the assertion
-  // fails against the pre-fix trigger and passes only because `onClick` now
-  // toggles the disclosure independently of the tooltip's own open state.
+  // never reach these strings at all.
   it("reveals an option's description on a touch tap of its details button", () => {
-    renderCard(
-      [
-        {
-          questionId: "q1",
-          question: "Pick one",
-          header: null,
-          options: [
-            { label: "Alpha", description: null, preview: null },
-            { label: "Beta", description: "Beta details", preview: null },
-          ],
-          multiSelect: false,
-          allowsCustomAnswer: null,
-        },
-      ],
-      vi.fn(),
-      null,
-    );
+    const detailsButton = renderDetailsCard();
+    expect(screen.queryByText(BETA_DESCRIPTION)).toBeNull();
 
-    expect(screen.queryByText("Beta details")).toBeNull();
-    const detailsButton = screen.getByRole("button", { name: "Beta details" });
+    tapWithFinger(detailsButton);
 
-    fireEvent.pointerMove(detailsButton, { pointerType: "touch" });
-    fireEvent.pointerDown(detailsButton, { pointerType: "touch" });
-    fireEvent.pointerUp(detailsButton, { pointerType: "touch" });
-    fireEvent.click(detailsButton);
-
-    expect(screen.getByText("Beta details")).toBeTruthy();
+    expect(screen.getByText(BETA_DESCRIPTION)).toBeTruthy();
   });
 
   it("collapses the revealed description on a second touch tap", () => {
-    renderCard(
-      [
-        {
-          questionId: "q1",
-          question: "Pick one",
-          header: null,
-          options: [
-            { label: "Alpha", description: null, preview: null },
-            { label: "Beta", description: "Beta details", preview: null },
-          ],
-          multiSelect: false,
-          allowsCustomAnswer: null,
-        },
-      ],
-      vi.fn(),
-      null,
-    );
+    const detailsButton = renderDetailsCard();
 
-    const detailsButton = screen.getByRole("button", { name: "Beta details" });
-    fireEvent.pointerMove(detailsButton, { pointerType: "touch" });
-    fireEvent.pointerDown(detailsButton, { pointerType: "touch" });
-    fireEvent.pointerUp(detailsButton, { pointerType: "touch" });
-    fireEvent.click(detailsButton);
-    expect(screen.getByText("Beta details")).toBeTruthy();
+    tapWithFinger(detailsButton);
+    expect(screen.getByText(BETA_DESCRIPTION)).toBeTruthy();
 
-    fireEvent.pointerMove(detailsButton, { pointerType: "touch" });
-    fireEvent.pointerDown(detailsButton, { pointerType: "touch" });
-    fireEvent.pointerUp(detailsButton, { pointerType: "touch" });
-    fireEvent.click(detailsButton);
-    expect(screen.queryByText("Beta details")).toBeNull();
+    tapWithFinger(detailsButton);
+    expect(screen.queryByText(BETA_DESCRIPTION)).toBeNull();
   });
 
   // The `?` sits at `z-20` over the row's own `absolute inset-0` toggle
@@ -2627,31 +2616,11 @@ describe("PendingInterviewCard keyboard navigation", () => {
   // so the disclosure is additive rather than a replacement for the row's
   // existing tap target.
   it("does not select the option when tapping its details button, but does when tapping the row", () => {
-    renderCard(
-      [
-        {
-          questionId: "q1",
-          question: "Pick one",
-          header: null,
-          options: [
-            { label: "Alpha", description: null, preview: null },
-            { label: "Beta", description: "Beta details", preview: null },
-          ],
-          multiSelect: false,
-          allowsCustomAnswer: null,
-        },
-      ],
-      vi.fn(),
-      null,
-    );
+    const detailsButton = renderDetailsCard();
 
-    const detailsButton = screen.getByRole("button", { name: "Beta details" });
-    fireEvent.pointerMove(detailsButton, { pointerType: "touch" });
-    fireEvent.pointerDown(detailsButton, { pointerType: "touch" });
-    fireEvent.pointerUp(detailsButton, { pointerType: "touch" });
-    fireEvent.click(detailsButton);
+    tapWithFinger(detailsButton);
 
-    expect(screen.getByText("Beta details")).toBeTruthy();
+    expect(screen.getByText(BETA_DESCRIPTION)).toBeTruthy();
     expect(
       screen.getByRole("button", { name: "2. Beta", pressed: false }),
     ).toBeTruthy();
@@ -2663,25 +2632,7 @@ describe("PendingInterviewCard keyboard navigation", () => {
   });
 
   it("flips aria-expanded and points aria-controls at the revealed region", () => {
-    renderCard(
-      [
-        {
-          questionId: "q1",
-          question: "Pick one",
-          header: null,
-          options: [
-            { label: "Alpha", description: null, preview: null },
-            { label: "Beta", description: "Beta details", preview: null },
-          ],
-          multiSelect: false,
-          allowsCustomAnswer: null,
-        },
-      ],
-      vi.fn(),
-      null,
-    );
-
-    const detailsButton = screen.getByRole("button", { name: "Beta details" });
+    const detailsButton = renderDetailsCard();
     expect(detailsButton.getAttribute("aria-expanded")).toBe("false");
     expect(detailsButton.getAttribute("aria-controls")).toBeNull();
 
@@ -2691,7 +2642,7 @@ describe("PendingInterviewCard keyboard navigation", () => {
     const controlsId = detailsButton.getAttribute("aria-controls");
     expect(controlsId).not.toBeNull();
     expect(document.getElementById(controlsId ?? "")).toBe(
-      screen.getByText("Beta details").closest("[role='note']"),
+      screen.getByText(BETA_DESCRIPTION).closest("[role='note']"),
     );
 
     fireEvent.click(detailsButton);

--- a/clients/gui-app/src/components/chat/segments/pending-interview/__tests__/pending-interview-card.test.tsx
+++ b/clients/gui-app/src/components/chat/segments/pending-interview/__tests__/pending-interview-card.test.tsx
@@ -2548,4 +2548,154 @@ describe("PendingInterviewCard keyboard navigation", () => {
     expect(focusRegisteredActiveComposer()).toBe(false);
     expect(document.activeElement).not.toBe(cardEl);
   });
+
+  // Radix Tooltip is hover/focus-only by construction: the trigger's
+  // `onPointerMove` returns early for `pointerType === "touch"`, and the
+  // tap's own `pointerdown` sets the flag that suppresses the focus
+  // fallback. Before the fix the `?` had no `onClick`, so a finger could
+  // never reach these strings at all - this drives the exact touch sequence
+  // Radix's own trigger sees (`pointerMove` touch, `pointerDown`,
+  // `pointerUp`, then the browser's synthesized `click`) so the assertion
+  // fails against the pre-fix trigger and passes only because `onClick` now
+  // toggles the disclosure independently of the tooltip's own open state.
+  it("reveals an option's description on a touch tap of its details button", () => {
+    renderCard(
+      [
+        {
+          questionId: "q1",
+          question: "Pick one",
+          header: null,
+          options: [
+            { label: "Alpha", description: null, preview: null },
+            { label: "Beta", description: "Beta details", preview: null },
+          ],
+          multiSelect: false,
+          allowsCustomAnswer: null,
+        },
+      ],
+      vi.fn(),
+      null,
+    );
+
+    expect(screen.queryByText("Beta details")).toBeNull();
+    const detailsButton = screen.getByRole("button", { name: "Beta details" });
+
+    fireEvent.pointerMove(detailsButton, { pointerType: "touch" });
+    fireEvent.pointerDown(detailsButton, { pointerType: "touch" });
+    fireEvent.pointerUp(detailsButton, { pointerType: "touch" });
+    fireEvent.click(detailsButton);
+
+    expect(screen.getByText("Beta details")).toBeTruthy();
+  });
+
+  it("collapses the revealed description on a second touch tap", () => {
+    renderCard(
+      [
+        {
+          questionId: "q1",
+          question: "Pick one",
+          header: null,
+          options: [
+            { label: "Alpha", description: null, preview: null },
+            { label: "Beta", description: "Beta details", preview: null },
+          ],
+          multiSelect: false,
+          allowsCustomAnswer: null,
+        },
+      ],
+      vi.fn(),
+      null,
+    );
+
+    const detailsButton = screen.getByRole("button", { name: "Beta details" });
+    fireEvent.pointerMove(detailsButton, { pointerType: "touch" });
+    fireEvent.pointerDown(detailsButton, { pointerType: "touch" });
+    fireEvent.pointerUp(detailsButton, { pointerType: "touch" });
+    fireEvent.click(detailsButton);
+    expect(screen.getByText("Beta details")).toBeTruthy();
+
+    fireEvent.pointerMove(detailsButton, { pointerType: "touch" });
+    fireEvent.pointerDown(detailsButton, { pointerType: "touch" });
+    fireEvent.pointerUp(detailsButton, { pointerType: "touch" });
+    fireEvent.click(detailsButton);
+    expect(screen.queryByText("Beta details")).toBeNull();
+  });
+
+  // The `?` sits at `z-20` over the row's own `absolute inset-0` toggle
+  // button. Tapping it must disclose the details WITHOUT also selecting the
+  // option underneath - and the row's own label must still select normally,
+  // so the disclosure is additive rather than a replacement for the row's
+  // existing tap target.
+  it("does not select the option when tapping its details button, but does when tapping the row", () => {
+    renderCard(
+      [
+        {
+          questionId: "q1",
+          question: "Pick one",
+          header: null,
+          options: [
+            { label: "Alpha", description: null, preview: null },
+            { label: "Beta", description: "Beta details", preview: null },
+          ],
+          multiSelect: false,
+          allowsCustomAnswer: null,
+        },
+      ],
+      vi.fn(),
+      null,
+    );
+
+    const detailsButton = screen.getByRole("button", { name: "Beta details" });
+    fireEvent.pointerMove(detailsButton, { pointerType: "touch" });
+    fireEvent.pointerDown(detailsButton, { pointerType: "touch" });
+    fireEvent.pointerUp(detailsButton, { pointerType: "touch" });
+    fireEvent.click(detailsButton);
+
+    expect(screen.getByText("Beta details")).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "2. Beta", pressed: false }),
+    ).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "2. Beta" }));
+    expect(
+      screen.getByRole("button", { name: "2. Beta", pressed: true }),
+    ).toBeTruthy();
+  });
+
+  it("flips aria-expanded and points aria-controls at the revealed region", () => {
+    renderCard(
+      [
+        {
+          questionId: "q1",
+          question: "Pick one",
+          header: null,
+          options: [
+            { label: "Alpha", description: null, preview: null },
+            { label: "Beta", description: "Beta details", preview: null },
+          ],
+          multiSelect: false,
+          allowsCustomAnswer: null,
+        },
+      ],
+      vi.fn(),
+      null,
+    );
+
+    const detailsButton = screen.getByRole("button", { name: "Beta details" });
+    expect(detailsButton.getAttribute("aria-expanded")).toBe("false");
+    expect(detailsButton.getAttribute("aria-controls")).toBeNull();
+
+    fireEvent.click(detailsButton);
+
+    expect(detailsButton.getAttribute("aria-expanded")).toBe("true");
+    const controlsId = detailsButton.getAttribute("aria-controls");
+    expect(controlsId).not.toBeNull();
+    expect(document.getElementById(controlsId ?? "")).toBe(
+      screen.getByText("Beta details").closest("[role='note']"),
+    );
+
+    fireEvent.click(detailsButton);
+    expect(detailsButton.getAttribute("aria-expanded")).toBe("false");
+    expect(detailsButton.getAttribute("aria-controls")).toBeNull();
+  });
 });

--- a/clients/gui-app/src/components/chat/segments/pending-interview/__tests__/pending-interview-card.test.tsx
+++ b/clients/gui-app/src/components/chat/segments/pending-interview/__tests__/pending-interview-card.test.tsx
@@ -2591,17 +2591,9 @@ describe("PendingInterviewCard keyboard navigation", () => {
   // tap's own `pointerdown` sets the flag that suppresses the focus
   // fallback. Before the fix the `?` had no `onClick`, so a finger could
   // never reach these strings at all.
-  it("reveals an option's description on a touch tap of its details button", () => {
+  it("reveals an option's description on a touch tap and collapses it on the next", () => {
     const detailsButton = renderDetailsCard();
     expect(screen.queryByText(BETA_DESCRIPTION)).toBeNull();
-
-    tapWithFinger(detailsButton);
-
-    expect(screen.getByText(BETA_DESCRIPTION)).toBeTruthy();
-  });
-
-  it("collapses the revealed description on a second touch tap", () => {
-    const detailsButton = renderDetailsCard();
 
     tapWithFinger(detailsButton);
     expect(screen.getByText(BETA_DESCRIPTION)).toBeTruthy();

--- a/clients/gui-app/src/components/chat/segments/pending-interview/question-page.tsx
+++ b/clients/gui-app/src/components/chat/segments/pending-interview/question-page.tsx
@@ -9,8 +9,8 @@ import type {
 import {
   InterviewOptionDetailsButton,
   InterviewOptionDetailsRegion,
-  useInterviewOptionDetailsDisclosure,
 } from "@/components/chat/segments/interview-visuals";
+import { useInterviewOptionDetailsDisclosure } from "@/components/chat/segments/use-interview-option-details-disclosure";
 import { questionAllowsCustomAnswer } from "@/components/chat/segments/interview-custom-answer";
 import { isMobileApp } from "@/lib/mobile-app";
 import { cn } from "@/lib/utils";

--- a/clients/gui-app/src/components/chat/segments/pending-interview/question-page.tsx
+++ b/clients/gui-app/src/components/chat/segments/pending-interview/question-page.tsx
@@ -308,10 +308,7 @@ function OptionRow(props: OptionRowProps) {
         {badge}
       </div>
       {option === null ? null : (
-        <InterviewOptionDetailsRegion
-          option={option}
-          disclosure={disclosure}
-        />
+        <InterviewOptionDetailsRegion option={option} disclosure={disclosure} />
       )}
     </m.div>
   );

--- a/clients/gui-app/src/components/chat/segments/pending-interview/question-page.tsx
+++ b/clients/gui-app/src/components/chat/segments/pending-interview/question-page.tsx
@@ -6,7 +6,11 @@ import type {
   InterviewQuestion,
   InterviewQuestionOption,
 } from "@traycer/protocol/persistence/epic/schemas";
-import { InterviewOptionDetailsButton } from "@/components/chat/segments/interview-visuals";
+import {
+  InterviewOptionDetailsButton,
+  InterviewOptionDetailsRegion,
+  useInterviewOptionDetailsDisclosure,
+} from "@/components/chat/segments/interview-visuals";
 import { questionAllowsCustomAnswer } from "@/components/chat/segments/interview-custom-answer";
 import { isMobileApp } from "@/lib/mobile-app";
 import { cn } from "@/lib/utils";
@@ -249,13 +253,14 @@ function OptionRow(props: OptionRowProps) {
     onToggle,
   } = props;
   const shouldReduceMotion = useReducedMotion();
+  const disclosure = useInterviewOptionDetailsDisclosure();
   return (
     <m.div
       animate={
         pending && !shouldReduceMotion ? { scale: [1, 1.015, 1] } : { scale: 1 }
       }
       transition={QUESTION_TRANSITION}
-      className="w-full"
+      className="flex w-full flex-col gap-1.5"
     >
       <div
         className={cn(
@@ -296,11 +301,18 @@ function OptionRow(props: OptionRowProps) {
             option={option}
             className="pointer-events-auto relative z-20 self-center"
             pinnedDetailRegionId={null}
+            disclosure={disclosure}
           />
         )}
         <span aria-hidden className="pointer-events-none min-w-0 flex-1" />
         {badge}
       </div>
+      {option === null ? null : (
+        <InterviewOptionDetailsRegion
+          option={option}
+          disclosure={disclosure}
+        />
+      )}
     </m.div>
   );
 }

--- a/clients/gui-app/src/components/chat/segments/use-interview-option-details-disclosure.ts
+++ b/clients/gui-app/src/components/chat/segments/use-interview-option-details-disclosure.ts
@@ -7,25 +7,11 @@ export interface InterviewOptionDetailsDisclosure {
 }
 
 /**
- * Per-option disclosure state for the `?` affordance, owned by whichever row
- * component renders it.
- *
- * A Radix tooltip is hover/focus-only BY CONSTRUCTION, so a finger could never
- * reach these strings: the trigger's `pointerMove` returns early on
- * `pointerType === "touch"` - the only open-from-pointer path there is - and
- * the tap's own `pointerdown` sets the flag that suppresses the focus
- * fallback. The `?` had no `onClick` either, so on a phone it was a dead hole
- * in the row that swallowed the tap without selecting the option (it sits at
- * `z-20` over the row's own `absolute inset-0` toggle).
- *
- * So the `?` doubles as a disclosure. This is deliberately NOT gated on
- * `useCoarsePointer()`: hover still previews on a fine pointer, and a click
- * pins the same text inline under the row where it survives a scroll - which
- * is an improvement on a mouse too, and one branch less to keep true.
- *
- * It lives in its own module rather than beside the components that use it
- * because `react-refresh/only-export-components` (warn, `--max-warnings 0`)
- * fails a component file that also exports a function.
+ * A row's disclosure state for its `?`. A click or tap pins the details
+ * inline; hover still previews them through the button's tooltip, which a
+ * Radix tooltip can never open from a touch pointer. Not gated on pointer
+ * type on purpose - one path to keep true. Own module because
+ * `react-refresh/only-export-components` rejects a hook in a component file.
  */
 export function useInterviewOptionDetailsDisclosure(): InterviewOptionDetailsDisclosure {
   const regionId = useId();

--- a/clients/gui-app/src/components/chat/segments/use-interview-option-details-disclosure.ts
+++ b/clients/gui-app/src/components/chat/segments/use-interview-option-details-disclosure.ts
@@ -1,0 +1,35 @@
+import { useCallback, useId, useState } from "react";
+
+export interface InterviewOptionDetailsDisclosure {
+  readonly regionId: string;
+  readonly expanded: boolean;
+  readonly toggle: () => void;
+}
+
+/**
+ * Per-option disclosure state for the `?` affordance, owned by whichever row
+ * component renders it.
+ *
+ * A Radix tooltip is hover/focus-only BY CONSTRUCTION, so a finger could never
+ * reach these strings: the trigger's `pointerMove` returns early on
+ * `pointerType === "touch"` - the only open-from-pointer path there is - and
+ * the tap's own `pointerdown` sets the flag that suppresses the focus
+ * fallback. The `?` had no `onClick` either, so on a phone it was a dead hole
+ * in the row that swallowed the tap without selecting the option (it sits at
+ * `z-20` over the row's own `absolute inset-0` toggle).
+ *
+ * So the `?` doubles as a disclosure. This is deliberately NOT gated on
+ * `useCoarsePointer()`: hover still previews on a fine pointer, and a click
+ * pins the same text inline under the row where it survives a scroll - which
+ * is an improvement on a mouse too, and one branch less to keep true.
+ *
+ * It lives in its own module rather than beside the components that use it
+ * because `react-refresh/only-export-components` (warn, `--max-warnings 0`)
+ * fails a component file that also exports a function.
+ */
+export function useInterviewOptionDetailsDisclosure(): InterviewOptionDetailsDisclosure {
+  const regionId = useId();
+  const [expanded, setExpanded] = useState(false);
+  const toggle = useCallback(() => setExpanded((open) => !open), []);
+  return { regionId, expanded, toggle };
+}


### PR DESCRIPTION
## The bug

Reported from the installed mobile app: tapping the circled `?` beside an option in a question card does nothing.

`InterviewOptionDetailsButton` was a Radix Tooltip trigger with **no `onClick`**. Radix Tooltip is hover/focus-only by construction — in `@radix-ui/react-tooltip@1.2.16` the trigger:

| Handler | Behaviour |
| --- | --- |
| `onPointerMove` | `if (event.pointerType === "touch") return;` — the only open-from-pointer path, and touch is excluded outright |
| `onPointerDown` | closes if open, sets `isPointerDownRef = true` |
| `onFocus` | `if (!isPointerDownRef.current) context.onOpen()` — suppressed, because the tap's own `pointerdown` just set the flag |
| `onClick` | `context.onClose()` |

So on a touch pointer there was **no code path that could open it**. The option's `description` / `preview` were unreachable outright on a phone.

It was also a dead spot: the `?` sits at `z-20` over the row's own `absolute inset-0` toggle button, so a tap there was swallowed without selecting the option either.

This is the app's only pure "help icon → tooltip" affordance, which is why it reads as broken while ~322 other `TooltipWrapper` call sites do not — they all label a control that *also* acts on tap.

## The fix

The `?` now doubles as a disclosure, reusing `InlineOptionDetails` — already in the same file, already rendered for search-pinned rows. Tap expands the Details/Preview text inline under the row; tap again collapses.

Both rows own the state — `OptionRow` (live card) and `StaticOptionRow` (historical card) — and render the region under their own row box so the text wraps at full width instead of inside the row's flex line.

**71 lines of real code** (102 added ignoring re-indentation, of which 31 are comments); no new component library, no new overlay stack.

### Two judgement calls

- **No `useCoarsePointer()` gate.** The disclosure is unconditional. Hover still previews on a fine pointer, and a click *pins* the same text inline where it survives a scroll — an improvement on a mouse too, and one branch fewer to keep true.
- **32px hit area, not 44px.** `after:absolute after:-inset-1.5 after:content-['']` (the idiom from `chat-message-user-body.tsx`) keeps the `?` visually 20px while growing its target. Deliberately short of the 44px guideline: the row's own select target is directly underneath and the next option is 6px away, so a 44px box would steal taps from the two things a finger is far likelier to be aiming at.

### Rejected alternatives

- **Coarse-pointer Popover** — popovers do open on tap, but it costs a second overlay stack and a new dismiss story inside an already-scrollable chat tile.
- **Controlled `open` on the tooltip** — fights Radix's own `onPointerDown`/`onClick` close handlers (`composeEventHandlers` runs ours first, then `context.onClose`, so it would never open), and tooltip content is `pointer-events-none` so a tap could not dismiss it.

## Verification

5 new assertions in the two existing suites: touch tap reveals, second tap collapses, `?` does not select the option while the row still does, `aria-expanded`/`aria-controls` round-trip, and the same disclosure on the historical card.

Confirmed to **fail against the pre-fix source and pass with it** by reverting the two source files and re-running — not merely observed green.

```
pending-interview-card.test.tsx + interview-segment.test.tsx   92 passed
5 adjacent interview-touching suites                          244 passed
@traycer-clients/gui-app compile                              exit 0
```