### PR TITLE
fix(gui-app): read servedBy with the cloud stamp so a merged-plane host covers its own agents

### DIFF
--- a/clients/gui-app/src/providers/notifications-session-provider.tsx
+++ b/clients/gui-app/src/providers/notifications-session-provider.tsx
@@ -1066,12 +1066,13 @@ function NotificationsSessionBody(
    * running on the very machine it is talking to.
    *
    * The gate is the NEGOTIATED minor, not the host's own plane selection.
-   * Those are different facts: a host may well serve local by default (the
-   * host tree has since moved to exactly that), but nothing on the wire says
-   * so, and `servedBy` reports the choice only after the room it was gating
-   * has already been acquired. This comment previously asserted the host
-   * selection itself - it had gone stale, and the stale sentence was the
-   * stated reason for withholding the lane.
+   * Those are different facts: a host's default plane is its own business
+   * (the host tree moved to local-first, then to a merged view that serves
+   * its own agents at once and still acquires the room for the others), but
+   * nothing on the wire says which, and `servedBy` reports the choice only
+   * after the room it was gating has already been acquired. This comment
+   * previously asserted the host selection itself - it had gone stale, and
+   * the stale sentence was the stated reason for withholding the lane.
    */
   const openForCurrentUser = useCallback(
     (settledFeedMode: NotificationFeedMode, cloudAuthorized: boolean): void => {

--- a/clients/gui-app/src/stores/__tests__/agent-activity-coverage.test.ts
+++ b/clients/gui-app/src/stores/__tests__/agent-activity-coverage.test.ts
@@ -3,7 +3,9 @@ import {
   __resetAgentActivityStoreForTests,
   __setHostAgentActivityHealthForTests,
   __setHostAgentActivityStateForTests,
+  agentActivityPlaneAnswers,
   agentActivityPlaneCoversHost,
+  agentActivityPlaneSpansFleet,
   selectAgentActivityCoverage,
   useAgentActivityStore,
 } from "@/stores/agent-activity-store";
@@ -128,6 +130,70 @@ describe("selectAgentActivityCoverage", () => {
     );
 
     expect(selectAgentActivityCoverage(byHost(), null)).toBe("covered");
+  });
+});
+
+describe("merged-plane servedBy interplay (lane: merged agent-activity plane)", () => {
+  // The merged plane sends `servedBy: "local"` (this host's origin store)
+  // under the REAL link stamp whenever its union does not reach the fleet -
+  // including a `connected`-adjacent value like `disconnected` while a room
+  // is held. `servedBy` is part of the claim these predicates read, not
+  // decoration on top of it.
+
+  it("a merged host's local frame under a down link covers its own host, and reads indeterminate (not unserved) for another", () => {
+    __setHostAgentActivityHealthForTests(HOST_A, {
+      connectionStatus: "open",
+      servedBy: "local",
+      cloudSyncStatus: "disconnected",
+      stateFrameSeenThisEpoch: true,
+    });
+
+    expect(selectAgentActivityCoverage(byHost(), HOST_A)).toBe("covered");
+    expect(selectAgentActivityCoverage(byHost(), HOST_B)).toBe("indeterminate");
+    expect(agentActivityPlaneSpansFleet()).toBe(false);
+    // A `disconnected` stamp is not the "nobody is working" vouch either -
+    // `hostActivityAnswers` excludes `disconnected` by name.
+    expect(agentActivityPlaneAnswers()).toBe(false);
+  });
+
+  it("a local frame stamped connected does not span the fleet - servedBy is part of the claim", () => {
+    __setHostAgentActivityHealthForTests(HOST_A, {
+      connectionStatus: "open",
+      servedBy: "local",
+      cloudSyncStatus: "connected",
+      stateFrameSeenThisEpoch: true,
+    });
+
+    expect(agentActivityPlaneSpansFleet()).toBe(false);
+    // The slice answers (a `connected` stamp is not excluded by
+    // `hostActivityAnswers`), so the OTHER host reads the narrow-union
+    // exclusion, `unserved` - not `indeterminate`.
+    expect(selectAgentActivityCoverage(byHost(), HOST_B)).toBe("unserved");
+    expect(selectAgentActivityCoverage(byHost(), HOST_A)).toBe("covered");
+  });
+
+  it("a cloud frame stamped connected still spans the fleet (unchanged)", () => {
+    __setHostAgentActivityHealthForTests(HOST_A, {
+      connectionStatus: "open",
+      servedBy: "cloud",
+      cloudSyncStatus: "connected",
+      stateFrameSeenThisEpoch: true,
+    });
+
+    expect(selectAgentActivityCoverage(byHost(), HOST_A)).toBe("covered");
+    expect(selectAgentActivityCoverage(byHost(), HOST_B)).toBe("covered");
+  });
+
+  it("an old cloud-plane host's disconnected frame still reads indeterminate for its own host (unchanged)", () => {
+    __setHostAgentActivityHealthForTests(HOST_A, {
+      connectionStatus: "open",
+      servedBy: "cloud",
+      cloudSyncStatus: "disconnected",
+      stateFrameSeenThisEpoch: true,
+    });
+
+    expect(selectAgentActivityCoverage(byHost(), HOST_A)).toBe("indeterminate");
+    expect(selectAgentActivityCoverage(byHost(), HOST_B)).toBe("indeterminate");
   });
 });
 

