### PR TITLE
feat(protocol): remove the cloud-sync entitlement fields and the entitlement-lapsed pause reason

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/panels/__tests__/epic-durability-plane.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/panels/__tests__/epic-durability-plane.test.tsx
@@ -2,7 +2,6 @@ import "../../../../../__tests__/test-browser-apis";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   cleanup,
-  fireEvent,
   render,
   screen,
   type RenderResult,
@@ -74,34 +73,6 @@ vi.mock("@/lib/epic-selectors", async (importOriginal) => {
 
 vi.mock("@/hooks/epic/use-epic-export-artifacts-mutation", () => ({
   useEpicExportArtifacts: () => ({ mutate: vi.fn(), isPending: false }),
-}));
-
-/**
- * A configured platform origin, distinct from `resolvePlatformBaseUrl`'s
- * production fallback (`https://platform.traycer.ai`): without this, the
- * upgrade click would exercise `resolvePlatformBaseUrl(undefined)`'s fallback
- * arm and never prove the remedy reads a REAL `signInUrl` off the runner host.
- */
-const CONFIGURED_SIGN_IN_URL = "https://auth.configured-shell.test/sign-in";
-
-vi.mock("@/providers/use-runner-host", () => ({
-  useRunnerHost: () => ({
-    authnBaseUrl: "https://authn.test",
-    signInUrl: CONFIGURED_SIGN_IN_URL,
-    openExternalLink: vi.fn(),
-  }),
-}));
-
-const openExternalLinkMutate = vi.hoisted(() => vi.fn());
-
-// The remedy opens the upgrade link through this hook rather than the bridge
-// directly (see the component's own comment), so this mock is what the click
-// assertion below spies on instead of asserting on copy alone.
-vi.mock("@/lib/links/open-link", () => ({
-  useOpenLinkWithPending: () => ({
-    openLink: openExternalLinkMutate,
-    isPending: false,
-  }),
 }));
 
 // ─── `deriveEpicDurabilityPlane` - the pure reading ────────────────────────
@@ -311,7 +282,6 @@ describe("deriveEpicDurabilityPlane", () => {
       "delete-tombstone-unscoped-cleared",
       { severity: "steady", sentence: "Delete recorded — tidying up" },
     ],
-    ["entitlement-lapsed", { severity: "warning", sentence: "Sync paused" }],
     [null, { severity: "warning", sentence: "Sync paused" }],
   ])("reads pause reason %s as %o", (pauseReason, expected) => {
     expect(
@@ -424,7 +394,6 @@ describe("deriveEpicDurabilityPlane", () => {
       "orphaned-local-edits-after-cloud-delete",
       "delete-pending-acknowledgement",
       "delete-tombstone-unscoped-cleared",
-      "entitlement-lapsed",
       null,
     ];
 
@@ -559,10 +528,7 @@ function resetDurabilityFixture(): void {
 
 describe("<EpicDurabilityRemedies />", () => {
   beforeEach(resetDurabilityFixture);
-  afterEach(() => {
-    cleanup();
-    openExternalLinkMutate.mockClear();
-  });
+  afterEach(cleanup);
 
   it("shows the export remedy, disabled with zero artifacts, for access-revoked", () => {
     durability.status = "paused";
@@ -588,30 +554,6 @@ describe("<EpicDurabilityRemedies />", () => {
     });
     expect(exportButton.disabled).toBe(true);
     expect(screen.queryByText("Upgrade")).toBeNull();
-  });
-
-  it("shows upgrade only for the entitlement-lapsed reason, with no export remedy", () => {
-    durability.status = "paused";
-    durability.pauseReason = "entitlement-lapsed";
-
-    renderRemedies();
-
-    expect(screen.getByText("Upgrade")).toBeTruthy();
-    expect(screen.queryByText("Export artifacts")).toBeNull();
-  });
-
-  it("opens the upgrade link at the runner host's configured platform origin", () => {
-    durability.status = "paused";
-    durability.pauseReason = "entitlement-lapsed";
-
-    renderRemedies();
-    fireEvent.click(screen.getByRole("button", { name: "Upgrade" }));
-
-    expect(openExternalLinkMutate).toHaveBeenCalledWith(
-      new URL(CONFIGURED_SIGN_IN_URL).origin,
-      "auth",
-      null,
-    );
   });
 
   it("renders nothing for an omitted pause reason", () => {

--- a/clients/gui-app/src/components/epic-canvas/panels/epic-durability-plane.ts
+++ b/clients/gui-app/src/components/epic-canvas/panels/epic-durability-plane.ts
@@ -433,7 +433,6 @@ function pausedCopy(
       return { label: "Delete pending", severity: "steady" };
     case "delete-tombstone-unscoped-cleared":
       return { label: "Delete recorded — tidying up", severity: "steady" };
-    case "entitlement-lapsed":
     case null:
       return { label: "Sync paused", severity: "warning" };
   }

--- a/clients/gui-app/src/components/epic-canvas/panels/epic-durability-remedies.tsx
+++ b/clients/gui-app/src/components/epic-canvas/panels/epic-durability-remedies.tsx
@@ -1,7 +1,6 @@
 import { Button } from "@/components/ui/button";
 import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 import { useEpicExportArtifacts } from "@/hooks/epic/use-epic-export-artifacts-mutation";
-import { useOpenLinkWithPending } from "@/lib/links/open-link";
 import {
   useEpicArtifactRecords,
   useEpicDurabilityPauseReason,
@@ -9,8 +8,6 @@ import {
   useEpicSnapshotMeta,
 } from "@/lib/epic-selectors";
 import { isEpicArtifactKind } from "@/lib/artifacts/node-display";
-import { resolvePlatformBaseUrl } from "@/lib/auth/platform-base-url";
-import { useRunnerHost } from "@/providers/use-runner-host";
 import type { EpicDurabilityPauseReasonV15 } from "@traycer/protocol/host/epic/subscribe";
 import { viewStatus } from "./epic-durability-plane";
 
@@ -28,21 +25,17 @@ export function EpicDurabilityRemedies() {
   const view = useEpicDurabilityView();
   const pauseReason = useEpicDurabilityPauseReason();
   // The status is decided BEFORE any provider-bound hook runs: the child
-  // below reads the runner host and the export mutation, which exist only
-  // under the app shell, and every status row renders this component. The
-  // old badge reached those hooks only on its paused arm, and so does this.
+  // below reads the export mutation, which exists only under the app shell,
+  // and every status row renders this component. The old badge reached that
+  // hook only on its paused arm, and so does this.
   if (viewStatus(view) !== "paused") return null;
-  if (pauseReason !== "entitlement-lapsed" && !exportIsTheRemedy(pauseReason)) {
+  if (!exportIsTheRemedy(pauseReason)) {
     return null;
   }
-  return <PausedRemedies pauseReason={pauseReason} />;
+  return <PausedRemedies />;
 }
 
-function PausedRemedies(props: {
-  readonly pauseReason: EpicDurabilityPauseReasonV15 | null;
-}) {
-  const { pauseReason } = props;
-  const runnerHost = useRunnerHost();
+function PausedRemedies() {
   const exportArtifacts = useEpicExportArtifacts();
   const records = useEpicArtifactRecords();
   const meta = useEpicSnapshotMeta();
@@ -60,18 +53,11 @@ function PausedRemedies(props: {
     });
   };
   return (
-    <>
-      {pauseReason === "entitlement-lapsed" ? (
-        <UpgradeAction signInUrl={runnerHost.signInUrl} />
-      ) : null}
-      {exportIsTheRemedy(pauseReason) ? (
-        <ExportArtifactsAction
-          disabled={artifacts.length === 0 || exportArtifacts.isPending}
-          pending={exportArtifacts.isPending}
-          onExport={exportLocalArtifacts}
-        />
-      ) : null}
-    </>
+    <ExportArtifactsAction
+      disabled={artifacts.length === 0 || exportArtifacts.isPending}
+      pending={exportArtifacts.isPending}
+      onExport={exportLocalArtifacts}
+    />
   );
 }
 
@@ -83,29 +69,6 @@ function RemedyActionSpinner() {
       testId={undefined}
       variant={undefined}
     />
-  );
-}
-
-/**
- * The link goes through `useRunnerOpenExternalLink` rather than the bridge
- * directly: the mutation owns the shared query key and the runner-error toast,
- * so a rejected `openExternalLink` is reported instead of silently dropped.
- */
-function UpgradeAction(props: { readonly signInUrl: string }) {
-  const { isPending, openLink } = useOpenLinkWithPending();
-  return (
-    <button
-      type="button"
-      className="text-ui-xs font-medium underline underline-offset-2"
-      data-testid="epic-durability-upgrade"
-      disabled={isPending}
-      onClick={() => {
-        void openLink(resolvePlatformBaseUrl(props.signInUrl), "auth", null);
-      }}
-    >
-      Upgrade
-      {isPending ? <RemedyActionSpinner /> : null}
-    </button>
   );
 }
 
@@ -141,9 +104,9 @@ function ExportArtifactsAction(props: {
  * so the person can take them somewhere. Reaching a preserved epic and finding
  * nothing to do with it would be the dark archive with a nicer label.
  *
- * The other three paused reasons are deliberately absent: an entitlement lapse
- * has an Upgrade path, and the two delete-bookkeeping reasons are transient
- * states of an epic that is not going anywhere.
+ * The other two paused reasons are deliberately absent: the two
+ * delete-bookkeeping reasons are transient states of an epic that is not going
+ * anywhere.
  */
 function exportIsTheRemedy(
   pauseReason: EpicDurabilityPauseReasonV15 | null,

--- a/protocol/src/auth/_internal/schemas.ts
+++ b/protocol/src/auth/_internal/schemas.ts
@@ -167,13 +167,6 @@ export const authenticatedUserBaseSchema = z.object({
   user: userSchema,
   userSubscription: traycerUserSubscriptionSchema,
   payAsYouGoUsage: payAsYouGoUsageSchema,
-  // Additive cloud-sync entitlement (traycer-server is the sole computation
-  // site; authn embeds the snapshot). Optional so old hosts and fail-soft
-  // payloads without the fields still parse; Zod clients on this contract
-  // retain the keys instead of stripping them as unknown.
-  cloudSyncAllowed: z.boolean().optional(),
-  cloudSyncObservedAt: z.string().datetime().optional(),
-  graceExpiresAt: z.string().optional(),
 });
 
 // ---- Authenticated-user response records ------------------------------- //

--- a/protocol/src/auth/user.ts
+++ b/protocol/src/auth/user.ts
@@ -110,18 +110,4 @@ export interface AuthenticatedUserBase {
   user: User;
   userSubscription: TraycerUserSubscription;
   payAsYouGoUsage: PayAsYouGoUsage;
-  /**
-   * Whether the caller may use cloud collab sync right now. Computed by
-   * traycer-server and embedded by authn-v3; optional so payloads without the
-   * field (old authn, or evaluate fail-soft) stay valid.
-   */
-  cloudSyncAllowed?: boolean;
-  /** Server evaluation instant, preserved across cache reads; absent on older payloads. */
-  cloudSyncObservedAt?: string;
-  /**
-   * ISO instant when free/pending tiers flip from allowed to denied — same
-   * wall clock `cloudSyncAllowed` compares against. Optional for the same
-   * fail-soft / old-host reasons as `cloudSyncAllowed`.
-   */
-  graceExpiresAt?: string;
 }

--- a/protocol/src/host/epic/__tests__/epic-subscribe.test.ts
+++ b/protocol/src/host/epic/__tests__/epic-subscribe.test.ts
@@ -190,10 +190,7 @@ describe("epic.subscribe@1.0 server frames", () => {
   });
 
   it("@1.6 keeps the pause reasons the frozen minors already spoke", () => {
-    for (const pauseReason of [
-      "entitlement-lapsed",
-      "access-revoked",
-    ] as const) {
+    for (const pauseReason of ["access-revoked"] as const) {
       const frame = {
         kind: "cloudSyncStatus" as const,
         epicId: "epic-1",

--- a/protocol/src/host/epic/subscribe.ts
+++ b/protocol/src/host/epic/subscribe.ts
@@ -255,14 +255,11 @@ export const epicPromotionStateSchema = z.enum(["pending", "active"]);
 export type EpicPromotionState = z.infer<typeof epicPromotionStateSchema>;
 
 /**
- * The two pause reasons the renderer must act on differently. The persisted
- * registry field is intentionally wider, so the host maps recognised values
- * to this closed wire union and omits unknown values.
+ * The pause reason the renderer must act on. The persisted registry field is
+ * intentionally wider, so the host maps recognised values to this closed wire
+ * union and omits unknown values.
  */
-export const epicDurabilityPauseReasonSchema = z.enum([
-  "entitlement-lapsed",
-  "access-revoked",
-]);
+export const epicDurabilityPauseReasonSchema = z.enum(["access-revoked"]);
 export type EpicDurabilityPauseReason = z.infer<
   typeof epicDurabilityPauseReasonSchema
 >;
@@ -294,7 +291,6 @@ export type EpicDurabilityPauseReason = z.infer<
  * it.
  */
 export const epicDurabilityPauseReasonSchemaV15 = z.enum([
-  "entitlement-lapsed",
   "access-revoked",
   "delete-pending-acknowledgement",
   "delete-tombstone-unscoped-cleared",


### PR DESCRIPTION
## Why

Cloud sync is free for every account. The cloud-sync entitlement machinery (traycer-server free-tier gate, authn-v3 payload embedding, host entitlement decisions) is being removed end to end. This PR is the OSS half.

## What

- `authenticatedUserBaseSchema` / `AuthenticatedUserBase` lose `cloudSyncAllowed`, `cloudSyncObservedAt`, `graceExpiresAt`.
- `epic.subscribe` pause-reason enums lose `entitlement-lapsed`.
- gui-app durability panel drops the entitlement-lapsed copy and the Upgrade remedy. Other pause reasons and the export remedy are unchanged.

## Protocol compatibility

No minor bump. These fields were added into `authenticated-user-response@1.0` (#889, #1829) and the pause-reason enums (#889) without a minor bump, and no shipped release carries them: `git tag --contains 4583698ac` and `git tag --contains 3824dbe0f` are both empty (newest releases: host-v1.3.1, desktop-v1.3.0). Removing them restores the released record shape. The compat gate's released-baseline surface contains none of these names.

Kept on purpose: `needs-cloud-sync` (still emitted when the home store is unavailable) and `FreeTierNoCloudSyncError` (released; swept later once the server no longer emits the code).

## Validation

- `bun run --cwd traycer compile`: all 6 projects pass.
- protocol `epic-subscribe.test.ts` 50/50, gui-app `epic-durability-plane.test.tsx` 30/30.

Internal half: traycerai/traycer-internal `cloud-for-all` (pins this branch; re-pinned to the squash after merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
