### PR TITLE
fix(gui-app): icon-only Add folder on a narrow composer

### DIFF
--- a/clients/gui-app/src/components/home/composer/composer-workspace-mode-row.tsx
+++ b/clients/gui-app/src/components/home/composer/composer-workspace-mode-row.tsx
@@ -1,4 +1,6 @@
 import type { ReactNode } from "react";
+import { ComposerNarrowProvider } from "@/components/home/composer/composer-narrow-context";
+import { useComposerNarrowObserver } from "@/components/home/composer/composer-narrow-hooks";
 
 interface ComposerWorkspaceRowProps {
   /**
@@ -13,11 +15,23 @@ interface ComposerReadonlyWorkspaceModeRowProps {
   readonly workspaceSlot: ReactNode;
 }
 
+/**
+ * The narrow boundary for the controls it lays out. It renders beside
+ * `ComposerShell`, not inside it, so the shell's narrow provider covers only
+ * the editor and toolbar; the row measures its own width against the same
+ * breakpoint and provides it to its controls.
+ */
 export function ComposerWorkspaceRow(props: ComposerWorkspaceRowProps) {
+  const { ref: narrowRef, isNarrow } = useComposerNarrowObserver();
   return (
-    <div className="@container grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-2 overflow-hidden">
-      {props.workspaceControls}
-    </div>
+    <ComposerNarrowProvider isNarrow={isNarrow}>
+      <div
+        ref={narrowRef}
+        className="@container grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-2 overflow-hidden"
+      >
+        {props.workspaceControls}
+      </div>
+    </ComposerNarrowProvider>
   );
 }
 

--- a/clients/gui-app/src/components/home/host-workspace-selector/__tests__/home-summary-empty.test.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/__tests__/home-summary-empty.test.tsx
@@ -7,6 +7,7 @@ import {
   render,
   screen,
   waitFor,
+  within,
 } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAuthStore } from "@/stores/auth/auth-store";
@@ -15,6 +16,7 @@ import type { WorktreeWorkspaceSummaryV15 } from "@traycer/protocol/host/worktre
 import type { JsonContent } from "@traycer/protocol/common/registry";
 import type { ResolvedFolder } from "@/lib/workspace/resolved-folder";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import { ComposerWorkspaceRow } from "@/components/home/composer/composer-workspace-mode-row";
 import type { ComposerPromptEditorHandle } from "@/components/chat/composer/composer-prompt-editor";
 import { createComposerEditorIncarnation } from "@/lib/composer/composer-editor-incarnation";
 import { useLandingComposerActions } from "@/components/home/hooks/use-landing-composer-actions";
@@ -418,6 +420,70 @@ function renderControl(layout: "inline" | "stacked") {
   return queryClient;
 }
 
