### PR TITLE
fix(gui-app): prevent submitted landing drafts from reopening

### DIFF
--- a/clients/gui-app/src/components/layout/__tests__/tab-strip.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/tab-strip.test.tsx
@@ -20,6 +20,7 @@ import {
 } from "@/stores/notifications/app-local-notifications-store";
 import { installTabSyncCoordinator } from "@/lib/tab-sync/tab-sync-coordinator";
 import { useTabsStore } from "@/stores/tabs/store";
+import { tabCommandCoordinator } from "@/stores/tabs/tab-command-coordinator";
 import { useAuthStore } from "@/stores/auth/auth-store";
 import {
   recordNegotiatedHostManifest,
@@ -969,6 +970,13 @@ describe("<TabStrip />", () => {
   it("renders a hover chrome layer for inactive header tabs", async () => {
     openEpicFixture(EPIC_A);
     openEpicFixture(EPIC_B);
+    // Source reconciliation preserves the current selection when B is added
+    // in the background. Explicitly select B for this active/inactive chrome
+    // fixture so its intended distinction is independent of insertion order.
+    tabCommandCoordinator.activateTab({
+      kind: "ref",
+      ref: { kind: "epic", id: EPIC_B.id },
+    });
     const router = buildRouter("/epics/e-b/e-b");
     render(<RouterProvider router={router} />);
 

--- a/clients/gui-app/src/lib/drafts/__tests__/draft-mirror-session.test.ts
+++ b/clients/gui-app/src/lib/drafts/__tests__/draft-mirror-session.test.ts
@@ -1208,6 +1208,206 @@ describe("DraftMirrorSession", () => {
     session.close();
   });
 
+  it("advances the committed upsert frontier before acknowledging deletion", async () => {
+    const draftId = "late-success-after-delete";
+    const heldRow = landingDocument({ draftId, revision: 4 });
+    const committedRow = landingDocument({ draftId, revision: 7 });
+    const stream = createStreamHarness();
+    const pendingDeletes = new Set<string>();
+    const writes: DraftDirtyWrite[] = [];
+    let upsertStarted = false;
+    let resolveUpsert:
+      | ((response: { readonly draft: DraftDocument }) => void)
+      | undefined;
+    const upsertResponse = new Promise<{ readonly draft: DraftDocument }>(
+      (resolve) => {
+        resolveUpsert = resolve;
+      },
+    );
+    const sink = createSink({
+      dirty: new Set(),
+      writes,
+      pendingDeletes,
+    });
+    const session = new DraftMirrorSession({
+      hostId: HOST_ID,
+      rpc: createRpc({
+        list: () => Promise.resolve(listResponse([], 0, EMPTY_LIST_TOMBSTONES)),
+        upsert: () => {
+          upsertStarted = true;
+          return upsertResponse;
+        },
+        delete: (id) => {
+          pendingDeletes.add(id);
+          return Promise.resolve({ deleted: true });
+        },
+      }),
+      streamClient: stream.client,
+      sink,
+      timing: { debounceMs: 0, maxWaitMs: 0 },
+      now: () => 0,
+    });
+    session.start();
+    await vi.waitFor(() => {
+      expect(stream.subscribeCalls.count).toBe(1);
+    });
+    stream.emit({
+      kind: "upsert",
+      hasBinaryPayload: false,
+      storeSeq: 4,
+      draftId,
+      revision: heldRow.revision,
+      draft: heldRow,
+    });
+    await Promise.resolve();
+    expect(sink.upserts).toEqual([heldRow]);
+
+    writes.push({ write: landingWrite(draftId, 4), generation: 1 });
+    const upserting = session.flush([draftId]);
+    await vi.waitFor(() => {
+      expect(upsertStarted).toBe(true);
+    });
+    const deleting = session.deleteOnHost(draftId);
+    resolveUpsert?.({ draft: committedRow });
+    await deleting;
+    pendingDeletes.delete(draftId);
+    await upserting;
+
+    // The delete ACK clears the chat-style pending receipt. Deletion must
+    // include committed r7 in its tombstone frontier to reject the late echo.
+    stream.emit({
+      kind: "upsert",
+      hasBinaryPayload: false,
+      storeSeq: 7,
+      draftId,
+      revision: committedRow.revision,
+      draft: committedRow,
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(sink.upserts).toEqual([heldRow]);
+    expect(sink.synced).toEqual([
+      { draftId, hostRevision: 4 },
+      { draftId, hostRevision: 0 },
+    ]);
+    session.close();
+  });
+
+  it("preserves a newer held row when an older retired upsert completes", async () => {
+    const draftId = "late-upsert-after-delete";
+    const heldRow = landingDocument({ draftId, revision: 4 });
+    const committedRow = landingDocument({ draftId, revision: 7 });
+    const stream = createStreamHarness();
+    const pendingDeletes = new Set<string>();
+    const writes: DraftDirtyWrite[] = [];
+    let upsertStarted = false;
+    let resolveUpsert:
+      | ((response: { readonly draft: DraftDocument }) => void)
+      | undefined;
+    const upsertResponse = new Promise<{ readonly draft: DraftDocument }>(
+      (resolve) => {
+        resolveUpsert = resolve;
+      },
+    );
+    const sink = createSink({
+      dirty: new Set(),
+      writes,
+      pendingDeletes,
+    });
+    const session = new DraftMirrorSession({
+      hostId: HOST_ID,
+      rpc: createRpc({
+        list: () => Promise.resolve(listResponse([], 0, EMPTY_LIST_TOMBSTONES)),
+        upsert: () => {
+          upsertStarted = true;
+          return upsertResponse;
+        },
+        delete: (id) => {
+          pendingDeletes.add(id);
+          return Promise.resolve({ deleted: true });
+        },
+      }),
+      streamClient: stream.client,
+      sink,
+      timing: { debounceMs: 0, maxWaitMs: 0 },
+      now: () => 0,
+    });
+    session.start();
+    await vi.waitFor(() => {
+      expect(stream.subscribeCalls.count).toBe(1);
+    });
+    stream.emit({
+      kind: "upsert",
+      hasBinaryPayload: false,
+      storeSeq: 4,
+      draftId,
+      revision: heldRow.revision,
+      draft: heldRow,
+    });
+    await Promise.resolve();
+    expect(sink.upserts).toEqual([heldRow]);
+
+    writes.push({ write: landingWrite(draftId, 4), generation: 1 });
+    const upserting = session.flush([draftId]);
+    await vi.waitFor(() => {
+      expect(upsertStarted).toBe(true);
+    });
+    const deleting = session.deleteOnHost(draftId);
+    const newerHeldRow = landingDocument({ draftId, revision: 9 });
+    stream.emit({
+      kind: "upsert",
+      hasBinaryPayload: false,
+      storeSeq: 9,
+      draftId,
+      revision: newerHeldRow.revision,
+      draft: newerHeldRow,
+    });
+    await Promise.resolve();
+    expect(sink.upserts).toEqual([heldRow, newerHeldRow]);
+    resolveUpsert?.({ draft: committedRow });
+    await deleting;
+    pendingDeletes.delete(draftId);
+    await upserting;
+
+    // The chat-style pending receipt is cleared after the ACK. The held
+    // tombstone, not a durable landing receipt, must still reject this late
+    // echo and any older response.
+    stream.emit({
+      kind: "upsert",
+      hasBinaryPayload: false,
+      storeSeq: 7,
+      draftId,
+      revision: committedRow.revision,
+      draft: committedRow,
+    });
+    stream.emit({
+      kind: "upsert",
+      hasBinaryPayload: false,
+      storeSeq: 9,
+      draftId,
+      revision: newerHeldRow.revision,
+      draft: newerHeldRow,
+    });
+    stream.emit({
+      kind: "upsert",
+      hasBinaryPayload: false,
+      storeSeq: 6,
+      draftId,
+      revision: 6,
+      draft: landingDocument({ draftId, revision: 6 }),
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(sink.upserts).toEqual([heldRow, newerHeldRow]);
+    expect(sink.synced).toEqual([
+      { draftId, hostRevision: 4 },
+      { draftId, hostRevision: 0 },
+    ]);
+    session.close();
+  });
+
   it("drops waiting landing saves at delete and gates generations appended after it", async () => {
     const draftId = "cancelled-landing";
     const first = landingWrite(draftId, 0);

--- a/clients/gui-app/src/lib/drafts/__tests__/draft-mirror-session.test.ts
+++ b/clients/gui-app/src/lib/drafts/__tests__/draft-mirror-session.test.ts
@@ -92,7 +92,10 @@ function listResponse(
   };
 }
 
-function landingWrite(draftId: string, revision: number): DraftWrite {
+function landingWrite(
+  draftId: string,
+  revision: number,
+): Extract<DraftWrite, { readonly kind: "landing" }> {
   return {
     draftId,
     kind: "landing",
@@ -181,6 +184,9 @@ function createSink(options: {
   readonly writes: DraftDirtyWrite[];
   readonly pendingDeletes?: Set<string>;
   readonly prepareWrite?: DraftMirrorSink["prepareWrite"];
+  readonly collectDirtyWrites?: DraftMirrorSink["collectDirtyWrites"];
+  readonly rememberSynced?: DraftMirrorSink["rememberSynced"];
+  readonly applyUpsert?: DraftMirrorSink["applyUpsert"];
   readonly dropAbsentFromList?: DraftMirrorSink["dropAbsentFromList"];
 }): DraftMirrorSink & {
   readonly upserts: DraftDocument[];
@@ -209,17 +215,22 @@ function createSink(options: {
     completeDelete: (draftId) => {
       options.pendingDeletes?.delete(draftId);
     },
-    applyUpsert: (document) => {
-      upserts.push(document);
-      return Promise.resolve();
-    },
+    applyUpsert:
+      options.applyUpsert ??
+      ((document) => {
+        upserts.push(document);
+        return Promise.resolve();
+      }),
     applyDelete: (draftId) => {
       deletes.push(draftId);
     },
-    collectDirtyWrites: () => Promise.resolve(options.writes),
-    rememberSynced: (draftId, hostRevision) => {
-      synced.push({ draftId, hostRevision });
-    },
+    collectDirtyWrites:
+      options.collectDirtyWrites ?? (() => Promise.resolve(options.writes)),
+    rememberSynced:
+      options.rememberSynced ??
+      ((draftId, hostRevision) => {
+        synced.push({ draftId, hostRevision });
+      }),
     prepareWrite:
       options.prepareWrite ?? ((_hostId, write) => Promise.resolve(write)),
     dropAbsentFromList:
@@ -1054,5 +1065,227 @@ describe("DraftMirrorSession", () => {
     session.close();
     useLandingDraftStore.setState({ drafts: [], activeDraftId: null });
     resetDraftMirrorCoordinatorForTests();
+  });
+
+  it("coalesces a newer landing save behind a stalled save to the latest snapshot", async () => {
+    const draftId = "coalesced-landing";
+    const first = landingWrite(draftId, 0);
+    const latest: Extract<DraftWrite, { readonly kind: "landing" }> = {
+      ...first,
+      lastTouchedAt: 2,
+      portable: {
+        ...first.portable,
+        content: {
+          type: "doc",
+          content: [
+            { type: "paragraph", content: [{ type: "text", text: "latest" }] },
+          ],
+        },
+      },
+    };
+    const writes: DraftDirtyWrite[] = [{ write: first, generation: 1 }];
+    const dirty = new Set([draftId]);
+    let collectCalls = 0;
+    let prepareCalls = 0;
+    let finishFirstPrepare: (() => void) | undefined;
+    const firstPrepare = new Promise<void>((resolve) => {
+      finishFirstPrepare = resolve;
+    });
+    const sent: DraftWrite[] = [];
+    const sink = createSink({
+      dirty,
+      writes,
+      collectDirtyWrites: () => {
+        collectCalls += 1;
+        return Promise.resolve([...writes]);
+      },
+      prepareWrite: async (_hostId, write) => {
+        prepareCalls += 1;
+        if (prepareCalls === 1) await firstPrepare;
+        return write;
+      },
+      rememberSynced: (draftId) => {
+        dirty.delete(draftId);
+      },
+    });
+    const stream = createStreamHarness();
+    const session = new DraftMirrorSession({
+      hostId: HOST_ID,
+      rpc: createRpc({
+        list: () => Promise.resolve(listResponse([], 1, EMPTY_LIST_TOMBSTONES)),
+        upsert: (write) => {
+          sent.push(write);
+          return Promise.resolve({
+            draft: landingDocument({ draftId: write.draftId, revision: 1 }),
+          });
+        },
+        delete: () => Promise.resolve({ deleted: true }),
+      }),
+      streamClient: stream.client,
+      sink,
+      timing: { debounceMs: 0, maxWaitMs: 0 },
+      now: () => 0,
+    });
+    const firstFlush = session.flush([draftId]);
+    await vi.waitFor(() => {
+      expect(prepareCalls).toBe(1);
+    });
+
+    writes.splice(0, writes.length, { write: latest, generation: 2 });
+    const latestFlush = session.flush([draftId]);
+    await vi.waitFor(() => {
+      expect(collectCalls).toBeGreaterThanOrEqual(2);
+    });
+    finishFirstPrepare?.();
+    await Promise.all([firstFlush, latestFlush]);
+
+    expect(sent).toEqual([first, latest]);
+    session.close();
+  });
+
+  it("does not ACK an incoming landing row when a local edit lands during apply", async () => {
+    const draftId = "incoming-apply-edit";
+    const incoming = landingDocument({ draftId, revision: 2 });
+    const stream = createStreamHarness();
+    const dirty = new Set<string>();
+    const applied: DraftDocument[] = [];
+    let applyFinished = false;
+    let finishApply: (() => void) | undefined;
+    const applyGate = new Promise<void>((resolve) => {
+      finishApply = resolve;
+    });
+    const sink = createSink({
+      dirty,
+      writes: [],
+      applyUpsert: async (document) => {
+        applied.push(document);
+        await applyGate;
+        applyFinished = true;
+      },
+    });
+    const session = new DraftMirrorSession({
+      hostId: HOST_ID,
+      rpc: createRpc({
+        list: () => Promise.resolve(listResponse([], 0, EMPTY_LIST_TOMBSTONES)),
+        upsert: (write) =>
+          Promise.resolve({
+            draft: landingDocument({
+              draftId: write.draftId,
+              revision: write.revision + 1,
+            }),
+          }),
+        delete: () => Promise.resolve({ deleted: true }),
+      }),
+      streamClient: stream.client,
+      sink,
+      timing: { debounceMs: 0, maxWaitMs: 0 },
+      now: () => 0,
+    });
+    session.start();
+    await vi.waitFor(() => {
+      expect(stream.subscribeCalls.count).toBe(1);
+    });
+
+    stream.emit({
+      kind: "upsert",
+      hasBinaryPayload: false,
+      storeSeq: 1,
+      draftId,
+      revision: incoming.revision,
+      draft: incoming,
+    });
+    await vi.waitFor(() => {
+      expect(applied).toEqual([incoming]);
+    });
+    dirty.add(draftId);
+    finishApply?.();
+    await vi.waitFor(() => {
+      expect(applyFinished).toBe(true);
+    });
+    await Promise.resolve();
+
+    expect(sink.synced).toEqual([]);
+    session.close();
+  });
+
+  it("drops waiting landing saves at delete and gates generations appended after it", async () => {
+    const draftId = "cancelled-landing";
+    const first = landingWrite(draftId, 0);
+    const second: Extract<DraftWrite, { readonly kind: "landing" }> = {
+      ...first,
+      lastTouchedAt: 2,
+    };
+    const third: Extract<DraftWrite, { readonly kind: "landing" }> = {
+      ...first,
+      lastTouchedAt: 3,
+    };
+    const writes: DraftDirtyWrite[] = [{ write: first, generation: 1 }];
+    const dirty = new Set([draftId]);
+    const pendingDeletes = new Set<string>();
+    let collectCalls = 0;
+    let finishFirstUpsert: (() => void) | undefined;
+    let upsertStarted = false;
+    const firstUpsert = new Promise<void>((resolve) => {
+      finishFirstUpsert = resolve;
+    });
+    const sent: DraftWrite[] = [];
+    const deletes: string[] = [];
+    const sink = createSink({
+      dirty,
+      writes,
+      pendingDeletes,
+      collectDirtyWrites: () => {
+        collectCalls += 1;
+        return Promise.resolve([...writes]);
+      },
+      rememberSynced: (draftId) => {
+        dirty.delete(draftId);
+      },
+    });
+    const session = new DraftMirrorSession({
+      hostId: HOST_ID,
+      rpc: createRpc({
+        list: () => Promise.resolve(listResponse([], 1, EMPTY_LIST_TOMBSTONES)),
+        upsert: (write) => {
+          sent.push(write);
+          upsertStarted = true;
+          return firstUpsert.then(() => ({
+            draft: landingDocument({ draftId: write.draftId, revision: 1 }),
+          }));
+        },
+        delete: (draftId) => {
+          deletes.push(draftId);
+          return Promise.resolve({ deleted: true });
+        },
+      }),
+      streamClient: createStreamHarness().client,
+      sink,
+      timing: { debounceMs: 0, maxWaitMs: 0 },
+      now: () => 0,
+    });
+    const firstFlush = session.flush([draftId]);
+    await vi.waitFor(() => {
+      expect(upsertStarted).toBe(true);
+    });
+
+    writes.splice(0, writes.length, { write: second, generation: 2 });
+    const secondFlush = session.flush([draftId]);
+    await vi.waitFor(() => {
+      expect(collectCalls).toBeGreaterThanOrEqual(2);
+    });
+    pendingDeletes.add(draftId);
+    const deleting = session.deleteOnHost(draftId);
+
+    writes.splice(0, writes.length, { write: third, generation: 3 });
+    const thirdFlush = session.flush([draftId]);
+    await vi.waitFor(() => {
+      expect(collectCalls).toBeGreaterThanOrEqual(3);
+    });
+    finishFirstUpsert?.();
+    await Promise.all([firstFlush, secondFlush, thirdFlush, deleting]);
+
+    expect(sent).toEqual([first]);
+    expect(deletes).toEqual([draftId]);
+    session.close();
   });
 });

--- a/clients/gui-app/src/lib/drafts/draft-mirror-coordinator.ts
+++ b/clients/gui-app/src/lib/drafts/draft-mirror-coordinator.ts
@@ -91,6 +91,14 @@ import {
   type DraftMirrorSink,
 } from "./draft-mirror-session";
 import type { DraftMirrorTiming } from "./draft-mirror-timing";
+import {
+  completeLandingDraftDelete,
+  landingDraftIsRetired,
+  pendingLandingDraftDeleteHostId,
+  pendingLandingDraftDeleteIdsForHost,
+  retireLandingDraft,
+  resolveLandingDraftRetirementOwner,
+} from "./landing-draft-retirement";
 
 type SessionEntry = {
   readonly session: DraftMirrorSession;
@@ -99,6 +107,7 @@ type SessionEntry = {
 
 const sessions = new Map<string, SessionEntry>();
 const sessionClients = new Map<string, HostRequester<HostRpcRegistry>>();
+const knownLandingDraftIds = new Set<string>();
 const cloudScopeIdByHost = new Map<string, string | null>();
 const cloudScopeListeners = new Set<() => void>();
 
@@ -338,18 +347,29 @@ const sink: DraftMirrorSink = {
     );
   },
   isDeletePending(draftId) {
-    return composerSubmittedDraftDeleteIsPending(draftId);
+    return (
+      landingDraftIsRetired(draftId) ||
+      composerSubmittedDraftDeleteIsPending(draftId)
+    );
   },
   pendingDeleteIdsForHost(hostId) {
-    return pendingSubmittedDraftDeleteIdsForHost(hostId);
+    return [
+      ...pendingLandingDraftDeleteIdsForHost(hostId),
+      ...pendingSubmittedDraftDeleteIdsForHost(hostId),
+    ];
   },
   completeDelete(draftId) {
+    completeLandingDraftDelete(draftId);
     useComposerDraftStore.getState().completeSubmittedDraftDelete(draftId);
   },
   applyUpsert(document) {
     return applyHostDocument(document);
   },
   applyDelete(draftId) {
+    // A tombstone can arrive while the first landing upsert awaits its images,
+    // before there is any local row for applyLandingHostDelete to remove.
+    if (knownLandingDraftIds.has(draftId)) retireLandingDraft(draftId, null);
+    completeLandingDraftDelete(draftId);
     useComposerDraftStore.getState().completeSubmittedDraftDelete(draftId);
     applyLandingHostDelete(draftId);
     applyComposerHostDelete(draftId);
@@ -388,7 +408,22 @@ const sink: DraftMirrorSink = {
   },
 };
 
+function rejectRetiredLandingDocument(document: DraftDocument): boolean {
+  if (document.kind !== "landing" || !landingDraftIsRetired(document.draftId))
+    return false;
+  // Desktop may restore content before it has recovered host adoption.
+  // The first owner document supplies the missing delete destination, never
+  // a replacement visible row. ACKed receipts cannot be rearmed here.
+  resolveLandingDraftRetirementOwner(document.draftId, document.ownerHostId);
+  if (pendingLandingDraftDeleteHostId(document.draftId) !== null) {
+    routeLocalDelete(document.draftId);
+  }
+  return true;
+}
+
 async function applyHostDocument(document: DraftDocument): Promise<void> {
+  if (document.kind === "landing") knownLandingDraftIds.add(document.draftId);
+  if (rejectRetiredLandingDocument(document)) return;
   if (composerSubmittedDraftDeleteIsPending(document.draftId)) {
     await retrySubmittedDraftDelete(document.draftId);
     return;
@@ -416,6 +451,7 @@ async function applyHostDocument(document: DraftDocument): Promise<void> {
     return;
   }
   if (document.kind === "landing") {
+    if (rejectRetiredLandingDocument(document)) return;
     applyLandingHostDocument(document, document.portable.content);
     return;
   }
@@ -552,6 +588,8 @@ function warnUnboundInterviewTarget(
 }
 
 function hostIdForDraft(draftId: string): string | null {
+  const landingDeleteHostId = pendingLandingDraftDeleteHostId(draftId);
+  if (landingDeleteHostId !== null) return landingDeleteHostId;
   const pendingDeleteHostId = pendingSubmittedDraftDeleteHostId(draftId);
   if (pendingDeleteHostId !== null) return pendingDeleteHostId;
   const landing = useLandingDraftStore
@@ -602,7 +640,9 @@ function routeLocalEdit(draftId: string): void {
 function routeLocalDelete(draftId: string): void {
   const session = sessionForDraft(draftId);
   if (session === null) return;
-  void session.deleteOnHost(draftId);
+  void session.deleteOnHost(draftId).then((deleted) => {
+    if (deleted) completeLandingDraftDelete(draftId);
+  });
 }
 
 function routeLocalFlush(draftId: string): void {
@@ -739,6 +779,7 @@ export function resetDraftMirrorCoordinatorForTests(): void {
   }
   sessions.clear();
   sessionClients.clear();
+  knownLandingDraftIds.clear();
   cloudScopeIdByHost.clear();
   composerHostByChatId.clear();
   interviewHostByKey.clear();

--- a/clients/gui-app/src/lib/drafts/draft-mirror-session.ts
+++ b/clients/gui-app/src/lib/drafts/draft-mirror-session.ts
@@ -83,10 +83,11 @@ type PendingFlush = {
   retryCount: number;
 };
 
-/** One draft's outstanding `drafts.upsert`, and the generation it carries. */
+/** One active write and at most one latest, not-yet-started snapshot. */
 type PendingSend = {
   promise: Promise<void>;
-  readonly highestGeneration: number;
+  highestGeneration: number;
+  next: DraftDirtyWrite | null;
 };
 
 /**
@@ -103,19 +104,22 @@ export class DraftMirrorSession {
   private readonly now: () => number;
 
   /**
-   * Per-draft send chain. Two `upsertDirty` runs can overlap (a debounce
+   * Per-draft send worker. Two `upsertDirty` runs can overlap (a debounce
    * timer firing while a `flush` is awaiting `collectDirtyWrites`), and the
    * request coordinator keys its FIFO queue by the FULL params - so two
    * writes for the same draft carry different params and land in different
    * queues. The host applies an upsert as a whole-document LWW, so an older
    * body reaching it last wins. Ordering therefore has to be owned here.
    *
+   * Waiting snapshots are replaced, not appended: slow image uploads must
+   * not turn every keystroke into a queued whole-document write.
    * The entry lives only while a send for that draft is outstanding, so no
    * generation bookkeeping survives a drained chain - a store that later
    * restarts its own generation counter (a re-created row) is unaffected.
    */
   private readonly sendChain = new Map<string, PendingSend>();
   private readonly deleteChain = new Map<string, Promise<boolean>>();
+  private readonly retiredDraftIds = new Set<string>();
 
   private snapshotSeq = 0;
   private listedScopeId: string | null = null;
@@ -155,7 +159,7 @@ export class DraftMirrorSession {
   }
 
   noteDirty(draftId: string): void {
-    if (this.isAbandoned()) return;
+    if (this.isAbandoned() || this.writeIsRetired(draftId)) return;
     this.schedule(draftId);
   }
 
@@ -221,6 +225,10 @@ export class DraftMirrorSession {
    * can still find the row.
    */
   async deleteOnHost(draftId: string): Promise<boolean> {
+    this.retiredDraftIds.add(draftId);
+    this.clearTimer(draftId);
+    const pending = this.sendChain.get(draftId);
+    if (pending !== undefined) pending.next = null;
     const outstanding = this.deleteChain.get(draftId);
     if (outstanding !== undefined) return outstanding;
     const deleting = this.runDeleteOnHost(draftId).finally(() => {
@@ -287,11 +295,7 @@ export class DraftMirrorSession {
         });
         if (!this.sink.isDirty(document.draftId)) {
           await this.sink.applyUpsert(document);
-          this.sink.rememberSynced(
-            document.draftId,
-            document.revision,
-            Number.POSITIVE_INFINITY,
-          );
+          this.rememberIncomingSynced(document);
         }
       }
       for (const tombstone of listed.tombstones) {
@@ -396,11 +400,7 @@ export class DraftMirrorSession {
         revision: frame.revision,
       });
       await this.sink.applyUpsert(frame.draft);
-      this.sink.rememberSynced(
-        frame.draftId,
-        frame.revision,
-        Number.POSITIVE_INFINITY,
-      );
+      this.rememberIncomingSynced(frame.draft);
       return;
     }
     this.held.set(frame.draftId, {
@@ -434,6 +434,25 @@ export class DraftMirrorSession {
     this.armTimer(existing);
   }
 
+  private rememberIncomingSynced(document: DraftDocument): void {
+    const held = this.held.get(document.draftId);
+    // Awaiting images can admit a newer frame or local edit. An old apply
+    // must neither lower the frontier nor acknowledge those unsent edits.
+    if (
+      this.isAbandoned() ||
+      this.writeIsRetired(document.draftId) ||
+      held?.kind !== "row" ||
+      held.revision !== document.revision ||
+      this.sink.isDirty(document.draftId)
+    )
+      return;
+    this.sink.rememberSynced(
+      document.draftId,
+      document.revision,
+      Number.POSITIVE_INFINITY,
+    );
+  }
+
   private armTimer(entry: PendingFlush): void {
     if (entry.timer !== null) clearTimeout(entry.timer);
     const elapsed = this.now() - entry.firstScheduledAt;
@@ -443,6 +462,7 @@ export class DraftMirrorSession {
     );
     entry.timer = setTimeout(() => {
       entry.timer = null;
+      entry.firstScheduledAt = this.now();
       void this.upsertDirty([entry.draftId]);
     }, wait);
   }
@@ -463,13 +483,14 @@ export class DraftMirrorSession {
   }
 
   /**
-   * One draft's upsert, queued behind that draft's own outstanding send.
+   * One draft's latest upsert, replacing any snapshot still waiting to send.
    * Collection order and send order are not the same order, so a body an
    * equal-or-newer generation already covers is dropped rather than queued
    * behind it - re-sending it would hand the host the older document last.
    */
   private sendUpsert(entry: DraftDirtyWrite): Promise<void> {
     const draftId = entry.write.draftId;
+    if (this.writeIsRetired(draftId)) return Promise.resolve();
     const outstanding = this.sendChain.get(draftId);
     if (
       outstanding !== undefined &&
@@ -477,12 +498,30 @@ export class DraftMirrorSession {
     ) {
       return outstanding.promise;
     }
+    if (outstanding !== undefined) {
+      outstanding.highestGeneration = entry.generation;
+      outstanding.next = entry;
+      return outstanding.promise;
+    }
     const pending: PendingSend = {
       promise: Promise.resolve(),
       highestGeneration: entry.generation,
+      next: entry,
     };
-    pending.promise = (outstanding?.promise ?? Promise.resolve())
-      .then(() => this.runUpsert(entry))
+    pending.promise = Promise.resolve()
+      .then(async () => {
+        while (pending.next !== null) {
+          const next = pending.next;
+          pending.next = null;
+          await this.runUpsert(next);
+        }
+        // Retire the worker before its promise settles: a collector resumed
+        // in the following microtask must start a new worker, not append to
+        // one whose loop has already finished.
+        if (this.sendChain.get(draftId) === pending) {
+          this.sendChain.delete(draftId);
+        }
+      })
       .finally(() => {
         if (this.sendChain.get(draftId) === pending) {
           this.sendChain.delete(draftId);
@@ -495,13 +534,14 @@ export class DraftMirrorSession {
   private async runUpsert(entry: DraftDirtyWrite): Promise<void> {
     if (this.isAbandoned()) return;
     const draftId = entry.write.draftId;
-    if (this.sink.isDeletePending(draftId)) return;
+    if (this.writeIsRetired(draftId)) return;
     try {
       const prepared = await this.sink.prepareWrite(this.hostId, entry.write);
       // Blob preparation is asynchronous. Submission can fence the row while
       // this write is waiting there, so gate again at actual RPC dispatch.
-      if (this.isAbandoned() || this.sink.isDeletePending(draftId)) return;
+      if (this.isAbandoned() || this.writeIsRetired(draftId)) return;
       const response = await this.rpc.upsert(prepared);
+      if (this.isAbandoned() || this.writeIsRetired(draftId)) return;
       this.held.set(response.draft.draftId, {
         kind: "row",
         revision: response.draft.revision,
@@ -529,10 +569,16 @@ export class DraftMirrorSession {
       });
       // Dirty gate is correct (keep suppressing host frames) but it must
       // have a live retry behind it — re-arm with bounded backoff.
-      if (this.sink.isDirty(draftId)) {
+      if (!this.writeIsRetired(draftId) && this.sink.isDirty(draftId)) {
         this.scheduleRetry(draftId);
       }
     }
+  }
+
+  private writeIsRetired(draftId: string): boolean {
+    return (
+      this.retiredDraftIds.has(draftId) || this.sink.isDeletePending(draftId)
+    );
   }
 
   private async retryPendingDeletes(): Promise<void> {

--- a/clients/gui-app/src/lib/drafts/draft-mirror-session.ts
+++ b/clients/gui-app/src/lib/drafts/draft-mirror-session.ts
@@ -541,11 +541,17 @@ export class DraftMirrorSession {
       // this write is waiting there, so gate again at actual RPC dispatch.
       if (this.isAbandoned() || this.writeIsRetired(draftId)) return;
       const response = await this.rpc.upsert(prepared);
-      if (this.isAbandoned() || this.writeIsRetired(draftId)) return;
-      this.held.set(response.draft.draftId, {
-        kind: "row",
-        revision: response.draft.revision,
-      });
+      if (this.isAbandoned()) return;
+      // A committed write still advances the host frontier after retirement.
+      // Deletion derives its tombstone from this frontier, and another stream
+      // may already have delivered a newer row or tombstone while RPC awaited.
+      if (response.draft.revision > this.revisionOfHeld(draftId)) {
+        this.held.set(draftId, {
+          kind: "row",
+          revision: response.draft.revision,
+        });
+      }
+      if (this.writeIsRetired(draftId)) return;
       this.sink.rememberSynced(
         response.draft.draftId,
         response.draft.revision,

--- a/clients/gui-app/src/lib/drafts/landing-draft-retirement.ts
+++ b/clients/gui-app/src/lib/drafts/landing-draft-retirement.ts
@@ -1,0 +1,143 @@
+import { z } from "zod";
+import { persistKey, scopedPersistKey, STORE_KEYS } from "@/lib/persist";
+import { appLogger, describeLogError } from "@/lib/logger";
+
+const retirementSchema = z.object({
+  hostId: z.string().nullable(),
+  pendingDelete: z.boolean(),
+  ownerResolved: z.boolean(),
+});
+
+interface LandingDraftRetirement {
+  readonly hostId: string | null;
+  readonly pendingDelete: boolean;
+  readonly ownerResolved: boolean;
+}
+
+// Desktop disables the landing store's localStorage persistence. Keep its
+// retirement receipts separately, one key per ID so windows cannot overwrite
+// each other's receipts. A host ACK does not prove a stale cloud head is gone:
+// retain the small receipt until the normal GUI-state wipe, without prompt bytes.
+const prefix = `${persistKey(STORE_KEYS.landingDraftRetirement)}:`;
+const volatileRetirements = new Map<string, LandingDraftRetirement>();
+
+function retirementKey(draftId: string): string {
+  return scopedPersistKey(
+    STORE_KEYS.landingDraftRetirement,
+    encodeURIComponent(draftId),
+  );
+}
+
+function readRetirement(draftId: string): LandingDraftRetirement | undefined {
+  const fallback = volatileRetirements.get(draftId);
+  if (fallback !== undefined) return fallback;
+  try {
+    const raw = window.localStorage.getItem(retirementKey(draftId));
+    if (raw === null) return undefined;
+    const parsed = retirementSchema.safeParse(JSON.parse(raw));
+    return parsed.success ? parsed.data : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function writeRetirement(
+  draftId: string,
+  retirement: LandingDraftRetirement,
+): void {
+  try {
+    window.localStorage.setItem(
+      retirementKey(draftId),
+      JSON.stringify(retirement),
+    );
+    volatileRetirements.delete(draftId);
+  } catch (error: unknown) {
+    // Storage failure must not reopen the submitted prompt in this renderer.
+    volatileRetirements.set(draftId, retirement);
+    appLogger.warn("[draft-retirement] could not persist deletion receipt", {
+      error: describeLogError(error),
+    });
+  }
+}
+
+function retiredIds(): string[] {
+  const ids = new Set(volatileRetirements.keys());
+  try {
+    for (let index = 0; index < window.localStorage.length; index += 1) {
+      const key = window.localStorage.key(index);
+      if (key?.startsWith(prefix)) {
+        ids.add(decodeURIComponent(key.slice(prefix.length)));
+      }
+    }
+  } catch {
+    // The in-memory receipts still protect a renderer with storage disabled.
+  }
+  return [...ids];
+}
+
+export function retireLandingDraft(
+  draftId: string,
+  hostId: string | null,
+): void {
+  if (readRetirement(draftId) !== undefined) return;
+  writeRetirement(draftId, {
+    hostId,
+    pendingDelete: hostId !== null,
+    ownerResolved: hostId !== null,
+  });
+}
+
+export function resolveLandingDraftRetirementOwner(
+  draftId: string,
+  hostId: string,
+): void {
+  const receipt = readRetirement(draftId);
+  if (receipt === undefined || receipt.ownerResolved) return;
+  writeRetirement(draftId, {
+    hostId,
+    pendingDelete: true,
+    ownerResolved: true,
+  });
+}
+
+export function isLandingDraftRetirementKey(key: string | null): boolean {
+  return key?.startsWith(prefix) === true;
+}
+
+export function landingDraftIsRetired(draftId: string): boolean {
+  return readRetirement(draftId) !== undefined;
+}
+
+export function pendingLandingDraftDeleteHostId(
+  draftId: string,
+): string | null {
+  const receipt = readRetirement(draftId);
+  return receipt?.pendingDelete ? receipt.hostId : null;
+}
+
+export function pendingLandingDraftDeleteIdsForHost(hostId: string): string[] {
+  return retiredIds().filter(
+    (draftId) => pendingLandingDraftDeleteHostId(draftId) === hostId,
+  );
+}
+
+export function completeLandingDraftDelete(draftId: string): void {
+  const receipt = readRetirement(draftId);
+  if (
+    receipt === undefined ||
+    (!receipt.pendingDelete && receipt.ownerResolved)
+  )
+    return;
+  writeRetirement(draftId, {
+    ...receipt,
+    pendingDelete: false,
+    ownerResolved: true,
+  });
+}
+
+export function resetLandingDraftRetirementsForTests(): void {
+  for (const draftId of retiredIds()) {
+    window.localStorage.removeItem(retirementKey(draftId));
+  }
+  volatileRetirements.clear();
+}

--- a/clients/gui-app/src/lib/persist/keys.ts
+++ b/clients/gui-app/src/lib/persist/keys.ts
@@ -235,10 +235,15 @@ export const PERSIST_STORES = [
   },
   { camelName: "readingPosition", leaf: "reading-position", kind: "scoped" },
 
-  // ── Scoped non-zustand key families (1) ──────────────────────────────────
+  // ── Scoped non-zustand key families (2) ──────────────────────────────────
   {
     camelName: "appLocalNotificationCompletionReceipt",
     leaf: "app-local-notification-completion-receipt",
+    kind: "scoped",
+  },
+  {
+    camelName: "landingDraftRetirement",
+    leaf: "landing-draft-retirement",
     kind: "scoped",
   },
 

--- a/clients/gui-app/src/lib/tab-recovery/__tests__/saved-draft.test.ts
+++ b/clients/gui-app/src/lib/tab-recovery/__tests__/saved-draft.test.ts
@@ -31,6 +31,10 @@ import { prepareSavedDraft } from "@/lib/tab-recovery/saved-draft";
 import type { ClosedHeaderTab } from "@/lib/tab-recovery/history";
 import { useTabRecoveryHistory } from "@/lib/tab-recovery/history";
 import {
+  resetLandingDraftRetirementsForTests,
+  retireLandingDraft,
+} from "@/lib/drafts/landing-draft-retirement";
+import {
   emptyLandingDraftWorkspaceSnapshot,
   freshLandingMirrorState,
   useLandingDraftStore,
@@ -282,6 +286,7 @@ describe("prepareSavedDraft", () => {
     resetLandingImageBudgetReservationsForTesting();
     useLandingDraftStore.setState({ drafts: [], activeDraftId: null });
     useTabRecoveryHistory.setState({ entries: [], ready: true });
+    resetLandingDraftRetirementsForTests();
     mocks.resolveNamedHostClient.mockReset();
     originalCreateObjectURLDescriptor = Object.getOwnPropertyDescriptor(
       URL,
@@ -310,6 +315,7 @@ describe("prepareSavedDraft", () => {
     originalCreateObjectURLDescriptor = undefined;
     useLandingDraftStore.setState({ drafts: [], activeDraftId: null });
     useTabRecoveryHistory.setState({ entries: [], ready: true });
+    resetLandingDraftRetirementsForTests();
     resetLandingImageBudgetReservationsForTesting();
   });
 
@@ -321,6 +327,21 @@ describe("prepareSavedDraft", () => {
 
     expect(result).toBe(false);
     expect(mocks.resolveNamedHostClient).not.toHaveBeenCalled();
+  });
+
+  it("rejects a retired retained row before consulting its host", async () => {
+    const draftId = "retired-saved-row";
+    const content = textDocument("retained before retirement");
+    const row = { ...localDraft(draftId, content), closed: true };
+    useLandingDraftStore.setState({ drafts: [row], activeDraftId: null });
+    retireLandingDraft(draftId, HOST_ID);
+
+    await expect(
+      prepareSavedDraft(recoveryItem(draftId, HOST_ID), () => true),
+    ).resolves.toBe(false);
+
+    expect(mocks.resolveNamedHostClient).not.toHaveBeenCalled();
+    expect(useLandingDraftStore.getState().drafts).toEqual([row]);
   });
 
   it("returns false when the named host has an authoritative absence", async () => {

--- a/clients/gui-app/src/lib/tab-recovery/saved-draft.ts
+++ b/clients/gui-app/src/lib/tab-recovery/saved-draft.ts
@@ -16,6 +16,7 @@ import {
 import { blobHashesOfDocument } from "@/lib/drafts/draft-write-codec";
 import { readDraftBlobsForRecovery } from "@/lib/drafts/draft-blob-transport";
 import { putImageBytesAtHash } from "@/lib/composer/landing-image-store";
+import { landingDraftIsRetired } from "@/lib/drafts/landing-draft-retirement";
 import type { ClosedHeaderTab } from "./history";
 
 /** Keep future live-byte accounting consistent with the bytes actually read. */
@@ -45,7 +46,9 @@ export async function prepareSavedDraft(
   item: Extract<ClosedHeaderTab, { kind: "draft" }>,
   stillCurrent: () => boolean,
 ): Promise<boolean> {
-  if (!stillCurrent()) return false;
+  const canRestore = (): boolean =>
+    stillCurrent() && !landingDraftIsRetired(item.draftId);
+  if (!canRestore()) return false;
   if (
     useLandingDraftStore
       .getState()
@@ -67,7 +70,7 @@ export async function prepareSavedDraft(
     staleTime: 0,
     retry: false,
   });
-  if (!stillCurrent()) return false;
+  if (!canRestore()) return false;
   // A local edit or another reopen that raced the read wins over the host copy.
   if (
     useLandingDraftStore
@@ -84,7 +87,7 @@ export async function prepareSavedDraft(
     throw new Error("The draft is not available from its host yet.");
   }
   if (document.kind !== "landing") return false;
-  return prepareHostDraft(document, item.hostId, client, stillCurrent);
+  return prepareHostDraft(document, item.hostId, client, canRestore);
 }
 
 async function prepareHostDraft(

--- a/clients/gui-app/src/stores/home/__tests__/landing-draft-mirror.test.ts
+++ b/clients/gui-app/src/stores/home/__tests__/landing-draft-mirror.test.ts
@@ -1,17 +1,35 @@
+import "fake-indexeddb/auto";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CloudChatSummary } from "@traycer/protocol/host/epic/cloud-chat";
 import type { DraftDocument } from "@traycer/protocol/host";
+import type {
+  IStreamSession,
+  ServerFrameHandler,
+} from "@traycer-clients/shared/host-transport/i-stream-session";
 import { fakeDraftStreamClient } from "@/lib/drafts/__tests__/draft-mirror-test-stream";
 import {
   acquireDraftMirrorSession,
   adoptUnadoptedLandingDraftsForHost,
+  applyIncomingDraftDocument,
   bindLandingAdoptionHost,
+  ingestCloudDraftSummary,
   resetDraftMirrorCoordinatorForTests,
 } from "@/lib/drafts/draft-mirror-coordinator";
+import { installFreshIndexedDb } from "@/lib/composer/__tests__/prompt-stash-fake-idb";
+import {
+  completeLandingDraftDelete,
+  landingDraftIsRetired,
+  pendingLandingDraftDeleteIdsForHost,
+  resetLandingDraftRetirementsForTests,
+  retireLandingDraft,
+} from "@/lib/drafts/landing-draft-retirement";
+import { scopedPersistKey, STORE_KEYS } from "@/lib/persist";
 import {
   adoptLandingDraft,
   applyLandingHostDocument,
   collectLandingDirtyWrites,
   collectUnadoptedLandingDrafts,
+  landingDraftIsDirty,
   landingDraftRememberSynced,
   freshLandingMirrorState,
   MAX_LOCAL_ADOPTED_LANDING_MIRRORS,
@@ -25,16 +43,43 @@ import {
 import { EMPTY_LANDING_DRAFT_CONTENT } from "@/stores/home/landing-draft-content";
 import { tabSourceRefs } from "@/stores/tabs/source-refs";
 
+function controlledStream(): {
+  readonly client: never;
+  readonly started: { value: boolean };
+} {
+  const started = { value: false };
+  const session: IStreamSession = {
+    sendClientFrame: () => undefined,
+    onServerFrame: (_handler: ServerFrameHandler) => undefined,
+    onStatusChange: () => undefined,
+    requestReconnect: () => undefined,
+    close: () => undefined,
+    getNegotiatedSchemaVersion: () => ({ major: 1, minor: 0 }),
+  };
+  return {
+    client: {
+      subscribe: () => {
+        started.value = true;
+        return session;
+      },
+    } as never,
+    started,
+  };
+}
+
 describe("landing draft host-mirror bookkeeping", () => {
   beforeEach(() => {
+    installFreshIndexedDb();
     useLandingDraftStore.setState({ drafts: [], activeDraftId: null });
     useTabRecoveryHistory.setState({ entries: [], ready: true });
+    resetLandingDraftRetirementsForTests();
     resetDraftMirrorCoordinatorForTests();
   });
 
   afterEach(() => {
     useLandingDraftStore.setState({ drafts: [], activeDraftId: null });
     useTabRecoveryHistory.setState({ entries: [], ready: true });
+    resetLandingDraftRetirementsForTests();
     resetDraftMirrorCoordinatorForTests();
   });
 
@@ -526,5 +571,383 @@ describe("landing draft host-mirror bookkeeping", () => {
     expect(
       tabSourceRefs().some((ref) => ref.kind === "draft" && ref.id === id),
     ).toBe(false);
+  });
+
+  it("fences a host upsert whose image read finishes after landing deletion", async () => {
+    const stream = controlledStream();
+    const hostId = "host-late-image";
+    const id = "late-image-landing";
+    const hash = "ef".repeat(32);
+    let releaseReadBlob:
+      | ((response: { readonly ok: false; readonly reason: "missing" }) => void)
+      | undefined;
+    const readBlob = new Promise<{
+      readonly ok: false;
+      readonly reason: "missing";
+    }>((resolve) => {
+      releaseReadBlob = resolve;
+    });
+    let readBlobStarted = false;
+    const client = {
+      request: (method: string, params: unknown) => {
+        if (method === "drafts.list") {
+          return Promise.resolve({
+            drafts: [],
+            tombstones: [],
+            snapshotSeq: 0,
+            scopeId: null,
+          });
+        }
+        if (method === "drafts.readBlob") {
+          readBlobStarted = true;
+          void params;
+          return readBlob;
+        }
+        if (method === "drafts.delete")
+          return Promise.resolve({ deleted: true });
+        return Promise.reject(new Error(`unexpected ${method}`));
+      },
+    };
+    acquireDraftMirrorSession({
+      hostId,
+      client: client as never,
+      streamClient: stream.client,
+      timing: undefined,
+    });
+    await vi.waitFor(() => {
+      expect(stream.started.value).toBe(true);
+    });
+
+    const initial: DraftDocument = {
+      draftId: id,
+      kind: "landing",
+      target: { epicId: null, chatId: null, blockId: null },
+      revision: 1,
+      lastTouchedAt: 1,
+      workspace: null,
+      ownerHostId: hostId,
+      origin: "own",
+      adoption: { state: "adopted", hostId },
+      publication: {
+        status: "unpublished",
+        lastPublishedAt: null,
+        publishedRevision: null,
+        halted: null,
+      },
+      portable: {
+        content: EMPTY_LANDING_DRAFT_CONTENT,
+        selection: null,
+        runSettings: null,
+        composerMode: "chat",
+        blobHashes: [],
+        closed: false,
+      },
+    };
+    await applyIncomingDraftDocument(initial);
+    expect(useLandingDraftStore.getState().drafts).toHaveLength(1);
+
+    const delayed = applyIncomingDraftDocument({
+      ...initial,
+      revision: 2,
+      portable: {
+        ...initial.portable,
+        blobHashes: [hash],
+        content: {
+          type: "doc",
+          content: [
+            {
+              type: "paragraph",
+              content: [{ type: "text", text: "old host body" }],
+            },
+          ],
+        },
+      },
+    });
+    await vi.waitFor(() => {
+      expect(readBlobStarted).toBe(true);
+    });
+    useLandingDraftStore.getState().deleteDraft(id);
+    expect(useLandingDraftStore.getState().drafts).toEqual([]);
+    releaseReadBlob?.({ ok: false, reason: "missing" });
+    await delayed;
+
+    expect(useLandingDraftStore.getState().drafts).toEqual([]);
+    expect(landingDraftIsRetired(id)).toBe(true);
+  });
+
+  it("keeps the host revision frontier when subscribe rows arrive out of order", () => {
+    const id = "landing-revision-frontier";
+    const base = {
+      draftId: id,
+      kind: "landing" as const,
+      target: { epicId: null, chatId: null, blockId: null },
+      revision: 0,
+      lastTouchedAt: 1,
+      workspace: null,
+      ownerHostId: "host-frontier",
+      origin: "own" as const,
+      adoption: { state: "adopted" as const, hostId: "host-frontier" },
+      publication: {
+        status: "unpublished" as const,
+        lastPublishedAt: null,
+        publishedRevision: null,
+        halted: null,
+      },
+      portable: {
+        content: EMPTY_LANDING_DRAFT_CONTENT,
+        selection: null,
+        runSettings: null,
+        composerMode: "chat" as const,
+        blobHashes: [],
+        closed: false,
+      },
+    } satisfies DraftDocument;
+    const row = (
+      revision: number,
+      text: string,
+    ): Extract<DraftDocument, { readonly kind: "landing" }> => ({
+      ...base,
+      revision,
+      portable: {
+        ...base.portable,
+        content: {
+          type: "doc",
+          content: [{ type: "paragraph", content: [{ type: "text", text }] }],
+        },
+      },
+    });
+
+    const newest = row(13, "newest");
+    const older = row(11, "older");
+    const middle = row(12, "middle");
+    applyLandingHostDocument(newest, newest.portable.content);
+    applyLandingHostDocument(older, older.portable.content);
+    applyLandingHostDocument(middle, middle.portable.content);
+
+    const draft = useLandingDraftStore
+      .getState()
+      .drafts.find((entry) => entry.id === id);
+    expect(draft?.hostRevision).toBe(13);
+    expect(draft?.content).toEqual(newest.portable.content);
+  });
+
+  it("removes a dirty row on an external retirement event without losing the owner delete retry", () => {
+    const hostId = "host-window-owner";
+    const id = useLandingDraftStore.getState().createDraft(null);
+    const key = scopedPersistKey(
+      STORE_KEYS.landingDraftRetirement,
+      encodeURIComponent(id),
+    );
+    adoptLandingDraft(id, hostId);
+    useLandingDraftStore.getState().setDraftContent(
+      id,
+      {
+        type: "doc",
+        content: [
+          { type: "paragraph", content: [{ type: "text", text: "dirty" }] },
+        ],
+      },
+      null,
+    );
+    expect(landingDraftIsRetired(id)).toBe(false);
+
+    const newValue = JSON.stringify({
+      hostId,
+      pendingDelete: true,
+      ownerResolved: false,
+    });
+    window.localStorage.setItem(key, newValue);
+    expect(landingDraftIsDirty(id)).toBe(false);
+    window.dispatchEvent(new StorageEvent("storage", { key, newValue }));
+
+    expect(useLandingDraftStore.getState().drafts).toEqual([]);
+    expect(landingDraftIsRetired(id)).toBe(true);
+    expect(pendingLandingDraftDeleteIdsForHost(hostId)).toEqual([id]);
+  });
+
+  it("consumes an unknown-owner retirement when its first owner document arrives", async () => {
+    const hostId = "host-recovered-owner";
+    const id = "unknown-owner-retirement";
+    const deletes: string[] = [];
+    retireLandingDraft(id, null);
+    expect(pendingLandingDraftDeleteIdsForHost(hostId)).toEqual([]);
+
+    const stream = controlledStream();
+    acquireDraftMirrorSession({
+      hostId,
+      client: {
+        request: (method: string, params: unknown) => {
+          if (method === "drafts.list") {
+            return Promise.resolve({
+              drafts: [],
+              tombstones: [],
+              snapshotSeq: 0,
+              scopeId: null,
+            });
+          }
+          if (method === "drafts.delete") {
+            deletes.push((params as { readonly draftId: string }).draftId);
+            return Promise.resolve({ deleted: true });
+          }
+          return Promise.reject(new Error(`unexpected ${method}`));
+        },
+      } as never,
+      streamClient: stream.client,
+      timing: undefined,
+    });
+    await vi.waitFor(() => {
+      expect(stream.started.value).toBe(true);
+    });
+
+    const incoming: DraftDocument = {
+      draftId: id,
+      kind: "landing",
+      target: { epicId: null, chatId: null, blockId: null },
+      revision: 4,
+      lastTouchedAt: 1,
+      workspace: null,
+      ownerHostId: hostId,
+      origin: "replica",
+      adoption: { state: "adopted", hostId },
+      publication: {
+        status: "unpublished",
+        lastPublishedAt: null,
+        publishedRevision: null,
+        halted: null,
+      },
+      portable: {
+        content: EMPTY_LANDING_DRAFT_CONTENT,
+        selection: null,
+        runSettings: null,
+        composerMode: "chat",
+        blobHashes: [],
+        closed: false,
+      },
+    };
+    await applyIncomingDraftDocument(incoming);
+
+    await vi.waitFor(() => {
+      expect(deletes).toEqual([id]);
+    });
+    expect(useLandingDraftStore.getState().drafts).toEqual([]);
+    expect(landingDraftIsRetired(id)).toBe(true);
+    await vi.waitFor(() => {
+      expect(pendingLandingDraftDeleteIdsForHost(hostId)).toEqual([]);
+    });
+  });
+
+  it("keeps a landing retirement receipt after cloud ingest and host-delete ACK", async () => {
+    const id = useLandingDraftStore.getState().createDraft(null);
+    adoptLandingDraft(id, "host-a");
+    useLandingDraftStore.getState().deleteDraft(id);
+    expect(landingDraftIsRetired(id)).toBe(true);
+
+    const summary: CloudChatSummary = {
+      identity: {
+        taskId: "scp_TESTDRAFTSSCOPEID000001",
+        chatId: id,
+        ownerUserId: "user-1",
+      },
+      ownerHostId: "host-b",
+      createdAt: 1,
+      visibility: "private",
+      title: null,
+      isTitleEditedByUser: false,
+      parentChatId: null,
+      isArchived: false,
+      runSettingsSummary: null,
+      metadataUpdatedAt: 1,
+      headSha256: "ab".repeat(32),
+      publishedAt: 1,
+      throughRecordSeq: 1,
+      isOwnedByViewer: true,
+    };
+    const document: DraftDocument = {
+      draftId: id,
+      kind: "landing",
+      target: { epicId: null, chatId: null, blockId: null },
+      revision: 0,
+      lastTouchedAt: 2,
+      workspace: null,
+      ownerHostId: "host-b",
+      origin: "replica",
+      adoption: { state: "adopted", hostId: "host-b" },
+      publication: {
+        status: "current",
+        lastPublishedAt: 1,
+        publishedRevision: null,
+        halted: null,
+      },
+      portable: {
+        content: {
+          type: "doc",
+          content: [
+            {
+              type: "paragraph",
+              content: [{ type: "text", text: "cloud body" }],
+            },
+          ],
+        },
+        selection: null,
+        runSettings: null,
+        composerMode: "chat",
+        blobHashes: [],
+        closed: false,
+      },
+    };
+
+    await ingestCloudDraftSummary({
+      hostId: "host-a",
+      summary,
+      document,
+    });
+    expect(useLandingDraftStore.getState().drafts).toEqual([]);
+
+    completeLandingDraftDelete(id);
+    expect(landingDraftIsRetired(id)).toBe(true);
+    expect(pendingLandingDraftDeleteIdsForHost("host-a")).toEqual([]);
+    await ingestCloudDraftSummary({
+      hostId: "host-a",
+      summary,
+      document,
+    });
+    expect(useLandingDraftStore.getState().drafts).toEqual([]);
+  });
+
+  it("retries a row-free landing retirement after host restart and retains its receipt", async () => {
+    const hostId = "host-retry-row-free";
+    const id = "row-free-retirement";
+    const deletes: string[] = [];
+    retireLandingDraft(id, hostId);
+    expect(pendingLandingDraftDeleteIdsForHost(hostId)).toEqual([id]);
+
+    acquireDraftMirrorSession({
+      hostId,
+      client: {
+        request: (method: string, params: unknown) => {
+          if (method === "drafts.list") {
+            return Promise.resolve({
+              drafts: [],
+              tombstones: [],
+              snapshotSeq: 0,
+              scopeId: null,
+            });
+          }
+          if (method === "drafts.delete") {
+            deletes.push((params as { readonly draftId: string }).draftId);
+            return Promise.resolve({ deleted: true });
+          }
+          return Promise.reject(new Error(`unexpected ${method}`));
+        },
+      } as never,
+      streamClient: fakeDraftStreamClient(),
+      timing: undefined,
+    });
+    await vi.waitFor(() => {
+      expect(deletes).toEqual([id]);
+    });
+    expect(pendingLandingDraftDeleteIdsForHost(hostId)).toEqual([]);
+    expect(landingDraftIsRetired(id)).toBe(true);
+    expect(useLandingDraftStore.getState().drafts).toEqual([]);
   });
 });

--- a/clients/gui-app/src/stores/home/__tests__/landing-draft-mirror.test.ts
+++ b/clients/gui-app/src/stores/home/__tests__/landing-draft-mirror.test.ts
@@ -46,11 +46,15 @@ import { tabSourceRefs } from "@/stores/tabs/source-refs";
 function controlledStream(): {
   readonly client: never;
   readonly started: { value: boolean };
+  readonly emit: (frame: Parameters<ServerFrameHandler>[0]) => void;
 } {
   const started = { value: false };
+  let onFrame: ServerFrameHandler | null = null;
   const session: IStreamSession = {
     sendClientFrame: () => undefined,
-    onServerFrame: (_handler: ServerFrameHandler) => undefined,
+    onServerFrame: (handler: ServerFrameHandler) => {
+      onFrame = handler;
+    },
     onStatusChange: () => undefined,
     requestReconnect: () => undefined,
     close: () => undefined,
@@ -64,6 +68,9 @@ function controlledStream(): {
       },
     } as never,
     started,
+    emit: (frame) => {
+      onFrame?.(frame, null);
+    },
   };
 }
 
@@ -675,7 +682,7 @@ describe("landing draft host-mirror bookkeeping", () => {
     expect(landingDraftIsRetired(id)).toBe(true);
   });
 
-  it("keeps the host revision frontier when subscribe rows arrive out of order", () => {
+  it("keeps the host revision frontier for direct host-document application", () => {
     const id = "landing-revision-frontier";
     const base = {
       draftId: id,
@@ -729,6 +736,154 @@ describe("landing draft host-mirror bookkeeping", () => {
       .drafts.find((entry) => entry.id === id);
     expect(draft?.hostRevision).toBe(13);
     expect(draft?.content).toEqual(newest.portable.content);
+  });
+
+  it("keeps the latest landing row when real subscribe applies finish images out of order", async () => {
+    const hostId = "host-stream-frontier";
+    const id = "stream-frontier";
+    type MissingBlobResponse = {
+      readonly ok: false;
+      readonly reason: "missing";
+    };
+    const hashes = new Map<
+      string,
+      { readonly resolve: (response: MissingBlobResponse) => void }
+    >();
+    const readBlobStarted = new Set<string>();
+    const readBlob = (hash: string): Promise<MissingBlobResponse> => {
+      let resolve: (response: MissingBlobResponse) => void = () => undefined;
+      const promise = new Promise<MissingBlobResponse>((nextResolve) => {
+        resolve = nextResolve;
+      });
+      hashes.set(hash, { resolve });
+      readBlobStarted.add(hash);
+      return promise;
+    };
+    const stream = controlledStream();
+    const client = {
+      request: (method: string, params: unknown) => {
+        if (method === "drafts.list") {
+          return Promise.resolve({
+            drafts: [],
+            tombstones: [],
+            snapshotSeq: 0,
+            scopeId: null,
+          });
+        }
+        if (method === "drafts.readBlob") {
+          return readBlob((params as { readonly sha256: string }).sha256);
+        }
+        return Promise.reject(new Error(`unexpected ${method}`));
+      },
+    };
+    acquireDraftMirrorSession({
+      hostId,
+      client: client as never,
+      streamClient: stream.client,
+      timing: undefined,
+    });
+    await vi.waitFor(() => {
+      expect(stream.started.value).toBe(true);
+    });
+
+    const base = {
+      draftId: id,
+      kind: "landing" as const,
+      target: { epicId: null, chatId: null, blockId: null },
+      revision: 0,
+      lastTouchedAt: 1,
+      workspace: null,
+      ownerHostId: hostId,
+      origin: "own" as const,
+      adoption: { state: "adopted" as const, hostId },
+      publication: {
+        status: "unpublished" as const,
+        lastPublishedAt: null,
+        publishedRevision: null,
+        halted: null,
+      },
+      portable: {
+        content: EMPTY_LANDING_DRAFT_CONTENT,
+        selection: null,
+        runSettings: null,
+        composerMode: "chat" as const,
+        blobHashes: [] as string[],
+        closed: false,
+      },
+    } satisfies DraftDocument;
+    const row = (
+      revision: number,
+      hash: string,
+      text: string,
+    ): Extract<DraftDocument, { readonly kind: "landing" }> => ({
+      ...base,
+      revision,
+      portable: {
+        ...base.portable,
+        blobHashes: [hash],
+        content: {
+          type: "doc",
+          content: [{ type: "paragraph", content: [{ type: "text", text }] }],
+        },
+      },
+    });
+    const hash11 = "aa".repeat(32);
+    const hash12 = "bb".repeat(32);
+    const hash13 = "cc".repeat(32);
+    const row11 = row(11, hash11, "older");
+    const row12 = row(12, hash12, "middle");
+    const row13 = row(13, hash13, "newest");
+
+    stream.emit({
+      kind: "upsert",
+      hasBinaryPayload: false,
+      storeSeq: 11,
+      draftId: id,
+      revision: row11.revision,
+      draft: row11,
+    });
+    stream.emit({
+      kind: "upsert",
+      hasBinaryPayload: false,
+      storeSeq: 12,
+      draftId: id,
+      revision: row12.revision,
+      draft: row12,
+    });
+    stream.emit({
+      kind: "upsert",
+      hasBinaryPayload: false,
+      storeSeq: 13,
+      draftId: id,
+      revision: row13.revision,
+      draft: row13,
+    });
+    await vi.waitFor(() => {
+      expect(readBlobStarted).toEqual(new Set([hash11, hash12, hash13]));
+    });
+
+    hashes.get(hash13)?.resolve({
+      ok: false,
+      reason: "missing",
+    });
+    hashes.get(hash11)?.resolve({
+      ok: false,
+      reason: "missing",
+    });
+    hashes.get(hash12)?.resolve({
+      ok: false,
+      reason: "missing",
+    });
+    // Let all three detached frame handlers consume their delayed reads and
+    // complete their landing-store attempts before checking the frontier.
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    await vi.waitFor(() => {
+      const draft = useLandingDraftStore
+        .getState()
+        .drafts.find((entry) => entry.id === id);
+      expect(draft?.hostRevision).toBe(13);
+      expect(draft?.content).toEqual(row13.portable.content);
+    });
   });
 
   it("removes a dirty row on an external retirement event without losing the owner delete retry", () => {
@@ -902,6 +1057,8 @@ describe("landing draft host-mirror bookkeeping", () => {
       document,
     });
     expect(useLandingDraftStore.getState().drafts).toEqual([]);
+    expect(pendingLandingDraftDeleteIdsForHost("host-a")).toEqual([id]);
+    expect(pendingLandingDraftDeleteIdsForHost("host-b")).toEqual([]);
 
     completeLandingDraftDelete(id);
     expect(landingDraftIsRetired(id)).toBe(true);

--- a/clients/gui-app/src/stores/home/landing-draft-store.ts
+++ b/clients/gui-app/src/stores/home/landing-draft-store.ts
@@ -42,6 +42,12 @@ import type {
 import type { DesktopPerWindowProjectionBridge } from "@/lib/windows/per-window-projection-debounce";
 import { basePersistOptions, persistKey, STORE_KEYS } from "@/lib/persist";
 import {
+  completeLandingDraftDelete,
+  isLandingDraftRetirementKey,
+  landingDraftIsRetired,
+  retireLandingDraft,
+} from "@/lib/drafts/landing-draft-retirement";
+import {
   resolvePrimaryPath,
   trimFoldersPreservingPrimary,
 } from "@/lib/worktree/resolve-primary-path";
@@ -480,6 +486,15 @@ function destroyLandingDraft(
   // A local delete needs a row to route its host request. A host tombstone is
   // already authoritative even when its local mirror was evicted.
   if (closing === undefined && routeHostDelete) return;
+  if (closing !== undefined) {
+    retireLandingDraft(
+      id,
+      routeHostDelete && closing.adoption.state === "adopted"
+        ? closing.adoption.hostId
+        : null,
+    );
+  }
+  if (!routeHostDelete) completeLandingDraftDelete(id);
   pruneRecoveryDraft(id);
   if (closing === undefined) return;
   draftRuntimeRegistry.close(id);
@@ -554,6 +569,7 @@ export const useLandingDraftStore = create<LandingDraftStoreState>()(
       },
 
       createDraftWithId: (id, settings) => {
+        if (landingDraftIsRetired(id)) return id;
         if (get().drafts.some((draft) => draft.id === id)) return id;
         // Workspace and default settings belong to the same placement host,
         // including drafts created through the tab strip or a split pane.
@@ -953,7 +969,7 @@ function uniqueLandingDrafts(
 ): ReadonlyArray<LandingDraftTab> {
   const seen = new Set<string>();
   return drafts.flatMap((draft) => {
-    if (seen.has(draft.id)) return [];
+    if (seen.has(draft.id) || landingDraftIsRetired(draft.id)) return [];
     seen.add(draft.id);
     return [draft];
   });
@@ -1614,6 +1630,7 @@ function nonNegativeNumber(value: unknown): number {
 }
 
 export function landingDraftIsDirty(draftId: string): boolean {
+  if (landingDraftIsRetired(draftId)) return false;
   const draft = useLandingDraftStore
     .getState()
     .drafts.find((entry) => entry.id === draftId);
@@ -1631,7 +1648,7 @@ export function landingDraftRememberSynced(
       if (draft.id !== draftId) return draft;
       return {
         ...draft,
-        hostRevision,
+        hostRevision: Math.max(draft.hostRevision, hostRevision),
         syncedGeneration:
           collectedGeneration >= draft.generation
             ? draft.generation
@@ -1655,10 +1672,19 @@ export function applyLandingHostDocument(
   document: DraftDocument,
   content: JsonContent,
 ): void {
-  if (document.kind !== "landing") return;
+  if (document.kind !== "landing" || landingDraftIsRetired(document.draftId))
+    return;
   const existing = useLandingDraftStore
     .getState()
     .drafts.find((draft) => draft.id === document.draftId);
+  // Image reads can finish out of order after subscribe-frame admission.
+  if (
+    existing !== undefined &&
+    existing.ownerHostId === document.ownerHostId &&
+    document.revision > 0 &&
+    existing.hostRevision > document.revision
+  )
+    return;
   if (
     existing !== undefined &&
     existing.generation > existing.syncedGeneration
@@ -1797,4 +1823,30 @@ function evictAdoptedLandingMirrors(
       .map((draft) => draft.id),
   );
   return drafts.filter((draft) => !evictIds.has(draft.id));
+}
+
+if (typeof window !== "undefined") {
+  window.addEventListener("storage", (event) => {
+    if (!isLandingDraftRetirementKey(event.key) || event.newValue === null)
+      return;
+    const retired = useLandingDraftStore
+      .getState()
+      .drafts.filter((draft) => landingDraftIsRetired(draft.id));
+    if (retired.length === 0) return;
+    for (const draft of retired) {
+      pruneRecoveryDraft(draft.id);
+      draftRuntimeRegistry.close(draft.id);
+    }
+    // Another window's receipt removes the visible row, but must not ACK its
+    // pending host delete. The owner receipt still routes reconnect retries.
+    useLandingDraftStore.setState((state) => ({
+      drafts: state.drafts.filter((draft) => !landingDraftIsRetired(draft.id)),
+      activeDraftId:
+        state.activeDraftId !== null &&
+        landingDraftIsRetired(state.activeDraftId)
+          ? null
+          : state.activeDraftId,
+    }));
+    scheduleLandingImageReconcile();
+  });
 }

--- a/clients/gui-app/src/stores/home/landing-draft-store.ts
+++ b/clients/gui-app/src/stores/home/landing-draft-store.ts
@@ -124,7 +124,7 @@ export const UNADOPTED_LANDING_DRAFT: LandingDraftAdoption = {
 };
 
 export function isOpenLandingDraft(draft: LandingDraftTab): boolean {
-  return !draft.closed;
+  return !draft.closed && !landingDraftIsRetired(draft.id);
 }
 
 /** Local persist cap for adopted mirrors; unadopted drafts are never LRU'd. */
@@ -638,6 +638,7 @@ export const useLandingDraftStore = create<LandingDraftStoreState>()(
       },
 
       openDraft: (id) => {
+        if (landingDraftIsRetired(id)) return;
         const draft = get().drafts.find((d) => d.id === id);
         if (draft === undefined) return;
         // A pending create keeps the runtime alive through close. Reopen
@@ -677,7 +678,7 @@ export const useLandingDraftStore = create<LandingDraftStoreState>()(
 
       setActiveDraft: (id) => {
         const draft = get().drafts.find((d) => d.id === id);
-        if (draft === undefined || draft.closed) return;
+        if (draft === undefined || !isOpenLandingDraft(draft)) return;
         set({ activeDraftId: id });
       },
 
@@ -1678,6 +1679,9 @@ export function applyLandingHostDocument(
     .getState()
     .drafts.find((draft) => draft.id === document.draftId);
   // Image reads can finish out of order after subscribe-frame admission.
+  // Cloud heads use synthetic revision 0 (unknown), even for a newer head
+  // fetched while the owner is offline. Compare only actual host revisions;
+  // permanent retirement above independently fences consumed cloud drafts.
   if (
     existing !== undefined &&
     existing.ownerHostId === document.ownerHostId &&

--- a/clients/gui-app/src/stores/tabs/__tests__/close-wiring-t10.test.ts
+++ b/clients/gui-app/src/stores/tabs/__tests__/close-wiring-t10.test.ts
@@ -11,12 +11,13 @@
  * resulting `useTabsStore` layout, so a regression back to the direct-source
  * bypass shows up here.
  */
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { tabRequestClose } from "@/stores/tabs/registry";
 import { getHeaderTabs } from "@/stores/tabs/use-header-tabs";
 import { useTabsStore } from "@/stores/tabs/store";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 import { useLandingDraftStore } from "@/stores/home/landing-draft-store";
+import { resetLandingDraftRetirementsForTests } from "@/lib/drafts/landing-draft-retirement";
 import { createEmptyCanvas } from "@/stores/epics/canvas/canvas-state";
 import type { EpicCanvasState, EpicViewTab } from "@/stores/epics/canvas/types";
 import type { TabRef } from "@/stores/tabs/types";
@@ -45,10 +46,15 @@ function seedEpicTabs(
   });
 }
 
+beforeEach(() => {
+  resetLandingDraftRetirementsForTests();
+});
+
 afterEach(() => {
   useTabsStore.setState(useTabsStore.getInitialState(), true);
   useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
   useLandingDraftStore.setState({ drafts: [], activeDraftId: null });
+  resetLandingDraftRetirementsForTests();
 });
 
 describe("T10 Area 1: requestClose routes through the coordinator", () => {

--- a/clients/gui-app/src/stores/tabs/__tests__/tab-recovery-coordinator.test.ts
+++ b/clients/gui-app/src/stores/tabs/__tests__/tab-recovery-coordinator.test.ts
@@ -24,6 +24,7 @@ import {
   pane,
 } from "@/stores/epics/canvas/__tests__/canvas-test-fixtures";
 import { registerChatTabViewportCapture } from "@/stores/chats/chat-tab-viewport-handoff";
+import { resetLandingDraftRetirementsForTests } from "@/lib/drafts/landing-draft-retirement";
 import { useLandingDraftStore } from "@/stores/home/landing-draft-store";
 import {
   flattenLayoutRefs,
@@ -49,6 +50,7 @@ function resetStores(): void {
   });
   useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
   useLandingDraftStore.setState({ drafts: [], activeDraftId: null });
+  resetLandingDraftRetirementsForTests();
   useTabRecoveryHistory.setState({ entries: [], ready: true });
   __resetTabSyncCoordinatorForTesting();
   tabCommandCoordinator.resetReconciliationForTesting();
@@ -123,6 +125,53 @@ afterEach(() => {
 });
 
 describe("tab recovery through the command coordinator", () => {
+  it("keeps the focused task active when a background landing draft source appears", () => {
+    const taskId = useEpicCanvasStore
+      .getState()
+      .openEpicTab("epic-background-draft", "Background draft");
+    const taskRef: TabRef = { kind: "epic", id: taskId };
+    seedStrip([taskRef], taskRef);
+    useTabsStore.setState({ activationHistory: [taskRef] });
+
+    const draftId = useLandingDraftStore.getState().createDraft(null);
+    const draftRef: TabRef = { kind: "draft", id: draftId };
+    tabCommandCoordinator.reconcileFromSourceStores();
+
+    expect(stripRefs().map(tabRefKey)).toEqual([
+      tabRefKey(taskRef),
+      tabRefKey(draftRef),
+    ]);
+    expect(useTabsStore.getState().activeItemId).toBe(tabItemId(taskRef));
+    expect(useTabsStore.getState().activationHistory).toEqual([taskRef]);
+  });
+
+  it("explicitly activates a newly created landing draft", () => {
+    const taskId = useEpicCanvasStore
+      .getState()
+      .openEpicTab("epic-explicit-draft", "Explicit draft");
+    const taskRef: TabRef = { kind: "epic", id: taskId };
+    seedStrip([taskRef], taskRef);
+
+    const activation = tabCommandCoordinator.activateTab({
+      kind: "draft",
+      draftId: null,
+      settings: null,
+      create: true,
+    });
+    expect(activation).not.toBeNull();
+    if (activation === null || activation.ref.kind !== "draft") {
+      throw new Error("expected explicit draft activation");
+    }
+
+    expect(useTabsStore.getState().activeItemId).toBe(
+      tabItemId(activation.ref),
+    );
+    expect(useLandingDraftStore.getState().activeDraftId).toBe(
+      activation.ref.id,
+    );
+    expect(stripRefs()).toContainEqual(activation.ref);
+  });
+
   it("journals a confirmed task close and restores strip visibility without stealing focus", () => {
     const taskA = useEpicCanvasStore.getState().openEpicTab("epic-a", "Task A");
     const taskB = useEpicCanvasStore.getState().openEpicTab("epic-b", "Task B");

--- a/clients/gui-app/src/stores/tabs/__tests__/tab-recovery-coordinator.test.ts
+++ b/clients/gui-app/src/stores/tabs/__tests__/tab-recovery-coordinator.test.ts
@@ -14,6 +14,7 @@ import {
 import {
   batchHeaderTabRecovery,
   useTabRecoveryHistory,
+  type ClosedHeaderTab,
 } from "@/lib/tab-recovery/history";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 import { closeTab } from "@/stores/epics/canvas/actions";
@@ -24,8 +25,13 @@ import {
   pane,
 } from "@/stores/epics/canvas/__tests__/canvas-test-fixtures";
 import { registerChatTabViewportCapture } from "@/stores/chats/chat-tab-viewport-handoff";
-import { resetLandingDraftRetirementsForTests } from "@/lib/drafts/landing-draft-retirement";
+import {
+  landingDraftIsRetired,
+  resetLandingDraftRetirementsForTests,
+  retireLandingDraft,
+} from "@/lib/drafts/landing-draft-retirement";
 import { useLandingDraftStore } from "@/stores/home/landing-draft-store";
+import { useSettingsStore } from "@/stores/settings/settings-store";
 import {
   flattenLayoutRefs,
   tabItemId,
@@ -33,6 +39,7 @@ import {
   type SplitStripItem,
   type PersistedTabStripLayout,
 } from "@/stores/tabs/layout";
+import { tabSourceRefs } from "@/stores/tabs/source-refs";
 import { tabCommandCoordinator } from "@/stores/tabs/tab-command-coordinator";
 import { readTabStripLayout, useTabsStore } from "@/stores/tabs/store";
 import type { TabRef } from "@/stores/tabs/types";
@@ -50,6 +57,7 @@ function resetStores(): void {
   });
   useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
   useLandingDraftStore.setState({ drafts: [], activeDraftId: null });
+  useSettingsStore.setState({ homeTabEnabled: false });
   resetLandingDraftRetirementsForTests();
   useTabRecoveryHistory.setState({ entries: [], ready: true });
   __resetTabSyncCoordinatorForTesting();
@@ -125,6 +133,117 @@ afterEach(() => {
 });
 
 describe("tab recovery through the command coordinator", () => {
+  it("preserves Home selection and history when a background draft source appears", () => {
+    useSettingsStore.setState({ homeTabEnabled: true });
+    const taskId = useEpicCanvasStore
+      .getState()
+      .openEpicTab("epic-home-background", "Home background");
+    const taskRef: TabRef = { kind: "epic", id: taskId };
+    seedStrip([taskRef], taskRef);
+    useTabsStore.setState({ activeItemId: null, activationHistory: [taskRef] });
+
+    const draftId = useLandingDraftStore.getState().createDraft(null);
+    const draftRef: TabRef = { kind: "draft", id: draftId };
+    tabCommandCoordinator.reconcileFromSourceStores();
+
+    expect(stripRefs().map(tabRefKey)).toEqual([
+      tabRefKey(taskRef),
+      tabRefKey(draftRef),
+    ]);
+    expect(useTabsStore.getState().activeItemId).toBeNull();
+    expect(useTabsStore.getState().activationHistory).toEqual([taskRef]);
+  });
+
+  it("does not restore a retired closed draft while Home is selected", () => {
+    useSettingsStore.setState({ homeTabEnabled: true });
+    const taskId = useEpicCanvasStore
+      .getState()
+      .openEpicTab("epic-retired-closed", "Retained task");
+    const taskRef: TabRef = { kind: "epic", id: taskId };
+    seedStrip([taskRef], taskRef);
+    useTabsStore.setState({ activeItemId: null, activationHistory: [taskRef] });
+
+    const draftId = "retired-closed-recovery";
+    useLandingDraftStore.getState().createDraftWithId(draftId, null);
+    useLandingDraftStore.getState().setDraftContent(
+      draftId,
+      {
+        type: "doc",
+        content: [
+          {
+            type: "paragraph",
+            content: [{ type: "text", text: "retained work" }],
+          },
+        ],
+      },
+      null,
+    );
+    useLandingDraftStore.getState().closeDraft(draftId);
+    const recoveryItem: Extract<ClosedHeaderTab, { kind: "draft" }> = {
+      kind: "draft",
+      draftId,
+      hostId: null,
+      index: 1,
+    };
+    const layoutBefore = readTabStripLayout();
+    const historyBefore = useTabsStore.getState().activationHistory;
+    const rowBefore = useLandingDraftStore
+      .getState()
+      .drafts.find((draft) => draft.id === draftId);
+    expect(rowBefore?.closed).toBe(true);
+
+    // Retire before the other window's storage event removes this retained row.
+    retireLandingDraft(draftId, null);
+    tabCommandCoordinator.restoreClosedHeaderTabs([recoveryItem], null);
+
+    expect(readTabStripLayout()).toEqual(layoutBefore);
+    expect(useTabsStore.getState().activationHistory).toEqual(historyBefore);
+    expect(useLandingDraftStore.getState().drafts).toEqual([rowBefore]);
+    expect(useLandingDraftStore.getState().activeDraftId).toBeNull();
+  });
+
+  it("rejects activation of a retired direct draft id without changing selection", () => {
+    const taskId = useEpicCanvasStore
+      .getState()
+      .openEpicTab("epic-retired-direct", "Retired direct");
+    const taskRef: TabRef = { kind: "epic", id: taskId };
+    seedStrip([taskRef], taskRef);
+    const before = readTabStripLayout();
+    const retiredId = "retired-direct-id";
+    retireLandingDraft(retiredId, null);
+
+    expect(
+      tabCommandCoordinator.activateTab({
+        kind: "draft",
+        draftId: retiredId,
+        settings: null,
+        create: true,
+      }),
+    ).toBeNull();
+    expect(readTabStripLayout()).toEqual(before);
+    expect(useLandingDraftStore.getState().activeDraftId).toBeNull();
+  });
+
+  it("rejects a retired ref target while its stale row remains before storage cleanup", () => {
+    const id = "retired-ref-target";
+    useLandingDraftStore.getState().createDraftWithId(id, null);
+    const ref: TabRef = { kind: "draft", id };
+    seedStrip([ref], ref);
+    useLandingDraftStore.getState().clearActiveDraft();
+    const before = readTabStripLayout();
+    retireLandingDraft(id, null);
+
+    expect(landingDraftIsRetired(id)).toBe(true);
+    expect(useLandingDraftStore.getState().drafts).toHaveLength(1);
+    expect(tabSourceRefs()).not.toContainEqual(ref);
+    expect(tabCommandCoordinator.activateTab({ kind: "ref", ref })).toBeNull();
+    expect(readTabStripLayout()).toEqual(before);
+    useLandingDraftStore.getState().openDraft(id);
+    useLandingDraftStore.getState().setActiveDraft(id);
+    expect(useLandingDraftStore.getState().activeDraftId).toBeNull();
+    expect(useLandingDraftStore.getState().drafts).toHaveLength(1);
+  });
+
   it("keeps the focused task active when a background landing draft source appears", () => {
     const taskId = useEpicCanvasStore
       .getState()

--- a/clients/gui-app/src/stores/tabs/__tests__/transaction-coordinator.test.ts
+++ b/clients/gui-app/src/stores/tabs/__tests__/transaction-coordinator.test.ts
@@ -974,7 +974,11 @@ describe("tab command coordinator transactions", () => {
       ref.kind === "epic" ? [ref.id] : [],
     );
     expect(canvas.openTabOrder).toEqual(layoutEpicIds);
-    expect(canvas.activeTabId).toBe(xId);
+    // X was opened in the background while the command left the split's
+    // right side focused but empty. The split remains the active layout item;
+    // compatibility has no selected epic to project back to the canvas.
+    expect(layout.activeItemId).toBe("split-proj-nested-x");
+    expect(canvas.activeTabId).toBeNull();
   });
 
   it("one-shot projection listener error still releases the ledger and permits another command", () => {

--- a/clients/gui-app/src/stores/tabs/source-refs.ts
+++ b/clients/gui-app/src/stores/tabs/source-refs.ts
@@ -7,8 +7,9 @@ import type { TabRef } from "@/stores/tabs/types";
 
 /**
  * The canonical set of refs a strip layout may reference: every open Epic tab
- * in canvas order, then every OPEN landing draft (`closed: false`). Closed
- * drafts stay in the store for history (T11) but are not strip sources.
+ * in canvas order, then every open, non-retired landing draft. Closed drafts
+ * stay in the store for history (T11) but are not strip sources. Retirement
+ * can precede another window's storage-event cleanup of its local row.
  *
  * Defined once on purpose. Reconciliation (the command coordinator) and
  * hydration/sanitize (desktop persistence) have to agree on exactly what counts

--- a/clients/gui-app/src/stores/tabs/tab-command-coordinator.ts
+++ b/clients/gui-app/src/stores/tabs/tab-command-coordinator.ts
@@ -27,6 +27,7 @@ import {
   useLandingDraftStore,
 } from "@/stores/home/landing-draft-store";
 import { isMobileApp } from "@/lib/mobile-app";
+import { landingDraftIsRetired } from "@/lib/drafts/landing-draft-retirement";
 import {
   isRegisteredTabKind,
   tabSurfaceDescriptor,
@@ -1101,7 +1102,7 @@ export class TabCommandCoordinator {
       target.draftId ??
       mobileStableDraftId ??
       (target.create ? uuidv4() : null);
-    if (draftId === null) return null;
+    if (draftId === null || landingDraftIsRetired(draftId)) return null;
     const drafts = useLandingDraftStore.getState().drafts;
     const present = drafts.some((draft) => draft.id === draftId);
     const open = drafts.some(
@@ -1956,8 +1957,18 @@ export class TabCommandCoordinator {
     const additions = knownSources.filter(
       (ref) => findStripItemForRef(withoutMissing, ref) === null,
     );
+    const withAdditions = additions.reduce(createLayoutItem, withoutMissing);
     return {
-      next: additions.reduce(createLayoutItem, withoutMissing),
+      // Background source updates must not select a newly mirrored draft.
+      // Explicit tab commands focus their target separately.
+      next:
+        additions.length === 0 || withoutMissing.activeItemId === null
+          ? withAdditions
+          : {
+              ...withAdditions,
+              activeItemId: withoutMissing.activeItemId,
+              activationHistory: withoutMissing.activationHistory,
+            },
       additions,
       removals,
     };

--- a/clients/gui-app/src/stores/tabs/tab-command-coordinator.ts
+++ b/clients/gui-app/src/stores/tabs/tab-command-coordinator.ts
@@ -1382,9 +1382,14 @@ export class TabCommandCoordinator {
   }
 
   restoreClosedHeaderTabs(
-    items: readonly ClosedHeaderTab[],
+    requestedItems: readonly ClosedHeaderTab[],
     replaceEmptyDraftId: string | null,
   ): void {
+    // Another window can retire a retained row before its storage event
+    // removes the local recovery entry. Do not reserve or place that ID.
+    const items = requestedItems.filter(
+      (item) => item.kind !== "draft" || !landingDraftIsRetired(item.draftId),
+    );
     if (items.length === 0) return;
     const previousLayout = currentLayout();
     const previousActiveDraftId = useLandingDraftStore.getState().activeDraftId;
@@ -1958,11 +1963,14 @@ export class TabCommandCoordinator {
       (ref) => findStripItemForRef(withoutMissing, ref) === null,
     );
     const withAdditions = additions.reduce(createLayoutItem, withoutMissing);
+    const keepSelection =
+      withoutMissing.activeItemId !== null ||
+      layoutHomeIsActive(withoutMissing);
     return {
       // Background source updates must not select a newly mirrored draft.
       // Explicit tab commands focus their target separately.
       next:
-        additions.length === 0 || withoutMissing.activeItemId === null
+        additions.length === 0 || !keepSelection
           ? withAdditions
           : {
               ...withAdditions,


### PR DESCRIPTION
## Summary

Submitting a landing task with images to a remote host could repeatedly reopen its draft with partial prompt snapshots. Autosaves accumulated behind slow blob uploads, delaying deletion; subscription echoes and cloud ingestion could restore the removed row.

- Persist retirement receipts before consuming/deleting a landing draft, and check them before and after incoming image reads in the shared subscription/cloud apply path. Keep receipts after host acknowledgement, recover unknown owners, retry deletion without a local row, and reconcile retirement across windows.
- Keep one active save plus the latest waiting snapshot. Deletion drops waiting work and prevents prepared writes from being dispatched. Preserve incoming revision order and unsent edits across asynchronous applies.
- Preserve the active tab or Home selection when background sources appear; explicit draft activation still selects its target. Reject retired drafts in direct activation and closed-tab recovery, including the window before cross-window cleanup.

## Validation

- 145 focused tests passed, covering delayed incoming images, stale cloud documents after ACK/restart, unknown-owner recovery, cross-window retirement, queue cancellation/coalescing, revision ordering, and tab focus.
- The completed review round passed 77 focused tests in four suites, including the real subscription/session/store path with out-of-order image reads, committed revision tracking across deletion, and retired draft recovery. Independent code and test review found no remaining correctness issues.
- The first CI pass exposed two existing fixture assumptions about reused draft IDs and implicit focus. Both were corrected without changing their assertions; the two affected suites pass locally (59 tests).
- Two local staging renderer reruns with a remote host, two images, and a 179-character prompt had zero reopenings through 95 seconds after each host tombstone. Delete dispatch wait was 0.076 s and 10.896 s versus 274.369 s in the failing baseline. Both tasks received the full prompt and images.
- Neither fixed rerun produced a late cloud-ingest callback; that guard is covered by deterministic tests and review. These captures used the fix on the earlier source base; this branch was subsequently updated to current `main`, including #1874.
- GUI type check, scoped lint, production renderer build, and independent review passed before the base update. React Doctor found no issues after updating the branch. Commit hooks and PR CI validate the combined changes.

## Related issue

Staging reproduction of landing drafts reopening after remote task submission.

## Checklist

- [x] Pre-commit static checks pass
- [x] Separate CI test checks pass
- [x] Tests added/updated where it makes sense
- [x] Commits are signed off (`git commit -s`) per the DCO
