### PR TITLE
fix(gui-app): draw one dead-tile banner over a substituted published copy

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/__tests__/published-copy-substitution-banner.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/published-copy-substitution-banner.test.tsx
@@ -1,0 +1,284 @@
+/**
+ * The canvas substitution rendered through the REAL tile renderer, down to the
+ * real `PublishedChatTile` - so the two surfaces that each know how to draw a
+ * dead-tile banner are on screen together.
+ *
+ * Why a third suite: `tab-group-view.test.tsx` stubs `EpicNodeTile`, and
+ * `published-chat-tile.test.tsx` mounts the tile alone. Each pins its own
+ * half correctly, and neither can see the other's banner - which is how the
+ * cross-host offline case shipped with two identical "Bound host is offline"
+ * bars and two Clone buttons (2026-09-09). This suite counts them.
+ *
+ * The seam this suite keeps is `ChatDeadTileBannerContainer`: both mounts
+ * go through it, and the real one runs the clone offer's host-runtime
+ * subscription and a cloud lookup this provider-less render has no hosts
+ * for. The stub renders the real `ChatDeadTileBanner`, so a Clone button on
+ * screen is one banner MOUNT - exactly the count under test.
+ */
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+import type { CloudChatSummary } from "@traycer/protocol/host/epic/cloud-chat";
+import type { ChatReplicaReadResponse } from "@traycer/protocol/host/epic/chat-replica-read";
+import type { CloudChatRead } from "@traycer-clients/shared/cloud-chat/cloud-chat-reader";
+import { ActiveTabBody } from "@/components/epic-canvas/canvas/tab-group-view";
+import type { ChatDeadTileBannerReason } from "@/components/epic-canvas/renderers/dead-tile-banner";
+import { resetChatRemoteDeletionRegistryForTesting } from "@/components/epic-canvas/surface-host/remote-deleted-chat-registry";
+import type { CloudChatTranscriptState } from "@/lib/chats/cloud-chat-transcript-state";
+import type { EpicCanvasTileRef } from "@/stores/epics/canvas/types";
+
+const CHAT: EpicCanvasTileRef = {
+  id: "chat-1",
+  instanceId: "inst-chat-1",
+  type: "chat",
+  name: "Chat",
+  hostId: "host-A",
+};
+
+interface TestState {
+  /** The Epic session's host - "same host" below means this one. */
+  sessionHostId: string;
+  /** Hosts `useHostReachability` answers `unreachable` for. */
+  readonly unreachableHostIds: Set<string>;
+  /** Artifact ids `useEpicArtifact` answers `null` for (swept locally). */
+  readonly missingArtifactIds: Set<string>;
+  /** Chat ids the cloud list carries as the viewer's own. */
+  readonly cloudKnownChatIds: Set<string>;
+}
+
+const testState = vi.hoisted((): TestState => ({
+  sessionHostId: "host-B",
+  unreachableHostIds: new Set(),
+  missingArtifactIds: new Set(),
+  cloudKnownChatIds: new Set(),
+}));
+
+vi.mock("@/lib/epic-selectors", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/epic-selectors")>()),
+  useEpicArtifact: (id: string) =>
+    testState.missingArtifactIds.has(id) ? null : { id, userId: "user-1" },
+  useEpicChatRetraction: () => null,
+  useEpicPermissionRole: () => "owner",
+  useEpicSnapshotLoaded: () => true,
+  useEpicChatRecordListAuthoritative: () => true,
+}));
+
+vi.mock("@/lib/registries/chat-session-registry", async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import("@/lib/registries/chat-session-registry")
+  >()),
+  useExistingChatSessionHandle: () => null,
+  useExistingChatSessionFatalClose: () => null,
+}));
+
+// Both the canvas (for the bound host) and the copy tile (for the owner host)
+// read this - the same host id in the substitution case, so one answer.
+vi.mock("@/hooks/agent/use-host-reachability", async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import("@/hooks/agent/use-host-reachability")
+  >()),
+  useHostReachability: (hostId: string) => ({
+    status: testState.unreachableHostIds.has(hostId)
+      ? "unreachable"
+      : "reachable",
+    hostLabel: hostId,
+    unavailability: null,
+    basis: "directory",
+    hostKind: "unknown",
+  }),
+}));
+
+vi.mock("@/components/epic-canvas/hooks/use-canvas-host-id", () => ({
+  useCanvasHostId: () => testState.sessionHostId,
+}));
+
+// No hosts in this render: the canvas's cloud list, the tile's cloud read and
+// `BrowserSessionsHostBoundary` all resolve a null client.
+vi.mock("@/hooks/epic/use-epic-session-host-client", () => ({
+  useEpicSessionHostClient: () => null,
+}));
+vi.mock("@/hooks/host/use-host-client-for-host-id", () => ({
+  useHostClientForHostId: () => null,
+}));
+
+vi.mock("@/hooks/chats/use-cloud-chat-queries", async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import("@/hooks/chats/use-cloud-chat-queries")
+  >()),
+  useCloudChatList: (args: { readonly enabled: boolean }) => ({
+    data: args.enabled
+      ? {
+          chats: [...testState.cloudKnownChatIds].map(
+            (chatId): CloudChatSummary => ({
+              identity: { taskId: "epic-1", chatId, ownerUserId: "user-1" },
+              ownerHostId: "host-A",
+              createdAt: 1,
+              visibility: "task",
+              title: null,
+              isTitleEditedByUser: false,
+              parentChatId: null,
+              isArchived: false,
+              runSettingsSummary: null,
+              metadataUpdatedAt: 1,
+              headSha256: null,
+              publishedAt: null,
+              throughRecordSeq: null,
+              isOwnedByViewer: true,
+            }),
+          ),
+        }
+      : undefined,
+    error: null,
+    isEnabled: args.enabled,
+    isError: false,
+    isSuccess: args.enabled,
+    isPending: false,
+    isFetching: false,
+  }),
+}));
+
+// The copy's data: the cloud read settles `unpublished`, the serving host's
+// doc replica answers - the same fixture `published-chat-tile.test.tsx` uses
+// to reach a rendered transcript without a cloud round-trip.
+vi.mock("@/hooks/chats/use-cloud-chat-transcript", () => ({
+  useCloudChatTranscript: (): CloudChatTranscriptState => {
+    const read: CloudChatRead = {
+      chat: null,
+      outcome: { kind: "unpublished" },
+    };
+    return { kind: "refused", read };
+  },
+}));
+vi.mock("@/hooks/chats/use-chat-replica-read", () => ({
+  useChatReplicaRead: (): {
+    readonly data: ChatReplicaReadResponse;
+    readonly isPending: boolean;
+    readonly isError: boolean;
+  } => ({
+    isPending: false,
+    isError: false,
+    data: {
+      outcome: {
+        status: "ok",
+        chat: {
+          chatId: "chat-1",
+          title: "Replica title",
+          userId: "user-1",
+          hostId: "host-A",
+          createdAt: 1,
+          updatedAt: 2,
+        },
+        messages: [],
+        events: [],
+      },
+    },
+  }),
+}));
+
+vi.mock("@/components/report-issue/report-issue-action", () => ({
+  ReportIssueAction: () => null,
+}));
+vi.mock("@/components/epic-canvas/renderers/published-chat-notice", () => ({
+  PublishedChatNotice: () => null,
+}));
+vi.mock("@/lib/chats/published-chat-source-provider", () => ({
+  PublishedChatSourceProvider: (props: { readonly children: ReactNode }) => (
+    <>{props.children}</>
+  ),
+}));
+
+vi.mock("@/components/epic-canvas/renderers/chat-tile", async () => {
+  const { ChatDeadTileBanner } = await vi.importActual<
+    typeof import("@/components/epic-canvas/renderers/dead-tile-banner")
+  >("@/components/epic-canvas/renderers/dead-tile-banner");
+  return {
+    // Never reached: the substitution replaces the live chat body. Present so
+    // the tile renderer's import of it resolves.
+    ChatTile: () => null,
+    ChatTileSessionView: () => <div data-testid="chat-tile-session-view" />,
+    ChatDeadTileBannerContainer: (props: {
+      readonly hostLabel: string;
+      readonly reason: ChatDeadTileBannerReason;
+      readonly showsPublishedCopy: boolean;
+      readonly testId: string;
+    }) => (
+      <ChatDeadTileBanner
+        hostLabel={props.hostLabel}
+        reason={props.reason}
+        ownedByViewer
+        cloneAllowed
+        showsPublishedCopy={props.showsPublishedCopy}
+        onClone={() => undefined}
+        cloning={false}
+        className={undefined}
+        testId={props.testId}
+      />
+    ),
+  };
+});
+
+function activeTabBody(): ReactNode {
+  return (
+    <ActiveTabBody
+      activeTab={CHAT}
+      epicId="epic-1"
+      groupId="group-1"
+      tabId="view-tab-1"
+      selected
+      globallyActive
+    />
+  );
+}
+
+describe("published-copy substitution renders exactly one dead-tile banner", () => {
+  afterEach(() => {
+    cleanup();
+    testState.sessionHostId = "host-B";
+    testState.unreachableHostIds.clear();
+    testState.missingArtifactIds.clear();
+    testState.cloudKnownChatIds.clear();
+    resetChatRemoteDeletionRegistryForTesting();
+  });
+
+  it("for a cross-host offline owner: the copy tile's banner, and no canvas banner over it", async () => {
+    testState.sessionHostId = "host-B";
+    testState.unreachableHostIds.add(CHAT.hostId);
+
+    render(activeTabBody());
+
+    await waitFor(() => {
+      expect(screen.getByTestId("chat-tile-session-view")).not.toBeNull();
+    });
+    // Ablation: restore the copy tile's old "skip when the owner is the
+    // serving host" guard, or the canvas's unreachable-host banner, and this
+    // reads 2.
+    expect(screen.getAllByRole("button", { name: "Clone agent" })).toHaveLength(
+      1,
+    );
+    expect(
+      screen.getByTestId(`published-chat-dead-tile-${CHAT.id}`),
+    ).not.toBeNull();
+    expect(screen.queryByTestId(`chat-dead-tile-${CHAT.id}`)).toBeNull();
+    expect(screen.getByText(/Bound host "host-A" is offline/)).not.toBeNull();
+  });
+
+  it("for a same-host offline owner with a cloud copy: still one banner", async () => {
+    testState.sessionHostId = CHAT.hostId;
+    testState.unreachableHostIds.add(CHAT.hostId);
+    testState.missingArtifactIds.add(CHAT.id);
+    testState.cloudKnownChatIds.add(CHAT.id);
+
+    render(activeTabBody());
+
+    await waitFor(() => {
+      expect(screen.getByTestId("chat-tile-session-view")).not.toBeNull();
+    });
+    expect(screen.getAllByRole("button", { name: "Clone agent" })).toHaveLength(
+      1,
+    );
+    expect(
+      screen.getByTestId(`published-chat-dead-tile-${CHAT.id}`),
+    ).not.toBeNull();
+    expect(screen.queryByTestId(`chat-dead-tile-${CHAT.id}`)).toBeNull();
+  });
+});

