### PR TITLE
fix(gui-app): one loader on the boot card

### DIFF
--- a/clients/gui-app/scripts/host-boot-family-gallery-browser.mjs
+++ b/clients/gui-app/scripts/host-boot-family-gallery-browser.mjs
@@ -49,19 +49,14 @@ const FACES = [
 ];
 /**
  * The faces that must not MOVE relative to one another (same top + height):
- * every healthy wait, INCLUDING the narrator with a lane reporting at 42% -
- * a launch crosses all five and the bar is on every one of them, so a lane
- * starting to report changes the sentence and the fill, not the box.
- * `narrator-slow` is deliberately not here: it grows a Retry action row,
- * which is a real state change on its own clock, not a hand-off.
+ * every healthy wait before a stage reports a percentage. `narrator-lane` is
+ * deliberately not here: its lane reports 42%, so it draws the progress bar
+ * the others have no position for, and is taller by that bar and its row
+ * gap.
+ * `narrator-slow` is not here either: it grows a Retry action row, which is a
+ * real state change on its own clock, not a hand-off.
  */
-const WAIT_FACES = new Set([
-  "runtime",
-  "attach",
-  "restoring",
-  "narrator-idle",
-  "narrator-lane",
-]);
+const WAIT_FACES = new Set(["runtime", "attach", "restoring", "narrator-idle"]);
 
 const args = process.argv.slice(2);
 const dark = args.includes("--dark");

--- a/clients/gui-app/src/components/__tests__/local-host-loading.test.tsx
+++ b/clients/gui-app/src/components/__tests__/local-host-loading.test.tsx
@@ -130,18 +130,29 @@ describe("<LocalHostLoadingContent />", () => {
     expect(useHostBootDetailsStore.getState().open).toBe(false);
   });
 
