### PR TITLE
fix(gui-app): drop the cloud-versus-device notices from the task list

### DIFF
--- a/clients/gui-app/src/components/epics/__tests__/epics-list-panel.test.tsx
+++ b/clients/gui-app/src/components/epics/__tests__/epics-list-panel.test.tsx
@@ -530,12 +530,13 @@ describe("<EpicsListPanel />", () => {
     };
     renderPanel("embedded", "/");
 
-    expect(
-      await screen.findByTestId("epics-list-cloud-page-unavailable"),
-    ).not.toBeNull();
+    expect(await screen.findByTestId("epics-list-unavailable")).not.toBeNull();
     // RED before the fix: "No tasks yet" rendered under the notice, a claim
     // about an account whose tasks may all live on other devices.
     expect(screen.queryByTestId("epics-list-empty")).toBeNull();
+
+    fireEvent.click(screen.getByTestId("epics-list-unavailable-retry"));
+    expect(testState.refetch).toHaveBeenCalled();
   });
 
   it("shows the explicit cloud-pending state instead of an empty list", async () => {
@@ -544,12 +545,7 @@ describe("<EpicsListPanel />", () => {
     renderPanel("embedded", "/");
 
     expect(screen.queryByTestId("epics-list-empty")).toBeNull();
-    expect(
-      await screen.findByTestId("epics-list-cloud-page-pending"),
-    ).not.toBeNull();
-    expect(screen.getByTestId("epics-list-completeness").textContent).toContain(
-      "Cloud tasks are still loading",
-    );
+    expect(await screen.findByTestId("epics-list-loading")).not.toBeNull();
   });
 
   it("labels a task that is already open in the tab strip", async () => {
@@ -726,48 +722,12 @@ describe("<EpicsListPanel />", () => {
     expect(rows.textContent).not.toContain("Preserved orphan");
   });
 
-  it("states what an offline page is missing instead of presenting it as complete", async () => {
+  it("never tells the user which rows came from the cloud or the device", async () => {
+    // The worst-case statement that used to render every line of the
+    // completeness notice: an unavailable cloud page, partial facets,
+    // a truncated local page and an order that is only a loaded union.
     testState.items = [
       historyItem({ id: "history-local", epicId: "local", title: "Local" }),
-    ];
-    testState.completeness = {
-      cloudPage: "unavailable",
-      facets: "partial",
-      localRows: "present",
-      sort: "loaded-union",
-    };
-    renderPanel("embedded", "/");
-
-    const notice = await screen.findByTestId("epics-list-completeness");
-    expect(notice.getAttribute("data-cloud-page")).toBe("unavailable");
-    expect(notice.textContent).toContain("Cloud tasks couldn't be reached");
-    // `facets: "partial"` means the counts describe a DIFFERENT set from the
-    // rows, so the notice may not claim they cover the listed tasks - the
-    // fixture sets exactly that, and the older wording asserted the opposite.
-    expect(notice.textContent).toContain("Order covers the tasks listed here");
-    expect(notice.textContent).toContain("filter counts may leave some");
-  });
-
-  it("keeps the complete-counts wording when only the ORDER is a loaded union", async () => {
-    testState.items = [
-      historyItem({ id: "history-local", epicId: "local", title: "Local" }),
-    ];
-    testState.completeness = {
-      cloudPage: "settled",
-      facets: "server",
-      localRows: "present",
-      sort: "loaded-union",
-    };
-    renderPanel("embedded", "/");
-
-    const notice = await screen.findByTestId("epics-list-completeness");
-    expect(notice.textContent).toContain("not everything you have");
-    expect(notice.textContent).not.toContain("filter counts may leave some");
-  });
-
-  it("says a truncated page may be missing tasks, without claiming where", async () => {
-    testState.items = [
-      historyItem({ id: "history-m1", epicId: "m1", title: "Mirror 1" }),
     ];
     testState.completeness = {
       cloudPage: "unavailable",
@@ -777,52 +737,17 @@ describe("<EpicsListPanel />", () => {
     };
     renderPanel("embedded", "/");
 
-    const notice = await screen.findByTestId("epics-list-completeness");
-    expect(notice.getAttribute("data-local-rows")).toBe("truncated");
-    // A `truncated` page that says nothing reads as covered-everything - the
-    // banner going silent is what this guards against, not one particular
-    // wording. The copy deliberately does not name WHERE the gap is:
-    // `truncated` has more than one producer (the page cap, an unprovable
-    // filter, an unread root doc), and the wire member does not distinguish
-    // them, so a client must not either.
-    expect(notice.textContent).toContain(
-      "couldn't be checked against your filters",
-    );
-  });
-
-  it("names a filter this device cannot check rather than showing an empty list", async () => {
-    testState.items = [];
-    testState.completeness = {
-      cloudPage: "unavailable",
-      facets: "partial",
-      localRows: "suppressed-unprovable-filter",
-      sort: "server",
-    };
-    renderPanel("embedded", "/");
-
-    const notice = await screen.findByTestId("epics-list-completeness");
-    expect(notice.getAttribute("data-local-rows")).toBe(
-      "suppressed-unprovable-filter",
-    );
-    expect(notice.textContent).toContain("can't be checked against tasks");
-  });
-
-  it("says nothing at all for a fully server-owned page", async () => {
-    testState.items = [
-      historyItem({ id: "history-cloud", epicId: "cloud", title: "Cloud" }),
-    ];
-    testState.completeness = {
-      cloudPage: "settled",
-      facets: "server",
-      localRows: "none",
-      sort: "server",
-    };
-    renderPanel("embedded", "/");
-
-    expect(await screen.findByText("Cloud")).not.toBeNull();
-    // A caveat that appears on a complete page is the same defect wearing the
-    // other sign.
-    expect(screen.queryByTestId("epics-list-completeness")).toBeNull();
+    const rows = await screen.findByTestId("epics-list-rows");
+    expect(rows.textContent).toContain("Local");
+    expect(screen.queryByRole("status")).toBeNull();
+    // Scoped to the list body's own container rather than the whole
+    // document: unrelated chrome (a filter chip label, for example) could
+    // otherwise fail this assertion for a reason that has nothing to do with
+    // the row or empty-state copy under test.
+    const listBody = rows.closest("section");
+    expect(listBody).not.toBeNull();
+    expect(listBody?.textContent ?? "").not.toMatch(/cloud/i);
+    expect(listBody?.textContent ?? "").not.toMatch(/device/i);
   });
 
   it("disables pin mutation for a local-home epic and names the cloud-sync boundary", async () => {

--- a/clients/gui-app/src/components/epics/__tests__/epics-list-panel.test.tsx
+++ b/clients/gui-app/src/components/epics/__tests__/epics-list-panel.test.tsx
@@ -539,6 +539,43 @@ describe("<EpicsListPanel />", () => {
     expect(testState.refetch).toHaveBeenCalled();
   });
 
+  it("does not call a filtered result empty when the listing was unavailable", async () => {
+    testState.items = [];
+    testState.completeness = {
+      cloudPage: "unavailable",
+      facets: "partial",
+      localRows: "suppressed-unprovable-filter",
+      sort: "server",
+    };
+    useHistorySearchStore.setState({
+      search: { ...DEFAULT_HISTORY_SEARCH, query: "missing" },
+    });
+    renderPanel("embedded", "/");
+
+    expect(await screen.findByTestId("epics-list-unavailable")).not.toBeNull();
+    expect(screen.queryByTestId("epics-list-filtered-empty")).toBeNull();
+    expect(screen.queryByTestId("epics-list-empty")).toBeNull();
+  });
+
+  it("shows the filtered empty state when the cloud page has settled", async () => {
+    testState.items = [];
+    testState.completeness = {
+      cloudPage: "settled",
+      facets: "server",
+      localRows: "none",
+      sort: "server",
+    };
+    useHistorySearchStore.setState({
+      search: { ...DEFAULT_HISTORY_SEARCH, query: "missing" },
+    });
+    renderPanel("embedded", "/");
+
+    expect(
+      await screen.findByTestId("epics-list-filtered-empty"),
+    ).not.toBeNull();
+    expect(screen.queryByTestId("epics-list-unavailable")).toBeNull();
+  });
+
   it("shows the explicit cloud-pending state instead of an empty list", async () => {
     testState.items = [];
     testState.cloudPagePending = true;

--- a/clients/gui-app/src/components/epics/__tests__/epics-list-panel.test.tsx
+++ b/clients/gui-app/src/components/epics/__tests__/epics-list-panel.test.tsx
@@ -530,13 +530,33 @@ describe("<EpicsListPanel />", () => {
     };
     renderPanel("embedded", "/");
 
-    expect(await screen.findByTestId("epics-list-unavailable")).not.toBeNull();
+    const unavailable = await screen.findByTestId("epics-list-unavailable");
+    expect(unavailable).not.toBeNull();
     // RED before the fix: "No tasks yet" rendered under the notice, a claim
     // about an account whose tasks may all live on other devices.
     expect(screen.queryByTestId("epics-list-empty")).toBeNull();
+    expect(unavailable.getAttribute("data-remedy")).toBe("retry");
 
     fireEvent.click(screen.getByTestId("epics-list-unavailable-retry"));
     expect(testState.refetch).toHaveBeenCalled();
+  });
+
+  it("offers sign-in instead of a dead Retry when the session is unverified", async () => {
+    testState.items = [];
+    testState.completeness = {
+      cloudPage: "unavailable",
+      facets: "partial",
+      localRows: "none",
+      sort: "server",
+    };
+    useAuthStore.setState({ status: "unverified" });
+    renderPanel("embedded", "/");
+
+    const unavailable = await screen.findByTestId("epics-list-unavailable");
+    expect(unavailable.getAttribute("data-remedy")).toBe("sign-in");
+    expect(screen.queryByTestId("epics-list-unavailable-retry")).toBeNull();
+    expect(unavailable.textContent).toContain("Sign in again");
+    expect(screen.queryByTestId("epics-list-empty")).toBeNull();
   });
 
   it("does not call a filtered result empty when the listing was unavailable", async () => {

--- a/clients/gui-app/src/components/epics/__tests__/mobile-history-list.test.tsx
+++ b/clients/gui-app/src/components/epics/__tests__/mobile-history-list.test.tsx
@@ -727,7 +727,9 @@ describe("<MobileHistoryList /> (via <EpicsListPanel /> at a mobile viewport)", 
       };
       renderPanel("embedded", "/");
 
-      expect(await screen.findByTestId("epics-list-unavailable")).not.toBeNull();
+      expect(
+        await screen.findByTestId("epics-list-unavailable"),
+      ).not.toBeNull();
       expect(screen.queryByTestId("epics-list-empty")).toBeNull();
     });
 

--- a/clients/gui-app/src/components/epics/__tests__/mobile-history-list.test.tsx
+++ b/clients/gui-app/src/components/epics/__tests__/mobile-history-list.test.tsx
@@ -727,9 +727,27 @@ describe("<MobileHistoryList /> (via <EpicsListPanel /> at a mobile viewport)", 
       };
       renderPanel("embedded", "/");
 
-      expect(
-        await screen.findByTestId("epics-list-unavailable"),
-      ).not.toBeNull();
+      const unavailable = await screen.findByTestId("epics-list-unavailable");
+      expect(unavailable).not.toBeNull();
+      expect(screen.queryByTestId("epics-list-empty")).toBeNull();
+      expect(unavailable.getAttribute("data-remedy")).toBe("retry");
+    });
+
+    it("offers sign-in instead of a dead Retry when the session is unverified", async () => {
+      testState.items = [];
+      testState.completeness = {
+        cloudPage: "unavailable",
+        facets: "partial",
+        localRows: "none",
+        sort: "server",
+      };
+      useAuthStore.setState({ status: "unverified" });
+      renderPanel("embedded", "/");
+
+      const unavailable = await screen.findByTestId("epics-list-unavailable");
+      expect(unavailable.getAttribute("data-remedy")).toBe("sign-in");
+      expect(screen.queryByTestId("epics-list-unavailable-retry")).toBeNull();
+      expect(unavailable.textContent).toContain("Sign in again");
       expect(screen.queryByTestId("epics-list-empty")).toBeNull();
     });
 

--- a/clients/gui-app/src/components/epics/__tests__/mobile-history-list.test.tsx
+++ b/clients/gui-app/src/components/epics/__tests__/mobile-history-list.test.tsx
@@ -716,7 +716,7 @@ describe("<MobileHistoryList /> (via <EpicsListPanel /> at a mobile viewport)", 
     });
   });
 
-  describe("completeness and pending cloud page", () => {
+  describe("unavailable and pending cloud page", () => {
     it("does not declare the account empty when the cloud page is unavailable", async () => {
       testState.items = [];
       testState.completeness = {
@@ -727,13 +727,11 @@ describe("<MobileHistoryList /> (via <EpicsListPanel /> at a mobile viewport)", 
       };
       renderPanel("embedded", "/");
 
-      expect(
-        await screen.findByTestId("epics-list-cloud-page-unavailable"),
-      ).not.toBeNull();
+      expect(await screen.findByTestId("epics-list-unavailable")).not.toBeNull();
       expect(screen.queryByTestId("epics-list-empty")).toBeNull();
     });
 
-    it("explains when cloud tasks are unavailable instead of implying a complete local list", async () => {
+    it("renders the rows with no cloud or device notice when the cloud page is unavailable", async () => {
       testState.items = [
         historyItem({ id: "history-local", epicId: "local", title: "Local" }),
       ];
@@ -745,28 +743,17 @@ describe("<MobileHistoryList /> (via <EpicsListPanel /> at a mobile viewport)", 
       };
       renderPanel("embedded", "/");
 
-      const notice = await screen.findByTestId("epics-list-completeness");
-      expect(notice.getAttribute("data-cloud-page")).toBe("unavailable");
-      expect(notice.textContent).toContain("Cloud tasks couldn't be reached");
-      expect(notice.textContent).toContain(
-        "Order covers the tasks listed here",
-      );
-    });
-
-    it("explains when local rows are truncated, without claiming where", async () => {
-      testState.completeness = {
-        cloudPage: "settled",
-        facets: "server",
-        localRows: "truncated",
-        sort: "loaded-union",
-      };
-      renderPanel("embedded", "/");
-
-      const notice = await screen.findByTestId("epics-list-completeness");
-      expect(notice.getAttribute("data-local-rows")).toBe("truncated");
-      expect(notice.textContent).toContain(
-        "couldn't be checked against your filters",
-      );
+      const rows = await screen.findByTestId("epics-list-rows");
+      expect(rows.textContent).toContain("Local");
+      expect(screen.queryByRole("status")).toBeNull();
+      // Scoped to the list body's own container rather than the whole
+      // document: unrelated chrome (a filter chip label, for example) could
+      // otherwise fail this assertion for a reason that has nothing to do
+      // with the row or empty-state copy under test.
+      const listBody = rows.closest("section");
+      expect(listBody).not.toBeNull();
+      expect(listBody?.textContent ?? "").not.toMatch(/cloud/i);
+      expect(listBody?.textContent ?? "").not.toMatch(/device/i);
     });
 
     it("explains an empty filtered result when the local filter is unprovable", async () => {
@@ -782,15 +769,10 @@ describe("<MobileHistoryList /> (via <EpicsListPanel /> at a mobile viewport)", 
       });
       renderPanel("embedded", "/");
 
-      const notice = await screen.findByTestId("epics-list-completeness");
-      expect(notice.getAttribute("data-local-rows")).toBe(
-        "suppressed-unprovable-filter",
-      );
-      expect(notice.textContent).toContain(
-        "can't be checked against tasks stored on the connected device",
-      );
+      expect(
+        await screen.findByTestId("epics-list-filtered-empty"),
+      ).not.toBeNull();
       expect(screen.queryByTestId("epics-list-empty")).toBeNull();
-      expect(screen.getByTestId("epics-list-filtered-empty")).not.toBeNull();
     });
 
     it("shows the explicit cloud-pending state when local storage is empty", async () => {
@@ -799,12 +781,7 @@ describe("<MobileHistoryList /> (via <EpicsListPanel /> at a mobile viewport)", 
       renderPanel("embedded", "/");
 
       expect(screen.queryByTestId("epics-list-empty")).toBeNull();
-      expect(
-        await screen.findByTestId("epics-list-cloud-page-pending"),
-      ).not.toBeNull();
-      expect(
-        screen.getByTestId("epics-list-completeness").textContent,
-      ).toContain("Cloud tasks are still loading");
+      expect(await screen.findByTestId("epics-list-loading")).not.toBeNull();
     });
   });
 

--- a/clients/gui-app/src/components/epics/__tests__/mobile-history-list.test.tsx
+++ b/clients/gui-app/src/components/epics/__tests__/mobile-history-list.test.tsx
@@ -758,7 +758,7 @@ describe("<MobileHistoryList /> (via <EpicsListPanel /> at a mobile viewport)", 
       expect(listBody?.textContent ?? "").not.toMatch(/device/i);
     });
 
-    it("explains an empty filtered result when the local filter is unprovable", async () => {
+    it("does not call a filtered result empty when the listing was unavailable", async () => {
       testState.items = [];
       testState.completeness = {
         cloudPage: "unavailable",
@@ -772,9 +772,10 @@ describe("<MobileHistoryList /> (via <EpicsListPanel /> at a mobile viewport)", 
       renderPanel("embedded", "/");
 
       expect(
-        await screen.findByTestId("epics-list-filtered-empty"),
+        await screen.findByTestId("epics-list-unavailable"),
       ).not.toBeNull();
       expect(screen.queryByTestId("epics-list-empty")).toBeNull();
+      expect(screen.queryByTestId("epics-list-filtered-empty")).toBeNull();
     });
 
     it("shows the explicit cloud-pending state when local storage is empty", async () => {

--- a/clients/gui-app/src/components/epics/epics-list-panel.tsx
+++ b/clients/gui-app/src/components/epics/epics-list-panel.tsx
@@ -1405,6 +1405,12 @@ function EpicsListBody(props: EpicsListBodyProps): ReactNode {
     if (isFetching) {
       return <EpicsListFilteringLoading />;
     }
+    // A filtered result with no settled page is not "No tasks match": the
+    // filter was never evaluated over the account. Same neutral state as the
+    // unfiltered arm - a failed load with a retry, and nothing about where.
+    if (completeness?.cloudPage === "unavailable") {
+      return <EpicsListUnavailable onRetry={onRetry} />;
+    }
   }
   const rowProps = {
     selectionMode,

--- a/clients/gui-app/src/components/epics/epics-list-panel.tsx
+++ b/clients/gui-app/src/components/epics/epics-list-panel.tsx
@@ -80,8 +80,6 @@ import {
 import { EpicsFilterPopover } from "@/components/epics/epics-filter-popover";
 import {
   EpicsListChatHostFilterUnsupported,
-  EpicsListCloudPagePending,
-  EpicsListCloudPageUnavailable,
   EpicsListEmpty,
   EpicsListError,
   EpicsListFilteredEmpty,
@@ -89,7 +87,7 @@ import {
   EpicsListHostRequiresCloudToList,
   EpicsListLoading,
   EpicsListShowMore,
-  HistoryCompletenessNotice,
+  EpicsListUnavailable,
   HistoryRowLeadingIcon,
 } from "@/components/epics/epics-list-shared";
 import {
@@ -311,10 +309,10 @@ function historyPanelView(
     availableWorkspaces: data.availableWorkspaces,
     facets: data.facets,
     // `?? null` rather than a straight read: `completeness` is declared
-    // non-optional but arrives absent from partial fixtures, and the notice
+    // non-optional but arrives absent from partial fixtures, and the body
     // below dereferences it. The previous `data?.completeness ?? null` carried
     // that same coercion, so dropping it turned an omitted field into a render
-    // crash rather than a missing notice.
+    // crash.
     completeness: data.completeness ?? null,
   };
 }
@@ -1389,49 +1387,23 @@ function EpicsListBody(props: EpicsListBodyProps): ReactNode {
   if (items.length === 0) {
     // A pending local-first page is a renderable device snapshot, not a settled
     // account result. Keep the distinct state ahead of every empty branch so an
-    // empty mirror never becomes the definitive "No tasks yet" claim.
+    // empty mirror never becomes the definitive "No tasks yet" claim - it is
+    // still a load.
     if (cloudPagePending) {
-      return (
-        <>
-          <HistoryCompletenessNotice
-            completeness={completeness}
-            cloudPagePending={cloudPagePending}
-          />
-          <EpicsListCloudPagePending />
-        </>
-      );
+      return <EpicsListLoading />;
     }
     if (!hasActiveFilters) {
-      // The notice renders HERE too, and this is the case it matters most for:
-      // an empty History with no explanation is the strongest possible claim of
-      // completeness, and it is the one a suppressed local projection or an
-      // unreachable cloud page produces. With NO cloud page the body must not
-      // make that claim either: zero local rows is not evidence of an empty
-      // account.
-      return (
-        <>
-          <HistoryCompletenessNotice
-            completeness={completeness}
-            cloudPagePending={cloudPagePending}
-          />
-          {completeness?.cloudPage === "unavailable" ? (
-            <EpicsListCloudPageUnavailable />
-          ) : (
-            <EpicsListEmpty />
-          )}
-        </>
+      // With NO settled page the body must not claim an empty account: zero
+      // rows is not evidence of one. It says the load failed, and nothing
+      // about where.
+      return completeness?.cloudPage === "unavailable" ? (
+        <EpicsListUnavailable onRetry={onRetry} />
+      ) : (
+        <EpicsListEmpty />
       );
     }
     if (isFetching) {
-      return (
-        <>
-          <HistoryCompletenessNotice
-            completeness={completeness}
-            cloudPagePending={cloudPagePending}
-          />
-          <EpicsListFilteringLoading />
-        </>
-      );
+      return <EpicsListFilteringLoading />;
     }
   }
   const rowProps = {
@@ -1452,10 +1424,6 @@ function EpicsListBody(props: EpicsListBodyProps): ReactNode {
   };
   return (
     <>
-      <HistoryCompletenessNotice
-        completeness={completeness}
-        cloudPagePending={cloudPagePending}
-      />
       {preservedItems.length > 0 ? (
         <section
           className="mb-3 flex flex-col gap-2"

--- a/clients/gui-app/src/components/epics/epics-list-panel.tsx
+++ b/clients/gui-app/src/components/epics/epics-list-panel.tsx
@@ -80,14 +80,11 @@ import {
 import { EpicsFilterPopover } from "@/components/epics/epics-filter-popover";
 import {
   EpicsListChatHostFilterUnsupported,
-  EpicsListEmpty,
   EpicsListError,
-  EpicsListFilteredEmpty,
-  EpicsListFilteringLoading,
   EpicsListHostRequiresCloudToList,
   EpicsListLoading,
+  EpicsListNoRows,
   EpicsListShowMore,
-  EpicsListUnavailable,
   HistoryRowLeadingIcon,
 } from "@/components/epics/epics-list-shared";
 import {
@@ -1379,38 +1376,21 @@ function EpicsListBody(props: EpicsListBodyProps): ReactNode {
   if (chatHostFilterUnsupported) {
     return <EpicsListChatHostFilterUnsupported />;
   }
-  // Every "there are no rows" reading, grouped under the one test they share.
-  // Ordering inside is load-bearing and unchanged; nesting only stops each arm
-  // from re-asking `items.length === 0`, and lets the last arm drop its
-  // `hasActiveFilters` re-test - the arm above it returns whenever that is
-  // false, so reaching the last one already means it is true.
+  // Every "there are no rows" reading, decided once for both responsive bodies
+  // in `EpicsListNoRows` - the ordering there is load-bearing.
   if (items.length === 0) {
-    // A pending local-first page is a renderable device snapshot, not a settled
-    // account result. Keep the distinct state ahead of every empty branch so an
-    // empty mirror never becomes the definitive "No tasks yet" claim - it is
-    // still a load.
-    if (cloudPagePending) {
-      return <EpicsListLoading />;
-    }
-    if (!hasActiveFilters) {
-      // With NO settled page the body must not claim an empty account: zero
-      // rows is not evidence of one. It says the load failed, and nothing
-      // about where.
-      return completeness?.cloudPage === "unavailable" ? (
-        <EpicsListUnavailable onRetry={onRetry} />
-      ) : (
-        <EpicsListEmpty />
-      );
-    }
-    if (isFetching) {
-      return <EpicsListFilteringLoading />;
-    }
-    // A filtered result with no settled page is not "No tasks match": the
-    // filter was never evaluated over the account. Same neutral state as the
-    // unfiltered arm - a failed load with a retry, and nothing about where.
-    if (completeness?.cloudPage === "unavailable") {
-      return <EpicsListUnavailable onRetry={onRetry} />;
-    }
+    return (
+      <EpicsListNoRows
+        cloudPagePending={cloudPagePending}
+        cloudPageUnavailable={completeness?.cloudPage === "unavailable"}
+        hasActiveFilters={hasActiveFilters}
+        isFetching={isFetching}
+        onRetry={onRetry}
+        hasNextPage={hasNextPage}
+        isFetchingNextPage={isFetchingNextPage}
+        onLoadMore={onLoadMore}
+      />
+    );
   }
   const rowProps = {
     selectionMode,
@@ -1484,14 +1464,11 @@ function EpicsListBody(props: EpicsListBodyProps): ReactNode {
         </ul>
       ) : null}
       {/*
-        Only when there is genuinely nothing to show. A page whose only rows
-        are preserved orphans is not an empty filter result, and telling the
-        person "no tasks match" over a section they can see would be the same
-        untruth from the other direction.
+        No "no tasks match" here: zero rows returned above through
+        `EpicsListNoRows`, and a page whose only rows are preserved orphans is
+        not an empty filter result - telling the person "no tasks match" over a
+        section they can see would be the same untruth from the other direction.
       */}
-      {ordinaryItems.length === 0 && preservedItems.length === 0 ? (
-        <EpicsListFilteredEmpty />
-      ) : null}
       <EpicsListShowMore
         hasNextPage={hasNextPage}
         isFetchingNextPage={isFetchingNextPage}

--- a/clients/gui-app/src/components/epics/epics-list-shared.tsx
+++ b/clients/gui-app/src/components/epics/epics-list-shared.tsx
@@ -23,6 +23,10 @@ import { NotificationIndicatorIcon } from "@/components/notifications/notificati
 import { useSurfaceNotificationIndicatorState } from "@/components/notifications/notification-indicator-context";
 import { useEpicActivityStatus } from "@/hooks/epic/use-epic-activity-status";
 import { createReportIssueContext } from "@/lib/report-issue-context";
+import {
+  authorizesCloudCapability,
+  useAuthStore,
+} from "@/stores/auth/auth-store";
 import type { HistoryItem } from "@/components/home/data/home-page.data";
 
 /**
@@ -196,31 +200,95 @@ export function EpicsListEmpty(): ReactNode {
 /**
  * No rows AND no settled page. Not an empty account: the listing failed or was
  * withheld, so "No tasks yet" would be the one claim of completeness this page
- * cannot make. It says only that, and offers the retry - the user is never
- * told which side of the listing failed.
+ * cannot make. It says only that - the user is never told which side of the
+ * listing failed - and offers the remedy that can actually change the answer.
+ *
+ * Under an unverified session that remedy is NOT a retry:
+ * `useCloudEpicTasksQuery` settles the page as unavailable without dispatching
+ * the cloud leg while the session holds no verdict, and its guarded `refetch`
+ * resolves without a request under the same condition, so a Retry there is a
+ * button that does nothing. Sign-in is what changes the verdict.
  */
 export function EpicsListUnavailable(props: {
   readonly onRetry: () => void;
 }): ReactNode {
+  const cloudAuthorized = useAuthStore((state) =>
+    authorizesCloudCapability(state.status),
+  );
   return (
     <div
       className="flex flex-col items-center justify-center gap-2 py-16 text-center text-ui-sm text-muted-foreground"
       data-testid="epics-list-unavailable"
+      data-remedy={cloudAuthorized ? "retry" : "sign-in"}
       role="status"
     >
       <p className="font-medium text-foreground">
         Couldn&apos;t load your tasks
       </p>
-      <Button
-        type="button"
-        size="sm"
-        variant="outline"
-        data-testid="epics-list-unavailable-retry"
-        onClick={props.onRetry}
-      >
-        Retry
-      </Button>
+      {cloudAuthorized ? (
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          data-testid="epics-list-unavailable-retry"
+          onClick={props.onRetry}
+        >
+          Retry
+        </Button>
+      ) : (
+        <p>
+          Your sign-in couldn&apos;t be confirmed. Sign in again to see them.
+        </p>
+      )}
     </div>
+  );
+}
+
+/**
+ * Every "there are no rows" reading, decided once for both responsive list
+ * bodies. Ordering is load-bearing:
+ *
+ * 1. A pending cloud page is a renderable device snapshot, not a settled
+ *    account result, so an empty one is still a load - never "No tasks yet".
+ * 2. With no filters, an unavailable page is a failed load, not an empty
+ *    account; a settled one is genuinely empty.
+ * 3. Under a filter, a fetch in flight is the search spinner; an unavailable
+ *    page is again a failed load (the filter was never evaluated over the
+ *    account); only a settled page may say "No tasks match".
+ *
+ * Renders `null` for nothing: a caller reaches this only with zero rows.
+ */
+export function EpicsListNoRows(props: {
+  readonly cloudPagePending: boolean;
+  readonly cloudPageUnavailable: boolean;
+  readonly hasActiveFilters: boolean;
+  readonly isFetching: boolean;
+  readonly onRetry: () => void;
+  readonly hasNextPage: boolean;
+  readonly isFetchingNextPage: boolean;
+  readonly onLoadMore: () => void;
+}): ReactNode {
+  if (props.cloudPagePending) return <EpicsListLoading />;
+  if (!props.hasActiveFilters) {
+    return props.cloudPageUnavailable ? (
+      <EpicsListUnavailable onRetry={props.onRetry} />
+    ) : (
+      <EpicsListEmpty />
+    );
+  }
+  if (props.isFetching) return <EpicsListFilteringLoading />;
+  if (props.cloudPageUnavailable) {
+    return <EpicsListUnavailable onRetry={props.onRetry} />;
+  }
+  return (
+    <>
+      <EpicsListFilteredEmpty />
+      <EpicsListShowMore
+        hasNextPage={props.hasNextPage}
+        isFetchingNextPage={props.isFetchingNextPage}
+        onLoadMore={props.onLoadMore}
+      />
+    </>
   );
 }
 

--- a/clients/gui-app/src/components/epics/epics-list-shared.tsx
+++ b/clients/gui-app/src/components/epics/epics-list-shared.tsx
@@ -24,7 +24,6 @@ import { useSurfaceNotificationIndicatorState } from "@/components/notifications
 import { useEpicActivityStatus } from "@/hooks/epic/use-epic-activity-status";
 import { createReportIssueContext } from "@/lib/report-issue-context";
 import type { HistoryItem } from "@/components/home/data/home-page.data";
-import type { ListTasksCompleteness } from "@traycer/protocol/host/epic/unary-schemas";
 
 /**
  * A task row's status: the epic's notification indicator when it has one, its
@@ -125,29 +124,6 @@ export function EpicsListFilteringLoading(): ReactNode {
 }
 
 /**
- * A local-first response can be ready to render before its cloud counterpart.
- * An empty local snapshot is therefore not an empty account: the cloud page is
- * still authoritative for that answer.
- */
-export function EpicsListCloudPagePending(): ReactNode {
-  return (
-    <div
-      className="flex flex-col items-center justify-center gap-2 py-16 text-center text-ui-sm text-muted-foreground"
-      data-testid="epics-list-cloud-page-pending"
-      aria-busy="true"
-      aria-live="polite"
-    >
-      <AgentSpinningDots
-        variant="dots"
-        className="text-muted-foreground"
-        testId={undefined}
-      />
-      <p className="font-medium text-foreground">Loading cloud tasks</p>
-    </div>
-  );
-}
-
-/**
  * Shown when a host filter is active but the serving peer cannot apply it, so
  * the rows were withheld. Deliberately NOT an empty-history message: the
  * account's tasks exist, this client just declined to show a list it could not
@@ -218,25 +194,32 @@ export function EpicsListEmpty(): ReactNode {
 }
 
 /**
- * No local rows AND no cloud page. Not an empty account: the cloud leg failed
- * or was withheld (an unverified session), so tasks that live only on other
- * devices are simply not visible from here, and "No tasks yet" would be the
- * one claim of completeness this page cannot make.
+ * No rows AND no settled page. Not an empty account: the listing failed or was
+ * withheld, so "No tasks yet" would be the one claim of completeness this page
+ * cannot make. It says only that, and offers the retry - the user is never
+ * told which side of the listing failed.
  */
-export function EpicsListCloudPageUnavailable(): ReactNode {
+export function EpicsListUnavailable(props: {
+  readonly onRetry: () => void;
+}): ReactNode {
   return (
     <div
       className="flex flex-col items-center justify-center gap-2 py-16 text-center text-ui-sm text-muted-foreground"
-      data-testid="epics-list-cloud-page-unavailable"
+      data-testid="epics-list-unavailable"
       role="status"
     >
       <p className="font-medium text-foreground">
-        Cloud tasks couldn&apos;t be loaded
+        Couldn&apos;t load your tasks
       </p>
-      <p>
-        This device holds no tasks of its own. Tasks from your other devices
-        will appear once the cloud can be reached.
-      </p>
+      <Button
+        type="button"
+        size="sm"
+        variant="outline"
+        data-testid="epics-list-unavailable-retry"
+        onClick={props.onRetry}
+      >
+        Retry
+      </Button>
     </div>
   );
 }
@@ -250,108 +233,6 @@ export function EpicsListFilteredEmpty(): ReactNode {
       <p className="font-medium text-foreground">
         No tasks match these filters.
       </p>
-    </div>
-  );
-}
-
-/**
- * What this page is NOT, stated once above either responsive list body.
- *
- * A `pending` cloud page is deliberately an early return. Its `facets` are
- * necessarily partial, but a filter-count caveat is secondary to explaining
- * that the account-wide page has not arrived yet.
- */
-export function HistoryCompletenessNotice(props: {
-  readonly completeness: ListTasksCompleteness | null;
-  readonly cloudPagePending: boolean;
-}): ReactNode {
-  const { completeness } = props;
-  const cloudPagePending =
-    props.cloudPagePending || completeness?.cloudPage === "pending";
-  if (cloudPagePending) {
-    return (
-      <div
-        role="status"
-        aria-live="polite"
-        data-testid="epics-list-completeness"
-        data-cloud-page="pending"
-        data-local-rows={completeness?.localRows}
-        className="mb-3 flex flex-col gap-1 rounded-md border border-dashed border-border/60 bg-muted/20 px-3 py-2 text-ui-xs text-muted-foreground"
-      >
-        <p>
-          Cloud tasks are still loading. Showing what the connected device
-          holds.
-        </p>
-      </div>
-    );
-  }
-  if (completeness === null) return null;
-  const lines: string[] = [];
-  if (completeness.cloudPage === "unavailable") {
-    lines.push(
-      "Cloud tasks couldn't be reached. Showing what the connected device holds.",
-    );
-  }
-  if (completeness.localRows === "truncated") {
-    // Deliberately says INCOMPLETE and not WHERE, because `truncated` has more
-    // than one producer and they leave the gap in different places. The page
-    // cap does drop a suffix; a filter meeting a row with no association
-    // evidence, or a text query judged against a row whose root document could
-    // not be read (so only the immutable creation title was available), drops a
-    // row from the MIDDLE - an epic renamed after creation vanishes from a
-    // search for the name it now has.
-    //
-    // The previous copy - "Showing the first tasks stored on this device, not
-    // all" - was written when the cap was the only producer, and for the others
-    // it is the wrong SHAPE of claim rather than merely imprecise: a reader
-    // told they have a prefix concludes the rest is further down the list.
-    //
-    // "the connected device", not "this device", for the same reason as
-    // `history-pin-availability.ts`: these rows are the SERVING HOST's local
-    // rows, and on a phone or a relay-only shell that is another machine.
-    //
-    // Do NOT branch this line on which producer fired. The wire member
-    // deliberately does not distinguish them, so a client that split the copy
-    // would be reading a distinction it was never sent.
-    lines.push(
-      "Some tasks on the connected device couldn't be checked against your filters, so this list may be missing a few.",
-    );
-  }
-  if (completeness.localRows === "suppressed-unprovable-filter") {
-    // The difference between "you have no local epics matching" and "this
-    // filter cannot be answered from the connected device". Collapsing them is
-    // how a filtered offline History came to look empty and authoritative.
-    lines.push(
-      "This filter can't be checked against tasks stored on the connected device, so they aren't listed.",
-    );
-  }
-  // `facets: "partial"` is the protocol saying the counts describe a DIFFERENT
-  // set from the rows - host rows were injected beside them, or the cloud page
-  // is missing. Both lines used to assert the opposite ("counts cover the tasks
-  // listed here"), so the one state where the numbers provably disagree with
-  // the list was reported as the state where they agree.
-  if (completeness.sort === "loaded-union") {
-    lines.push(
-      completeness.facets === "partial"
-        ? "Order covers the tasks listed here, and filter counts may leave some of them out."
-        : "Order and counts cover the tasks listed here, not everything you have.",
-    );
-  } else if (completeness.facets === "partial") {
-    lines.push("Filter counts may not include every task listed here.");
-  }
-  if (lines.length === 0) return null;
-  return (
-    <div
-      role="status"
-      aria-live="polite"
-      data-testid="epics-list-completeness"
-      data-cloud-page={completeness.cloudPage}
-      data-local-rows={completeness.localRows}
-      className="mb-3 flex flex-col gap-1 rounded-md border border-dashed border-border/60 bg-muted/20 px-3 py-2 text-ui-xs text-muted-foreground"
-    >
-      {lines.map((line) => (
-        <p key={line}>{line}</p>
-      ))}
     </div>
   );
 }

--- a/clients/gui-app/src/components/epics/mobile/mobile-history-list.tsx
+++ b/clients/gui-app/src/components/epics/mobile/mobile-history-list.tsx
@@ -4,14 +4,11 @@ import type { HistoryItem } from "@/components/home/data/home-page.data";
 import type { ListTasksCompleteness } from "@traycer/protocol/host/epic/unary-schemas";
 import {
   EpicsListChatHostFilterUnsupported,
-  EpicsListEmpty,
   EpicsListError,
-  EpicsListFilteredEmpty,
-  EpicsListFilteringLoading,
   EpicsListHostRequiresCloudToList,
   EpicsListLoading,
+  EpicsListNoRows,
   EpicsListShowMore,
-  EpicsListUnavailable,
 } from "@/components/epics/epics-list-shared";
 import { MobileHistoryRow } from "@/components/epics/mobile/mobile-history-row";
 import {
@@ -268,56 +265,41 @@ function MobileHistoryListBody(props: MobileHistoryListBodyProps): ReactNode {
   if (props.chatHostFilterUnsupported) {
     return <EpicsListChatHostFilterUnsupported />;
   }
-  // The first page is a usable local snapshot while the cloud leg resolves.
-  // Empty local storage cannot answer whether the account has tasks yet, so
-  // this stays a load, never "No tasks yet".
-  if (props.items.length === 0 && props.cloudPagePending) {
-    return <EpicsListLoading />;
-  }
-  if (props.items.length === 0 && !props.hasActiveFilters) {
-    // Same rule as the desktop panel: no settled page means no claim of an
-    // empty account.
-    return props.completeness?.cloudPage === "unavailable" ? (
-      <EpicsListUnavailable onRetry={props.onRetry} />
-    ) : (
-      <EpicsListEmpty />
+  // Every "there are no rows" reading, decided once for both responsive bodies
+  // in `EpicsListNoRows` - the same rules as the desktop panel by construction.
+  if (props.items.length === 0) {
+    return (
+      <EpicsListNoRows
+        cloudPagePending={props.cloudPagePending}
+        cloudPageUnavailable={props.completeness?.cloudPage === "unavailable"}
+        hasActiveFilters={props.hasActiveFilters}
+        isFetching={props.isFetching}
+        onRetry={props.onRetry}
+        hasNextPage={props.hasNextPage}
+        isFetchingNextPage={props.isFetchingNextPage}
+        onLoadMore={props.onLoadMore}
+      />
     );
-  }
-  if (props.items.length === 0 && props.hasActiveFilters && props.isFetching) {
-    return <EpicsListFilteringLoading />;
-  }
-  // A filtered result with no settled page is not "No tasks match": the filter
-  // was never evaluated over the account. Same neutral state as the unfiltered
-  // arm above.
-  if (
-    props.items.length === 0 &&
-    props.completeness?.cloudPage === "unavailable"
-  ) {
-    return <EpicsListUnavailable onRetry={props.onRetry} />;
   }
   return (
     <>
-      {props.items.length > 0 ? (
-        <ul className="flex flex-col gap-2" data-testid="epics-list-rows">
-          {props.items.map((item) => (
-            <MobileHistoryRow
-              key={item.id}
-              item={item}
-              selectionMode={props.selectionMode}
-              isSelected={props.selectedIds.has(item.epicId)}
-              isTrayOpen={props.openTrayEpicId === item.epicId}
-              isPinPending={props.pendingSetPinnedEpicIds.has(item.epicId)}
-              onTrayOpenChange={props.onTrayOpenChange}
-              onToggleSelection={props.onToggleSelection}
-              onRequestDelete={props.onRequestDelete}
-              onSetPinned={props.onSetPinned}
-              onOpen={props.onOpenItem}
-            />
-          ))}
-        </ul>
-      ) : (
-        <EpicsListFilteredEmpty />
-      )}
+      <ul className="flex flex-col gap-2" data-testid="epics-list-rows">
+        {props.items.map((item) => (
+          <MobileHistoryRow
+            key={item.id}
+            item={item}
+            selectionMode={props.selectionMode}
+            isSelected={props.selectedIds.has(item.epicId)}
+            isTrayOpen={props.openTrayEpicId === item.epicId}
+            isPinPending={props.pendingSetPinnedEpicIds.has(item.epicId)}
+            onTrayOpenChange={props.onTrayOpenChange}
+            onToggleSelection={props.onToggleSelection}
+            onRequestDelete={props.onRequestDelete}
+            onSetPinned={props.onSetPinned}
+            onOpen={props.onOpenItem}
+          />
+        ))}
+      </ul>
       <EpicsListShowMore
         hasNextPage={props.hasNextPage}
         isFetchingNextPage={props.isFetchingNextPage}

--- a/clients/gui-app/src/components/epics/mobile/mobile-history-list.tsx
+++ b/clients/gui-app/src/components/epics/mobile/mobile-history-list.tsx
@@ -286,6 +286,15 @@ function MobileHistoryListBody(props: MobileHistoryListBodyProps): ReactNode {
   if (props.items.length === 0 && props.hasActiveFilters && props.isFetching) {
     return <EpicsListFilteringLoading />;
   }
+  // A filtered result with no settled page is not "No tasks match": the filter
+  // was never evaluated over the account. Same neutral state as the unfiltered
+  // arm above.
+  if (
+    props.items.length === 0 &&
+    props.completeness?.cloudPage === "unavailable"
+  ) {
+    return <EpicsListUnavailable onRetry={props.onRetry} />;
+  }
   return (
     <>
       {props.items.length > 0 ? (

--- a/clients/gui-app/src/components/epics/mobile/mobile-history-list.tsx
+++ b/clients/gui-app/src/components/epics/mobile/mobile-history-list.tsx
@@ -4,8 +4,6 @@ import type { HistoryItem } from "@/components/home/data/home-page.data";
 import type { ListTasksCompleteness } from "@traycer/protocol/host/epic/unary-schemas";
 import {
   EpicsListChatHostFilterUnsupported,
-  EpicsListCloudPagePending,
-  EpicsListCloudPageUnavailable,
   EpicsListEmpty,
   EpicsListError,
   EpicsListFilteredEmpty,
@@ -13,7 +11,7 @@ import {
   EpicsListHostRequiresCloudToList,
   EpicsListLoading,
   EpicsListShowMore,
-  HistoryCompletenessNotice,
+  EpicsListUnavailable,
 } from "@/components/epics/epics-list-shared";
 import { MobileHistoryRow } from "@/components/epics/mobile/mobile-history-row";
 import {
@@ -271,52 +269,25 @@ function MobileHistoryListBody(props: MobileHistoryListBodyProps): ReactNode {
     return <EpicsListChatHostFilterUnsupported />;
   }
   // The first page is a usable local snapshot while the cloud leg resolves.
-  // Empty local storage cannot answer whether the account has tasks yet.
+  // Empty local storage cannot answer whether the account has tasks yet, so
+  // this stays a load, never "No tasks yet".
   if (props.items.length === 0 && props.cloudPagePending) {
-    return (
-      <>
-        <HistoryCompletenessNotice
-          completeness={props.completeness}
-          cloudPagePending={props.cloudPagePending}
-        />
-        <EpicsListCloudPagePending />
-      </>
-    );
+    return <EpicsListLoading />;
   }
   if (props.items.length === 0 && !props.hasActiveFilters) {
-    // Same rule as the desktop panel: no cloud page means no claim of an
+    // Same rule as the desktop panel: no settled page means no claim of an
     // empty account.
-    return (
-      <>
-        <HistoryCompletenessNotice
-          completeness={props.completeness}
-          cloudPagePending={props.cloudPagePending}
-        />
-        {props.completeness?.cloudPage === "unavailable" ? (
-          <EpicsListCloudPageUnavailable />
-        ) : (
-          <EpicsListEmpty />
-        )}
-      </>
+    return props.completeness?.cloudPage === "unavailable" ? (
+      <EpicsListUnavailable onRetry={props.onRetry} />
+    ) : (
+      <EpicsListEmpty />
     );
   }
   if (props.items.length === 0 && props.hasActiveFilters && props.isFetching) {
-    return (
-      <>
-        <HistoryCompletenessNotice
-          completeness={props.completeness}
-          cloudPagePending={props.cloudPagePending}
-        />
-        <EpicsListFilteringLoading />
-      </>
-    );
+    return <EpicsListFilteringLoading />;
   }
   return (
     <>
-      <HistoryCompletenessNotice
-        completeness={props.completeness}
-        cloudPagePending={props.cloudPagePending}
-      />
       {props.items.length > 0 ? (
         <ul className="flex flex-col gap-2" data-testid="epics-list-rows">
           {props.items.map((item) => (


### PR DESCRIPTION
## Why

The local-first History (#889) rendered a dashed status box above the task rows whenever the host's `completeness` statement said local rows sat beside the cloud page ("Order covers the tasks listed here, and filter counts may leave some of them out."), plus cloud-specific loading ("Loading cloud tasks") and unavailable ("Cloud tasks couldn't be loaded. This device holds no tasks of its own…") states. The user does not care which side a row came from; they know their tasks.

It was also firing on a healthy online list: the host counts a mirror row as "injected" before deduplicating it against the cloud page, so any epic opened in the last seven days that is also on page 1 flipped the page to `loaded-union` / `partial` with zero rows actually added. Removing the notice makes that host-side quirk invisible; its only other consumer is the filter-option union in `use-history-query.ts`, which is additive.

## What

- `epics-list-shared.tsx`: delete `HistoryCompletenessNotice`, `EpicsListCloudPagePending` and `EpicsListCloudPageUnavailable`. Add `EpicsListUnavailable`: "Couldn't load your tasks" + Retry, no cloud or device vocabulary.
- `epics-list-panel.tsx` and `mobile/mobile-history-list.tsx`: a pending cloud page with no rows renders the ordinary loading skeleton; no rows + no filters + `cloudPage: "unavailable"` renders `EpicsListUnavailable` wired to the list's retry; every other state renders exactly what it did, minus the notice above the rows.
- The `completeness` wire field and the host resolver are untouched. `cloudPagePending` and `completeness.cloudPage` still gate the empty-state decision so an empty local snapshot never reads as "No tasks yet".

Left as is, deliberately: the preserved-orphan section heading ("Deleted in cloud — local edits kept on this device") and the pin-unavailable tooltips. Those are per-row affordance reasons for rows that genuinely behave differently, not list-level provenance banners. Say the word and they go too.

## Tests

`epics-list-panel.test.tsx` and `mobile-history-list.test.tsx`: the five notice-copy tests are replaced by one per surface that renders the worst-case completeness statement (unavailable, partial, truncated, loaded-union) and asserts the row renders, no `role="status"` element exists, and the list body's text matches neither /cloud/i nor /device/i. The unavailable state pins `epics-list-unavailable` and that Retry calls the query's refetch; the pending state pins `epics-list-loading`.

Local: `bun run vitest run` on both files, 102/102.
