### PR TITLE
fix(gui-app): distinguish interview single- vs multi-choice

### DIFF
--- a/clients/gui-app/src/components/chat/segments/__tests__/static-interview-custom-row.test.tsx
+++ b/clients/gui-app/src/components/chat/segments/__tests__/static-interview-custom-row.test.tsx
@@ -95,4 +95,37 @@ describe("StaticInterviewOptions and the withdrawn custom-answer channel", () =>
 
     expect(screen.getByText("something the user typed")).toBeTruthy();
   });
+
+  it("renders radio glyphs on listed single-choice rows, not on Other", () => {
+    renderOptions({
+      question: question(null, ["Alpha", "Beta"]),
+      customText: null,
+    });
+
+    expect(
+      document.querySelectorAll('[data-interview-choice-glyph="radio"]'),
+    ).toHaveLength(2);
+    expect(
+      document.querySelector('[data-interview-choice-glyph="checkbox"]'),
+    ).toBeNull();
+    expect(screen.getByText("Other")).toBeTruthy();
+  });
+
+  it("renders checkbox glyphs on listed multi-choice rows", () => {
+    renderOptions({
+      question: { ...question(false, ["Alpha", "Beta"]), multiSelect: true },
+      customText: null,
+    });
+
+    expect(
+      document.querySelectorAll('[data-interview-choice-glyph="checkbox"]'),
+    ).toHaveLength(2);
+    expect(
+      document.querySelector('[data-interview-choice-glyph="radio"]'),
+    ).toBeNull();
+    const selected = document.querySelector(
+      '[data-interview-choice-glyph="checkbox"][data-selected="true"]',
+    );
+    expect(selected).not.toBeNull();
+  });
 });

--- a/clients/gui-app/src/components/chat/segments/interview-visuals.tsx
+++ b/clients/gui-app/src/components/chat/segments/interview-visuals.tsx
@@ -2,6 +2,7 @@ import {
   Check,
   ChevronLeft,
   ChevronRight,
+  Circle,
   CircleHelp,
   Pencil,
 } from "lucide-react";
@@ -37,6 +38,42 @@ export function InterviewDraftStatus() {
   );
 }
 