-  it("renders spinner, heading, and no Retry or [host] logs hint", () => {
-    // P3.4 deleted the `stage="slow"` arm outright (every surviving caller
-    // passes a start that is still progressing), so this body no longer
-    // branches - there is no slow copy or Retry to withhold, only to
-    // structurally never have.
+  it("renders the idle card as the shimmering mark and the heading only - no spinner, no bar, no Retry or [host] logs hint", () => {
+    // ONE activity signal: the mark's shimmer says the card is busy and the
+    // heading says with what, so nothing else on the idle card animates.
     const container = mountLoadingContent(buildHost(), null);
 
-    // Spinner is visible.
-    expect(screen.queryByTestId("local-host-loading-spinner")).not.toBeNull();
+    // Positive first: the mark and its shimmer are the activity signal, so
+    // their presence is what makes the absences below a choice rather than a
+    // card that failed to draw.
+    expect(
+      screen.getByTestId("brand-entrance-mark-shimmer").querySelector("svg"),
+    ).not.toBeNull();
+    const stage = screen.getByTestId("local-host-loading-stage");
+    expect(stage.textContent).toBe("Starting Traycer…");
 
-    // Primary heading.
-    expect(container.textContent).toContain("Starting Traycer…");
+    // No spinner: the heading is alone in its row. The spinner is an
+    // aria-hidden, text-less span stacked in this same row, so the row's
+    // element count is where its return would show.
+    expect(stage.parentElement?.childElementCount).toBe(1);
+
+    // No bar: nothing has a measured position yet.
+    expect(screen.queryByRole("progressbar")).toBeNull();
+    expect(screen.queryByTestId("local-host-download-progress")).toBeNull();
+    expect(container.textContent).not.toContain("%");
 
     expect(screen.queryByTestId("local-host-loading-slow-copy")).toBeNull();
     expect(screen.queryByTestId("local-host-retry")).toBeNull();
@@ -275,60 +286,65 @@ describe("<LocalHostLoadingContent />", () => {
     expect(container.textContent.match(/Setting up/g)?.length ?? 0).toBe(1);
   });
 
-  it("draws an indeterminate bar when no lane is running, and when a lane reports no percentage", () => {
-    // THE CONTRACT: no measured position => indeterminate, and the bar is on
-    // EVERY wait face. This REVERSES an earlier pin here ("draws NO bar when no
-    // lane is running"), which read the bar as a claim that a lane runs. It is
-    // not: an indeterminate `progressbar` means "busy, position unknown", which
-    // is exactly what a start that has not reported yet is - and a bar that
-    // appeared only once a lane reported was a mid-wait height change on a
-    // centred card. Reported after a real install as "3-4 different modals …
-    // the UI feels jumpy when the modal size keeps changing", the ruling
-    // changed. The height it holds is measured in the browser gallery
-    // (`scripts/host-boot-family-gallery-browser.mjs`); jsdom cannot see it.
+  it("draws the bar only while the running stage reports a percentage", () => {
+    // THE CONTRACT: a bar only with a measured position. The heading names
+    // the stage and the mark says the card is busy, so a stage that reports no
+    // percentage gets neither a bar nor a figure - there is no position to
+    // draw, and inventing one would be a number nobody measured.
     //
-    // `progress: null` is exactly the no-lane state - `useHostProvisioningProgress`
-    // returns null when no lane is running, and the body falls back to
-    // HOST_PROGRESS_IDLE_HEADING.
-    mountLoadingContent(buildHost(), null);
-    const idleBar = screen.getByTestId("local-host-download-progress");
-    expect(idleBar.dataset.indeterminate).toBe("true");
-    expect(
-      screen.getByRole("progressbar").getAttribute("aria-valuenow"),
-    ).toBeNull();
-    expect(idleBar.textContent).not.toContain("%");
-
-    cleanup();
-
-    // A RUNNING lane with no percentage: the same bar, still indeterminate,
-    // with no percentage figure beside it.
+    // Positive control first, on the stage that DOES report one: the same lane
+    // kind, so the only difference from the arm below is the percentage.
     mountLoadingContent(
       buildHost(),
       buildHostProgressView({
         kind: "ensure",
         startedAt: LANE_STARTED_AT,
         progress: {
-          stage: "extract",
-          percent: null,
+          stage: "download",
+          percent: 43,
           bytes: null,
           totalBytes: null,
-          message: "extracting host 1.2.3",
-          workUnits: 120,
+          message: null,
+          workUnits: null,
         },
       }),
     );
-    const bar = screen.getByTestId("local-host-download-progress");
-    expect(bar.dataset.indeterminate).toBe("true");
-    expect(
-      screen.getByTestId("local-host-progress-indeterminate"),
-    ).toBeTruthy();
-    // No `aria-valuenow` while indeterminate: that is what the role means by it -
-    // busy with an unknown position, rather than a specific amount done.
-    expect(
-      screen.getByRole("progressbar").getAttribute("aria-valuenow"),
-    ).toBeNull();
-    // And no percentage figure, which would be a number nobody measured.
-    expect(bar.textContent).not.toContain("%");
+    const stage = screen.getByTestId("local-host-loading-stage");
+    expect(stage.textContent).toBe("Downloading Traycer Host…");
+    // No spinner on a progressing card either: the heading is alone in its row.
+    expect(stage.parentElement?.childElementCount).toBe(1);
+    expect(screen.getByRole("progressbar").getAttribute("aria-valuenow")).toBe(
+      "43",
+    );
+    expect(screen.getByTestId("local-host-download-progress").textContent).toBe(
+      "43%",
+    );
+
+    cleanup();
+
+    // A RUNNING lane on a stage with no percentage (`verify` reports none):
+    // its heading, and no bar at all.
+    const container = mountLoadingContent(
+      buildHost(),
+      buildHostProgressView({
+        kind: "ensure",
+        startedAt: LANE_STARTED_AT,
+        progress: {
+          stage: "verify",
+          percent: null,
+          bytes: null,
+          totalBytes: 250_609_664,
+          message: "verifying host 1.2.3",
+          workUnits: null,
+        },
+      }),
+    );
+    expect(screen.getByTestId("local-host-loading-stage").textContent).toBe(
+      "Setting up Traycer Host…",
+    );
+    expect(screen.queryByRole("progressbar")).toBeNull();
+    expect(screen.queryByTestId("local-host-download-progress")).toBeNull();
+    expect(container.textContent).not.toContain("%");
   });
 
   /**

--- a/clients/gui-app/src/components/centered-card.tsx
+++ b/clients/gui-app/src/components/centered-card.tsx
@@ -34,12 +34,12 @@ export const HOST_BOOT_CARD_SURFACE = "host-boot-card";
  * with a large foreground spinner floating on its own line - and the
  * narrator's card was `max-w-md` again while the two before it were `sm`.
  *
- * One width, one alignment, one spinner treatment - and one BODY for every
- * healthy wait (`LocalHostLoadingContent`: headline, bar, footer, whether or
- * not a lane has spoken yet), so across a healthy launch only the sentence
- * and the bar's fill change inside a box that does not move. Only a settled
- * failure ADDS to it (a title, diagnostics, actions), which reads as one
- * surface filling in rather than several modals taking turns.
+ * One width, one alignment - and one BODY for every healthy wait
+ * (`LocalHostLoadingContent`: mark, headline, footer, plus a progress bar
+ * while a stage reports a percentage), so across a healthy launch only the
+ * sentence and that bar change. Only a settled failure ADDS to it (a title,
+ * diagnostics, actions), which reads as one surface filling in rather than
+ * several modals taking turns.
  *
  * `pointer-events-auto` is unconditional and inert everywhere but one place:
  * the narrator's startup layer is `pointer-events-none` so toasts and the gate

--- a/clients/gui-app/src/components/host/host-boot-surface.tsx
+++ b/clients/gui-app/src/components/host/host-boot-surface.tsx
@@ -4,15 +4,15 @@ import { LocalHostLoadingContent } from "@/components/local-host-loading";
 import { usePressStartActivation } from "@/lib/host/press-start-activation";
 
 /**
- * The WHOLE boot card - headline, progress bar, details disclosure and
+ * The WHOLE boot card - mark, headline, details disclosure and
  * `Open settings` - for the phases that precede the window narrator.
  *
  * It is the narrator's own healthy body (`LocalHostLoadingContent`) with no
  * lane, drawn in the shared card. Not "the same headline and controls" - the
- * SAME BODY, bar included, so the card the runtime fallback draws before the
- * router exists is, to the pixel, the card the narrator draws once a lane is
- * reporting: same box, same rows, and the only things that change across a
- * healthy launch are the sentence and the bar's fill. There is deliberately
+ * SAME BODY, so the card the runtime fallback draws before the router exists
+ * is, to the pixel, the card the narrator draws before a lane reports: same
+ * box, same rows. Across a healthy launch only the sentence changes, plus the
+ * progress bar while a stage reports a percentage. There is deliberately
  * no `message` prop: every wait face says the body's idle heading
  * (`HOST_PROGRESS_IDLE_HEADING`) until a lane says something new, and a prop
  * would be a way for one phase to say it differently.
@@ -22,10 +22,7 @@ import { usePressStartActivation } from "@/lib/host/press-start-activation";
  * `Open settings`; the first two were bare. So the card visibly GREW controls
  * partway through a wait, which reads as a different dialog replacing the
  * first rather than one surface progressing - the "why do we have these 2
- * modals" report. The bar followed the same rule one review later: it used
- * to appear only once a lane reported, and a fresh install showed "3-4
- * different modals … a modal shows some progress bar in the middle … the UI
- * feels jumpy when the modal size keeps changing".
+ * modals" report.
  *
  * Both controls are genuinely LIVE here, which is why they are rendered rather
  * than stubbed disabled:

--- a/clients/gui-app/src/components/host/host-runtime-boot-fallback.tsx
+++ b/clients/gui-app/src/components/host/host-runtime-boot-fallback.tsx
@@ -10,7 +10,7 @@ import { isMobileApp } from "@/lib/mobile-app";
  * draws before the runtime binding exists, i.e. before any app chrome.
  *
  * Deliberately the same component as the two after it - same card, same
- * sentence, same bar, same controls (`HostBootSurface`). Giving each phase its
+ * sentence, same controls (`HostBootSurface`). Giving each phase its
  * own shape and its own phrasing is what made one continuous wait look like a
  * sequence of unrelated modals.
  *
@@ -33,8 +33,7 @@ export function HostRuntimeBootFallback(props: {
   // the same ground as the native launch image so the handoff is invisible.
   //
   // Desktop is untouched: there the same window really is a host starting, and
-  // the card's heading, progress bar and `Open settings` escape hatch all mean
-  // what they say.
+  // the card's heading and `Open settings` escape hatch mean what they say.
   if (isMobileApp()) {
     return (
       <div

--- a/clients/gui-app/src/components/layout/__tests__/default-host-ready-gate.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/default-host-ready-gate.test.tsx
@@ -771,18 +771,18 @@ describe("<HostReadyGate />", () => {
     expect(
       screen.getAllByRole("button", { name: "Open settings" }),
     ).toHaveLength(1);
-    // Nothing is starting: no spinner, no boot headline.
-    expect(screen.queryByTestId("local-host-loading-spinner")).toBeNull();
+    // Nothing is starting: no boot headline.
+    expect(screen.queryByTestId("local-host-loading-stage")).toBeNull();
     expect(screen.queryByText("Starting Traycer…")).toBeNull();
   });
 
-  it("draws restoring-request-context as the shared boot surface: idle heading, spinner, indeterminate bar, Show details and Open settings", () => {
+  it("draws restoring-request-context as the shared boot surface: idle heading, no bar, Show details and Open settings", () => {
     // A WAIT, not a terminal, and it can sit between the attach cover and the
     // narrator's card on any launch. It used to be a bare "Restoring
-    // authenticated session…" line with no spinner and no controls - a fourth
-    // card shape in a launch that must have one. Now it is the same card, the
-    // same idle sentence, the same bar and the same footer pair as the
-    // surfaces on either side of it, so the hand-off is invisible. The
+    // authenticated session…" line with no controls - a fourth card shape in
+    // a launch that must have one. Now it is the same card, the same idle
+    // sentence and the same footer pair as the surfaces on either side of it,
+    // so the hand-off is invisible. The
     // testids are the boot BODY's own (`local-host-loading-*`): the surface
     // is that body with no lane, not a look-alike.
     renderGateWithCli(
@@ -795,13 +795,11 @@ describe("<HostReadyGate />", () => {
       "host-ready-gate-restoring-request-context",
     );
     expect(card.getAttribute("data-surface")).toBe(HOST_BOOT_CARD_SURFACE);
-    expect(screen.getByTestId("local-host-loading-spinner")).toBeTruthy();
     expect(screen.getByTestId("local-host-loading-stage").textContent).toBe(
       "Starting Traycer…",
     );
-    expect(
-      screen.getByTestId("local-host-download-progress").dataset.indeterminate,
-    ).toBe("true");
+    // No lane, so no measured position and no bar.
+    expect(screen.queryByRole("progressbar")).toBeNull();
     expect(screen.queryByText("Restoring authenticated session…")).toBeNull();
     expect(
       screen.getByTestId("local-host-loading-toggle-details"),

--- a/clients/gui-app/src/components/layout/dialogs/__tests__/window-host-modal-host.test.tsx
+++ b/clients/gui-app/src/components/layout/dialogs/__tests__/window-host-modal-host.test.tsx
@@ -282,12 +282,11 @@ afterEach(() => {
 });
 
 describe("<WindowHostModalHost />", () => {
-  it("∅ (no-usable-host): settled failure — Retry, Report issue and Open settings(button) present; spinner + progress heading absent; attempt panel + log toggle present", async () => {
-    // Previously asserted `local-host-loading-spinner` truthy on this arm -
-    // THAT was the reported defect (B4): a live "starting" spinner drawn over
-    // a state where nothing is starting, with Retry and Report issue beside
-    // it as if a real attempt were in flight. Kept only as the negative
-    // assertion below, with a comment recording why, so nobody restores it.
+  it("∅ (no-usable-host): settled failure — Retry, Report issue and Open settings(button) present; progress heading absent; attempt panel + log toggle present", async () => {
+    // The reported defect on this arm (B4) was a live "starting" narration
+    // drawn over a state where nothing is starting, with Retry and Report
+    // issue beside it as if a real attempt were in flight. Pinned by the
+    // negative assertions below so nobody restores it.
     hostStatus.data = BOOTSTRAP_MARKERS;
     applySnapshot({
       attached: true,
@@ -324,7 +323,7 @@ describe("<WindowHostModalHost />", () => {
     expect(openSettings).toBeTruthy();
 
     // Nothing is starting, so nothing narrates a start.
-    expect(screen.queryByTestId("local-host-loading-spinner")).toBeNull();
+    expect(screen.queryByTestId("local-host-loading-stage")).toBeNull();
     expect(screen.queryByText("Starting Traycer…")).toBeNull();
 
     // The attempt panel is what explains this state, and it is present...
@@ -366,11 +365,11 @@ describe("<WindowHostModalHost />", () => {
     await waitFor(() => {
       expect(screen.getByTestId("window-host-modal")).toBeTruthy();
     });
-    expect(screen.queryByTestId("local-host-loading-spinner")).toBeNull();
+    expect(screen.queryByTestId("local-host-loading-stage")).toBeNull();
     expect(screen.queryByTestId("local-host-bootstrap-log-path")).toBeNull();
   });
 
-  it("cold-start on a REMOTE target draws the SAME boot body as a local one: headline, spinner, inline Open settings, no action row", async () => {
+  it("cold-start on a REMOTE target draws the SAME boot body as a local one: headline, inline Open settings, no action row", async () => {
     // THE REPORTED LAUNCH. A fresh install on an account that has remote hosts
     // derives a remote as effective until the local host registers (the
     // engine's third arm: no preference, no local row, first usable remote), so
@@ -409,12 +408,13 @@ describe("<WindowHostModalHost />", () => {
     // Drawn THROUGH the shared boot card, not merely resembling it.
     expect(card.getAttribute("data-surface")).toBe(HOST_BOOT_CARD_SURFACE);
 
-    // The boot body: spinner + the family's idle heading (no lane is running,
-    // and no machine has been named that a lane could describe).
-    expect(screen.getByTestId("local-host-loading-spinner")).toBeTruthy();
+    // The boot body: the family's idle heading (no lane is running, and no
+    // machine has been named that a lane could describe) and no bar, since
+    // nothing has a measured position.
     expect(screen.getByTestId("local-host-loading-stage").textContent).toBe(
       "Starting Traycer…",
     );
+    expect(screen.queryByRole("progressbar")).toBeNull();
     // The footer pair, exactly as the two surfaces before this one draw it:
     // `Show details` with `Open settings` INLINE beside it ...
     expect(
@@ -436,12 +436,13 @@ describe("<WindowHostModalHost />", () => {
     ).toBeNull();
   });
 
-  it("cold-start on a REMOTE target while this machine's lane runs: the lane heading in the boot headline and the bar, never the boxed lane line", async () => {
+  it("cold-start on a REMOTE target while this machine's lane runs: the lane heading in the boot headline, never the boxed lane line", async () => {
     // The second shape of the same launch: the desktop's reconciler is
     // installing the local host underneath while the derived target is still
     // the remote. The lane is real and it is this machine's, so the boot body
-    // narrates it the way every other phase would - headline + progress bar -
-    // instead of the bordered `LaneProgressLine` strip that titled faces use
+    // narrates it the way every other phase would - its headline, plus the
+    // progress bar once a stage reports a percentage - instead of the
+    // bordered `LaneProgressLine` strip that titled faces use
     // under their own description. That strip under NO title was the
     // "weird-looking Setting up Traycer" card.
     controllerStatus.data = {
@@ -477,7 +478,8 @@ describe("<WindowHostModalHost />", () => {
     expect(screen.getByTestId("local-host-loading-stage").textContent).toBe(
       "Setting up Traycer Host…",
     );
-    expect(screen.getByTestId("local-host-download-progress")).toBeTruthy();
+    // The lane has reported no percentage yet, so there is no bar to draw.
+    expect(screen.queryByRole("progressbar")).toBeNull();
     expect(screen.queryByTestId("window-host-modal-progress")).toBeNull();
     // Still the healthy footer, still no action row.
     expect(screen.getByTestId("host-boot-open-settings")).toBeTruthy();
@@ -513,14 +515,14 @@ describe("<WindowHostModalHost />", () => {
     });
     expect(screen.queryByTestId("local-host-bootstrap-details")).toBeNull();
     expect(screen.queryByTestId("local-host-bootstrap-log-path")).toBeNull();
-    expect(screen.queryByTestId("local-host-loading-spinner")).toBeNull();
+    expect(screen.queryByTestId("local-host-loading-stage")).toBeNull();
     expect(
       screen.queryByTestId("local-host-loading-toggle-details"),
     ).toBeNull();
     expect(screen.getByTestId("window-host-modal-open-settings")).toBeTruthy();
   });
 
-  it("cold-start, healthy (stage: loading, no provisioningError): Retry, Report issue absent; Open settings present as a link; spinner shown; no attempt summary", async () => {
+  it("cold-start, healthy (stage: loading, no provisioningError): Retry, Report issue absent; Open settings present as a link; idle heading shown; no attempt summary", async () => {
     // The markers MUST be available for this assertion to mean anything. The
     // first version of this test left the status query empty, so the summary
     // was absent because there was nothing to summarise - it passed with the
@@ -564,7 +566,9 @@ describe("<WindowHostModalHost />", () => {
     expect(openSettings).toBeTruthy();
     expect(screen.queryByTestId("window-host-modal-open-settings")).toBeNull();
 
-    expect(screen.getByTestId("local-host-loading-spinner")).toBeTruthy();
+    expect(screen.getByTestId("local-host-loading-stage").textContent).toBe(
+      "Starting Traycer…",
+    );
     expect(screen.queryByTestId("local-host-bootstrap-details")).toBeNull();
 
     // This is the reported defect's own state: a start with no failure of any
@@ -641,8 +645,8 @@ describe("<WindowHostModalHost />", () => {
     });
 
     // The markers must be AVAILABLE for the body assertions below to mean
-    // anything - the attempt panel is what replaces the spinner here, and
-    // without markers it renders nothing and "no spinner" would be satisfied by
+    // anything - the attempt panel is what replaces the loading body here, and
+    // without markers it renders nothing and "no heading" would be satisfied by
     // an empty body.
     hostStatus.data = BOOTSTRAP_MARKERS;
 
@@ -679,20 +683,19 @@ describe("<WindowHostModalHost />", () => {
 
     // THE BODY, which this test used to say nothing about - and that silence was
     // worse than an omission. The row was enumerated, so it read as covered,
-    // while the arm it covers went on drawing a live spinner and "Starting local
-    // Traycer Host…" beside the Retry and Report issue asserted above. The ∅
-    // test has had this negative assertion all along; the arm that was actually
-    // broken did not.
+    // while the arm it covers went on drawing a live "Starting local Traycer
+    // Host…" beside the Retry and Report issue asserted above. The ∅ test has
+    // had this negative assertion all along; the arm that was actually broken
+    // did not.
     //
     // Positive first: the attempt panel is what this arm draws INSTEAD of the
-    // spinner, so its presence is what makes the absences below meaningful
-    // rather than vacuous.
+    // loading body, so its presence is what makes the absences below
+    // meaningful rather than vacuous.
     expect(screen.getByTestId("local-host-bootstrap-details")).toBeTruthy();
     expect(
       screen.getByTestId("local-host-loading-toggle-details"),
     ).toBeTruthy();
 
-    expect(screen.queryByTestId("local-host-loading-spinner")).toBeNull();
     expect(screen.queryByTestId("local-host-loading-stage")).toBeNull();
     // The copy itself, not just the node: the stage line's fallback is the exact
     // sentence this arm must not say, and asserting the testid alone would pass
@@ -1103,7 +1106,7 @@ describe("<WindowHostModalHost />", () => {
       // assertion above is satisfied by an empty div rendered beside them.
       expect(
         screen
-          .getByTestId("local-host-loading-spinner")
+          .getByTestId("local-host-loading-stage")
           .closest('[data-testid="local-host-body"]'),
       ).toBe(coldStartBody);
       expect(

--- a/clients/gui-app/src/components/layout/dialogs/window-host-modal-host.tsx
+++ b/clients/gui-app/src/components/layout/dialogs/window-host-modal-host.tsx
@@ -433,8 +433,9 @@ function resolveUpdateHost(
  *  - A start that has NOT settled gets the loading body WHATEVER the target's
  *    kind. It is the shared boot headline (the lane's F19 heading when this
  *    machine's controller is doing something, the idle "Starting Traycer…"
- *    when it is not), the current stage's bar, and the Show details / Open
- *    settings footer - the same card the two boot surfaces before it drew.
+ *    when it is not), the current stage's bar when it reports a percentage,
+ *    and the Show details / Open settings footer - the same card the two boot
+ *    surfaces before it drew.
  *    This arm used to be withheld unless the target was this machine, on the
  *    argument that the bootstrap log describes this computer. It does - and
  *    that is TRUE information under a remote-target start too: on a desktop
@@ -469,7 +470,7 @@ function resolveUpdateHost(
  * `stage` and grow a second one on `"slow"`: its own Retry, and the
  * failed-attempt diagnostics. The Retry was a second place for this modal to
  * state an action it already states in one row, and the diagnostics belong on
- * the settled arm where they are TRUE, not under a healthy spinner. That the
+ * the settled arm where they are TRUE, not under a healthy heading. That the
  * bootstrap.log path survives all of this is the whole point - it is the one
  * thing that lets a user take a stuck startup somewhere else, and it has been
  * orphaned by a surface move once already.
@@ -490,13 +491,13 @@ function buildBootBody(args: {
   readonly settingsOnly: boolean;
 }): ReactNode | null {
   if (args.variant.kind !== "offline") return null;
-  // NOTHING IS STARTING, so nothing may claim to be. The spinner and the stage
-  // line are gated on the settled FAILURE rather than placed beside it:
+  // NOTHING IS STARTING, so nothing may claim to be. The stage line is gated
+  // on the settled FAILURE rather than placed beside it:
   // `LocalHostLoadingContent`'s stage line falls back to
   // `HOST_PROGRESS_IDLE_HEADING` exactly when no lane is running, which is
-  // precisely this state. A live spinner over a crash report tells a user to
-  // wait for a start that is not happening, and they report a hang instead of
-  // a crash.
+  // precisely this state. "Starting Traycer…" over a crash report tells a user
+  // to wait for a start that is not happening, and they report a hang instead
+  // of a crash.
   //
   // GATED ON THE FAILURE, NOT THE CAUSE - and it was the cause until a review
   // caught it. `cause === "no-usable-host"` covers only the arm where nothing can

--- a/clients/gui-app/src/components/layout/dialogs/window-host-modal.tsx
+++ b/clients/gui-app/src/components/layout/dialogs/window-host-modal.tsx
@@ -413,7 +413,8 @@ function WindowHostModalBody(props: {
  * the full boot body (`buildBootBody`), and drawing this boxed line there
  * instead was the "weird-looking Setting up Traycer" report - a bordered
  * strip with a truncated heading and a percentage where every other phase of
- * the launch draws the headline, the bar and the details footer.
+ * the launch draws the headline, the bar when there is a percentage, and the
+ * details footer.
  *
  * Heading and percentage ONLY - the same two things the boot body's bar says.
  * The lane's byte count and its own message line (`transferLabel`, `detail`)

--- a/clients/gui-app/src/components/local-host-loading.tsx
+++ b/clients/gui-app/src/components/local-host-loading.tsx
@@ -41,8 +41,8 @@ export interface BootstrapLogDisclosureProps {
  * Exported separately from {@link LocalHostLoadingContent} because the two are
  * true in different states. The log affordance is the one thing that lets a
  * user take a stuck startup somewhere else, so it belongs on the FAILED arm as
- * well - while the spinner and the progress heading belong only to a start that
- * is actually in progress. Composing it beside the failure diagnostics is how
+ * well - while the progress heading and bar belong only to a start that is
+ * actually in progress. Composing it beside the failure diagnostics is how
  * the failed arm gets the log without the "Starting local Traycer Host…" lie,
  * and it keeps `LocalHostLoadingContent`'s one-purpose rule intact rather than
  * regrowing the second face P3.4 deleted.
@@ -148,8 +148,9 @@ export interface LocalHostLoadingContentProps {
 }
 
 /**
- * The host-boot body: brand entrance, spinner, heading, progress bar, and the
- * bootstrap-log disclosure (with the "Configure shell…" shortcut).
+ * The host-boot body: brand entrance, heading, a progress bar while the running
+ * stage reports a percentage, and the bootstrap-log disclosure (with the
+ * "Configure shell…" shortcut).
  * Deliberately has no outer chrome (no `min-h-svh` wrapper, no `<AppHeader>`,
  * no `<Card>`) so its caller provides its own bounded layout.
  *
@@ -162,16 +163,17 @@ export interface LocalHostLoadingContentProps {
  * body on the arm where they are true. A body with no branch cannot disagree
  * with the surface it sits in about what is happening.
  *
- * ONE HEIGHT, whatever the lane has said. Every member of this body is drawn
- * on every call - `progress: null` (no lane yet) draws the idle heading over
- * an indeterminate bar, a reporting lane draws its heading over a filling
- * bar - so the same body serves the two boot surfaces BEFORE the narrator
- * (`HostBootSurface`) and the narrator's healthy face itself, and the card is
- * one box from the first frame of a launch until a lane finishes. It used to
- * add the bar (and a lane-detail line) only once a lane reported, which made
- * the card grow mid-wait; on a centred card that moves both edges, and it was
- * reported after a real install as "3-4 different modals … the UI feels jumpy
- * when the modal size keeps changing".
+ * ONE ACTIVITY SIGNAL. The shimmering mark is what says the card is busy, and
+ * the heading says what it is busy with - so there is no spinner, and no bar
+ * without a position. `progress: null` (no lane yet) draws the idle heading
+ * alone; a lane draws its own heading, plus the progress bar only while its
+ * stage reports a measured percentage (the host download). A stage that
+ * reports none - `verify`, `swap`, `service-start`, anything added later - is
+ * the heading alone too: a bar with no position is a second "busy" signal that
+ * says nothing the mark does not. The same body serves the two boot surfaces
+ * BEFORE the narrator (`HostBootSurface`) and the narrator's healthy face
+ * itself, so every healthy wait is one card. The price is that the card
+ * changes height when a percentage starts or stops arriving.
  *
  * NO LANE-DETAIL LINE. `HostProgressView.detail` is the lane's own message -
  * "extracting host archive into ~/.traycer/…/staging", "atomically replacing
@@ -185,6 +187,7 @@ export function LocalHostLoadingContent(
   props: LocalHostLoadingContentProps,
 ): ReactNode {
   const progressView = props.progress;
+  const percent = progressView?.percent ?? null;
 
   return (
     <LocalHostBodyShell>
@@ -193,32 +196,27 @@ export function LocalHostLoadingContent(
           traycer
         </p>
       </BrandEntrance>
-      {/* THE ONE HEADING this surface has, and the spinner belongs TO it.
-          The healthy startup card renders no dialog title above this body
-          anymore - the old modal put "Setting up Traycer" 2px above this
-          line's "Setting up Traycer Host…" above the bar's "Setting up…", one
-          event announced three times by three layers.
+      {/* THE ONE HEADING this surface has. The healthy startup card renders
+          no dialog title above this body, and the bar below carries only a
+          position, so this line is the single voice for the event.
 
           Drawn through the SHARED boot headline so this phase is
           pixel-identical to the two boot surfaces before it (see
-          `HostBootCard`): a launch crosses three React trees, and the spinner
-          used to jump from small-and-muted-and-centred to
-          large-and-foreground-on-its-own-line as it did. The COPY still comes
-          from D10's shared table. */}
+          `HostBootCard`): a launch crosses three React trees. No spinner - the
+          mark above is the card's activity signal. The COPY comes from the
+          shared host-progress table. */}
       <HostBootHeadline
         message={progressView?.heading ?? HOST_PROGRESS_IDLE_HEADING}
-        spinnerVariant="sparkle"
-        spinnerTestId="local-host-loading-spinner"
+        spinnerVariant={null}
+        spinnerTestId={null}
         messageTestId="local-host-loading-stage"
       />
-      {/* THE CONTRACT, not a special case: no measured position => indeterminate.
-          That covers a lane that reports no percentage (`verify`, `swap`,
-          `service-start`, anything added later) AND the wait before any lane
-          has spoken - both are "busy, position unknown", which is exactly what
-          an indeterminate `progressbar` means. The block is the CURRENT
-          stage's, not "the download's": it stopped being that the moment the
-          carry-forward was scoped to one stage. */}
-      <HostProgress percent={progressView?.percent ?? null} />
+      {/* THE CONTRACT: a bar only with a measured position. No lane, or a
+          stage that reports no percentage, draws nothing here - the heading
+          already says what is happening, and the mark already says it is
+          happening. The percentage is the CURRENT stage's, never carried
+          forward from an earlier one. */}
+      {percent === null ? null : <HostProgress percent={percent} />}
       <BootstrapLogDisclosure
         onConfigureShell={props.onConfigureShell}
         trailing={props.footerTrailing}
@@ -228,23 +226,15 @@ export function LocalHostLoadingContent(
 }
 
 interface HostProgressProps {
-  /** `null` while nothing has a measured position - see the contract above. */
-  readonly percent: number | null;
+  /** The running stage's measured position, 0-100. */
+  readonly percent: number;
 }
 
 /**
- * The boot card's ONE progress bar: determinate when the running stage
- * reports a percentage, indeterminate otherwise - and present on EVERY wait
- * face, the idle "Starting Traycer…" included.
- *
- * WHY IT RENDERS AT ALL WITHOUT A NUMBER. Before this, the block was gated on
- * `percent !== null`, so at a stage transition the whole thing unmounted and the
- * card lost 48px - and because the modal is centred with `-translate-y-1/2`, both
- * of its edges moved 24px and the whole dialog jumped mid-install. Measured, on
- * the one surface this epic exists to fix. Holding the space is the point - and
- * it now holds it from the first frame of the launch (see
- * `LocalHostLoadingContent`), because a bar that appeared when the lane began
- * reporting was the same jump one phase earlier.
+ * The boot card's ONE progress bar, and it is always determinate: the body
+ * mounts it only while the running stage reports a percentage (see the
+ * contract in `LocalHostLoadingContent`), so it never has to draw a position
+ * nobody measured.
  *
  * NO BYTES. This row used to carry "100 MB of 239 MB" beside the percentage.
  * On a card that is on screen the moment the app opens, a byte count reads as
@@ -253,19 +243,17 @@ interface HostProgressProps {
  * transfer figures stay in the shared table (`HostProgressView.transferLabel`)
  * for Settings ▸ Host, where a user has gone looking for them.
  *
- * ⚠ AND IT MUST NOT HIDE A STALL. It cannot: stall detection is entirely the
- * staged wait's (`LOCAL_HOST_SLOW_START_THRESHOLD_MS` and
- * `laneProgressAdvanceKey`), which reads the lane's POSITION and promotes to the
- * Retry surface on its own clock. A genuinely wedged extract still gets there
- * while this animates. The two mechanisms compose and neither is load-bearing for
- * the other - worth knowing before anyone "fixes" this bar to stop after a while.
+ * ⚠ STALL DETECTION IS NOT THIS BAR'S JOB. It is entirely the staged wait's
+ * (`LOCAL_HOST_SLOW_START_THRESHOLD_MS` and `laneProgressAdvanceKey`), which
+ * reads the lane's POSITION and promotes to the Retry surface on its own
+ * clock - a download frozen at one percentage still gets there, and so does a
+ * stage that draws no bar at all. The two mechanisms compose and neither is
+ * load-bearing for the other.
  */
 function HostProgress(props: HostProgressProps) {
-  const indeterminate = props.percent === null;
   return (
     <div
       data-testid="local-host-download-progress"
-      data-indeterminate={indeterminate ? "true" : "false"}
       // `items-center`: the figure below the track centres, like everything
       // else on this card (heading above, footer below). A right-aligned
       // figure with nothing on its left - which is what dropping the byte
@@ -276,54 +264,25 @@ function HostProgress(props: HostProgressProps) {
         role="progressbar"
         aria-valuemin={0}
         aria-valuemax={100}
-        // Omitted while indeterminate, which is what the ARIA role means by it -
-        // a `progressbar` with no `aria-valuenow` is announced as busy with an
-        // unknown position, rather than as a specific amount done.
-        aria-valuenow={props.percent ?? undefined}
-        // Thin, fully rounded, and CLIPPED: `overflow-hidden` is what keeps
-        // the sweeping segment (which travels from -100% to +340% of its own
-        // width) inside the track's rounded ends, and the track is `w-full`
-        // of the body column, so it can never run past the card's padding.
-        // The track's fill is an alpha of the foreground, which survives
-        // every preset theme on a raised surface (see AGENTS.md).
+        aria-valuenow={props.percent}
+        // Thin, fully rounded, and CLIPPED: `overflow-hidden` keeps the fill
+        // inside the track's rounded ends at small percentages, and the track
+        // is `w-full` of the body column, so it can never run past the card's
+        // padding. The track's fill is an alpha of the foreground, which
+        // survives every preset theme on a raised surface (see AGENTS.md).
         className="h-1.5 w-full overflow-hidden rounded-full bg-foreground/8"
       >
-        {indeterminate ? (
-          // A SWEEPING SEGMENT, not a pulsing full-width fill: a full bar reads as
-          // finished however it is animated, which is the exact lie the scoped
-          // carry-forward removed. `w-2/5` + a translate keeps it obviously
-          // partial. `animation` inline because the keyframe is app CSS
-          // (`index.css`) and there is no utility for it.
-          <div
-            data-testid="local-host-progress-indeterminate"
-            className="h-full w-2/5 rounded-full bg-primary"
-            style={{
-              animation:
-                "host-progress-indeterminate 1.4s ease-in-out infinite",
-            }}
-          />
-        ) : (
-          <div
-            className="h-full rounded-full bg-primary transition-[width] duration-300 ease-out"
-            style={{ width: `${String(props.percent)}%` }}
-          />
-        )}
+        <div
+          className="h-full rounded-full bg-primary transition-[width] duration-300 ease-out"
+          style={{ width: `${String(props.percent)}%` }}
+        />
       </div>
-      {/* The percentage ONLY, under the track. This slot used to sit above
-          the bar and fall back to the stage's short label ("Setting up…"),
-          which merely repeated the heading two lines up in fewer words - the
-          third of the three "Setting up"s - and later carried the byte count
-          (see above). The row keeps its height either way so a percentage
-          appearing at the download stage does not bounce the centred card,
-          and `tabular-nums` keeps "9%" -> "10%" from shifting as it counts.
-
-          `min-h-[1lh]`, not a fixed `min-h-4`: the reserved slot is exactly
-          one line OF THIS ROW, so it follows `text-ui-xs`'s line height
-          instead of restating today's value of it in `rem` - the two agree
-          now and a token change is where they would stop. The unit is
-          already used across the composer surfaces. */}
-      <div className="flex min-h-[1lh] items-center justify-center text-ui-xs text-muted-foreground tabular-nums">
-        {indeterminate ? null : <span>{props.percent}%</span>}
+      {/* The percentage ONLY, under the track - never the stage's short label
+          ("Setting up…"), which would repeat the heading two lines up in
+          fewer words. `tabular-nums` keeps "9%" -> "10%" from shifting as it
+          counts. */}
+      <div className="flex items-center justify-center text-ui-xs text-muted-foreground tabular-nums">
+        <span>{props.percent}%</span>
       </div>
     </div>
   );
@@ -340,7 +299,7 @@ interface DetailsDisclosureProps {
 /**
  * Tucks the bootstrap.log tail and the "Configure shell…" affordance
  * behind a single text toggle. The default loading card stays clean
- * (spinner + heading + optional Retry); users only see logs and the
+ * (mark + heading); users only see logs and the
  * shell-settings shortcut when they explicitly ask.
  */
 function DetailsDisclosure(props: DetailsDisclosureProps) {

--- a/clients/gui-app/src/index.css
+++ b/clients/gui-app/src/index.css
@@ -33,8 +33,8 @@
    RUNNING but reports no percentage. Plain CSS - no motion runtime, so it
    animates regardless of the LazyMotion provider.
 
-   ONE keyframe, two directions BY DECLARATION. The host-install bars
-   (`local-host-loading`, `update-progress-bar`) run it one-way; the
+   ONE keyframe, two directions BY DECLARATION. The host-update bar
+   (`update-progress-bar`) runs it one-way; the
    stream-syncing strip below runs the same travel with
    `animation-direction: alternate`, so the segment returns instead of wrapping.
    The declaration is where the two differ - do not add a second keyframe for a
@@ -49,8 +49,8 @@
    not a progress claim: it carries no percentage semantics and the word
    "Syncing…" beside it is what the reader is actually reading.)
 
-   `transform` only, so it composites without laying out - this runs for the whole
-   multi-minute extract. */
+   `transform` only, so it composites without laying out - on the host-update bar
+   this runs for minutes. */
 @keyframes host-progress-indeterminate {
   from {
     transform: translateX(-100%);
@@ -61,8 +61,8 @@
 }
 
 /* The stream-syncing strip's travelling segment. A CLASS, not the inline
-   `animation` style the two install bars use, for one reason: an inline style
-   cannot be reached by a `motion-reduce:` variant, so those two do not honour
+   `animation` style the host-update bar uses, for one reason: an inline style
+   cannot be reached by a `motion-reduce:` variant, so that bar does not honour
    reduced motion at all. This one does, below.
 
    The strip drops this class entirely once it escalates, falling back to plain
@@ -76,8 +76,8 @@
      2.8s round trip with nothing on screen at all. On an install bar that runs
      for minutes the gap reads as pacing; on an indicator that lives two to four
      seconds it can be most of what the user sees, and it is what makes the
-     motion read as restarting rather than travelling. The install bars keep the
-     old value through the fallback in the keyframe. */
+     motion read as restarting rather than travelling. The host-update bar keeps
+     the old value through the fallback in the keyframe. */
   --host-progress-sweep-end: 250%;
   animation: host-progress-indeterminate 1.4s ease-in-out infinite alternate;
   /* The one moving element on screen during a reconnect, and a bar this thin


### PR DESCRIPTION
## What changes for the user

The "Starting Traycer…" boot card showed three loaders at once: the shimmering Traycer mark, a spinner above the heading, and a progress bar that swept back and forth whenever nothing had a measured position. Now it shows one.

- **Idle** ("Starting Traycer…", no install running): the shimmering mark and the heading. No spinner, no bar.
- **A host install/download in progress**: the mark and the stage heading ("Downloading Traycer Host…", "Setting up Traycer Host…", …). The progress bar appears **only while the running stage reports a real percentage** — in practice the host download — and shows that percentage. Stages that report none (verify, swap, service start) get the heading alone; no percentage is ever invented.

## Why

The spinner and the indeterminate bar didn't tell the user anything. The shimmering mark already says the card is busy, and the heading says what it's busy with. A bar is useful only when it has a position to show.

Tradeoff: the card now gets taller by the bar and its row gap when a download starts reporting a percentage, and shorter again when the next stage starts. Before, the always-on bar kept the height fixed. In the boot-family gallery the four pre-lane wait faces still share one box (211px at 1200×900), and the 42% download face is 257px.

## What's unchanged

- "Show details" / "Open settings" escape hatches
- The wordmark, the `BrandEntrance` mark and its shimmer
- The stage copy (shared host-progress table)
- The shared `host-progress-indeterminate` keyframe: `UpdateProgressBar` and the stream-syncing strip still use it

## Notes

- Every boot surface draws this body: the runtime fallback, the gate's attach/restoring covers (both via `HostBootSurface`) and the window narrator's startup card (`LocalHostLoadingContent`). So the change reaches all of them.
- Doc comments that described the old "bar on every wait face" contract are rewritten to describe the new one (`local-host-loading.tsx`, `host-boot-surface.tsx`, `centered-card.tsx`, the narrator, `index.css`). The manual gallery script's wait-face set drops the 42% lane face to match.

## Tests

- `local-host-loading.test.tsx`: idle card has the mark and heading, with no `progressbar` and nothing next to the heading. A `download` lane at 43% has the bar with `aria-valuenow=43` and the stage heading. A `verify` lane with no percentage has its heading and no bar. Mutation-checked: putting the spinner back, or always drawing the bar, fails both new tests.
- `window-host-modal-host.test.tsx`, `default-host-ready-gate.test.tsx`: spinner/indeterminate assertions replaced with heading and no-`progressbar` assertions.
