### PR TITLE
feat(gui-app): show local timestamps on chat messages

### DIFF
--- a/clients/gui-app/src/components/chat/__tests__/chat-message-assistant-body.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/chat-message-assistant-body.test.tsx
@@ -12,6 +12,7 @@ import type { ReactNode } from "react";
 import { ChatExpansionTestProviders } from "@/components/chat/__tests__/chat-expansion-test-providers";
 import { AssistantMessageBody } from "@/components/chat/chat-message-assistant-body";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import { formatMessageTimeWithSeconds } from "@/lib/relative-time";
 import type {
   AssistantTurnMeta,
   ChatMessageRunState,
@@ -540,5 +541,194 @@ describe("AssistantMessageBody stopped turn rendering", () => {
     expect(
       screen.getAllByText("env: ANTHROPIC_API_KEY (sign-in bypassed)").length,
     ).toBeGreaterThan(0);
+  });
+});
+
+describe("AssistantMessageBody Timing tooltip section", () => {
+  // Started/completed timestamps are taken relative to `Date.now()` at test
+  // time (not a fixed epoch) so the day-scoping rule always resolves to "same
+  // day" regardless of when this suite runs, and the expected string is
+  // derived with `formatMessageTimeWithSeconds` (the exact function the
+  // source calls) rather than a hard-coded literal - per the "no pinned
+  // TZ/locale" trap.
+
+  it("shows Started and Finished rows on a naturally completed turn's tooltip, and no Stopped section", async () => {
+    const user = userEvent.setup();
+    const startedAt = Date.now() - 130_000;
+    const completedAt = Date.now();
+    render(
+      <AssistantMessageBody
+        {...bodyProps({
+          segments: [TEXT_SEGMENT],
+          elapsedStartedAt: startedAt,
+          completedAt,
+          meta: META,
+        })}
+      />,
+    );
+
+    const footer = screen.getByTestId("assistant-elapsed-footer");
+    await user.tab();
+    expect(document.activeElement).toBe(footer);
+
+    await waitFor(() => {
+      expect(screen.getAllByText("Started").length).toBeGreaterThan(0);
+    });
+    expect(screen.getAllByText("Finished").length).toBeGreaterThan(0);
+
+    const now = Date.now();
+    const expectedStarted = formatMessageTimeWithSeconds(startedAt, now);
+    const expectedFinished = formatMessageTimeWithSeconds(completedAt, now);
+    expect(screen.getAllByText(expectedStarted).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(expectedFinished).length).toBeGreaterThan(0);
+
+    // Positive/negative pairing for the stopped-turn test below: a naturally
+    // finished turn carries no "Stopped" section at all.
+    expect(screen.queryByText("Stopped at")).toBeNull();
+  });
+
+  // The live pre-turn run indicator's `createdAt` is a synthetic sort anchor,
+  // not a real send time (it can be epoch+1 on an empty transcript), so its
+  // tooltip is wired with `startedAt={null}` and the whole Timing section is
+  // gated on `startedAt !== null`. Paired with the test above: same
+  // `meta: META`, reached through `AssistantRunIndicator` instead of the
+  // elapsed footer. The Agent section is the positive arm proving the
+  // tooltip really did mount - Timing's absence is a deliberate gate, not a
+  // failure to open.
+  it("shows no Timing section at all on the live pre-turn run indicator's hover card", async () => {
+    const user = userEvent.setup();
+    render(
+      <AssistantMessageBody
+        {...bodyProps({
+          segments: [],
+          runState: "running",
+          elapsedStartedAt: Date.now() - 45_000,
+          meta: META,
+        })}
+      />,
+    );
+
+    const indicator = screen.getByTestId("assistant-run-indicator");
+    await user.hover(indicator);
+
+    await waitFor(() => {
+      expect(screen.getAllByText("Agent").length).toBeGreaterThan(0);
+    });
+    expect(screen.queryByText("Timing")).toBeNull();
+    expect(screen.queryByText("Started")).toBeNull();
+    expect(screen.queryByText("Finished")).toBeNull();
+  });
+
+  // A stopped turn's `completedAt` is resolved to the stop instant itself
+  // (`assistantTurnTiming`'s `stoppedAt ?? persisted`), so the tooltip prints
+  // "Stopped at" INSTEAD OF "Finished" - not both - or the reader would see
+  // one instant twice under two labels. Positive arm for "Finished" is the
+  // naturally-completed test above; this one, with `stopped` flipped on,
+  // must not show it.
+  it('shows "Stopped at" in place of "Finished" on a stopped turn\'s tooltip, never the old "Time" label', async () => {
+    const user = userEvent.setup();
+    const startedAt = Date.now() - 60_000;
+    const completedAt = Date.now();
+    render(
+      <AssistantMessageBody
+        {...bodyProps({
+          segments: [TEXT_SEGMENT],
+          elapsedStartedAt: startedAt,
+          completedAt,
+          stopped: STOPPED,
+          meta: META,
+        })}
+      />,
+    );
+
+    const footer = screen.getByTestId("assistant-elapsed-footer");
+    await user.tab();
+    expect(document.activeElement).toBe(footer);
+
+    await waitFor(() => {
+      expect(screen.getAllByText("Stopped at").length).toBeGreaterThan(0);
+    });
+    expect(screen.queryByText("Time")).toBeNull();
+    expect(screen.queryByText("Finished")).toBeNull();
+
+    const now = Date.now();
+    const expectedStoppedAt = formatMessageTimeWithSeconds(
+      STOPPED.stoppedAt,
+      now,
+    );
+    expect(screen.getAllByText(expectedStoppedAt).length).toBeGreaterThan(0);
+  });
+
+  // Paired with the test above: same stopped turn, one field flipped
+  // (`reason: null`). The dedicated "Stopped" section header exists only to
+  // carry the reason, so with no reason to show it must not render at all -
+  // "Stopped at" already said everything the stop knows, up in Timing.
+  it("omits the dedicated Stopped section header when a stopped turn carries no reason", async () => {
+    const user = userEvent.setup();
+    const stoppedNoReason: ChatMessageStoppedInfo = {
+      ...STOPPED,
+      reason: null,
+    };
+    const startedAt = Date.now() - 60_000;
+    const completedAt = Date.now();
+    render(
+      <AssistantMessageBody
+        {...bodyProps({
+          segments: [TEXT_SEGMENT],
+          elapsedStartedAt: startedAt,
+          completedAt,
+          stopped: stoppedNoReason,
+          meta: META,
+        })}
+      />,
+    );
+
+    const footer = screen.getByTestId("assistant-elapsed-footer");
+    await user.tab();
+    expect(document.activeElement).toBe(footer);
+
+    await waitFor(() => {
+      expect(screen.getAllByText("Stopped at").length).toBeGreaterThan(0);
+    });
+    // The footer's own visible "Stopped · Ns" label is a <span>, always
+    // present once `stopped !== null`; the section header this test is about
+    // is the tooltip's own `<div>`, so scope the query to that tag to avoid a
+    // false negative from the unrelated footer text.
+    expect(screen.queryByText("Stopped", { selector: "div" })).toBeNull();
+    expect(screen.queryByText("Reason")).toBeNull();
+  });
+
+  // Regression coverage for the row-state-matrix change: a footer with no
+  // agent metadata and no stop record used to render as a plain,
+  // un-hoverable `<div>` with no card at all. It must now be a real tooltip
+  // trigger whose card discloses Timing - the only section such a footer has.
+  it("is hoverable and discloses Timing even with no agent metadata and no stop record", async () => {
+    const user = userEvent.setup();
+    const startedAt = Date.now() - 10_000;
+    const completedAt = Date.now();
+    render(
+      <AssistantMessageBody
+        {...bodyProps({
+          segments: [TEXT_SEGMENT],
+          elapsedStartedAt: startedAt,
+          completedAt,
+          meta: null,
+          stopped: null,
+        })}
+      />,
+    );
+
+    const footer = screen.getByTestId("assistant-elapsed-footer");
+    await user.tab();
+    expect(document.activeElement).toBe(footer);
+
+    await waitFor(() => {
+      expect(screen.getAllByText("Timing").length).toBeGreaterThan(0);
+    });
+    expect(screen.getAllByText("Started").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Finished").length).toBeGreaterThan(0);
+    // No agent metadata, so no Agent section - Timing is the only content.
+    expect(screen.queryByText("Agent")).toBeNull();
+    expect(screen.queryByText("Provider")).toBeNull();
   });
 });

--- a/clients/gui-app/src/components/chat/__tests__/chat-message-user-body.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/chat-message-user-body.test.tsx
@@ -1682,17 +1682,34 @@ describe("<ChatMessage /> sender overline timestamp", () => {
   // fixture, `createdAt` flipped to an instant `Date` itself rejects.
   // `ChatMessageTimestamp` renders nothing rather than crash the row on
   // `toISOString()`, which throws instead of producing "Invalid Date".
-  it("renders no timestamp element for an instant Date itself rejects", () => {
-    render(
-      <ChatMessage
-        message={{ ...plainUserMessage("Status?"), createdAt: Number.NaN }}
-        actions={null}
-        backgroundToolBlockIds={EMPTY_BACKGROUND_TOOL_BLOCK_IDS}
-        nextStepActions={null}
-      />,
-    );
+  //
+  // Both input classes are covered because they fail differently on the way
+  // in: `NaN` is never a time, while 8.64e15 + 1 is a perfectly finite number
+  // that a `Date` still cannot represent - so a guard written as
+  // `Number.isFinite` would let the second one through to the throw.
+  it.each([
+    ["NaN", Number.NaN],
+    ["one millisecond past the maximum representable instant", 8.64e15 + 1],
+  ])(
+    "renders no timestamp element, and no orphaned separator, for %s",
+    (_label, createdAt) => {
+      render(
+        <ChatMessage
+          message={{ ...plainUserMessage("Status?"), createdAt }}
+          actions={null}
+          backgroundToolBlockIds={EMPTY_BACKGROUND_TOOL_BLOCK_IDS}
+          nextStepActions={null}
+        />,
+      );
 
-    screen.getByText("You");
-    expect(screen.queryByTestId("chat-message-timestamp")).toBeNull();
-  });
+      expect(screen.queryByTestId("chat-message-timestamp")).toBeNull();
+      // The separator is drawn by `chat-message.tsx`, NOT by the stamp, so a
+      // component that renders `null` leaves the dot stranded unless the call
+      // site drops it too. Asserting only the label's own text would miss
+      // that - it lives in a sibling span - so read the whole overline: it
+      // must be "You", never "You · ".
+      const overline = screen.getByText("You").parentElement;
+      expect(overline?.textContent).toBe("You");
+    },
+  );
 });

--- a/clients/gui-app/src/components/chat/__tests__/chat-message-user-body.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/chat-message-user-body.test.tsx
@@ -6,6 +6,7 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Mock } from "vitest";
 import { useState, type ReactNode } from "react";
