### PR TITLE
feat(gui-app): shimmer the boot card mark while starting

### DIFF
--- a/clients/gui-app/src/components/__tests__/local-host-loading.test.tsx
+++ b/clients/gui-app/src/components/__tests__/local-host-loading.test.tsx
@@ -116,6 +116,11 @@ describe("<LocalHostLoadingContent />", () => {
     expect(brand.getAttribute("data-size")).toBe("boot");
     expect(brand.querySelector("svg")).not.toBeNull();
     expect(brand.textContent).toBe("traycer");
+    // The mark shimmers for as long as this card is up (the sweep itself is
+    // covered in `brand-entrance.test.tsx`); the wordmark is outside it.
+    const shimmer = screen.getByTestId("brand-entrance-mark-shimmer");
+    expect(shimmer.querySelector("svg")).not.toBeNull();
+    expect(shimmer.textContent).toBe("");
   });
 
   it("does NOT carry an open disclosure into a fresh launch", () => {

--- a/clients/gui-app/src/components/auth/__tests__/brand-entrance.test.tsx
+++ b/clients/gui-app/src/components/auth/__tests__/brand-entrance.test.tsx
@@ -1,3 +1,6 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { act, cleanup, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { BrandEntrance } from "@/components/auth/brand-entrance";
@@ -119,5 +122,73 @@ describe('<BrandEntrance size="boot" /> mark shimmer', () => {
     expect(
       screen.getByTestId("brand-entrance").querySelector("svg"),
     ).not.toBeNull();
+  });
+});
+
+/**
+ * The stylesheet half of the same two contracts. jsdom does not process CSS,
+ * so the inline-style assertions above cannot see an `animation:` added to
+ * the class, or a mask rule moved out from under the motion media query -
+ * either of which would pass every render-time check while a reduced-motion
+ * user got a permanently dimmed mark, or every user paid for an always-on
+ * CSS animation. Read the source instead.
+ */
+describe("auth-arrival.css: the boot mark shimmer rules", () => {
+  const css = readFileSync(
+    path.join(
+      path.dirname(fileURLToPath(import.meta.url)),
+      "..",
+      "..",
+      "..",
+      "styles",
+      "auth-arrival.css",
+    ),
+    "utf8",
+  );
+
+  /** Every `.brand-entrance-mark-shimmer { … }` declaration block, with the index it starts at. */
+  function shimmerRules(): { readonly start: number; readonly body: string }[] {
+    const rules: { start: number; body: string }[] = [];
+    const pattern = /\.brand-entrance-mark-shimmer\s*\{([^}]*)\}/g;
+    for (const match of css.matchAll(pattern)) {
+      rules.push({ start: match.index, body: match[1] });
+    }
+    return rules;
+  }
+
+  /** `[start, end)` of the body of the `prefers-reduced-motion: no-preference` block. */
+  function motionBlockRange(): readonly [number, number] {
+    const open = css.indexOf("@media (prefers-reduced-motion: no-preference)");
+    expect(open).toBeGreaterThanOrEqual(0);
+    const bodyStart = css.indexOf("{", open) + 1;
+    let depth = 1;
+    for (let i = bodyStart; i < css.length; i++) {
+      if (css[i] === "{") depth += 1;
+      else if (css[i] === "}") {
+        depth -= 1;
+        if (depth === 0) return [bodyStart, i];
+      }
+    }
+    throw new Error("unterminated motion media block");
+  }
+
+  it("declares the mask only under the motion media query", () => {
+    const [start, end] = motionBlockRange();
+    const masked = shimmerRules().filter((rule) =>
+      rule.body.includes("mask-image"),
+    );
+    expect(masked.length).toBe(1);
+    for (const rule of masked) {
+      expect(rule.start).toBeGreaterThan(start);
+      expect(rule.start).toBeLessThan(end);
+    }
+  });
+
+  it("never drives the sweep with a CSS animation", () => {
+    const rules = shimmerRules();
+    expect(rules.length).toBeGreaterThan(0);
+    for (const rule of rules) {
+      expect(rule.body).not.toMatch(/animation|transition/);
+    }
   });
 });