--- a/clients/gui-app/src/components/epic-canvas/__tests__/tab-group-view.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/tab-group-view.test.tsx
@@ -1363,7 +1363,7 @@ describe("<TabGroupView /> published-copy fallback for an unreachable bound host
 
   const PUBLISHED_COPY_TILE_ID = "published-chat:epic-1:user-1:chat-1";
 
-  it("renders the published copy + dead-tile banner instead of the live chat body", async () => {
+  it("renders the published copy instead of the live chat body, and leaves the offline-host banner to the copy tile", async () => {
     testState.unreachableHostIds.add(CHAT.hostId);
     testState.sessionHostId = "host-B";
     seedCanvas([CHAT], CHAT.instanceId);
@@ -1376,18 +1376,13 @@ describe("<TabGroupView /> published-copy fallback for an unreachable bound host
         ),
       ).not.toBeNull();
     });
-    const banner = container.querySelector(
-      `[data-testid="chat-dead-tile-${CHAT.id}"]`,
-    );
-    expect(banner).not.toBeNull();
-    // Nothing answered for this chat, so the banner is about the HOST - the
-    // one state of the three that is allowed to tell the reader to go wake a
-    // machine (ticket 47/48's copy split).
-    expect(banner?.getAttribute("data-reason")).toBe("host-offline");
-    // The owner the opening row resolved rides into the banner - the ref in
-    // PUBLISHED_COPY_TILE_ID names user-1, and the banner's ownership
-    // verdict must come from that same row rather than a second lookup.
-    expect(banner?.getAttribute("data-source-owner")).toBe("user-1");
+    // Nothing answered for this chat, so the banner is about the HOST - and
+    // the published-chat tile draws that one itself from the owner's
+    // reachability (`published-chat-tile.test.tsx`). A canvas banner here
+    // was the second of two identical "Bound host is offline" bars.
+    expect(
+      container.querySelector(`[data-testid="chat-dead-tile-${CHAT.id}"]`),
+    ).toBeNull();
     // The live chat body must NOT render alongside the copy.
     expect(
       container.querySelector(`[data-testid="tile-${CHAT.id}"]`),
@@ -1573,6 +1568,10 @@ describe("<TabGroupView /> published-copy fallback for a confirmed-absent chat o
     );
     expect(banner).not.toBeNull();
     expect(banner?.getAttribute("data-reason")).toBe("chat-not-visible");
+    // The owner the opening row resolved rides into the banner - the ref in
+    // PUBLISHED_COPY_TILE_ID names user-1, and the banner's ownership
+    // verdict must come from that same row rather than a second lookup.
+    expect(banner?.getAttribute("data-source-owner")).toBe("user-1");
     // The live chat body must NOT render alongside the copy.
     expect(
       container.querySelector(`[data-testid="tile-${CHAT.id}"]`),
@@ -1732,15 +1731,14 @@ describe("<TabGroupView /> published-copy fallback for a same-host chat with no 
         ),
       ).not.toBeNull();
     });
-    const banner = container.querySelector(
-      `[data-testid="chat-dead-tile-${CHAT.id}"]`,
-    );
-    expect(banner).not.toBeNull();
     // SAME host, but nothing answered - reachability outranks the (absent)
-    // terminate, so this keeps the host sentence rather than claiming the
-    // history "is no longer on this host", which would assert something no
-    // one has said while the host is down.
-    expect(banner?.getAttribute("data-reason")).toBe("host-offline");
+    // terminate, so the reader gets the host sentence rather than a claim
+    // that the history "is no longer on this host", which would assert
+    // something no one has said while the host is down. The host sentence
+    // is the copy tile's to draw, so the canvas mounts no banner of its own.
+    expect(
+      container.querySelector(`[data-testid="chat-dead-tile-${CHAT.id}"]`),
+    ).toBeNull();
     expect(
       container.querySelector(`[data-testid="tile-${CHAT.id}"]`),
     ).toBeNull();

--- a/clients/gui-app/src/components/epic-canvas/canvas/tab-group-view.tsx
+++ b/clients/gui-app/src/components/epic-canvas/canvas/tab-group-view.tsx
@@ -10,7 +10,6 @@ import {
 } from "react";
 import { Button } from "@/components/ui/button";
 import type { ChatRecordRemovalReason } from "@traycer/protocol/host/epic/chat-records";
-import type { HostUnavailability } from "@traycer-clients/shared/host-client/remote-fetcher";
 import { useCanvasHostId } from "@/components/epic-canvas/hooks/use-canvas-host-id";
 import { useEpicSessionHostClient } from "@/hooks/epic/use-epic-session-host-client";
 import { useHostReachability } from "@/hooks/agent/use-host-reachability";
@@ -666,7 +665,8 @@ const noopClone = (): void => undefined;
 
 interface ChatFallbackDecision {
   readonly substitute: boolean;
-  readonly reason: ChatDeadTileBannerReason;
+  /** The banner the canvas mounts above the copy; `null` leaves it to the copy tile. */
+  readonly bannerReason: ChatDeadTileBannerReason | null;
   readonly ownerUserId: string | null;
 }
 
@@ -682,7 +682,6 @@ function resolveChatFallbackDecision(args: {
   readonly isChat: boolean;
   readonly isSameHost: boolean;
   readonly hostUnreachable: boolean;
-  readonly unavailability: HostUnavailability | null;
   readonly confirmedAbsent: boolean;
   readonly cloudChatOwnerUserId: string | null;
   readonly liveArtifactOwnerUserId: string | null;
@@ -705,44 +704,37 @@ function resolveChatFallbackDecision(args: {
     args.isSameHost && sameHostCloudCopyAvailable && absent;
   const crossHostFallback = !args.isSameHost && absent;
   const substitute = args.isChat && (crossHostFallback || sameHostFallback);
-  const reason = deadTileBannerReason({
+  const bannerReason = substitutionBannerReason({
     hostUnreachable: args.hostUnreachable,
-    unavailability: args.unavailability,
     isSameHost: args.isSameHost,
   });
   const ownerUserId = args.liveArtifactOwnerUserId ?? args.cloudChatOwnerUserId;
-  return { substitute, reason, ownerUserId };
+  return { substitute, bannerReason, ownerUserId };
 }
 
 /**
- * WHICH of the two triggers above fired, and whose host answered.
+ * The banner the canvas itself mounts above a substituted copy, or `null`.
  *
- * The banner says three different things (see `ChatDeadTileBannerReason`) and
- * picking the wrong one is how this surface came to name a healthy local
- * machine as unreachable on 2026-08-11.
+ * The published-chat tile under the substitution already reads the owner's
+ * reachability for its own footer, and draws the unreachable-owner banner
+ * (offline or plan-restricted) from that same read - so for an unreachable
+ * host the canvas draws nothing, or the reader gets the sentence twice with
+ * two Clone buttons. Unreachability outranks a `CHAT_NOT_VISIBLE` terminate
+ * on purpose: the terminate is a fact from an earlier moment, reachability is
+ * the state right now, and a reader whose host has since gone away needs the
+ * host sentence, not a report about a subscribe that is no longer possible.
  *
- * Unreachability outranks a `CHAT_NOT_VISIBLE` terminate on purpose: the
- * terminate is a fact from an earlier moment, reachability is the state right
- * now, and a reader whose host has since gone away needs the host sentence,
- * not a report about a subscribe that is no longer possible. Below it the
- * split is simply whose machine spoke - a host that answers "not here" about
- * ITSELF is reporting a missing chat, not a device the reader has to go wake.
+ * What the canvas alone knows is that a REACHABLE host answered "not here",
+ * and whose machine spoke: a host that says so about ITSELF is reporting a
+ * missing chat, not a device the reader has to go wake - picking the wrong
+ * sentence there is how this surface came to name a healthy local machine as
+ * unreachable on 2026-08-11.
  */
-function deadTileBannerReason(input: {
+function substitutionBannerReason(input: {
   readonly hostUnreachable: boolean;
-  readonly unavailability: HostUnavailability | null;
   readonly isSameHost: boolean;
-}): ChatDeadTileBannerReason {
-  if (input.hostUnreachable) {
-    // The hook's reason, not a constant - collapsing every unreachable
-    // result to `host-offline` is how a `plan-restricted` host (running
-    // fine, just with no remote route on this account's plan) got reported
-    // to its owner as being off. Same fix as `chat-tile.tsx`'s live-render
-    // path.
-    return input.unavailability === "plan-restricted"
-      ? "host-plan-restricted"
-      : "host-offline";
-  }
+}): ChatDeadTileBannerReason | null {
+  if (input.hostUnreachable) return null;
   return input.isSameHost ? "chat-not-on-this-host" : "chat-not-visible";
 }
 
@@ -765,7 +757,7 @@ function usePublishedChatFallbackRef(args: {
    */
   readonly fallbackRef: PublishedChatTileRef | null;
   readonly ownerHostLabel: string;
-  readonly reason: ChatDeadTileBannerReason;
+  readonly bannerReason: ChatDeadTileBannerReason | null;
   readonly isCloudKnown: boolean;
   readonly cloudListAuthorizesChatAbsence: boolean;
 } {
@@ -817,12 +809,11 @@ function usePublishedChatFallbackRef(args: {
     isChat,
     isSameHost,
     hostUnreachable: reachability.status === "unreachable",
-    unavailability: reachability.unavailability,
     confirmedAbsent,
     cloudChatOwnerUserId: cloudChatRecord?.identity.ownerUserId ?? null,
     liveArtifactOwnerUserId,
   });
-  const { substitute, reason, ownerUserId } = decision;
+  const { substitute, bannerReason, ownerUserId } = decision;
   // The SERVING host is chosen once, when this fallback first opens, and then
   // held. `activeHostId` has to stay reactive for the decision above it (the
   // record gate and `isSameHost` are questions about the projection this render
@@ -865,7 +856,7 @@ function usePublishedChatFallbackRef(args: {
   return {
     fallbackRef,
     ownerHostLabel: reachability.hostLabel,
-    reason,
+    bannerReason,
     isCloudKnown: cloudChatRecord !== null,
     cloudListAuthorizesChatAbsence:
       cloudChatListAuthorizesRecordSweep(cloudChats),
@@ -926,7 +917,7 @@ export function ActiveTabBody(props: ActiveTabBodyProps) {
   const {
     fallbackRef: publishedFallbackRef,
     ownerHostLabel,
-    reason: deadTileBannerReason,
+    bannerReason: substitutionBanner,
     isCloudKnown,
     cloudListAuthorizesChatAbsence,
   } = usePublishedChatFallbackRef({
@@ -1068,21 +1059,23 @@ export function ActiveTabBody(props: ActiveTabBodyProps) {
   if (publishedFallbackRef !== null) {
     return (
       <div className="flex h-full min-h-0 flex-1 flex-col">
-        <ChatDeadTileBannerContainer
-          epicId={epicId}
-          tabId={tabId}
-          chatId={activeTab.id}
-          sourceHostId={activeTab.hostId}
-          hostLabel={ownerHostLabel}
-          reason={deadTileBannerReason}
-          showsPublishedCopy
-          testId={`chat-dead-tile-${activeTab.id}`}
-          // The owner the opening row already resolved (the fallback ref is
-          // only built once one exists) - threading it means the banner's
-          // ownership verdict cannot disagree with the copy rendered under
-          // it, and does not depend on the container's own cloud lookup.
-          sourceOwnerUserId={publishedFallbackRef.ownerUserId}
-        />
+        {substitutionBanner !== null ? (
+          <ChatDeadTileBannerContainer
+            epicId={epicId}
+            tabId={tabId}
+            chatId={activeTab.id}
+            sourceHostId={activeTab.hostId}
+            hostLabel={ownerHostLabel}
+            reason={substitutionBanner}
+            showsPublishedCopy
+            testId={`chat-dead-tile-${activeTab.id}`}
+            // The owner the opening row already resolved (the fallback ref is
+            // only built once one exists) - threading it means the banner's
+            // ownership verdict cannot disagree with the copy rendered under
+            // it, and does not depend on the container's own cloud lookup.
+            sourceOwnerUserId={publishedFallbackRef.ownerUserId}
+          />
+        ) : null}
         <EpicNodeTile
           node={publishedFallbackRef}
           viewTabId={tabId}

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/published-chat-tile.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/published-chat-tile.test.tsx
@@ -53,6 +53,8 @@ interface MockReplicaQueryResult {
 interface MockHostReachability {
   readonly status: "reachable" | "unreachable";
   readonly hostLabel: string;
+  /** Absent on most fixtures, like the real hook's `null`. */
+  readonly unavailability?: "offline" | "plan-restricted";
 }
 
 /**
@@ -658,9 +660,10 @@ describe("PublishedChatTile - dead-tile clone banner", () => {
     expect(screen.getByTestId("chat-tile-session-view")).not.toBeNull();
   });
 
-  it("mounts no banner when the copy's owner IS the serving host, even while unreachable", () => {
-    // The canvas-substitution case: `tab-group-view` already mounts its own
-    // banner above this tile there, so a second one here would double it.
+  it("mounts the banner when the copy's owner IS the serving host, too", () => {
+    // The canvas-substitution case. This tile owns the unreachable-owner
+    // banner in every mount; `tab-group-view` draws one above it only for a
+    // REACHABLE host's "not here" answer, so nothing doubles.
     mockUseCloudChatTranscript.mockReturnValue(refusedUnpublished());
     mockUseChatReplicaRead.mockReturnValue(replicaOk());
 
@@ -674,8 +677,35 @@ describe("PublishedChatTile - dead-tile clone banner", () => {
       />,
     );
 
-    expect(screen.queryByTestId("published-chat-dead-tile-chat-1")).toBeNull();
+    expect(
+      screen.getByTestId("published-chat-dead-tile-chat-1"),
+    ).not.toBeNull();
     expect(screen.getByTestId("chat-tile-session-view")).not.toBeNull();
+  });
+
+  it("names the plan restriction, not an outage, when that is why the owner is unreachable", () => {
+    mockUseCloudChatTranscript.mockReturnValue(refusedUnpublished());
+    mockUseChatReplicaRead.mockReturnValue(replicaOk());
+    mockUseHostReachability.mockReturnValue({
+      status: "unreachable",
+      hostLabel: "Ada's Mac",
+      unavailability: "plan-restricted",
+    });
+
+    render(
+      <PublishedChatTile
+        node={NODE}
+        viewTabId="tab-1"
+        tileId="pane-1"
+        isActive
+        epicId="epic-1"
+      />,
+    );
+
+    expect(deadTileBannerContainerProps).toHaveLength(1);
+    expect(deadTileBannerContainerProps[0]?.reason).toBe(
+      "host-plan-restricted",
+    );
   });
 });
 

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/published-chat-tile.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/published-chat-tile.test.tsx
@@ -683,6 +683,53 @@ describe("PublishedChatTile - dead-tile clone banner", () => {
     expect(screen.getByTestId("chat-tile-session-view")).not.toBeNull();
   });
 
+  // The canvas no longer draws a banner over this tile for an unreachable
+  // owner, so the tile's own has to be there on every branch - a reader
+  // stuck on the load state or a refused read still needs the host sentence
+  // and the Clone way out (PR #1818 review). Neither branch has a copy on
+  // screen, so neither may claim one.
+  it("keeps the banner above the load state before the first copy", () => {
+    mockUseCloudChatTranscript.mockReturnValue(refusedUnpublished());
+    mockUseChatReplicaRead.mockReturnValue(replicaNotFetched());
+
+    render(
+      <PublishedChatTile
+        node={NODE}
+        viewTabId="tab-1"
+        tileId="pane-1"
+        isActive
+        epicId="epic-1"
+      />,
+    );
+
+    expect(
+      screen.queryByTestId(`published-chat-tile-load-${NODE.id}`),
+    ).not.toBeNull();
+    expect(screen.getByRole("button", { name: "Clone agent" })).toBeTruthy();
+    expect(deadTileBannerContainerProps).toHaveLength(1);
+    expect(deadTileBannerContainerProps[0]?.showsPublishedCopy).toBe(false);
+  });
+
+  it("keeps the banner above the notice when no copy could be read", () => {
+    mockUseCloudChatTranscript.mockReturnValue(refusedUnpublished());
+    mockUseChatReplicaRead.mockReturnValue(replicaAbsent());
+
+    render(
+      <PublishedChatTile
+        node={NODE}
+        viewTabId="tab-1"
+        tileId="pane-1"
+        isActive
+        epicId="epic-1"
+      />,
+    );
+
+    expect(screen.queryByTestId("published-chat-notice")).not.toBeNull();
+    expect(screen.getByRole("button", { name: "Clone agent" })).toBeTruthy();
+    expect(deadTileBannerContainerProps).toHaveLength(1);
+    expect(deadTileBannerContainerProps[0]?.showsPublishedCopy).toBe(false);
+  });
+
   it("names the plan restriction, not an outage, when that is why the owner is unreachable", () => {
     mockUseCloudChatTranscript.mockReturnValue(refusedUnpublished());
     mockUseChatReplicaRead.mockReturnValue(replicaOk());

--- a/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
@@ -184,6 +184,7 @@ import {
   ChatHostStartingBanner,
   type ChatDeadTileBannerReason,
 } from "./dead-tile-banner";
+import { unreachableHostBannerReason } from "./unreachable-host-banner-reason";
 import { useHostQuery } from "@/hooks/host/use-host-query";
 import { useRecordHostOlderThanDataRefusal } from "@/hooks/chats/use-host-refuses-epic-store";
 import { useHostDirectoryEntry } from "@/hooks/host/use-host-directory-entry";
@@ -517,15 +518,7 @@ export function ChatTile(props: ChatTileProps) {
           chatId={node.id}
           sourceHostId={tabHostId}
           hostLabel={reachability.hostLabel}
-          // The hook's reason, not a constant. This used to hard-code
-          // `host-offline` for every unreachable result, which is how a
-          // `plan-restricted` host — running fine, just with no remote route on
-          // this account's plan — was reported to its owner as being off.
-          reason={
-            reachability.unavailability === "plan-restricted"
-              ? "host-plan-restricted"
-              : "host-offline"
-          }
+          reason={unreachableHostBannerReason(reachability.unavailability)}
           // This mount's body is a load state or a cached live session -
           // never a published copy the banner could truthfully point at.
           showsPublishedCopy={false}

--- a/clients/gui-app/src/components/epic-canvas/renderers/published-chat-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/published-chat-tile.tsx
@@ -230,7 +230,14 @@ export function PublishedChatTile(props: PublishedChatTileProps): ReactNode {
   // The same Clone offer the LIVE tile's dead-tile banner makes, on the copy.
   // Gated (inside the child) on the SAME reachability the lock sentence below
   // reads, so the banner and the sentence can never describe one host two ways.
-  const deadTileBanner = (
+  //
+  // Mounted on EVERY branch below, not only the ones with a transcript: this
+  // tile owns the unreachable-owner banner (the canvas no longer draws one
+  // over it), and a reader stuck on the load state or a refused read still
+  // needs the host sentence and the way out. `showsPublishedCopy` is what
+  // differs per branch - only the transcript branches have a copy on screen
+  // for the foreign-owner sentence to point at.
+  const deadTileBanner = (showsPublishedCopy: boolean): ReactNode => (
     <PublishedChatDeadTileBanner
       node={node}
       epicId={props.epicId}
@@ -238,6 +245,7 @@ export function PublishedChatTile(props: PublishedChatTileProps): ReactNode {
       ownerStatus={ownerReachability.status}
       ownerUnavailability={ownerReachability.unavailability}
       ownerLabel={ownerLabel}
+      showsPublishedCopy={showsPublishedCopy}
     />
   );
 
@@ -357,6 +365,7 @@ export function PublishedChatTile(props: PublishedChatTileProps): ReactNode {
   if (boundedLoad.kind !== "ready") {
     return (
       <div className="flex h-full min-h-0 flex-col" data-node-id={node.id}>
+        {deadTileBanner(false)}
         <TileHostLoadState
           load={boundedLoad}
           subject="agent"
@@ -370,7 +379,7 @@ export function PublishedChatTile(props: PublishedChatTileProps): ReactNode {
   if (replicaHandle !== null && replicaConversion !== null) {
     return (
       <div className="flex h-full min-h-0 flex-col" data-node-id={node.id}>
-        {deadTileBanner}
+        {deadTileBanner(true)}
         <ChatTileSessionView
           isLiveSession={false}
           handle={replicaHandle}
@@ -404,6 +413,7 @@ export function PublishedChatTile(props: PublishedChatTileProps): ReactNode {
   if (applied === null) {
     return (
       <div className="flex h-full min-h-0 flex-col" data-node-id={node.id}>
+        {deadTileBanner(false)}
         <PublishedChatNotice
           state={
             replicaFailure === null
@@ -423,7 +433,7 @@ export function PublishedChatTile(props: PublishedChatTileProps): ReactNode {
 
   return (
     <div className="flex h-full min-h-0 flex-col" data-node-id={node.id}>
-      {deadTileBanner}
+      {deadTileBanner(true)}
       {/* The heavy content this transcript NAMES - file diffs, full plans -
           is not in the published document; it is content-addressed in the
           cloud. The blocks that expand it decide their own fetch several
@@ -608,6 +618,8 @@ function PublishedChatDeadTileBanner(props: {
   readonly ownerStatus: HostReachabilityStatus;
   readonly ownerUnavailability: HostUnavailability | null;
   readonly ownerLabel: string;
+  /** See `ChatDeadTileBannerProps.showsPublishedCopy`. */
+  readonly showsPublishedCopy: boolean;
 }): ReactNode {
   if (props.ownerStatus !== "unreachable") {
     return null;
@@ -620,7 +632,7 @@ function PublishedChatDeadTileBanner(props: {
       sourceHostId={props.node.ownerHostId}
       hostLabel={props.ownerLabel}
       reason={unreachableHostBannerReason(props.ownerUnavailability)}
-      showsPublishedCopy
+      showsPublishedCopy={props.showsPublishedCopy}
       testId={`published-chat-dead-tile-${props.node.chatId}`}
       sourceOwnerUserId={props.node.ownerUserId}
     />

--- a/clients/gui-app/src/components/epic-canvas/renderers/published-chat-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/published-chat-tile.tsx
@@ -3,6 +3,7 @@ import type { UseQueryResult } from "@tanstack/react-query";
 import { createStore, useStore } from "zustand";
 import type { ChatReplicaReadResponse } from "@traycer/protocol/host/epic/chat-replica-read";
 import type { HostRpcError } from "@traycer-clients/shared/host-transport/host-messenger";
+import type { HostUnavailability } from "@traycer-clients/shared/host-client/remote-fetcher";
 import type { PublishedChatTileRef } from "@/stores/epics/canvas/types";
 import { useTabHostClient } from "@/hooks/host/use-tab-host-client";
 import { useTabHostId } from "@/components/epic-canvas/hooks/use-tab-host-id";
@@ -29,6 +30,7 @@ import {
   type PublishedChatSessionHandle,
 } from "@/lib/chats/published-chat-session";
 import { ChatDeadTileBannerContainer, ChatTileSessionView } from "./chat-tile";
+import { unreachableHostBannerReason } from "./unreachable-host-banner-reason";
 import { PublishedChatNotice } from "./published-chat-notice";
 import { PublishedChatSourceProvider } from "@/lib/chats/published-chat-source-provider";
 import {
@@ -226,16 +228,15 @@ export function PublishedChatTile(props: PublishedChatTileProps): ReactNode {
   );
 
   // The same Clone offer the LIVE tile's dead-tile banner makes, on the copy.
-  // Gated (inside the child) on the SAME two signals the lock sentence below
-  // reads - the owner's reachability and `ownerIsThisHost` - so the banner and
-  // the sentence can never describe one host two ways.
+  // Gated (inside the child) on the SAME reachability the lock sentence below
+  // reads, so the banner and the sentence can never describe one host two ways.
   const deadTileBanner = (
     <PublishedChatDeadTileBanner
       node={node}
       epicId={props.epicId}
       tabId={props.viewTabId}
       ownerStatus={ownerReachability.status}
-      ownerIsThisHost={ownerIsThisHost}
+      ownerUnavailability={ownerReachability.unavailability}
       ownerLabel={ownerLabel}
     />
   );
@@ -590,22 +591,25 @@ function publishedCopyRefresh(
 /**
  * The clone banner an unreachable owner earns on the copy, or nothing.
  *
- * Reachable owner: the row offers the live tab, no clone needed. Owner IS the
- * serving host: that is the canvas substitution arm, whose banner
- * `tab-group-view` already mounts above this tile - a second one here would
- * double it. The ref carries the owner (`ownerUserId`), so it is threaded
- * through rather than re-resolved from the cloud list, which a post-restart
- * host with swept registry facts cannot answer.
+ * Reachable owner: the row offers the live tab, no clone needed. This tile
+ * OWNS the unreachable-owner banner wherever it is mounted - opened directly
+ * from a sidebar row, or substituted by the canvas for a live tab whose bound
+ * host went away. The canvas (`tab-group-view`) mounts a banner above this
+ * tile only for the reasons it alone can know, a REACHABLE host answering
+ * that it has no such chat, so the two never both draw one. The ref carries
+ * the owner (`ownerUserId`), so it is threaded through rather than
+ * re-resolved from the cloud list, which a post-restart host with swept
+ * registry facts cannot answer.
  */
 function PublishedChatDeadTileBanner(props: {
   readonly node: PublishedChatTileRef;
   readonly epicId: string;
   readonly tabId: string;
   readonly ownerStatus: HostReachabilityStatus;
-  readonly ownerIsThisHost: boolean;
+  readonly ownerUnavailability: HostUnavailability | null;
   readonly ownerLabel: string;
 }): ReactNode {
-  if (props.ownerStatus !== "unreachable" || props.ownerIsThisHost) {
+  if (props.ownerStatus !== "unreachable") {
     return null;
   }
   return (
@@ -615,7 +619,7 @@ function PublishedChatDeadTileBanner(props: {
       chatId={props.node.chatId}
       sourceHostId={props.node.ownerHostId}
       hostLabel={props.ownerLabel}
-      reason="host-offline"
+      reason={unreachableHostBannerReason(props.ownerUnavailability)}
       showsPublishedCopy
       testId={`published-chat-dead-tile-${props.node.chatId}`}
       sourceOwnerUserId={props.node.ownerUserId}

--- a/clients/gui-app/src/components/epic-canvas/renderers/unreachable-host-banner-reason.ts
+++ b/clients/gui-app/src/components/epic-canvas/renderers/unreachable-host-banner-reason.ts
@@ -1,0 +1,21 @@
+import type { HostUnavailability } from "@traycer-clients/shared/host-client/remote-fetcher";
+import type { ChatDeadTileBannerReason } from "./dead-tile-banner";
+
+/**
+ * The reason for a bound host `useHostReachability` reports unreachable.
+ *
+ * One mapping for every mount that turns the hook's verdict into copy, so no
+ * surface can report a `plan-restricted` host (running fine, just with no
+ * remote route on this account's plan) to its owner as being off - which is
+ * how each of these mounts got it wrong at least once.
+ *
+ * Its own module rather than a sibling of `ChatDeadTileBanner`: that file is
+ * components-only for fast refresh.
+ */
+export function unreachableHostBannerReason(
+  unavailability: HostUnavailability | null,
+): ChatDeadTileBannerReason {
+  return unavailability === "plan-restricted"
+    ? "host-plan-restricted"
+    : "host-offline";
+}


### PR DESCRIPTION
## What

When a chat's bound host is offline, the canvas swaps in the last published copy. Two surfaces each knew how to draw the "Bound host is offline" banner, and the copy tile's dedupe guard only covered the same-host substitution. A cross-host offline owner therefore got two identical banners with two Clone buttons, both reading:

> Bound host "traycer" is offline. Continuing here creates a new agent on the active host; this one stays bound to "traycer".

## Fix

Ownership is now split by what each surface knows:

- `published-chat-tile.tsx` draws the unreachable-owner banner in every mount. It already reads the owner's reachability for its footer sentence.
- `tab-group-view.tsx` draws a banner only for a **reachable** host answering "not here" (`chat-not-visible` / `chat-not-on-this-host`), the fact only the canvas sees. `substitutionBannerReason` returns `null` for an unreachable host.
- The offline-vs-plan-restricted mapping moves into one shared helper, `unreachableHostBannerReason`, used by the live chat tile and the copy tile. Side effect: the copy tile stops reporting a plan-restricted host as "offline".

## Tests

- `published-copy-substitution-banner.test.tsx` (new): renders `ActiveTabBody` through the real tile renderer down to the real `PublishedChatTile` and asserts exactly one Clone button for a cross-host and a same-host offline owner. Both existing suites were blind to this (one stubs the tile, the other mounts it alone). Ablation verified: restoring the canvas's unreachable-host banner fails both cases with two buttons.
- `tab-group-view.test.tsx`: the two unreachable-host substitution cases now assert no canvas banner; the owner-threading assertion moved to the `chat-not-visible` case.
- `published-chat-tile.test.tsx`: the same-host case flips to "mounts the banner"; adds a plan-restricted case.

Internal pin bump: traycerai/traycer-internal PR to follow.
