### PR TITLE
fix(gui-app): sync escalation counts foreground waiting only

### DIFF
--- a/clients/gui-app/src/hooks/sync/__tests__/use-stream-syncing-spell.test.tsx
+++ b/clients/gui-app/src/hooks/sync/__tests__/use-stream-syncing-spell.test.tsx
@@ -39,8 +39,8 @@ function createRunnerHost(): MockRunnerHost {
 
 /**
  * Counts the hook's live `onSystemResumed` subscriptions on `host`. The mock
- * keeps its handler set private, and a leaked subscriber is otherwise silent -
- * React no longer complains about a state write on an unmounted hook.
+ * keeps its handler set private, and a leaked subscriber is otherwise silent:
+ * React does not warn on a state write to an unmounted hook.
  */
 function trackResumeSubscribers(host: MockRunnerHost): {
   readonly live: () => number;
@@ -229,10 +229,10 @@ describe("useStreamSyncingSpell", () => {
   describe("across a system resume", () => {
     // The clock measures how long a PERSON has waited, and a person who left
     // the app was not waiting. WKWebView freezes timers on suspension and, on
-    // thaw, fires any whose deadline passed - measured on device at 25 ms
-    // BEFORE the shell's resume signal reaches a subscriber. So the wait has to
-    // restart at resume, and an escalation the thaw already fired has to be
-    // taken back, not merely prevented.
+    // thaw, fires any whose deadline passed BEFORE the shell's resume signal
+    // reaches a subscriber. So the wait has to restart at resume, and an
+    // escalation the thaw already fired has to be taken back, not merely
+    // prevented.
 
     it("restarts the wait from the resume, not from when the stream dropped", () => {
       vi.useFakeTimers();
@@ -259,7 +259,7 @@ describe("useStreamSyncingSpell", () => {
     });
 
     it("takes back an escalation the thaw fired before the resume signal arrived", () => {
-      // The measured order: the 60 s deadline passes during suspension, the
+      // The order on thaw: the 60 s deadline passes during suspension, the
       // timer fires as JS thaws, and ONLY THEN does `onSystemResumed` run.
       vi.useFakeTimers();
       const host = createRunnerHost();

--- a/clients/gui-app/src/hooks/sync/__tests__/use-stream-syncing-spell.test.tsx
+++ b/clients/gui-app/src/hooks/sync/__tests__/use-stream-syncing-spell.test.tsx
@@ -4,6 +4,9 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { StreamConnectionStatus } from "@traycer-clients/shared/host-transport/i-stream-session";
 import { useStreamSyncingSpell } from "@/hooks/sync/use-stream-syncing-spell";
 import { LINK_DOWN_ESCALATION_MS } from "@/lib/link-down-escalation";
+import { RunnerHostContext } from "@/providers/runner-host-context";
+import { MockRunnerHost } from "@traycer-clients/shared/host-client/mock/mock-runner-host";
+import type { ReactNode } from "react";
 
 afterEach(() => {
   cleanup();
@@ -19,6 +22,53 @@ interface SpellInput {
 function renderSpell(initial: SpellInput) {
   return renderHook((input: SpellInput) => useStreamSyncingSpell(input), {
     initialProps: initial,
+  });
+}
+
+function createRunnerHost(): MockRunnerHost {
+  return new MockRunnerHost({
+    signInUrl: "https://auth.example/sign-in",
+    authnBaseUrl: "https://auth.example",
+    localHost: null,
+    hosts: [],
+    workspaceFolderPickerPaths: undefined,
+    hasLocalHost: undefined,
+    traycerCli: undefined,
+  });
+}
+
+/**
+ * Counts the hook's live `onSystemResumed` subscriptions on `host`. The mock
+ * keeps its handler set private, and a leaked subscriber is otherwise silent -
+ * React no longer complains about a state write on an unmounted hook.
+ */
+function trackResumeSubscribers(host: MockRunnerHost): {
+  readonly live: () => number;
+} {
+  let live = 0;
+  const subscribe = host.onSystemResumed.bind(host);
+  vi.spyOn(host, "onSystemResumed").mockImplementation((handler) => {
+    live += 1;
+    const subscription = subscribe(handler);
+    return {
+      dispose: () => {
+        live -= 1;
+        subscription.dispose();
+      },
+    };
+  });
+  return { live: () => live };
+}
+
+/** The spell under a shell that can report a system resume. */
+function renderSpellWithShell(initial: SpellInput, host: MockRunnerHost) {
+  return renderHook((input: SpellInput) => useStreamSyncingSpell(input), {
+    initialProps: initial,
+    wrapper: ({ children }: { readonly children: ReactNode }) => (
+      <RunnerHostContext.Provider value={host}>
+        {children}
+      </RunnerHostContext.Provider>
+    ),
   });
 }
 
@@ -174,5 +224,150 @@ describe("useStreamSyncingSpell", () => {
       vi.advanceTimersByTime(LINK_DOWN_ESCALATION_MS);
     });
     expect(result.current.escalated).toBe(false);
+  });
+
+  describe("across a system resume", () => {
+    // The clock measures how long a PERSON has waited, and a person who left
+    // the app was not waiting. WKWebView freezes timers on suspension and, on
+    // thaw, fires any whose deadline passed - measured on device at 25 ms
+    // BEFORE the shell's resume signal reaches a subscriber. So the wait has to
+    // restart at resume, and an escalation the thaw already fired has to be
+    // taken back, not merely prevented.
+
+    it("restarts the wait from the resume, not from when the stream dropped", () => {
+      vi.useFakeTimers();
+      const host = createRunnerHost();
+      const { result } = renderSpellWithShell(
+        { status: "reconnecting", hasContent: true, identity: "a" },
+        host,
+      );
+      act(() => {
+        vi.advanceTimersByTime(LINK_DOWN_ESCALATION_MS * 0.7);
+      });
+      act(() => {
+        host.emitSystemResumed({ backgroundedForMs: 180_000 });
+      });
+      // 0.7 + 0.7 = 1.4 intervals since the drop, but only 0.7 since resume.
+      act(() => {
+        vi.advanceTimersByTime(LINK_DOWN_ESCALATION_MS * 0.7);
+      });
+      expect(result.current.escalated).toBe(false);
+      act(() => {
+        vi.advanceTimersByTime(LINK_DOWN_ESCALATION_MS * 0.3);
+      });
+      expect(result.current.escalated).toBe(true);
+    });
+
+    it("takes back an escalation the thaw fired before the resume signal arrived", () => {
+      // The measured order: the 60 s deadline passes during suspension, the
+      // timer fires as JS thaws, and ONLY THEN does `onSystemResumed` run.
+      vi.useFakeTimers();
+      const host = createRunnerHost();
+      const { result } = renderSpellWithShell(
+        { status: "reconnecting", hasContent: true, identity: "a" },
+        host,
+      );
+      act(() => {
+        vi.advanceTimersByTime(LINK_DOWN_ESCALATION_MS);
+      });
+      expect(result.current.escalated).toBe(true);
+
+      act(() => {
+        host.emitSystemResumed({ backgroundedForMs: 180_000 });
+      });
+      expect(result.current.escalated).toBe(false);
+
+      // And the full interval runs again before it may escalate.
+      act(() => {
+        vi.advanceTimersByTime(LINK_DOWN_ESCALATION_MS - 1);
+      });
+      expect(result.current.escalated).toBe(false);
+      act(() => {
+        vi.advanceTimersByTime(1);
+      });
+      expect(result.current.escalated).toBe(true);
+    });
+
+    it("takes back an escalation whose deadline passes after the resume but before React commits", () => {
+      // The other order. The resume handler's state update waits for React's
+      // scheduler, and an expired deadline can run in the gap - against a
+      // record that already carries the new epoch. Both land in ONE act so
+      // nothing is committed between them.
+      vi.useFakeTimers();
+      const host = createRunnerHost();
+      const { result } = renderSpellWithShell(
+        { status: "reconnecting", hasContent: true, identity: "a" },
+        host,
+      );
+      act(() => {
+        vi.advanceTimersByTime(LINK_DOWN_ESCALATION_MS - 1);
+      });
+      act(() => {
+        host.emitSystemResumed({ backgroundedForMs: 180_000 });
+        vi.advanceTimersByTime(1);
+      });
+      expect(result.current.escalated).toBe(false);
+
+      act(() => {
+        vi.advanceTimersByTime(LINK_DOWN_ESCALATION_MS - 1);
+      });
+      expect(result.current.escalated).toBe(false);
+      act(() => {
+        vi.advanceTimersByTime(1);
+      });
+      expect(result.current.escalated).toBe(true);
+    });
+
+    it("gates on the signal, not on a measured dwell", () => {
+      // Desktop's powerMonitor reports no sleep duration and sends `null`; a
+      // laptop that slept mid-outage still was not being watched.
+      vi.useFakeTimers();
+      const host = createRunnerHost();
+      const { result } = renderSpellWithShell(
+        { status: "reconnecting", hasContent: true, identity: "a" },
+        host,
+      );
+      act(() => {
+        vi.advanceTimersByTime(LINK_DOWN_ESCALATION_MS);
+      });
+      expect(result.current.escalated).toBe(true);
+      act(() => {
+        host.emitSystemResumed({ backgroundedForMs: null });
+      });
+      expect(result.current.escalated).toBe(false);
+    });
+
+    it("does not listen while no spell is running", () => {
+      vi.useFakeTimers();
+      const host = createRunnerHost();
+      const subscribers = trackResumeSubscribers(host);
+      const { result } = renderSpellWithShell(
+        { status: "open", hasContent: true, identity: "a" },
+        host,
+      );
+      expect(subscribers.live()).toBe(0);
+      act(() => {
+        host.emitSystemResumed({ backgroundedForMs: 5_000 });
+      });
+      expect(result.current).toEqual({ syncing: false, escalated: false });
+    });
+
+    it("listens only for the life of the spell", () => {
+      vi.useFakeTimers();
+      const host = createRunnerHost();
+      const subscribers = trackResumeSubscribers(host);
+      const { rerender, unmount } = renderSpellWithShell(
+        { status: "reconnecting", hasContent: true, identity: "a" },
+        host,
+      );
+      expect(subscribers.live()).toBe(1);
+      // The stream is back: nothing left to restart, so nothing to hear.
+      rerender({ status: "open", hasContent: true, identity: "a" });
+      expect(subscribers.live()).toBe(0);
+      rerender({ status: "reconnecting", hasContent: true, identity: "a" });
+      expect(subscribers.live()).toBe(1);
+      unmount();
+      expect(subscribers.live()).toBe(0);
+    });
   });
 });

--- a/clients/gui-app/src/hooks/sync/use-stream-syncing-spell.ts
+++ b/clients/gui-app/src/hooks/sync/use-stream-syncing-spell.ts
@@ -46,10 +46,10 @@ interface SpellRecord {
    * timers frozen and, on thaw, fires every one whose deadline passed - so a
    * wait armed before a minutes-long background lands the escalated word on
    * the very first frame after return, before the fresh restore has even
-   * begun. Measured on device: the overdue timer fires 25 ms BEFORE the resume
-   * event reaches any subscriber. That order is why a resume must undo an
-   * escalation rather than only postpone one, and why `performance.now()` is
-   * no help - it advances through the suspension too.
+   * begun. The overdue timer fires BEFORE the resume event reaches any
+   * subscriber. That order is why a resume must undo an escalation rather than
+   * only postpone one, and why `performance.now()` is no help - it advances
+   * through the suspension too.
    */
   readonly waitEpoch: number;
 }

--- a/clients/gui-app/src/hooks/sync/use-stream-syncing-spell.ts
+++ b/clients/gui-app/src/hooks/sync/use-stream-syncing-spell.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import type { StreamConnectionStatus } from "@traycer-clients/shared/host-transport/i-stream-session";
 import { LINK_DOWN_ESCALATION_MS } from "@/lib/link-down-escalation";
+import { useRunnerHostOrNull } from "@/providers/use-runner-host";
 import {
   isStreamSyncing,
   type StreamSyncingSpell,
@@ -34,6 +35,23 @@ interface StreamSyncingSpellInput {
 interface SpellRecord {
   readonly identity: string;
   readonly escalated: boolean;
+  /**
+   * Which stretch of FOREGROUND waiting the clock is timing: the wait since
+   * the person was last present, not foreground time accumulated across
+   * absences. Bumped by the shell's resume signal, which re-arms the deadline
+   * for a full interval and takes back any escalation already reached.
+   *
+   * The clock measures how long a person has watched the indicator, and a
+   * person who left the app was not watching. A suspended WebView keeps its
+   * timers frozen and, on thaw, fires every one whose deadline passed - so a
+   * wait armed before a minutes-long background lands the escalated word on
+   * the very first frame after return, before the fresh restore has even
+   * begun. Measured on device: the overdue timer fires 25 ms BEFORE the resume
+   * event reaches any subscriber. That order is why a resume must undo an
+   * escalation rather than only postpone one, and why `performance.now()` is
+   * no help - it advances through the suspension too.
+   */
+  readonly waitEpoch: number;
 }
 
 /**
@@ -50,27 +68,45 @@ interface SpellRecord {
  * Render-phase transitions rather than effects, matching `useLinkDownTooLong`:
  * the moment the stream is back, or the subject changes, the escalated verdict
  * must not paint even one frame.
+ *
+ * The wait counts foreground time only: the shell's resume signal restarts it
+ * (see {@link SpellRecord.waitEpoch}). Gated on the SIGNAL, not on a measured
+ * dwell - desktop's power monitor reports none and sends `null`, and a laptop
+ * that slept mid-outage was not being watched either.
  */
 export function useStreamSyncingSpell(
   input: StreamSyncingSpellInput,
 ): StreamSyncingSpell {
   const { status, hasContent, identity } = input;
   const syncing = isStreamSyncing(status, hasContent);
+  const runnerHost = useRunnerHostOrNull();
   const [record, setRecord] = useState<SpellRecord>({
     identity,
     escalated: false,
+    waitEpoch: 0,
   });
 
   if (record.identity !== identity) {
-    setRecord({ identity, escalated: false });
+    setRecord({ identity, escalated: false, waitEpoch: 0 });
   } else if (!syncing && record.escalated) {
-    setRecord({ identity, escalated: false });
+    setRecord({ identity, escalated: false, waitEpoch: record.waitEpoch });
   }
+
+  const { waitEpoch } = record;
 
   useEffect(() => {
     if (!syncing) return undefined;
     const timer = setTimeout(() => {
-      setRecord({ identity, escalated: true });
+      setRecord((current) =>
+        // Checked against the epoch this timer was armed for, not merely
+        // cleared by the effect's cleanup: the resume handler's state update
+        // is committed by React's scheduler on a LATER task, and a deadline
+        // that expires in between fires against the record that already
+        // carries the new epoch. Its verdict belongs to the wait that ended.
+        current.waitEpoch === waitEpoch
+          ? { ...current, escalated: true }
+          : current,
+      );
     }, LINK_DOWN_ESCALATION_MS);
     return () => {
       clearTimeout(timer);
@@ -78,8 +114,23 @@ export function useStreamSyncingSpell(
     // Keyed on the SPELL - is one running, and about what - never on the raw
     // status: `connecting` and `reconnecting` are one outage seen twice, and
     // re-running on that flip would restart the clock on a link that flaps and
-    // so never let it escalate at all.
-  }, [syncing, identity]);
+    // so never let it escalate at all. `waitEpoch` is the one deliberate
+    // restart: a system resume.
+  }, [syncing, identity, waitEpoch]);
+
+  useEffect(() => {
+    if (!syncing || runnerHost === null) return undefined;
+    const subscription = runnerHost.onSystemResumed(() => {
+      setRecord((current) => ({
+        ...current,
+        escalated: false,
+        waitEpoch: current.waitEpoch + 1,
+      }));
+    });
+    return () => {
+      subscription.dispose();
+    };
+  }, [syncing, identity, runnerHost]);
 
   return {
     syncing,

--- a/clients/gui-app/src/lib/host/__tests__/session-connectivity.test.ts
+++ b/clients/gui-app/src/lib/host/__tests__/session-connectivity.test.ts
@@ -144,6 +144,36 @@ function createControllableClock(): {
  */
 const POLL_MS = 1_000;
 
+/** A resume source that never fires - the shell never suspended. */
+const NEVER_RESUMES = (): (() => void) => () => undefined;
+
+/**
+ * A resume source a test can pull, standing in for the shell's
+ * `onSystemResumed`. `subscribe` returns the disposer the store must call on
+ * teardown.
+ */
+interface ResumeSource {
+  readonly subscribe: (listener: () => void) => () => void;
+  readonly emit: () => void;
+  readonly listenerCount: () => number;
+}
+
+function createResumeSource(): ResumeSource {
+  const listeners = new Set<() => void>();
+  return {
+    subscribe: (listener) => {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    emit: () => {
+      for (const listener of [...listeners]) listener();
+    },
+    listenerCount: () => listeners.size,
+  };
+}
+
 /** Long enough that the poll never fires, isolating the episode deadlines. */
 const POLL_NEVER_MS = SESSION_CONNECTIVITY_ESCALATE_AFTER_MS * 10;
 
@@ -163,6 +193,7 @@ describe("createSessionConnectivityStore", () => {
       streamClient: null,
       isReady: () => true,
       now: clock.now,
+      subscribeResume: NEVER_RESUMES,
       pollMs: POLL_MS,
       announceAfterMs: SESSION_CONNECTIVITY_ANNOUNCE_AFTER_MS,
       escalateAfterMs: SESSION_CONNECTIVITY_ESCALATE_AFTER_MS,
@@ -187,6 +218,7 @@ describe("createSessionConnectivityStore", () => {
       streamClient: createFakeHostStreamClient(ready.isReady),
       isReady: ready.isReady,
       now: createControllableClock().now,
+      subscribeResume: NEVER_RESUMES,
       pollMs: POLL_MS,
       announceAfterMs: SESSION_CONNECTIVITY_ANNOUNCE_AFTER_MS,
       escalateAfterMs: SESSION_CONNECTIVITY_ESCALATE_AFTER_MS,
@@ -204,6 +236,7 @@ describe("createSessionConnectivityStore", () => {
       streamClient: createFakeHostStreamClient(ready.isReady),
       isReady: ready.isReady,
       now: clock.now,
+      subscribeResume: NEVER_RESUMES,
       pollMs: POLL_MS,
       announceAfterMs: SESSION_CONNECTIVITY_ANNOUNCE_AFTER_MS,
       escalateAfterMs: SESSION_CONNECTIVITY_ESCALATE_AFTER_MS,
@@ -228,6 +261,7 @@ describe("createSessionConnectivityStore", () => {
       streamClient: createFakeHostStreamClient(ready.isReady),
       isReady: ready.isReady,
       now: clock.now,
+      subscribeResume: NEVER_RESUMES,
       pollMs: POLL_MS,
       announceAfterMs: SESSION_CONNECTIVITY_ANNOUNCE_AFTER_MS,
       escalateAfterMs: SESSION_CONNECTIVITY_ESCALATE_AFTER_MS,
@@ -260,6 +294,7 @@ describe("createSessionConnectivityStore", () => {
       streamClient: client,
       isReady: ready.isReady,
       now: clock.now,
+      subscribeResume: NEVER_RESUMES,
       pollMs: POLL_NEVER_MS,
       announceAfterMs: SESSION_CONNECTIVITY_ANNOUNCE_AFTER_MS,
       escalateAfterMs: SESSION_CONNECTIVITY_ESCALATE_AFTER_MS,
@@ -285,6 +320,7 @@ describe("createSessionConnectivityStore", () => {
       streamClient: createFakeHostStreamClient(ready.isReady),
       isReady: ready.isReady,
       now: clock.now,
+      subscribeResume: NEVER_RESUMES,
       pollMs: POLL_MS,
       announceAfterMs: SESSION_CONNECTIVITY_ANNOUNCE_AFTER_MS,
       escalateAfterMs: SESSION_CONNECTIVITY_ESCALATE_AFTER_MS,
@@ -315,6 +351,7 @@ describe("createSessionConnectivityStore", () => {
       streamClient: client,
       isReady: ready.isReady,
       now: clock.now,
+      subscribeResume: NEVER_RESUMES,
       pollMs: POLL_MS,
       announceAfterMs: SESSION_CONNECTIVITY_ANNOUNCE_AFTER_MS,
       escalateAfterMs: SESSION_CONNECTIVITY_ESCALATE_AFTER_MS,
@@ -345,6 +382,7 @@ describe("createSessionConnectivityStore", () => {
       streamClient: createFakeHostStreamClient(ready.isReady),
       isReady: ready.isReady,
       now: clock.now,
+      subscribeResume: NEVER_RESUMES,
       pollMs: POLL_MS,
       announceAfterMs: SESSION_CONNECTIVITY_ANNOUNCE_AFTER_MS,
       escalateAfterMs: SESSION_CONNECTIVITY_ESCALATE_AFTER_MS,
@@ -374,6 +412,7 @@ describe("createSessionConnectivityStore", () => {
       streamClient: createFakeHostStreamClient(readyA.isReady),
       isReady: readyA.isReady,
       now: clockA.now,
+      subscribeResume: NEVER_RESUMES,
       pollMs: POLL_MS,
       announceAfterMs: SESSION_CONNECTIVITY_ANNOUNCE_AFTER_MS,
       escalateAfterMs: SESSION_CONNECTIVITY_ESCALATE_AFTER_MS,
@@ -391,6 +430,7 @@ describe("createSessionConnectivityStore", () => {
       streamClient: createFakeHostStreamClient(readyB.isReady),
       isReady: readyB.isReady,
       now: createControllableClock().now,
+      subscribeResume: NEVER_RESUMES,
       pollMs: POLL_MS,
       announceAfterMs: SESSION_CONNECTIVITY_ANNOUNCE_AFTER_MS,
       escalateAfterMs: SESSION_CONNECTIVITY_ESCALATE_AFTER_MS,
@@ -411,6 +451,7 @@ describe("createSessionConnectivityStore", () => {
       streamClient: client,
       isReady: ready.isReady,
       now: clock.now,
+      subscribeResume: NEVER_RESUMES,
       pollMs: POLL_NEVER_MS,
       announceAfterMs: SESSION_CONNECTIVITY_ANNOUNCE_AFTER_MS,
       escalateAfterMs: SESSION_CONNECTIVITY_ESCALATE_AFTER_MS,
@@ -458,6 +499,7 @@ describe("createSessionConnectivityStore", () => {
       streamClient: client,
       isReady: ready.isReady,
       now: clock.now,
+      subscribeResume: NEVER_RESUMES,
       pollMs: POLL_NEVER_MS,
       announceAfterMs: SESSION_CONNECTIVITY_ANNOUNCE_AFTER_MS,
       escalateAfterMs: SESSION_CONNECTIVITY_ESCALATE_AFTER_MS,
@@ -491,6 +533,7 @@ describe("createSessionConnectivityStore", () => {
       streamClient: client,
       isReady: ready.isReady,
       now: clock.now,
+      subscribeResume: NEVER_RESUMES,
       pollMs: POLL_MS,
       announceAfterMs: SESSION_CONNECTIVITY_ANNOUNCE_AFTER_MS,
       escalateAfterMs: SESSION_CONNECTIVITY_ESCALATE_AFTER_MS,
@@ -523,6 +566,7 @@ describe("createSessionConnectivityStore", () => {
       streamClient: client,
       isReady: ready.isReady,
       now: clock.now,
+      subscribeResume: NEVER_RESUMES,
       pollMs: POLL_NEVER_MS,
       announceAfterMs: SESSION_CONNECTIVITY_ANNOUNCE_AFTER_MS,
       escalateAfterMs: SESSION_CONNECTIVITY_ESCALATE_AFTER_MS,
@@ -550,6 +594,7 @@ describe("createSessionConnectivityStore", () => {
       streamClient: client,
       isReady: ready.isReady,
       now: createControllableClock().now,
+      subscribeResume: NEVER_RESUMES,
       pollMs: POLL_NEVER_MS,
       announceAfterMs: SESSION_CONNECTIVITY_ANNOUNCE_AFTER_MS,
       escalateAfterMs: SESSION_CONNECTIVITY_ESCALATE_AFTER_MS,
@@ -566,6 +611,116 @@ describe("createSessionConnectivityStore", () => {
     expect(listener).toHaveBeenCalledTimes(2);
 
     dispose();
+  });
+});
+
+describe("createSessionConnectivityStore across a system resume", () => {
+  // The deadlines are for a person watching (see the store's own doc). A
+  // suspended WebView keeps neither its timers nor its person, yet `Date.now()`
+  // keeps counting, so on thaw `downSince` reads minutes old and the 15 s
+  // deadline - which fires as JS thaws, BEFORE the resume signal is delivered -
+  // escalates an outage nobody has watched for a second. The episode is
+  // re-dated to the resume instead.
+
+  function buildDownStore(resume: ResumeSource) {
+    const ready = createReadyControl(true);
+    const clock = createControllableClock();
+    const client = createFakeHostStreamClient(ready.isReady);
+    const store = createSessionConnectivityStore({
+      streamClient: client,
+      isReady: ready.isReady,
+      now: clock.now,
+      subscribeResume: resume.subscribe,
+      // No poll: every transition below is the work of an episode deadline
+      // or of the resume itself, which is what these cases are about.
+      pollMs: POLL_NEVER_MS,
+      announceAfterMs: SESSION_CONNECTIVITY_ANNOUNCE_AFTER_MS,
+      escalateAfterMs: SESSION_CONNECTIVITY_ESCALATE_AFTER_MS,
+    });
+    const unsubscribe = store.subscribe(vi.fn());
+    expect(store.getSnapshot()).toBe("ready");
+    ready.setReady(false);
+    // The close signal is what notices the drop; the episode is dated here.
+    client.fireClosed();
+    expect(store.getSnapshot()).toBe("settling");
+    return { clock, store, unsubscribe, ready };
+  }
+
+  it("re-dates the outage to the resume and clears an escalation the thaw fired", () => {
+    const resume = createResumeSource();
+    const { clock, store, unsubscribe } = buildDownStore(resume);
+    // Long past the escalate deadline, as a 3-minute background reads on thaw.
+    clock.advance(SESSION_CONNECTIVITY_ESCALATE_AFTER_MS * 12);
+    expect(store.getSnapshot()).toBe("interrupted-prolonged");
+
+    resume.emit();
+    // Back to the start of an episode: inside the announce window.
+    expect(store.getSnapshot()).toBe("settling");
+    clock.advance(SESSION_CONNECTIVITY_ANNOUNCE_AFTER_MS);
+    expect(store.getSnapshot()).toBe("interrupted");
+    clock.advance(
+      SESSION_CONNECTIVITY_ESCALATE_AFTER_MS -
+        SESSION_CONNECTIVITY_ANNOUNCE_AFTER_MS -
+        1,
+    );
+    expect(store.getSnapshot()).toBe("interrupted");
+    clock.advance(1);
+    expect(store.getSnapshot()).toBe("interrupted-prolonged");
+    unsubscribe();
+  });
+
+  it("restarts the wait even when the deadline had not yet passed", () => {
+    const resume = createResumeSource();
+    const { clock, store, unsubscribe } = buildDownStore(resume);
+    clock.advance(SESSION_CONNECTIVITY_ESCALATE_AFTER_MS * 0.7);
+    expect(store.getSnapshot()).toBe("interrupted");
+    resume.emit();
+    clock.advance(SESSION_CONNECTIVITY_ESCALATE_AFTER_MS * 0.7);
+    // 1.4 deadlines since the drop, 0.7 since the resume.
+    expect(store.getSnapshot()).toBe("interrupted");
+    clock.advance(SESSION_CONNECTIVITY_ESCALATE_AFTER_MS * 0.3);
+    expect(store.getSnapshot()).toBe("interrupted-prolonged");
+    unsubscribe();
+  });
+
+  it("does nothing on a resume while the session is ready", () => {
+    const resume = createResumeSource();
+    const clock = createControllableClock();
+    const ready = createReadyControl(true);
+    const store = createSessionConnectivityStore({
+      streamClient: createFakeHostStreamClient(ready.isReady),
+      isReady: ready.isReady,
+      now: clock.now,
+      subscribeResume: resume.subscribe,
+      pollMs: POLL_NEVER_MS,
+      announceAfterMs: SESSION_CONNECTIVITY_ANNOUNCE_AFTER_MS,
+      escalateAfterMs: SESSION_CONNECTIVITY_ESCALATE_AFTER_MS,
+    });
+    const unsubscribe = store.subscribe(vi.fn());
+    expect(store.getSnapshot()).toBe("ready");
+    resume.emit();
+    expect(store.getSnapshot()).toBe("ready");
+    unsubscribe();
+  });
+
+  it("subscribes to the resume signal with the other signals and releases it with them", () => {
+    const resume = createResumeSource();
+    const clock = createControllableClock();
+    const ready = createReadyControl(true);
+    const store = createSessionConnectivityStore({
+      streamClient: createFakeHostStreamClient(ready.isReady),
+      isReady: ready.isReady,
+      now: clock.now,
+      subscribeResume: resume.subscribe,
+      pollMs: POLL_NEVER_MS,
+      announceAfterMs: SESSION_CONNECTIVITY_ANNOUNCE_AFTER_MS,
+      escalateAfterMs: SESSION_CONNECTIVITY_ESCALATE_AFTER_MS,
+    });
+    expect(resume.listenerCount()).toBe(0);
+    const unsubscribe = store.subscribe(vi.fn());
+    expect(resume.listenerCount()).toBe(1);
+    unsubscribe();
+    expect(resume.listenerCount()).toBe(0);
   });
 });
 

--- a/clients/gui-app/src/lib/host/__tests__/session-connectivity.test.ts
+++ b/clients/gui-app/src/lib/host/__tests__/session-connectivity.test.ts
@@ -619,8 +619,8 @@ describe("createSessionConnectivityStore across a system resume", () => {
   // suspended WebView keeps neither its timers nor its person, yet `Date.now()`
   // keeps counting, so on thaw `downSince` reads minutes old and the 15 s
   // deadline - which fires as JS thaws, BEFORE the resume signal is delivered -
-  // escalates an outage nobody has watched for a second. The episode is
-  // re-dated to the resume instead.
+  // escalates an outage nobody has watched for a second. The episode is dated
+  // from the resume, so the deadlines measure the wait since return.
 
   function buildDownStore(resume: ResumeSource) {
     const ready = createReadyControl(true);

--- a/clients/gui-app/src/lib/host/session-connectivity.ts
+++ b/clients/gui-app/src/lib/host/session-connectivity.ts
@@ -2,6 +2,7 @@ import { useCallback, useMemo, useSyncExternalStore } from "react";
 import type { IHostStreamClient } from "@traycer-clients/shared/host-transport/host-stream-client";
 import type { HostStreamRpcRegistry } from "@traycer/protocol/host/registry";
 import { useWsStreamClient } from "@/lib/host/stream-runtime-context";
+import { useRunnerHostOrNull } from "@/providers/use-runner-host";
 import { isMobileApp } from "@/lib/mobile-app";
 
 /**
@@ -143,11 +144,28 @@ const wallClockNow = (): number => Date.now();
  * first observed, not inferred from poll ticks. The poll decides WHEN a drop is
  * noticed; the timers decide when it is announced and when it escalates, so
  * neither boundary inherits the poll's resolution.
+ *
+ * Both deadlines count only the waiting since the person was last present - a
+ * FOREGROUND wait, restarted by each return. The store dates an episode from
+ * `now()`, and `now()` keeps counting while a suspended WebView does not: on
+ * thaw a three-minute background reads as a three-minute outage, and the
+ * escalate deadline - a frozen timer that fires the moment JS resumes, before
+ * the shell's resume signal is delivered - stamps the outage prolonged before
+ * anyone has watched it for a second. `subscribeResume` is the shell's own
+ * "the person is back" edge; on it the episode is re-dated to the resume and
+ * any escalation taken back, so the deadlines describe waiting rather than
+ * absence. Gated on the signal, not on a measured dwell: desktop reports none.
  */
 export function createSessionConnectivityStore(args: {
   readonly streamClient: IHostStreamClient<HostStreamRpcRegistry> | null;
   readonly isReady: () => boolean;
   readonly now: () => number;
+  /**
+   * The shell's resume edge (`IRunnerHost.onSystemResumed`), as a subscription
+   * returning its disposer. Injected rather than read here so the store stays
+   * a pure function of its inputs and a test can pull the edge by hand.
+   */
+  readonly subscribeResume: (listener: () => void) => () => void;
   readonly pollMs: number;
   readonly announceAfterMs: number;
   readonly escalateAfterMs: number;
@@ -156,6 +174,7 @@ export function createSessionConnectivityStore(args: {
     streamClient,
     isReady,
     now,
+    subscribeResume,
     pollMs,
     announceAfterMs,
     escalateAfterMs,
@@ -225,12 +244,30 @@ export function createSessionConnectivityStore(args: {
     }
     const stopRecovered = streamClient.subscribeAvailabilityRecovered(notify);
     const stopClosed = streamClient.onClosed(notify);
+    const stopResume = subscribeResume(restartEpisodeWait);
     const poll = window.setInterval(notify, pollMs);
     detachSignals = () => {
       stopRecovered();
       stopClosed();
+      stopResume();
       window.clearInterval(poll);
     };
+  };
+
+  /**
+   * The person is back. Whatever the episode had accrued while they were away
+   * is not waiting, so it starts over from this instant: re-dated, deadlines
+   * re-armed for their full length, and an escalation the thaw may already have
+   * fired taken back. A ready session has no episode to restart.
+   */
+  const restartEpisodeWait = (): void => {
+    if (downSince === null) {
+      return;
+    }
+    downSince = now();
+    escalated = false;
+    armEpisodeTimers();
+    notify();
   };
 
   const refresh = (): void => {
@@ -315,17 +352,29 @@ export function createSessionConnectivityStore(args: {
 export function useHostSessionConnectivity(): HostSessionConnectivity {
   const activeClient = useWsStreamClient();
   const streamClient = isMobileApp() ? activeClient : null;
+  const runnerHost = useRunnerHostOrNull();
   const store = useMemo(
     () =>
       createSessionConnectivityStore({
         streamClient,
         isReady: () => streamClient !== null && streamClient.isReady(),
         now: wallClockNow,
+        subscribeResume: (listener) => {
+          if (runnerHost === null) {
+            return () => undefined;
+          }
+          const subscription = runnerHost.onSystemResumed(() => {
+            listener();
+          });
+          return () => {
+            subscription.dispose();
+          };
+        },
         pollMs: SESSION_CONNECTIVITY_POLL_MS,
         announceAfterMs: SESSION_CONNECTIVITY_ANNOUNCE_AFTER_MS,
         escalateAfterMs: SESSION_CONNECTIVITY_ESCALATE_AFTER_MS,
       }),
-    [streamClient],
+    [streamClient, runnerHost],
   );
   return useSyncExternalStore(
     store.subscribe,


### PR DESCRIPTION
## Symptom

On the phone (main, after #1815): background the app for a few minutes while a surface is syncing, come back, and the strip reads **"Still syncing…"** on the very first frame instead of the plain bar for the first minute.

## Cause, from on-device readings (probe build, iOS WKWebView)

Both escalation clocks measure wall time from when the outage was first seen: the surface spell's 60 s (`useStreamSyncingSpell`, "Still syncing…") and the session store's 15 s (`createSessionConnectivityStore`, "Still reconnecting"). Neither knows the person left.

| Reading | Result |
| --- | --- |
| JS timers across suspension | Frozen while backgrounded. A `setTimeout` whose deadline passed fires immediately on thaw. |
| Overdue timer vs. the shell's resume event | The timer fires about 25 ms **before** `IRunnerHost.onSystemResumed` reaches any subscriber. So a fix that only re-arms on resume is too late: the escalated word has already been set. |
| `performance.now()` | Advances across the suspension, same as `Date.now()`. A monotonic clock is no escape. |
| Driven 3-minute dwell (devicectl launches Preferences, waits, relaunches the app) | The WebView freezes about 1 ms after `pause`. Streams flip to `reconnecting` only at thaw, so both clocks arm at resume and nothing escalates. This path does **not** reproduce the symptom. |
| App-switcher dwell (inactive-but-not-suspended before the freeze) | The shape that arms the clocks *before* the freeze. Switcher reading: **pending** (manual run on the phone). |

## Rule

Escalation measures only time the person has actually **waited in the foreground**. On the shell's resume signal, both clocks take back any escalation already reached and restart their full wait from the resume:

- **Spell (60 s):** subscribes to `onSystemResumed` while a spell is running. On resume it clears `escalated` and bumps a `waitEpoch` in state that the timer effect depends on, so the timer re-arms for a full interval from the resume.
- **Store (15 s):** new required `subscribeResume` input, subscribed in `attachSignals` and released with the other signals. On resume mid-outage it re-dates `downSince` to now, clears `escalated`, re-arms both deadlines and notifies. A ready session ignores it. `useHostSessionConnectivity` feeds it from the runner host.

Gated on the **signal**, not on the reported dwell: desktop's powerMonitor sends `backgroundedForMs: null`, and a laptop that slept mid-outage was not being watched either.

Not a grace timer. The measured ordering (timer fires, then resume arrives) is why the resume must *undo* an escalation, not merely postpone one. The spell's timer also checks the epoch it was armed for, because the reverse order exists too: the resume's state update waits for React's scheduler, and a deadline expiring in that gap would otherwise land on the new epoch.

**Design limit.** The escalated word can still paint during the ~25 ms between the thaw and the resume signal. There is no first-frame guarantee, only a same-tick retraction. What the rule measures is the uninterrupted wait since the person was last present, not foreground time accumulated across absences: a three-minute foreground outage followed by a brief background starts the wait over.

## Desktop consequence

The spell hook runs on desktop too, so a powerMonitor resume during an outage restarts its 60 s wait. Intended. The session store stays mobile-only (`isMobileApp()` gate unchanged).

## Tests

Both clocks under fake timers with a synthetic resume (`MockRunnerHost.emitSystemResumed` for the hook, an injected resume source for the store):

- The measured order reproduced: escalated after the deadline, resume arrives, escalated is false, and a full fresh interval passes before it may escalate again.
- Restart from resume rather than from the drop (0.7 + 0.7 intervals is not an escalation; +0.3 is).
- Signal, not dwell: `backgroundedForMs: null` restarts the wait.
- No effect while not syncing / while ready.
- Subscription lifetime: the hook listens only while a spell runs and releases on end or unmount; the store subscribes and releases with its other signals.

Mutation-checked: dropping the reset, the re-date, the subscription, the disposal, or gating on dwell each fails at least one test. Two guards no test could kill were deleted rather than kept.

## Verification on device

Probe build stays on the phone until the switcher run is logged; the fix build follows for a look before merge.
