### PR TITLE
fix(gui-app): rename Application Settings Notifications to Sounds

### DIFF
--- a/clients/gui-app/src/components/layout/dialogs/desktop/report-issue-dialog.tsx
+++ b/clients/gui-app/src/components/layout/dialogs/desktop/report-issue-dialog.tsx
@@ -111,7 +111,7 @@ const ROUTE_TEMPLATE_LABELS: Readonly<
   "/settings/": "Settings",
   "/settings/agents": "Settings - Agents",
   "/settings/app-diagnostics": "Settings - App diagnostics",
-  "/settings/app-notifications": "Settings - Application notifications",
+  "/settings/app-notifications": "Settings - Sounds",
   "/settings/appearance": "Settings - Appearance",
   "/settings/devices": "Settings - Devices",
   "/settings/diagnostics": "Settings - Host diagnostics",

--- a/clients/gui-app/src/components/settings/__tests__/settings-group.test.tsx
+++ b/clients/gui-app/src/components/settings/__tests__/settings-group.test.tsx
@@ -93,4 +93,22 @@ describe("SettingsGroup", () => {
         .closest("section"),
     ).toBe(section);
   });
+
+  it("omits the group heading when the page title already names the card", () => {
+    render(
+      <SettingsGroup
+        title={undefined}
+        tone="default"
+        dataTestId="settings-group-untitled"
+        fill={false}
+      >
+        <div>row</div>
+      </SettingsGroup>,
+    );
+
+    const section = screen.getByTestId("settings-group-untitled");
+    expect(section.tagName).toBe("SECTION");
+    expect(screen.queryByRole("heading")).toBeNull();
+    expect(section.querySelector(".rounded-lg")).not.toBeNull();
+  });
 });

--- a/clients/gui-app/src/components/settings/__tests__/settings-sidebar.test.tsx
+++ b/clients/gui-app/src/components/settings/__tests__/settings-sidebar.test.tsx
@@ -240,6 +240,17 @@ describe("<SettingsSidebar /> leader hints", () => {
     expect(labels).not.toContain("Agents");
   });
 