@@ -21,7 +22,10 @@ import {
   parseComposerClipboardHtml,
 } from "@/lib/composer/composer-clipboard";
 import type { ChatMessage as ChatMessageModel } from "@/stores/composer/chat-store";
-import type { ChatMessageUserActions } from "@/components/chat/chat-message";
+import {
+  ChatMessage,
+  type ChatMessageUserActions,
+} from "@/components/chat/chat-message";
 import { useSetA2AReceivedOpen } from "@/stores/chats/a2a-open-store-context";
 import {
   chatTranscriptJumpKey,
@@ -33,6 +37,7 @@ import {
 } from "@/stores/chats/chat-find-force-store-context";
 import { collectImageAtoms } from "@/lib/composer/image-atoms";
 import { bytesToBase64 } from "@/lib/composer/image-base64";
+import { formatFullTimestamp, formatMessageTime } from "@/lib/relative-time";
 import { useWorkspaceFoldersStore } from "@/stores/workspace/workspace-folders-store";
 
 const attachmentMocks = vi.hoisted(() => {
@@ -899,6 +904,10 @@ describe("<UserMessageBody /> agent messages", () => {
     expect(screen.getByText("Review Agent")).toBeTruthy();
     expect(screen.getByText(/Investigate this failure/)).toBeTruthy();
     expect(screen.queryByText("Message")).toBeNull();
+    // The arrival stamp trails the header - the one place a timeline is
+    // hardest to reconstruct otherwise, since these rows have no human send
+    // above them.
+    expect(screen.getAllByTestId("chat-message-timestamp")).toHaveLength(1);
     // Reply-expected is a compact icon in the always-visible header; the
     // spelled-out line only appears once the card is expanded.
     expect(screen.getByRole("img", { name: "Reply expected" })).toBeTruthy();
@@ -919,6 +928,36 @@ describe("<UserMessageBody /> agent messages", () => {
         .closest(".md-prose")
         ?.hasAttribute("data-quotable"),
     ).toBe(false);
+  });
+
+  // `AgentMessageDisplayView` is wired to `message.sentAt ?? message.createdAt`
+  // rather than `createdAt` alone: a nested steer row's `createdAt` gets
+  // re-anchored to its turn's start so it sorts contiguously with the turn
+  // (a SORT position, not a send time), and `sentAt` is where the real
+  // instant survives that re-anchor. `createdAt` and `sentAt` are set far
+  // enough apart here that using the wrong one is not just wrong but
+  // detectably wrong under `formatMessageTime`'s minute precision.
+  it("stamps the received card with sentAt, not createdAt, when the two diverge", () => {
+    const sentAt = Date.now() - 5 * 60_000;
+    const createdAt = Date.now() - 20 * 60_000;
+    render(
+      <UserMessageBody
+        actions={null}
+        message={{
+          ...agentMessage("Investigate this failure."),
+          createdAt,
+          sentAt,
+        }}
+      />,
+    );
+
+    const now = Date.now();
+    const expected = formatMessageTime(sentAt, now);
+    const wrongIfUsingCreatedAt = formatMessageTime(createdAt, now);
+    expect(expected).not.toBe(wrongIfUsingCreatedAt);
+    expect(screen.getByTestId("chat-message-timestamp").textContent).toBe(
+      expected,
+    );
   });
 
   it("parks a receipt jump for the sender's chat tile when the sender name is clicked", () => {
@@ -1551,3 +1590,109 @@ function restoreProperty(
   }
   Object.defineProperty(target, key, descriptor);
 }
+
+describe("<ChatMessage /> sender overline timestamp", () => {
+  const EMPTY_BACKGROUND_TOOL_BLOCK_IDS: ReadonlySet<string> = new Set();
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders exactly one timestamp on a sent YOU row", () => {
+    render(
+      <ChatMessage
+        message={plainUserMessage("Status?")}
+        actions={null}
+        backgroundToolBlockIds={EMPTY_BACKGROUND_TOOL_BLOCK_IDS}
+        nextStepActions={null}
+      />,
+    );
+
+    screen.getByText("You");
+    expect(screen.getAllByTestId("chat-message-timestamp")).toHaveLength(1);
+  });
+
+  // Paired with the test above: same fixture, only `statusLabel` flipped to
+  // "Pending" - the one status label a user row ever carries
+  // (`statusLabel === null` is the exact queued gate in chat-message.tsx). A
+  // queued row has not been sent yet, so it leads with the status instead of
+  // a send time it does not have.
+  it("renders no timestamp on a queued (Pending) YOU row", () => {
+    render(
+      <ChatMessage
+        message={{ ...plainUserMessage("Status?"), statusLabel: "Pending" }}
+        actions={null}
+        backgroundToolBlockIds={EMPTY_BACKGROUND_TOOL_BLOCK_IDS}
+        nextStepActions={null}
+      />,
+    );
+
+    screen.getByText("You - Pending");
+    expect(screen.queryByTestId("chat-message-timestamp")).toBeNull();
+  });
+
+  // Same `sentAt`-over-`createdAt` contract as the agent-sender received
+  // card, on the plain "YOU" overline: `chat-message.tsx` reads
+  // `message.sentAt ?? message.createdAt`, so a nested steer row (whose
+  // `createdAt` is re-anchored to its turn's start) still stamps the moment
+  // it was actually sent.
+  it("stamps the overline with sentAt, not createdAt, when the two diverge", () => {
+    const sentAt = Date.now() - 5 * 60_000;
+    const createdAt = Date.now() - 20 * 60_000;
+    render(
+      <ChatMessage
+        message={{ ...plainUserMessage("Status?"), createdAt, sentAt }}
+        actions={null}
+        backgroundToolBlockIds={EMPTY_BACKGROUND_TOOL_BLOCK_IDS}
+        nextStepActions={null}
+      />,
+    );
+
+    const now = Date.now();
+    const expected = formatMessageTime(sentAt, now);
+    const wrongIfUsingCreatedAt = formatMessageTime(createdAt, now);
+    expect(expected).not.toBe(wrongIfUsingCreatedAt);
+    expect(screen.getByTestId("chat-message-timestamp").textContent).toBe(
+      expected,
+    );
+  });
+
+  it("shows the unabridged timestamp on hover, restoring the weekday/year/seconds the row label drops", async () => {
+    const user = userEvent.setup();
+    const sentAt = new Date(2026, 3, 23, 15, 45, 12).getTime();
+    render(
+      <ChatMessage
+        message={{ ...plainUserMessage("Status?"), createdAt: sentAt }}
+        actions={null}
+        backgroundToolBlockIds={EMPTY_BACKGROUND_TOOL_BLOCK_IDS}
+        nextStepActions={null}
+      />,
+    );
+
+    const stamp = screen.getByTestId("chat-message-timestamp");
+    await user.hover(stamp);
+
+    const expected = formatFullTimestamp(sentAt);
+    await waitFor(() => {
+      expect(screen.getAllByText(expected).length).toBeGreaterThan(0);
+    });
+  });
+
+  // Paired with "renders exactly one timestamp on a sent YOU row" above: same
+  // fixture, `createdAt` flipped to an instant `Date` itself rejects.
+  // `ChatMessageTimestamp` renders nothing rather than crash the row on
+  // `toISOString()`, which throws instead of producing "Invalid Date".
+  it("renders no timestamp element for an instant Date itself rejects", () => {
+    render(
+      <ChatMessage
+        message={{ ...plainUserMessage("Status?"), createdAt: Number.NaN }}
+        actions={null}
+        backgroundToolBlockIds={EMPTY_BACKGROUND_TOOL_BLOCK_IDS}
+        nextStepActions={null}
+      />,
+    );
+
+    screen.getByText("You");
+    expect(screen.queryByTestId("chat-message-timestamp")).toBeNull();
+  });
+});

--- a/clients/gui-app/src/components/chat/chat-message-assistant-body.tsx
+++ b/clients/gui-app/src/components/chat/chat-message-assistant-body.tsx
@@ -22,6 +22,10 @@ import { useClipboardCopy } from "@/hooks/ui/use-clipboard-copy";
 import { useElapsedSeconds } from "@/hooks/use-elapsed-seconds";
 import { collectAssistantReplyText } from "@/lib/chat/collect-assistant-reply-text";
 import { formatClockDuration } from "@/lib/format-duration";
+import {
+  formatMessageTimeWithSeconds,
+  useSampledNow,
+} from "@/lib/relative-time";
 import { cn } from "@/lib/utils";
 import type { ChatMessageForkAction } from "./chat-message";
 import type { InterviewDeliveryRetryAction } from "./segments/interview-delivery-retry-action";
@@ -361,9 +365,13 @@ function AssistantElapsedFooter({
   silentAutonomousResume: boolean;
 }) {
   if (completedAt === null) return null;
-  // Wind-down time counts toward the elapsed duration - a Stop doesn't get a
-  // separate truncated-at-click timer, it uses the same
-  // `completedAt - createdAt - pausedDurationMs` rule as a natural finish.
+  // One rule for both endings: a Stop gets no separate truncated-at-click
+  // timer, it uses the same `completedAt - createdAt - pausedDurationMs` as a
+  // natural finish. It still READS as truncated at the click, because the
+  // projection resolves a stopped turn's `completedAt` to the stop instant
+  // itself - `assistantTurnTiming` takes `stoppedAt ?? persistedCompletedAt`,
+  // and its one call site always passes `stoppedAt` when the row is stopped.
+  // So the stop's wind-down is excluded by the DATA, not by a second formula.
   const elapsedMs = completedAt - createdAt - pausedDurationMs;
   const verb = pickElapsedVerb(messageId);
   const nonStoppedElapsedLabel = silentAutonomousResume
@@ -382,43 +390,43 @@ function AssistantElapsedFooter({
       )}
     </>
   );
-  // Hovering the whole footer reveals the agent run details (provider, model,
-  // reasoning effort, fast mode) - no separate info icon, so the row stays
-  // clean. `w-fit` keeps the hover target tight to the text.
-  const elapsed =
-    meta === null && stopped === null ? (
-      <div
-        data-testid="assistant-elapsed-footer"
-        className="flex w-fit cursor-default items-center gap-1.5 py-0.5 text-ui-sm text-muted-foreground/70"
-      >
-        {elapsedContent}
-      </div>
-    ) : (
-      <button
-        type="button"
-        data-testid="assistant-elapsed-footer"
-        className="flex w-fit cursor-default items-center gap-1.5 py-0.5 text-ui-sm text-muted-foreground/70"
-      >
-        {elapsedContent}
-      </button>
-    );
-  // The meta tooltip wraps only the elapsed text, not the copy button, so the
-  // copy hit-target stays its own affordance rather than re-triggering the
-  // agent-details popover. Shown whenever there's either agent metadata or
-  // stop detail to surface.
-  const elapsedWithTooltip =
-    meta === null && stopped === null ? (
-      elapsed
-    ) : (
-      <TooltipWrapper
-        label={<AssistantMetaTooltip meta={meta} stopped={stopped} />}
-        side="top"
-        align="start"
-        sideOffset={6}
-      >
-        {elapsed}
-      </TooltipWrapper>
-    );
+  // Hovering the whole footer reveals the turn's details (provider, model,
+  // reasoning effort, fast mode, and when it ran) - no separate info icon, so
+  // the row stays clean. `w-fit` keeps the hover target tight to the text.
+  //
+  // Always a button, never a bare div: every completed turn now has timing to
+  // disclose, so there is no such thing as a footer with nothing behind it,
+  // and the button is what puts the card on the keyboard path as well as the
+  // pointer's.
+  const elapsed = (
+    <button
+      type="button"
+      data-testid="assistant-elapsed-footer"
+      className="flex w-fit cursor-default items-center gap-1.5 py-0.5 text-ui-sm text-muted-foreground/70"
+    >
+      {elapsedContent}
+    </button>
+  );
+  // The tooltip wraps only the elapsed text, not the copy button, so the copy
+  // hit-target stays its own affordance rather than re-triggering the details
+  // card.
+  const elapsedWithTooltip = (
+    <TooltipWrapper
+      label={
+        <AssistantMetaTooltip
+          meta={meta}
+          stopped={stopped}
+          startedAt={createdAt}
+          completedAt={completedAt}
+        />
+      }
+      side="top"
+      align="start"
+      sideOffset={6}
+    >
+      {elapsed}
+    </TooltipWrapper>
+  );
   return (
     <div className="flex items-center gap-1">
       {elapsedWithTooltip}
@@ -499,19 +507,41 @@ function AssistantForkButton({
 }
 
 /**
- * Hover content for the elapsed-footer info icon: provider, profile, model,
- * reasoning effort, and fast mode (only when enabled), plus - for a
- * user-stopped turn - the stop time and reason from the `turn.stopped` event.
- * Mirrors the context-usage chip's label/value row layout so the two tooltips
- * read consistently. Either section is optional; `AssistantElapsedFooter`
- * only renders this tooltip at all when at least one is present.
+ * Hover content for the elapsed footer: provider, profile, model, reasoning
+ * effort, and fast mode (only when enabled); then when the turn ran and when
+ * it finished; then - for a user-stopped turn - the stop time and reason from
+ * the `turn.stopped` event. Mirrors the context-usage chip's label/value row
+ * layout so the two tooltips read consistently.
+ *
+ * Timing answers what the visible footer deliberately does not: the footer
+ * states a DURATION, and a single clock time next to a duration cannot say
+ * which end of it it names. Two labelled rows can, and they also cover the
+ * turns whose start no user row records - a queued message, an autonomous
+ * wakeup, an agent-to-agent send. Every completed footer has it, which is why
+ * the footer no longer has an un-hoverable variant.
+ *
+ * A stopped turn's end row is `Stopped at`, REPLACING `Finished` rather than
+ * joining it. The projection resolves a stopped turn's `completedAt` to the
+ * stop instant itself (`assistantTurnTiming`'s `stoppedAt ?? persisted`), so
+ * rendering both would print one instant twice under two labels and invite
+ * the reader to look for a difference that is not there.
+ *
+ * `startedAt` is `null` for a row whose `createdAt` is a synthetic sort
+ * anchor rather than a real instant - the pre-turn pending indicator, whose
+ * anchor is "newest row + 1ms" and is epoch+1 on an empty transcript. Such a
+ * row states no time at all: a live turn already shows an elapsed counter,
+ * and a wrong start is worse than no start.
  */
 function AssistantMetaTooltip({
   meta,
   stopped,
+  startedAt,
+  completedAt,
 }: {
   meta: AssistantTurnMeta | null;
   stopped: ChatMessageStoppedInfo | null;
+  startedAt: number | null;
+  completedAt: number | null;
 }) {
   const reasoning = meta?.reasoningEffortLabel ?? null;
   const fastModeEnabled = meta !== null && isFastModeEnabled(meta.serviceTier);
@@ -552,40 +582,20 @@ function AssistantMetaTooltip({
           ) : null}
         </>
       )}
-      {stopped === null ? null : (
-        <>
-          <div
-            className={cn(
-              "font-medium",
-              meta !== null && "border-t border-background/20 pt-1.5",
-            )}
-          >
-            Stopped
-          </div>
-          <AssistantMetaRow
-            label="Time"
-            value={formatStoppedAt(stopped.stoppedAt)}
-          />
-          {stopped.reason === null ? null : (
-            <AssistantMetaRow label="Reason" value={stopped.reason} />
-          )}
-        </>
+      {startedAt === null ? null : (
+        <AssistantTimingSection
+          startedAt={startedAt}
+          completedAt={completedAt}
+          stopped={stopped}
+          dividerAbove={meta !== null}
+        />
       )}
+      <AssistantStoppedSection
+        stopped={stopped}
+        dividerAbove={meta !== null || startedAt !== null}
+      />
     </div>
   );
-}
-
-/**
- * Absolute clock time for the stop-detail tooltip row (e.g. "3:45 PM"). A
- * user Stop is a here-and-now action the user just took, so the exact time of
- * day is more useful than a relative/elapsed label - unlike `formatWorkedFor`,
- * which measures the turn's duration, not when it ended.
- */
-function formatStoppedAt(timestampMs: number): string {
-  return new Date(timestampMs).toLocaleTimeString(undefined, {
-    hour: "numeric",
-    minute: "2-digit",
-  });
 }
 
 /**
@@ -628,6 +638,95 @@ function assistantProfileMetaValue(meta: AssistantTurnMeta): string {
     return `env: ${meta.envCredentialVar} (sign-in bypassed)`;
   }
   return `${meta.profileLabel} (bypassed — env: ${meta.envCredentialVar})`;
+}
+
+/**
+ * How a turn ENDED, named for the way it ended rather than for the slot it
+ * occupies. A stopped turn's end is the stop itself: the projection resolves
+ * its `completedAt` to the stop instant, so "Finished" and "Stopped at" would
+ * be one time printed twice. `null` is a turn with no end yet.
+ */
+function assistantTurnEndRow(
+  stopped: ChatMessageStoppedInfo | null,
+  completedAt: number | null,
+): { readonly label: string; readonly at: number } | null {
+  if (stopped !== null) return { label: "Stopped at", at: stopped.stoppedAt };
+  if (completedAt === null) return null;
+  return { label: "Finished", at: completedAt };
+}
+
+/**
+ * The card's Timing section. Its own component so the shared clock is
+ * subscribed only where a time is actually rendered - a card with no timing
+ * to show (the pre-turn indicator) reads no clock at all. Radix keeps tooltip
+ * content unmounted at rest, so even then it is the hovered row subscribing,
+ * never every finished turn in the transcript.
+ */
+function AssistantTimingSection({
+  startedAt,
+  completedAt,
+  stopped,
+  dividerAbove,
+}: {
+  startedAt: number;
+  completedAt: number | null;
+  stopped: ChatMessageStoppedInfo | null;
+  dividerAbove: boolean;
+}) {
+  const now = useSampledNow();
+  const end = assistantTurnEndRow(stopped, completedAt);
+  return (
+    <>
+      <div
+        className={cn(
+          "font-medium",
+          dividerAbove && "border-t border-background/20 pt-1.5",
+        )}
+      >
+        Timing
+      </div>
+      <AssistantMetaRow
+        label="Started"
+        value={formatMessageTimeWithSeconds(startedAt, now)}
+      />
+      {end === null ? null : (
+        <AssistantMetaRow
+          label={end.label}
+          value={formatMessageTimeWithSeconds(end.at, now)}
+        />
+      )}
+    </>
+  );
+}
+
+/**
+ * The stop's own section, which survives only to carry the reason - not a
+ * timing fact, and with nowhere else to go. With no reason recorded there is
+ * nothing to put here at all: `Stopped at` in the Timing section above
+ * already says everything the stop knows, and a bare header would announce a
+ * section with no rows.
+ */
+function AssistantStoppedSection({
+  stopped,
+  dividerAbove,
+}: {
+  stopped: ChatMessageStoppedInfo | null;
+  dividerAbove: boolean;
+}) {
+  if (stopped === null || stopped.reason === null) return null;
+  return (
+    <>
+      <div
+        className={cn(
+          "font-medium",
+          dividerAbove && "border-t border-background/20 pt-1.5",
+        )}
+      >
+        Stopped
+      </div>
+      <AssistantMetaRow label="Reason" value={stopped.reason} />
+    </>
+  );
 }
 
 function AssistantMetaRow({ label, value }: { label: string; value: string }) {
@@ -757,7 +856,18 @@ function AssistantRunIndicator({
   if (meta === null) return indicator;
   return (
     <TooltipWrapper
-      label={<AssistantMetaTooltip meta={meta} stopped={null} />}
+      label={
+        // No Timing on the pre-turn indicator: this row's `createdAt` is a
+        // synthetic list anchor ("newest row + 1ms"), not an instant the turn
+        // actually started at, and the live counter beside it already answers
+        // how long the turn has been going.
+        <AssistantMetaTooltip
+          meta={meta}
+          stopped={null}
+          startedAt={null}
+          completedAt={null}
+        />
+      }
       side="top"
       align="start"
       sideOffset={6}

--- a/clients/gui-app/src/components/chat/chat-message-timestamp.tsx
+++ b/clients/gui-app/src/components/chat/chat-message-timestamp.tsx
@@ -1,0 +1,59 @@
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
+import { formatFullTimestamp, useMessageTime } from "@/lib/relative-time";
+
+/**
+ * The clock time a transcript row was sent, rendered beside its sender label.
+ *
+ * Its own leaf component so the shared 60s tick repaints this one element
+ * rather than the message row around it - `useMessageTime` subscribes, and a
+ * transcript re-rendering every row once a minute is exactly what that hook's
+ * leaf guidance exists to prevent.
+ *
+ * `<time>` rather than a span: the visible label is day-scoped and locale-
+ * shaped, so the machine-readable instant is the only form that stays
+ * unambiguous for assistive tech and for anything reading the DOM. The hover
+ * label is what lets the visible one abbreviate - it restores the weekday,
+ * the date, the year and the seconds the row drops.
+ *
+ * Deliberately NOT focusable. Radix does not make a `<time>` trigger a tab
+ * stop on its own, and adding one here would put an extra stop in front of
+ * every message in the transcript to reach a label whose content the
+ * `dateTime` attribute already exposes to assistive tech.
+ *
+ * `shrink-0` is baked in rather than passed per call site. In the sender
+ * overline the stamp is inline and the property is inert; in the agent-sender
+ * card header it is a flex item beside a name that IS allowed to shrink, and
+ * the stamp must not be the thing that collapses.
+ */
+export function ChatMessageTimestamp({
+  timestamp,
+}: {
+  readonly timestamp: number;
+}) {
+  const label = useMessageTime(timestamp);
+  // `toISOString()` is the one call in this feature that THROWS on a bad
+  // instant rather than rendering "Invalid Date", and it would take the whole
+  // message row down with it. The test has to be the Date's own validity, not
+  // `Number.isFinite` on the input: 8.64e15 + 1 is a perfectly finite number
+  // and still out of range for a Date. Nothing to print is the honest answer
+  // for a stamp that names no time.
+  const date = new Date(timestamp);
+  const iso = Number.isNaN(date.getTime()) ? null : date.toISOString();
+  if (iso === null) return null;
+  return (
+    <TooltipWrapper
+      label={formatFullTimestamp(timestamp)}
+      side="top"
+      align="center"
+      sideOffset={undefined}
+    >
+      <time
+        dateTime={iso}
+        data-testid="chat-message-timestamp"
+        className="shrink-0 font-normal tabular-nums text-muted-foreground/50"
+      >
+        {label}
+      </time>
+    </TooltipWrapper>
+  );
+}

--- a/clients/gui-app/src/components/chat/chat-message-timestamp.tsx
+++ b/clients/gui-app/src/components/chat/chat-message-timestamp.tsx
@@ -1,5 +1,9 @@
 import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
-import { formatFullTimestamp, useMessageTime } from "@/lib/relative-time";
+import {
+  formatFullTimestamp,
+  hasRenderableMessageTime,
+  useMessageTime,
+} from "@/lib/relative-time";
 
 /**
  * The clock time a transcript row was sent, rendered beside its sender label.
@@ -36,10 +40,11 @@ export function ChatMessageTimestamp({
   // message row down with it. The test has to be the Date's own validity, not
   // `Number.isFinite` on the input: 8.64e15 + 1 is a perfectly finite number
   // and still out of range for a Date. Nothing to print is the honest answer
-  // for a stamp that names no time.
-  const date = new Date(timestamp);
-  const iso = Number.isNaN(date.getTime()) ? null : date.toISOString();
-  if (iso === null) return null;
+  // for a stamp that names no time. Guarding through the exported predicate
+  // keeps this decision and the caller's separator on one rule; past it,
+  // `toISOString()` cannot throw.
+  if (!hasRenderableMessageTime(timestamp)) return null;
+  const iso = new Date(timestamp).toISOString();
   return (
     <TooltipWrapper
       label={formatFullTimestamp(timestamp)}

--- a/clients/gui-app/src/components/chat/chat-message-user-body.tsx
+++ b/clients/gui-app/src/components/chat/chat-message-user-body.tsx
@@ -80,6 +80,7 @@ import type {
   ChatMessageEditing,
   ChatMessageUserActions,
 } from "./chat-message";
+import { ChatMessageTimestamp } from "./chat-message-timestamp";
 import { ChatUserMessageContent } from "./chat-user-message-content";
 import { UserMessageAttachmentGallery } from "./user-message-attachment-gallery";
 import { BrowserReferenceChips } from "./browser-reference-chips";
@@ -191,6 +192,7 @@ export function UserMessageBody({
           messageText={message.content}
           agentMessage={message.agentMessage}
           agentSenderInfo={message.agentSenderInfo}
+          sentAt={message.sentAt ?? message.createdAt}
         />
       </>
     );
@@ -209,11 +211,13 @@ function AgentMessageDisplayView({
   messageText,
   agentMessage,
   agentSenderInfo,
+  sentAt,
 }: {
   messageId: string;
   messageText: string;
   agentMessage: ChatMessageModel["agentMessage"];
   agentSenderInfo: NonNullable<ChatMessageModel["agentSenderInfo"]>;
+  sentAt: number;
 }): ReactNode {
   const tileInstanceId = useChatCollapsibleTileInstanceId();
   const collapsibleKey = useMemo(
@@ -307,6 +311,11 @@ function AgentMessageDisplayView({
   // name is the only element allowed to shrink, so the direction words are
   // for assistive tech only and reply-expected is an icon. The icon plus
   // "from" carry the meaning for sighted users.
+  //
+  // The arrival stamp trails the row, past the `flex-1` name cell, so it lands
+  // at the header's right edge. Agent-to-agent traffic is where a timeline is
+  // hardest to reconstruct - these rows have no human send behind them - so it
+  // is the one place the stamp is load-bearing rather than a convenience.
   const header = (
     <>
       <Inbox className="size-3.5 shrink-0 text-primary" aria-hidden />
@@ -319,6 +328,7 @@ function AgentMessageDisplayView({
         />
         {expectReply ? <ReplyExpectedIcon /> : null}
       </span>
+      <ChatMessageTimestamp timestamp={sentAt} />
     </>
   );
 

--- a/clients/gui-app/src/components/chat/chat-message.tsx
+++ b/clients/gui-app/src/components/chat/chat-message.tsx
@@ -5,6 +5,7 @@ import type { JsonContent } from "@traycer/protocol/common/registry";
 import type { GuiHarnessId } from "@traycer/protocol/host/index";
 import { AssistantMessageBody } from "./chat-message-assistant-body";
 import { chatFindSegmentUnitId } from "./chat-find";
+import { ChatMessageTimestamp } from "./chat-message-timestamp";
 import { singleSpecialSegment } from "./chat-special-segment";
 import { UserMessageBody } from "./chat-message-user-body";
 import { ForkedChatLinkSegment } from "./segments/forked-chat-link-segment";
@@ -203,9 +204,22 @@ function ChatMessageImpl(props: ChatMessageProps) {
     message.statusLabel === null
       ? senderLabel
       : `${senderLabel} - ${message.statusLabel}`;
+  // A queued row leads with its status instead of a time: it has not been sent
+  // yet, so stamping it would read as a send time it does not have. A non-null
+  // `statusLabel` means exactly that here - the other two labels ("Streaming",
+  // "Completed") are applied under a `role === "assistant"` guard, and an
+  // assistant row returns above without ever reaching this overline.
   const sender = (
     <span className="text-overline font-medium text-muted-foreground/60">
       <span className="uppercase">{label}</span>
+      {message.statusLabel === null ? (
+        <>
+          <span aria-hidden> · </span>
+          <ChatMessageTimestamp
+            timestamp={message.sentAt ?? message.createdAt}
+          />
+        </>
+      ) : null}
     </span>
   );
 

--- a/clients/gui-app/src/components/chat/chat-message.tsx
+++ b/clients/gui-app/src/components/chat/chat-message.tsx
@@ -1,4 +1,5 @@
 import { memo, type ReactElement } from "react";
+import { hasRenderableMessageTime } from "@/lib/relative-time";
 import { cn } from "@/lib/utils";
 import type { ChatMessage as ChatMessageModel } from "@/stores/composer/chat-store";
 import type { JsonContent } from "@traycer/protocol/common/registry";
@@ -209,15 +210,18 @@ function ChatMessageImpl(props: ChatMessageProps) {
   // `statusLabel` means exactly that here - the other two labels ("Streaming",
   // "Completed") are applied under a `role === "assistant"` guard, and an
   // assistant row returns above without ever reaching this overline.
+  // The separator is drawn here but the stamp decides whether it renders, so
+  // both hang off the same predicate: a persisted row can carry an instant a
+  // `Date` cannot represent, and a lone " · " after the label is worse than no
+  // stamp at all.
+  const sentAt = message.sentAt ?? message.createdAt;
   const sender = (
     <span className="text-overline font-medium text-muted-foreground/60">
       <span className="uppercase">{label}</span>
-      {message.statusLabel === null ? (
+      {message.statusLabel === null && hasRenderableMessageTime(sentAt) ? (
         <>
           <span aria-hidden> · </span>
-          <ChatMessageTimestamp
-            timestamp={message.sentAt ?? message.createdAt}
-          />
+          <ChatMessageTimestamp timestamp={sentAt} />
         </>
       ) : null}
     </span>

--- a/clients/gui-app/src/components/chat/chat-stable-rows.ts
+++ b/clients/gui-app/src/components/chat/chat-stable-rows.ts
@@ -114,6 +114,7 @@ const CHAT_MESSAGE_FIELD_UNCHANGED: {
   browserAnnotations: (a, b) => a.browserAnnotations === b.browserAnnotations,
   settings: (a, b) => a.settings === b.settings,
   createdAt: (a, b) => a.createdAt === b.createdAt,
+  sentAt: (a, b) => a.sentAt === b.sentAt,
   elapsedStartedAt: (a, b) => a.elapsedStartedAt === b.elapsedStartedAt,
   turnHasOnlyAutonomousResumeSegments: (a, b) =>
     a.turnHasOnlyAutonomousResumeSegments ===

--- a/clients/gui-app/src/lib/__tests__/relative-time.test.ts
+++ b/clients/gui-app/src/lib/__tests__/relative-time.test.ts
@@ -253,7 +253,7 @@ describe("formatFullTimestamp", () => {
 
     const result = formatFullTimestamp(timestamp);
 
-    const expected = new Date(timestamp).toLocaleString(undefined, {
+    const options: Intl.DateTimeFormatOptions = {
       weekday: "short",
       month: "short",
       day: "numeric",
@@ -261,9 +261,23 @@ describe("formatFullTimestamp", () => {
       hour: "numeric",
       minute: "2-digit",
       second: "2-digit",
-    });
+    };
+    const expected = new Date(timestamp).toLocaleString(undefined, options);
     expect(result).toBe(expected);
-    expect(result).toContain("2026");
+    // The equality above still passes if the source and this fixture ever
+    // drift to the same wrong options, so anchor the year independently - it
+    // is the part this format exists to restore. It has to be read out of the
+    // formatter rather than written as "2026": per the note above the suite,
+    // no locale is pinned, and under one with non-Latin digits (ar-EG) or a
+    // non-Gregorian calendar (th-TH renders the Buddhist year 2569) the ASCII
+    // Gregorian year appears nowhere in `result`.
+    const yearPart = new Intl.DateTimeFormat(undefined, options)
+      .formatToParts(new Date(timestamp))
+      .find((part) => part.type === "year");
+    if (yearPart === undefined) {
+      throw new Error("the full format produced no year part to anchor on");
+    }
+    expect(result).toContain(yearPart.value);
     // A day-scoped, same-day render of the same instant never carries a year
     // - this is the "unabridged" form that restores it unconditionally.
     expect(result).not.toBe(formatMessageTime(timestamp, timestamp));

--- a/clients/gui-app/src/lib/__tests__/relative-time.test.ts
+++ b/clients/gui-app/src/lib/__tests__/relative-time.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
+  formatFullTimestamp,
+  formatMessageTime,
+  formatMessageTimeWithSeconds,
   formatRelativeTimestamp,
   formatResetCountdown,
   formatResetDateTime,
@@ -126,5 +129,143 @@ describe("formatResetDateTime", () => {
     const formatted = formatResetFullDateTime(timestamp);
     expect(formatted).toContain("2026");
     expect(formatted).not.toBe(formatResetDateTime(timestamp));
+  });
+});
+
+// `vitest.config.ts` pins neither `TZ` nor a locale, so every case below is
+// built from `new Date(year, month, day, hour, minute, second)` - local
+// calendar fields, interpreted in whatever zone the runner happens to use -
+// rather than a fixed UTC ISO string. That keeps a case deterministic without
+// needing to know or pin the zone: the day-boundary comparison inside
+// `formatMessageTime` reads the same local fields the fixture was built from,
+// so the two agree in any timezone. Expected strings are derived from
+// `toLocaleTimeString`/`toLocaleDateString` with the exact options the source
+// uses (no `hour12`), never a hard-coded literal like "3:45 PM" - that passes
+// on this machine and fails in CI under a different locale.
+describe("formatMessageTime", () => {
+  it("renders the time alone when the timestamp is on the same local day as `now`", () => {
+    const now = new Date(2026, 3, 23, 14, 30, 0).getTime();
+    const createdAt = new Date(2026, 3, 23, 9, 15, 0).getTime();
+    const expected = new Date(createdAt).toLocaleTimeString(undefined, {
+      hour: "numeric",
+      minute: "2-digit",
+    });
+    const result = formatMessageTime(createdAt, now);
+    expect(result).toBe(expected);
+    // Structural guard: a date-prefixed render always joins with ", ", so an
+    // un-prefixed render must not contain one.
+    expect(result).not.toContain(",");
+  });
+
+  // The trap the day rule exists for: two instants only two hours apart, but
+  // 11pm and 1am are different CALENDAR days. A `< 24h` delta would call this
+  // "recent enough" and wrongly omit the date.
+  it("prefixes a short date for two instants only two hours apart that straddle local midnight", () => {
+    const yesterdayLate = new Date(2026, 3, 22, 23, 0, 0).getTime();
+    const todayEarly = new Date(2026, 3, 23, 1, 0, 0).getTime();
+
+    const result = formatMessageTime(yesterdayLate, todayEarly);
+
+    const expectedDate = new Date(yesterdayLate).toLocaleDateString(undefined, {
+      month: "short",
+      day: "numeric",
+    });
+    const expectedTime = new Date(yesterdayLate).toLocaleTimeString(undefined, {
+      hour: "numeric",
+      minute: "2-digit",
+    });
+    expect(result).toBe(`${expectedDate}, ${expectedTime}`);
+  });
+
+  // The mirror case: a ~23h gap that a `< 24h` delta would call "yesterday",
+  // but both instants fall on the same calendar day, so no date is added.
+  it("omits the date prefix for a ~23h-old instant that is still the same calendar day", () => {
+    const createdAt = new Date(2026, 3, 23, 0, 30, 0).getTime();
+    const now = new Date(2026, 3, 23, 23, 30, 0).getTime();
+
+    const result = formatMessageTime(createdAt, now);
+
+    const expectedTime = new Date(createdAt).toLocaleTimeString(undefined, {
+      hour: "numeric",
+      minute: "2-digit",
+    });
+    expect(result).toBe(expectedTime);
+    expect(result).not.toContain(",");
+  });
+
+  // Documents the "locale decides 12h/24h" contract directly: unlike
+  // `formatResetDateTime` (which hard-codes `hour12: true`), this formatter
+  // passes no `hour12` at all, so its output must match the locale's own
+  // default rendering rather than a forced 12-hour one. Whether this actually
+  // differs from a `hour12: true` render depends on the runner's locale (most
+  // CI locales default to 12-hour), so the discriminating half of this
+  // contract cannot be asserted without pinning a 24-hour locale - this
+  // documents the intent and would catch a `hour12: true` regression under
+  // any 24-hour-default locale.
+  it("passes no explicit hour12 option, unlike formatResetDateTime", () => {
+    const now = new Date(2026, 3, 23, 15, 45, 0).getTime();
+    const expected = new Date(now).toLocaleTimeString(undefined, {
+      hour: "numeric",
+      minute: "2-digit",
+    });
+    expect(formatMessageTime(now, now)).toBe(expected);
+  });
+});
+
+describe("formatMessageTimeWithSeconds", () => {
+  it("carries seconds on a same-day render", () => {
+    const now = new Date(2026, 3, 23, 14, 30, 0).getTime();
+    const createdAt = new Date(2026, 3, 23, 14, 25, 42).getTime();
+
+    const result = formatMessageTimeWithSeconds(createdAt, now);
+
+    const expected = new Date(createdAt).toLocaleTimeString(undefined, {
+      hour: "numeric",
+      minute: "2-digit",
+      second: "2-digit",
+    });
+    expect(result).toBe(expected);
+    expect(result).not.toContain(",");
+  });
+
+  it("follows the same day-scoping rule as formatMessageTime, seconds included", () => {
+    const now = new Date(2026, 3, 23, 10, 0, 0).getTime();
+    const createdAt = new Date(2026, 3, 20, 10, 0, 5).getTime();
+
+    const result = formatMessageTimeWithSeconds(createdAt, now);
+
+    const expectedDate = new Date(createdAt).toLocaleDateString(undefined, {
+      month: "short",
+      day: "numeric",
+    });
+    const expectedTime = new Date(createdAt).toLocaleTimeString(undefined, {
+      hour: "numeric",
+      minute: "2-digit",
+      second: "2-digit",
+    });
+    expect(result).toBe(`${expectedDate}, ${expectedTime}`);
+  });
+});
+
+describe("formatFullTimestamp", () => {
+  it("restores the weekday, year and seconds that formatMessageTime drops", () => {
+    const timestamp = new Date(2026, 3, 23, 15, 45, 12).getTime();
+
+    const result = formatFullTimestamp(timestamp);
+
+    const expected = new Date(timestamp).toLocaleString(undefined, {
+      weekday: "short",
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+      second: "2-digit",
+    });
+    expect(result).toBe(expected);
+    expect(result).toContain("2026");
+    // A day-scoped, same-day render of the same instant never carries a year
+    // - this is the "unabridged" form that restores it unconditionally.
+    expect(result).not.toBe(formatMessageTime(timestamp, timestamp));
   });
 });

--- a/clients/gui-app/src/lib/relative-time.ts
+++ b/clients/gui-app/src/lib/relative-time.ts
@@ -23,7 +23,16 @@ const listeners = new Set<() => void>();
 
 function startIfNeeded(): void {
   if (intervalHandle !== null) return;
+  // Publish the restart sample through `tick`, not just into `sampledNow`.
+  // `getSnapshot` returns `tick`, so a resample that leaves it alone is
+  // invisible to `useSyncExternalStore`'s post-subscribe comparison: the
+  // first render after a cold start keeps whatever the last consumer left
+  // behind, with nothing able to correct it until the next interval fire.
+  // That is harmless for a relative label ("2m ago" is stale by a minute) and
+  // wrong for an absolute one - reopen a transcript at 00:01 after the app
+  // sat idle and every stamp from yesterday still claims to be today.
   sampledNow = Date.now();
+  tick += 1;
   intervalHandle = window.setInterval(() => {
     tick += 1;
     sampledNow = Date.now();
@@ -252,6 +261,119 @@ export function formatAbsoluteDateTime(timestamp: number): string {
     minute: "2-digit",
     hour12: true,
   });
+}
+
+/**
+ * How much of the clock a message stamp spells out. The transcript row shows
+ * minutes; the assistant footer's hover card shows seconds, where it sits
+ * beside a duration that is itself second-precise.
+ */
+type MessageTimePrecision = "minute" | "second";
+
+/**
+ * Whether two epoch-ms instants fall on the same day in the VIEWER's timezone.
+ *
+ * Compared part by part rather than through a formatted string: the calendar
+ * parts are what the decision is about, and going through a formatter would
+ * tie "is this today" to a display format that is free to change.
+ */
+function isSameLocalDay(a: number, b: number): boolean {
+  const dateA = new Date(a);
+  const dateB = new Date(b);
+  return (
+    dateA.getFullYear() === dateB.getFullYear() &&
+    dateA.getMonth() === dateB.getMonth() &&
+    dateA.getDate() === dateB.getDate()
+  );
+}
+
+function formatDayScopedTime(
+  timestamp: number,
+  now: number,
+  precision: MessageTimePrecision,
+): string {
+  // No `hour12` here, unlike `formatResetDateTime`. A transcript stamp reads
+  // down a column of times the viewer scans, so it should be written the way
+  // their own locale writes a clock - "15:45" where that is the convention.
+  const time = new Date(timestamp).toLocaleTimeString(
+    undefined,
+    precision === "second"
+      ? { hour: "numeric", minute: "2-digit", second: "2-digit" }
+      : { hour: "numeric", minute: "2-digit" },
+  );
+  if (isSameLocalDay(timestamp, now)) return time;
+  return `${formatShortDate(timestamp)}, ${time}`;
+}
+
+/**
+ * A transcript row's own clock time, scoped to the day it happened on: the
+ * time alone when that day is today ("3:45 PM"), a short date ahead of it
+ * otherwise ("Sep 8, 3:45 PM").
+ *
+ * Absolute rather than relative on purpose. A chat is read as a timeline, and
+ * "2m ago" both churns every minute and makes two adjacent messages read
+ * identically; a clock time never goes stale and can be compared between rows.
+ * The date is dropped for today because that is the common case and the
+ * prefix would be noise on every row of a session held in one sitting - but it
+ * is never dropped otherwise, since these chats routinely span days.
+ *
+ * Pure, taking `now` as an argument. {@link useMessageTime} is the reactive
+ * form for a component that must survive a day rollover.
+ */
+export function formatMessageTime(timestamp: number, now: number): string {
+  return formatDayScopedTime(timestamp, now, "minute");
+}
+
+/**
+ * {@link formatMessageTime} with seconds, for the roomy detail surfaces (the
+ * assistant footer's hover card) where the extra precision is readable and
+ * the neighbouring duration is already stated to the second.
+ */
+export function formatMessageTimeWithSeconds(
+  timestamp: number,
+  now: number,
+): string {
+  return formatDayScopedTime(timestamp, now, "second");
+}
+
+/**
+ * The unabridged form of a message stamp - weekday, full date, year and time
+ * to the second - for the hover label behind {@link formatMessageTime}'s
+ * day-scoped one.
+ *
+ * This is what makes an absolute stamp safe to abbreviate on the row: the
+ * visible label drops the date for today and the year always, and the reader
+ * gets both back on demand rather than losing them. Pure and complete, so it
+ * needs no `now` and never goes stale.
+ */
+export function formatFullTimestamp(timestamp: number): string {
+  return new Date(timestamp).toLocaleString(undefined, {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+}
+
+/**
+ * {@link formatMessageTime} bound to the shared 60s clock.
+ *
+ * The subscription is there for one transition only: a stamp showing "3:45 PM"
+ * has to become "Sep 10, 3:45 PM" once the day rolls over under a tab left
+ * open overnight. Reading the clock at render time instead would freeze the
+ * label at whatever the last render happened to observe, which is not coarse
+ * but wrong.
+ *
+ * Same leaf-component guidance as {@link useRelativeTimestamp}: call it from a
+ * small leaf (`<ChatMessageTimestamp />`) so the tick repaints that one element
+ * rather than the transcript row around it.
+ */
+export function useMessageTime(timestamp: number): string {
+  useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+  return formatMessageTime(timestamp, sampledNow);
 }
 
 /**

--- a/clients/gui-app/src/lib/relative-time.ts
+++ b/clients/gui-app/src/lib/relative-time.ts
@@ -337,6 +337,22 @@ export function formatMessageTimeWithSeconds(
 }
 
 /**
+ * Whether `timestamp` names an instant a message stamp can render at all.
+ *
+ * A persisted row can carry a number no `Date` represents - `8.64e15 + 1` is
+ * perfectly finite and still out of range - and `toISOString()` THROWS on one
+ * rather than producing "Invalid Date", so the stamp renders nothing for it.
+ * That decision has to be readable from outside the component: a call site
+ * drawing its own separator beside the stamp cannot see a `null` return, and
+ * would otherwise leave a lone " · " after the sender label. Exported so the
+ * separator and the stamp are decided by one predicate instead of two that
+ * can drift.
+ */
+export function hasRenderableMessageTime(timestamp: number): boolean {
+  return !Number.isNaN(new Date(timestamp).getTime());
+}
+
+/**
  * The unabridged form of a message stamp - weekday, full date, year and time
  * to the second - for the hover label behind {@link formatMessageTime}'s
  * day-scoped one.

--- a/clients/gui-app/src/stores/chats/__tests__/rendered-messages.test.tsx
+++ b/clients/gui-app/src/stores/chats/__tests__/rendered-messages.test.tsx
@@ -3726,6 +3726,38 @@ describe("useRenderedMessages setup card integration", () => {
     expect(indicator?.id).toBe("assistant:turn-setup");
   });
 
+  it("threads the active turn's real startedAt onto the pre-turn indicator, distinct from its createdAt list anchor", () => {
+    const { result } = renderRenderedMessages({
+      activeTurn: { ...RUNNING_ACTIVE_TURN, startedAt: 5000 },
+      runStatus: "running",
+    });
+
+    const indicator = result.current.find(
+      (message) => message.role === "assistant",
+    );
+    // `createdAt` stays the list anchor (`max(rendered.createdAt) + 1`, here
+    // `0 + 1` on an empty transcript) - it must not be reused as the elapsed
+    // clock's start, which is why 5000 was chosen to be unmistakably not 1.
+    expect(indicator?.createdAt).toBe(1);
+    expect(indicator?.elapsedStartedAt).toBe(5000);
+    expect(indicator?.elapsedStartedAt).not.toBe(indicator?.createdAt);
+  });
+
+  it("omits elapsedStartedAt from the pre-turn indicator when no active turn exists yet", () => {
+    const { result } = renderRenderedMessages({
+      activeTurn: null,
+      runStatus: "running",
+    });
+
+    const indicator = result.current.find(
+      (message) => message.role === "assistant",
+    );
+    // Same list anchor as the active-turn case above - only the presence of
+    // `elapsedStartedAt` differs, since there is genuinely no known start.
+    expect(indicator?.createdAt).toBe(1);
+    expect(indicator?.elapsedStartedAt).toBeUndefined();
+  });
+
   it("still shows the Working indicator when setup has already completed", () => {
     const { result } = renderRenderedMessages({
       events: [
@@ -5725,6 +5757,56 @@ describe("useRenderedMessages turn.stopped", () => {
     expect(
       collectAssistantReplyText(trailingRow.stopped?.turnReplySegments ?? []),
     ).toBe("");
+  });
+
+  it("preserves the real send instant on an orphaned steer row's sentAt while re-anchoring createdAt to the turn start", () => {
+    // No persisted user message for "steer-msg-1" - renderSteerBlockUserMessage
+    // falls through to the orphaned (renderSteeredUserMessage) branch.
+    const assistant = {
+      ...assistantMessage("turn-1", 10_000),
+      timestamp: 100_500,
+      blocks: [steerBlock("block-1", "steer-msg-1", 100_000)],
+    };
+
+    const { result } = renderRenderedMessages({
+      messages: [userMessage("m1"), assistant],
+    });
+
+    const steerRow = result.current.find(
+      (row) => row.id === "steer:queue:block-1",
+    );
+    // A turn that started at 10_000 carries a steer actually sent at 100_000 -
+    // the gap is deliberately large so the two values can never be confused.
+    expect(steerRow?.sentAt).toBe(100_000);
+    // createdAt still anchors to the turn start (the sort position), not the
+    // real send time - re-deriving it from sentAt would reorder the row out
+    // of its turn.
+    expect(steerRow?.createdAt).toBe(10_000);
+    expect(steerRow?.sentAt).not.toBe(steerRow?.createdAt);
+  });
+
+  it("preserves the real send instant on a persisted-message steer row's sentAt while re-anchoring createdAt to the turn start", () => {
+    // A persisted user message for the steer exists - renderSteerBlockUserMessage
+    // takes the renderUserMessage branch instead of the orphaned one above.
+    const steeredUser = userMessageAt("m2", 100_000);
+    const assistant = {
+      ...assistantMessage("turn-1", 10_000),
+      timestamp: 100_500,
+      blocks: [steerBlock("block-1", steeredUser.messageId, 100_000)],
+    };
+
+    const { result } = renderRenderedMessages({
+      messages: [userMessage("m1"), assistant, steeredUser],
+    });
+
+    const steerRow = result.current.find(
+      (row) => row.id === steeredUser.messageId,
+    );
+    // Same large, unmistakable gap between the turn's start and the steer's
+    // real send time as the orphaned-branch case above.
+    expect(steerRow?.sentAt).toBe(100_000);
+    expect(steerRow?.createdAt).toBe(10_000);
+    expect(steerRow?.sentAt).not.toBe(steerRow?.createdAt);
   });
 
   it("shows the stopped marker only once the turn.stopped event actually lands, across a rerender", () => {

--- a/clients/gui-app/src/stores/chats/rendered-messages.ts
+++ b/clients/gui-app/src/stores/chats/rendered-messages.ts
@@ -857,6 +857,42 @@ function isInterviewWaitEndEvent(event: ChatEvent): boolean {
   );
 }
 
+/**
+ * The active turn's stable primitive fields, or all-`null` when no turn is
+ * running. Spelled out once here so `useRenderedMessages` reads them as plain
+ * values: a per-field `activeTurn?.x ?? null` at the call site is five
+ * branches in the hook body for no gain, and the absent turn is one decision,
+ * not five.
+ *
+ * `startedAt` is the turn's real wall-clock start. The pre-turn indicator is
+ * synthesized with a `createdAt` that is a list anchor rather than an instant,
+ * so this is the only place that row can learn when its turn actually began.
+ */
+function activeTurnPrimitives(activeTurn: ChatActiveTurn | null): {
+  readonly turnId: string | null;
+  readonly userMessageId: string | null;
+  readonly harnessId: ChatActiveTurn["harnessId"] | null;
+  readonly profileId: string | null;
+  readonly startedAt: number | null;
+} {
+  if (activeTurn === null) {
+    return {
+      turnId: null,
+      userMessageId: null,
+      harnessId: null,
+      profileId: null,
+      startedAt: null,
+    };
+  }
+  return {
+    turnId: activeTurn.turnId,
+    userMessageId: activeTurn.userMessageId,
+    harnessId: activeTurn.harnessId,
+    profileId: activeTurn.profileId,
+    startedAt: activeTurn.startedAt,
+  };
+}
+
 export function useRenderedMessages(
   input: RenderedMessagesInput,
   displayContext: RenderedMessagesDisplayContext,
@@ -865,10 +901,13 @@ export function useRenderedMessages(
   // on its stable primitive fields (not the object identity) to avoid busting
   // this memo each frame. These are all set at turn-start and never rewritten
   // per delta, so they make safe, churn-free deps.
-  const activeTurnId = input.activeTurn?.turnId ?? null;
-  const activeTurnUserMessageId = input.activeTurn?.userMessageId ?? null;
-  const activeTurnHarnessId = input.activeTurn?.harnessId ?? null;
-  const activeTurnProfileId = input.activeTurn?.profileId ?? null;
+  const {
+    turnId: activeTurnId,
+    userMessageId: activeTurnUserMessageId,
+    harnessId: activeTurnHarnessId,
+    profileId: activeTurnProfileId,
+    startedAt: activeTurnStartedAt,
+  } = activeTurnPrimitives(input.activeTurn);
   // Re-keyed from ROW ids to TURN keys once per publish. Every row of a turn
   // carries the same context object, so the map is at most one entry per
   // hydrated turn, and the derivations below all hold a turn key rather than a
@@ -1250,6 +1289,7 @@ export function useRenderedMessages(
       : renderPendingRunIndicator({
           activeRunState,
           activeTurnId,
+          activeTurnStartedAt,
           activeTurnMeta: pendingTurnMeta(activeTurnMetaInput, displayContext),
           turnPauseAccounting,
           rendered: [...persisted, ...activeTurn, ...pending, ...live],
@@ -1367,6 +1407,7 @@ export function useRenderedMessages(
     setupCardEntries,
     activeRunState,
     activeTurnId,
+    activeTurnStartedAt,
     activeTurnMetaInput,
     turnPauseAccounting,
     displayContext,
@@ -2633,12 +2674,21 @@ function renderAssistantTurnRows(
       // Anchor the nested steer row at the turn start too, so it stays
       // contiguous with its surrounding slices under the stable `createdAt`
       // sort instead of jumping out by its own block timestamp.
+      //
+      // That anchor is a sort position, NOT when the steer was sent - a turn
+      // that started at 10:00 can carry a steer sent at 10:20. `sentAt`
+      // captures whatever instant the renderer produced before the re-anchor,
+      // which is the real send time down either branch (a persisted user
+      // message's, or the block's), so the transcript stamp reports the
+      // moment the person actually typed rather than the turn's start.
+      const steerRow = renderSteerBlockUserMessage(
+        block,
+        input.ctx,
+        input.userMessagesById.get(block.messageId) ?? null,
+      );
       return {
-        ...renderSteerBlockUserMessage(
-          block,
-          input.ctx,
-          input.userMessagesById.get(block.messageId) ?? null,
-        ),
+        ...steerRow,
+        sentAt: steerRow.createdAt,
         createdAt: input.rowAnchorAt,
       };
     }
@@ -3205,6 +3255,13 @@ function renderLiveAssistant(
 function renderPendingRunIndicator(input: {
   readonly activeRunState: ChatMessageRunState | null;
   readonly activeTurnId: string | null;
+  /**
+   * The turn's real wall-clock start, or `null` in the short window before a
+   * turn id (and so a turn) exists. `createdAt` below cannot serve as one:
+   * it is a list anchor, so the elapsed timer would measure from the previous
+   * row's position rather than from when the turn actually began.
+   */
+  readonly activeTurnStartedAt: number | null;
   readonly activeTurnMeta: AssistantTurnMeta | null;
   readonly turnPauseAccounting: ReadonlyMap<string, TurnPauseAccounting>;
   readonly rendered: ReadonlyArray<ChatMessageModel>;
@@ -3212,6 +3269,7 @@ function renderPendingRunIndicator(input: {
   const {
     activeRunState,
     activeTurnId,
+    activeTurnStartedAt,
     activeTurnMeta,
     turnPauseAccounting,
     rendered,
@@ -3241,7 +3299,13 @@ function renderPendingRunIndicator(input: {
       structuredContent: null,
       attachments: [],
       settings: null,
+      // A list anchor, not an instant: it exists to sort this row last. The
+      // turn's real start rides `elapsedStartedAt` beside it, which is what
+      // the elapsed timer measures from.
       createdAt: latestCreatedAt + 1,
+      ...(activeTurnStartedAt === null
+        ? {}
+        : { elapsedStartedAt: activeTurnStartedAt }),
       completedAt: null,
       stopped: null,
       pausedDurationMs: pause.pausedDurationMs,

--- a/clients/gui-app/src/stores/composer/chat-store.ts
+++ b/clients/gui-app/src/stores/composer/chat-store.ts
@@ -632,7 +632,19 @@ export interface ChatMessage {
   settings: ChatRunSettings | null;
   createdAt: number;
   /**
-   * Wall-clock start used by the assistant elapsed timer. Defaults to
+   * Wall-clock time this row's event actually happened, which is what the
+   * transcript stamp reads. Defaults to `createdAt`.
+   *
+   * The two differ wherever a row's `createdAt` has been moved to keep the
+   * transcript in order: `createdAt` is the canonical SORT key, so a nested
+   * steer bubble is re-anchored to its turn's start to stay contiguous with
+   * the slices around it. That anchor is not when the person sent the steer,
+   * and rendering it as one would silently report the wrong time.
+   */
+  sentAt?: number;
+  /**
+   * Wall-clock start of the assistant turn: the elapsed timer measures from
+   * it, and the footer's hover card reports it as `Started`. Defaults to
    * `createdAt`; differs when a persisted notification is adopted by a later
    * provider run but must keep its original transcript position.
    */


### PR DESCRIPTION
## Problem

A transcript carried no wall-clock time anywhere. The only clock strings in the stream were inside the stopped-turn tooltip and the imported-chat marker; everything else was an elapsed duration ("Worked for 2m 10s"). A reader could not place a conversation in time, or see where it paused overnight.

## Design

- The sender overline reads `YOU · 3:45 PM`. The stamp is **day-scoped**: the clock time alone when it happened today, a short date ahead of it otherwise. Sameness is a calendar-part comparison in local time, **not** a `< 24h` delta — 11pm yesterday and 1am today are two hours apart and different days, and a delta test gets that backwards. No `hour12`, so a 24-hour locale renders `15:45`. Hovering restores the weekday, date, year and seconds the row drops.
- The same stamp trails the agent-sender received card, where a timeline is hardest to reconstruct: those rows have no human send behind them.
- **The assistant footer's visible text is unchanged.** A single clock time beside a duration cannot say which end of it it names, so both ends live in the hover card as a labelled `Timing` section. A stopped turn's end row is `Stopped at`, **replacing** `Finished` rather than joining it: the projection resolves a stopped turn's `completedAt` to the stop instant, so printing both would be one time twice under two labels.
- Every completed footer now has timing to disclose, so its old un-hoverable `<div>` variant is gone; the `<button>` puts the card on the keyboard path.
- `ChatMessageTimestamp` is a leaf, so the shared 60s tick repaints one `<time>` element rather than the transcript row around it. That subscription exists for one transition only: the midnight rollover under a tab left open.

## Two anchors that are not timestamps

`createdAt` is the canonical transcript **sort** key, and two rows deliberately carry an anchor in it rather than a real instant.

- A **nested steer row** is re-anchored to its turn's start so it stays contiguous with the slices around it. A turn starting 10:00 carrying a steer sent at 10:20 would have stamped that steer 10:00 — and across midnight, wrong by a date. `ChatMessage.sentAt` records the real instant, captured at the one site that re-anchors; readers use `sentAt ?? createdAt`, mirroring the existing `elapsedStartedAt ?? createdAt` idiom. The field map in `chat-stable-rows.ts` is compile-time exhaustive, so it required the matching comparator.
- The **pre-turn indicator's** `createdAt` is `max(rows) + 1`, which is epoch+1ms on an empty transcript. `ChatActiveTurn.startedAt` was on the wire the whole time and simply never destructured, so that row's live elapsed timer measured from the anchor; it now carries a real `elapsedStartedAt`. Its hover card still states no `Started` when no turn exists yet — a fabricated start is worse than none.

Two adjacent fixes ride along, both pre-existing and both made visible by this feature:

- `startIfNeeded` resampled the shared clock without bumping `tick`. `getSnapshot` returns `tick`, so the resample was invisible to `useSyncExternalStore`: reopen a transcript at 00:01 after the app sat idle and every stamp from yesterday still claimed to be today. Harmless for a relative label, wrong for an absolute one.
- A comment claimed a Stop's wind-down counts toward the elapsed duration. It does not — the single `assistantTurnTiming` call site always passes `stoppedAt` when the row is stopped, so the elapsed is truncated at the click by the **data**, not by a second formula.

## Tests

481 tests across 15 suites, including the shared-clock consumers the `startIfNeeded` fix could disturb.

Timestamps are asserted against `toLocaleTimeString(undefined, …)` with the source's own options, over fixtures built from local calendar fields — never a literal like `"3:45 PM"`, because `vitest.config.ts` pins neither `TZ` nor a locale, so a hard-coded time passes locally and fails in CI.

Every behavior was ablated and confirmed to redden a named test (**9/9**). Worth recording: the first run of that matrix was **8/9**. Deleting the steer row's `sentAt` left the component suites fully green, because they set the field on a fixture and so proved only that the component *reads* it, never that the projection *produces* it — leaving the one line that fixes the steer-row defect uncovered. Two projection-level tests now cover both branches of `renderSteerBlockUserMessage`.

## Test plan

- [ ] Send a message: the overline reads `YOU · <time>`; hovering the stamp shows the full weekday/date/year/seconds.
- [ ] A message from an earlier day carries a short date prefix.
- [ ] Queue a message while a turn runs: the `YOU - Pending` row shows no time.
- [ ] Steer mid-turn: the steer bubble shows when it was **sent**, not the turn's start, and stays in position in the transcript.
- [ ] Hover a finished turn's "Worked for …" footer: `Started` / `Finished`.
- [ ] Stop a turn, hover its footer: `Started` / `Stopped at`, no `Finished`.
- [ ] Hover a running turn's indicator: agent details, no `Timing` section.
- [ ] A 24-hour locale renders `15:45`; a 12-hour locale renders `3:45 PM`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
