### PR TITLE
fix(gui-app): log the component stack when a route error reaches RouteErrorComponent

### DIFF
--- a/clients/gui-app/src/components/errors/__tests__/route-error-component.test.tsx
+++ b/clients/gui-app/src/components/errors/__tests__/route-error-component.test.tsx
@@ -1,16 +1,23 @@
 import { StrictMode } from "react";
 import { cleanup, render } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { appLogger } from "@/lib/logger";
+import type {
+  ReportIssueErrorCapture,
+  ReportIssueErrorCaptureInput,
+} from "@/lib/report-issue-error-capture";
 
+// Derived from the input so the log assertions below see the stack the
+// component forwarded, not a constant the mock would echo for any input.
 const captureReportIssueError = vi.hoisted(() =>
-  vi.fn(() => ({
+  vi.fn((input: ReportIssueErrorCaptureInput): ReportIssueErrorCapture => ({
     cause: {
       type: "Error",
       message: "route failed",
       stack: null,
-      componentStack: null,
+      componentStack: input.componentStack,
       errorCode: null,
-      sourceAction: "Route error",
+      sourceAction: input.sourceAction,
       timestamp: 1,
     },
     correlationId: "correlation-1",
@@ -19,6 +26,8 @@ const captureReportIssueError = vi.hoisted(() =>
   })),
 );
 
+const errorSummary = vi.hoisted(() => vi.fn<typeof appLogger.errorSummary>());
+
 vi.mock("@tanstack/react-router", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@tanstack/react-router")>()),
   useRouter: () => ({ navigate: vi.fn() }),
@@ -26,6 +35,11 @@ vi.mock("@tanstack/react-router", async (importOriginal) => ({
 
 vi.mock("@/lib/report-issue-error-capture", () => ({
   captureReportIssueError,
+}));
+
+vi.mock("@/lib/logger", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/logger")>()),
+  appLogger: { errorSummary, info: vi.fn(), warn: vi.fn() },
 }));
 
 vi.mock("@/components/errors/app-error-screen", () => ({
@@ -37,6 +51,7 @@ import { RouteErrorComponent } from "@/components/errors/route-error-component";
 afterEach(() => {
   cleanup();
   captureReportIssueError.mockClear();
+  errorSummary.mockClear();
 });
 
 describe("<RouteErrorComponent />", () => {
@@ -72,5 +87,52 @@ describe("<RouteErrorComponent />", () => {
       errorCode: null,
       sourceAction: "Route error",
     });
+  });
+
+  it("logs the component stack once per occurrence under StrictMode", () => {
+    // A production React build reduces a render loop to "Minified React error
+    // #185" with no component name, so the stack the router hands over is
+    // the only thing that says which route component crashed. It must reach
+    // the desktop log, not only Sentry - and once, like the Sentry capture.
+    const error = new Error("Minified React error #185");
+    const componentStack = "\n    at LandingTerminalFleet\n    at StartPage";
+    render(
+      <StrictMode>
+        <RouteErrorComponent
+          error={error}
+          info={{ componentStack }}
+          reset={() => undefined}
+        />
+      </StrictMode>,
+    );
+
+    expect(captureReportIssueError).toHaveBeenCalledWith({
+      error,
+      componentStack,
+      errorCode: null,
+      sourceAction: "Route error",
+    });
+    expect(errorSummary).toHaveBeenCalledTimes(1);
+    expect(errorSummary).toHaveBeenCalledWith(
+      "[renderer] route error reached RouteErrorComponent",
+      { componentStack },
+      error,
+    );
+  });
+
+  it("still logs a route failure the router hands over without a stack", () => {
+    const error = new Error("loader failed");
+    render(
+      <StrictMode>
+        <RouteErrorComponent error={error} reset={() => undefined} />
+      </StrictMode>,
+    );
+
+    expect(errorSummary).toHaveBeenCalledTimes(1);
+    expect(errorSummary).toHaveBeenCalledWith(
+      "[renderer] route error reached RouteErrorComponent",
+      { componentStack: null },
+      error,
+    );
   });
 });

--- a/clients/gui-app/src/components/errors/route-error-component.tsx
+++ b/clients/gui-app/src/components/errors/route-error-component.tsx
@@ -1,6 +1,7 @@
 import { useState, type ReactNode } from "react";
 import { useRouter, type ErrorComponentProps } from "@tanstack/react-router";
 import { AppErrorScreen } from "@/components/errors/app-error-screen";
+import { appLogger } from "@/lib/logger";
 import {
   captureReportIssueError,
   type ReportIssueErrorCapture,
@@ -31,6 +32,16 @@ function captureRouteError(
     sourceAction: "Route error",
   });
   captureByOccurrence.set(props, capture);
+  // Logged here, on the once-per-occurrence path, and not only sent to Sentry:
+  // a production React build strips the component name from a render-loop
+  // error ("Minified React error #185"), so the component stack is the only
+  // thing in the desktop log that says WHICH route component crashed - the
+  // same line `RootErrorBoundary` writes for a crash above the route tree.
+  appLogger.errorSummary(
+    "[renderer] route error reached RouteErrorComponent",
+    { componentStack: capture.cause.componentStack },
+    props.error,
+  );
   return capture;
 }
 


### PR DESCRIPTION
## What

`RouteErrorComponent` (the router's `defaultErrorComponent`) now writes the caught error and its component stack to the desktop log through `appLogger.errorSummary`, the same line `RootErrorBoundary` already writes for a crash above the route tree.

## Why

Everything thrown inside the route tree lands on `RouteErrorComponent`, which forwarded the component stack to Sentry only. A production React build reduces a render loop to `Minified React error #185` with no component name, so the six Start Page crashes on `1.3.1-staging.19` left a bare minified message in the desktop log and nothing that said which route component was looping. The root cause (#1827) had to be pinned over CDP instead of read from the log.

## How

- The log is emitted from the once-per-occurrence capture path (the `WeakMap` keyed by the props object), so it fires once under StrictMode like the Sentry capture does.
- The test's mocked capture now derives from its input so the assertion sees the stack the component forwarded, not a constant. Two new cases pin one log per occurrence with and without a router-supplied stack.

Falsified before pushing: dropping the log fails both new cases on 0 calls; logging outside the dedupe gate fails them on 2 calls.

Companion to #1827 (the loop itself). Independent of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