+const WORKSPACE_ROW_HOST_TEST_ID = "composer-workspace-row-host";
+// Either side of the composer's 512px narrow breakpoint.
+const NARROW_ROW_WIDTH = 390;
+const WIDE_ROW_WIDTH = 720;
+
+/**
+ * Mounts the controls inside the composer's real workspace row and gives that
+ * row a measured width, so the narrow read comes from the row's own observer
+ * rather than a hand-set provider. jsdom measures every element at 0px, which
+ * would otherwise make every row narrow.
+ */
+function renderControlInWorkspaceRow(rowWidth: number): QueryClient {
+  vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
+    function measure(this: HTMLElement): DOMRect {
+      if (this.parentElement?.dataset.testid === WORKSPACE_ROW_HOST_TEST_ID) {
+        return new DOMRect(0, 0, rowWidth, 28);
+      }
+      return new DOMRect(0, 0, 0, 0);
+    },
+  );
+  const rowHost = document.createElement("div");
+  rowHost.dataset.testid = WORKSPACE_ROW_HOST_TEST_ID;
+  document.body.appendChild(rowHost);
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  render(
+    <QueryClientProvider client={queryClient}>
+      <TooltipProvider>
+        <ComposerWorkspaceRow
+          workspaceControls={
+            <ActiveHostWorkspaceControls
+              disabled={false}
+              stagingKey={{
+                surface: "landing",
+                hostId: "host-home",
+                draftId: null,
+              }}
+              workspaceSeed={null}
+              seedIntent={null}
+              seedIntentOverride={null}
+              layout="inline"
+              hostScope={{ kind: "active" }}
+            />
+          }
+        />
+      </TooltipProvider>
+    </QueryClientProvider>,
+    { container: rowHost },
+  );
+  return queryClient;
+}
+
+function seedOneRecentWorkspace(): void {
+  mocks.negotiatedVersion.current = { major: 1, minor: 2 };
+  mocks.recentsQuery.current = {
+    data: {
+      recentWorkspaces: [
+        { path: "/workspace/recent", lastOpenedAt: "2026-08-18T00:00:00.000Z" },
+      ],
+    },
+  };
+}
+
 /** The composer's resolved placement (P1.2), pointed at the mocked host. */
 function useTestPlacementTarget(): LandingPlacementTarget {
   return {
@@ -640,6 +706,71 @@ describe("landing workspace summary empty state", () => {
     expect(mocks.pickAndPrepareFolders).toHaveBeenCalledTimes(1);
 
     queryClient.clear();
+  });
+
+  describe("inside a narrow composer workspace row", () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("folds the Add folder word into its icon and keeps the name on hover", async () => {
+      const queryClient = renderControlInWorkspaceRow(NARROW_ROW_WIDTH);
+
+      const addFolder = screen.getByRole("button", { name: "Add folder" });
+      expect(addFolder).toBe(screen.getByTestId("folder-add"));
+      expect(screen.queryByText("Add folder")).toBeNull();
+      expect(addFolder.querySelector("svg")).not.toBeNull();
+
+      fireEvent.focus(addFolder);
+      expect((await screen.findByRole("tooltip")).textContent).toBe(
+        "Add folder",
+      );
+
+      fireEvent.click(addFolder);
+      expect(mocks.pickAndPrepareFolders).toHaveBeenCalledTimes(1);
+      queryClient.clear();
+    });
+
+    it("keeps the Add folder word when the row is wide", () => {
+      const queryClient = renderControlInWorkspaceRow(WIDE_ROW_WIDTH);
+
+      const addFolder = screen.getByTestId("folder-add");
+      expect(addFolder.textContent).toContain("Add folder");
+      expect(addFolder.hasAttribute("aria-label")).toBe(false);
+      queryClient.clear();
+    });
+
+    it("folds the recent-folders trigger too, but not the picker's own Add folder row", async () => {
+      seedOneRecentWorkspace();
+      const queryClient = renderControlInWorkspaceRow(NARROW_ROW_WIDTH);
+
+      const trigger = screen.getByRole("button", { name: "Add folder" });
+      expect(trigger).toBe(screen.getByTestId("folder-add"));
+      expect(trigger.textContent).toBe("");
+      expect(trigger.querySelector("svg")).not.toBeNull();
+
+      fireEvent.focus(trigger);
+      expect((await screen.findByRole("tooltip")).textContent).toBe(
+        "Add folder",
+      );
+
+      fireEvent.click(trigger);
+      const popover = await screen.findByTestId("home-workspace-rows-popover");
+      expect(within(popover).getByTestId("folder-add").textContent).toContain(
+        "Add folder",
+      );
+      queryClient.clear();
+    });
+
+    it("keeps the recent-folders trigger's word when the row is wide", () => {
+      seedOneRecentWorkspace();
+      const queryClient = renderControlInWorkspaceRow(WIDE_ROW_WIDTH);
+
+      const trigger = screen.getByTestId("folder-add");
+      expect(trigger.textContent).toContain("Add folder");
+      expect(trigger.hasAttribute("aria-label")).toBe(false);
+      queryClient.clear();
+    });
   });
 
   it("keeps a folder active when moving it to Recent fails", async () => {

--- a/clients/gui-app/src/components/home/host-workspace-selector/workspace-folder-rows.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/workspace-folder-rows.tsx
@@ -92,6 +92,7 @@ export function WorkspaceFolderRows(props: {
       pending={props.addFolderPending}
       disabled={props.addFolderDisabled}
       disabledReason={props.addFolderDisabledReason}
+      iconOnly={false}
     />
   );
   // Terminal-agent "Update" action: pinned to the far right of the folder block
@@ -215,20 +216,30 @@ function DiscardStagedButton(props: {
   );
 }
 
+export const ADD_FOLDER_LABEL = "Add folder";
+
+/**
+ * `iconOnly` drops the visible word for a row too narrow to spare it; the
+ * button keeps its name through `aria-label` and a hover tooltip. A disabled
+ * reason still owns the tooltip when there is one - a button gets one tooltip.
+ */
 export function AddFolderButton(props: {
   readonly onAddFolder: AddFolderHandler;
   readonly pending: boolean;
   readonly disabled: boolean;
   readonly disabledReason: string | null;
+  readonly iconOnly: boolean;
 }) {
+  const buttonDisabled = props.pending || props.disabled;
   const button = (
     <Button
       type="button"
-      size="sm"
+      size={props.iconOnly ? "icon-sm" : "sm"}
       variant="ghost"
       className="rounded-lg text-muted-foreground"
       data-testid="folder-add"
-      disabled={props.pending || props.disabled}
+      aria-label={props.iconOnly ? ADD_FOLDER_LABEL : undefined}
+      disabled={buttonDisabled}
       onClick={() => {
         void props.onAddFolder();
       }}
@@ -242,22 +253,40 @@ export function AddFolderButton(props: {
       ) : (
         <FolderPlus data-icon="inline-start" />
       )}
-      <span className="truncate">Add folder</span>
+      {props.iconOnly ? null : (
+        <span className="truncate">{ADD_FOLDER_LABEL}</span>
+      )}
     </Button>
   );
-  if (props.disabled && props.disabledReason !== null) {
-    return (
-      <TooltipWrapper
-        label={props.disabledReason}
-        side="top"
-        sideOffset={undefined}
-        align={undefined}
-      >
+  const tooltipLabel = addFolderTooltipLabel(props);
+  if (tooltipLabel === null) return button;
+  return (
+    <TooltipWrapper
+      label={tooltipLabel}
+      side="top"
+      sideOffset={undefined}
+      align={undefined}
+    >
+      {/* A disabled button fires no pointer events, so a wrapper takes the
+          hover in its place. */}
+      {buttonDisabled ? (
         <span className="inline-flex w-fit">{button}</span>
-      </TooltipWrapper>
-    );
+      ) : (
+        button
+      )}
+    </TooltipWrapper>
+  );
+}
+
+function addFolderTooltipLabel(input: {
+  readonly disabled: boolean;
+  readonly disabledReason: string | null;
+  readonly iconOnly: boolean;
+}): string | null {
+  if (input.disabled && input.disabledReason !== null) {
+    return input.disabledReason;
   }
-  return button;
+  return input.iconOnly ? ADD_FOLDER_LABEL : null;
 }
 
 /**

--- a/clients/gui-app/src/components/home/host-workspace-selector/workspace-folder-summary-control.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/workspace-folder-summary-control.tsx
@@ -13,6 +13,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { useActivePaneEffect } from "@/components/epic-tabs/pane-visibility-context";
+import { useIsComposerNarrow } from "@/components/home/composer/composer-narrow-hooks";
 import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 import { Button } from "@/components/ui/button";
 import { HoverPreviewCard } from "@/components/ui/hover-preview-card";
@@ -27,6 +28,7 @@ import { useCompactRelativeTime } from "@/lib/relative-time";
 import { preserveWhenNestedOverlay } from "./preserve-when-nested-overlay";
 import { useDialogOverlayBoundaryEl } from "@/providers/dialog-overlay-boundary-context";
 import {
+  ADD_FOLDER_LABEL,
   AddFolderButton,
   type AddFolderHandler,
   WorkspaceFolderRows,
@@ -169,6 +171,10 @@ export function WorkspaceFolderSummaryControl(props: {
   readonly moveToRecent: boolean;
 }) {
   const itemCount = props.items.length;
+  // The word folds away on a narrow composer, where the row this control
+  // shares with its siblings has the least width to give. Outside a composer
+  // the context reads wide, so the word stays.
+  const iconOnly = useIsComposerNarrow();
   const [overlayState, setOverlayState] = useState<SummaryOverlayState>({
     workspacePopoverOpen: false,
     summaryHoverOpen: false,
@@ -285,6 +291,7 @@ export function WorkspaceFolderSummaryControl(props: {
         pending={props.addFolderPending}
         disabled={props.addFolderDisabled}
         disabledReason={props.addFolderDisabledReason}
+        iconOnly={iconOnly}
       />
     );
   }
@@ -295,19 +302,14 @@ export function WorkspaceFolderSummaryControl(props: {
     <button
       type="button"
       data-testid="folder-add"
+      aria-label={iconOnly ? ADD_FOLDER_LABEL : undefined}
       disabled={emptyRecentDisabled}
       className="inline-flex w-fit items-center gap-2 rounded-md px-1.5 py-1 text-ui-sm text-muted-foreground outline-none transition-[background-color,color] hover:bg-foreground/5 hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/60 disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
     >
-      {props.addFolderPending ? (
-        <AgentSpinningDots
-          className="text-current"
-          testId={undefined}
-          variant="dots"
-        />
-      ) : (
-        <FolderPlus className="size-4" aria-hidden />
-      )}
-      <span>Add folder</span>
+      <EmptyRecentAddFolderContent
+        pending={props.addFolderPending}
+        iconOnly={iconOnly}
+      />
     </button>
   ) : (
     <WorkspaceSummaryTrigger
@@ -328,6 +330,7 @@ export function WorkspaceFolderSummaryControl(props: {
       disabledReason={
         props.addFolderDisabled ? props.addFolderDisabledReason : null
       }
+      iconOnly={iconOnly}
     />
   ) : (
     <HoverPreviewCard
@@ -448,13 +451,44 @@ export function WorkspaceFolderSummaryControl(props: {
   );
 }
 
+function EmptyRecentAddFolderContent(props: {
+  readonly pending: boolean;
+  readonly iconOnly: boolean;
+}): ReactNode {
+  return (
+    <>
+      {props.pending ? (
+        <AgentSpinningDots
+          className="text-current"
+          testId={undefined}
+          variant="dots"
+        />
+      ) : (
+        <FolderPlus className="size-4" aria-hidden />
+      )}
+      {props.iconOnly ? null : <span>{ADD_FOLDER_LABEL}</span>}
+    </>
+  );
+}
+
 function EmptyRecentFolderTrigger(props: {
   readonly trigger: ReactNode;
   readonly disabled: boolean;
   readonly disabledReason: string | null;
+  readonly iconOnly: boolean;
 }): ReactNode {
   if (!props.disabled) {
-    return <PopoverTrigger asChild>{props.trigger}</PopoverTrigger>;
+    // An icon-only trigger names itself on hover; `null` renders no tooltip.
+    return (
+      <TooltipWrapper
+        label={props.iconOnly ? ADD_FOLDER_LABEL : null}
+        side="top"
+        sideOffset={undefined}
+        align={undefined}
+      >
+        <PopoverTrigger asChild>{props.trigger}</PopoverTrigger>
+      </TooltipWrapper>
+    );
   }
   if (props.disabledReason === null) return props.trigger;
   return (


### PR DESCRIPTION
## What changes

On a narrow composer (the phone, or any composer under the 512px narrow breakpoint), the **Add folder** control in the row below the input drops its word and shows only the folder icon. The icon keeps its accessible name (`aria-label="Add folder"`) and shows "Add folder" as a tooltip on hover/focus, the same way the composer toolbar's icon-only buttons do.

Both shapes of the control fold:

- the direct **Add folder** button (no folders, no recent folders)
- the **Add folder** trigger that opens the picker when recent folders exist

## Why

The row below the input has to hold the host picker, the folder control and the trailing chips. On a narrow composer it has the least room, and the "Add folder" word was the widest thing in it.

The row renders beside `ComposerShell`, not inside it, so the shell's narrow provider never reached these controls. `ComposerWorkspaceRow` now measures its own width against the same breakpoint (`useComposerNarrowObserver`) and provides it to the controls it lays out. Nothing else inside the row reads the narrow context today, so Add folder is the only thing that changes.

## Unchanged

- A wide composer keeps the word.
- The picker popover's own "Add folder" row keeps the word at every width (`AddFolderButton` takes an explicit `iconOnly`, and the popover passes `false`).
- Surfaces outside a composer (tiles, dialogs) read the context default (wide), so they keep the word.
- Handlers, `data-testid="folder-add"`, pending spinner and disabled states. A disabled reason still owns the tooltip when present, so a button never gets two tooltips.

## Tests

`home-summary-empty.test.tsx` mounts the real `ComposerWorkspaceRow` around the real controls with the row's measured width stubbed either side of 512px:

- narrow: no "Add folder" text, the button is still found by role name "Add folder", icon present, tooltip reads "Add folder", click still adds
- wide: word visible, no `aria-label`
- the recent-folders trigger folds too, while the picker's own Add folder row keeps the word

Mutation-checked: making the control ignore the narrow read, making the row provide `false`, or flipping the popover row to icon-only each fails the new tests.