--- a/clients/gui-app/src/stores/__tests__/agent-activity-store.test.ts
+++ b/clients/gui-app/src/stores/__tests__/agent-activity-store.test.ts
@@ -160,8 +160,11 @@ describe("subscribeAgentActivityPlaneHealth", () => {
 
     // Narrow -> fleet-wide, with the answer unchanged at true. The cap's busy
     // gate reads both predicates, so a consumer not woken here would sit on
-    // "cannot speak for this session" until an unrelated write.
+    // "cannot speak for this session" until an unrelated write. A merged
+    // host flips `servedBy` and the stamp in the same frame; the stamp alone
+    // would still be narrow.
     __setHostAgentActivityHealthForTests(HOST_A, {
+      servedBy: "cloud",
       cloudSyncStatus: "connected",
     });
     expect(callCount).toBe(2);
@@ -199,7 +202,23 @@ describe("agentActivityPlaneSpansFleet", () => {
     expect(agentActivityPlaneSpansFleet()).toBe(false);
   });
 
-  it("is true for a local plane whose host attests a connected cloud link", () => {
+  it("is true for a cloud-served frame whose host attests a connected cloud link", () => {
+    __setHostAgentActivityHealthForTests(HOST_A, {
+      connectionStatus: "open",
+      stateFrameSeenThisEpoch: true,
+      servedBy: "cloud",
+      cloudSyncStatus: "connected",
+    });
+
+    expect(agentActivityPlaneSpansFleet()).toBe(true);
+  });
+
+  it("is false for a local plane even when its stamp says connected", () => {
+    // A merged-plane host reports `servedBy: "cloud"` the moment its union
+    // reaches the other hosts, and `"local"` under the REAL link stamp while
+    // it does not - so `"local"` is narrow whatever the stamp says. Before the
+    // merged plane this pairing was fleet-spanning; that reading would trust
+    // a frame that carries only this machine's agents.
     __setHostAgentActivityHealthForTests(HOST_A, {
       connectionStatus: "open",
       stateFrameSeenThisEpoch: true,
@@ -207,7 +226,10 @@ describe("agentActivityPlaneSpansFleet", () => {
       cloudSyncStatus: "connected",
     });
 
-    expect(agentActivityPlaneSpansFleet()).toBe(true);
+    expect(agentActivityPlaneAnswers()).toBe(true);
+    expect(agentActivityPlaneSpansFleet()).toBe(false);
+    expect(agentActivityPlaneCoversHost(HOST_A)).toBe(true);
+    expect(agentActivityPlaneCoversHost(HOST_B)).toBe(false);
   });
 
   it("is false for a local plane with no cloud claim", () => {

--- a/clients/gui-app/src/stores/agent-activity-store.ts
+++ b/clients/gui-app/src/stores/agent-activity-store.ts
@@ -60,6 +60,12 @@ export interface HostAgentActivity {
    * `disconnected` value means the union below was built while the host could
    * not see other hosts' agents: it is a true statement about what the host
    * saw, not about who is working.
+   *
+   * Read WITH `servedBy`: a merged-plane host that holds a room whose link is
+   * down sends its origin-store view as `servedBy: "local"` under that link
+   * stamp. The local half is authoritative for the host's own agents
+   * ({@link hostSliceCoversItsOwnHost}); the stamp names the half that is
+   * missing. Only a `"cloud"` frame stamped `connected` reaches the fleet.
    */
   readonly cloudSyncStatus: AgentActivityCloudSyncStatus | null;
   readonly byEpic: ReadonlyMap<string, EpicAgentActivity>;
@@ -546,11 +552,38 @@ function selectPlaneSpansFleet(
   byHost: ReadonlyMap<string, HostAgentActivity>,
 ): boolean {
   for (const host of byHost.values()) {
-    if (hostActivityAnswers(host) && host.cloudSyncStatus === "connected") {
+    // `servedBy` is part of the claim, not decoration: a merged-plane host
+    // sends `servedBy: "local"` under a real link stamp whenever its union
+    // does NOT reach the fleet (awareness mid-rebuild, link flapping), and
+    // that frame must not be read as fleet coverage on the strength of the
+    // stamp alone. A cloud-plane host of any released line stamps only its
+    // `"cloud"` frames, so nothing it sends changes answer here.
+    if (
+      hostActivityAnswers(host) &&
+      host.servedBy === "cloud" &&
+      host.cloudSyncStatus === "connected"
+    ) {
       return true;
     }
   }
   return false;
+}
+
+/**
+ * Whether this host's slice vouches for ITS OWN agents. Wider than
+ * {@link hostActivityAnswers} by exactly one arm: a `servedBy: "local"` frame
+ * is the host's origin store and is authoritative for the machine it came
+ * from whatever its cloud link is doing - a merged-plane host keeps sending
+ * it, stamped with the real link status, while its room is down. That stamp
+ * still withholds fleet coverage (see {@link selectPlaneSpansFleet}) and the
+ * "nobody is working" vouch ({@link agentActivityPlaneAnswers}); it only
+ * stops the host's own rows from reading as unknown during a socket flap.
+ */
+function hostSliceCoversItsOwnHost(host: HostAgentActivity): boolean {
+  if (host.connectionStatus !== "open" || !host.stateFrameSeenThisEpoch) {
+    return false;
+  }
+  return host.servedBy === "local" || hostActivityAnswers(host);
 }
 
 function selectPlaneAnswers(
@@ -602,7 +635,7 @@ export function selectAgentActivityCoverage(
   // `indeterminate` by hand for this same no-host case.
   if (hostId === null) return "indeterminate";
   const host = byHost.get(hostId);
-  if (host !== undefined && hostActivityAnswers(host)) return "covered";
+  if (host !== undefined && hostSliceCoversItsOwnHost(host)) return "covered";
   return selectPlaneAnswers(byHost) ? "unserved" : "indeterminate";
 }
 

--- a/protocol/src/host/agent/__tests__/agent-activity-plane-minors.test.ts
+++ b/protocol/src/host/agent/__tests__/agent-activity-plane-minors.test.ts
@@ -7,12 +7,13 @@ import {
   agentActivitySubscribeV10,
   agentActivitySubscribeV11,
   agentActivitySubscribeV12,
+  agentActivitySubscribeV13,
 } from "@traycer/protocol/host/agent/activity";
 
 describe("agent.activity.subscribe@1.2", () => {
   it("is registered alongside the frozen 1.0 and 1.1 contracts", () => {
     const registry = hostStreamRpcRegistry["agent.activity.subscribe"];
-    expect(registry[1].latestMinor).toBe(2);
+    expect(registry[1].latestMinor).toBe(3);
     expect(registry[1].versions[0].contract.schemaVersion).toEqual({
       major: 1,
       minor: 0,
@@ -25,6 +26,24 @@ describe("agent.activity.subscribe@1.2", () => {
       major: 1,
       minor: 2,
     });
+  });
+
+  it("registers 1.3 as the latest minor, wire-identical to 1.2", () => {
+    const registry = hostStreamRpcRegistry["agent.activity.subscribe"];
+    expect(registry[1].versions[3].contract).toBe(agentActivitySubscribeV13);
+    expect(registry[1].versions[3].contract.schemaVersion).toEqual({
+      major: 1,
+      minor: 3,
+    });
+    expect(agentActivitySubscribeV13.openRequestSchema).toBe(
+      agentActivitySubscribeV12.openRequestSchema,
+    );
+    expect(agentActivitySubscribeV13.serverFrameSchema).toBe(
+      agentActivitySubscribeV12.serverFrameSchema,
+    );
+    expect(agentActivitySubscribeV13.clientFrameSchema).toBe(
+      agentActivitySubscribeV12.clientFrameSchema,
+    );
   });
 
   it("frozen line strips the plane selector", () => {

--- a/protocol/src/host/agent/__tests__/agent-activity-subscribe.test.ts
+++ b/protocol/src/host/agent/__tests__/agent-activity-subscribe.test.ts
@@ -141,6 +141,29 @@ describe("agent.activity.subscribe@1.1", () => {
     );
   });
 
+  // The 1.3 contract itself, asserted through the parser rather than the
+  // reference equality above: a `servedBy: "local"` frame MAY carry a real
+  // link status. A later cross-field restriction (local implies null) would
+  // keep every reference check green while breaking the merged plane's
+  // "own agents authoritative, fleet unknown" frame.
+  it("1.3 accepts a local frame stamped with a real link status", () => {
+    const frame = {
+      kind: "state",
+      servedBy: "local",
+      byEpic: {},
+      cloudSyncStatus: "disconnected",
+      hasBinaryPayload: false,
+    };
+    expect(agentActivitySubscribeV13.serverFrameSchema.parse(frame)).toEqual(
+      frame,
+    );
+    expect(
+      hostStreamRpcRegistry[
+        "agent.activity.subscribe"
+      ][1].versions[3].contract.serverFrameSchema.parse(frame),
+    ).toEqual(frame);
+  });
+
   // Read the schema OFF THE REGISTRY, not the imported symbol: a later edit
   // re-pointing `1.0` at a laxer schema must fail here, not only in the
   // protocol-compat CI gate.

--- a/protocol/src/host/agent/__tests__/agent-activity-subscribe.test.ts
+++ b/protocol/src/host/agent/__tests__/agent-activity-subscribe.test.ts
@@ -5,6 +5,7 @@ import {
   agentActivitySubscribeV10,
   agentActivitySubscribeV11,
   agentActivitySubscribeV12,
+  agentActivitySubscribeV13,
 } from "@traycer/protocol/host/agent/activity";
 import { hostStreamRpcRegistry } from "@traycer/protocol/host/registry";
 
@@ -105,7 +106,7 @@ describe("agent.activity.subscribe@1.1", () => {
     ).toBe(false);
   });
 
-  it("registers 1.0, 1.1 and 1.2 densely with 1.2 as the latest minor", () => {
+  it("registers 1.0 through 1.3 densely with 1.3 as the latest minor", () => {
     expect(
       agentActivitySubscribeClientFrameSchema.parse({
         kind: "ping",
@@ -113,10 +114,31 @@ describe("agent.activity.subscribe@1.1", () => {
       }),
     ).toEqual({ kind: "ping", hasBinaryPayload: false });
     const entry = hostStreamRpcRegistry["agent.activity.subscribe"];
-    expect(entry[1].latestMinor).toBe(2);
+    expect(entry[1].latestMinor).toBe(3);
     expect(entry[1].versions[0].contract).toBe(agentActivitySubscribeV10);
     expect(entry[1].versions[1].contract).toBe(agentActivitySubscribeV11);
     expect(entry[1].versions[2].contract).toBe(agentActivitySubscribeV12);
+    expect(entry[1].versions[3].contract).toBe(agentActivitySubscribeV13);
+  });
+
+  // `1.3` grows nothing on the wire - it exists only so the host can tell
+  // which readers understand a `servedBy: "local"` frame's stamp as a real
+  // link status (see `agentActivitySubscribeCarriesLocalLinkStamp` on the
+  // host). Its three schemas must be 1.2's, by reference.
+  it("1.3 is wire-identical to 1.2: same schemaVersion.major, same schemas by reference", () => {
+    expect(agentActivitySubscribeV13.schemaVersion).toEqual({
+      major: 1,
+      minor: 3,
+    });
+    expect(agentActivitySubscribeV13.openRequestSchema).toBe(
+      agentActivitySubscribeV12.openRequestSchema,
+    );
+    expect(agentActivitySubscribeV13.serverFrameSchema).toBe(
+      agentActivitySubscribeV12.serverFrameSchema,
+    );
+    expect(agentActivitySubscribeV13.clientFrameSchema).toBe(
+      agentActivitySubscribeV12.clientFrameSchema,
+    );
   });
 
   // Read the schema OFF THE REGISTRY, not the imported symbol: a later edit

--- a/protocol/src/host/agent/activity.ts
+++ b/protocol/src/host/agent/activity.ts
@@ -15,13 +15,18 @@
  * CLAIM: a local-plane frame, or a `1.0` host that predates the field. A
  * consumer must never read `null` as "connected".
  *
- * A host serving the MERGED plane (origin store plus other hosts' entries)
- * uses the same two words: `servedBy: "cloud"` only while its union reaches
- * the fleet (`cloudSyncStatus: "connected"`), and `servedBy: "local"` under
- * the real link stamp otherwise - so a `"local"` frame may carry a non-null
- * status. Read `servedBy` together with the stamp: fleet coverage is the
- * `"cloud"` + `connected` pair, and a `"local"` frame stays authoritative for
- * the sending host's own agents whatever the stamp says about its link.
+ * `1.3` changes no schema; it changes what a `state` frame's stamp MEANS on a
+ * `servedBy: "local"` frame. A host serving the MERGED plane (origin store
+ * plus other hosts' entries) uses the same two words: `servedBy: "cloud"`
+ * only while its union reaches the fleet (`cloudSyncStatus: "connected"`),
+ * and `servedBy: "local"` under the real link stamp otherwise - so on `1.3`
+ * a `"local"` frame may carry a non-null status. Read `servedBy` together
+ * with the stamp: fleet coverage is the `"cloud"` + `connected` pair, and a
+ * `"local"` frame stays authoritative for the sending host's own agents
+ * whatever the stamp says about its link. The released `1.1`/`1.2` readers
+ * consult the stamp alone, so a host sends them a `"local"` frame with the
+ * stamp projected to `null` - the local plane they already understand - and
+ * the real stamp only to a peer that negotiated `1.3`.
  *
  * `1.0` is frozen below (`agentActivitySubscribeServerFrameSchemaV10`) - it
  * has shipped, and `canBridgeStream()` needs the `{1,0}` line registered to
@@ -195,6 +200,22 @@ export const agentActivitySubscribeV11 = defineStreamRpcContract({
 export const agentActivitySubscribeV12 = defineStreamRpcContract({
   method: "agent.activity.subscribe",
   schemaVersion: { major: 1, minor: 2 } as const,
+  openRequestSchema: agentActivitySubscribeOpenRequestSchema,
+  serverFrameSchema: agentActivitySubscribeServerFrameSchema,
+  clientFrameSchema: agentActivitySubscribeClientFrameSchema,
+});
+
+// `@1.3` grows NOTHING on the wire - open request, server frame and client
+// frame are `@1.2`'s, byte for byte. It exists so a host can tell which
+// readers understand a `servedBy: "local"` frame's stamp as the sending host's
+// real link status (the merged plane's "own agents authoritative, fleet
+// unknown" frame) and project that stamp to `null` for the ones that do not.
+// A minor rather than a note because the difference is in what the PEER does
+// with a frame, and the negotiated version is the only fact about the peer a
+// host holds.
+export const agentActivitySubscribeV13 = defineStreamRpcContract({
+  method: "agent.activity.subscribe",
+  schemaVersion: { major: 1, minor: 3 } as const,
   openRequestSchema: agentActivitySubscribeOpenRequestSchema,
   serverFrameSchema: agentActivitySubscribeServerFrameSchema,
   clientFrameSchema: agentActivitySubscribeClientFrameSchema,

--- a/protocol/src/host/agent/activity.ts
+++ b/protocol/src/host/agent/activity.ts
@@ -15,6 +15,14 @@
  * CLAIM: a local-plane frame, or a `1.0` host that predates the field. A
  * consumer must never read `null` as "connected".
  *
+ * A host serving the MERGED plane (origin store plus other hosts' entries)
+ * uses the same two words: `servedBy: "cloud"` only while its union reaches
+ * the fleet (`cloudSyncStatus: "connected"`), and `servedBy: "local"` under
+ * the real link stamp otherwise - so a `"local"` frame may carry a non-null
+ * status. Read `servedBy` together with the stamp: fleet coverage is the
+ * `"cloud"` + `connected` pair, and a `"local"` frame stays authoritative for
+ * the sending host's own agents whatever the stamp says about its link.
+ *
  * `1.0` is frozen below (`agentActivitySubscribeServerFrameSchemaV10`) - it
  * has shipped, and `canBridgeStream()` needs the `{1,0}` line registered to
  * bridge a `1.1` client down to a `1.0` host. Do not add fields to it.

--- a/protocol/src/host/registry.ts
+++ b/protocol/src/host/registry.ts
@@ -182,6 +182,7 @@ import {
   agentActivitySubscribeV10,
   agentActivitySubscribeV11,
   agentActivitySubscribeV12,
+  agentActivitySubscribeV13,
 } from "@traycer/protocol/host/agent/activity";
 import {
   agentRolesClaimUpgradeV10ToV11,
@@ -10778,7 +10779,7 @@ const HOST_STREAM_RPC_REGISTRY_OTHER_DEFINITION = {
   // registered verbatim so a newer client bridges down to an older host.
   "agent.activity.subscribe": {
     1: {
-      latestMinor: 2,
+      latestMinor: 3,
       versions: {
         0: {
           contract: agentActivitySubscribeV10,
@@ -10788,6 +10789,9 @@ const HOST_STREAM_RPC_REGISTRY_OTHER_DEFINITION = {
         },
         2: {
           contract: agentActivitySubscribeV12,
+        },
+        3: {
+          contract: agentActivitySubscribeV13,
         },
       },
     },


### PR DESCRIPTION
## Why

The host is moving to a **merged** agent-activity plane (internal PR traycerai/traycer-internal#5616). On the wire that is still `agent.activity.subscribe@1.x` with `servedBy: "cloud" | "local"` and the 1.1 `cloudSyncStatus`, plus one new pairing: a `"local"` frame under a **non-null** stamp, sent whenever the host's union does not reach the fleet (link flapping, awareness mid-rebuild). This PR teaches the store to read `servedBy` together with the stamp.

## What changes

- `selectPlaneSpansFleet`: fleet coverage is `servedBy: "cloud"` **and** `connected`. A `"local"` frame stamped `connected` (which a merged host never sends and an old cloud-plane host cannot) is not read as reaching every machine.
- `selectAgentActivityCoverage`: a host's slice covers **its own** agents when it is open with a frame and either says `"local"` or answers normally (`hostSliceCoversItsOwnHost`). A merged host whose room is down keeps its own rows honest instead of flipping them to unknown for the length of a socket flap; other hosts stay `indeterminate` (the pill says `cloud-down`); `unserved` remains the narrow-union case only.
- Protocol: the `@1.1` doc comment records the pairing. No schema change.

## Compatibility

An old cloud-plane host's frames answer exactly as before: `"cloud"` frames carry the stamp, `"local"` frames carry `null`. `agentActivityPlaneAnswers` (the "nobody is working" vouch used by the busy gate) is unchanged and stays conservative under a down link.

## Tests

`agent-activity-coverage.test.ts`: merged local frame under a down link covers its own host and leaves others indeterminate; a local frame stamped connected does not span the fleet; cloud + connected still spans (control); an old host's cloud + disconnected frame still reads indeterminate (control). Each rule ablated individually.

## Round 2 (cold review): `agent.activity.subscribe@1.3`

The cold review found that the GUI-side rule above only helps readers that carry it: the released `1.1`/`1.2` readers consult the stamp without `servedBy`, so a merged-plane host's `local` + `connected` frame (awareness mid-rebuild, link up) reads there as fleet coverage of a payload that carries only one machine's agents, and `local` + `disconnected` withholds the coverage of the very host the local view is authoritative for.

`1.3` grows nothing on the wire (open request, server frame and client frame are `1.2`'s by reference). It exists so the host can tell which readers understand a `local` frame's real stamp; for `1.1`/`1.2` peers the host projects that stamp to `null` (the local plane those readers already understand). Registered with `latestMinor: 3`; the released-baseline compat tripwire and the protocol minors suites pass. Host side: traycerai/traycer-internal#5616.
