### PR TITLE
fix(gui-app): reachable toast close button on touch and top placement on mobile

### DIFF
--- a/clients/gui-app/scripts/boot-escape-hatch-press-browser.mjs
+++ b/clients/gui-app/scripts/boot-escape-hatch-press-browser.mjs
@@ -74,6 +74,7 @@ try {
   const launched = await launchChromeWithDevTools(
     chromePath,
     "traycer-boot-press-",
+    [],
   );
   chrome = launched.chrome;
   chromeProfilePath = launched.profilePath;

--- a/clients/gui-app/scripts/chrome-launcher.mjs
+++ b/clients/gui-app/scripts/chrome-launcher.mjs
@@ -74,8 +74,16 @@ export async function findChrome(purpose) {
  *
  * `profilePrefix` is the `mkdtemp` prefix for this driver's profile
  * directories, so a stray temp dir names the driver that leaked it.
+ *
+ * `extraArgs` are appended to the fixed flags, for a driver whose premise
+ * depends on something the runner would otherwise decide - the input
+ * devices Chrome reports, for one. Pass `[]` for none.
  */
-export async function launchChromeWithDevTools(chromePath, profilePrefix) {
+export async function launchChromeWithDevTools(
+  chromePath,
+  profilePrefix,
+  extraArgs,
+) {
   const chromeEnv = { ...process.env };
   delete chromeEnv.DBUS_SESSION_BUS_ADDRESS;
   const attempts = 3;
@@ -97,6 +105,7 @@ export async function launchChromeWithDevTools(chromePath, profilePrefix) {
         "--no-sandbox",
         "--remote-debugging-port=0",
         `--user-data-dir=${profilePath}`,
+        ...extraArgs,
         "about:blank",
       ],
       { env: chromeEnv, stdio: ["ignore", "ignore", "pipe"], detached: true },

--- a/clients/gui-app/scripts/destructive-dialog-focus-browser.mjs
+++ b/clients/gui-app/scripts/destructive-dialog-focus-browser.mjs
@@ -68,6 +68,7 @@ try {
   const launched = await launchChromeWithDevTools(
     chromePath,
     "traycer-dialog-focus-",
+    [],
   );
   chrome = launched.chrome;
   chromeProfilePath = launched.profilePath;

--- a/clients/gui-app/scripts/diff-edit-browser-regression.mjs
+++ b/clients/gui-app/scripts/diff-edit-browser-regression.mjs
@@ -58,6 +58,7 @@ try {
   const launched = await launchChromeWithDevTools(
     chromePath,
     "traycer-diff-edit-",
+    [],
   );
   chrome = launched.chrome;
   chromeProfilePath = launched.profilePath;

--- a/clients/gui-app/scripts/quit-intercept-cancel-browser.mjs
+++ b/clients/gui-app/scripts/quit-intercept-cancel-browser.mjs
@@ -68,6 +68,7 @@ try {
   const launched = await launchChromeWithDevTools(
     chromePath,
     "traycer-quit-cancel-",
+    [],
   );
   chrome = launched.chrome;
   chromeProfilePath = launched.profilePath;

--- a/clients/gui-app/scripts/run-tests.ts
+++ b/clients/gui-app/scripts/run-tests.ts
@@ -140,6 +140,12 @@ if (runsFirstShard) {
     // `onClick` turns this red (0 activations) while its ordinary-click
     // premise stays green.
     runBrowserRegression("scripts/boot-escape-hatch-press-browser.mjs");
+    // Same gate: the toast close button's touch visibility is a MEDIA-QUERY
+    // question and jsdom evaluates none, so a jsdom test sees identical class
+    // names on a phone and a desktop. Ablated before wiring: an unscoped
+    // hide, a missing hit area and a missing mobile-app offset each turn it
+    // red.
+    runBrowserRegression("scripts/toast-close-button-touch-browser.mjs");
     // NOT here, deliberately, and each for its own reason:
     // - `scripts/window-host-modal-alignment-browser.mjs` measures the
     //   local-bootstrap body against ONE LEFT EDGE (A1/A2/A5/PC4) - the design

--- a/clients/gui-app/scripts/toast-close-button-touch-browser.mjs
+++ b/clients/gui-app/scripts/toast-close-button-touch-browser.mjs
@@ -1,0 +1,418 @@
+// Browser regression for the toast close button on touch devices, and for
+// where the toaster sits in the installed mobile app.
+//
+// jsdom cannot answer either: it evaluates no media queries, so a class scoped
+// to `(hover: none) and (pointer: coarse)` looks the same on every device, and
+// it has no layout, so an offset written as a CSS `calc()` is never resolved.
+// This renders the real `Toaster` against the real stylesheet and flips the
+// media query with Chrome's touch emulation, which switches both `hover` and
+// `pointer` exactly as a phone reports them.
+//
+// Structure follows `destructive-dialog-focus-browser.mjs` (vite + headless
+// Chrome over CDP); wired into `scripts/run-tests.ts` behind
+// RUN_DIFF_EDIT_BROWSER_REGRESSION, which CI sets for this package.
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { rm } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { createServer as createTcpServer } from "node:net";
+import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { fileURLToPath } from "node:url";
+import {
+  findChrome,
+  launchChromeWithDevTools,
+  terminateProcessTree,
+} from "./chrome-launcher.mjs";
+
+const projectRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+const fixtureUrlPath = "/src/__tests__/browser/toast-close-button-touch.html";
+const chromePath = await findChrome("the toast close-button touch regression");
+const vitePort = await freePort();
+const TOUCH_QUERY = "(hover: none) and (pointer: coarse)";
+const CLOSE_BUTTON =
+  '[data-sonner-toast][data-mounted="true"] [data-close-button]';
+// Sonner's 20px close glyph, grown to a 44px hit area on touch.
+const TOUCH_HIT_AREA_PX = 44;
+let chrome;
+let chromeProfilePath;
+let client;
+let viteProcess;
+
+try {
+  const pageUrl = `http://127.0.0.1:${vitePort}${fixtureUrlPath}`;
+  const requireFromHere = createRequire(import.meta.url);
+  const viteManifestPath = requireFromHere.resolve("vite/package.json");
+  const viteManifest = requireFromHere(viteManifestPath);
+  const viteEntry = path.resolve(
+    path.dirname(viteManifestPath),
+    viteManifest.bin.vite,
+  );
+  viteProcess = spawn(
+    "node",
+    [
+      viteEntry,
+      "--config",
+      path.join(projectRoot, "vitest.config.ts"),
+      "--host",
+      "127.0.0.1",
+      "--port",
+      String(vitePort),
+      "--strictPort",
+    ],
+    { cwd: projectRoot, stdio: ["ignore", "ignore", "pipe"] },
+  );
+  let viteError = "";
+  viteProcess.stderr.setEncoding("utf8");
+  viteProcess.stderr.on("data", (chunk) => {
+    viteError += chunk;
+  });
+  await waitForHttp(pageUrl, viteProcess, () => viteError, "Vite");
+
+  const launched = await launchChromeWithDevTools(
+    chromePath,
+    "traycer-toast-touch-",
+  );
+  chrome = launched.chrome;
+  chromeProfilePath = launched.profilePath;
+  const devtoolsUrl = launched.devtoolsHttpUrl;
+  await waitForHttp(
+    new URL("/json/version", devtoolsUrl).href,
+    chrome,
+    launched.readError,
+    "Chrome DevTools",
+  );
+  const targetResponse = await fetch(
+    new URL(`/json/new?${encodeURIComponent(pageUrl)}`, devtoolsUrl),
+    { method: "PUT" },
+  );
+  if (!targetResponse.ok) {
+    throw new Error(
+      `Chrome could not open the fixture: ${targetResponse.status}`,
+    );
+  }
+  const target = await targetResponse.json();
+  client = await connectCdp(target.webSocketDebuggerUrl);
+  await client.send("Runtime.enable");
+  await client.send("Page.enable");
+  await client.send("Emulation.setDeviceMetricsOverride", {
+    width: 1200,
+    height: 800,
+    deviceScaleFactor: 1,
+    mobile: false,
+  });
+  await waitForToast(client);
+
+  // --- Desktop: hidden until hover, exactly as before. ---
+  await moveMouse(client, 5, 5);
+  const desktop = await readCloseButton(client);
+  assert.equal(
+    desktop.touchQuery,
+    false,
+    "desktop arm must not match the touch query",
+  );
+  assert.equal(
+    desktop.position,
+    "bottom-right",
+    "desktop toaster must keep its default anchor",
+  );
+  assert.equal(
+    desktop.opacity,
+    "0",
+    "desktop close button must be hidden until hover",
+  );
+  assert.equal(
+    desktop.pointerEvents,
+    "none",
+    "a hidden desktop close button must not take clicks",
+  );
+  assert.equal(
+    desktop.hitNearCorner,
+    false,
+    "desktop close button must not grow a touch hit area",
+  );
+
+  await moveMouse(client, desktop.toastCenter.x, desktop.toastCenter.y);
+  const hovered = await readCloseButton(client);
+  assert.equal(
+    hovered.opacity,
+    "1",
+    "hovering the toast must reveal the close button",
+  );
+  assert.equal(
+    hovered.pointerEvents,
+    "auto",
+    "a revealed close button must take clicks",
+  );
+  await moveMouse(client, 5, 5);
+
+  // --- Touch: sonner's own always-visible default stands. ---
+  await client.send("Emulation.setTouchEmulationEnabled", {
+    enabled: true,
+    maxTouchPoints: 5,
+  });
+  const touch = await readCloseButton(client);
+  assert.equal(
+    touch.touchQuery,
+    true,
+    `touch emulation must match ${TOUCH_QUERY}`,
+  );
+  assert.equal(
+    touch.opacity,
+    "1",
+    "the close button must be visible without hover on touch",
+  );
+  assert.equal(
+    touch.pointerEvents,
+    "auto",
+    "the close button must be tappable on touch",
+  );
+  assert.equal(
+    touch.glyphWidth,
+    desktop.glyphWidth,
+    "the touch hit area must not change the glyph's size",
+  );
+  assert.equal(touch.hitAreaWidth, TOUCH_HIT_AREA_PX, "touch hit area width");
+  assert.equal(touch.hitAreaHeight, TOUCH_HIT_AREA_PX, "touch hit area height");
+  assert.equal(
+    touch.hitNearCorner,
+    true,
+    "a tap just outside the glyph must land on the close button",
+  );
+
+  await client.send("Emulation.setTouchEmulationEnabled", { enabled: false });
+  const desktopAgain = await readCloseButton(client);
+  assert.equal(
+    desktopAgain.opacity,
+    "0",
+    "leaving touch must restore the hover-only close button",
+  );
+
+  // --- Installed mobile app: top-center, below the header. ---
+  await client.send("Emulation.setTouchEmulationEnabled", {
+    enabled: true,
+    maxTouchPoints: 5,
+  });
+  const placements = [];
+  for (const viewport of [
+    // Portrait reads sonner's `mobileOffset` (<=600px) ...
+    { width: 390, height: 844 },
+    // ... and landscape its `offset`, so both must carry the header offset.
+    { width: 844, height: 390 },
+  ]) {
+    await client.send("Emulation.setDeviceMetricsOverride", {
+      ...viewport,
+      deviceScaleFactor: 1,
+      mobile: true,
+    });
+    await client.send("Page.navigate", { url: `${pageUrl}?mobile-app=1` });
+    await waitForToast(client);
+    const mobile = await readCloseButton(client);
+    const label = `${viewport.width}x${viewport.height}`;
+    assert.equal(
+      mobile.position,
+      "top-center",
+      `mobile app toaster anchor at ${label}`,
+    );
+    // No device insets headless, so the header's bottom edge is its 2.5rem
+    // height and the toaster's top is that plus the 1.25rem gap.
+    assert.equal(
+      mobile.toasterTop,
+      mobile.rootFontPx * 3.75,
+      `mobile app toaster top at ${label}`,
+    );
+    assert.ok(
+      mobile.hitAreaTop >= mobile.rootFontPx * 2.5,
+      `the close button's hit area must stay clear of the header at ${label} (hit area top ${mobile.hitAreaTop})`,
+    );
+    assert.equal(
+      mobile.opacity,
+      "1",
+      `mobile app close button visible at ${label}`,
+    );
+    placements.push(
+      `${label} top=${mobile.toasterTop} hitTop=${mobile.hitAreaTop}`,
+    );
+  }
+
+  console.log(
+    "toast close-button touch regression passed: desktop hidden/hover-revealed, touch visible with a 44px hit area, mobile app " +
+      placements.join(", "),
+  );
+} catch (error) {
+  console.error("MEASUREMENT FAILED:", error);
+  process.exitCode = 1;
+} finally {
+  client?.close();
+  if (chrome !== undefined) {
+    await terminateProcessTree(chrome);
+  }
+  viteProcess?.kill("SIGTERM");
+  if (chromeProfilePath !== undefined) {
+    await rm(chromeProfilePath, {
+      recursive: true,
+      force: true,
+      maxRetries: 3,
+    });
+  }
+}
+
+async function waitForToast(client) {
+  await waitFor(
+    client,
+    "the toast to mount",
+    `document.querySelector(${JSON.stringify(CLOSE_BUTTON)}) !== null`,
+  );
+  // Sonner's enter transition is 400ms; read styles once it has finished.
+  await evaluate(client, `new Promise((r) => setTimeout(r, 600))`);
+}
+
+async function moveMouse(client, x, y) {
+  await client.send("Input.dispatchMouseEvent", { type: "mouseMoved", x, y });
+  await settle(client);
+}
+
+async function readCloseButton(client) {
+  await settle(client);
+  return evaluate(
+    client,
+    `(() => {
+       const button = document.querySelector(${JSON.stringify(CLOSE_BUTTON)});
+       const toast = button.closest("[data-sonner-toast]");
+       const toaster = button.closest("[data-sonner-toaster]");
+       const style = getComputedStyle(button);
+       const after = getComputedStyle(button, "::after");
+       const glyph = button.getBoundingClientRect();
+       const toastRect = toast.getBoundingClientRect();
+       const hitAreaHeight = parseFloat(after.height) || 0;
+       const centerX = glyph.left + glyph.width / 2;
+       const centerY = glyph.top + glyph.height / 2;
+       // Inside a 44px square around the glyph, outside the 20px glyph.
+       const probe = document.elementFromPoint(centerX + 18, centerY + 18);
+       return {
+         touchQuery: matchMedia(${JSON.stringify(TOUCH_QUERY)}).matches,
+         position: toaster.dataset.yPosition + "-" + toaster.dataset.xPosition,
+         opacity: style.opacity,
+         pointerEvents: style.pointerEvents,
+         glyphWidth: glyph.width,
+         hitAreaWidth: parseFloat(after.width) || 0,
+         hitAreaHeight,
+         hitAreaTop: centerY - hitAreaHeight / 2,
+         hitNearCorner: probe !== null && probe.closest("[data-close-button]") === button,
+         toastCenter: {
+           x: toastRect.left + toastRect.width / 2,
+           y: toastRect.top + toastRect.height / 2,
+         },
+         toasterTop: toaster.getBoundingClientRect().top,
+         rootFontPx: parseFloat(getComputedStyle(document.documentElement).fontSize),
+       };
+     })()`,
+  );
+}
+
+function settle(client) {
+  return evaluate(client, `new Promise((r) => setTimeout(r, 250))`);
+}
+
+function freePort() {
+  return new Promise((resolve, reject) => {
+    const server = createTcpServer();
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      const port =
+        typeof address === "object" && address !== null ? address.port : 0;
+      server.close(() => resolve(port));
+    });
+  });
+}
+
+async function waitForHttp(url, child, readError, label) {
+  const deadline = Date.now() + 60_000;
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null) {
+      throw new Error(`${label} exited early: ${readError()}`);
+    }
+    try {
+      const response = await fetch(url);
+      if (response.ok) return;
+    } catch {
+      // not up yet
+    }
+    await delay(150);
+  }
+  throw new Error(`${label} did not become reachable: ${readError()}`);
+}
+
+function connectCdp(url) {
+  return new Promise((resolve, reject) => {
+    const socket = new WebSocket(url);
+    const pending = new Map();
+    let nextId = 0;
+    const connectTimer = setTimeout(
+      () => reject(new Error("CDP connect timed out")),
+      15_000,
+    );
+    socket.addEventListener("error", (event) =>
+      reject(new Error(String(event))),
+    );
+    socket.addEventListener("message", (event) => {
+      const message = JSON.parse(String(event.data));
+      if (typeof message.id !== "number") return;
+      const request = pending.get(message.id);
+      if (request === undefined) return;
+      pending.delete(message.id);
+      if (message.error === undefined) request.resolve(message.result);
+      else request.reject(new Error(message.error.message));
+    });
+    socket.addEventListener("open", () => {
+      clearTimeout(connectTimer);
+      resolve({
+        send(method, params = {}) {
+          return new Promise((requestResolve, requestReject) => {
+            const id = ++nextId;
+            pending.set(id, { resolve: requestResolve, reject: requestReject });
+            socket.send(JSON.stringify({ id, method, params }));
+          });
+        },
+        close() {
+          socket.close();
+        },
+      });
+    });
+  });
+}
+
+async function evaluate(client, expression) {
+  const response = await client.send("Runtime.evaluate", {
+    expression,
+    awaitPromise: true,
+    returnByValue: true,
+  });
+  if (response.exceptionDetails !== undefined) {
+    throw new Error(
+      response.exceptionDetails.exception?.description ??
+        response.exceptionDetails.text ??
+        "Browser evaluation failed",
+    );
+  }
+  return response.result.value;
+}
+
+async function waitFor(client, label, expression) {
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    if (await evaluate(client, expression)) return;
+    await delay(50);
+  }
+  const pageState = await evaluate(
+    client,
+    `({ text: document.body.innerText, html: document.body.innerHTML.slice(0, 3000) })`,
+  );
+  throw new Error(
+    `Timed out waiting for ${label}:\n${JSON.stringify(pageState, null, 2)}`,
+  );
+}

--- a/clients/gui-app/scripts/toast-close-button-touch-browser.mjs
+++ b/clients/gui-app/scripts/toast-close-button-touch-browser.mjs
@@ -33,6 +33,16 @@ const fixtureUrlPath = "/src/__tests__/browser/toast-close-button-touch.html";
 const chromePath = await findChrome("the toast close-button touch regression");
 const vitePort = await freePort();
 const TOUCH_QUERY = "(pointer: coarse)";
+// The desktop arms need a mouse, and headless Chrome otherwise reports
+// whatever input devices the host has: a CI runner with none reports
+// `hover: none` / `pointer: none`, under which Tailwind's `group-hover:`
+// never applies and the hover arm can only fail. Pin a fine, hovering
+// pointer so the premise belongs to this driver, not to the runner. (Blink's
+// hover/pointer enums: hover 2 = hover; pointer 4 = fine.) Touch emulation
+// still overrides these while it is on.
+const MOUSE_INPUT_ARGS = [
+  "--blink-settings=primaryHoverType=2,availableHoverTypes=2,primaryPointerType=4,availablePointerTypes=4",
+];
 const CLOSE_BUTTON =
   '[data-sonner-toast][data-mounted="true"][data-front="true"] [data-close-button]';
 // The header's icon buttons get a 44px hit area on touch
@@ -79,6 +89,7 @@ try {
   const launched = await launchChromeWithDevTools(
     chromePath,
     "traycer-toast-touch-",
+    MOUSE_INPUT_ARGS,
   );
   chrome = launched.chrome;
   chromeProfilePath = launched.profilePath;
@@ -113,6 +124,11 @@ try {
   // --- Desktop: hidden until hover, exactly as before. ---
   await moveMouse(client, 5, 5);
   const desktop = await readCloseButton(client);
+  assert.equal(
+    desktop.hoverQuery,
+    true,
+    "desktop arm premise: Chrome must report a hovering pointer",
+  );
   assert.equal(
     desktop.touchQuery,
     false,
@@ -223,7 +239,7 @@ try {
       deviceScaleFactor: 1,
       mobile: true,
     });
-    await client.send("Page.navigate", { url: `${pageUrl}?mobile-app=1` });
+    await navigate(client, `${pageUrl}?mobile-app=1`);
     await waitForToast(client);
     const mobile = await readCloseButton(client);
     const label = `${viewport.width}x${viewport.height}`;
@@ -344,6 +360,39 @@ async function assertCollapsedStackInert(client, label) {
   return "collapsed stack inert";
 }
 
+/**
+ * Navigates and returns once the NEW document is the one being evaluated.
+ * `Page.navigate` answers before the old document is gone, and both documents
+ * show a toast, so polling for the toast alone could read the old one - or
+ * lose its context mid-read. The old document carries a marker the new one
+ * cannot have, and a context destroyed by the navigation is retried.
+ */
+async function navigate(client, url) {
+  await evaluate(client, "window.__probeStaleDocument = true");
+  await client.send("Page.navigate", { url });
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    try {
+      const ready = await evaluate(
+        client,
+        `window.__probeStaleDocument !== true && document.readyState === "complete"`,
+      );
+      if (ready) return;
+    } catch (error) {
+      if (!isNavigationContextError(error)) throw error;
+    }
+    await delay(50);
+  }
+  throw new Error(`Timed out waiting for the navigation to ${url}`);
+}
+
+function isNavigationContextError(error) {
+  const message = error instanceof Error ? error.message : String(error);
+  return /context was destroyed|Cannot find context|Inspected target navigated/i.test(
+    message,
+  );
+}
+
 async function waitForToast(client) {
   await waitFor(
     client,
@@ -378,6 +427,7 @@ async function readCloseButton(client) {
        const probe = document.elementFromPoint(centerX + 18, centerY + 18);
        return {
          touchQuery: matchMedia(${JSON.stringify(TOUCH_QUERY)}).matches,
+         hoverQuery: matchMedia("(hover: hover)").matches,
          position: toaster.dataset.yPosition + "-" + toaster.dataset.xPosition,
          opacity: style.opacity,
          pointerEvents: style.pointerEvents,
@@ -436,12 +486,27 @@ function connectCdp(url) {
     const socket = new WebSocket(url);
     const pending = new Map();
     let nextId = 0;
+    let closedReason = null;
     const connectTimer = setTimeout(
       () => reject(new Error("CDP connect timed out")),
       15_000,
     );
+    // A socket that errors or closes mid-run must fail every outstanding
+    // request: `run-tests.ts` spawns this script without a timeout, so a
+    // request left unsettled would hold the CI job until its own timeout
+    // and hide the real error.
+    const fail = (reason) => {
+      closedReason = reason;
+      clearTimeout(connectTimer);
+      for (const request of pending.values()) request.reject(reason);
+      pending.clear();
+      reject(reason);
+    };
     socket.addEventListener("error", (event) =>
-      reject(new Error(String(event))),
+      fail(new Error(`CDP socket error: ${String(event)}`)),
+    );
+    socket.addEventListener("close", () =>
+      fail(new Error("CDP socket closed before the run finished")),
     );
     socket.addEventListener("message", (event) => {
       const message = JSON.parse(String(event.data));
@@ -456,9 +521,23 @@ function connectCdp(url) {
       clearTimeout(connectTimer);
       resolve({
         send(method, params = {}) {
+          if (closedReason !== null) return Promise.reject(closedReason);
           return new Promise((requestResolve, requestReject) => {
             const id = ++nextId;
-            pending.set(id, { resolve: requestResolve, reject: requestReject });
+            const timer = setTimeout(() => {
+              pending.delete(id);
+              requestReject(new Error(`CDP ${method} timed out`));
+            }, 30_000);
+            pending.set(id, {
+              resolve: (result) => {
+                clearTimeout(timer);
+                requestResolve(result);
+              },
+              reject: (reason) => {
+                clearTimeout(timer);
+                requestReject(reason);
+              },
+            });
             socket.send(JSON.stringify({ id, method, params }));
           });
         },

--- a/clients/gui-app/scripts/toast-close-button-touch-browser.mjs
+++ b/clients/gui-app/scripts/toast-close-button-touch-browser.mjs
@@ -2,7 +2,7 @@
 // where the toaster sits in the installed mobile app.
 //
 // jsdom cannot answer either: it evaluates no media queries, so a class scoped
-// to `(hover: none) and (pointer: coarse)` looks the same on every device, and
+// to `(pointer: coarse)` looks the same on every device, and
 // it has no layout, so an offset written as a CSS `calc()` is never resolved.
 // This renders the real `Toaster` against the real stylesheet and flips the
 // media query with Chrome's touch emulation, which switches both `hover` and
@@ -32,7 +32,7 @@ const projectRoot = path.resolve(
 const fixtureUrlPath = "/src/__tests__/browser/toast-close-button-touch.html";
 const chromePath = await findChrome("the toast close-button touch regression");
 const vitePort = await freePort();
-const TOUCH_QUERY = "(hover: none) and (pointer: coarse)";
+const TOUCH_QUERY = "(pointer: coarse)";
 const CLOSE_BUTTON =
   '[data-sonner-toast][data-mounted="true"][data-front="true"] [data-close-button]';
 // The header's icon buttons get a 44px hit area on touch

--- a/clients/gui-app/scripts/toast-close-button-touch-browser.mjs
+++ b/clients/gui-app/scripts/toast-close-button-touch-browser.mjs
@@ -34,7 +34,11 @@ const chromePath = await findChrome("the toast close-button touch regression");
 const vitePort = await freePort();
 const TOUCH_QUERY = "(hover: none) and (pointer: coarse)";
 const CLOSE_BUTTON =
-  '[data-sonner-toast][data-mounted="true"] [data-close-button]';
+  '[data-sonner-toast][data-mounted="true"][data-front="true"] [data-close-button]';
+// The header's icon buttons get a 44px hit area on touch
+// (`mobile-shell-touch-targets.css`), centred on a 40px row, so it overhangs
+// the row's bottom edge by 2px.
+const HEADER_HIT_OVERHANG_PX = 2;
 // Sonner's 20px close glyph, grown to a 44px hit area on touch.
 const TOUCH_HIT_AREA_PX = 44;
 let chrome;
@@ -147,6 +151,13 @@ try {
     "auto",
     "a revealed close button must take clicks",
   );
+  // The resting desktop reading cannot tell: pointer-events none hides any
+  // hit area from the probe. Revealed, a leaked touch hit area would show.
+  assert.equal(
+    hovered.hitNearCorner,
+    false,
+    "a revealed desktop close button must not carry the touch hit area",
+  );
   await moveMouse(client, 5, 5);
 
   // --- Touch: sonner's own always-visible default stands. ---
@@ -181,6 +192,10 @@ try {
     touch.hitNearCorner,
     true,
     "a tap just outside the glyph must land on the close button",
+  );
+  const desktopWidthStack = await assertCollapsedStackInert(
+    client,
+    "1200x800 touch",
   );
 
   await client.send("Emulation.setTouchEmulationEnabled", { enabled: false });
@@ -218,14 +233,14 @@ try {
       `mobile app toaster anchor at ${label}`,
     );
     // No device insets headless, so the header's bottom edge is its 2.5rem
-    // height and the toaster's top is that plus the 1.25rem gap.
+    // height and the toaster's top is that plus the 1.5rem gap.
     assert.equal(
       mobile.toasterTop,
-      mobile.rootFontPx * 3.75,
+      mobile.rootFontPx * 4,
       `mobile app toaster top at ${label}`,
     );
     assert.ok(
-      mobile.hitAreaTop >= mobile.rootFontPx * 2.5,
+      mobile.hitAreaTop >= mobile.rootFontPx * 2.5 + HEADER_HIT_OVERHANG_PX,
       `the close button's hit area must stay clear of the header at ${label} (hit area top ${mobile.hitAreaTop})`,
     );
     assert.equal(
@@ -233,13 +248,16 @@ try {
       "1",
       `mobile app close button visible at ${label}`,
     );
+    const stack = await assertCollapsedStackInert(client, label);
     placements.push(
-      `${label} top=${mobile.toasterTop} hitTop=${mobile.hitAreaTop}`,
+      `${label} top=${mobile.toasterTop} hitTop=${mobile.hitAreaTop} ${stack}`,
     );
   }
 
   console.log(
-    "toast close-button touch regression passed: desktop hidden/hover-revealed, touch visible with a 44px hit area, mobile app " +
+    "toast close-button touch regression passed: desktop hidden/hover-revealed, touch visible with a 44px hit area (" +
+      desktopWidthStack +
+      "), mobile app " +
       placements.join(", "),
   );
 } catch (error) {
@@ -258,6 +276,72 @@ try {
       maxRetries: 3,
     });
   }
+}
+
+/**
+ * Stacks two newer toasts in front of the first and checks that the back
+ * toasts' close buttons - invisible, because sonner hides a collapsed stack's
+ * back toasts with `opacity: 0` alone - take no taps anywhere, including the
+ * strip where they peek out past the front toast.
+ */
+async function assertCollapsedStackInert(client, label) {
+  await evaluate(client, "window.__probeStackToasts()");
+  await waitFor(
+    client,
+    "the stacked toasts to mount",
+    `document.querySelectorAll('[data-sonner-toast][data-mounted="true"][data-front="false"]').length === 2`,
+  );
+  await evaluate(client, `new Promise((r) => setTimeout(r, 600))`);
+  const stack = await evaluate(
+    client,
+    `(() => {
+       const back = Array.from(
+         document.querySelectorAll('[data-sonner-toast][data-front="false"] [data-close-button]'),
+       );
+       const hits = [];
+       for (const button of back) {
+         const rect = button.getBoundingClientRect();
+         const centerX = rect.left + rect.width / 2;
+         const centerY = rect.top + rect.height / 2;
+         for (let dx = -24; dx <= 24; dx += 3) {
+           for (let dy = -24; dy <= 24; dy += 3) {
+             const hit = document
+               .elementFromPoint(centerX + dx, centerY + dy)
+               ?.closest("[data-close-button]");
+             if (hit !== undefined && hit !== null && back.includes(hit)) {
+               hits.push([Math.round(centerX + dx), Math.round(centerY + dy)]);
+             }
+           }
+         }
+       }
+       return {
+         count: back.length,
+         collapsed: back.every(
+           (button) => button.closest("[data-sonner-toast]").dataset.expanded === "false",
+         ),
+         pointerEvents: back.map((button) => getComputedStyle(button).pointerEvents),
+         hitCount: hits.length,
+         firstHits: hits.slice(0, 5),
+       };
+     })()`,
+  );
+  assert.equal(stack.count, 2, `two back toasts at ${label}`);
+  assert.equal(
+    stack.collapsed,
+    true,
+    `the stack must be collapsed at ${label}`,
+  );
+  assert.deepEqual(
+    stack.pointerEvents,
+    ["none", "none"],
+    `back toasts' close buttons must take no taps at ${label}`,
+  );
+  assert.equal(
+    stack.hitCount,
+    0,
+    `a tap must never land on a hidden back toast's close button at ${label} (hits at ${JSON.stringify(stack.firstHits)})`,
+  );
+  return "collapsed stack inert";
 }
 
 async function waitForToast(client) {

--- a/clients/gui-app/scripts/toast-over-modal-hittest.mjs
+++ b/clients/gui-app/scripts/toast-over-modal-hittest.mjs
@@ -62,6 +62,7 @@ try {
   const launched = await launchChromeWithDevTools(
     chromePath,
     "traycer-hittest-",
+    [],
   );
   chrome = launched.chrome;
   chromeProfilePath = launched.profilePath;

--- a/clients/gui-app/src/__tests__/browser/toast-close-button-touch.html
+++ b/clients/gui-app/src/__tests__/browser/toast-close-button-touch.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Toast close button - touch visibility and placement</title>
+    <style>
+      html,
+      body,
+      #root {
+        width: 100%;
+        height: 100%;
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./toast-close-button-touch.tsx"></script>
+  </body>
+</html>

--- a/clients/gui-app/src/__tests__/browser/toast-close-button-touch.tsx
+++ b/clients/gui-app/src/__tests__/browser/toast-close-button-touch.tsx
@@ -1,0 +1,38 @@
+import { useEffect } from "react";
+import { createRoot } from "react-dom/client";
+import { toast } from "sonner";
+import { Toaster } from "@/components/ui/sonner";
+import { setMobileApp } from "@/lib/mobile-app";
+import "@/index.css";
+
+/**
+ * Real-layout fixture for the toaster's touch behaviour: whether the close
+ * button is visible and tappable under sonner's touch media query, and where
+ * the toaster sits in the installed mobile app.
+ *
+ * jsdom evaluates no media queries and has no hit testing, so it can only
+ * check which class names are applied; this renders the real `Toaster`
+ * against the real stylesheet so the driver can read computed styles and
+ * `elementFromPoint` while Chrome's touch emulation flips the query.
+ *
+ * `?mobile-app=1` marks the page as the installed mobile app before the first
+ * render, the same way the phone entry does.
+ */
+export function ToastCloseButtonTouchFixture(): React.ReactElement {
+  useEffect(() => {
+    toast("Worktree deleted", {
+      id: "probe-toast",
+      description: "Swipe, wait, or tap the close button.",
+      duration: Infinity,
+    });
+  }, []);
+
+  return <Toaster />;
+}
+
+setMobileApp(
+  new URLSearchParams(window.location.search).get("mobile-app") === "1",
+);
+const container = document.querySelector("#root");
+if (container === null) throw new Error("probe root missing");
+createRoot(container).render(<ToastCloseButtonTouchFixture />);

--- a/clients/gui-app/src/__tests__/browser/toast-close-button-touch.tsx
+++ b/clients/gui-app/src/__tests__/browser/toast-close-button-touch.tsx
@@ -25,6 +25,18 @@ export function ToastCloseButtonTouchFixture(): React.ReactElement {
       description: "Swipe, wait, or tap the close button.",
       duration: Infinity,
     });
+    // Stacks two more behind it, for the collapsed-stack check. Driven from
+    // the page rather than on mount so the single-toast readings come first.
+    const probeWindow = window as Window & { __probeStackToasts?: () => void };
+    probeWindow.__probeStackToasts = () => {
+      for (const id of ["probe-toast-2", "probe-toast-3"]) {
+        toast("Draft kept", {
+          id,
+          description: "A newer toast in front of the first.",
+          duration: Infinity,
+        });
+      }
+    };
   }, []);
 
   return <Toaster />;

--- a/clients/gui-app/src/components/layout/header/__tests__/app-header-height.test.ts
+++ b/clients/gui-app/src/components/layout/header/__tests__/app-header-height.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import {
+  APP_HEADER_HEIGHT,
+  APP_HEADER_HEIGHT_CLASS,
+  BELOW_APP_HEADER_TOP_CLASS,
+} from "@/components/layout/header/app-header-height";
+
+// Tailwind's default spacing step; `h-10` is `calc(var(--spacing) * 10)`.
+const SPACING_STEP_REM = 0.25;
+
+describe("app header height", () => {
+  it("keeps the CSS length in step with the height and offset classes", () => {
+    const heightSteps = Number(APP_HEADER_HEIGHT_CLASS.replace(/^h-/, ""));
+    const topSteps = Number(BELOW_APP_HEADER_TOP_CLASS.replace(/^top-/, ""));
+
+    expect(topSteps).toBe(heightSteps);
+    expect(APP_HEADER_HEIGHT).toBe(`${heightSteps * SPACING_STEP_REM}rem`);
+  });
+});

--- a/clients/gui-app/src/components/layout/header/app-header-height.ts
+++ b/clients/gui-app/src/components/layout/header/app-header-height.ts
@@ -11,8 +11,11 @@
  * the whole viewport and once against the area under a 40px header moved 20px
  * at each hand-off.
  *
- * The two literals MUST agree; they are separate because Tailwind resolves
- * class names statically and `top-` and `h-` cannot share one token.
+ * The literals MUST agree; they are separate because Tailwind resolves
+ * class names statically and `top-` and `h-` cannot share one token, and a
+ * library that takes its geometry as a CSS value (the toaster's `offset`)
+ * cannot take a class at all.
  */
 export const APP_HEADER_HEIGHT_CLASS = "h-10";
 export const BELOW_APP_HEADER_TOP_CLASS = "top-10";
+export const APP_HEADER_HEIGHT = "2.5rem";

--- a/clients/gui-app/src/components/layout/header/mobile-app-header.tsx
+++ b/clients/gui-app/src/components/layout/header/mobile-app-header.tsx
@@ -3,6 +3,7 @@ import { ChevronRight, Menu } from "lucide-react";
 import { Link } from "@tanstack/react-router";
 import { useShallow } from "zustand/react/shallow";
 import { Button } from "@/components/ui/button";
+import { APP_HEADER_HEIGHT_CLASS } from "@/components/layout/header/app-header-height";
 import { SETTINGS_SECTIONS } from "@/lib/settings-sections";
 import { RateLimitIconButton } from "@/components/layout/header/rate-limit-icon";
 import { ResourceMonitorPopover } from "@/components/resources/resource-monitor-popover";
@@ -10,6 +11,7 @@ import { MobileNotificationsButton } from "@/components/notifications/mobile-not
 import { MobileEpicHeaderTitle } from "@/components/epic-canvas/mobile/epic-mobile-header-actions";
 import "@/components/layout/shell/mobile-shell-touch-targets.css";
 import { useRegisteredEpicTitle } from "@/lib/epic-selectors";
+import { cn } from "@/lib/utils";
 import { useMobileNavStore } from "@/stores/layout/mobile-nav-store";
 import { useMobileHeaderRightActions } from "@/stores/layout/mobile-header-right-actions";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
@@ -52,7 +54,12 @@ export function MobileAppHeader(): ReactNode {
       // reserved by `#root`, and `bg-background` is the same token the strip
       // shows, so the two read as one surface without the header having to
       // reach under the bar.
-      className="relative z-20 flex h-10 shrink-0 items-center gap-1 bg-background px-2 text-foreground after:absolute after:inset-x-0 after:bottom-0 after:z-1 after:h-px after:bg-border/90 after:content-[''] pointer-coarse:touch-chrome"
+      // The height is the shared token the toaster clears on the phone, so
+      // the two cannot drift apart.
+      className={cn(
+        APP_HEADER_HEIGHT_CLASS,
+        "relative z-20 flex shrink-0 items-center gap-1 bg-background px-2 text-foreground after:absolute after:inset-x-0 after:bottom-0 after:z-1 after:h-px after:bg-border/90 after:content-[''] pointer-coarse:touch-chrome",
+      )}
     >
       <Button
         type="button"

--- a/clients/gui-app/src/components/ui/__tests__/sonner-toast-placement.test.tsx
+++ b/clients/gui-app/src/components/ui/__tests__/sonner-toast-placement.test.tsx
@@ -193,7 +193,7 @@ describe("<Toaster /> toast placement", () => {
     const props = lastSonnerToasterProps();
     expect(props.position).toBe("top-center");
     const expectedOffset = {
-      top: "calc(var(--safe-area-inset-top) + 2.5rem + 1.25rem)",
+      top: "calc(var(--safe-area-inset-top) + 2.5rem + 1.5rem)",
     };
     expect(props.offset).toEqual(expectedOffset);
     expect(props.mobileOffset).toEqual(expectedOffset);

--- a/clients/gui-app/src/components/ui/__tests__/sonner-toast-placement.test.tsx
+++ b/clients/gui-app/src/components/ui/__tests__/sonner-toast-placement.test.tsx
@@ -5,6 +5,7 @@ import type { BrowserViewTileKey } from "@traycer-clients/shared/platform/browse
 import { Toaster } from "@/components/ui/sonner";
 import type { TileRect } from "@/lib/browser-view/tiles/tile-rect-registry";
 import { registerTileRect } from "@/lib/browser-view/tiles/tile-rect-registry";
+import { setMobileApp } from "@/lib/mobile-app";
 
 // Ticket 06: the toaster picks the least-overlapping of sonner's six fixed
 // anchors against live registered tile rects, and freezes that choice while
@@ -167,6 +168,7 @@ describe("<Toaster /> toast placement", () => {
   afterEach(() => {
     pendingDeregisters.forEach((deregister) => deregister());
     pendingDeregisters = [];
+    setMobileApp(false);
     cleanup();
   });
 
@@ -174,6 +176,48 @@ describe("<Toaster /> toast placement", () => {
     render(<Toaster />);
 
     expect(lastSonnerToasterProps().position).toBe("bottom-right");
+  });
+
+  it("leaves sonner's offsets alone outside the installed mobile app", () => {
+    render(<Toaster />);
+
+    expect(lastSonnerToasterProps().offset).toBeUndefined();
+    expect(lastSonnerToasterProps().mobileOffset).toBeUndefined();
+  });
+
+  it("anchors top-center below the header in the installed mobile app", () => {
+    setMobileApp(true);
+
+    render(<Toaster />);
+
+    const props = lastSonnerToasterProps();
+    expect(props.position).toBe("top-center");
+    const expectedOffset = {
+      top: "calc(var(--safe-area-inset-top) + 2.5rem + 1.25rem)",
+    };
+    expect(props.offset).toEqual(expectedOffset);
+    expect(props.mobileOffset).toEqual(expectedOffset);
+  });
+
+  it("keeps the mobile app's anchor when a tile covers the desktop default", async () => {
+    setMobileApp(true);
+    const { rerender } = render(<Toaster />);
+    await primeMeasurement(rerender);
+
+    await act(async () => {
+      registerTile("covers-default", BOTTOM_RIGHT_RECT);
+      await flush();
+    });
+
+    expect(lastSonnerToasterProps().position).toBe("top-center");
+  });
+
+  it("lets a caller's position win in the installed mobile app", () => {
+    setMobileApp(true);
+
+    render(<Toaster position="bottom-left" />);
+
+    expect(lastSonnerToasterProps().position).toBe("bottom-left");
   });
 
   it("moves off the default anchor when a tile covers it", async () => {

--- a/clients/gui-app/src/components/ui/__tests__/sonner.test.tsx
+++ b/clients/gui-app/src/components/ui/__tests__/sonner.test.tsx
@@ -33,16 +33,34 @@ describe("<Toaster />", () => {
     expect(lastSonnerToasterProps().closeButton).toBe(true);
   });
 
-  it("shows close buttons only on toast hover or focus", () => {
+  it("hides close buttons until toast hover or focus on hover-capable devices", () => {
     render(<Toaster />);
 
     const classNames = lastSonnerToasterProps().toastOptions?.classNames;
+    const closeButton = closeButtonTokens();
 
     expect(classNames?.toast).toContain("group/toast");
-    expect(classNames?.closeButton).toContain("opacity-0");
-    expect(classNames?.closeButton).toContain("group-hover/toast:opacity-100");
-    expect(classNames?.closeButton).toContain(
-      "group-focus-within/toast:opacity-100",
+    expect(closeButton).toContain("can-hover:opacity-0");
+    expect(closeButton).toContain("can-hover:pointer-events-none");
+    expect(closeButton).toContain("group-hover/toast:opacity-100");
+    expect(closeButton).toContain("group-focus-within/toast:opacity-100");
+  });
+
+  it("leaves close buttons visible and tappable on touch devices", () => {
+    render(<Toaster />);
+
+    // Every hiding utility is scoped to `can-hover`, so under sonner's touch
+    // query nothing overrides its always-visible default. The real media
+    // query is exercised in `scripts/toast-close-button-touch-browser.mjs`.
+    const hides = closeButtonTokens().filter((token) =>
+      /(^|:)(opacity-0|pointer-events-none)$/.test(token),
+    );
+    expect(hides).toEqual([
+      "can-hover:pointer-events-none",
+      "can-hover:opacity-0",
+    ]);
+    expect(closeButtonTokens()).toEqual(
+      expect.arrayContaining(["touch:after:absolute", "touch:after:size-11"]),
     );
   });
 
@@ -60,6 +78,15 @@ describe("<Toaster />", () => {
     expect(lastSonnerToasterProps().theme).toBe("system");
   });
 });
+
+function closeButtonTokens(): string[] {
+  const closeButton =
+    lastSonnerToasterProps().toastOptions?.classNames?.closeButton;
+  if (closeButton === undefined) {
+    throw new Error("Expected a close button class name.");
+  }
+  return closeButton.split(/\s+/);
+}
 
 function lastSonnerToasterProps(): ToasterProps {
   const lastCall = sonnerToasterProps.mock.lastCall;

--- a/clients/gui-app/src/components/ui/__tests__/sonner.test.tsx
+++ b/clients/gui-app/src/components/ui/__tests__/sonner.test.tsx
@@ -33,24 +33,24 @@ describe("<Toaster />", () => {
     expect(lastSonnerToasterProps().closeButton).toBe(true);
   });
 
-  it("hides close buttons until toast hover or focus on hover-capable devices", () => {
+  it("hides close buttons until toast hover or focus for a fine pointer", () => {
     render(<Toaster />);
 
     const classNames = lastSonnerToasterProps().toastOptions?.classNames;
     const closeButton = closeButtonTokens();
 
     expect(classNames?.toast).toContain("group/toast");
-    expect(closeButton).toContain("can-hover:opacity-0");
-    expect(closeButton).toContain("can-hover:pointer-events-none");
+    expect(closeButton).toContain("not-pointer-coarse:opacity-0");
+    expect(closeButton).toContain("not-pointer-coarse:pointer-events-none");
     expect(closeButton).toContain("group-hover/toast:opacity-100");
     expect(closeButton).toContain("group-focus-within/toast:opacity-100");
   });
 
-  it("leaves close buttons visible and tappable on touch devices", () => {
+  it("leaves close buttons visible and tappable for a coarse pointer", () => {
     render(<Toaster />);
 
-    // Every hiding utility is scoped to `can-hover`, so under sonner's touch
-    // query nothing overrides its always-visible default - except for the
+    // Every hiding utility is scoped to `not-pointer-coarse`, so for a coarse
+    // pointer nothing overrides sonner's always-visible default - except for the
     // back toasts of a collapsed stack, which sonner has already made
     // invisible. The real media query is exercised in
     // `scripts/toast-close-button-touch-browser.mjs`.
@@ -58,12 +58,15 @@ describe("<Toaster />", () => {
       /(^|:)(opacity-0|pointer-events-none)$/.test(token),
     );
     expect(hides).toEqual([
-      "can-hover:pointer-events-none",
-      "can-hover:opacity-0",
+      "not-pointer-coarse:pointer-events-none",
+      "not-pointer-coarse:opacity-0",
       "group-data-[expanded=false]/toast:group-data-[front=false]/toast:pointer-events-none",
     ]);
     expect(closeButtonTokens()).toEqual(
-      expect.arrayContaining(["touch:after:absolute", "touch:after:size-11"]),
+      expect.arrayContaining([
+        "pointer-coarse:after:absolute",
+        "pointer-coarse:after:size-11",
+      ]),
     );
   });
 

--- a/clients/gui-app/src/components/ui/__tests__/sonner.test.tsx
+++ b/clients/gui-app/src/components/ui/__tests__/sonner.test.tsx
@@ -50,14 +50,17 @@ describe("<Toaster />", () => {
     render(<Toaster />);
 
     // Every hiding utility is scoped to `can-hover`, so under sonner's touch
-    // query nothing overrides its always-visible default. The real media
-    // query is exercised in `scripts/toast-close-button-touch-browser.mjs`.
+    // query nothing overrides its always-visible default - except for the
+    // back toasts of a collapsed stack, which sonner has already made
+    // invisible. The real media query is exercised in
+    // `scripts/toast-close-button-touch-browser.mjs`.
     const hides = closeButtonTokens().filter((token) =>
       /(^|:)(opacity-0|pointer-events-none)$/.test(token),
     );
     expect(hides).toEqual([
       "can-hover:pointer-events-none",
       "can-hover:opacity-0",
+      "group-data-[expanded=false]/toast:group-data-[front=false]/toast:pointer-events-none",
     ]);
     expect(closeButtonTokens()).toEqual(
       expect.arrayContaining(["touch:after:absolute", "touch:after:size-11"]),

--- a/clients/gui-app/src/components/ui/sonner.tsx
+++ b/clients/gui-app/src/components/ui/sonner.tsx
@@ -25,8 +25,12 @@ import {
 
 const TOAST_CLASS_NAME = cn("cn-toast", "group/toast");
 // Sonner itself always shows the close button. Hiding it until hover only
-// makes sense where hover exists, so the hide is scoped to `can-hover`; on a
-// touch device sonner's own visibility stands and the button is tappable.
+// makes sense for a fine pointer, so the hide is scoped to
+// `not-pointer-coarse` - the app's touch convention, the same `pointer-coarse`
+// the mobile header keys its touch chrome on. A coarse pointer keeps sonner's
+// own visibility, and the button is tappable, even on a device that can also
+// hover. (Sonner's stylesheet uses the stricter `(hover: none) and (pointer:
+// coarse)`, but only to reset its own lift transform.)
 // There the 20px glyph also gets a 44px hit area: a pseudo-element square
 // centred on it, so the visual size and sonner's corner transform are
 // untouched (the pseudo-element moves with the button). Sized outright rather
@@ -39,14 +43,14 @@ const TOAST_CLASS_NAME = cn("cn-toast", "group/toast");
 // reveal on specificity, and on desktop hovering the toaster expands the
 // stack first, so it never fights a hover reveal.
 const TOAST_CLOSE_BUTTON_CLASS_NAME = cn(
-  "can-hover:pointer-events-none",
-  "can-hover:opacity-0",
-  "touch:after:absolute",
-  "touch:after:top-1/2",
-  "touch:after:left-1/2",
-  "touch:after:size-11",
-  "touch:after:-translate-x-1/2",
-  "touch:after:-translate-y-1/2",
+  "not-pointer-coarse:pointer-events-none",
+  "not-pointer-coarse:opacity-0",
+  "pointer-coarse:after:absolute",
+  "pointer-coarse:after:top-1/2",
+  "pointer-coarse:after:left-1/2",
+  "pointer-coarse:after:size-11",
+  "pointer-coarse:after:-translate-x-1/2",
+  "pointer-coarse:after:-translate-y-1/2",
   "group-hover/toast:pointer-events-auto",
   "group-hover/toast:opacity-100",
   "group-focus-within/toast:pointer-events-auto",

--- a/clients/gui-app/src/components/ui/sonner.tsx
+++ b/clients/gui-app/src/components/ui/sonner.tsx
@@ -31,6 +31,13 @@ const TOAST_CLASS_NAME = cn("cn-toast", "group/toast");
 // centred on it, so the visual size and sonner's corner transform are
 // untouched (the pseudo-element moves with the button). Sized outright rather
 // than inset, because an inset measures from inside the button's border.
+//
+// A collapsed stack's back toasts are hidden by sonner with `opacity: 0` on
+// their children and nothing else, so without the hide above their close
+// buttons stay tappable while invisible - and they peek out past the front
+// toast. The last rule takes them out of hit testing; it outranks every
+// reveal on specificity, and on desktop hovering the toaster expands the
+// stack first, so it never fights a hover reveal.
 const TOAST_CLOSE_BUTTON_CLASS_NAME = cn(
   "can-hover:pointer-events-none",
   "can-hover:opacity-0",
@@ -46,6 +53,7 @@ const TOAST_CLOSE_BUTTON_CLASS_NAME = cn(
   "group-focus-within/toast:opacity-100",
   "focus-visible:pointer-events-auto",
   "focus-visible:opacity-100",
+  "group-data-[expanded=false]/toast:group-data-[front=false]/toast:pointer-events-none",
 );
 const TOAST_CANCEL_BUTTON_CLASS_NAME = cn(
   "border border-border bg-background text-foreground",
@@ -67,12 +75,13 @@ const SONNER_TOASTER_LIST_SELECTOR = "[data-sonner-toaster]";
 // expected on a phone; sonner derives swipe-up-to-dismiss from the position.
 // The toaster is `fixed` and paints above everything, so it is offset past
 // the app header rather than over it - the header row sits directly under
-// `#root`'s top inset and never scrolls. The extra 1.25rem clears the close
-// button's touch hit area: sonner pulls the 20px button 7px above the toast's
-// top edge and the 44px hit area reaches 12px past that, so anything less
-// lets a visible toast steal the bottom of the header's own buttons.
+// `#root`'s top inset and never scrolls. The extra 1.5rem keeps the close
+// button's touch hit area clear of the header's: sonner pulls the 20px button
+// 6px above the toast's outer edge, so its 44px hit area reaches 18px above
+// the toast, and the header's own 44px hit areas overhang its 40px row by
+// 2px. 1.25rem would make the two touch exactly; 1.5rem leaves 4px.
 const MOBILE_APP_TOASTER_ANCHOR: ToasterAnchor = "top-center";
-const MOBILE_APP_TOASTER_TOP = `calc(var(--safe-area-inset-top) + ${APP_HEADER_HEIGHT} + 1.25rem)`;
+const MOBILE_APP_TOASTER_TOP = `calc(var(--safe-area-inset-top) + ${APP_HEADER_HEIGHT} + 1.5rem)`;
 // Both offsets: sonner reads `mobileOffset` at <=600px and `offset` above
 // it, and a phone in landscape is wider than that.
 const MOBILE_APP_TOASTER_OFFSET = { top: MOBILE_APP_TOASTER_TOP };

--- a/clients/gui-app/src/components/ui/sonner.tsx
+++ b/clients/gui-app/src/components/ui/sonner.tsx
@@ -10,6 +10,8 @@ import {
 } from "lucide-react";
 import { ProgressToastIcon } from "@/components/ui/progress-toast-icon";
 import { cn } from "@/lib/utils";
+import { isMobileApp } from "@/lib/mobile-app";
+import { APP_HEADER_HEIGHT } from "@/components/layout/header/app-header-height";
 import {
   listTileRects,
   subscribeTileRects,
@@ -22,9 +24,22 @@ import {
 } from "@/components/ui/toaster-anchor";
 
 const TOAST_CLASS_NAME = cn("cn-toast", "group/toast");
+// Sonner itself always shows the close button. Hiding it until hover only
+// makes sense where hover exists, so the hide is scoped to `can-hover`; on a
+// touch device sonner's own visibility stands and the button is tappable.
+// There the 20px glyph also gets a 44px hit area: a pseudo-element square
+// centred on it, so the visual size and sonner's corner transform are
+// untouched (the pseudo-element moves with the button). Sized outright rather
+// than inset, because an inset measures from inside the button's border.
 const TOAST_CLOSE_BUTTON_CLASS_NAME = cn(
-  "pointer-events-none",
-  "opacity-0",
+  "can-hover:pointer-events-none",
+  "can-hover:opacity-0",
+  "touch:after:absolute",
+  "touch:after:top-1/2",
+  "touch:after:left-1/2",
+  "touch:after:size-11",
+  "touch:after:-translate-x-1/2",
+  "touch:after:-translate-y-1/2",
   "group-hover/toast:pointer-events-auto",
   "group-hover/toast:opacity-100",
   "group-focus-within/toast:pointer-events-auto",
@@ -48,6 +63,19 @@ const NOTIFICATION_TOAST_ACTION_SELECTOR = "[data-notification-toast-action]";
 // that position. Size is measured from those lists so toast placement can
 // prefer anchors that miss live browser tiles.
 const SONNER_TOASTER_LIST_SELECTOR = "[data-sonner-toaster]";
+// The installed phone app shows toasts at the top, where a notification is
+// expected on a phone; sonner derives swipe-up-to-dismiss from the position.
+// The toaster is `fixed` and paints above everything, so it is offset past
+// the app header rather than over it - the header row sits directly under
+// `#root`'s top inset and never scrolls. The extra 1.25rem clears the close
+// button's touch hit area: sonner pulls the 20px button 7px above the toast's
+// top edge and the 44px hit area reaches 12px past that, so anything less
+// lets a visible toast steal the bottom of the header's own buttons.
+const MOBILE_APP_TOASTER_ANCHOR: ToasterAnchor = "top-center";
+const MOBILE_APP_TOASTER_TOP = `calc(var(--safe-area-inset-top) + ${APP_HEADER_HEIGHT} + 1.25rem)`;
+// Both offsets: sonner reads `mobileOffset` at <=600px and `offset` above
+// it, and a phone in landscape is wider than that.
+const MOBILE_APP_TOASTER_OFFSET = { top: MOBILE_APP_TOASTER_TOP };
 
 const Toaster = ({ ...props }: ToasterProps) => {
   const { theme = "system" } = useTheme();
@@ -63,6 +91,9 @@ const Toaster = ({ ...props }: ToasterProps) => {
   // size - see `toaster-anchor.ts`.
   const toasterSizeRef = useRef<ToasterSize | null>(null);
   const [anchor, setAnchor] = useState<ToasterAnchor>(DEFAULT_TOASTER_ANCHOR);
+  // Read at render, not at module load: the phone entry sets it before the
+  // first render, which is after this module has been imported.
+  const mobileApp = isMobileApp();
 
   const recomputeAnchor = useCallback(() => {
     if (toastVisibleRef.current) return;
@@ -131,7 +162,16 @@ const Toaster = ({ ...props }: ToasterProps) => {
         }}
         {...props}
         closeButton={props.closeButton ?? true}
-        position={props.position ?? anchor}
+        position={
+          props.position ?? (mobileApp ? MOBILE_APP_TOASTER_ANCHOR : anchor)
+        }
+        offset={
+          props.offset ?? (mobileApp ? MOBILE_APP_TOASTER_OFFSET : undefined)
+        }
+        mobileOffset={
+          props.mobileOffset ??
+          (mobileApp ? MOBILE_APP_TOASTER_OFFSET : undefined)
+        }
       />
     </DismissableLayer.Branch>
   );

--- a/clients/gui-app/src/index.css
+++ b/clients/gui-app/src/index.css
@@ -14,14 +14,6 @@
    `syncDocumentWindowControlsOverlayClass`). Mac fullscreen autohide
    and browser shells both leave this class off. */
 @custom-variant wco (&:is(.wco, .wco *));
-/* A touch-first device: the exact query sonner's own stylesheet uses for
-   touch, so a toast's touch styling and ours switch on the same devices.
-   `can-hover` is its complement, written out rather than as `not-touch:` -
-   Tailwind negates a compound media variant as `not (a) and (b)`, which is
-   not valid media-query grammar and would match nothing. The MQ3 form
-   `not all and …` negates the whole query. */
-@custom-variant touch (@media (hover: none) and (pointer: coarse));
-@custom-variant can-hover (@media not all and (hover: none) and (pointer: coarse));
 @plugin "tailwindcss-animate";
 @plugin "@tailwindcss/typography";
 

--- a/clients/gui-app/src/index.css
+++ b/clients/gui-app/src/index.css
@@ -14,6 +14,14 @@
    `syncDocumentWindowControlsOverlayClass`). Mac fullscreen autohide
    and browser shells both leave this class off. */
 @custom-variant wco (&:is(.wco, .wco *));
+/* A touch-first device: the exact query sonner's own stylesheet uses for
+   touch, so a toast's touch styling and ours switch on the same devices.
+   `can-hover` is its complement, written out rather than as `not-touch:` -
+   Tailwind negates a compound media variant as `not (a) and (b)`, which is
+   not valid media-query grammar and would match nothing. The MQ3 form
+   `not all and …` negates the whole query. */
+@custom-variant touch (@media (hover: none) and (pointer: coarse));
+@custom-variant can-hover (@media not all and (hover: none) and (pointer: coarse));
 @plugin "tailwindcss-animate";
 @plugin "@tailwindcss/typography";
 


### PR DESCRIPTION
## Problem

On a phone, a toast could only be dismissed by swiping it or waiting: its close button appeared only on hover, and a touch screen never hovers. Toasts also sat bottom-right, where a phone user does not look for them.

## What sonner does (2.0.8, from `dist/`)

- Sonner **always** renders the close button (`index.mjs`: `closeButton && !toast.jsx && type !== 'loading'`), and its stylesheet has no `opacity` or `pointer-events` rule for `[data-close-button]` and no hover gate. The hover-only behaviour was entirely ours: `TOAST_CLOSE_BUTTON_CLASS_NAME` applied `opacity-0 pointer-events-none` unconditionally, and Tailwind v4 wraps `group-hover:` in `@media (hover: hover)`, so on iOS the reveal never fired.
- Swipe-to-dismiss follows the position: `getDefaultSwipeDirections(position)` splits `top-center` into `['top', 'center']`, so a top toast dismisses by swiping up (horizontal swipes do nothing). No `swipeDirections` override is needed.
- `offset` / `mobileOffset` take per-edge CSS strings and write them verbatim into `--offset-*` / `--mobile-offset-*`; unspecified edges keep sonner's defaults. `mobileOffset` applies at <=600px, `offset` above it.

## Design

**Close button**
- The hide is scoped to `not-pointer-coarse:`, the app's existing touch convention (the same `pointer-coarse` the mobile header keys its touch chrome on). With a coarse pointer, sonner's own always-visible default stands - including on a device that can also hover. Sonner's stylesheet uses the stricter `(hover: none) and (pointer: coarse)`, but only for its own lift transform. Both variants are Tailwind built-ins; `index.css` is unchanged. (A single-feature `not (pointer: coarse)` is valid media-query grammar. Negating a compound query through Tailwind's `not-*` is not - it emits `not (a) and (b)`, which lightningcss rejects - so this deliberately stays on one feature.)
- With a coarse pointer, the 20px glyph gets a 44px hit area: a centred `::after` square. The visual size and sonner's corner transform are untouched. It is sized outright rather than inset, because an inset measures from inside the button's 1px border (that measured 42px).

**Collapsed-stack fix**
- Sonner hides a collapsed stack's back toasts with `opacity: 0` on their children and nothing else. Once the hover-only hide stopped applying on touch, those invisible close buttons took taps - including the strip where they peek out past the front toast - silently dismissing toasts the user never saw. `group-data-[expanded=false]/toast:group-data-[front=false]/toast:pointer-events-none` takes them out of hit testing; at (0,3,0) it outranks every reveal, and on desktop hovering the toaster expands the stack first, so it never fights a hover reveal.

**Placement in the installed mobile app** (`isMobileApp()`, read at render)
- Toasts anchor `top-center`, skipping the desktop tile-avoiding picker. A caller's `position` still wins.
- Both `offset.top` and `mobileOffset.top` are `calc(var(--safe-area-inset-top) + 2.5rem + 1.5rem)`: the toaster is `fixed` and paints above everything, and the app header is the in-flow first row under `#root`'s top inset that never scrolls, so the toast sits below it rather than over it. The 1.5rem clears the header buttons' own 44px hit areas (which overhang the 40px row by 2px) from the close button's hit area (which reaches 18px above the toast) with 4px to spare. Composes the sanctioned `--safe-area-inset-top` custom property, never `env()`.
- `APP_HEADER_HEIGHT` (`"2.5rem"`) is exported beside `APP_HEADER_HEIGHT_CLASS`, `MobileAppHeader` now uses the shared class, and a unit test keeps `h-10` / `top-10` / `2.5rem` in step.

## Deliberately unchanged

- **Desktop:** the close button is still hidden until hover or focus; placement is still `bottom-right` with the tile-avoiding picker; sonner's default offsets are untouched (the offset props stay `undefined` outside the mobile app).
- **Landscape centring:** above 600px sonner centres the toaster on the viewport rather than on `#root`'s asymmetric insets, so in phone landscape the toast sits about 25px off the header's centre. Cosmetic; left as is.
- Sonner's swipe derivation and all other sonner styling.

## Tests

- jsdom: `sonner.test.tsx` (hide utilities are scoped, hit area present), `sonner-toast-placement.test.tsx` (top-center + offsets in the mobile app, unchanged otherwise, caller position wins, tiles ignored in the mobile app), `app-header-height.test.ts`.
- New headless-Chrome regression `scripts/toast-close-button-touch-browser.mjs` (fixture `src/__tests__/browser/toast-close-button-touch.{html,tsx}`), wired into `run-tests.ts` behind the existing `RUN_DIFF_EDIT_BROWSER_REGRESSION` gate. jsdom evaluates no media queries and does no layout, so it renders the real `Toaster` against the real stylesheet and flips the query with CDP `Emulation.setTouchEmulationEnabled` (verified to flip `(pointer: coarse)` and back). The driver launches Chrome with a fine, hovering pointer (`--blink-settings`) and asserts that premise first: a CI runner with no input device reports `hover: none` / `pointer: none`, under which `group-hover:` never applies. `launchChromeWithDevTools` gained an explicit `extraArgs` for this (the other drivers pass `[]`). It asserts:
  - desktop: hidden (opacity 0, pointer-events none), revealed on hover, and no hit area while revealed;
  - coarse pointer: visible and tappable, glyph size unchanged, `::after` 44x44, a tap 18px off the glyph lands on the button;
  - collapsed stack of three: no tap in a 48px grid around a back toast's close button reaches it;
  - mobile app at 390x844 (`mobileOffset`) and 844x390 (`offset`): `top-center`, toaster top at 4rem, hit area clear of the header.
- Ablated before wiring - each of these turns it red: an unscoped hide, no hit area, no mobile-app offset, a gap too small, no back-toast guard (caught by the tap scan on its own, not only the computed style), and the hit area leaking onto desktop.

Device: installed on an iPhone (iOS 26.6.1, production bundle id, built from c26c2cd15; later commits are test-only) for hands-on testing; the verdict is not in at merge time.

