### PR TITLE
fix(gui-app): halve the boot card branding

### DIFF
--- a/clients/gui-app/src/components/__tests__/local-host-loading.test.tsx
+++ b/clients/gui-app/src/components/__tests__/local-host-loading.test.tsx
@@ -106,6 +106,18 @@ describe("<LocalHostLoadingContent />", () => {
     ).toBe("true");
   });
 
+  it("keeps the mark and wordmark on the card at the boot size", () => {
+    // The boot size keeps the brand a small header over the card's own heading
+    // and progress, rather than the lockup the card is organised around. jsdom
+    // has no layout, so the rendered size is only visible in a real browser -
+    // `scripts/host-boot-family-gallery-browser.mjs` screenshots every face.
+    mountLoadingContent(buildHost(), null);
+    const brand = screen.getByTestId("brand-entrance");
+    expect(brand.getAttribute("data-size")).toBe("boot");
+    expect(brand.querySelector("svg")).not.toBeNull();
+    expect(brand.textContent).toBe("traycer");
+  });
+
   it("does NOT carry an open disclosure into a fresh launch", () => {
     // The other side of the same decision: the flag is session state, not a
     // preference. Nothing persists it, so a store that started life expanded

--- a/clients/gui-app/src/components/auth/brand-entrance.tsx
+++ b/clients/gui-app/src/components/auth/brand-entrance.tsx
@@ -3,24 +3,30 @@ import { BrandMark } from "@/components/auth/cinematic-backdrop";
 import { cn } from "@/lib/utils";
 import "@/styles/auth-arrival.css";
 
+/**
+ * `hero` is the full-screen launch splash. `boot` is a header on the host boot
+ * card - a small mark over a small wordmark, so the card's own heading and
+ * progress stay what the eye lands on.
+ */
 export function BrandEntrance(props: {
-  readonly size: "hero" | "compact";
+  readonly size: "hero" | "boot";
   readonly children: ReactNode;
 }): ReactNode {
   return (
     <div
       className={cn(
         "flex flex-col items-center",
-        props.size === "hero" ? "gap-[clamp(1.2rem,2.8vh,2rem)]" : "gap-3",
+        props.size === "hero" ? "gap-[clamp(1.2rem,2.8vh,2rem)]" : "gap-1",
       )}
       data-testid="brand-entrance"
+      data-size={props.size}
     >
       <BrandMark
         className={cn(
           "brand-entrance-mark h-auto",
           props.size === "hero"
             ? "w-[clamp(3.75rem,8vw,5.4rem)] drop-shadow-[0_1.5rem_2.5rem_rgba(0,0,0,0.42)]"
-            : "w-[clamp(3rem,12vw,4.5rem)]",
+            : "w-[clamp(1.5rem,6vw,2.25rem)]",
         )}
       />
       {props.children}

--- a/clients/gui-app/src/components/local-host-loading.tsx
+++ b/clients/gui-app/src/components/local-host-loading.tsx
@@ -188,8 +188,8 @@ export function LocalHostLoadingContent(
 
   return (
     <LocalHostBodyShell>
-      <BrandEntrance size="compact">
-        <p className="brand-entrance-copy font-heading text-title-lg font-medium tracking-tight text-foreground">
+      <BrandEntrance size="boot">
+        <p className="brand-entrance-copy font-heading text-title-xs font-medium tracking-tight text-foreground">
           traycer
         </p>
       </BrandEntrance>


### PR DESCRIPTION
The mark and wordmark heading the host boot card ("Starting Traycer…") were sized as a lockup, which made them the largest thing on a card whose job is the heading and the progress bar under them. This halves them on desktop and mobile alike.

## Change

`BrandEntrance`'s small variant (its only consumer is the boot card) becomes `boot`, sized as a header:

| | Before | After |
| --- | --- | --- |
| Mark width | `clamp(3rem, 12vw, 4.5rem)` | `clamp(1.5rem, 6vw, 2.25rem)` — exactly half at every viewport |
| Wordmark | `text-title-lg` (30px / 36px line) | `text-title-xs` (14px / 18px line) |
| Mark ↔ wordmark gap | `gap-3` (12px) | `gap-1` (4px) |

Nothing else on the card moves: the body's own rhythm, the heading, the bar and the footer are untouched, and the hero splash keeps its size.

## Measured

Brand block (`[data-testid="brand-entrance"]`) height on the `narrator-idle` face of the host boot family gallery:

| Viewport | Before | After | Ratio |
| --- | --- | --- | --- |
| 1280 × 800 | 122.4px (mark 72 × 74.4) | 59.2px (mark 36 × 37.2) | 48.4% |
| 390 × 844 | 97.6px (mark 48 × 49.6) | 46.8px (mark 24 × 24.8) | 48.0% |

The card shrinks with it (346.4 → 283.2px at 1280). `scripts/host-boot-family-gallery-browser.mjs` still reports all 12 family faces on one card and all 5 wait faces on one box, at both viewports.

## Screenshots

**Desktop (1280 × 800)**

| Before | After |
| --- | --- |
| ![desktop before](https://gist.githubusercontent.com/pranshugupta54/22d7d7479ded7e7d7430cf1735ca1e00/raw/589d978bb28c6598e9ca7d6a0ce8d057558660a3/boot-card-desktop-before.png) | ![desktop after](https://gist.githubusercontent.com/pranshugupta54/22d7d7479ded7e7d7430cf1735ca1e00/raw/589d978bb28c6598e9ca7d6a0ce8d057558660a3/boot-card-desktop-after.png) |

**Mobile (390 × 844)**

| Before | After |
| --- | --- |
| ![mobile before](https://gist.githubusercontent.com/pranshugupta54/22d7d7479ded7e7d7430cf1735ca1e00/raw/589d978bb28c6598e9ca7d6a0ce8d057558660a3/boot-card-mobile-before.png) | ![mobile after](https://gist.githubusercontent.com/pranshugupta54/22d7d7479ded7e7d7430cf1735ca1e00/raw/589d978bb28c6598e9ca7d6a0ce8d057558660a3/boot-card-mobile-after.png) |

## Validation

- `local-host-loading.test.tsx` asserts the boot card keeps the mark and wordmark and uses the `boot` size; it fails if the card is put back on the `hero` size (checked by reverting the call site).
- `default-host-ready-gate` and `auth-brand-splash` suites pass unchanged.
- Pre-commit build, compile, lint and format.
