### PR TITLE
fix(shared): answer remote capability reads with one identity per manifest

### DIFF
--- a/clients/gui-app/src/lib/host/stream-runtime-context.ts
+++ b/clients/gui-app/src/lib/host/stream-runtime-context.ts
@@ -121,6 +121,13 @@ export type StreamMethodSupportSource =
 // null-client handling; only the per-snapshot read differs. The readers are
 // module-level constants so `getSnapshot`'s identity stays keyed on
 // `[client, method]` alone.
+//
+// The other half of that contract is the CLIENT's: `getMethodSupport` and
+// `getMethodSchemaVersion` must answer with one identity between
+// `subscribeMethodSupport` notifications, because `useSyncExternalStore`
+// re-reads the snapshot after every commit and a fresh object is a change to
+// commit again - fifty deep and React throws #185. `RemoteSession` once built
+// its version per read and took the Start Page down with it.
 function useStreamMethodValueForClient<
   TClient extends StreamMethodSupportSource,
   T,

--- a/clients/shared/host-transport/remote/__tests__/remote-session.test.ts
+++ b/clients/shared/host-transport/remote/__tests__/remote-session.test.ts
@@ -2090,6 +2090,75 @@ describe("RemoteStreamClient dynamic subscribe params", () => {
   );
 
   it(
+    "answers repeated capability reads with one identity until the manifest moves",
+    async () => {
+      const relay = new FakeRelayHost();
+      // Host and client on the SAME registry: equal minors, so the verdict
+      // picks the client canonical - the half `selectConnectionManifestForPeer`
+      // rebuilds per call. That is the arm that looped: the reads are
+      // `useSyncExternalStore` snapshots, and a fresh object per read is a
+      // re-render per commit until React throws #185.
+      relay.streamManifest = buildStreamManifest(
+        cursorStreamRegistry,
+        SERVES_EVERY_INSTALLED_MAJOR,
+      );
+      const lease = new MutableBearerLease("valid-token", "user-1");
+      const session = new RemoteSession({
+        ...buildSessionOptions(relay, lease, null),
+        streamRegistry: cursorStreamRegistry,
+      });
+      const streamClient = new RemoteStreamClient<
+        VersionedRpcRegistry,
+        typeof cursorStreamRegistry
+      >(session, () => null);
+
+      try {
+        session.start();
+        await vi.waitFor(() => expect(session.isReady()).toBe(true), WAIT);
+        const version = streamClient.getMethodSchemaVersion("cursor.subscribe");
+        expect(version).toEqual({ major: 1, minor: 0, supportedMajors: [1] });
+        expect(streamClient.getMethodSchemaVersion("cursor.subscribe")).toBe(
+          version,
+        );
+        // Reading the sibling verdict must not disturb the version identity.
+        expect(streamClient.getMethodSupport("cursor.subscribe")).toBe(
+          "supported",
+        );
+        expect(streamClient.getMethodSchemaVersion("cursor.subscribe")).toBe(
+          version,
+        );
+
+        // A drop retracts the manifest and the version with it; the redial's
+        // ack installs a manifest again and the version is readable again,
+        // and once more stable across reads.
+        relay.dropCurrentConnection();
+        await vi.waitFor(
+          () =>
+            expect(
+              streamClient.getMethodSchemaVersion("cursor.subscribe"),
+            ).toBe(null),
+          WAIT,
+        );
+        await vi.waitFor(
+          () =>
+            expect(
+              streamClient.getMethodSchemaVersion("cursor.subscribe"),
+            ).toEqual({ major: 1, minor: 0, supportedMajors: [1] }),
+          WAIT,
+        );
+        const reacked = streamClient.getMethodSchemaVersion("cursor.subscribe");
+        expect(streamClient.getMethodSchemaVersion("cursor.subscribe")).toBe(
+          reacked,
+        );
+        expect(relay.errors).toEqual([]);
+      } finally {
+        session.close();
+      }
+    },
+    TEST_BUDGET_MS,
+  );
+
+  it(
     "routes a pinned remote incompatibility through the batch client's unsupported fallback seam",
     async () => {
       const relay = new FakeRelayHost();

--- a/clients/shared/host-transport/remote/__tests__/remote-session.test.ts
+++ b/clients/shared/host-transport/remote/__tests__/remote-session.test.ts
@@ -2128,16 +2128,36 @@ describe("RemoteStreamClient dynamic subscribe params", () => {
           version,
         );
 
-        // A drop retracts the manifest and the version with it; the redial's
-        // ack installs a manifest again and the version is readable again,
-        // and once more stable across reads.
+        // A drop retracts the manifest and the version with it. The redial's
+        // ack installs a DIFFERENT manifest - one without the method - and
+        // the verdict must follow it: a cache keyed on the method alone would
+        // keep answering the retired manifest's `supported` here.
         relay.dropCurrentConnection();
+        relay.streamManifest = {};
         await vi.waitFor(
           () =>
             expect(
               streamClient.getMethodSchemaVersion("cursor.subscribe"),
             ).toBe(null),
           WAIT,
+        );
+        await vi.waitFor(
+          () =>
+            expect(streamClient.getMethodSupport("cursor.subscribe")).toBe(
+              "unsupported",
+            ),
+          WAIT,
+        );
+        expect(streamClient.getMethodSchemaVersion("cursor.subscribe")).toBe(
+          null,
+        );
+
+        // And back: the method returns with the next ack, readable again and
+        // once more one identity across reads.
+        relay.dropCurrentConnection();
+        relay.streamManifest = buildStreamManifest(
+          cursorStreamRegistry,
+          SERVES_EVERY_INSTALLED_MAJOR,
         );
         await vi.waitFor(
           () =>

--- a/clients/shared/host-transport/remote/remote-session.ts
+++ b/clients/shared/host-transport/remote/remote-session.ts
@@ -618,6 +618,23 @@ interface ActiveConnection {
  */
 let nextRemoteEvidenceScope = 0;
 
+type StreamMethodCapability = {
+  readonly support: StreamMethodSupport;
+  readonly schemaVersion: SchemaVersion | null;
+};
+
+// Module constants, not literals at the return sites: the verdict is read as
+// a `useSyncExternalStore` snapshot, so even the "nothing known" answers must
+// keep one identity across reads.
+const UNKNOWN_STREAM_METHOD_CAPABILITY: StreamMethodCapability = {
+  support: "unknown",
+  schemaVersion: null,
+};
+const UNSUPPORTED_STREAM_METHOD_CAPABILITY: StreamMethodCapability = {
+  support: "unsupported",
+  schemaVersion: null,
+};
+
 export class RemoteSession<
   RpcRegistry extends VersionedRpcRegistry,
   StreamRegistry extends VersionedStreamRpcRegistry,
@@ -626,6 +643,20 @@ export class RemoteSession<
 {
   private readonly options: RemoteSessionOptions<RpcRegistry, StreamRegistry>;
   private readonly clientManifests: SessionManifests;
+  /**
+   * Per-method verdicts of {@link streamMethodCapability}, keyed on the host
+   * manifest object they were derived from. Everything else the verdict
+   * reads (`options.streamRegistry`, `clientManifests`) is fixed for the
+   * session's life, so the manifest object is the whole input. It is also
+   * the same clock the method-support listeners run on: `handleOpenAck`
+   * installs a new manifest and notifies, `teardownConnection` drops it and
+   * notifies - so a cached verdict can only change when a listener is told
+   * it changed. No explicit invalidation: a new manifest misses the cache.
+   */
+  private streamMethodCapabilityCache: {
+    readonly hostManifest: SessionManifests;
+    readonly byMethod: Map<string, StreamMethodCapability>;
+  } | null = null;
   /** `clientManifests.rpc` + `.optionalRpc` merged - the dispatch view. */
   private readonly clientRpcMerged: ConnectionManifest;
   /**
@@ -2877,15 +2908,42 @@ export class RemoteSession<
    * without opening a stream. A remote session has one peer manifest, so this
    * is the exact answer a fresh subscription would reach on its current
    * connection.
+   *
+   * Answered from {@link streamMethodCapabilityCache}, and the cache is for
+   * IDENTITY, not speed. `getMethodSupport` / `getMethodSchemaVersion` are
+   * read as `useSyncExternalStore` snapshots (gui-app's
+   * `useStreamMethodValueForClient`), and a snapshot has to hold one identity
+   * between notifications: React re-reads it after every commit, treats a
+   * fresh object as a change, commits again and reads again - fifty deep and
+   * it throws #185. `selectConnectionManifestForPeer` builds a new entry per
+   * call, so the client-canonical half of the answer below was a new object on
+   * every read whenever it won the minor comparison, which is whenever the
+   * host is at least as new as this client. The Start Page renders one such
+   * reader per remote host and crashed on open.
    */
-  private streamMethodCapability(method: string): {
-    readonly support: StreamMethodSupport;
-    readonly schemaVersion: SchemaVersion | null;
-  } {
+  private streamMethodCapability(method: string): StreamMethodCapability {
     const hostManifest = this.connection?.hostManifest;
     if (hostManifest === null || hostManifest === undefined) {
-      return { support: "unknown", schemaVersion: null };
+      return UNKNOWN_STREAM_METHOD_CAPABILITY;
     }
+    let cache = this.streamMethodCapabilityCache;
+    if (cache === null || cache.hostManifest !== hostManifest) {
+      cache = { hostManifest, byMethod: new Map() };
+      this.streamMethodCapabilityCache = cache;
+    }
+    const cached = cache.byMethod.get(method);
+    if (cached !== undefined) {
+      return cached;
+    }
+    const computed = this.computeStreamMethodCapability(hostManifest, method);
+    cache.byMethod.set(method, computed);
+    return computed;
+  }
+
+  private computeStreamMethodCapability(
+    hostManifest: SessionManifests,
+    method: string,
+  ): StreamMethodCapability {
     const selectedClientManifest = selectConnectionManifestForPeer(
       this.options.streamRegistry,
       this.clientManifests.stream,
@@ -2894,7 +2952,7 @@ export class RemoteSession<
     const clientCanonical = selectedClientManifest[method];
     const hostCanonical = hostManifest.stream[method];
     if (clientCanonical === undefined || hostCanonical === undefined) {
-      return { support: "unsupported", schemaVersion: null };
+      return UNSUPPORTED_STREAM_METHOD_CAPABILITY;
     }
     const compatibility = checkStreamMethodCompatibility(
       this.options.streamRegistry,
@@ -2904,7 +2962,7 @@ export class RemoteSession<
       method,
     );
     if (!compatibility.ok) {
-      return { support: "unsupported", schemaVersion: null };
+      return UNSUPPORTED_STREAM_METHOD_CAPABILITY;
     }
     // `prepareStreamSubscribeRequest` declares the older same-major minor.
     // Compatibility above proved that either canonical can be selected safely;


### PR DESCRIPTION
## The Start Page crash on `1.3.1-staging.19`, pinned

React #185 ("Maximum update depth exceeded") on opening the landing page, on every machine with a remote host that is at least as new as the desktop. Production React 19 emits no component stack, so this was pinned over CDP instead: relaunch the staging app with `--remote-debugging-port`, set a conditional breakpoint inside React's `updateStoreInstance` (`!Object.is(nextSnapshot, getSnapshot())`), and on each hit read `[[FunctionLocation]]` of the `getSnapshot` closure and of the owning fiber's component.

| hits before `#185` | `getSnapshot` | owner |
| --- | --- | --- |
| **52, consecutive** | `useStreamMethodValueForClient` (`stream-runtime-context.ts`) reading `getMethodSchemaVersion("terminal.subscribe")` | `LandingTerminalAuthorityFleet`'s per-host entry → `usePlainTerminalAuthority` |
| 1–5 each | TanStack Query `getCurrentResult`, zustand selectors, a closed-stream read | real transitions |

Every one of the 52 reads returned `{ major: 2, minor: 1, supportedMajors: [1, 2] }` — the same value with a fresh `supportedMajors` array. Deep-equal, never identical.

## Mechanism

`RemoteSession.streamMethodCapability` called `selectConnectionManifestForPeer(...)` on every read. That helper **builds** a manifest entry per method per call. The verdict then returns that fresh entry as the schema version whenever `clientCanonical.minor <= hostCanonical.minor`, and the stable `hostCanonical` object (off the parsed host manifest) otherwise. So:

- host **older** than the client → stable object → fine;
- host **equal or newer** → fresh object per read → `useSyncExternalStore` sees a new snapshot after every commit → commits again → 50 deep → `#185`.

That version relationship is why it looked like the desktop/host update cutover, and why "even `.19` host still crashes": equal minors pick the client half. The local ws client answers from a `Map` and never had this; the landing fleet mounts one reader **per remote host**.

## Fix

Cache the verdict per method, keyed on the host manifest object. The manifest is the verdict's only non-constant input (`options.streamRegistry` and `clientManifests` are fixed for the session), and it is installed at `handleOpenAck` and dropped at `teardownConnection` — both of which notify the method-support listeners — so a cached verdict can only change when a listener is told it changed. The `unknown` / `unsupported` answers become module constants for the same reason. No explicit invalidation: a new manifest misses the cache.

One sentence added to `useStreamMethodValueForClient`'s comment naming the client-side half of the contract.

## Test

`answers repeated capability reads with one identity until the manifest moves` (`remote-session.test.ts`): same registry on both peers so the client half wins, read the version twice, require `toBe`; drop the connection, wait for `null`, wait for the re-ack, require `toBe` again.

Falsifier run against the previous `remote-session.ts` under this test:

```
× answers repeated capability reads with one identity until the manifest moves
AssertionError: expected { major: 1, minor: +0, …(1) } to be { major: 1, minor: +0, …(1) } // Object.is equality
Received: serializes to the same string
```

The pre-existing `toEqual` pin two tests up could never see this class.

## Not this bug

#1823 bounded the browser-sessions retry sweep. That was a real latent loop, but it was not this one; the CDP run was on the pre-#1823 bundle and the sweep never appeared in the hit table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