--- a/clients/gui-app/src/components/auth/__tests__/brand-entrance.test.tsx
+++ b/clients/gui-app/src/components/auth/__tests__/brand-entrance.test.tsx
@@ -1,0 +1,123 @@
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { BrandEntrance } from "@/components/auth/brand-entrance";
+import {
+  STATUS_ANIMATION_TICK_MS,
+  resetStatusAnimationClockForTests,
+} from "@/lib/animation/status-animation-clock";
+
+/**
+ * The global test shim answers every media query with `matches: false`. This
+ * narrows the reduced-motion query alone; the clock reads only `matches`.
+ */
+function stubReducedMotion(reduced: boolean): void {
+  vi.stubGlobal("matchMedia", (query: string) => ({
+    matches: reduced && query === "(prefers-reduced-motion: reduce)",
+    media: query,
+    onchange: null,
+    addEventListener: () => undefined,
+    removeEventListener: () => undefined,
+    dispatchEvent: () => false,
+  }));
+}
+
+function queryShimmer(): HTMLElement | null {
+  return screen.queryByTestId("brand-entrance-mark-shimmer");
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  resetStatusAnimationClockForTests();
+});
+
+afterEach(() => {
+  cleanup();
+  resetStatusAnimationClockForTests();
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+describe('<BrandEntrance size="boot" /> mark shimmer', () => {
+  it("wraps the MARK alone and sweeps its mask from the shared clock, not a CSS animation", () => {
+    render(<BrandEntrance size="boot">{<p>traycer</p>}</BrandEntrance>);
+    const shimmer = queryShimmer();
+    expect(shimmer).not.toBeNull();
+    if (shimmer === null) throw new Error("unreachable");
+
+    // The highlight is clipped to the mark: the wrapper holds the SVG and
+    // nothing else, so the wordmark beside it is never under the mask.
+    expect(shimmer.children.length).toBe(1);
+    expect(shimmer.firstElementChild?.tagName.toLowerCase()).toBe("svg");
+    expect(shimmer.contains(screen.getByText("traycer"))).toBe(false);
+
+    // Pre-paint first write: the band starts parked off the left edge.
+    expect(shimmer.style.maskPosition).toBe("100% center");
+    // Mounted on the clock, not on `animation:` - the card can stay up for
+    // minutes, and an always-on CSS animation is the cost the clock exists
+    // to avoid.
+    expect(shimmer.style.animation).toBe("");
+    expect(shimmer.className).not.toMatch(/animate/);
+
+    act(() => {
+      vi.advanceTimersByTime(STATUS_ANIMATION_TICK_MS * 4);
+    });
+    const next = shimmer.style.maskPosition;
+    expect(next).not.toBe("100% center");
+    expect(parseFloat(next)).toBeLessThan(100);
+    expect(parseFloat(next)).toBeGreaterThan(0);
+  });
+
+  it("parks the band between sweeps and starts the next one from the far edge", () => {
+    render(<BrandEntrance size="boot">{null}</BrandEntrance>);
+    const shimmer = queryShimmer();
+    if (shimmer === null) throw new Error("shimmer missing");
+
+    // Past the travel window, inside the pause: the band sits at 0% (off the
+    // right edge) and stays there until the period wraps.
+    act(() => {
+      vi.advanceTimersByTime(1400);
+    });
+    expect(shimmer.style.maskPosition).toBe("0% center");
+    act(() => {
+      vi.advanceTimersByTime(800);
+    });
+    expect(shimmer.style.maskPosition).toBe("0% center");
+
+    // The period wraps at 2800ms and the band re-enters from the left.
+    act(() => {
+      vi.advanceTimersByTime(600);
+    });
+    expect(shimmer.style.maskPosition).toBe("100% center");
+  });
+
+  it("writes nothing under reduced motion, leaving the static mark", () => {
+    stubReducedMotion(true);
+    render(<BrandEntrance size="boot">{null}</BrandEntrance>);
+    const shimmer = queryShimmer();
+    if (shimmer === null) throw new Error("shimmer missing");
+    expect(shimmer.style.maskPosition).toBe("");
+    act(() => {
+      vi.advanceTimersByTime(STATUS_ANIMATION_TICK_MS * 10);
+    });
+    expect(shimmer.style.maskPosition).toBe("");
+  });
+
+  it("clears its inline position when the boot card goes away", () => {
+    const { unmount } = render(
+      <BrandEntrance size="boot">{null}</BrandEntrance>,
+    );
+    const shimmer = queryShimmer();
+    if (shimmer === null) throw new Error("shimmer missing");
+    expect(shimmer.style.maskPosition).not.toBe("");
+    unmount();
+    expect(shimmer.style.maskPosition).toBe("");
+  });
+
+  it("does not shimmer the hero mark", () => {
+    render(<BrandEntrance size="hero">{null}</BrandEntrance>);
+    expect(queryShimmer()).toBeNull();
+    expect(
+      screen.getByTestId("brand-entrance").querySelector("svg"),
+    ).not.toBeNull();
+  });
+});

--- a/clients/gui-app/src/components/auth/brand-entrance.tsx
+++ b/clients/gui-app/src/components/auth/brand-entrance.tsx
@@ -1,17 +1,38 @@
-import type { ReactNode } from "react";
+import { useCallback, useRef, type ReactNode } from "react";
 import { BrandMark } from "@/components/auth/cinematic-backdrop";
+import {
+  STATUS_ANIMATION_SMOOTH_CADENCE_MS,
+  useStatusAnimation,
+} from "@/lib/animation/status-animation-clock";
 import { cn } from "@/lib/utils";
 import "@/styles/auth-arrival.css";
 
 /**
  * `hero` is the full-screen launch splash. `boot` is a header on the host boot
  * card - a small mark over a small wordmark, so the card's own heading and
- * progress stay what the eye lands on.
+ * progress stay what the eye lands on - and its mark carries a slow highlight
+ * sweep for as long as the card is up (see {@link BootMarkShimmer}).
+ *
+ * The hero mark is white by construction: it only ever sits on the cinematic
+ * dark backdrop. The boot mark sits on a themed card, so it takes the
+ * foreground colour - a white mark on the light theme's white card is no mark
+ * at all. The SVG's own `<mask>` keeps its white fill (white is "show" there),
+ * which is why the rule targets the drawn paths and not every `<path>`.
  */
 export function BrandEntrance(props: {
   readonly size: "hero" | "boot";
   readonly children: ReactNode;
 }): ReactNode {
+  const mark = (
+    <BrandMark
+      className={cn(
+        "brand-entrance-mark h-auto",
+        props.size === "hero"
+          ? "w-[clamp(3.75rem,8vw,5.4rem)] drop-shadow-[0_1.5rem_2.5rem_rgba(0,0,0,0.42)]"
+          : "w-[clamp(1.5rem,6vw,2.25rem)] text-foreground [&_g>path]:fill-current",
+      )}
+    />
+  );
   return (
     <div
       className={cn(
@@ -21,15 +42,68 @@ export function BrandEntrance(props: {
       data-testid="brand-entrance"
       data-size={props.size}
     >
-      <BrandMark
-        className={cn(
-          "brand-entrance-mark h-auto",
-          props.size === "hero"
-            ? "w-[clamp(3.75rem,8vw,5.4rem)] drop-shadow-[0_1.5rem_2.5rem_rgba(0,0,0,0.42)]"
-            : "w-[clamp(1.5rem,6vw,2.25rem)]",
-        )}
-      />
+      {props.size === "boot" ? <BootMarkShimmer>{mark}</BootMarkShimmer> : mark}
       {props.children}
     </div>
+  );
+}
+
+/** One sweep and the pause after it; the band is in motion for the first {@link SWEEP_TRAVEL_MS}. */
+const SWEEP_PERIOD_MS = 2800;
+const SWEEP_TRAVEL_MS = 1300;
+
+/**
+ * A soft diagonal highlight crossing the boot card's mark, left to right,
+ * every few seconds - so a card that can sit for minutes while a host installs
+ * reads as waiting rather than stamped.
+ *
+ * GEOMETRY. The wrapper is masked (`.brand-entrance-mark-shimmer` in
+ * auth-arrival.css) with a gradient three times its own width: the mark at a
+ * slightly lowered alpha everywhere, rising to full alpha in a narrow band
+ * around the gradient's centre. Sliding that mask's `mask-position` from 100%
+ * to 0% carries the band across the box, and because a mask only ever
+ * modulates the pixels already drawn, the highlight is clipped to the mark's
+ * shape by construction - nothing spills onto the card. The mark is the only
+ * child, so its wordmark sibling is untouched.
+ *
+ * THE CLOCK, not a CSS animation. This card is on screen from the first frame
+ * of a launch until a host answers, which on a slow install is minutes, and an
+ * always-on CSS animation is exactly the cost `status-animation-clock.ts`
+ * exists to avoid. The sweep is written as one inline `mask-position` per
+ * tick from the shared clock, the same mechanism as `WorkingShimmerText`'s
+ * `background-position` - one style write on one element, no layout, and the
+ * clock stops while the document is hidden.
+ *
+ * REDUCED MOTION. `useStatusAnimation` never subscribes and clears the inline
+ * position, and the stylesheet's reduced-motion rule drops the mask entirely,
+ * so the mark is simply the full-alpha static mark. Between sweeps, and before
+ * the first write lands, the band is parked off the mark's right edge (the
+ * stylesheet's own `mask-position`), so the resting mark is one flat alpha.
+ */
+function BootMarkShimmer(props: { readonly children: ReactNode }): ReactNode {
+  const ref = useRef<HTMLSpanElement | null>(null);
+  const write = useCallback((element: HTMLSpanElement, elapsedMs: number) => {
+    const phase = elapsedMs % SWEEP_PERIOD_MS;
+    const travel = Math.min(phase / SWEEP_TRAVEL_MS, 1);
+    // Sinusoidal ease-in-out: the band enters and leaves the mark gently
+    // rather than snapping in from the edge.
+    const eased = 0.5 - 0.5 * Math.cos(Math.PI * travel);
+    // 100% parks the band off the LEFT edge, 0% off the RIGHT; the pause is
+    // spent at 0%, so the jump back to 100% at the next cycle moves nothing
+    // visible.
+    element.style.maskPosition = `${100 - eased * 100}% center`;
+  }, []);
+  const clear = useCallback((element: HTMLSpanElement) => {
+    element.style.maskPosition = "";
+  }, []);
+  useStatusAnimation(ref, write, clear, STATUS_ANIMATION_SMOOTH_CADENCE_MS);
+  return (
+    <span
+      ref={ref}
+      data-testid="brand-entrance-mark-shimmer"
+      className="brand-entrance-mark-shimmer"
+    >
+      {props.children}
+    </span>
   );
 }

--- a/clients/gui-app/src/styles/auth-arrival.css
+++ b/clients/gui-app/src/styles/auth-arrival.css
@@ -66,6 +66,13 @@
   }
 }
 
+/* The boot mark's shimmer wrapper is a box, not a line box: an inline span
+   around an SVG reserves descender space under it and would shift the card by
+   a few pixels depending on whether the motion rule below is applied. */
+.brand-entrance-mark-shimmer {
+  display: flex;
+}
+
 @media (prefers-reduced-motion: no-preference) {
   .brand-entrance-mark g > path {
     transform-box: fill-box;
@@ -101,6 +108,36 @@
 
   .brand-entrance-copy {
     animation: brand-copy-arrive 600ms 120ms cubic-bezier(0.22, 1, 0.36, 1) both;
+  }
+
+  /* The boot card mark's highlight sweep - the STATIC half. The mask is three
+     times the box wide: the mark at a lowered alpha throughout, rising to full
+     in a narrow diagonal band around the centre (~30% of the mark's width
+     once the 115deg lean is accounted for). `BootMarkShimmer` slides
+     `mask-position` from 100% to 0% as an inline style from the shared status
+     animation clock; there is deliberately no `animation:` here - see
+     `status-animation-clock.ts` for what an always-on CSS animation costs on a
+     card that can stay up for minutes. 0% parks the band off the right edge,
+     which is where it rests between sweeps and before the first write.
+
+     Inside the no-preference block on purpose: under reduced motion nothing
+     writes the position, and a mask that never moves would hold the mark at
+     the lowered alpha for the whole wait. No rule here means no mask, so the
+     mark is simply drawn in full. */
+  .brand-entrance-mark-shimmer {
+    --boot-mark-rest: rgb(0 0 0 / 0.75);
+
+    mask-image: linear-gradient(
+      115deg,
+      var(--boot-mark-rest) 0%,
+      var(--boot-mark-rest) 45%,
+      #000 50%,
+      var(--boot-mark-rest) 55%,
+      var(--boot-mark-rest) 100%
+    );
+    mask-size: 300% 100%;
+    mask-repeat: no-repeat;
+    mask-position: 0% center;
   }
 
   .auth-splash {


### PR DESCRIPTION
The mark heading the host boot card ("Starting Traycer…") sat static for the whole wait — on a slow install, minutes — and read as a stamp rather than as something in progress. This gives it a slow, subtle light sweep for as long as the card is up, on desktop and mobile alike.

## Change

`BrandEntrance`'s `boot` variant wraps the mark — and only the mark — in a masked span (`BootMarkShimmer`, `clients/gui-app/src/components/auth/brand-entrance.tsx`). The wordmark and everything below it are untouched; the `hero` splash is unchanged.

| | |
| --- | --- |
| Geometry | CSS mask three times the box wide (`.brand-entrance-mark-shimmer`, `styles/auth-arrival.css`): the mark at 75% alpha everywhere, rising to full in a soft 115° band ~30% of the mark's width. Because a mask only modulates pixels already drawn, the highlight is clipped to the mark's shape by construction. |
| Timing | Band crosses left → right over 1.3 s (sinusoidal ease-in-out), rests off the edge for 1.5 s, repeats — 2.8 s period. |
| Drive | **Not a CSS animation.** One inline `mask-position` write per tick from the shared status animation clock (`lib/animation/status-animation-clock.ts`, `useStatusAnimation` at the smooth cadence) — the same mechanism `WorkingShimmerText` uses for its `background-position`. One style write on one element per tick, no layout; the clock stops while the document is hidden. See the `index.css` note on what an always-on CSS animation costs a card that can stay up for minutes. |
| Reduced motion | The clock never subscribes and the mask rule lives inside the `no-preference` media block, so the mark is simply the static, full-alpha mark. |
| At rest | Between sweeps the band is parked off the right edge; the mark sits at one flat 75% alpha. |

The boot mark also takes the foreground colour (`text-foreground [&_g>path]:fill-current`) instead of the hero's hard-coded `fill="#fff"` — on the light theme's white card that was no mark at all. The SVG's own `<mask>` path keeps its white fill (white is "show" there); the selector reaches only the four drawn paths.

## Recording

Desktop, 1200 × 900, dark (headless Chrome at 20 fps, ~4.5 s — one full sweep and pause):

![boot card mark shimmer](https://gist.githubusercontent.com/pranshugupta54/a7c6082596c5347920fcad6b56110351/raw/6ebf165d1c26481271ca8fe3821f431b6694840e/boot-mark-shimmer.gif)

| Light, mid-sweep | Reduced motion (static) |
| --- | --- |
| ![light mid-sweep](https://gist.githubusercontent.com/pranshugupta54/a7c6082596c5347920fcad6b56110351/raw/6ebf165d1c26481271ca8fe3821f431b6694840e/boot-mark-light-midsweep.png) | ![reduced motion](https://gist.githubusercontent.com/pranshugupta54/a7c6082596c5347920fcad6b56110351/raw/6ebf165d1c26481271ca8fe3821f431b6694840e/boot-mark-reduced-motion.png) |

Also verified at 390 × 844 (band crosses the 24 px mark, wordmark untouched). The shimmer wrapper measures exactly the SVG's box (36 × 37.19 px at 1200 wide), so the card's geometry does not move.

## Tests

`src/components/auth/__tests__/brand-entrance.test.tsx`:

- wraps the SVG alone (wordmark outside), first write pre-paint, moves after clock ticks, no inline `animation`, no `animate-*` class
- parks at 0% through the pause and re-enters at 100% when the period wraps
- writes nothing under reduced motion; clears its inline position on unmount
- hero mark has no shimmer
- stylesheet guards (jsdom does not process CSS): the mask rule is declared only inside the `prefers-reduced-motion: no-preference` block, and no `.brand-entrance-mark-shimmer` rule carries `animation`/`transition`

`local-host-loading.test.tsx` asserts the boot card carries the shimmer around the mark only.

Mutation-checked: detaching from the clock (static write + CSS animation) fails 4 tests; bypassing the reduced-motion gate fails 2; wrapping the wordmark too fails 2; adding `animation:` to the class or moving the mask rule out of the media block fails the two stylesheet guards.

React Compiler: the component's render output does not depend on the clock — `elapsedMs` reaches only the imperative writer, never a render-time value — so nothing here is exposed to the memoized-past-the-timer failure; no addition to `vitest.config.ts`'s compiled subset was needed.