+/**
+ * Decorative selection glyph. Listed rows stay buttons (`aria-pressed`)
+ * because a single-choice pick continues — that is not radio semantics.
+ */
+export function InterviewChoiceGlyph(props: {
+  readonly multiSelect: boolean;
+  readonly selected: boolean;
+}) {
+  const kind = props.multiSelect ? "checkbox" : "radio";
+  let fill = "border-input bg-background/60";
+  let indicator: ReactNode = null;
+  if (props.selected && props.multiSelect) {
+    fill = "border-primary bg-primary text-primary-foreground";
+    indicator = <Check className="size-3.5" aria-hidden />;
+  } else if (props.selected) {
+    fill = "border-primary bg-background/60";
+    indicator = (
+      <Circle className="size-2 fill-primary text-primary" aria-hidden />
+    );
+  }
+  return (
+    <span
+      aria-hidden
+      data-interview-choice-glyph={kind}
+      data-selected={props.selected ? "true" : "false"}
+      className={cn(
+        "pointer-events-none relative z-10 inline-flex size-4 shrink-0 items-center justify-center border shadow-xs",
+        props.multiSelect ? "rounded-sm" : "rounded-full",
+        fill,
+      )}
+    >
+      {indicator}
+    </span>
+  );
+}
+
 function meaningfulText(value: string | null): string | null {
   const trimmed = value?.trim() ?? "";
   return trimmed.length > 0 ? trimmed : null;
@@ -68,6 +105,7 @@ export function InterviewQuestionHeader(props: {
   readonly questionText: string;
   readonly headerFindUnitId: string | null;
   readonly questionFindUnitId: string | null;
+  readonly modeHint: string | null;
 }) {
   const header = meaningfulText(props.header);
   return (
@@ -86,6 +124,14 @@ export function InterviewQuestionHeader(props: {
       >
         {props.questionText}
       </p>
+      {props.modeHint === null ? null : (
+        <p
+          data-testid="interview-choice-mode-hint"
+          className="m-0 text-ui-xs text-muted-foreground"
+        >
+          {props.modeHint}
+        </p>
+      )}
     </div>
   );
 }
@@ -253,23 +299,27 @@ function OptionBadge(props: {
   readonly selected: boolean;
   readonly custom: boolean;
 }) {
-  let content: ReactNode = props.index;
-  if (props.selected) {
-    content = <Check className="size-3" aria-hidden />;
-  } else if (props.custom) {
-    content = <Pencil className="size-3" aria-hidden />;
+  if (props.custom) {
+    return (
+      <span
+        aria-hidden
+        className={cn(
+          "inline-flex size-5 shrink-0 items-center justify-center rounded-full border text-[0.625rem] font-semibold tabular-nums",
+          props.selected
+            ? "border-primary/70 bg-primary/90 text-primary-foreground"
+            : "border-border/70 bg-background/60 text-muted-foreground/70",
+        )}
+      >
+        <Pencil className="size-3" aria-hidden />
+      </span>
+    );
   }
   return (
     <span
       aria-hidden
-      className={cn(
-        "inline-flex size-5 shrink-0 items-center justify-center rounded-full border text-[0.625rem] font-semibold tabular-nums",
-        props.selected
-          ? "border-primary/70 bg-primary/90 text-primary-foreground"
-          : "border-border/70 bg-background/60 text-muted-foreground/70",
-      )}
+      className="inline-flex size-5 shrink-0 items-center justify-center rounded-full border border-border/70 bg-background/60 text-[0.625rem] font-semibold tabular-nums text-muted-foreground/70"
     >
-      {content}
+      {props.index}
     </span>
   );
 }
@@ -280,6 +330,7 @@ function StaticOptionRow(props: {
   readonly index: number;
   readonly selected: boolean;
   readonly custom: boolean;
+  readonly choiceKind: "single" | "multi" | null;
   readonly labelFindUnitId: string | null;
   readonly pinnedDetailRegionId: string | null;
   readonly children: ReactNode;
@@ -295,6 +346,12 @@ function StaticOptionRow(props: {
             : "text-muted-foreground",
         )}
       >
+        {props.choiceKind === null ? null : (
+          <InterviewChoiceGlyph
+            multiSelect={props.choiceKind === "multi"}
+            selected={props.selected}
+          />
+        )}
         {/* Historical option labels intentionally wrap while live rows truncate for review readability. */}
         <span
           data-chat-find-unit={props.labelFindUnitId ?? undefined}
@@ -378,6 +435,7 @@ export function StaticInterviewOptions(props: {
               index={index + 1}
               selected={isSelected}
               custom={false}
+              choiceKind={props.question.multiSelect ? "multi" : "single"}
               labelFindUnitId={findUnitIds.label}
               pinnedDetailRegionId={detailRegionId}
             >
@@ -404,6 +462,7 @@ export function StaticInterviewOptions(props: {
             index={props.question.options.length + 1}
             selected={props.customText !== null}
             custom
+            choiceKind={null}
             labelFindUnitId={props.customFindUnitId}
             pinnedDetailRegionId={null}
           >

--- a/clients/gui-app/src/components/chat/segments/pending-interview/__tests__/pending-interview-card.test.tsx
+++ b/clients/gui-app/src/components/chat/segments/pending-interview/__tests__/pending-interview-card.test.tsx
@@ -2682,3 +2682,95 @@ describe("PendingInterviewCard keyboard navigation", () => {
     expect(detailsButton.getAttribute("aria-controls")).toBeNull();
   });
 });
+
+describe("PendingInterviewCard choice mode chrome", () => {
+  afterEach(() => {
+    cleanup();
+    useInterviewDraftStore.setState({ draftsByChat: {} });
+    window.localStorage.clear();
+    setMobileApp(false);
+  });
+
+  it("names a last single-choice pick as send, with radio glyphs", () => {
+    renderCard(
+      [withoutCustomAnswer(singleSelect("q1", "Choose", ["Alpha", "Beta"]))],
+      vi.fn(),
+      null,
+    );
+
+    expect(screen.getByTestId("interview-choice-mode-hint").textContent).toBe(
+      "Pick one to send",
+    );
+    expect(
+      document.querySelectorAll('[data-interview-choice-glyph="radio"]'),
+    ).toHaveLength(2);
+    expect(
+      document.querySelector('[data-interview-choice-glyph="checkbox"]'),
+    ).toBeNull();
+  });
+
+  it("names an earlier single-choice pick as continue", () => {
+    renderCard(
+      [
+        withoutCustomAnswer(singleSelect("q1", "First?", ["Alpha"])),
+        withoutCustomAnswer(singleSelect("q2", "Second?", ["Beta"])),
+      ],
+      vi.fn(),
+      null,
+    );
+
+    expect(screen.getByTestId("interview-choice-mode-hint").textContent).toBe(
+      "Pick one to continue",
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+    expect(screen.getByTestId("interview-choice-mode-hint").textContent).toBe(
+      "Pick one to send",
+    );
+  });
+
+  it("names a last multi-choice pick as Submit, with checkbox glyphs", () => {
+    renderCard(
+      [withoutCustomAnswer(multiSelect("m", "Pick some", ["Alpha", "Beta"]))],
+      vi.fn(),
+      null,
+    );
+
+    expect(screen.getByTestId("interview-choice-mode-hint").textContent).toBe(
+      "Pick any, then Submit",
+    );
+    expect(
+      document.querySelectorAll('[data-interview-choice-glyph="checkbox"]'),
+    ).toHaveLength(2);
+    expect(
+      document.querySelector('[data-interview-choice-glyph="radio"]'),
+    ).toBeNull();
+  });
+
+  it("names an earlier multi-choice pick as Next", () => {
+    renderCard(
+      [
+        withoutCustomAnswer(multiSelect("m1", "Pick some", ["Alpha"])),
+        withoutCustomAnswer(singleSelect("q2", "Second?", ["Beta"])),
+      ],
+      vi.fn(),
+      null,
+    );
+
+    expect(screen.getByTestId("interview-choice-mode-hint").textContent).toBe(
+      "Pick any, then Next",
+    );
+  });
+
+  it("omits the mode line on a free-text-only question", () => {
+    renderCard([singleSelect("free", "Describe it", [])], vi.fn(), null);
+    expect(screen.queryByTestId("interview-choice-mode-hint")).toBeNull();
+  });
+
+  it("keeps Other without a choice glyph", () => {
+    renderCard([singleSelect("q1", "Choose", ["Alpha"])], vi.fn(), null);
+    expect(
+      document.querySelectorAll('[data-interview-choice-glyph="radio"]'),
+    ).toHaveLength(1);
+    expect(screen.getByRole("button", { name: "Other" })).toBeTruthy();
+  });
+});

--- a/clients/gui-app/src/components/chat/segments/pending-interview/interview-choice-mode.ts
+++ b/clients/gui-app/src/components/chat/segments/pending-interview/interview-choice-mode.ts
@@ -1,0 +1,14 @@
+/**
+ * Mode line under a pending question with listed options. Cardinality lives
+ * on the radio/checkbox glyph; this string names what a click does and
+ * matches the footer button that is actually on the card (Next vs Submit).
+ */
+export function interviewChoiceModeHint(
+  multiSelect: boolean,
+  isLastQuestion: boolean,
+): string {
+  if (multiSelect) {
+    return isLastQuestion ? "Pick any, then Submit" : "Pick any, then Next";
+  }
+  return isLastQuestion ? "Pick one to send" : "Pick one to continue";
+}

--- a/clients/gui-app/src/components/chat/segments/pending-interview/pending-interview-card.tsx
+++ b/clients/gui-app/src/components/chat/segments/pending-interview/pending-interview-card.tsx
@@ -15,6 +15,7 @@ import {
   InterviewQuestionHeader,
   InterviewQuestionPager,
 } from "@/components/chat/segments/interview-visuals";
+import { interviewChoiceModeHint } from "./interview-choice-mode";
 import { QuestionPage } from "./question-page";
 import { QUESTION_TRANSITION, useInterviewCard } from "./use-interview-card";
 
@@ -112,6 +113,7 @@ export function PendingInterviewCard(props: PendingInterviewCardProps) {
           questionText="Input needed"
           headerFindUnitId={null}
           questionFindUnitId={null}
+          modeHint={null}
         />
       ) : (
         <AnimatePresence mode="wait" initial={false}>
@@ -136,6 +138,11 @@ export function PendingInterviewCard(props: PendingInterviewCardProps) {
               questionText={question.question}
               headerFindUnitId={null}
               questionFindUnitId={null}
+              modeHint={
+                question.options.length === 0
+                  ? null
+                  : interviewChoiceModeHint(question.multiSelect, isLast)
+              }
             />
             <QuestionPage
               question={question}

--- a/clients/gui-app/src/components/chat/segments/pending-interview/question-page.tsx
+++ b/clients/gui-app/src/components/chat/segments/pending-interview/question-page.tsx
@@ -7,6 +7,7 @@ import type {
   InterviewQuestionOption,
 } from "@traycer/protocol/persistence/epic/schemas";
 import {
+  InterviewChoiceGlyph,
   InterviewOptionDetailsButton,
   InterviewOptionDetailsRegion,
 } from "@/components/chat/segments/interview-visuals";
@@ -142,9 +143,8 @@ export function QuestionPage(props: QuestionPageProps) {
                 selected={selected}
                 pending={pendingOptionIndex === index}
                 disabled={disabled}
-                badge={
-                  <OptionNumberBadge index={index + 1} selected={selected} />
-                }
+                choiceKind={question.multiSelect ? "multi" : "single"}
+                badge={<OptionNumberBadge index={index + 1} />}
                 onToggle={() => onToggleOption(index)}
               />
             </li>
@@ -206,6 +206,7 @@ function OtherRow(props: OtherRowProps) {
       selected={false}
       pending={false}
       disabled={disabled}
+      choiceKind={null}
       badge={<OtherIconBadge selected={false} />}
       onToggle={onSelect}
     />
@@ -237,6 +238,7 @@ interface OptionRowProps {
   selected: boolean;
   pending: boolean;
   disabled: boolean;
+  choiceKind: "single" | "multi" | null;
   badge: ReactNode;
   onToggle: () => void;
 }
@@ -249,6 +251,7 @@ function OptionRow(props: OptionRowProps) {
     selected,
     pending,
     disabled,
+    choiceKind,
     badge,
     onToggle,
   } = props;
@@ -292,6 +295,12 @@ function OptionRow(props: OptionRowProps) {
           disabled={disabled}
           className="absolute inset-0 z-0 rounded-md outline-none focus-visible:ring-3 focus-visible:ring-ring/40"
         />
+        {choiceKind === null ? null : (
+          <InterviewChoiceGlyph
+            multiSelect={choiceKind === "multi"}
+            selected={selected}
+          />
+        )}
         <span className="pointer-events-none relative z-10 min-w-0 truncate font-medium text-foreground/90">
           {label}
         </span>
@@ -314,18 +323,13 @@ function OptionRow(props: OptionRowProps) {
   );
 }
 
-// The right-side circular badge doubles as the keyboard hint (its number) and
-// the selection indicator (filled when selected).
-function OptionNumberBadge(props: { index: number; selected: boolean }) {
+// The right-side circular badge is the keyboard hint. Selection lives on the
+// left radio/checkbox glyph, so this stays a number even when the row is on.
+function OptionNumberBadge(props: { index: number }) {
   return (
     <span
       aria-hidden
-      className={cn(
-        "pointer-events-none relative z-10 inline-flex size-5 shrink-0 items-center justify-center rounded-full border text-[0.625rem] font-semibold tabular-nums transition-colors",
-        props.selected
-          ? "border-primary/70 bg-primary/90 text-primary-foreground"
-          : "border-border/70 bg-background/60 text-muted-foreground/70",
-      )}
+      className="pointer-events-none relative z-10 inline-flex size-5 shrink-0 items-center justify-center rounded-full border border-border/70 bg-background/60 text-[0.625rem] font-semibold tabular-nums text-muted-foreground/70"
     >
       {props.index}
     </span>

--- a/clients/gui-app/src/components/chat/segments/resolved-interview-card.tsx
+++ b/clients/gui-app/src/components/chat/segments/resolved-interview-card.tsx
@@ -360,6 +360,7 @@ function ReviewPage(props: {
           optionIndex: null,
           valueIndex: null,
         })}
+        modeHint={null}
       />
       {showsOptions ? (
         <StaticInterviewOptions


### PR DESCRIPTION
## Summary

Interview option rows looked the same in single- and multi-choice, so a listed click that sends was indistinguishable from a click that only toggles.

- Single-choice: radio on the left, **Pick one to continue** / **Pick one to send** (earlier page vs last/only). A listed pick still highlights then advances, and still sends on the last question.
- Multi-choice: checkbox on the left, **Pick any, then Next** / **Pick any, then Submit** so the hint names the footer button that is actually on the card.
- Number badges stay numbers (keyboard hints). The left glyph is the selection indicator.
- History / post-submit card uses the same glyphs when expanded. It omits the mode line because nothing is clickable.

## Test plan

- [ ] One-question single-choice: the line says **Pick one to send**; clicking a listed option still sends; Other still waits for Submit.
- [ ] Multi-page single-choice: first page says **Pick one to continue**; last page says **Pick one to send**.
- [ ] Multi-choice: checkboxes; first page says **Pick any, then Next**; last page says **Pick any, then Submit**; clicks only toggle.
- [ ] Expand a submitted interview from the transcript: radios vs checkboxes match the question, no mode line.

Checklist:
- [x] Tests added/updated where it makes sense
- [x] Commits are signed off (`git commit -s`) per the DCO


Made with [Cursor](https://cursor.com)