+  it("labels application sounds apart from host notification events", () => {
+    const app = SETTINGS_SECTIONS.find(
+      (section) => section.id === "app-notifications",
+    );
+    const host = SETTINGS_SECTIONS.find(
+      (section) => section.id === "notifications",
+    );
+    expect(app?.label).toBe("Sounds");
+    expect(host?.label).toBe("Notifications");
+  });
+
   it("delays sub-leader digit badges in settings navigation", async () => {
     const router = buildRouter("/settings/general");
     render(

--- a/clients/gui-app/src/components/settings/panels/__tests__/app-notifications-settings-panel.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/app-notifications-settings-panel.test.tsx
@@ -45,12 +45,17 @@ describe("<AppNotificationsSettingsPanel />", () => {
   it("owns the app-wide sound setting without host filtering", () => {
     renderPanel({ pushPermission: null, systemSettings: null });
 
+    expect(screen.getByRole("heading", { name: "Sounds" })).toBeTruthy();
     expect(
-      within(screen.getByTestId("notification-chime-section")).getByRole(
-        "heading",
-        { name: "Sound" },
+      screen.getByText(
+        "Which chime plays for each kind of alert, across hosts.",
       ),
     ).toBeTruthy();
+    expect(
+      within(screen.getByTestId("notification-chime-section")).queryByRole(
+        "heading",
+      ),
+    ).toBeNull();
     expect(
       screen.getByRole("combobox", { name: "Needs action sound" }),
     ).toBeTruthy();

--- a/clients/gui-app/src/components/settings/panels/__tests__/push-permission-section.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/push-permission-section.test.tsx
@@ -279,7 +279,7 @@ describe("<PushPermissionSection />", () => {
     // Built on the REAL app query client: its 60s `staleTime` is the whole
     // point. The `onChange` subscription is disposed while this row is
     // unmounted, so nothing invalidates in between - leave a person to change
-    // the switch in the OS Settings app between two visits to Notifications
+    // the switch in the OS Settings app between two visits to Sounds
     // and a cached answer would show them "Off · Open Settings" on a phone
     // where push is already on.
     const permission = doubleFor("denied");

--- a/clients/gui-app/src/components/settings/panels/app-notifications-settings-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/app-notifications-settings-panel.tsx
@@ -14,8 +14,8 @@ export function AppNotificationsSettingsPanel() {
 
   return (
     <SettingsPanelShell
-      title="Notifications"
-      description="How this app alerts you across hosts."
+      title="Sounds"
+      description="Which chime plays for each kind of alert, across hosts."
       bodyClassName="overflow-visible rounded-none border-none bg-transparent"
     >
       <div className={cn("flex flex-col", compact ? "gap-3.5" : "gap-5")}>

--- a/clients/gui-app/src/components/settings/panels/notification-chime-settings-section.tsx
+++ b/clients/gui-app/src/components/settings/panels/notification-chime-settings-section.tsx
@@ -53,7 +53,10 @@ export function NotificationChimeSettingsSection() {
 
   return (
     <SettingsGroup
-      title="Sound"
+      // The page is already titled Sounds; a group heading (Sound, Chimes)
+      // would be a second name for the same four dropdowns. System / Events
+      // below keep titles because they are different destinations.
+      title={undefined}
       tone="default"
       dataTestId="notification-chime-section"
       fill={false}

--- a/clients/gui-app/src/components/settings/panels/notifications-settings-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/notifications-settings-panel.tsx
@@ -181,7 +181,7 @@ function NotificationsSettingsPanelContent(props: {
   return (
     <SettingsPanelShell
       title="Notifications"
-      description="What this host surfaces, and what its automation receives."
+      description="Which events this host surfaces, and what its automation receives. Choose chimes under Application → Sounds; manage banners in your operating system's notification settings."
       fillHeight
       bodyClassName="overflow-visible rounded-none border-none bg-transparent"
       // The header named the scoped host until the sidebar started doing it a

--- a/clients/gui-app/src/components/settings/panels/push-permission-section.tsx
+++ b/clients/gui-app/src/components/settings/panels/push-permission-section.tsx
@@ -34,7 +34,7 @@ const READ_FAILED = "Couldn't read this phone's notification setting.";
 
 /**
  * The OS push permission of the phone this renderer runs on. It belongs under
- * Application → Notifications because it never varies with the selected host.
+ * Application → Sounds because it never varies with the selected host.
  *
  * It exists because the OS remembers a refusal forever - the app asks once,
  * and after a "Don't Allow" no amount of relaunching can re-prompt. Without

--- a/clients/gui-app/src/components/settings/settings-group.tsx
+++ b/clients/gui-app/src/components/settings/settings-group.tsx
@@ -3,7 +3,11 @@ import { cn } from "@/lib/utils";
 import { useSettingsDensity } from "@/providers/settings-density-context";
 
 interface SettingsGroupProps {
-  readonly title: string;
+  /**
+   * Label outside the card. Pass `undefined` when the page heading already
+   * names this group — a second word next to it is a duplicate, not orientation.
+   */
+  readonly title: string | undefined;
   readonly tone: "default" | "danger";
   readonly dataTestId: string | undefined;
   readonly children: ReactNode;
@@ -35,16 +39,18 @@ export function SettingsGroup(props: SettingsGroupProps): ReactNode {
       data-testid={dataTestId}
       className={cn(fill && "flex h-full min-h-0 flex-col")}
     >
-      <h2
-        className={cn(
-          "px-1 font-semibold text-ui-xs text-muted-foreground",
-          compact ? "mb-1" : "mb-1.5",
-          tone === "danger" && "text-destructive/80",
-          fill && "shrink-0",
-        )}
-      >
-        {title}
-      </h2>
+      {title === undefined ? null : (
+        <h2
+          className={cn(
+            "px-1 font-semibold text-ui-xs text-muted-foreground",
+            compact ? "mb-1" : "mb-1.5",
+            tone === "danger" && "text-destructive/80",
+            fill && "shrink-0",
+          )}
+        >
+          {title}
+        </h2>
+      )}
       <div
         className={cn(
           "overflow-hidden rounded-lg border border-border/60 bg-card/40",

--- a/clients/gui-app/src/hooks/runner/use-push-permission-query.ts
+++ b/clients/gui-app/src/hooks/runner/use-push-permission-query.ts
@@ -12,7 +12,7 @@ import { useRunnerHost } from "@/providers/use-runner-host";
 export type PushPermissionQuery = UseQueryResult<PushPermissionState>;
 
 /**
- * This phone's OS push permission, for the Settings → Notifications "This
+ * This phone's OS push permission, for the Settings → Sounds "This
  * phone" row. Disabled - and therefore never fetched - on the shells that
  * have no OS push at all (desktop, dev web, tests), where the row is hidden
  * outright.
@@ -61,7 +61,7 @@ export function usePushPermissionQuery(): PushPermissionQuery {
       // query fresh for 60s, but the OS owns this value and moves it while
       // Traycer is backgrounded - and the `onChange` subscription above is
       // disposed the moment this row unmounts, so nothing invalidates in
-      // between. Without this, reopening Notifications within a minute of
+      // between. Without this, reopening Sounds within a minute of
       // enabling push in the OS Settings app renders "Off · Open Settings" on
       // a phone where push is already on.
       staleTime: 0,

--- a/clients/gui-app/src/lib/commands/__tests__/navigation.source.test.tsx
+++ b/clients/gui-app/src/lib/commands/__tests__/navigation.source.test.tsx
@@ -107,4 +107,15 @@ describe("navigationSource", () => {
     expect(ids).not.toContain("nav:settings/appearance");
     expect(ids).toContain("nav:settings/general");
   });
+
+  it("distinguishes application Sounds from host Notifications", () => {
+    const items = captureSettingsSubpage("/");
+    const app = items.find((i) => i.id === "nav:settings/app-notifications");
+    const host = items.find((i) => i.id === "nav:settings/notifications");
+    expect(app?.label).toBe("Sounds");
+    expect(app?.statusBadge).toBe("Application");
+    expect(app?.keywords).toContain("notifications");
+    expect(host?.label).toBe("Notifications");
+    expect(host?.statusBadge).toBe("Host");
+  });
 });

--- a/clients/gui-app/src/lib/commands/sources/navigation.source.ts
+++ b/clients/gui-app/src/lib/commands/sources/navigation.source.ts
@@ -111,6 +111,9 @@ function buildSectionItem(section: SettingsSection): CommandItem {
       "settings",
       section.label.toLowerCase(),
       section.id,
+      // Hyphenated ids stay findable by each segment ("notifications" still
+      // reaches Sounds after that row dropped the word from its label).
+      ...section.id.split("-"),
       ...(group === undefined ? [] : [group.toLowerCase()]),
     ],
     group: "navigation",

--- a/clients/gui-app/src/lib/query-keys/runner-mutation-keys.ts
+++ b/clients/gui-app/src/lib/query-keys/runner-mutation-keys.ts
@@ -119,7 +119,7 @@ export const runnerMutationKeys = {
     ["runner.appUpdates.setAllowPrerelease"] as const,
   globalShortcutsSet: (id: GlobalShortcutId) =>
     ["runner.globalShortcuts.set", id] as const,
-  // Settings → Notifications → "This phone". Both act on the ONE device this
+  // Settings → Sounds → "This phone". Both act on the ONE device this
   // renderer runs on, so a static key is the whole scope - there is no second
   // OS permission to hold a separate entry for.
   pushPermissionRequest: () => ["runner.pushPermission.request"] as const,
@@ -347,7 +347,7 @@ export const runnerQueryKeys = {
     target: string,
   ) =>
     ["runner.support.frozenLogTail", supportScopeId, draftId, target] as const,
-  // This phone's OS push permission (Settings → Notifications → "This
+  // This phone's OS push permission (Settings → Sounds → "This
   // phone"). Machine-local and singular - one renderer, one OS switch - so a
   // static key suffices, like `logLevels` and `installedFonts` above.
   pushPermission: () => ["runner.pushPermission"] as const,

--- a/clients/gui-app/src/lib/settings-sections.ts
+++ b/clients/gui-app/src/lib/settings-sections.ts
@@ -14,6 +14,7 @@ import {
   ShieldCheck,
   Settings as SettingsIcon,
   TerminalSquare,
+  Volume2,
 } from "lucide-react";
 import { isMobileApp } from "@/lib/mobile-app";
 
@@ -105,7 +106,7 @@ export interface SettingsSection {
  * are the eleventh through sixteenth and go without. Providers is the newest
  * to lose one, to Opening behavior taking the third Application slot.
  *
- * Worktrees is the one that lost a digit to the app-scoped Notifications
+ * Worktrees is the one that lost a digit to the app-scoped Sounds
  * entry below. That follows from keeping Application entries together at the
  * start: giving Worktrees its digit back would require shortcut order to
  * diverge from both sidebar reading order and command-palette row order.
@@ -113,6 +114,16 @@ export interface SettingsSection {
  * Section `id`s are a compatibility surface — routes (`/settings/<id>`), the
  * settings-modal panel table, the command palette and remembered tab paths key
  * off them — so ids never change even when labels do.
+ *
+ * The rail label names WHAT the page controls; the group heading names WHOSE
+ * it is. Two pages that control the same thing at two scopes share word and
+ * icon (Diagnostics). Two pages that control different things get different
+ * words and icons (Sounds vs Notifications). Surfaces with no scope carrier
+ * qualify the label themselves — report-issue route labels already do
+ * ("App diagnostics" / "Host diagnostics"). The mobile header still shows
+ * the bare section label; that case is unresolved, not an example of the rule.
+ * Putting the group word into a row the heading already scopes is the
+ * inconsistent move, not the consistent one.
  */
 export const SETTINGS_SECTIONS: ReadonlyArray<SettingsSection> = [
   {
@@ -136,13 +147,13 @@ export const SETTINGS_SECTIONS: ReadonlyArray<SettingsSection> = [
     icon: PanelsTopLeft,
     group: "app",
   },
-  // Application and Host intentionally both have a Notifications page. The
-  // group heading states the scope: this one owns renderer sound and the
-  // phone's OS permission; the host one owns filtering and automation.
+  // Different controls than Host → Notifications, so a different word and
+  // icon (see the rail-table rule above). The section `id` stays
+  // `app-notifications`.
   {
     id: "app-notifications",
-    label: "Notifications",
-    icon: Bell,
+    label: "Sounds",
+    icon: Volume2,
     group: "app",
   },
   {
@@ -151,12 +162,10 @@ export const SETTINGS_SECTIONS: ReadonlyArray<SettingsSection> = [
     icon: Keyboard,
     group: "app",
   },
-  // Application, not Host, and it is the same word as the host section on
-  // purpose: both pages ARE diagnostics, and the group heading above each is
-  // what says whose. The split exists because this half never varied by host —
-  // the app's log verbosity, its log file and its heap describe one window —
-  // so under the picker it was drawn once per host in the account, offering the
-  // same single setting from N places.
+  // Same kind of page as Host → Diagnostics, partitioned by scope, so the
+  // same word and icon. The split exists because this half never varied by
+  // host — the app's log verbosity, its log file and its heap describe one
+  // window — so under the picker it was drawn once per host in the account.
   {
     id: "app-diagnostics",
     label: "Diagnostics",
@@ -215,6 +224,8 @@ export const SETTINGS_SECTIONS: ReadonlyArray<SettingsSection> = [
     icon: GitBranch,
     group: "host",
   },
+  // Event policy and automation for the selected host. Different controls
+  // than Application → Sounds, so it keeps the generic word and the bell.
   {
     id: "notifications",
     label: "Notifications",
@@ -238,9 +249,9 @@ export const SETTINGS_SECTIONS: ReadonlyArray<SettingsSection> = [
     icon: TerminalSquare,
     group: "host",
   },
-  // The host half: `cli`/`host` log verbosity and that machine's own log
-  // files. Everything left here answers differently per host, which is what
-  // earns it a place under the picker.
+  // Same kind of page as Application → Diagnostics, partitioned by scope, so
+  // the same word and icon. Everything left here answers differently per host,
+  // which is what earns it a place under the picker.
   {
     id: "diagnostics",
     label: "Diagnostics",

--- a/clients/shared/platform/runner-host.ts
+++ b/clients/shared/platform/runner-host.ts
@@ -678,7 +678,7 @@ export type PushPermissionState = "prompt" | "granted" | "denied";
 
 /**
  * Read/repair surface for the device's OS push permission, backing the
- * Settings → Notifications "this phone" row. Only reachable where
+ * Settings → Sounds "this phone" row. Only reachable where
  * `IRunnerHost.pushPermission` is non-null.
  */
 export interface IPushPermissionHost {


### PR DESCRIPTION
## Summary
- Rename Application Settings **Notifications** to **Sounds** (volume icon) so it no longer collides with Host **Notifications** (bell), which still owns event policy and automation.
- Leave the Diagnostics pair sharing a word and icon: those pages are the same kind of setting, scoped by the Application vs Host group heading.
- Copy follow-through: untitled chime card under Sounds, Host subtitle points to Sounds for chimes and to the OS for banners, command palette still finds Sounds via the `app-notifications` id.

## Test plan
- [ ] Open Settings and confirm Application shows **Sounds**, Host shows **Notifications**, both Diagnostics rows still say Diagnostics.
- [ ] Application → Sounds: page title is Sounds, chime dropdowns have no extra group heading, System/Events cards still titled.
- [ ] Host → Notifications subtitle points to Application → Sounds for chimes and to OS settings for banners.
- [ ] Command palette: search “notifications” still lists Sounds (Application badge) and Notifications (Host badge).
- [ ] macOS/Windows: Sounds still has OS notifications → Open Settings. Linux: no System card, subtitle does not claim banners live on Sounds.


Made with [Cursor](https://cursor.com)