### PR TITLE
fix(gui-app): bound the browser-sessions release retry sweep

### DIFF
--- a/clients/gui-app/src/lib/browser-view/sessions/__tests__/browser-sessions-coordinator.test.ts
+++ b/clients/gui-app/src/lib/browser-view/sessions/__tests__/browser-sessions-coordinator.test.ts
@@ -52,6 +52,28 @@ function createTransportHarness(): {
   };
 }
 
+/**
+ * Like {@link createTransportHarness}, but its sessions are never born
+ * connected - an UNDIALABLE device. The auto-opening harness cannot express
+ * one: every retry it serves succeeds on subscribe, so a coordinator can never
+ * be observed failing an attempt, which is the whole state the release sweep's
+ * bound is about.
+ */
+function createDownTransportHarness(): {
+  readonly openTransport: (hostId: string) => DurableStreamTransport;
+  readonly clients: FakeStreamClient[];
+} {
+  const clients: FakeStreamClient[] = [];
+  return {
+    clients,
+    openTransport: () => {
+      const client = new FakeStreamClient(false);
+      clients.push(client);
+      return { wsStreamClient: client, close: () => undefined };
+    },
+  };
+}
+
 function buildRuntime(
   openTransport: (hostId: string) => DurableStreamTransport,
 ): {
@@ -394,6 +416,99 @@ describe("browser sessions coordinator registry", () => {
     expect(browserSessionsCoordinatorState(undialable.key)?.lifecycle).toBe(
       "failed",
     );
+  });
+
+  // The release edge cannot bound itself any more. The always-mounted
+  // tombstone recovery bridge rotates devices through its slots, and a device
+  // YIELDS by failing to answer - which is also what leaves its coordinator
+  // failed - so a release arrives with no UI gesture behind it. A `failed`
+  // lifecycle also changes what consumers render, so a retry that fails again
+  // can unmount the consumer holding an acquisition, and that cleanup is
+  // another release. Either way the sweep fed itself, and unbounded nested
+  // updates surface as React #185, which takes the window to the crash card.
+  it("re-asks a failed coordinator at most once per failure episode", () => {
+    const live = createTransportHarness();
+    const down = createDownTransportHarness();
+    const undialable = acquire({
+      scope: epicScope("epic-1"),
+      openTransport: down.openTransport,
+    });
+    soleSession(soleClient(down.clients)).emitFatal(
+      "This host cannot be dialed.",
+    );
+    expect(browserSessionsCoordinatorState(undialable.key)?.lifecycle).toBe(
+      "failed",
+    );
+    expect(down.clients).toHaveLength(1);
+
+    // One release: the sweep re-asks it, on a fresh transport, and that
+    // attempt fails too.
+    const firstBystander = acquire({
+      scope: epicScope("epic-2"),
+      openTransport: live.openTransport,
+    });
+    firstBystander.release();
+    expect(down.clients).toHaveLength(2);
+    const retried = down.clients.at(1);
+    if (retried === undefined) throw new Error("expected a retry transport");
+    soleSession(retried).emitFatal("This host cannot be dialed.");
+    expect(browserSessionsCoordinatorState(undialable.key)?.lifecycle).toBe(
+      "failed",
+    );
+
+    // A second release finds nothing has moved this coordinator since its
+    // re-ask, so it is left alone. Without the bound every release re-asked
+    // it, and each re-ask could produce the next release.
+    const secondBystander = acquire({
+      scope: epicScope("epic-3"),
+      openTransport: live.openTransport,
+    });
+    secondBystander.release();
+    expect(down.clients).toHaveLength(2);
+    expect(browserSessionsCoordinatorState(undialable.key)?.lifecycle).toBe(
+      "failed",
+    );
+  });
+
+  // The bound is per EPISODE, not for the life of the coordinator: a device
+  // that comes back and later drops again is a new outage and earns a fresh
+  // re-ask. Reaching `live` is what re-arms it - and deliberately not merely
+  // leaving `failed`, since a retry publishes `connecting` on its way out and
+  // arming on that would hand the flag back once per attempt.
+  it("re-arms the release sweep once the stream actually opens", () => {
+    const live = createTransportHarness();
+    const down = createDownTransportHarness();
+    const flaky = acquire({
+      scope: epicScope("epic-1"),
+      openTransport: down.openTransport,
+    });
+    soleSession(soleClient(down.clients)).emitFatal(
+      "This host cannot be dialed.",
+    );
+
+    const firstBystander = acquire({
+      scope: epicScope("epic-2"),
+      openTransport: live.openTransport,
+    });
+    firstBystander.release();
+    expect(down.clients).toHaveLength(2);
+    const retried = down.clients.at(1);
+    if (retried === undefined) throw new Error("expected a retry transport");
+
+    // This attempt OPENS, then drops later - a second, genuine outage.
+    soleSession(retried).emitStatus("open");
+    expect(browserSessionsCoordinatorState(flaky.key)?.lifecycle).toBe("live");
+    soleSession(retried).emitFatal("This host cannot be dialed.");
+    expect(browserSessionsCoordinatorState(flaky.key)?.lifecycle).toBe(
+      "failed",
+    );
+
+    const secondBystander = acquire({
+      scope: epicScope("epic-3"),
+      openTransport: live.openTransport,
+    });
+    secondBystander.release();
+    expect(down.clients).toHaveLength(3);
   });
 
   it("keys two scopes on the same host and identity into two coordinators, independent of scope field order", () => {

--- a/clients/gui-app/src/lib/browser-view/sessions/browser-sessions-coordinator.ts
+++ b/clients/gui-app/src/lib/browser-view/sessions/browser-sessions-coordinator.ts
@@ -281,11 +281,17 @@ interface BrowserSessionsCoordinator {
    * coordinator since it last entered `failed`. It is what bounds that sweep -
    * see its docblock for why the release edge can no longer bound itself.
    *
-   * Cleared on any transition OUT of `failed`, which is the only real
-   * progress: the stream opened, or is at least reconnecting, so the next
-   * failure is a NEW episode and earns a fresh re-ask. A coordinator that
-   * fails, is re-asked, and fails again is left alone until something other
-   * than the sweep moves it.
+   * Cleared when the stream reaches `live`, which is the only real progress:
+   * it actually opened, so the next failure is a NEW episode and earns a fresh
+   * re-ask. A coordinator that fails, is re-asked, and fails again is left
+   * alone until something other than the sweep moves it.
+   *
+   * Deliberately NOT "left `failed`". A retry publishes `connecting` on its
+   * way out and main forwards that as a status like any other, so clearing on
+   * it would hand the flag back once per ATTEMPT - which is once per sweep,
+   * leaving the sweep able to feed itself exactly as before the bound.
+   * `reconnecting` needs no arm of its own: it is only reachable from `live`,
+   * which has already cleared this.
    */
   sweptSinceFailure: boolean;
   /**
@@ -442,18 +448,20 @@ export function acquireBrowserSessionsCoordinator(args: {
  *     React rather than through this call stack, which no reentrancy flag
  *     would catch.
  *
- * So the sweep could feed itself, and with several undialable devices it did:
- * exactly the failure {@link retryCapRefusedCoordinators} refuses to risk -
- * "two undialable hosts would each free a slot the other's failure swept on,
- * forever" - reached from the other edge. Unbounded nested updates surface as
- * React error #185 ("maximum update depth exceeded"), which takes the window
- * down to the crash card.
+ * So the sweep can feed itself: exactly the failure
+ * {@link retryCapRefusedCoordinators} refuses to risk - "two undialable hosts
+ * would each free a slot the other's failure swept on, forever" - reached from
+ * the other edge. Unbounded nested updates surface as React error #185
+ * ("maximum update depth exceeded"), which takes the window down to the crash
+ * card. A staging machine with three undialable remote devices hit #185
+ * repeatedly and stopped once they were dialable again; that is the
+ * correlation this was derived from, not an observed loop.
  *
  * `sweptSinceFailure` restores a bound without narrowing what a release may
  * revive: each coordinator is re-asked at most ONCE per failure episode, so a
- * chain is bounded by the number of failed coordinators, and only a transition
- * out of `failed` re-arms one. Same shape as the cap-refused sweep's bound,
- * for the same reason.
+ * chain is bounded by the number of failed coordinators, and only reaching
+ * `live` re-arms one (see the field's docblock for why `connecting` must not).
+ * Same shape as the cap-refused sweep's bound, for the same reason.
  *
  * Ordering: the released coordinator's close went to main before these opens
  * (`stop()` inside `dispose()` sends it), and main handles a renderer's

--- a/clients/gui-app/src/lib/browser-view/sessions/browser-sessions-coordinator.ts
+++ b/clients/gui-app/src/lib/browser-view/sessions/browser-sessions-coordinator.ts
@@ -277,6 +277,18 @@ interface BrowserSessionsCoordinator {
   readonly scope: HostResourceScope;
   state: BrowserSessionsState;
   /**
+   * Whether {@link retryFailedCoordinators} has already re-asked this
+   * coordinator since it last entered `failed`. It is what bounds that sweep -
+   * see its docblock for why the release edge can no longer bound itself.
+   *
+   * Cleared on any transition OUT of `failed`, which is the only real
+   * progress: the stream opened, or is at least reconnecting, so the next
+   * failure is a NEW episode and earns a fresh re-ask. A coordinator that
+   * fails, is re-asked, and fails again is left alone until something other
+   * than the sweep moves it.
+   */
+  sweptSinceFailure: boolean;
+  /**
    * Snapshot-only capture of one tab on this coordinator's host, for a chat
    * pinned to ANOTHER host (spec decision #10). It hangs off the coordinator
    * rather than off `BrowserSessionsState` because only the mention picker
@@ -411,20 +423,51 @@ export function acquireBrowserSessionsCoordinator(args: {
  * device a tombstone still names), and the coordinator refused is then a
  * visible one: the panel's, or a canvas tile's.
  *
- * Every failed coordinator is re-asked here, not only the cap-refused ones. A
- * release is a discrete gesture in the UI rather than something a retry can
- * produce, so the sweep cannot re-trigger itself however the retries land;
- * that costs one open per release, and only while a stream stays failed.
- * {@link retryCapRefusedCoordinators} is the same idea on the edge main frees
- * a slot on by itself, where that guarantee does NOT hold.
+ * Every failed coordinator is re-asked here, not only the cap-refused ones,
+ * because a release genuinely frees a slot and any of them may now fit.
+ *
+ * This used to rest on "a release is a discrete gesture in the UI rather than
+ * something a retry can produce, so the sweep cannot re-trigger itself however
+ * the retries land". That is no longer true, in two ways that compose:
+ *
+ *   - The always-mounted tombstone recovery bridge reaches this edge on its
+ *     own. `LANDING_BROWSER_RECOVERY_HOST_CAP`'s docblock says so outright: a
+ *     release happens "when its tombstones drain, and, since the rotation
+ *     below, also when it yields" - and a device YIELDS precisely by failing
+ *     to answer, which is also what leaves its coordinator `failed`.
+ *   - A `failed` lifecycle changes what consumers render (`browser-peek-tile`,
+ *     `epic-browser-sidebar`, `switcher-browsers-list`), so a retry that fails
+ *     again can unmount the consumer holding an acquisition - and that
+ *     unmount's cleanup IS another release. The sweep then re-enters through
+ *     React rather than through this call stack, which no reentrancy flag
+ *     would catch.
+ *
+ * So the sweep could feed itself, and with several undialable devices it did:
+ * exactly the failure {@link retryCapRefusedCoordinators} refuses to risk -
+ * "two undialable hosts would each free a slot the other's failure swept on,
+ * forever" - reached from the other edge. Unbounded nested updates surface as
+ * React error #185 ("maximum update depth exceeded"), which takes the window
+ * down to the crash card.
+ *
+ * `sweptSinceFailure` restores a bound without narrowing what a release may
+ * revive: each coordinator is re-asked at most ONCE per failure episode, so a
+ * chain is bounded by the number of failed coordinators, and only a transition
+ * out of `failed` re-arms one. Same shape as the cap-refused sweep's bound,
+ * for the same reason.
  *
  * Ordering: the released coordinator's close went to main before these opens
  * (`stop()` inside `dispose()` sends it), and main handles a renderer's
  * invokes in order, so the count the cap reads no longer includes it.
  */
 function retryFailedCoordinators(): void {
-  for (const coordinator of browserSessionsCoordinators.values()) {
-    if (coordinator.state.lifecycle === "failed") coordinator.state.retry();
+  for (const coordinator of [...browserSessionsCoordinators.values()]) {
+    if (coordinator.state.lifecycle !== "failed") continue;
+    if (coordinator.sweptSinceFailure) continue;
+    // Set BEFORE the retry: `retry()` restarts a stream and is free to publish
+    // synchronously, including a fresh `failed`, and a re-ask that has not yet
+    // recorded itself would be eligible all over again.
+    coordinator.sweptSinceFailure = true;
+    coordinator.state.retry();
   }
 }
 
@@ -765,6 +808,19 @@ function createBrowserSessionsCoordinator(args: {
           ? allocateConnectionGeneration()
           : coordinator.state.connectionGeneration,
     });
+    // Reaching `live` is the progress that re-arms the release sweep for this
+    // coordinator: the stream actually opened, so a later failure is a new
+    // episode rather than the one already swept.
+    //
+    // `live` and NOT merely "left `failed`". A retry publishes `connecting`
+    // on the way out, and main forwards that as a status like any other, so
+    // re-arming on it would hand the flag back once per ATTEMPT - which is
+    // once per sweep, leaving the sweep able to feed itself exactly as before.
+    // `reconnecting` needs no arm of its own: it is only reachable from
+    // `live`, which has already cleared this.
+    //
+    // Set before the sweep below, which may re-enter this setter synchronously.
+    if (next === "live") coordinator.sweptSinceFailure = false;
     // AFTER the patch, so this coordinator is already carrying the message the
     // sweep reads it by and cannot be re-asked as one of its own targets.
     if (next === "failed" && !isBrowserSessionsWindowCapRefusal(errorMessage)) {
@@ -850,6 +906,8 @@ function createBrowserSessionsCoordinator(args: {
     owner: args.owner,
     scope: args.scope,
     captureTabPreview,
+    // Starts `connecting`, so there is no failure episode to have swept yet.
+    sweptSinceFailure: false,
     state: {
       hostId: args.owner.hostId,
       lifecycle: "connecting",


### PR DESCRIPTION
## What

`retryFailedCoordinators` re-asked **every** failed browser-sessions coordinator on **every** coordinator release. This bounds it to at most one re-ask per coordinator per failure episode, re-armed when the stream actually reaches `live`.

## Why

The sweep's safety argument is written in its own docblock:

> Every failed coordinator is re-asked here, not only the cap-refused ones. A release is a discrete gesture in the UI rather than something a retry can produce, so the sweep cannot re-trigger itself however the retries land.

That invariant no longer holds, in two ways that compose:

1. **The rotating tombstone recovery bridge reaches the release edge by itself.** `LANDING_BROWSER_RECOVERY_HOST_CAP` says so outright — a release happens *"when its tombstones drain, and, since the rotation below, also when it yields"* — and a device yields precisely by **failing to answer**, which is also what leaves its coordinator `failed`.
2. **`failed` changes what consumers render** (`browser-peek-tile`, `epic-browser-sidebar`, `switcher-browsers-list`), so a retry that fails again can unmount the consumer holding an acquisition — and that cleanup is another release. The sweep re-enters through React, not through the call stack, so no reentrancy flag would catch it.

So the sweep could feed itself. That is exactly the failure the sibling `retryCapRefusedCoordinators` refuses to risk from the other edge:

> Re-asking every failed coordinator instead would spin: two undialable hosts would each free a slot the other's failure swept on, forever.

Unbounded nested updates surface as **React #185** ("maximum update depth exceeded"), which takes the window to the crash card.

## Field evidence

Observed on a staging machine with 3 remote hosts, where a desktop/host version skew left the local host refusing dials (`[selection-authority] … outcome: 'confirmed-refusal', consecutiveNonCounting: 3`). Six React #185 crashes across two renderer bundles; a clean uninstall/reinstall did not help, and they stopped once the hosts became dialable again.

To be straight about the limit: the mechanism is derived from the three docblocks above plus that correlation, **not** from an observed loop. No component stack was ever captured — see the follow-up below.

## The fix

`sweptSinceFailure` on the coordinator record. It bounds the chain without narrowing what a release may revive, so a genuinely freed slot still gets its re-ask:

- re-asked at most once per failure episode → a chain is bounded by the number of failed coordinators, the same bound the cap-refused sweep relies on;
- re-armed on `live`, and deliberately **not** on merely leaving `failed` — a retry publishes `connecting` on its way out, so arming on that would hand the flag back once per *attempt* and leave the sweep able to feed itself as before.

## Tests

Two, and both directions are pinned by ablation:

| Test | Ablation | Result |
| --- | --- | --- |
| `re-asks a failed coordinator at most once per failure episode` | drop the guard | **red** |
| `re-arms the release sweep once the stream actually opens` | drop the re-arm | **red** |

Needed a new `createDownTransportHarness` (`FakeStreamClient(false)`): the existing harness auto-opens on subscribe, so every retry it serves succeeds and a coordinator can never be observed failing an attempt — which is the whole state the bound is about.

`browser-sessions-coordinator.test.ts` 21/21; `src/lib/browser-view` + `landing-browser-recovery-slots` 276/276; gui-app `compile` clean; pre-commit `build · compile · lint · format (nx affected)` passed.

## Follow-up, not in this PR

A route-tree crash logs **no component stack locally**. `RootErrorBoundary` logs one via `appLogger.errorSummary`; the router's `RouteErrorComponent` — which is what actually catches these, and what the user sees — reports to Sentry and logs nothing (`grep "uncaught error reached"` → 0 across six crashes). That asymmetry is why pinning this cost what it did, and it is worth closing on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
