### PR TITLE
fix(gui-app): retire stale-only records a complete serve of their turn no longer lists

### DIFF
--- a/clients/gui-app/src/stores/chats/__tests__/transcript-window-turn-membership.test.ts
+++ b/clients/gui-app/src/stores/chats/__tests__/transcript-window-turn-membership.test.ts
@@ -211,6 +211,7 @@ describe("reconcileServedTurnMembership", () => {
 
     // Retired from the ledger too, not merely unreferenced by a span.
     expect(after.records.messages.has("ghost")).toBe(false);
+    expect(after.hydratedBytes).toBe(transcriptWindowChargedBytes(after));
   });
 
   it("keeps a legitimate non-empty prefix the serve's membership still lists", () => {
@@ -308,6 +309,9 @@ describe("reconcileServedTurnMembership", () => {
     );
     expect(hydratedIds).not.toContain("ghost");
     expect(hydratedIds).toContain("real");
+    // The stored charge is re-derived after the live tail shrinks - the
+    // ghost's bytes leave the figure the budget reads, not only the tail.
+    expect(after.hydratedBytes).toBe(transcriptWindowChargedBytes(after));
   });
 
   it("never reconciles an unplaced live ghost of the active turn", () => {

--- a/clients/gui-app/src/stores/chats/__tests__/transcript-window-turn-membership.test.ts
+++ b/clients/gui-app/src/stores/chats/__tests__/transcript-window-turn-membership.test.ts
@@ -1,0 +1,467 @@
+import { describe, expect, it } from "vitest";
+import type { JsonContent } from "@traycer/protocol/common/registry";
+import type {
+  ChatEvent,
+  Message,
+} from "@traycer/protocol/persistence/epic/schemas";
+import type { RowSkeletonEntry } from "@traycer/protocol/persistence/chat-transcript/row-skeleton";
+import type { ChatRangeResponse } from "@traycer/protocol/host/agent/gui/subscribe-windowed";
+import { assistantRowId } from "@traycer/protocol/persistence/chat-transcript/row-projection";
+import {
+  appendLiveRecords,
+  applyRangeResponse,
+  applySkeletonChunk,
+  applyWindowedSnapshot,
+  emptyTranscriptWindow,
+  hydratedRecords,
+  settleWindowBytes,
+  transcriptWindowChargedBytes,
+  type TranscriptWindow,
+} from "@/stores/chats/transcript-window";
+
+/**
+ * `reconcileServedTurnMembership` closes a specific gap: a steer that lands
+ * before the model has written anything makes the host COLLAPSE the turn's
+ * original (empty) assistant row and continue the turn under a fresh
+ * `messageId` in a new row. Nothing on the wire retracts the original - it
+ * was already served to this client under the row it occupied, so it
+ * survives a rebase into `staleSpans` (or as an unplaced `liveMessages`
+ * record) forever, and the renderer folds it into the turn as a phantom
+ * prefix ("ghost").
+ *
+ * A COMPLETE serve of the turn (the row is not in `incompleteRowIds`) is the
+ * only thing that can prove the ghost is gone: it lists every record the host
+ * still holds for that turn, and a record of the same turn the window is
+ * holding outside the fresh tier, that the serve does not list, is retired.
+ */
+
+const CONTENT: JsonContent = {
+  type: "doc",
+  content: [{ type: "paragraph", content: [{ type: "text", text: "hi" }] }],
+};
+
+function userMessage(messageId: string, timestamp: number): Message {
+  return {
+    role: "user",
+    messageId,
+    sender: { type: "user", userId: "owner-1" },
+    message: { kind: "user", content: CONTENT, browserAnnotations: [] },
+    timestamp,
+    sessionAnchor: null,
+  };
+}
+
+function assistantMessage(
+  messageId: string,
+  turnId: string | null,
+  timestamp: number,
+): Extract<Message, { role: "assistant" }> {
+  return {
+    role: "assistant",
+    messageId,
+    sender: {
+      type: "agent",
+      harnessId: "codex",
+      agentId: "codex",
+      displayName: "Codex",
+      reply: { expectsReply: false },
+      inReplyTo: null,
+    },
+    blocks: [],
+    startedAt: timestamp,
+    timestamp,
+    turnId,
+    usage: null,
+    reasoningEffort: null,
+    serviceTier: null,
+    envCredentialVar: null,
+    imageResolutions: [],
+  };
+}
+
+function skeletonEntry(rowId: string, ordinal: number): RowSkeletonEntry {
+  return {
+    rowId,
+    createdAt: 1000 + ordinal,
+    role: "user",
+    byteLength: 128,
+    bodyDigest: `d-${rowId}`,
+  };
+}
+
+function rangeResponse(input: {
+  readonly epoch: number;
+  readonly fromOrdinal: number;
+  readonly rowIds: readonly string[];
+  readonly incompleteRowIds?: readonly string[];
+  readonly messages: readonly Message[];
+  readonly events?: readonly ChatEvent[];
+}): ChatRangeResponse {
+  return {
+    requestId: `req-${input.fromOrdinal}`,
+    epoch: input.epoch,
+    fromOrdinal: input.fromOrdinal,
+    rowIds: [...input.rowIds],
+    incompleteRowIds: [...(input.incompleteRowIds ?? [])],
+    messages: [...input.messages],
+    events: [...(input.events ?? [])],
+    rowContext: {},
+    reachedStart: input.fromOrdinal === 0,
+    reachedEnd: false,
+  };
+}
+
+/**
+ * A window with a two-row skeleton at epoch 1 and nothing hydrated: a
+ * survivor `row-0` and a second, freely named row.
+ */
+function windowWithSkeletonRows(
+  rowIds: readonly [string, string],
+): TranscriptWindow {
+  const seeded = applyWindowedSnapshot(
+    emptyTranscriptWindow(),
+    {
+      epoch: 1,
+      rowCount: rowIds.length,
+      indexRevision: null,
+      tail: { fromOrdinal: rowIds.length, messages: [], events: [] },
+    },
+    null,
+    null,
+  );
+  return applySkeletonChunk(seeded, {
+    epoch: 1,
+    fromOrdinal: 0,
+    entries: rowIds.map((rowId, index) => skeletonEntry(rowId, index)),
+    isFinal: true,
+  });
+}
+
+/**
+ * The production defect shape: a provisional row ("assistant:turn:prov") is
+ * served complete at epoch 1 holding the turn's collapsed, empty original
+ * body ("ghost"). A rebase to epoch 2 demotes that whole span to
+ * `staleSpans`; the epoch-2 skeleton then re-lists the turn under its
+ * canonical row id (`assistantRowId("T")`), a DIFFERENT row id from the
+ * provisional one - so nothing at the skeleton layer can tell the two rows
+ * are the same turn. Only a complete serve of that canonical row settles it.
+ */
+function rebasedWindowWithGhost(): TranscriptWindow {
+  const epoch1 = windowWithSkeletonRows(["row-0", "assistant:turn:prov"]);
+  const served = applyRangeResponse(
+    epoch1,
+    rangeResponse({
+      epoch: 1,
+      fromOrdinal: 0,
+      rowIds: ["row-0", "assistant:turn:prov"],
+      messages: [userMessage("m-0", 0), assistantMessage("ghost", "T", 1)],
+    }),
+    null,
+    null,
+  );
+  const rebased = applyWindowedSnapshot(
+    served,
+    {
+      epoch: 2,
+      rowCount: 2,
+      indexRevision: null,
+      tail: { fromOrdinal: 2, messages: [], events: [] },
+    },
+    null,
+    null,
+  );
+  return applySkeletonChunk(rebased, {
+    epoch: 2,
+    fromOrdinal: 0,
+    entries: [skeletonEntry("row-0", 0), skeletonEntry(assistantRowId("T"), 1)],
+    isFinal: true,
+  });
+}
+
+describe("reconcileServedTurnMembership", () => {
+  it("retires a ghost record the complete serve does not list", () => {
+    const before = rebasedWindowWithGhost();
+    expect(before.staleSpans).toHaveLength(1);
+    expect(before.staleSpans[0].messageIds).toContain("ghost");
+
+    const after = applyRangeResponse(
+      before,
+      rangeResponse({
+        epoch: 2,
+        fromOrdinal: 1,
+        rowIds: [assistantRowId("T")],
+        messages: [assistantMessage("real", "T", 2)],
+      }),
+      null,
+      null,
+    );
+
+    const hydratedIds = hydratedRecords(after).messages.map(
+      (message) => message.messageId,
+    );
+    expect(hydratedIds).not.toContain("ghost");
+    expect(hydratedIds).toContain("m-0");
+    expect(hydratedIds).toContain("real");
+
+    // The stale span itself survives (row-0 is still uncovered by the fresh
+    // tier) - only the ghost's membership is dropped from it.
+    expect(after.staleSpans).toHaveLength(1);
+    expect(after.staleSpans[0].messageIds).not.toContain("ghost");
+    expect(after.staleSpans[0].rowIds).toContain("row-0");
+
+    // Retired from the ledger too, not merely unreferenced by a span.
+    expect(after.records.messages.has("ghost")).toBe(false);
+  });
+
+  it("keeps a legitimate non-empty prefix the serve's membership still lists", () => {
+    const before = rebasedWindowWithGhost();
+
+    const after = applyRangeResponse(
+      before,
+      rangeResponse({
+        epoch: 2,
+        fromOrdinal: 1,
+        rowIds: [assistantRowId("T")],
+        // The serve lists "ghost" itself alongside the continuation - a
+        // legitimate non-empty prefix the host still holds.
+        messages: [
+          assistantMessage("ghost", "T", 1),
+          assistantMessage("real", "T", 2),
+        ],
+      }),
+      null,
+      null,
+    );
+
+    const hydratedIds = hydratedRecords(after).messages.map(
+      (message) => message.messageId,
+    );
+    expect(hydratedIds).toContain("ghost");
+    expect(hydratedIds).toContain("real");
+    expect(after.records.messages.has("ghost")).toBe(true);
+  });
+
+  it("retires nothing when the serve of the turn is incomplete", () => {
+    const before = rebasedWindowWithGhost();
+
+    const after = applyRangeResponse(
+      before,
+      rangeResponse({
+        epoch: 2,
+        fromOrdinal: 1,
+        rowIds: [assistantRowId("T")],
+        incompleteRowIds: [assistantRowId("T")],
+        messages: [assistantMessage("real", "T", 2)],
+      }),
+      null,
+      null,
+    );
+
+    expect(after.staleSpans[0].messageIds).toContain("ghost");
+    expect(after.records.messages.has("ghost")).toBe(true);
+  });
+
+  it("never reconciles the active turn", () => {
+    const before = rebasedWindowWithGhost();
+
+    const after = applyRangeResponse(
+      before,
+      rangeResponse({
+        epoch: 2,
+        fromOrdinal: 1,
+        rowIds: [assistantRowId("T")],
+        messages: [assistantMessage("real", "T", 2)],
+      }),
+      "T",
+      null,
+    );
+
+    expect(after.staleSpans[0].messageIds).toContain("ghost");
+    expect(after.records.messages.has("ghost")).toBe(true);
+  });
+
+  it("retires an unplaced live ghost record", () => {
+    const epoch1 = windowWithSkeletonRows(["row-0", assistantRowId("T")]);
+    const withLiveGhost = appendLiveRecords(epoch1, {
+      messages: [assistantMessage("ghost", "T", 1)],
+      events: [],
+    });
+    expect(withLiveGhost.liveMessages.map((m) => m.messageId)).toContain(
+      "ghost",
+    );
+
+    const after = applyRangeResponse(
+      withLiveGhost,
+      rangeResponse({
+        epoch: 1,
+        fromOrdinal: 1,
+        rowIds: [assistantRowId("T")],
+        messages: [assistantMessage("real", "T", 2)],
+      }),
+      null,
+      null,
+    );
+
+    expect(after.liveMessages.map((m) => m.messageId)).not.toContain("ghost");
+    const hydratedIds = hydratedRecords(after).messages.map(
+      (message) => message.messageId,
+    );
+    expect(hydratedIds).not.toContain("ghost");
+    expect(hydratedIds).toContain("real");
+  });
+
+  it("never reconciles an unplaced live ghost of the active turn", () => {
+    const epoch1 = windowWithSkeletonRows(["row-0", assistantRowId("T")]);
+    const withLiveGhost = appendLiveRecords(epoch1, {
+      messages: [assistantMessage("ghost", "T", 1)],
+      events: [],
+    });
+
+    const after = applyRangeResponse(
+      withLiveGhost,
+      rangeResponse({
+        epoch: 1,
+        fromOrdinal: 1,
+        rowIds: [assistantRowId("T")],
+        messages: [assistantMessage("real", "T", 2)],
+      }),
+      "T",
+      null,
+    );
+
+    expect(after.liveMessages.map((m) => m.messageId)).toContain("ghost");
+  });
+
+  it("leaves a stale record of a different turn untouched by this turn's serve", () => {
+    const epoch1 = applySkeletonChunk(
+      applyWindowedSnapshot(
+        emptyTranscriptWindow(),
+        {
+          epoch: 1,
+          rowCount: 2,
+          indexRevision: null,
+          tail: { fromOrdinal: 2, messages: [], events: [] },
+        },
+        null,
+        null,
+      ),
+      {
+        epoch: 1,
+        fromOrdinal: 0,
+        entries: [
+          skeletonEntry(assistantRowId("U"), 0),
+          skeletonEntry("assistant:turn:prov", 1),
+        ],
+        isFinal: true,
+      },
+    );
+    const served = applyRangeResponse(
+      epoch1,
+      rangeResponse({
+        epoch: 1,
+        fromOrdinal: 0,
+        rowIds: [assistantRowId("U"), "assistant:turn:prov"],
+        messages: [
+          assistantMessage("other", "U", 0),
+          assistantMessage("ghost", "T", 1),
+        ],
+      }),
+      null,
+      null,
+    );
+    const rebased = applyWindowedSnapshot(
+      served,
+      {
+        epoch: 2,
+        rowCount: 2,
+        indexRevision: null,
+        tail: { fromOrdinal: 2, messages: [], events: [] },
+      },
+      null,
+      null,
+    );
+    const before = applySkeletonChunk(rebased, {
+      epoch: 2,
+      fromOrdinal: 0,
+      entries: [
+        skeletonEntry(assistantRowId("U"), 0),
+        skeletonEntry(assistantRowId("T"), 1),
+      ],
+      isFinal: true,
+    });
+    expect(before.staleSpans[0].messageIds).toEqual(
+      expect.arrayContaining(["other", "ghost"]),
+    );
+
+    const after = applyRangeResponse(
+      before,
+      rangeResponse({
+        epoch: 2,
+        fromOrdinal: 1,
+        rowIds: [assistantRowId("T")],
+        messages: [assistantMessage("real", "T", 2)],
+      }),
+      null,
+      null,
+    );
+
+    // "ghost" (turn T) is retired; "other" (turn U) is untouched, even though
+    // both lived in the same stale span.
+    expect(after.staleSpans[0].messageIds).not.toContain("ghost");
+    expect(after.staleSpans[0].messageIds).toContain("other");
+    expect(after.records.messages.has("other")).toBe(true);
+  });
+
+  it("retires a stale ghost via the snapshot tail seat, not only a range", () => {
+    const before = rebasedWindowWithGhost();
+    expect(before.staleSpans[0].messageIds).toContain("ghost");
+
+    const rebasedAgain = applyWindowedSnapshot(
+      before,
+      {
+        epoch: 3,
+        rowCount: 2,
+        indexRevision: null,
+        tail: {
+          fromOrdinal: 1,
+          rowIds: [assistantRowId("T")],
+          messages: [assistantMessage("real", "T", 2)],
+          events: [],
+        },
+      },
+      null,
+      null,
+    );
+
+    const hydratedIds = hydratedRecords(rebasedAgain).messages.map(
+      (message) => message.messageId,
+    );
+    expect(hydratedIds).not.toContain("ghost");
+    expect(hydratedIds).toContain("real");
+  });
+
+  it("keeps the charge figure finite, and lower than if the ghost had survived", () => {
+    const before = rebasedWindowWithGhost();
+    const serve = rangeResponse({
+      epoch: 2,
+      fromOrdinal: 1,
+      rowIds: [assistantRowId("T")],
+      messages: [assistantMessage("real", "T", 2)],
+    });
+
+    // Same serve, applied twice: once as the active turn (so the ghost
+    // survives - see the "never reconciles the active turn" test above) and
+    // once not (so it is retired). The retired window's charge must not
+    // exceed the survived one's, which isolates the ghost's own bytes rather
+    // than comparing against a state that never added "real" at all.
+    const survived = applyRangeResponse(before, serve, "T", null);
+    const retired = applyRangeResponse(before, serve, null, null);
+
+    const survivedBytes = transcriptWindowChargedBytes(survived);
+    const retiredBytes = transcriptWindowChargedBytes(retired);
+    expect(Number.isFinite(survivedBytes)).toBe(true);
+    expect(Number.isFinite(retiredBytes)).toBe(true);
+    expect(retiredBytes).toBeLessThanOrEqual(survivedBytes);
+    expect(() => settleWindowBytes(retired)).not.toThrow();
+  });
+});

--- a/clients/gui-app/src/stores/chats/transcript-window.ts
+++ b/clients/gui-app/src/stores/chats/transcript-window.ts
@@ -2750,25 +2750,26 @@ function seatSnapshotTailSpan(input: {
     completeBase.spans,
     tailSpan,
   );
-  return retireCoveredStaleSpans(
-    pruneSupersededLiveRecords(
-      {
-        ...completeBase,
-        records,
-        spans,
-        hydratedBytes: chargedWindowBytes(
+  const servedRowIds = declaredCompleteTailRowIds(tail);
+  return reconcileServedTurnMembership(
+    retireCoveredStaleSpans(
+      pruneSupersededLiveRecords(
+        {
+          ...completeBase,
           records,
           spans,
-          completeBase.liveMessages,
-          completeBase.liveEvents,
-        ),
-      },
-      servedAssistantTurns(
-        declaredCompleteTailRowIds(tail),
-        messages,
-        tail.events,
+          hydratedBytes: chargedWindowBytes(
+            records,
+            spans,
+            completeBase.liveMessages,
+            completeBase.liveEvents,
+          ),
+        },
+        servedAssistantTurns(servedRowIds, messages, tail.events),
       ),
     ),
+    servedTurnMembership(servedRowIds, messages, tail.events),
+    input.activeTurnId,
   );
 }
 
@@ -3784,6 +3785,149 @@ function retireCoveredStaleSpans(window: TranscriptWindow): TranscriptWindow {
   return unchanged
     ? window
     : pruneUnreferencedRecords({ ...window, staleSpans: bounded });
+}
+
+/**
+ * The complete record membership of every turn a serve is authority on.
+ *
+ * A row the host serves COMPLETE (not in `incompleteRowIds`) comes with every
+ * record of its turn - `rowRecordIds` hands an assistant slice the whole turn's
+ * `messageIds`, and the host marks the row incomplete when any of them is
+ * missing from its lookup. So for each turn one of those rows belongs to, the
+ * served assistant records ARE the turn: a record of that turn the serve does
+ * not carry is one the host no longer holds.
+ *
+ * Keyed by turn key, valued by the served assistant record ids. Turns reached
+ * only through an incomplete row are absent, because an incomplete serve says
+ * nothing about what the turn does not contain.
+ */
+function servedTurnMembership(
+  rowIds: readonly string[],
+  messages: readonly Message[],
+  events: readonly ChatEvent[],
+): ReadonlyMap<string, ReadonlySet<string>> {
+  const membership = new Map<string, Set<string>>();
+  for (const turnKey of assistantTurnKeysForServedRows(
+    rowIds,
+    messages,
+    events,
+  )) {
+    membership.set(turnKey, new Set());
+  }
+  if (membership.size === 0) return membership;
+  for (const message of messages) {
+    if (message.role !== "assistant") continue;
+    membership.get(assistantTurnKey(message))?.add(message.messageId);
+  }
+  return membership;
+}
+
+/**
+ * Drop the records of a served turn that the serve proves gone.
+ *
+ * ## The gap this closes
+ *
+ * A steer that lands before the model has written anything makes the host
+ * COLLAPSE the turn's original assistant row and continue the turn in a row
+ * under a fresh `messageId` (`chat-session-manager.ts`, the steered user
+ * split). Nothing on the wire retracts the original: the snapshot that follows
+ * describes rows, and the original had already been served to this client
+ * under the provisional live row it occupied. It then sits in the ledger with
+ * the turn's `turnId`, receives the deltas routed to the turn while it is the
+ * last record carrying that id, and is carried into the stale tier by the next
+ * rebase.
+ *
+ * {@link retireCoveredStaleSpans} cannot reach it. That pass keeps a span for
+ * its surviving rows, and a carry that mixes the collapsed row with rows the
+ * fresh tier has not re-served yet is kept whole - records and all. Meanwhile
+ * {@link hydratedRecords} merges the stale tier into `messages`, the renderer
+ * folds every record sharing a `turnId` into one turn, the steer block splits
+ * the merged list, and the turn's real content lands in a `part:1` row the
+ * skeleton never names. Once the real record is span-seated and no longer
+ * live-backed, the row merger drops that row, and the turn renders as its
+ * collapsed prefix alone: no final text, no answered interview.
+ *
+ * ## Why membership, and not "a newer record with the same turn id"
+ *
+ * A non-empty original row legitimately survives a split as the turn's prefix
+ * (the host keeps a row the model wrote to), so two records per turn is a
+ * valid shape and record age proves nothing. The skeleton cannot arbitrate
+ * either: it carries row ids, never record ids. What CAN decide is a complete
+ * serve of the turn - see {@link servedTurnMembership} - which lists exactly
+ * the records the host still holds for it. A record of that turn the client
+ * holds outside the fresh tier, and the serve does not list, is retired.
+ *
+ * ## Scope
+ *
+ * - Only records the FRESH tier does not reference. A fresh reference is a
+ *   serve too, and the two agree by construction.
+ * - Never the active turn. A range is sliced before it is delivered, and the
+ *   host mints the continuation row DURING the turn, so a serve of the
+ *   streaming turn can predate the very record it would otherwise retire.
+ *   Everything this repairs is visible only after the turn settles, so waiting
+ *   for that costs nothing.
+ * - Stale-span references and unplaced live records alike: the host pushes a
+ *   record whole before the index places it, and a collapsed row can be held
+ *   in either home.
+ *
+ * Runs after {@link retireCoveredStaleSpans}, on both seat paths (a range and
+ * the snapshot tail), because those are the only two places a complete serve
+ * enters the window.
+ */
+function reconcileServedTurnMembership(
+  window: TranscriptWindow,
+  membership: ReadonlyMap<string, ReadonlySet<string>>,
+  activeTurnId: string | null,
+): TranscriptWindow {
+  if (membership.size === 0) return window;
+  if (window.staleSpans.length === 0 && window.liveMessages.length === 0) {
+    return window;
+  }
+  const freshReferenced = referencedRecordIds([window.spans]).messageIds;
+  const retired = (message: Message): boolean => {
+    if (message.role !== "assistant") return false;
+    if (freshReferenced.has(message.messageId)) return false;
+    const turnKey = assistantTurnKey(message);
+    if (turnKey === activeTurnId) return false;
+    const served = membership.get(turnKey);
+    // A served turn with no served record is not evidence of an empty turn -
+    // a complete assistant row always carries at least the record it
+    // projects from - so it decides nothing rather than everything.
+    if (served === undefined || served.size === 0) return false;
+    return !served.has(message.messageId);
+  };
+  let changed = false;
+  const staleSpans = window.staleSpans.map((span) => {
+    const messageIds = span.messageIds.filter((messageId) => {
+      const entry = window.records.messages.get(messageId);
+      return entry === undefined || !retired(entry.record);
+    });
+    if (messageIds.length === span.messageIds.length) return span;
+    changed = true;
+    return { ...span, messageIds };
+  });
+  const liveMessages = window.liveMessages.filter(
+    (message) => !retired(message),
+  );
+  if (liveMessages.length !== window.liveMessages.length) changed = true;
+  if (!changed) return window;
+  // A membership change on both tiers. The ledger releases what no span
+  // references any more (and bumps the revision the row-backing memos key
+  // on); the charge is re-derived because the live tail is a term of it.
+  const pruned = pruneUnreferencedRecords({
+    ...window,
+    staleSpans,
+    liveMessages,
+  });
+  return {
+    ...pruned,
+    hydratedBytes: chargedWindowBytes(
+      pruned.records,
+      pruned.spans,
+      liveMessages,
+      pruned.liveEvents,
+    ),
+  };
 }
 
 /**
@@ -4905,26 +5049,30 @@ export function applyRangeResponse(
     completeWindow.spans,
     span,
   );
-  return retireCoveredStaleSpans(
-    pruneSupersededLiveRecords(
-      {
-        ...completeWindow,
-        records,
-        spans,
-        hydratedBytes: chargedWindowBytes(
+  const servedRowIds = completeServedRowIds(
+    response.rowIds,
+    response.incompleteRowIds,
+  );
+  return reconcileServedTurnMembership(
+    retireCoveredStaleSpans(
+      pruneSupersededLiveRecords(
+        {
+          ...completeWindow,
           records,
           spans,
-          completeWindow.liveMessages,
-          completeWindow.liveEvents,
-        ),
-        clock,
-      },
-      servedAssistantTurns(
-        completeServedRowIds(response.rowIds, response.incompleteRowIds),
-        messages,
-        response.events,
+          hydratedBytes: chargedWindowBytes(
+            records,
+            spans,
+            completeWindow.liveMessages,
+            completeWindow.liveEvents,
+          ),
+          clock,
+        },
+        servedAssistantTurns(servedRowIds, messages, response.events),
       ),
     ),
+    servedTurnMembership(servedRowIds, messages, response.events),
+    activeTurnId,
   );
 }
 


### PR DESCRIPTION
## Problem

After a steered turn, a chat can render the assistant turn without its final text and its answered interview card. Seen in staging on the "Schema" chat: the text was visible until the next send, then vanished.

A steer that lands before the model has written anything makes the host collapse the turn's original assistant row and continue the turn under a fresh `messageId` with the same `turnId`. Nothing on the wire retracts the original. A client that had already been served it keeps it: it receives the turn's deltas while it is the last record carrying that `turnId`, and the next rebase carries it into the stale span tier. `hydratedRecords` merges the stale tier into `messages`, the renderer folds both records of the turn into one accumulator, the steer block splits the merged block list, and the real content lands in a `part:1` row the skeleton never names. Once the real record is span-seated and no longer live-backed, the row merger drops that row.

## Fix

Reconcile whole-turn membership at seat time in `transcript-window.ts`. Every complete assistant row serves the turn's full `messageIds` (`rowRecordIds`), so a complete serve is authority on what the host still holds for that turn. A record of that turn held only in the stale tier or as an unplaced live record, and absent from the served membership, is retired and released from the ledger.

Scope rules:
- The active turn is exempt: the continuation row is minted mid-turn, so a serve of the streaming turn can predate the record it would otherwise retire.
- Fresh-tier references are exempt.
- Rows in `incompleteRowIds` decide nothing.
- A served turn with zero served assistant records decides nothing.
- Runs on both seat paths: the range response and the snapshot tail.

No renderer or list-merge special cases. Host retraction of `collapsedAssistantMessageId` on the steer split remains a separate follow-up; this repairs ghosts already held by clients.

## Tests

New `transcript-window-turn-membership.test.ts`:
- mixed stale span with an unrelated survivor plus the ghost: complete serve retires the ghost from span, ledger and hydrated output, survivor kept
- a prefix the serve still lists is kept
- incomplete serve retires nothing
- active turn never reconciled (stale-held and live-held ghost)
- live-held ghost of a settled turn retired
- a different turn's record in the same stale span untouched
- snapshot tail seat retires the ghost too
- charge stays finite and does not exceed the ghost-surviving path

All four transcript-window suites pass (214 tests). gui-app compile, eslint and oxfmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
